### PR TITLE
fix: declare missing list levels on Increase Indent instead of disabling it

### DIFF
--- a/.changeset/indent-declares-missing-list-levels.md
+++ b/.changeset/indent-declares-missing-list-levels.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Increase Indent now works on any list item, even when the document's list definition stops at the current level. The missing level is declared with Word's default format for that depth — bullets cycle •, o, ▪ and numbered lists cycle decimal, letters, roman — instead of the control greying out. Decrease Indent restores the item's own authored level on the way back.

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -23,6 +23,7 @@ import {
   withPart,
   writeOoxmlPackage,
   ensureListDefinition,
+  ensureNumberingLevel,
   paragraphTextOf,
   type EmbeddedFont,
   type ListKind,
@@ -210,6 +211,15 @@ export interface TreeDocxSession {
    * definition of the same kind is reused rather than duplicated.
    */
   ensureListDefinition(kind: ListKind): string | null;
+  /**
+   * Declare `level` in the list definition `numId` names, with Word's default format for
+   * that depth, or answer false.
+   *
+   * Word never greys Increase Indent out on a list item: demoting past the deepest level
+   * a definition declares makes Word define the level, cycling its stock bullets and
+   * number formats. An already-declared level answers true without changing anything.
+   */
+  ensureNumberingLevel(numId: string, level: number, kind: ListKind): boolean;
 }
 
 export type { DocumentStyleEntry } from './document-catalog.ts';
@@ -568,6 +578,19 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
         numberingRootResolved = false;
         numberingRoot = null;
         return ensured.numId;
+      },
+
+      ensureNumberingLevel(numId, level, kind) {
+        // Same lane as `ensureListDefinition`: the numbering part lives on the PACKAGE,
+        // and the memoized numbering root must forget what it read before this write.
+        const ensured = ensureNumberingLevel(currentPackage(), numId, level, kind);
+        if (!ensured) return false;
+        if (ensured !== currentPackage()) {
+          pkg = ensured;
+          numberingRootResolved = false;
+          numberingRoot = null;
+        }
+        return true;
       },
     },
   };

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -218,6 +218,10 @@ export interface TreeDocxSession {
    * Word never greys Increase Indent out on a list item: demoting past the deepest level
    * a definition declares makes Word define the level, cycling its stock bullets and
    * number formats. An already-declared level answers true without changing anything.
+   *
+   * The declaration lives on the PACKAGE, outside the store's history — undoing the edit
+   * that needed it restores the paragraph but leaves the level declared, which is
+   * harmless: an unreferenced level renders nothing and Word writes files full of them.
    */
   ensureNumberingLevel(numId: string, level: number, kind: ListKind): boolean;
 }
