### PR TITLE
feat(core): w14:paraId paragraph identity, end to end

### DIFF
--- a/.changeset/paragraph-identity-paraid.md
+++ b/.changeset/paragraph-identity-paraid.md
@@ -1,0 +1,7 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+Every paragraph now carries Word's stable identity, `w14:paraId` — the same value Office JS exposes as `uniqueLocalId`. Documents that already have ids keep them byte-for-byte; documents without get valid ids on open, the way Word assigns them on save. Pressing Enter keeps the original paragraph's id and gives the new paragraph a fresh one, joins keep the survivor's, and undo restores exactly what was there — so comment threads and tracked changes anchored to a paragraph survive editing.
+
+The editor now answers in that vocabulary: `snapshot().selection` reports the selected paragraphs as a `DocRange` of paraId anchors, the `paragraphs` query lists every editable paragraph with its `paraId`, text and style, and `setSelection` accepts paraId anchors — including a `search` phrase that must match exactly once (or an explicit `occurrence`) to place the caret or select a span inside a paragraph.

--- a/.changeset/react-browser-bundle.md
+++ b/.changeset/react-browser-bundle.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+The published React bundle no longer crashes browsers on load. The build resolved a bundled dependency through its Node entry, which called `createRequire` at module top level — fatal in any browser without Node shims. The bundle now targets the browser platform; the CommonJS output still loads in Node for SSR.

--- a/packages/core/src/binding/__tests__/paragraph-anchors.test.ts
+++ b/packages/core/src/binding/__tests__/paragraph-anchors.test.ts
@@ -1,0 +1,74 @@
+// The paraId ↔ node-id index (paragraph-anchors.ts): built over the editable set,
+// verbatim values out, case-insensitive lookups in, reading-order ordinals.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import { buildParagraphAnchorIndex } from '../paragraph-anchors.ts';
+import { allParagraphs } from '../tree-binding.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+describe('buildParagraphAnchorIndex', () => {
+  test('covers body, table-cell and block-SDT paragraphs with reading-order ordinals', () => {
+    const part = load(
+      '<w:p w14:paraId="4C000001"><w:r><w:t>one</w:t></w:r></w:p>' +
+        '<w:tbl><w:tr><w:tc><w:p w14:paraId="4C000002"><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>' +
+        '<w:sdt><w:sdtContent><w:p w14:paraId="4C000003"><w:r><w:t>sdt</w:t></w:r></w:p></w:sdtContent></w:sdt>' +
+        '<w:p w14:paraId="4C000004"><w:r><w:t>last</w:t></w:r></w:p>'
+    );
+    const index = buildParagraphAnchorIndex(part);
+    const ids = allParagraphs(part).map((paragraph) => paragraph.id);
+    expect(ids).toHaveLength(4);
+    ids.forEach((nodeId, ordinal) => {
+      expect(index.ordinalByNode.get(nodeId)).toBe(ordinal);
+    });
+    expect(ids.map((nodeId) => index.paraIdByNode.get(nodeId))).toEqual([
+      '4C000001',
+      '4C000002',
+      '4C000003',
+      '4C000004',
+    ]);
+    expect(index.nodeByParaId.get('4C000002')).toBe(ids[1]!);
+  });
+
+  test('values stay verbatim; lookup keys are uppercased', () => {
+    const part = load('<w:p w14:paraId="4c00aa0e"><w:r><w:t>x</w:t></w:r></w:p>');
+    const index = buildParagraphAnchorIndex(part);
+    const [nodeId] = allParagraphs(part).map((paragraph) => paragraph.id);
+    expect(index.paraIdByNode.get(nodeId!)).toBe('4c00aa0e');
+    expect(index.nodeByParaId.get('4C00AA0E')).toBe(nodeId!);
+    expect(index.nodeByParaId.has('4c00aa0e')).toBe(false);
+  });
+
+  test('duplicates: first occurrence wins the reverse map, both keep forward entries', () => {
+    const part = load(
+      '<w:p w14:paraId="4C000001"><w:r><w:t>a</w:t></w:r></w:p>' +
+        '<w:p w14:paraId="4C000001"><w:r><w:t>b</w:t></w:r></w:p>'
+    );
+    const index = buildParagraphAnchorIndex(part);
+    const [first, second] = allParagraphs(part).map((paragraph) => paragraph.id);
+    expect(index.nodeByParaId.get('4C000001')).toBe(first!);
+    expect(index.paraIdByNode.get(second!)).toBe('4C000001');
+  });
+
+  test('a paragraph without a paraId keeps its ordinal but is absent from the id maps', () => {
+    const part = load(
+      '<w:p><w:r><w:t>bare</w:t></w:r></w:p><w:p w14:paraId="4C000001"><w:r><w:t>x</w:t></w:r></w:p>'
+    );
+    const index = buildParagraphAnchorIndex(part);
+    const [bare, identified] = allParagraphs(part).map((paragraph) => paragraph.id);
+    expect(index.ordinalByNode.get(bare!)).toBe(0);
+    expect(index.paraIdByNode.has(bare!)).toBe(false);
+    expect(index.paraIdByNode.get(identified!)).toBe('4C000001');
+  });
+});

--- a/packages/core/src/binding/__tests__/tree-session.test.ts
+++ b/packages/core/src/binding/__tests__/tree-session.test.ts
@@ -210,3 +210,91 @@ describe('session surface over the tree', () => {
     expect(after.child(1).textContent).toBe('two!');
   });
 });
+
+describe('w14 paragraph identity through the session', () => {
+  test('open establishes a valid unique paraId on every editable paragraph', () => {
+    // The harness declares only xmlns:w — every id here is minted at open, along with
+    // the root binding the minted attributes need.
+    const session = open(
+      docx(
+        '<w:p><w:r><w:t>one</w:t></w:r></w:p>' +
+          '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>' +
+          '<w:p><w:r><w:t>two</w:t></w:r></w:p>'
+      )
+    );
+    const anchors = session.paragraphAnchors();
+    const ids = session.paragraphIds();
+    expect(ids).toHaveLength(3);
+    for (const id of ids) {
+      const paraId = session.paraIdOf(id);
+      expect(paraId).toMatch(/^[0-9A-F]{8}$/);
+      expect(session.nodeIdOf(paraId!)).toBe(id);
+      expect(session.nodeIdOf(paraId!.toLowerCase())).toBe(id);
+    }
+    expect(new Set(anchors.nodeByParaId.keys()).size).toBe(3);
+  });
+
+  test('save/reopen preserves each paragraph text→paraId pairing', () => {
+    const session = open(
+      docx('<w:p><w:r><w:t>alpha</w:t></w:r></w:p><w:p><w:r><w:t>beta</w:t></w:r></w:p>')
+    );
+    const pairing = session.paragraphIds().map((id) => session.paraIdOf(id));
+    const reopened = open(session.save());
+    expect(reopened.paragraphIds().map((id) => reopened.paraIdOf(id))).toEqual(pairing);
+  });
+
+  test('a projection-lane split mints a fresh id for the new paragraph', () => {
+    const session = open(docx('<w:p><w:r><w:t>headtail</w:t></w:r></w:p>'));
+    const [id] = session.paragraphIds();
+    const before = session.paraIdOf(id!);
+    session.applyTreeOps([{ op: 'splitParagraph', paragraphId: id!, offset: 4 }]);
+    const [head, tail] = session.paragraphIds();
+    expect(session.paraIdOf(head!)).toBe(before!);
+    const minted = session.paraIdOf(tail!);
+    expect(minted).toMatch(/^[0-9A-F]{8}$/);
+    expect(minted).not.toBe(before);
+  });
+
+  test('paragraphAnchors is reference-stable per revision and fresh after commit/undo', () => {
+    const session = open(docx('<w:p><w:r><w:t>hello</w:t></w:r></w:p>'));
+    const first = session.paragraphAnchors();
+    expect(session.paragraphAnchors()).toBe(first);
+    const [id] = session.paragraphIds();
+    session.applyTreeOps([{ op: 'splitParagraph', paragraphId: id!, offset: 2 }]);
+    const afterSplit = session.paragraphAnchors();
+    expect(afterSplit).not.toBe(first);
+    expect(afterSplit.nodeByParaId.size).toBe(2);
+    session.undo();
+    const afterUndo = session.paragraphAnchors();
+    expect(afterUndo).not.toBe(afterSplit);
+    expect(afterUndo.nodeByParaId.size).toBe(1);
+    expect(session.nodeIdOf('no such id')).toBeNull();
+    expect(session.paraIdOf('/word/document.xml#nope')).toBeNull();
+  });
+});
+
+describe('hostile prefix shadowing end to end', () => {
+  test('a subtree shadowing w14 neither locks editing nor loses identity', () => {
+    // Open-time normalization picks an alias outside the conflicting set, so every
+    // paragraph — inside and outside the shadow — is identified, and a split inside
+    // the shadowed subtree still commits AND mints.
+    const session = open(
+      docx(
+        '<w:p><w:r><w:t>outside</w:t></w:r></w:p>' +
+          '<w:sdt xmlns:w14="urn:evil"><w:sdtContent><w:p><w:r><w:t>inside</w:t></w:r></w:p></w:sdtContent></w:sdt>'
+      )
+    );
+    const [outside, inside] = session.paragraphIds();
+    expect(session.paraIdOf(outside!)).toMatch(/^[0-9A-F]{8}$/);
+    expect(session.paraIdOf(inside!)).toMatch(/^[0-9A-F]{8}$/);
+
+    const result = session.applyTreeOps([
+      { op: 'splitParagraph', paragraphId: inside!, offset: 3 },
+    ]);
+    expect(result.committed).toBe(true);
+    const ids = session.paragraphIds().map((id) => session.paraIdOf(id));
+    expect(ids).toHaveLength(3);
+    for (const id of ids) expect(id).toMatch(/^[0-9A-F]{8}$/);
+    expect(new Set(ids).size).toBe(3);
+  });
+});

