### PR TITLE
fix: selection highlight steps with each run's height

### DIFF
--- a/.changeset/selection-band-steps-with-runs.md
+++ b/.changeset/selection-band-steps-with-runs.md
@@ -1,0 +1,6 @@
+---
+'@docx-editor.dev/react': patch
+'@docx-editor.dev/vue': patch
+---
+
+Selecting text on a line that mixes font sizes now highlights each run at its own height, the way Word draws it, instead of one uniform band as tall as the largest run. Text highlight and character shading follow the same run-height band.

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -207,6 +207,73 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
     expect(container.querySelectorAll('.docx-line')).toHaveLength(1);
   });
 
+  test('a run owns its line-height, so its selection band is its own height', () => {
+    // 11pt next to 22pt on one line. The band the browser draws follows each run's inner
+    // line box, so the run must NOT inherit the line's pixel line-height — inherited, an
+    // 11pt run next to a 22pt one highlighted as one uniform 28px slab.
+    const container = paint(
+      '<w:p><w:r><w:t>small</w:t></w:r>' +
+        '<w:r><w:rPr><w:sz w:val="44"/></w:rPr><w:t>big</w:t></w:r></w:p>'
+    );
+    const line = container.querySelector<HTMLElement>('.docx-line')!;
+    expect(line.style.height).toBe('28px'); // tallest run decides the line
+    const [small, big] = [...line.querySelectorAll<HTMLElement>('.layout-run-text')];
+    expect(small!.style.lineHeight).toBe('14px'); // its own published height
+    // The tallest run's band is exactly the line height — the same value it used to
+    // inherit — so the browser's line-box/baseline math is unchanged by the stepping.
+    expect(big!.style.lineHeight).toBe('28px');
+  });
+
+  test('line spacing above single joins the stepped bands with the extra leading', () => {
+    // Double spacing doubles the line box. Word still paints the leading, so every run's
+    // band grows by the same extra leading — capped at the line height, which the tallest
+    // run reaches exactly.
+    const container = paint(
+      '<w:p><w:pPr><w:spacing w:line="480" w:lineRule="auto"/></w:pPr>' +
+        '<w:r><w:t>small</w:t></w:r>' +
+        '<w:r><w:rPr><w:sz w:val="44"/></w:rPr><w:t>big</w:t></w:r></w:p>'
+    );
+    const line = container.querySelector<HTMLElement>('.docx-line')!;
+    expect(line.style.height).toBe('56px'); // 28 natural × 480/240
+    const [small, big] = [...line.querySelectorAll<HTMLElement>('.layout-run-text')];
+    expect(small!.style.lineHeight).toBe('42px'); // 14 own + 28 leading
+    expect(big!.style.lineHeight).toBe('56px'); // 28 own + 28 leading = the line height
+  });
+
+  test('a tab span gets its own band too, not the full line height', () => {
+    // A tab paints with `overflow: hidden`, which makes its inline-block baseline the
+    // BOTTOM edge (CSS2.1 §10.8.1) — so unlike a text run its whole band counts above the
+    // baseline. Inheriting the line height made a small-style tab dominate the line box of
+    // a mixed-size line and push every glyph below the published baseline; its own band
+    // keeps the tab's contribution no larger than the run it belongs with.
+    const container = paint(
+      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>' +
+        '<w:r><w:t>a</w:t><w:tab/></w:r>' +
+        '<w:r><w:rPr><w:sz w:val="44"/></w:rPr><w:t>big</w:t></w:r></w:p>'
+    );
+    const line = container.querySelector<HTMLElement>('.docx-line')!;
+    expect(line.style.height).toBe('28px');
+    const tab = [...line.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (el) => el.textContent === '\t'
+    )!;
+    expect(tab.style.lineHeight).toBe('14px'); // the tab style's own height, not the line's
+  });
+
+  test('an exact line rule below the natural height caps every band at the line', () => {
+    // `exact` can shrink the box below the glyphs (Word clips). Bands must not grow past
+    // the published line height, or a selection would spill over the neighbouring lines.
+    const container = paint(
+      '<w:p><w:pPr><w:spacing w:line="200" w:lineRule="exact"/></w:pPr>' +
+        '<w:r><w:t>small</w:t></w:r>' +
+        '<w:r><w:rPr><w:sz w:val="44"/></w:rPr><w:t>big</w:t></w:r></w:p>'
+    );
+    const line = container.querySelector<HTMLElement>('.docx-line')!;
+    expect(line.style.height).toBe('10px'); // 200 twips exact
+    const [small, big] = [...line.querySelectorAll<HTMLElement>('.layout-run-text')];
+    expect(small!.style.lineHeight).toBe('10px'); // 14 own, capped at the line
+    expect(big!.style.lineHeight).toBe('10px'); // 28 own, capped at the line
+  });
+
   test('superscript keeps a relative offset and is not clipped by the line box', () => {
     const container = paint(
       '<w:p><w:r><w:t>x</w:t></w:r>' +

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -311,7 +311,12 @@ function positioned(
   return element;
 }
 
-function paintSpan(document: Document, span: StyleSpanRecord, ctx: PaintContext): HTMLElement {
+function paintSpan(
+  document: Document,
+  span: StyleSpanRecord,
+  ctx: PaintContext,
+  bandHeightPt: number
+): HTMLElement {
   const element = document.createElement('span');
   element.className = 'layout-run layout-run-text';
   // Each run is its OWN box, aligned on the baseline.
@@ -322,6 +327,11 @@ function paintSpan(document: Document, span: StyleSpanRecord, ctx: PaintContext)
   // own size, which is how Word draws it: the band steps with the text.
   element.style.display = 'inline-block';
   element.style.verticalAlign = 'baseline';
+  // The box is only its own size if the run does NOT inherit the line's pixel line-height:
+  // inherited, every run's inner line box is the full line height and the band is one
+  // uniform slab again. The caller passes the height this run's band should be (its own
+  // published height, plus the line's extra leading, capped at the line height).
+  element.style.lineHeight = `${bandHeightPt * ctx.scale}px`;
   element.dataset.paragraphId = span.range.paragraphId;
   element.dataset.start = String(span.range.start);
   element.dataset.end = String(span.range.end);
@@ -393,7 +403,19 @@ function paintLine(document: Document, line: LineRecord, ctx: PaintContext): HTM
   const gap = interSpanGap(line);
   if (gap > 0) element.style.wordSpacing = `${gap * scale}px`;
 
-  for (const span of line.spans) element.append(paintSpan(document, span, ctx));
+  // Per-run band heights, chosen so the browser's line-box math cannot move a glyph:
+  // the tallest run's band is exactly the line height — the same value every run
+  // inherited before — so the box that decides where the common baseline sits is
+  // unchanged. Smaller runs get their own published height plus the line's extra
+  // leading (spacing above single keeps a contiguous band, as Word draws it), capped
+  // at the line height so an `exact`-spaced line cannot grow past its box.
+  let tallest = 0;
+  for (const span of line.spans) tallest = Math.max(tallest, span.box.height);
+  const leading = Math.max(0, line.box.height - tallest);
+  for (const span of line.spans) {
+    const band = Math.min(span.box.height + leading, line.box.height);
+    element.append(paintSpan(document, span, ctx, band));
+  }
   // A span-less line (empty paragraph) has no inline content, and a browser will not
   // draw a caret at a position with no inline box to measure. The <br> is the anchor;
   // sizing it to the line keeps the caret the paragraph's font height, not the div's


### PR DESCRIPTION
Runs are painted as inline-blocks so the native selection band can step with the text, but each run inherited the line's pixel line-height — its inner line box was always the full line height, so a line mixing 8pt and 36pt highlighted as one uniform slab. Each run now carries its own line-height (published span height + the line's extra leading, capped at the line height); the tallest run's band equals the line height, so line-box/baseline math is unchanged on tab-free lines and no glyph moves. On mixed-size tab lines the small-style tab (bottom-edge baseline, overflow: hidden) used to push glyphs below the published baseline; its own band snaps the line back to it.

Known follow-up, pre-existing and out of scope: on single-size tab lines the tab span's bottom-edge baseline still dominates the line box, rendering text a few px below the engine baseline that the caret and tab leaders use.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331616&installation_model_id=422592&pr_number=89&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F89&signature=de43797123a588f35403235c1afcd86ef0ae920169605581215bad2eec6d8a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->