### PR TITLE
feat(fonts): paint embedded fonts through an engine-minted alias

### DIFF
--- a/.changeset/font-paint-aliasing.md
+++ b/.changeset/font-paint-aliasing.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+Fonts embedded in a DOCX now paint with their real glyphs, not just measure with them. The bytes are registered with the browser under an internal alias rather than the family name the document declares, so a file can never repaint the host application's own UI. New `createFontSource(bytes, request)` turns font bytes you already hold into a composable source with the hash computed for you, and `loadFonts` now fetches its URLs concurrently, refuses responses that are not fonts (an HTML error page served with 200 no longer poisons the cache), and reports both as typed per-source failures. The shaped-font remount no longer drops keyboard focus.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -9,6 +9,7 @@ import { ChromeSlotId } from '@docx-editor.dev/core-contract/editor';
 import { ColorValue } from '@docx-editor.dev/core-contract/contracts/editor';
 import { commandForSlot } from '@docx-editor.dev/core-contract/editor';
 import { composeFontConfiguration } from '@docx-editor.dev/core-contract/editor';
+import { createFontSource } from '@docx-editor.dev/core-contract/editor';
 import { CSSProperties } from 'react';
 import { DisplayItem } from '@docx-editor.dev/core-contract/contracts/geometry';
 import { DisplayPage } from '@docx-editor.dev/core-contract/contracts/geometry';
@@ -72,6 +73,8 @@ export { ChromeSlotId }
 export { commandForSlot }
 
 export { composeFontConfiguration }
+
+export { createFontSource }
 
 export { DisplayItem }
 

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -105,6 +105,64 @@ base: FontConfigurationBase,
 }
 
 // @public
+export function createFontSource(
+bytes: Uint8Array,
+request: FontFaceRequest & { readonly faceIndex?: number },
+options: { readonly id?: string; readonly maxFontBytes?: number } = {}
+): { readonly source: FontSource } | { readonly failure: FontLoadFailure } {
+    const // (undocumented)
+    faceRequest: FontFaceRequest = Object.freeze({
+        family: request.family,
+        weight: request.weight,
+        style: request.style,
+    });
+    const // (undocumented)
+    url =
+    options.id ?? `bytes:${faceRequest.family}#${faceRequest.weight}#${faceRequest.style}`;
+    const // (undocumented)
+    descriptorProblem = faceRequestProblem(faceRequest);
+    if (descriptorProblem) {
+        return {
+            failure: {
+                url,
+                request: faceRequest,
+                reason: 'invalidRequest',
+                diagnostic: descriptorProblem,
+            },
+        };
+    }
+    if (bytes.byteLength === 0) {
+        return { failure: { url, request: faceRequest, reason: 'emptyResponse' } };
+    }
+    if (bytes.byteLength > (options.maxFontBytes ?? HARD_MAX_FONT_BYTES)) {
+        return { failure: { url, request: faceRequest, reason: 'overLimit' } };
+    }
+    const // (undocumented)
+    faceIndex = request.faceIndex ?? 0;
+    const // (undocumented)
+    structural = boundedStructuralFontValidator(bytes, faceIndex);
+    if (!structural.valid) {
+        return {
+            failure: {
+                url,
+                request: faceRequest,
+                reason: 'malformed',
+                diagnostic: structural.diagnostic,
+            },
+        };
+    }
+    return {
+        source: {
+            request: faceRequest,
+            id: url,
+            bytes,
+            hash: sha256FontBytes(bytes),
+            faceIndex,
+        },
+    };
+}
+
+// @public
 export const DEFERRED_DIALOGS: readonly ["findReplace", "hyperlink", "insertImage", "insertTable", "insertSymbol", "imageProperties", "footnoteProperties"];
 
 // @public (undocumented)
@@ -748,7 +806,9 @@ export type FontLoadFailureReason =
 | 'overLimit'
 | 'emptyResponse'
 /** The declared face itself is unusable (empty family, out-of-range weight); nothing was fetched. */
-| 'invalidRequest';
+| 'invalidRequest'
+/** The bytes are not a font at all — most often an HTML error page served with 200. */
+| 'malformed';
 
 // @public
 export interface FontSource {
@@ -885,15 +945,11 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
     const // (undocumented)
     cache = await openCache(request.cacheName ?? 'docx-editor-fonts');
 
-    const // (undocumented)
-    sources: FontSource[] = [];
-    const // (undocumented)
-    failures: FontLoadFailure[] = [];
+    // (undocumented)
+    export type Outcome = { readonly source: FontSource } | { readonly failure: FontLoadFailure };
 
-    // Sequential per list order keeps admission deterministic; the fetches themselves are
-    // the slow part and typically few. Callers needing parallelism can shard the list.
-    for (const // (undocumented)
-    source of request.sources) {
+    // (undocumented)
+    export async function loadOne(source: FontUrlSource): Promise<Outcome> {
         const // (undocumented)
         faceRequest: FontFaceRequest = Object.freeze({
             family: source.family,
@@ -903,25 +959,41 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
         // Screened HERE, not at composition: the request contract refuses a malformed face
         // with a THROW, so admitting one would detonate the configuration carrying every
         // other font instead of degrading this single source. Same discipline the embedded
-        // lane applies to file-declared families.
+        // lane applies to file-declared families. Nothing is fetched for a bad descriptor.
         const // (undocumented)
         descriptorProblem = faceRequestProblem(faceRequest);
         if (descriptorProblem) {
-            failures.push({
-                url: source.url,
-                request: faceRequest,
-                reason: 'invalidRequest',
-                diagnostic: descriptorProblem,
-            });
-            continue;
+            return {
+                failure: {
+                    url: source.url,
+                    request: faceRequest,
+                    reason: 'invalidRequest',
+                    diagnostic: descriptorProblem,
+                },
+            };
         }
+
         const // (undocumented)
-        admit = (bytes: Uint8Array, fromCache: boolean): 'admitted' | FontLoadFailure => {
+        admit = (bytes: Uint8Array, fromCache: boolean): FontSource | FontLoadFailure => {
             if (bytes.byteLength === 0) {
                 return { url: source.url, request: faceRequest, reason: 'emptyResponse' };
             }
             if (bytes.byteLength > maxFontBytes) {
                 return { url: source.url, request: faceRequest, reason: 'overLimit' };
+            }
+            // A 200 response carrying an HTML error page passes every size check. Without this
+            // it would be admitted, cached, and then fail deep in shaping on EVERY later load,
+            // with nothing ever discarding the entry. A signature check is cheap and turns that
+            // into one typed failure at the boundary.
+            const // (undocumented)
+            structural = boundedStructuralFontValidator(bytes, source.faceIndex ?? 0);
+            if (!structural.valid) {
+                return {
+                    url: source.url,
+                    request: faceRequest,
+                    reason: 'malformed',
+                    diagnostic: structural.diagnostic,
+                };
             }
             const // (undocumented)
             actualHash = sha256FontBytes(bytes);
@@ -935,14 +1007,13 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
                     ...(fromCache ? { diagnostic: 'cached bytes failed revalidation' } : {}),
                 };
             }
-            sources.push({
+            return {
                 request: faceRequest,
                 id: `url:${source.url}`,
                 bytes,
                 hash: actualHash,
                 faceIndex: source.faceIndex ?? 0,
-            });
-            return 'admitted';
+            };
         };
 
         // Cache first, revalidated by content hash. A poisoned or stale entry is discarded
@@ -952,7 +1023,7 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
         if (cached) {
             const // (undocumented)
             verdict = admit(cached, true);
-            if (verdict === 'admitted') continue;
+            if (!('reason' in verdict)) return { source: verdict };
             await discardEntry(cache, source.url);
         }
 
@@ -962,22 +1033,24 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
             response = await fetcher(source.url);
         } catch (// (undocumented)
         error) {
-            failures.push({
-                url: source.url,
-                request: faceRequest,
-                reason: 'networkError',
-                diagnostic: error instanceof Error ? error.message : String(error),
-            });
-            continue;
+            return {
+                failure: {
+                    url: source.url,
+                    request: faceRequest,
+                    reason: 'networkError',
+                    diagnostic: error instanceof Error ? error.message : String(error),
+                },
+            };
         }
         if (!response.ok) {
-            failures.push({
-                url: source.url,
-                request: faceRequest,
-                reason: 'httpError',
-                status: response.status,
-            });
-            continue;
+            return {
+                failure: {
+                    url: source.url,
+                    request: faceRequest,
+                    reason: 'httpError',
+                    status: response.status,
+                },
+            };
         }
         let // (undocumented)
         bytes: Uint8Array;
@@ -985,23 +1058,37 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
             bytes = new Uint8Array(await response.arrayBuffer());
         } catch (// (undocumented)
         error) {
-            failures.push({
-                url: source.url,
-                request: faceRequest,
-                reason: 'networkError',
-                diagnostic: error instanceof Error ? error.message : String(error),
-            });
-            continue;
+            return {
+                failure: {
+                    url: source.url,
+                    request: faceRequest,
+                    reason: 'networkError',
+                    diagnostic: error instanceof Error ? error.message : String(error),
+                },
+            };
         }
         const // (undocumented)
         verdict = admit(bytes, false);
-        if (verdict === 'admitted') {
-            await storeBytes(cache, source.url, bytes);
-        } else {
-            failures.push(verdict);
-        }
+        if ('reason' in verdict) return { failure: verdict };
+        await storeBytes(cache, source.url, bytes);
+        return { source: verdict };
     }
 
+    // Fetched CONCURRENTLY — eight brand faces should be one round trip's wait, not eight.
+    // Results are reassembled in list order, so admission stays deterministic regardless of
+    // which response lands first.
+    const // (undocumented)
+    outcomes = await Promise.all(request.sources.map((source) => loadOne(source)));
+
+    const // (undocumented)
+    sources: FontSource[] = [];
+    const // (undocumented)
+    failures: FontLoadFailure[] = [];
+    for (const // (undocumented)
+    outcome of outcomes) {
+        if ('source' in outcome) sources.push(outcome.source);
+        else failures.push(outcome.failure);
+    }
     return { sources, failures };
 }
 

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -16,7 +16,14 @@ combine.
 **1. Fonts embedded in the document — automatic.** A `.docx` can carry the faces it was
 written in. When it does, the editor extracts them on load and measures with them. No
 configuration, no assets, no network: a document that brings its own fonts is