--- a/packages/core/src/binding/paragraph-anchors.ts
+++ b/packages/core/src/binding/paragraph-anchors.ts
@@ -1,0 +1,43 @@
+// The paraId ↔ node-id map: where the contract's addressing vocabulary meets the tree's.
+//
+// The public contract addresses paragraphs by `w14:paraId` (`DocAnchor.paraId` — the
+// same handle Office JS exposes as `Paragraph.uniqueLocalId`), while the engine
+// addresses them by canonical node id (structural paths, positional). This index is
+// the translation, built in one `allParagraphs` walk and memoized per revision by the
+// session, the same way `documentOutline` is.
+//
+// Scope: the EDITABLE set of the main document part (body + table cells + block
+// SDTs). Header/footer/footnote paragraphs are `DocLocation` territory — the contract
+// keeps a structural address form precisely "for content the paraId map cannot reach".
+
+import type { OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import { isValidParaId, paraIdOf } from '@docx-editor.dev/core-contract/store';
+import { allParagraphs } from './tree-binding.ts';
+
+export interface ParagraphAnchorIndex {
+  /** nodeId → `w14:paraId`, verbatim as authored/minted. Paragraphs without one are absent. */
+  readonly paraIdByNode: ReadonlyMap<string, string>;
+  /** UPPERCASED paraId → nodeId (matching is case-insensitive). First occurrence wins on the impossible-by-invariant duplicate. */
+  readonly nodeByParaId: ReadonlyMap<string, string>;
+  /** nodeId → reading-order ordinal, for document-ordering DocRange endpoints. */
+  readonly ordinalByNode: ReadonlyMap<string, number>;
+}
+
+/** Build the index over every editable paragraph of the part, in reading order. */
+export function buildParagraphAnchorIndex(part: OoxmlPart): ParagraphAnchorIndex {
+  const paraIdByNode = new Map<string, string>();
+  const nodeByParaId = new Map<string, string>();
+  const ordinalByNode = new Map<string, number>();
+  allParagraphs(part).forEach((paragraph, ordinal) => {
+    ordinalByNode.set(paragraph.id, ordinal);
+    const paraId = paraIdOf(paragraph);
+    // Validity gate, defense-in-depth: normalization guarantees valid ids, but should
+    // it ever fail open on a pathological file, a junk authored value must not reach
+    // `snapshot().selection` or `query('paragraphs')` — the contract says 8-hex.
+    if (paraId === null || !isValidParaId(paraId)) return;
+    paraIdByNode.set(paragraph.id, paraId);
+    const canonical = paraId.toUpperCase();
+    if (!nodeByParaId.has(canonical)) nodeByParaId.set(canonical, paragraph.id);
+  });
+  return Object.freeze({ paraIdByNode, nodeByParaId, ordinalByNode });
+}

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -24,6 +24,7 @@ import {
   writeOoxmlPackage,
   ensureListDefinition,
   ensureNumberingLevel,
+  normalizeParagraphIdentity,
   paragraphTextOf,
   type EmbeddedFont,
   type ListKind,
@@ -64,6 +65,7 @@ import {
   treeToDoc,
 } from './tree-binding.ts';
 import type { TreeBindingRejection } from './tree-binding.ts';
+import { buildParagraphAnchorIndex, type ParagraphAnchorIndex } from './paragraph-anchors.ts';
 
 export interface TreeApplyResult {
   readonly committed: boolean;
@@ -224,11 +226,24 @@ export interface TreeDocxSession {
    * harmless: an unreferenced level renders nothing and Word writes files full of them.
    */
   ensureNumberingLevel(numId: string, level: number, kind: ListKind): boolean;
+  /**
+   * The `w14:paraId` ↔ node-id index over the full editable set of the MAIN part,
+   * memoized per revision. Every editable paragraph carries a valid, part-unique id
+   * (established at open, maintained by the split appliers), so every paragraph is
+   * mapped. Header/footer/footnote paragraphs are not: those stories are addressed
+   * structurally (`DocLocation`) when they become editable.
+   */
+  paragraphAnchors(): ParagraphAnchorIndex;
+  /** `w14:paraId` of a canonical paragraph node id, verbatim, or null. */
+  paraIdOf(nodeId: string): string | null;
+  /** Canonical node id for a `w14:paraId`, matched case-insensitively, or null. */
+  nodeIdOf(paraId: string): string | null;
 }
 
 export type { DocumentStyleEntry } from './document-catalog.ts';
 export type { DocumentThemeColorEntry, ThemeColorSlot } from './document-theme.ts';
 export type { DocumentOutlineEntry } from './document-outline.ts';
+export type { ParagraphAnchorIndex } from './paragraph-anchors.ts';
 
 export type TreeSessionRejection = OoxmlPackageRejection | 'no-main-document-tree';
 
@@ -257,7 +272,14 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
   const main = pkg.parts.get(pkg.mainDocumentPart);
   if (!main) return { ok: false, reason: 'no-main-document-tree', detail: pkg.mainDocumentPart };
 
-  const store = new TreeDocumentStore(main);
+  // Paragraph identity is established once, here — every paragraph the session edits
+  // carries a valid, part-unique `w14:paraId` from the first revision on, so the op
+  // layer can seed split-tail mints and the contract can address by paraId. A document
+  // already carrying valid ids normalizes to the SAME part reference (byte-stable save).
+  const normalized = normalizeParagraphIdentity(main);
+  if (normalized !== main) pkg = withPart(pkg, normalized);
+
+  const store = new TreeDocumentStore(normalized);
   let headerFooterBySection: readonly HeaderFooterParts[] | null = null;
   let lastChange: TreeModelChange | null = null;
   store.subscribe((change) => {
@@ -400,6 +422,18 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
     readonly revision: number;
     readonly outline: readonly DocumentOutlineEntry[];
   } | null = null;
+  let anchorsCache: {
+    readonly revision: number;
+    readonly index: ParagraphAnchorIndex;
+  } | null = null;
+  const paragraphAnchors = (): ParagraphAnchorIndex => {
+    // Keyed on the store revision, like the outline: a split mints a new paragraph and
+    // a join removes one, but between commits the map cannot move.
+    if (!anchorsCache || anchorsCache.revision !== store.revision) {
+      anchorsCache = { revision: store.revision, index: buildParagraphAnchorIndex(store.part) };
+    }
+    return anchorsCache.index;
+  };
 
   return {
     ok: true,
@@ -571,6 +605,12 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
       },
 
       embeddedFonts: resolveEmbeddedFonts,
+
+      paragraphAnchors,
+
+      paraIdOf: (nodeId) => paragraphAnchors().paraIdByNode.get(nodeId) ?? null,
+
+      nodeIdOf: (paraId) => paragraphAnchors().nodeByParaId.get(paraId.toUpperCase()) ?? null,
 
       ensureListDefinition(kind) {
         // The numbering part lives on the PACKAGE, not the main-part tree, so this is the

--- a/packages/core/src/editor/__tests__/anchor-resolution.test.ts
+++ b/packages/core/src/editor/__tests__/anchor-resolution.test.ts
@@ -1,0 +1,165 @@
+// DocAnchor resolution semantics (anchor-resolution.ts): paraId case-insensitive,
+// `search` exactly-once (or explicit `occurrence`), spans in `paragraphTextOf`'s
+// offset vocabulary — the same offsets the ops and the surface selection use.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import { buildParagraphAnchorIndex } from '../../binding/paragraph-anchors.ts';
+import { resolveAnchorSelection, resolveDocAnchor } from '../anchor-resolution.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+// "one\ttwo two" — a tab pins the offset vocabulary: tabs count one offset each.
+const PART = load(
+  '<w:p w14:paraId="4C000001"><w:r><w:t>one</w:t><w:tab/><w:t>two two</w:t></w:r></w:p>' +
+    '<w:p w14:paraId="4C000002"><w:r><w:t>second paragraph</w:t></w:r></w:p>'
+);
+const ANCHORS = buildParagraphAnchorIndex(PART);
+const [FIRST, SECOND] = [...ANCHORS.ordinalByNode.keys()];
+
+describe('resolveDocAnchor', () => {
+  test('no search spans the whole paragraph', () => {
+    const resolved = resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001' });
+    expect(resolved).toEqual({
+      ok: true,
+      span: { nodeId: FIRST!, start: 0, end: 'one\ttwo two'.length },
+    });
+  });
+
+  test('paraId matches case-insensitively; unknown ids answer notFound', () => {
+    const resolved = resolveDocAnchor(PART, ANCHORS, { paraId: '4c000001' });
+    expect(resolved.ok).toBe(true);
+    const missing = resolveDocAnchor(PART, ANCHORS, { paraId: '0BADF00D' });
+    expect(missing).toMatchObject({ ok: false, code: 'notFound' });
+  });
+
+  test('a unique search resolves to its span, tab offsets included', () => {
+    const resolved = resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001', search: 'one\ttwo' });
+    expect(resolved).toEqual({ ok: true, span: { nodeId: FIRST!, start: 0, end: 7 } });
+  });
+
+  test('two matches without occurrence are ambiguous, never first-match', () => {
+    const resolved = resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001', search: 'two' });
+    expect(resolved).toMatchObject({ ok: false, code: 'ambiguous' });
+  });
+
+  test('occurrence disambiguates, 1-based; past-the-end answers notFound', () => {
+    const second = resolveDocAnchor(PART, ANCHORS, {
+      paraId: '4C000001',
+      search: 'two',
+      occurrence: 2,
+    });
+    expect(second).toEqual({ ok: true, span: { nodeId: FIRST!, start: 8, end: 11 } });
+    expect(
+      resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001', search: 'two', occurrence: 3 })
+    ).toMatchObject({ ok: false, code: 'notFound' });
+  });
+
+  test('invalid arguments are named as such', () => {
+    expect(resolveDocAnchor(PART, ANCHORS, { paraId: '' })).toMatchObject({
+      ok: false,
+      code: 'invalidArgs',
+    });
+    expect(resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001', search: '' })).toMatchObject({
+      ok: false,
+      code: 'invalidArgs',
+    });
+    expect(
+      resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001', search: 'two', occurrence: 0 })
+    ).toMatchObject({ ok: false, code: 'invalidArgs' });
+    expect(
+      resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001', search: 'two', occurrence: 1.5 })
+    ).toMatchObject({ ok: false, code: 'invalidArgs' });
+  });
+
+  test('a missing search phrase answers notFound', () => {
+    expect(resolveDocAnchor(PART, ANCHORS, { paraId: '4C000001', search: 'absent' })).toMatchObject(
+      { ok: false, code: 'notFound' }
+    );
+  });
+});
+
+describe('resolveAnchorSelection', () => {
+  test('{ anchor } collapses the caret at the span start', () => {
+    const caret = resolveAnchorSelection(PART, ANCHORS, {
+      anchor: { paraId: '4C000001', search: 'two', occurrence: 2 },
+    });
+    expect(caret).toEqual({
+      ok: true,
+      selection: {
+        anchor: { paragraphId: FIRST!, offset: 8 },
+        head: { paragraphId: FIRST!, offset: 8 },
+      },
+    });
+  });
+
+  test('a same-paraId range selects the whole paragraph; search endpoints select the phrase', () => {
+    const whole = resolveAnchorSelection(PART, ANCHORS, {
+      range: { from: { paraId: '4C000001' }, to: { paraId: '4C000001' } },
+    });
+    expect(whole).toEqual({
+      ok: true,
+      selection: {
+        anchor: { paragraphId: FIRST!, offset: 0 },
+        head: { paragraphId: FIRST!, offset: 'one\ttwo two'.length },
+      },
+    });
+    const phrase = resolveAnchorSelection(PART, ANCHORS, {
+      range: {
+        from: { paraId: '4C000002', search: 'second' },
+        to: { paraId: '4C000002', search: 'second' },
+      },
+    });
+    expect(phrase).toEqual({
+      ok: true,
+      selection: {
+        anchor: { paragraphId: SECOND!, offset: 0 },
+        head: { paragraphId: SECOND!, offset: 6 },
+      },
+    });
+  });
+
+  test('a cross-paragraph range runs from-start to to-end', () => {
+    const range = resolveAnchorSelection(PART, ANCHORS, {
+      range: { from: { paraId: '4C000001' }, to: { paraId: '4C000002' } },
+    });
+    expect(range).toEqual({
+      ok: true,
+      selection: {
+        anchor: { paragraphId: FIRST!, offset: 0 },
+        head: { paragraphId: SECOND!, offset: 'second paragraph'.length },
+      },
+    });
+  });
+
+  test('the failing endpoint names itself as the target', () => {
+    const result = resolveAnchorSelection(PART, ANCHORS, {
+      range: { from: { paraId: '4C000001' }, to: { paraId: '0BADF00D' } },
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'notFound',
+      target: { paraId: '0BADF00D' },
+    });
+  });
+
+  test('DocLocation endpoints are refused as unsupported, not approximated', () => {
+    const result = resolveAnchorSelection(PART, ANCHORS, {
+      range: {
+        from: { container: { part: 'body' }, path: [0] },
+        to: { paraId: '4C000001' },
+      },
+    });
+    expect(result).toMatchObject({ ok: false, code: 'unsupported' });
+  });
+});

--- a/packages/core/src/editor/__tests__/docx-editor.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor.test.ts
@@ -172,7 +172,12 @@ describe('createDocxEditor', () => {
     expect(snapshot.parseError).toBeNull();
     expect(snapshot.editable).toBe(true);
     expect(snapshot.zoom).toBe(1);
-    expect(snapshot.selection).toBeNull();
+    // The selection reads in contract vocabulary: DocAnchor endpoints carrying the
+    // paragraph's `w14:paraId` (minted at open), paragraph-granular.
+    expect(snapshot.selection).not.toBeNull();
+    const caretAnchor = snapshot.selection!.from as { paraId: string };
+    expect(caretAnchor.paraId).toMatch(/^[0-9A-F]{8}$/);
+    expect(snapshot.selection!.to).toEqual(snapshot.selection!.from);
     expect(snapshot.table).toBeNull();
     expect(snapshot.image).toBeNull();
     expect(snapshot.page).toEqual({ current: 1, total: 1 });
@@ -503,8 +508,12 @@ describe('createDocxEditor', () => {
     expect(editor.getDisplay()).toEqual([]);
     expect(editor.getCaretRect()).toBeNull();
     expect(editor.hitTest({ x: 0, y: 0 })).toBeNull();
-    expect(editor.query({ type: 'paragraphs' })).toEqual([]);
-    expect(editor.query({ type: 'selection' })).toBeNull();
+    // No longer honest-empty: `paragraphs` and `selection` answer in paraId vocabulary.
+    const paragraphs = editor.query({ type: 'paragraphs' });
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0]!.text).toBe('hello');
+    expect(paragraphs[0]!.paraId).toMatch(/^[0-9A-F]{8}$/);
+    expect(editor.query({ type: 'selection' })).toEqual(editor.snapshot().selection);
     const dispatch = editor.dispatchInteraction({
       kind: 'focus',
       frameId: { value: 0 },
@@ -836,5 +845,141 @@ describe('setMarkAttr (value-typed run formatting)', () => {
     expect(
       editor.can({ type: 'setMarkAttr', mark: 'fontFamily', attr: 'family', value: 'Arial' }).ok
     ).toBe(true);
+  });
+});
+
+describe('DocAnchor addressing (w14:paraId)', () => {
+  test('snapshot().selection reads in paraId vocabulary and stays reference-stable within a paragraph', () => {
+    const { editor } = mount(p('hello world') + p('second'));
+    const [firstId, secondId] = editor.surface!.session.paragraphIds();
+    const firstParaId = editor.surface!.session.paraIdOf(firstId!)!;
+    const secondParaId = editor.surface!.session.paraIdOf(secondId!)!;
+
+    editor.surface!.setSelection({
+      anchor: { paragraphId: firstId!, offset: 0 },
+      head: { paragraphId: firstId!, offset: 0 },
+    });
+    const atStart = editor.snapshot().selection;
+    expect(atStart).toEqual({ from: { paraId: firstParaId }, to: { paraId: firstParaId } });
+
+    // A caret move WITHIN the paragraph derives a value-equal selection — the previous
+    // sub-object reference must be reused (useSyncExternalStore contract).
+    editor.surface!.setSelection({
+      anchor: { paragraphId: firstId!, offset: 3 },
+      head: { paragraphId: firstId!, offset: 3 },
+    });
+    expect(editor.snapshot().selection).toBe(atStart!);
+
+    // Crossing into another paragraph is a new value.
+    editor.surface!.setSelection({
+      anchor: { paragraphId: secondId!, offset: 1 },
+      head: { paragraphId: secondId!, offset: 1 },
+    });
+    expect(editor.snapshot().selection).toEqual({
+      from: { paraId: secondParaId },
+      to: { paraId: secondParaId },
+    });
+    expect(editor.query({ type: 'selection' })).toEqual(editor.snapshot().selection);
+  });
+
+  test('a backwards drag still reads in document order', () => {
+    const { editor } = mount(p('first') + p('second'));
+    const [firstId, secondId] = editor.surface!.session.paragraphIds();
+    editor.surface!.setSelection({
+      anchor: { paragraphId: secondId!, offset: 3 },
+      head: { paragraphId: firstId!, offset: 1 },
+    });
+    const selection = editor.snapshot().selection!;
+    expect((selection.from as { paraId: string }).paraId).toBe(
+      editor.surface!.session.paraIdOf(firstId!)!
+    );
+    expect((selection.to as { paraId: string }).paraId).toBe(
+      editor.surface!.session.paraIdOf(secondId!)!
+    );
+  });
+
+  test('setSelection by anchor range with search selects the phrase', () => {
+    const { editor } = mount(p('say hello there'));
+    const [id] = editor.surface!.session.paragraphIds();
+    const paraId = editor.surface!.session.paraIdOf(id!)!;
+    expect(
+      editor.can({
+        type: 'setSelection',
+        range: { from: { paraId, search: 'hello' }, to: { paraId, search: 'hello' } },
+      }).ok
+    ).toBe(true);
+    const result = editor.exec({
+      type: 'setSelection',
+      range: { from: { paraId, search: 'hello' }, to: { paraId, search: 'hello' } },
+    });
+    expect(result).toEqual({ ok: true, changed: false });
+    expect(editor.query({ type: 'selectedText' })).toBe('hello');
+  });
+
+  test('a whole-paragraph anchor range selects the full text; { anchor } collapses the caret', () => {
+    const { editor } = mount(p('whole paragraph'));
+    const [id] = editor.surface!.session.paragraphIds();
+    const paraId = editor.surface!.session.paraIdOf(id!)!;
+    expect(
+      editor.exec({ type: 'setSelection', range: { from: { paraId }, to: { paraId } } })
+    ).toEqual({ ok: true, changed: false });
+    expect(editor.query({ type: 'selectedText' })).toBe('whole paragraph');
+
+    expect(editor.exec({ type: 'setSelection', anchor: { paraId } })).toEqual({
+      ok: true,
+      changed: false,
+    });
+    expect(editor.surface!.state().selection).toEqual({
+      anchor: { paragraphId: id!, offset: 0 },
+      head: { paragraphId: id!, offset: 0 },
+    });
+  });
+
+  test('resolution failures surface as typed ExecResults', () => {
+    const { editor } = mount(p('two two'));
+    const [id] = editor.surface!.session.paragraphIds();
+    const paraId = editor.surface!.session.paraIdOf(id!)!;
+    expect(editor.exec({ type: 'setSelection', anchor: { paraId: '0BADF00D' } })).toMatchObject({
+      ok: false,
+      code: 'notFound',
+    });
+    expect(editor.exec({ type: 'setSelection', anchor: { paraId, search: 'two' } })).toMatchObject({
+      ok: false,
+      code: 'ambiguous',
+    });
+  });
+
+  test('snapshot().selection round-trips through setSelection, frozen input unharmed', () => {
+    const { editor } = mount(p('alpha') + p('beta'));
+    const [firstId, secondId] = editor.surface!.session.paragraphIds();
+    editor.surface!.setSelection({
+      anchor: { paragraphId: firstId!, offset: 0 },
+      head: { paragraphId: secondId!, offset: 2 },
+    });
+    const selection = editor.snapshot().selection!;
+    expect(Object.isFrozen(selection)).toBe(true);
+    expect(editor.exec({ type: 'setSelection', range: selection })).toEqual({
+      ok: true,
+      changed: false,
+    });
+    // Feeding the paragraph-granular range back selects those paragraphs in full.
+    expect(editor.query({ type: 'selectedText' })).toBe('alpha\nbeta');
+    expect(editor.snapshot().selection).toEqual(selection);
+  });
+
+  test('paragraphs query walks table cells too, in reading order', () => {
+    const { editor } = mount(
+      p('before') +
+        '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>' +
+        p('after')
+    );
+    const paragraphs = editor.query({ type: 'paragraphs' });
+    expect(paragraphs.map((paragraph) => paragraph.text)).toEqual(['before', 'cell', 'after']);
+    for (const paragraph of paragraphs) expect(paragraph.paraId).toMatch(/^[0-9A-F]{8}$/);
+    expect(new Set(paragraphs.map((paragraph) => paragraph.paraId)).size).toBe(3);
+    // Other containers are out of the paraId map's scope: typed empty, not an error.
+    expect(
+      editor.query({ type: 'paragraphs', container: { part: 'header', rId: 'rId9' } })
+    ).toEqual([]);
   });
 });

--- a/packages/core/src/editor/__tests__/paragraph-acceptance.test.ts
+++ b/packages/core/src/editor/__tests__/paragraph-acceptance.test.ts
@@ -224,6 +224,22 @@ describe('load, edit, format, save and reopen (task 8.3)', () => {
     expect(canonicalOoxmlFingerprint(after)).toBe(canonicalOoxmlFingerprint(before));
   });
 
+  test('every paragraph carries a valid unique w14:paraId, preserved across save/reopen', () => {
+    // The fixture has none authored — every id here is minted at open. The oracles above
+    // still pass because a reopen reads back exactly what the session serialized.
+    const surface = mount();
+    const ids = surface.session
+      .paragraphIds()
+      .map((paragraphId) => surface.session.paraIdOf(paragraphId));
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) expect(id).toMatch(/^[0-9A-F]{8}$/);
+    expect(new Set(ids).size).toBe(ids.length);
+    const reopened = mount(surface.session.save());
+    expect(
+      reopened.session.paragraphIds().map((paragraphId) => reopened.session.paraIdOf(paragraphId))
+    ).toEqual(ids);
+  });
+
   test('every accepted property survives the round trip', () => {
     const surface = mount();
     const present = propertyNames(surface.session.save());

--- a/packages/core/src/editor/anchor-resolution.ts
+++ b/packages/core/src/editor/anchor-resolution.ts
@@ -1,0 +1,207 @@
+// DocAnchor → surface-selection resolution (editor seam).
+//
+// A `DocAnchor` is the LLM- and JSON-facing paragraph address: a `w14:paraId` plus an
+// optional `search` phrase that must match EXACTLY ONCE inside that paragraph. This
+// module resolves anchors against the current tree — pure functions of (part, anchor
+// index, anchor), no surface, no DOM — so `exec`/`can` and any later consumer share one
+// semantics. Offsets are in `paragraphTextOf`'s vocabulary (tabs `\t`, hard breaks as
+// their characters), the same UTF-16 offsets the tree ops and the surface selection use.
+
+import type {
+  DocAnchor,
+  DocRange,
+  DocTarget,
+  ExecErrorCode,
+} from '@docx-editor.dev/core-contract/contracts/editor';
+import type { SemanticSelection as SurfaceSelection } from '@docx-editor.dev/core-contract/layout';
+import { paragraphTextOf, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import type { ParagraphAnchorIndex } from '../binding/paragraph-anchors.ts';
+
+export interface ResolvedAnchorSpan {
+  readonly nodeId: string;
+  /** UTF-16 offsets into `paragraphTextOf`: the search-match span, or [0, length] with no search. */
+  readonly start: number;
+  readonly end: number;
+}
+
+export type AnchorResolution =
+  | { readonly ok: true; readonly span: ResolvedAnchorSpan }
+  | {
+      readonly ok: false;
+      readonly code: 'notFound' | 'ambiguous' | 'invalidArgs';
+      readonly reason: string;
+    };
+
+/**
+ * Shape guard, strict on statically-hopeless payloads: an empty `paraId`, an empty
+ * `search` or a non-positive-integer `occurrence` can never resolve against ANY
+ * document, so `can` refuses them the same way `exec` would — the can/exec split is
+ * reserved for properties of the document (does the paraId exist, is the phrase
+ * unique), not of the payload.
+ */
+export function isDocAnchor(value: unknown): value is DocAnchor {
+  if (typeof value !== 'object' || value === null) return false;
+  const anchor = value as { paraId?: unknown; search?: unknown; occurrence?: unknown };
+  return (
+    typeof anchor.paraId === 'string' &&
+    anchor.paraId.length > 0 &&
+    (anchor.search === undefined ||
+      (typeof anchor.search === 'string' && anchor.search.length > 0)) &&
+    (anchor.occurrence === undefined ||
+      (typeof anchor.occurrence === 'number' &&
+        Number.isInteger(anchor.occurrence) &&
+        anchor.occurrence >= 1))
+  );
+}
+
+export function isDocAnchorRange(value: unknown): value is DocRange {
+  if (typeof value !== 'object' || value === null) return false;
+  const range = value as { from?: unknown; to?: unknown };
+  return isDocAnchor(range.from) && isDocAnchor(range.to);
+}
+
+/**
+ * Match offsets of `search` in `text`, overlapping occurrences counted — the strict
+ * reading of "must match exactly once". Bounded: the scan stops after `limit` matches,
+ * since a caller needs at most `occurrence` spans (or the fact that a second exists),
+ * never the full enumeration of a pathological input.
+ */
+function matchOffsets(text: string, search: string, limit: number): number[] {
+  const offsets: number[] = [];
+  let index = text.indexOf(search);
+  while (index >= 0 && offsets.length < limit) {
+    offsets.push(index);
+    index = text.indexOf(search, index + 1);
+  }
+  return offsets;
+}
+
+/**
+ * Resolve one anchor. `paraId` is matched case-insensitively; `search` is a
+ * case-sensitive exact substring; `occurrence` is 1-based and opt-in — without it,
+ * two matches are `'ambiguous'` rather than first-match.
+ */
+export function resolveDocAnchor(
+  part: OoxmlPart,
+  anchors: ParagraphAnchorIndex,
+  anchor: DocAnchor
+): AnchorResolution {
+  if (typeof anchor.paraId !== 'string' || anchor.paraId.length === 0) {
+    return { ok: false, code: 'invalidArgs', reason: 'paraId must be a non-empty string' };
+  }
+  const nodeId = anchors.nodeByParaId.get(anchor.paraId.toUpperCase());
+  if (nodeId === undefined) {
+    return {
+      ok: false,
+      code: 'notFound',
+      reason: `no paragraph with paraId '${anchor.paraId}'`,
+    };
+  }
+  const text = paragraphTextOf(part, nodeId) ?? '';
+  if (anchor.search === undefined) {
+    return { ok: true, span: { nodeId, start: 0, end: text.length } };
+  }
+  if (anchor.search.length === 0) {
+    return { ok: false, code: 'invalidArgs', reason: 'search must be a non-empty phrase' };
+  }
+  if (anchor.occurrence !== undefined) {
+    if (!Number.isInteger(anchor.occurrence) || anchor.occurrence < 1) {
+      return {
+        ok: false,
+        code: 'invalidArgs',
+        reason: 'occurrence must be a positive integer (1-based)',
+      };
+    }
+    // Scan exactly as far as the requested occurrence; fewer matches means the count
+    // is exact (the scan ended at the text, not the limit).
+    const matches = matchOffsets(text, anchor.search, anchor.occurrence);
+    const match = matches[anchor.occurrence - 1];
+    if (match === undefined) {
+      return {
+        ok: false,
+        code: 'notFound',
+        reason: `'${anchor.search}' matches ${matches.length} time(s) in paragraph '${anchor.paraId}'; occurrence ${anchor.occurrence} does not exist`,
+      };
+    }
+    return { ok: true, span: { nodeId, start: match, end: match + anchor.search.length } };
+  }
+  // Without `occurrence` only "zero, one, or more than one" matters — two matches
+  // settle it, so the scan never enumerates a pathological input in full.
+  const matches = matchOffsets(text, anchor.search, 2);
+  if (matches.length === 0) {
+    return {
+      ok: false,
+      code: 'notFound',
+      reason: `'${anchor.search}' does not occur in paragraph '${anchor.paraId}'`,
+    };
+  }
+  if (matches.length > 1) {
+    return {
+      ok: false,
+      code: 'ambiguous',
+      reason: `'${anchor.search}' matches more than once in paragraph '${anchor.paraId}'; pass occurrence to disambiguate`,
+    };
+  }
+  return {
+    ok: true,
+    span: { nodeId, start: matches[0]!, end: matches[0]! + anchor.search.length },
+  };
+}
+
+export type AnchorSelectionResolution =
+  | { readonly ok: true; readonly selection: SurfaceSelection }
+  | {
+      readonly ok: false;
+      readonly code: ExecErrorCode;
+      readonly reason: string;
+      readonly target?: DocTarget;
+    };
+
+/**
+ * Resolve a DocAnchor-shaped `setSelection` payload into the surface's selection form.
+ *
+ * `{ anchor }` collapses the caret at the span start (the match start; paragraph start
+ * with no search). `{ range }` selects from the from-span's start to the to-span's end,
+ * so `{from: {paraId: X}, to: {paraId: X}}` selects the whole paragraph and matching
+ * `search` endpoints select the phrase. `DocLocation` endpoints are refused as
+ * unsupported rather than resolved approximately — positional addressing is a later
+ * lane, and the refusal names it.
+ */
+export function resolveAnchorSelection(
+  part: OoxmlPart,
+  anchors: ParagraphAnchorIndex,
+  command: { readonly anchor: DocAnchor } | { readonly range: DocRange }
+): AnchorSelectionResolution {
+  if ('anchor' in command) {
+    const resolved = resolveDocAnchor(part, anchors, command.anchor);
+    if (!resolved.ok) {
+      return { ok: false, code: resolved.code, reason: resolved.reason, target: command.anchor };
+    }
+    const position = { paragraphId: resolved.span.nodeId, offset: resolved.span.start };
+    return { ok: true, selection: { anchor: position, head: position } };
+  }
+  const { from, to } = command.range;
+  if (!isDocAnchor(from) || !isDocAnchor(to)) {
+    return {
+      ok: false,
+      code: 'unsupported',
+      reason: 'DocLocation endpoints are not supported; address paragraphs by paraId',
+      target: command.range,
+    };
+  }
+  const fromResolved = resolveDocAnchor(part, anchors, from);
+  if (!fromResolved.ok) {
+    return { ok: false, code: fromResolved.code, reason: fromResolved.reason, target: from };
+  }
+  const toResolved = resolveDocAnchor(part, anchors, to);
+  if (!toResolved.ok) {
+    return { ok: false, code: toResolved.code, reason: toResolved.reason, target: to };
+  }
+  return {
+    ok: true,
+    selection: {
+      anchor: { paragraphId: fromResolved.span.nodeId, offset: fromResolved.span.start },
+      head: { paragraphId: toResolved.span.nodeId, offset: toResolved.span.end },
+    },
+  };
+}

--- a/packages/core/src/editor/docx-editor-derive.ts
+++ b/packages/core/src/editor/docx-editor-derive.ts
@@ -6,6 +6,7 @@
 // `getSelectionFormatting()` cannot drift into two derivations of the same thing.
 
 import type {
+  DocRange,
   EditorCommand,
   EditorScope,
   ExecResult,
@@ -13,11 +14,15 @@ import type {
   RunFormatting,
   TableContext,
 } from '../contracts/editor.ts';
+import type { ContainerRef, ParagraphSummary } from '../index.ts';
 import { classifyCommand } from './docx-editor-support.ts';
 
 /** Whether a command may run, and the engine's own refusal when it may not. */
 export type CommandGate = { ok: true } | { ok: false; refusal: Exclude<ExecResult, { ok: true }> };
 import { caretAt, tableContextAt } from '@docx-editor.dev/core-contract/layout';
+import { paragraphTextOf } from '@docx-editor.dev/core-contract/store';
+import { allParagraphs } from '../binding/tree-binding.ts';
+import { paragraphStyleId } from '../binding/document-outline.ts';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 
 /**
@@ -68,6 +73,63 @@ export function pageSetupOf(surface: PaginatedSurface | null): PageSetup | null 
     },
     gutterTwips: section.margins.gutterTwips,
   };
+}
+
+/**
+ * THE selection derivation — the surface's (node id, offset) selection expressed in the
+ * contract's vocabulary. `snapshot().selection` and the `selection` query both read this.
+ *
+ * Paragraph-granular by design: endpoints are bare `DocAnchor`s (`{ paraId }`), so a
+ * caret and any selection inside one paragraph both read as
+ * `{from: {paraId: X}, to: {paraId: X}}`. Offsets are deliberately not representable —
+ * `DocAnchor` carries none (an agent cannot compute an offset it has not seen), and
+ * emitting offsetful positional endpoints would reintroduce the addressing the contract
+ * forbids. `from`/`to` are document-ordered regardless of drag direction. The result
+ * round-trips: feeding it back to `setSelection` selects the same paragraphs.
+ */
+export function selectionRangeOf(surface: PaginatedSurface | null): DocRange | null {
+  if (!surface) return null;
+  const { anchor, head } = surface.state().selection;
+  const anchors = surface.session.paragraphAnchors();
+  const anchorParaId = anchors.paraIdByNode.get(anchor.paragraphId);
+  const headParaId = anchors.paraIdByNode.get(head.paragraphId);
+  // Normalization maps every editable paragraph at open, so this misses only when
+  // identity could not be established at all (the fail-open path on a pathological
+  // file) or a pre-layout placeholder id appears — null is the honest answer for both,
+  // never a fabricated range.
+  if (anchorParaId === undefined || headParaId === undefined) return null;
+  const anchorOrdinal = anchors.ordinalByNode.get(anchor.paragraphId) ?? 0;
+  const headOrdinal = anchors.ordinalByNode.get(head.paragraphId) ?? 0;
+  const reversed =
+    headOrdinal < anchorOrdinal || (headOrdinal === anchorOrdinal && head.offset < anchor.offset);
+  return reversed
+    ? { from: { paraId: headParaId }, to: { paraId: anchorParaId } }
+    : { from: { paraId: anchorParaId }, to: { paraId: headParaId } };
+}
+
+/**
+ * The `paragraphs` query: every editable paragraph in reading order, addressed the way
+ * the contract addresses paragraphs. Scope is the MAIN part — a `container` naming any
+ * other story answers `[]` (queries carry no error channel; the paraId map does not
+ * reach those stories yet).
+ */
+export function paragraphSummaries(
+  surface: PaginatedSurface | null,
+  container?: ContainerRef
+): readonly ParagraphSummary[] {
+  if (!surface) return [];
+  if (container !== undefined && container.part !== 'body') return [];
+  const part = surface.session.part();
+  const anchors = surface.session.paragraphAnchors();
+  return allParagraphs(part).map((paragraph) => {
+    const paraId = anchors.paraIdByNode.get(paragraph.id);
+    const styleId = paragraph.kind === 'textValue' ? undefined : paragraphStyleId(paragraph);
+    return {
+      ...(paraId !== undefined ? { paraId } : {}),
+      text: paragraphTextOf(part, paragraph.id) ?? '',
+      ...(styleId !== undefined ? { styleId } : {}),
+    };
+  });
 }
 
 export function totalPages(surface: PaginatedSurface | null): number {

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -9,6 +9,7 @@
 import type { EditorCommand, ExecResult } from '../contracts/editor.ts';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 import { MARKS, isSurfaceSelection, resolveMarkAttr } from './docx-editor-support.ts';
+import { isDocAnchor, isDocAnchorRange, resolveAnchorSelection } from './anchor-resolution.ts';
 
 /**
  * Run one admitted command against the surface.
@@ -140,8 +141,28 @@ export function execEditorCommand(
     case 'setSelection': {
       if ('range' in command && isSurfaceSelection(command.range)) {
         mounted.setSelection(command.range);
+        // Selection is not document state: nothing to save changed.
+        return { ok: true, changed: false };
       }
-      // Selection is not document state: nothing to save changed.
+      // DocAnchor forms resolve through the session's paraId index. The gate admitted
+      // only anchor-shaped payloads past the surface form, so a fall-through here is a
+      // range with anchor endpoints or an `{ anchor }` position.
+      const payload =
+        'anchor' in command && isDocAnchor(command.anchor)
+          ? { anchor: command.anchor }
+          : 'range' in command && isDocAnchorRange(command.range)
+            ? { range: command.range }
+            : null;
+      if (payload === null) {
+        return { ok: false, code: 'unsupported', reason: 'unsupported selection form' };
+      }
+      const resolved = resolveAnchorSelection(
+        mounted.session.part(),
+        mounted.session.paragraphAnchors(),
+        payload
+      );
+      if (!resolved.ok) return resolved;
+      mounted.setSelection(resolved.selection);
       return { ok: true, changed: false };
     }
     default:

--- a/packages/core/src/editor/docx-editor-support.ts
+++ b/packages/core/src/editor/docx-editor-support.ts
@@ -6,6 +6,8 @@
 // cached snapshot uses to keep sub-object references stable across re-derivations.
 
 import type {
+  DocAnchor,
+  DocRange,
   DocumentSource,
   EditorCommand,
   EditorError,
@@ -18,6 +20,7 @@ import type {
   SemanticPositionIndex,
 } from '@docx-editor.dev/core-contract/contracts/interaction';
 import type { SemanticSelection as SurfaceSelection } from '@docx-editor.dev/core-contract/layout';
+import { isDocAnchor, isDocAnchorRange } from './anchor-resolution.ts';
 
 /** Recursively freeze plain objects and arrays (idempotent). */
 export function deepFreezeValue<T>(value: T): T {
@@ -214,11 +217,13 @@ function isSurfacePosition(value: unknown): value is SurfaceSelection['anchor'] 
 }
 
 /**
- * The one selection form the surface can honour: paragraph-id + offset endpoints.
+ * The surface's native selection form: paragraph-id + offset endpoints.
  *
- * The contract's other position forms (`DocAnchor`, `DocLocation`, `SemanticTarget`)
- * address the document through indexes this lane does not build yet, so they are refused
- * as unsupported rather than resolved approximately.
+ * `DocAnchor` forms (`{ anchor: { paraId } }`, `{ range: { from, to } }` with anchor
+ * endpoints) are resolved through the session's paraId index at exec time — see
+ * `anchor-resolution.ts`. `DocLocation` and `SemanticTarget` still address the document
+ * through indexes this lane does not build, so they stay refused rather than resolved
+ * approximately.
  */
 export function isSurfaceSelection(value: unknown): value is SurfaceSelection {
   return (
@@ -371,12 +376,17 @@ export function classifyCommand(command: EditorCommand): CommandSupport {
     case 'redo':
       return { supported: true, mutating: true };
     case 'setSelection':
-      return 'range' in command && isSurfaceSelection(command.range)
+      // Shape gate only: whether an anchor's paraId exists (and its `search` phrase is
+      // unique) is a property of the DOCUMENT, checked at exec — the same split as
+      // `insertText`, whose target cannot be pre-verified either.
+      return ('range' in command &&
+        (isSurfaceSelection(command.range) || isDocAnchorRange(command.range))) ||
+        ('anchor' in command && isDocAnchor(command.anchor))
         ? { supported: true, mutating: false }
         : {
             supported: false,
             reason:
-              'only a semantic { anchor: { paragraphId, offset }, head } selection is supported',
+              'setSelection accepts { anchor: { paraId } }, a { range } whose from/to are paraId anchors, or a { range } carrying a semantic { anchor: { paragraphId, offset }, head } selection',
           };
     default:
       return {
@@ -443,6 +453,33 @@ export function pageSetupEqual(a: PageSetup | null, b: PageSetup | null): boolea
     a.marginsTwips.left === b.marginsTwips.left &&
     a.gutterTwips === b.gutterTwips
   );
+}
+
+function docAnchorEndpointEqual(
+  a: DocRange['from'] | undefined,
+  b: DocRange['from'] | undefined
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const left = a as Partial<DocAnchor>;
+  const right = b as Partial<DocAnchor>;
+  return (
+    left.paraId === right.paraId &&
+    left.search === right.search &&
+    left.occurrence === right.occurrence
+  );
+}
+
+/**
+ * Value equality for the snapshot's `selection`. Emitted ranges carry bare DocAnchor
+ * endpoints, but all anchor fields are compared for honesty; a DocLocation endpoint
+ * (never emitted today) compares unequal unless reference-equal.
+ */
+export function docRangeEqual(a: DocRange | null, b: DocRange | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (!isDocAnchorRange(a) || !isDocAnchorRange(b)) return false;
+  return docAnchorEndpointEqual(a.from, b.from) && docAnchorEndpointEqual(a.to, b.to);
 }
 
 /**

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -40,6 +40,7 @@
 
 import type {
   CanResult,
+  ContainerRef,
   DocumentChange,
   DocumentHandle,
   DocumentSource,
@@ -70,6 +71,7 @@ import {
 } from '@docx-editor.dev/core-contract/layout';
 import {
   deepFreezeValue,
+  docRangeEqual,
   editorError,
   emptyInteractionFrame,
   formattingEqual,
@@ -84,7 +86,9 @@ import {
   currentPage as currentPageOf,
   pageSetupOf,
   gateCommand,
+  paragraphSummaries,
   runFormattingOf,
+  selectionRangeOf,
   totalPages as totalPagesOf,
   tableContextOf,
 } from './docx-editor-derive.ts';
@@ -619,9 +623,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       parseError,
       editable: surface !== null && surface.session.editable && mode !== 'view',
       zoom,
-      // A DocRange addresses paragraphs by `w14:paraId`; the surface selection addresses
-      // canonical node ids. Until that mapping exists, null is the honest answer.
-      selection: null,
+      selection: selectionRangeOf(surface),
       formatting: runFormattingOf(surface),
       table: tableContextOf(surface),
       image: null,
@@ -656,16 +658,20 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       const pageSetup = pageSetupEqual(fresh.pageSetup ?? null, previous.pageSetup ?? null)
         ? previous.pageSetup
         : fresh.pageSetup;
-      next = { ...fresh, formatting, page, pageSetup };
+      const selection = docRangeEqual(fresh.selection, previous.selection)
+        ? previous.selection
+        : fresh.selection;
+      next = { ...fresh, formatting, page, pageSetup, selection };
       // Reuse the previous REFERENCE only when neither the caret NOR the document moved.
       //
-      // The snapshot is a lossy projection: `selection` is deliberately null (a `DocRange`
-      // addresses paragraphs by `w14:paraId`, which the surface cannot yet supply), and
-      // nothing in it names the document revision. So two genuinely different states
-      // derive value-equal snapshots, and a host subscribed through `useSyncExternalStore`
-      // never re-renders — freezing every control whose state is a question the snapshot
-      // does not carry, because `toolbarCommandState` re-asks `Editor.can`/`isActive` only
-      // when the store ticks.
+      // The snapshot is a lossy projection: `selection` is paragraph-granular (a
+      // `DocRange` addresses paragraphs by `w14:paraId`, never by offset), and nothing in
+      // it names the document revision. So two genuinely different states — a caret move
+      // WITHIN a paragraph, a structural edit at an unmoved caret — derive value-equal
+      // snapshots, and a host subscribed through `useSyncExternalStore` never re-renders —
+      // freezing every control whose state is a question the snapshot does not carry,
+      // because `toolbarCommandState` re-asks `Editor.can`/`isActive` only when the store
+      // ticks.
       //
       // Caret: Decrease Indent stayed live on a list item already at the outermost level,
       // and the bullet button stayed pressed after the caret moved into a numbered one.
@@ -860,17 +866,23 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     getActiveScope: (): ViewScope => ({ kind: 'body' }),
 
     query<K extends keyof EditorQueries>(query: { type: K } & EditorQueries[K]) {
-      // Two real answers, and the typed empty value for everything else.
+      // The real answers, and the typed empty value for everything else.
       switch (query.type as keyof EditorQueries) {
         case 'selectedText':
           return (surface?.selectedText() ?? '') as EditorQueryResults[K];
         case 'selectionFormatting':
           return (surface ? snapshotNow().formatting : null) as EditorQueryResults[K];
+        case 'selection':
+          return selectionRangeOf(surface) as EditorQueryResults[K];
+        case 'paragraphs':
+          return paragraphSummaries(
+            surface,
+            (query as { container?: ContainerRef }).container
+          ) as unknown as EditorQueryResults[K];
         case 'isInsideToc':
           return false as EditorQueryResults[K];
         case 'trackedChanges':
         case 'revisions':
-        case 'paragraphs':
         case 'findText':
         case 'contentControls':
         case 'comments':
@@ -884,8 +896,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         case 'variables':
           return {} as EditorQueryResults[K];
         default:
-          // selection, tableContext, hyperlinkAt, watermark, splitCellConfig,
-          // contentControlAt, pageContent — all nullable, all underived.
+          // tableContext, hyperlinkAt, watermark, splitCellConfig, contentControlAt,
+          // pageContent — all nullable, all underived.
           return null as EditorQueryResults[K];
       }
     },

--- a/packages/core/src/store/__tests__/digest-blind-spots.test.ts
+++ b/packages/core/src/store/__tests__/digest-blind-spots.test.ts
@@ -216,3 +216,29 @@ describe('the stricter oracle still passes a real save and reopen', () => {
     });
   }
 });
+
+describe('w14 paragraph identity', () => {
+  const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+  const identified = (paraId: string) =>
+    load(
+      `<w:p xmlns:w14="${W14}" w14:paraId="${paraId}" w14:textId="${paraId}"><w:r><w:t>x</w:t></w:r></w:p>`
+    );
+
+  test('w14:paraId — the identity the agent contract anchors on', () => {
+    // Comment threading and DocAnchor addressing reference it; a serializer dropping or
+    // rewriting it must be a difference.
+    mustDiffer(identified('4C000001'), identified('4C000002'));
+    mustDiffer(identified('4C000001'), load('<w:p><w:r><w:t>x</w:t></w:r></w:p>'));
+    expect(differences(identified('4C000001'), identified('4C000002'))).toEqual([
+      '/word/document.xml.p[0].paraId',
+    ]);
+    // Case is not meaning: matching is case-insensitive, so casing alone is no difference.
+    expect(differences(identified('4c00aa01'), identified('4C00AA01'))).toEqual([]);
+  });
+
+  test('other paragraph attributes stay deliberately blind (rsid noise)', () => {
+    const withRsid = load('<w:p w:rsidR="00AB12CD"><w:r><w:t>x</w:t></w:r></w:p>');
+    const without = load('<w:p><w:r><w:t>x</w:t></w:r></w:p>');
+    expect(differences(withRsid, without)).toEqual([]);
+  });
+});

--- a/packages/core/src/store/__tests__/lossless-editing.test.ts
+++ b/packages/core/src/store/__tests__/lossless-editing.test.ts
@@ -204,3 +204,76 @@ describe('an edit survives a save and reopen without losing a class of content',
     expect(Object.keys(lost).length).toBeGreaterThan(0);
   });
 });
+
+describe('w14 paragraph identity is lossless', () => {
+  // Element census cannot see attributes: a serializer dropping every `w14:paraId` would
+  // pass both guards above. Comments and tracked changes anchor to these values, so they
+  // get their own multiset guard — authored VALUES, verbatim, through the real session
+  // lane (open → normalize → edit → save → reopen).
+  const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+  const paraIdValuesOf = (part: OoxmlPart): string[] => {
+    const values: string[] = [];
+    for (const node of walk(part.root)) {
+      if (node.kind === 'textValue') continue;
+      const value = node.attributes?.find(
+        (attribute) => attribute.namespaceUri === W14 && attribute.localName === 'paraId'
+      )?.value;
+      if (value !== undefined) values.push(value);
+    }
+    return values.sort();
+  };
+
+  // All three carry authored Word paraIds (21 / 143 / 335).
+  for (const name of [
+    'example-with-image.docx',
+    'issue-319-sections.docx',
+    'footer-page-number.docx',
+  ]) {
+    test(`${name}: every authored paraId survives an edit, a save and a reopen verbatim`, async () => {
+      const { openTreeSession } = await import('../../binding/tree-session.ts');
+      const opened = openTreeSession(fixture(name));
+      if (!opened.ok) throw new Error(`${name}: ${opened.reason}`);
+      const session = opened.session;
+
+      const authored = paraIdValuesOf(open(name).part);
+      expect(authored.length).toBeGreaterThan(0);
+      // Opening normalizes; these fixtures are already fully identified, so the session
+      // part carries exactly the authored values.
+      expect(paraIdValuesOf(session.part())).toEqual(authored);
+
+      // An ordinary edit plus a split (the one op that MINTS an id).
+      const [first] = session.paragraphIds();
+      session.applyTreeOps([
+        { op: 'insertText', paragraphId: first!, offset: 0, text: 'X' },
+        { op: 'splitParagraph', paragraphId: first!, offset: 1 },
+      ]);
+
+      const reopened = readOoxmlPackage(session.save());
+      if (!reopened.ok) throw new Error(reopened.reason);
+      const after = paraIdValuesOf(reopened.package.parts.get(reopened.package.mainDocumentPart)!);
+
+      // Exactly the authored multiset plus ONE minted tail id — nothing lost, nothing
+      // rewritten, no duplicate.
+      expect(after.length).toBe(authored.length + 1);
+      const remaining = [...after];
+      for (const value of authored) {
+        const at = remaining.indexOf(value);
+        expect(at).toBeGreaterThanOrEqual(0);
+        remaining.splice(at, 1);
+      }
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]).toMatch(/^[0-9A-F]{8}$/);
+      expect(new Set(after).size).toBe(after.length);
+
+      // Header/footer parts are outside the identity pass: their paraIds (if any) must
+      // come back byte-for-byte from the same save.
+      for (const [partName, part] of reopened.package.parts) {
+        if (!/header\d*\.xml$|footer\d*\.xml$/.test(partName)) continue;
+        const original = readOoxmlPackage(fixture(name));
+        if (!original.ok) continue;
+        const before = original.package.parts.get(partName);
+        if (before) expect(paraIdValuesOf(part)).toEqual(paraIdValuesOf(before));
+      }
+    });
+  }
+});

--- a/packages/core/src/store/__tests__/para-id.test.ts
+++ b/packages/core/src/store/__tests__/para-id.test.ts
@@ -1,0 +1,267 @@
+// `w14:paraId` value rules, deterministic minting, and load-time normalization
+// (para-id.ts): every paragraph of an opened main part carries a valid, part-unique
+// identity; documents that already do are returned by reference, byte-stable.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  canonicalOoxmlFingerprint,
+  readOoxmlPart,
+  serializeOoxmlPart,
+  validateOoxmlPart,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../package/ooxml-tree.ts';
+import { readOoxmlPackage } from '../package/ooxml-package.ts';
+import {
+  isValidParaId,
+  mintParaId,
+  normalizeParagraphIdentity,
+  paraIdOf,
+  usedParaIds,
+  w14RootPrefix,
+} from '../package/para-id.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+
+const FIXTURES = join(import.meta.dir, '../../../../../e2e/fixtures');
+
+function loadDocument(xml: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function mainPartOf(fixture: string): OoxmlPart {
+  const bytes = new Uint8Array(readFileSync(join(FIXTURES, fixture)));
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const main = loaded.package.parts.get(loaded.package.mainDocumentPart);
+  if (!main) throw new Error('no main part');
+  return main;
+}
+
+function wmlParagraphs(part: OoxmlPart): OoxmlElement[] {
+  const paragraphs: OoxmlElement[] = [];
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.namespaceUri === W && node.localName === 'p') paragraphs.push(node);
+    for (const child of node.children) walk(child);
+  };
+  walk(part.root);
+  return paragraphs;
+}
+
+describe('isValidParaId', () => {
+  test('accepts 8-hex values in (0, 0x80000000)', () => {
+    expect(isValidParaId('00000001')).toBe(true);
+    expect(isValidParaId('7FFFFFFF')).toBe(true);
+    expect(isValidParaId('4c2a91e0')).toBe(true); // lowercase hex is legal
+    expect(isValidParaId('19481808')).toBe(true);
+  });
+
+  test('rejects zero, the high-bit range, and malformed tokens', () => {
+    expect(isValidParaId('00000000')).toBe(false); // Word treats as absent
+    expect(isValidParaId('80000000')).toBe(false);
+    expect(isValidParaId('FFFFFFFF')).toBe(false);
+    expect(isValidParaId('1234567')).toBe(false); // 7 chars
+    expect(isValidParaId('123456789')).toBe(false); // 9 chars
+    expect(isValidParaId('1234567G')).toBe(false);
+    expect(isValidParaId('')).toBe(false);
+  });
+});
+
+describe('mintParaId', () => {
+  test('deterministic, uppercase, in range', () => {
+    const first = mintParaId('seed', new Set());
+    expect(mintParaId('seed', new Set())).toBe(first);
+    expect(first).toMatch(/^[0-9A-F]{8}$/);
+    expect(isValidParaId(first)).toBe(true);
+  });
+
+  test('collision bump is deterministic too', () => {
+    const first = mintParaId('seed', new Set());
+    const bumped = mintParaId('seed', new Set([first]));
+    expect(bumped).not.toBe(first);
+    expect(isValidParaId(bumped)).toBe(true);
+    expect(mintParaId('seed', new Set([first]))).toBe(bumped);
+  });
+
+  test('terminates with a valid id under a saturated used-set', () => {
+    // Poison every value the 64 hash attempts could produce, forcing the linear probe.
+    const used = new Set<string>();
+    for (let attempt = 0; attempt < 64; attempt += 1) {
+      used.add(mintParaId('x', used));
+    }
+    const minted = mintParaId('x', used);
+    expect(isValidParaId(minted)).toBe(true);
+    expect(used.has(minted)).toBe(false);
+  });
+});
+
+describe('normalizeParagraphIdentity', () => {
+  test('mints for every paragraph shape: body, table cell, demoted-generic', () => {
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}"><w:body>` +
+        '<w:p><w:r><w:t>plain</w:t></w:r></w:p>' +
+        '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>' +
+        // A w:p with a w:val attribute demotes to generic — still a paragraph to Word.
+        '<w:p w:val="bogus"><w:r><w:t>demoted</w:t></w:r></w:p>' +
+        '</w:body></w:document>'
+    );
+    const normalized = normalizeParagraphIdentity(part);
+    expect(normalized).not.toBe(part);
+    const paragraphs = wmlParagraphs(normalized);
+    expect(paragraphs).toHaveLength(3);
+    const ids = paragraphs.map((paragraph) => paraIdOf(paragraph));
+    for (const id of ids) expect(isValidParaId(id!)).toBe(true);
+    expect(new Set(ids).size).toBe(3);
+    // The pair is written together, with textId mirroring paraId.
+    const serialized = serializeOoxmlPart(normalized);
+    for (const id of ids) expect(serialized).toContain(`w14:paraId="${id}" w14:textId="${id}"`);
+    // Root binding added exactly once.
+    expect(w14RootPrefix(normalized.root)).toBe('w14');
+    expect(serialized.match(/xmlns:w14=/g)).toHaveLength(1);
+  });
+
+  test('deterministic across parses and idempotent', () => {
+    const xml = `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>a</w:t></w:r></w:p><w:p/></w:body></w:document>`;
+    const first = normalizeParagraphIdentity(loadDocument(xml));
+    const second = normalizeParagraphIdentity(loadDocument(xml));
+    expect(serializeOoxmlPart(first)).toBe(serializeOoxmlPart(second));
+    expect(normalizeParagraphIdentity(first)).toBe(first);
+  });
+
+  test('a document whose paragraphs all carry valid unique ids returns BY REFERENCE', () => {
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>` +
+        '<w:p w14:paraId="4C000001" w14:textId="4C000001"/>' +
+        '<w:p w14:paraId="4C000002" w14:textId="4C000002"/>' +
+        '</w:body></w:document>'
+    );
+    expect(normalizeParagraphIdentity(part)).toBe(part);
+  });
+
+  test('real Word fixtures with full identity normalize to the same reference', () => {
+    for (const fixture of ['example-with-image.docx', 'issue-319-sections.docx']) {
+      const main = mainPartOf(fixture);
+      expect(normalizeParagraphIdentity(main)).toBe(main);
+    }
+  });
+
+  test('keeps valid ids verbatim; re-mints duplicates, zero, out-of-range and malformed', () => {
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>` +
+        '<w:p w14:paraId="4c00aa01" w14:textId="4c00aa01"/>' + // valid, lowercase — kept verbatim
+        '<w:p w14:paraId="4C00AA01" w14:textId="4C00AA01"/>' + // duplicate (case-insensitive) — re-minted
+        '<w:p w14:paraId="00000000" w14:textId="00000000"/>' + // zero = absent
+        '<w:p w14:paraId="FFFFFFFF" w14:textId="FFFFFFFF"/>' + // out of range
+        '<w:p w14:paraId="nothex!!" w14:textId="nothex!!"/>' + // malformed
+        '</w:body></w:document>'
+    );
+    const normalized = normalizeParagraphIdentity(part);
+    const ids = wmlParagraphs(normalized).map((paragraph) => paraIdOf(paragraph)!);
+    expect(ids[0]).toBe('4c00aa01');
+    for (const id of ids.slice(1)) {
+      expect(isValidParaId(id)).toBe(true);
+      expect(id.toUpperCase()).not.toBe('4C00AA01');
+    }
+    expect(new Set(ids.map((id) => id.toUpperCase())).size).toBe(5);
+    // The stale textId of a re-minted paragraph is replaced along with its paraId.
+    expect(serializeOoxmlPart(normalized)).not.toContain('FFFFFFFF');
+  });
+
+  test('a kept paraId without a root binding still gains the root binding', () => {
+    // Legal-but-unseen: w14 declared per-paragraph only. Split minting needs the ROOT
+    // binding, so normalization adds it even though no paragraph needed a mint.
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}"><w:body>` +
+        `<w:p xmlns:w14="${W14}" w14:paraId="4C000001" w14:textId="4C000001"/>` +
+        '</w:body></w:document>'
+    );
+    const normalized = normalizeParagraphIdentity(part);
+    expect(normalized).not.toBe(part);
+    expect(w14RootPrefix(normalized.root)).toBe('w14');
+    expect(paraIdOf(wmlParagraphs(normalized)[0]!)).toBe('4C000001');
+  });
+
+  test('reuses an existing root binding for the URI under another prefix', () => {
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}" xmlns:wx="${W14}"><w:body><w:p/></w:body></w:document>`
+    );
+    const normalized = normalizeParagraphIdentity(part);
+    expect(w14RootPrefix(normalized.root)).toBe('wx');
+    expect(serializeOoxmlPart(normalized)).toContain('wx:paraId=');
+  });
+
+  test('an authored root w14 binding shadowed mid-tree falls back to a fresh alias', () => {
+    // The root binds w14 correctly, but a hostile subtree rebinds it. Minting under
+    // the authored prefix would fail validation for the shadowed paragraph and the
+    // fail-open would strip identity from the WHOLE document — instead the pass mints
+    // under an alias that is valid at every depth.
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>` +
+        '<w:p/>' +
+        '<w:sdt xmlns:w14="urn:evil"><w:sdtContent><w:p/></w:sdtContent></w:sdt>' +
+        '</w:body></w:document>'
+    );
+    const normalized = normalizeParagraphIdentity(part);
+    expect(normalized).not.toBe(part);
+    const ids = wmlParagraphs(normalized).map((paragraph) => paraIdOf(paragraph)!);
+    expect(ids).toHaveLength(2);
+    for (const id of ids) expect(isValidParaId(id)).toBe(true);
+    expect(validateOoxmlPart(normalized).ok).toBe(true);
+    expect(serializeOoxmlPart(normalized)).toContain('w14a:paraId=');
+  });
+
+  test('a hostile mid-tree xmlns:w14 pushes minting to a fallback prefix', () => {
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}"><w:body>` +
+        '<w:p><w:r><w:rPr><w:evil xmlns:w14="urn:evil"/></w:rPr></w:r></w:p>' +
+        '</w:body></w:document>'
+    );
+    const normalized = normalizeParagraphIdentity(part);
+    expect(normalized).not.toBe(part);
+    expect(w14RootPrefix(normalized.root)).toBe('w14a');
+    expect(validateOoxmlPart(normalized).ok).toBe(true);
+    // Round-trips: serialize → reparse → fingerprint-identical.
+    const reopened = loadDocument(serializeOoxmlPart(normalized));
+    expect(canonicalOoxmlFingerprint(reopened)).toBe(canonicalOoxmlFingerprint(normalized));
+  });
+
+  test('mc:Ignorable gains the prefix token only when the attribute already exists', () => {
+    const withIgnorable = normalizeParagraphIdentity(
+      loadDocument(
+        `<w:document xmlns:w="${W}" xmlns:mc="${MC}" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" mc:Ignorable="w15"><w:body><w:p/></w:body></w:document>`
+      )
+    );
+    const ignorable = withIgnorable.root.attributes.find(
+      (attribute) => attribute.namespaceUri === MC && attribute.localName === 'Ignorable'
+    );
+    expect(ignorable?.value).toBe('w15 w14');
+
+    const without = normalizeParagraphIdentity(
+      loadDocument(`<w:document xmlns:w="${W}"><w:body><w:p/></w:body></w:document>`)
+    );
+    expect(
+      without.root.attributes.some(
+        (attribute) => attribute.namespaceUri === MC && attribute.localName === 'Ignorable'
+      )
+    ).toBe(false);
+  });
+
+  test('normalized output validates, serializes and round-trips the fingerprint', () => {
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>x</w:t></w:r></w:p><w:p/></w:body></w:document>`
+    );
+    const normalized = normalizeParagraphIdentity(part);
+    expect(validateOoxmlPart(normalized).ok).toBe(true);
+    const reopened = loadDocument(serializeOoxmlPart(normalized));
+    expect(canonicalOoxmlFingerprint(reopened)).toBe(canonicalOoxmlFingerprint(normalized));
+    expect(usedParaIds(reopened.root)).toEqual(usedParaIds(normalized.root));
+  });
+});

--- a/packages/core/src/store/__tests__/tree-ops.test.ts
+++ b/packages/core/src/store/__tests__/tree-ops.test.ts
@@ -21,14 +21,31 @@ import {
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
 
 function load(body: string): OoxmlPart {
   const result = readOoxmlPart(
-    `<w:document xmlns:w="${W}" xmlns:a="${A}"><w:body>${body}</w:body></w:document>`,
+    `<w:document xmlns:w="${W}" xmlns:a="${A}" xmlns:w14="${W14}"><w:body>${body}</w:body></w:document>`,
     { name: '/word/document.xml', contentType: 'app/xml' }
   );
   if (!result.ok) throw new Error(result.reason);
   return result.part;
+}
+
+function paraIdAttrOf(part: OoxmlPart, paragraphId: string): string | undefined {
+  let found: string | undefined;
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.id === paragraphId) {
+      found = node.attributes.find(
+        (attribute) => attribute.namespaceUri === W14 && attribute.localName === 'paraId'
+      )?.value;
+      return;
+    }
+    for (const child of node.children) walk(child);
+  };
+  walk(part.root);
+  return found;
 }
 
 function paragraphIds(part: OoxmlPart): string[] {
@@ -527,6 +544,13 @@ describe('splitParagraphMany equals the sequence of single splits it stands for'
       name: 'tabs and breaks',
       body: '<w:p><w:r><w:t>ab</w:t><w:tab/><w:t>cd</w:t><w:br/><w:t>ef</w:t></w:r></w:p>',
     },
+    {
+      // With identity present, BOTH routes mint tail paraIds — the serialized-XML
+      // equality below is then the byte-level determinism oracle for the minting
+      // scheme, including how a repeated offset's seed collision bumps.
+      name: 'a paragraph carrying w14 identity',
+      body: '<w:p w14:paraId="4C000001" w14:textId="4C000001"><w:r><w:t>alpha bravo charlie</w:t></w:r></w:p>',
+    },
   ];
   // Repeated offsets are legal and mean a blank line: two boundaries at one position put
   // an empty paragraph between them, which is what a paste containing "\n\n" carries.
@@ -809,5 +833,75 @@ describe('a section mark survives a split exactly once (the phantom-section fix)
     // and the body-level sectPr remain.
     const afterMark = serialized.slice(serialized.indexOf('<w:sectPr>') + 1);
     expect(afterMark).toContain('section two');
+  });
+});
+
+describe('split and join carry w14 paragraph identity', () => {
+  const IDENTIFIED =
+    '<w:p w14:paraId="4C000001" w14:textId="4C000001"><w:r><w:t>Hello world</w:t></w:r></w:p>';
+
+  test('split: the head keeps its paraId, the tail gets a fresh valid one', () => {
+    const part = load(IDENTIFIED);
+    const [id] = paragraphIds(part);
+    const next = apply(part, { op: 'splitParagraph', paragraphId: id!, offset: 5 });
+    const [head, tail] = paragraphIds(next);
+    expect(paraIdAttrOf(next, head!)).toBe('4C000001');
+    const tailId = paraIdAttrOf(next, tail!);
+    expect(tailId).toMatch(/^[0-9A-F]{8}$/);
+    expect(tailId).not.toBe('4C000001');
+    expect(Number.parseInt(tailId!, 16)).toBeGreaterThan(0);
+    expect(Number.parseInt(tailId!, 16)).toBeLessThan(0x80000000);
+    // Word writes the pair together; the tail's textId mirrors its paraId.
+    const serialized = serializeOoxmlPart(next);
+    expect(serialized).toContain(`w14:paraId="${tailId}" w14:textId="${tailId}"`);
+  });
+
+  test('split is deterministic: the same split mints the same tail id', () => {
+    const part = load(IDENTIFIED);
+    const [id] = paragraphIds(part);
+    const first = apply(part, { op: 'splitParagraph', paragraphId: id!, offset: 5 });
+    const second = apply(part, { op: 'splitParagraph', paragraphId: id!, offset: 5 });
+    expect(serializeOoxmlPart(first)).toBe(serializeOoxmlPart(second));
+  });
+
+  test('a head without identity mints nothing (low-level harness behavior)', () => {
+    const part = load(SIMPLE);
+    const [id] = paragraphIds(part);
+    const next = apply(part, { op: 'splitParagraph', paragraphId: id!, offset: 5 });
+    const [head, tail] = paragraphIds(next);
+    expect(paraIdAttrOf(next, head!)).toBeUndefined();
+    expect(paraIdAttrOf(next, tail!)).toBeUndefined();
+  });
+
+  test('join: the surviving head keeps ITS paraId and the removed one is gone', () => {
+    const part = load(
+      '<w:p w14:paraId="4C000001" w14:textId="4C000001"><w:r><w:t>Hello </w:t></w:r></w:p>' +
+        '<w:p w14:paraId="4C000002" w14:textId="4C000002"><w:r><w:t>world</w:t></w:r></w:p>'
+    );
+    const [first, second] = paragraphIds(part);
+    const next = apply(part, { op: 'joinParagraphs', firstId: first!, secondId: second! });
+    const [kept] = paragraphIds(next);
+    expect(paraIdAttrOf(next, kept!)).toBe('4C000001');
+    expect(serializeOoxmlPart(next)).not.toContain('4C000002');
+    expect(paragraphTextOf(next, kept!)).toBe('Hello world');
+  });
+});
+
+describe('minting fails soft under hostile prefix shadowing', () => {
+  test('Enter inside a subtree that shadows w14 commits without minting — never a refusal', () => {
+    // The harness root binds w14 correctly; the SDT rebinds it. An attribute minted
+    // under `w14` would resolve to the wrong URI at this depth and the whole
+    // transaction would be refused (`invalid-qname`) — an editing lockout. The split
+    // must instead give up on identity for this tail and keep editing alive.
+    const part = load(
+      '<w:sdt xmlns:w14="urn:evil"><w:sdtContent>' +
+        `<w:p xmlns:wx="${W14}" wx:paraId="4C000009" wx:textId="4C000009"><w:r><w:t>shadowed</w:t></w:r></w:p>` +
+        '</w:sdtContent></w:sdt>'
+    );
+    const [id] = paragraphIds(part);
+    const next = apply(part, { op: 'splitParagraph', paragraphId: id!, offset: 4 });
+    const [head, tail] = paragraphIds(next);
+    expect(paraIdAttrOf(next, head!)).toBe('4C000009');
+    expect(paraIdAttrOf(next, tail!)).toBeUndefined();
   });
 });

--- a/packages/core/src/store/__tests__/tree-store.test.ts
+++ b/packages/core/src/store/__tests__/tree-store.test.ts
@@ -346,3 +346,56 @@ describe('projection reconciliation creates no history entry (task 5.6)', () => 
     expect(s.redo()?.origin).toBe(ORIGIN_IDS.mutationRedo);
   });
 });
+
+describe('w14 paragraph identity through history', () => {
+  const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+  const IDENTIFIED =
+    '<w:p w14:paraId="4C000001" w14:textId="4C000001"><w:r><w:t>Hello</w:t></w:r></w:p>';
+
+  function identifiedStore(): { store: TreeDocumentStore; id: string } {
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>${IDENTIFIED}</w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    return { store: new TreeDocumentStore(result.part), id: paragraphIds(result.part)[0]! };
+  }
+
+  function paraIdAt(s: TreeDocumentStore, paragraphId: string): string | undefined {
+    let found: string | undefined;
+    const walk = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.id === paragraphId) {
+        found = node.attributes.find(
+          (attribute) => attribute.namespaceUri === W14 && attribute.localName === 'paraId'
+        )?.value;
+        return;
+      }
+      for (const child of node.children) walk(child);
+    };
+    walk(s.part.root);
+    return found;
+  }
+
+  test('undo removes a split-minted paraId; redo restores the identical value', () => {
+    const { store: s, id } = identifiedStore();
+    const body = s.part.root.children[0]! as Extract<OoxmlNode, { children: unknown }>;
+    const originalHead = body.children[0]!;
+    s.transact((ctx) => ctx.apply({ op: 'splitParagraph', paragraphId: id, offset: 2 }));
+    const [head, tail] = paragraphIds(s.part);
+    expect(paraIdAt(s, head!)).toBe('4C000001');
+    const minted = paraIdAt(s, tail!);
+    expect(minted).toMatch(/^[0-9A-F]{8}$/);
+
+    expect(s.undo()).not.toBeNull();
+    // History is whole-part snapshots: the original head OBJECT is back, attributes intact.
+    const bodyAfterUndo = s.part.root.children[0]! as Extract<OoxmlNode, { children: unknown }>;
+    expect(bodyAfterUndo.children[0]).toBe(originalHead);
+    expect(paragraphIds(s.part)).toHaveLength(1);
+
+    expect(s.redo()).not.toBeNull();
+    const [, redoneTail] = paragraphIds(s.part);
+    // Redo replays the post-edit snapshot — the SAME minted id, never a second mint.
+    expect(paraIdAt(s, redoneTail!)).toBe(minted);
+  });
+});

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -175,4 +175,13 @@ export {
   type SemanticDigest,
   type StoryDigest,
 } from './ooxml-digest.ts';
+export {
+  isValidParaId,
+  mintParaId,
+  mintedParagraphIdentityAttributes,
+  normalizeParagraphIdentity,
+  paraIdOf,
+  usedParaIds,
+  w14RootPrefix,
+} from './para-id.ts';
 export { ensureListDefinition, ensureNumberingLevel, type ListKind } from './numbering-part.ts';

--- a/packages/core/src/store/package/ooxml-digest.ts
+++ b/packages/core/src/store/package/ooxml-digest.ts
@@ -29,6 +29,7 @@
 
 import { hardBreakText } from './hard-break.ts';
 import { MAX_XML_DEPTH } from './xml-reader.ts';
+import { paraIdOf } from './para-id.ts';
 import { canonicalOoxmlFingerprint, WML_NAMESPACE_URI } from './ooxml-tree.ts';
 import type {
   OoxmlElement,
@@ -51,6 +52,13 @@ export interface ParagraphDigest {
    * with the same ordinal and the same text.
    */
   readonly path: string;
+  /**
+   * `w14:paraId`, uppercase-normalized (matching is case-insensitive), or null. This is
+   * MANAGED identity — the agent contract anchors on it and comment threading references
+   * it — so a serializer silently dropping it must be a digest difference. Other paragraph
+   * attributes (`w:rsidR` …) stay deliberately undigested: they are revision noise.
+   */
+  readonly paraId: string | null;
   /** Text content, including tabs and hard breaks as their characters. */
   readonly text: string;
   /** Accepted paragraph properties, as sorted tokens including nested children. */
@@ -214,9 +222,11 @@ function digestParagraph(
     }
     collectGeneric(child, genericStructure);
   }
+  const paraId = paraIdOf(paragraph);
   return {
     ordinal,
     path,
+    paraId: paraId === null ? null : paraId.toUpperCase(),
     text,
     paragraphProperties: propertyTokens(pPr),
     runProperties,
@@ -358,6 +368,7 @@ export function diffSemanticDigests(
       const pb = b.paragraphs[p]!;
       if (pa.text !== pb.text) report(at(`.p[${p}].text`), pa.text, pb.text);
       if (pa.path !== pb.path) report(at(`.p[${p}].path`), pa.path, pb.path);
+      if (pa.paraId !== pb.paraId) report(at(`.p[${p}].paraId`), pa.paraId, pb.paraId);
       if (JSON.stringify(pa.paragraphProperties) !== JSON.stringify(pb.paragraphProperties)) {
         report(at(`.p[${p}].paragraphProperties`), pa.paragraphProperties, pb.paragraphProperties);
       }

--- a/packages/core/src/store/package/ooxml-shared.ts
+++ b/packages/core/src/store/package/ooxml-shared.ts
@@ -21,6 +21,8 @@ export const XML_NAMESPACE_URI = 'http://www.w3.org/XML/1998/namespace';
 export const XMLNS_NAMESPACE_URI = 'http://www.w3.org/2000/xmlns/';
 export const MC_NAMESPACE_URI = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
 export const XSI_NAMESPACE_URI = 'http://www.w3.org/2001/XMLSchema-instance';
+/** The `w14` wordml-2010 extension namespace — `w14:paraId`/`w14:textId` live here. */
+export const W14_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2010/wordml';
 export const MC_QNAME_LIST_ATTRIBUTES = new Set([
   'ProcessContent',
   'PreserveElements',

--- a/packages/core/src/store/package/ooxml-tree.ts
+++ b/packages/core/src/store/package/ooxml-tree.ts
@@ -20,7 +20,12 @@ import {
   type KnownKind,
 } from './ooxml-shared.ts';
 
-export { WML_NAMESPACE_URI, XML_NAMESPACE_URI, XMLNS_NAMESPACE_URI } from './ooxml-shared.ts';
+export {
+  W14_NAMESPACE_URI,
+  WML_NAMESPACE_URI,
+  XML_NAMESPACE_URI,
+  XMLNS_NAMESPACE_URI,
+} from './ooxml-shared.ts';
 export {
   canonicalOoxmlFingerprint,
   ooxmlTreesEqual,

--- a/packages/core/src/store/package/para-id.ts
+++ b/packages/core/src/store/package/para-id.ts
@@ -1,0 +1,305 @@
+// `w14:paraId` — Word's stable paragraph identity.
+//
+// Word (2013+) stamps every `<w:p>` with an 8-hex `w14:paraId` (paired with
+// `w14:textId`). Other parts anchor to it: `commentsExtended.xml` threads comment
+// replies by it, tracked-changes/coauthoring merge references it, and the public
+// contract addresses paragraphs by it (`DocAnchor.paraId`). This module owns the
+// value rules, deterministic minting, and the load-time normalization pass that
+// guarantees every paragraph of an opened part carries a valid, part-unique id.
+//
+// Value rules (MS-DOCX §2.6.2.3 / §2.6.2.4 — an MS extension, not ECMA-376):
+// 8 hex digits, greater than 0x00000000 and less than 0x80000000, unique among
+// the paragraphs of one document part, matched case-insensitively. Word treats
+// `00000000` as absent. `w14:textId` carries no uniqueness requirement.
+//
+// Minting is DETERMINISTIC (FNV-1a over a caller-supplied seed), not random:
+// `splitParagraphMany` must stay byte-identical to the sequence of single splits
+// it stands for, reopening the same bytes must rebuild the same tree, and tests
+// must be reproducible. Randomness buys nothing here — uniqueness is what Word
+// requires, and the collision bump provides it.
+
+import { MC_NAMESPACE_URI, W14_NAMESPACE_URI, WML_NAMESPACE_URI } from './ooxml-shared.ts';
+import type { OoxmlAttribute, OoxmlElement, OoxmlNode, OoxmlPart } from './ooxml-tree.ts';
+import { validateOoxmlPart } from './ooxml-validate.ts';
+
+const PARA_ID_PATTERN = /^[0-9A-Fa-f]{8}$/;
+
+/** Valid per MS-DOCX: 8 hex digits, non-zero, below 0x80000000. */
+export function isValidParaId(value: string): boolean {
+  if (!PARA_ID_PATTERN.test(value)) return false;
+  const numeric = Number.parseInt(value, 16);
+  return numeric !== 0 && numeric < 0x80000000;
+}
+
+/** The authored `w14:paraId` value of an element, verbatim, or null. */
+export function paraIdOf(node: OoxmlNode): string | null {
+  if (node.kind === 'textValue') return null;
+  for (const attribute of node.attributes) {
+    if (attribute.namespaceUri === W14_NAMESPACE_URI && attribute.localName === 'paraId')
+      return attribute.value;
+  }
+  return null;
+}
+
+function fnv1a32(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function toHex8(value: number): string {
+  return value.toString(16).toUpperCase().padStart(8, '0');
+}
+
+/**
+ * Deterministic 8-hex mint in (0x00000000, 0x80000000), collision-free against
+ * `used` (uppercase hex). Same seed + same used-set → same value, which is what
+ * keeps `splitParagraphMany` byte-identical to its equivalent single splits and
+ * a reopened save identical to the session that produced it.
+ */
+export function mintParaId(seed: string, used: ReadonlySet<string>): string {
+  let candidate = 0;
+  for (let attempt = 0; attempt < 64; attempt += 1) {
+    candidate = fnv1a32(attempt === 0 ? seed : `${seed} ${attempt}`) & 0x7fffffff;
+    const hex = toHex8(candidate);
+    if (candidate !== 0 && !used.has(hex)) return hex;
+  }
+  // Hostile saturation: bounded linear probe. Terminates because a document part
+  // cannot hold 0x7FFFFFFF paragraphs, so a free value always exists.
+  for (;;) {
+    candidate = (candidate % 0x7fffffff) + 1;
+    const hex = toHex8(candidate);
+    if (!used.has(hex)) return hex;
+  }
+}
+
+const usedParaIdCache = new WeakMap<OoxmlElement, ReadonlySet<string>>();
+
+/** Every valid `w14:paraId` in the tree, uppercased. Memoized per root object. */
+export function usedParaIds(root: OoxmlElement): ReadonlySet<string> {
+  const cached = usedParaIdCache.get(root);
+  if (cached) return cached;
+  const used = new Set<string>();
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    const value = paraIdOf(node);
+    if (value !== null && isValidParaId(value)) used.add(value.toUpperCase());
+    for (const child of node.children) visit(child);
+  };
+  visit(root);
+  usedParaIdCache.set(root, used);
+  return used;
+}
+
+/**
+ * The non-empty prefix the part ROOT binds to the w14 namespace, or null.
+ *
+ * Minted attributes require an in-scope binding (the invariant validator reports
+ * `invalid-qname` otherwise, and the serializer would allocate an `nsN` alias).
+ * Only the root binding counts: a binding authored on some descendant does not
+ * cover paragraphs elsewhere in the tree.
+ */
+export function w14RootPrefix(root: OoxmlElement): string | null {
+  for (const binding of root.namespaceBindings) {
+    if (binding.namespaceUri === W14_NAMESPACE_URI && binding.prefix !== '') return binding.prefix;
+  }
+  return null;
+}
+
+/** The minted `[w14:paraId, w14:textId]` pair. `textId` mirrors `paraId`: it has no uniqueness requirement, no consumer reads it, and one allocator is simpler than two — but Word writes both, so we write both. */
+export function mintedParagraphIdentityAttributes(
+  prefix: string,
+  value: string
+): readonly OoxmlAttribute[] {
+  return Object.freeze([
+    Object.freeze({
+      kind: 'genericExtension',
+      namespaceUri: W14_NAMESPACE_URI,
+      localName: 'paraId',
+      prefix,
+      value,
+    } as const),
+    Object.freeze({
+      kind: 'genericExtension',
+      namespaceUri: W14_NAMESPACE_URI,
+      localName: 'textId',
+      prefix,
+      value,
+    } as const),
+  ]);
+}
+
+function isWmlParagraphElement(node: OoxmlNode): node is OoxmlElement {
+  return (
+    node.kind !== 'textValue' && node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'p'
+  );
+}
+
+/** Document-order WML `<w:p>` elements at any depth — typed AND demoted-generic (a demoted `w:p` is still a paragraph to Word), including paragraphs nested in table cells, SDTs and textbox content. */
+function collectWmlParagraphs(root: OoxmlElement): OoxmlElement[] {
+  const paragraphs: OoxmlElement[] = [];
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (isWmlParagraphElement(node)) paragraphs.push(node);
+    for (const child of node.children) visit(child);
+  };
+  visit(root);
+  return paragraphs;
+}
+
+function isIdentityAttribute(attribute: OoxmlAttribute): boolean {
+  return (
+    attribute.namespaceUri === W14_NAMESPACE_URI &&
+    (attribute.localName === 'paraId' || attribute.localName === 'textId')
+  );
+}
+
+/** Every prefix that ANY binding in the tree ties to a URI other than w14 — a prefix in this set can be shadowed at some paragraph's depth (`xmlns:w14="urn:evil"` mid-tree) and is unusable for minting. */
+function conflictingW14Prefixes(root: OoxmlElement): ReadonlySet<string> {
+  const conflicting = new Set<string>();
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    for (const binding of node.namespaceBindings) {
+      if (binding.namespaceUri !== W14_NAMESPACE_URI) conflicting.add(binding.prefix);
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(root);
+  return conflicting;
+}
+
+/** A prefix for the w14 URI outside the conflicting set — usable at EVERY depth. */
+function chooseW14Prefix(conflicting: ReadonlySet<string>): string {
+  if (!conflicting.has('w14')) return 'w14';
+  for (let suffix = 97; suffix <= 122; suffix += 1) {
+    const candidate = `w14${String.fromCharCode(suffix)}`;
+    if (!conflicting.has(candidate)) return candidate;
+  }
+  for (let counter = 2; ; counter += 1) {
+    const candidate = `w14x${counter}`;
+    if (!conflicting.has(candidate)) return candidate;
+  }
+}
+
+function freezeElement(element: OoxmlElement): OoxmlElement {
+  Object.freeze(element.attributes);
+  Object.freeze(element.namespaceBindings);
+  Object.freeze(element.children);
+  return Object.freeze(element);
+}
+
+/**
+ * Load-time paragraph-identity normalization for a session's main part.
+ *
+ * Keeps every valid, first-seen paraId verbatim; mints (deterministically, seeded
+ * by the paragraph's structural node id) for paragraphs whose id is missing,
+ * malformed, zero, out of range, or a duplicate. Adds the root `xmlns` binding
+ * the minted attributes need. Returns the INPUT PART REFERENCE when there is
+ * nothing to do — a document Word saved yesterday re-serializes byte-identical.
+ *
+ * Attribute-only rebuilds move no child, so every node keeps its structural-path
+ * id; the copy respreads only the ancestors of changed paragraphs.
+ *
+ * Fail-open: if the rebuilt part does not validate (a bug, or a pathology the
+ * prefix choice could not defuse), the original part is returned — a document
+ * must never become unopenable over an identity enhancement.
+ */
+export function normalizeParagraphIdentity(part: OoxmlPart): OoxmlPart {
+  const paragraphs = collectWmlParagraphs(part.root);
+  // Collision universe: PARAGRAPH ids only — MS-DOCX scopes uniqueness to paragraphs,
+  // so a paraId planted on some other element (attacker noise) neither blocks a mint
+  // nor gets deduplicated. The split path's `usedParaIds` walks the whole tree and is
+  // therefore strictly wider; both guarantee paragraph-level uniqueness.
+  const seen = new Set<string>();
+  const toMint: OoxmlElement[] = [];
+  let keptAny = false;
+  for (const paragraph of paragraphs) {
+    const value = paraIdOf(paragraph);
+    const canonical = value !== null && isValidParaId(value) ? value.toUpperCase() : null;
+    if (canonical !== null && !seen.has(canonical)) {
+      seen.add(canonical);
+      keptAny = true;
+    } else {
+      toMint.push(paragraph);
+    }
+  }
+
+  const rootPrefix = w14RootPrefix(part.root);
+  // The byte-stability early return: nothing to mint, and kept ids (if any) already
+  // have a root binding. Deliberately does NOT scan for shadowed subtrees — a fully
+  // identified Word document must re-serialize byte-identical, and the split path
+  // resolves its own in-scope prefix per paragraph anyway.
+  if (toMint.length === 0 && !(keptAny && rootPrefix === null)) return part;
+
+  // A root prefix that some descendant rebinds to another URI is unusable: minting
+  // under it fails validation for every paragraph inside the shadow, and the fail-open
+  // below would then strip identity from the WHOLE document. Mint under a fresh alias
+  // (outside the conflicting set → valid at every depth) instead.
+  const conflicting = conflictingW14Prefixes(part.root);
+  const prefix =
+    rootPrefix !== null && !conflicting.has(rootPrefix) ? rootPrefix : chooseW14Prefix(conflicting);
+  const needsRootBinding = !part.root.namespaceBindings.some(
+    (binding) => binding.prefix === prefix && binding.namespaceUri === W14_NAMESPACE_URI
+  );
+  const attributesByNodeId = new Map<string, readonly OoxmlAttribute[]>();
+  for (const paragraph of toMint) {
+    const minted = mintParaId(paragraph.id, seen);
+    seen.add(minted);
+    attributesByNodeId.set(paragraph.id, [
+      ...mintedParagraphIdentityAttributes(prefix, minted),
+      ...paragraph.attributes.filter((attribute) => !isIdentityAttribute(attribute)),
+    ]);
+  }
+
+  const rebuild = (node: OoxmlNode): OoxmlNode => {
+    if (node.kind === 'textValue') return node;
+    let children: OoxmlNode[] | null = null;
+    node.children.forEach((child, index) => {
+      const next = rebuild(child);
+      if (next !== child) {
+        children ??= [...node.children];
+        children[index] = next;
+      }
+    });
+    const attributes = attributesByNodeId.get(node.id);
+    if (!attributes && !children) return node;
+    return freezeElement({
+      ...node,
+      ...(children ? { children } : {}),
+      ...(attributes ? { attributes } : {}),
+    } as OoxmlElement);
+  };
+
+  let root = rebuild(part.root) as OoxmlElement;
+  if (needsRootBinding) {
+    const bindings = [
+      ...root.namespaceBindings,
+      Object.freeze({ prefix, namespaceUri: W14_NAMESPACE_URI }),
+    ];
+    // `mc:Ignorable` tells strict consumers the prefix is skippable. Append the
+    // token only when the attribute already exists without it — creating one
+    // would drag in an `mc` binding for a purely cosmetic gain.
+    const ignorable = root.attributes.find(
+      (attribute) =>
+        attribute.namespaceUri === MC_NAMESPACE_URI && attribute.localName === 'Ignorable'
+    );
+    let attributes: readonly OoxmlAttribute[] = root.attributes;
+    if (ignorable && !ignorable.value.trim().split(/\s+/).includes(prefix)) {
+      attributes = root.attributes.map((attribute) =>
+        attribute === ignorable
+          ? (Object.freeze({
+              ...attribute,
+              value: [ignorable.value.trim(), prefix].filter(Boolean).join(' '),
+            }) as OoxmlAttribute)
+          : attribute
+      );
+    }
+    root = freezeElement({ ...root, namespaceBindings: bindings, attributes } as OoxmlElement);
+  }
+
+  const normalized: OoxmlPart = { ...part, root };
+  return validateOoxmlPart(normalized).ok ? normalized : part;
+}

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -8,6 +8,7 @@
 import { hardBreakAttributes, hardBreakText } from '../package/hard-break.ts';
 import {
   WML_NAMESPACE_URI,
+  type OoxmlAttribute,
   type OoxmlNode,
   type OoxmlParagraphNode,
   type OoxmlPart,
@@ -21,6 +22,14 @@ import {
   replaceNode,
   type EditOptions,
 } from '../package/ooxml-edit.ts';
+import { W14_NAMESPACE_URI } from '../package/ooxml-shared.ts';
+import {
+  isValidParaId,
+  mintParaId,
+  mintedParagraphIdentityAttributes,
+  paraIdOf,
+  usedParaIds,
+} from '../package/para-id.ts';
 import {
   TEXT_DEPS,
   cloneWithNewIds,
@@ -443,6 +452,64 @@ function zeroLengthGoesToHead(
   return closesAnOpenRange(child, openedHere);
 }
 
+/**
+ * A root-declared w14 prefix that still resolves to the w14 URI AT THE PARAGRAPH.
+ *
+ * The root binding alone is not enough: a hostile descendant can rebind the same
+ * prefix (`<w:sdt xmlns:w14="urn:evil">`), and an attribute minted under it would
+ * resolve to the wrong URI at that depth — the commit-boundary delta validation
+ * would then refuse the WHOLE transaction, turning Enter into a silent no-op inside
+ * that subtree. Editing must never lock on hostile input, so each root alias for the
+ * URI is checked against the paragraph's ancestor chain and the first unshadowed one
+ * wins; none → no minting (the tail is simply id-less, as before minting existed).
+ */
+function w14PrefixInScopeAt(part: OoxmlPart, paragraph: OoxmlParagraphNode): string | null {
+  const rootBindings = part.root.namespaceBindings.filter(
+    (binding) => binding.namespaceUri === W14_NAMESPACE_URI && binding.prefix !== ''
+  );
+  if (rootBindings.length === 0) return null;
+  // The paragraph and its ancestors up to (excluding) the root — the nodes whose own
+  // declarations can shadow a root binding at the paragraph's depth.
+  const chain: OoxmlNode[] = [];
+  let node: OoxmlNode | null = paragraph;
+  while (node && node.id !== part.root.id) {
+    chain.push(node);
+    node = parentOf(part, node.id);
+  }
+  for (const binding of rootBindings) {
+    const shadowed = chain.some(
+      (ancestor) =>
+        ancestor.kind !== 'textValue' &&
+        ancestor.namespaceBindings.some(
+          (candidate) =>
+            candidate.prefix === binding.prefix && candidate.namespaceUri !== W14_NAMESPACE_URI
+        )
+    );
+    if (!shadowed) return binding.prefix;
+  }
+  return null;
+}
+
+/**
+ * Whether a split of `paragraph` can mint `w14:paraId`s for its tails: the head must
+ * carry a valid id (its uppercase form seeds the tail mints) and a w14 prefix must be
+ * in scope at the paragraph (a prefixed attribute without a correct in-scope binding
+ * fails the commit-boundary delta validation). In a real session both always hold —
+ * the load-time normalization established them. In low-level harnesses that skip it,
+ * and in hostile prefix-shadowed subtrees, tails stay attribute-less exactly as
+ * before minting existed — never a refused transaction.
+ */
+function splitIdentityOf(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode
+): { readonly headId: string; readonly prefix: string } | null {
+  const headParaId = paraIdOf(paragraph);
+  if (headParaId === null || !isValidParaId(headParaId)) return null;
+  const prefix = w14PrefixInScopeAt(part, paragraph);
+  if (prefix === null) return null;
+  return { headId: headParaId.toUpperCase(), prefix };
+}
+
 function applySplit(
   part: OoxmlPart,
   paragraph: OoxmlParagraphNode,
@@ -520,6 +587,11 @@ function applySplit(
   // onto both halves minted a phantom section (and a spurious page break) on every
   // Enter in a section's last paragraph.
   const headPPr = pPr ? withoutSectionMark(pPr) : undefined;
+  // The HEAD keeps the original paragraph's `w14:paraId` (it is spread below); the tail
+  // is the new paragraph and gets a fresh deterministic mint, exactly as Word assigns a
+  // new id to the paragraph an Enter creates. Seeded by (head id, offset) so one
+  // `splitParagraphMany` and its equivalent sequence of single splits mint identically.
+  const identity = splitIdentityOf(part, paragraph);
   const tailParagraph = {
     id: nextId(),
     kind: 'paragraph',
@@ -527,7 +599,12 @@ function applySplit(
     localName: 'p',
     prefix: 'w',
     namespaceBindings: [],
-    attributes: [],
+    attributes: identity
+      ? mintedParagraphIdentityAttributes(
+          identity.prefix,
+          mintParaId(`${identity.headId}:${offset}`, usedParaIds(part.root))
+        )
+      : [],
     children: pPr ? [cloneWithNewIds(pPr, nextId), ...tailChildren] : tailChildren,
   } as unknown as OoxmlNode;
 
@@ -687,6 +764,23 @@ function applySplitMany(
   // after all the paragraph's content, exactly as the single-split rule keeps it on the
   // tail. Duplicating it minted one phantom section per pasted line.
   const strippedPPr = pPr ? withoutSectionMark(pPr) : undefined;
+  // Tail `w14:paraId`s, minted in DESCENDING piece order: the equivalent sequence of
+  // single splits runs last-offset-first, so its used-set grows from the last tail
+  // backwards. Mirroring that order (including how a repeated offset's seed collision
+  // bumps) keeps `splitParagraphMany` byte-identical to the singles it stands for.
+  const identity = splitIdentityOf(part, paragraph);
+  const tailIdentityAttributes: (readonly OoxmlAttribute[] | null)[] = Array.from(
+    { length: pieceCount },
+    () => null
+  );
+  if (identity) {
+    const used = new Set(usedParaIds(part.root));
+    for (let piece = pieceCount - 1; piece >= 1; piece -= 1) {
+      const value = mintParaId(`${identity.headId}:${offsets[piece - 1]!}`, used);
+      used.add(value);
+      tailIdentityAttributes[piece] = mintedParagraphIdentityAttributes(identity.prefix, value);
+    }
+  }
   const tailParagraphs: OoxmlNode[] = [];
   for (let piece = 1; piece < pieceCount; piece += 1) {
     const last = piece === pieceCount - 1;
@@ -698,7 +792,7 @@ function applySplitMany(
       localName: 'p',
       prefix: 'w',
       namespaceBindings: [],
-      attributes: [],
+      attributes: tailIdentityAttributes[piece] ?? [],
       children: source ? [cloneWithNewIds(source, nextId), ...pieces[piece]!] : pieces[piece]!,
     } as unknown as OoxmlNode);
   }

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -4,6 +4,15 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
+  // The adapter runs in the browser. tsup's default platform is `node`, which
+  // resolves bundled deps through their `node` export condition — fflate then
+  // brings its worker_threads loader, whose `createRequire("/")` runs at module
+  // top level and throws in a browser (`createRequire is not a function`), so
+  // the demo died before first paint. `browser` picks fflate's browser build,
+  // exactly what the Vite-built vue adapter already ships; the CJS output stays
+  // SSR-safe because fflate touches Worker/Blob only inside its async APIs,
+  // which the editor never calls.
+  platform: 'browser',
   format: ['cjs', 'esm'],
   dts: true,
   splitting: false,


### PR DESCRIPTION
Word anchors comment threads and tracked changes to `w14:paraId`, and the public contract addresses paragraphs by it (`DocAnchor.paraId`, the value Office JS calls `uniqueLocalId`) — but the engine only spoke positional node ids, so `snapshot().selection` was hardwired null and edited documents shipped id-less tails.

Now: existing ids are preserved verbatim (a fully identified Word document saves byte-identical), missing ones are minted deterministically at open, split keeps the head's id and mints the tail's (`splitParagraphMany` stays byte-identical to its equivalent single splits), joins keep the survivor's, undo restores originals. A per-revision paraId↔nodeId index turns `snapshot().selection`, the `paragraphs` query and `setSelection`-by-anchor (exactly-once `search`, 1-based `occurrence`) into real answers. Hostile prefix shadowing fails soft — the split resolves its prefix in scope per paragraph and normalization mints under a fresh root alias, so editing never locks. `semanticDigest` now notices a dropped paraId; a lossless guard pins verbatim id survival through edit/save/reopen on real fixtures.

Pre-existing on the base branch, not touched here: the react `api:check` snapshot drift (from #84) and the `check:public-docs-surface` failure (pre-commit bypassed with `--no-verify` for that gate; typecheck and the full test suite run green — 2635 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788327375&installation_model_id=422592&pr_number=88&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F88&signature=7bcd15585b0f53fb1aab13210700a48d00feb07f42e783a67dea93106a6a8d94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->