### PR TITLE
fix(demo): normal-weight header chrome, unblock the default build

### DIFF
--- a/examples/vite/src/styles.css
+++ b/examples/vite/src/styles.css
@@ -58,7 +58,7 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  padding: 8px 16px;
+  padding: 8px 16px 0;
 }
 
 .demo-header__left,
@@ -93,7 +93,7 @@
 
 .demo-title {
   font-size: 15px;
-  font-weight: 500;
+  font-weight: 400;
   color: var(--doc-text);
   background: transparent;
   border: 1px solid transparent;
@@ -127,7 +127,7 @@
   background: transparent;
   color: var(--doc-text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 400;
   padding: 5px 10px;
   border-radius: 6px;
   cursor: pointer;

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   "scripts": {
     "api:check": "node scripts/api-extractor.mjs",
     "api:extract": "node scripts/api-extractor.mjs --local",
-    "build": "bun run build:packages && bun run build:react && bun run build:vue && bun run build:assemble",
-    "build:assemble": "rm -rf examples/parity/dist && mkdir -p examples/parity/dist && cp -R examples/vite/dist examples/parity/dist/react && cp -R examples/vue/dist examples/parity/dist/vue && cp examples/parity/index.html examples/parity/dist/index.html",
+    "build": "bun run build:packages:demo && bun run build:react && bun run build:assemble",
+    "build:assemble": "rm -rf examples/parity/dist && mkdir -p examples/parity/dist && cp -R examples/vite/dist examples/parity/dist/react && cp examples/parity/index.html examples/parity/dist/index.html",
     "build:packages": "bun run --filter '@docx-editor.dev/i18n' build && bun run --filter '@docx-editor.dev/react' build && bun run --filter '@docx-editor.dev/agents' --filter '@docx-editor.dev/vue' build && bun run --filter '@docx-editor.dev/nuxt' build",
+    "build:packages:demo": "bun run --filter '@docx-editor.dev/i18n' build && bun run --filter '@docx-editor.dev/react' build",
     "build:react": "cd examples/vite && USE_PUBLISHED_PACKAGES=true VITE_BASE_PATH=/react/ vite build",
     "build:spike:poc": "cd packages/core/spike && bun run build:poc",
     "build:vue": "cd examples/vue && USE_PUBLISHED_PACKAGES=true VITE_BASE_PATH=/vue/ vite build",


### PR DESCRIPTION
Demo header: title and the File/Format/Insert/Help row were medium weight, now 400. Header padding-bottom is 0 so the only gap above the toolbar pill is the toolbar's own margin.

`bun run build` (the Vercel deploy command) now uses a new `build:packages:demo` — i18n + react only. `@docx-editor.dev/agents` does not compile on this branch: `src/bridge.ts` was deleted in 8cfe34ea9 but `server.ts`, `reviewerBridge.ts`, `useAgentChat.ts`, `useDocxAgentTools.ts`, and `wordCompat.ts` still import it. vue and nuxt drop out with it, so the deploy is React-only for now.

`build:packages` is deliberately unchanged: CI and `release.yml` still build every package's dist before publish, and they will keep failing on agents until `bridge.ts` is restored. The `/vue/` rewrite in `vercel.json` is left in place so restoring is a one-line revert; the framework switcher is off in the deploy build, so nothing links to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpkjiFWniMdJq9mQG68YB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788174286&installation_model_id=422592&pr_number=82&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F82&signature=d3e50696a35aa1c3f05c80bff1828f5917871d4055c60fc72023b61dea581553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->