@@ -583,9 +587,12 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
       ensureNumberingLevel(numId, level, kind) {
         // Same lane as `ensureListDefinition`: the numbering part lives on the PACKAGE,
         // and the memoized numbering root must forget what it read before this write.
-        const ensured = ensureNumberingLevel(currentPackage(), numId, level, kind);
+        // `currentPackage()` mints a fresh object per call, so the identity check must
+        // compare against the SAME instance the write was given.
+        const before = currentPackage();
+        const ensured = ensureNumberingLevel(before, numId, level, kind);
         if (!ensured) return false;
-        if (ensured !== currentPackage()) {
+        if (ensured !== before) {
           pkg = ensured;
           numberingRootResolved = false;
           numberingRoot = null;

--- a/packages/core/src/editor/__tests__/fixture-list-indent.test.ts
+++ b/packages/core/src/editor/__tests__/fixture-list-indent.test.ts
@@ -57,27 +57,35 @@ const caretIn = (surface: PaginatedSurface, paragraphId: string) =>
   });
 
 describe('a real document whose list declares only level 0', () => {
-  test('the bullet survives an indent, and the control says so first', () => {
+  test('indenting declares the level and the bullet cycles, as Word does', () => {
     withFixture((surface) => {
       const item = itemNamed(surface, 'First bullet item');
       expect(item.marker?.text).toBe('•');
       caretIn(surface, item.paragraphId);
 
-      expect(surface.canAdjustIndent('increase')).toBe(false);
-      expect(surface.adjustIndent('increase')).toBe(false);
+      expect(surface.canAdjustIndent('increase')).toBe(true);
+      expect(surface.adjustIndent('increase')).toBe(true);
+      // Depth 1 of Word's stock bullet cycle: Courier `o`.
+      expect(itemNamed(surface, 'First bullet item').marker).toMatchObject({
+        text: 'o',
+        level: 1,
+      });
+      // And back out to the item's own authored level.
+      expect(surface.adjustIndent('decrease')).toBe(true);
       expect(itemNamed(surface, 'First bullet item').marker?.text).toBe('•');
     });
   });
 
-  test('the roman numeral survives too', () => {
+  test('the roman numeral cycles through the number formats too', () => {
     withFixture((surface) => {
       const item = itemNamed(surface, 'Introduction');
       expect(item.marker?.text).toBe('I.');
       caretIn(surface, item.paragraphId);
 
-      expect(surface.canAdjustIndent('increase')).toBe(false);
-      expect(surface.adjustIndent('increase')).toBe(false);
-      expect(itemNamed(surface, 'Introduction').marker?.text).toBe('I.');
+      expect(surface.canAdjustIndent('increase')).toBe(true);
+      expect(surface.adjustIndent('increase')).toBe(true);
+      // Depth 1 of Word's default cycle is lowerLetter.
+      expect(itemNamed(surface, 'Introduction').marker?.text).toBe('a.');
     });
   });
 

--- a/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
+++ b/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
@@ -42,13 +42,26 @@ const NUMBERING =
   '<w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>' +
   '<w:num w:numId="3"><w:abstractNumId w:val="2"/></w:num></w:numbering>';
 
-function docx(body: string, withNumbering = false): Uint8Array {
+const STY = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+interface DocxParts {
+  /** Replaces the default NUMBERING body (the `w:numbering` children). */
+  numberingXml?: string;
+  /** Adds `/word/styles.xml` with these `w:styles` children. */
+  stylesXml?: string;
+}
+
+function docx(body: string, withNumbering = false, parts: DocxParts = {}): Uint8Array {
+  const withStyles = parts.stylesXml !== undefined;
   const files: Record<string, Uint8Array> = {
     '[Content_Types].xml': strToU8(
       `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
         '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
         (withNumbering
           ? '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>'
+          : '') +
+        (withStyles
+          ? '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>'
           : '') +
         '</Types>'
     ),
@@ -59,17 +72,29 @@ function docx(body: string, withNumbering = false): Uint8Array {
       `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
     ),
   };
+  const rels: string[] = [];
   if (withNumbering) {
-    files['word/numbering.xml'] = strToU8(NUMBERING);
+    files['word/numbering.xml'] = strToU8(
+      parts.numberingXml !== undefined
+        ? `<w:numbering xmlns:w="${W}">${parts.numberingXml}</w:numbering>`
+        : NUMBERING
+    );
+    rels.push(`<Relationship Id="rId9" Type="${NUM}" Target="numbering.xml"/>`);
+  }
+  if (withStyles) {
+    files['word/styles.xml'] = strToU8(`<w:styles xmlns:w="${W}">${parts.stylesXml}</w:styles>`);
+    rels.push(`<Relationship Id="rId8" Type="${STY}" Target="styles.xml"/>`);
+  }
+  if (rels.length > 0) {
     files['word/_rels/document.xml.rels'] = strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${NUM}" Target="numbering.xml"/></Relationships>`
+      `<Relationships xmlns="${REL}">${rels.join('')}</Relationships>`
     );
   }
   return zipSync(files);
 }
 
-function mount(body: string, withNumbering = false): PaginatedSurface {
-  return mountBytes(docx(body, withNumbering));
+function mount(body: string, withNumbering = false, parts: DocxParts = {}): PaginatedSurface {
+  return mountBytes(docx(body, withNumbering, parts));
 }
 
 function mountBytes(bytes: Uint8Array): PaginatedSurface {
@@ -307,11 +332,11 @@ describe('Bullets and Numbering', () => {
   });
 });
 
-describe('a list definition that declares only level 0', () => {
-  const shallow = (text: string, numId: string) =>
-    `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${numId}"/>` +
-    `</w:numPr></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const shallow = (text: string, numId: string) =>
+  `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${numId}"/>` +
+  `</w:numPr></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
+describe('a list definition that declares only level 0', () => {
   test('indenting DECLARES the missing level rather than erasing the bullet', () => {
     // numId 2 declares `ilvl 0` only. Demoting to a level it does not declare used to
     // resolve to no marker at all — and before that was guarded, the paragraph silently
@@ -358,6 +383,96 @@ describe('a list definition that declares only level 0', () => {
     expect(surface.canAdjustIndent('increase')).toBe(true);
     expect(surface.adjustIndent('increase')).toBe(true);
     expect(markerOf(surface)).toMatchObject({ text: '○', level: 1 });
+  });
+
+  test('nine levels is the ceiling: eight presses declare them all, the ninth refuses', () => {
+    const surface = mount(shallow('alpha', '2'), true);
+    for (let press = 1; press <= 8; press += 1) {
+      expect(surface.adjustIndent('increase')).toBe(true);
+      expect(markerOf(surface)?.level).toBe(press);
+    }
+    expect(surface.canAdjustIndent('increase')).toBe(false);
+    expect(surface.adjustIndent('increase')).toBe(false);
+    expect(markerOf(surface)?.level).toBe(8);
+    // And the whole ladder is still resolvable on the way back down.
+    for (let press = 7; press >= 0; press -= 1) {
+      expect(surface.adjustIndent('decrease')).toBe(true);
+      expect(markerOf(surface)?.level).toBe(press);
+    }
+  });
+
+  test('the declared ORDERED level survives a save and reopen too', () => {
+    const surface = mount(shallow('Introduction', '3'), true);
+    expect(surface.adjustIndent('increase')).toBe(true);
+    const reopened = mountBytes(surface.session.save());
+    expect(markerOf(reopened)).toMatchObject({ text: 'a.', level: 1 });
+  });
+});
+
+describe('numbering.xml that fights the graft', () => {
+  test('a foreign-namespace lvl cannot pass for a declaration', () => {
+    // The write path used to match `lvl` by local name alone while the layout index
+    // requires the WML namespace: `<x:lvl x:ilvl="1">` made "already declared" answer
+    // true, the level op committed, and the marker resolved to NOTHING — the exact
+    // destruction this feature exists to prevent.
+    const hostile =
+      '<w:abstractNum w:abstractNumId="1">' +
+      '<w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="§"/>' +
+      '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>' +
+      '<x:lvl x:ilvl="1" xmlns:x="urn:evil"/>' +
+      '</w:abstractNum>' +
+      '<w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>';
+    const surface = mount(shallow('alpha', '2'), true, { numberingXml: hostile });
+    expect(markerOf(surface)).toMatchObject({ text: '§', level: 0 });
+    expect(surface.adjustIndent('increase')).toBe(true);
+    expect(markerOf(surface)).toMatchObject({ text: 'o', level: 1 });
+  });
+});
+
+describe('a w:numStyleLink definition', () => {
+  // Word's built-in List Bullet shape: the abstract a paragraph names carries NO levels
+  // and delegates to a style, whose w:numPr names the num that owns the real levels.
+  const linked = (ownerLevels: string) =>
+    '<w:abstractNum w:abstractNumId="0"><w:numStyleLink w:val="ListBullet"/></w:abstractNum>' +
+    `<w:abstractNum w:abstractNumId="1"><w:styleLink w:val="ListBullet"/>${ownerLevels}</w:abstractNum>` +
+    '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>' +
+    '<w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>';
+  const LINKED_STYLES =
+    '<w:style w:type="paragraph" w:styleId="ListBullet"><w:name w:val="List Bullet"/>' +
+    '<w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr></w:style>';
+  const LEVEL_0 =
+    '<w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="•"/>' +
+    '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>';
+  const LEVEL_1 =
+    '<w:lvl w:ilvl="1"><w:numFmt w:val="bullet"/><w:lvlText w:val="○"/>' +
+    '<w:pPr><w:ind w:left="1440" w:hanging="360"/></w:pPr></w:lvl>';
+
+  test('a level the LINK declares indents without any graft', () => {
+    const surface = mount(shallow('alpha', '1'), true, {
+      numberingXml: linked(LEVEL_0 + LEVEL_1),
+      stylesXml: LINKED_STYLES,
+    });
+    expect(markerOf(surface)).toMatchObject({ text: '•', level: 0 });
+    expect(surface.canAdjustIndent('increase')).toBe(true);
+    expect(surface.adjustIndent('increase')).toBe(true);
+    // The LINKED level-1 glyph, not the engine's Courier `o` default — no level was
+    // grafted, the existing declaration resolved through the link.
+    expect(markerOf(surface)).toMatchObject({ text: '○', level: 1 });
+    expect(JSON.stringify(surface.session.part().root)).not.toContain('Courier New');
+  });
+
+  test('a level past the deepest LINKED one refuses rather than shadow-grafting', () => {
+    const surface = mount(shallow('alpha', '1'), true, {
+      numberingXml: linked(LEVEL_0),
+      stylesXml: LINKED_STYLES,
+    });
+    expect(markerOf(surface)).toMatchObject({ text: '•', level: 0 });
+    // A graft onto the delegating abstract would be shadowed by the link resolve, so the
+    // press is a safe no-op: nothing committed, nothing written, marker intact.
+    expect(surface.adjustIndent('increase')).toBe(false);
+    expect(markerOf(surface)).toMatchObject({ text: '•', level: 0 });
+    const reopened = mountBytes(surface.session.save());
+    expect(markerOf(reopened)).toMatchObject({ text: '•', level: 0 });
   });
 });
 

--- a/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
+++ b/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
@@ -9,7 +9,7 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
-import { zipSync, strToU8 } from 'fflate';
+import { zipSync, unzipSync, strToU8, strFromU8 } from 'fflate';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
 import { createKeyDownHandler } from '../surface-input.ts';
 
@@ -426,6 +426,27 @@ describe('numbering.xml that fights the graft', () => {
     expect(markerOf(surface)).toMatchObject({ text: '§', level: 0 });
     expect(surface.adjustIndent('increase')).toBe(true);
     expect(markerOf(surface)).toMatchObject({ text: 'o', level: 1 });
+  });
+
+  test('a graft never de-escapes a hostile authored value on save', () => {
+    // The part being edited carries an attacker string that WOULD be markup if it ever
+    // reached the file unescaped. The graft edits the same part; the save must re-escape
+    // the authored value exactly as it arrived.
+    const hostile =
+      '<w:abstractNum w:abstractNumId="1">' +
+      '<w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/>' +
+      '<w:lvlText w:val="&quot;/&gt;&lt;w:sectPr/&gt;&lt;w:lvl w:ilvl=&quot;1&quot;"/>' +
+      '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>' +
+      '</w:abstractNum>' +
+      '<w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>';
+    const surface = mount(shallow('alpha', '2'), true, { numberingXml: hostile });
+    expect(surface.adjustIndent('increase')).toBe(true);
+    const saved = strFromU8(unzipSync(surface.session.save())['word/numbering.xml']!);
+    // The payload is still character data, not markup …
+    expect(saved).not.toContain('/><w:sectPr/>');
+    expect(saved).toContain('&lt;w:sectPr/&gt;');
+    // … and the graft itself landed.
+    expect(saved).toContain('Courier New');
   });
 });
 

--- a/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
+++ b/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
@@ -312,32 +312,44 @@ describe('a list definition that declares only level 0', () => {
     `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${numId}"/>` +
     `</w:numPr></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
-  test('indenting refuses rather than erasing the bullet', () => {
-    // numId 2 declares `ilvl 0` only. Demoting to a level it does not declare resolved to
-    // no marker at all: the paragraph silently stopped being a list item and sprang back
-    // to the margin, taking its bullet with it.
+  test('indenting DECLARES the missing level rather than erasing the bullet', () => {
+    // numId 2 declares `ilvl 0` only. Demoting to a level it does not declare used to
+    // resolve to no marker at all — and before that was guarded, the paragraph silently
+    // stopped being a list item. Word never greys Increase Indent out here: it defines
+    // the level with its stock bullet for that depth, and so does this.
     const surface = mount(shallow('alpha', '2'), true);
     expect(markerOf(surface)).toMatchObject({ text: '§', level: 0 });
-    expect(surface.adjustIndent('increase')).toBe(false);
+    expect(surface.adjustIndent('increase')).toBe(true);
+    expect(markerOf(surface)).toMatchObject({ text: 'o', level: 1 });
+    // And back: the item's own level 0 still resolves to its authored glyph.
+    expect(surface.adjustIndent('decrease')).toBe(true);
     expect(markerOf(surface)).toMatchObject({ text: '§', level: 0 });
   });
 
-  test('the same holds for a numbered list', () => {
+  test("a numbered list gains Word's default format for the depth", () => {
     const surface = mount(shallow('Introduction', '3'), true);
     expect(markerOf(surface)?.text).toBe('I.');
-    expect(surface.adjustIndent('increase')).toBe(false);
-    expect(markerOf(surface)?.text).toBe('I.');
+    expect(surface.adjustIndent('increase')).toBe(true);
+    // Depth 1 of Word's default cycle is lowerLetter.
+    expect(markerOf(surface)?.text).toBe('a.');
   });
 
-  test('Tab does not destroy it either', () => {
+  test('the declared level survives a save and reopen', () => {
+    const surface = mount(shallow('alpha', '2'), true);
+    expect(surface.adjustIndent('increase')).toBe(true);
+    const reopened = mountBytes(surface.session.save());
+    expect(markerOf(reopened)).toMatchObject({ text: 'o', level: 1 });
+  });
+
+  test('Tab takes the same lane', () => {
     const surface = mount(shallow('alpha', '2'), true);
     createKeyDownHandler(surface)(key({ key: 'Tab' }));
-    expect(markerOf(surface)).toMatchObject({ text: '§', level: 0 });
+    expect(markerOf(surface)).toMatchObject({ text: 'o', level: 1 });
   });
 
-  test('the control reports itself disabled, so the toolbar can grey it out', () => {
+  test('the control stays enabled, greying out only at the ends of the range', () => {
     const surface = mount(shallow('alpha', '2'), true);
-    expect(surface.canAdjustIndent('increase')).toBe(false);
+    expect(surface.canAdjustIndent('increase')).toBe(true);
     expect(surface.canAdjustIndent('decrease')).toBe(false);
   });
 

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -122,8 +122,11 @@ export interface PaginatedSurface {
    *
    * A NUMBERED or BULLETED paragraph changes LEVEL: `w:numPr/w:ilvl` moves by one, which
    * re-resolves its marker from `numbering.xml` — so a bullet becomes a hollow circle, a
-   * `1.` becomes an `a.`, exactly as Word demotes a list item. Everything else moves its
-   * `w:ind/@left` by one default tab stop, never past the margin.
+   * `1.` becomes an `a.`, exactly as Word demotes a list item. A level the definition
+   * does not declare is DECLARED on the way, with Word's default format for that depth
+   * (its stock bullets and number formats cycle every three levels) — a definition that
+   * stops at `ilvl 0` never blocks the press. Everything else moves its `w:ind/@left` by
+   * one default tab stop, never past the margin.
    *
    * Answers whether anything changed, so a caller can fall back (Tab inserting a tab
    * where there is no list to demote).
@@ -132,9 +135,9 @@ export interface PaginatedSurface {
   /**
    * Whether Increase/Decrease Indent would do anything right now.
    *
-   * A list item at level 0 cannot outdent, and one whose definition declares no deeper
-   * level cannot indent — Word greys both out rather than letting the press silently
-   * destroy the marker.
+   * A list item at level 0 cannot outdent and one at level 8 cannot indent — `w:ilvl`
+   * has nine levels and Word greys the control out at the ends. A missing level
+   * DEFINITION never disables it: `adjustIndent` declares the level as it goes.
    */
   canAdjustIndent(direction: 'increase' | 'decrease'): boolean;
   /**

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -137,7 +137,10 @@ export interface PaginatedSurface {
    *
    * A list item at level 0 cannot outdent and one at level 8 cannot indent — `w:ilvl`
    * has nine levels and Word greys the control out at the ends. A missing level
-   * DEFINITION never disables it: `adjustIndent` declares the level as it goes.
+   * DEFINITION never disables it: `adjustIndent` declares the level as it goes. The one
+   * residue: a `w:numStyleLink` definition missing the level refuses the declaration
+   * (its levels belong to the linked style), so there the press is a safe no-op rather
+   * than a greyed control.
    */
   canAdjustIndent(direction: 'increase' | 'decrease'): boolean;
   /**

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -30,6 +30,7 @@ import {
   resolveNumberingLevel,
   moveCaret,
   paragraphTextFromLayout,
+  withNumberingStyleLinks,
   wordBoundary,
   type LayoutScope,
   type SemanticLayout,
@@ -198,8 +199,16 @@ export function mountPaginatedSurface(
     collapsedAt: (position) => collapsedAt(position),
     deleteSelectionOps: () => deleteSelectionOps(),
     paragraphTextOf: (paragraphId) => textOf(paragraphId),
+    // Resolved through `w:numStyleLink` the way LAYOUT resolves markers (§17.9.21):
+    // against the raw index a delegating definition has no levels of its own, so every
+    // level of Word's List Bullet / List Number styles read as missing and a plain
+    // `setListLevel` was refused where layout would have rendered the marker fine.
     numberingLevelExists: (numId, level) =>
-      resolveNumberingLevel(numberingIndex(), numId, level) !== null,
+      resolveNumberingLevel(
+        withNumberingStyleLinks(numberingIndex(), styleCascade),
+        numId,
+        level
+      ) !== null,
   });
   let desiredX: number | null = null;
 

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -179,11 +179,17 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
   function ensureListLevel(marker: ListMarkerRecord, level: number): boolean {
     if (level < 0 || level > MAX_LIST_LEVEL) return false;
     if (deps.numberingLevelExists(marker.numId, level)) return true;
-    return session.ensureNumberingLevel(
+    const declared = session.ensureNumberingLevel(
       marker.numId,
       level,
       marker.numFmt === 'bullet' ? 'bullet' : 'ordered'
     );
+    // The write path and the layout index are DIFFERENT readers of numbering.xml, and a
+    // hostile file can make them disagree — a foreign-namespace `lvl` satisfies a lax
+    // "already declared" while resolving to nothing. Only the index's answer decides
+    // whether `setListLevel` is safe: an ensure the index cannot see is a skip, not a
+    // commit that silently erases the marker.
+    return declared && deps.numberingLevelExists(marker.numId, level);
   }
 
   /** Authored `w:ind/@left` in twips, zero when the paragraph states none. */

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -155,17 +155,35 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
   }
 
   /**
-   * Whether a list paragraph could move to `level`.
+   * Whether a list paragraph could move to `level` WITHOUT touching `numbering.xml`.
    *
    * A `w:abstractNum` need not declare all nine levels — plenty of real documents declare
    * only `ilvl 0` — and a paragraph moved to a level its definition does not declare
    * resolves to no marker at all: it silently stops being a list item and springs back to
-   * the margin. Refusing the move keeps the list intact, which is what Word's greyed-out
-   * Increase Indent communicates.
+   * the margin. `adjustIndent` answers that by DECLARING the level first (Word's own move:
+   * its stock bullets and number formats cycle by depth); this check is for the paths that
+   * must not write, like Enter on an empty item deciding between outdent and exit.
    */
   function listLevelExists(marker: ListMarkerRecord, level: number): boolean {
     if (level < 0 || level > MAX_LIST_LEVEL) return false;
     return deps.numberingLevelExists(marker.numId, level);
+  }
+
+  /**
+   * Make `level` resolvable for `marker`'s definition, declaring it when missing.
+   *
+   * The declared format is Word's default for that depth. Refusal (a delegating
+   * `w:numStyleLink` definition, a vanished part) leaves the document untouched and the
+   * move skipped.
+   */
+  function ensureListLevel(marker: ListMarkerRecord, level: number): boolean {
+    if (level < 0 || level > MAX_LIST_LEVEL) return false;
+    if (deps.numberingLevelExists(marker.numId, level)) return true;
+    return session.ensureNumberingLevel(
+      marker.numId,
+      level,
+      marker.numFmt === 'bullet' ? 'bullet' : 'ordered'
+    );
   }
 
   /** Authored `w:ind/@left` in twips, zero when the paragraph states none. */
@@ -309,10 +327,15 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       if (firstIndex === -1 || lastIndex === -1) return false;
       const step = direction === 'increase' ? 1 : -1;
       // Enabled when ANY paragraph the selection touches could move. Word greys the
-      // control out only when nothing would happen at all.
+      // control out only when nothing would happen at all — and for a list item that is
+      // the ENDS of the level range, never a missing definition: a level `numbering.xml`
+      // does not declare gets declared on the way (see `ensureListLevel`).
       return order.slice(firstIndex, lastIndex + 1).some((paragraphId) => {
         const marker = markerOf(paragraphId);
-        if (marker) return listLevelExists(marker, marker.level + step);
+        if (marker) {
+          const next = marker.level + step;
+          return next >= 0 && next <= MAX_LIST_LEVEL;
+        }
         const current = leftIndentTwipsOf(paragraphPropertiesOf(currentLayout.value, paragraphId));
         return Math.max(0, current + step * INDENT_STEP_TWIPS) !== current;
       });
@@ -334,8 +357,13 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
           // A list item DEMOTES rather than shifting: `w:ilvl` is what picks the level's
           // format out of numbering.xml, so the marker changes with the indent the way
           // Word's Tab does. Nine levels exist (17.9.24); the ends are no-ops, not errors.
+          // A level the definition does not declare is DECLARED first — Word's own move,
+          // cycling its stock bullets and number formats by depth. The declaration lands
+          // outside the transaction, like `toggleList`'s `ensureListDefinition`: if the
+          // commit then fails, the extra level is unreferenced and harmless.
           const next = level + step;
-          if (!listLevelExists(marker, next)) continue;
+          if (next < 0 || next > MAX_LIST_LEVEL) continue;
+          if (!ensureListLevel(marker, next)) continue;
           ops.push({
             op: 'setListLevel',
             paragraphId,

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -252,6 +252,7 @@ export {
   readNumPr,
   resolveStoryListItems,
   walkStoryParagraphs,
+  withNumberingStyleLinks,
   withResolvedListItems,
   type ResolvedListItem,
 } from './list-resolve.ts';

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -175,4 +175,4 @@ export {
   type SemanticDigest,
   type StoryDigest,
 } from './ooxml-digest.ts';
-export { ensureListDefinition, type ListKind } from './numbering-part.ts';
+export { ensureListDefinition, ensureNumberingLevel, type ListKind } from './numbering-part.ts';

--- a/packages/core/src/store/package/numbering-part.ts
+++ b/packages/core/src/store/package/numbering-part.ts
@@ -264,6 +264,102 @@ export function ensureListDefinition(
   return { pkg: next, numId: String(numId) };
 }
 
+/**
+ * `CT_AbstractNum`'s child sequence (ECMA-376 17.9.1). ORDER IS LOAD-BEARING.
+ *
+ * `nsid?, multiLevelType?, tmpl?, name?, styleLink?, numStyleLink?, lvl*` is a strict
+ * `xsd:sequence`, so a grafted `w:lvl` must land after every header element. Among the
+ * `w:lvl` siblings themselves the schema imposes no order, but Word writes them by `ilvl`
+ * and this keeps that shape.
+ */
+const CT_ABSTRACT_NUM_SEQUENCE = [
+  'nsid',
+  'multiLevelType',
+  'tmpl',
+  'name',
+  'styleLink',
+  'numStyleLink',
+  'lvl',
+];
+
+/** Where a new `w:lvl` of `ilvl` belongs among an abstractNum's children. */
+function levelInsertIndex(children: readonly OoxmlNode[], ilvl: number): number {
+  let at = 0;
+  children.forEach((child, index) => {
+    if (child.kind === 'textValue') return;
+    if (child.localName === 'lvl') {
+      const raw = attribute(child as OoxmlElement, 'ilvl');
+      const existing = raw !== undefined && /^\d$/.test(raw) ? Number(raw) : 0;
+      if (existing < ilvl) at = index + 1;
+      return;
+    }
+    if (CT_ABSTRACT_NUM_SEQUENCE.includes(child.localName)) at = index + 1;
+  });
+  return at;
+}
+
+/**
+ * Declare `level` in the definition `numId` names, with Word's default format for that
+ * level, or refuse.
+ *
+ * Word never greys Increase Indent out on a list item: demoting past the deepest level a
+ * `w:abstractNum` declares makes Word DEFINE the level, cycling its stock bullets
+ * (Symbol •, Courier `o`, Wingdings ▪) or number formats (decimal, lowerLetter,
+ * lowerRoman) by depth. This is that write. An already-declared level returns the package
+ * unchanged, so callers may ask first and act second without a second lookup.
+ *
+ * A delegating definition (`w:numStyleLink`, 17.9.21) is refused: its levels live on the
+ * linked style's definition, and a `w:lvl` grafted here would be shadowed the moment the
+ * link resolves.
+ */
+export function ensureNumberingLevel(
+  pkg: OoxmlPackage,
+  numId: string,
+  level: number,
+  kind: ListKind
+): OoxmlPackage | null {
+  if (!Number.isInteger(level) || level < 0 || level >= LEVEL_COUNT) return null;
+  const numbering = pkg.parts.get(NUMBERING_PART);
+  if (!numbering) return null;
+  const root = numbering.root;
+
+  const num = childrenNamed(root, 'num').find((node) => attribute(node, 'numId') === numId);
+  const abstractRef = num ? childrenNamed(num, 'abstractNumId')[0] : undefined;
+  const abstractId = abstractRef ? attribute(abstractRef, 'val') : undefined;
+  if (!abstractId) return null;
+  const abstract = childrenNamed(root, 'abstractNum').find(
+    (node) => attribute(node, 'abstractNumId') === abstractId
+  );
+  if (!abstract) return null;
+  if (childrenNamed(abstract, 'numStyleLink').length > 0) return null;
+
+  const declared = childrenNamed(abstract, 'lvl').some(
+    (node) => attribute(node, 'ilvl') === String(level)
+  );
+  if (declared) return pkg;
+
+  const authored = readOoxmlPart(
+    `<w:numbering xmlns:w="${W}">${levelXml(kind, level)}</w:numbering>`,
+    { name: NUMBERING_PART, contentType: NUMBERING_CONTENT_TYPE }
+  );
+  if (!authored.ok) return null;
+  const node = authored.part.root.children[0];
+  if (!node) return null;
+  const nextId = createNodeIdAllocator(numbering);
+  const inserted = insertChildren(
+    numbering,
+    abstract.id,
+    levelInsertIndex(abstract.children, level),
+    [withFreshIds(node, nextId)]
+  );
+  if (!inserted.ok) return null;
+
+  return Object.freeze({
+    ...pkg,
+    parts: new Map([...pkg.parts, [NUMBERING_PART, inserted.part]]),
+  });
+}
+
 /** Re-key a grafted subtree so it cannot collide with the part it is joining. */
 function withFreshIds(node: OoxmlNode, nextId: () => string): OoxmlNode {
   if (node.kind === 'textValue') return { ...node, id: nextId() } as OoxmlNode;

--- a/packages/core/src/store/package/numbering-part.ts
+++ b/packages/core/src/store/package/numbering-part.ts
@@ -71,23 +71,26 @@ function levelXml(kind: ListKind, ilvl: number): string {
   // 0.25" per level, with the marker in a 0.25" hanging slot — Word's own list geometry.
   const left = 720 * (ilvl + 1);
   const start = '<w:start w:val="1"/>';
-  // Everything from `w:lvlJc` on: the tail of the sequence, shared by both kinds.
-  const tail =
-    `<w:lvlJc w:val="left"/>` + `<w:pPr><w:ind w:left="${left}" w:hanging="360"/></w:pPr>`;
   if (kind === 'bullet') {
     const bullet = BULLETS[ilvl % BULLETS.length]!;
     return (
       `<w:lvl w:ilvl="${ilvl}">${start}<w:numFmt w:val="bullet"/>` +
-      `<w:lvlText w:val="${bullet.text}"/>${tail}` +
+      `<w:lvlText w:val="${bullet.text}"/><w:lvlJc w:val="left"/>` +
+      `<w:pPr><w:ind w:left="${left}" w:hanging="360"/></w:pPr>` +
       `<w:rPr><w:rFonts w:ascii="${bullet.font}" w:hAnsi="${bullet.font}" w:hint="default"/></w:rPr>` +
       '</w:lvl>'
     );
   }
   const format = NUMBER_FORMATS[ilvl % NUMBER_FORMATS.length]!;
+  // Word's stock template right-aligns its roman levels in a narrower 180-twip hanging
+  // slot (a "viii." grows leftward from the marker edge); the other formats are
+  // left-aligned in the ordinary 360-twip slot.
+  const roman = format === 'lowerRoman';
   // `%N` is the placeholder for level N+1's counter; each level shows only its own.
   return (
     `<w:lvl w:ilvl="${ilvl}">${start}<w:numFmt w:val="${format}"/>` +
-    `<w:lvlText w:val="%${ilvl + 1}."/>${tail}</w:lvl>`
+    `<w:lvlText w:val="%${ilvl + 1}."/><w:lvlJc w:val="${roman ? 'right' : 'left'}"/>` +
+    `<w:pPr><w:ind w:left="${left}" w:hanging="${roman ? 180 : 360}"/></w:pPr></w:lvl>`
   );
 }
 
@@ -113,6 +116,11 @@ const childrenNamed = (node: OoxmlElement, localName: string): OoxmlElement[] =>
   const found: OoxmlElement[] = [];
   for (const child of node.children) {
     if (child.kind === 'textValue' || child.localName !== localName) continue;
+    // Namespace-checked like the layout index's reader: these bytes come out of an
+    // attacker-supplied `.docx`, and a foreign-namespace `<x:lvl>` matched by local name
+    // alone made this module and layout disagree about what is declared — the write path
+    // "saw" a level the index resolves to nothing.
+    if (child.namespaceUri !== W) continue;
     found.push(child as OoxmlElement);
   }
   return found;
@@ -282,15 +290,24 @@ const CT_ABSTRACT_NUM_SEQUENCE = [
   'lvl',
 ];
 
+/**
+ * A `w:ilvl` attribute parsed with the SAME rule the layout index uses (`integerAttr`), so
+ * "declared" here can never mean something the index refuses to resolve. Null for absent,
+ * non-decimal, or lenient spellings the index rejects (`+1`, `1e0`).
+ */
+function parsedIlvl(node: OoxmlElement): number | null {
+  const raw = attribute(node, 'ilvl');
+  if (raw === undefined || !/^\d{1,9}$/.test(raw)) return null;
+  return Number(raw);
+}
+
 /** Where a new `w:lvl` of `ilvl` belongs among an abstractNum's children. */
 function levelInsertIndex(children: readonly OoxmlNode[], ilvl: number): number {
   let at = 0;
   children.forEach((child, index) => {
     if (child.kind === 'textValue') return;
-    if (child.localName === 'lvl') {
-      const raw = attribute(child as OoxmlElement, 'ilvl');
-      const existing = raw !== undefined && /^\d$/.test(raw) ? Number(raw) : 0;
-      if (existing < ilvl) at = index + 1;
+    if (child.localName === 'lvl' && (child as OoxmlElement).namespaceUri === W) {
+      if ((parsedIlvl(child as OoxmlElement) ?? 0) < ilvl) at = index + 1;
       return;
     }
     if (CT_ABSTRACT_NUM_SEQUENCE.includes(child.localName)) at = index + 1;
@@ -333,10 +350,12 @@ export function ensureNumberingLevel(
   if (!abstract) return null;
   if (childrenNamed(abstract, 'numStyleLink').length > 0) return null;
 
-  const declared = childrenNamed(abstract, 'lvl').some(
-    (node) => attribute(node, 'ilvl') === String(level)
-  );
-  if (declared) return pkg;
+  const levels = childrenNamed(abstract, 'lvl');
+  if (levels.some((node) => parsedIlvl(node) === level)) return pkg;
+  // `CT_AbstractNum` caps `lvl` at nine (17.9.1). An abstract already at the cap whose
+  // levels do not include this one is authored junk (duplicate ilvls); a tenth would make
+  // the part schema-invalid, which Word repairs by dropping it.
+  if (levels.length >= LEVEL_COUNT) return null;
 
   const authored = readOoxmlPart(
     `<w:numbering xmlns:w="${W}">${levelXml(kind, level)}</w:numbering>`,

--- a/packages/core/src/store/package/numbering-part.ts
+++ b/packages/core/src/store/package/numbering-part.ts
@@ -129,6 +129,50 @@ const childrenNamed = (node: OoxmlElement, localName: string): OoxmlElement[] =>
 const attribute = (node: OoxmlElement, localName: string): string | undefined =>
   node.attributes.find((entry) => entry.localName === localName)?.value;
 
+/** What one grafted element must look like, verified AFTER the authored XML is parsed. */
+interface AuthoredShape {
+  readonly localName: string;
+  /** An attribute whose value must match exactly, pinning the element to its id. */
+  readonly attribute?: { readonly localName: string; readonly value: string };
+}
+
+/**
+ * Parse engine-authored numbering XML and verify it is EXACTLY the elements the template
+ * meant to produce — same philosophy as `withNumberingContentType`'s post-condition.
+ *
+ * The templates above interpolate only validated integers and engine constants, so this
+ * can never fire today; it exists so a future edit that lets anything else into an
+ * interpolation grafts NOTHING instead of grafting a surprise. Returns the elements in
+ * shape order, or null when the parse or the shape check refuses.
+ */
+function authoredElements(
+  xml: string,
+  shapes: readonly AuthoredShape[]
+): readonly OoxmlElement[] | null {
+  const read = readOoxmlPart(`<w:numbering xmlns:w="${W}">${xml}</w:numbering>`, {
+    name: NUMBERING_PART,
+    contentType: NUMBERING_CONTENT_TYPE,
+  });
+  if (!read.ok) return null;
+  const elements: OoxmlElement[] = [];
+  for (const node of read.part.root.children) {
+    if (node.kind !== 'textValue') elements.push(node as OoxmlElement);
+  }
+  if (elements.length !== shapes.length) return null;
+  for (let index = 0; index < shapes.length; index += 1) {
+    const element = elements[index]!;
+    const shape = shapes[index]!;
+    if (element.namespaceUri !== W || element.localName !== shape.localName) return null;
+    if (
+      shape.attribute &&
+      attribute(element, shape.attribute.localName) !== shape.attribute.value
+    ) {
+      return null;
+    }
+  }
+  return elements;
+}
+
 /**
  * `CT_Numbering`'s child sequence (ECMA-376 17.9.16). ORDER IS LOAD-BEARING.
  *
@@ -222,21 +266,24 @@ export function ensureListDefinition(
 
   const abstractNumId = nextFreeId(abstractNums, 'abstractNumId');
   const numId = nextFreeId(nums, 'numId');
-  // The new definitions are authored as their own document, then GRAFTED under fresh ids.
-  // `w:abstractNum` must precede every `w:num` (17.9.1), and Word's reader is strict about
-  // it, so the two groups are inserted at their own boundaries rather than appended.
-  const authored = readOoxmlPart(
-    `<w:numbering xmlns:w="${W}">` +
-      abstractNumXml(kind, abstractNumId) +
-      `<w:num w:numId="${numId}"><w:abstractNumId w:val="${abstractNumId}"/></w:num>` +
-      '</w:numbering>',
-    { name: NUMBERING_PART, contentType: NUMBERING_CONTENT_TYPE }
+  // The new definitions are authored as their own document, shape-verified, then GRAFTED
+  // under fresh ids. `w:abstractNum` must precede every `w:num` (17.9.1), and Word's
+  // reader is strict about it, so the two groups are inserted at their own boundaries
+  // rather than appended.
+  const authored = authoredElements(
+    abstractNumXml(kind, abstractNumId) +
+      `<w:num w:numId="${numId}"><w:abstractNumId w:val="${abstractNumId}"/></w:num>`,
+    [
+      {
+        localName: 'abstractNum',
+        attribute: { localName: 'abstractNumId', value: String(abstractNumId) },
+      },
+      { localName: 'num', attribute: { localName: 'numId', value: String(numId) } },
+    ]
   );
-  if (!authored.ok) return null;
+  if (!authored) return null;
   const nextId = createNodeIdAllocator(numbering);
-  const [newAbstract, newNum] = authored.part.root.children.map((node) =>
-    withFreshIds(node, nextId)
-  );
+  const [newAbstract, newNum] = authored.map((node) => withFreshIds(node, nextId));
   if (!newAbstract || !newNum) return null;
 
   // Each lands at its CT_NUMBERING_SEQUENCE slot — see `sequenceInsertIndex`. `w:num` is
@@ -336,6 +383,10 @@ export function ensureNumberingLevel(
   kind: ListKind
 ): OoxmlPackage | null {
   if (!Number.isInteger(level) || level < 0 || level >= LEVEL_COUNT) return null;
+  // `numId` is FILE-DERIVED (a paragraph's `w:numPr`), used here only as a comparison
+  // key — bounded like the layout index bounds ids, so a pathological id cannot make the
+  // lookups below churn through megabyte string comparisons.
+  if (numId.length === 0 || numId.length > 64) return null;
   const numbering = pkg.parts.get(NUMBERING_PART);
   if (!numbering) return null;
   const root = numbering.root;
@@ -357,19 +408,16 @@ export function ensureNumberingLevel(
   // the part schema-invalid, which Word repairs by dropping it.
   if (levels.length >= LEVEL_COUNT) return null;
 
-  const authored = readOoxmlPart(
-    `<w:numbering xmlns:w="${W}">${levelXml(kind, level)}</w:numbering>`,
-    { name: NUMBERING_PART, contentType: NUMBERING_CONTENT_TYPE }
-  );
-  if (!authored.ok) return null;
-  const node = authored.part.root.children[0];
-  if (!node) return null;
+  const authored = authoredElements(levelXml(kind, level), [
+    { localName: 'lvl', attribute: { localName: 'ilvl', value: String(level) } },
+  ]);
+  if (!authored) return null;
   const nextId = createNodeIdAllocator(numbering);
   const inserted = insertChildren(
     numbering,
     abstract.id,
     levelInsertIndex(abstract.children, level),
-    [withFreshIds(node, nextId)]
+    [withFreshIds(authored[0]!, nextId)]
   );
   if (!inserted.ok) return null;
 


### PR DESCRIPTION
Increase Indent was greyed out on any list whose `w:abstractNum` stops at the current level — the shape a great many real documents have (a bullet list declaring only `ilvl 0`). Word never disables the control there: it defines the level with its default format for that depth.

`adjustIndent` now grafts the missing `w:lvl` into the definition before `setListLevel` — bullets cycle Symbol •, Courier `o`, Wingdings ▪ and numbered lists cycle decimal/lowerLetter/lowerRoman — and `canAdjustIndent` gates only on the 0..8 `ilvl` range. Delegating definitions (`w:numStyleLink`) are refused rather than shadow-edited. The declared level round-trips through save/reopen.

Note: the pre-existing `check:public-docs-surface` failure (React plugin surface, `createTemplatePlugin` et al.) is unrelated and still fails on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788281131&installation_model_id=422592&pr_number=86&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F86&signature=d2e89d5dd3fbf671897c21d30da77f46144824ce5b89d547070ca7f43040e37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->