-Word-accurate out of the box.
+Word-accurate out of the box, in metrics and in pixels — the editor also registers the
+embedded bytes with the browser so the painted pages show the real glyphs, not a platform
+substitute.
+
+Those faces register under an internal alias, never under the family name the document
+declares. A `.docx` controls its own font names, and the browser's font registry is
+page-wide, so registering a document's `Segoe UI` would repaint your application's own
+buttons and dialogs with glyphs from that file.
 
 **2. Metric-compatible substitutes — one call.** Most documents use Word's default
 fonts (Calibri, Cambria, Times New Roman, Arial, Courier New), which are proprietary
@@ -112,6 +119,21 @@ console.log(result.sources.map((source) => `${source.id}: ${source.hash}`));
 
 Paste those into your source list (or generate the list at build time, which is how
 `@docx-editor.dev/fonts` bakes the hashes for its own assets).
+
+Already hold the bytes — a file input, IndexedDB, a bundler import? `createFontSource`
+turns them into a source directly, with the hash computed for you. It returns a typed
+failure rather than throwing when the descriptor or the bytes are unusable:
+
+```ts
+import { createFontSource, composeFontConfiguration } from '@docx-editor.dev/react';
+
+const made = createFontSource(bytes, { family: 'Acme Sans', weight: 400, style: 'normal' });
+if ('source' in made) {
+  const fonts = composeFontConfiguration({ sources: [made.source] });
+} else {
+  report(made.failure.reason); // 'malformed', 'overLimit', 'invalidRequest', …
+}
+```
 
 ## How sources combine
 

--- a/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
+++ b/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
@@ -14,7 +14,7 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { zipSync, strToU8 } from 'fflate';
 import type { EditorFontError } from '../../contracts/editor.ts';
@@ -435,6 +435,100 @@ describe('a hostile run family cannot destroy the mounted document', () => {
     expect(container.textContent).toContain('crafted');
     expect(editor.surface!.session.bodyText()).toContain('crafted');
     expect(editor.snapshot().parseError ?? null).toBeNull();
+    editor.destroy();
+  });
+});
+
+// Paint-side registration, end to end (issue #78). Happy-dom ships neither
+// `document.fonts` nor `FontFace`, so the environment is stubbed per test.
+describe('embedded faces paint through an engine-minted alias', () => {
+  class StubFontFace {
+    constructor(
+      readonly family: string,
+      readonly bytes: ArrayBuffer,
+      readonly descriptors: { readonly weight: string; readonly style: string }
+    ) {}
+    load(): Promise<unknown> {
+      return Promise.resolve(this);
+    }
+  }
+  class StubFontFaceSet {
+    readonly faces = new Set<StubFontFace>();
+    add(face: StubFontFace): void {
+      this.faces.add(face);
+    }
+    delete(face: StubFontFace): boolean {
+      return this.faces.delete(face);
+    }
+  }
+
+  let fontSet: StubFontFaceSet;
+  beforeEach(() => {
+    fontSet = new StubFontFaceSet();
+    (document as unknown as { fonts: StubFontFaceSet }).fonts = fontSet;
+    (globalThis as unknown as { FontFace: typeof StubFontFace }).FontFace = StubFontFace;
+  });
+  afterEach(() => {
+    delete (document as unknown as { fonts?: StubFontFaceSet }).fonts;
+    delete (globalThis as unknown as { FontFace?: typeof StubFontFace }).FontFace;
+  });
+
+  test('a hostile declared family never reaches document.fonts, but still paints', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      // The document claims to embed the host application's own UI font.
+      document: docxWithEmbeds(p('spoofed', 'Segoe UI'), [
+        { family: 'Segoe UI', slot: 'embedRegular', bytes: regularBytes },
+      ]),
+      onFontError: () => {},
+    });
+    await fontsSettled(editor);
+
+    const registered = [...fontSet.faces].map((face) => face.family);
+    expect(registered).toHaveLength(1);
+    // THE security property: the page-global registry never learns "Segoe UI".
+    expect(registered[0]).not.toBe('Segoe UI');
+    expect(registered[0]).toMatch(/^docx-embedded-/);
+
+    // And the painted run asks for the alias FIRST, with the declared family behind it,
+    // so the embedded glyphs are used without shadowing anything.
+    const painted = container.querySelector<HTMLElement>('[data-paragraph-id] .layout-run-text');
+    expect(painted).not.toBeNull();
+    expect(painted!.style.fontFamily).toContain(registered[0]!);
+    expect(painted!.style.fontFamily).toContain('Segoe UI');
+    expect(painted!.style.fontFamily.indexOf(registered[0]!)).toBeLessThan(
+      painted!.style.fontFamily.indexOf('Segoe UI')
+    );
+    editor.destroy();
+    expect(fontSet.faces.size).toBe(0);
+  });
+
+  test('a replaced document removes the previous document’s faces', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      document: docxWithEmbeds(p('first'), EMBED_BOTH),
+    });
+    await fontsSettled(editor);
+    expect(fontSet.faces.size).toBe(2);
+    editor.load(docxWithEmbeds(p('second, no embeds'), []));
+    expect(fontSet.faces.size).toBe(0);
+    editor.destroy();
+  });
+
+  test('a validator-rejected face is never registered', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      document: docxWithEmbeds(p('partial'), [
+        { family: 'DejaVu Sans', slot: 'embedRegular', bytes: regularBytes },
+        { family: 'Broken Face', slot: 'embedRegular', bytes: new Uint8Array(4096).fill(0x42) },
+      ]),
+      onFontError: () => {},
+    });
+    await fontsSettled(editor);
+    expect(fontSet.faces.size).toBe(1);
     editor.destroy();
   });
 });

