### PR TITLE
feat: editable page setup and per-section layout

### DIFF
--- a/.changeset/page-setup-margins-orientation.md
+++ b/.changeset/page-setup-margins-orientation.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': minor
 ---
 
-Page setup is now editable: a Page Setup dialog (`DocxEditor.PageSetupDialog`), draggable ruler margins, and a `usePageSetup` hook over the new `setPageSetup` command. Changes apply to the whole document — every section — as one undo step, and page setup joins the editor snapshot as `snapshot().pageSetup`. Documents storing landscape dimensions without the `w:orient` attribute now report landscape.
+Page setup is now editable and sections paginate individually. A Page Setup dialog (`DocxEditor.PageSetupDialog`) with Word's "Apply to: Whole document / This section", draggable ruler margins, a `usePageSetup` hook, and next-page section break insertion (`insertBreak` with kind `section`). Every section lays out against its own page geometry, so documents mixing portrait and landscape pages render as Word shows them; the rulers and `snapshot().pageSetup` follow the caret's section. A whole-document orientation flip swaps each section's own dimensions, preserving distinct paper sizes. Documents storing landscape dimensions without the `w:orient` attribute now report landscape.

--- a/.changeset/page-setup-margins-orientation.md
+++ b/.changeset/page-setup-margins-orientation.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+Page setup is now editable: a Page Setup dialog (`DocxEditor.PageSetupDialog`), draggable ruler margins, and a `usePageSetup` hook over the new `setPageSetup` command. Changes apply to the whole document — every section — as one undo step, and page setup joins the editor snapshot as `snapshot().pageSetup`. Documents storing landscape dimensions without the `w:orient` attribute now report landscape.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -20,7 +20,6 @@ import { DocxDocument } from '@docx-editor.dev/core-contract/contracts/types';
 import { DocxEditorInstance } from '@docx-editor.dev/core-contract/editor';
 import { Editor } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorCommand } from '@docx-editor.dev/core-contract/contracts/editor';
-import { EditorCommands } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorEvents } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorFontError } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorFontErrorCode } from '@docx-editor.dev/core-contract/contracts/editor';
@@ -496,8 +495,27 @@ export function PageIndicator(input: {
     visible: boolean;
 }): React$1.JSX.Element;
 
+export { PageSetup }
+
 // @public
-export type PageSetupUpdate = EditorCommands['setPageSetup'];
+export interface PageSetupUpdate {
+    // (undocumented)
+    readonly marginBottomTwips?: number;
+    // (undocumented)
+    readonly marginLeftTwips?: number;
+    // (undocumented)
+    readonly marginRightTwips?: number;
+    // (undocumented)
+    readonly marginTopTwips?: number;
+    // (undocumented)
+    readonly orientation?: 'portrait' | 'landscape';
+    // (undocumented)
+    readonly pageHeightTwips?: number;
+    // (undocumented)
+    readonly pageWidthTwips?: number;
+    // (undocumented)
+    readonly scope?: 'document' | 'section';
+}
 
 // @public (undocumented)
 export function PaginatedDocxEditor(input: PaginatedDocxEditorProps): React$1.JSX.Element;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -20,6 +20,7 @@ import { DocxDocument } from '@docx-editor.dev/core-contract/contracts/types';
 import { DocxEditorInstance } from '@docx-editor.dev/core-contract/editor';
 import { Editor } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorCommand } from '@docx-editor.dev/core-contract/contracts/editor';
+import { EditorCommands } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorEvents } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorFontError } from '@docx-editor.dev/core-contract/contracts/editor';
 import { EditorFontErrorCode } from '@docx-editor.dev/core-contract/contracts/editor';
@@ -43,6 +44,7 @@ import { loadFonts } from '@docx-editor.dev/core-contract/editor';
 import { LoadFontsRequest } from '@docx-editor.dev/core-contract/editor';
 import { LoadFontsResult } from '@docx-editor.dev/core-contract/editor';
 import { NavigationCommand } from '@docx-editor.dev/core-contract/editor';
+import { PageSetup } from '@docx-editor.dev/core-contract/contracts/editor';
 import { PaginatedSurfaceState } from '@docx-editor.dev/core-contract/editor';
 import { PX_PER_CM } from '@docx-editor.dev/core-contract/editor';
 import { PX_PER_INCH } from '@docx-editor.dev/core-contract/editor';
@@ -114,6 +116,7 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEdito
     readonly Content: typeof DocxEditorContent;
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
     readonly HorizontalRuler: typeof DocxEditorHorizontalRuler;
+    readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
     // (undocumented)
     readonly Root: typeof DocxEditorRoot;
     // (undocumented)
@@ -121,6 +124,17 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEdito
     readonly VerticalRuler: typeof DocxEditorVerticalRuler;
     // (undocumented)
     readonly Viewport: typeof DocxEditorViewport;
+}
+
+// @public
+export function DocxEditorPageSetupDialog(input: DocxEditorPageSetupDialogProps): ReactElement | null;
+
+// @public
+export interface DocxEditorPageSetupDialogProps {
+    // (undocumented)
+    className?: string;
+    onClose: () => void;
+    open: boolean;
 }
 
 // @public