--- a/packages/core/src/editor/__tests__/embedded-font-faces.test.ts
+++ b/packages/core/src/editor/__tests__/embedded-font-faces.test.ts
@@ -1,0 +1,157 @@
+// The security contract of paint-side registration (issue #78).
+//
+// `FontFaceSet` is per-DOCUMENT, so a face registered under a family name hides the
+// installed font of that name for the whole page. Family names in a DOCX are
+// attacker-controlled, so the ONE property that matters here is: a document-declared
+// family never reaches the browser's font registry. Everything else (which faces
+// register, what the painter is told, disposal) exists to make that safe AND useful.
+
+import { describe, expect, test } from 'bun:test';
+import type { FontSource } from '../../contracts/editor.ts';
+import {
+  registerEmbeddedFontFaces,
+  type FontFaceLike,
+  type FontFaceSetLike,
+} from '../embedded-font-faces.ts';
+
+function source(
+  family: string,
+  weight = 400,
+  style: 'normal' | 'italic' = 'normal',
+  hash = `sha256:${family}-${weight}-${style}`
+): FontSource {
+  return {
+    request: { family, weight, style },
+    id: `${family}#${weight}#${style}`,
+    bytes: new Uint8Array([1, 2, 3]),
+    hash,
+    faceIndex: 0,
+  };
+}
+
+class FakeFace implements FontFaceLike {
+  constructor(
+    readonly family: string,
+    readonly bytes: Uint8Array,
+    readonly descriptors: { readonly weight: string; readonly style: string },
+    private readonly fail: boolean
+  ) {}
+  load(): Promise<unknown> {
+    return this.fail ? Promise.reject(new Error('parse failure')) : Promise.resolve(this);
+  }
+}
+
+/**
+ * `failWhenFamilyMatches` is tested against the family the module actually passes to
+ * `FontFace`, which is the ALIAS — the caller never sees a declared name here, which is
+ * the whole point of the design.
+ */
+function fakeEnvironment(options: { failWhenFamilyMatches?: string } = {}) {
+  const added: FakeFace[] = [];
+  const deleted: FakeFace[] = [];
+  const created: FakeFace[] = [];
+  const fontSet: FontFaceSetLike = {
+    add: (face) => added.push(face as FakeFace),
+    delete: (face) => {
+      deleted.push(face as FakeFace);
+      return true;
+    },
+  };
+  return {
+    added,
+    deleted,
+    created,
+    environment: {
+      fontSet,
+      createFontFace: (family: string, bytes: Uint8Array, descriptors: never) => {
+        const shouldFail =
+          options.failWhenFamilyMatches !== undefined &&
+          family.includes(options.failWhenFamilyMatches);
+        const face = new FakeFace(family, bytes, descriptors, shouldFail);
+        created.push(face);
+        return face;
+      },
+    },
+  };
+}
+
+describe('registerEmbeddedFontFaces', () => {
+  test('a document-declared family NEVER reaches the FontFaceSet', async () => {
+    const env = fakeEnvironment();
+    const hostile = ['Segoe UI', 'Roboto', 'Material Symbols Outlined', 'Arial'];
+    const registration = await registerEmbeddedFontFaces(
+      hostile.map((family) => source(family)),
+      env.environment
+    );
+    expect(registration.installed).toBe(4);
+    for (const family of hostile) {
+      expect(env.added.some((face) => face.family === family)).toBe(false);
+      expect(env.added.some((face) => face.family.includes(family))).toBe(false);
+    }
+    // Every registered family is an engine-minted alias.
+    for (const face of env.added) expect(face.family).toMatch(/^docx-embedded-[a-z0-9]+$/);
+  });
+
+  test('the painter is told the alias for a declared family, and nothing else', async () => {
+    const env = fakeEnvironment();
+    const registration = await registerEmbeddedFontFaces(
+      [source('Segoe UI'), source('Segoe UI', 700)],
+      env.environment
+    );
+    const alias = registration.alias('Segoe UI');
+    expect(alias).toMatch(/^docx-embedded-/);
+    // Both faces of the family share one alias; CSS picks weight through the descriptors.
+    expect(new Set(env.added.map((face) => face.family)).size).toBe(1);
+    expect(env.added.map((face) => face.descriptors.weight).sort()).toEqual(['400', '700']);
+    // A family the document did not embed has no alias, so paint uses the declared name.
+    expect(registration.alias('Calibri')).toBeUndefined();
+  });
+
+  test('two documents embedding the same family name get different aliases', async () => {
+    const first = await registerEmbeddedFontFaces(
+      [source('Calibri', 400, 'normal', 'sha256:aaa')],
+      fakeEnvironment().environment
+    );
+    const second = await registerEmbeddedFontFaces(
+      [source('Calibri', 400, 'normal', 'sha256:bbb')],
+      fakeEnvironment().environment
+    );
+    expect(first.alias('Calibri')).not.toBe(second.alias('Calibri'));
+  });
+
+  test('a family whose every face fails to load advertises no alias', async () => {
+    const env = fakeEnvironment({ failWhenFamilyMatches: 'docx-embedded-' });
+    const registration = await registerEmbeddedFontFaces([source('Broken')], env.environment);
+    expect(registration.installed).toBe(0);
+    expect(registration.alias('Broken')).toBeUndefined();
+  });
+
+  test('dispose removes exactly the added faces, once, and stops advertising', async () => {
+    const env = fakeEnvironment();
+    const registration = await registerEmbeddedFontFaces(
+      [source('Calibri'), source('Calibri', 700), source('Cambria')],
+      env.environment
+    );
+    expect(registration.alias('Calibri')).toBeDefined();
+    registration.dispose();
+    registration.dispose();
+    expect(env.deleted).toEqual(env.added);
+    expect(env.deleted).toHaveLength(3);
+    // A disposed registration must not keep pointing paint at a removed face.
+    expect(registration.alias('Calibri')).toBeUndefined();
+  });
+
+  test('no FontFaceSet in the environment is a silent no-op', async () => {
+    const registration = await registerEmbeddedFontFaces([source('Calibri')], {});
+    expect(registration.installed).toBe(0);
+    expect(registration.alias('Calibri')).toBeUndefined();
+    registration.dispose();
+  });
+
+  test('no sources is a no-op without touching the set', async () => {
+    const env = fakeEnvironment();
+    const registration = await registerEmbeddedFontFaces([], env.environment);
+    expect(registration.installed).toBe(0);
+    expect(env.created).toHaveLength(0);
+  });
+});

--- a/packages/core/src/editor/__tests__/load-fonts.test.ts
+++ b/packages/core/src/editor/__tests__/load-fonts.test.ts
@@ -7,13 +7,28 @@
 // hash-revalidated bytes (a poisoned entry is discarded and refetched).
 
 import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { sha256FontBytes } from '../../layout/index.ts';
-import { loadFonts } from '../load-fonts.ts';
+import { createFontSource, loadFonts } from '../load-fonts.ts';
 import { composeFontConfiguration } from '../font-composition.ts';
 
-const fontA = new Uint8Array([1, 2, 3, 4]);
-const fontB = new Uint8Array([5, 6, 7, 8]);
-const fontC = new Uint8Array([9, 10, 11, 12]);
+// REAL font bytes: `loadFonts` screens the sfnt signature at the boundary, so synthetic
+// payloads would all be refused as `malformed` — which is the point of that screen, and
+// is asserted on its own below. Distinct faces give distinct hashes.
+const fixture = (name: string): Uint8Array =>
+  new Uint8Array(
+    readFileSync(new URL(`../../layout/__tests__/fixtures/fonts/${name}`, import.meta.url))
+  );
+const fontA = fixture('DejaVuSans.ttf');
+const fontB = fixture('DejaVuSans-Bold.ttf');
+// A third DISTINCT but still structurally valid face: trailing padding changes the
+// content hash without touching the sfnt header or table directory.
+const fontC = ((): Uint8Array => {
+  const base = fixture('DejaVuSans.ttf');
+  const padded = new Uint8Array(base.byteLength + 16);
+  padded.set(base);
+  return padded;
+})();
 
 interface FakeFetch {
   readonly fetcher: typeof fetch;
@@ -225,7 +240,7 @@ describe('malformed face descriptors degrade that source only', () => {
       ],
       fetcher: (async (input: RequestInfo | URL) => {
         fetched.push(String(input));
-        return new Response(new Uint8Array([1, 2, 3, 4]));
+        return new Response(fontA.slice());
       }) as unknown as typeof fetch,
     });
     // Only the well-formed source was even requested.
@@ -237,5 +252,48 @@ describe('malformed face descriptors degrade that source only', () => {
     ]);
     // And the admitted set composes without throwing — the point of screening early.
     expect(() => composeFontConfiguration(result)).not.toThrow();
+  });
+});
+
+describe('bytes that are not a font are refused at the boundary', () => {
+  test('a 200 response carrying an HTML error page fails as malformed and is not cached', async () => {
+    const buckets = installFakeCaches();
+    const html = new TextEncoder().encode('<!doctype html><title>404</title>');
+    const { fetcher } = fakeFetch({ 'https://x/notafont.ttf': html });
+    const result = await loadFonts({
+      sources: [{ url: 'https://x/notafont.ttf', family: 'Acme', weight: 400, style: 'normal' }],
+      fetcher,
+    });
+    expect(result.sources).toHaveLength(0);
+    expect(result.failures[0]).toMatchObject({ reason: 'malformed' });
+    // Nothing poisons the cache, so a later load retries instead of failing forever.
+    expect(buckets.get('docx-editor-fonts')?.has('https://x/notafont.ttf') ?? false).toBe(false);
+  });
+});
+
+describe('createFontSource: bytes you already hold', () => {
+  test('valid bytes become a composable source with a computed hash', () => {
+    const result = createFontSource(fontA, { family: 'Acme', weight: 400, style: 'normal' });
+    expect('source' in result).toBe(true);
+    const source = (result as { source: { hash: string; id: string } }).source;
+    expect(source.hash).toBe(sha256FontBytes(fontA));
+    expect(source.id).toBe('bytes:Acme#400#normal');
+    // Composes without ceremony — the point of the helper.
+    expect(() =>
+      composeFontConfiguration({ sources: [(result as { source: never }).source] })
+    ).not.toThrow();
+  });
+
+  test('a bad descriptor or non-font bytes returns a typed failure, never throws', () => {
+    expect(createFontSource(fontA, { family: '  ', weight: 400, style: 'normal' })).toMatchObject({
+      failure: { reason: 'invalidRequest' },
+    });
+    expect(
+      createFontSource(new Uint8Array([1, 2, 3, 4]), {
+        family: 'Acme',
+        weight: 400,
+        style: 'normal',
+      })
+    ).toMatchObject({ failure: { reason: 'malformed' } });
   });
 });

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -92,6 +92,10 @@ import {
 } from './font-configuration.ts';
 import { composeFontConfiguration, type FontConfigurationFragment } from './font-composition.ts';
 import { embeddedFontSources } from './embedded-font-sources.ts';