@@ -444,6 +458,7 @@ export interface HorizontalRulerProps {
     onIndentRightChange?: (indentTwips: number) => void;
     // (undocumented)
     onLeftMarginChange?: (marginTwips: number) => void;
+    onMarginDragEnd?: () => void;
     // (undocumented)
     onRightMarginChange?: (marginTwips: number) => void;
     // (undocumented)
@@ -480,6 +495,9 @@ export function PageIndicator(input: {
     totalPages: number;
     visible: boolean;
 }): React$1.JSX.Element;
+
+// @public
+export type PageSetupUpdate = EditorCommands['setPageSetup'];
 
 // @public (undocumented)
 export function PaginatedDocxEditor(input: PaginatedDocxEditorProps): React$1.JSX.Element;
@@ -742,6 +760,16 @@ export interface UseFontFamilyResult {
 }
 
 // @public
+export function usePageSetup(): UsePageSetupReturn;
+
+// @public
+export interface UsePageSetupReturn {
+    readonly apply: (update: PageSetupUpdate) => boolean;
+    readonly isEnabled: boolean;
+    readonly pageSetup: PageSetup | null;
+}
+
+// @public
 export const VERSION = "0.0.2";
 
 // @public (undocumented)
@@ -752,6 +780,7 @@ export interface VerticalRulerProps {
     className?: string;
     editable?: boolean;
     onBottomMarginChange?: (marginTwips: number) => void;
+    onMarginDragEnd?: () => void;
     onTopMarginChange?: (marginTwips: number) => void;
     pageSetup?: RulerPageSetup | null;
     style?: CSSProperties;

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -642,7 +642,7 @@ export type EditorScope =
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | { kind: 'all' };
 
-// @public (undocumented)
+// @public
 export interface EditorSnapshot {
     // (undocumented)
     readonly canRedo?: boolean;
@@ -1045,6 +1045,24 @@ export interface PageIndicatorProps {
     readonly editor: Editor | null;
     // (undocumented)
     readonly visible?: boolean;
+}
+
+// @public
+export interface PageSetup {
+    readonly gutterTwips?: number;
+    // (undocumented)
+    readonly marginsTwips: {
+        readonly top: number;
+        readonly right: number;
+        readonly bottom: number;
+        readonly left: number;
+    };
+    // (undocumented)
+    readonly orientation: 'portrait' | 'landscape';
+    // (undocumented)
+    readonly pageHeightTwips: number;
+    // (undocumented)
+    readonly pageWidthTwips: number;
 }
 
 // @public (undocumented)

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -492,17 +492,7 @@ export interface Editor {
         readonly blockId: string;
     }[];
     getPageGeometry(): readonly { index: number; box: Rect; contentBox: Rect }[];
-    getPageSetup(): {
-        readonly pageWidthTwips: number;
-        readonly pageHeightTwips: number;
-        readonly orientation: 'portrait' | 'landscape';
-        readonly marginsTwips: {
-            readonly top: number;
-            readonly right: number;
-            readonly bottom: number;
-            readonly left: number;
-        };
-    } | null;
+    getPageSetup(): PageSetup | null;
     getScrollGeometry(): ScrollGeometry;
     getSelectedImage(): {
         readonly id: string;
@@ -652,7 +642,7 @@ export type EditorScope =
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | { kind: 'all' };
 
-// @public
+// @public (undocumented)
 export interface EditorSnapshot {
     // (undocumented)
     readonly canRedo?: boolean;
@@ -666,6 +656,7 @@ export interface EditorSnapshot {
     readonly isLoading: boolean;
     // (undocumented)
     readonly page: { readonly current: number; readonly total: number };
+    readonly pageSetup?: PageSetup | null;
     // (undocumented)
     readonly parseError: string | null;
     // (undocumented)

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -528,7 +528,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Margins editable; mid-body sectPr (section breaks) render and round-trip. Inserting new sections from the UI is not built yet.',
+      'Page size, orientation and margins editable per section or whole document (Page Setup dialog, ruler drags); each section paginates against its own geometry, so mixed portrait/landscape documents render as Word shows them. Next-page section breaks insertable. Even/odd-page break parity and per-section columns are not modelled yet.',
   },
   {
     id: 'layout.headers-footers',

--- a/docs/superpowers/specs/2026-07-31-page-setup-design.md
+++ b/docs/superpowers/specs/2026-07-31-page-setup-design.md
@@ -17,9 +17,14 @@ portrait.
 
 1. **One new `TreeDocOp`: `setSectionProperties`.** Fields, all optional (at
    least one required): `pageWidthTwips`, `pageHeightTwips`, `orientation`,
-   `marginTopTwips/RightTwips/BottomTwips/LeftTwips`. It addresses the
-   body-level `w:sectPr` (created as the body's last child if missing) — no
-   paragraph id, unlike every existing op. Validation mirrors the read-side
+   `marginTopTwips/RightTwips/BottomTwips/LeftTwips`. It applies to EVERY
+   `w:sectPr` in the part — mid-body sections included — because the dialog
+   and the ruler mean "this document" (Word's "Apply to: Whole document").
+   Updating only the body-level section left a multi-section file saying
+   "portrait, …, landscape", which Word renders as mixed orientation (found
+   live on the demo document, which carries five sections). A document with
+   no section at all gets a body-level one minted as the body's last child.
+   No paragraph id, unlike every existing op. Validation mirrors the read-side
    clamps (`section-properties.ts`): page dims integer 1..63360, margins
    integer 0..31680 (the write path refuses negative margins even though the
    reader tolerates them), orientation a closed enum, and the merged result
@@ -72,7 +77,11 @@ portrait.
 
 ## Out of scope
 
-Per-section (mid-body `sectPr`) editing, paper-size `w:code` maintenance
+Per-section LAYOUT (rendering a document's own mixed orientations — the demo
+doc's landscape section renders portrait today because layout paginates the
+whole flow against the body-level section; that is the deferred per-section
+lane), per-section-targeted editing ("Apply to: this section"), paper-size
+`w:code` maintenance
 beyond dropping it when dimensions change, header/footer distance UI, gutter
 UI, indent drag on rulers (needs the stored-selection indent lane).
 

--- a/docs/superpowers/specs/2026-07-31-page-setup-design.md
+++ b/docs/superpowers/specs/2026-07-31-page-setup-design.md
@@ -75,13 +75,28 @@ portrait.
    toggle; the slot registry stays untouched. Vue twin is deferred, matching
    the adapter-parity lane.
 
+## Per-section lane (added in the same PR)
+
+Initially deferred, then pulled in: `readDocumentSections` maps every section
+to the blocks it governs; `layoutSemanticDocument` takes a `sections` input
+and paginates each against its own geometry (next-page boundaries start a new
+sheet; `continuous` with an unchanged geometry shares one; sheets of mixed
+sizes stack cumulatively and centre against the widest). Reads
+(`getPageSetup`, `snapshot().pageSetup`, rulers) follow the CARET's section.
+Writes take Word's "Apply to": `scope: 'section'` anchors the op to the
+selection's governing section; ruler drags are always this-section. An
+orientation change without explicit dimensions swaps each written section's
+own dimensions. `insertBreak` kind `section` splits at the caret and mints a
+`w:pPr/w:sectPr` cloning the governing setup. The apply is ONE
+structural-sharing tree rebuild regardless of section count (a per-section
+rebuild was quadratic in a file-controlled number), and validation checks the
+planned result per targeted section.
+
 ## Out of scope
 
-Per-section LAYOUT (rendering a document's own mixed orientations — the demo
-doc's landscape section renders portrait today because layout paginates the
-whole flow against the body-level section; that is the deferred per-section
-lane), per-section-targeted editing ("Apply to: this section"), paper-size
-`w:code` maintenance
+Even/odd-page break parity (those break like nextPage), per-section columns
+and header/footer re-breaking at section width (furniture is positioned per
+page but broken at the body width), paper-size `w:code` maintenance
 beyond dropping it when dimensions change, header/footer distance UI, gutter
 UI, indent drag on rulers (needs the stored-selection indent lane).
 

--- a/docs/superpowers/specs/2026-07-31-page-setup-design.md
+++ b/docs/superpowers/specs/2026-07-31-page-setup-design.md
@@ -1,0 +1,83 @@
+# Page setup: margins, size, orientation — write path, rulers, dialog
+
+Date: 2026-07-31. Branch: `docx-editor-v2`.
+
+## Goal
+
+The v2 engine reads section geometry (`readSectionProperties` →
+`geometryOfSection` → layout) but has no write path. This change adds one, and
+wires it into chrome: draggable ruler margins and a Page Setup dialog
+(File > Page setup in the Google-Docs reference screenshots). Opening files
+with landscape pages already paginates correctly (layout uses `pgSz@w/@h`
+directly); the read-side gap is only that `landscape` is derived solely from
+`w:orient`, so a file storing swapped dimensions without the attribute reports
+portrait.
+
+## Decisions
+
+1. **One new `TreeDocOp`: `setSectionProperties`.** Fields, all optional (at
+   least one required): `pageWidthTwips`, `pageHeightTwips`, `orientation`,
+   `marginTopTwips/RightTwips/BottomTwips/LeftTwips`. It addresses the
+   body-level `w:sectPr` (created as the body's last child if missing) — no
+   paragraph id, unlike every existing op. Validation mirrors the read-side
+   clamps (`section-properties.ts`): page dims integer 1..63360, margins
+   integer 0..31680 (the write path refuses negative margins even though the
+   reader tolerates them), orientation a closed enum, and the merged result
+   must keep a positive content area (the read side falls back to default
+   geometry when margins swallow the page; refusing the write is honest,
+   falling back silently is not). Apply is surgical: merge only the attributes
+   the op carries into `pgSz`/`pgMar`, preserving `header`/`footer`/`gutter`
+   and unknown attributes and every sibling child (`cols`, `titlePg`,
+   `headerReference`, ...). `orient="landscape"` is written when landscape;
+   the attribute is removed for portrait (Word's own shape). Impact:
+   `flow-structural` with empty dirty set — the layout session context string
+   already includes geometry, so checkpoints and caches invalidate; undo
+   snapshots the whole part, so history is free.
+
+2. **Command layer owns orientation normalization.** `exec({type:
+   'setPageSetup'})` (already declared in `EditorCommands`) resolves the final
+   dimensions: when orientation is given, width/height (given or current) are
+   swapped if needed so landscape stores width > height. The op itself writes
+   literal values only.
+
+3. **`landscape` read becomes render-truthful**: `orient === 'landscape' ||
+   width > height`.
+
+4. **Page setup joins the snapshot.** `EditorSnapshot.pageSetup?` (additive,
+   the `getPageSetup()` shape, named `PageSetup` in the contract) with
+   value-equality reference reuse like `formatting`/`page`. Without it a
+   second margin change moves no snapshot field and the rulers would never
+   re-render — the snapshot's identity is the one change signal for document
+   state.
+
+5. **React: everything through hooks.** New public `usePageSetup()` →
+   `{ pageSetup, isEnabled, apply(update) }` over `useEditorState` +
+   `editor.exec`. `DocxEditor.HorizontalRuler`/`VerticalRuler` become
+   editable: margin drags preview locally (the underlying ruler components
+   gain an `onMarginDragEnd` callback) and commit ONCE on release — one undo
+   entry per drag, no relayout storm. Editability follows
+   `can({type:'setPageSetup'})` and `snapshot.editable`.
+
+6. **`DocxEditor.PageSetupDialog`** — controlled (`open`/`onClose`), size
+   presets (Letter/A4/Legal/A3/A5/B5/Executive/Custom; portrait-normalized
+   matching with ±20 twip tolerance so orientation never breaks preset
+   detection — recovered rule from the v1 dialog at `c815d02f3`), orientation
+   select, margin inputs in inches. i18n keys `dialogs.pageSetup.*` already
+   exist. `--doc-*` tokens, caret-preserving mousedown. The vite demo gets a
+   Page setup control opening it.
+
+7. **No new chrome slot.** Page setup is dialog/ruler chrome, not a toolbar
+   toggle; the slot registry stays untouched. Vue twin is deferred, matching
+   the adapter-parity lane.
+
+## Out of scope
+
+Per-section (mid-body `sectPr`) editing, paper-size `w:code` maintenance
+beyond dropping it when dimensions change, header/footer distance UI, gutter
+UI, indent drag on rulers (needs the stored-selection indent lane).
+
+## Tests
+
+Op validate/apply (create-vs-merge, preservation, hostile values, undo);
+orientation read; exec normalization + snapshot stability; React ruler/dialog
+smoke tests.

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -507,6 +507,7 @@ function EditorChrome({
 }) {
   const editor = useDocxEditor();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [showPageSetup, setShowPageSetup] = useState(false);
 
   const openFile = (file: File) => {
     void file.arrayBuffer().then((buffer) => {
@@ -553,6 +554,9 @@ function EditorChrome({
               </MenuItem>
               <MenuItem onSelect={saveDocument} disabled={!editor}>
                 Save as .docx
+              </MenuItem>
+              <MenuItem onSelect={() => setShowPageSetup(true)} disabled={!editor}>
+                Page setup&hellip;
               </MenuItem>
             </DemoMenu>
             <FormatMenu />
@@ -619,6 +623,9 @@ function EditorChrome({
           </DocxEditor.Toolbar.FontFamily.Content>
         </DocxEditor.Toolbar.FontFamily>
       </DocxEditor.Toolbar>
+
+      {/* File > Page setup: the library dialog, applied as one undo step. */}
+      <DocxEditor.PageSetupDialog open={showPageSetup} onClose={() => setShowPageSetup(false)} />
     </div>
   );
 }

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -192,11 +192,18 @@ function InsertMenu() {
   // The chrome spec's menu row is File · Format · Insert · Help. Image and table
   // insertion are UNWIRED engine slots (`image.insert` / `table.insert`), so the items
   // bind through `useEditorCommand` and render disabled with the engine's own reason —
-  // present but disabled, never faked.
+  // present but disabled, never faked. The section break is a live engine command.
+  const editor = useDocxEditor();
   return (
     <DemoMenu label="Insert">
       <CommandMenuItem slot="image.insert">Image</CommandMenuItem>
       <CommandMenuItem slot="table.insert">Table</CommandMenuItem>
+      <MenuItem
+        onSelect={() => editor?.exec({ type: 'insertBreak', kind: 'section' })}
+        disabled={!editor}
+      >
+        Section break (next page)
+      </MenuItem>
     </DemoMenu>
   );
 }

--- a/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
+++ b/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
@@ -57,6 +57,14 @@ exemptions go when it lands.
 - `EditorCommandState` — the result type of `useEditorCommand`.
 - `useEditorEvent` — typed facade event subscription hook; Vue twin is a composable,
   future task.
+- `usePageSetup` — page-setup read/write hook over `snapshot().pageSetup` and the
+  `setPageSetup` command; Vue twin is a composable, lands with the composable layer.
+- `PageSetupUpdate` — the fields `usePageSetup().apply` accepts.
+- `UsePageSetupReturn` — the hook's return type.
+- `DocxEditorPageSetupDialog` — context-fed Page Setup dialog part
+  (`DocxEditor.PageSetupDialog`) over `usePageSetup`; Vue twin lands with the
+  composable layer.
+- `DocxEditorPageSetupDialogProps` — the dialog part's props.
 - `CHROME_GROUPS` — core chrome registry re-exported for hook-built toolbars; Vue
   re-exports it when its composable layer lands.
 

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -563,7 +563,10 @@ export interface EditorCommands extends EditorCommandShape<DocEdits> {
    * Section-level page setup: the fields Word's Page Setup dialog and the rulers'
    * margin drags change. Twips throughout, matching OOXML. Every field is optional —
    * a margin drag sends one, the dialog sends several — and an omitted field is left
-   * as it is rather than reset.
+   * as it is rather than reset. `scope` is Word's "Apply to": `'document'` (the
+   * default) writes every section; `'section'` writes only the section the selection
+   * is in. An orientation change without explicit dimensions swaps each written
+   * section's own dimensions, preserving distinct paper sizes.
    */
   setPageSetup: {
     pageWidth?: number;
@@ -573,6 +576,7 @@ export interface EditorCommands extends EditorCommandShape<DocEdits> {
     marginBottom?: number;
     marginLeft?: number;
     orientation?: 'portrait' | 'landscape';
+    scope?: 'document' | 'section';
   };
 
   /** Remove the tab stop at this position (twips) from the current paragraph. */
@@ -751,13 +755,10 @@ export interface HyperlinkInfo {
 }
 
 /**
- * A read model of the current editor state, safe to hand to framework
- * rendering. Named `EditorSnapshot` rather than `EditorState` so it never
- * collides with an editing engine's own state type.
- */
-/**
  * Section page setup — size, orientation and margins, in twips — as `getPageSetup()`
- * and `snapshot().pageSetup` report it and the `setPageSetup` command writes it.
+ * and `snapshot().pageSetup` report it and the `setPageSetup` command writes it. In a
+ * multi-section document this is the setup of the section the SELECTION is in, which
+ * is what a ruler or a dialog reflects — Word's behaviour.
  */
 export interface PageSetup {
   readonly pageWidthTwips: number;
@@ -769,8 +770,15 @@ export interface PageSetup {
     readonly bottom: number;
     readonly left: number;
   };
+  /** Binding gutter (`w:gutter`), folded into the left margin by layout. */
+  readonly gutterTwips?: number;
 }
 
+/**
+ * A read model of the current editor state, safe to hand to framework
+ * rendering. Named `EditorSnapshot` rather than `EditorState` so it never
+ * collides with an editing engine's own state type.
+ */
 export interface EditorSnapshot {
   readonly scope: EditorScope;
   readonly isLoading: boolean;

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -377,17 +377,7 @@ export interface Editor {
   } | null;
 
   /** Section page setup — size, orientation and margins — for the page-setup dialog. */
-  getPageSetup(): {
-    readonly pageWidthTwips: number;
-    readonly pageHeightTwips: number;
-    readonly orientation: 'portrait' | 'landscape';
-    readonly marginsTwips: {
-      readonly top: number;
-      readonly right: number;
-      readonly bottom: number;
-      readonly left: number;
-    };
-  } | null;
+  getPageSetup(): PageSetup | null;
 
   /** The document watermark, for the watermark dialog. */
   getWatermark(): { readonly kind: 'text' | 'image'; readonly text?: string } | null;
@@ -765,6 +755,22 @@ export interface HyperlinkInfo {
  * rendering. Named `EditorSnapshot` rather than `EditorState` so it never
  * collides with an editing engine's own state type.
  */
+/**
+ * Section page setup — size, orientation and margins, in twips — as `getPageSetup()`
+ * and `snapshot().pageSetup` report it and the `setPageSetup` command writes it.
+ */
+export interface PageSetup {
+  readonly pageWidthTwips: number;
+  readonly pageHeightTwips: number;
+  readonly orientation: 'portrait' | 'landscape';
+  readonly marginsTwips: {
+    readonly top: number;
+    readonly right: number;
+    readonly bottom: number;
+    readonly left: number;
+  };
+}
+
 export interface EditorSnapshot {
   readonly scope: EditorScope;
   readonly isLoading: boolean;
@@ -785,6 +791,12 @@ export interface EditorSnapshot {
    */
   readonly canUndo?: boolean;
   readonly canRedo?: boolean;
+  /**
+   * The section's page setup, reference-stable across ticks that did not change it.
+   * Optional and additive like `canUndo`: absent means the implementation has not
+   * derived it, `null` means no document is loaded.
+   */
+  readonly pageSetup?: PageSetup | null;
 }
 
 export interface ImageContext {

--- a/packages/core/src/editor/__tests__/docx-editor.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor.test.ts
@@ -292,6 +292,69 @@ describe('createDocxEditor', () => {
     });
   });
 
+  test('setPageSetup writes margins, repaginates, and undoes as one step', () => {
+    const { editor } = mount(p('hello'));
+    expect(editor.can({ type: 'setPageSetup', marginLeft: 720 })).toEqual({ ok: true });
+    const result = editor.exec({ type: 'setPageSetup', marginLeft: 720, marginTop: 900 });
+    expect(result).toEqual({ ok: true, changed: true });
+    expect(editor.getPageSetup()?.marginsTwips).toEqual({
+      top: 900,
+      right: 1440,
+      bottom: 1440,
+      left: 720,
+    });
+    expect(editor.snapshot().canUndo).toBe(true);
+    editor.exec({ type: 'undo' });
+    expect(editor.getPageSetup()?.marginsTwips.left).toBe(1440);
+  });
+
+  test('setPageSetup orientation swaps the stored dimensions', () => {
+    const { editor } = mount(p('hello'));
+    editor.exec({ type: 'setPageSetup', orientation: 'landscape' });
+    expect(editor.getPageSetup()).toMatchObject({
+      pageWidthTwips: 15840,
+      pageHeightTwips: 12240,
+      orientation: 'landscape',
+    });
+    // Back to portrait: the dimensions swap back, whichever way they were stored.
+    editor.exec({ type: 'setPageSetup', orientation: 'portrait' });
+    expect(editor.getPageSetup()).toMatchObject({
+      pageWidthTwips: 12240,
+      pageHeightTwips: 15840,
+      orientation: 'portrait',
+    });
+  });
+
+  test('setPageSetup refuses hostile values with typed reasons', () => {
+    const { editor } = mount(p('hello'));
+    expect(editor.can({ type: 'setPageSetup' })).toMatchObject({ ok: false });
+    expect(editor.can({ type: 'setPageSetup', pageWidth: 0 })).toMatchObject({
+      ok: false,
+      code: 'invalidArgs',
+    });
+    expect(editor.can({ type: 'setPageSetup', marginLeft: -1 })).toMatchObject({
+      ok: false,
+      code: 'invalidArgs',
+    });
+    // Margins that swallow the page are refused by the op layer: nothing commits.
+    const before = editor.getDocumentHandle().revision;
+    editor.exec({ type: 'setPageSetup', marginLeft: 8000, marginRight: 8000 });
+    expect(editor.getDocumentHandle().revision).toBe(before);
+  });
+
+  test('snapshot().pageSetup is reference-stable until the section changes', () => {
+    const { editor } = mount(p('hello'));
+    const first = editor.snapshot().pageSetup;
+    expect(first).toEqual(editor.getPageSetup());
+    // An edit that does not touch the section keeps the same sub-object reference.
+    editor.exec({ type: 'insertText', text: 'X' });
+    expect(editor.snapshot().pageSetup).toBe(first);
+    // A section write moves it.
+    editor.exec({ type: 'setPageSetup', marginLeft: 720 });
+    expect(editor.snapshot().pageSetup).not.toBe(first);
+    expect(editor.snapshot().pageSetup?.marginsTwips.left).toBe(720);
+  });
+
   test('zoom is validated, stored, and reported', () => {
     const { editor } = mount(p('hello'));
     expect(editor.getZoom()).toBe(1);

--- a/packages/core/src/editor/__tests__/docx-editor.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor.test.ts
@@ -289,6 +289,7 @@ describe('createDocxEditor', () => {
       pageHeightTwips: 15840,
       orientation: 'portrait',
       marginsTwips: { top: 1440, right: 1440, bottom: 1440, left: 1440 },
+      gutterTwips: 0,
     });
   });
 
@@ -353,6 +354,89 @@ describe('createDocxEditor', () => {
     editor.exec({ type: 'setPageSetup', marginLeft: 720 });
     expect(editor.snapshot().pageSetup).not.toBe(first);
     expect(editor.snapshot().pageSetup?.marginsTwips.left).toBe(720);
+  });
+
+  test('a refused page setup surfaces as a typed error, not silent success', () => {
+    const { editor } = mount(p('hello'));
+    // Each margin passes per-field bounds; together they swallow the page.
+    const result = editor.exec({ type: 'setPageSetup', marginLeft: 8000, marginRight: 8000 });
+    expect(result).toMatchObject({ ok: false, code: 'invalidArgs' });
+  });
+
+  test('scope: section writes only the caret section of a multi-section document', () => {
+    const midBody =
+      '<w:p><w:pPr><w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr></w:pPr>' +
+      '<w:r><w:t>first section</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>second section</w:t></w:r></w:p>' +
+      '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>';
+    const { editor } = mount(midBody);
+    const first = editor.surface!.session.paragraphIds()[0]!;
+    editor.surface!.setSelection({
+      anchor: { paragraphId: first, offset: 0 },
+      head: { paragraphId: first, offset: 0 },
+    });
+    editor.exec({ type: 'setPageSetup', orientation: 'landscape', scope: 'section' });
+    // The caret's section flipped; snapshot follows the caret, so it reads landscape…
+    expect(editor.getPageSetup()).toMatchObject({ orientation: 'landscape' });
+    // …while the tail section kept portrait.
+    const second = editor.surface!.session.paragraphIds()[1]!;
+    editor.surface!.setSelection({
+      anchor: { paragraphId: second, offset: 0 },
+      head: { paragraphId: second, offset: 0 },
+    });
+    expect(editor.getPageSetup()).toMatchObject({ orientation: 'portrait' });
+  });
+
+  test('whole-document orientation flip preserves each section paper size', () => {
+    const midBody =
+      '<w:p><w:pPr><w:sectPr><w:pgSz w:w="11906" w:h="16838"/></w:sectPr></w:pPr>' +
+      '<w:r><w:t>a4 section</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>letter tail</w:t></w:r></w:p>' +
+      '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>';
+    const { editor } = mount(midBody);
+    editor.exec({ type: 'setPageSetup', orientation: 'landscape' });
+    const first = editor.surface!.session.paragraphIds()[0]!;
+    editor.surface!.setSelection({
+      anchor: { paragraphId: first, offset: 0 },
+      head: { paragraphId: first, offset: 0 },
+    });
+    // The A4 section swapped its OWN dimensions rather than inheriting Letter's.
+    expect(editor.getPageSetup()).toMatchObject({
+      pageWidthTwips: 16838,
+      pageHeightTwips: 11906,
+      orientation: 'landscape',
+    });
+  });
+
+  test('insertBreak section splits at the caret and starts a new section', () => {
+    const { editor } = mount(p('before after'));
+    const id = editor.surface!.session.paragraphIds()[0]!;
+    editor.surface!.setSelection({
+      anchor: { paragraphId: id, offset: 6 },
+      head: { paragraphId: id, offset: 6 },
+    });
+    expect(editor.can({ type: 'insertBreak', kind: 'section' } as never)).toEqual({ ok: true });
+    const result = editor.exec({ type: 'insertBreak', kind: 'section' } as never);
+    expect(result).toMatchObject({ ok: true, changed: true });
+    expect(editor.surface!.session.paragraphIds()).toHaveLength(2);
+    // The document now has two sections; one undo removes the break entirely.
+    expect(editor.surface!.layout().pages.length).toBeGreaterThanOrEqual(2);
+    editor.exec({ type: 'undo' });
+    expect(editor.surface!.session.paragraphIds()).toHaveLength(1);
+  });
+
+  test('the caret section drives the layout: a landscape section paginates landscape', () => {
+    const midBody =
+      '<w:p><w:pPr><w:sectPr><w:pgSz w:w="15840" w:h="12240" w:orient="landscape"/></w:sectPr></w:pPr>' +
+      '<w:r><w:t>landscape page</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>portrait page</w:t></w:r></w:p>' +
+      '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>';
+    const { editor } = mount(midBody);
+    const pages = editor.surface!.layout().pages;
+    expect(pages).toHaveLength(2);
+    // Twips to points: 15840/20 = 792 wide landscape sheet, then the portrait one.
+    expect([pages[0]!.box.width, pages[0]!.box.height]).toEqual([792, 612]);
+    expect([pages[1]!.box.width, pages[1]!.box.height]).toEqual([612, 792]);
   });
 
   test('zoom is validated, stored, and reported', () => {

--- a/packages/core/src/editor/docx-editor-support.ts
+++ b/packages/core/src/editor/docx-editor-support.ts
@@ -281,8 +281,9 @@ export function classifyCommand(command: EditorCommand): CommandSupport {
         ? { supported: true, mutating: true }
         : { supported: false, reason: 'setIndent requires at least one indent field' };
     case 'insertBreak':
-      // Page/column/section breaks belong to lanes the surface does not own yet.
-      return command.kind === 'line'
+      // Line breaks and next-page section breaks are wired; page/column breaks belong
+      // to lanes the surface does not own yet.
+      return command.kind === 'line' || command.kind === 'section'
         ? { supported: true, mutating: true }
         : { supported: false, reason: `break kind '${command.kind}' is not supported` };
     case 'insertText':
@@ -343,6 +344,17 @@ export function classifyCommand(command: EditorCommand): CommandSupport {
           supported: false,
           code: 'invalidArgs',
           reason: "orientation must be 'portrait' or 'landscape'",
+        };
+      }
+      if (
+        command.scope !== undefined &&
+        command.scope !== 'document' &&
+        command.scope !== 'section'
+      ) {
+        return {
+          supported: false,
+          code: 'invalidArgs',
+          reason: "scope must be 'document' or 'section'",
         };
       }
       return { supported: true, mutating: true };
@@ -420,7 +432,8 @@ export function pageSetupEqual(a: PageSetup | null, b: PageSetup | null): boolea
     a.marginsTwips.top === b.marginsTwips.top &&
     a.marginsTwips.right === b.marginsTwips.right &&
     a.marginsTwips.bottom === b.marginsTwips.bottom &&
-    a.marginsTwips.left === b.marginsTwips.left
+    a.marginsTwips.left === b.marginsTwips.left &&
+    a.gutterTwips === b.gutterTwips
   );
 }
 

--- a/packages/core/src/editor/docx-editor-support.ts
+++ b/packages/core/src/editor/docx-editor-support.ts
@@ -10,6 +10,7 @@ import type {
   EditorCommand,
   EditorError,
   EditorSnapshot,
+  PageSetup,
   RunFormatting,
 } from '@docx-editor.dev/core-contract/contracts/editor';
 import type {
@@ -298,6 +299,54 @@ export function classifyCommand(command: EditorCommand): CommandSupport {
             supported: false,
             reason: 'DocTarget addressing is not supported; deletion removes the selection',
           };
+    case 'setPageSetup': {
+      const dims = [command.pageWidth, command.pageHeight];
+      const margins = [
+        command.marginTop,
+        command.marginRight,
+        command.marginBottom,
+        command.marginLeft,
+      ];
+      if (
+        dims.every((value) => value === undefined) &&
+        margins.every((value) => value === undefined) &&
+        command.orientation === undefined
+      ) {
+        return { supported: false, reason: 'setPageSetup requires at least one field' };
+      }
+      // The same bounds the op layer enforces, refused here so `can` answers honestly
+      // BEFORE a dialog submits.
+      for (const value of dims) {
+        if (value !== undefined && (!Number.isInteger(value) || value < 1 || value > 63360)) {
+          return {
+            supported: false,
+            code: 'invalidArgs',
+            reason: 'page dimensions must be integer twips between 1 and 63360',
+          };
+        }
+      }
+      for (const value of margins) {
+        if (value !== undefined && (!Number.isInteger(value) || value < 0 || value > 31680)) {
+          return {
+            supported: false,
+            code: 'invalidArgs',
+            reason: 'margins must be integer twips between 0 and 31680',
+          };
+        }
+      }
+      if (
+        command.orientation !== undefined &&
+        command.orientation !== 'portrait' &&
+        command.orientation !== 'landscape'
+      ) {
+        return {
+          supported: false,
+          code: 'invalidArgs',
+          reason: "orientation must be 'portrait' or 'landscape'",
+        };
+      }
+      return { supported: true, mutating: true };
+    }
     case 'undo':
     case 'redo':
       return { supported: true, mutating: true };
@@ -360,6 +409,21 @@ export function pageEqual(a: EditorSnapshot['page'], b: EditorSnapshot['page']):
   return a.current === b.current && a.total === b.total;
 }
 
+/** Value equality for the snapshot's `pageSetup` sub-object. */
+export function pageSetupEqual(a: PageSetup | null, b: PageSetup | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.pageWidthTwips === b.pageWidthTwips &&
+    a.pageHeightTwips === b.pageHeightTwips &&
+    a.orientation === b.orientation &&
+    a.marginsTwips.top === b.marginsTwips.top &&
+    a.marginsTwips.right === b.marginsTwips.right &&
+    a.marginsTwips.bottom === b.marginsTwips.bottom &&
+    a.marginsTwips.left === b.marginsTwips.left
+  );
+}
+
 /**
  * Whether two snapshots are value-equal AFTER sub-object reuse — i.e. every field can be
  * compared by reference or primitive. When true, the previous snapshot object itself is
@@ -378,6 +442,7 @@ export function snapshotsEqual(a: EditorSnapshot, b: EditorSnapshot): boolean {
     a.image === b.image &&
     a.page === b.page &&
     a.canUndo === b.canUndo &&
-    a.canRedo === b.canRedo
+    a.canRedo === b.canRedo &&
+    a.pageSetup === b.pageSetup
   );
 }

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -858,7 +858,13 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         }
         case 'insertBreak':
           if (command.kind === 'section') {
-            mounted.insertSectionBreak();
+            if (!mounted.insertSectionBreak()) {
+              return {
+                ok: false,
+                code: 'invalidArgs',
+                reason: mounted.state().lastRejection ?? 'the section break was refused',
+              };
+            }
             break;
           }
           mounted.insertLineBreak();

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -618,11 +618,13 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
 
   /**
    * THE page-setup derivation — `getPageSetup()` and `snapshot().pageSetup` both read
-   * this shape, so the dialog and the rulers can never disagree about the section.
+   * this shape, so the dialog and the rulers can never disagree about the section. In a
+   * multi-section document it is the CARET's section, which is what a ruler reflects
+   * when the caret crosses a section boundary — Word's behaviour.
    */
   function pageSetupOf(): PageSetup | null {
     if (!surface) return null;
-    const section = surface.sectionProperties();
+    const section = surface.sectionPropertiesAt(surface.state().selection.head.paragraphId);
     return {
       pageWidthTwips: section.pageSize.widthTwips,
       pageHeightTwips: section.pageSize.heightTwips,
@@ -633,6 +635,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         bottom: section.margins.bottomTwips,
         left: section.margins.leftTwips,
       },
+      gutterTwips: section.margins.gutterTwips,
     };
   }
 
@@ -812,22 +815,24 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
           break;
         }
         case 'setPageSetup': {
-          // Orientation NORMALIZATION lives here, not in the op: Word stores landscape as
-          // swapped dimensions plus the attribute, so a command asking for landscape must
-          // end with width > height whether the caller sent dimensions or not. The op
-          // below records only literal values.
+          const anchor =
+            command.scope === 'section' ? mounted.state().selection.head.paragraphId : undefined;
+          // When orientation arrives WITH explicit dimensions, the dimensions are
+          // oriented here — Word stores landscape as swapped dimensions plus the
+          // attribute. Orientation ALONE stays alone: the op swaps each written
+          // section's own dimensions, so distinct paper sizes survive the flip.
           let width = command.pageWidth;
           let height = command.pageHeight;
-          if (command.orientation !== undefined) {
-            const section = mounted.sectionProperties();
-            const w = command.pageWidth ?? section.pageSize.widthTwips;
-            const h = command.pageHeight ?? section.pageSize.heightTwips;
-            const long = Math.max(w, h);
-            const short = Math.min(w, h);
-            width = command.orientation === 'landscape' ? long : short;
-            height = command.orientation === 'landscape' ? short : long;
+          if (command.orientation !== undefined && (width !== undefined || height !== undefined)) {
+            const section = anchor
+              ? mounted.sectionPropertiesAt(anchor)
+              : mounted.sectionProperties();
+            const w = width ?? section.pageSize.widthTwips;
+            const h = height ?? section.pageSize.heightTwips;
+            width = command.orientation === 'landscape' ? Math.max(w, h) : Math.min(w, h);
+            height = command.orientation === 'landscape' ? Math.min(w, h) : Math.max(w, h);
           }
-          mounted.setSectionProperties({
+          const committed = mounted.setSectionProperties({
             ...(width !== undefined ? { pageWidthTwips: width } : {}),
             ...(height !== undefined ? { pageHeightTwips: height } : {}),
             ...(command.orientation !== undefined ? { orientation: command.orientation } : {}),
@@ -837,10 +842,25 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
               ? { marginBottomTwips: command.marginBottom }
               : {}),
             ...(command.marginLeft !== undefined ? { marginLeftTwips: command.marginLeft } : {}),
+            ...(anchor !== undefined ? { anchorParagraphId: anchor } : {}),
           });
+          // The op layer can refuse what per-field bounds cannot see — margins that
+          // together swallow a page. A refusal must surface as one, not close a dialog
+          // claiming success.
+          if (!committed) {
+            return {
+              ok: false,
+              code: 'invalidArgs',
+              reason: mounted.state().lastRejection ?? 'the page setup change was refused',
+            };
+          }
           break;
         }
         case 'insertBreak':
+          if (command.kind === 'section') {
+            mounted.insertSectionBreak();
+            break;
+          }
           mounted.insertLineBreak();
           break;
         case 'insertText':

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -53,6 +53,7 @@ import type {
   EditorSnapshot,
   ExecResult,
   FontConfiguration,
+  PageSetup,
   RunFormatting,
   TextMatch,
   Unsubscribe,
@@ -82,6 +83,7 @@ import {
   isSurfaceSelection,
   normalizeSource,
   pageEqual,
+  pageSetupEqual,
   selectionsMatch,
   snapshotsEqual,
 } from './docx-editor-support.ts';
@@ -614,6 +616,26 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     };
   }
 
+  /**
+   * THE page-setup derivation — `getPageSetup()` and `snapshot().pageSetup` both read
+   * this shape, so the dialog and the rulers can never disagree about the section.
+   */
+  function pageSetupOf(): PageSetup | null {
+    if (!surface) return null;
+    const section = surface.sectionProperties();
+    return {
+      pageWidthTwips: section.pageSize.widthTwips,
+      pageHeightTwips: section.pageSize.heightTwips,
+      orientation: section.landscape ? ('landscape' as const) : ('portrait' as const),
+      marginsTwips: {
+        top: section.margins.topTwips,
+        right: section.margins.rightTwips,
+        bottom: section.margins.bottomTwips,
+        left: section.margins.leftTwips,
+      },
+    };
+  }
+
   function totalPages(): number {
     return surface ? surface.state().pageCount : 0;
   }
@@ -643,6 +665,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       page: { current: currentPage(), total: totalPages() },
       canUndo: state?.canUndo ?? false,
       canRedo: state?.canRedo ?? false,
+      pageSetup: pageSetupOf(),
     };
   }
 
@@ -661,7 +684,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         ? previous.formatting
         : fresh.formatting;
       const page = pageEqual(fresh.page, previous.page) ? previous.page : fresh.page;
-      next = { ...fresh, formatting, page };
+      const pageSetup = pageSetupEqual(fresh.pageSetup ?? null, previous.pageSetup ?? null)
+        ? previous.pageSetup
+        : fresh.pageSetup;
+      next = { ...fresh, formatting, page, pageSetup };
       if (snapshotsEqual(next, previous)) next = previous;
     }
     cachedSnapshot = deepFreezeValue(next);
@@ -785,6 +811,35 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
           mounted.setParagraphProperty('ind', attributes);
           break;
         }
+        case 'setPageSetup': {
+          // Orientation NORMALIZATION lives here, not in the op: Word stores landscape as
+          // swapped dimensions plus the attribute, so a command asking for landscape must
+          // end with width > height whether the caller sent dimensions or not. The op
+          // below records only literal values.
+          let width = command.pageWidth;
+          let height = command.pageHeight;
+          if (command.orientation !== undefined) {
+            const section = mounted.sectionProperties();
+            const w = command.pageWidth ?? section.pageSize.widthTwips;
+            const h = command.pageHeight ?? section.pageSize.heightTwips;
+            const long = Math.max(w, h);
+            const short = Math.min(w, h);
+            width = command.orientation === 'landscape' ? long : short;
+            height = command.orientation === 'landscape' ? short : long;
+          }
+          mounted.setSectionProperties({
+            ...(width !== undefined ? { pageWidthTwips: width } : {}),
+            ...(height !== undefined ? { pageHeightTwips: height } : {}),
+            ...(command.orientation !== undefined ? { orientation: command.orientation } : {}),
+            ...(command.marginTop !== undefined ? { marginTopTwips: command.marginTop } : {}),
+            ...(command.marginRight !== undefined ? { marginRightTwips: command.marginRight } : {}),
+            ...(command.marginBottom !== undefined
+              ? { marginBottomTwips: command.marginBottom }
+              : {}),
+            ...(command.marginLeft !== undefined ? { marginLeftTwips: command.marginLeft } : {}),
+          });
+          break;
+        }
         case 'insertBreak':
           mounted.insertLineBreak();
           break;
@@ -885,21 +940,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     getSelectedImage: () => null,
     getSelectedTable: () => null,
 
-    getPageSetup() {
-      if (!surface) return null;
-      const section = surface.sectionProperties();
-      return {
-        pageWidthTwips: section.pageSize.widthTwips,
-        pageHeightTwips: section.pageSize.heightTwips,
-        orientation: section.landscape ? ('landscape' as const) : ('portrait' as const),
-        marginsTwips: {
-          top: section.margins.topTwips,
-          right: section.margins.rightTwips,
-          bottom: section.margins.bottomTwips,
-          left: section.margins.leftTwips,
-        },
-      };
-    },
+    getPageSetup: () => pageSetupOf(),
 
     getWatermark: () => null,
     getHeaderFooterState: () => null,

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -133,9 +133,17 @@ export interface PaginatedSurface {
    */
   sectionProperties(): SectionProperties;
   /**
-   * Write body-level section fields — page size, orientation, margins — as ONE undoable
-   * transaction. Twips throughout; omitted fields are left as authored. Returns whether
-   * the write committed (a hostile value is refused by the op layer).
+   * The section GOVERNING one paragraph — what a ruler or dialog reflects when the
+   * caret sits in a multi-section document. Falls back to the body-level section for
+   * an unknown id.
+   */
+  sectionPropertiesAt(paragraphId: string): SectionProperties;
+  /**
+   * Write section page-setup fields — size, orientation, margins — as ONE undoable
+   * transaction. Twips throughout; omitted fields are left as authored. With
+   * `anchorParagraphId` only that paragraph's governing section is written (Word's
+   * "Apply to: This section"); without it, every section. Returns whether the write
+   * committed (a hostile value is refused by the op layer).
    */
   setSectionProperties(update: {
     readonly pageWidthTwips?: number;
@@ -145,7 +153,14 @@ export interface PaginatedSurface {
     readonly marginRightTwips?: number;
     readonly marginBottomTwips?: number;
     readonly marginLeftTwips?: number;
+    readonly anchorParagraphId?: string;
   }): boolean;
+  /**
+   * Insert a next-page section break at the caret: the paragraph splits, and the head
+   * ends a new section cloning the governing section's page setup — Word's Layout >
+   * Breaks > Next Page. One undoable step. Returns whether the break committed.
+   */
+  insertSectionBreak(): boolean;
   /** The layout session, so a host or a test can see how much work a pass actually did. */
   layoutSession(): {
     readonly stats: {

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -132,6 +132,20 @@ export interface PaginatedSurface {
    * What a ruler is made of, and what pagination is measured against.
    */
   sectionProperties(): SectionProperties;
+  /**
+   * Write body-level section fields — page size, orientation, margins — as ONE undoable
+   * transaction. Twips throughout; omitted fields are left as authored. Returns whether
+   * the write committed (a hostile value is refused by the op layer).
+   */
+  setSectionProperties(update: {
+    readonly pageWidthTwips?: number;
+    readonly pageHeightTwips?: number;
+    readonly orientation?: 'portrait' | 'landscape';
+    readonly marginTopTwips?: number;
+    readonly marginRightTwips?: number;
+    readonly marginBottomTwips?: number;
+    readonly marginLeftTwips?: number;
+  }): boolean;
   /** The layout session, so a host or a test can see how much work a pass actually did. */
   layoutSession(): {
     readonly stats: {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -661,6 +661,19 @@ export function mountPaginatedSurface(
 
     sectionProperties: () => readSectionProperties(session.part()),
 
+    setSectionProperties(update) {
+      let committed = false;
+      commit(() => {
+        const result = session.applyTreeOps(
+          [{ op: 'setSectionProperties', ...update }],
+          selectionMark()
+        );
+        committed = result.committed;
+        return result;
+      });
+      return committed;
+    },
+
     formatting: () =>
       formattingAt(currentLayout, selection, (paragraphId, runProperties) =>
         session.effectiveRunDefaults(paragraphId, runProperties)

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -163,15 +163,25 @@ export function mountPaginatedSurface(
   let currentLayout = layoutOnce();
   let desiredX: number | null = null;
 
+  // The per-section lane: every section paginates against its own geometry, so a
+  // landscape section among portrait ones lays out as Word shows it. Re-read per pass
+  // for the same reason the geometry is; the sectPr node id is the section's stable
+  // identity in the layout context.
+  function layoutSections() {
+    return readDocumentSections(session.part()).map((section) => ({
+      geometry: section.geometry,
+      firstBlock: section.firstBlock,
+      breakType: section.breakType,
+      ...(section.sectPrId !== null ? { id: section.sectPrId } : {}),
+    }));
+  }
+
   function layoutOnce(): SemanticLayout {
     const began = now();
     const layout = layoutSemanticDocument(session.part(), session.revision(), {
       measurer,
       geometry: furnitureSource.geometry(),
-      // The per-section lane: every section paginates against its own geometry, so a
-      // landscape section among portrait ones lays out as Word shows it. Re-read per
-      // pass for the same reason the geometry is.
-      sections: readDocumentSections(session.part()),
+      sections: layoutSections(),
       cache: layoutCache,
       session: layoutSession,
       producer,
@@ -199,7 +209,7 @@ export function mountPaginatedSurface(
       const layout = layoutSemanticDocument(session.part(), scope.revision, {
         measurer,
         geometry: furnitureSource.geometry(),
-        sections: readDocumentSections(session.part()),
+        sections: layoutSections(),
         cache: layoutCache,
         session: layoutSession,
         producer,
@@ -716,6 +726,8 @@ export function mountPaginatedSurface(
         () => {
           const result = session.applyTreeOps(
             [
+              // A break REPLACES a selection, like every other insertion.
+              ...deleteSelectionOps(),
               { op: 'splitParagraph', paragraphId: start.paragraphId, offset: start.offset },
               // The HEAD keeps the original id; it ends the new section, cloning the
               // governing setup so the break changes where pages break, not how they look.

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -24,7 +24,9 @@ import {
   createLayoutScheduler,
   createLayoutSession,
   createParagraphLayoutCache,
+  readDocumentSections,
   readSectionProperties,
+  storyBlocks,
   documentOrder,
   layoutSemanticDocument,
   moveCaret,
@@ -166,6 +168,10 @@ export function mountPaginatedSurface(
     const layout = layoutSemanticDocument(session.part(), session.revision(), {
       measurer,
       geometry: furnitureSource.geometry(),
+      // The per-section lane: every section paginates against its own geometry, so a
+      // landscape section among portrait ones lays out as Word shows it. Re-read per
+      // pass for the same reason the geometry is.
+      sections: readDocumentSections(session.part()),
       cache: layoutCache,
       session: layoutSession,
       producer,
@@ -193,6 +199,7 @@ export function mountPaginatedSurface(
       const layout = layoutSemanticDocument(session.part(), scope.revision, {
         measurer,
         geometry: furnitureSource.geometry(),
+        sections: readDocumentSections(session.part()),
         cache: layoutCache,
         session: layoutSession,
         producer,
@@ -661,6 +668,33 @@ export function mountPaginatedSurface(
 
     sectionProperties: () => readSectionProperties(session.part()),
 
+    sectionPropertiesAt(paragraphId) {
+      const sections = readDocumentSections(session.part());
+      if (sections.length === 1) return sections[0]!.properties;
+      const blocks = storyBlocks(session.part());
+      const contains = (node: (typeof blocks)[number], id: string): boolean => {
+        if (node.id === id) return true;
+        for (const child of node.children) {
+          if (child.kind !== 'textValue' && contains(child as (typeof blocks)[number], id)) {
+            return true;
+          }
+        }
+        return false;
+      };
+      const blockIndex = blocks.findIndex(
+        (block) => block.id === paragraphId || contains(block, paragraphId)
+      );
+      // An unknown id falls back to the tail section — the document-wide answer.
+      let owner = sections[sections.length - 1]!;
+      if (blockIndex !== -1) {
+        for (const section of sections) {
+          if (section.firstBlock <= blockIndex) owner = section;
+          else break;
+        }
+      }
+      return owner.properties;
+    },
+
     setSectionProperties(update) {
       let committed = false;
       commit(() => {
@@ -671,6 +705,34 @@ export function mountPaginatedSurface(
         committed = result.committed;
         return result;
       });
+      return committed;
+    },
+
+    insertSectionBreak() {
+      const start = orderedStart();
+      const before = new Set(session.paragraphIds());
+      let committed = false;
+      commit(
+        () => {
+          const result = session.applyTreeOps(
+            [
+              { op: 'splitParagraph', paragraphId: start.paragraphId, offset: start.offset },
+              // The HEAD keeps the original id; it ends the new section, cloning the
+              // governing setup so the break changes where pages break, not how they look.
+              { op: 'setSectionMark', paragraphId: start.paragraphId },
+            ],
+            selectionMark()
+          );
+          committed = result.committed;
+          return result;
+        },
+        () => {
+          // The caret lands at the start of the tail — the first paragraph of the
+          // section the user keeps typing in, exactly where Word puts it.
+          const tail = session.paragraphIds().find((id) => !before.has(id));
+          return tail ? collapsedAt({ paragraphId: tail, offset: 0 }) : null;
+        }
+      );
       return committed;
     },
 

--- a/packages/core/src/layout/__tests__/section-properties.test.ts
+++ b/packages/core/src/layout/__tests__/section-properties.test.ts
@@ -60,6 +60,13 @@ describe('a section is read from the document (task 11.1)', () => {
     expect(section.titlePage).toBe(true);
   });
 
+  test('swapped dimensions without the attribute still read as landscape', () => {
+    // Layout paginates against the dimensions, so a page wider than tall IS landscape
+    // whatever `w:orient` says (or fails to say).
+    const section = readSectionProperties(withSection('<w:pgSz w:w="15840" w:h="12240"/>'));
+    expect(section.landscape).toBe(true);
+  });
+
   test('columns are read, with a sane count', () => {
     const section = readSectionProperties(withSection('<w:cols w:num="3" w:space="540"/>'));
     expect(section.columns).toEqual({ count: 3, gapTwips: 540 });

--- a/packages/core/src/layout/__tests__/semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-layout.test.ts
@@ -304,3 +304,93 @@ describe('paragraph alignment moves the published span boxes (w:jc)', () => {
     expect(last.box.x + last.box.width).toBeCloseTo(10 + (available - 10), 5);
   });
 });
+
+describe('per-section pagination (the per-section lane)', () => {
+  const PORTRAIT: PageGeometry = {
+    width: 200,
+    height: 300,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+  };
+  const LANDSCAPE: PageGeometry = {
+    width: 300,
+    height: 200,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+  };
+
+  test('a landscape section among portrait ones gets its own sheet, sized landscape', () => {
+    const part = load(paragraph('one') + paragraph('two') + paragraph('three'));
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      sections: [
+        { geometry: PORTRAIT, firstBlock: 0 },
+        { geometry: LANDSCAPE, firstBlock: 1 },
+        { geometry: PORTRAIT, firstBlock: 2 },
+      ],
+    });
+    expect(layout.pages).toHaveLength(3);
+    expect(layout.pages.map((page) => [page.box.width, page.box.height])).toEqual([
+      [200, 300],
+      [300, 200],
+      [200, 300],
+    ]);
+    // Sheets stack with the 24pt gutter, cumulative because heights differ.
+    expect(layout.pages.map((page) => page.box.y)).toEqual([0, 324, 548]);
+    // Each page's content box reflects ITS section's margins.
+    expect(layout.pages[1]!.contentBox.width).toBe(280);
+  });
+
+  test('lines break at their OWN section width', () => {
+    // 6px per char, portrait content width 180 → 30 chars; landscape 280 → 46 chars.
+    const text = 'word '.repeat(24).trim();
+    const part = load(paragraph(text) + paragraph(text));
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      sections: [
+        { geometry: PORTRAIT, firstBlock: 0 },
+        { geometry: LANDSCAPE, firstBlock: 1 },
+      ],
+    });
+    const ids = layout.pages.flatMap((page) =>
+      page.fragments.map((fragment) => (fragment.kind === 'paragraph' ? fragment.paragraphId : ''))
+    );
+    const first = fragmentsOfParagraph(layout, ids[0]!);
+    const second = fragmentsOfParagraph(layout, ids[ids.length - 1]!);
+    expect(first[0]!.lines.length).toBeGreaterThan(second[0]!.lines.length);
+    expect(second[0]!.lines[0]!.range.end).toBeGreaterThan(first[0]!.lines[0]!.range.end);
+  });
+
+  test('a continuous boundary with identical geometry shares the page', () => {
+    const part = load(paragraph('one') + paragraph('two'));
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      sections: [
+        { geometry: PORTRAIT, firstBlock: 0 },
+        { geometry: PORTRAIT, firstBlock: 1, breakType: 'continuous' },
+      ],
+    });
+    expect(layout.pages).toHaveLength(1);
+  });
+
+  test('a continuous boundary with a DIFFERENT geometry still breaks the page', () => {
+    // Two sections cannot share a sheet that has two sizes.
+    const part = load(paragraph('one') + paragraph('two'));
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      sections: [
+        { geometry: PORTRAIT, firstBlock: 0 },
+        { geometry: LANDSCAPE, firstBlock: 1, breakType: 'continuous' },
+      ],
+    });
+    expect(layout.pages).toHaveLength(2);
+  });
+
+  test('single-section input matches the plain geometry call exactly', () => {
+    const part = load(paragraph('hello world') + paragraph('again'));
+    const plain = lay(part, SMALL);
+    const sectioned = layoutSemanticDocument(part, 1, {
+      measurer,
+      sections: [{ geometry: SMALL, firstBlock: 0 }],
+    });
+    expect(JSON.stringify(sectioned.pages)).toBe(JSON.stringify(plain.pages));
+  });
+});

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -155,6 +155,7 @@ export {
   createLayoutSession,
   layoutSemanticDocument,
   type HeaderFooterVariantName,
+  type LayoutSectionInput,
   type LayoutSession,
   type LayoutSessionStats,
   type PageFurniture,
@@ -170,7 +171,12 @@ export {
 export {
   DEFAULT_SECTION_PROPERTIES,
   geometryOfSection,
+  paragraphSectionNode,
+  readDocumentSections,
   readSectionProperties,
+  sectionPropertiesOf,
+  type DocumentSection,
+  type SectionBreakType,
   type SectionMargins,
   type SectionProperties,
 } from './section-properties.ts';

--- a/packages/core/src/layout/section-properties.ts
+++ b/packages/core/src/layout/section-properties.ts
@@ -155,7 +155,10 @@ export function readSectionProperties(part: OoxmlPart): SectionProperties {
       count: cols ? Math.max(1, Math.min(12, Number(attribute(cols, 'num') ?? '1') || 1)) : 1,
       gapTwips: cols ? twips(attribute(cols, 'space'), 720, 31680) : defaults.columns.gapTwips,
     },
-    landscape: orientation === 'landscape',
+    // Render-truthful: Word writes swapped dimensions AND the attribute, but a file may
+    // carry only one. Width exceeding height IS a landscape page whatever the attribute
+    // says, because layout paginates against the dimensions.
+    landscape: orientation === 'landscape' || width > height,
     titlePage: childNamed(sectPr, 'titlePg') !== undefined,
   };
 }

--- a/packages/core/src/layout/section-properties.ts
+++ b/packages/core/src/layout/section-properties.ts
@@ -13,6 +13,7 @@
 
 import type { OoxmlNode, OoxmlPart } from '@docx-editor.dev/core-contract/store';
 import { DEFAULT_PAGE_GEOMETRY, type PageGeometry } from './semantic-records.ts';
+import { storyBlocks } from './story-roots.ts';
 
 export interface SectionMargins {
   readonly topTwips: number;
@@ -106,14 +107,17 @@ function bodySectionNode(part: OoxmlPart): OoxmlNode | undefined {
 }
 
 /**
- * The section properties a part declares, or Word's defaults where it says nothing.
- *
- * Only the BODY-level section today. A document with mid-body section breaks has several,
- * and honouring them is the per-section lane; taking the first would be worse than taking
- * the last, because the body-level one is the one that governs the document as a whole.
+ * The BODY-LEVEL section properties a part declares, or Word's defaults where it says
+ * nothing. A document with mid-body section breaks has several sections;
+ * `readDocumentSections` reads them all, and this remains the document-wide answer —
+ * the section that governs the tail, and the one a whole-document write targets.
  */
 export function readSectionProperties(part: OoxmlPart): SectionProperties {
-  const sectPr = bodySectionNode(part);
+  return sectionPropertiesOf(bodySectionNode(part));
+}
+
+/** One section node's properties (null reads as Word's defaults). */
+export function sectionPropertiesOf(sectPr: OoxmlNode | null | undefined): SectionProperties {
   if (!sectPr) return DEFAULT_SECTION_PROPERTIES;
 
   const pgSz = childNamed(sectPr, 'pgSz');
@@ -161,6 +165,78 @@ export function readSectionProperties(part: OoxmlPart): SectionProperties {
     landscape: orientation === 'landscape' || width > height,
     titlePage: childNamed(sectPr, 'titlePg') !== undefined,
   };
+}
+
+/** How a section begins relative to the one before it (ECMA-376 §17.6.22, `w:type`). */
+export type SectionBreakType = 'nextPage' | 'continuous' | 'evenPage' | 'oddPage' | 'nextColumn';
+
+/** One section of the document, with the blocks it governs. */
+export interface DocumentSection {
+  readonly properties: SectionProperties;
+  readonly geometry: PageGeometry;
+  /** Index into `storyBlocks(part)` of the first block this section governs. */
+  readonly firstBlock: number;
+  /** How this section begins. The FIRST section's value is irrelevant to pagination. */
+  readonly breakType: SectionBreakType;
+  /** The `w:sectPr` node id, or null for the defaulted section of a sectPr-less document. */
+  readonly sectPrId: string | null;
+}
+
+const BREAK_TYPES: ReadonlySet<string> = new Set([
+  'nextPage',
+  'continuous',
+  'evenPage',
+  'oddPage',
+  'nextColumn',
+]);
+
+function breakTypeOf(sectPr: OoxmlNode | null): SectionBreakType {
+  const type = sectPr ? childNamed(sectPr, 'type') : undefined;
+  const value = type ? attribute(type, 'val') : undefined;
+  return value !== undefined && BREAK_TYPES.has(value) ? (value as SectionBreakType) : 'nextPage';
+}
+
+/** The `w:sectPr` inside a paragraph's `w:pPr`, marking the end of a mid-body section. */
+export function paragraphSectionNode(block: OoxmlNode): OoxmlNode | undefined {
+  if (block.kind !== 'paragraph') return undefined;
+  const pPr = block.children.find((child) => child.kind === 'paragraphProperties');
+  return pPr ? childNamed(pPr, 'sectPr') : undefined;
+}
+
+/**
+ * Every section of the document, in order, each knowing the first block it governs.
+ *
+ * A mid-body `w:sectPr` lives in the `w:pPr` of the LAST paragraph of its section
+ * (§17.6.17); the body-level `w:sectPr` governs the tail. Always at least one section:
+ * a document with no `sectPr` at all is one defaulted section over every block.
+ */
+export function readDocumentSections(part: OoxmlPart): readonly DocumentSection[] {
+  const blocks = storyBlocks(part);
+  const sections: DocumentSection[] = [];
+  let firstBlock = 0;
+  for (const [index, block] of blocks.entries()) {
+    const sectPr = paragraphSectionNode(block);
+    if (!sectPr) continue;
+    const properties = sectionPropertiesOf(sectPr);
+    sections.push({
+      properties,
+      geometry: geometryOfSection(properties),
+      firstBlock,
+      breakType: breakTypeOf(sectPr),
+      sectPrId: sectPr.id,
+    });
+    firstBlock = index + 1;
+  }
+  const bodySect = bodySectionNode(part) ?? null;
+  const properties = sectionPropertiesOf(bodySect);
+  sections.push({
+    properties,
+    geometry: geometryOfSection(properties),
+    firstBlock,
+    breakType: breakTypeOf(bodySect),
+    sectPrId: bodySect && bodySect.kind !== 'textValue' ? bodySect.id : null,
+  });
+  return sections;
 }
 
 /**

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -66,6 +66,13 @@ export interface LayoutSectionInput {
   readonly firstBlock: number;
   /** How the section begins. `continuous` with an unchanged geometry shares the page. */
   readonly breakType?: 'nextPage' | 'continuous' | 'evenPage' | 'oddPage' | 'nextColumn';
+  /**
+   * A stable identity for the section (the `w:sectPr` node id). Folded into the layout
+   * context INSTEAD of `firstBlock`, so inserting or deleting a paragraph — which shifts
+   * every later block index but moves no section — keeps checkpoints resumable rather
+   * than forcing a full-document relayout on every Enter in a multi-section document.
+   */
+  readonly id?: string;
 }
 
 export interface SemanticLayoutOptions {
@@ -336,11 +343,14 @@ export function layoutSemanticDocument(
       ';' +
       [...furniture.footers].map(([variant, story]) => `f${variant}=${story.flowHeight}`).join(',')
     : '';
-  // EVERY section participates: a change to any section's geometry or extent moves breaks,
-  // so it must invalidate checkpoints exactly as the single geometry did.
+  // EVERY section participates: a change to any section's geometry, order or break type
+  // moves breaks, so it must invalidate checkpoints exactly as the single geometry did.
+  // Keyed by section IDENTITY, not block index: an insertion shifts every later block
+  // index without moving a section, and the per-index resume machinery (keys, firstChanged,
+  // convergence) already accounts for shifted content.
   const sectionsContext = sections
-    .map(({ geometry: g, firstBlock, breakType }) => {
-      return `${firstBlock}${breakType ?? 'nextPage'}@${g.width}x${g.height}|${g.margin.top},${g.margin.right},${g.margin.bottom},${g.margin.left}|${g.headerDistance ?? 36},${g.footerDistance ?? 36}`;
+    .map(({ geometry: g, breakType, id }) => {
+      return `${id ?? 'default'}~${breakType ?? 'nextPage'}@${g.width}x${g.height}|${g.margin.top},${g.margin.right},${g.margin.bottom},${g.margin.left}|${g.headerDistance ?? 36},${g.footerDistance ?? 36}`;
     })
     .join(';');
   const context = `${producer}|${sectionsContext}${furnitureContext}`;
@@ -545,7 +555,12 @@ export function layoutSemanticDocument(
 
   // Sheets of mixed widths centre against the widest, as Word lays a landscape page
   // among portrait ones. Single-section documents keep x = 0 exactly as before.
-  const maxSheetWidth = Math.max(...sectionMetrics.map((metrics) => metrics.geometry.width));
+  // A loop, not a spread: the section count is file-controlled and a spread of a huge
+  // array throws instead of degrading.
+  let maxSheetWidth = 0;
+  for (const metrics of sectionMetrics) {
+    maxSheetWidth = Math.max(maxSheetWidth, metrics.geometry.width);
+  }
 
   const flushPage = (): void => {
     const index = pages.length;

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -59,8 +59,24 @@ export interface PageFurniture {
   readonly footers: ReadonlyMap<HeaderFooterVariantName, HeaderFooterStoryLayout>;
 }
 
+/** One section's slice of the flow, as pagination consumes it. */
+export interface LayoutSectionInput {
+  readonly geometry: PageGeometry;
+  /** Index into the story's blocks of the first block this section governs. */
+  readonly firstBlock: number;
+  /** How the section begins. `continuous` with an unchanged geometry shares the page. */
+  readonly breakType?: 'nextPage' | 'continuous' | 'evenPage' | 'oddPage' | 'nextColumn';
+}
+
 export interface SemanticLayoutOptions {
   readonly geometry?: PageGeometry;
+  /**
+   * Per-section page geometry (the per-section lane). Sections partition the story's
+   * blocks by `firstBlock`; each paginates against its own geometry, and a non-continuous
+   * boundary starts a new page — one landscape section among portrait ones lays out as
+   * Word shows it. Absent or single-entry means the whole story flows in `geometry`.
+   */
+  readonly sections?: readonly LayoutSectionInput[];
   readonly measurer: TextMeasurer;
   /**
    * Reuse of measured-and-broken paragraphs across revisions (task 9.2).
@@ -193,6 +209,20 @@ function fragmentSignature(fragment: BlockFragmentRecord): string {
   return signature;
 }
 
+/** Whether two sections could share a sheet: identical page box and margins. */
+function sameGeometry(a: PageGeometry, b: PageGeometry): boolean {
+  return (
+    a.width === b.width &&
+    a.height === b.height &&
+    a.margin.top === b.margin.top &&
+    a.margin.right === b.margin.right &&
+    a.margin.bottom === b.margin.bottom &&
+    a.margin.left === b.margin.left &&
+    (a.headerDistance ?? 36) === (b.headerDistance ?? 36) &&
+    (a.footerDistance ?? 36) === (b.footerDistance ?? 36)
+  );
+}
+
 /** Whether a paragraph must start a new page (`w:pageBreakBefore`). */
 function breaksBefore(props: readonly OoxmlProperty[]): boolean {
   return props.some(
@@ -239,50 +269,81 @@ export function layoutSemanticDocument(
   revision: number,
   options: SemanticLayoutOptions
 ): SemanticLayout {
-  const geometry = options.geometry ?? DEFAULT_PAGE_GEOMETRY;
   const measurer = options.measurer;
   const cache = options.cache;
   // Defaults to a constant deliberately NAMED for the risk: fonts resolve asynchronously, so
   // a caller that swaps the measurer without changing this is served the pre-font layout for
   // the rest of the session.
   const producer = options.producer ?? 'unversioned-measurer';
-
-  const contentWidth = geometry.width - geometry.margin.left - geometry.margin.right;
-
-  // PAGE FURNITURE. A header taller than the top-margin remainder pushes the content area
-  // down (Word's behaviour), computed as the worst case over the variants in use so the
-  // content column is one height for every page. Capped at 40% of the sheet per edge: a
-  // hostile header of five hundred paragraphs must not shrink the content area to nothing,
-  // because pagination into a zero-height column never terminates.
   const furniture = options.furniture;
-  const headerDistance = geometry.headerDistance ?? 36;
-  const footerDistance = geometry.footerDistance ?? 36;
+
+  // SECTIONS. The flow is partitioned into sections, each paginating against its own
+  // geometry. The single-geometry call is the degenerate one-section case, so there is
+  // exactly one pagination path.
+  const sections: readonly LayoutSectionInput[] =
+    options.sections && options.sections.length > 0
+      ? options.sections
+      : [{ geometry: options.geometry ?? DEFAULT_PAGE_GEOMETRY, firstBlock: 0 }];
+
+  // PAGE FURNITURE push-down, derived per section geometry. A header taller than the
+  // top-margin remainder pushes the content area down (Word's behaviour), computed as the
+  // worst case over the variants in use so the content column is one height for every page
+  // of the section. Capped at 40% of the sheet per edge: a hostile header of five hundred
+  // paragraphs must not shrink the content area to nothing, because pagination into a
+  // zero-height column never terminates.
   const maxFlow = (stories: ReadonlyMap<string, HeaderFooterStoryLayout> | undefined): number => {
     let max = 0;
     for (const story of stories?.values() ?? []) max = Math.max(max, story.flowHeight);
     return max;
   };
-  const furnitureCap = geometry.height * 0.4;
-  const effectiveTop = Math.min(
-    furnitureCap,
-    Math.max(geometry.margin.top, furniture ? headerDistance + maxFlow(furniture.headers) : 0)
-  );
-  const effectiveBottom = Math.min(
-    furnitureCap,
-    Math.max(geometry.margin.bottom, furniture ? footerDistance + maxFlow(furniture.footers) : 0)
-  );
-  const contentHeight = geometry.height - effectiveTop - effectiveBottom;
+  interface SectionMetrics {
+    readonly geometry: PageGeometry;
+    readonly contentWidth: number;
+    readonly contentHeight: number;
+    readonly effectiveTop: number;
+    readonly headerDistance: number;
+    readonly footerDistance: number;
+  }
+  const metricsOf = (geometry: PageGeometry): SectionMetrics => {
+    const headerDistance = geometry.headerDistance ?? 36;
+    const footerDistance = geometry.footerDistance ?? 36;
+    const furnitureCap = geometry.height * 0.4;
+    const effectiveTop = Math.min(
+      furnitureCap,
+      Math.max(geometry.margin.top, furniture ? headerDistance + maxFlow(furniture.headers) : 0)
+    );
+    const effectiveBottom = Math.min(
+      furnitureCap,
+      Math.max(geometry.margin.bottom, furniture ? footerDistance + maxFlow(furniture.footers) : 0)
+    );
+    return {
+      geometry,
+      contentWidth: geometry.width - geometry.margin.left - geometry.margin.right,
+      contentHeight: geometry.height - effectiveTop - effectiveBottom,
+      effectiveTop,
+      headerDistance,
+      footerDistance,
+    };
+  };
+  const sectionMetrics = sections.map((section) => metricsOf(section.geometry));
 
   const session = options.session;
   const furnitureContext = furniture
-    ? `|hf:${headerDistance},${footerDistance},${furniture.titlePage ? 1 : 0}${furniture.evenAndOddHeaders ? 1 : 0};` +
+    ? `|hf:${furniture.titlePage ? 1 : 0}${furniture.evenAndOddHeaders ? 1 : 0};` +
       [...furniture.headers]
         .map(([variant, story]) => `h${variant}=${story.flowHeight}`)
         .join(',') +
       ';' +
       [...furniture.footers].map(([variant, story]) => `f${variant}=${story.flowHeight}`).join(',')
     : '';
-  const context = `${producer}|${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}${furnitureContext}`;
+  // EVERY section participates: a change to any section's geometry or extent moves breaks,
+  // so it must invalidate checkpoints exactly as the single geometry did.
+  const sectionsContext = sections
+    .map(({ geometry: g, firstBlock, breakType }) => {
+      return `${firstBlock}${breakType ?? 'nextPage'}@${g.width}x${g.height}|${g.margin.top},${g.margin.right},${g.margin.bottom},${g.margin.left}|${g.headerDistance ?? 36},${g.footerDistance ?? 36}`;
+    })
+    .join(';');
+  const context = `${producer}|${sectionsContext}${furnitureContext}`;
 
   // Prepass: everything needed to KEY a paragraph, before any of them is placed. Resuming
   // means knowing where the first change is, and that cannot be discovered while walking.
@@ -293,7 +354,27 @@ export function layoutSemanticDocument(
   // for every paragraph on every pass made the prepass, not placement, the cost of an
   // incremental layout: a one-character edit re-keyed the entire document.
   const bodies = storyBlocks(part);
-  const prepared = bodies.map((block): PreparedBlock => {
+
+  // Which section governs each block. Sections partition the block list by `firstBlock`;
+  // blocks before the first section's start (malformed input) flow in the first section.
+  const sectionOfBlock = new Array<number>(bodies.length);
+  {
+    let sectionIndex = 0;
+    for (let index = 0; index < bodies.length; index += 1) {
+      while (
+        sectionIndex + 1 < sections.length &&
+        sections[sectionIndex + 1]!.firstBlock <= index
+      ) {
+        sectionIndex += 1;
+      }
+      sectionOfBlock[index] = sectionIndex;
+    }
+  }
+
+  const prepared = bodies.map((block, blockIndex): PreparedBlock => {
+    // A block is broken at ITS section's width — that is what makes a landscape section's
+    // lines longer than its portrait neighbours'.
+    const contentWidth = sectionMetrics[sectionOfBlock[blockIndex]!]!.contentWidth;
     const memo = preparedBlocks.get(block);
     if (memo && memo.contentWidth === contentWidth && memo.producer === producer) {
       return memo.entry;
@@ -394,6 +475,14 @@ export function layoutSemanticDocument(
   let placed = 0;
   let reusedPages = 0;
 
+  // The section whose geometry the page being built uses. The boundary switch happens as
+  // part of PLACING a section's first block, after that block's checkpoint — so a resumed
+  // pass re-derives the same switch from the same block index.
+  let activeSectionIndex = 0;
+  let active = sectionMetrics[0]!;
+  /** Where the NEXT page's sheet begins. Cumulative, because sheets vary in height. */
+  let pageTop = 0;
+
   // RESUME. The checkpoint before the first changed paragraph describes a flow the new
   // document still agrees with, so the pages completed by then are carried over by
   // REFERENCE — unchanged pages keep their identity, which is what lets a consumer skip
@@ -407,14 +496,13 @@ export function layoutSemanticDocument(
     startIndex = firstChanged;
     reusedPages = pages.length;
     checkpoints.push(...session.checkpoints.slice(0, firstChanged));
+    const lastCarried = pages[pages.length - 1];
+    pageTop = lastCarried ? lastCarried.box.y + lastCarried.box.height + 24 : 0;
+    // The page being built belongs to the section of the block placed BEFORE the resume
+    // point; the loop re-runs the boundary switch if the resumed block starts a section.
+    activeSectionIndex = sectionOfBlock[startIndex - 1] ?? 0;
+    active = sectionMetrics[activeSectionIndex]!;
   }
-
-  const pageBox = (index: number): LayoutBox => ({
-    x: 0,
-    y: index * (geometry.height + 24), // 24pt gutter between sheets, for the scroll surface
-    width: geometry.width,
-    height: geometry.height,
-  });
 
   /** The variant page `index` shows: title page first, then even/odd when declared. */
   const variantFor = (index: number): HeaderFooterVariantName =>
@@ -436,20 +524,41 @@ export function layoutSemanticDocument(
     if (!story) return undefined;
     const y =
       kind === 'header'
-        ? box.y + headerDistance
-        : box.y + geometry.height - footerDistance - story.flowHeight;
+        ? box.y + active.headerDistance
+        : box.y + active.geometry.height - active.footerDistance - story.flowHeight;
+    // The story's lines were BROKEN at the body section's width (furniture is laid out
+    // once per variant); on a page of another section it is positioned in that page's
+    // margins. Re-breaking furniture per section is a follow-up refinement.
     return {
       kind,
       variant,
       partName: story.partName,
-      box: { x: box.x + geometry.margin.left, y, width: contentWidth, height: story.flowHeight },
+      box: {
+        x: box.x + active.geometry.margin.left,
+        y,
+        width: active.contentWidth,
+        height: story.flowHeight,
+      },
       fragments: story.fragments,
     };
   };
 
+  // Sheets of mixed widths centre against the widest, as Word lays a landscape page
+  // among portrait ones. Single-section documents keep x = 0 exactly as before.
+  const maxSheetWidth = Math.max(...sectionMetrics.map((metrics) => metrics.geometry.width));
+
   const flushPage = (): void => {
     const index = pages.length;
-    const box = pageBox(index);
+    const geometry = active.geometry;
+    // 24pt gutter between sheets, for the scroll surface. Cumulative, not index-derived:
+    // sheets no longer share one height.
+    const box: LayoutBox = {
+      x: (maxSheetWidth - geometry.width) / 2,
+      y: pageTop,
+      width: geometry.width,
+      height: geometry.height,
+    };
+    pageTop += geometry.height + 24;
     const header = furnitureFor('header', index, box);
     const footer = furnitureFor('footer', index, box);
     pages.push({
@@ -458,9 +567,9 @@ export function layoutSemanticDocument(
       box,
       contentBox: {
         x: box.x + geometry.margin.left,
-        y: box.y + effectiveTop,
-        width: contentWidth,
-        height: contentHeight,
+        y: box.y + active.effectiveTop,
+        width: active.contentWidth,
+        height: active.contentHeight,
       },
       fragments: pageFragments,
       ...(header ? { header } : {}),
@@ -484,7 +593,7 @@ export function layoutSemanticDocument(
    * leading `w:tblHeader` rows re-emit atop each continuation page before a body row.
    */
   const layoutTableInFlow = (table: OoxmlElement): void => {
-    const structure = readTableStructure(table, contentWidth, 0);
+    const structure = readTableStructure(table, active.contentWidth, 0);
     if (!structure || structure.rows.length === 0) return;
     const lineHeight = measurer.lineMetrics(DEFAULT_RUN_STYLE).height;
     const headerRows = [];
@@ -507,7 +616,7 @@ export function layoutSemanticDocument(
         box: {
           x: 0,
           y: fragmentTop,
-          width: contentWidth,
+          width: active.contentWidth,
           height: last.box.y + last.box.height - fragmentTop,
         },
       });
@@ -515,7 +624,7 @@ export function layoutSemanticDocument(
       rows = [];
     };
     for (const row of structure.rows) {
-      if (cursorY + lineHeight + 2 * CELL_PAD > contentHeight && cursorY > 0) {
+      if (cursorY + lineHeight + 2 * CELL_PAD > active.contentHeight && cursorY > 0) {
         closeTableFragment();
         flushPage();
         fragmentTop = 0;
@@ -596,6 +705,22 @@ export function layoutSemanticDocument(
       }
     }
 
+    // SECTION BOUNDARY. This block belongs to a later section: close the page the previous
+    // section was filling (unless it is still empty) and switch the flow onto the new
+    // section's geometry. `continuous` with an unchanged geometry shares the page —
+    // Word's column-change case; a changed geometry cannot share a sheet, so it breaks.
+    // Even/odd parity blanks are not modelled: those types break like `nextPage`.
+    const blockSection = sectionOfBlock[index] ?? sections.length - 1;
+    if (blockSection !== activeSectionIndex) {
+      const next = sectionMetrics[blockSection]!;
+      const sharesPage =
+        (sections[blockSection]!.breakType ?? 'nextPage') === 'continuous' &&
+        sameGeometry(active.geometry, next.geometry);
+      if (!sharesPage && pageFragments.length > 0) flushPage();
+      activeSectionIndex = blockSection;
+      active = next;
+    }
+
     placed += 1;
 
     if (entry.kind === 'table') {
@@ -650,7 +775,7 @@ export function layoutSemanticDocument(
 
     for (const [lineIndex, pendingLine] of lines.entries()) {
       if (
-        cursorY + pendingLine.height > contentHeight &&
+        cursorY + pendingLine.height > active.contentHeight &&
         (pending.length > 0 || pageFragments.length > 0)
       ) {
         flushFragment();

--- a/packages/core/src/store/__tests__/tree-ops.test.ts
+++ b/packages/core/src/store/__tests__/tree-ops.test.ts
@@ -713,3 +713,40 @@ describe('setSectionProperties writes page setup surgically', () => {
     expect(canonicalOoxmlFingerprint(part)).toBe(fingerprint);
   });
 });
+
+describe('a section mark survives a split exactly once (the phantom-section fix)', () => {
+  const BOUNDARY =
+    '<w:p><w:pPr><w:jc w:val="center"/><w:sectPr><w:pgSz w:w="15840" w:h="12240"/></w:sectPr></w:pPr>' +
+    '<w:r><w:t>end of section one</w:t></w:r></w:p>' +
+    '<w:p><w:r><w:t>section two</w:t></w:r></w:p>' +
+    '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>';
+
+  test('Enter in a section-boundary paragraph keeps ONE mark, on the tail', () => {
+    const part = load(BOUNDARY);
+    const [id] = paragraphIds(part);
+    const next = apply(part, { op: 'splitParagraph', paragraphId: id!, offset: 6 });
+    const serialized = serializeOoxmlPart(next);
+    // Still exactly two sectPr: the (moved) mid-body one and the body-level one. The
+    // section boundary stays after ALL the original content — with the tail — while
+    // other paragraph properties survive on both halves.
+    expect(serialized.match(/<w:sectPr>/g)).toHaveLength(2);
+    const [head, tail] = paragraphIds(next);
+    const headXml = serialized.slice(serialized.indexOf('<w:p>'), serialized.indexOf('</w:p>'));
+    expect(headXml).not.toContain('sectPr');
+    expect(serialized.match(/w:jc/g)).toHaveLength(2);
+    void head;
+    void tail;
+  });
+
+  test('a many-way split keeps the mark on the LAST piece only', () => {
+    const part = load(BOUNDARY);
+    const [id] = paragraphIds(part);
+    const next = apply(part, { op: 'splitParagraphMany', paragraphId: id!, offsets: [3, 6, 10] });
+    const serialized = serializeOoxmlPart(next);
+    expect(serialized.match(/<w:sectPr>/g)).toHaveLength(2);
+    // The mid-body mark sits in the last produced piece: after it, only "section two"
+    // and the body-level sectPr remain.
+    const afterMark = serialized.slice(serialized.indexOf('<w:sectPr>') + 1);
+    expect(afterMark).toContain('section two');
+  });
+});

--- a/packages/core/src/store/__tests__/tree-ops.test.ts
+++ b/packages/core/src/store/__tests__/tree-ops.test.ts
@@ -534,3 +534,182 @@ describe('splitParagraphMany equals the sequence of single splits it stands for'
     if (!result.ok) expect(result.reason).toBe('offset-out-of-range');
   });
 });
+
+// ---------------------------------------------------------------------------------------
+// setSectionProperties: the body-level section write path (page setup).
+// ---------------------------------------------------------------------------------------
+
+/** The body-level `w:sectPr`, plus attribute maps of a named child, straight off the tree. */
+function sectionOf(part: OoxmlPart): OoxmlNode | null {
+  let found: OoxmlNode | null = null;
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue' || found) return;
+    if (node.kind === 'body') {
+      for (const child of node.children) {
+        if (child.kind !== 'textValue' && 'localName' in child && child.localName === 'sectPr') {
+          found = child;
+        }
+      }
+      return;
+    }
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(part.root);
+  return found;
+}
+
+function sectionChildAttrs(part: OoxmlPart, localName: string): Record<string, string> | null {
+  const sectPr = sectionOf(part);
+  if (!sectPr || sectPr.kind === 'textValue') return null;
+  for (const child of sectPr.children) {
+    if (child.kind === 'textValue' || !('localName' in child) || child.localName !== localName) {
+      continue;
+    }
+    const attrs: Record<string, string> = {};
+    for (const entry of child.attributes ?? []) attrs[entry.localName] = entry.value;
+    return attrs;
+  }
+  return null;
+}
+
+const WITH_SECTION =
+  '<w:p><w:r><w:t>x</w:t></w:r></w:p>' +
+  '<w:sectPr><w:headerReference w:type="default" r:id="rId9" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"/>' +
+  '<w:pgSz w:w="12240" w:h="15840" w:code="1"/>' +
+  '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="708" w:footer="708" w:gutter="120"/>' +
+  '<w:cols w:num="2" w:space="708"/><w:titlePg/></w:sectPr>';
+
+describe('setSectionProperties writes page setup surgically', () => {
+  test('a margin write touches only the sides it names', () => {
+    const part = load(WITH_SECTION);
+    const next = apply(part, {
+      op: 'setSectionProperties',
+      marginLeftTwips: 720,
+      marginTopTwips: 900,
+    });
+    expect(sectionChildAttrs(next, 'pgMar')).toEqual({
+      top: '900',
+      right: '1440',
+      bottom: '1440',
+      left: '720',
+      header: '708',
+      footer: '708',
+      gutter: '120',
+    });
+    // Untouched siblings keep their authored form, references included.
+    expect(sectionChildAttrs(next, 'cols')).toEqual({ num: '2', space: '708' });
+    expect(serializeOoxmlPart(next)).toContain('headerReference');
+    expect(serializeOoxmlPart(next)).toContain('titlePg');
+  });
+
+  test('landscape writes swapped-ready orient and drops a stale paper code on resize', () => {
+    const part = load(WITH_SECTION);
+    const next = apply(part, {
+      op: 'setSectionProperties',
+      pageWidthTwips: 15840,
+      pageHeightTwips: 12240,
+      orientation: 'landscape',
+    });
+    expect(sectionChildAttrs(next, 'pgSz')).toEqual({
+      w: '15840',
+      h: '12240',
+      orient: 'landscape',
+    });
+  });
+
+  test('portrait is the absence of the orient attribute', () => {
+    const part = load(WITH_SECTION.replace('w:code="1"', 'w:code="1" w:orient="landscape"'));
+    const next = apply(part, { op: 'setSectionProperties', orientation: 'portrait' });
+    // Only orientation changed: the dimensions and the paper code survive.
+    expect(sectionChildAttrs(next, 'pgSz')).toEqual({ w: '12240', h: '15840', code: '1' });
+  });
+
+  test('a document with no sectPr gets one, as the body last child', () => {
+    const part = load(SIMPLE);
+    const next = apply(part, {
+      op: 'setSectionProperties',
+      pageWidthTwips: 11906,
+      pageHeightTwips: 16838,
+      marginLeftTwips: 1080,
+    });
+    expect(sectionChildAttrs(next, 'pgSz')).toEqual({ w: '11906', h: '16838' });
+    // A minted pgMar carries the full schema set, defaults made explicit.
+    expect(sectionChildAttrs(next, 'pgMar')).toEqual({
+      top: '1440',
+      right: '1440',
+      bottom: '1440',
+      left: '1080',
+      header: '720',
+      footer: '720',
+      gutter: '0',
+    });
+    const serialized = serializeOoxmlPart(next);
+    expect(serialized.indexOf('<w:sectPr')).toBeGreaterThan(serialized.indexOf('</w:p>'));
+  });
+
+  test('a sectPr without pgMar gains one placed after pgSz', () => {
+    const part = load(
+      '<w:p><w:r><w:t>x</w:t></w:r></w:p><w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:cols w:num="1"/></w:sectPr>'
+    );
+    const next = apply(part, { op: 'setSectionProperties', marginTopTwips: 720 });
+    const serialized = serializeOoxmlPart(next);
+    expect(serialized.indexOf('<w:pgMar')).toBeGreaterThan(serialized.indexOf('<w:pgSz'));
+    expect(serialized.indexOf('<w:pgMar')).toBeLessThan(serialized.indexOf('<w:cols'));
+  });
+
+  test('a multi-section document is updated WHOLE — every sectPr, not just the last', () => {
+    // Word's dialog semantics: page setup applies to the whole document. Touching only
+    // the body-level section leaves "portrait, …, landscape", which Word renders as one
+    // landscape page among portrait ones.
+    const part = load(
+      '<w:p><w:pPr><w:sectPr><w:pgSz w:w="12240" w:h="15840"/>' +
+        '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="708" w:footer="708" w:gutter="0"/>' +
+        '</w:sectPr></w:pPr><w:r><w:t>section one</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>section two</w:t></w:r></w:p>' +
+        '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>'
+    );
+    const next = apply(part, {
+      op: 'setSectionProperties',
+      pageWidthTwips: 15840,
+      pageHeightTwips: 12240,
+      orientation: 'landscape',
+      marginLeftTwips: 720,
+    });
+    const serialized = serializeOoxmlPart(next);
+    // Both sections carry the landscape size…
+    expect(serialized.match(/w:orient="landscape"/g)).toHaveLength(2);
+    expect(serialized.match(/<w:pgSz [^>]*w:w="15840"/g)).toHaveLength(2);
+    expect(serialized).not.toContain('w:w="12240"');
+    // …and both carry the margin, the mid-body one keeping its authored header/footer.
+    expect(serialized.match(/w:left="720"/g)).toHaveLength(2);
+    expect(serialized).toContain('w:header="708"');
+  });
+
+  test('the effect is flow-structural, so everything repaginates', () => {
+    const part = load(WITH_SECTION);
+    const result = applyTreeOp(part, { op: 'setSectionProperties', marginLeftTwips: 720 });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.effect.impact).toBe('flow-structural');
+  });
+
+  test('hostile or empty writes are refused before any tree work', () => {
+    const part = load(WITH_SECTION);
+    const fingerprint = canonicalOoxmlFingerprint(part);
+    const hostile: TreeDocOp[] = [
+      { op: 'setSectionProperties' },
+      { op: 'setSectionProperties', pageWidthTwips: 0 },
+      { op: 'setSectionProperties', pageWidthTwips: 999999999 },
+      { op: 'setSectionProperties', pageWidthTwips: 612.5 },
+      { op: 'setSectionProperties', marginLeftTwips: -720 },
+      { op: 'setSectionProperties', orientation: 'sideways' as 'portrait' },
+      // Margins that swallow the page: layout would fall back silently; the write refuses.
+      { op: 'setSectionProperties', marginLeftTwips: 8000, marginRightTwips: 8000 },
+    ];
+    for (const op of hostile) {
+      const result = applyTreeOp(part, op);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('invalid-property-value');
+    }
+    expect(canonicalOoxmlFingerprint(part)).toBe(fingerprint);
+  });
+});

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -25,13 +25,14 @@ import {
 } from '../package/ooxml-edit.ts';
 import { DEPENDENCY_KEY_IDS } from '../registry/frozen-ids.ts';
 import {
-  allSectionNodes,
   bodyNodeOf,
   isParagraph,
   metricsOfSection,
+  plannedSectionDimensions,
   sectionAttribute,
   sectionChild,
   segmentsOf,
+  targetSectionNodes,
   validateTreeOp,
   type OoxmlProperty,
   type TreeDocOp,
@@ -131,6 +132,7 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
 
   if (op.op === 'joinParagraphs') return applyJoin(part, op.firstId, op.secondId, options);
   if (op.op === 'setSectionProperties') return applySetSectionProperties(part, op, options);
+  if (op.op === 'setSectionMark') return applySetSectionMark(part, op.paragraphId, options);
 
   const paragraph = findNode(part, op.paragraphId) as OoxmlParagraphNode;
   const nextId = createNodeIdAllocator(part);
@@ -641,13 +643,15 @@ const childrenOf = (node: OoxmlNode | null): readonly OoxmlNode[] =>
   node && node.kind !== 'textValue' ? (node.children ?? []) : [];
 
 /**
- * Merge the op's fields into EVERY `w:sectPr` in the part — the mid-body ones and the
- * body-level one — minting a body-level section when the document never declared any.
+ * Merge the op's fields into its TARGET sections — every `w:sectPr` in the part
+ * (Word's "Apply to: Whole document", the default), or only the section governing
+ * `anchorParagraphId` ("Apply to: This section"). A body-level section is minted when
+ * the write must reach the implicit tail section.
  *
- * Whole-document on purpose: the page-setup dialog and the ruler drags mean "this
- * document", exactly Word's "Apply to: Whole document". Updating only the body-level
- * section left a multi-section document saying "portrait, …, landscape", which Word
- * renders as one landscape page among portrait ones.
+ * ONE tree rebuild whatever the section count: the replacements are collected first and
+ * applied in a single structural-sharing map over the root, because a per-section
+ * rebuild copied the body's entire child list once per section — quadratic in a
+ * file-controlled count, which a hostile many-section document turns into a freeze.
  *
  * Per section the merge is surgical: only the attributes the op carries are rewritten.
  * Everything else — `header`/`footer`/`gutter` distances, unknown `pgSz` attributes,
@@ -682,27 +686,117 @@ function applySetSectionProperties(
     impact: 'flow-structural',
   };
 
-  const sections = allSectionNodes(part);
-
-  if (sections.length === 0) {
-    const nextId = createNodeIdAllocator(part);
-    const children = mergedSectionChildren(null, op, touchesSize, touchesMargins, nextId);
-    const minted = sectionElement(nextId(), 'sectPr', [], children);
-    // The body-level section is the body's LAST child per the schema.
-    return fromEdit(insertChildren(part, body.id, body.children.length, [minted], options), effect);
+  const nextId = createNodeIdAllocator(part);
+  const targets = targetSectionNodes(part, op.anchorParagraphId);
+  const replacements = new Map<string, readonly OoxmlNode[]>();
+  let mintedBodySection: OoxmlNode | null = null;
+  for (const section of targets) {
+    const children = mergedSectionChildren(section, op, touchesSize, touchesMargins, nextId);
+    if (section) replacements.set(section.id, children);
+    // A null target is the implicit body-level section: mint it, as the body's LAST
+    // child per the schema.
+    else mintedBodySection = sectionElement(nextId(), 'sectPr', [], children);
   }
 
-  let current = part;
-  for (const section of sections) {
-    const live = findNode(current, section.id);
-    if (!live || live.kind === 'textValue') continue;
-    const nextId = createNodeIdAllocator(current);
-    const children = mergedSectionChildren(live, op, touchesSize, touchesMargins, nextId);
-    const replaced = replaceChildren(current, live.id, children, options);
-    if (!replaced.ok) return fromEdit(replaced, effect);
-    current = replaced.part;
+  const rebuilt = (node: OoxmlNode): OoxmlNode => {
+    if (node.kind === 'textValue') return node;
+    const replacement = replacements.get(node.id);
+    if (replacement) return { ...node, children: replacement } as OoxmlNode;
+    let changed = false;
+    const children = node.children.map((child) => {
+      const next = rebuilt(child);
+      if (next !== child) changed = true;
+      return next;
+    });
+    if (node.kind === 'body' && mintedBodySection) {
+      return { ...node, children: [...children, mintedBodySection] } as OoxmlNode;
+    }
+    return changed ? ({ ...node, children } as OoxmlNode) : node;
+  };
+
+  const nextRootChildren = part.root.children.map(rebuilt);
+  return fromEdit(replaceChildren(part, part.root.id, nextRootChildren, options), effect);
+}
+
+/**
+ * End a section at one paragraph: mint `w:pPr/w:sectPr` cloning the governing section's
+ * effective page setup, so the new section looks exactly like the one it was cut from —
+ * which is what Word's next-page section break does.
+ */
+function applySetSectionMark(
+  part: OoxmlPart,
+  paragraphId: string,
+  options?: EditOptions
+): TreeOpResult {
+  const paragraph = findNode(part, paragraphId) as OoxmlParagraphNode;
+  const nextId = createNodeIdAllocator(part);
+  const governing = targetSectionNodes(part, paragraphId)[0] ?? null;
+  const metrics = metricsOfSection(governing);
+  const effect: TreeOpEffect = {
+    dirty: [paragraphId],
+    created: [],
+    deleted: [],
+    dependencyKeys: TEXT_DEPS,
+    impact: 'flow-structural',
+  };
+
+  const sectPr = sectionElement(
+    nextId(),
+    'sectPr',
+    [],
+    [
+      sectionElement(
+        nextId(),
+        'pgSz',
+        [
+          wmlAttribute('w', String(metrics.widthTwips)),
+          wmlAttribute('h', String(metrics.heightTwips)),
+          ...(metrics.widthTwips > metrics.heightTwips
+            ? [wmlAttribute('orient', 'landscape')]
+            : []),
+        ],
+        []
+      ),
+      sectionElement(
+        nextId(),
+        'pgMar',
+        [
+          wmlAttribute('top', String(metrics.topTwips)),
+          wmlAttribute('right', String(metrics.rightTwips)),
+          wmlAttribute('bottom', String(metrics.bottomTwips)),
+          wmlAttribute('left', String(metrics.leftTwips)),
+          wmlAttribute('header', String(metrics.headerTwips)),
+          wmlAttribute('footer', String(metrics.footerTwips)),
+          wmlAttribute('gutter', String(metrics.gutterTwips)),
+        ],
+        []
+      ),
+    ]
+  );
+
+  const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
+  if (!pPr) {
+    const minted = {
+      id: nextId(),
+      kind: 'paragraphProperties',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'pPr',
+      prefix: 'w',
+      namespaceBindings: [],
+      attributes: [],
+      children: [sectPr],
+    } as unknown as OoxmlNode;
+    // `w:pPr` must be the paragraph's FIRST child per the schema.
+    return fromEdit(insertChildren(part, paragraph.id, 0, [minted], options), effect);
   }
-  return ok(current, effect);
+  // `w:sectPr` sits near the END of CT_PPr's sequence, before only `w:pPrChange`.
+  const change = pPr.children.findIndex(
+    (child) => 'localName' in child && child.localName === 'pPrChange'
+  );
+  return fromEdit(
+    insertChildren(part, pPr.id, change === -1 ? pPr.children.length : change, [sectPr], options),
+    effect
+  );
 }
 
 /** One section's rebuilt child list with the op's pgSz/pgMar fields merged in. */
@@ -718,8 +812,10 @@ function mergedSectionChildren(
   const existingPgSz = sectionChild(sectPr, 'pgSz');
   let nextPgSz: OoxmlNode | null = null;
   if (touchesSize) {
-    const width = op.pageWidthTwips ?? current.widthTwips;
-    const height = op.pageHeightTwips ?? current.heightTwips;
+    // Per-section dimensions, from the SAME planner validation approved: an orientation
+    // change without explicit dimensions swaps this section's own — an A4 section stays
+    // A4-sized through a whole-document landscape flip.
+    const { widthTwips: width, heightTwips: height } = plannedSectionDimensions(current, op);
     const dimensionsChanged = width !== current.widthTwips || height !== current.heightTwips;
     const orient =
       op.orientation !== undefined
@@ -790,27 +886,57 @@ function mergedSectionChildren(
     if (existingPgSz) {
       children = children.map((child) => (child.id === existingPgSz.id ? nextPgSz : child));
     } else {
-      // `w:pgSz` precedes `w:pgMar` and `w:cols` in the schema's sequence.
-      const before = children.findIndex(
-        (child) =>
-          child.kind !== 'textValue' &&
-          'localName' in child &&
-          (child.localName === 'pgMar' || child.localName === 'cols')
-      );
-      children.splice(before === -1 ? children.length : before, 0, nextPgSz);
+      children.splice(sectionInsertIndex(children, 'pgSz'), 0, nextPgSz);
     }
   }
   if (nextPgMar) {
     if (existingPgMar) {
       children = children.map((child) => (child.id === existingPgMar.id ? nextPgMar : child));
     } else {
-      const afterPgSz = children.findIndex(
-        (child) => child.kind !== 'textValue' && 'localName' in child && child.localName === 'pgSz'
-      );
-      children.splice(afterPgSz === -1 ? children.length : afterPgSz + 1, 0, nextPgMar);
+      children.splice(sectionInsertIndex(children, 'pgMar'), 0, nextPgMar);
     }
   }
   return children;
+}
+
+/**
+ * `CT_SectPr`'s child sequence from `w:pgSz` on — a minted element must precede every
+ * LATER-sequence sibling already present (`docGrid`, `sectPrChange`, …), or Word
+ * reports the file as corrupt.
+ */
+const SECT_PR_SEQUENCE = [
+  'pgSz',
+  'pgMar',
+  'paperSrc',
+  'pgBorders',
+  'lnNumType',
+  'pgNumType',
+  'cols',
+  'formProt',
+  'vAlign',
+  'noEndnote',
+  'titlePg',
+  'textDirection',
+  'bidi',
+  'rtlGutter',
+  'docGrid',
+  'printerSettings',
+  'sectPrChange',
+] as const;
+
+function sectionInsertIndex(children: readonly OoxmlNode[], localName: string): number {
+  const laterSiblings = new Set(
+    SECT_PR_SEQUENCE.slice(
+      SECT_PR_SEQUENCE.indexOf(localName as (typeof SECT_PR_SEQUENCE)[number]) + 1
+    )
+  );
+  const before = children.findIndex(
+    (child) =>
+      child.kind !== 'textValue' &&
+      'localName' in child &&
+      laterSiblings.has(child.localName as (typeof SECT_PR_SEQUENCE)[number])
+  );
+  return before === -1 ? children.length : before;
 }
 
 function applyJoin(

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -408,6 +408,12 @@ function applySplit(
     }
   }
 
+  // A `w:sectPr` in the split paragraph's mark belongs to the TAIL: Word splits by
+  // inserting a fresh mark before the existing one, so the original mark — and the
+  // section boundary it carries — stays after ALL the paragraph's content. Cloning it
+  // onto both halves minted a phantom section (and a spurious page break) on every
+  // Enter in a section's last paragraph.
+  const headPPr = pPr ? withoutSectionMark(pPr) : undefined;
   const tailParagraph = {
     id: nextId(),
     kind: 'paragraph',
@@ -437,7 +443,7 @@ function applySplit(
   if (!parent) return { ok: false, reason: 'tree-invariant', detail: 'paragraph has no parent' };
   const headParagraph = Object.freeze({
     ...paragraph,
-    children: pPr ? [pPr, ...headChildren] : headChildren,
+    children: headPPr ? [headPPr, ...headChildren] : headChildren,
   }) as OoxmlNode;
   const siblings = parent.children.flatMap((child) =>
     child.id === paragraph.id ? [headParagraph, tailParagraph] : [child]
@@ -553,8 +559,14 @@ function applySplitMany(
     }
   }
 
+  // A `w:sectPr` in the mark belongs to the LAST piece only — the original mark ends up
+  // after all the paragraph's content, exactly as the single-split rule keeps it on the
+  // tail. Duplicating it minted one phantom section per pasted line.
+  const strippedPPr = pPr ? withoutSectionMark(pPr) : undefined;
   const tailParagraphs: OoxmlNode[] = [];
   for (let piece = 1; piece < pieceCount; piece += 1) {
+    const last = piece === pieceCount - 1;
+    const source = last ? pPr : strippedPPr;
     tailParagraphs.push({
       id: nextId(),
       kind: 'paragraph',
@@ -563,7 +575,7 @@ function applySplitMany(
       prefix: 'w',
       namespaceBindings: [],
       attributes: [],
-      children: pPr ? [cloneWithNewIds(pPr, nextId), ...pieces[piece]!] : pieces[piece]!,
+      children: source ? [cloneWithNewIds(source, nextId), ...pieces[piece]!] : pieces[piece]!,
     } as unknown as OoxmlNode);
   }
 
@@ -580,12 +592,27 @@ function applySplitMany(
   if (!parent) return { ok: false, reason: 'tree-invariant', detail: 'paragraph has no parent' };
   const headParagraph = Object.freeze({
     ...paragraph,
-    children: pPr ? [pPr, ...pieces[0]!] : pieces[0]!,
+    children: strippedPPr ? [strippedPPr, ...pieces[0]!] : pieces[0]!,
   }) as OoxmlNode;
   const siblings = parent.children.flatMap((child) =>
     child.id === paragraph.id ? [headParagraph, ...tailParagraphs] : [child]
   );
   return fromEdit(replaceChildren(part, parent.id, siblings, options), effect);
+}
+
+/**
+ * A `w:pPr` without its `w:sectPr`, keeping identity when there is none. `undefined`
+ * when the section mark was its only content — an empty `w:pPr` serializes markup a
+ * paragraph that never had one does not.
+ */
+function withoutSectionMark(pPr: OoxmlNode): OoxmlNode | undefined {
+  if (pPr.kind === 'textValue') return undefined;
+  const children = pPr.children.filter(
+    (child) => !('localName' in child) || child.localName !== 'sectPr'
+  );
+  if (children.length === pPr.children.length) return pPr;
+  if (children.length === 0) return undefined;
+  return { ...pPr, children } as OoxmlNode;
 }
 
 /** A deep copy with freshly minted identities, for content duplicated by a split. */
@@ -740,39 +767,46 @@ function applySetSectionMark(
     impact: 'flow-structural',
   };
 
-  const sectPr = sectionElement(
-    nextId(),
-    'sectPr',
-    [],
-    [
-      sectionElement(
+  // The WHOLE governing section is cloned — header/footer references, columns,
+  // `titlePg`, page numbering, everything. The new section becomes an EARLIER section,
+  // and §17.10.5 header inheritance only looks backwards: cloning just the page
+  // geometry would strip the headers off every page before the break. A document with
+  // no section at all gets the effective defaults, written out.
+  const sectPr = governing
+    ? cloneWithNewIds(governing, nextId)
+    : sectionElement(
         nextId(),
-        'pgSz',
+        'sectPr',
+        [],
         [
-          wmlAttribute('w', String(metrics.widthTwips)),
-          wmlAttribute('h', String(metrics.heightTwips)),
-          ...(metrics.widthTwips > metrics.heightTwips
-            ? [wmlAttribute('orient', 'landscape')]
-            : []),
-        ],
-        []
-      ),
-      sectionElement(
-        nextId(),
-        'pgMar',
-        [
-          wmlAttribute('top', String(metrics.topTwips)),
-          wmlAttribute('right', String(metrics.rightTwips)),
-          wmlAttribute('bottom', String(metrics.bottomTwips)),
-          wmlAttribute('left', String(metrics.leftTwips)),
-          wmlAttribute('header', String(metrics.headerTwips)),
-          wmlAttribute('footer', String(metrics.footerTwips)),
-          wmlAttribute('gutter', String(metrics.gutterTwips)),
-        ],
-        []
-      ),
-    ]
-  );
+          sectionElement(
+            nextId(),
+            'pgSz',
+            [
+              wmlAttribute('w', String(metrics.widthTwips)),
+              wmlAttribute('h', String(metrics.heightTwips)),
+              ...(metrics.widthTwips > metrics.heightTwips
+                ? [wmlAttribute('orient', 'landscape')]
+                : []),
+            ],
+            []
+          ),
+          sectionElement(
+            nextId(),
+            'pgMar',
+            [
+              wmlAttribute('top', String(metrics.topTwips)),
+              wmlAttribute('right', String(metrics.rightTwips)),
+              wmlAttribute('bottom', String(metrics.bottomTwips)),
+              wmlAttribute('left', String(metrics.leftTwips)),
+              wmlAttribute('header', String(metrics.headerTwips)),
+              wmlAttribute('footer', String(metrics.footerTwips)),
+              wmlAttribute('gutter', String(metrics.gutterTwips)),
+            ],
+            []
+          ),
+        ]
+      );
 
   const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
   if (!pPr) {

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -25,7 +25,12 @@ import {
 } from '../package/ooxml-edit.ts';
 import { DEPENDENCY_KEY_IDS } from '../registry/frozen-ids.ts';
 import {
+  allSectionNodes,
+  bodyNodeOf,
   isParagraph,
+  metricsOfSection,
+  sectionAttribute,
+  sectionChild,
   segmentsOf,
   validateTreeOp,
   type OoxmlProperty,
@@ -125,6 +130,7 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
   if (rejection) return { ok: false, reason: rejection };
 
   if (op.op === 'joinParagraphs') return applyJoin(part, op.firstId, op.secondId, options);
+  if (op.op === 'setSectionProperties') return applySetSectionProperties(part, op, options);
 
   const paragraph = findNode(part, op.paragraphId) as OoxmlParagraphNode;
   const nextId = createNodeIdAllocator(part);
@@ -594,6 +600,217 @@ function parentOf(part: OoxmlPart, nodeId: string): OoxmlElement | null {
   // Served from the part's node index rather than a fresh full-tree walk: split and join
   // ask for a parent on every op, and the walk made each one O(document).
   return parentNodeOf(part, nodeId);
+}
+
+type SetSectionPropertiesOp = Extract<TreeDocOp, { op: 'setSectionProperties' }>;
+
+function wmlAttribute(localName: string, value: string) {
+  return {
+    kind: 'genericExtension' as const,
+    namespaceUri: WML_NAMESPACE_URI,
+    localName,
+    prefix: 'w',
+    value,
+  };
+}
+
+function sectionElement(
+  id: string,
+  localName: string,
+  attributes: readonly unknown[],
+  children: readonly OoxmlNode[]
+): OoxmlNode {
+  return {
+    id,
+    kind: 'generic',
+    namespaceUri: WML_NAMESPACE_URI,
+    localName,
+    prefix: 'w',
+    namespaceBindings: [],
+    attributes,
+    children,
+  } as unknown as OoxmlNode;
+}
+
+const attributesOf = (node: OoxmlNode | null): readonly { localName: string; value: string }[] =>
+  node && node.kind !== 'textValue' && 'attributes' in node
+    ? (node.attributes as readonly { localName: string; value: string }[])
+    : [];
+
+const childrenOf = (node: OoxmlNode | null): readonly OoxmlNode[] =>
+  node && node.kind !== 'textValue' ? (node.children ?? []) : [];
+
+/**
+ * Merge the op's fields into EVERY `w:sectPr` in the part — the mid-body ones and the
+ * body-level one — minting a body-level section when the document never declared any.
+ *
+ * Whole-document on purpose: the page-setup dialog and the ruler drags mean "this
+ * document", exactly Word's "Apply to: Whole document". Updating only the body-level
+ * section left a multi-section document saying "portrait, …, landscape", which Word
+ * renders as one landscape page among portrait ones.
+ *
+ * Per section the merge is surgical: only the attributes the op carries are rewritten.
+ * Everything else — `header`/`footer`/`gutter` distances, unknown `pgSz` attributes,
+ * `cols`, `titlePg`, header/footer references — keeps its authored bytes and its node
+ * identity, so a margin drag cannot degrade fidelity anywhere it did not touch. The one
+ * deliberate drop is the `pgSz` paper `code` when the dimensions change: a stale paper
+ * code contradicts the new size, and Word rewrites it on its own next save.
+ */
+function applySetSectionProperties(
+  part: OoxmlPart,
+  op: SetSectionPropertiesOp,
+  options?: EditOptions
+): TreeOpResult {
+  const body = bodyNodeOf(part);
+  if (!body) return { ok: false, reason: 'tree-invariant', detail: 'part has no body' };
+
+  const touchesSize =
+    op.pageWidthTwips !== undefined ||
+    op.pageHeightTwips !== undefined ||
+    op.orientation !== undefined;
+  const touchesMargins =
+    op.marginTopTwips !== undefined ||
+    op.marginRightTwips !== undefined ||
+    op.marginBottomTwips !== undefined ||
+    op.marginLeftTwips !== undefined;
+
+  const effect: TreeOpEffect = {
+    dirty: [],
+    created: [],
+    deleted: [],
+    dependencyKeys: TEXT_DEPS,
+    impact: 'flow-structural',
+  };
+
+  const sections = allSectionNodes(part);
+
+  if (sections.length === 0) {
+    const nextId = createNodeIdAllocator(part);
+    const children = mergedSectionChildren(null, op, touchesSize, touchesMargins, nextId);
+    const minted = sectionElement(nextId(), 'sectPr', [], children);
+    // The body-level section is the body's LAST child per the schema.
+    return fromEdit(insertChildren(part, body.id, body.children.length, [minted], options), effect);
+  }
+
+  let current = part;
+  for (const section of sections) {
+    const live = findNode(current, section.id);
+    if (!live || live.kind === 'textValue') continue;
+    const nextId = createNodeIdAllocator(current);
+    const children = mergedSectionChildren(live, op, touchesSize, touchesMargins, nextId);
+    const replaced = replaceChildren(current, live.id, children, options);
+    if (!replaced.ok) return fromEdit(replaced, effect);
+    current = replaced.part;
+  }
+  return ok(current, effect);
+}
+
+/** One section's rebuilt child list with the op's pgSz/pgMar fields merged in. */
+function mergedSectionChildren(
+  sectPr: OoxmlNode | null,
+  op: SetSectionPropertiesOp,
+  touchesSize: boolean,
+  touchesMargins: boolean,
+  nextId: () => string
+): OoxmlNode[] {
+  const current = metricsOfSection(sectPr);
+
+  const existingPgSz = sectionChild(sectPr, 'pgSz');
+  let nextPgSz: OoxmlNode | null = null;
+  if (touchesSize) {
+    const width = op.pageWidthTwips ?? current.widthTwips;
+    const height = op.pageHeightTwips ?? current.heightTwips;
+    const dimensionsChanged = width !== current.widthTwips || height !== current.heightTwips;
+    const orient =
+      op.orientation !== undefined
+        ? op.orientation === 'landscape'
+          ? 'landscape'
+          : undefined // Word's portrait is the ABSENCE of the attribute.
+        : sectionAttribute(existingPgSz, 'orient');
+    const dropped = new Set(['w', 'h', 'orient', ...(dimensionsChanged ? ['code'] : [])]);
+    const kept = attributesOf(existingPgSz).filter((entry) => !dropped.has(entry.localName));
+    nextPgSz = sectionElement(
+      existingPgSz?.id ?? nextId(),
+      'pgSz',
+      [
+        wmlAttribute('w', String(width)),
+        wmlAttribute('h', String(height)),
+        ...(orient ? [wmlAttribute('orient', orient)] : []),
+        ...kept,
+      ],
+      childrenOf(existingPgSz)
+    );
+  }
+
+  const existingPgMar = sectionChild(sectPr, 'pgMar');
+  let nextPgMar: OoxmlNode | null = null;
+  if (touchesMargins) {
+    const sides: readonly [string, number | undefined, number][] = [
+      ['top', op.marginTopTwips, current.topTwips],
+      ['right', op.marginRightTwips, current.rightTwips],
+      ['bottom', op.marginBottomTwips, current.bottomTwips],
+      ['left', op.marginLeftTwips, current.leftTwips],
+    ];
+    if (existingPgMar) {
+      const written = new Set(
+        sides.filter(([, value]) => value !== undefined).map(([name]) => name)
+      );
+      const kept = attributesOf(existingPgMar).filter((entry) => !written.has(entry.localName));
+      nextPgMar = sectionElement(
+        existingPgMar.id,
+        'pgMar',
+        [
+          ...sides
+            .filter(([, value]) => value !== undefined)
+            .map(([name, value]) => wmlAttribute(name, String(value))),
+          ...kept,
+        ],
+        childrenOf(existingPgMar)
+      );
+    } else {
+      // Minting `w:pgMar` writes the full attribute set the schema requires, with the
+      // effective values for everything the op did not say — explicit defaults are the
+      // same document the implicit ones were.
+      nextPgMar = sectionElement(
+        nextId(),
+        'pgMar',
+        [
+          ...sides.map(([name, value, fallback]) => wmlAttribute(name, String(value ?? fallback))),
+          wmlAttribute('header', String(current.headerTwips)),
+          wmlAttribute('footer', String(current.footerTwips)),
+          wmlAttribute('gutter', String(current.gutterTwips)),
+        ],
+        []
+      );
+    }
+  }
+
+  let children = [...childrenOf(sectPr)];
+  if (nextPgSz) {
+    if (existingPgSz) {
+      children = children.map((child) => (child.id === existingPgSz.id ? nextPgSz : child));
+    } else {
+      // `w:pgSz` precedes `w:pgMar` and `w:cols` in the schema's sequence.
+      const before = children.findIndex(
+        (child) =>
+          child.kind !== 'textValue' &&
+          'localName' in child &&
+          (child.localName === 'pgMar' || child.localName === 'cols')
+      );
+      children.splice(before === -1 ? children.length : before, 0, nextPgSz);
+    }
+  }
+  if (nextPgMar) {
+    if (existingPgMar) {
+      children = children.map((child) => (child.id === existingPgMar.id ? nextPgMar : child));
+    } else {
+      const afterPgSz = children.findIndex(
+        (child) => child.kind !== 'textValue' && 'localName' in child && child.localName === 'pgSz'
+      );
+      children.splice(afterPgSz === -1 ? children.length : afterPgSz + 1, 0, nextPgMar);
+    }
+  }
+  return children;
 }
 
 function applyJoin(

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -122,13 +122,14 @@ export type TreeDocOp =
     }
   | {
       /**
-       * Set page-setup fields — page size, orientation, margins — on EVERY `w:sectPr`
-       * in the part: Word's "Apply to: Whole document". The one op not addressed by
-       * paragraph id; a document with no section gets a body-level one minted as the
-       * body's last child. Omitted fields are left exactly as authored per section;
-       * `orientation` writes or removes the `w:orient` attribute only — dimension
-       * swapping is the COMMAND layer's business, so the op stays a literal record of
-       * what changed.
+       * Set page-setup fields — page size, orientation, margins — on every targeted
+       * `w:sectPr`: all of them (Word's "Apply to: Whole document", the default) or
+       * only the one governing `anchorParagraphId`. A document whose write must reach
+       * the implicit tail section gets a body-level `w:sectPr` minted as the body's
+       * last child. Omitted fields are left exactly as authored per section. Explicit
+       * dimensions are written literally; `orientation` WITHOUT dimensions swaps each
+       * section's own (see `plannedSectionDimensions`), so distinct paper sizes
+       * survive a whole-document flip.
        */
       readonly op: 'setSectionProperties';
       readonly pageWidthTwips?: number;
@@ -138,6 +139,22 @@ export type TreeDocOp =
       readonly marginRightTwips?: number;
       readonly marginBottomTwips?: number;
       readonly marginLeftTwips?: number;
+      /**
+       * Word's "Apply to: This section": update only the section GOVERNING this
+       * paragraph — the nearest mid-body `w:sectPr` at or after it, else the body-level
+       * one. Absent means every section.
+       */
+      readonly anchorParagraphId?: string;
+    }
+  | {
+      /**
+       * End a section AT this paragraph: mint a `w:pPr/w:sectPr` cloning the governing
+       * section's effective page setup, so the blocks up to and including this paragraph
+       * become their own section (a next-page section break). The paragraph must not
+       * already carry one.
+       */
+      readonly op: 'setSectionMark';
+      readonly paragraphId: string;
     };
 
 export type TreeDocOpKind = TreeDocOp['op'];
@@ -153,6 +170,7 @@ export const TREE_DOC_OP_KINDS = [
   'setRunProperties',
   'setParagraphProperties',
   'setSectionProperties',
+  'setSectionMark',
 ] as const satisfies readonly TreeDocOpKind[];
 
 // Compile-time exhaustiveness, matching the legacy `DOC_OP_KINDS` guard: a new op must be
@@ -324,6 +342,68 @@ export function currentSectionMetrics(part: OoxmlPart): SectionMetrics {
   return metricsOfSection(bodySectionOf(part));
 }
 
+type SectionWriteOp = Extract<TreeDocOp, { op: 'setSectionProperties' }>;
+
+/**
+ * The dimensions ONE section ends up with under this op — the single source both
+ * validation and application read, so a value the check approved is exactly the value
+ * written. An orientation change WITHOUT explicit dimensions swaps the section's own
+ * current dimensions, so distinct paper sizes survive a whole-document orientation flip.
+ */
+export function plannedSectionDimensions(
+  metrics: SectionMetrics,
+  op: SectionWriteOp
+): { readonly widthTwips: number; readonly heightTwips: number } {
+  let width = op.pageWidthTwips ?? metrics.widthTwips;
+  let height = op.pageHeightTwips ?? metrics.heightTwips;
+  if (
+    op.orientation !== undefined &&
+    op.pageWidthTwips === undefined &&
+    op.pageHeightTwips === undefined
+  ) {
+    const long = Math.max(metrics.widthTwips, metrics.heightTwips);
+    const short = Math.min(metrics.widthTwips, metrics.heightTwips);
+    width = op.orientation === 'landscape' ? long : short;
+    height = op.orientation === 'landscape' ? short : long;
+  }
+  return { widthTwips: width, heightTwips: height };
+}
+
+/**
+ * The sections this op writes: the one governing the anchor paragraph, or all of them.
+ * `null` entries mean "the body-level section, which must be minted".
+ */
+export function targetSectionNodes(
+  part: OoxmlPart,
+  anchorParagraphId: string | undefined
+): readonly (OoxmlNode | null)[] {
+  if (anchorParagraphId === undefined) {
+    const all = allSectionNodes(part);
+    // A body-level section governs the tail even when the document never wrote one; a
+    // whole-document write must reach that implicit section too, so it is minted.
+    return bodySectionOf(part) ? all : [...all, null];
+  }
+  // The governing section of a paragraph: the first paragraph AT or AFTER it (in
+  // document order) carrying a `w:pPr/w:sectPr`, else the body-level section.
+  let seenAnchor = false;
+  let governing: OoxmlNode | null | undefined;
+  const walk = (node: OoxmlNode): void => {
+    if (governing !== undefined || node.kind === 'textValue') return;
+    if (node.kind === 'paragraph') {
+      if (node.id === anchorParagraphId) seenAnchor = true;
+      if (seenAnchor) {
+        const pPr = node.children.find((child) => child.kind === 'paragraphProperties');
+        const sectPr = pPr ? sectionChild(pPr, 'sectPr') : null;
+        if (sectPr) governing = sectPr;
+      }
+      return;
+    }
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(part.root);
+  return [governing ?? bodySectionOf(part)];
+}
+
 /** The effective metrics of ONE section node (null reads as Word's defaults). */
 export function metricsOfSection(sectPr: OoxmlNode | null): SectionMetrics {
   const pgSz = sectionChild(sectPr, 'pgSz');
@@ -440,20 +520,27 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
     ) {
       return 'invalid-property-value';
     }
+    if (op.anchorParagraphId !== undefined) {
+      const anchor = findNode(part, op.anchorParagraphId);
+      if (!anchor) return 'unknown-paragraph';
+      if (!isParagraph(anchor)) return 'not-a-paragraph';
+    }
     if (!bodyNodeOf(part)) return 'tree-invariant';
-    // The merged result must keep a positive content area. The read side falls back to
-    // default geometry when margins swallow the page; a WRITE that would trip that
-    // fallback is refused instead, so the user sees a rejection rather than a document
-    // that silently snaps to Letter.
-    const current = currentSectionMetrics(part);
-    const width = op.pageWidthTwips ?? current.widthTwips;
-    const height = op.pageHeightTwips ?? current.heightTwips;
-    const top = op.marginTopTwips ?? current.topTwips;
-    const right = op.marginRightTwips ?? current.rightTwips;
-    const bottom = op.marginBottomTwips ?? current.bottomTwips;
-    const left = op.marginLeftTwips ?? current.leftTwips;
-    if (width - left - current.gutterTwips - right <= 0 || height - top - bottom <= 0) {
-      return 'invalid-property-value';
+    // EVERY section the op will write must keep a positive content area — checked against
+    // the same planned values apply writes, so a value the check approved is exactly the
+    // value written. The read side falls back to default geometry when margins swallow
+    // the page; a WRITE that would trip that fallback is refused instead, so the user
+    // sees a rejection rather than a document that silently snaps to Letter.
+    for (const section of targetSectionNodes(part, op.anchorParagraphId)) {
+      const current = metricsOfSection(section);
+      const { widthTwips, heightTwips } = plannedSectionDimensions(current, op);
+      const top = op.marginTopTwips ?? current.topTwips;
+      const right = op.marginRightTwips ?? current.rightTwips;
+      const bottom = op.marginBottomTwips ?? current.bottomTwips;
+      const left = op.marginLeftTwips ?? current.leftTwips;
+      if (widthTwips - left - current.gutterTwips - right <= 0 || heightTwips - top - bottom <= 0) {
+        return 'invalid-property-value';
+      }
     }
     return null;
   }
@@ -528,6 +615,12 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
     }
     case 'setParagraphProperties':
       return validateProperties(op.properties, PARAGRAPH_PROPERTY_SET);
+    case 'setSectionMark': {
+      const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
+      // A paragraph already ending a section cannot end two.
+      if (pPr && sectionChild(pPr, 'sectPr')) return 'invalid-property-value';
+      return null;
+    }
     default:
       return 'unknown-op';
   }

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -119,6 +119,25 @@ export type TreeDocOp =
       readonly op: 'setParagraphProperties';
       readonly paragraphId: string;
       readonly properties: readonly OoxmlProperty[];
+    }
+  | {
+      /**
+       * Set page-setup fields — page size, orientation, margins — on EVERY `w:sectPr`
+       * in the part: Word's "Apply to: Whole document". The one op not addressed by
+       * paragraph id; a document with no section gets a body-level one minted as the
+       * body's last child. Omitted fields are left exactly as authored per section;
+       * `orientation` writes or removes the `w:orient` attribute only — dimension
+       * swapping is the COMMAND layer's business, so the op stays a literal record of
+       * what changed.
+       */
+      readonly op: 'setSectionProperties';
+      readonly pageWidthTwips?: number;
+      readonly pageHeightTwips?: number;
+      readonly orientation?: 'portrait' | 'landscape';
+      readonly marginTopTwips?: number;
+      readonly marginRightTwips?: number;
+      readonly marginBottomTwips?: number;
+      readonly marginLeftTwips?: number;
     };
 
 export type TreeDocOpKind = TreeDocOp['op'];
@@ -133,6 +152,7 @@ export const TREE_DOC_OP_KINDS = [
   'joinParagraphs',
   'setRunProperties',
   'setParagraphProperties',
+  'setSectionProperties',
 ] as const satisfies readonly TreeDocOpKind[];
 
 // Compile-time exhaustiveness, matching the legacy `DOC_OP_KINDS` guard: a new op must be
@@ -189,6 +209,136 @@ export interface Segment {
 
 export function isParagraph(node: OoxmlNode | null): node is OoxmlParagraphNode {
   return node !== null && node.kind === 'paragraph';
+}
+
+// ---------------------------------------------------------------------------------------
+// Section addressing (setSectionProperties).
+//
+// The store may not import the layout package (the dependency points the other way), so
+// the few section reads validation needs — current dimensions and margins, to refuse a
+// write that leaves no content area — are derived here with the same clamps the layout
+// reader applies. Fields an op does not touch fall back to what the document effectively
+// uses today, which is exactly what the merged write will leave in place.
+// ---------------------------------------------------------------------------------------
+
+/** The `w:body` element of a part, or null when the root holds none. */
+export function bodyNodeOf(
+  part: OoxmlPart
+): (OoxmlNode & { children: readonly OoxmlNode[] }) | null {
+  const walk = (node: OoxmlNode): (OoxmlNode & { children: readonly OoxmlNode[] }) | null => {
+    if (node.kind === 'textValue') return null;
+    if (node.kind === 'body') return node;
+    for (const child of node.children ?? []) {
+      const found = walk(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  return walk(part.root);
+}
+
+/** The body-level `w:sectPr` (a generic node), or null. */
+export function bodySectionOf(part: OoxmlPart): OoxmlNode | null {
+  const body = bodyNodeOf(part);
+  if (!body) return null;
+  for (const child of body.children) {
+    if (child.kind !== 'textValue' && 'localName' in child && child.localName === 'sectPr') {
+      return child;
+    }
+  }
+  return null;
+}
+
+/**
+ * EVERY `w:sectPr` in the part, in document order: the mid-body ones (inside a
+ * paragraph's `w:pPr`, ending a section) and the body-level one last.
+ *
+ * A page-setup write is "apply to whole document" — Word's dialog default — so it must
+ * reach all of them. Updating only the body-level section leaves a multi-section
+ * document saying "portrait, portrait, …, landscape", which any per-section consumer
+ * (Word itself) then renders as a mixed-orientation document.
+ */
+export function allSectionNodes(part: OoxmlPart): OoxmlNode[] {
+  const found: OoxmlNode[] = [];
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if ('localName' in node && node.localName === 'sectPr') {
+      found.push(node);
+      return;
+    }
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(part.root);
+  return found;
+}
+
+/** A `w:`-namespace attribute value by local name, off any element node. */
+export function sectionAttribute(node: OoxmlNode | null, name: string): string | undefined {
+  if (!node || node.kind === 'textValue' || !('attributes' in node)) return undefined;
+  for (const entry of node.attributes ?? []) {
+    if (entry.localName === name) return entry.value;
+  }
+  return undefined;
+}
+
+/** A named child element of a section container. */
+export function sectionChild(node: OoxmlNode | null, localName: string): OoxmlNode | null {
+  if (!node || node.kind === 'textValue') return null;
+  for (const child of node.children ?? []) {
+    if (child.kind !== 'textValue' && 'localName' in child && child.localName === localName) {
+      return child;
+    }
+  }
+  return null;
+}
+
+export interface SectionMetrics {
+  readonly widthTwips: number;
+  readonly heightTwips: number;
+  readonly topTwips: number;
+  readonly rightTwips: number;
+  readonly bottomTwips: number;
+  readonly leftTwips: number;
+  readonly headerTwips: number;
+  readonly footerTwips: number;
+  readonly gutterTwips: number;
+}
+
+const clampedTwips = (raw: string | undefined, fallback: number, max: number): number => {
+  if (raw === undefined || !/^-?\d{1,7}$/.test(raw)) return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0 || value > max) return fallback;
+  return value;
+};
+
+const clampedMargin = (raw: string | undefined, fallback: number): number => {
+  if (raw === undefined || !/^-?\d{1,7}$/.test(raw)) return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || Math.abs(value) > 31680) return fallback;
+  return value;
+};
+
+/** What the document EFFECTIVELY uses today — declared values under the read-side clamps,
+ *  Word's defaults where it says nothing. */
+export function currentSectionMetrics(part: OoxmlPart): SectionMetrics {
+  return metricsOfSection(bodySectionOf(part));
+}
+
+/** The effective metrics of ONE section node (null reads as Word's defaults). */
+export function metricsOfSection(sectPr: OoxmlNode | null): SectionMetrics {
+  const pgSz = sectionChild(sectPr, 'pgSz');
+  const pgMar = sectionChild(sectPr, 'pgMar');
+  return {
+    widthTwips: clampedTwips(sectionAttribute(pgSz, 'w'), 12240, 63360),
+    heightTwips: clampedTwips(sectionAttribute(pgSz, 'h'), 15840, 63360),
+    topTwips: clampedMargin(sectionAttribute(pgMar, 'top'), 1440),
+    rightTwips: clampedMargin(sectionAttribute(pgMar, 'right'), 1440),
+    bottomTwips: clampedMargin(sectionAttribute(pgMar, 'bottom'), 1440),
+    leftTwips: clampedMargin(sectionAttribute(pgMar, 'left'), 1440),
+    headerTwips: clampedMargin(sectionAttribute(pgMar, 'header'), 720),
+    footerTwips: clampedMargin(sectionAttribute(pgMar, 'footer'), 720),
+    gutterTwips: clampedMargin(sectionAttribute(pgMar, 'gutter'), 0),
+  };
 }
 
 /** Flatten a paragraph into UTF-16 addressable segments, in document order. */
@@ -253,6 +403,60 @@ function validateProperties(
 /** Structural validation, run before any tree work so a rejection changes nothing. */
 export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection | null {
   if (!TREE_DOC_OP_KINDS.includes(op.op)) return 'unknown-op';
+
+  if (op.op === 'setSectionProperties') {
+    const dims = [op.pageWidthTwips, op.pageHeightTwips];
+    const margins = [
+      op.marginTopTwips,
+      op.marginRightTwips,
+      op.marginBottomTwips,
+      op.marginLeftTwips,
+    ];
+    if (
+      dims.every((value) => value === undefined) &&
+      margins.every((value) => value === undefined) &&
+      op.orientation === undefined
+    ) {
+      return 'invalid-property-value';
+    }
+    for (const value of dims) {
+      // The same bound the read side clamps to: a page dimension is a pagination loop
+      // bound, so the write path must not admit what the read path would refuse.
+      if (value !== undefined && (!Number.isInteger(value) || value < 1 || value > 63360)) {
+        return 'invalid-property-value';
+      }
+    }
+    for (const value of margins) {
+      // Stricter than the read side, which tolerates authored negative margins: the write
+      // path is a dialog or a ruler drag, and neither means "bleed into the margin".
+      if (value !== undefined && (!Number.isInteger(value) || value < 0 || value > 31680)) {
+        return 'invalid-property-value';
+      }
+    }
+    if (
+      op.orientation !== undefined &&
+      op.orientation !== 'portrait' &&
+      op.orientation !== 'landscape'
+    ) {
+      return 'invalid-property-value';
+    }
+    if (!bodyNodeOf(part)) return 'tree-invariant';
+    // The merged result must keep a positive content area. The read side falls back to
+    // default geometry when margins swallow the page; a WRITE that would trip that
+    // fallback is refused instead, so the user sees a rejection rather than a document
+    // that silently snaps to Letter.
+    const current = currentSectionMetrics(part);
+    const width = op.pageWidthTwips ?? current.widthTwips;
+    const height = op.pageHeightTwips ?? current.heightTwips;
+    const top = op.marginTopTwips ?? current.topTwips;
+    const right = op.marginRightTwips ?? current.rightTwips;
+    const bottom = op.marginBottomTwips ?? current.bottomTwips;
+    const left = op.marginLeftTwips ?? current.leftTwips;
+    if (width - left - current.gutterTwips - right <= 0 || height - top - bottom <= 0) {
+      return 'invalid-property-value';
+    }
+    return null;
+  }
 
   if (op.op === 'joinParagraphs') {
     const first = findNode(part, op.firstId);

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -280,6 +280,9 @@ export function allSectionNodes(part: OoxmlPart): OoxmlNode[] {
   const found: OoxmlNode[] = [];
   const walk = (node: OoxmlNode): void => {
     if (node.kind === 'textValue') return;
+    // A `sectPr` inside a table is not a section Word recognises and layout ignores it;
+    // writing to one would make the dialog appear to do nothing.
+    if (node.kind === 'table') return;
     if ('localName' in node && node.localName === 'sectPr') {
       found.push(node);
       return;
@@ -288,6 +291,24 @@ export function allSectionNodes(part: OoxmlPart): OoxmlNode[] {
   };
   walk(part.root);
   return found;
+}
+
+/** Whether a node sits inside a `w:tbl` — where a section mark must not be minted. */
+export function isTableNested(part: OoxmlPart, nodeId: string): boolean {
+  let nested = false;
+  let found = false;
+  const walk = (node: OoxmlNode, inTable: boolean): void => {
+    if (found || node.kind === 'textValue') return;
+    if (node.id === nodeId) {
+      nested = inTable;
+      found = true;
+      return;
+    }
+    const below = inTable || node.kind === 'table';
+    for (const child of node.children ?? []) walk(child, below);
+  };
+  walk(part.root, false);
+  return nested;
 }
 
 /** A `w:`-namespace attribute value by local name, off any element node. */
@@ -384,23 +405,26 @@ export function targetSectionNodes(
     return bodySectionOf(part) ? all : [...all, null];
   }
   // The governing section of a paragraph: the first paragraph AT or AFTER it (in
-  // document order) carrying a `w:pPr/w:sectPr`, else the body-level section.
+  // document order) carrying a `w:pPr/w:sectPr`, else the body-level section. The
+  // anchor may sit inside a table (the table belongs to a section), but a table-nested
+  // `sectPr` is never a boundary — Word does not recognise one.
   let seenAnchor = false;
   let governing: OoxmlNode | null | undefined;
-  const walk = (node: OoxmlNode): void => {
+  const walk = (node: OoxmlNode, inTable: boolean): void => {
     if (governing !== undefined || node.kind === 'textValue') return;
     if (node.kind === 'paragraph') {
       if (node.id === anchorParagraphId) seenAnchor = true;
-      if (seenAnchor) {
+      if (seenAnchor && !inTable) {
         const pPr = node.children.find((child) => child.kind === 'paragraphProperties');
         const sectPr = pPr ? sectionChild(pPr, 'sectPr') : null;
         if (sectPr) governing = sectPr;
       }
       return;
     }
-    for (const child of node.children ?? []) walk(child);
+    const below = inTable || node.kind === 'table';
+    for (const child of node.children ?? []) walk(child, below);
   };
-  walk(part.root);
+  walk(part.root, false);
   return [governing ?? bodySectionOf(part)];
 }
 
@@ -619,6 +643,9 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
       const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
       // A paragraph already ending a section cannot end two.
       if (pPr && sectionChild(pPr, 'sectPr')) return 'invalid-property-value';
+      // A section cannot end inside a table cell: Word never writes one there, and the
+      // read side would ignore it — a committed no-op the user cannot see.
+      if (isTableNested(part, op.paragraphId)) return 'invalid-property-value';
       return null;
     }
     default:

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -413,7 +413,10 @@
         "a5": "A5 (5,83\" × 8,27\")",
         "b5": "B5 (6,93\" × 9,84\")",
         "executive": "Executive (7,25\" × 10,5\")"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "Tabelleneigenschaften",

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -429,6 +429,9 @@
       "bottom": "Bottom",
       "left": "Left",
       "right": "Right",
+      "applyTo": "Apply to",
+      "applyToDocument": "Whole document",
+      "applyToSection": "This section",
       "pageSizes": {
         "letter": "Letter (8.5\" × 11\")",
         "a4": "A4 (8.27\" × 11.69\")",

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -413,7 +413,10 @@
         "a5": "A5 (14,8 × 21 cm)",
         "b5": "B5 (17,6 × 25 cm)",
         "executive": "Executive (18,4 × 26,7 cm)"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "Propriétés du tableau",

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -413,7 +413,10 @@
         "a5": "A5 (5.83\" × 8.27\")",
         "b5": "B5 (6.93\" × 9.84\")",
         "executive": "Executive (7.25\" × 10.5\")"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "מאפייני טבלה",

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -413,7 +413,10 @@
         "a5": "A5 (5.83\" × 8.27\")",
         "b5": "B5 (6.93\" × 9.84\")",
         "executive": "Executive (7.25\" × 10.5\")"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "तालिका की विशेषताएँ",

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -434,7 +434,10 @@
         "a5": "A5 (14,8 × 21 cm)",
         "b5": "B5 (17,6 × 25 cm)",
         "executive": "Executive (18,42 × 26,67 cm)"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "Properti Tabel",

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -413,7 +413,10 @@
         "a5": "A5 (5,83\" × 8,27\")",
         "b5": "B5 (6,93\" × 9,84\")",
         "executive": "Executive (7,25\" × 10,5\")"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "Właściwości tabeli",

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -413,7 +413,10 @@
         "a5": "A5 (5,83\" × 8,27\")",
         "b5": "B5 (6,93\" × 9,84\")",
         "executive": "Executivo (7,25\" × 10,5\")"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "Propriedades da tabela",

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -413,7 +413,10 @@
         "a5": "A5 (5.83\" × 8.27\")",
         "b5": "B5 (6.93\" × 9.84\")",
         "executive": "Executive (7.25\" × 10.5\")"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "Tablo özellikleri",

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -413,7 +413,10 @@
         "a5": "A5 (5.83\" × 8.27\")",
         "b5": "B5 (6.93\" × 9.84\")",
         "executive": "Executive (7.25\" × 10.5\")"
-      }
+      },
+      "applyTo": null,
+      "applyToDocument": null,
+      "applyToSection": null
     },
     "tableProperties": {
       "title": "表格属性",

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -10,6 +10,7 @@ import { useDocxEditorRefApi } from './DocxEditor/hooks/useDocxEditorRefApi';
 import { DocxEditorToolbar } from '../editor/toolbar';
 import { DocxEditorHorizontalRuler, DocxEditorVerticalRuler } from '../editor/DocxEditorRulers';
 import { DocxEditorDocumentOutline } from '../editor/DocxEditorOutline';
+import { DocxEditorPageSetupDialog } from '../editor/DocxEditorPageSetup';
 import { useTranslation } from '../i18n';
 import type { TranslationKey } from '../i18n';
 import type { DocxEditorProps, DocxEditorRef } from '../types';
@@ -238,12 +239,14 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<
   readonly Viewport: typeof DocxEditorViewport;
   readonly Content: typeof DocxEditorContent;
   readonly Toolbar: typeof DocxEditorToolbar;
-  /** Context-fed horizontal ruler (read-only; the props-driven export stays). */
+  /** Context-fed horizontal ruler with draggable margins (props-driven export stays). */
   readonly HorizontalRuler: typeof DocxEditorHorizontalRuler;
-  /** Context-fed vertical ruler (read-only; the props-driven export stays). */
+  /** Context-fed vertical ruler with draggable margins (props-driven export stays). */
   readonly VerticalRuler: typeof DocxEditorVerticalRuler;
   /** Context-fed heading outline over `Editor.getOutline()`. */
   readonly DocumentOutline: typeof DocxEditorDocumentOutline;
+  /** Page Setup dialog — size, orientation, margins — applied as one undo step. */
+  readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
 }
 
 export const DocxEditor: DocxEditorNamespace = Object.assign(DocxEditorImpl, {
@@ -254,4 +257,5 @@ export const DocxEditor: DocxEditorNamespace = Object.assign(DocxEditorImpl, {
   HorizontalRuler: DocxEditorHorizontalRuler,
   VerticalRuler: DocxEditorVerticalRuler,
   DocumentOutline: DocxEditorDocumentOutline,
+  PageSetupDialog: DocxEditorPageSetupDialog,
 });

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -41,6 +41,8 @@ export interface HorizontalRulerProps {
   editable?: boolean;
   onLeftMarginChange?: (marginTwips: number) => void;
   onRightMarginChange?: (marginTwips: number) => void;
+  /** Fires when a margin drag is released — the moment to commit what the drag previewed. */
+  onMarginDragEnd?: () => void;
   onFirstLineIndentChange?: (indentTwips: number) => void;
   showFirstLineIndent?: boolean;
   firstLineIndent?: number;
@@ -98,6 +100,7 @@ export function HorizontalRuler({
   editable = false,
   onLeftMarginChange,
   onRightMarginChange,
+  onMarginDragEnd,
   onFirstLineIndentChange,
   showFirstLineIndent = false,
   firstLineIndent = 0,
@@ -211,10 +214,11 @@ export function HorizontalRuler({
   );
 
   const handleDragEnd = useCallback(() => {
+    if (dragging === 'leftMargin' || dragging === 'rightMargin') onMarginDragEnd?.();
     setDragging(null);
     setDragValue(null);
     setDragPositionPx(null);
-  }, []);
+  }, [dragging, onMarginDragEnd]);
 
   useEffect(() => {
     if (dragging) {

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -126,6 +126,9 @@ export function HorizontalRuler({
   const pageWidthTwips = pageSetup?.pageWidthTwips ?? DEFAULT_PAGE_WIDTH_TWIPS;
   const leftMarginTwips = pageSetup?.marginsTwips.left ?? DEFAULT_MARGIN_TWIPS;
   const rightMarginTwips = pageSetup?.marginsTwips.right ?? DEFAULT_MARGIN_TWIPS;
+  // The binding gutter narrows the content area exactly as the left margin does, so the
+  // drag clamps must count it — the engine refuses margins that swallow the page.
+  const gutterTwips = pageSetup?.gutterTwips ?? 0;
   const contentTwips = pageWidthTwips - leftMarginTwips - rightMarginTwips;
 
   // Pixel conversions
@@ -164,13 +167,13 @@ export function HorizontalRuler({
       const positionTwips = pixelsToTwips(x / zoom);
 
       if (dragging === 'leftMargin') {
-        const maxMargin = pageWidthTwips - rightMarginTwips - 720;
+        const maxMargin = pageWidthTwips - rightMarginTwips - gutterTwips - 720;
         const rounded = Math.round(Math.max(0, Math.min(positionTwips, maxMargin)));
         setDragValue(rounded);
         onLeftMarginChange?.(rounded);
       } else if (dragging === 'rightMargin') {
         const fromRight = pageWidthTwips - positionTwips;
-        const maxMargin = pageWidthTwips - leftMarginTwips - 720;
+        const maxMargin = pageWidthTwips - leftMarginTwips - gutterTwips - 720;
         const rounded = Math.round(Math.max(0, Math.min(fromRight, maxMargin)));
         setDragValue(rounded);
         onRightMarginChange?.(rounded);
@@ -202,6 +205,7 @@ export function HorizontalRuler({
       pageWidthTwips,
       leftMarginTwips,
       rightMarginTwips,
+      gutterTwips,
       contentTwips,
       indentLeft,
       indentRight,

--- a/packages/react/src/components/ui/VerticalRuler.tsx
+++ b/packages/react/src/components/ui/VerticalRuler.tsx
@@ -31,6 +31,8 @@ export interface VerticalRulerProps {
   onTopMarginChange?: (marginTwips: number) => void;
   /** Callback when bottom margin changes (in twips) */
   onBottomMarginChange?: (marginTwips: number) => void;
+  /** Fires when a margin drag is released — the moment to commit what the drag previewed. */
+  onMarginDragEnd?: () => void;
   /** Unit to display (inches or cm) */
   unit?: 'inch' | 'cm';
   /** Additional CSS class name */
@@ -70,6 +72,7 @@ export function VerticalRuler({
   editable = false,
   onTopMarginChange,
   onBottomMarginChange,
+  onMarginDragEnd,
   unit = 'inch',
   className = '',
   style,
@@ -133,8 +136,9 @@ export function VerticalRuler({
 
   // Handle drag end
   const handleDragEnd = useCallback(() => {
+    if (dragging !== null) onMarginDragEnd?.();
     setDragging(null);
-  }, []);
+  }, [dragging, onMarginDragEnd]);
 
   // Add/remove document event listeners
   useEffect(() => {

--- a/packages/react/src/editor/DocxEditorPageSetup.tsx
+++ b/packages/react/src/editor/DocxEditorPageSetup.tsx
@@ -1,0 +1,332 @@
+// The Page Setup dialog as a context-fed part (`DocxEditor.PageSetupDialog`).
+//
+// Size preset, orientation and margins — the fields Word's dialog and the reference
+// Google-Docs chrome expose — read from `usePageSetup()` and written back as ONE
+// `setPageSetup` command on Apply, so the whole dialog is a single undo step. The host
+// owns visibility (`open`/`onClose`); the engine owns everything else.
+
+import { useCallback, useEffect, useState } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
+import { useTranslation } from '../i18n';
+import { usePageSetup } from './usePageSetup';
+
+/**
+ * Common page sizes in twips, PORTRAIT-normalized (width < height). Matching tolerates
+ * ±20 twips and ignores orientation, so a landscape A4 still reads as "A4".
+ */
+const PAGE_SIZES = [
+  { labelKey: 'dialogs.pageSetup.pageSizes.letter' as const, width: 12240, height: 15840 },
+  { labelKey: 'dialogs.pageSetup.pageSizes.a4' as const, width: 11906, height: 16838 },
+  { labelKey: 'dialogs.pageSetup.pageSizes.legal' as const, width: 12240, height: 20160 },
+  { labelKey: 'dialogs.pageSetup.pageSizes.a3' as const, width: 16838, height: 23811 },
+  { labelKey: 'dialogs.pageSetup.pageSizes.a5' as const, width: 8391, height: 11906 },
+  { labelKey: 'dialogs.pageSetup.pageSizes.b5' as const, width: 9979, height: 14175 },
+  { labelKey: 'dialogs.pageSetup.pageSizes.executive' as const, width: 10440, height: 15120 },
+] as const;
+
+const TWIPS_PER_INCH = 1440;
+
+const twipsToInches = (twips: number): number => Math.round((twips / TWIPS_PER_INCH) * 100) / 100;
+const inchesToTwips = (inches: number): number => Math.round(inches * TWIPS_PER_INCH);
+
+function findPageSizeIndex(w: number, h: number): number {
+  const pw = Math.min(w, h);
+  const ph = Math.max(w, h);
+  return PAGE_SIZES.findIndex(
+    (size) => Math.abs(size.width - pw) < 20 && Math.abs(size.height - ph) < 20
+  );
+}
+
+/** Props for `DocxEditor.PageSetupDialog`. @public */
+export interface DocxEditorPageSetupDialogProps {
+  /** Whether the dialog is shown. The host owns this state. */
+  open: boolean;
+  /** Called on Cancel, Escape, overlay click, and after a successful Apply. */
+  onClose: () => void;
+  className?: string;
+}
+
+const overlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'var(--doc-overlay)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 10000,
+};
+
+const dialogStyle: CSSProperties = {
+  backgroundColor: 'var(--doc-surface)',
+  borderRadius: 8,
+  boxShadow: '0 4px 20px var(--doc-shadow)',
+  minWidth: 400,
+  maxWidth: 480,
+  width: '100%',
+  margin: 20,
+};
+
+const headerStyle: CSSProperties = {
+  padding: '16px 20px 12px',
+  borderBottom: '1px solid var(--doc-border)',
+  fontSize: 16,
+  fontWeight: 600,
+  color: 'var(--doc-text)',
+};
+
+const bodyStyle: CSSProperties = {
+  padding: '16px 20px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+};
+
+const sectionLabelStyle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'var(--doc-text-muted)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+};
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+};
+
+const labelStyle: CSSProperties = {
+  width: 80,
+  fontSize: 13,
+  color: 'var(--doc-text-muted)',
+};
+
+const inputStyle: CSSProperties = {
+  flex: 1,
+  padding: '6px 8px',
+  border: '1px solid var(--doc-border)',
+  borderRadius: 4,
+  fontSize: 13,
+  backgroundColor: 'var(--doc-surface)',
+  color: 'var(--doc-text)',
+};
+
+const unitStyle: CSSProperties = {
+  fontSize: 11,
+  color: 'var(--doc-text-muted)',
+  width: 16,
+};
+
+const footerStyle: CSSProperties = {
+  padding: '12px 20px 16px',
+  borderTop: '1px solid var(--doc-border)',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: 8,
+};
+
+const btnStyle: CSSProperties = {
+  padding: '6px 16px',
+  fontSize: 13,
+  border: '1px solid var(--doc-border)',
+  borderRadius: 4,
+  cursor: 'pointer',
+  backgroundColor: 'var(--doc-surface)',
+  color: 'var(--doc-text)',
+};
+
+const DEFAULT_WIDTH = 12240;
+const DEFAULT_HEIGHT = 15840;
+const DEFAULT_MARGIN = 1440;
+
+/**
+ * Page Setup dialog: size preset, orientation, margins in inches. Reads the section
+ * through `usePageSetup()` and applies the whole form as one undoable command.
+ *
+ * @public
+ */
+export function DocxEditorPageSetupDialog({
+  open,
+  onClose,
+  className,
+}: DocxEditorPageSetupDialogProps): ReactElement | null {
+  const { t } = useTranslation();
+  const { pageSetup, isEnabled, apply } = usePageSetup();
+  const [pageWidth, setPageWidth] = useState(DEFAULT_WIDTH);
+  const [pageHeight, setPageHeight] = useState(DEFAULT_HEIGHT);
+  const [orientation, setOrientation] = useState<'portrait' | 'landscape'>('portrait');
+  const [marginTop, setMarginTop] = useState(DEFAULT_MARGIN);
+  const [marginBottom, setMarginBottom] = useState(DEFAULT_MARGIN);
+  const [marginLeft, setMarginLeft] = useState(DEFAULT_MARGIN);
+  const [marginRight, setMarginRight] = useState(DEFAULT_MARGIN);
+
+  // Re-seed the form from the document each time the dialog OPENS — not on every
+  // section tick, or a concurrent edit would fight the user's typing.
+  useEffect(() => {
+    if (!open) return;
+    setPageWidth(pageSetup?.pageWidthTwips ?? DEFAULT_WIDTH);
+    setPageHeight(pageSetup?.pageHeightTwips ?? DEFAULT_HEIGHT);
+    setOrientation(pageSetup?.orientation ?? 'portrait');
+    setMarginTop(pageSetup?.marginsTwips.top ?? DEFAULT_MARGIN);
+    setMarginBottom(pageSetup?.marginsTwips.bottom ?? DEFAULT_MARGIN);
+    setMarginLeft(pageSetup?.marginsTwips.left ?? DEFAULT_MARGIN);
+    setMarginRight(pageSetup?.marginsTwips.right ?? DEFAULT_MARGIN);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed on open only
+  }, [open]);
+
+  const handlePageSizeChange = useCallback(
+    (index: number) => {
+      const size = PAGE_SIZES[index];
+      if (!size) return;
+      // Presets are portrait-normalized; the current orientation decides the stored order.
+      setPageWidth(orientation === 'landscape' ? size.height : size.width);
+      setPageHeight(orientation === 'landscape' ? size.width : size.height);
+    },
+    [orientation]
+  );
+
+  const handleOrientationChange = useCallback(
+    (next: 'portrait' | 'landscape') => {
+      if (next === orientation) return;
+      setOrientation(next);
+      setPageWidth(pageHeight);
+      setPageHeight(pageWidth);
+    },
+    [orientation, pageWidth, pageHeight]
+  );
+
+  const handleApply = useCallback(() => {
+    const accepted = apply({
+      pageWidth,
+      pageHeight,
+      orientation,
+      marginTop,
+      marginRight,
+      marginBottom,
+      marginLeft,
+    });
+    if (accepted) onClose();
+  }, [
+    apply,
+    pageWidth,
+    pageHeight,
+    orientation,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    onClose,
+  ]);
+
+  if (!open) return null;
+
+  const sizeIndex = findPageSizeIndex(pageWidth, pageHeight);
+
+  const marginRow = (
+    labelKey: 'top' | 'bottom' | 'left' | 'right',
+    value: number,
+    set: (twips: number) => void
+  ) => (
+    <div style={rowStyle}>
+      <label style={labelStyle}>{t(`dialogs.pageSetup.${labelKey}`)}</label>
+      <input
+        type="number"
+        style={inputStyle}
+        min={0}
+        max={22}
+        step={0.1}
+        value={twipsToInches(value)}
+        onChange={(event) => set(Math.max(0, inchesToTwips(Number(event.target.value) || 0)))}
+        aria-label={t(`dialogs.pageSetup.${labelKey}`)}
+      />
+      <span style={unitStyle}>in</span>
+    </div>
+  );
+
+  return (
+    <div
+      className={className}
+      style={overlayStyle}
+      onClick={onClose}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose();
+        if (event.key === 'Enter') handleApply();
+      }}
+    >
+      <div
+        style={dialogStyle}
+        onClick={(event) => event.stopPropagation()}
+        // A mousedown that reaches the painted pages moves the caret; the inputs still
+        // need theirs, and stopping propagation (not preventing default) gives them that.
+        onMouseDown={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('dialogs.pageSetup.title')}
+      >
+        <div style={headerStyle}>{t('dialogs.pageSetup.title')}</div>
+
+        <div style={bodyStyle}>
+          <div style={sectionLabelStyle}>{t('dialogs.pageSetup.pageSize')}</div>
+
+          <div style={rowStyle}>
+            <label style={labelStyle}>{t('dialogs.pageSetup.sizeLabel')}</label>
+            <select
+              style={inputStyle}
+              value={sizeIndex}
+              onChange={(event) => handlePageSizeChange(Number(event.target.value))}
+              aria-label={t('dialogs.pageSetup.sizeLabel')}
+            >
+              {PAGE_SIZES.map((size, index) => (
+                <option key={size.labelKey} value={index}>
+                  {t(size.labelKey)}
+                </option>
+              ))}
+              {sizeIndex < 0 && <option value={-1}>{t('dialogs.pageSetup.custom')}</option>}
+            </select>
+          </div>
+
+          <div style={rowStyle}>
+            <label style={labelStyle}>{t('dialogs.pageSetup.orientation')}</label>
+            <select
+              style={inputStyle}
+              value={orientation}
+              onChange={(event) =>
+                handleOrientationChange(event.target.value as 'portrait' | 'landscape')
+              }
+              aria-label={t('dialogs.pageSetup.orientation')}
+            >
+              <option value="portrait">{t('dialogs.pageSetup.portrait')}</option>
+              <option value="landscape">{t('dialogs.pageSetup.landscape')}</option>
+            </select>
+          </div>
+
+          <div style={{ ...sectionLabelStyle, marginTop: 4 }}>{t('dialogs.pageSetup.margins')}</div>
+          {marginRow('top', marginTop, setMarginTop)}
+          {marginRow('bottom', marginBottom, setMarginBottom)}
+          {marginRow('left', marginLeft, setMarginLeft)}
+          {marginRow('right', marginRight, setMarginRight)}
+        </div>
+
+        <div style={footerStyle}>
+          <button type="button" style={btnStyle} onClick={onClose}>
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            style={{
+              ...btnStyle,
+              backgroundColor: 'var(--doc-primary)',
+              color: 'var(--doc-on-primary)',
+              borderColor: 'var(--doc-primary)',
+              opacity: isEnabled ? 1 : 0.5,
+            }}
+            disabled={!isEnabled}
+            onClick={handleApply}
+          >
+            {t('common.apply')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/editor/DocxEditorPageSetup.tsx
+++ b/packages/react/src/editor/DocxEditorPageSetup.tsx
@@ -172,6 +172,13 @@ export function DocxEditorPageSetupDialog({
       seeded.current = 'no';
       return;
     }
+    // A document unload while open (host called `load()`) drops the section to null:
+    // forget the seed so the NEXT document's section re-seeds instead of the old one
+    // being stamped over it.
+    if (seeded.current === 'yes' && pageSetup === null) {
+      seeded.current = 'no';
+      return;
+    }
     if (seeded.current === 'yes' || (seeded.current === 'loading' && pageSetup === null)) return;
     setPageWidth(pageSetup?.pageWidthTwips ?? DEFAULT_WIDTH);
     setPageHeight(pageSetup?.pageHeightTwips ?? DEFAULT_HEIGHT);

--- a/packages/react/src/editor/DocxEditorPageSetup.tsx
+++ b/packages/react/src/editor/DocxEditorPageSetup.tsx
@@ -5,7 +5,7 @@
 // `setPageSetup` command on Apply, so the whole dialog is a single undo step. The host
 // owns visibility (`open`/`onClose`); the engine owns everything else.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CSSProperties, ReactElement } from 'react';
 import { useTranslation } from '../i18n';
 import { usePageSetup } from './usePageSetup';
@@ -159,11 +159,20 @@ export function DocxEditorPageSetupDialog({
   const [marginBottom, setMarginBottom] = useState(DEFAULT_MARGIN);
   const [marginLeft, setMarginLeft] = useState(DEFAULT_MARGIN);
   const [marginRight, setMarginRight] = useState(DEFAULT_MARGIN);
+  const [scope, setScope] = useState<'document' | 'section'>('document');
+  const panelRef = useRef<HTMLDivElement | null>(null);
 
-  // Re-seed the form from the document each time the dialog OPENS — not on every
-  // section tick, or a concurrent edit would fight the user's typing.
+  // Seed the form from the document when the dialog OPENS — not on every section tick,
+  // or a concurrent edit would fight the user's typing. `'loading'` covers a dialog
+  // mounted open before the document finishes loading: the first non-null section
+  // re-seeds once, so Apply can never stamp placeholder defaults over a real document.
+  const seeded = useRef<'no' | 'loading' | 'yes'>('no');
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      seeded.current = 'no';
+      return;
+    }
+    if (seeded.current === 'yes' || (seeded.current === 'loading' && pageSetup === null)) return;
     setPageWidth(pageSetup?.pageWidthTwips ?? DEFAULT_WIDTH);
     setPageHeight(pageSetup?.pageHeightTwips ?? DEFAULT_HEIGHT);
     setOrientation(pageSetup?.orientation ?? 'portrait');
@@ -171,7 +180,13 @@ export function DocxEditorPageSetupDialog({
     setMarginBottom(pageSetup?.marginsTwips.bottom ?? DEFAULT_MARGIN);
     setMarginLeft(pageSetup?.marginsTwips.left ?? DEFAULT_MARGIN);
     setMarginRight(pageSetup?.marginsTwips.right ?? DEFAULT_MARGIN);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed on open only
+    setScope('document');
+    seeded.current = pageSetup === null ? 'loading' : 'yes';
+  }, [open, pageSetup]);
+
+  // Focus the panel on open so Escape works before any field is clicked.
+  useEffect(() => {
+    if (open) panelRef.current?.focus();
   }, [open]);
 
   const handlePageSizeChange = useCallback(
@@ -196,14 +211,17 @@ export function DocxEditorPageSetupDialog({
   );
 
   const handleApply = useCallback(() => {
+    // A refused write (margins that swallow the page) keeps the dialog OPEN: `apply`
+    // is honest about op-layer rejections, so closing here would claim success.
     const accepted = apply({
-      pageWidth,
-      pageHeight,
+      pageWidthTwips: pageWidth,
+      pageHeightTwips: pageHeight,
       orientation,
-      marginTop,
-      marginRight,
-      marginBottom,
-      marginLeft,
+      marginTopTwips: marginTop,
+      marginRightTwips: marginRight,
+      marginBottomTwips: marginBottom,
+      marginLeftTwips: marginLeft,
+      scope,
     });
     if (accepted) onClose();
   }, [
@@ -215,6 +233,7 @@ export function DocxEditorPageSetupDialog({
     marginRight,
     marginBottom,
     marginLeft,
+    scope,
     onClose,
   ]);
 
@@ -254,6 +273,8 @@ export function DocxEditorPageSetupDialog({
       }}
     >
       <div
+        ref={panelRef}
+        tabIndex={-1}
         style={dialogStyle}
         onClick={(event) => event.stopPropagation()}
         // A mousedown that reaches the painted pages moves the caret; the inputs still
@@ -305,6 +326,19 @@ export function DocxEditorPageSetupDialog({
           {marginRow('bottom', marginBottom, setMarginBottom)}
           {marginRow('left', marginLeft, setMarginLeft)}
           {marginRow('right', marginRight, setMarginRight)}
+
+          <div style={rowStyle}>
+            <label style={labelStyle}>{t('dialogs.pageSetup.applyTo')}</label>
+            <select
+              style={inputStyle}
+              value={scope}
+              onChange={(event) => setScope(event.target.value as 'document' | 'section')}
+              aria-label={t('dialogs.pageSetup.applyTo')}
+            >
+              <option value="document">{t('dialogs.pageSetup.applyToDocument')}</option>
+              <option value="section">{t('dialogs.pageSetup.applyToSection')}</option>
+            </select>
+          </div>
         </div>
 
         <div style={footerStyle}>

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -1,27 +1,24 @@
 // Context-fed ruler parts: `DocxEditor.HorizontalRuler` / `DocxEditor.VerticalRuler`.
 //
 // Thin wrappers over the props-driven `HorizontalRuler` / `VerticalRuler` components
-// (which stay exported unchanged): the wrappers read `Editor.getPageSetup()` and the
-// zoom REACTIVELY and feed them in. The subscription is the established pattern from
-// `useFontFamily`'s options read — select the version-cached snapshot ITSELF (a new
-// reference exactly when observable state moved) and re-derive the page setup keyed on
-// it — because page setup is document state (a load swaps it) and the snapshot's
-// identity is the one change signal for ALL document state.
+// (which stay exported unchanged): the wrappers read the page setup and zoom REACTIVELY
+// off the snapshot via `usePageSetup` and feed them in.
 //
-// READ-ONLY on purpose: the engine has no page-margin or paragraph-indent command yet,
-// so the wrappers pass no drag callbacks and `editable={false}`. Wiring a fake drag
-// would claim a capability the engine does not have; the props-driven components remain
-// available for hosts that bring their own persistence.
+// Margin drags are LIVE but commit ONCE: while a drag is in flight the wrapper previews
+// the pending margin locally (the gray zone follows the cursor), and only the release
+// writes through the engine's `setPageSetup` command — one transaction, one undo entry,
+// no relayout storm at mousemove frequency. Editability follows what the engine reports
+// (`usePageSetup().isEnabled`), so against a read-only document the handles stay inert.
 
-import { useMemo } from 'react';
+import { useCallback, useState } from 'react';
 import type { CSSProperties, ReactElement } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core-contract/contracts/editor';
 import { HorizontalRuler, type RulerPageSetup } from '../components/ui/HorizontalRuler';
 import { VerticalRuler } from '../components/ui/VerticalRuler';
-import { useDocxEditor } from './context';
 import { useEditorState } from './useEditorState';
+import { usePageSetup } from './usePageSetup';
 
-const selectSnapshot = (snapshot: EditorSnapshot) => snapshot;
+const selectZoom = (snapshot: EditorSnapshot): number => snapshot.zoom;
 
 /** Props for the context-fed ruler parts. @public */
 export interface DocxEditorRulerProps {
@@ -31,31 +28,65 @@ export interface DocxEditorRulerProps {
   style?: CSSProperties;
 }
 
-/** The current page setup and zoom, re-read when the snapshot's identity moves. */
-function usePageSetup(): { pageSetup: RulerPageSetup | null; zoom: number } {
-  const editor = useDocxEditor();
-  const snapshot = useEditorState(selectSnapshot);
-  const pageSetup = useMemo(
-    () => (editor && !snapshot.isLoading ? editor.getPageSetup() : null),
-    [editor, snapshot]
+type PendingMargins = Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>;
+
+/** The page setup with any in-flight drag preview folded in. */
+function previewed(
+  pageSetup: RulerPageSetup | null,
+  pending: PendingMargins
+): RulerPageSetup | null {
+  if (!pageSetup || Object.keys(pending).length === 0) return pageSetup;
+  return { ...pageSetup, marginsTwips: { ...pageSetup.marginsTwips, ...pending } };
+}
+
+function useMarginDrag(): {
+  pending: PendingMargins;
+  preview: (side: keyof PendingMargins) => (twips: number) => void;
+  commit: () => void;
+} {
+  const { apply } = usePageSetup();
+  const [pending, setPending] = useState<PendingMargins>({});
+  const preview = useCallback(
+    (side: keyof PendingMargins) => (twips: number) =>
+      setPending((current) => ({ ...current, [side]: Math.round(twips) })),
+    []
   );
-  return { pageSetup, zoom: snapshot.zoom };
+  const commit = useCallback(() => {
+    setPending((current) => {
+      if (Object.keys(current).length > 0) {
+        apply({
+          ...(current.top !== undefined ? { marginTop: current.top } : {}),
+          ...(current.right !== undefined ? { marginRight: current.right } : {}),
+          ...(current.bottom !== undefined ? { marginBottom: current.bottom } : {}),
+          ...(current.left !== undefined ? { marginLeft: current.left } : {}),
+        });
+      }
+      return {};
+    });
+  }, [apply]);
+  return { pending, preview, commit };
 }
 
 /**
  * The horizontal ruler as a context-fed part (`DocxEditor.HorizontalRuler`): page
- * width, margins and zoom straight from the editor. Read-only — margin and indent
- * dragging need engine commands that do not exist yet.
+ * width, margins and zoom straight from the editor. Left/right margin handles are
+ * draggable when the engine supports page-setup writes; the drag previews locally and
+ * commits one undoable step on release.
  *
  * @public
  */
 export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactElement {
-  const { pageSetup, zoom } = usePageSetup();
+  const { pageSetup, isEnabled } = usePageSetup();
+  const zoom = useEditorState(selectZoom);
+  const { pending, preview, commit } = useMarginDrag();
   return (
     <HorizontalRuler
-      pageSetup={pageSetup}
+      pageSetup={previewed(pageSetup, pending)}
       zoom={zoom}
-      editable={false}
+      editable={isEnabled}
+      onLeftMarginChange={preview('left')}
+      onRightMarginChange={preview('right')}
+      onMarginDragEnd={commit}
       unit={props.unit ?? 'inch'}
       className={props.className ?? ''}
       style={props.style}
@@ -65,17 +96,23 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
 
 /**
  * The vertical ruler as a context-fed part (`DocxEditor.VerticalRuler`): page height,
- * margins and zoom straight from the editor. Read-only, like the horizontal part.
+ * margins and zoom straight from the editor. Top/bottom margin handles are draggable
+ * when the engine supports page-setup writes, committing one undoable step on release.
  *
  * @public
  */
 export function DocxEditorVerticalRuler(props: DocxEditorRulerProps): ReactElement {
-  const { pageSetup, zoom } = usePageSetup();
+  const { pageSetup, isEnabled } = usePageSetup();
+  const zoom = useEditorState(selectZoom);
+  const { pending, preview, commit } = useMarginDrag();
   return (
     <VerticalRuler
-      pageSetup={pageSetup}
+      pageSetup={previewed(pageSetup, pending)}
       zoom={zoom}
-      editable={false}
+      editable={isEnabled}
+      onTopMarginChange={preview('top')}
+      onBottomMarginChange={preview('bottom')}
+      onMarginDragEnd={commit}
       unit={props.unit ?? 'inch'}
       className={props.className ?? ''}
       style={props.style}

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -10,7 +10,7 @@
 // no relayout storm at mousemove frequency. Editability follows what the engine reports
 // (`usePageSetup().isEnabled`), so against a read-only document the handles stay inert.
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { CSSProperties, ReactElement } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core-contract/contracts/editor';
 import { HorizontalRuler, type RulerPageSetup } from '../components/ui/HorizontalRuler';
@@ -46,22 +46,30 @@ function useMarginDrag(): {
 } {
   const { apply } = usePageSetup();
   const [pending, setPending] = useState<PendingMargins>({});
+  // The ref mirrors the state so `commit` can read the latest drag value WITHOUT doing
+  // work inside a setState updater — updaters must stay pure (StrictMode double-invokes
+  // them, which would commit two undo entries per drag).
+  const pendingRef = useRef<PendingMargins>({});
   const preview = useCallback(
-    (side: keyof PendingMargins) => (twips: number) =>
-      setPending((current) => ({ ...current, [side]: Math.round(twips) })),
+    (side: keyof PendingMargins) => (twips: number) => {
+      pendingRef.current = { ...pendingRef.current, [side]: Math.round(twips) };
+      setPending(pendingRef.current);
+    },
     []
   );
   const commit = useCallback(() => {
-    setPending((current) => {
-      if (Object.keys(current).length > 0) {
-        apply({
-          ...(current.top !== undefined ? { marginTop: current.top } : {}),
-          ...(current.right !== undefined ? { marginRight: current.right } : {}),
-          ...(current.bottom !== undefined ? { marginBottom: current.bottom } : {}),
-          ...(current.left !== undefined ? { marginLeft: current.left } : {}),
-        });
-      }
-      return {};
+    const current = pendingRef.current;
+    pendingRef.current = {};
+    setPending({});
+    if (Object.keys(current).length === 0) return;
+    // A ruler drag is Word's "this section" gesture: dragging the margin of a landscape
+    // section must not reshape the portrait sections around it.
+    apply({
+      ...(current.top !== undefined ? { marginTopTwips: current.top } : {}),
+      ...(current.right !== undefined ? { marginRightTwips: current.right } : {}),
+      ...(current.bottom !== undefined ? { marginBottomTwips: current.bottom } : {}),
+      ...(current.left !== undefined ? { marginLeftTwips: current.left } : {}),
+      scope: 'section',
     });
   }, [apply]);
   return { pending, preview, commit };

--- a/packages/react/src/editor/usePageSetup.ts
+++ b/packages/react/src/editor/usePageSetup.ts
@@ -3,20 +3,31 @@
 // dialog and any consumer chrome, so they can never disagree about the section.
 
 import { useCallback, useMemo } from 'react';
-import type {
-  EditorCommands,
-  EditorSnapshot,
-  PageSetup,
-} from '@docx-editor.dev/core-contract/contracts/editor';
+import type { EditorSnapshot, PageSetup } from '@docx-editor.dev/core-contract/contracts/editor';
 import { useDocxEditor } from './context';
 import { useEditorState } from './useEditorState';
 
-/** The fields `apply` accepts — the engine's `setPageSetup` payload, twips throughout. @public */
-export type PageSetupUpdate = EditorCommands['setPageSetup'];
+/**
+ * The fields `apply` accepts — twips throughout, like every read shape. Omitted fields
+ * are left as authored. `scope` is Word's "Apply to": `'document'` (the default) writes
+ * every section, `'section'` only the one the selection is in.
+ *
+ * @public
+ */
+export interface PageSetupUpdate {
+  readonly pageWidthTwips?: number;
+  readonly pageHeightTwips?: number;
+  readonly orientation?: 'portrait' | 'landscape';
+  readonly marginTopTwips?: number;
+  readonly marginRightTwips?: number;
+  readonly marginBottomTwips?: number;
+  readonly marginLeftTwips?: number;
+  readonly scope?: 'document' | 'section';
+}
 
 /** What `usePageSetup` returns. @public */
 export interface UsePageSetupReturn {
-  /** The section's page setup, or null while nothing is loaded. Reference-stable. */
+  /** The CARET section's page setup, or null while nothing is loaded. Reference-stable. */
   readonly pageSetup: PageSetup | null;
   /** Whether the engine can write page setup right now (mounted, editable). */
   readonly isEnabled: boolean;
@@ -31,7 +42,8 @@ const selectEditable = (snapshot: EditorSnapshot): boolean => snapshot.editable;
  * The section's page setup — size, orientation, margins — plus the command to change it.
  *
  * Reads `snapshot().pageSetup`, which is reference-stable across ticks that did not move
- * the section, so a subscriber re-renders only when the page actually changes shape.
+ * the section, so a subscriber re-renders only when the page actually changes shape. In
+ * a multi-section document it reflects the CARET's section, as Word's ruler does.
  *
  * @public
  */
@@ -50,7 +62,21 @@ export function usePageSetup(): UsePageSetupReturn {
   const apply = useCallback(
     (update: PageSetupUpdate): boolean => {
       if (!editor) return false;
-      const result = editor.exec({ type: 'setPageSetup', ...update });
+      // The literal `type` comes LAST so no runtime caller can override it through the
+      // update object.
+      const result = editor.exec({
+        ...(update.pageWidthTwips !== undefined ? { pageWidth: update.pageWidthTwips } : {}),
+        ...(update.pageHeightTwips !== undefined ? { pageHeight: update.pageHeightTwips } : {}),
+        ...(update.orientation !== undefined ? { orientation: update.orientation } : {}),
+        ...(update.marginTopTwips !== undefined ? { marginTop: update.marginTopTwips } : {}),
+        ...(update.marginRightTwips !== undefined ? { marginRight: update.marginRightTwips } : {}),
+        ...(update.marginBottomTwips !== undefined
+          ? { marginBottom: update.marginBottomTwips }
+          : {}),
+        ...(update.marginLeftTwips !== undefined ? { marginLeft: update.marginLeftTwips } : {}),
+        ...(update.scope !== undefined ? { scope: update.scope } : {}),
+        type: 'setPageSetup',
+      });
       return result.ok;
     },
     [editor]

--- a/packages/react/src/editor/usePageSetup.ts
+++ b/packages/react/src/editor/usePageSetup.ts
@@ -1,0 +1,60 @@
+// Page setup as a hook: the read side off the snapshot, the write side through the
+// engine's `setPageSetup` command. One derivation feeds the rulers, the Page Setup
+// dialog and any consumer chrome, so they can never disagree about the section.
+
+import { useCallback, useMemo } from 'react';
+import type {
+  EditorCommands,
+  EditorSnapshot,
+  PageSetup,
+} from '@docx-editor.dev/core-contract/contracts/editor';
+import { useDocxEditor } from './context';
+import { useEditorState } from './useEditorState';
+
+/** The fields `apply` accepts — the engine's `setPageSetup` payload, twips throughout. @public */
+export type PageSetupUpdate = EditorCommands['setPageSetup'];
+
+/** What `usePageSetup` returns. @public */
+export interface UsePageSetupReturn {
+  /** The section's page setup, or null while nothing is loaded. Reference-stable. */
+  readonly pageSetup: PageSetup | null;
+  /** Whether the engine can write page setup right now (mounted, editable). */
+  readonly isEnabled: boolean;
+  /** Write the given fields as one undoable step. Returns whether the engine accepted. */
+  readonly apply: (update: PageSetupUpdate) => boolean;
+}
+
+const selectPageSetup = (snapshot: EditorSnapshot): PageSetup | null => snapshot.pageSetup ?? null;
+const selectEditable = (snapshot: EditorSnapshot): boolean => snapshot.editable;
+
+/**
+ * The section's page setup — size, orientation, margins — plus the command to change it.
+ *
+ * Reads `snapshot().pageSetup`, which is reference-stable across ticks that did not move
+ * the section, so a subscriber re-renders only when the page actually changes shape.
+ *
+ * @public
+ */
+export function usePageSetup(): UsePageSetupReturn {
+  const editor = useDocxEditor();
+  const pageSetup = useEditorState(selectPageSetup);
+  const editable = useEditorState(selectEditable);
+
+  // `can` needs a representative payload (an empty command is refused); a zero top margin
+  // is always classifiable, so the answer reflects only the mount/mode gates.
+  const isEnabled = useMemo(
+    () => editable && editor !== null && editor.can({ type: 'setPageSetup', marginTop: 0 }).ok,
+    [editor, editable]
+  );
+
+  const apply = useCallback(
+    (update: PageSetupUpdate): boolean => {
+      if (!editor) return false;
+      const result = editor.exec({ type: 'setPageSetup', ...update });
+      return result.ok;
+    },
+    [editor]
+  );
+
+  return useMemo(() => ({ pageSetup, isEnabled, apply }), [pageSetup, isEnabled, apply]);
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -32,9 +32,14 @@ export {
   DocxEditorDocumentOutline,
   type DocxEditorDocumentOutlineProps,
 } from './editor/DocxEditorOutline';
+export {
+  DocxEditorPageSetupDialog,
+  type DocxEditorPageSetupDialogProps,
+} from './editor/DocxEditorPageSetup';
 export { useEditorState } from './editor/useEditorState';
 export { useEditorCommand, type EditorCommandState } from './editor/useEditorCommand';
 export { useEditorEvent } from './editor/useEditorEvent';
+export { usePageSetup, type PageSetupUpdate, type UsePageSetupReturn } from './editor/usePageSetup';
 
 // The compound toolbar (also reachable as `DocxEditor.Toolbar`): default set with
 // in-place slot overrides, generic Button, and the font-family compound + hook. The

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -119,6 +119,7 @@ export type {
   EditorQuery,
   EditorSnapshot,
   EditorScope,
+  PageSetup,
 } from '@docx-editor.dev/core-contract/contracts/editor';
 export type {
   DisplayPage,

--- a/packages/react/test/chrome-parts.test.tsx
+++ b/packages/react/test/chrome-parts.test.tsx
@@ -2,11 +2,12 @@
 // .DocumentOutline.
 //
 // Against the REAL engine, like toolbar-composition.test.tsx. What these pin down: the
-// ruler parts read `Editor.getPageSetup()` through the provider (page geometry in the
-// painted widths) and are READ-ONLY (no drag handles — the engine has no margin/indent
-// commands); the outline part lists `Editor.getOutline()`'s headings and a click moves
-// the CARET to the heading paragraph through the facade's semantic setSelection; and
-// the parts are reachable as namespace statics.
+// ruler parts read the page setup through the provider (page geometry in the painted
+// widths) and MARGIN DRAGS commit one undoable `setPageSetup` step on release (indent
+// handles stay absent — the indent-drag lane is not wired); the outline part lists
+// `Editor.getOutline()`'s headings and a click moves the CARET to the heading paragraph
+// through the facade's semantic setSelection; and the parts are reachable as namespace
+// statics.
 
 // MUST be first: happy-dom registration happens on import.
 import './dom-setup.ts';
@@ -15,7 +16,7 @@ import './dom-setup.ts';
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import type { ReactNode } from 'react';
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
 import type { DocxEditorInstance } from '@docx-editor.dev/core-contract/editor';
 import { DocxEditor } from '../src/components/DocxEditor.tsx';
@@ -113,8 +114,51 @@ describe('the context-fed ruler parts', () => {
     const ruler = view.container.querySelector('.docx-horizontal-ruler') as HTMLElement;
     expect(ruler).not.toBeNull();
     expect(ruler.style.width).toBe('816px');
-    // READ-ONLY: no indent drag handles, no margin-drag cursor affordance faked.
+    // Indent drag handles stay absent: the indent-drag lane is not wired.
     expect(view.container.querySelectorAll('.docx-ruler-indent').length).toBe(0);
+  });
+
+  test('dragging the left margin zone commits ONE setPageSetup step on release', async () => {
+    const { view, editor } = mountWith(<DocxEditorHorizontalRuler />, PLAIN_SOURCE);
+    const ruler = view.container.querySelector('.docx-horizontal-ruler') as HTMLElement;
+    // The left margin zone is the ruler's first child (the gray band).
+    const leftZone = ruler.firstElementChild as HTMLElement;
+    const before = editor().getDocumentHandle().revision;
+    await act(async () => {
+      fireEvent.mouseDown(leftZone, { clientX: 96 });
+    });
+    await act(async () => {
+      // happy-dom reports a zero rect, so clientX IS the ruler-local x: 48px → 720 twips.
+      fireEvent.mouseMove(document, { clientX: 64 });
+      fireEvent.mouseMove(document, { clientX: 48 });
+    });
+    // Nothing commits while the drag previews.
+    expect(editor().getDocumentHandle().revision).toBe(before);
+    await act(async () => {
+      fireEvent.mouseUp(document);
+    });
+    expect(editor().getPageSetup()!.marginsTwips.left).toBe(720);
+    // One transaction: a single undo restores the original margin.
+    await act(async () => {
+      editor().exec({ type: 'undo' });
+    });
+    expect(editor().getPageSetup()!.marginsTwips.left).toBe(1440);
+  });
+
+  test('dragging the top margin marker on the vertical ruler commits on release', async () => {
+    const { view, editor } = mountWith(<DocxEditorVerticalRuler />, PLAIN_SOURCE);
+    const marker = view.container.querySelector('.docx-ruler-marker-topMargin') as HTMLElement;
+    expect(marker).not.toBeNull();
+    await act(async () => {
+      fireEvent.mouseDown(marker, { clientY: 96 });
+    });
+    await act(async () => {
+      fireEvent.mouseMove(document, { clientY: 48 });
+    });
+    await act(async () => {
+      fireEvent.mouseUp(document);
+    });
+    expect(editor().getPageSetup()!.marginsTwips.top).toBe(720);
   });
 
   test('VerticalRuler paints the page height from Editor.getPageSetup()', () => {

--- a/packages/react/test/page-setup-dialog.test.tsx
+++ b/packages/react/test/page-setup-dialog.test.tsx
@@ -1,0 +1,148 @@
+// DocxEditor.PageSetupDialog against the REAL engine: the form seeds from the section,
+// Apply writes ONE setPageSetup command (single undo step), orientation swaps the
+// stored dimensions, and Cancel writes nothing.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { zipSync, strToU8 } from 'fflate';
+import type { DocxEditorInstance } from '@docx-editor.dev/core-contract/editor';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorPageSetupDialog } from '../src/editor/DocxEditorPageSetup.tsx';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const PLAIN_SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
+
+function mountDialog(onClose: () => void = () => {}): {
+  view: ReturnType<typeof render>;
+  editor: () => DocxEditorInstance;
+} {
+  let instance: DocxEditorInstance | null = null;
+  const view = render(
+    <DocxEditorRoot
+      document={PLAIN_SOURCE}
+      onReady={(editor) => {
+        instance = editor as DocxEditorInstance;
+      }}
+    >
+      <DocxEditorPageSetupDialog open onClose={onClose} />
+      <DocxEditorViewport>
+        <DocxEditorContent />
+      </DocxEditorViewport>
+    </DocxEditorRoot>
+  );
+  return { view, editor: () => instance! };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DocxEditor.PageSetupDialog', () => {
+  test('seeds from the section and applies the form as one undo step', async () => {
+    let closed = false;
+    const { view, editor } = mountDialog(() => {
+      closed = true;
+    });
+    const top = view.getByLabelText('Top') as HTMLInputElement;
+    // Seeded from the document: Letter defaults, one-inch margins.
+    expect(top.value).toBe('1');
+
+    await act(async () => {
+      fireEvent.change(top, { target: { value: '0.5' } });
+      fireEvent.change(view.getByLabelText('Left'), { target: { value: '0.75' } });
+    });
+    await act(async () => {
+      fireEvent.click(view.getByText('Apply'));
+    });
+
+    expect(closed).toBe(true);
+    expect(editor().getPageSetup()!.marginsTwips).toEqual({
+      top: 720,
+      right: 1440,
+      bottom: 1440,
+      left: 1080,
+    });
+    // ONE command: a single undo restores both margins.
+    await act(async () => {
+      editor().exec({ type: 'undo' });
+    });
+    expect(editor().getPageSetup()!.marginsTwips).toEqual({
+      top: 1440,
+      right: 1440,
+      bottom: 1440,
+      left: 1440,
+    });
+  });
+
+  test('switching orientation stores swapped dimensions', async () => {
+    const { view, editor } = mountDialog();
+    await act(async () => {
+      fireEvent.change(view.getByLabelText('Orientation'), { target: { value: 'landscape' } });
+    });
+    await act(async () => {
+      fireEvent.click(view.getByText('Apply'));
+    });
+    expect(editor().getPageSetup()).toMatchObject({
+      pageWidthTwips: 15840,
+      pageHeightTwips: 12240,
+      orientation: 'landscape',
+    });
+  });
+
+  test('a size preset applies its dimensions', async () => {
+    const { view, editor } = mountDialog();
+    await act(async () => {
+      // Index 1 is A4 in the preset list.
+      fireEvent.change(view.getByLabelText('Size'), { target: { value: '1' } });
+    });
+    await act(async () => {
+      fireEvent.click(view.getByText('Apply'));
+    });
+    expect(editor().getPageSetup()).toMatchObject({
+      pageWidthTwips: 11906,
+      pageHeightTwips: 16838,
+    });
+  });
+
+  test('Cancel writes nothing', async () => {
+    let closed = false;
+    const { view, editor } = mountDialog(() => {
+      closed = true;
+    });
+    const before = editor().getDocumentHandle().revision;
+    await act(async () => {
+      fireEvent.change(view.getByLabelText('Top'), { target: { value: '2' } });
+      fireEvent.click(view.getByText('Cancel'));
+    });
+    expect(closed).toBe(true);
+    expect(editor().getDocumentHandle().revision).toBe(before);
+  });
+});

--- a/packages/react/test/page-setup-dialog.test.tsx
+++ b/packages/react/test/page-setup-dialog.test.tsx
@@ -132,6 +132,66 @@ describe('DocxEditor.PageSetupDialog', () => {
     });
   });
 
+  test('a refused apply keeps the dialog OPEN instead of claiming success', async () => {
+    let closed = false;
+    const { view, editor } = mountDialog(() => {
+      closed = true;
+    });
+    const before = editor().getDocumentHandle().revision;
+    await act(async () => {
+      // Each margin is individually legal; together they swallow a Letter page.
+      fireEvent.change(view.getByLabelText('Left'), { target: { value: '8' } });
+      fireEvent.change(view.getByLabelText('Right'), { target: { value: '8' } });
+    });
+    await act(async () => {
+      fireEvent.click(view.getByText('Apply'));
+    });
+    expect(closed).toBe(false);
+    expect(editor().getDocumentHandle().revision).toBe(before);
+  });
+
+  test('Apply to: this section writes only the caret section', async () => {
+    const midBody = docx(
+      '<w:p><w:pPr><w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr></w:pPr>' +
+        '<w:r><w:t>first section</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>second section</w:t></w:r></w:p>' +
+        '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>'
+    );
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={midBody}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorPageSetupDialog open onClose={() => {}} />
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const editor = () => instance! as DocxEditorInstance;
+    // Caret sits in the FIRST section (the default selection starts at the top).
+    await act(async () => {
+      fireEvent.change(view.getByLabelText('Apply to'), { target: { value: 'section' } });
+      fireEvent.change(view.getByLabelText('Orientation'), { target: { value: 'landscape' } });
+    });
+    await act(async () => {
+      fireEvent.click(view.getByText('Apply'));
+    });
+    // The caret's section is landscape; the tail section stayed portrait.
+    expect(editor().getPageSetup()).toMatchObject({ orientation: 'landscape' });
+    const second = editor().surface!.session.paragraphIds()[1]!;
+    await act(async () => {
+      editor().surface!.setSelection({
+        anchor: { paragraphId: second, offset: 0 },
+        head: { paragraphId: second, offset: 0 },
+      });
+    });
+    expect(editor().getPageSetup()).toMatchObject({ orientation: 'portrait' });
+  });
+
   test('Cancel writes nothing', async () => {
     let closed = false;
     const { view, editor } = mountDialog(() => {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -52,6 +52,7 @@ export type {
   EditorQuery,
   EditorSnapshot,
   EditorScope,
+  PageSetup,
 } from '@docx-editor.dev/core-contract/contracts/editor';
 export type {
   DisplayPage,


### PR DESCRIPTION
Page Setup dialog (size, orientation, margins, Word's Apply-to scope), draggable ruler margins, a usePageSetup hook, and next-page section break insertion. Every section paginates against its own geometry, so mixed portrait/landscape documents render as Word shows them; reads and rulers follow the caret's section. Splitting a section-boundary paragraph now keeps one section mark, on the tail.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788164438&installation_model_id=422592&pr_number=81&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F81&signature=c5935866f9baf840461f43c111c457b0900f39112e11c481b6c9a913f3c551ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->