+import {
+  registerEmbeddedFontFaces,
+  type EmbeddedFontFaceRegistration,
+} from './embedded-font-faces.ts';
 import { mountPaginatedSurface, type PaginatedSurface } from './paginated-surface.ts';
 
 export interface DocxEditorConfig {
@@ -218,6 +222,16 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   let shapedMeasurer: TextMeasurer | undefined;
   let shapedProducer: string | undefined;
   /**
+   * Browser registration for this document's embedded faces, under engine-minted aliases
+   * (issue #78 — a file's own family name must never reach the page-global FontFaceSet).
+   * Owned per load: a replaced document and `destroy()` remove exactly these faces.
+   */
+  let embeddedFaces: EmbeddedFontFaceRegistration | null = null;
+  function disposeEmbeddedFaces(): void {
+    embeddedFaces?.dispose();
+    embeddedFaces = null;
+  }
+  /**
    * Which DOCUMENT the shaped measurer belongs to. Embedded faces are a property of the
    * loaded file, so `loadSeq` bumps per `load()` (and per constructor document) and every
    * async resolution carries the sequence it was started for — a resolution that lands
@@ -292,6 +306,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       ...(shapedMeasurer
         ? { measurer: shapedMeasurer, ...(shapedProducer ? { producer: shapedProducer } : {}) }
         : {}),
+      ...(embeddedFaces ? { fontAlias: embeddedFaces.alias } : {}),
       onChange: (state) => {
         // The mount-time render reports before `surface` is assigned; nothing observable
         // has changed at that point, so it is not a selection change.
@@ -350,6 +365,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     loadSeq += 1;
     shapedMeasurer = undefined;
     shapedProducer = undefined;
+    disposeEmbeddedFaces();
     // A superseded in-flight resolution belongs to the PREVIOUS sequence; its stale
     // guard will refuse to touch state, so the flag must reset here or a load that
     // starts no font work of its own reports `resolving: true` forever.
@@ -488,6 +504,34 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         bump();
         return;
       }
+      // Paint-side twin, BEFORE the remount so the first shaped paint already carries the
+      // embedded glyphs. Only faces the validator ADMITTED are handed over, and each
+      // resolves through the shaping snapshot so the bytes registered are the validated,
+      // owned copies — never the raw file view.
+      const admitted = fromDocument.sources
+        .filter((source) => !refusedEmbedded.has(source.id))
+        .map((source) => {
+          const resolved = shaping.fonts.resolve(source.request);
+          return resolved instanceof FontResolutionError || resolved.id !== source.id
+            ? null
+            : {
+                request: source.request,
+                id: resolved.id,
+                bytes: resolved.bytes,
+                hash: resolved.hash,
+                faceIndex: resolved.faceIndex,
+              };
+        })
+        .filter((source): source is NonNullable<typeof source> => source !== null);
+      const registration = await registerEmbeddedFontFaces(admitted);
+      if (destroyed || seq !== loadSeq) {
+        registration.dispose();
+        disposeLayoutShaping(shaping);
+        if (seq === loadSeq) fontsResolving = false;
+        return;
+      }
+      disposeEmbeddedFaces();
+      embeddedFaces = registration;
       shapedMeasurer = createShapedMeasurer({
         shaper: shaping.shaper,
         resolveFont: (style) => {
@@ -523,8 +567,17 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         // a mount that throws must leave a recoverable editor, not an empty container
         // with the document gone. Font fidelity is never worth losing the document.
         const saved = surface.session.save();
+        // A remount replaces the whole subtree, so focus lands on `document.body` — the
+        // user typing while fonts resolved would silently stop being able to type.
+        // Restore it when the OLD surface had it; never steal it otherwise.
+        const hadFocus =
+          typeof document !== 'undefined' &&
+          document.activeElement !== null &&
+          container !== null &&
+          container.contains(document.activeElement);
         try {
           mountBytes(saved);
+          if (hadFocus) surface?.focus();
         } catch (remountError) {
           shapedMeasurer = undefined;
           shapedProducer = undefined;
@@ -1030,6 +1083,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
 
     destroy() {
       destroyed = true;
+      disposeEmbeddedFaces();
       teardownSurface();
       container = null;
       pendingBytes = null;

--- a/packages/core/src/editor/embedded-font-faces.ts
+++ b/packages/core/src/editor/embedded-font-faces.ts
@@ -1,0 +1,161 @@
+// Paint-side twin of embedded-font auto-wiring, done safely (issue #78).
+//
+// Measurement never touches the browser's font machinery: HarfBuzz shapes the admitted
+// bytes directly. But painted pages are ordinary DOM, so a font that exists only inside
+// the DOCX renders in a platform substitute unless the SAME bytes are registered as a
+// `FontFace`.
+//
+// The naive version of that — register under the family the DOCUMENT declares — is a
+// zero-click UI-redressing hole, and was reverted once already. `FontFaceSet` is
+// per-DOCUMENT, not per-subtree: a face added for a family name hides the installed font
+// of that name for the WHOLE page. A file fully controls `w:font/@w:name`, so a document
+// naming its face `Segoe UI` would repaint the host application's own chrome with
+// attacker-chosen glyphs. CSS-quoting the name stops CSS injection, not shadowing —
+// quoting is not namespacing.
+//
+// So faces register under an ENGINE-MINTED alias derived from the admitted face's content
+// hash, and the painter emits `font-family: "<alias>", "<declared family>"`. Document text
+// gets the embedded glyphs; the declared name keeps whatever it means to the host page.
+
+import type { FontSource } from '../contracts/editor.ts';
+
+/** The slice of `FontFace` this module needs; injectable for tests. */
+export interface FontFaceLike {
+  load(): Promise<unknown>;
+}
+
+/** The slice of `FontFaceSet` this module needs; injectable for tests. */
+export interface FontFaceSetLike {
+  add(face: FontFaceLike): unknown;
+  delete(face: FontFaceLike): unknown;
+}
+
+export interface EmbeddedFontFaceEnvironment {
+  readonly fontSet?: FontFaceSetLike | undefined;
+  readonly createFontFace?: (
+    family: string,
+    bytes: Uint8Array,
+    descriptors: { readonly weight: string; readonly style: 'normal' | 'italic' }
+  ) => FontFaceLike;
+}
+
+/** Faces registered for one document load; disposing removes exactly those faces. */
+export interface EmbeddedFontFaceRegistration {
+  /** Faces actually admitted into the set (per-face failures are dropped silently). */
+  readonly installed: number;
+  /**
+   * Declared family -> alias, for the painter. Empty when nothing registered, which makes
+   * painting fall back to the declared family alone.
+   */
+  readonly alias: (family: string) => string | undefined;
+  dispose(): void;
+}
+
+const NO_REGISTRATION: EmbeddedFontFaceRegistration = Object.freeze({
+  installed: 0,
+  alias: () => undefined,
+  dispose() {},
+});
+
+/**
+ * The alias for one document's face set.
+ *
+ * Derived from content hashes, so it is engine-minted and a document cannot collide with
+ * a host family name — the whole point. The `docx-embedded-` prefix keeps it recognisable
+ * in devtools, and the alias is per-FAMILY (not per-face) because CSS selects weight and
+ * style through the descriptors, not the name.
+ */
+function aliasForFamily(hashes: readonly string[]): string {
+  let digest = 0;
+  for (const hash of hashes) {
+    for (let index = 0; index < hash.length; index += 1) {
+      digest = (digest * 31 + hash.charCodeAt(index)) >>> 0;
+    }
+  }
+  return `docx-embedded-${digest.toString(36)}`;
+}
+
+function defaultEnvironment(): EmbeddedFontFaceEnvironment {
+  const doc = typeof document !== 'undefined' ? document : undefined;
+  const fontSet = (doc as { fonts?: FontFaceSetLike } | undefined)?.fonts;
+  if (!fontSet || typeof FontFace === 'undefined') return {};
+  return {
+    fontSet,
+    createFontFace: (family, bytes, descriptors) =>
+      // A copy, not the admitted view: FontFace snapshots its source, but slicing keeps
+      // the engine's buffers from ever being aliased by browser internals.
+      new FontFace(family, bytes.slice().buffer, descriptors) as unknown as FontFaceLike,
+  };
+}
+
+/**
+ * Register admitted embedded faces under engine-minted aliases and return the lookup the
+ * painter uses. Resolves after every face has either loaded into the set or failed;
+ * per-face failure only lowers `installed`.
+ *
+ * Callers MUST pass faces that survived validation — these bytes reach the browser's own
+ * font loader.
+ */
+export async function registerEmbeddedFontFaces(
+  sources: readonly FontSource[],
+  environment: EmbeddedFontFaceEnvironment = defaultEnvironment()
+): Promise<EmbeddedFontFaceRegistration> {
+  const { fontSet, createFontFace } = environment;
+  if (!fontSet || !createFontFace || sources.length === 0) return NO_REGISTRATION;
+
+  // One alias per declared family, covering all of that family's faces.
+  const byFamily = new Map<string, FontSource[]>();
+  for (const source of sources) {
+    const family = source.request.family;
+    const list = byFamily.get(family);
+    if (list) list.push(source);
+    else byFamily.set(family, [source]);
+  }
+
+  const aliases = new Map<string, string>();
+  const added: FontFaceLike[] = [];
+  await Promise.all(
+    [...byFamily].map(async ([family, faces]) => {
+      const alias = aliasForFamily(faces.map((face) => face.hash));
+      let anyLoaded = false;
+      await Promise.all(
+        faces.map(async (face) => {
+          try {
+            const fontFace = createFontFace(alias, face.bytes, {
+              weight: String(face.request.weight),
+              style: face.request.style,
+            });
+            await fontFace.load();
+            fontSet.add(fontFace);
+            added.push(fontFace);
+            anyLoaded = true;
+          } catch {
+            // Paint fidelity is best-effort; the face still measures shaped.
+          }
+        })
+      );
+      // Only advertise an alias the browser actually accepted: pointing the painter at a
+      // family with no registered face would push text to the generic fallback instead of
+      // the declared family behind it.
+      if (anyLoaded) aliases.set(family, alias);
+    })
+  );
+  if (added.length === 0) return NO_REGISTRATION;
+
+  let disposed = false;
+  return {
+    installed: added.length,
+    alias: (family) => (disposed ? undefined : aliases.get(family)),
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const face of added) {
+        try {
+          fontSet.delete(face);
+        } catch {
+          /* removing from a torn-down set is not an error */
+        }
+      }
+    },
+  };
+}

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -22,6 +22,7 @@ export {
   type FontConfigurationFragment,
 } from './font-composition.ts';
 export {
+  createFontSource,
   loadFonts,
   type FontLoadFailure,
   type FontLoadFailureReason,

--- a/packages/core/src/editor/load-fonts.ts
+++ b/packages/core/src/editor/load-fonts.ts
@@ -15,7 +15,11 @@
 // coverage (unresolved families measure via the fixed fallback) and report.
 
 import type { FontFaceRequest, FontSource } from '@docx-editor.dev/core-contract/contracts/editor';
-import { HARD_MAX_FONT_BYTES, sha256FontBytes } from '@docx-editor.dev/core-contract/layout';
+import {
+  HARD_MAX_FONT_BYTES,
+  boundedStructuralFontValidator,
+  sha256FontBytes,
+} from '@docx-editor.dev/core-contract/layout';
 import type { FontConfigurationFragment } from './font-composition.ts';
 
 /** One URL to fetch and the face it claims to be. */
@@ -49,7 +53,9 @@ export type FontLoadFailureReason =
   | 'overLimit'
   | 'emptyResponse'
   /** The declared face itself is unusable (empty family, out-of-range weight); nothing was fetched. */
-  | 'invalidRequest';
+  | 'invalidRequest'
+  /** The bytes are not a font at all — most often an HTML error page served with 200. */
+  | 'malformed';
 
 export interface FontLoadFailure {
   readonly url: string;
@@ -138,12 +144,9 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
   const maxFontBytes = request.maxFontBytes ?? HARD_MAX_FONT_BYTES;
   const cache = await openCache(request.cacheName ?? 'docx-editor-fonts');
 
-  const sources: FontSource[] = [];
-  const failures: FontLoadFailure[] = [];
+  type Outcome = { readonly source: FontSource } | { readonly failure: FontLoadFailure };
 
-  // Sequential per list order keeps admission deterministic; the fetches themselves are
-  // the slow part and typically few. Callers needing parallelism can shard the list.
-  for (const source of request.sources) {
+  async function loadOne(source: FontUrlSource): Promise<Outcome> {
     const faceRequest: FontFaceRequest = Object.freeze({
       family: source.family,
       weight: source.weight,
@@ -152,23 +155,38 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
     // Screened HERE, not at composition: the request contract refuses a malformed face
     // with a THROW, so admitting one would detonate the configuration carrying every
     // other font instead of degrading this single source. Same discipline the embedded
-    // lane applies to file-declared families.
+    // lane applies to file-declared families. Nothing is fetched for a bad descriptor.
     const descriptorProblem = faceRequestProblem(faceRequest);
     if (descriptorProblem) {
-      failures.push({
-        url: source.url,
-        request: faceRequest,
-        reason: 'invalidRequest',
-        diagnostic: descriptorProblem,
-      });
-      continue;
+      return {
+        failure: {
+          url: source.url,
+          request: faceRequest,
+          reason: 'invalidRequest',
+          diagnostic: descriptorProblem,
+        },
+      };
     }
-    const admit = (bytes: Uint8Array, fromCache: boolean): 'admitted' | FontLoadFailure => {
+
+    const admit = (bytes: Uint8Array, fromCache: boolean): FontSource | FontLoadFailure => {
       if (bytes.byteLength === 0) {
         return { url: source.url, request: faceRequest, reason: 'emptyResponse' };
       }
       if (bytes.byteLength > maxFontBytes) {
         return { url: source.url, request: faceRequest, reason: 'overLimit' };
+      }
+      // A 200 response carrying an HTML error page passes every size check. Without this
+      // it would be admitted, cached, and then fail deep in shaping on EVERY later load,
+      // with nothing ever discarding the entry. A signature check is cheap and turns that
+      // into one typed failure at the boundary.
+      const structural = boundedStructuralFontValidator(bytes, source.faceIndex ?? 0);
+      if (!structural.valid) {
+        return {
+          url: source.url,
+          request: faceRequest,
+          reason: 'malformed',
+          diagnostic: structural.diagnostic,
+        };
       }
       const actualHash = sha256FontBytes(bytes);
       if (source.hash !== undefined && source.hash !== actualHash) {
@@ -181,14 +199,13 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
           ...(fromCache ? { diagnostic: 'cached bytes failed revalidation' } : {}),
         };
       }
-      sources.push({
+      return {
         request: faceRequest,
         id: `url:${source.url}`,
         bytes,
         hash: actualHash,
         faceIndex: source.faceIndex ?? 0,
-      });
-      return 'admitted';
+      };
     };
 
     // Cache first, revalidated by content hash. A poisoned or stale entry is discarded
@@ -196,7 +213,7 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
     const cached = await cachedBytes(cache, source.url);
     if (cached) {
       const verdict = admit(cached, true);
-      if (verdict === 'admitted') continue;
+      if (!('reason' in verdict)) return { source: verdict };
       await discardEntry(cache, source.url);
     }
 
@@ -204,42 +221,114 @@ export async function loadFonts(request: LoadFontsRequest): Promise<LoadFontsRes
     try {
       response = await fetcher(source.url);
     } catch (error) {
-      failures.push({
-        url: source.url,
-        request: faceRequest,
-        reason: 'networkError',
-        diagnostic: error instanceof Error ? error.message : String(error),
-      });
-      continue;
+      return {
+        failure: {
+          url: source.url,
+          request: faceRequest,
+          reason: 'networkError',
+          diagnostic: error instanceof Error ? error.message : String(error),
+        },
+      };
     }
     if (!response.ok) {
-      failures.push({
-        url: source.url,
-        request: faceRequest,
-        reason: 'httpError',
-        status: response.status,
-      });
-      continue;
+      return {
+        failure: {
+          url: source.url,
+          request: faceRequest,
+          reason: 'httpError',
+          status: response.status,
+        },
+      };
     }
     let bytes: Uint8Array;
     try {
       bytes = new Uint8Array(await response.arrayBuffer());
     } catch (error) {
-      failures.push({
-        url: source.url,
-        request: faceRequest,
-        reason: 'networkError',
-        diagnostic: error instanceof Error ? error.message : String(error),
-      });
-      continue;
+      return {
+        failure: {
+          url: source.url,
+          request: faceRequest,
+          reason: 'networkError',
+          diagnostic: error instanceof Error ? error.message : String(error),
+        },
+      };
     }
     const verdict = admit(bytes, false);
-    if (verdict === 'admitted') {
-      await storeBytes(cache, source.url, bytes);
-    } else {
-      failures.push(verdict);
-    }
+    if ('reason' in verdict) return { failure: verdict };
+    await storeBytes(cache, source.url, bytes);
+    return { source: verdict };
   }
 
+  // Fetched CONCURRENTLY — eight brand faces should be one round trip's wait, not eight.
+  // Results are reassembled in list order, so admission stays deterministic regardless of
+  // which response lands first.
+  const outcomes = await Promise.all(request.sources.map((source) => loadOne(source)));
+
+  const sources: FontSource[] = [];
+  const failures: FontLoadFailure[] = [];
+  for (const outcome of outcomes) {
+    if ('source' in outcome) sources.push(outcome.source);
+    else failures.push(outcome.failure);
+  }
   return { sources, failures };
+}
+
+/**
+ * Turn font bytes you ALREADY hold into a `FontSource` — a file input, IndexedDB, a
+ * bundler import. `loadFonts` covers URLs; this covers everything else, so no caller has
+ * to hand-assemble the record or reach for a hashing helper.
+ *
+ * Returns a typed failure instead of throwing when the descriptor or the bytes are
+ * unusable, matching `loadFonts`: one bad face degrades itself, never its neighbours.
+ */
+export function createFontSource(
+  bytes: Uint8Array,
+  request: FontFaceRequest & { readonly faceIndex?: number },
+  options: { readonly id?: string; readonly maxFontBytes?: number } = {}
+): { readonly source: FontSource } | { readonly failure: FontLoadFailure } {
+  const faceRequest: FontFaceRequest = Object.freeze({
+    family: request.family,
+    weight: request.weight,
+    style: request.style,
+  });
+  const url =
+    options.id ?? `bytes:${faceRequest.family}#${faceRequest.weight}#${faceRequest.style}`;
+  const descriptorProblem = faceRequestProblem(faceRequest);
+  if (descriptorProblem) {
+    return {
+      failure: {
+        url,
+        request: faceRequest,
+        reason: 'invalidRequest',
+        diagnostic: descriptorProblem,
+      },
+    };
+  }
+  if (bytes.byteLength === 0) {
+    return { failure: { url, request: faceRequest, reason: 'emptyResponse' } };
+  }
+  if (bytes.byteLength > (options.maxFontBytes ?? HARD_MAX_FONT_BYTES)) {
+    return { failure: { url, request: faceRequest, reason: 'overLimit' } };
+  }
+  const faceIndex = request.faceIndex ?? 0;
+  const structural = boundedStructuralFontValidator(bytes, faceIndex);
+  if (!structural.valid) {
+    return {
+      failure: {
+        url,
+        request: faceRequest,
+        reason: 'malformed',
+        diagnostic: structural.diagnostic,
+      },
+    };
+  }
+  return {
+    source: {
+      request: faceRequest,
+      id: url,
+      bytes,
+      hash: sha256FontBytes(bytes),
+      faceIndex,
+    },
+  };
 }

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -22,6 +22,12 @@ export interface PaginatedSurfaceOptions {
    * cached pre-font layout is served for the rest of the session.
    */
   readonly producer?: string;
+  /**
+   * Maps a document-declared font family to the alias its registered bytes live under, so
+   * painted runs can use embedded glyphs without the file's family name entering the
+   * page-global CSS font namespace.
+   */
+  readonly fontAlias?: (family: string) => string | undefined;
   /** Points to CSS pixels. */
   readonly scale?: number;
   readonly onChange?: (state: PaginatedSurfaceState) => void;

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -257,6 +257,7 @@ export function mountPaginatedSurface(
     materializedSet = visiblePages();
     paintSemanticLayout(pagesLayer, currentLayout, {
       scale,
+      ...(options.fontAlias ? { fontAlias: options.fontAlias } : {}),
       // Only what is on screen, plus a band either side and the pages the caret and the
       // selection touch. A five-hundred-page document has five hundred pages of records and
       // a screen holds two; building them all is the difference between opening and hanging.

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -20,6 +20,36 @@ import type {
   TableFragmentRecord,
 } from '@docx-editor.dev/core-contract/layout';
 
+/**
+ * What the run painters need beyond the records: the pixel scale, and the optional
+ * family-alias lookup that lets embedded fonts paint without their file-declared family
+ * name entering the page-global CSS font namespace.
+ */
+export interface PaintContext {
+  readonly scale: number;
+  /**
+   * Maps a document-declared family to the alias the host registered its bytes under, or
+   * `undefined` when that family has no aliased face. Engine-minted values only.
+   */
+  readonly fontAlias?: (family: string) => string | undefined;
+}
+
+/**
+ * A stable per-function token so the paint-reuse key can tell one alias lookup from
+ * another. Identity is what matters (a new lookup means new fonts); the value is opaque.
+ */
+const aliasTokens = new WeakMap<object, string>();
+let nextAliasToken = 0;
+function aliasIdentity(alias: (family: string) => string | undefined): string {
+  let token = aliasTokens.get(alias);
+  if (!token) {
+    nextAliasToken += 1;
+    token = `alias${nextAliasToken}`;
+    aliasTokens.set(alias, token);
+  }
+  return token;
+}
+
 export interface PaintOptions {
   /** Points to CSS pixels. 96/72 renders a point as a CSS point at 100% zoom. */
   readonly scale?: number;
@@ -33,6 +63,12 @@ export interface PaintOptions {
    * instead of reflowing everything underneath.
    */
   readonly materialize?: ReadonlySet<number>;
+  /**
+   * Family-alias lookup for fonts the host registered on behalf of THIS document (see
+   * {@link PaintContext.fontAlias}). Painted runs emit the alias ahead of the declared
+   * family, so a file can never shadow a family name the host page uses.
+   */
+  readonly fontAlias?: (family: string) => string | undefined;
 }
 
 const HEX = /^[0-9A-Fa-f]{6}$/;
@@ -90,8 +126,9 @@ const HIGHLIGHT = new Map<string, string>(
 );
 
 /** Apply a resolved run style to an element, value by validated value. */
-function applyRunStyle(element: HTMLElement, style: ResolvedRunStyle, scale: number): void {
+function applyRunStyle(element: HTMLElement, style: ResolvedRunStyle, ctx: PaintContext): void {
   const css = element.style;
+  const scale = ctx.scale;
   // Super/subscript draw at three quarters — the same reduction the measurer applies, so
   // the painted glyphs match the advance layout reserved. Painting them full size while
   // measuring them small made every line containing one slightly too wide.
@@ -102,7 +139,13 @@ function applyRunStyle(element: HTMLElement, style: ResolvedRunStyle, scale: num
   // Re-validated here even though the resolver already checked: this is the sink, and a
   // sink that trusts its caller is one refactor away from being the hole.
   if (style.fontFamily && FONT_NAME.test(style.fontFamily)) {
-    css.fontFamily = `"${style.fontFamily}"`;
+    // An alias names bytes the host registered for THIS document under a family a file
+    // cannot collide with. It leads, with the declared family behind it: document text
+    // gets the embedded glyphs while the page-global CSS font namespace keeps its own
+    // meaning for the declared name. `FONT_NAME` gates the declared family; the alias is
+    // engine-minted, never file-derived.
+    const alias = ctx.fontAlias?.(style.fontFamily);
+    css.fontFamily = alias ? `"${alias}", "${style.fontFamily}"` : `"${style.fontFamily}"`;
   }
   if (style.color && HEX.test(style.color)) css.color = `#${style.color}`;
   const highlight = style.highlight ? HIGHLIGHT.get(style.highlight) : undefined;
@@ -168,7 +211,7 @@ function positioned(
   return element;
 }
 
-function paintSpan(document: Document, span: StyleSpanRecord, scale: number): HTMLElement {
+function paintSpan(document: Document, span: StyleSpanRecord, ctx: PaintContext): HTMLElement {
   const element = document.createElement('span');
   element.className = 'layout-run layout-run-text';
   // Each run is its OWN box, aligned on the baseline.
@@ -182,12 +225,12 @@ function paintSpan(document: Document, span: StyleSpanRecord, scale: number): HT
   element.dataset.paragraphId = span.range.paragraphId;
   element.dataset.start = String(span.range.start);
   element.dataset.end = String(span.range.end);
-  applyRunStyle(element, span.style, scale);
+  applyRunStyle(element, span.style, ctx);
   if (span.style.horizontalScalePercent !== 100) {
     // The transform stretches the glyphs but reserves nothing, so the element is given the
     // advance layout already scaled. Without it the stretched run painted over its
     // neighbour and their selection bands overlapped.
-    element.style.width = `${span.box.width * scale}px`;
+    element.style.width = `${span.box.width * ctx.scale}px`;
   }
   element.textContent = span.text; // SAFE: textContent, never innerHTML
   return element;
@@ -209,7 +252,8 @@ function paintSpan(document: Document, span: StyleSpanRecord, scale: number): HT
  * `white-space: pre` keeps the browser from re-wrapping a line layout already decided, so
  * a line that measured slightly wide overflows by a hair rather than becoming two lines.
  */
-function paintLine(document: Document, line: LineRecord, scale: number): HTMLElement {
+function paintLine(document: Document, line: LineRecord, ctx: PaintContext): HTMLElement {
+  const scale = ctx.scale;
   const element = document.createElement('div');
   element.className = 'docx-line layout-line';
   element.dataset.lineId = line.id;
@@ -243,7 +287,7 @@ function paintLine(document: Document, line: LineRecord, scale: number): HTMLEle
   const gap = interSpanGap(line);
   if (gap > 0) element.style.wordSpacing = `${gap * scale}px`;
 
-  for (const span of line.spans) element.append(paintSpan(document, span, scale));
+  for (const span of line.spans) element.append(paintSpan(document, span, ctx));
   // A span-less line (empty paragraph) has no inline content, and a browser will not
   // draw a caret at a position with no inline box to measure. The <br> is the anchor;
   // sizing it to the line keeps the caret the paragraph's font height, not the div's
@@ -272,14 +316,15 @@ function interSpanGap(line: LineRecord): number {
 function paintFragment(
   document: Document,
   fragment: ParagraphFragmentRecord,
-  scale: number
+  ctx: PaintContext
 ): HTMLElement {
+  const scale = ctx.scale;
   const element = positioned(document, 'div', fragment.box, scale);
   element.className = 'docx-paragraph-fragment layout-paragraph';
   element.dataset.paragraphId = fragment.paragraphId;
   element.dataset.fragmentIndex = String(fragment.fragmentIndex);
   for (const line of fragment.lines) {
-    const painted = paintLine(document, line, scale);
+    const painted = paintLine(document, line, ctx);
     // Line boxes are page-relative; inside a fragment they are drawn relative to it —
     // BOTH axes. The fragment box already carries the x origin (indent, or a table cell's
     // content edge), so an absolute left here would count that origin twice.
@@ -301,8 +346,9 @@ function paintFragment(
 function paintTableFragment(
   document: Document,
   fragment: TableFragmentRecord,
-  scale: number
+  ctx: PaintContext
 ): HTMLElement {
+  const scale = ctx.scale;
   const element = positioned(document, 'div', fragment.box, scale);
   element.className = 'docx-table-fragment layout-table';
   element.dataset.tableId = fragment.tableId;
@@ -328,8 +374,8 @@ function paintTableFragment(
       for (const block of cell.blocks) {
         const painted =
           block.kind === 'table'
-            ? paintTableFragment(document, block, scale)
-            : paintFragment(document, block, scale);
+            ? paintTableFragment(document, block, ctx)
+            : paintFragment(document, block, ctx);
         painted.style.left = `${(block.box.x - cell.box.x) * scale}px`;
         painted.style.top = `${(block.box.y - cell.box.y) * scale}px`;
         cellElement.append(painted);
@@ -344,7 +390,7 @@ function paintTableFragment(
 function paintPage(
   document: Document,
   page: PageRecord,
-  options: { readonly scale: number; readonly ariaHidden: boolean },
+  options: PaintContext & { readonly ariaHidden: boolean },
   materialize: boolean
 ): HTMLElement {
   const element = positioned(document, 'div', page.box, options.scale);
@@ -376,8 +422,8 @@ function paintPage(
   for (const fragment of page.fragments) {
     content.append(
       fragment.kind === 'table'
-        ? paintTableFragment(document, fragment, options.scale)
-        : paintFragment(document, fragment, options.scale)
+        ? paintTableFragment(document, fragment, options)
+        : paintFragment(document, fragment, options)
     );
   }
   element.append(content);
@@ -401,8 +447,8 @@ function paintPage(
     for (const fragment of story.fragments) {
       container.append(
         fragment.kind === 'table'
-          ? paintTableFragment(document, fragment, options.scale)
-          : paintFragment(document, fragment, options.scale)
+          ? paintTableFragment(document, fragment, options)
+          : paintFragment(document, fragment, options)
       );
     }
     element.append(container);
@@ -449,9 +495,12 @@ export function paintSemanticLayout(
   const resolved = {
     scale: options.scale ?? 96 / 72,
     ariaHidden: options.ariaHidden ?? true,
+    ...(options.fontAlias ? { fontAlias: options.fontAlias } : {}),
   };
   const document = container.ownerDocument;
-  const parameters = `${resolved.scale}|${resolved.ariaHidden}`;
+  // The alias lookup is part of the paint parameters: a page painted before fonts
+  // registered must not be reused verbatim afterwards.
+  const parameters = `${resolved.scale}|${resolved.ariaHidden}|${resolved.fontAlias ? aliasIdentity(resolved.fontAlias) : ''}`;
   const previous = retainedPaints.get(container);
   const reusable =
     previous && previous.parameters === parameters

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -96,6 +96,7 @@ export type {
 export {
   WORD_DEFAULT_FONT,
   composeFontConfiguration,
+  createFontSource,
   loadFonts,
   type FontConfigurationBase,
   type FontConfigurationFragment,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -34,6 +34,7 @@ export type {
 export {
   WORD_DEFAULT_FONT,
   composeFontConfiguration,
+  createFontSource,
   loadFonts,
   type FontConfigurationBase,
   type FontConfigurationFragment,


### PR DESCRIPTION
Stacked on #77. Closes #78; picks off the contained items from #79.

## Embedded fonts now paint, safely (#78)

Embedded faces already drove measurement. They now also register with the browser, so a document carrying a font nobody has installed shows its real glyphs instead of a platform substitute.

The obvious way to do that is a security hole, which is why the first attempt was reverted: `FontFaceSet` is per-document, not per-subtree, so a face registered under a family name hides the installed font of that name for the **whole page**. A `.docx` fully controls `w:font/@w:name`, so a document naming its face `Segoe UI` would repaint the host application's buttons and dialogs with glyphs from that file. Quoting the name stops CSS injection, not shadowing.

So faces register under an engine-minted alias derived from the admitted face's content hash, and the painter emits:

```css
font-family: "docx-embedded-1k4j2h", "Segoe UI";
```

Document text gets the embedded glyphs; the declared name keeps whatever it means to the host page. Aliases are per-family (CSS picks weight and style through the descriptors), scoped to one load, and removed when the document is replaced or the editor is destroyed. Only faces the validator admitted are registered, and the bytes handed over are the validated owned copies.

The security property has its own test: a document declaring `w:name="Segoe UI"` must produce no `FontFace` with that family. It fails without the fix.

## From #79

**`createFontSource(bytes, request)`** — `loadFonts` only took URLs, so a consumer with an ArrayBuffer had to hand-assemble the record and find a hashing helper that was not exported. Now:

```ts
const made = createFontSource(bytes, { family: 'Acme Sans', weight: 400, style: 'normal' });
if ('source' in made) {
  const fonts = composeFontConfiguration({ sources: [made.source] });
} else {
  report(made.failure.reason);
}
```

**`loadFonts` fetches concurrently.** Eight brand faces were eight serial round trips. Results are reassembled in list order, so admission stays deterministic.

**Non-font responses are refused at the boundary.** A 200 response carrying an HTML error page passed every size check, was admitted, cached, and then failed deep in shaping on every later load with nothing discarding the entry. It now fails once as a typed `malformed` failure and never reaches the cache.

**The shaped remount no longer drops focus.** The remount replaces the subtree, so focus fell to `document.body` — a user who opened a file with embedded fonts and started typing silently stopped being able to type ~200ms later. Focus is restored when the old surface had it, and never stolen otherwise.

## Still open in #79

Observable font state through the store (`fontMeasurement()` is not on the snapshot and Vue has no path to it), unpinned-hash cache revalidation/TTL, the double hashing of embedded bytes, and the overlapping `EditorFontErrorCode` members. Those change public API shape and are better as their own PR.

## Verification

1686 tests pass, typecheck, `api:check`, parity contract, lane boundaries, fonts manifest all clean; demo builds. The red Vercel check is the pre-existing legacy `agents` package failure, identical on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788163055&installation_model_id=422592&pr_number=80&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F80&signature=06428aa9d2674fc03c25df449d250b6d3dd6c45aa3d8c5859186e58c2eae353b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->