### PR TITLE
feat(core): typed hyperlinks and bookmarks

### DIFF
--- a/.changeset/typed-hyperlinks-and-bookmarks.md
+++ b/.changeset/typed-hyperlinks-and-bookmarks.md
@@ -1,0 +1,11 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Hyperlinks and bookmarks: link text now renders, and links can be inserted, edited, followed and removed.
+
+`w:hyperlink` is a typed node, so the words inside a link are laid out, painted and selectable like any other text — previously they were dropped and a sentence with links rendered with holes in it. Clicking an external link opens a popover (`DocxEditor.HyperLink`) with the target, copy, edit and unlink; clicking an internal link scrolls to its bookmark and moves the caret, including targets on pages that have not been painted yet. Ctrl/Cmd+K and the toolbar's link button insert or edit at the selection.
+
+A link's text takes direct formatting like any other text — select it and make it red, bold or larger, and the change wins over the `Hyperlink` character style without removing it. This also fixes run formatting in any paragraph that contains a link: a range edit now addresses the runs after a link at their real offsets instead of landing inside the link.
+
+Targets are allowlisted at the trust boundary: `http(s)`, `mailto`, `tel` and `ftp` only, and an external target must be an absolute URL. Anything else renders inert and still round-trips unchanged. Opening a document never requests a link target.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -60,6 +60,7 @@ import { RulerUnit } from '@docx-editor.dev/core-contract/editor';
 import { runToolbarCommand } from '@docx-editor.dev/core-contract/editor';
 import { SectionProperties } from '@docx-editor.dev/core-contract/editor';
 import { SurfaceFormatting } from '@docx-editor.dev/core-contract/editor';
+import { SurfaceHyperlink } from '@docx-editor.dev/core-contract/editor';
 import { TextMeasurer } from '@docx-editor.dev/core-contract/editor';
 import { Theme } from '@docx-editor.dev/core-contract/contracts/editor';
 import { ToolbarCommandState } from '@docx-editor.dev/core-contract/editor';
@@ -112,6 +113,31 @@ export interface DocxEditorDocumentOutlineProps {
 // @public
 export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactElement;
 
+// @public (undocumented)
+export const DocxEditorHyperLink: DocxEditorHyperLinkNamespace;
+
+// @public
+export interface DocxEditorHyperLinkNamespace {
+    // (undocumented)
+    (props: HyperLinkProps): ReturnType<typeof HyperLinkRoot>;
+    // (undocumented)
+    readonly Apply: typeof HyperLinkApply;
+    // (undocumented)
+    readonly Cancel: typeof HyperLinkCancel;
+    // (undocumented)
+    readonly Copy: typeof HyperLinkCopy;
+    // (undocumented)
+    readonly Edit: typeof HyperLinkEdit;
+    // (undocumented)
+    readonly Error: typeof HyperLinkError;
+    // (undocumented)
+    readonly Fields: typeof HyperLinkFields;
+    // (undocumented)
+    readonly Unlink: typeof HyperLinkUnlink;
+    // (undocumented)
+    readonly Url: typeof HyperLinkUrl;
+}
+
 // @public
 export const DocxEditorLoading: DocxEditorLoadingComponent;
 
@@ -143,6 +169,7 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEdito
     readonly Content: typeof DocxEditorContent;
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
     readonly HorizontalRuler: typeof DocxEditorHorizontalRuler;
+    readonly HyperLink: typeof DocxEditorHyperLink;
     readonly Loading: typeof DocxEditorLoading;
     readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
     // (undocumented)
@@ -175,6 +202,7 @@ export interface DocxEditorProps {
     readonly colorMode?: 'light' | 'dark' | 'system';
     document?: DocumentSource;
     fonts?: FontConfiguration | FontConfigurationFragment;
+    hyperlinkPopup?: boolean;
     // (undocumented)
     locale?: string;
     mode?: EditorMode;
@@ -503,6 +531,56 @@ export interface HorizontalRulerProps {
     unit?: 'inch' | 'cm';
     // (undocumented)
     zoom?: number;
+}
+
+// @public
+export interface HyperLinkActionProps extends HyperLinkPartProps {
+    icon?: ReactNode;
+}
+
+// @public
+export interface HyperLinkPartProps {
+    asChild?: boolean;
+    // (undocumented)
+    children?: ReactNode;
+    // (undocumented)
+    className?: string;
+    hidden?: boolean;
+}
+
+// @public
+export interface HyperlinkPopupAnchor {
+    // (undocumented)
+    readonly left: number;
+    // (undocumented)
+    readonly top: number;
+}
+
+// @public
+export type HyperlinkPopupMode =
+/** Not shown. */
+'closed'
+/** An existing link: its target, plus copy / edit / unlink. */
+| 'reading'
+/** Text + URL fields, for a new link or a change to an existing one. */
+| 'editing';
+
+// @public
+export interface HyperlinkPopupState {
+    readonly anchor: HyperlinkPopupAnchor | null;
+    readonly canEdit: boolean;
+    readonly copied: boolean;
+    readonly error: boolean;
+    readonly link: SurfaceHyperlink | null;
+    // (undocumented)
+    readonly mode: HyperlinkPopupMode;
+    readonly text: string;
+    readonly url: string;
+}
+
+// @public
+export interface HyperLinkProps extends HyperLinkPartProps {
+    preset?: boolean;
 }
 
 export { loadFonts }
@@ -853,6 +931,31 @@ export interface UseFontFamilyResult {
     readonly options: readonly string[];
     readonly setValue: (family: string) => void;
     readonly value: string | null;
+}
+
+// @public
+export function useHyperlinkPopup(): UseHyperlinkPopupResult;
+
+// @public
+export function useHyperlinkPopupInstance(active?: boolean): UseHyperlinkPopupResult;
+
+// @public
+export interface UseHyperlinkPopupResult {
+    beginEdit: () => void;
+    // (undocumented)
+    close: () => void;
+    commitEdit: () => boolean;
+    copy: () => Promise<boolean>;
+    open: (link?: SurfaceHyperlink | null, anchor?: HyperlinkPopupAnchor | null) => void;
+    openAtCaret: () => void;
+    openTarget: () => boolean;
+    // (undocumented)
+    setText: (text: string) => void;
+    // (undocumented)
+    setUrl: (url: string) => void;
+    // (undocumented)
+    readonly state: HyperlinkPopupState;
+    unlink: () => boolean;
 }
 
 // @public

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -723,16 +723,22 @@ export const wordFeatures: WordFeature[] = [
     rendering: 'full',
     roundTrip: 'full',
     tier: 'community',
+    notes:
+      'Insert, edit and remove with Ctrl/Cmd+K or the toolbar. Targets are allowlisted ' +
+      '(http(s), mailto, tel, ftp); anything else renders inert and still round-trips. ' +
+      'Opening a document never requests a link target — activation is an explicit gesture.',
   },
   {
     id: 'fields.bookmarks',
     name: 'Bookmarks & internal links',
     category: 'fields',
-    editing: 'none',
-    rendering: 'partial',
+    editing: 'partial',
+    rendering: 'full',
     roundTrip: 'full',
     tier: 'community',
-    notes: 'Parsed and preserved losslessly; bookmark editing UI is deferred.',
+    notes:
+      'Internal links jump to their bookmark and move the caret, including targets on ' +
+      'pages that have not been painted yet. Creating and renaming bookmarks is deferred.',
   },
   {
     id: 'fields.page-numbers',

--- a/e2e/hyperlinks.interaction.spec.ts
+++ b/e2e/hyperlinks.interaction.spec.ts
@@ -49,12 +49,54 @@ async function scrollToParagraph(page: Page, needle: string): Promise<Locator> {
       .first();
     if ((await fragment.count()) > 0) {
       await fragment.scrollIntoViewIfNeeded();
+      // `scrollIntoViewIfNeeded` is a PROGRAMMATIC scroll, and a programmatic scroll can
+      // leave the engine's page virtualization a step behind — the fragment is painted but
+      // the pages either side of it may not be, and the next repaint replaces the very node
+      // this locator resolved. Settle first, so a click lands on a node that will still be
+      // there when it arrives.
+      await settle(page);
       return fragment;
     }
     await scroller.evaluate((el) => (el.scrollTop += el.clientHeight * 0.9));
-    await page.waitForTimeout(150);
+    await settle(page);
   }
   throw new Error(`No painted paragraph contains ${JSON.stringify(needle)}`);
+}
+
+/**
+ * Let the surface finish rematerializing after a programmatic scroll.
+ *
+ * The engine decides which pages to build in detail from a real scroll signal, so a test
+ * that moves `scrollTop` directly has to nudge it and then wait for the repaint to land.
+ */
+async function settle(page: Page): Promise<void> {
+  await page
+    .locator(SCROLLER)
+    .first()
+    .evaluate((el) => el.dispatchEvent(new WheelEvent('wheel', { deltaY: 1, bubbles: true })));
+  await page.waitForTimeout(250);
+}
+
+/**
+ * Click a painted link at its LIVE position.
+ *
+ * `locator.click()` measures the element, then dispatches — and in between, the surface can
+ * repaint: materializing another page changes the sheet extent, which re-centres every page
+ * horizontally, so the measured box is stale by a few pixels and the click lands on the page
+ * background instead of the link. (Observed directly: the click's target came back as
+ * `.docx-pages`.) Reading the rect immediately before dispatching closes that window.
+ */
+async function clickLink(page: Page, link: Locator): Promise<void> {
+  await expect(link).toHaveCount(1);
+  await settle(page);
+  // Past the surface's multi-click window (500ms), so two clicks on the same link in one
+  // test are two CLICKS and not a double-click. A double-click selects the word — a range —
+  // and a range selection deliberately does not open the popover, so without this the second
+  // click in the dismiss test was testing the wrong gesture.
+  await page.waitForTimeout(600);
+  const box = await link.boundingBox();
+  if (!box) throw new Error('link has no box');
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 }
 
 /** True when the paragraph fragment containing `needle` intersects the viewport. */
@@ -93,15 +135,20 @@ test.describe('section 9 rendering', () => {
     ).toHaveText('Anthropic’s website');
 
     // The Hyperlink character style resolves through the cascade: colored + underlined.
+    //
+    // Read from the TEXT-BEARING nodes, not from the anchor. Colour and decoration belong to
+    // the runs — that is where the resolved character style lands, and it is why an authored
+    // override still wins over the style. The anchor is furniture and deliberately imposes
+    // neither, so asking it would be asking the wrong element.
     const style = await example.evaluate((a) => {
-      const nodes = [a, ...a.querySelectorAll<HTMLElement>('*')];
+      const nodes = [...a.querySelectorAll<HTMLElement>('*')];
       return {
-        color: getComputedStyle(a).color,
+        colors: nodes.map((n) => getComputedStyle(n).color),
         underlined: nodes.some((n) => getComputedStyle(n).textDecorationLine.includes('underline')),
       };
     });
     expect(style.underlined).toBe(true);
-    expect(style.color).not.toBe('rgb(0, 0, 0)');
+    expect(style.colors.some((color) => color !== 'rgb(0, 0, 0)')).toBe(true);
   });
 
   test('internal cross-references paint as anchors targeting their bookmarks', async ({
@@ -125,7 +172,7 @@ test.describe('section 9 rendering', () => {
 test.describe('external link activation', () => {
   test('click opens the hyperlink popover with the URL and never navigates', async ({ page }) => {
     const p91 = await scrollToParagraph(page, 'Visit ');
-    await p91.locator('a.docx-hyperlink[href="https://example.com"]').click();
+    await clickLink(page, p91.locator('a.docx-hyperlink[href="https://example.com"]'));
 
     const popup = page.locator(POPUP);
     await expect(popup).toBeVisible();
@@ -138,7 +185,7 @@ test.describe('external link activation', () => {
 
   test('popover exposes copy, edit, and unlink actions', async ({ page }) => {
     const p91 = await scrollToParagraph(page, 'Visit ');
-    await p91.locator('a.docx-hyperlink[href="https://example.com"]').click();
+    await clickLink(page, p91.locator('a.docx-hyperlink[href="https://example.com"]'));
 
     const popup = page.locator(POPUP);
     await expect(popup).toBeVisible();
@@ -151,12 +198,12 @@ test.describe('external link activation', () => {
     const p91 = await scrollToParagraph(page, 'Visit ');
     const link = p91.locator('a.docx-hyperlink[href="https://example.com"]');
 
-    await link.click();
+    await clickLink(page, link);
     await expect(page.locator(POPUP)).toBeVisible();
     await page.keyboard.press('Escape');
     await expect(page.locator(POPUP)).not.toBeVisible();
 
-    await link.click();
+    await clickLink(page, link);
     await expect(page.locator(POPUP)).toBeVisible();
     await page.locator('.docx-page').first().click({ position: { x: 30, y: 30 } });
     await expect(page.locator(POPUP)).not.toBeVisible();
@@ -170,7 +217,7 @@ test.describe('in-document navigation', () => {
     const p92 = await scrollToParagraph(page, 'Jump to:');
     const before = await scrollTop(page);
 
-    await p92.locator('a.docx-hyperlink[href="#section1"]').click();
+    await clickLink(page, p92.locator('a.docx-hyperlink[href="#section1"]'));
 
     await headingInViewport(page, '1. Text Formatting & Typography');
     expect(await scrollTop(page)).toBeLessThan(before);
@@ -185,7 +232,7 @@ test.describe('in-document navigation', () => {
     const p92 = await scrollToParagraph(page, 'Jump to:');
     const before = await scrollTop(page);
 
-    await p92.locator('a.docx-hyperlink[href="#section12"]').click();
+    await clickLink(page, p92.locator('a.docx-hyperlink[href="#section12"]'));
 
     await headingInViewport(page, '12. Form Elements & Checkboxes');
     expect(await scrollTop(page)).toBeGreaterThan(before);
@@ -195,7 +242,7 @@ test.describe('in-document navigation', () => {
   test('mid-document bookmark jump lands on the section 6 heading', async ({ page }) => {
     const p92 = await scrollToParagraph(page, 'Jump to:');
 
-    await p92.locator('a.docx-hyperlink[href="#section6"]').click();
+    await clickLink(page, p92.locator('a.docx-hyperlink[href="#section6"]'));
 
     await headingInViewport(page, '6. Nested Tables');
     await expect(page.locator(POPUP)).toHaveCount(0);

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -777,6 +777,10 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
                 <DocxEditor.VerticalRuler />
               </div>
               <DocxEditor.Content />
+              {/* The link popover. Inside the viewport so it stays with the page while
+                  scrolling. `<DocxEditor>` mounts it for you; a composition like this one
+                  places it by name, exactly like the rulers above. */}
+              <DocxEditor.HyperLink />
             </DocxEditor.Viewport>
             {/* Floating diagnostics chrome, above the overlay panels. */}
             <PerfHud />

--- a/openspec/changes/typed-hyperlinks-and-bookmarks/tasks.md
+++ b/openspec/changes/typed-hyperlinks-and-bookmarks/tasks.md
@@ -1,57 +1,57 @@
 ## 0. Baseline before code
 
-- [ ] 0.1 Load `comprehensive-word-element-test.docx` in the demo and confirm the current loss: 9.1 paints "Visit  or .", 9.2 paints "Jump to:  |  |", zero `<a>` elements inside painted pages
-- [ ] 0.2 Record the current `bun test` baseline per the active change's convention
-- [ ] 0.3 Run `e2e/hyperlinks.interaction.spec.ts` and record it red — it is this lane's acceptance gate and must only turn green through the tasks below
+- [x] 0.1 Load `comprehensive-word-element-test.docx` in the demo and confirm the current loss: 9.1 paints "Visit  or .", 9.2 paints "Jump to:  |  |", zero `<a>` elements inside painted pages
+- [x] 0.2 Record the current `bun test` baseline per the active change's convention
+- [x] 0.3 Run `e2e/hyperlinks.interaction.spec.ts` and record it red — it is this lane's acceptance gate and must only turn green through the tasks below
 
 ## 1. Typed nodes and save
 
-- [ ] 1.1 Add `hyperlink` to the node-kind union in `ooxml-tree.ts`; type `@r:id`, `@w:anchor`, `@w:tooltip`, `@w:history`, `@w:docLocation`, `@w:tgtFrame`, with run children in the paragraph inline sequence
-- [ ] 1.2 Type `w:bookmarkStart`/`w:bookmarkEnd` as zero-length point anchors; keep `tree-op-split-anchors.test.ts` green unchanged
-- [ ] 1.3 Resolve `@r:id` through part relationships; classify `TargetMode="External"`; demote a dangling relationship to plain runs without losing text
-- [ ] 1.4 Non-run hyperlink children (drawing, field, SDT) stay `generic` at their positions under the typed hyperlink
-- [ ] 1.5 Compute `sanitizedHref` once at tree construction via `sanitizeHref`; keep the authored raw target for save through `escapeXml`
-- [ ] 1.6 Canonical-fingerprint equality for all five fixture hyperlinks and all 22 bookmarks loaded and saved unedited
-- [ ] 1.7 Unit test: `javascript:` target loads inert, saves byte-identical under escaping; no network request for any target at load or save
+- [x] 1.1 Add `hyperlink` to the node-kind union in `ooxml-tree.ts`; type `@r:id`, `@w:anchor`, `@w:tooltip`, `@w:history`, `@w:docLocation`, `@w:tgtFrame`, with run children in the paragraph inline sequence
+- [x] 1.2 Type `w:bookmarkStart`/`w:bookmarkEnd` as zero-length point anchors; keep `tree-op-split-anchors.test.ts` green unchanged
+- [x] 1.3 Resolve `@r:id` through part relationships; classify `TargetMode="External"`; demote a dangling relationship to plain runs without losing text
+- [x] 1.4 Non-run hyperlink children (drawing, field, SDT) stay `generic` at their positions under the typed hyperlink
+- [x] 1.5 Compute `sanitizedHref` once at tree construction via `sanitizeHref`; keep the authored raw target for save through `escapeXml`
+- [x] 1.6 Canonical-fingerprint equality for all five fixture hyperlinks and all 22 bookmarks loaded and saved unedited
+- [x] 1.7 Unit test: `javascript:` target loads inert, saves byte-identical under escaping; no network request for any target at load or save
 
 ## 2. Layout and paint
 
-- [ ] 2.1 `tokensOfParagraph` flattens hyperlink runs into the inline token stream (delete the `unknownLabel` placeholder path for `hyperlink`)
-- [ ] 2.2 Resolve the `Hyperlink` character style through the run-style cascade (themed `hlink` color, underline), direct formatting winning
-- [ ] 2.3 Paint per-line `a.docx-hyperlink` wrappers: external `href` = sanitized projection + `title` from tooltip; internal `href="#<anchor>"`; inert links get no `href`; run spans keep `data-paragraph-id`/`data-start`/`data-end`
-- [ ] 2.4 Bookmarks measure zero and paint nothing; heading metrics unchanged
-- [ ] 2.5 Selection and hit-testing across link runs resolve through run spans exactly as plain text (layout test + interaction check)
-- [ ] 2.6 Header/footer furniture links paint styled but inert (`tabindex="-1"`, no `href`)
-- [ ] 2.7 Layout tests: 9.1/9.2 full text present; link runs wrap across lines by normal break rules
+- [x] 2.1 `tokensOfParagraph` flattens hyperlink runs into the inline token stream (delete the `unknownLabel` placeholder path for `hyperlink`)
+- [x] 2.2 Resolve the `Hyperlink` character style through the run-style cascade (themed `hlink` color, underline), direct formatting winning
+- [x] 2.3 Paint per-line `a.docx-hyperlink` wrappers: external `href` = sanitized projection + `title` from tooltip; internal `href="#<anchor>"`; inert links get no `href`; run spans keep `data-paragraph-id`/`data-start`/`data-end`
+- [x] 2.4 Bookmarks measure zero and paint nothing; heading metrics unchanged
+- [x] 2.5 Selection and hit-testing across link runs resolve through run spans exactly as plain text (layout test + interaction check)
+- [x] 2.6 Header/footer furniture links paint styled but inert (`tabindex="-1"`, no `href`)
+- [x] 2.7 Layout tests: 9.1/9.2 full text present; link runs wrap across lines by normal break rules
 
 ## 3. Navigation
 
-- [ ] 3.1 Prevent native anchor navigation for every anchor inside painted pages
-- [ ] 3.2 Click classification: collapsed-selection click on external → popover; internal → jump; range-selection end → nothing
-- [ ] 3.3 Bookmark index `name → { paragraphId, offset }` maintained from typed anchors; duplicates resolve to first in document order
-- [ ] 3.4 Internal jump: resolve target through layout geometry, scroll the container to the target page/y (virtualized targets included), place the engine caret at the target position; dangling anchor is inert
-- [ ] 3.5 Single external-activation call site: `window.open(sanitizedHref, '_blank', 'noopener,noreferrer')` from popover open and Ctrl/Cmd+Click only
-- [ ] 3.6 Interaction tests for both jump directions and the no-popover-on-internal rule
+- [x] 3.1 Prevent native anchor navigation for every anchor inside painted pages
+- [x] 3.2 Click classification: collapsed-selection click on external → popover; internal → jump; range-selection end → nothing
+- [x] 3.3 Bookmark index `name → { paragraphId, offset }` maintained from typed anchors; duplicates resolve to first in document order
+- [x] 3.4 Internal jump: resolve target through layout geometry, scroll the container to the target page/y (virtualized targets included), place the engine caret at the target position; dangling anchor is inert
+- [x] 3.5 Single external-activation call site: `window.open(sanitizedHref, '_blank', 'noopener,noreferrer')` from popover open and Ctrl/Cmd+Click only
+- [x] 3.6 Interaction tests for both jump directions and the no-popover-on-internal rule
 
 ## 4. Editor operations
 
-- [ ] 4.1 `TreeDocOp`: insertHyperlink (adds relationship + node in one transaction), set-target, unlink (splice children in place, formatting and anchors preserved); each one `transact` = one undo step
-- [ ] 4.2 Implement `hyperlinkAt` in `docx-editor.ts` returning `HyperlinkInfo` per the existing contract; remove it from the typed-empty list
-- [ ] 4.3 Store tests: unlink keeps text/formatting; edit target does not leave a dangling authored relationship; undo restores in one step
+- [x] 4.1 `TreeDocOp`: insertHyperlink (adds relationship + node in one transaction), set-target, unlink (splice children in place, formatting and anchors preserved); each one `transact` = one undo step
+- [x] 4.2 Implement `hyperlinkAt` in `docx-editor.ts` returning `HyperlinkInfo` per the existing contract; remove it from the typed-empty list
+- [x] 4.3 Store tests: unlink keeps text/formatting; edit target does not leave a dangling authored relationship; undo restores in one step
 
 ## 5. React adapter — DocxEditor.HyperLink
 
-- [ ] 5.1 `useHyperlinkPopup()` context hook: `{ state, open, close, copy, beginEdit, commitEdit, unlink }`, backed by click classification (3.2) and the ops (4.1)
-- [ ] 5.2 `DocxEditorHyperLink.tsx` compound: `Root/Url/Copy/Edit/Unlink` parts on the toolbar customization ladder (`className`/`data-*`, `icon`, `asChild`, in-place override, `hidden`, `preset={false}`); static on `DocxEditor`; preset rendered by sugar, `hyperlinkPopup={false}` removes, child replaces
-- [ ] 5.3 Mount inside the viewport (follows page on scroll); position under the link fragment, clamped horizontally; dismiss on Escape/outside mousedown/selection move; chrome mousedown `preventDefault()` except text inputs
-- [ ] 5.4 Read-only renders URL + copy only; edit mode's inputs focus and type correctly
-- [ ] 5.5 Stable testids (`hyperlink-popup`, `-copy`, `-edit`, `-unlink`); i18n keys for every string (localized copy confirmation); `--doc-*` tokens only; z-index from the stylesheet
-- [ ] 5.6 Wire `text.link` in `SLOT_COMMANDS` + Ctrl/Cmd+K: plain text → insert flow, caret in link → edit mode seeded by `hyperlinkAt`
-- [ ] 5.7 `bun run api:extract` and commit snapshots; parity contract untouched (Vue deferred with reason)
+- [x] 5.1 `useHyperlinkPopup()` context hook: `{ state, open, close, copy, beginEdit, commitEdit, unlink }`, backed by click classification (3.2) and the ops (4.1)
+- [x] 5.2 `DocxEditorHyperLink.tsx` compound: `Root/Url/Copy/Edit/Unlink` parts on the toolbar customization ladder (`className`/`data-*`, `icon`, `asChild`, in-place override, `hidden`, `preset={false}`); static on `DocxEditor`; preset rendered by sugar, `hyperlinkPopup={false}` removes, child replaces
+- [x] 5.3 Mount inside the viewport (follows page on scroll); position under the link fragment, clamped horizontally; dismiss on Escape/outside mousedown/selection move; chrome mousedown `preventDefault()` except text inputs
+- [x] 5.4 Read-only renders URL + copy only; edit mode's inputs focus and type correctly
+- [x] 5.5 Stable testids (`hyperlink-popup`, `-copy`, `-edit`, `-unlink`); i18n keys for every string (localized copy confirmation); `--doc-*` tokens only; z-index from the stylesheet
+- [x] 5.6 Wire `text.link` in `SLOT_COMMANDS` + Ctrl/Cmd+K: plain text → insert flow, caret in link → edit mode seeded by `hyperlinkAt`
+- [x] 5.7 `bun run api:extract` and commit snapshots; parity contract untouched (Vue deferred with reason)
 
 ## 6. Acceptance
 
-- [ ] 6.1 `e2e/hyperlinks.interaction.spec.ts` green: rendering, popover actions/dismissal, both jump directions
-- [ ] 6.2 D9 oracles green on the comprehensive fixture; `bun test` matches or improves baseline
-- [ ] 6.3 Security audit grep from CLAUDE.md on the diff; verify the single `window.open` call site and no new sinks
-- [ ] 6.4 Update `docs/site/data/word-features.ts` hyperlink rows and the relevant docs page in the same PR
+- [x] 6.1 `e2e/hyperlinks.interaction.spec.ts` green: rendering, popover actions/dismissal, both jump directions
+- [x] 6.2 D9 oracles green on the comprehensive fixture; `bun test` matches or improves baseline
+- [x] 6.3 Security audit grep from CLAUDE.md on the diff; verify the single `window.open` call site and no new sinks
+- [x] 6.4 Update `docs/site/data/word-features.ts` hyperlink rows and the relevant docs page in the same PR

--- a/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
+++ b/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
@@ -117,6 +117,28 @@ part/prop exports go with it.
 - `ParagraphStyleItemProps`
 - `ParagraphStyleNamespace` — ParagraphStyle with `.Trigger`/`.Content`/`.Item` statics.
 
+The hyperlink popover rides the same provider/hooks layer: it is a context-backed hook
+plus a compound over it, so its Vue twin is the composable form and lands with the rest of
+that layer. The ENGINE half is already adapter-neutral — typed links, the sanitized
+projection, click classification, bookmark jumps, the ops and `hyperlinkAt` all live in
+core, and Vue's `text.link` control enables from the same `toolbarCommandState` React's
+does. Only the panel is React-only.
+
+- `DocxEditorHyperLink` — the link popover compound (`Url`/`Copy`/`Edit`/`Unlink`/
+  `Fields`/`Apply`/`Cancel` statics).
+- `DocxEditorHyperLinkNamespace`
+- `HyperLinkProps`
+- `HyperLinkPartProps`
+- `HyperLinkActionProps`
+- `useHyperlinkPopup` — the popover's behavior hook (state / open / close / copy /
+  beginEdit / commitEdit / unlink / openTarget), context-backed so a toolbar button and
+  the panel share one state.
+- `useHyperlinkPopupInstance` — the un-provided form, for a host publishing its own context.
+- `UseHyperlinkPopupResult`
+- `HyperlinkPopupState`
+- `HyperlinkPopupMode`
+- `HyperlinkPopupAnchor`
+
 ## Vue-only
 
 - `DocxEditorShellProps`

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -24,8 +24,12 @@ import {
   writeOoxmlPackage,
   ensureListDefinition,
   ensureNumberingLevel,
+  ensureHyperlinkRelationship,
+  buildBookmarkIndex,
+  relationshipTargetIn,
   normalizeParagraphIdentity,
   paragraphTextOf,
+  type BookmarkIndex,
   type EmbeddedFont,
   type ListKind,
   type HeaderFooterParts,
@@ -212,6 +216,32 @@ export interface TreeDocxSession {
    * bullet a user asks for has to bring the whole definition with it. An existing
    * definition of the same kind is reused rather than duplicated.
    */
+  /**
+   * What the MAIN part's relationships answer for one `r:id`: the authored target and
+   * whether it is external. `null` for an id the part does not declare.
+   *
+   * Live rather than memoized: inserting a link mints a relationship mid-session, and a
+   * cached resolver would report the link this session just created as dangling.
+   */
+  relationshipTarget(
+    relationshipId: string
+  ): { readonly target: string; readonly external: boolean } | null;
+  /**
+   * `bookmarkName -> { paragraphId, offset }` over the main part, memoized per revision.
+   *
+   * What an internal hyperlink's `w:anchor` resolves through. Keyed on the store revision
+   * because an edit can move, split or delete the paragraph a bookmark sits in.
+   */
+  bookmarks(): BookmarkIndex;
+  /**
+   * The relationship id for an external hyperlink target, minting one if the package has
+   * none, or `null` when the URL is refused.
+   *
+   * Lives on the PACKAGE, outside `store.transact`, like the numbering definitions: the
+   * undoable half is the tree op that names the id. An unreferenced relationship left
+   * behind by an undo is inert and is what Word writes anyway.
+   */
+  ensureHyperlinkRelationship(url: string): string | null;
   ensureListDefinition(kind: ListKind): string | null;
   /**
    * Declare `level` in the list definition `numId` names, with Word's default format for
@@ -426,6 +456,7 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
     readonly revision: number;
     readonly index: ParagraphAnchorIndex;
   } | null = null;
+  let bookmarksCache: { readonly revision: number; readonly index: BookmarkIndex } | null = null;
   const paragraphAnchors = (): ParagraphAnchorIndex => {
     // Keyed on the store revision, like the outline: a split mints a new paragraph and
     // a join removes one, but between commits the map cannot move.
@@ -619,6 +650,27 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
       paraIdOf: (nodeId) => paragraphAnchors().paraIdByNode.get(nodeId) ?? null,
 
       nodeIdOf: (paraId) => paragraphAnchors().nodeByParaId.get(paraId.toUpperCase()) ?? null,
+
+      relationshipTarget: (relationshipId) =>
+        relationshipTargetIn(pkg, pkg.mainDocumentPart, relationshipId),
+
+      bookmarks: () => {
+        if (!bookmarksCache || bookmarksCache.revision !== store.revision) {
+          bookmarksCache = { revision: store.revision, index: buildBookmarkIndex(store.part) };
+        }
+        return bookmarksCache.index;
+      },
+
+      ensureHyperlinkRelationship(url) {
+        // Same lane as `ensureListDefinition`: a package write, not a tree op, so it sits
+        // outside the undo stack. `currentPackage()` mints a fresh object per call, so the
+        // identity check compares against the SAME instance the write was given.
+        const before = currentPackage();
+        const ensured = ensureHyperlinkRelationship(before, url);
+        if (!ensured) return null;
+        if (ensured.pkg !== before) pkg = ensured.pkg;
+        return ensured.relationshipId;
+      },
 
       ensureListDefinition(kind) {
         // The numbering part lives on the PACKAGE, not the main-part tree, so this is the

--- a/packages/core/src/editor/__tests__/hyperlink-editing.test.ts
+++ b/packages/core/src/editor/__tests__/hyperlink-editing.test.ts
@@ -1,0 +1,524 @@
+// Hyperlink editing and navigation through the mounted editor.
+//
+// End to end over a real surface: insert a link, edit it, unlink it, jump to a bookmark, and
+// confirm the two rules that matter most — the host page never navigates, and `window.open`
+// is reachable from exactly one gate that only ever sees a sanitized target.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import type { OoxmlNode } from '@docx-editor.dev/core-contract/store';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+/** Word's own hyperlink character style, for the documents that declare one. */
+const STYLES_WITH_HYPERLINK =
+  `<w:styles xmlns:w="${W}">` +
+  '<w:style w:type="character" w:styleId="Hyperlink"><w:name w:val="Hyperlink"/>' +
+  '<w:rPr><w:color w:val="0563C1"/><w:u w:val="single"/></w:rPr></w:style>' +
+  '</w:styles>';
+
+function docx(body: string, rels = '', stylesXml = ''): Uint8Array {
+  const stylesRel = stylesXml
+    ? `<Relationship Id="rIdStyles" Type="${R}/styles" Target="styles.xml"/>`
+    : '';
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+        (stylesXml
+          ? '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>'
+          : '') +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">${rels}${stylesRel}</Relationships>`
+    ),
+    ...(stylesXml ? { 'word/styles.xml': strToU8(stylesXml) } : {}),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const PID = (index: number) => `/word/document.xml#0.0.${index}`;
+
+/**
+ * A mounted editor and ITS OWN container.
+ *
+ * Every query below is scoped to this element. `document.querySelector` would find the
+ * first editor any test in the file mounted — the painted anchors and the pages layer both
+ * exist once per mount, and the whole-document lookup silently answered for a different
+ * document than the one under test.
+ */
+interface Mounted {
+  readonly editor: DocxEditorInstance;
+  readonly container: HTMLElement;
+}
+
+function mount(body: string, rels = '', stylesXml = ''): Mounted {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: docx(body, rels, stylesXml) });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return { editor, container };
+}
+
+function select(mounted: Mounted, index: number, start: number, end: number): void {
+  mounted.editor.surface!.setSelection({
+    anchor: { paragraphId: PID(index), offset: start },
+    head: { paragraphId: PID(index), offset: end },
+  });
+}
+
+function caret(mounted: Mounted, index: number, offset: number): void {
+  select(mounted, index, offset, offset);
+}
+
+/** The painted anchor whose text is `text`, within THIS editor's container. */
+function anchorFor(mounted: Mounted, text: string): HTMLElement {
+  const anchors = [...mounted.container.querySelectorAll('a.docx-hyperlink')] as HTMLElement[];
+  const found = anchors.find((anchor) => anchor.textContent === text);
+  if (!found) {
+    const seen = anchors.map((anchor) => anchor.textContent);
+    throw new Error(
+      `no painted anchor with text ${JSON.stringify(text)}; saw ${JSON.stringify(seen)}`
+    );
+  }
+  return found;
+}
+
+/** The pages layer of THIS editor, for dispatching keyboard events at. */
+function pagesOf(mounted: Mounted): HTMLElement {
+  const pages = mounted.container.querySelector('.docx-pages');
+  if (!pages) throw new Error('no pages layer');
+  return pages as HTMLElement;
+}
+
+/** Click an element the way a browser does, and report whether the default was prevented. */
+function click(element: HTMLElement, modifiers: { accel?: boolean } = {}): boolean {
+  const event = new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    ...(modifiers.accel ? { metaKey: true } : {}),
+  });
+  element.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+describe('editing a hyperlink through the editor', () => {
+  test('insertHyperlink links the selection and the text is unchanged', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    const result = mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+    expect(result.ok).toBe(true);
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()).toHaveLength(1);
+    const link = mounted.editor.surface!.hyperlinks.linksInCaretParagraph()[0]!;
+    expect(link.text).toBe('example');
+    expect(link.href).toBe('https://example.com');
+    expect(link.kind).toBe('external');
+  });
+
+  test('a refused scheme never reaches the document', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    const result = mounted.editor.exec({ type: 'insertHyperlink', href: 'javascript:alert(1)' });
+    expect(result.ok).toBe(false);
+    // Nothing partial: no link, and no relationship left behind pointing at it.
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()).toEqual([]);
+  });
+
+  test('a bookmark target links as an internal anchor', () => {
+    const mounted = mount(p('Jump there now'));
+    select(mounted, 0, 5, 10);
+    expect(mounted.editor.exec({ type: 'insertHyperlink', href: '#section3' }).ok).toBe(true);
+    const link = mounted.editor.surface!.hyperlinks.linksInCaretParagraph()[0]!;
+    expect(link.kind).toBe('internal');
+    expect(link.anchor).toBe('section3');
+    expect(link.href).toBe('#section3');
+  });
+
+  test('hyperlinkAt answers inside a link and null outside it', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+    caret(mounted, 0, 8);
+    expect(mounted.editor.query({ type: 'hyperlinkAt' })?.href).toBe('https://example.com');
+    caret(mounted, 0, 2);
+    expect(mounted.editor.query({ type: 'hyperlinkAt' })).toBeNull();
+  });
+
+  test('an inert link is REPORTED, with no target to follow', () => {
+    const mounted = mount(
+      `<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Click</w:t></w:r></w:hyperlink></w:p>`,
+      `<Relationship Id="rId9" Type="${R}/hyperlink" Target="javascript:alert(1)" TargetMode="External"/>`
+    );
+    caret(mounted, 0, 2);
+    // There IS a link here — an editor must offer to fix or remove it — and no href.
+    const info = mounted.editor.query({ type: 'hyperlinkAt' });
+    expect(info).not.toBeNull();
+    expect(info!.href).toBe('');
+  });
+
+  test('removeHyperlink keeps the text and takes the link off', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+    caret(mounted, 0, 8);
+    expect(mounted.editor.exec({ type: 'removeHyperlink' }).ok).toBe(true);
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()).toEqual([]);
+    expect(mounted.editor.surface!.session.bodyText()).toBe('Visit example today');
+  });
+
+  test('removeHyperlink with no link at the caret refuses rather than doing nothing quietly', () => {
+    const mounted = mount(p('plain text'));
+    caret(mounted, 0, 3);
+    const result = mounted.editor.exec({ type: 'removeHyperlink' });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.code).toBe('notFound');
+  });
+
+  test('insert then undo is ONE step', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()).toHaveLength(1);
+    mounted.editor.exec({ type: 'undo' });
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()).toEqual([]);
+    expect(mounted.editor.surface!.session.bodyText()).toBe('Visit example today');
+  });
+
+  test('retargeting an existing link keeps its identity and its text', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+    const before = mounted.editor.surface!.hyperlinks.linksInCaretParagraph()[0]!;
+    caret(mounted, 0, 8);
+    expect(mounted.editor.surface!.hyperlinks.applyHyperlink({ url: 'https://example.org' })).toBe(
+      true
+    );
+    const after = mounted.editor.surface!.hyperlinks.linksInCaretParagraph()[0]!;
+    expect(after.id).toBe(before.id);
+    expect(after.text).toBe('example');
+    expect(after.href).toBe('https://example.org');
+    expect(mounted.editor.surface!.session.bodyText()).toBe('Visit example today');
+  });
+
+  test('editing an existing link’s DISPLAY TEXT keeps the link', () => {
+    // The ordinary Ctrl+K-then-change-the-text flow. Replacing the text as
+    // delete-then-insert emptied every run in the link, the delete's own cleanup removed the
+    // emptied `w:hyperlink`, and the insert landed in a plain run — the link vanished while
+    // the operation reported success.
+    const mounted = mount(p('Visit example today'), '', STYLES_WITH_HYPERLINK);
+    select(mounted, 0, 6, 13);
+    mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+    caret(mounted, 0, 8);
+
+    expect(
+      mounted.editor.surface!.hyperlinks.applyHyperlink({
+        url: 'https://example.com/new',
+        text: 'our site',
+      })
+    ).toBe(true);
+
+    const links = mounted.editor.surface!.hyperlinks.linksInCaretParagraph();
+    expect(links).toHaveLength(1);
+    expect(links[0]!.text).toBe('our site');
+    expect(links[0]!.href).toBe('https://example.com/new');
+    expect(mounted.editor.surface!.session.bodyText()).toBe('Visit our site today');
+  });
+
+  test('deleting a link’s whole text keeps the bookmarks that were inside it', () => {
+    // Removing the emptied `w:hyperlink` took its subtree with it, so an anchor other links
+    // point at disappeared — while the identical marker written OUTSIDE a link survives the
+    // same deletion.
+    const mounted = mount(
+      '<w:p><w:r><w:t>ab</w:t></w:r>' +
+        '<w:hyperlink w:anchor="t"><w:bookmarkStart w:id="1" w:name="inside"/>' +
+        '<w:r><w:t>cd</w:t></w:r><w:bookmarkEnd w:id="1"/></w:hyperlink>' +
+        '<w:r><w:t>ef</w:t></w:r></w:p>'
+    );
+    expect(mounted.editor.surface!.bookmarks().has('inside')).toBe(true);
+    select(mounted, 0, 2, 4);
+    expect(mounted.editor.exec({ type: 'deleteText' }).ok).toBe(true);
+    expect(mounted.editor.surface!.session.bodyText()).toBe('abef');
+    // The link is gone (it has no text left); the anchor it contained is not.
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()).toEqual([]);
+    expect(mounted.editor.surface!.bookmarks().has('inside')).toBe(true);
+  });
+
+  test('a collapsed caret links the URL as its own display text', () => {
+    const mounted = mount(p(''));
+    caret(mounted, 0, 0);
+    expect(mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' }).ok).toBe(
+      true
+    );
+    const link = mounted.editor.surface!.hyperlinks.linksInCaretParagraph()[0]!;
+    expect(link.text).toBe('https://example.com');
+  });
+
+  test('supplied display text replaces the selection', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    expect(
+      mounted.editor.exec({
+        type: 'insertHyperlink',
+        href: 'https://example.com',
+        text: 'our site',
+      }).ok
+    ).toBe(true);
+    expect(mounted.editor.surface!.session.bodyText()).toBe('Visit our site today');
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()[0]!.text).toBe('our site');
+  });
+
+  test('a new link takes the document’s Hyperlink character style, by reference', () => {
+    // Without this a new link is indistinguishable from the words around it and the user
+    // cannot tell the command worked. By REFERENCE (`w:rStyle`), never by baking the
+    // style's colour and underline onto the run — the two look identical and only one of
+    // them saves as what Word wrote.
+    const mounted = mount(p('Visit example today'), '', STYLES_WITH_HYPERLINK);
+    select(mounted, 0, 6, 13);
+    expect(mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' }).ok).toBe(
+      true
+    );
+    const part = mounted.editor.surface!.session.part();
+    const styles: string[] = [];
+    const walk = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.localName === 'rStyle') {
+        styles.push(node.attributes.find((a) => a.localName === 'val')?.value ?? '');
+      }
+      for (const child of node.children) walk(child);
+    };
+    walk(part.root);
+    expect(styles).toContain('Hyperlink');
+    // One undo step for the whole thing — the style rides the insert's transaction.
+    mounted.editor.exec({ type: 'undo' });
+    expect(mounted.editor.surface!.hyperlinks.linksInCaretParagraph()).toEqual([]);
+  });
+
+  test('a document with no Hyperlink style still gets a working link', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    expect(mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' }).ok).toBe(
+      true
+    );
+    caret(mounted, 0, 8);
+    // A reference to a style the document does not declare would be a dangling one; the
+    // link works and simply looks like its surroundings.
+    expect(mounted.editor.surface!.hyperlinks.linkAtCaret()?.href).toBe('https://example.com');
+  });
+
+  test('a link’s text can be restyled, and the direct formatting wins over the style', () => {
+    // Word lets you select a hyperlink and make it red, bold, whatever — the `Hyperlink`
+    // character style is a default, not a lock. Formatting must therefore reach the runs
+    // INSIDE the `w:hyperlink` (they are ordinary runs at a depth the ops address by id),
+    // and the direct property must beat the style reference in the cascade.
+    const mounted = mount(p('Visit example today'), '', STYLES_WITH_HYPERLINK);
+    select(mounted, 0, 6, 13);
+    mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+
+    select(mounted, 0, 6, 13);
+    expect(
+      mounted.editor.exec({ type: 'setMarkAttr', mark: 'color', attr: 'val', value: 'FF0000' }).ok
+    ).toBe(true);
+
+    // The link is intact and still points where it did.
+    caret(mounted, 0, 8);
+    expect(mounted.editor.surface!.hyperlinks.linkAtCaret()?.href).toBe('https://example.com');
+    expect(mounted.editor.surface!.session.bodyText()).toBe('Visit example today');
+
+    // The style REFERENCE survives — a later edit must not have silently unstyled the link —
+    // and the direct colour is what the run resolves to.
+    const part = mounted.editor.surface!.session.part();
+    const seen: string[] = [];
+    const walk = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.localName === 'rStyle' || node.localName === 'color') {
+        seen.push(
+          `${node.localName}=${node.attributes.find((a) => a.localName === 'val')?.value ?? ''}`
+        );
+      }
+      for (const child of node.children) walk(child);
+    };
+    walk(part.root);
+    expect(seen).toContain('rStyle=Hyperlink');
+    expect(seen).toContain('color=FF0000');
+
+    // And it PAINTS red: the cascade resolves direct formatting over the character style.
+    const painted = [...mounted.container.querySelectorAll('a.docx-hyperlink [data-start]')].map(
+      (span) => (span as HTMLElement).style.color
+    );
+    expect(painted.map((color) => color.toLowerCase())).toContain('#ff0000');
+    expect(painted.some((color) => color.toLowerCase() === '#0563c1')).toBe(false);
+  });
+
+  test('a link survives a save and reopen with its target intact', () => {
+    const mounted = mount(p('Visit example today'));
+    select(mounted, 0, 6, 13);
+    mounted.editor.exec({ type: 'insertHyperlink', href: 'https://example.com' });
+    const bytes = mounted.editor.surface!.session.save();
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    const reopened = createDocxEditor({ container, document: bytes });
+    reopened.surface!.setSelection({
+      anchor: { paragraphId: PID(0), offset: 8 },
+      head: { paragraphId: PID(0), offset: 8 },
+    });
+    const link = reopened.surface!.hyperlinks.linksInCaretParagraph()[0];
+    expect(link?.href).toBe('https://example.com');
+    expect(reopened.surface!.session.bodyText()).toBe('Visit example today');
+  });
+});
+
+describe('clicking a painted link', () => {
+  const EXTERNAL = `<Relationship Id="rId9" Type="${R}/hyperlink" Target="https://example.com" TargetMode="External"/>`;
+
+  test('the host page NEVER navigates, whatever the click means', () => {
+    const mounted = mount(
+      `<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Example</w:t></w:r></w:hyperlink></w:p>`,
+      EXTERNAL
+    );
+    // Default prevented even with no popover registered and no modifier: the browser is
+    // never the one deciding, because following the link would unload unsaved work.
+    expect(click(anchorFor(mounted, 'Example'))).toBe(true);
+  });
+
+  test('a plain click on an external link asks the host for a popover', () => {
+    const mounted = mount(
+      `<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Example</w:t></w:r></w:hyperlink></w:p>`,
+      EXTERNAL
+    );
+    const seen: string[] = [];
+    mounted.editor.setHyperlinkChrome({
+      onPopover: (activation) => seen.push(activation.link.href ?? ''),
+    });
+    caret(mounted, 0, 3);
+    click(anchorFor(mounted, 'Example'));
+    expect(seen).toEqual(['https://example.com']);
+  });
+
+  test('a click that ends a RANGE selection does not pop', () => {
+    const mounted = mount(
+      `<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Example</w:t></w:r></w:hyperlink></w:p>`,
+      EXTERNAL
+    );
+    const seen: string[] = [];
+    mounted.editor.setHyperlinkChrome({ onPopover: (activation) => seen.push(activation.link.id) });
+    select(mounted, 0, 0, 5);
+    click(anchorFor(mounted, 'Example'));
+    expect(seen).toEqual([]);
+  });
+
+  test('an internal link jumps to its bookmark and moves the caret; no popover', () => {
+    const mounted = mount(
+      `<w:p><w:hyperlink w:anchor="target"><w:r><w:t>Go</w:t></w:r></w:hyperlink></w:p>` +
+        p('filler') +
+        `<w:p><w:bookmarkStart w:id="1" w:name="target"/><w:r><w:t>Destination</w:t></w:r></w:p>`
+    );
+    const seen: string[] = [];
+    mounted.editor.setHyperlinkChrome({ onPopover: (activation) => seen.push(activation.link.id) });
+    caret(mounted, 0, 1);
+    click(anchorFor(mounted, 'Go'));
+    expect(seen).toEqual([]);
+    expect(mounted.editor.surface!.state().selection.head.paragraphId).toBe(PID(2));
+  });
+
+  test('a dangling anchor is an inert click: no jump, no popover, no error', () => {
+    const mounted = mount(
+      `<w:p><w:hyperlink w:anchor="nowhere"><w:r><w:t>Go</w:t></w:r></w:hyperlink></w:p>` +
+        p('rest')
+    );
+    const seen: string[] = [];
+    mounted.editor.setHyperlinkChrome({ onPopover: (activation) => seen.push(activation.link.id) });
+    caret(mounted, 0, 1);
+    click(anchorFor(mounted, 'Go'));
+    expect(seen).toEqual([]);
+    expect(mounted.editor.surface!.state().selection.head.paragraphId).toBe(PID(0));
+  });
+
+  test('a duplicate bookmark name resolves to the FIRST in document order', () => {
+    const mounted = mount(
+      `<w:p><w:bookmarkStart w:id="1" w:name="dup"/><w:r><w:t>first</w:t></w:r></w:p>` +
+        `<w:p><w:bookmarkStart w:id="2" w:name="dup"/><w:r><w:t>second</w:t></w:r></w:p>` +
+        `<w:p><w:hyperlink w:anchor="dup"><w:r><w:t>Go</w:t></w:r></w:hyperlink></w:p>`
+    );
+    caret(mounted, 2, 1);
+    click(anchorFor(mounted, 'Go'));
+    expect(mounted.editor.surface!.state().selection.head.paragraphId).toBe(PID(0));
+  });
+});
+
+describe('external activation has exactly one gate', () => {
+  test('openExternal refuses an inert link, a fragment, and nothing at all', () => {
+    const mounted = mount(p('text'));
+    const navigation = mounted.editor.surface!.navigation;
+    expect(navigation.openExternal(null)).toBe(false);
+    expect(navigation.openExternal('')).toBe(false);
+    // A fragment is an in-document jump, not something to open in a tab.
+    expect(navigation.openExternal('#section1')).toBe(false);
+  });
+
+  test('a bookmark jump is available headlessly and answers false for an unknown name', () => {
+    const mounted = mount(
+      p('one') + `<w:p><w:bookmarkStart w:id="1" w:name="known"/><w:r><w:t>two</w:t></w:r></w:p>`
+    );
+    expect(mounted.editor.surface!.navigation.goToBookmark('known')).toBe(true);
+    expect(mounted.editor.surface!.state().selection.head.paragraphId).toBe(PID(1));
+    expect(mounted.editor.surface!.navigation.goToBookmark('unknown')).toBe(false);
+  });
+
+  test('Word’s own _GoBack scratch bookmark is not a jump target', () => {
+    const mounted = mount(
+      `<w:p><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:r><w:t>one</w:t></w:r></w:p>`
+    );
+    expect(mounted.editor.surface!.bookmarks().has('_GoBack')).toBe(false);
+  });
+});
+
+describe('Ctrl/Cmd+K reports the request to the host', () => {
+  test('the keymap asks; it does not invent a dialog', () => {
+    const mounted = mount(p('alpha'));
+    let asked = 0;
+    mounted.editor.setHyperlinkChrome({ onRequest: () => (asked += 1) });
+    const pages = pagesOf(mounted);
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    pages.dispatchEvent(event);
+    expect(asked).toBe(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('unregistering restores the previous handler', () => {
+    const mounted = mount(p('alpha'));
+    const order: string[] = [];
+    const outer = mounted.editor.setHyperlinkChrome({ onRequest: () => order.push('outer') });
+    const inner = mounted.editor.setHyperlinkChrome({ onRequest: () => order.push('inner') });
+    const pages = pagesOf(mounted);
+    const press = () =>
+      pages.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true, cancelable: true })
+      );
+    press();
+    inner();
+    press();
+    outer();
+    expect(order).toEqual(['inner', 'outer']);
+  });
+});

--- a/packages/core/src/editor/__tests__/retained-selection.test.ts
+++ b/packages/core/src/editor/__tests__/retained-selection.test.ts
@@ -1,0 +1,181 @@
+// A selection pinned so it stays visible while a panel holds focus.
+//
+// A document has ONE selection. The moment the hyperlink panel focuses its URL field, the
+// browser moves that selection into the input and the words the user highlighted stop looking
+// highlighted — at exactly the moment the panel is asking "what should this text link to?".
+// Word and Google Docs both keep the range lit while their dialog is up.
+//
+// The engine draws it on its own overlay instead, and owns the release rule: the pin drops
+// when the caret LEAVES the range. That rule lives here rather than in an adapter so a host
+// closing its panel on "the user clicked elsewhere" reads a fact instead of recomputing
+// document order, and so React and Vue cannot drift into two different definitions of
+// "elsewhere".
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const P = (index: number) => `/word/document.xml#0.0.${index}`;
+const BODY =
+  '<w:p><w:r><w:t>Visit example today</w:t></w:r></w:p>' +
+  '<w:p><w:r><w:t>Second paragraph here</w:t></w:r></w:p>';
+
+interface Mounted {
+  readonly surface: PaginatedSurface;
+  readonly container: HTMLElement;
+}
+
+function mount(): Mounted {
+  const container = document.createElement('div');
+  container.className = 'docx-paginated-surface';
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(BODY));
+  if (!opened.ok) throw new Error(opened.reason);
+  return { surface: opened.surface, container };
+}
+
+/** Select `[start, end)` of paragraph `index`. */
+function select(mounted: Mounted, index: number, start: number, end: number): void {
+  mounted.surface.setSelection({
+    anchor: { paragraphId: P(index), offset: start },
+    head: { paragraphId: P(index), offset: end },
+  });
+}
+
+const caret = (mounted: Mounted, index: number, offset: number) =>
+  select(mounted, index, offset, offset);
+
+/** Rectangles the retained-selection overlay is currently drawing. */
+const retainedRects = (mounted: Mounted) =>
+  mounted.container.querySelectorAll('.docx-retained-selection-rect').length;
+
+describe('a retained selection stays lit while focus is elsewhere', () => {
+  test('nothing is retained until a host asks', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    expect(mounted.surface.retainedSelection()).toBeNull();
+    expect(retainedRects(mounted)).toBe(0);
+  });
+
+  test('retaining pins the range and paints it', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    const pinned = mounted.surface.retainedSelection();
+    expect(pinned?.anchor.offset).toBe(6);
+    expect(pinned?.head.offset).toBe(13);
+    // Drawn on the engine's overlay, which is what survives the browser moving its one
+    // selection into a panel's input.
+    expect(retainedRects(mounted)).toBeGreaterThan(0);
+  });
+
+  test('the MODEL selection is untouched, so the op still addresses the same text', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    // The pin is a sibling of the selection, not a replacement for it.
+    expect(mounted.surface.state().selection.anchor.offset).toBe(6);
+    expect(mounted.surface.state().selection.head.offset).toBe(13);
+    expect(mounted.surface.selectedText()).toBe('example');
+  });
+
+  test('a caret INSIDE the range keeps the pin — clicking your own selection is not leaving', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    caret(mounted, 0, 9);
+    expect(mounted.surface.retainedSelection()).not.toBeNull();
+    expect(retainedRects(mounted)).toBeGreaterThan(0);
+  });
+
+  test('either EDGE counts as inside', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    caret(mounted, 0, 6);
+    expect(mounted.surface.retainedSelection()).not.toBeNull();
+    caret(mounted, 0, 13);
+    expect(mounted.surface.retainedSelection()).not.toBeNull();
+  });
+
+  test('a caret OUTSIDE the range releases the pin and clears the paint', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    caret(mounted, 0, 2);
+    expect(mounted.surface.retainedSelection()).toBeNull();
+    expect(retainedRects(mounted)).toBe(0);
+  });
+
+  test('a caret in ANOTHER paragraph releases the pin', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    caret(mounted, 1, 3);
+    expect(mounted.surface.retainedSelection()).toBeNull();
+  });
+
+  test('a backwards selection retains the same range', () => {
+    const mounted = mount();
+    // head before anchor — the pin must order the range, not trust the field names.
+    select(mounted, 0, 13, 6);
+    mounted.surface.retainSelection();
+    caret(mounted, 0, 9);
+    expect(mounted.surface.retainedSelection()).not.toBeNull();
+    caret(mounted, 0, 2);
+    expect(mounted.surface.retainedSelection()).toBeNull();
+  });
+
+  test('a COLLAPSED pin (Ctrl+K with nothing selected) releases on any move', () => {
+    const mounted = mount();
+    caret(mounted, 0, 4);
+    mounted.surface.retainSelection();
+    expect(mounted.surface.retainedSelection()).not.toBeNull();
+    // Zero-width range: staying put is inside, moving at all is out.
+    caret(mounted, 0, 4);
+    expect(mounted.surface.retainedSelection()).not.toBeNull();
+    caret(mounted, 0, 5);
+    expect(mounted.surface.retainedSelection()).toBeNull();
+  });
+
+  test('releasing explicitly drops the pin whether or not the caret ever left', () => {
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    mounted.surface.releaseSelection();
+    expect(mounted.surface.retainedSelection()).toBeNull();
+    expect(retainedRects(mounted)).toBe(0);
+  });
+
+  test('a cell rectangle still paints as cells, not as a retained range', () => {
+    // The two share one overlay layer and must not share one appearance: "these cells are
+    // chosen" and "your selection is still here" are different statements.
+    const mounted = mount();
+    select(mounted, 0, 6, 13);
+    mounted.surface.retainSelection();
+    expect(mounted.container.querySelectorAll('.docx-cell-selection-rect').length).toBe(0);
+  });
+});

--- a/packages/core/src/editor/__tests__/run-property-edits-hyperlink.test.ts
+++ b/packages/core/src/editor/__tests__/run-property-edits-hyperlink.test.ts
@@ -1,0 +1,135 @@
+// `runPropertyEdits` addresses the runs INSIDE a `w:hyperlink`.
+//
+// This is the plan step between "the user selected this range and pressed a button" and the
+// `setRunProperties` ops that carry it out. It walks the paragraph's children accumulating
+// offsets, and it used to skip a `w:hyperlink` outright — which was wrong twice over:
+//
+//   the link's own text could not be formatted AT ALL, because no edit ever named its runs; and
+//   the offset did not advance across the link either, so every run AFTER one was addressed as
+//   if the link's characters did not exist.
+//
+// The second is the damaging one. Colouring `Visit [example] today` planned a single edit at
+// 6..12 carrying the ` today` run's properties — the applier resolved those offsets against the
+// real segment map, so ` today`'s formatting landed on six of the link's seven characters and
+// the seventh kept the old colour. Nothing was added or lost, so no census, digest or
+// fingerprint guard could see it. Only asking what the plan ADDRESSES can.
+//
+// The offsets asserted here are the ones `segmentsOf` publishes, because those are the ones the
+// applier resolves; the two walks have to descend in exactly the same places.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import { runPropertyEdits } from '../surface-formatting.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PARAGRAPH = '/word/document.xml#0.0.0';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const RED = { localName: 'color', attributes: { val: 'FF0000' } } as const;
+
+/** The ranges a plan addresses, as `start..end` — the shape a failure can be read from. */
+const ranges = (part: OoxmlPart, start: number, end: number): string[] =>
+  runPropertyEdits(part, PARAGRAPH, start, end, RED).map((edit) => `${edit.start}..${edit.end}`);
+
+/** `Visit ` + a link around `example` + ` today` — offsets 0..6, 6..13, 13..19. */
+const LINKED = load(
+  '<w:p>' +
+    '<w:r><w:t xml:space="preserve">Visit </w:t></w:r>' +
+    '<w:hyperlink r:id="rId9">' +
+    '<w:r><w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr><w:t>example</w:t></w:r>' +
+    '</w:hyperlink>' +
+    '<w:r><w:t xml:space="preserve"> today</w:t></w:r>' +
+    '</w:p>'
+);
+
+describe('a range edit crossing a link addresses every run it covers', () => {
+  test('the whole paragraph plans one edit per run, links included, with no gap', () => {
+    // Three runs, three edits, contiguous and covering 0..19. A gap would be text the user
+    // selected that no op will ever reach.
+    expect(ranges(LINKED, 0, 19)).toEqual(['0..6', '6..13', '13..19']);
+  });
+
+  test('selecting only the link plans an edit over exactly the link’s text', () => {
+    expect(ranges(LINKED, 6, 13)).toEqual(['6..13']);
+  });
+
+  test('the run after a link is addressed at its real offsets, not the link’s', () => {
+    // The regression, stated directly: ` today` starts at 13. Skipping the link without
+    // advancing put it at 6 — inside the link.
+    expect(ranges(LINKED, 13, 19)).toEqual(['13..19']);
+  });
+
+  test('a selection ending inside the link stops inside the link', () => {
+    expect(ranges(LINKED, 3, 9)).toEqual(['3..6', '6..9']);
+  });
+
+  test('the link’s edit carries the LINK run’s own properties, not a neighbour’s', () => {
+    const linked = load(
+      '<w:p>' +
+        '<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">Visit </w:t></w:r>' +
+        '<w:hyperlink r:id="rId9">' +
+        '<w:r><w:rPr><w:i/></w:rPr><w:t>example</w:t></w:r>' +
+        '</w:hyperlink>' +
+        '<w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t xml:space="preserve"> today</w:t></w:r>' +
+        '</w:p>'
+    );
+    const names = runPropertyEdits(linked, PARAGRAPH, 0, 19, RED).map((edit) =>
+      edit.properties
+        .map((property) => property.localName)
+        .sort()
+        .join('+')
+    );
+    // `setRunProperties` REPLACES the container, so each edit restates its OWN run's
+    // properties. Handing the link's runs the following run's bag was how a colour change
+    // silently italicised or underlined text it had no business touching.
+    expect(names).toEqual(['b+color', 'color+i', 'color+u']);
+  });
+
+  test('two links in one paragraph both get edits, in document order', () => {
+    const twoLinks = load(
+      '<w:p>' +
+        '<w:hyperlink w:anchor="a"><w:r><w:t>one</w:t></w:r></w:hyperlink>' +
+        '<w:r><w:t xml:space="preserve"> and </w:t></w:r>' +
+        '<w:hyperlink w:anchor="b"><w:r><w:t>two</w:t></w:r></w:hyperlink>' +
+        '</w:p>'
+    );
+    expect(ranges(twoLinks, 0, 11)).toEqual(['0..3', '3..8', '8..11']);
+  });
+
+  test('a link holding several runs contributes one edit each', () => {
+    const split = load(
+      '<w:p>' +
+        '<w:hyperlink w:anchor="a">' +
+        '<w:r><w:t>ex</w:t></w:r>' +
+        '<w:r><w:rPr><w:b/></w:rPr><w:t>ample</w:t></w:r>' +
+        '</w:hyperlink>' +
+        '<w:r><w:t>!</w:t></w:r>' +
+        '</w:p>'
+    );
+    expect(ranges(split, 0, 8)).toEqual(['0..2', '2..7', '7..8']);
+  });
+
+  test('bookmark markers around a link measure nothing and shift no offset', () => {
+    // `segmentsOf` gives bookmarks zero width, so this plan must too — otherwise every
+    // offset past a bookmarked heading would drift.
+    const bookmarked = load(
+      '<w:p>' +
+        '<w:bookmarkStart w:id="1" w:name="here"/>' +
+        '<w:r><w:t xml:space="preserve">Visit </w:t></w:r>' +
+        '<w:hyperlink w:anchor="here"><w:r><w:t>example</w:t></w:r></w:hyperlink>' +
+        '<w:bookmarkEnd w:id="1"/>' +
+        '<w:r><w:t xml:space="preserve"> today</w:t></w:r>' +
+        '</w:p>'
+    );
+    expect(ranges(bookmarked, 0, 19)).toEqual(['0..6', '6..13', '13..19']);
+  });
+});

--- a/packages/core/src/editor/__tests__/toolbar-commands.test.ts
+++ b/packages/core/src/editor/__tests__/toolbar-commands.test.ts
@@ -10,6 +10,7 @@ import type {
   ExecResult,
 } from '@docx-editor.dev/core-contract/contracts/editor';
 import {
+  chromeProbeForSlot,
   commandForSlot,
   commandForSlotValue,
   runSave,
@@ -95,17 +96,45 @@ describe('toolbar command wiring (task M4.0)', () => {
 
   test('an unwired slot is disabled without ever calling the editor', () => {
     const { editor, calls } = fakeEditor(ALLOW);
-    // `text.highlight` graduated to a value-typed slot; `text.link` stays unwired.
-    const state = toolbarCommandState(editor, 'text.link');
+    // `review.comments` has no command and no probe: genuinely unwired, and it says so
+    // without troubling the engine. (`text.highlight` graduated to a value-typed slot and
+    // `text.link` to a chrome-driven one; both now ASK the engine, which is the point.)
+    const state = toolbarCommandState(editor, 'review.comments');
     expect(state.enabled).toBe(false);
     expect(state.disabledReason).toBe('not wired to an editor command');
     expect(calls.can).toEqual([]);
-    expect(runToolbarCommand(editor, 'text.highlight')).toEqual({
+    expect(runToolbarCommand(editor, 'review.comments')).toEqual({
       ok: false,
       code: 'unsupported',
       reason: 'not wired to an editor command',
     });
     expect(calls.exec).toEqual([]);
+  });
+
+  test('a chrome-driven slot stays out of the shared table, and offers a probe instead', () => {
+    const { editor, calls } = fakeEditor(ALLOW);
+    // `text.link` is NOT in `SLOT_COMMANDS`. Putting it there would enable the control in
+    // EVERY adapter — including one with no link UI, where an enabled button can only be
+    // refused, which is the worse lie. Chrome that owns a link UI asks with the probe and
+    // dispatches through that UI; chrome that does not gets the honest unwired answer.
+    expect(commandForSlot('text.link')).toBeNull();
+    expect(toolbarCommandState(editor, 'text.link')).toEqual({
+      id: 'text.link',
+      enabled: false,
+      disabledReason: 'not wired to an editor command',
+      active: false,
+    });
+    expect(calls.can).toEqual([]);
+
+    const probe = chromeProbeForSlot('text.link');
+    expect(probe).toEqual({ type: 'insertHyperlink', href: 'https://example.com' });
+    // The probe is a real command the engine can answer — that is the whole point of it.
+    expect(editor.can(probe!).ok).toBe(true);
+  });
+
+  test('a slot with no link UI has no probe', () => {
+    expect(chromeProbeForSlot('text.bold')).toBeNull();
+    expect(chromeProbeForSlot('review.comments')).toBeNull();
   });
 
   test('a refused control is disabled and carries the engine reason verbatim', () => {

--- a/packages/core/src/editor/__tests__/toolbar-honesty.test.ts
+++ b/packages/core/src/editor/__tests__/toolbar-honesty.test.ts
@@ -255,9 +255,21 @@ describe('no wired toggle is a lie of omission', () => {
     const state = toolbarCommandState(editor, 'file.save');
     expect(state.disabledReason).toBe('save is not a command; run it with runSave(editor)');
     // A genuinely unwired slot keeps the original wording.
+    expect(toolbarCommandState(editor, 'review.comments').disabledReason).toBe(
+      'not wired to an editor command'
+    );
+  });
+
+  test('the link capability is real even though the shared slot is unwired', () => {
+    // `text.link` reports "not wired" because it is not in the shared command table — a
+    // deliberate choice, so an adapter with no link UI does not grow an enabled button it
+    // cannot serve. The CAPABILITY is nonetheless there, and chrome that owns a link UI
+    // asks the engine directly. This pins both halves, so neither can rot alone.
+    const editor = mount(p('alpha'));
     expect(toolbarCommandState(editor, 'text.link').disabledReason).toBe(
       'not wired to an editor command'
     );
+    expect(editor.can({ type: 'insertHyperlink', href: 'https://example.com' }).ok).toBe(true);
   });
 });
 

--- a/packages/core/src/editor/docx-editor-derive.ts
+++ b/packages/core/src/editor/docx-editor-derive.ts
@@ -10,6 +10,7 @@ import type {
   EditorCommand,
   EditorScope,
   ExecResult,
+  HyperlinkInfo,
   PageSetup,
   RunFormatting,
   TableContext,
@@ -105,6 +106,30 @@ export function selectionRangeOf(surface: PaginatedSurface | null): DocRange | n
   return reversed
     ? { from: { paraId: headParaId }, to: { paraId: anchorParaId } }
     : { from: { paraId: anchorParaId }, to: { paraId: headParaId } };
+}
+
+/**
+ * The `hyperlinkAt` query: the link the caret sits in, or null.
+ *
+ * `href` is the SANITIZED projection, so a caller that puts it straight into a DOM
+ * attribute or a `window.open` cannot be handed a scheme the engine refuses. An inert link
+ * — a refused scheme, a dangling relationship — answers with an empty `href`: there IS a
+ * link at that position (an editor should offer to fix or remove it) and there is nothing
+ * to follow.
+ */
+export function hyperlinkAtOf(surface: PaginatedSurface | null): HyperlinkInfo | null {
+  if (!surface) return null;
+  const link = surface.hyperlinks.linkAtCaret();
+  if (!link) return null;
+  const paraId = surface.session.paragraphAnchors().paraIdByNode.get(link.paragraphId);
+  // A `DocRange` addresses paragraphs by `w14:paraId`; without one there is no honest
+  // range to report, and a fabricated one is worse than none.
+  if (paraId === undefined) return null;
+  return {
+    href: link.href ?? '',
+    range: { from: { paraId }, to: { paraId } },
+    ...(link.tooltip !== undefined ? { tooltip: link.tooltip } : {}),
+  };
 }
 
 /**

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -144,6 +144,35 @@ export function execEditorCommand(
       }
       mounted.insertLineBreak();
       break;
+    case 'insertHyperlink': {
+      // `#name` is a bookmark in this document; anything else is an external target and
+      // goes through the package's URL allowlist on the way to a relationship. A refusal
+      // there surfaces as one rather than committing a link with nowhere to go.
+      const internal = command.href.startsWith('#');
+      const applied = mounted.hyperlinks.applyHyperlink({
+        ...(internal ? { anchor: command.href.slice(1) } : { url: command.href }),
+        ...(command.text !== undefined ? { text: command.text } : {}),
+      });
+      if (!applied) {
+        return {
+          ok: false,
+          code: 'invalidArgs',
+          reason:
+            mounted.state().lastRejection ??
+            'the link was refused: the target is not an allowed scheme, or there is no text to link',
+        };
+      }
+      break;
+    }
+    case 'removeHyperlink':
+      if (!mounted.hyperlinks.removeHyperlink()) {
+        return {
+          ok: false,
+          code: 'notFound',
+          reason: 'there is no hyperlink at the selection',
+        };
+      }
+      break;
     case 'insertText':
       mounted.type(command.text);
       break;

--- a/packages/core/src/editor/docx-editor-support.ts
+++ b/packages/core/src/editor/docx-editor-support.ts
@@ -303,6 +303,33 @@ export function classifyCommand(command: EditorCommand): CommandSupport {
       }
       return { supported: true, mutating: true };
     }
+    case 'insertHyperlink': {
+      if (command.target !== undefined) {
+        return {
+          supported: false,
+          reason: 'DocTarget addressing is not supported; a link applies at the selection',
+        };
+      }
+      // The `href` vocabulary is the WEB's, because that is what the contract declares and
+      // what a host already has: `#name` is a bookmark in this document, anything else is
+      // an external target. The allowlist is applied where the relationship is written, so
+      // `can` reports only what it can check without touching the package.
+      if (typeof command.href !== 'string' || command.href.length === 0) {
+        return {
+          supported: false,
+          code: 'invalidArgs',
+          reason: 'insertHyperlink requires an href',
+        };
+      }
+      return { supported: true, mutating: true };
+    }
+    case 'removeHyperlink':
+      return command.target === undefined
+        ? { supported: true, mutating: true }
+        : {
+            supported: false,
+            reason: 'DocTarget addressing is not supported; unlink acts at the selection',
+          };
     case 'setIndent':
       return command.left !== undefined ||
         command.right !== undefined ||

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -86,6 +86,7 @@ import {
   currentPage as currentPageOf,
   pageSetupOf,
   gateCommand,
+  hyperlinkAtOf,
   paragraphSummaries,
   runFormattingOf,
   selectionRangeOf,
@@ -108,6 +109,7 @@ import {
   type PaginatedSurface,
   type PaginatedSurfaceState,
 } from './paginated-surface.ts';
+import type { HyperlinkActivation } from './surface-navigation.ts';
 
 export interface DocxEditorConfig {
   /**
@@ -157,6 +159,21 @@ export interface FontMeasurementState {
 }
 
 /**
+ * The host chrome that answers the engine's hyperlink gestures.
+ *
+ * A CLICK on an external link and Ctrl/Cmd+K both mean "the user wants the link UI", and the
+ * engine deliberately does not know what that looks like. Registered rather than passed at
+ * construction because the chrome mounts after the editor does, and it survives a document
+ * reload — the surface is rebuilt, the handlers are not.
+ */
+export interface HyperlinkChromeHandlers {
+  /** A plain click on an external or inert link: show the popover at `activation.rect`. */
+  readonly onPopover?: (activation: HyperlinkActivation) => void;
+  /** Ctrl/Cmd+K: open insert-or-edit for the selection. */
+  readonly onRequest?: () => void;
+}
+
+/**
  * The concrete facade type: the full `Editor` contract plus the instance-only surface.
  *
  * `surface`, `stateVersion`, `attach` and `detach` live HERE rather than on `Editor`:
@@ -169,6 +186,15 @@ export interface DocxEditorInstance extends Editor {
    * contract does not carry yet (select-all, node-id addressed selection).
    */
   readonly surface: PaginatedSurface | null;
+  /**
+   * Wire the host's hyperlink chrome to the engine's gestures — a click on an external
+   * link, and Ctrl/Cmd+K. Returns an unsubscribe that restores whatever was registered
+   * before, so a popover component can register in an effect and clean up in its teardown.
+   *
+   * Instance-only, like `surface`: it is what a MOUNTING host needs, not what a document
+   * command needs.
+   */
+  setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
   /**
    * Monotonic version of the observable editor state. Bumps whenever anything
    * `snapshot()` reports could have moved — a committed change, a selection move, zoom,
@@ -234,6 +260,19 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
    * back the same array while the armed set is unchanged.
    */
   let lastPendingFormat: PaginatedSurfaceState['pendingFormat'] = null;
+  /**
+   * Registered hyperlink chrome, as a STACK — the top entry is live.
+   *
+   * Save-and-restore only survives strictly nested teardown. Two hosts registering and then
+   * unregistering out of order (React does not promise effect-cleanup order between
+   * siblings) had the outer one's cleanup resurrect a handler whose owner had already
+   * unmounted: the engine went on reporting chrome as wired while every click and Ctrl+K
+   * called into a dead component, and the popover silently stopped opening. Splicing by
+   * identity is order-independent.
+   */
+  const hyperlinkChromeStack: HyperlinkChromeHandlers[] = [];
+  const liveHyperlinkChrome = (): HyperlinkChromeHandlers =>
+    hyperlinkChromeStack[hyperlinkChromeStack.length - 1] ?? {};
   let destroyed = false;
 
   /** The measurer built per LOAD from `config.fonts` plus the document's embedded faces. */
@@ -330,6 +369,11 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         ? { measurer: shapedMeasurer, ...(shapedProducer ? { producer: shapedProducer } : {}) }
         : {}),
       ...(embeddedFaces ? { fontAlias: embeddedFaces.alias } : {}),
+      // Read through the holder rather than captured: the popover mounts AFTER the editor
+      // exists (the provider-first shape), and a document that reloads must not leave the
+      // host's chrome wired to the surface it replaced.
+      onHyperlinkPopover: (activation) => liveHyperlinkChrome().onPopover?.(activation),
+      onRequestHyperlink: () => liveHyperlinkChrome().onRequest?.(),
       onChange: (state) => {
         // The mount-time render reports before `surface` is assigned; nothing observable
         // has changed at that point, so it is not a selection change.
@@ -720,6 +764,17 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       return surface;
     },
 
+    setHyperlinkChrome(handlers) {
+      hyperlinkChromeStack.push(handlers);
+      return () => {
+        // Splice by IDENTITY, not by position: unregistering out of order must remove this
+        // entry and leave whatever else is registered alone, never resurrect a handler whose
+        // owner has already torn down.
+        const at = hyperlinkChromeStack.lastIndexOf(handlers);
+        if (at >= 0) hyperlinkChromeStack.splice(at, 1);
+      };
+    },
+
     stateVersion: () => stateVersion,
 
     fontMeasurement: () => ({
@@ -903,6 +958,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
           ) as unknown as EditorQueryResults[K];
         case 'isInsideToc':
           return false as EditorQueryResults[K];
+        case 'hyperlinkAt':
+          return hyperlinkAtOf(surface) as EditorQueryResults[K];
         case 'trackedChanges':
         case 'revisions':
         case 'findText':
@@ -918,8 +975,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         case 'variables':
           return {} as EditorQueryResults[K];
         default:
-          // tableContext, hyperlinkAt, watermark, splitCellConfig, contentControlAt,
-          // pageContent — all nullable, all underived.
+          // tableContext, watermark, splitCellConfig, contentControlAt, pageContent — all
+          // nullable, all underived.
           return null as EditorQueryResults[K];
       }
     },

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -39,6 +39,7 @@ export {
   type RulerUnit,
 } from './ruler-ticks.ts';
 export {
+  chromeProbeForSlot,
   commandForSlot,
   commandForSlotValue,
   runSave,
@@ -70,7 +71,14 @@ export {
   type PaginatedSurfaceState,
   type SurfaceFormatting,
 } from './paginated-surface.ts';
-export { createDocxEditor, type DocxEditorInstance, type DocxEditorConfig } from './docx-editor.ts';
+export {
+  createDocxEditor,
+  type DocxEditorInstance,
+  type DocxEditorConfig,
+  type HyperlinkChromeHandlers,
+} from './docx-editor.ts';
+export type { HyperlinkOps, SurfaceHyperlink } from './surface-hyperlinks.ts';
+export type { HyperlinkActivation, SurfaceNavigation } from './surface-navigation.ts';
 // The types an adapter needs to CALL the surface, re-exported from the composition root.
 // Adapters may depend on this package and not on the layout lane, so a host reaching into
 // `engine-layout` for a parameter type would be reaching past the boundary for a name.

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -5,6 +5,9 @@
 // paginated-surface.ts implements and re-exports them, so importers keep one entry point.
 
 import type { TreeDocxSession } from '@docx-editor.dev/core-contract/binding';
+import type { BookmarkIndex } from '@docx-editor.dev/core-contract/store';
+import type { HyperlinkOps } from './surface-hyperlinks.ts';
+import type { HyperlinkActivation, SurfaceNavigation } from './surface-navigation.ts';
 import type {
   CellSelection,
   NavigationCommand,
@@ -40,6 +43,20 @@ export interface PaginatedSurfaceOptions {
    */
   readonly pointer?: 'engine' | 'native';
   readonly onChange?: (state: PaginatedSurfaceState) => void;
+  /**
+   * A plain click on an external (or inert) hyperlink, for a host to open its popover with.
+   *
+   * Absent means such a click does nothing. That is deliberate: a host with no popover
+   * mounted must not have clicks silently opening tabs, and the popover is the only path to
+   * activation (see the navigation module's single `window.open` gate).
+   */
+  readonly onHyperlinkPopover?: (activation: HyperlinkActivation) => void;
+  /**
+   * Ctrl/Cmd+K — Word's Insert Hyperlink. The engine reports the request; the host's chrome
+   * decides what a link dialog looks like. A host that passes nothing leaves the key alone
+   * rather than doing something surprising with it.
+   */
+  readonly onRequestHyperlink?: () => void;
 }
 
 /**
@@ -295,6 +312,24 @@ export interface PaginatedSurface {
       readonly reusedPages: number;
     };
   };
+  /**
+   * The hyperlink lane: what link the caret is in, and the insert / retarget / unlink verbs.
+   *
+   * Every verb is one `transact`, so it is one undo step. Targets going IN are host-supplied
+   * and pass the package's own URL allowlist; targets coming OUT are the sanitized
+   * projection, so a caller cannot accidentally hand a refused scheme to a sink.
+   */
+  readonly hyperlinks: HyperlinkOps;
+  /**
+   * Bookmark jumps and the ONE external-activation gate. A host's popover "open" action
+   * calls `openExternal`; nothing else in the engine may call `window.open`.
+   */
+  readonly navigation: SurfaceNavigation;
+  /**
+   * `bookmarkName -> position` over the current revision, for resolving an internal link.
+   * First in document order wins a duplicate name, matching Word.
+   */
+  bookmarks(): BookmarkIndex;
   /** The selected text, for copy and cut. */
   selectedText(): string;
   /** Remove the selection, if any. Returns whether anything was deleted. */

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -326,6 +326,24 @@ export interface PaginatedSurface {
    */
   readonly navigation: SurfaceNavigation;
   /**
+   * Pin the current selection so it stays VISIBLY selected while focus is elsewhere.
+   *
+   * A document has one selection: the moment a panel focuses an input of its own the browser
+   * takes the highlight off the text, which is when the user most needs to see what the panel
+   * is about to act on. This draws the range on the engine's own overlay instead, so it
+   * survives the focus move. The MODEL selection is untouched — the op the panel finally runs
+   * addresses the same characters it always would.
+   *
+   * The pin releases itself when the caret leaves the range (either edge counts as inside),
+   * which is what lets a host close its panel on "the user clicked somewhere else" without
+   * every adapter reimplementing that comparison.
+   */
+  retainSelection(): void;
+  /** Drop the pin and stop drawing it, whether or not the caret ever left. */
+  releaseSelection(): void;
+  /** The pinned range, or null once it was released or escaped. */
+  retainedSelection(): SemanticSelection | null;
+  /**
    * `bookmarkName -> position` over the current revision, for resolving an internal link.
    * First in document order wins a duplicate name, matching Word.
    */

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -26,6 +26,7 @@ import {
   createParagraphLayoutCache,
   resolveDefaultSurfaceMeasurer,
   cellSelectionRects,
+  selectionRects,
   caretAt,
   cellSelectionText,
   documentOrder,
@@ -193,6 +194,42 @@ export function mountPaginatedSurface(
    */
   let cellSelection: CellSelection | null = null;
   let lastRejection: string | null = null;
+
+  /**
+   * A range pinned to stay VISIBLY selected while the focus is somewhere else.
+   *
+   * A document has one selection. The moment a panel focuses an input of its own, the browser
+   * moves that selection into the input and the text the user highlighted stops looking
+   * highlighted — which is exactly when they most need to see what the panel is about to act
+   * on. Word and Google Docs both keep the range lit; this is how.
+   *
+   * It is a SIBLING of `selection`, not a replacement: the model selection is untouched, so
+   * the op the panel finally runs still addresses the same characters. This only decides what
+   * the overlay draws, and how long the panel is entitled to stay open.
+   */
+  let retainedSelection: SemanticSelection | null = null;
+
+  /** Document-order comparison of two positions: negative, zero or positive. */
+  function comparePositions(a: SemanticPosition, b: SemanticPosition): number {
+    if (a.paragraphId === b.paragraphId) return a.offset - b.offset;
+    const order = documentOrder(currentLayout);
+    return order.indexOf(a.paragraphId) - order.indexOf(b.paragraphId);
+  }
+
+  /**
+   * Drop the retained range once the caret leaves it.
+   *
+   * "Leaves" is inclusive of both edges, so clicking at either end of your own selection is
+   * still inside it. A COLLAPSED retained position (Ctrl+K with nothing selected) is left the
+   * moment the caret moves at all, which is the same rule with a zero-width range.
+   */
+  function releaseRetainedIfEscaped(next: SemanticSelection): void {
+    if (!retainedSelection) return;
+    const { from, to } = orderedRangeOf(currentLayout, retainedSelection);
+    const head = next.head;
+    if (comparePositions(head, from) >= 0 && comparePositions(head, to) <= 0) return;
+    retainedSelection = null;
+  }
 
   /**
    * The armed typing format: what was pressed (`properties`) over the face the caret had
@@ -684,6 +721,7 @@ export function mountPaginatedSurface(
     // Moving the caret discards a stored caret format — Word's rule. Landing back on the
     // exact armed position (the mirror re-adopting the same caret) keeps it.
     reconcilePendingWith(next);
+    releaseRetainedIfEscaped(next);
     selection = next;
     // Any plain selection cancels a rectangle. A caret placed by a click, a keystroke or an
     // edit is a text selection by definition, and leaving the rectangle behind would keep
@@ -717,6 +755,7 @@ export function mountPaginatedSurface(
     // this runs inside is about to do both.
     adoptSelection: (next) => {
       reconcilePendingWith(next);
+      releaseRetainedIfEscaped(next);
       selection = next;
       desiredX = null;
     },
@@ -757,11 +796,19 @@ export function mountPaginatedSurface(
     paintSelectionOverlay(
       overlayLayer,
       currentLayout,
-      cellSelection ? cellSelectionRects(currentLayout, cellSelection.cellIds) : [],
+      cellSelection
+        ? cellSelectionRects(currentLayout, cellSelection.cellIds)
+        : retainedSelection
+          ? selectionRects(currentLayout, retainedSelection)
+          : [],
       // Pages of differing width are centred individually, so the overlay has to carry the
       // same per-page offset the painter applied or a highlight in a landscape section would
       // sit beside the cells it describes.
-      { scale, pageOffsetX: materializedExtent?.pageOffsetX }
+      {
+        scale,
+        pageOffsetX: materializedExtent?.pageOffsetX,
+        ...(cellSelection ? {} : { className: 'docx-retained-selection-rect' }),
+      }
     );
   }
 
@@ -1013,6 +1060,16 @@ export function mountPaginatedSurface(
     },
 
     hyperlinks,
+    retainSelection: () => {
+      retainedSelection = selection;
+      renderOverlay();
+    },
+    releaseSelection: () => {
+      if (!retainedSelection) return;
+      retainedSelection = null;
+      renderOverlay();
+    },
+    retainedSelection: () => retainedSelection,
 
     navigation,
 

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -19,7 +19,7 @@
 // environment in surface-pages.ts — all re-exported or consumed from this module.
 
 import { openTreeSession, type TreeDocxSession } from '@docx-editor.dev/core-contract/binding';
-import type { TreeDocOp } from '@docx-editor.dev/core-contract/store';
+import { hyperlinkTargetOf, type TreeDocOp } from '@docx-editor.dev/core-contract/store';
 import {
   createLayoutScheduler,
   createLayoutSession,
@@ -83,6 +83,8 @@ import {
 import { createPointerController, type PointerController } from './surface-pointer.ts';
 import { createSurfaceSelectionSync } from './surface-selection-sync.ts';
 import { createSurfaceStructure } from './surface-structure.ts';
+import { createHyperlinkOps } from './surface-hyperlinks.ts';
+import { createSurfaceNavigation } from './surface-navigation.ts';
 
 export type {
   OpenPaginatedResult,
@@ -320,6 +322,26 @@ export function mountPaginatedSurface(
     defaultTabStopPt,
   });
 
+  /**
+   * The engine's ONE hyperlink trust boundary, handed to layout.
+   *
+   * The resolver reads the session's live relationships, so a link inserted this session
+   * resolves immediately rather than only after a save and reopen. `hyperlinkTargetOf`
+   * produces the sanitized projection; everything downstream — paint, click routing, the
+   * popover, the clipboard — consumes only that.
+   */
+  const projectLink = (link: Parameters<typeof hyperlinkTargetOf>[0]) => {
+    const target = hyperlinkTargetOf(link, (id) => session.relationshipTarget(id));
+    if (link.kind === 'textValue') return null;
+    return {
+      id: link.id,
+      kind: target.kind,
+      href: target.href,
+      ...(target.anchor !== undefined ? { anchor: target.anchor } : {}),
+      ...(target.tooltip !== undefined ? { tooltip: target.tooltip } : {}),
+    };
+  };
+
   let currentLayout = layoutOnce();
   // Structural edits — breaks, lists, indent, sections — are their own lane over the same
   // session and commit path.
@@ -380,6 +402,27 @@ export function mountPaginatedSurface(
         level
       ) !== null,
   });
+  const hyperlinks = createHyperlinkOps({
+    session,
+    selection: () => selection,
+    orderedRange: () => orderedRange(),
+    selectionMark: () => selectionMark(),
+    textOf: (paragraphId) => textOf(paragraphId),
+    commit: (run, selectionAfter) => commit(run, selectionAfter),
+  });
+  const navigation = createSurfaceNavigation({
+    pagesLayer,
+    container,
+    scale,
+    layout: () => currentLayout,
+    bookmarks: () => session.bookmarks(),
+    linkById: (linkId) => hyperlinks.linkById(linkId),
+    setSelection: (position) => setSelection(collapsedAt(position)),
+    isCollapsedSelection: () =>
+      selection.anchor.paragraphId === selection.head.paragraphId &&
+      selection.anchor.offset === selection.head.offset,
+    ...(options.onHyperlinkPopover ? { onPopover: options.onHyperlinkPopover } : {}),
+  });
   let desiredX: number | null = null;
 
   function layoutOnce(): SemanticLayout {
@@ -394,6 +437,7 @@ export function mountPaginatedSurface(
       numberingIndex: numberingIndex(),
       sectionFurniture: furnitureSource.sectionFurniture(),
       furniture: furnitureSource.furniture(),
+      projectLink,
     });
     lastLayoutMs = now() - began;
     return layout;
@@ -424,6 +468,7 @@ export function mountPaginatedSurface(
         numberingIndex: numberingIndex(),
         sectionFurniture: furnitureSource.sectionFurniture(),
         furniture: furnitureSource.furniture(),
+        projectLink,
       });
       lastLayoutMs = now() - began;
       return layout;
@@ -967,6 +1012,12 @@ export function mountPaginatedSurface(
       });
     },
 
+    hyperlinks,
+
+    navigation,
+
+    bookmarks: () => session.bookmarks(),
+
     selectedText() {
       // A rectangle copies as a grid — tabs between cells, newlines between rows — because
       // the text range it stands in for would paste back as one run with the grid gone.
@@ -991,7 +1042,11 @@ export function mountPaginatedSurface(
 
     undo: () => restoreSelection(session.undo()),
     redo: () => restoreSelection(session.redo()),
-    focus: () => pagesLayer.focus(),
+    // `preventScroll`: the pages layer is the WHOLE document tall, and focusing it scrolls
+    // it into view — to its top. The first click anywhere in a long document therefore
+    // threw the reader back to page 1 before the caret it had just placed could be seen.
+    // The caret is positioned from layout regardless, so nothing needs the browser's scroll.
+    focus: () => pagesLayer.focus({ preventScroll: true }),
     destroy() {
       document.removeEventListener('selectionchange', onSelectionChange);
       pagesLayer.removeEventListener('keydown', onKeyDown);
@@ -1003,6 +1058,7 @@ export function mountPaginatedSurface(
       pagesLayer.removeEventListener('compositionend', onCompositionEnd);
       document.removeEventListener('scroll', onScroll, { capture: true });
       pointer?.destroy();
+      navigation.destroy();
       // Drop pending layout work and stop listening BEFORE the DOM goes, or a commit from
       // another editor sharing this store would paint into a detached container.
       scheduler.cancel();
@@ -1143,7 +1199,10 @@ export function mountPaginatedSurface(
    * the DOM guessed.
    */
   let pointer: PointerController | null = null;
-  const onKeyDown = createKeyDownHandler(surface);
+  const onKeyDown = createKeyDownHandler(
+    surface,
+    options.onRequestHyperlink ? { onRequestHyperlink: options.onRequestHyperlink } : {}
+  );
   const { onCopy, onCut, onPaste } = createClipboardHandlers(surface, insertPlainText);
   const onBeforeInput = createBeforeInputHandler(surface, {
     isComposing: () => selectionSync.isComposing(),
@@ -1266,7 +1325,11 @@ export function mountPaginatedSurface(
       setSelection: (next) => setSelection(next),
       cellSelection: () => cellSelection,
       setCellSelection: (next) => setCellSelection(next),
-      focus: () => pagesLayer.focus(),
+      // `preventScroll`: the pages layer is the WHOLE document tall, and focusing it scrolls
+      // it into view — to its top. The first click anywhere in a long document therefore
+      // threw the reader back to page 1 before the caret it had just placed could be seen.
+      // The caret is positioned from layout regardless, so nothing needs the browser's scroll.
+      focus: () => pagesLayer.focus({ preventScroll: true }),
     },
     options.pointer ? { mode: options.pointer } : {}
   );

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -249,16 +249,30 @@ export function runPropertyEdits(
   if (!paragraph || paragraph.kind === 'textValue') return [];
   const edits: RunPropertyEdit[] = [];
   let offset = 0;
-  for (const child of paragraph.children) {
-    if (child.kind !== 'run') continue;
+  /**
+   * Every run the range covers, at the depth it actually sits at.
+   *
+   * A `w:hyperlink` holds ordinary runs, and skipping it outright was wrong twice over: the
+   * link's own text could not be formatted at all, and — because the offset did not advance
+   * across it either — every run AFTER the link was addressed as if the link's characters did
+   * not exist. Colouring a link then wrote the FOLLOWING run's properties over the link's
+   * text, one character short. This descends exactly where `segmentsOf` does, so the offsets
+   * computed here are the ones the applier resolves.
+   */
+  const visit = (child: OoxmlNode): void => {
+    if (child.kind === 'hyperlink') {
+      for (const inner of child.children) visit(inner);
+      return;
+    }
+    if (child.kind !== 'run') return;
     const runStart = offset;
     offset += addressableLength(child);
     // A run with no addressable content — a field character, a bare `w:rPr` — is not
     // reachable by any range, so no op should name one.
-    if (offset === runStart) continue;
+    if (offset === runStart) return;
     const from = Math.max(runStart, start);
     const to = Math.min(offset, end);
-    if (from >= to) continue;
+    if (from >= to) return;
     edits.push({
       start: from,
       end: to,
@@ -270,7 +284,8 @@ export function runPropertyEdits(
         incoming
       ),
     });
-  }
+  };
+  for (const child of paragraph.children) visit(child);
   return edits;
 }
 

--- a/packages/core/src/editor/surface-hyperlinks.ts
+++ b/packages/core/src/editor/surface-hyperlinks.ts
@@ -1,0 +1,393 @@
+// The surface's hyperlink lane (paginated-surface seam).
+//
+// Insert, retarget, unlink and "what link is the caret in" — every one expressed as ONE
+// `transact` so it is one undo step, which is what makes editing a URL feel like editing a
+// word rather than like a script that ran.
+//
+// The trust boundary stays where it was. A URL arriving here is HOST-supplied (a popover
+// input, an agent call) and is written to the package only through
+// `session.ensureHyperlinkRelationship`, which refuses anything `sanitizeHref` refuses. What
+// comes BACK — for the popover to show, for a click to open — is always the sanitized
+// projection layout already resolved, never the authored string.
+
+import type { TreeDocxSession } from '@docx-editor.dev/core-contract/binding';
+import {
+  hyperlinkTargetOf,
+  type OoxmlNode,
+  type OoxmlPart,
+  type TreeDocOp,
+} from '@docx-editor.dev/core-contract/store';
+import type { SemanticPosition, SemanticSelection } from '@docx-editor.dev/core-contract/layout';
+
+/**
+ * A hyperlink as the surface reports it: its identity, where it sits, and the SANITIZED
+ * target. `href: null` is an inert link — a refused scheme or a dangling relationship — which
+ * a UI shows and offers to edit but must never offer to open.
+ */
+export interface SurfaceHyperlink {
+  /** Canonical node id of the `w:hyperlink`. */
+  readonly id: string;
+  readonly paragraphId: string;
+  /** UTF-16 range of the link's display text within its paragraph. */
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+  readonly kind: 'external' | 'internal' | 'unresolved';
+  /** Sanitized projection: an absolute URL, `#anchor`, or null when inert. */
+  readonly href: string | null;
+  /** The authored target, for an editor to seed its input with. */
+  readonly authored: string;
+  readonly anchor?: string;
+  readonly tooltip?: string;
+}
+
+/** Every run under a node, at any depth — a `w:r`, or the runs inside a link. */
+function runsUnder(node: OoxmlNode): OoxmlNode[] {
+  if (node.kind === 'run') return [node];
+  if (node.kind !== 'hyperlink') return [];
+  return node.children.flatMap((child) => runsUnder(child));
+}
+
+/** The measurable length of one inline node, in `paragraphTextOf`'s vocabulary. */
+function inlineLength(node: OoxmlNode): number {
+  if (node.kind === 'textValue') return node.value.length;
+  if (node.kind === 'tab' || node.kind === 'hardBreak') return 1;
+  if (node.kind === 'runProperties' || node.kind === 'generic') return 0;
+  let total = 0;
+  for (const child of node.children) total += inlineLength(child);
+  return total;
+}
+
+/**
+ * Every typed hyperlink in one paragraph, with the offsets it covers.
+ *
+ * Walks the paragraph's inline children in order, accumulating the same offsets `segmentsOf`
+ * produces, so a range reported here is a range the ops accept.
+ */
+export function hyperlinksInParagraph(
+  part: OoxmlPart,
+  paragraphId: string,
+  resolve: (relationshipId: string) => { target: string; external: boolean } | null,
+  textOf: (paragraphId: string) => string
+): SurfaceHyperlink[] {
+  const paragraph = findNode(part, paragraphId);
+  if (!paragraph || paragraph.kind !== 'paragraph') return [];
+  const text = textOf(paragraphId);
+  const found: SurfaceHyperlink[] = [];
+  let offset = 0;
+  for (const child of paragraph.children) {
+    if (child.kind === 'run') {
+      offset += inlineLength(child);
+      continue;
+    }
+    if (child.kind !== 'hyperlink') continue;
+    const start = offset;
+    for (const run of runsUnder(child)) offset += inlineLength(run);
+    const target = hyperlinkTargetOf(child, resolve);
+    found.push({
+      id: child.id,
+      paragraphId,
+      start,
+      end: offset,
+      text: text.slice(start, offset),
+      kind: target.kind,
+      href: target.href,
+      authored: target.authored,
+      ...(target.anchor !== undefined ? { anchor: target.anchor } : {}),
+      ...(target.tooltip !== undefined ? { tooltip: target.tooltip } : {}),
+    });
+  }
+  return found;
+}
+
+/** A node by id, without importing the store's private walk. */
+function findNode(part: OoxmlPart, nodeId: string): OoxmlNode | null {
+  const walk = (node: OoxmlNode): OoxmlNode | null => {
+    if (node.kind === 'textValue') return node.id === nodeId ? node : null;
+    if (node.id === nodeId) return node;
+    for (const child of node.children) {
+      const found = walk(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  return walk(part.root);
+}
+
+/**
+ * The link a position sits in, or null.
+ *
+ * INCLUSIVE OF BOTH EDGES, deliberately. A caret at the very end of a link is still "in" it
+ * for the purposes of Ctrl+K and the popover, because that is where the caret lands after
+ * clicking the last character — and Word treats it the same way. It is NOT inclusive for
+ * typing (that is the ops' business, and they append outside the link, as Word does).
+ */
+export function hyperlinkAtPosition(
+  links: readonly SurfaceHyperlink[],
+  position: SemanticPosition
+): SurfaceHyperlink | null {
+  for (const link of links) {
+    if (link.paragraphId !== position.paragraphId) continue;
+    if (position.offset >= link.start && position.offset <= link.end) return link;
+  }
+  return null;
+}
+
+export interface HyperlinkOpsDeps {
+  readonly session: TreeDocxSession;
+  readonly selection: () => SemanticSelection;
+  readonly orderedRange: () => { from: SemanticPosition; to: SemanticPosition };
+  readonly selectionMark: () => { paragraphId: string; start: number; end: number } | null;
+  readonly textOf: (paragraphId: string) => string;
+  readonly commit: (
+    run: () => ReturnType<TreeDocxSession['applyTreeOps']> | boolean,
+    selectionAfter?: () => SemanticSelection | null
+  ) => void;
+}
+
+export interface HyperlinkOps {
+  /** Every link in the paragraph the caret is in. */
+  linksInCaretParagraph(): SurfaceHyperlink[];
+  /** The link the caret sits in, or null. */
+  linkAtCaret(): SurfaceHyperlink | null;
+  /** The link with this node id, or null. */
+  linkById(linkId: string): SurfaceHyperlink | null;
+  /**
+   * Apply a link to the selection, or retarget the one the caret is already in.
+   *
+   * `text` replaces the display text when supplied. Returns whether anything committed;
+   * a refusal leaves the document exactly as it was.
+   */
+  applyHyperlink(input: {
+    readonly url?: string;
+    readonly anchor?: string;
+    readonly text?: string;
+    readonly tooltip?: string;
+  }): boolean;
+  /** Take the link off the one at the caret (or a named one). Returns whether it committed. */
+  removeHyperlink(linkId?: string): boolean;
+}
+
+export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
+  const resolve = (relationshipId: string) => deps.session.relationshipTarget(relationshipId);
+
+  const linksIn = (paragraphId: string): SurfaceHyperlink[] =>
+    hyperlinksInParagraph(deps.session.part(), paragraphId, resolve, deps.textOf);
+
+  const linkAtCaret = (): SurfaceHyperlink | null =>
+    hyperlinkAtPosition(linksIn(deps.selection().head.paragraphId), deps.selection().head);
+
+  const linkById = (linkId: string): SurfaceHyperlink | null => {
+    // The link's own paragraph is the one holding it; walking the caret's paragraph first
+    // covers every real caller in one lookup, and the full scan is the fallback.
+    const caretParagraph = deps.selection().head.paragraphId;
+    const near = linksIn(caretParagraph).find((link) => link.id === linkId);
+    if (near) return near;
+    for (const paragraphId of deps.session.paragraphIds()) {
+      const found = linksIn(paragraphId).find((link) => link.id === linkId);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  return {
+    linksInCaretParagraph: () => linksIn(deps.selection().head.paragraphId),
+    linkAtCaret,
+    linkById,
+
+    applyHyperlink(input) {
+      const wantsExternal = input.url !== undefined && input.url.length > 0;
+      const wantsInternal = input.anchor !== undefined && input.anchor.length > 0;
+      // Exactly one target, matching the op's own rule — a caller that supplies both does
+      // not know which it wants, and picking one for it writes a link nobody chose.
+      if (wantsExternal === wantsInternal) return false;
+
+      // The relationship is minted BEFORE the transaction: it lives on the package, outside
+      // the undo stack, and a refused URL must not leave a half-applied edit behind.
+      let relationshipId: string | undefined;
+      if (wantsExternal) {
+        const minted = deps.session.ensureHyperlinkRelationship(input.url!);
+        if (!minted) return false;
+        relationshipId = minted;
+      }
+      const target = {
+        ...(relationshipId !== undefined ? { relationshipId } : {}),
+        ...(wantsInternal ? { anchor: input.anchor! } : {}),
+        ...(input.tooltip !== undefined ? { tooltip: input.tooltip } : {}),
+      };
+
+      const existing = linkAtCaret();
+      const range = deps.orderedRange();
+      const collapsed =
+        range.from.paragraphId === range.to.paragraphId && range.from.offset === range.to.offset;
+
+      // RETARGET when the caret is inside a link and the selection adds nothing: this is
+      // Ctrl+K on an existing link, and replacing the element would throw away its authored
+      // `w:history` / `w:tgtFrame` and its identity.
+      if (existing && (collapsed || withinLink(existing, range))) {
+        const ops: TreeDocOp[] = [{ op: 'setHyperlinkTarget', linkId: existing.id, ...target }];
+        // Replacing the display text is a delete plus an insert over the link's own range;
+        // both land inside the link because the range is strictly inside it.
+        if (input.text !== undefined && input.text !== existing.text) {
+          const replaced = replaceTextOps(
+            existing.paragraphId,
+            existing.start,
+            existing.end,
+            input.text
+          );
+          if (!replaced) return false;
+          ops.push(...replaced);
+        }
+        let committed = false;
+        deps.commit(
+          () => {
+            const result = deps.session.applyTreeOps(ops, deps.selectionMark());
+            committed = result.committed;
+            return result;
+          },
+          () => null
+        );
+        return committed;
+      }
+
+      // INSERT. A collapsed caret has no text to wrap, so the display text — the URL itself
+      // when the caller supplied none — is inserted first and then wrapped, in one
+      // transaction. That is Word's behaviour and it is what makes Ctrl+K on an empty caret
+      // produce a usable link rather than nothing at all.
+      const paragraphId = range.from.paragraphId;
+      if (range.to.paragraphId !== paragraphId) return false; // a link cannot span paragraphs
+      const ops: TreeDocOp[] = [];
+      let start = range.from.offset;
+      let end = range.to.offset;
+
+      if (collapsed) {
+        const display = input.text ?? input.url ?? input.anchor ?? '';
+        if (display.length === 0) return false;
+        ops.push({ op: 'insertText', paragraphId, offset: start, text: display });
+        end = start + display.length;
+      } else if (
+        input.text !== undefined &&
+        input.text !== deps.textOf(paragraphId).slice(start, end)
+      ) {
+        const replaced = replaceTextOps(paragraphId, start, end, input.text);
+        if (!replaced) return false;
+        ops.push(...replaced);
+        end = start + input.text.length;
+      }
+      if (end <= start) return false;
+      // Word marks a new link's text with the `Hyperlink` CHARACTER STYLE, and without it
+      // the user gets a link indistinguishable from the words around it — no way to tell
+      // the command worked. The op carries it, so wrapping and marking are one step and one
+      // undo. Only when the document actually declares the style: a reference to a style
+      // that is not there is a dangling one, and a link with the surrounding appearance is
+      // the honest fallback.
+      const styleId = hyperlinkStyleId(deps.session);
+      ops.push({
+        op: 'insertHyperlink',
+        paragraphId,
+        start,
+        end,
+        ...target,
+        ...(styleId ? { styleId } : {}),
+      });
+
+      let committed = false;
+      const after = { paragraphId, offset: end };
+      deps.commit(
+        () => {
+          const result = deps.session.applyTreeOps(ops, deps.selectionMark(), {
+            paragraphId,
+            start: end,
+            end,
+          });
+          committed = result.committed;
+          return result;
+        },
+        () => ({ anchor: after, head: after })
+      );
+      return committed;
+    },
+
+    removeHyperlink(linkId) {
+      const link = linkId ? linkById(linkId) : linkAtCaret();
+      if (!link) return false;
+      let committed = false;
+      // The caret stays where the text is: unlinking must not move it, because the user's
+      // next keystroke is aimed at the word they were just looking at.
+      const after = { paragraphId: link.paragraphId, offset: link.end };
+      deps.commit(
+        () => {
+          const result = deps.session.applyTreeOps(
+            [{ op: 'removeHyperlink', linkId: link.id }],
+            deps.selectionMark()
+          );
+          committed = result.committed;
+          return result;
+        },
+        () => ({ anchor: after, head: after })
+      );
+      return committed;
+    },
+  };
+}
+
+/**
+ * The document's own hyperlink character style, or null when it declares none.
+ *
+ * Matched by STYLE ID (`Hyperlink`, Word's own, case-insensitively) among the character
+ * styles. Creating the style when it is absent belongs to a styles-editing lane; until then
+ * a document without it gets a working link with the surrounding appearance, which is
+ * lossless and honest — rather than a reference to a style that does not exist.
+ */
+function hyperlinkStyleId(session: TreeDocxSession): string | null {
+  for (const style of session.documentStyles()) {
+    if (style.type !== 'character') continue;
+    if (style.styleId.toLowerCase() === 'hyperlink') return style.styleId;
+  }
+  return null;
+}
+
+/** Whether a selection lies entirely within one link's display text. */
+function withinLink(
+  link: SurfaceHyperlink,
+  range: { from: SemanticPosition; to: SemanticPosition }
+): boolean {
+  return (
+    range.from.paragraphId === link.paragraphId &&
+    range.to.paragraphId === link.paragraphId &&
+    range.from.offset >= link.start &&
+    range.to.offset <= link.end
+  );
+}
+
+/**
+ * Replace one range's text, INSERT FIRST.
+ *
+ * Delete-then-insert reads more naturally and destroys a link. Deleting a link's whole
+ * display text empties every run inside it, the delete's own cleanup then removes the
+ * emptied `w:hyperlink`, and the insert that follows lands in a plain run — so editing the
+ * display text of an existing link silently unlinked it while reporting success. That is
+ * the ordinary Ctrl+K-then-change-the-text flow.
+ *
+ * Inserting at `start` first puts the new text inside the link (the offset is a boundary of
+ * the link's first run), and the old text — now shifted right by the inserted length — is
+ * deleted after. The link is never empty at any point, so nothing sweeps it away.
+ */
+function replaceTextOps(
+  paragraphId: string,
+  start: number,
+  end: number,
+  text: string
+): TreeDocOp[] | null {
+  if (text.length === 0) return null;
+  const ops: TreeDocOp[] = [{ op: 'insertText', paragraphId, offset: start, text }];
+  if (end > start) {
+    ops.push({
+      op: 'deleteText',
+      paragraphId,
+      start: start + text.length,
+      end: end + text.length,
+    });
+  }
+  return ops;
+}

--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -45,7 +45,18 @@ const FORMATTING: Record<string, { localName: string; attributes?: Record<string
   u: { localName: 'u', attributes: { val: 'single' } },
 };
 
-export function createKeyDownHandler(surface: PaginatedSurface): (event: KeyboardEvent) => void {
+export function createKeyDownHandler(
+  surface: PaginatedSurface,
+  hooks: {
+    /**
+     * Ctrl/Cmd+K — Word's Insert Hyperlink. The keymap does not know what a link dialog
+     * looks like, so it reports the request and the host's chrome answers it; a host with
+     * no hyperlink UI simply does not pass this, and the key falls through to the browser
+     * rather than doing something surprising.
+     */
+    readonly onRequestHyperlink?: () => void;
+  } = {}
+): (event: KeyboardEvent) => void {
   return (event: KeyboardEvent): void => {
     const accel = event.metaKey || event.ctrlKey;
     const command = NAVIGATION[event.key];
@@ -126,6 +137,13 @@ export function createKeyDownHandler(surface: PaginatedSurface): (event: Keyboar
     }
     if (accel && event.key.toLowerCase() === 'a') {
       surface.selectAll();
+      event.preventDefault();
+      return;
+    }
+    if (accel && !event.shiftKey && event.key.toLowerCase() === 'k' && hooks.onRequestHyperlink) {
+      // Word's Insert Hyperlink. On an existing link this opens EDIT mode seeded from it,
+      // which is the host's job — the keymap only says the user asked.
+      hooks.onRequestHyperlink();
       event.preventDefault();
       return;
     }

--- a/packages/core/src/editor/surface-navigation.ts
+++ b/packages/core/src/editor/surface-navigation.ts
@@ -1,0 +1,214 @@
+// Hyperlink navigation over the painted pages (paginated-surface seam).
+//
+// THE HOST PAGE NEVER NAVIGATES. Painted links carry a real `href` so they announce as links,
+// copy as links and print as links — which also means a browser left to itself would follow
+// one and unload the editor, taking every unsaved edit with it. Every click on an anchor
+// inside the pages is prevented here, unconditionally and regardless of pointer mode, and
+// what happens next is a decision this module makes.
+//
+// THREE OUTCOMES, and only three:
+//
+//   internal link  -> scroll to the bookmark and put the caret there. Never leaves the page.
+//   external link  -> hand the host a popover request. Ctrl/Cmd+Click activates directly.
+//   anything else  -> nothing. A drag that ENDED on a link is a selection, not a click on it;
+//                     an inert link (refused scheme, dangling relationship) has no target;
+//                     a furniture link in a header is read-only in this slice.
+//
+// `window.open` is called from ONE place in the whole engine — `openExternal` below — and
+// only ever with the sanitized projection, never with an authored target.
+
+import { caretAt, type SemanticLayout } from '@docx-editor.dev/core-contract/layout';
+import type { BookmarkIndex } from '@docx-editor.dev/core-contract/store';
+import type { SurfaceHyperlink } from './surface-hyperlinks.ts';
+
+/** A click on a painted link, after native navigation was refused. */
+export interface HyperlinkActivation {
+  readonly link: SurfaceHyperlink;
+  /** The clicked line fragment's viewport rect, so a popover can be placed under it. */
+  readonly rect: {
+    readonly left: number;
+    readonly top: number;
+    readonly bottom: number;
+    readonly right: number;
+  };
+}
+
+export interface NavigationDeps {
+  readonly pagesLayer: HTMLElement;
+  readonly container: HTMLElement;
+  readonly scale: number;
+  readonly layout: () => SemanticLayout;
+  readonly bookmarks: () => BookmarkIndex;
+  readonly linkById: (linkId: string) => SurfaceHyperlink | null;
+  readonly setSelection: (position: { paragraphId: string; offset: number }) => void;
+  readonly isCollapsedSelection: () => boolean;
+  /**
+   * Show the hyperlink popover for an external link. Absent means a plain click on an
+   * external link does nothing — which is the honest behaviour for a host that has not
+   * mounted a popover, rather than opening a tab the user did not ask for.
+   */
+  readonly onPopover?: (activation: HyperlinkActivation) => void;
+}
+
+export interface SurfaceNavigation {
+  /**
+   * Scroll a bookmark into view and place the caret at it. Answers false for a name no
+   * bookmark declares — an inert click, which is what Word does with a dangling anchor.
+   */
+  goToBookmark(name: string): boolean;
+  /**
+   * THE external-activation call site. Refuses anything but a sanitized projection, so a
+   * caller cannot route an authored target through it by mistake.
+   */
+  openExternal(href: string | null): boolean;
+  destroy(): void;
+}
+
+/** How much room to leave above a jump target, so it does not land flush against the edge. */
+const JUMP_MARGIN_PX = 24;
+
+export function createSurfaceNavigation(deps: NavigationDeps): SurfaceNavigation {
+  const { pagesLayer } = deps;
+  const view = pagesLayer.ownerDocument.defaultView;
+
+  /** The scroll container this surface sits in, looked up live (chrome can mount later). */
+  function scroller(): HTMLElement | null {
+    return deps.container.closest('.docx-editor__scroll-container');
+  }
+
+  const openExternal = (href: string | null): boolean => {
+    // `href` is layout's sanitized projection: `sanitizeHref` already refused
+    // `javascript:`/`data:`/`vbscript:`/`file:`, and an inert link carries null. Re-checked
+    // here because this is the sink, and a sink that trusts its caller is one refactor away
+    // from being the hole.
+    if (!href || href.length === 0 || href.startsWith('#')) return false;
+    if (!view) return false;
+    // `noopener` is what stops the opened page reaching back through `window.opener` into
+    // the editor; `noreferrer` keeps the document's own URL out of the request.
+    view.open(href, '_blank', 'noopener,noreferrer');
+    return true;
+  };
+
+  const goToBookmark = (name: string): boolean => {
+    const anchor = deps.bookmarks().get(name);
+    if (!anchor) return false;
+    // Geometry from the LAYOUT, not the DOM. The target of a cross-document jump is normally
+    // on a virtualized page with no DOM at all, so `scrollIntoView` would resolve exactly the
+    // jumps that did not need it and fail every one that did.
+    const layout = deps.layout();
+    const caret = caretAt(layout, { paragraphId: anchor.paragraphId, offset: anchor.offset });
+    if (!caret) return false;
+    const page = layout.pages[caret.pageIndex];
+    if (!page) return false;
+
+    // The caret is published in PAGE-CONTENT coordinates; the scroll container measures the
+    // whole sheet stack, so the page's own origin has to be added back.
+    const sheetY = page.box.y + (page.contentBox.y - page.box.y) + caret.y;
+    const element = scroller();
+    if (element) {
+      element.scrollTop = Math.max(0, sheetY * deps.scale - JUMP_MARGIN_PX);
+    }
+    // The caret moves whether or not there was anywhere to scroll: the jump's POINT is that
+    // the user is now editing at the target, and a document short enough to need no scroll
+    // must still move the caret.
+    deps.setSelection({ paragraphId: anchor.paragraphId, offset: anchor.offset });
+    return true;
+  };
+
+  /**
+   * The link under the pointer at PRESS time, and where it was.
+   *
+   * A press on the surface commits a selection, and a commit can repaint the pages — which
+   * detaches the very span the press landed on. The browser then has no live target to
+   * compute the `click` event from and reports the nearest surviving ancestor, the pages
+   * layer: the click arrived with every trace of the link gone from it. Remembering what was
+   * under the pointer before any of that happens is the only reading that survives a
+   * repaint, and it is the reading the user meant.
+   */
+  let pressed: { readonly linkId: string; readonly rect: HyperlinkActivation['rect'] } | null =
+    null;
+
+  const onPointerDown = (event: PointerEvent): void => {
+    pressed = null;
+    const target = event.target as Element | null;
+    const anchor = target?.closest('a.docx-hyperlink') as HTMLElement | null;
+    if (!anchor || anchor.closest('[data-docx-hf]')) return;
+    const linkId = anchor.dataset.docxLink;
+    if (!linkId) return;
+    const rect = anchor.getBoundingClientRect();
+    pressed = {
+      linkId,
+      rect: { left: rect.left, top: rect.top, bottom: rect.bottom, right: rect.right },
+    };
+  };
+
+  const onClick = (event: MouseEvent): void => {
+    const target = event.target as Element | null;
+    const anchor = target?.closest('a.docx-hyperlink') as HTMLElement | null;
+    if (!anchor) {
+      // No live anchor on the event — either the press was not on a link, or the repaint
+      // took it. The press record tells the two apart.
+      const remembered = pressed;
+      pressed = null;
+      if (!remembered) return;
+      event.preventDefault();
+      classify(remembered.linkId, remembered.rect, event);
+      return;
+    }
+    pressed = null;
+    // PREVENTED FIRST, classified second — the same discipline `beforeinput` uses. Whatever
+    // this handler decides, the browser is not following the link.
+    event.preventDefault();
+    // Header and footer links are read-only furniture in this slice. They paint without an
+    // `href` already; refusing here as well keeps that a property rather than an accident.
+    if (anchor.closest('[data-docx-hf]')) return;
+    const linkId = anchor.dataset.docxLink;
+    if (!linkId) return;
+    const rect = anchor.getBoundingClientRect();
+    classify(
+      linkId,
+      { left: rect.left, top: rect.top, bottom: rect.bottom, right: rect.right },
+      event
+    );
+  };
+
+  /** What a click on `linkId` means, once the link and its position are known. */
+  function classify(linkId: string, rect: HyperlinkActivation['rect'], event: MouseEvent): void {
+    const link = deps.linkById(linkId);
+    if (!link) return;
+
+    const accel = event.metaKey || event.ctrlKey;
+    // Ctrl/Cmd+Click follows Word: open now, no popover. Through the same single gate.
+    if (accel) {
+      if (link.kind === 'external') openExternal(link.href);
+      else if (link.anchor) goToBookmark(link.anchor);
+      return;
+    }
+    // A click that ended a DRAG is a selection, not an activation. Popping a panel over the
+    // text someone just selected is the most annoying possible response to that gesture.
+    if (!deps.isCollapsedSelection()) return;
+
+    if (link.kind === 'internal') {
+      if (link.anchor) goToBookmark(link.anchor);
+      return;
+    }
+    // External and unresolved both go to the popover: an inert link is still a link the user
+    // may want to see, fix or remove, and the popover is where those live. What it must not
+    // do is open — which `openExternal` refuses for a null href regardless.
+    deps.onPopover?.({ link, rect });
+  }
+
+  // Capture phase on the press: the surface's own pointerdown handler prevents the
+  // default and commits a selection, and this must read the DOM before any of that.
+  pagesLayer.addEventListener('pointerdown', onPointerDown, true);
+  pagesLayer.addEventListener('click', onClick);
+
+  return {
+    goToBookmark,
+    openExternal,
+    destroy() {
+      pagesLayer.removeEventListener('pointerdown', onPointerDown, true);
+      pagesLayer.removeEventListener('click', onClick);
+    },
+  };
+}

--- a/packages/core/src/editor/toolbar-commands.ts
+++ b/packages/core/src/editor/toolbar-commands.ts
@@ -51,6 +51,31 @@ const SLOT_COMMANDS: Partial<Record<ChromeSlotId, EditorCommand>> = {
 };
 
 /**
+ * The probe a slot uses to ask "would the engine honour this right now?" when its real
+ * command needs an argument the slot itself cannot supply.
+ *
+ * `text.link` is the case: whether this selection could become a link is the engine's
+ * question, but WHICH link is a URL field's. Chrome that owns a link UI (React's
+ * `ToolbarLink`) asks with this and dispatches through that UI.
+ *
+ * DELIBERATELY NOT in `SLOT_COMMANDS`. Enabled state has one source, and putting the probe
+ * there would enable the control in EVERY adapter — including Vue, which has grown no link
+ * UI, where the result is an enabled button whose click can only be refused. A dead button
+ * is the worse lie: `file.save` was a disabled control for a capability that works, and this
+ * would be an enabled control for one that is not reachable. Vue's slot therefore keeps
+ * reporting the honest "not wired to an editor command" until its popover lands.
+ *
+ * @public
+ */
+export function chromeProbeForSlot(slotId: ChromeSlotId): EditorCommand | null {
+  return CHROME_PROBES[slotId] ?? null;
+}
+
+const CHROME_PROBES: Partial<Record<ChromeSlotId, EditorCommand>> = {
+  'text.link': { type: 'insertHyperlink', href: 'https://example.com' },
+};
+
+/**
  * The public editor command behind one chrome slot, or `null` when the slot is
  * not wired to a command yet (parity-only chrome, or save — which is not a
  * command). The single source of command truth for both adapters.

--- a/packages/core/src/layout/__tests__/hyperlink-layout.test.ts
+++ b/packages/core/src/layout/__tests__/hyperlink-layout.test.ts
@@ -1,0 +1,295 @@
+// Hyperlink runs are ordinary paragraph content: measured, broken, painted, addressable.
+//
+// The regression these guard is not subtle. While `w:hyperlink` was an opaque child its runs
+// never entered the token stream, so section 9 of the comprehensive fixture painted
+// "Visit  or ." — a sentence with its two links deleted out of it, and no indication anything
+// was missing.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  hyperlinkTargetOf,
+  readOoxmlPackage,
+  relationshipTargetIn,
+  type OoxmlNode,
+  type OoxmlPackage,
+  type OoxmlPart,
+} from '@docx-editor.dev/core-contract/store';
+import { createFixedMeasurer } from '../index.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import type { HyperlinkProjector } from '../field-projection.ts';
+import type { SemanticLayout, StyleSpanRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const FIXTURE = `${import.meta.dir}/../../../../../e2e/fixtures/comprehensive-word-element-test.docx`;
+const measurer = createFixedMeasurer(6, 14);
+
+/** The projector the real surface installs, over a package's own relationships. */
+function projectorFor(pkg: OoxmlPackage): HyperlinkProjector {
+  return (link: OoxmlNode) => {
+    if (link.kind === 'textValue') return null;
+    const target = hyperlinkTargetOf(link, (id) =>
+      relationshipTargetIn(pkg, pkg.mainDocumentPart, id)
+    );
+    return {
+      id: link.id,
+      kind: target.kind,
+      href: target.href,
+      ...(target.anchor !== undefined ? { anchor: target.anchor } : {}),
+      ...(target.tooltip !== undefined ? { tooltip: target.tooltip } : {}),
+    };
+  };
+}
+
+function layoutOf(pkg: OoxmlPackage): SemanticLayout {
+  const part = pkg.parts.get(pkg.mainDocumentPart)!;
+  return layoutSemanticDocument(part, 1, { measurer, projectLink: projectorFor(pkg) });
+}
+
+/** Every span of the layout, in document order. */
+function spansOf(layout: SemanticLayout): StyleSpanRecord[] {
+  const spans: StyleSpanRecord[] = [];
+  const walk = (blocks: readonly { kind: string }[]): void => {
+    for (const block of blocks) {
+      if (block.kind === 'table') {
+        for (const row of (block as { rows: { cells: { blocks: unknown[] }[] }[] }).rows) {
+          for (const cell of row.cells) walk(cell.blocks as { kind: string }[]);
+        }
+        continue;
+      }
+      for (const line of (block as unknown as { lines: { spans: StyleSpanRecord[] }[] }).lines) {
+        spans.push(...line.spans);
+      }
+    }
+  };
+  for (const page of layout.pages) walk(page.fragments);
+  return spans;
+}
+
+/** The painted text of one paragraph, reassembled from its spans in offset order. */
+function paintedTextOf(layout: SemanticLayout, paragraphId: string): string {
+  return spansOf(layout)
+    .filter((span) => span.range.paragraphId === paragraphId)
+    .sort((a, b) => a.range.start - b.range.start)
+    .map((span) => span.text)
+    .join('');
+}
+
+function loadFixture(): OoxmlPackage {
+  const result = readOoxmlPackage(new Uint8Array(readFileSync(FIXTURE)));
+  if (!result.ok) throw new Error(`package read failed: ${result.reason}`);
+  return result.package;
+}
+
+function packageOf(body: string, rels = ''): OoxmlPackage {
+  const entries: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">${rels}</Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+  };
+  const loaded = readOoxmlPackage(zipSync(entries));
+  if (!loaded.ok) throw new Error(`load failed: ${loaded.reason}`);
+  return loaded.package;
+}
+
+/** The paragraph whose painted text contains `needle`. */
+function paragraphContaining(layout: SemanticLayout, needle: string): string {
+  const ids = new Set(spansOf(layout).map((span) => span.range.paragraphId));
+  for (const id of ids) {
+    if (paintedTextOf(layout, id).includes(needle)) return id;
+  }
+  throw new Error(`no painted paragraph contains ${JSON.stringify(needle)}`);
+}
+
+describe('hyperlink runs are laid out like sibling runs (comprehensive fixture)', () => {
+  const layout = layoutOf(loadFixture());
+
+  test('9.1 paints its whole sentence, not the sentence minus its links', () => {
+    const id = paragraphContaining(layout, 'Visit ');
+    expect(paintedTextOf(layout, id)).toBe('Visit Example.com or Anthropic’s website.');
+  });
+
+  test('9.2 paints its cross-references, en dashes intact', () => {
+    const id = paragraphContaining(layout, 'Jump to:');
+    expect(paintedTextOf(layout, id)).toBe(
+      'Jump to: Section 1 | Section 6 – Nested Tables | Section 12 – Form Elements'
+    );
+  });
+
+  test('external link spans carry the resolved external target', () => {
+    const id = paragraphContaining(layout, 'Visit ');
+    const links = spansOf(layout)
+      .filter((span) => span.range.paragraphId === id && span.link)
+      .map((span) => span.link!);
+    expect(
+      links.some((link) => link.kind === 'external' && link.href === 'https://example.com')
+    ).toBe(true);
+    expect(
+      links.some((link) => link.kind === 'external' && link.href === 'https://www.anthropic.com')
+    ).toBe(true);
+  });
+
+  test('internal link spans carry the anchor as a fragment', () => {
+    const id = paragraphContaining(layout, 'Jump to:');
+    const anchors = new Set(
+      spansOf(layout)
+        .filter((span) => span.range.paragraphId === id && span.link)
+        .map((span) => span.link!.href)
+    );
+    expect(anchors).toEqual(new Set(['#section1', '#section6', '#section12']));
+  });
+
+  test('every link span of one link shares that link’s node identity', () => {
+    const id = paragraphContaining(layout, 'Visit ');
+    const byHref = new Map<string, Set<string>>();
+    for (const span of spansOf(layout)) {
+      if (span.range.paragraphId !== id || !span.link?.href) continue;
+      const ids = byHref.get(span.link.href) ?? new Set<string>();
+      ids.add(span.link.id);
+      byHref.set(span.link.href, ids);
+    }
+    // One `w:hyperlink` element per target, so one id per target however many spans it took.
+    for (const ids of byHref.values()) expect(ids.size).toBe(1);
+  });
+
+  test('plain runs beside a link carry no link', () => {
+    const id = paragraphContaining(layout, 'Visit ');
+    const visit = spansOf(layout).find(
+      (span) => span.range.paragraphId === id && span.text.startsWith('Visit')
+    );
+    expect(visit?.link).toBeUndefined();
+  });
+});
+
+describe('link targets cross the trust boundary exactly once', () => {
+  test('a javascript: target loads INERT — painted, addressable, unactivatable', () => {
+    const pkg = packageOf(
+      '<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Click me</w:t></w:r></w:hyperlink></w:p>',
+      `<Relationship Id="rId9" Type="${R}/hyperlink" Target="javascript:alert(1)" TargetMode="External"/>`
+    );
+    const layout = layoutOf(pkg);
+    const id = paragraphContaining(layout, 'Click me');
+    // The TEXT survives: a refused scheme is not a reason to lose the words.
+    expect(paintedTextOf(layout, id)).toBe('Click me');
+    const link = spansOf(layout).find((span) => span.range.paragraphId === id)?.link;
+    expect(link?.kind).toBe('external');
+    // ...and there is nothing to follow.
+    expect(link?.href).toBeNull();
+  });
+
+  test('a scheme smuggled past a naive check is refused too', () => {
+    const pkg = packageOf(
+      '<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Sneaky</w:t></w:r></w:hyperlink></w:p>',
+      `<Relationship Id="rId9" Type="${R}/hyperlink" Target="java&#9;script:alert(1)" TargetMode="External"/>`
+    );
+    const layout = layoutOf(pkg);
+    const id = paragraphContaining(layout, 'Sneaky');
+    expect(spansOf(layout).find((span) => span.range.paragraphId === id)?.link?.href).toBeNull();
+  });
+
+  test('a RELATIVE target is inert — it would resolve against the host application', () => {
+    // `sanitizeHref` is a SCHEME allowlist and admits relative URLs on purpose; that is the
+    // right rule for a value a host authored and the wrong one for a value a `.docx` did.
+    // A target with no scheme resolves against whatever origin the editor is embedded in,
+    // so a link reading "Company policy" becomes an authenticated same-origin request to
+    // the host app. The package's own absolute-URI verdict is what refuses it.
+    for (const target of ['/admin/api/delete-account', '//evil.example/x', 'evil.html']) {
+      const pkg = packageOf(
+        '<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Company policy</w:t></w:r></w:hyperlink></w:p>',
+        `<Relationship Id="rId9" Type="${R}/hyperlink" Target="${target}" TargetMode="External"/>`
+      );
+      const layout = layoutOf(pkg);
+      const id = paragraphContaining(layout, 'Company policy');
+      // The text is still there — an inert link is not a deleted one.
+      expect(paintedTextOf(layout, id)).toBe('Company policy');
+      const link = spansOf(layout).find((span) => span.range.paragraphId === id)?.link;
+      expect(link?.href, target).toBeNull();
+      // ...and the authored value is retained, so the save is still lossless.
+      expect(link?.kind).toBe('external');
+    }
+  });
+
+  test('an absolute allowlisted target is still admitted', () => {
+    const pkg = packageOf(
+      '<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Fine</w:t></w:r></w:hyperlink></w:p>',
+      `<Relationship Id="rId9" Type="${R}/hyperlink" Target="https://example.com/a?b=1" TargetMode="External"/>`
+    );
+    const layout = layoutOf(pkg);
+    const id = paragraphContaining(layout, 'Fine');
+    expect(spansOf(layout).find((span) => span.range.paragraphId === id)?.link?.href).toBe(
+      'https://example.com/a?b=1'
+    );
+  });
+
+  test('a dangling relationship demotes to plain runs without losing the text', () => {
+    const pkg = packageOf(
+      '<w:p><w:hyperlink r:id="rIdMissing"><w:r><w:t>Orphan</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const layout = layoutOf(pkg);
+    const id = paragraphContaining(layout, 'Orphan');
+    expect(paintedTextOf(layout, id)).toBe('Orphan');
+    const link = spansOf(layout).find((span) => span.range.paragraphId === id)?.link;
+    expect(link?.kind).toBe('unresolved');
+    expect(link?.href).toBeNull();
+  });
+
+  test('non-run content inside a link keeps its position and the runs still paint', () => {
+    const pkg = packageOf(
+      '<w:p><w:hyperlink w:anchor="top">' +
+        '<w:r><w:t>before</w:t></w:r><w:drawing/><w:r><w:t>after</w:t></w:r>' +
+        '</w:hyperlink></w:p>'
+    );
+    const layout = layoutOf(pkg);
+    const id = paragraphContaining(layout, 'before');
+    expect(paintedTextOf(layout, id)).toBe('beforeafter');
+  });
+});
+
+describe('bookmarks occupy no space', () => {
+  test('a heading carrying a bookmark measures like one without', () => {
+    const withBookmark = layoutOf(
+      packageOf(
+        '<w:p><w:bookmarkStart w:id="1" w:name="here"/><w:r><w:t>Heading</w:t></w:r>' +
+          '<w:bookmarkEnd w:id="1"/></w:p>'
+      )
+    );
+    const plain = layoutOf(packageOf('<w:p><w:r><w:t>Heading</w:t></w:r></w:p>'));
+    const boxOf = (layout: SemanticLayout) =>
+      (layout.pages[0]!.fragments[0] as unknown as { lines: { box: unknown }[] }).lines[0]!.box;
+    expect(boxOf(withBookmark)).toEqual(boxOf(plain));
+    // And the bookmark contributes no offsets, so the text starts at 0.
+    const id = paragraphContaining(withBookmark, 'Heading');
+    const first = spansOf(withBookmark).find((span) => span.range.paragraphId === id);
+    expect(first?.range.start).toBe(0);
+  });
+});
+
+describe('a part with no relationship resolver still paints its link text', () => {
+  test('layout without projectLink loses the target, never the words', () => {
+    const pkg = packageOf(
+      '<w:p><w:hyperlink w:anchor="top"><w:r><w:t>Somewhere</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const part: OoxmlPart = pkg.parts.get(pkg.mainDocumentPart)!;
+    const layout = layoutSemanticDocument(part, 1, { measurer });
+    const id = paragraphContaining(layout, 'Somewhere');
+    expect(paintedTextOf(layout, id)).toBe('Somewhere');
+    expect(spansOf(layout).find((span) => span.range.paragraphId === id)?.link).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -23,7 +23,11 @@ import {
   type OoxmlProperty,
 } from '@docx-editor.dev/core-contract/store';
 import { resolveRunStyle, type ResolvedRunStyle } from './run-style.ts';
-import type { HeaderFooterStoryRecord, SemanticLayout } from './semantic-records.ts';
+import type {
+  HeaderFooterStoryRecord,
+  SemanticLayout,
+  SpanLinkRecord,
+} from './semantic-records.ts';
 
 /** Optional per-run merge of inherited + direct `rPr` (character styles, defaults). */
 export type RunPropertyCascader = (
@@ -107,6 +111,8 @@ export interface FieldAwarePiece {
    * would disagree with the store.
    */
   readonly positionalTab?: PositionalTab;
+  /** The hyperlink this piece came from, already sanitized, or absent for ordinary text. */
+  readonly link?: SpanLinkRecord;
 }
 
 const PTAB_ALIGNMENTS = new Set(['left', 'center', 'right']);
@@ -144,6 +150,16 @@ export function positionalTabOf(node: OoxmlNode): PositionalTab | null {
       : {}),
   };
 }
+
+/**
+ * How layout turns a typed `w:hyperlink` node into the sanitized record spans carry.
+ *
+ * Injected rather than computed here because resolving `r:id` needs the PACKAGE's
+ * relationships and this module only ever sees one part's tree. `null` means the caller
+ * declined to project — the runs still measure and paint, they simply carry no link, which is
+ * the right degradation: text is never lost for want of a target.
+ */
+export type HyperlinkProjector = (link: OoxmlNode) => SpanLinkRecord | null;
 
 const MERGEFORMAT_SUFFIX = /\s*\\\*\s*MERGEFORMAT\s*$/i;
 
@@ -450,12 +466,15 @@ export function piecesOfParagraph(
   paragraph: OoxmlNode,
   inheritedRunProperties: readonly OoxmlProperty[] = [],
   pageContext?: FieldPageContext,
-  cascadeRuns?: RunPropertyCascader
+  cascadeRuns?: RunPropertyCascader,
+  projectLink?: HyperlinkProjector
 ): FieldAwarePiece[] {
   if (paragraph.kind === 'textValue') return [];
 
   const pieces: FieldAwarePiece[] = [];
   let offset = 0;
+  /** The link the walk is currently inside, so every piece it emits is tagged with it. */
+  let currentLink: SpanLinkRecord | undefined;
 
   // Complex-field machine — document order across runs within this paragraph.
   const field = createFieldParseState();
@@ -473,12 +492,21 @@ export function piecesOfParagraph(
     positionalTab?: PositionalTab
   ): void => {
     if (text.length === 0 && !projected) return;
+    const link = currentLink ? { link: currentLink } : {};
     if (projected) {
-      pieces.push({ text, props, style, start, end, projected: true });
+      pieces.push({ text, props, style, start, end, projected: true, ...link });
       return;
     }
     if (text.length === 0) return;
-    pieces.push({ text, props, style, start, end, ...(positionalTab ? { positionalTab } : {}) });
+    pieces.push({
+      text,
+      props,
+      style,
+      start,
+      end,
+      ...(positionalTab ? { positionalTab } : {}),
+      ...link,
+    });
   };
 
   const commitPendingProjection = (): void => {
@@ -628,13 +656,27 @@ export function piecesOfParagraph(
     }
   };
 
-  // Only typed runs contribute measurable / selectable text. Generic siblings (including
-  // `w:fldSimple`) are structurally preserved but layout-inert for model-offset purposes.
+  // Typed runs contribute measurable / selectable text — including the runs inside a
+  // `w:hyperlink`, which is a run CONTAINER and not a leaf. Skipping it is what made every
+  // link's words vanish from the painted page while still occupying model offsets. Generic
+  // siblings (including `w:fldSimple`) stay structurally preserved but layout-inert.
   // Paragraph root counts as depth 0; run children sit at depth 1.
   if (!consumeScanNode(budget)) return pieces;
-  for (const child of paragraph.children) {
-    if (child.kind === 'run') processRun(child, 1);
-  }
+  const processInline = (child: OoxmlNode, depth: number): void => {
+    if (child.kind === 'run') {
+      processRun(child, depth);
+      return;
+    }
+    if (child.kind !== 'hyperlink') return;
+    if (depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
+    // The link is projected ONCE per element, not per run: sanitization is not free, and a
+    // link's runs must all carry the same record so paint can group them by identity.
+    const previous = currentLink;
+    currentLink = projectLink?.(child) ?? undefined;
+    for (const inner of child.children) processInline(inner, depth + 1);
+    currentLink = previous;
+  };
+  for (const child of paragraph.children) processInline(child, 1);
   // Malformed field missing end: fail closed (no live projection) but keep cached result text.
   abandonPendingProjection();
 

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -150,6 +150,7 @@ export {
   type ParagraphSpacing,
   type SemanticLayout,
   type SourceRange,
+  type SpanLinkRecord,
   type StyleSpanRecord,
   type TableCellFragmentRecord,
   type TableFragmentRecord,
@@ -214,6 +215,7 @@ export {
   type PageFurniture,
   type SemanticLayoutOptions,
 } from './semantic-layout.ts';
+export type { HyperlinkProjector } from './field-projection.ts';
 export {
   EMPTY_NUMBERING_INDEX,
   MAX_LVL_OVERRIDES,

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -15,6 +15,7 @@ import {
   propertiesOfRunContainer,
   type FieldPageContext,
   type PositionalTab,
+  type HyperlinkProjector,
   type RunPropertyCascader,
 } from './field-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
@@ -59,6 +60,14 @@ export interface ParagraphFlowOptions {
    * which is the same answer whenever the paragraph carries no indents.
    */
   readonly marginExtent?: { readonly left: number; readonly right: number };
+  /**
+   * Turns a typed `w:hyperlink` into the sanitized record its spans carry.
+   *
+   * Supplied by the document layout, which is the level that can see the package's
+   * relationships. Absent means link runs still measure and paint — they simply carry no
+   * link, which is what a table-cell or furniture pass without a resolver gets.
+   */
+  readonly projectLink?: HyperlinkProjector;
 }
 
 /** One measurable piece of a paragraph: text carrying one property set. */
@@ -346,7 +355,13 @@ export function breakParagraph(
   // `w:firstLine`, left (negative) for `w:hanging`. Every later line starts at the indent.
   const firstLineOffset = flow?.firstLineOffset ?? 0;
 
-  const pieces = piecesOfParagraph(paragraph, inheritedRunProperties, pageContext, cascadeRuns);
+  const pieces = piecesOfParagraph(
+    paragraph,
+    inheritedRunProperties,
+    pageContext,
+    cascadeRuns,
+    flow?.projectLink
+  );
   const emptyStyle =
     inheritedRunProperties.length === 0
       ? DEFAULT_RUN_STYLE
@@ -395,6 +410,7 @@ export function breakParagraph(
         props: piece.props,
         style: piece.style,
         box: { x: lineOrigin() + line.width, y: 0, width: 0, height: breakMetrics.height },
+        ...(piece.link ? { link: piece.link } : {}),
       });
       line.height = Math.max(line.height, breakMetrics.height);
       line.baseline = Math.max(line.baseline, breakMetrics.baseline);
@@ -417,6 +433,7 @@ export function breakParagraph(
         props: piece.props,
         style: piece.style,
         box: { x: lineOrigin() + line.width, y: 0, width: 0, height: breakMetrics.height },
+        ...(piece.link ? { link: piece.link } : {}),
       });
       line.height = Math.max(line.height, breakMetrics.height);
       line.baseline = Math.max(line.baseline, breakMetrics.baseline);
@@ -492,6 +509,7 @@ export function breakParagraph(
                 ),
               }
             : {}),
+          ...(piece.link ? { link: piece.link } : {}),
         });
         line.width += width;
         line.height = Math.max(line.height, metrics.height);
@@ -511,6 +529,7 @@ export function breakParagraph(
         props: piece.props,
         style: piece.style,
         box: { x: lineOrigin() + line.width, y: 0, width, height: metrics.height },
+        ...(piece.link ? { link: piece.link } : {}),
       });
       line.width += width;
       line.height = Math.max(line.height, metrics.height);

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -15,7 +15,7 @@ import type {
   OoxmlPart,
   OoxmlProperty,
 } from '@docx-editor.dev/core-contract/store';
-import { finalizePageFieldProjection } from './field-projection.ts';
+import { finalizePageFieldProjection, type HyperlinkProjector } from './field-projection.ts';
 import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
 import { alignSpans, breakParagraph, type Alignment, type PendingLine } from './paragraph-flow.ts';
 import {
@@ -179,6 +179,15 @@ export interface SemanticLayoutOptions {
    * here — which is why the prepared-block memo does not key on it.
    */
   readonly defaultTabStopPt?: number;
+  /**
+   * Turns a typed `w:hyperlink` into the SANITIZED record its spans carry.
+   *
+   * An option because resolving `r:id` needs the package's relationships, which layout — a
+   * per-part walk — cannot see. Absent means link runs still measure, break and paint;
+   * they simply carry no link, so nothing is clickable and no text is lost. That is the
+   * degradation a headless test or a furniture-only pass gets, and it is the safe one.
+   */
+  readonly projectLink?: HyperlinkProjector;
 }
 
 /** Prepass results by block node, valid while the width and producer both hold. */
@@ -687,6 +696,7 @@ function layoutBlocksWithGeometry(
     styleCascade,
     listItems,
     ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
+    ...(options.projectLink ? { projectLink: options.projectLink } : {}),
     borderOwnershipBudget: createTableBorderOwnershipBudget(),
     vMergeResolveBudget: createTableVMergeResolveBudget(),
   };
@@ -726,6 +736,7 @@ function layoutBlocksWithGeometry(
         // The page's text column, so a `w:ptab` measuring against the margin ignores the
         // paragraph's own indents the way Word does.
         marginExtent: { left: 0, right: entry.indent.left + entry.available + entry.indent.right },
+        ...(options.projectLink ? { projectLink: options.projectLink } : {}),
       }
     );
 

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -79,6 +79,29 @@ export interface ParagraphBorderStrokeRecord {
   readonly box: LayoutBox;
 }
 
+/**
+ * The hyperlink a span sits inside, as layout resolved it.
+ *
+ * Already SANITIZED: `href` is the runtime projection produced once at the trust boundary,
+ * and `null` means the link is inert — a refused scheme, or a relationship the package does
+ * not declare. Paint, hit-testing and the popover consume this and never the authored target,
+ * so there is exactly one place a file-derived URL becomes something a browser can follow.
+ *
+ * `id` is the `w:hyperlink` node's canonical id, which is what makes the spans of one link
+ * recognisable as one link across the several lines it wraps onto — and what an unlink or a
+ * retarget addresses.
+ */
+export interface SpanLinkRecord {
+  readonly id: string;
+  readonly kind: 'external' | 'internal' | 'unresolved';
+  /** Sanitized runtime projection: an absolute URL, `#anchor`, or null when inert. */
+  readonly href: string | null;
+  /** Bookmark name for an internal link, so navigation need not re-parse the fragment. */
+  readonly anchor?: string;
+  /** `w:tooltip` — paint puts it on the anchor's `title`. */
+  readonly tooltip?: string;
+}
+
 /** A run of text on one line sharing identical resolved formatting. */
 export interface StyleSpanRecord {
   readonly range: SourceRange;
@@ -111,6 +134,14 @@ export interface StyleSpanRecord {
    * typed there would be — which is what Word draws.
    */
   readonly tabLeaderAdvancePt?: number;
+  /**
+   * The hyperlink this span belongs to, or absent for ordinary text.
+   *
+   * Carried on the SPAN rather than looked up at paint time because a link that wraps
+   * produces one set of spans per line, and paint has no paragraph to walk — only the line
+   * it was handed.
+   */
+  readonly link?: SpanLinkRecord;
 }
 
 export interface LineRecord {

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -19,7 +19,7 @@
 // `breakParagraph`, so they hit the same cache with keys at the cell's content width.
 
 import type { OoxmlElement } from '@docx-editor.dev/core-contract/store';
-import type { FieldPageContext } from './field-projection.ts';
+import type { FieldPageContext, HyperlinkProjector } from './field-projection.ts';
 import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
 import { alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
 import { collapsedSpaceBefore, paragraphBorderExtentPt } from './paragraph-style.ts';
@@ -122,6 +122,11 @@ export interface TableFlowDeps {
    * paragraph tabs on the same document-wide grid as a body paragraph.
    */
   readonly defaultTabStopPt?: number;
+  /**
+   * Turns a typed `w:hyperlink` into the sanitized record its spans carry. A link in a
+   * table cell is an ordinary link; without this it would paint its text and be dead.
+   */
+  readonly projectLink?: HyperlinkProjector;
   /**
    * Shared sparse ownership-interval budget for border finalize across nested tables in
    * one layout pass. Created once per flow; omit only in isolated unit tests.
@@ -321,6 +326,7 @@ function placeCellParagraph(
       firstLineOffset,
       // A cell's own content box is the column a positional tab measures against.
       marginExtent: { left: 0, right: indent.left + available + indent.right },
+      ...(deps.projectLink ? { projectLink: deps.projectLink } : {}),
     }
   );
 

--- a/packages/core/src/output/__tests__/hyperlink-paint.test.ts
+++ b/packages/core/src/output/__tests__/hyperlink-paint.test.ts
@@ -1,0 +1,192 @@
+// The painted hyperlink DOM contract.
+//
+// The anchor is furniture: it adds link SEMANTICS (href, title, focus, announcement) and it
+// is never authoritative for anything. Every assertion here is either "the anchor carries the
+// semantics" or "the spans inside it kept the selection contract they always had".
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  hyperlinkTargetOf,
+  readOoxmlPackage,
+  relationshipTargetIn,
+  type OoxmlNode,
+  type OoxmlPackage,
+} from '@docx-editor.dev/core-contract/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '@docx-editor.dev/core-contract/layout';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function packageOf(body: string, rels = ''): OoxmlPackage {
+  const entries: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">${rels}</Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+  };
+  const loaded = readOoxmlPackage(zipSync(entries));
+  if (!loaded.ok) throw new Error(`load failed: ${loaded.reason}`);
+  return loaded.package;
+}
+
+function paint(body: string, rels = ''): HTMLElement {
+  const pkg = packageOf(body, rels);
+  const part = pkg.parts.get(pkg.mainDocumentPart)!;
+  const layout = layoutSemanticDocument(part, 3, {
+    measurer: createFixedMeasurer(6, 14),
+    projectLink: (link: OoxmlNode) => {
+      if (link.kind === 'textValue') return null;
+      const target = hyperlinkTargetOf(link, (id) =>
+        relationshipTargetIn(pkg, pkg.mainDocumentPart, id)
+      );
+      return {
+        id: link.id,
+        kind: target.kind,
+        href: target.href,
+        ...(target.anchor !== undefined ? { anchor: target.anchor } : {}),
+        ...(target.tooltip !== undefined ? { tooltip: target.tooltip } : {}),
+      };
+    },
+  });
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, { ariaHidden: false });
+  return container;
+}
+
+const EXTERNAL_REL = `<Relationship Id="rId9" Type="${R}/hyperlink" Target="https://example.com" TargetMode="External"/>`;
+
+describe('painted hyperlink anchors', () => {
+  test('an external link paints an anchor carrying the sanitized target', () => {
+    const container = paint(
+      '<w:p><w:r><w:t>Visit </w:t></w:r>' +
+        '<w:hyperlink r:id="rId9" w:tooltip="Our site"><w:r><w:t>Example</w:t></w:r></w:hyperlink>' +
+        '</w:p>',
+      EXTERNAL_REL
+    );
+    const anchor = container.querySelector('a.docx-hyperlink')!;
+    expect(anchor.getAttribute('href')).toBe('https://example.com');
+    expect(anchor.getAttribute('title')).toBe('Our site');
+    expect(anchor.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  test('an internal link paints a fragment href and no rel', () => {
+    const container = paint(
+      '<w:p><w:hyperlink w:anchor="section12"><w:r><w:t>Section 12</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const anchor = container.querySelector('a.docx-hyperlink')!;
+    expect(anchor.getAttribute('href')).toBe('#section12');
+    expect(anchor.getAttribute('rel')).toBeNull();
+  });
+
+  test('a refused scheme paints the link with NO href and out of the tab order', () => {
+    const container = paint(
+      '<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Click</w:t></w:r></w:hyperlink></w:p>',
+      `<Relationship Id="rId9" Type="${R}/hyperlink" Target="javascript:alert(1)" TargetMode="External"/>`
+    );
+    const anchor = container.querySelector('a.docx-hyperlink')!;
+    expect(anchor.hasAttribute('href')).toBe(false);
+    expect(anchor.getAttribute('tabindex')).toBe('-1');
+    // The words are still on the page — an inert link is not a deleted one.
+    expect(anchor.textContent).toBe('Click');
+  });
+
+  test('a LIVE link is out of the tab order too — the pages layer owns focus', () => {
+    // The regression: Chrome focuses an anchor on mousedown, the surface's pointer path
+    // focuses the pages layer back, and re-focusing a document-tall contenteditable scrolls
+    // the viewport to its top. Clicking a link on page 10 threw the reader back to page 1.
+    const container = paint(
+      '<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Example</w:t></w:r></w:hyperlink></w:p>',
+      EXTERNAL_REL
+    );
+    const anchor = container.querySelector('a.docx-hyperlink')!;
+    expect(anchor.getAttribute('tabindex')).toBe('-1');
+    // ...and it is still a real link for the clipboard, print, and assistive tech.
+    expect(anchor.getAttribute('href')).toBe('https://example.com');
+  });
+
+  test('run spans inside an anchor keep the selection contract', () => {
+    const container = paint(
+      '<w:p><w:hyperlink w:anchor="top"><w:r><w:t>Linked</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const span = container.querySelector('a.docx-hyperlink [data-paragraph-id][data-start]');
+    expect(span).not.toBeNull();
+    expect((span as HTMLElement).dataset.start).toBe('0');
+    expect((span as HTMLElement).dataset.end).toBe('6');
+    expect((span as HTMLElement).dataset.paragraphId).toBeTruthy();
+  });
+
+  test('the anchor itself is not a selection target', () => {
+    const container = paint(
+      '<w:p><w:hyperlink w:anchor="top"><w:r><w:t>Linked</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const anchor = container.querySelector('a.docx-hyperlink') as HTMLElement;
+    // No source range of its own: `dom-selection` resolves through the spans inside.
+    expect(anchor.dataset.start).toBeUndefined();
+    expect(anchor.dataset.end).toBeUndefined();
+    // But it names the link it paints, so a click can identify it without geometry.
+    expect(anchor.dataset.docxLink).toBeTruthy();
+    expect(anchor.dataset.docxLinkKind).toBe('internal');
+  });
+
+  test('one link across several formatting runs paints ONE anchor', () => {
+    const container = paint(
+      '<w:p><w:hyperlink w:anchor="top">' +
+        '<w:r><w:rPr><w:b/></w:rPr><w:t>Bold</w:t></w:r>' +
+        '<w:r><w:t> and plain</w:t></w:r>' +
+        '</w:hyperlink></w:p>'
+    );
+    const anchors = container.querySelectorAll('a.docx-hyperlink');
+    expect(anchors.length).toBe(1);
+    expect(anchors[0]!.textContent).toBe('Bold and plain');
+  });
+
+  test('two links in one paragraph paint two anchors, and plain text stays outside both', () => {
+    const container = paint(
+      '<w:p><w:r><w:t>a </w:t></w:r>' +
+        '<w:hyperlink w:anchor="one"><w:r><w:t>first</w:t></w:r></w:hyperlink>' +
+        '<w:r><w:t> b </w:t></w:r>' +
+        '<w:hyperlink w:anchor="two"><w:r><w:t>second</w:t></w:r></w:hyperlink>' +
+        '</w:p>'
+    );
+    const anchors = [...container.querySelectorAll('a.docx-hyperlink')];
+    expect(anchors.map((a) => a.textContent)).toEqual(['first', 'second']);
+    expect(anchors.map((a) => a.getAttribute('href'))).toEqual(['#one', '#two']);
+    // The plain run is a direct child of the line, not swallowed by either anchor.
+    const line = container.querySelector('.docx-line')!;
+    const plain = [...line.children].filter((child) => child.tagName !== 'A');
+    expect(plain.some((child) => child.textContent === 'a ')).toBe(true);
+  });
+
+  test('no file-derived string is ever parsed as markup', () => {
+    const container = paint(
+      '<w:p><w:hyperlink r:id="rId9" w:tooltip="&lt;img src=x onerror=alert(1)&gt;">' +
+        '<w:r><w:t>&lt;script&gt;</w:t></w:r></w:hyperlink></w:p>',
+      EXTERNAL_REL
+    );
+    // The tooltip lands as an ATTRIBUTE VALUE and the text as a text node — neither becomes
+    // an element, which is what `setAttribute` + `textContent` guarantee.
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('script')).toBeNull();
+    const anchor = container.querySelector('a.docx-hyperlink')!;
+    expect(anchor.getAttribute('title')).toBe('<img src=x onerror=alert(1)>');
+    expect(anchor.textContent).toBe('<script>');
+  });
+});

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -18,6 +18,7 @@ import type {
   ParagraphFragmentRecord,
   ResolvedRunStyle,
   SemanticLayout,
+  SpanLinkRecord,
   StyleSpanRecord,
   TableCellFragmentRecord,
   TableFragmentRecord,
@@ -35,6 +36,13 @@ export interface PaintContext {
    * `undefined` when that family has no aliased face. Engine-minted values only.
    */
   readonly fontAlias?: (family: string) => string | undefined;
+  /**
+   * Paint hyperlinks without an `href` and out of the tab order.
+   *
+   * Set while painting page furniture: headers and footers are read-only in this slice, so
+   * a live link there would be the one thing in the furniture that answers a gesture.
+   */
+  readonly inertLinks?: boolean;
 }
 
 /**
@@ -366,6 +374,78 @@ function paintSpan(
 }
 
 /**
+ * The anchor element wrapping one line's worth of a hyperlink's runs.
+ *
+ * FURNITURE, NEVER AUTHORITY. It carries semantics the run spans cannot — `href`, `title`,
+ * a focus stop, the "link" role assistive technology announces — and nothing else. Selection
+ * mapping, hit-testing and the caret all read the `data-paragraph-id`/`data-start`/
+ * `data-end` on the spans INSIDE it, exactly as they do for plain text, so an anchor can be
+ * added or removed without any of them changing behaviour.
+ *
+ * `href` is the SANITIZED projection layout already produced, never the authored target. A
+ * link whose scheme was refused, whose relationship is missing, or that sits in read-only
+ * page furniture gets no `href` at all: it still paints, still selects, still saves, and
+ * there is no attribute for a click or a keyboard activation to follow.
+ */
+function paintHyperlinkAnchor(
+  document: Document,
+  link: SpanLinkRecord,
+  ctx: PaintContext
+): HTMLElement {
+  const element = document.createElement('a');
+  element.className = 'docx-hyperlink';
+  // The link's identity, so a click can name the `w:hyperlink` it landed on without the
+  // pointer path re-deriving it from geometry.
+  element.dataset.docxLink = link.id;
+  element.dataset.docxLinkKind = link.kind;
+  // NEVER A FOCUS TARGET. The pages layer is the surface's single focus host — a
+  // contenteditable spanning the whole document — and an `<a>` inside it is a competing one.
+  // Chrome focuses an anchor on mousedown, the pointer path then focuses the pages layer
+  // back, and re-focusing an element tens of thousands of pixels tall scrolls the viewport
+  // to its TOP: clicking a link on page 10 threw the reader back to page 1.
+  //
+  // Nothing is lost by taking it out of the tab order, because tabbing was never how a link
+  // is reached here: the caret is, and Ctrl/Cmd+K opens the popover on the link the caret is
+  // in. That is Word's model rather than a browser's tab-through-links model, and it is the
+  // one the rest of this surface already implements.
+  element.setAttribute('tabindex', '-1');
+  // Inert furniture links (headers and footers) are not activation targets either: header
+  // editing is a later slice, so a live `href` there would be the one part of the furniture
+  // that responds to a click.
+  if (!ctx.inertLinks && link.href) {
+    // SAFE: `setAttribute`, and the value is the allowlisted projection from `sanitizeHref`
+    // — `javascript:`/`data:`/`vbscript:`/`file:` never reach here.
+    element.setAttribute('href', link.href);
+    // A same-page bookmark jump is handled by the engine; an external target is opened only
+    // through the popover. Either way the browser must not navigate on its own, which the
+    // surface enforces — this is belt and braces for the print and clipboard paths, where
+    // the anchor leaves the editable surface entirely.
+    if (link.kind === 'external') element.setAttribute('rel', 'noopener noreferrer');
+  }
+  // `w:tooltip` is Word's hover text. `title` takes a plain string, not markup.
+  if (link.tooltip) element.setAttribute('title', link.tooltip);
+  // SHRINK-WRAPPED, BASELINE-ALIGNED — the same box model the runs inside it use.
+  //
+  // A plain `display: inline` anchor measures ZERO HIGH here: the line is a `font-size: 0`
+  // flow, so the inline box's own height is nothing and its rect never grows to cover the
+  // inline-block runs within it. A person could still click the link (the run takes the
+  // click and it bubbles), but nothing that MEASURES could: automation refused it as
+  // invisible, and accessibility and hit-testing saw a link with no extent.
+  //
+  // `inline-block` gives it a box that shrink-wraps its children; `vertical-align: baseline`
+  // keeps that box on the same baseline they were already on, because an inline-block's
+  // baseline is its last line box's — the children's. Layout is unchanged and the element is
+  // now real.
+  element.style.display = 'inline-block';
+  element.style.verticalAlign = 'baseline';
+  // Decoration and colour stay with the RUNS, which carry the resolved `Hyperlink` character
+  // style. Imposing them here would overrule an authored override.
+  element.style.textDecoration = 'none';
+  element.style.color = 'inherit';
+  return element;
+}
+
+/**
  * A line is ONE inline flow, not a row of absolutely positioned words.
  *
  * Layout decides what goes on the line, where the line sits, and where the page breaks —
@@ -425,9 +505,28 @@ function paintLine(document: Document, line: LineRecord, ctx: PaintContext): HTM
   let tallest = 0;
   for (const span of line.spans) tallest = Math.max(tallest, span.box.height);
   const leading = Math.max(0, line.box.height - tallest);
+  // Consecutive spans of the SAME link share one anchor, so a link that spans several
+  // formatting runs on one line is one `<a>` — one focus stop, one hover target, one thing
+  // a screen reader announces. A link that WRAPS gets one anchor per line, which is the
+  // only shape an absolutely-positioned line model can express.
+  let anchor: HTMLElement | null = null;
+  let anchorLinkId: string | null = null;
   for (const span of line.spans) {
     const band = Math.min(span.box.height + leading, line.box.height);
-    element.append(paintSpan(document, span, ctx, band));
+    const painted = paintSpan(document, span, ctx, band);
+    const link = span.link;
+    if (!link) {
+      anchor = null;
+      anchorLinkId = null;
+      element.append(painted);
+      continue;
+    }
+    if (!anchor || anchorLinkId !== link.id) {
+      anchor = paintHyperlinkAnchor(document, link, ctx);
+      anchorLinkId = link.id;
+      element.append(anchor);
+    }
+    anchor.append(painted);
   }
   // A span-less line (empty paragraph) has no inline content, and a browser will not
   // draw a caret at a position with no inline box to measure. The <br> is the anchor;
@@ -882,11 +981,16 @@ function paintPage(
     container.style.width = `${story.box.width * options.scale}px`;
     container.style.height = `${story.box.height * options.scale}px`;
     container.style.overflow = 'hidden';
+    // Furniture links paint styled but inert — see `paintHyperlinkAnchor`.
+    const furnitureCtx: PaintContext & { readonly ariaHidden: boolean } = {
+      ...options,
+      inertLinks: true,
+    };
     for (const fragment of story.fragments) {
       container.append(
         fragment.kind === 'table'
-          ? paintTableFragment(document, fragment, options)
-          : paintFragment(document, fragment, options)
+          ? paintTableFragment(document, fragment, furnitureCtx)
+          : paintFragment(document, fragment, furnitureCtx)
       );
     }
     element.append(container);

--- a/packages/core/src/output/semantic-selection-overlay.ts
+++ b/packages/core/src/output/semantic-selection-overlay.ts
@@ -30,6 +30,15 @@ export interface SelectionOverlayOptions {
    * beside the cells it describes.
    */
   readonly pageOffsetX?: ReadonlyMap<number, number>;
+  /**
+   * Class for each painted rectangle. Defaults to the cell-selection class, because a cell
+   * rectangle was the only thing this layer drew when it was written.
+   *
+   * A retained TEXT range is drawn here too and must not look like selected cells — one is
+   * "these cells are chosen", the other is "your selection is still here while you type in
+   * this panel". Same geometry, different meaning, so the caller names the class.
+   */
+  readonly className?: string;
 }
 
 /**
@@ -52,7 +61,7 @@ export function paintSelectionOverlay(
     const page = layout.pages[rect.pageIndex];
     if (!page) continue;
     const element = document.createElement('div');
-    element.className = 'docx-cell-selection-rect';
+    element.className = options.className ?? 'docx-cell-selection-rect';
     element.style.position = 'absolute';
     // Page-content coordinates to the sheet space the layer is laid out in.
     const offsetX = options.pageOffsetX?.get(rect.pageIndex) ?? 0;

--- a/packages/core/src/store/__tests__/hyperlink-lossless-editing.test.ts
+++ b/packages/core/src/store/__tests__/hyperlink-lossless-editing.test.ts
@@ -1,0 +1,436 @@
+// EDITING a link on a real Word document loses nothing else in it.
+//
+// `hyperlink-roundtrip.test.ts` proves an UNEDITED load -> save -> reopen is faithful. That is
+// the weaker half. The question a user actually asks is "if I retarget this link, or unlink it,
+// or make it red, does the rest of my document come back?" — and the parts most at risk are the
+// ones nowhere near the link: a `w:hyperlink` sits among bookmark markers, tracked changes,
+// content controls and fields, and every op here rebuilds the paragraph that holds it.
+//
+// So each case applies ONE hyperlink edit to the comprehensive fixture, saves the package,
+// reopens it, and asserts four things:
+//
+//   CENSUS       no class of element anywhere in the package dropped in count. This is the
+//                guard that does not need the test to guess what might vanish.
+//   NEIGHBOURS   every link the edit did not name keeps its authored attributes verbatim, and
+//                every bookmark keeps its id and name — the anchors a link resolves through.
+//   RELS         the external relationship targets are still there, still pointing where they did.
+//   TEXT         the document's text is byte-identical, except where the edit was supposed to
+//                change it (none of these edits changes text at all).
+//
+// Deliberately no DOM and no layout: this is the store's contract, and it has to hold whether
+// or not anything is on screen.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { readOoxmlPackage, writeOoxmlPackage, withPart } from '../package/ooxml-package.ts';
+import { TreeDocumentStore } from '../store/tree-store.ts';
+import { paragraphTextOf } from '../store/tree-op-apply.ts';
+import { diffSemanticDigests, semanticDigest } from '../package/ooxml-digest.ts';
+import type { OoxmlNode, OoxmlPackage, OoxmlPart } from '../package/ooxml-tree.ts';
+import type { TreeDocOp } from '../store/tree-op-validate.ts';
+
+const FIXTURE = `${import.meta.dir}/../../../../../e2e/fixtures/comprehensive-word-element-test.docx`;
+const original = readFileSync(FIXTURE);
+
+/** A freshly read package, so each case starts from the same bytes. */
+function readPackage(): OoxmlPackage {
+  const loaded = readOoxmlPackage(new Uint8Array(original));
+  if (!loaded.ok) throw new Error(loaded.reason);
+  return loaded.package;
+}
+
+const mainPartOf = (pkg: OoxmlPackage): OoxmlPart => {
+  const part = pkg.parts.get(pkg.mainDocumentPart);
+  if (!part) throw new Error('no main document part');
+  return part;
+};
+
+function* walk(node: OoxmlNode): Generator<OoxmlNode> {
+  yield node;
+  if (node.kind === 'textValue') return;
+  for (const child of node.children ?? []) yield* walk(child);
+}
+
+function nodesOfKind(part: OoxmlPart, kind: string): OoxmlNode[] {
+  return [...walk(part.root)].filter((node) => node.kind === kind);
+}
+
+function attributeOf(node: OoxmlNode, localName: string): string | undefined {
+  if (node.kind === 'textValue') return undefined;
+  return node.attributes.find((attribute) => attribute.localName === localName)?.value;
+}
+
+/** Element counts by local name, across every XML part of the package. */
+function elementCensus(pkg: OoxmlPackage): Map<string, number> {
+  const census = new Map<string, number>();
+  for (const part of pkg.parts.values()) {
+    for (const node of walk(part.root)) {
+      if (node.kind === 'textValue') continue;
+      census.set(node.localName, (census.get(node.localName) ?? 0) + 1);
+    }
+  }
+  return census;
+}
+
+/** Names whose count dropped, with before/after — the shape a reader can act on. */
+function losses(before: Map<string, number>, after: Map<string, number>): Record<string, string> {
+  const lost: Record<string, string> = {};
+  for (const [name, count] of before) {
+    const now = after.get(name) ?? 0;
+    if (now < count) lost[name] = `${count} -> ${now}`;
+  }
+  return lost;
+}
+
+/** Authored identity of every link, in document order — what a neighbour must not lose. */
+const linkIdentities = (part: OoxmlPart) =>
+  nodesOfKind(part, 'hyperlink').map((link) => ({
+    id: attributeOf(link, 'id'),
+    anchor: attributeOf(link, 'anchor'),
+    history: attributeOf(link, 'history'),
+    tooltip: attributeOf(link, 'tooltip'),
+  }));
+
+const bookmarkIdentities = (part: OoxmlPart) =>
+  nodesOfKind(part, 'bookmarkStart').map((node) => [
+    attributeOf(node, 'id'),
+    attributeOf(node, 'name'),
+  ]);
+
+const hyperlinkTargets = (pkg: OoxmlPackage) =>
+  pkg.externalTargets
+    .filter((entry) => entry.type.endsWith('/hyperlink'))
+    .map((entry) => entry.rawTarget)
+    .sort();
+
+/** Every paragraph's text, in document order — the content a user would notice missing. */
+const allText = (part: OoxmlPart): string[] =>
+  [...walk(part.root)]
+    .filter((node) => node.kind === 'paragraph')
+    .map((node) => paragraphTextOf(part, node.id) ?? '');
+
+/** The paragraph holding a link, and the link's own extent in that paragraph's offsets. */
+function paragraphHolding(part: OoxmlPart, linkId: string): string {
+  for (const node of walk(part.root)) {
+    if (node.kind !== 'paragraph') continue;
+    if ([...walk(node)].some((inner) => inner.id === linkId)) return node.id;
+  }
+  throw new Error(`no paragraph holds ${linkId}`);
+}
+
+/** Apply ops, save, reopen. */
+function roundTrip(plan: (part: OoxmlPart, pkg: OoxmlPackage) => readonly TreeDocOp[]) {
+  const before = readPackage();
+  const store = new TreeDocumentStore(mainPartOf(before));
+  const ops = plan(store.part, before);
+  expect(ops.length).toBeGreaterThan(0);
+  store.transact((tx) => {
+    for (const op of ops) {
+      const result = tx.apply(op);
+      if (result && result.ok === false) throw new Error(`${op.op} refused: ${result.reason}`);
+    }
+  });
+  const saved = writeOoxmlPackage(withPart(before, store.part));
+  const reopened = readOoxmlPackage(saved);
+  if (!reopened.ok) throw new Error(`reopen failed: ${reopened.reason}`);
+  return { before, after: reopened.package, edited: store.part };
+}
+
+/** The fixture's links, read once, so a plan can name one by index. */
+const baseline = mainPartOf(readPackage());
+const baselineLinks = nodesOfKind(baseline, 'hyperlink');
+
+/**
+ * One edit, and which link it deliberately consumes.
+ *
+ * `removesALink` marks the only case allowed to reduce the `w:hyperlink` count — unlinking is
+ * SUPPOSED to remove the element. Everything else in the census still has to hold for it, which
+ * is the point: Remove Hyperlink must give the runs back, not swallow them.
+ */
+interface EditCase {
+  readonly what: string;
+  readonly plan: (part: OoxmlPart, pkg: OoxmlPackage) => readonly TreeDocOp[];
+  readonly removesALink?: boolean;
+}
+
+/** The external link (`r:id`) and an internal one (`w:anchor`), by index into the fixture. */
+const externalIndex = baselineLinks.findIndex((link) => attributeOf(link, 'id') !== undefined);
+const internalIndex = baselineLinks.findIndex((link) => attributeOf(link, 'anchor') !== undefined);
+
+const linkAt = (part: OoxmlPart, index: number): OoxmlNode => {
+  const link = nodesOfKind(part, 'hyperlink')[index];
+  if (!link) throw new Error(`no link at index ${index}`);
+  return link;
+};
+
+const EDITS: readonly EditCase[] = [
+  {
+    what: 'retargeting an external link to a bookmark in the same document',
+    plan: (part) => [
+      { op: 'setHyperlinkTarget', linkId: linkAt(part, externalIndex).id, anchor: 'section1' },
+    ],
+  },
+  {
+    what: 'retargeting an internal link to another bookmark',
+    plan: (part) => [
+      { op: 'setHyperlinkTarget', linkId: linkAt(part, internalIndex).id, anchor: 'section6' },
+    ],
+  },
+  {
+    what: 'adding a tooltip to an existing link',
+    plan: (part) => [
+      {
+        op: 'setHyperlinkTarget',
+        linkId: linkAt(part, internalIndex).id,
+        anchor: 'section12',
+        tooltip: 'Jump to section 12',
+      },
+    ],
+  },
+  {
+    what: 'unlinking an external link',
+    plan: (part) => [{ op: 'removeHyperlink', linkId: linkAt(part, externalIndex).id }],
+    removesALink: true,
+  },
+  {
+    what: 'colouring a link’s text red',
+    plan: (part) => {
+      const link = linkAt(part, externalIndex);
+      const paragraphId = paragraphHolding(part, link.id);
+      const text = paragraphTextOf(part, paragraphId) ?? '';
+      // Whole paragraph, so the write sweeps the link and the runs either side of it — the
+      // range that used to address runs past the link at the wrong offset.
+      return [
+        {
+          op: 'setRunProperties',
+          paragraphId,
+          start: 0,
+          end: text.length,
+          properties: [{ localName: 'color', attributes: { val: 'FF0000' } }],
+        },
+      ];
+    },
+  },
+  {
+    what: 'typing inside a link',
+    plan: (part) => {
+      const link = linkAt(part, internalIndex);
+      const paragraphId = paragraphHolding(part, link.id);
+      const text = paragraphTextOf(part, paragraphId) ?? '';
+      return [{ op: 'insertText', paragraphId, offset: Math.min(12, text.length), text: 'X' }];
+    },
+  },
+  {
+    what: 'linking a fresh range in a paragraph that already holds links',
+    plan: (part) => {
+      const paragraphId = paragraphHolding(part, linkAt(part, internalIndex).id);
+      // The first four characters of `9.2 Jump to: ...` — before the first link, so the new
+      // link neither overlaps nor nests.
+      return [{ op: 'insertHyperlink', paragraphId, start: 0, end: 4, anchor: 'section1' }];
+    },
+  },
+];
+
+describe('formatting a link’s text reaches the runs inside it', () => {
+  // The teeth for the offset half of this. A `w:hyperlink` holds ordinary runs, and a range
+  // write that skipped the link without ADVANCING past its characters addressed every run
+  // after it one link-length early: colouring a paragraph wrote the following run's
+  // properties over the link's text, one character short of its end. Nothing was lost, so no
+  // census or digest guard could see it — only asking where the colour actually landed can.
+
+  /** Every run in a paragraph, at any depth, with its own direct `w:color`. */
+  function runColours(part: OoxmlPart, paragraphId: string): (string | undefined)[] {
+    const paragraph = [...walk(part.root)].find((node) => node.id === paragraphId);
+    if (!paragraph) throw new Error('no paragraph');
+    return [...walk(paragraph)]
+      .filter((node) => node.kind === 'run')
+      .map((run) => {
+        const rPr =
+          run.kind === 'textValue'
+            ? undefined
+            : run.children.find((c) => c.kind === 'runProperties');
+        const colour = rPr?.children.find((c) => c.kind !== 'textValue' && c.localName === 'color');
+        return colour ? attributeOf(colour, 'val') : undefined;
+      });
+  }
+
+  test('colouring the whole paragraph colours every run, including the linked ones', () => {
+    const { edited } = roundTrip((part) => {
+      const paragraphId = paragraphHolding(part, linkAt(part, internalIndex).id);
+      const text = paragraphTextOf(part, paragraphId) ?? '';
+      return [
+        {
+          op: 'setRunProperties',
+          paragraphId,
+          start: 0,
+          end: text.length,
+          properties: [{ localName: 'color', attributes: { val: 'FF0000' } }],
+        },
+      ];
+    });
+    const paragraphId = paragraphHolding(edited, linkAt(edited, internalIndex).id);
+    const colours = runColours(edited, paragraphId);
+    expect(colours.length).toBeGreaterThan(1);
+    // Not "some run is red" — EVERY run is, links included. A run left uncoloured is a run
+    // the range never reached, which is precisely the failure.
+    expect(colours.every((colour) => colour === 'FF0000')).toBe(true);
+  });
+
+  test('colouring only the link colours the link and nothing else', () => {
+    const link = linkAt(baseline, internalIndex);
+    const paragraphId = paragraphHolding(baseline, link.id);
+    const text = paragraphTextOf(baseline, paragraphId) ?? '';
+    // `9.2` paragraph: `Jump to: Section 1 | ...`. The first link is `Section 1`.
+    const start = text.indexOf('Section 1');
+    const end = start + 'Section 1'.length;
+    expect(start).toBeGreaterThan(0);
+
+    const { edited } = roundTrip(() => [
+      {
+        op: 'setRunProperties',
+        paragraphId,
+        start,
+        end,
+        properties: [{ localName: 'color', attributes: { val: 'FF0000' } }],
+      },
+    ]);
+
+    // Exactly the linked text is red, and it is INSIDE the link — not the run after it.
+    const firstLink = nodesOfKind(edited, 'hyperlink').find(
+      (node) => attributeOf(node, 'anchor') === 'section1'
+    );
+    if (!firstLink) throw new Error('the link is gone');
+    const insideColours = [...walk(firstLink)]
+      .filter((node) => node.kind === 'run')
+      .map((run) => {
+        const rPr =
+          run.kind === 'textValue'
+            ? undefined
+            : run.children.find((c) => c.kind === 'runProperties');
+        const colour = rPr?.children.find((c) => c.kind !== 'textValue' && c.localName === 'color');
+        return colour ? attributeOf(colour, 'val') : undefined;
+      });
+    expect(insideColours.length).toBeGreaterThan(0);
+    expect(insideColours.every((colour) => colour === 'FF0000')).toBe(true);
+
+    // And the link still reads `Section 1` — the write divided runs, it did not move text.
+    expect(paragraphTextOf(edited, paragraphHolding(edited, firstLink.id))).toBe(text);
+
+    // Nothing outside the link picked up the colour.
+    const outside = runColours(edited, paragraphId).filter((_, index) => index >= 0);
+    expect(outside.filter((colour) => colour === 'FF0000')).toHaveLength(insideColours.length);
+  });
+
+  test('the character style survives the colour, so the link still looks like a link', () => {
+    const { edited } = roundTrip((part) => {
+      const paragraphId = paragraphHolding(part, linkAt(part, internalIndex).id);
+      const text = paragraphTextOf(part, paragraphId) ?? '';
+      return [
+        {
+          op: 'setRunProperties',
+          paragraphId,
+          start: 0,
+          end: text.length,
+          properties: [{ localName: 'color', attributes: { val: 'FF0000' } }],
+        },
+      ];
+    });
+    // `w:rStyle` is preserved rather than accepted, so a property write must not delete it.
+    const styles = [...walk(edited.root)]
+      .filter((node) => node.kind !== 'textValue' && node.localName === 'rStyle')
+      .map((node) => attributeOf(node, 'val'));
+    expect(styles).toContain('Hyperlink');
+  });
+});
+
+describe('editing a hyperlink on a real Word document loses nothing else', () => {
+  test('the premise: the fixture has both kinds of link and bookmarks to aim at', () => {
+    expect(externalIndex).toBeGreaterThanOrEqual(0);
+    expect(internalIndex).toBeGreaterThanOrEqual(0);
+    expect(bookmarkIdentities(baseline).length).toBeGreaterThan(0);
+  });
+
+  for (const edit of EDITS) {
+    describe(edit.what, () => {
+      test('no class of element is lost anywhere in the package', () => {
+        const { before, after } = roundTrip(edit.plan);
+        const lost = losses(elementCensus(before), elementCensus(after));
+        // Unlinking is supposed to consume its own `w:hyperlink` — and nothing else.
+        const expected = edit.removesALink
+          ? {
+              hyperlink: `${nodesOfKind(mainPartOf(before), 'hyperlink').length} -> ${nodesOfKind(mainPartOf(after), 'hyperlink').length}`,
+            }
+          : {};
+        expect(lost).toEqual(expected);
+      });
+
+      test('the document’s text is unchanged, paragraph for paragraph', () => {
+        const { before, after } = roundTrip(edit.plan);
+        const textBefore = allText(mainPartOf(before));
+        const textAfter = allText(mainPartOf(after));
+        if (edit.what === 'typing inside a link') {
+          // The one edit that is MEANT to change text changes exactly one character in
+          // exactly one paragraph, and leaves every other paragraph alone.
+          expect(textAfter).toHaveLength(textBefore.length);
+          const changed = textAfter.filter((line, index) => line !== textBefore[index]);
+          expect(changed).toHaveLength(1);
+        } else {
+          expect(textAfter).toEqual(textBefore);
+        }
+      });
+
+      test('every bookmark keeps its id and name', () => {
+        const { before, after } = roundTrip(edit.plan);
+        expect(bookmarkIdentities(mainPartOf(after))).toEqual(
+          bookmarkIdentities(mainPartOf(before))
+        );
+      });
+
+      test('the external relationship targets survive', () => {
+        const { before, after } = roundTrip(edit.plan);
+        // Word keeps a relationship a link stopped using — an unused rel is not corruption,
+        // and re-pointing a link must never delete a target another link may share.
+        for (const target of hyperlinkTargets(before)) {
+          expect(hyperlinkTargets(after)).toContain(target);
+        }
+      });
+
+      test('the links the edit did not name keep their authored attributes verbatim', () => {
+        const { before, after, edited } = roundTrip(edit.plan);
+        // Identify the untouched links by their position among the survivors: an edit names
+        // exactly one link, so comparing the others pins any collateral rewrite.
+        const beforeIds = linkIdentities(mainPartOf(before));
+        const afterIds = linkIdentities(mainPartOf(after));
+        expect(afterIds).toHaveLength(nodesOfKind(edited, 'hyperlink').length);
+        // Every surviving link's identity must be one the document authored, or the one the
+        // edit deliberately wrote — never a third thing invented by the round trip.
+        const untouched = afterIds.filter((entry) =>
+          beforeIds.some(
+            (was) =>
+              was.id === entry.id &&
+              was.anchor === entry.anchor &&
+              was.history === entry.history &&
+              was.tooltip === entry.tooltip
+          )
+        );
+        // The edit changes at most one link, so all but one must match verbatim.
+        expect(untouched.length).toBeGreaterThanOrEqual(afterIds.length - 1);
+      });
+
+      test('the semantic digest differs only where the edit reached', () => {
+        const { before, after } = roundTrip(edit.plan);
+        const diff = diffSemanticDigests(
+          semanticDigest([mainPartOf(before)]),
+          semanticDigest([mainPartOf(after)])
+        );
+        // Counted per PARAGRAPH, not per entry: one edit legitimately moves several facets of
+        // the paragraph it lands on — wrapping a range in a link changes that paragraph's
+        // structure AND splits a run, which the digest reports separately. What must not
+        // happen is a second paragraph moving, which is what "the save rewrote something it
+        // never visited" looks like.
+        const touched = new Set(diff.map((entry) => entry.path.replace(/\.[^.]+$/, '')));
+        expect([...touched].length).toBeLessThanOrEqual(1);
+      });
+    });
+  }
+});

--- a/packages/core/src/store/__tests__/hyperlink-ops.test.ts
+++ b/packages/core/src/store/__tests__/hyperlink-ops.test.ts
@@ -1,0 +1,575 @@
+// insertHyperlink / setHyperlinkTarget / removeHyperlink over the canonical tree.
+//
+// The property under test throughout is that a link is a WRAPPER: applying one and taking it
+// off again must leave the paragraph's text and every run's formatting exactly as they were.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  validateOoxmlPart,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../package/ooxml-tree.ts';
+import { canonicalOoxmlFingerprint, serializeOoxmlPart } from '../package/ooxml-serialize.ts';
+import { buildBookmarkIndex } from '../package/bookmarks.ts';
+import { applyTreeOp, paragraphTextOf, type TreeDocOp } from '../store/tree-ops.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function apply(part: OoxmlPart, op: TreeDocOp): OoxmlPart {
+  const result = applyTreeOp(part, op);
+  if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
+  expect(validateOoxmlPart(result.part).ok).toBe(true);
+  return result.part;
+}
+
+function reject(part: OoxmlPart, op: TreeDocOp): string {
+  const result = applyTreeOp(part, op);
+  if (result.ok) throw new Error('expected a rejection');
+  return result.reason;
+}
+
+const PARAGRAPH = '/word/document.xml#0.0.0';
+
+/** A paragraph's children as `name` tokens, so order is readable in a failure. */
+function shapeOf(part: OoxmlPart, paragraphId: string): string[] {
+  const node = findById(part.root, paragraphId);
+  if (!node || node.kind === 'textValue') return [];
+  return node.children
+    .filter((child) => child.kind !== 'textValue' && child.localName !== 'pPr')
+    .map((child) => (child.kind === 'textValue' ? '' : child.localName));
+}
+
+function findById(node: OoxmlNode, id: string): OoxmlNode | null {
+  if (node.kind === 'textValue') return node.id === id ? node : null;
+  if (node.id === id) return node;
+  for (const child of node.children) {
+    const found = findById(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** The first `w:hyperlink` node id in a part. */
+function linkIdOf(part: OoxmlPart): string {
+  const walk = (node: OoxmlNode): string | null => {
+    if (node.kind === 'textValue') return null;
+    if (node.kind === 'hyperlink') return node.id;
+    for (const child of node.children) {
+      const found = walk(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  const id = walk(part.root);
+  if (!id) throw new Error('no hyperlink in part');
+  return id;
+}
+
+function attributeOf(part: OoxmlPart, nodeId: string, localName: string): string | undefined {
+  const node = findById(part.root, nodeId);
+  if (!node || node.kind === 'textValue') return undefined;
+  return node.attributes.find((attribute) => attribute.localName === localName)?.value;
+}
+
+describe('insertHyperlink wraps a range without disturbing it', () => {
+  const PLAIN = '<w:p><w:r><w:t>Visit example today</w:t></w:r></w:p>';
+
+  test('the text is unchanged and the range is now a link', () => {
+    const part = load(PLAIN);
+    const next = apply(part, {
+      op: 'insertHyperlink',
+      paragraphId: PARAGRAPH,
+      start: 6,
+      end: 13,
+      relationshipId: 'rId9',
+    });
+    expect(paragraphTextOf(next, PARAGRAPH)).toBe('Visit example today');
+    expect(shapeOf(next, PARAGRAPH)).toEqual(['r', 'hyperlink', 'r']);
+    expect(attributeOf(next, linkIdOf(next), 'id')).toBe('rId9');
+    expect(attributeOf(next, linkIdOf(next), 'history')).toBe('1');
+  });
+
+  test('an anchor link carries w:anchor and no r:id', () => {
+    const next = apply(load(PLAIN), {
+      op: 'insertHyperlink',
+      paragraphId: PARAGRAPH,
+      start: 6,
+      end: 13,
+      anchor: 'section3',
+    });
+    const link = linkIdOf(next);
+    expect(attributeOf(next, link, 'anchor')).toBe('section3');
+    expect(attributeOf(next, link, 'id')).toBeUndefined();
+  });
+
+  test('run formatting on each side of the link survives the cut', () => {
+    const part = load('<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>bold link tail</w:t></w:r></w:p>');
+    const next = apply(part, {
+      op: 'insertHyperlink',
+      paragraphId: PARAGRAPH,
+      start: 5,
+      end: 9,
+      anchor: 'top',
+    });
+    expect(paragraphTextOf(next, PARAGRAPH)).toBe('bold link tail');
+    // Three runs now, and every one of them kept the `w:rPr` the original carried.
+    const paragraph = findById(next.root, PARAGRAPH)!;
+    if (paragraph.kind === 'textValue') throw new Error('unreachable');
+    const runs: OoxmlNode[] = [];
+    const collect = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.kind === 'run') runs.push(node);
+      for (const child of node.children) collect(child);
+    };
+    collect(paragraph);
+    expect(runs.length).toBe(3);
+    for (const run of runs) {
+      if (run.kind === 'textValue') continue;
+      expect(run.children.some((child) => child.localName === 'rPr')).toBe(true);
+    }
+  });
+
+  test('a bookmark inside the linked range travels into the link', () => {
+    const part = load(
+      '<w:p><w:r><w:t>abc</w:t></w:r><w:bookmarkStart w:id="1" w:name="mid"/>' +
+        '<w:r><w:t>def</w:t></w:r></w:p>'
+    );
+    const next = apply(part, {
+      op: 'insertHyperlink',
+      paragraphId: PARAGRAPH,
+      start: 3,
+      end: 6,
+      anchor: 'top',
+    });
+    expect(shapeOf(next, PARAGRAPH)).toEqual(['r', 'hyperlink']);
+    const link = findById(next.root, linkIdOf(next))!;
+    if (link.kind === 'textValue') throw new Error('unreachable');
+    expect(
+      link.children.map((child) => (child.kind === 'textValue' ? '' : child.localName))
+    ).toEqual(['bookmarkStart', 'r']);
+  });
+
+  test('a collapsed range is refused', () => {
+    expect(
+      reject(load(PLAIN), {
+        op: 'insertHyperlink',
+        paragraphId: PARAGRAPH,
+        start: 4,
+        end: 4,
+        anchor: 'top',
+      })
+    ).toBe('invalid-range');
+  });
+
+  test('naming both a relationship and an anchor is refused, and so is naming neither', () => {
+    expect(
+      reject(load(PLAIN), {
+        op: 'insertHyperlink',
+        paragraphId: PARAGRAPH,
+        start: 0,
+        end: 5,
+        anchor: 'top',
+        relationshipId: 'rId9',
+      })
+    ).toBe('invalid-property-value');
+    expect(
+      reject(load(PLAIN), { op: 'insertHyperlink', paragraphId: PARAGRAPH, start: 0, end: 5 })
+    ).toBe('invalid-property-value');
+  });
+
+  test('a range overlapping an existing link is refused rather than nested', () => {
+    const part = load(
+      '<w:p><w:r><w:t>a </w:t></w:r>' +
+        '<w:hyperlink w:anchor="one"><w:r><w:t>linked</w:t></w:r></w:hyperlink>' +
+        '<w:r><w:t> b</w:t></w:r></w:p>'
+    );
+    expect(
+      reject(part, {
+        op: 'insertHyperlink',
+        paragraphId: PARAGRAPH,
+        start: 0,
+        end: 6,
+        anchor: 'two',
+      })
+    ).toBe('invalid-property-value');
+  });
+
+  test('a rejected op leaves the part byte-identical', () => {
+    const part = load(PLAIN);
+    const before = canonicalOoxmlFingerprint(part);
+    applyTreeOp(part, {
+      op: 'insertHyperlink',
+      paragraphId: PARAGRAPH,
+      start: 0,
+      end: 999,
+      anchor: 'top',
+    });
+    expect(canonicalOoxmlFingerprint(part)).toBe(before);
+  });
+});
+
+describe('removeHyperlink gives the runs back unchanged', () => {
+  const LINKED =
+    '<w:p><w:r><w:t>Visit </w:t></w:r>' +
+    '<w:hyperlink r:id="rId9" w:history="1"><w:r><w:rPr><w:b/></w:rPr><w:t>example</w:t></w:r></w:hyperlink>' +
+    '<w:r><w:t> today</w:t></w:r></w:p>';
+
+  test('text and formatting survive; no w:hyperlink remains', () => {
+    const part = load(LINKED);
+    const next = apply(part, { op: 'removeHyperlink', linkId: linkIdOf(part) });
+    expect(paragraphTextOf(next, PARAGRAPH)).toBe('Visit example today');
+    expect(shapeOf(next, PARAGRAPH)).toEqual(['r', 'r', 'r']);
+    const run = findById(next.root, PARAGRAPH)!;
+    if (run.kind === 'textValue') throw new Error('unreachable');
+    // The formatted run kept its `w:rPr` and its identity through the splice.
+    const middle = run.children[1]!;
+    if (middle.kind === 'textValue') throw new Error('unreachable');
+    expect(middle.children.some((child) => child.localName === 'rPr')).toBe(true);
+  });
+
+  test('link then unlink round-trips to the original tree', () => {
+    const part = load('<w:p><w:r><w:t>Visit example today</w:t></w:r></w:p>');
+    const linked = apply(part, {
+      op: 'insertHyperlink',
+      paragraphId: PARAGRAPH,
+      start: 6,
+      end: 13,
+      anchor: 'top',
+    });
+    const unlinked = apply(linked, { op: 'removeHyperlink', linkId: linkIdOf(linked) });
+    // The RUNS were cut in three by the insert and are not re-joined by the unlink — Word
+    // behaves the same way — so text and shape are what matter, not node count.
+    expect(paragraphTextOf(unlinked, PARAGRAPH)).toBe('Visit example today');
+    expect(shapeOf(unlinked, PARAGRAPH)).toEqual(['r', 'r', 'r']);
+  });
+
+  test('a bookmark inside the link stays where it was', () => {
+    const part = load(
+      '<w:p><w:hyperlink w:anchor="x"><w:bookmarkStart w:id="1" w:name="in"/>' +
+        '<w:r><w:t>text</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const next = apply(part, { op: 'removeHyperlink', linkId: linkIdOf(part) });
+    expect(shapeOf(next, PARAGRAPH)).toEqual(['bookmarkStart', 'r']);
+  });
+});
+
+describe('a many-way split is equivalent to the singles it stands for', () => {
+  // `splitParagraphMany` exists so a paste does not rebuild the body once per line. Its
+  // whole contract is equivalence with the sequence of single splits — and the hyperlink
+  // walk broke it by measuring a link's zero-length children from offset zero instead of
+  // from the link's own start. A bookmark travelled to a paragraph its text did not, and an
+  // EMPTY `w:hyperlink` husk was emitted holding the original link's node id.
+  const BODY =
+    '<w:p><w:r><w:t>0123456789</w:t></w:r>' +
+    '<w:hyperlink w:anchor="t"><w:bookmarkStart w:id="1" w:name="lead"/>' +
+    '<w:r><w:t>ABCDEFGHIJ</w:t></w:r></w:hyperlink></w:p>';
+
+  /** Paragraph shapes of a part's body, in document order. */
+  function bodyShapes(part: OoxmlPart): string[][] {
+    const shapes: string[][] = [];
+    const walk = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.kind === 'paragraph') {
+        shapes.push(
+          node.children
+            .filter((child) => child.kind !== 'textValue' && child.localName !== 'pPr')
+            .map((child) => (child.kind === 'textValue' ? '' : child.localName))
+        );
+        return;
+      }
+      for (const child of node.children) walk(child);
+    };
+    walk(part.root);
+    return shapes;
+  }
+
+  test('the many-way result matches two sequential single splits', () => {
+    const many = apply(load(BODY), {
+      op: 'splitParagraphMany',
+      paragraphId: PARAGRAPH,
+      offsets: [5, 15],
+    });
+    // The equivalent singles run LAST offset first, so earlier offsets stay valid.
+    let singles = load(BODY);
+    const last = applyTreeOp(singles, { op: 'splitParagraph', paragraphId: PARAGRAPH, offset: 15 });
+    if (!last.ok) throw new Error(last.reason);
+    singles = last.part;
+    const first = applyTreeOp(singles, { op: 'splitParagraph', paragraphId: PARAGRAPH, offset: 5 });
+    if (!first.ok) throw new Error(first.reason);
+    singles = first.part;
+
+    expect(bodyShapes(many)).toEqual(bodyShapes(singles));
+  });
+
+  test('no empty hyperlink husk is emitted, and the bookmark rides with its text', () => {
+    const next = apply(load(BODY), {
+      op: 'splitParagraphMany',
+      paragraphId: PARAGRAPH,
+      offsets: [5, 15],
+    });
+    const links: OoxmlNode[] = [];
+    const walk = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.kind === 'hyperlink') links.push(node);
+      for (const child of node.children) walk(child);
+    };
+    walk(next.root);
+    // Every link that survives holds content. An empty `w:hyperlink` is markup with nothing
+    // to click, and it kept the original node id — so a later retarget addressed the husk.
+    for (const link of links) {
+      if (link.kind === 'textValue') continue;
+      expect(link.children.length).toBeGreaterThan(0);
+    }
+    // The bookmark stays INSIDE its link, in the paragraph that holds the link's first
+    // characters — not stranded in the piece before it. Measured through the index an
+    // internal hyperlink actually resolves through.
+    const index = buildBookmarkIndex(next);
+    const lead = index.get('lead');
+    expect(lead).toBeDefined();
+    expect(paragraphTextOf(next, lead!.paragraphId)).toBe('56789ABCDE');
+    expect(lead!.offset).toBe(5);
+  });
+});
+
+describe('setHyperlinkTarget re-aims without replacing the element', () => {
+  const LINKED =
+    '<w:p><w:hyperlink r:id="rId9" w:history="1" w:tgtFrame="_blank">' +
+    '<w:r><w:t>example</w:t></w:r></w:hyperlink></w:p>';
+
+  test('a new relationship replaces the old one', () => {
+    const part = load(LINKED);
+    const next = apply(part, {
+      op: 'setHyperlinkTarget',
+      linkId: linkIdOf(part),
+      relationshipId: 'rId42',
+    });
+    const link = linkIdOf(next);
+    expect(attributeOf(next, link, 'id')).toBe('rId42');
+    expect(attributeOf(next, link, 'anchor')).toBeUndefined();
+  });
+
+  test('switching to an anchor clears the relationship, and back again clears the anchor', () => {
+    const part = load(LINKED);
+    const internal = apply(part, {
+      op: 'setHyperlinkTarget',
+      linkId: linkIdOf(part),
+      anchor: 'section2',
+    });
+    expect(attributeOf(internal, linkIdOf(internal), 'id')).toBeUndefined();
+    expect(attributeOf(internal, linkIdOf(internal), 'anchor')).toBe('section2');
+    const external = apply(internal, {
+      op: 'setHyperlinkTarget',
+      linkId: linkIdOf(internal),
+      relationshipId: 'rId7',
+    });
+    expect(attributeOf(external, linkIdOf(external), 'anchor')).toBeUndefined();
+    expect(attributeOf(external, linkIdOf(external), 'id')).toBe('rId7');
+  });
+
+  test('authored attributes the op did not name are retained', () => {
+    const part = load(LINKED);
+    const next = apply(part, {
+      op: 'setHyperlinkTarget',
+      linkId: linkIdOf(part),
+      relationshipId: 'rId42',
+    });
+    const link = linkIdOf(next);
+    // `w:tgtFrame` and `w:history` belong to the LINK, not to the target it points at.
+    expect(attributeOf(next, link, 'tgtFrame')).toBe('_blank');
+    expect(attributeOf(next, link, 'history')).toBe('1');
+  });
+
+  test('the display text is untouched', () => {
+    const part = load(LINKED);
+    const next = apply(part, {
+      op: 'setHyperlinkTarget',
+      linkId: linkIdOf(part),
+      anchor: 'elsewhere',
+    });
+    expect(paragraphTextOf(next, PARAGRAPH)).toBe('example');
+  });
+
+  test('a tooltip replaces the old one; omitting it keeps the old one', () => {
+    const part = load(
+      '<w:p><w:hyperlink w:anchor="a" w:tooltip="old"><w:r><w:t>t</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const replaced = apply(part, {
+      op: 'setHyperlinkTarget',
+      linkId: linkIdOf(part),
+      anchor: 'b',
+      tooltip: 'new',
+    });
+    expect(attributeOf(replaced, linkIdOf(replaced), 'tooltip')).toBe('new');
+    const kept = apply(part, { op: 'setHyperlinkTarget', linkId: linkIdOf(part), anchor: 'b' });
+    expect(attributeOf(kept, linkIdOf(kept), 'tooltip')).toBe('old');
+  });
+
+  test('an id that is not a link is refused', () => {
+    const part = load('<w:p><w:r><w:t>plain</w:t></w:r></w:p>');
+    expect(reject(part, { op: 'setHyperlinkTarget', linkId: PARAGRAPH, anchor: 'x' })).toBe(
+      'not-a-paragraph'
+    );
+  });
+});
+
+describe('CT_Hyperlink’s full attribute set (ECMA-376 §17.16.22)', () => {
+  // §17.16.22 declares six attributes. Three are MODELED — `r:id`, `w:anchor`, `w:tooltip` are
+  // what the ops read and write. The other three are PRESERVED: nothing here interprets
+  // `w:tgtFrame`, `w:docLocation` or `w:history`, and they survive only because attributes are
+  // carried verbatim. That makes them exactly the kind of thing a refactor drops silently, so
+  // it is pinned rather than left to the general preservation guarantee.
+  const ALL_SIX =
+    '<w:p><w:hyperlink r:id="rId9" w:tgtFrame="_top" w:docLocation="part2" w:tooltip="tip"' +
+    ' w:history="1"><w:r><w:t>x</w:t></w:r></w:hyperlink></w:p>';
+
+  test('all six attributes survive a read and re-serialize', () => {
+    const part = load(ALL_SIX);
+    const link = linkIdOf(part);
+    expect(attributeOf(part, link, 'id')).toBe('rId9');
+    expect(attributeOf(part, link, 'tgtFrame')).toBe('_top');
+    expect(attributeOf(part, link, 'docLocation')).toBe('part2');
+    expect(attributeOf(part, link, 'tooltip')).toBe('tip');
+    expect(attributeOf(part, link, 'history')).toBe('1');
+    // And the element is still typed — none of the six demotes it.
+    expect(findById(part.root, link)?.kind).toBe('hyperlink');
+  });
+
+  test('retargeting keeps docLocation, the one that changes where a link LANDS', () => {
+    const part = load(ALL_SIX);
+    const next = apply(part, {
+      op: 'setHyperlinkTarget',
+      linkId: linkIdOf(part),
+      anchor: 'sec1',
+    });
+    const link = linkIdOf(next);
+    // The target attribute swapped, as asked.
+    expect(attributeOf(next, link, 'anchor')).toBe('sec1');
+    expect(attributeOf(next, link, 'id')).toBeUndefined();
+    // Everything the op did not name is exactly as authored. `w:docLocation` names a location
+    // INSIDE the target document, so dropping it here would move the link without saying so.
+    expect(attributeOf(next, link, 'docLocation')).toBe('part2');
+    expect(attributeOf(next, link, 'tgtFrame')).toBe('_top');
+    expect(attributeOf(next, link, 'history')).toBe('1');
+  });
+});
+
+describe('a link nested in a link', () => {
+  // `CT_Hyperlink`'s content model is `EG_PContent`, which lists `w:hyperlink` among its own
+  // members — so a link inside a link is schema-legal, and Word can write one. The reader
+  // keeps BOTH typed. Demoting the inner one to `generic` would be the easier type and would
+  // reintroduce the bug typing this element fixed: a generic link's runs never reach the
+  // token stream, so the words inside it stop painting.
+  const NESTED =
+    '<w:p><w:hyperlink w:anchor="outer"><w:r><w:t xml:space="preserve">a </w:t></w:r>' +
+    '<w:hyperlink w:anchor="inner"><w:r><w:t>b</w:t></w:r></w:hyperlink>' +
+    '<w:r><w:t xml:space="preserve"> c</w:t></w:r></w:hyperlink></w:p>';
+
+  const linksOf = (part: OoxmlPart): OoxmlNode[] => {
+    const found: OoxmlNode[] = [];
+    const walk = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.kind === 'hyperlink') found.push(node);
+      for (const child of node.children) walk(child);
+    };
+    walk(part.root);
+    return found;
+  };
+
+  test('both links stay typed and the part validates', () => {
+    const part = load(NESTED);
+    const links = linksOf(part);
+    expect(links).toHaveLength(2);
+    expect(links.map((link) => link.kind)).toEqual(['hyperlink', 'hyperlink']);
+    expect(links.map((link) => attributeOf(part, link.id, 'anchor'))).toEqual(['outer', 'inner']);
+    expect(validateOoxmlPart(part).ok).toBe(true);
+  });
+
+  test('the inner link’s text is addressable, so its runs measure and paint', () => {
+    // The whole point: offsets run THROUGH both links. If the inner one were generic its
+    // character would vanish from the paragraph's text and every offset past it would drift.
+    expect(paragraphTextOf(load(NESTED), PARAGRAPH)).toBe('a b c');
+  });
+
+  test('a range edit reaches the run inside the inner link', () => {
+    const part = load(NESTED);
+    const next = apply(part, {
+      op: 'setRunProperties',
+      paragraphId: PARAGRAPH,
+      start: 0,
+      end: 5,
+      properties: [{ localName: 'b' }],
+    });
+    // Every run at every depth, bolded — including the doubly-nested one.
+    const runs: OoxmlNode[] = [];
+    const walk = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      if (node.kind === 'run') runs.push(node);
+      for (const child of node.children) walk(child);
+    };
+    walk(next.root);
+    expect(runs).toHaveLength(3);
+    const bolded = runs.filter(
+      (run) =>
+        run.kind !== 'textValue' &&
+        run.children.some(
+          (child) =>
+            child.kind !== 'textValue' &&
+            child.localName === 'rPr' &&
+            child.children.some((g) => g.kind !== 'textValue' && g.localName === 'b')
+        )
+    );
+    expect(bolded).toHaveLength(3);
+    expect(paragraphTextOf(next, PARAGRAPH)).toBe('a b c');
+  });
+
+  test('the nesting survives a real serialize -> reparse unchanged', () => {
+    const part = load(NESTED);
+    // Serialize what was PARSED and read the output back, rather than loading the same source
+    // twice — comparing two fresh loads of one string proves nothing about the writer.
+    const reparsed = readOoxmlPart(serializeOoxmlPart(part), {
+      name: '/word/document.xml',
+      contentType: 'app/xml',
+    });
+    if (!reparsed.ok) throw new Error(reparsed.reason);
+    expect(canonicalOoxmlFingerprint(reparsed.part)).toBe(canonicalOoxmlFingerprint(part));
+    const links = linksOf(reparsed.part);
+    expect(links).toHaveLength(2);
+    expect(links.map((link) => attributeOf(reparsed.part, link.id, 'anchor'))).toEqual([
+      'outer',
+      'inner',
+    ]);
+    expect(paragraphTextOf(reparsed.part, PARAGRAPH)).toBe('a b c');
+  });
+
+  test('unlinking the OUTER link leaves the inner one intact', () => {
+    const part = load(NESTED);
+    const outer = linksOf(part)[0]!;
+    const next = apply(part, { op: 'removeHyperlink', linkId: outer.id });
+    const left = linksOf(next);
+    // Exactly one link goes — the one named — and the inner survives with its own target.
+    expect(left).toHaveLength(1);
+    expect(attributeOf(next, left[0]!.id, 'anchor')).toBe('inner');
+    expect(paragraphTextOf(next, PARAGRAPH)).toBe('a b c');
+  });
+
+  test('unlinking the INNER link leaves the outer one intact', () => {
+    const part = load(NESTED);
+    const inner = linksOf(part)[1]!;
+    const next = apply(part, { op: 'removeHyperlink', linkId: inner.id });
+    const left = linksOf(next);
+    expect(left).toHaveLength(1);
+    expect(attributeOf(next, left[0]!.id, 'anchor')).toBe('outer');
+    expect(paragraphTextOf(next, PARAGRAPH)).toBe('a b c');
+  });
+});

--- a/packages/core/src/store/__tests__/hyperlink-roundtrip.test.ts
+++ b/packages/core/src/store/__tests__/hyperlink-roundtrip.test.ts
@@ -1,0 +1,127 @@
+// Links and bookmarks survive an unedited load -> save -> reopen unchanged.
+//
+// Typing `w:hyperlink` and the bookmark markers changed how the reader CLASSIFIES them, and
+// a classification change is exactly the kind of thing that quietly rewrites a document: an
+// attribute dropped because the typed node did not model it, a marker demoted and re-emitted
+// in a different shape. The D9 oracles are the guard — the canonical fingerprint for
+// structural identity, the semantic digest for content — and this points them at the
+// comprehensive fixture's five links and twenty-two bookmarks.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { readOoxmlPackage, writeOoxmlPackage } from '../package/ooxml-package.ts';
+import { canonicalOoxmlFingerprint } from '../package/ooxml-serialize.ts';
+import { diffSemanticDigests, semanticDigest } from '../package/ooxml-digest.ts';
+import type { OoxmlNode, OoxmlPart } from '../package/ooxml-tree.ts';
+
+const FIXTURE = `${import.meta.dir}/../../../../../e2e/fixtures/comprehensive-word-element-test.docx`;
+
+function mainPartOf(bytes: Uint8Array): { part: OoxmlPart; externalCount: number } {
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(`package read failed: ${loaded.reason}`);
+  const part = loaded.package.parts.get(loaded.package.mainDocumentPart);
+  if (!part) throw new Error('no main document part');
+  return { part, externalCount: loaded.package.externalTargets.length };
+}
+
+/** Every node of a kind, in document order. */
+function nodesOfKind(part: OoxmlPart, kind: string): OoxmlNode[] {
+  const found: OoxmlNode[] = [];
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.kind === kind) found.push(node);
+    for (const child of node.children) walk(child);
+  };
+  walk(part.root);
+  return found;
+}
+
+function attributeOf(node: OoxmlNode, localName: string): string | undefined {
+  if (node.kind === 'textValue') return undefined;
+  return node.attributes.find((attribute) => attribute.localName === localName)?.value;
+}
+
+const original = readFileSync(FIXTURE);
+
+describe('the comprehensive fixture round-trips its links and bookmarks unedited', () => {
+  const first = mainPartOf(new Uint8Array(original));
+
+  test('the premise: five typed hyperlinks and twenty-two bookmarks', () => {
+    const links = nodesOfKind(first.part, 'hyperlink');
+    expect(links).toHaveLength(5);
+    // Two external (by relationship) and three internal (by anchor), as authored.
+    const external = links.filter((link) => attributeOf(link, 'id') !== undefined);
+    const internal = links.filter((link) => attributeOf(link, 'anchor') !== undefined);
+    expect(external).toHaveLength(2);
+    expect(internal).toHaveLength(3);
+    expect(internal.map((link) => attributeOf(link, 'anchor'))).toEqual([
+      'section1',
+      'section6',
+      'section12',
+    ]);
+
+    const starts = nodesOfKind(first.part, 'bookmarkStart');
+    const ends = nodesOfKind(first.part, 'bookmarkEnd');
+    expect(starts).toHaveLength(22);
+    expect(ends).toHaveLength(22);
+    expect(starts.map((node) => attributeOf(node, 'name'))).toContain('section12');
+  });
+
+  test('the canonical fingerprint is unchanged by a save and reopen', () => {
+    const reopened = mainPartOf(writeOoxmlPackage(readPackage()));
+    expect(canonicalOoxmlFingerprint(reopened.part)).toBe(canonicalOoxmlFingerprint(first.part));
+  });
+
+  test('the semantic digest reports no difference', () => {
+    const reopened = mainPartOf(writeOoxmlPackage(readPackage()));
+    expect(
+      diffSemanticDigests(semanticDigest([first.part]), semanticDigest([reopened.part]))
+    ).toEqual([]);
+  });
+
+  test('every link keeps its authored attributes verbatim', () => {
+    const reopened = mainPartOf(writeOoxmlPackage(readPackage()));
+    const before = nodesOfKind(first.part, 'hyperlink').map((link) => ({
+      id: attributeOf(link, 'id'),
+      anchor: attributeOf(link, 'anchor'),
+      history: attributeOf(link, 'history'),
+      tooltip: attributeOf(link, 'tooltip'),
+    }));
+    const after = nodesOfKind(reopened.part, 'hyperlink').map((link) => ({
+      id: attributeOf(link, 'id'),
+      anchor: attributeOf(link, 'anchor'),
+      history: attributeOf(link, 'history'),
+      tooltip: attributeOf(link, 'tooltip'),
+    }));
+    expect(after).toEqual(before);
+  });
+
+  test('every bookmark keeps its authored id and name', () => {
+    const reopened = mainPartOf(writeOoxmlPackage(readPackage()));
+    const pairs = (part: OoxmlPart) =>
+      nodesOfKind(part, 'bookmarkStart').map((node) => [
+        attributeOf(node, 'id'),
+        attributeOf(node, 'name'),
+      ]);
+    expect(pairs(reopened.part)).toEqual(pairs(first.part));
+  });
+
+  test('the external relationships survive with their targets', () => {
+    const loaded = readOoxmlPackage(writeOoxmlPackage(readPackage()));
+    if (!loaded.ok) throw new Error(loaded.reason);
+    const hyperlinks = loaded.package.externalTargets.filter((entry) =>
+      entry.type.endsWith('/hyperlink')
+    );
+    expect(hyperlinks.map((entry) => entry.rawTarget).sort()).toEqual([
+      'https://example.com',
+      'https://www.anthropic.com',
+    ]);
+  });
+});
+
+/** A freshly read package, so each test writes from the same starting point. */
+function readPackage() {
+  const loaded = readOoxmlPackage(new Uint8Array(original));
+  if (!loaded.ok) throw new Error(loaded.reason);
+  return loaded.package;
+}

--- a/packages/core/src/store/__tests__/tree-op-split-anchors.test.ts
+++ b/packages/core/src/store/__tests__/tree-op-split-anchors.test.ts
@@ -111,7 +111,10 @@ describe('a split places zero-length content by its position (comprehensive fixt
   const COMMENTED = '/word/document.xml#0.0.110';
 
   test('the fixture paragraphs are the ones under test (guards the premise)', () => {
-    expect(paragraphTextOf(document(), LINKS)).toBe('Visit  or .');
+    // The link text is ADDRESSABLE: a `w:hyperlink` is a run container, so its runs take
+    // paragraph offsets like any other. While it was an opaque child this read
+    // "Visit  or ." — the sentence with its two links deleted out of it.
+    expect(paragraphTextOf(document(), LINKS)).toBe('Visit Example.com or Anthropic’s website.');
     expect(shapeOf(nodeById(document(), LINKS))).toEqual(['r', 'hyperlink', 'r', 'hyperlink', 'r']);
     expect(shapeOf(nodeById(document(), COMMENTED))).toEqual([
       'r',

--- a/packages/core/src/store/package/bookmarks.ts
+++ b/packages/core/src/store/package/bookmarks.ts
@@ -1,0 +1,112 @@
+// The bookmark index: every `w:bookmarkStart` name, and the paragraph position it marks.
+//
+// This is what an internal hyperlink's `w:anchor` resolves through. It is built from the
+// TREE — paragraph node id plus UTF-16 offset — never from the DOM, because the paragraph a
+// cross-document jump targets is normally on a virtualized page with no DOM at all. A
+// bookmark index built by querying elements would resolve exactly the jumps that did not need
+// it and fail every one that did.
+//
+// Names come out of the file, so the index is bounded: a document can declare as many
+// bookmarks as it likes, and a lookup structure built from attacker input gets a cap like
+// every other one.
+
+import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
+import type { OoxmlNode, OoxmlPart } from './ooxml-tree.ts';
+
+/** Word's own limit is 40 characters; this is the fail-closed bound, not a fidelity claim. */
+const MAX_BOOKMARK_NAME_LENGTH = 256;
+
+/** Ceiling on indexed anchors. Beyond it the extra names simply do not resolve. */
+const MAX_BOOKMARKS = 10_000;
+
+/**
+ * Word's own scratch bookmark, present in most documents and never a jump target: it marks
+ * where the caret was when the file was last saved.
+ */
+const GO_BACK = '_GoBack';
+
+export interface BookmarkAnchor {
+  readonly name: string;
+  /** Canonical node id of the paragraph the marker sits in. */
+  readonly paragraphId: string;
+  /** UTF-16 offset within that paragraph, in `paragraphTextOf`'s vocabulary. */
+  readonly offset: number;
+}
+
+export type BookmarkIndex = ReadonlyMap<string, BookmarkAnchor>;
+
+function attributeValue(node: OoxmlNode, localName: string): string | undefined {
+  if (node.kind === 'textValue') return undefined;
+  for (const attribute of node.attributes) {
+    if (attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName) {
+      return attribute.value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build `name -> position` for every bookmark start in a part, in document order.
+ *
+ * FIRST IN DOCUMENT ORDER WINS on a duplicate name. Word treats a repeated bookmark name as
+ * the same bookmark and jumps to the first, and the alternative — last-wins — makes a jump
+ * target move when an edit far away happens to duplicate a name.
+ *
+ * The offset is measured the way the ops measure: text of the runs before the marker inside
+ * its own paragraph, hyperlink runs included, so the position a jump places the caret at is a
+ * position `setSelection` accepts.
+ */
+export function buildBookmarkIndex(part: OoxmlPart): BookmarkIndex {
+  const index = new Map<string, BookmarkAnchor>();
+
+  const inlineLength = (node: OoxmlNode): number => {
+    if (node.kind === 'textValue') return node.value.length;
+    if (node.kind === 'tab' || node.kind === 'hardBreak') return 1;
+    if (node.kind === 'runProperties' || node.kind === 'generic') return 0;
+    let total = 0;
+    for (const child of node.children) total += inlineLength(child);
+    return total;
+  };
+
+  const scanParagraph = (paragraph: OoxmlNode): void => {
+    if (paragraph.kind === 'textValue') return;
+    let offset = 0;
+    const walkInline = (child: OoxmlNode): void => {
+      if (child.kind === 'bookmarkStart') {
+        const name = attributeValue(child, 'name');
+        if (
+          name !== undefined &&
+          name.length > 0 &&
+          name.length <= MAX_BOOKMARK_NAME_LENGTH &&
+          name !== GO_BACK &&
+          !index.has(name) &&
+          index.size < MAX_BOOKMARKS
+        ) {
+          index.set(name, { name, paragraphId: paragraph.id, offset });
+        }
+        return;
+      }
+      if (child.kind === 'run') {
+        offset += inlineLength(child);
+        return;
+      }
+      // A link's markers sit at real positions inside it, so the walk descends rather than
+      // charging the whole link's width before looking.
+      if (child.kind === 'hyperlink') {
+        for (const inner of child.children) walkInline(inner);
+      }
+    };
+    for (const child of paragraph.children) walkInline(child);
+  };
+
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue' || index.size >= MAX_BOOKMARKS) return;
+    if (node.kind === 'paragraph') {
+      scanParagraph(node);
+      return;
+    }
+    for (const child of node.children) walk(child);
+  };
+  walk(part.root);
+  return index;
+}

--- a/packages/core/src/store/package/hyperlink-part.ts
+++ b/packages/core/src/store/package/hyperlink-part.ts
@@ -1,0 +1,203 @@
+// Minting the relationship an external hyperlink needs.
+//
+// An external link's target does not live in `document.xml` — the paragraph holds only an
+// `r:id`, and the URL sits in `/word/_rels/document.xml.rels`. So inserting a link is TWO
+// writes in different places, and only one of them is a tree op. This module owns the other,
+// on the same lane as `ensureListDefinition`: the package changes outside `store.transact`,
+// and the tree op that names the id is what the undo stack records.
+//
+// A LEFTOVER RELATIONSHIP IS HARMLESS; A MISSING ONE IS NOT. Undoing an insert removes the
+// `w:hyperlink` but leaves its relationship declared, and an unreferenced hyperlink
+// relationship is something Word writes freely and ignores on load. Removing it eagerly would
+// instead break every redo, and break any other link that had been given the same reused id.
+//
+// The URL here is HOST-supplied (a popover input), not file-derived, but it reaches XML all
+// the same, so it is validated and escaped rather than interpolated on trust.
+
+import { createNodeIdAllocator, insertChildren } from './ooxml-edit.ts';
+import { readOoxmlPart } from './ooxml-tree.ts';
+import type { OoxmlNode } from './ooxml-tree.ts';
+import type { OoxmlPackage } from './ooxml-package.ts';
+import { escapeXmlChecked, isValidXmlText, sanitizeHref } from './sinks.ts';
+import { validateExternalTarget } from './opc-names.ts';
+import { HYPERLINK_RELATIONSHIP_TYPE } from './hyperlink.ts';
+
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const RELS_CONTENT_TYPE = 'application/vnd.openxmlformats-package.relationships+xml';
+
+/**
+ * Longest target accepted into a relationship.
+ *
+ * A `.docx` is a zip an attacker controls and so is a paste into a URL field; nothing
+ * downstream benefits from an unbounded one, and every consumer of the rels part pays for it.
+ */
+const MAX_TARGET_LENGTH = 2048;
+
+export interface EnsuredHyperlinkRelationship {
+  readonly pkg: OoxmlPackage;
+  readonly relationshipId: string;
+}
+
+/** `/word/document.xml` -> `/word/_rels/document.xml.rels`. */
+function relsPartNameFor(partName: string): string {
+  const slash = partName.lastIndexOf('/');
+  return `${partName.slice(0, slash)}/_rels/${partName.slice(slash + 1)}.rels`;
+}
+
+/** An `rIdN` no owner in the package already uses. */
+function freeRelationshipId(pkg: OoxmlPackage): string {
+  let max = 0;
+  for (const records of pkg.relationships.values()) {
+    for (const record of records) {
+      const match = /^rId(\d{1,9})$/.exec(record.id);
+      if (match) max = Math.max(max, Number(match[1]));
+    }
+  }
+  // External targets live OUTSIDE `relationships` (that map holds the internal ones), so an
+  // id already spent on a hyperlink would be handed out a second time without this — two
+  // links pointing at one URL, and editing either would silently move the other.
+  for (const external of pkg.externalTargets) {
+    const match = /^rId(\d{1,9})$/.exec(external.id);
+    if (match) max = Math.max(max, Number(match[1]));
+  }
+  return `rId${max + 1}`;
+}
+
+/** Re-key a grafted subtree so it cannot collide with the part it is joining. */
+function withFreshIds(node: OoxmlNode, nextId: () => string): OoxmlNode {
+  if (node.kind === 'textValue') return { ...node, id: nextId() } as OoxmlNode;
+  return {
+    ...node,
+    id: nextId(),
+    children: node.children.map((child) => withFreshIds(child, nextId)),
+  } as OoxmlNode;
+}
+
+/**
+ * The external hyperlink relationship for `url` on the main document part, reusing an
+ * existing one with the same target, or `null` when the URL is not something to write.
+ *
+ * REUSE IS BY EXACT TARGET, matching Word: linking twice to the same address produces one
+ * relationship. It is safe because a hyperlink relationship carries nothing but its target —
+ * two links sharing one are indistinguishable from two links with identical targets, and
+ * retargeting one always mints rather than rewriting (see the edit op).
+ *
+ * The URL is refused unless `sanitizeHref` admits it. Storing a `javascript:` target that a
+ * FILE authored is required — round-tripping never rewrites a document — but AUTHORING one
+ * here is not: there is no legitimate reason for this engine to write a scheme it would then
+ * refuse to open, and writing it would hand the next reader a live target this reader made.
+ */
+export function ensureHyperlinkRelationship(
+  pkg: OoxmlPackage,
+  url: string
+): EnsuredHyperlinkRelationship | null {
+  if (typeof url !== 'string' || url.length === 0 || url.length > MAX_TARGET_LENGTH) return null;
+  if (!isValidXmlText(url)) return null;
+  const projection = sanitizeHref(url);
+  if (!projection.ok || projection.href.length === 0) return null;
+  const target = projection.href;
+  // The same gate the READ side applies, applied on the way in: an authored external
+  // relationship must be an absolute URI. Writing `/admin/delete-account` as
+  // `TargetMode="External"` is not a shape Word produces, and it would hand the next
+  // reader a target that resolves against whatever origin opens the file.
+  if (!validateExternalTarget(target).ok) return null;
+
+  const owner = pkg.mainDocumentPart;
+  const reusable = pkg.externalTargets.find(
+    (entry) =>
+      entry.ownerPart === owner &&
+      entry.type === HYPERLINK_RELATIONSHIP_TYPE &&
+      entry.rawTarget === target
+  );
+  if (reusable) return { pkg, relationshipId: reusable.id };
+
+  const relsName = relsPartNameFor(owner);
+  const existing = pkg.parts.get(relsName);
+  const id = freeRelationshipId(pkg);
+  const authored = readOoxmlPart(
+    `<Relationships xmlns="${REL}">` +
+      `<Relationship Id="${escapeXmlChecked(id, 'relationship id')}"` +
+      ` Type="${HYPERLINK_RELATIONSHIP_TYPE}"` +
+      ` Target="${escapeXmlChecked(target, 'relationship target')}"` +
+      ' TargetMode="External"/>' +
+      '</Relationships>',
+    { name: relsName, contentType: RELS_CONTENT_TYPE }
+  );
+  if (!authored.ok) return null;
+
+  // The external record is what `hyperlinkTargetOf` resolves against, so it is added in the
+  // same breath as the tree node. Writing only the tree left the resolver blind to a link
+  // this session had just created: it painted inert until the document was saved and
+  // reopened.
+  const externalTargets = [
+    ...pkg.externalTargets,
+    {
+      ownerPart: owner,
+      id,
+      type: HYPERLINK_RELATIONSHIP_TYPE,
+      rawTarget: target,
+      sinkSafe: true,
+    },
+  ];
+
+  if (!existing) {
+    return {
+      pkg: Object.freeze({
+        ...pkg,
+        parts: new Map([...pkg.parts, [relsName, authored.part]]),
+        externalTargets,
+      }),
+      relationshipId: id,
+    };
+  }
+  const nextId = createNodeIdAllocator(existing);
+  const node = authored.part.root.children[0];
+  if (!node) return null;
+  const inserted = insertChildren(existing, existing.root.id, existing.root.children.length, [
+    withFreshIds(node, nextId),
+  ]);
+  if (!inserted.ok) return null;
+  return {
+    pkg: Object.freeze({
+      ...pkg,
+      parts: new Map([...pkg.parts, [relsName, inserted.part]]),
+      externalTargets,
+    }),
+    relationshipId: id,
+  };
+}
+
+/**
+ * What a part's relationships answer for one `r:id`, over both maps.
+ *
+ * `relationships` holds the internal records and `externalTargets` the external ones, so a
+ * resolver reading only the first sees every hyperlink as dangling.
+ */
+export function relationshipTargetIn(
+  pkg: OoxmlPackage,
+  ownerPart: string,
+  relationshipId: string
+): {
+  readonly target: string;
+  readonly external: boolean;
+  readonly sinkSafe?: boolean;
+} | null {
+  for (const external of pkg.externalTargets) {
+    if (external.ownerPart === ownerPart && external.id === relationshipId) {
+      // `sinkSafe` travels WITH the target. The package computed it at load
+      // (`validateExternalTarget`: absolute URI, safe scheme) and it answers the question
+      // `sanitizeHref` structurally cannot — whether a target with no scheme at all is
+      // safe to follow. Dropping it here is what let `Target="/admin/delete-account"`
+      // reach a live `href` resolving against the host application's origin.
+      return { target: external.rawTarget, external: true, sinkSafe: external.sinkSafe };
+    }
+  }
+  const internal = (pkg.relationships.get(ownerPart) ?? []).find(
+    (record) => record.id === relationshipId
+  );
+  if (internal) return { target: internal.rawTarget, external: false };
+  return null;
+}
+
+/** Unused ids are never reclaimed, so an unreferenced relationship keeps its slot. */
+export const HYPERLINK_RELATIONSHIP_MAX_TARGET_LENGTH = MAX_TARGET_LENGTH;

--- a/packages/core/src/store/package/hyperlink.ts
+++ b/packages/core/src/store/package/hyperlink.ts
@@ -1,0 +1,203 @@
+// Reading a typed `w:hyperlink` into a target record, and the ONE place a file-derived link
+// target becomes a runtime URL.
+//
+// TWO VALUES, NEVER ONE. `authored` is the target exactly as the document wrote it — that is
+// what serialization re-emits, XML-escaped, and it is never touched by sanitization, so a
+// round trip is lossless whatever the target says. `href` is the runtime projection, produced
+// once here through `sanitizeHref`, and it is the only value allowed to reach a DOM
+// attribute, `window.open`, or the clipboard. A refused scheme (`javascript:`, `data:`,
+// `vbscript:`, `file:`) yields `href: null` — an INERT link: it still paints, still holds its
+// text, still saves, and has no way to be activated.
+//
+// Sanitizing here rather than at each consumer is the whole point. Paint, the popover,
+// navigation and the editor query are four sinks; a boundary crossed once cannot be crossed
+// inconsistently, and a new consumer inherits the guarantee instead of having to remember it.
+//
+// NOTHING IN THIS MODULE FETCHES. Resolving a relationship means reading the package's own
+// rels record; an external target is classified and validated as a string and never
+// requested. Opening a document performs no network access for any hyperlink.
+
+import { sanitizeHref } from './sinks.ts';
+import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
+import type { OoxmlNode } from './ooxml-tree.ts';
+
+/** The relationship namespace `r:id` lives in. */
+export const OFFICE_RELATIONSHIP_NAMESPACE_URI =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+/** The `Type` a hyperlink relationship declares. */
+export const HYPERLINK_RELATIONSHIP_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink';
+
+/**
+ * What a part's relationships answer for one `r:id`: the authored target and whether the
+ * package declared it external. `null` for an id the part does not declare — a DANGLING
+ * relationship, which is a real thing in real documents.
+ */
+export type RelationshipTargetResolver = (relationshipId: string) => {
+  readonly target: string;
+  readonly external: boolean;
+  /**
+   * The PACKAGE's own verdict on this target (`validateExternalTarget`): whether it is an
+   * absolute URI with a safe scheme.
+   *
+   * Carried separately because `sanitizeHref` cannot answer it. That function is a SCHEME
+   * allowlist and deliberately admits relative URLs — the right rule for a value the host
+   * authored, and the wrong one for a value a `.docx` did. A file-supplied
+   * `Target="/admin/delete-account"` has no scheme to refuse, so it would pass the
+   * allowlist and resolve against the EMBEDDING APPLICATION'S origin: a link reading
+   * "Company policy" that issues an authenticated same-origin request to whatever host
+   * app the editor is mounted in. Absent, a target is treated as unverified.
+   */
+  readonly sinkSafe?: boolean;
+} | null;
+
+export type HyperlinkKind =
+  /** `r:id` → a relationship with `TargetMode="External"`. Opens somewhere else. */
+  | 'external'
+  /** `w:anchor` → a bookmark in this document. Scrolls, never navigates. */
+  | 'internal'
+  /**
+   * `r:id` naming a relationship the part does not declare, or one that is not external.
+   *
+   * The link keeps its runs — the text is never lost twice — but there is nothing to
+   * activate, so it paints inert exactly like a refused scheme.
+   */
+  | 'unresolved';
+
+export interface HyperlinkTarget {
+  readonly kind: HyperlinkKind;
+  /**
+   * The authored target, verbatim: the relationship's `Target` for an `r:id` link, the
+   * anchor name for an internal one. Save re-emits from the tree, never from this — it is
+   * here so a UI can show what the document actually says.
+   */
+  readonly authored: string;
+  /**
+   * The sanitized runtime projection, or `null` when there is nothing safe to navigate to.
+   * The ONLY value permitted in a DOM `href`, `window.open`, or a copied link.
+   */
+  readonly href: string | null;
+  /** `w:anchor`, for an internal link. */
+  readonly anchor?: string;
+  /** `w:tooltip` — Word's hover text; paint puts it on the anchor's `title`. */
+  readonly tooltip?: string;
+  /** The authored `r:id`, so an edit can rewrite the relationship it names. */
+  readonly relationshipId?: string;
+}
+
+function attributeValue(
+  node: OoxmlNode,
+  namespaceUri: string,
+  localName: string
+): string | undefined {
+  if (node.kind === 'textValue') return undefined;
+  for (const attribute of node.attributes) {
+    if (attribute.namespaceUri === namespaceUri && attribute.localName === localName) {
+      return attribute.value;
+    }
+  }
+  return undefined;
+}
+
+/** Whether a node is a typed `w:hyperlink`. */
+export function isHyperlinkNode(node: OoxmlNode): boolean {
+  return node.kind === 'hyperlink';
+}
+
+/** A typed hyperlink's `w:anchor`, or undefined. */
+export function hyperlinkAnchorOf(link: OoxmlNode): string | undefined {
+  return attributeValue(link, WML_NAMESPACE_URI, 'anchor');
+}
+
+/** A typed hyperlink's `r:id`, or undefined. */
+export function hyperlinkRelationshipIdOf(link: OoxmlNode): string | undefined {
+  return attributeValue(link, OFFICE_RELATIONSHIP_NAMESPACE_URI, 'id');
+}
+
+/**
+ * Read a typed `w:hyperlink` into its target record.
+ *
+ * `r:id` wins over `w:anchor` when a link carries both, matching Word: the relationship
+ * names the document and the anchor names a place inside it, so the pair is a link to a
+ * bookmark in ANOTHER file — which this engine will not follow, but whose external half is
+ * the part that decides where it points.
+ *
+ * A link with neither is `unresolved`: it paints its runs and does nothing.
+ */
+export function hyperlinkTargetOf(
+  link: OoxmlNode,
+  resolve: RelationshipTargetResolver
+): HyperlinkTarget {
+  const tooltip = attributeValue(link, WML_NAMESPACE_URI, 'tooltip');
+  const relationshipId = hyperlinkRelationshipIdOf(link);
+  const anchor = hyperlinkAnchorOf(link);
+
+  if (relationshipId !== undefined && relationshipId !== '') {
+    const record = resolve(relationshipId);
+    if (record && record.external) {
+      // TWO gates, not one. The scheme allowlist refuses `javascript:` and friends; the
+      // package's absolute-URI check refuses a target with no scheme at all, which the
+      // allowlist passes through by design. A file-derived target must clear BOTH — a
+      // relative or protocol-relative target resolves against the host application's
+      // origin, which is not somewhere this document gets to point.
+      const projection = sanitizeHref(record.target);
+      const admitted = projection.ok && record.sinkSafe === true;
+      return {
+        kind: 'external',
+        authored: record.target,
+        href: admitted ? projection.href : null,
+        ...(anchor !== undefined ? { anchor } : {}),
+        ...(tooltip !== undefined ? { tooltip } : {}),
+        relationshipId,
+      };
+    }
+    // A missing relationship, or one the package resolved INTERNALLY (a link to another
+    // part of this package). Neither is something to open: the first has no target at all,
+    // the second would be a same-package navigation this engine does not model. The runs
+    // still paint, which is the part that matters.
+    return {
+      kind: 'unresolved',
+      authored: record?.target ?? '',
+      href: null,
+      ...(anchor !== undefined ? { anchor } : {}),
+      ...(tooltip !== undefined ? { tooltip } : {}),
+      relationshipId,
+    };
+  }
+
+  if (anchor !== undefined && anchor !== '') {
+    return {
+      kind: 'internal',
+      authored: anchor,
+      // A fragment, not a URL: it never leaves the page, and the anchor name is
+      // file-derived so it goes through the same allowlist as everything else. A name that
+      // sanitizes away leaves an inert link rather than an attribute built from raw input.
+      href: sanitizeFragment(anchor),
+      anchor,
+      ...(tooltip !== undefined ? { tooltip } : {}),
+    };
+  }
+
+  return {
+    kind: 'unresolved',
+    authored: '',
+    href: null,
+    ...(tooltip !== undefined ? { tooltip } : {}),
+  };
+}
+
+/**
+ * `#<anchor>` for a bookmark name, or null.
+ *
+ * The fragment is built from a file-derived name, so it takes the same allowlist path as an
+ * external target: `sanitizeHref` strips the embedded tab/LF/CR used to smuggle a scheme
+ * past a naive check, and a name that manages to look like `javascript:` — a legal bookmark
+ * name contains no colon, but nothing stops a hostile file writing one — is refused rather
+ * than concatenated onto a `#`.
+ */
+function sanitizeFragment(anchor: string): string | null {
+  const projection = sanitizeHref(anchor);
+  if (!projection.ok || projection.href.length === 0) return null;
+  return `#${projection.href}`;
+}

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -69,6 +69,9 @@ export {
   type OoxmlParagraphPropertiesNode,
   type OoxmlTabNode,
   type OoxmlHardBreakNode,
+  type OoxmlHyperlinkNode,
+  type OoxmlBookmarkStartNode,
+  type OoxmlBookmarkEndNode,
   type OoxmlGenericElementNode,
   type OoxmlTextNode,
   type OoxmlElement,
@@ -185,3 +188,20 @@ export {
   w14RootPrefix,
 } from './para-id.ts';
 export { ensureListDefinition, ensureNumberingLevel, type ListKind } from './numbering-part.ts';
+export { buildBookmarkIndex, type BookmarkAnchor, type BookmarkIndex } from './bookmarks.ts';
+export {
+  ensureHyperlinkRelationship,
+  relationshipTargetIn,
+  type EnsuredHyperlinkRelationship,
+} from './hyperlink-part.ts';
+export {
+  HYPERLINK_RELATIONSHIP_TYPE,
+  OFFICE_RELATIONSHIP_NAMESPACE_URI,
+  hyperlinkAnchorOf,
+  hyperlinkRelationshipIdOf,
+  hyperlinkTargetOf,
+  isHyperlinkNode,
+  type HyperlinkKind,
+  type HyperlinkTarget,
+  type RelationshipTargetResolver,
+} from './hyperlink.ts';

--- a/packages/core/src/store/package/ooxml-digest.ts
+++ b/packages/core/src/store/package/ooxml-digest.ts
@@ -194,7 +194,29 @@ function collectGeneric(node: OoxmlNode, out: string[]): void {
     out.push(canonicalOoxmlFingerprint(node));
     return; // fingerprint covers the whole subtree; do not double-count descendants
   }
+  // Bookmark markers are TYPED but they are still preserved evidence, not structure the
+  // digest reconstructs from anything else: they carry no text and no properties, so a
+  // walk that merely recursed past them (they have no children) reported nothing when one
+  // was dropped. Fingerprinting them keeps a lost anchor a reported loss, which is what it
+  // was while they were generic.
+  if (node.kind === 'bookmarkStart' || node.kind === 'bookmarkEnd') {
+    out.push(canonicalOoxmlFingerprint(node));
+    return;
+  }
   for (const child of node.children) collectGeneric(child, out);
+}
+
+/**
+ * A hyperlink's own identity, as a structure token: its authored attributes, sorted.
+ *
+ * The link element itself carries no text, so without this a save that dropped the target
+ * off a link — or changed `w:anchor` — would digest identically to one that kept it.
+ */
+function linkIdentityToken(link: OoxmlElement): string {
+  const attributes = link.attributes
+    .map((attribute) => `${attribute.namespaceUri}|${attribute.localName}=${attribute.value}`)
+    .sort();
+  return `hyperlink(${attributes.join(',')})`;
 }
 
 function digestParagraph(
@@ -208,7 +230,11 @@ function digestParagraph(
   const runProperties: string[][] = [];
   let text = '';
   const genericStructure: string[] = [];
-  for (const child of paragraph.children) {
+  // A `w:hyperlink` contributes its own identity (target, tooltip, history) AND its runs'
+  // text and properties. Digesting the link as an opaque blob would have been the easy
+  // reading, but then editing a word inside a link would show up as "the whole link changed"
+  // and a lost run inside one would not show up at all.
+  const visit = (child: OoxmlNode): void => {
     if (child.kind === 'run') {
       const rPr = child.children.find(
         (grand): grand is OoxmlRunPropertiesNode => grand.kind === 'runProperties'
@@ -218,10 +244,16 @@ function digestParagraph(
       // Includes the run's own `w:rPr`, so a FOREIGN-namespace property child is digested
       // exactly once (there) rather than falling between the two collectors.
       for (const grand of child.children) collectGeneric(grand, genericStructure);
-      continue;
+      return;
+    }
+    if (child.kind === 'hyperlink') {
+      genericStructure.push(linkIdentityToken(child));
+      for (const inner of child.children) visit(inner);
+      return;
     }
     collectGeneric(child, genericStructure);
-  }
+  };
+  for (const child of paragraph.children) visit(child);
   const paraId = paraIdOf(paragraph);
   return {
     ordinal,

--- a/packages/core/src/store/package/ooxml-indexes.ts
+++ b/packages/core/src/store/package/ooxml-indexes.ts
@@ -91,12 +91,20 @@ function runText(node: OoxmlNode): string {
 function indexParagraph(paragraph: OoxmlElement, ordinal: number): ParagraphIndexEntry {
   const runIds: string[] = [];
   let text = '';
-  for (const child of paragraph.children) {
+  // A `w:hyperlink` is a run CONTAINER: its runs are part of the paragraph's text, so the
+  // index descends into it. Reading only direct `w:r` children left the index disagreeing
+  // with `segmentsOf` about how long every paragraph holding a link was.
+  const visit = (child: OoxmlNode): void => {
     if (child.kind === 'run') {
       runIds.push(child.id);
       text += runText(child);
+      return;
     }
-  }
+    if (child.kind === 'hyperlink') {
+      for (const inner of child.children) visit(inner);
+    }
+  };
+  for (const child of paragraph.children) visit(child);
   return { nodeId: paragraph.id, ordinal, text, runIds };
 }
 

--- a/packages/core/src/store/package/ooxml-shared.ts
+++ b/packages/core/src/store/package/ooxml-shared.ts
@@ -144,28 +144,64 @@ export function validateQNameAttributeValues(
  */
 const PPR_ELEMENTS_AFTER_RPR = new Set(['sectPr', 'pPrChange']);
 
+/**
+ * Content that is PRESERVED rather than structural, and may therefore sit anywhere a
+ * `generic` child may sit.
+ *
+ * Bookmark markers are the reason this exists. Word writes them between block-level
+ * siblings as freely as it writes them between runs — around a table, around a row, at the
+ * top of the body — so once they carry a typed kind, every container that previously
+ * accepted them only as `generic` would stop recognising its own children and DEMOTE. A
+ * demoted `w:body` is not a cosmetic loss: nothing downstream finds a paragraph in it, so a
+ * document with one stray bookmark would open blank. Admitting them wherever `generic` is
+ * admitted keeps typing them additive.
+ */
+function isPreservedChild(child: OoxmlNode): boolean {
+  return (
+    child.kind === 'generic' ||
+    child.kind === 'bookmarkStart' ||
+    child.kind === 'bookmarkEnd' ||
+    child.kind === 'hyperlink'
+  );
+}
+
 export function validKnownKind(kind: KnownKind, children: readonly OoxmlNode[]): boolean {
   switch (kind) {
     case 'document':
       return (
-        children.every((child) => child.kind === 'body' || child.kind === 'generic') &&
+        children.every((child) => child.kind === 'body' || isPreservedChild(child)) &&
         children.filter((child) => child.kind === 'body').length === 1
       );
     case 'body':
       return children.every(
-        (child) => child.kind === 'paragraph' || child.kind === 'table' || child.kind === 'generic'
+        (child) => child.kind === 'paragraph' || child.kind === 'table' || isPreservedChild(child)
       );
     case 'paragraph': {
       const properties = children.findIndex((child) => child.kind === 'paragraphProperties');
       return (
         children.every(
           (child) =>
-            child.kind === 'paragraphProperties' || child.kind === 'run' || child.kind === 'generic'
+            child.kind === 'paragraphProperties' || child.kind === 'run' || isPreservedChild(child)
         ) &&
         (properties < 0 || properties === 0) &&
         children.filter((child) => child.kind === 'paragraphProperties').length <= 1
       );
     }
+    /**
+     * A hyperlink holds runs and range markers. Anything else it wraps — a drawing, a
+     * complex field, a nested content control — stays generic AT ITS POSITION rather than
+     * demoting the link, so the runs beside it still paint and the link identity survives.
+     *
+     * `isPreservedChild` admits `hyperlink`, so a link nested in a link stays TYPED. That is
+     * not an accident of sharing the helper: `CT_Hyperlink`'s content model is `EG_PContent`
+     * (ECMA-376 §17.16.22), which lists `w:hyperlink` among its members, so nesting is
+     * schema-legal and a reader that demoted it would stop the inner link's runs painting.
+     */
+    case 'hyperlink':
+      return children.every((child) => child.kind === 'run' || isPreservedChild(child));
+    case 'bookmarkStart':
+    case 'bookmarkEnd':
+      return children.length === 0;
     case 'run': {
       const properties = children.findIndex((child) => child.kind === 'runProperties');
       return (
@@ -175,6 +211,8 @@ export function validKnownKind(kind: KnownKind, children: readonly OoxmlNode[]):
             child.kind === 'text' ||
             child.kind === 'tab' ||
             child.kind === 'hardBreak' ||
+            child.kind === 'bookmarkStart' ||
+            child.kind === 'bookmarkEnd' ||
             child.kind === 'generic'
         ) &&
         (properties < 0 || properties === 0) &&
@@ -213,16 +251,16 @@ export function validKnownKind(kind: KnownKind, children: readonly OoxmlNode[]):
             child.kind === 'tableRow' ||
             child.kind === 'tableProperties' ||
             child.kind === 'tableGrid' ||
-            child.kind === 'generic'
+            isPreservedChild(child)
         ) &&
         children.filter((child) => child.kind === 'tableProperties').length <= 1 &&
         children.filter((child) => child.kind === 'tableGrid').length <= 1
       );
     case 'tableRow':
-      return children.every((child) => child.kind === 'tableCell' || child.kind === 'generic');
+      return children.every((child) => child.kind === 'tableCell' || isPreservedChild(child));
     case 'tableCell':
       return children.every(
-        (child) => child.kind === 'paragraph' || child.kind === 'table' || child.kind === 'generic'
+        (child) => child.kind === 'paragraph' || child.kind === 'table' || isPreservedChild(child)
       );
     case 'tableGrid':
     case 'tableProperties':

--- a/packages/core/src/store/package/ooxml-tree.ts
+++ b/packages/core/src/store/package/ooxml-tree.ts
@@ -158,12 +158,99 @@ export interface OoxmlTablePropertiesNode extends OoxmlElementBase<
 }
 
 export interface OoxmlParagraphNode extends OoxmlElementBase<
-  readonly (OoxmlParagraphPropertiesNode | OoxmlRunNode | OoxmlGenericElementNode)[],
+  readonly (
+    | OoxmlParagraphPropertiesNode
+    | OoxmlRunNode
+    | OoxmlHyperlinkNode
+    | OoxmlBookmarkStartNode
+    | OoxmlBookmarkEndNode
+    | OoxmlGenericElementNode
+  )[],
   readonly OoxmlKnownNodeAttribute[]
 > {
   readonly kind: 'paragraph';
   readonly namespaceUri: typeof WML_NAMESPACE_URI;
   readonly localName: 'p';
+}
+
+/**
+ * `CT_Hyperlink` (ECMA-376 §17.16.22) — a RUN CONTAINER, not a leaf.
+ *
+ * Its runs are part of the paragraph's inline sequence: they measure, paint, select and
+ * take offsets exactly like a run written directly under the `w:p`. Typing the element is
+ * what lets them in; while it was generic, its runs never reached the token stream and the
+ * words inside every link simply did not paint.
+ *
+ * Targets live in the ATTRIBUTES, and §17.16.22 declares exactly six. They divide into two
+ * groups, and the difference is load-bearing:
+ *
+ *   MODELED    `r:id` (a relationship, resolved against the owning part's rels), `w:anchor`
+ *              (a bookmark name in this document) and `w:tooltip`. These are the three the
+ *              ops read and write — `setHyperlinkTarget` sets one target attribute and
+ *              CLEARS the other, so a link never carries both and resolves by the wrong one.
+ *
+ *   PRESERVED  `w:tgtFrame`, `w:docLocation` and `w:history`. Nothing in this engine
+ *              interprets them and no op names them; they survive because attributes are
+ *              carried verbatim, and `setHyperlinkTarget` must leave them exactly as
+ *              authored. That is a REQUIREMENT, not an incidental property of the current
+ *              applier: `w:docLocation` names a location inside the target document, so
+ *              silently dropping it on a retarget would change where a link goes.
+ *              `hyperlink-lossless-editing.test.ts` pins both against a retarget.
+ *
+ * Nothing here is a runtime URL — the sanitized projection is computed separately (see
+ * `hyperlinkTargetOf`), and only that reaches a DOM or navigation sink.
+ *
+ * Bookmark markers are admitted as children because Word writes them inside links; anything
+ * else it can carry (a drawing, a field, a nested SDT) stays `generic` at its position, so a
+ * link around a picture keeps both the picture and the link.
+ *
+ * A link may contain ANOTHER link: §17.16.22's content model is `EG_PContent`, which lists
+ * `w:hyperlink` among its own members. That is why this child union is self-referential
+ * rather than bottoming out at runs. Demoting the inner one to `generic` would have been the
+ * easier type, and it would have reintroduced exactly the bug typing this element fixed —
+ * a generic link's runs never reach the token stream, so the words inside it stop painting.
+ * Every walk that descends a link therefore recurses (`segmentsOf`, `runsUnder`,
+ * `runPropertyEdits`) instead of descending one level.
+ */
+export interface OoxmlHyperlinkNode extends OoxmlElementBase<
+  readonly (
+    | OoxmlRunNode
+    | OoxmlHyperlinkNode
+    | OoxmlBookmarkStartNode
+    | OoxmlBookmarkEndNode
+    | OoxmlGenericElementNode
+  )[],
+  readonly OoxmlKnownNodeAttribute[]
+> {
+  readonly kind: 'hyperlink';
+  readonly namespaceUri: typeof WML_NAMESPACE_URI;
+  readonly localName: 'hyperlink';
+}
+
+/**
+ * `w:bookmarkStart` — a ZERO-LENGTH point anchor (`@w:id`, `@w:name`).
+ *
+ * It takes no text offset and paints nothing; it only marks a position, which is what an
+ * internal hyperlink's `w:anchor` names. Split and join place it by that position, the
+ * behaviour `tree-op-split-anchors.test.ts` pins.
+ */
+export interface OoxmlBookmarkStartNode extends OoxmlElementBase<
+  readonly [],
+  readonly OoxmlKnownNodeAttribute[]
+> {
+  readonly kind: 'bookmarkStart';
+  readonly namespaceUri: typeof WML_NAMESPACE_URI;
+  readonly localName: 'bookmarkStart';
+}
+
+/** `w:bookmarkEnd` — the closing point anchor (`@w:id`), zero-length like its start. */
+export interface OoxmlBookmarkEndNode extends OoxmlElementBase<
+  readonly [],
+  readonly OoxmlKnownNodeAttribute[]
+> {
+  readonly kind: 'bookmarkEnd';
+  readonly namespaceUri: typeof WML_NAMESPACE_URI;
+  readonly localName: 'bookmarkEnd';
 }
 
 export interface OoxmlRunNode extends OoxmlElementBase<
@@ -241,6 +328,9 @@ export type OoxmlElement =
   | OoxmlBodyNode
   | OoxmlParagraphNode
   | OoxmlRunNode
+  | OoxmlHyperlinkNode
+  | OoxmlBookmarkStartNode
+  | OoxmlBookmarkEndNode
   | OoxmlRunPropertiesNode
   | OoxmlTextElementNode
   | OoxmlParagraphPropertiesNode
@@ -335,6 +425,9 @@ const KNOWN_WML_ELEMENTS: Readonly<Record<string, KnownKind>> = {
   tc: 'tableCell',
   tblGrid: 'tableGrid',
   tblPr: 'tableProperties',
+  hyperlink: 'hyperlink',
+  bookmarkStart: 'bookmarkStart',
+  bookmarkEnd: 'bookmarkEnd',
 };
 
 function deepFreezeNode(node: OoxmlNode): OoxmlNode {

--- a/packages/core/src/store/package/ooxml-validate.ts
+++ b/packages/core/src/store/package/ooxml-validate.ts
@@ -43,6 +43,9 @@ const KNOWN_ELEMENT_NAMES: Readonly<
   tableCell: [WML_NAMESPACE_URI, 'tc'],
   tableGrid: [WML_NAMESPACE_URI, 'tblGrid'],
   tableProperties: [WML_NAMESPACE_URI, 'tblPr'],
+  hyperlink: [WML_NAMESPACE_URI, 'hyperlink'],
+  bookmarkStart: [WML_NAMESPACE_URI, 'bookmarkStart'],
+  bookmarkEnd: [WML_NAMESPACE_URI, 'bookmarkEnd'],
 };
 
 function knownAttributesAreValid(attributes: readonly OoxmlAttribute[]): boolean {

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -57,7 +57,9 @@ import {
 } from './tree-op-section.ts';
 import {
   isParagraph,
+  runsUnder,
   segmentsOf,
+  type Segment,
   validateTreeOp,
   type OoxmlProperty,
   type TreeDocOp,
@@ -128,6 +130,8 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
   if (rejection) return { ok: false, reason: rejection };
 
   if (op.op === 'joinParagraphs') return applyJoin(part, op.firstId, op.secondId, options);
+  if (op.op === 'setHyperlinkTarget') return applySetHyperlinkTarget(part, op, options);
+  if (op.op === 'removeHyperlink') return applyRemoveHyperlink(part, op.linkId, options);
   if (op.op === 'setSectionProperties') return applySetSectionProperties(part, op, options);
   if (op.op === 'setSectionMark') return applySetSectionMark(part, op.paragraphId, options);
 
@@ -175,6 +179,8 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
       );
     case 'deleteText':
       return applyDeleteText(part, paragraph, op.start, op.end, options);
+    case 'insertHyperlink':
+      return applyInsertHyperlink(part, paragraph, op, options);
     case 'splitParagraph':
       return applySplit(part, paragraph, op.offset, options);
     case 'splitParagraphMany':
@@ -347,21 +353,389 @@ function applyDeleteText(
   }
 
   // Drop runs left with no content. A run holding only `w:rPr` renders nothing and would
-  // otherwise accumulate on every deletion.
+  // otherwise accumulate on every deletion. Runs inside a HYPERLINK are swept too — they
+  // empty exactly the same way — and a link whose last run went with them is removed
+  // outright: a `w:hyperlink` with no runs is a target with nothing to click, and leaving it
+  // behind would make the next character typed at that offset silently join the dead link.
   const after = findNode(current, paragraph.id);
   if (after && after.kind === 'paragraph') {
-    for (const child of after.children) {
-      if (child.kind !== 'run') continue;
-      // A run's children are elements only, so "content" is simply anything that is not
-      // the run's own property container.
-      const hasContent = child.children.some((grand) => !isRunPropertiesNode(grand));
-      if (hasContent) continue;
-      const removed = removeNode(current, child.id, options);
-      if (!removed.ok) return fromEdit(removed, effect);
-      current = removed.part;
-    }
+    const sweep = (children: readonly OoxmlNode[]): TreeOpResult | null => {
+      for (const child of children) {
+        if (child.kind === 'hyperlink') {
+          const nested = sweep(child.children);
+          if (nested) return nested;
+          const link = findNode(current, child.id);
+          if (link && link.kind !== 'textValue' && runsUnder(link).length === 0) {
+            // SPLICE, never remove the subtree. A link emptied of runs can still hold
+            // bookmark and comment-range markers, and removing the element took them with
+            // it — an anchor other links point at, or a `commentRangeEnd` whose start is
+            // still in the paragraph. The same markers written OUTSIDE a link survive the
+            // identical deletion, so removing them here was an inconsistency as well as a
+            // loss. Only the wrapper goes; whatever it held stays where it was.
+            const parent = parentOf(current, child.id);
+            if (!parent) return { ok: false, reason: 'tree-invariant' };
+            const spliced = replaceChildren(
+              current,
+              parent.id,
+              parent.children.flatMap((sibling) =>
+                sibling.id === child.id ? [...link.children] : [sibling]
+              ),
+              options
+            );
+            if (!spliced.ok) return fromEdit(spliced, effect);
+            current = spliced.part;
+          }
+          continue;
+        }
+        if (child.kind !== 'run') continue;
+        // A run's children are elements only, so "content" is simply anything that is not
+        // the run's own property container.
+        const hasContent = child.children.some((grand) => !isRunPropertiesNode(grand));
+        if (hasContent) continue;
+        const removed = removeNode(current, child.id, options);
+        if (!removed.ok) return fromEdit(removed, effect);
+        current = removed.part;
+      }
+      return null;
+    };
+    const failure = sweep(after.children);
+    if (failure) return failure;
   }
   return ok(current, effect);
+}
+
+/** The `r:id` namespace — the one attribute on a `w:hyperlink` that is not in `w:`. */
+const RELATIONSHIP_NAMESPACE_URI =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+/**
+ * A `w:hyperlink` element with the attributes an op asked for.
+ *
+ * `w:history="1"` is written on every link Word creates — it is the "followed links" flag,
+ * and a link without it reads as an oddity in Word's own UI. Attribute VALUES are validated
+ * by `validateHyperlinkTarget` before this runs, so nothing unescapable reaches the tree; the
+ * serializer escapes on the way out regardless.
+ */
+function hyperlinkElement(
+  nextId: () => string,
+  target: {
+    readonly relationshipId?: string;
+    readonly anchor?: string;
+    readonly tooltip?: string;
+  },
+  children: readonly OoxmlNode[]
+): OoxmlNode {
+  const attributes: OoxmlAttribute[] = [
+    {
+      kind: 'genericExtension',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'history',
+      prefix: 'w',
+      value: '1',
+    },
+  ];
+  if (target.relationshipId !== undefined) {
+    attributes.push({
+      kind: 'genericExtension',
+      namespaceUri: RELATIONSHIP_NAMESPACE_URI,
+      localName: 'id',
+      prefix: 'r',
+      value: target.relationshipId,
+    });
+  }
+  if (target.anchor !== undefined) {
+    attributes.push({
+      kind: 'genericExtension',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'anchor',
+      prefix: 'w',
+      value: target.anchor,
+    });
+  }
+  if (target.tooltip !== undefined) {
+    attributes.push({
+      kind: 'genericExtension',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'tooltip',
+      prefix: 'w',
+      value: target.tooltip,
+    });
+  }
+  return {
+    id: nextId(),
+    kind: 'hyperlink',
+    namespaceUri: WML_NAMESPACE_URI,
+    localName: 'hyperlink',
+    prefix: 'w',
+    namespaceBindings: [],
+    attributes,
+    children,
+  } as unknown as OoxmlNode;
+}
+
+/**
+ * Mark a run with a character style (`w:rStyle`), keeping everything else it carries.
+ *
+ * `w:rStyle` is the FIRST child of `w:rPr` (CT_RPr, ECMA-376 §17.3.2.27) and there is at
+ * most one, so an existing reference is REPLACED in place rather than joined by a second —
+ * two `w:rStyle` children make the `w:rPr` schema-invalid, which Word repairs by dropping
+ * the run's formatting entirely.
+ */
+function withCharacterStyle(node: OoxmlNode, styleId: string, nextId: () => string): OoxmlNode {
+  if (node.kind === 'hyperlink') {
+    return withChildren(
+      node,
+      node.children.map((child) => withCharacterStyle(child, styleId, nextId)),
+      null
+    );
+  }
+  if (node.kind !== 'run') return node;
+  const rStyle = {
+    id: nextId(),
+    kind: 'generic',
+    namespaceUri: WML_NAMESPACE_URI,
+    localName: 'rStyle',
+    prefix: 'w',
+    namespaceBindings: [],
+    attributes: [
+      {
+        kind: 'genericExtension',
+        namespaceUri: WML_NAMESPACE_URI,
+        localName: 'val',
+        prefix: 'w',
+        value: styleId,
+      },
+    ],
+    children: [],
+  } as unknown as OoxmlNode;
+
+  const rPr = runPropertiesNodeOf(node);
+  if (!rPr) {
+    const created = {
+      id: nextId(),
+      kind: 'runProperties',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'rPr',
+      prefix: 'w',
+      namespaceBindings: [],
+      attributes: [],
+      children: [rStyle],
+    } as unknown as OoxmlNode;
+    // `w:rPr` must be the run's first child.
+    return withChildren(node, [created, ...node.children], null);
+  }
+  const withoutOld = rPr.children.filter(
+    (child) =>
+      child.kind === 'textValue' ||
+      child.localName !== 'rStyle' ||
+      // Namespace-checked: an `<x:rStyle>` from a foreign namespace is preserved content,
+      // not the WML character-style reference this replaces.
+      child.namespaceUri !== WML_NAMESPACE_URI
+  );
+  const nextRpr = withChildren(rPr, [rStyle, ...withoutOld], null);
+  return withChildren(
+    node,
+    node.children.map((child) => (child.id === rPr.id ? nextRpr : child)),
+    null
+  );
+}
+
+/**
+ * Wrap `[start, end)` of a paragraph in a `w:hyperlink`.
+ *
+ * The paragraph's inline children are walked once and sorted into three buckets — before the
+ * range, inside it, after it — with any child straddling an edge divided by the SAME
+ * `divideInline` a split uses, so a link that starts mid-word cuts the run exactly where a
+ * paragraph break would. The three buckets are then reassembled with the middle wrapped, in
+ * one `replaceChildren`, so the whole insert is a single tree revision.
+ *
+ * `styleId` marks the wrapped runs with a character style (`w:rStyle`), which is how Word
+ * makes a new link LOOK like one. It is written here rather than through `setRunProperties`
+ * because `w:rStyle` is preserved, not accepted: it is not in the set a property write
+ * replaces, so routing it through one would make a later bold toggle delete it. Direct
+ * formatting on the runs is untouched — a style reference sits beside it, and the cascade
+ * already resolves direct formatting as the winner.
+ */
+function applyInsertHyperlink(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  op: { readonly start: number; readonly end: number } & {
+    readonly relationshipId?: string;
+    readonly anchor?: string;
+    readonly tooltip?: string;
+    readonly styleId?: string;
+  },
+  options?: EditOptions
+): TreeOpResult {
+  const nextId = createNodeIdAllocator(part);
+  const segments = segmentsOf(paragraph);
+  const before: OoxmlNode[] = [];
+  const inside: OoxmlNode[] = [];
+  const after: OoxmlNode[] = [];
+  const effect: TreeOpEffect = {
+    dirty: [paragraph.id],
+    created: [],
+    deleted: [],
+    dependencyKeys: TEXT_DEPS,
+    impact: 'paragraph-local',
+  };
+
+  let cursor = 0;
+  for (const child of paragraph.children) {
+    if (isParagraphPropertiesNode(child)) continue;
+    const childSegments = segmentsForChild(child, segments);
+    if (childSegments.length === 0) {
+      // Zero-length content takes the bucket its POSITION puts it in: a bookmark marker
+      // inside the linked range belongs inside the link, one before it stays outside.
+      (cursor < op.start ? before : cursor < op.end ? inside : after).push(child);
+      continue;
+    }
+    const childStart = childSegments[0]!.start;
+    const childEnd = childSegments[childSegments.length - 1]!.end;
+    cursor = childEnd;
+    if (childEnd <= op.start) {
+      before.push(child);
+      continue;
+    }
+    if (childStart >= op.end) {
+      after.push(child);
+      continue;
+    }
+    if (childStart >= op.start && childEnd <= op.end) {
+      inside.push(child);
+      continue;
+    }
+    // Straddles an edge. Cut at BOTH offsets in one pass against the original segments.
+    //
+    // Cutting twice in sequence does not work: the second cut would run against a run this
+    // function had just rebuilt, whose fresh node ids appear in no segment, so every child
+    // read as unplaceable and the trailing text silently vanished. The many-way divide
+    // already answers exactly this question — where does each character go, given these
+    // boundaries — measured once against the tree as it stands.
+    const [outsideBefore, within, outsideAfter] = distributeInline(
+      child,
+      [op.start, op.end],
+      3,
+      segments,
+      nextId
+    );
+    before.push(...outsideBefore!);
+    inside.push(...within!);
+    after.push(...outsideAfter!);
+  }
+
+  if (inside.length === 0) return { ok: false, reason: 'invalid-range' };
+  const styled =
+    op.styleId === undefined
+      ? inside
+      : inside.map((child) => withCharacterStyle(child, op.styleId!, nextId));
+  const link = hyperlinkElement(nextId, op, styled);
+  const pPr = paragraphPropertiesNodeOf(paragraph);
+  const children = [...(pPr ? [pPr] : []), ...before, link, ...after];
+  return fromEdit(replaceChildren(part, paragraph.id, children, options), effect);
+}
+
+/** Re-aim a link: one target attribute replaces the other, and the tooltip follows. */
+function applySetHyperlinkTarget(
+  part: OoxmlPart,
+  op: {
+    readonly linkId: string;
+    readonly relationshipId?: string;
+    readonly anchor?: string;
+    readonly tooltip?: string;
+  },
+  options?: EditOptions
+): TreeOpResult {
+  const link = findNode(part, op.linkId);
+  if (!link || link.kind !== 'hyperlink') return { ok: false, reason: 'tree-invariant' };
+  const owner = parentOf(part, link.id);
+  if (!owner) return { ok: false, reason: 'tree-invariant' };
+
+  // RETAIN EVERYTHING THE OP DID NOT NAME. `w:history`, `w:docLocation` and `w:tgtFrame` are
+  // properties of this LINK, not of its target, so re-aiming must not drop them — that is
+  // the difference between editing a URL and replacing the element. `w:docLocation` in
+  // particular names a location INSIDE the target (ECMA-376 §17.16.22), so dropping it on a
+  // retarget would silently change where the link lands. What goes is the old
+  // target attribute (whichever of the two it was, since supplying one supersedes both) and
+  // the old tooltip when a new one was supplied.
+  const retained = link.attributes.filter((attribute) => {
+    if (attribute.namespaceUri === RELATIONSHIP_NAMESPACE_URI && attribute.localName === 'id') {
+      return false;
+    }
+    if (attribute.namespaceUri !== WML_NAMESPACE_URI) return true;
+    if (attribute.localName === 'anchor') return false;
+    if (attribute.localName === 'tooltip') return op.tooltip === undefined;
+    return true;
+  });
+  const target: OoxmlAttribute[] = [];
+  if (op.relationshipId !== undefined) {
+    target.push({
+      kind: 'genericExtension',
+      namespaceUri: RELATIONSHIP_NAMESPACE_URI,
+      localName: 'id',
+      prefix: 'r',
+      value: op.relationshipId,
+    });
+  }
+  if (op.anchor !== undefined) {
+    target.push({
+      kind: 'genericExtension',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'anchor',
+      prefix: 'w',
+      value: op.anchor,
+    });
+  }
+  if (op.tooltip !== undefined) {
+    target.push({
+      kind: 'genericExtension',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'tooltip',
+      prefix: 'w',
+      value: op.tooltip,
+    });
+  }
+  const next = { ...link, attributes: [...retained, ...target] } as OoxmlNode;
+  const effect: TreeOpEffect = {
+    dirty: [owner.id],
+    created: [],
+    deleted: [],
+    dependencyKeys: TEXT_DEPS,
+    impact: 'paragraph-local',
+  };
+  return fromEdit(replaceNode(part, link.id, next, options), effect);
+}
+
+/**
+ * Unlink: splice the link's children into its parent where the link was.
+ *
+ * Everything inside keeps its identity — runs, their `w:rPr`, and any bookmark markers — so
+ * the text, its formatting and every anchor around it are exactly what they were. Only the
+ * wrapper goes. A link with no children removes cleanly rather than leaving an empty slot.
+ */
+function applyRemoveHyperlink(
+  part: OoxmlPart,
+  linkId: string,
+  options?: EditOptions
+): TreeOpResult {
+  const link = findNode(part, linkId);
+  if (!link || link.kind !== 'hyperlink') return { ok: false, reason: 'tree-invariant' };
+  const owner = parentOf(part, link.id);
+  if (!owner) return { ok: false, reason: 'tree-invariant' };
+  const children = owner.children.flatMap((child) =>
+    child.id === link.id ? [...link.children] : [child]
+  );
+  const effect: TreeOpEffect = {
+    dirty: [owner.id],
+    created: [],
+    // `deleted` names PARAGRAPHS the block sequence lost, and an unlink loses none: the
+    // paragraph keeps every run it had. Listing the link node here would tell the scheduler
+    // the flow changed structurally and make every commit re-project the whole document.
+    deleted: [],
+    dependencyKeys: TEXT_DEPS,
+    impact: 'paragraph-local',
+  };
+  return fromEdit(replaceChildren(part, owner.id, children, options), effect);
 }
 
 /**
@@ -510,6 +884,108 @@ function splitIdentityOf(
   return { headId: headParaId.toUpperCase(), prefix };
 }
 
+/** The segments of one paragraph child, at any depth — a run's own, or every run in a link. */
+function segmentsForChild(child: OoxmlNode, segments: readonly Segment[]): Segment[] {
+  const runIds = new Set(runsUnder(child).map((run) => run.id));
+  if (runIds.size === 0) return [];
+  return segments.filter((segment) => runIds.has(segment.runId));
+}
+
+/**
+ * Divide ONE inline paragraph child that straddles a split point.
+ *
+ * A run divides by content: its children go left or right of the offset, and a `w:t` sitting
+ * across it is cut in two, with `w:rPr` duplicated onto both halves so formatting survives.
+ *
+ * A HYPERLINK divides by recursion, and the result is TWO hyperlinks carrying the same
+ * authored attributes — the same target, tooltip and history on each half. That is what Word
+ * writes when Enter lands inside a link, and the alternative (sending the whole link to one
+ * side) either drags text backwards out of the sentence it belongs to or carries it forward
+ * into a paragraph the user meant to be empty. Either half may come back empty, in which case
+ * only the other is emitted; an empty `w:hyperlink` is markup with nothing to click.
+ */
+function divideInline(
+  child: OoxmlNode,
+  offset: number,
+  segments: readonly Segment[],
+  nextId: () => string
+): { readonly head: OoxmlNode | null; readonly tail: OoxmlNode | null } {
+  if (child.kind === 'hyperlink') {
+    const headChildren: OoxmlNode[] = [];
+    const tailChildren: OoxmlNode[] = [];
+    // Where the walk has reached inside this link, so zero-length content between two runs
+    // takes the side its POSITION puts it on — the same rule the paragraph walk applies.
+    //
+    // Seeded from the LINK'S OWN START, not 0. These are absolute paragraph offsets, and
+    // starting at zero said "before every boundary" for content that sits well past one.
+    let cursor = segmentsForChild(child, segments)[0]?.start ?? 0;
+    for (const inner of child.children) {
+      const innerSegments = segmentsForChild(inner, segments);
+      if (innerSegments.length === 0) {
+        (cursor < offset ? headChildren : tailChildren).push(inner);
+        continue;
+      }
+      const start = innerSegments[0]!.start;
+      const end = innerSegments[innerSegments.length - 1]!.end;
+      cursor = end;
+      if (end <= offset) headChildren.push(inner);
+      else if (start >= offset) tailChildren.push(inner);
+      else {
+        const divided = divideInline(inner, offset, segments, nextId);
+        if (divided.head) headChildren.push(divided.head);
+        if (divided.tail) tailChildren.push(divided.tail);
+      }
+    }
+    return {
+      head: headChildren.length > 0 ? withChildren(child, headChildren, null) : null,
+      tail: tailChildren.length > 0 ? withChildren(child, tailChildren, nextId) : null,
+    };
+  }
+
+  if (child.kind !== 'run') return { head: child, tail: null };
+
+  const runSegments = segments.filter((segment) => segment.runId === child.id);
+  const rPr = runPropertiesNodeOf(child);
+  const headContent: OoxmlNode[] = [];
+  const tailContent: OoxmlNode[] = [];
+  for (const grand of child.children) {
+    if (isRunPropertiesNode(grand)) continue;
+    const segment = runSegments.find((candidate) => contains(grand, candidate.node.id));
+    if (!segment) {
+      headContent.push(grand);
+      continue;
+    }
+    if (segment.end <= offset) headContent.push(grand);
+    else if (segment.start >= offset) tailContent.push(grand);
+    else if (segment.node.kind === 'textValue') {
+      const local = offset - segment.start;
+      headContent.push(textElement(nextId, segment.node.value.slice(0, local)));
+      tailContent.push(textElement(nextId, segment.node.value.slice(local)));
+    } else headContent.push(grand);
+  }
+  const clonedRpr = rPr ? cloneWithNewIds(rPr, nextId) : null;
+  return {
+    head:
+      headContent.length > 0 ? runElement(nextId, rPr ? [rPr, ...headContent] : headContent) : null,
+    tail:
+      tailContent.length > 0
+        ? runElement(nextId, clonedRpr ? [clonedRpr, ...tailContent] : tailContent)
+        : null,
+  };
+}
+
+/**
+ * The same element with different children — retaining the original identity, or minting a
+ * fresh one for the copy a split leaves on the other side of the break.
+ */
+function withChildren(
+  node: OoxmlNode,
+  children: readonly OoxmlNode[],
+  nextId: (() => string) | null
+): OoxmlNode {
+  return { ...node, ...(nextId ? { id: nextId() } : {}), children } as OoxmlNode;
+}
+
 function applySplit(
   part: OoxmlPart,
   paragraph: OoxmlParagraphNode,
@@ -530,8 +1006,7 @@ function applySplit(
   const openedHere = new Set<string>();
   for (const child of paragraph.children) {
     if (isParagraphPropertiesNode(child)) continue;
-    const runSegments =
-      child.kind === 'run' ? segments.filter((segment) => segment.runId === child.id) : [];
+    const runSegments = segmentsForChild(child, segments);
     if (runSegments.length === 0) {
       (zeroLengthGoesToHead(child, cursor, offset, openedHere) ? headChildren : tailChildren).push(
         child
@@ -552,33 +1027,9 @@ function applySplit(
       tailChildren.push(child);
       continue;
     }
-    // The run straddles the split: divide its content children, keeping `w:rPr` on BOTH
-    // halves so formatting survives the split.
-    const rPr = runPropertiesNodeOf(child);
-    const headContent: OoxmlNode[] = [];
-    const tailContent: OoxmlNode[] = [];
-    for (const grand of child.children) {
-      if (isRunPropertiesNode(grand)) continue;
-      const segment = runSegments.find((candidate) => contains(grand, candidate.node.id));
-      if (!segment) {
-        headContent.push(grand);
-        continue;
-      }
-      if (segment.end <= offset) headContent.push(grand);
-      else if (segment.start >= offset) tailContent.push(grand);
-      else if (segment.node.kind === 'textValue') {
-        const local = offset - segment.start;
-        headContent.push(textElement(nextId, segment.node.value.slice(0, local)));
-        tailContent.push(textElement(nextId, segment.node.value.slice(local)));
-      } else headContent.push(grand);
-    }
-    if (headContent.length > 0) {
-      headChildren.push(runElement(nextId, rPr ? [rPr, ...headContent] : headContent));
-    }
-    if (tailContent.length > 0) {
-      const clonedRpr = rPr ? cloneWithNewIds(rPr, nextId) : null;
-      tailChildren.push(runElement(nextId, clonedRpr ? [clonedRpr, ...tailContent] : tailContent));
-    }
+    const divided = divideInline(child, offset, segments, nextId);
+    if (divided.head) headChildren.push(divided.head);
+    if (divided.tail) tailChildren.push(divided.tail);
   }
 
   // A `w:sectPr` in the split paragraph's mark belongs to the TAIL: Word splits by
@@ -656,6 +1107,120 @@ function pieceIndexOf(
 }
 
 /**
+ * Spread ONE inline paragraph child that straddles at least one of `offsets` across the
+ * resulting pieces, in piece order.
+ *
+ * The many-way twin of {@link divideInline}: a run divides its content by boundary, keeping
+ * `w:rPr` on every piece it lands in, and a hyperlink recurses and re-wraps each piece's
+ * share in a copy of itself so every fragment of a link stays a link with the same target.
+ * The original identity is kept by the FIRST piece that gets content; later pieces are
+ * clones, matching what the equivalent sequence of single splits produces.
+ */
+function distributeInline(
+  child: OoxmlNode,
+  offsets: readonly number[],
+  pieceCount: number,
+  segments: readonly Segment[],
+  nextId: () => string
+): OoxmlNode[][] {
+  const byPiece: OoxmlNode[][] = Array.from({ length: pieceCount }, () => []);
+
+  if (child.kind === 'hyperlink') {
+    const innerByPiece: OoxmlNode[][] = Array.from({ length: pieceCount }, () => []);
+    // Absolute paragraph offsets, seeded from the link's own start — see `divideInline`.
+    // At zero, `pieceIndexOf` put every zero-length child of a link in the FIRST piece: a
+    // bookmark travelled to a paragraph its text did not, an empty `w:hyperlink` husk was
+    // emitted (which this file's own rule forbids), and the husk kept the original node id
+    // while the real link got a fresh one — so a later retarget addressed the husk.
+    let cursor = segmentsForChild(child, segments)[0]?.start ?? 0;
+    for (const inner of child.children) {
+      const innerSegments = segmentsForChild(inner, segments);
+      if (innerSegments.length === 0) {
+        innerByPiece[pieceIndexOf(offsets, cursor)]!.push(inner);
+        continue;
+      }
+      const start = innerSegments[0]!.start;
+      const end = innerSegments[innerSegments.length - 1]!.end;
+      cursor = end;
+      const startPiece = pieceIndexOf(offsets, start);
+      const endPiece = end > start ? pieceIndexOf(offsets, end - 1) : startPiece;
+      if (startPiece === endPiece) {
+        innerByPiece[startPiece]!.push(inner);
+        continue;
+      }
+      const nested = distributeInline(inner, offsets, pieceCount, segments, nextId);
+      for (let piece = 0; piece < pieceCount; piece += 1) {
+        for (const node of nested[piece]!) innerByPiece[piece]!.push(node);
+      }
+    }
+    let keptOriginal = false;
+    for (let piece = 0; piece < pieceCount; piece += 1) {
+      const children = innerByPiece[piece]!;
+      if (children.length === 0) continue;
+      byPiece[piece]!.push(withChildren(child, children, keptOriginal ? nextId : null));
+      keptOriginal = true;
+    }
+    return byPiece;
+  }
+
+  if (child.kind !== 'run') {
+    byPiece[pieceIndexOf(offsets, 0)]!.push(child);
+    return byPiece;
+  }
+
+  const runSegments = segments.filter((segment) => segment.runId === child.id);
+  const startPiece = pieceIndexOf(offsets, runSegments[0]?.start ?? 0);
+  const rPr = runPropertiesNodeOf(child);
+  const contentByPiece: OoxmlNode[][] = Array.from({ length: pieceCount }, () => []);
+  for (const grand of child.children) {
+    if (isRunPropertiesNode(grand)) continue;
+    const segment = runSegments.find((candidate) => contains(grand, candidate.node.id));
+    if (!segment) {
+      contentByPiece[startPiece]!.push(grand);
+      continue;
+    }
+    if (segment.node.kind !== 'textValue') {
+      contentByPiece[pieceIndexOf(offsets, segment.start)]!.push(grand);
+      continue;
+    }
+    const from = segment.start;
+    const until = segment.end;
+    let sliceStart = from;
+    let piece = pieceIndexOf(offsets, from);
+    let cut = false;
+    for (const boundary of offsets) {
+      if (boundary <= from) continue;
+      if (boundary >= until) break;
+      // A REPEATED boundary yields an empty slice: the piece between two equal offsets
+      // is an empty paragraph, and an empty `w:t` inside it would serialize markup the
+      // equivalent single splits never produce — so the piece advances and nothing is
+      // emitted, exactly as a split at a paragraph edge emits no text.
+      const slice = segment.node.value.slice(sliceStart - from, boundary - from);
+      if (slice.length > 0) contentByPiece[piece]!.push(textElement(nextId, slice));
+      sliceStart = boundary;
+      piece += 1;
+      cut = true;
+    }
+    if (!cut) {
+      // No boundary inside this value: it moves whole, identity intact.
+      contentByPiece[piece]!.push(grand);
+      continue;
+    }
+    const lastSlice = segment.node.value.slice(sliceStart - from);
+    if (lastSlice.length > 0) contentByPiece[piece]!.push(textElement(nextId, lastSlice));
+  }
+  let keptOriginalRpr = false;
+  for (let piece = 0; piece < pieceCount; piece += 1) {
+    const content = contentByPiece[piece]!;
+    if (content.length === 0) continue;
+    const pieceRpr = rPr ? (keptOriginalRpr ? cloneWithNewIds(rPr, nextId) : rPr) : null;
+    keptOriginalRpr = true;
+    byPiece[piece]!.push(runElement(nextId, pieceRpr ? [pieceRpr, ...content] : content));
+  }
+  return byPiece;
+}
+
+/**
  * Split a `w:p` at every offset in one pass.
  *
  * Semantically the sequence of single splits from the last offset to the first, produced
@@ -684,8 +1249,7 @@ function applySplitMany(
   const openedHere = new Set<string>();
   for (const child of paragraph.children) {
     if (isParagraphPropertiesNode(child)) continue;
-    const runSegments =
-      child.kind === 'run' ? segments.filter((segment) => segment.runId === child.id) : [];
+    const runSegments = segmentsForChild(child, segments);
     if (runSegments.length === 0) {
       const piece = pieceIndexOf(
         offsets,
@@ -704,59 +1268,13 @@ function applySplitMany(
     const startPiece = pieceIndexOf(offsets, runStart);
     const endPiece = runEnd > runStart ? pieceIndexOf(offsets, runEnd - 1) : startPiece;
     if (startPiece === endPiece) {
-      // Wholly inside one resulting paragraph: the run survives with its identity.
+      // Wholly inside one resulting paragraph: the child survives with its identity.
       pieces[startPiece]!.push(child);
       continue;
     }
-
-    // The run straddles at least one boundary: divide its content children, keeping
-    // `w:rPr` on every produced piece so formatting survives each break.
-    const rPr = runPropertiesNodeOf(child);
-    const contentByPiece: OoxmlNode[][] = Array.from({ length: pieceCount }, () => []);
-    for (const grand of child.children) {
-      if (isRunPropertiesNode(grand)) continue;
-      const segment = runSegments.find((candidate) => contains(grand, candidate.node.id));
-      if (!segment) {
-        contentByPiece[startPiece]!.push(grand);
-        continue;
-      }
-      if (segment.node.kind !== 'textValue') {
-        contentByPiece[pieceIndexOf(offsets, segment.start)]!.push(grand);
-        continue;
-      }
-      const from = segment.start;
-      const until = segment.end;
-      let sliceStart = from;
-      let piece = pieceIndexOf(offsets, from);
-      let cut = false;
-      for (const boundary of offsets) {
-        if (boundary <= from) continue;
-        if (boundary >= until) break;
-        // A REPEATED boundary yields an empty slice: the piece between two equal offsets
-        // is an empty paragraph, and an empty `w:t` inside it would serialize markup the
-        // equivalent single splits never produce — so the piece advances and nothing is
-        // emitted, exactly as a split at a paragraph edge emits no text.
-        const slice = segment.node.value.slice(sliceStart - from, boundary - from);
-        if (slice.length > 0) contentByPiece[piece]!.push(textElement(nextId, slice));
-        sliceStart = boundary;
-        piece += 1;
-        cut = true;
-      }
-      if (!cut) {
-        // No boundary inside this value: it moves whole, identity intact.
-        contentByPiece[piece]!.push(grand);
-        continue;
-      }
-      const lastSlice = segment.node.value.slice(sliceStart - from);
-      if (lastSlice.length > 0) contentByPiece[piece]!.push(textElement(nextId, lastSlice));
-    }
-    let keptOriginalRpr = false;
+    const distributed = distributeInline(child, offsets, pieceCount, segments, nextId);
     for (let piece = 0; piece < pieceCount; piece += 1) {
-      const content = contentByPiece[piece]!;
-      if (content.length === 0) continue;
-      const pieceRpr = rPr ? (keptOriginalRpr ? cloneWithNewIds(rPr, nextId) : rPr) : null;
-      keptOriginalRpr = true;
-      pieces[piece]!.push(runElement(nextId, pieceRpr ? [pieceRpr, ...content] : content));
+      for (const node of distributed[piece]!) pieces[piece]!.push(node);
     }
   }
 

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -40,6 +40,10 @@ export const ACCEPTED_RUN_PROPERTIES = [
   'w', // horizontal scaling
   'kern',
 ] as const;
+// `w:rStyle` is deliberately ABSENT. It is preserved, not accepted: this list is the set a
+// property write REPLACES, so admitting the character style would make a bold toggle delete
+// it. `insertHyperlink` writes `w:rStyle` itself, as part of making the run a link, which is
+// what Word does and what leaves every other write alone.
 
 /** The accepted PARAGRAPH property boundary (design D8). */
 export const ACCEPTED_PARAGRAPH_PROPERTIES = [
@@ -194,6 +198,60 @@ export type TreeDocOp =
        */
       readonly op: 'setSectionMark';
       readonly paragraphId: string;
+    }
+  | {
+      /**
+       * Wrap `[start, end)` of a paragraph in a `w:hyperlink`.
+       *
+       * The RANGE is the link — text and formatting inside it are untouched, and runs that
+       * straddle either edge are divided so the link covers exactly the characters asked
+       * for. Exactly one of `relationshipId` (an external target, already minted on the
+       * package) or `anchor` (a bookmark in this document) names where it goes.
+       *
+       * A collapsed range is refused: a link with no text is markup with nothing to click,
+       * and the caller that wants "insert a link with display text" inserts the text first.
+       */
+      readonly op: 'insertHyperlink';
+      readonly paragraphId: string;
+      readonly start: number;
+      readonly end: number;
+      readonly relationshipId?: string;
+      readonly anchor?: string;
+      readonly tooltip?: string;
+      /**
+       * Character style to mark the linked runs with (`w:rStyle`), normally `Hyperlink`.
+       *
+       * Written HERE rather than through `setRunProperties` because `w:rStyle` is preserved,
+       * not accepted: it is not in the set a property write replaces, and putting it there
+       * would make a later bold toggle delete it. Marking the text is part of making it a
+       * link — Word does both in one operation — so the op that wraps it also styles it.
+       * Omitted for a document that declares no such style.
+       */
+      readonly styleId?: string;
+    }
+  | {
+      /**
+       * Re-aim an existing link. `relationshipId` moves it to another external target,
+       * `anchor` to a bookmark; supplying one CLEARS the other, so a link never ends up
+       * carrying both and resolving by the wrong one.
+       */
+      readonly op: 'setHyperlinkTarget';
+      readonly linkId: string;
+      readonly relationshipId?: string;
+      readonly anchor?: string;
+      readonly tooltip?: string;
+    }
+  | {
+      /**
+       * Unlink: splice the `w:hyperlink`'s children into the paragraph in its place.
+       *
+       * The runs keep their identity, their formatting and their order, and any bookmark
+       * markers inside the link stay exactly where they were. Only the link element goes,
+       * which is what Word's Remove Hyperlink does — the text is not the link's, it was
+       * only wrapped by it.
+       */
+      readonly op: 'removeHyperlink';
+      readonly linkId: string;
     };
 
 export type TreeDocOpKind = TreeDocOp['op'];
@@ -214,6 +272,9 @@ export const TREE_DOC_OP_KINDS = [
   'setParagraphProperties',
   'setSectionProperties',
   'setSectionMark',
+  'insertHyperlink',
+  'setHyperlinkTarget',
+  'removeHyperlink',
 ] as const satisfies readonly TreeDocOpKind[];
 
 // Compile-time exhaustiveness, matching the legacy `DOC_OP_KINDS` guard: a new op must be
@@ -489,7 +550,20 @@ export function metricsOfSection(sectPr: OoxmlNode | null): SectionMetrics {
   };
 }
 
-/** Flatten a paragraph into UTF-16 addressable segments, in document order. */
+/**
+ * Flatten a paragraph into UTF-16 addressable segments, in document order.
+ *
+ * A HYPERLINK's runs are addressed too. `w:hyperlink` is a run container, not a leaf, and
+ * the characters inside a link are ordinary paragraph text: the user selects them, types
+ * over them and deletes them like any other. Skipping the container — which is what
+ * iterating only direct `w:r` children did — left every link's text with no offsets at all,
+ * so `paragraphTextOf` read "Visit  or ." for a sentence that says "Visit Example.com or
+ * Anthropic's website." and layout, selection and the ops all agreed on the wrong string.
+ *
+ * `runId` stays the id of the run the content actually lives in, at whatever depth: the
+ * appliers resolve it with `findNode` and rebuild that run's children, so nesting costs them
+ * nothing.
+ */
 export function segmentsOf(paragraph: OoxmlParagraphNode): Segment[] {
   const segments: Segment[] = [];
   let offset = 0;
@@ -507,11 +581,25 @@ export function segmentsOf(paragraph: OoxmlParagraphNode): Segment[] {
     if (node.kind === 'runProperties' || node.kind === 'generic') return;
     for (const child of node.children) visit(child, runId);
   };
-  for (const child of paragraph.children) {
-    if (child.kind !== 'run') continue;
-    for (const grand of child.children) visit(grand, child.id);
-  }
+  const visitInline = (child: OoxmlNode): void => {
+    if (child.kind === 'run') {
+      for (const grand of child.children) visit(grand, child.id);
+      return;
+    }
+    // Bookmark markers and everything generic measure nothing; only a link descends.
+    if (child.kind === 'hyperlink') {
+      for (const inner of child.children) visitInline(inner);
+    }
+  };
+  for (const child of paragraph.children) visitInline(child);
   return segments;
+}
+
+/** The runs a paragraph child owns, at any depth — a `w:r`, or every run inside a link. */
+export function runsUnder(child: OoxmlNode): OoxmlNode[] {
+  if (child.kind === 'run') return [child];
+  if (child.kind !== 'hyperlink') return [];
+  return child.children.flatMap((inner) => runsUnder(inner));
 }
 
 function paragraphLength(paragraph: OoxmlParagraphNode): number {
@@ -544,6 +632,52 @@ function validateProperties(
       if (!/^[A-Za-z_][\w.-]*$/.test(name)) return 'invalid-property-value';
       if (typeof value !== 'string' || !isValidXmlText(value)) return 'invalid-property-value';
     }
+  }
+  return null;
+}
+
+/** Longest `r:id`, `w:anchor` or `w:tooltip` an op may write. */
+const MAX_HYPERLINK_ATTRIBUTE_LENGTH = 512;
+
+/** Whether `[start, end)` overlaps any text already inside a `w:hyperlink`. */
+function rangeTouchesHyperlink(paragraph: OoxmlParagraphNode, start: number, end: number): boolean {
+  const segments = segmentsOf(paragraph);
+  const linked = new Set<string>();
+  const collect = (node: OoxmlNode, inside: boolean): void => {
+    if (node.kind === 'textValue') return;
+    const within = inside || node.kind === 'hyperlink';
+    if (within && node.kind === 'run') linked.add(node.id);
+    for (const child of node.children) collect(child, within);
+  };
+  for (const child of paragraph.children) collect(child, false);
+  if (linked.size === 0) return false;
+  return segments.some(
+    (segment) => linked.has(segment.runId) && segment.start < end && segment.end > start
+  );
+}
+
+/**
+ * The target half of an insert or a retarget: EXACTLY ONE of relationship or anchor, and
+ * every value legal in XML.
+ *
+ * Both at once is refused rather than resolved by precedence. In a FILE that pair means "a
+ * bookmark inside another document", which the read side honours; as an authored op it means
+ * the caller does not know which it wants, and admitting it would write a link whose
+ * behaviour depends on a resolution rule the caller never saw.
+ */
+function validateHyperlinkTarget(op: {
+  readonly relationshipId?: string;
+  readonly anchor?: string;
+  readonly tooltip?: string;
+}): TreeOpRejection | null {
+  const hasRelationship = op.relationshipId !== undefined;
+  const hasAnchor = op.anchor !== undefined;
+  if (hasRelationship === hasAnchor) return 'invalid-property-value';
+  for (const value of [op.relationshipId, op.anchor, op.tooltip]) {
+    if (value === undefined) continue;
+    if (typeof value !== 'string' || value.length === 0) return 'invalid-property-value';
+    if (value.length > MAX_HYPERLINK_ATTRIBUTE_LENGTH) return 'invalid-property-value';
+    if (!isValidXmlText(value)) return 'invalid-property-value';
   }
   return null;
 }
@@ -618,6 +752,14 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
     const second = findNode(part, op.secondId);
     if (!first || !second) return 'unknown-paragraph';
     if (!isParagraph(first) || !isParagraph(second)) return 'not-a-paragraph';
+    return null;
+  }
+
+  if (op.op === 'setHyperlinkTarget' || op.op === 'removeHyperlink') {
+    const link = findNode(part, op.linkId);
+    if (!link) return 'unknown-paragraph';
+    if (link.kind !== 'hyperlink') return 'not-a-paragraph';
+    if (op.op === 'setHyperlinkTarget') return validateHyperlinkTarget(op);
     return null;
   }
 
@@ -703,6 +845,30 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
     }
     case 'setParagraphProperties':
       return validateProperties(op.properties, PARAGRAPH_PROPERTY_SET);
+    case 'insertHyperlink': {
+      if (!Number.isInteger(op.start) || !Number.isInteger(op.end)) return 'invalid-range';
+      if (op.start < 0 || op.end > length) return 'offset-out-of-range';
+      // A collapsed range would produce a link with no text: markup with nothing to click,
+      // and nothing for a later unlink to give back.
+      if (op.start >= op.end) return 'invalid-range';
+      if (splitsSurrogate(paragraph, op.start) || splitsSurrogate(paragraph, op.end)) {
+        return 'splits-surrogate-pair';
+      }
+      // Nested links are not a shape Word writes and not one this engine reads: the inner
+      // link's runs would resolve through the outer one's target on every walk that stops
+      // at the first `w:hyperlink` it finds.
+      if (rangeTouchesHyperlink(paragraph, op.start, op.end)) return 'invalid-property-value';
+      if (op.styleId !== undefined) {
+        // Written straight into an attribute, so it is checked here rather than at the sink.
+        if (typeof op.styleId !== 'string' || op.styleId.length === 0) {
+          return 'invalid-property-value';
+        }
+        if (op.styleId.length > MAX_HYPERLINK_ATTRIBUTE_LENGTH || !isValidXmlText(op.styleId)) {
+          return 'invalid-property-value';
+        }
+      }
+      return validateHyperlinkTarget(op);
+    }
     case 'setSectionMark': {
       const pPr = paragraphPropertiesNodeOf(paragraph);
       // A paragraph already ending a section cannot end two.

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -534,6 +534,32 @@
   color: inherit !important;
 }
 
+/* Painted hyperlinks.
+ *
+ * The anchor is FURNITURE: colour and underline come from the resolved `Hyperlink`
+ * character style on the runs inside it, exactly as Word paints them, so this must not
+ * impose a colour of its own or an authored override would be overruled by chrome.
+ * What it adds is the affordance the character style cannot carry — a pointer cursor, a
+ * visible focus ring — plus the inert case, where there is nothing to click. */
+a.docx-hyperlink {
+  cursor: pointer;
+  /* The runs inside carry their own colour/decoration; the anchor stays transparent. */
+  color: inherit;
+  text-decoration: none;
+}
+
+a.docx-hyperlink:not([href]) {
+  /* A refused scheme, a dangling relationship, or read-only page furniture: it still reads
+   * as a link because the document says it is one, and it does nothing. */
+  cursor: default;
+}
+
+a.docx-hyperlink:focus-visible {
+  outline: 2px solid var(--doc-focus-ring);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
 /* Selection in hyperlinks */
 .docx-hyperlink::selection,
 .docx-hyperlink *::selection {
@@ -3074,4 +3100,151 @@
   .docx-editor__loading-spinner {
     animation: none;
   }
+}
+
+/* ─── Hyperlink popover (DocxEditor.HyperLink) ────────────────────────────────────────
+ *
+ * The Google-Docs arrangement: a small panel under the clicked link, showing the target
+ * and the actions on it. CHROME, not document — so it is themed from the `--doc-*` tokens
+ * like the toolbar, unlike the painted page it sits over.
+ *
+ * z-index lives here rather than as an inline constant in the component, so a host that
+ * stacks its own chrome over the editor can re-layer the popover in CSS alone.
+ */
+.docx-hyperlink-popup {
+  position: absolute;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 420px;
+  padding: 6px 8px;
+  border: 1px solid var(--doc-border);
+  border-radius: 8px;
+  background: var(--doc-surface);
+  color: var(--doc-text);
+  box-shadow: 0 2px 10px var(--doc-shadow);
+  font-size: 13px;
+  /* Offset from the clicked line so the panel sits UNDER it rather than over the words. */
+  margin-top: 4px;
+}
+
+.docx-hyperlink-popup[data-mode='editing'] {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  min-width: 280px;
+}
+
+/* The target readout. Truncates rather than wrapping: a long URL must not make the panel
+ * taller than the line it is describing. */
+.docx-hyperlink-popup__url {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 260px;
+  overflow: hidden;
+  padding: 2px 4px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--doc-link);
+  font: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.docx-hyperlink-popup__url:hover:not([data-inert]) {
+  text-decoration: underline;
+}
+
+/* An inert target — a refused scheme, a dangling relationship — reads as text, not as a
+ * control: there is nothing behind it to press. */
+.docx-hyperlink-popup__url[data-inert] {
+  color: var(--doc-text-muted);
+  cursor: default;
+}
+
+.docx-hyperlink-popup__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: none;
+}
+
+.docx-hyperlink-popup__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--doc-text-muted);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.docx-hyperlink-popup__action:hover {
+  background: var(--doc-border);
+  color: var(--doc-text);
+}
+
+.docx-hyperlink-popup__action[data-copied] {
+  color: var(--doc-text);
+}
+
+.docx-hyperlink-popup__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.docx-hyperlink-popup__input {
+  width: 100%;
+  padding: 4px 6px;
+  border: 1px solid var(--doc-border-input);
+  border-radius: 4px;
+  background: var(--doc-bg-input);
+  color: var(--doc-text);
+  font: inherit;
+}
+
+.docx-hyperlink-popup__input:focus-visible {
+  outline: 2px solid var(--doc-focus-ring);
+  outline-offset: -1px;
+}
+
+.docx-hyperlink-popup__apply,
+.docx-hyperlink-popup__cancel {
+  padding: 4px 10px;
+  border: 1px solid var(--doc-border-input);
+  border-radius: 4px;
+  background: var(--doc-bg-input);
+  color: var(--doc-text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.docx-hyperlink-popup__apply:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.docx-hyperlink-popup[data-mode='editing'] .docx-hyperlink-popup__actions {
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* Why the last Apply was refused. A panel that stays open saying nothing is worse than
+ * either closing or explaining. */
+.docx-hyperlink-popup__error {
+  color: var(--doc-error);
+  font-size: 12px;
+  line-height: 1.35;
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -2385,6 +2385,17 @@ a.docx-hyperlink:focus-visible {
   background-color: var(--doc-cell-selection);
 }
 
+/*
+ * A selection the engine keeps lit while a panel holds focus.
+ *
+ * The same colour the browser's own `::selection` uses, because it is standing in for exactly
+ * that: the user's highlight did not change, only which element the browser thinks is
+ * focused. A different colour here would read as a different KIND of selection.
+ */
+.docx-paginated-surface .docx-retained-selection-rect {
+  background-color: var(--doc-selection);
+}
+
 /* ========================================================================
  * COMPOUND TOOLBAR (`docx-toolbar` family) — the composition API's default
  * chrome bar, the chrome spec's visual recipe:

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -824,7 +824,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "Link kopieren",
     "editLink": "Link bearbeiten",
-    "removeLink": "Link entfernen"
+    "removeLink": "Link entfernen",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "Kopfzeile",

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -846,7 +846,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "Copy link",
     "editLink": "Edit link",
-    "removeLink": "Remove link"
+    "removeLink": "Remove link",
+    "openLink": "Open link",
+    "apply": "Apply",
+    "cancel": "Cancel",
+    "insertTitle": "Insert link",
+    "editTitle": "Edit link",
+    "inertTarget": "This link points somewhere the editor will not open",
+    "bookmarkTarget": "Goes to a place in this document",
+    "refused": "That link could not be applied. Check the address and try again."
   },
   "headerFooter": {
     "header": "Header",

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -827,7 +827,15 @@
     "urlPlaceholder": "https://exemple.com",
     "copyLink": "Copier le lien",
     "editLink": "Modifier le lien",
-    "removeLink": "Supprimer le lien"
+    "removeLink": "Supprimer le lien",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "En-tête",

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -824,7 +824,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "העתק קישור",
     "editLink": "ערוך קישור",
-    "removeLink": "הסר קישור"
+    "removeLink": "הסר קישור",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "כותרת עליונה",

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -827,7 +827,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "लिंक कॉपी करें",
     "editLink": "लिंक संपादित करें",
-    "removeLink": "लिंक हटाएं"
+    "removeLink": "लिंक हटाएं",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "हेडर",

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -843,7 +843,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "Salin Tautan",
     "editLink": "Edit Tautan",
-    "removeLink": "Hapus Tautan"
+    "removeLink": "Hapus Tautan",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "Header",

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -824,7 +824,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "Kopiuj link",
     "editLink": "Edytuj link",
-    "removeLink": "Usuń link"
+    "removeLink": "Usuń link",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "Nagłówek",

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -824,7 +824,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "Copiar link",
     "editLink": "Editar link",
-    "removeLink": "Remover link"
+    "removeLink": "Remover link",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "Cabeçalho",

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -827,7 +827,15 @@
     "urlPlaceholder": "https://ornek.com",
     "copyLink": "Bağlantıyı kopyala",
     "editLink": "Bağlantıyı düzenle",
-    "removeLink": "Bağlantıyı kaldır"
+    "removeLink": "Bağlantıyı kaldır",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "Üstbilgi",

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -824,7 +824,15 @@
     "urlPlaceholder": "https://example.com",
     "copyLink": "复制链接",
     "editLink": "编辑链接",
-    "removeLink": "删除链接"
+    "removeLink": "删除链接",
+    "apply": null,
+    "bookmarkTarget": null,
+    "cancel": null,
+    "editTitle": null,
+    "inertTarget": null,
+    "insertTitle": null,
+    "openLink": null,
+    "refused": null
   },
   "headerFooter": {
     "header": "页眉",

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -12,6 +12,7 @@ import { DocxEditorToolbar } from '../editor/toolbar';
 import { DocxEditorHorizontalRuler, DocxEditorVerticalRuler } from '../editor/DocxEditorRulers';
 import { DocxEditorDocumentOutline } from '../editor/DocxEditorOutline';
 import { DocxEditorPageSetupDialog } from '../editor/DocxEditorPageSetup';
+import { DocxEditorHyperLink } from '../editor/DocxEditorHyperLink';
 import { useTranslation } from '../i18n';
 import type { TranslationKey } from '../i18n';
 import type { DocxEditorProps, DocxEditorRef } from '../types';
@@ -116,6 +117,7 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
     onChange,
     onFontError,
     onSave,
+    hyperlinkPopup,
   } = props;
 
   // Chrome colour mode: 'system' subscribes to the OS setting. Only the chrome
@@ -148,12 +150,17 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
   // classes) around the primitive Content (the engine's mount point). Chrome-off
   // hosts get the caller's className on the viewport itself; chrome-on hosts theme
   // the viewport with `dark` and put the className on the chrome wrapper below.
+  // The link popover mounts INSIDE the viewport, so ordinary CSS keeps it attached to the
+  // page while the user scrolls — no scroll listener, no per-frame reposition. It renders
+  // nothing until a link click or Ctrl/Cmd+K opens it, and `hyperlinkPopup={false}` drops
+  // the packaged panel while leaving the engine's gestures wired for a host's own UI.
   const viewport = (
     <DocxEditorViewport
       className={chrome ? (isDark ? 'dark' : undefined) : className}
       style={chrome ? SCROLL_AREA_STYLE : undefined}
     >
       <DocxEditorContent />
+      <DocxEditorHyperLink hidden={hyperlinkPopup === false} />
     </DocxEditorViewport>
   );
 
@@ -250,6 +257,11 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<
   readonly DocumentOutline: typeof DocxEditorDocumentOutline;
   /** Page Setup dialog — size, orientation, margins — applied as one undo step. */
   readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
+  /**
+   * The link popover — target readout, copy, edit, unlink — and its parts. Mounted by
+   * default inside the viewport; `hyperlinkPopup={false}` removes it.
+   */
+  readonly HyperLink: typeof DocxEditorHyperLink;
 }
 
 export const DocxEditor: DocxEditorNamespace = Object.assign(DocxEditorImpl, {
@@ -262,4 +274,5 @@ export const DocxEditor: DocxEditorNamespace = Object.assign(DocxEditorImpl, {
   VerticalRuler: DocxEditorVerticalRuler,
   DocumentOutline: DocxEditorDocumentOutline,
   PageSetupDialog: DocxEditorPageSetupDialog,
+  HyperLink: DocxEditorHyperLink,
 });

--- a/packages/react/src/editor/DocxEditorHyperLink.tsx
+++ b/packages/react/src/editor/DocxEditorHyperLink.tsx
@@ -1,0 +1,566 @@
+// `DocxEditor.HyperLink` — the link popover, on the toolbar's customization ladder.
+//
+// The arrangement is Google Docs': click a link and a small panel appears under it with the
+// target and three actions (copy, edit, unlink); Ctrl/Cmd+K or the toolbar button opens the
+// same panel in edit mode with display-text and URL fields.
+//
+// CUSTOMIZATION LADDER, the same five rungs `DocxEditorToolbar` establishes:
+//
+//   1. `className` / `data-*`      restyle the default parts with CSS
+//   2. `icon`                      swap one part's glyph
+//   3. `asChild`                   merge a part's wiring onto your own element
+//   4. in-place part override      a `<HyperLink.Copy>` child replaces that slot;
+//                                  `hidden` removes it; `preset={false}` drops the defaults
+//   5. `useHyperlinkPopup()`       the raw hook, for a UI with nothing in common with this
+//
+// EVERY string is an i18n key and every colour a `--doc-*` token, so a consumer never has to
+// fork the component to translate or theme it. Test ids are stable and unlocalized
+// (`hyperlink-popup`, `-copy`, `-edit`, `-unlink`), because selecting on a `title` attribute
+// breaks the moment the locale changes.
+
+import {
+  Fragment,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { useTranslation } from '../i18n';
+import { HyperlinkPopupContext, type UseHyperlinkPopupResult } from './useHyperlinkPopup';
+import { Slot } from './toolbar/Slot';
+
+/** Keeps the caret: a mousedown that bubbles to the editor moves it. Inputs are exempt. */
+function guardMousedown(event: React.MouseEvent): void {
+  const tag = (event.target as HTMLElement | null)?.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  event.preventDefault();
+}
+
+/** Shared props for every part. @public */
+export interface HyperLinkPartProps {
+  className?: string;
+  /** Merge this part's wiring onto the single child element instead of the default one. */
+  asChild?: boolean;
+  /** Render nothing — inside the default arrangement this removes the part. */
+  hidden?: boolean;
+  children?: ReactNode;
+}
+
+/** Props for the action parts, which also take an icon. @public */
+export interface HyperLinkActionProps extends HyperLinkPartProps {
+  /** Icon override; falls back to `children`, then to the part's default glyph. */
+  icon?: ReactNode;
+}
+
+/** Props for `DocxEditor.HyperLink`. @public */
+export interface HyperLinkProps extends HyperLinkPartProps {
+  /**
+   * Render the packaged arrangement. `false` mounts only the popover shell and whatever
+   * parts you pass as children — the rung for "I want the wiring, not the layout".
+   */
+  preset?: boolean;
+}
+
+// Inline SVG, like the toolbar's icons: this package ships no icon font.
+const icon = (path: string): ReactNode => (
+  <svg viewBox="0 -960 960 960" width={16} height={16} aria-hidden="true" focusable="false">
+    <path d={path} fill="currentColor" />
+  </svg>
+);
+
+const COPY_ICON =
+  'M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z';
+const EDIT_ICON =
+  'M200-200h57l391-391-57-57-391 391v57Zm-80 80v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T817-647L290-120H120Zm640-584-56-56 56 56Zm-141 85-28-29 57 57-29-28Z';
+const UNLINK_ICON =
+  'M770-302 656-416l57-57 114 114-57 57ZM603-469 469-603l57-57 134 134-57 57ZM280-280h133v80H280q-83 0-141.5-58.5T80-400q0-83 58.5-141.5T280-600h133v80H280q-50 0-85 35t-35 85q0 50 35 85t85 35Zm40-80v-80h101l80 80H320Zm493-15-57-57q23-11 33.5-32t10.5-36q0-50-35-85t-85-35H547v-80h133q83 0 141.5 58.5T880-400q0 32-11 61.5T813-375ZM792-56 56-792l56-56 736 736-56 56Z';
+const OPEN_ICON =
+  'M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z';
+
+/**
+ * The popover panel.
+ *
+ * Positioned inside the VIEWPORT (the scroll container), so ordinary CSS keeps it attached to
+ * the page while the user scrolls — no scroll listener, no per-frame reposition. The
+ * coordinates the engine reports are viewport-relative, so they are converted against the
+ * container's own rect once, at open.
+ */
+function HyperLinkRoot({ className, asChild, hidden, children, preset = true }: HyperLinkProps) {
+  // The state is PROVIDED by `DocxEditor.Root`, not created here. The toolbar's link button
+  // is a sibling of this panel, not an ancestor of it, so a state owned by the panel would
+  // leave the button opening a popover nothing renders — and, worse, the button's own
+  // instance would win the engine's chrome registration.
+  const popup = useHyperlinkPopup();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const { state, close } = popup;
+
+  // Escape and an outside mousedown both dismiss. Bound only while open, so a closed
+  // popover costs nothing and cannot swallow a key the editor wants.
+  useEffect(() => {
+    if (state.mode === 'closed') return undefined;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      close();
+    };
+    const onMouseDown = (event: MouseEvent): void => {
+      const panel = panelRef.current;
+      if (panel && event.target instanceof Node && panel.contains(event.target)) return;
+      close();
+    };
+    // Capture phase for the mousedown: the surface prevents default on its own pointerdown,
+    // and a bubbling listener would never see a click that lands on the pages.
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onMouseDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onMouseDown, true);
+    };
+  }, [state.mode, close]);
+
+  // The engine reports VIEWPORT coordinates; the panel is an absolutely positioned child of
+  // the scroll container. Converting once at open — client rect plus the container's current
+  // scroll — is what makes ordinary CSS keep the panel attached to the page as it scrolls.
+  // Left in viewport coordinates with `position: fixed` it stayed pinned to the browser
+  // window while the link moved out from under it.
+  const [placement, setPlacement] = useState<CSSProperties | null>(null);
+  useLayoutEffect(() => {
+    const anchor = state.anchor;
+    const panel = panelRef.current;
+    if (!anchor || !panel) {
+      setPlacement(null);
+      return;
+    }
+    const container = panel.offsetParent as HTMLElement | null;
+    if (!container) {
+      setPlacement(null);
+      return;
+    }
+    const box = container.getBoundingClientRect();
+    const left = anchor.left - box.left + container.scrollLeft;
+    const top = anchor.top - box.top + container.scrollTop;
+    // Clamped horizontally so a link near the right edge does not push the panel off it.
+    const maxLeft = Math.max(0, container.scrollWidth - panel.offsetWidth);
+    setPlacement({ left: Math.max(0, Math.min(left, maxLeft)), top });
+  }, [state.anchor]);
+
+  const { t } = useTranslation();
+  const title =
+    state.mode === 'editing'
+      ? t(state.link ? 'hyperlinkPopup.editTitle' : 'hyperlinkPopup.insertTitle')
+      : t('hyperlinkPopup.editLink');
+
+  const body = preset ? <HyperLinkPreset>{children}</HyperLinkPreset> : children;
+
+  // `hidden` drops the packaged PANEL only. The engine's gestures stay wired (the Root owns
+  // that), so a host that hides this to render its own UI keeps Ctrl/Cmd+K and link clicks.
+  // Children still honour the open/closed state — returning them unconditionally rendered a
+  // bare `<HyperLink.Edit/>` permanently, since the parts have no mode check of their own.
+  if (hidden) return state.mode === 'closed' ? null : <>{children}</>;
+
+  const shared = {
+    ref: panelRef,
+    className: `docx-hyperlink-popup${className ? ` ${className}` : ''}`,
+    'data-testid': 'hyperlink-popup',
+    'data-mode': state.mode,
+    role: 'dialog' as const,
+    'aria-modal': false,
+    onMouseDown: guardMousedown,
+    // `position: absolute` comes from the stylesheet; only the offsets are inline, and only
+    // once the layout effect has converted them. Until then the panel is placed by flow,
+    // which is a frame of imprecision rather than a frame in the wrong place.
+    style: placement ?? undefined,
+    // Named for assistive tech: an unnamed dialog announces as "dialog" and nothing else.
+    'aria-label': title,
+  };
+
+  if (state.mode === 'closed') return null;
+  return asChild ? <Slot {...shared}>{children}</Slot> : <div {...shared}>{body}</div>;
+}
+
+/**
+ * The packaged arrangement, with in-place part override.
+ *
+ * A part passed as a child REPLACES the preset's copy of that part rather than appending to
+ * it — the toolbar's rule, so `<HyperLink.Unlink hidden />` removes the unlink action from
+ * the default panel instead of adding a second hidden one beside it.
+ */
+function HyperLinkPreset({ children }: { children?: ReactNode }) {
+  const { state } = useHyperlinkPopup();
+  const overrides = useMemo(() => partOverrides(children), [children]);
+  const take = (key: string, fallback: ReactNode): ReactNode =>
+    key in overrides ? overrides[key] : fallback;
+
+  if (state.mode === 'editing') {
+    return (
+      <>
+        {take('Fields', <HyperLinkFields />)}
+        {take('Error', <HyperLinkError />)}
+        <div className="docx-hyperlink-popup__actions">
+          {take('Apply', <HyperLinkApply />)}
+          {take('Cancel', <HyperLinkCancel />)}
+        </div>
+        {overrides.__extra}
+      </>
+    );
+  }
+  return (
+    <>
+      {take('Url', <HyperLinkUrl />)}
+      <div className="docx-hyperlink-popup__actions">
+        {take('Copy', <HyperLinkCopy />)}
+        {/* Editing actions are absent, not disabled, in a read-only document: a control
+            that can never do anything is chrome pretending to be a capability. */}
+        {state.canEdit ? take('Edit', <HyperLinkEdit />) : null}
+        {state.canEdit ? take('Unlink', <HyperLinkUnlink />) : null}
+      </div>
+      {overrides.__extra}
+    </>
+  );
+}
+
+/** Map a child's part marker to itself, so the preset can swap it in place. */
+function partOverrides(children: ReactNode): Record<string, ReactNode> {
+  const found: Record<string, ReactNode> = {};
+  const extra: ReactNode[] = [];
+  const visit = (node: ReactNode): void => {
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (!node || typeof node !== 'object' || !('type' in node)) {
+      if (node) extra.push(node);
+      return;
+    }
+    // A FRAGMENT is grouping, not content. Passing two overrides as `<><Copy/><Unlink/></>`
+    // is the natural way to write them, and treating the fragment as an unrecognised child
+    // put both INSIDE the panel while the preset still rendered its own copies of each —
+    // two copy buttons, and a `hidden` that removed nothing.
+    if (node.type === Fragment) {
+      visit((node.props as { children?: ReactNode }).children);
+      return;
+    }
+    const marker = (node.type as { docxHyperLinkPart?: string }).docxHyperLinkPart;
+    if (marker) found[marker] = node;
+    else extra.push(node);
+  };
+  visit(children);
+  if (extra.length > 0) found.__extra = extra;
+  return found;
+}
+
+/**
+ * The popover state the parts read.
+ *
+ * Parts always render inside `HyperLinkRoot`, which provides it. The inert stand-in is for
+ * a part rendered outside the compound by mistake: it should show nothing, not throw in the
+ * middle of someone's render.
+ */
+function useHyperlinkPopup(): UseHyperlinkPopupResult {
+  return useContext(HyperlinkPopupContext) ?? INERT_POPUP;
+}
+
+const INERT_POPUP: UseHyperlinkPopupResult = {
+  state: {
+    mode: 'closed',
+    link: null,
+    anchor: null,
+    text: '',
+    url: '',
+    copied: false,
+    error: false,
+    canEdit: false,
+  },
+  open: () => {},
+  openAtCaret: () => {},
+  close: () => {},
+  copy: async () => false,
+  beginEdit: () => {},
+  setText: () => {},
+  setUrl: () => {},
+  commitEdit: () => false,
+  unlink: () => false,
+  openTarget: () => false,
+};
+
+/** The target readout, and the action that follows it. @public */
+function HyperLinkUrl({ className, asChild, hidden, children }: HyperLinkPartProps) {
+  const { state, openTarget } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  if (hidden || !state.link) return null;
+  const inert = !state.link.href;
+  const internal = state.link.kind === 'internal';
+  const text = internal ? `#${state.link.anchor ?? ''}` : state.link.authored;
+  const hint = inert
+    ? t('hyperlinkPopup.inertTarget')
+    : internal
+      ? t('hyperlinkPopup.bookmarkTarget')
+      : t('hyperlinkPopup.openLink');
+  const shared = {
+    className: `docx-hyperlink-popup__url${className ? ` ${className}` : ''}`,
+    'data-testid': 'hyperlink-popup-url',
+    ...(inert ? { 'data-inert': '' } : {}),
+    title: hint,
+    onMouseDown: guardMousedown,
+    // An inert link is not a button: there is nothing behind it to press.
+    ...(inert ? {} : { onClick: () => openTarget(), type: 'button' as const }),
+  };
+  if (asChild) return <Slot {...shared}>{children}</Slot>;
+  if (inert) {
+    return (
+      <span {...shared}>
+        {children ?? text}
+        <span className="ep-sr-only">{hint}</span>
+      </span>
+    );
+  }
+  return (
+    <button {...shared}>
+      {children ?? text}
+      {icon(OPEN_ICON)}
+    </button>
+  );
+}
+HyperLinkUrl.docxHyperLinkPart = 'Url' as const;
+
+/** Copy the sanitized target to the clipboard. @public */
+function HyperLinkCopy({
+  className,
+  asChild,
+  hidden,
+  children,
+  icon: glyph,
+}: HyperLinkActionProps) {
+  const { state, copy } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  if (hidden || !state.link?.href) return null;
+  const label = state.copied ? t('editor.linkCopied') : t('hyperlinkPopup.copyLink');
+  const shared = {
+    type: 'button' as const,
+    className: `docx-hyperlink-popup__action${className ? ` ${className}` : ''}`,
+    'data-testid': 'hyperlink-popup-copy',
+    ...(state.copied ? { 'data-copied': '' } : {}),
+    'aria-label': label,
+    title: label,
+    onMouseDown: guardMousedown,
+    onClick: () => void copy(),
+  };
+  if (asChild) return <Slot {...shared}>{children}</Slot>;
+  return <button {...shared}>{glyph ?? children ?? icon(COPY_ICON)}</button>;
+}
+HyperLinkCopy.docxHyperLinkPart = 'Copy' as const;
+
+/** Switch the panel into edit mode. @public */
+function HyperLinkEdit({
+  className,
+  asChild,
+  hidden,
+  children,
+  icon: glyph,
+}: HyperLinkActionProps) {
+  const { beginEdit } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  if (hidden) return null;
+  const label = t('hyperlinkPopup.editLink');
+  const shared = {
+    type: 'button' as const,
+    className: `docx-hyperlink-popup__action${className ? ` ${className}` : ''}`,
+    'data-testid': 'hyperlink-popup-edit',
+    'aria-label': label,
+    title: label,
+    onMouseDown: guardMousedown,
+    onClick: () => beginEdit(),
+  };
+  if (asChild) return <Slot {...shared}>{children}</Slot>;
+  return <button {...shared}>{glyph ?? children ?? icon(EDIT_ICON)}</button>;
+}
+HyperLinkEdit.docxHyperLinkPart = 'Edit' as const;
+
+/** Remove the link, keeping its text. @public */
+function HyperLinkUnlink({
+  className,
+  asChild,
+  hidden,
+  children,
+  icon: glyph,
+}: HyperLinkActionProps) {
+  const { unlink } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  if (hidden) return null;
+  const label = t('hyperlinkPopup.removeLink');
+  const shared = {
+    type: 'button' as const,
+    className: `docx-hyperlink-popup__action${className ? ` ${className}` : ''}`,
+    'data-testid': 'hyperlink-popup-unlink',
+    'aria-label': label,
+    title: label,
+    onMouseDown: guardMousedown,
+    onClick: () => unlink(),
+  };
+  if (asChild) return <Slot {...shared}>{children}</Slot>;
+  return <button {...shared}>{glyph ?? children ?? icon(UNLINK_ICON)}</button>;
+}
+HyperLinkUnlink.docxHyperLinkPart = 'Unlink' as const;
+
+/** Display-text and URL fields. @public */
+function HyperLinkFields({ className, hidden }: HyperLinkPartProps) {
+  const { state, setText, setUrl, commitEdit, close } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  const urlRef = useRef<HTMLInputElement | null>(null);
+  const textId = useId();
+  const urlId = useId();
+
+  // Focus the URL field on open: it is the one field that always needs a value, and Word's
+  // dialog does the same. Guarded to edit mode so a re-render in reading mode cannot steal
+  // focus back from the document.
+  useEffect(() => {
+    if (state.mode !== 'editing') return;
+    // `preventScroll`: focusing an input scrolls its scroll container to reach it, and this
+    // input lives INSIDE the document's scroller. Whenever the panel had not been placed yet
+    // — or was placed near the edge — that scroll threw the reader to the top of the
+    // document, which is the opposite of what pressing Ctrl/Cmd+K asked for. The panel is
+    // already positioned at the caret; nothing needs the browser to go find it.
+    urlRef.current?.focus({ preventScroll: true });
+    urlRef.current?.select();
+  }, [state.mode]);
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        commitEdit();
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    },
+    [commitEdit, close]
+  );
+
+  if (hidden) return null;
+  return (
+    <div className={`docx-hyperlink-popup__fields${className ? ` ${className}` : ''}`}>
+      <label className="ep-sr-only" htmlFor={textId}>
+        {t('hyperlinkPopup.displayTextPlaceholder')}
+      </label>
+      <input
+        id={textId}
+        data-testid="hyperlink-popup-text"
+        className="docx-hyperlink-popup__input"
+        value={state.text}
+        placeholder={t('hyperlinkPopup.displayTextPlaceholder')}
+        onChange={(event) => setText(event.target.value)}
+        onKeyDown={onKeyDown}
+      />
+      <label className="ep-sr-only" htmlFor={urlId}>
+        {t('hyperlinkPopup.urlPlaceholder')}
+      </label>
+      <input
+        id={urlId}
+        ref={urlRef}
+        data-testid="hyperlink-popup-url-input"
+        className="docx-hyperlink-popup__input"
+        value={state.url}
+        placeholder={t('hyperlinkPopup.urlPlaceholder')}
+        onChange={(event) => setUrl(event.target.value)}
+        onKeyDown={onKeyDown}
+      />
+    </div>
+  );
+}
+HyperLinkFields.docxHyperLinkPart = 'Fields' as const;
+
+/** Commit the draft. @public */
+function HyperLinkApply({ className, asChild, hidden, children }: HyperLinkPartProps) {
+  const { state, commitEdit } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  if (hidden) return null;
+  const label = t('hyperlinkPopup.apply');
+  const shared = {
+    type: 'button' as const,
+    className: `docx-hyperlink-popup__apply${className ? ` ${className}` : ''}`,
+    'data-testid': 'hyperlink-popup-apply',
+    disabled: state.url.trim().length === 0,
+    onMouseDown: guardMousedown,
+    onClick: () => commitEdit(),
+  };
+  if (asChild) return <Slot {...shared}>{children}</Slot>;
+  return <button {...shared}>{children ?? label}</button>;
+}
+
+/**
+ * Why the last Apply did nothing.
+ *
+ * A refusal that closes nothing and says nothing is the worst of both: the panel sits open
+ * and the user re-presses the same button. The engine already knows the reason (a scheme it
+ * will not write, a selection spanning paragraphs, no text to link); this shows it.
+ */
+function HyperLinkError({ className, hidden }: HyperLinkPartProps) {
+  const { state } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  if (hidden || !state.error) return null;
+  return (
+    <div
+      className={`docx-hyperlink-popup__error${className ? ` ${className}` : ''}`}
+      data-testid="hyperlink-popup-error"
+      role="alert"
+    >
+      {t('hyperlinkPopup.refused')}
+    </div>
+  );
+}
+HyperLinkError.docxHyperLinkPart = 'Error' as const;
+HyperLinkApply.docxHyperLinkPart = 'Apply' as const;
+
+/** Dismiss without applying. @public */
+function HyperLinkCancel({ className, asChild, hidden, children }: HyperLinkPartProps) {
+  const { close } = useHyperlinkPopup();
+  const { t } = useTranslation();
+  if (hidden) return null;
+  const label = t('hyperlinkPopup.cancel');
+  const shared = {
+    type: 'button' as const,
+    className: `docx-hyperlink-popup__cancel${className ? ` ${className}` : ''}`,
+    'data-testid': 'hyperlink-popup-cancel',
+    onMouseDown: guardMousedown,
+    onClick: () => close(),
+  };
+  if (asChild) return <Slot {...shared}>{children}</Slot>;
+  return <button {...shared}>{children ?? label}</button>;
+}
+HyperLinkCancel.docxHyperLinkPart = 'Cancel' as const;
+
+/**
+ * The link popover compound.
+ *
+ * @public
+ */
+export interface DocxEditorHyperLinkNamespace {
+  (props: HyperLinkProps): ReturnType<typeof HyperLinkRoot>;
+  readonly Url: typeof HyperLinkUrl;
+  readonly Copy: typeof HyperLinkCopy;
+  readonly Edit: typeof HyperLinkEdit;
+  readonly Unlink: typeof HyperLinkUnlink;
+  readonly Fields: typeof HyperLinkFields;
+  readonly Error: typeof HyperLinkError;
+  readonly Apply: typeof HyperLinkApply;
+  readonly Cancel: typeof HyperLinkCancel;
+}
+
+export const DocxEditorHyperLink: DocxEditorHyperLinkNamespace = Object.assign(HyperLinkRoot, {
+  Url: HyperLinkUrl,
+  Copy: HyperLinkCopy,
+  Edit: HyperLinkEdit,
+  Unlink: HyperLinkUnlink,
+  Fields: HyperLinkFields,
+  Error: HyperLinkError,
+  Apply: HyperLinkApply,
+  Cancel: HyperLinkCancel,
+});

--- a/packages/react/src/editor/DocxEditorRoot.tsx
+++ b/packages/react/src/editor/DocxEditorRoot.tsx
@@ -27,6 +27,7 @@ import type {
   FontConfigurationFragment,
 } from '@docx-editor.dev/core-contract/editor';
 import { DocxEditorContext } from './context';
+import { HyperlinkPopupContext, useHyperlinkPopupInstance } from './useHyperlinkPopup';
 
 /**
  * Props for `DocxEditor.Root`. Creation parameters (`document`, `fonts`, `author`,
@@ -115,5 +116,21 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
     if (zoom !== undefined) editor?.setZoom(zoom);
   }, [editor, zoom]);
 
-  return <DocxEditorContext.Provider value={editor}>{children}</DocxEditorContext.Provider>;
+  return (
+    <DocxEditorContext.Provider value={editor}>
+      {/* ONE link-popover state per editor, published here so a TOOLBAR button and the
+          popover panel — which are siblings, not ancestor and descendant — see the same
+          open/closed state and only one of them registers with the engine's gestures. */}
+      <HyperlinkPopupProvider>{children}</HyperlinkPopupProvider>
+    </DocxEditorContext.Provider>
+  );
+}
+
+/**
+ * Publishes the popover state. A child of the editor context rather than part of `Root`
+ * itself, because it consumes that context and a component cannot read its own provider.
+ */
+function HyperlinkPopupProvider({ children }: { children?: ReactNode }) {
+  const popup = useHyperlinkPopupInstance(true);
+  return <HyperlinkPopupContext.Provider value={popup}>{children}</HyperlinkPopupContext.Provider>;
 }

--- a/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
+++ b/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
@@ -88,6 +88,10 @@ const SHAPED_PARTS: Partial<Record<ChromeSlotId, PartLike>> = {
   'font.size': ToolbarFontSize,
   'text.color': ToolbarFontColor,
   'text.highlight': ToolbarHighlight,
+  // Insert Link is icon-SHAPED but not command-driven: a link needs a target, so the press
+  // opens the popover instead of running the slot's command. Its enabled state still comes
+  // from the engine, like every other control.
+  'text.link': ToolbarLink,
   'list.lineSpacing': ToolbarLineSpacing,
   'review.editingMode': ToolbarEditingMode,
   'file.save': ToolbarSave,

--- a/packages/react/src/editor/toolbar/parts.tsx
+++ b/packages/react/src/editor/toolbar/parts.tsx
@@ -17,9 +17,15 @@
 //   (`styles.style` graduated to the live `ParagraphStyle` compound.)
 
 import { useContext } from 'react';
-import { CHROME_UNAVAILABLE_KEY, type ChromeSlotId } from '@docx-editor.dev/core-contract/editor';
+import {
+  CHROME_UNAVAILABLE_KEY,
+  chromeProbeForSlot,
+  type ChromeSlotId,
+} from '@docx-editor.dev/core-contract/editor';
 import { useDocxEditor } from '../context';
+import { useHyperlinkPopup } from '../useHyperlinkPopup';
 import { ToolbarContext, useToolbarLabel } from './toolbar-context';
+import { Slot } from './Slot';
 import {
   ToolbarButton,
   chromeControlForSlot,
@@ -62,7 +68,6 @@ export const ToolbarBold = definePart('text.bold');
 export const ToolbarItalic = definePart('text.italic');
 export const ToolbarUnderline = definePart('text.underline');
 export const ToolbarStrike = definePart('text.strike');
-export const ToolbarLink = definePart('text.link');
 export const ToolbarClearFormatting = definePart('format.clear');
 export const ToolbarSuperscript = definePart('script.super');
 export const ToolbarSubscript = definePart('script.sub');
@@ -78,6 +83,51 @@ export const ToolbarImageInsert = definePart('image.insert');
 export const ToolbarImageProperties = definePart('image.properties');
 export const ToolbarTableInsert = definePart('table.insert');
 export const ToolbarComments = definePart('review.comments');
+
+/**
+ * Insert Link.
+ *
+ * Enabled state comes from the engine like every other control — `text.link` is wired, and
+ * `toolbarCommandState` asks whether this selection could become a link. The CLICK does not
+ * run the command, because a link needs a target and only the popover can supply one; it
+ * opens the same panel Ctrl/Cmd+K opens, seeded from the link at the caret when there is one.
+ */
+function ToolbarLinkImpl({ className, hidden, icon, asChild, children }: ToolbarPartProps) {
+  const editor = useDocxEditor();
+  const { openAtCaret } = useHyperlinkPopup();
+  // Enabled state comes from the ENGINE, like every other control — but through a probe
+  // this part owns rather than through the shared command table. `text.link` is deliberately
+  // absent from `SLOT_COMMANDS`: putting it there would enable the control in every adapter,
+  // including one with no link UI, where an enabled button can only be refused.
+  const probe = chromeProbeForSlot('text.link');
+  const allowed = editor && probe ? editor.can(probe) : null;
+  const isEnabled = allowed?.ok === true;
+  const disabledReason = allowed && !allowed.ok ? allowed.reason : null;
+  const label = useToolbarLabel();
+  if (hidden) return null;
+  const control = chromeControlForSlot('text.link');
+  const text = label(control?.labelKey ?? 'text.link');
+  const shared = {
+    type: 'button' as const,
+    className: `docx-toolbar__button${className ? ` ${className}` : ''}`,
+    'data-slot': 'text.link',
+    disabled: !isEnabled,
+    ...(!isEnabled ? { 'data-disabled': '' } : {}),
+    'aria-label': text,
+    title: disabledReason ?? text,
+    onMouseDown: guardToolbarMousedown,
+    // Exactly what Ctrl/Cmd+K does — one behaviour, so the button and the shortcut cannot
+    // drift: edit mode pre-filled when the caret is in a link, a fresh insert seeded with
+    // the selected text otherwise, anchored at the caret either way.
+    onClick: () => openAtCaret(),
+  };
+  if (asChild) return <Slot {...shared}>{children}</Slot>;
+  return <button {...shared}>{icon ?? children ?? chromeIcon(control?.paths)}</button>;
+}
+
+export const ToolbarLink: ToolbarPartComponent = Object.assign(ToolbarLinkImpl, {
+  docxSlot: 'text.link' as ChromeSlotId,
+});
 
 /**
  * A disabled combobox-lookalike for a dropdown-shaped control the engine does not

--- a/packages/react/src/editor/useHyperlinkPopup.ts
+++ b/packages/react/src/editor/useHyperlinkPopup.ts
@@ -212,7 +212,10 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
     [editor]
   );
 
-  const close = useCallback(() => setState(CLOSED), []);
+  const close = useCallback(() => {
+    editor?.surface?.releaseSelection();
+    setState(CLOSED);
+  }, [editor]);
 
   /**
    * Open for the caret's own link, or for a new one — what Ctrl/Cmd+K and the toolbar
@@ -238,6 +241,11 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
       return;
     }
     const selected = editor?.query({ type: 'selectedText' }) ?? '';
+    // The text stays SELECTED while the panel is up. Focusing the URL field moves the
+    // browser's one selection into it, so without this the highlight the user is about to
+    // turn into a link vanishes exactly when they need to see it. The engine draws it on its
+    // own overlay and releases the pin when the caret leaves — which is what closes us below.
+    editor?.surface?.retainSelection();
     setState({
       mode: 'editing',
       link: null,
@@ -279,6 +287,24 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
     if (current.mode !== 'reading' || !current.link) return;
     const atCaret = editor?.surface?.hyperlinks.linkAtCaret() ?? null;
     if (atCaret && atCaret.id === current.link.id) return;
+    setState(CLOSED);
+  }, [snapshot, editor]);
+
+  // A CREATE panel closes when the caret leaves the range it is about to link.
+  //
+  // The same question as above — "is what the panel says still true" — asked of a panel that
+  // has no link yet: what it says is "these words are about to become a link", and clicking
+  // somewhere else makes that false. The engine owns the comparison (it releases the pin when
+  // the caret escapes, either edge counting as inside), so this reads a fact rather than
+  // recomputing document order in the adapter, and Vue gets the same rule from the same place.
+  //
+  // Only a panel that RETAINED something is governed by this: an edit panel opened on an
+  // existing link is covered by the effect above, and typing in the URL field moves no caret.
+  useEffect(() => {
+    const current = stateRef.current;
+    if (current.mode !== 'editing' || current.link) return;
+    const surface = editor?.surface;
+    if (!surface || surface.retainedSelection()) return;
     setState(CLOSED);
   }, [snapshot, editor]);
 
@@ -330,18 +356,20 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
       setState((previous) => ({ ...previous, error: true }));
       return false;
     }
-    setState(CLOSED);
+    // Through `close`, not a bare `setState`: applying must also drop the retained
+    // highlight, or the words stay lit over a link that already exists.
+    close();
     return true;
-  }, [editor]);
+  }, [editor, close]);
 
   const unlink = useCallback(() => {
     const hyperlinks = editor?.surface?.hyperlinks;
     const link = stateRef.current.link;
     if (!hyperlinks) return false;
     const removed = hyperlinks.removeHyperlink(link?.id);
-    if (removed) setState(CLOSED);
+    if (removed) close();
     return removed;
-  }, [editor]);
+  }, [editor, close]);
 
   const openTarget = useCallback(() => {
     const navigation = editor?.surface?.navigation;

--- a/packages/react/src/editor/useHyperlinkPopup.ts
+++ b/packages/react/src/editor/useHyperlinkPopup.ts
@@ -1,0 +1,392 @@
+// The hyperlink popover's behavior, UI-free.
+//
+// Everything `DocxEditor.HyperLink` does lives here, so a host that wants a completely
+// different link UI takes this hook and ignores the parts — the same shape `useFontFamily`
+// established for the font picker.
+//
+// The engine decides WHEN. A click on an external link and Ctrl/Cmd+K are gestures the
+// surface classifies (a drag that merely ended on a link is not a click on it), so this hook
+// registers with `setHyperlinkChrome` rather than binding listeners of its own. What it owns
+// is the popover's own state: open or closed, reading or editing, and where it sits.
+//
+// The engine decides WHAT IS SAFE. `href` is always the sanitized projection, and the only
+// path to opening one is `surface.navigation.openExternal` — the engine's single
+// `window.open` gate. Nothing here builds a URL.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { SurfaceHyperlink } from '@docx-editor.dev/core-contract/editor';
+import { useDocxEditor } from './context';
+import { useEditorState } from './useEditorState';
+import type { EditorSnapshot } from '@docx-editor.dev/core-contract/contracts/editor';
+
+/** Where the popover sits, in viewport coordinates. */
+export interface HyperlinkPopupAnchor {
+  readonly left: number;
+  readonly top: number;
+}
+
+/** What the popover is showing. @public */
+export type HyperlinkPopupMode =
+  /** Not shown. */
+  | 'closed'
+  /** An existing link: its target, plus copy / edit / unlink. */
+  | 'reading'
+  /** Text + URL fields, for a new link or a change to an existing one. */
+  | 'editing';
+
+/** The popover's observable state. @public */
+export interface HyperlinkPopupState {
+  readonly mode: HyperlinkPopupMode;
+  /** The link being read or edited, or null while inserting a new one. */
+  readonly link: SurfaceHyperlink | null;
+  /** Viewport position for the panel; null means "the host places it". */
+  readonly anchor: HyperlinkPopupAnchor | null;
+  /** Draft display text, in edit mode. */
+  readonly text: string;
+  /** Draft target, in edit mode. */
+  readonly url: string;
+  /** True after a copy, until the next state change — for a "Copied" confirmation. */
+  readonly copied: boolean;
+  /** True when the last Apply was refused, so the panel can say so instead of sitting there. */
+  readonly error: boolean;
+  /** Whether the document can be edited right now; read-only trims the actions. */
+  readonly canEdit: boolean;
+}
+
+/** What `useHyperlinkPopup` answers. @public */
+export interface UseHyperlinkPopupResult {
+  readonly state: HyperlinkPopupState;
+  /** Open in reading mode over a link, or in editing mode when there is none. */
+  open: (link?: SurfaceHyperlink | null, anchor?: HyperlinkPopupAnchor | null) => void;
+  /**
+   * Open insert-or-edit for the SELECTION — what Ctrl/Cmd+K and the toolbar's link button
+   * do. Anchors itself at the caret, seeds the display text from the selection, and opens
+   * edit mode pre-filled when the caret is already inside a link.
+   */
+  openAtCaret: () => void;
+  close: () => void;
+  /** Copy the sanitized target. Answers false when there is nothing safe to copy. */
+  copy: () => Promise<boolean>;
+  /** Switch to editing, seeded from the link at the caret. */
+  beginEdit: () => void;
+  setText: (text: string) => void;
+  setUrl: (url: string) => void;
+  /** Apply the draft. Answers false when the engine refused it (a bad scheme, no text). */
+  commitEdit: () => boolean;
+  /** Take the link off, keeping its text. */
+  unlink: () => boolean;
+  /**
+   * Open the target in a new tab, through the engine's single `window.open` gate. Answers
+   * false for an inert link — there is nothing to open, and this never invents a URL.
+   */
+  openTarget: () => boolean;
+}
+
+const CLOSED: HyperlinkPopupState = Object.freeze({
+  mode: 'closed' as const,
+  link: null,
+  anchor: null,
+  text: '',
+  url: '',
+  copied: false,
+  error: false,
+  canEdit: true,
+});
+
+const selectTick = (snapshot: EditorSnapshot) => snapshot;
+
+/**
+ * Where the caret is on screen, for anchoring a keyboard-opened panel.
+ *
+ * A click supplies its own rect; Ctrl/Cmd+K has none, and an UNANCHORED panel is not
+ * merely misplaced — it falls to the top of the scroll container, and focusing its URL
+ * input then scrolls the whole document up to reach it. So the keyboard path reads the
+ * caret's own rect.
+ *
+ * The surface mirrors its model selection into the DOM, so the browser's range is the
+ * engine's caret rather than a second opinion about where the caret is. A collapsed range
+ * can report a zero-size rect at the start of a line; the fallback is the containing
+ * element's box, and a total miss leaves the panel unanchored rather than mis-anchored.
+ */
+function caretViewportAnchor(): HyperlinkPopupAnchor | null {
+  const usable = (rect: DOMRect | undefined): rect is DOMRect =>
+    !!rect && (rect.width > 0 || rect.height > 0);
+
+  // FIRST the engine's OWN painted caret. It is the authoritative insertion point — the
+  // surface paints it from layout and suppresses the native one — so it has a real rect at
+  // an empty paragraph, at a line end, and everywhere the browser's range does not.
+  if (typeof document !== 'undefined') {
+    const painted = document.querySelector('[data-docx-caret]');
+    const rect = painted?.getBoundingClientRect();
+    if (usable(rect)) return { left: rect.left, top: rect.bottom };
+  }
+
+  // Then the browser's range, which the surface mirrors the model selection into.
+  const selection = typeof window === 'undefined' ? null : window.getSelection();
+  if (selection && selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+    if (usable(rect)) return { left: rect.left, top: rect.bottom };
+    const node = range.startContainer;
+    const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+    const fallback = element?.getBoundingClientRect();
+    if (usable(fallback)) return { left: fallback.left, top: fallback.bottom };
+  }
+
+  // Nothing measurable. The panel places itself by flow rather than at a made-up point —
+  // and, because its input focuses with `preventScroll`, that no longer moves the document.
+  return null;
+}
+
+/**
+ * ONE popover state per editor, published by `DocxEditor.HyperLink`.
+ *
+ * The compound and every consumer of the hook must see the SAME open/closed state, or a
+ * toolbar button and a mounted popover would each hold their own and only one of them would
+ * ever be showing.
+ */
+export const HyperlinkPopupContext = createContext<UseHyperlinkPopupResult | null>(null);
+
+/**
+ * The hyperlink popover's behavior.
+ *
+ * Inside a `DocxEditor.HyperLink` (which the packaged editor mounts by default) this is the
+ * SHARED state that compound is driving, so a custom toolbar button and the popover agree.
+ * Outside one it is a standalone instance that registers with the engine itself — a host
+ * building its own link UI from scratch needs nothing else.
+ *
+ * @public
+ */
+export function useHyperlinkPopup(): UseHyperlinkPopupResult {
+  const provided = useContext(HyperlinkPopupContext);
+  // Both hooks run every render, in the same order: `standalone` only decides whether the
+  // instance below registers with the engine, never whether it exists.
+  const own = useHyperlinkPopupInstance(provided === null);
+  return provided ?? own;
+}
+
+/**
+ * A popover instance. `active` gates ENGINE REGISTRATION only — an instance created inside
+ * a provider still exists, it just does not compete for the surface's chrome handlers.
+ *
+ * @public
+ */
+export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResult {
+  const editor = useDocxEditor();
+  const [state, setState] = useState<HyperlinkPopupState>(CLOSED);
+  // The engine's gestures fire from listeners registered ONCE; reading the live state
+  // through a ref keeps that registration off the render path, so opening the popover does
+  // not tear down and rebind the surface's chrome handlers.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  // The snapshot's identity is the engine's "something moved" signal. A committed edit, an
+  // undo or a caret move all invalidate what an open popover is describing.
+  const snapshot = useEditorState(selectTick);
+  const canEdit = editor ? editor.can({ type: 'insertText', text: '' }).ok : false;
+
+  const open = useCallback(
+    (link?: SurfaceHyperlink | null, anchor?: HyperlinkPopupAnchor | null) => {
+      setState({
+        // A link to read; nothing to read means the user is creating one.
+        mode: link ? 'reading' : 'editing',
+        link: link ?? null,
+        anchor: anchor ?? null,
+        text: link?.text ?? '',
+        // The AUTHORED target seeds the field, not the sanitized projection: the user is
+        // editing what the document says, and showing them a rewritten value would make an
+        // untouched save look like a change.
+        url: link ? (link.kind === 'internal' ? `#${link.anchor ?? ''}` : link.authored) : '',
+        copied: false,
+        error: false,
+        canEdit: editor ? editor.can({ type: 'insertText', text: '' }).ok : false,
+      });
+    },
+    [editor]
+  );
+
+  const close = useCallback(() => setState(CLOSED), []);
+
+  /**
+   * Open for the caret's own link, or for a new one — what Ctrl/Cmd+K and the toolbar
+   * button do. Reading mode when the caret is already inside a link (Word reopens the
+   * dialog on it), editing mode otherwise.
+   */
+  const openAtCaret = useCallback(() => {
+    const anchor = caretViewportAnchor();
+    const link = editor?.surface?.hyperlinks.linkAtCaret() ?? null;
+    if (link) {
+      // Ctrl+K on an existing link goes straight to EDIT — the user pressed the key to
+      // change it, and making them press Edit as well is a step for nothing.
+      setState({
+        mode: 'editing',
+        link,
+        anchor,
+        text: link.text,
+        url: link.kind === 'internal' ? `#${link.anchor ?? ''}` : link.authored,
+        copied: false,
+        error: false,
+        canEdit: editor ? editor.can({ type: 'insertText', text: '' }).ok : false,
+      });
+      return;
+    }
+    const selected = editor?.query({ type: 'selectedText' }) ?? '';
+    setState({
+      mode: 'editing',
+      link: null,
+      anchor,
+      text: selected,
+      url: '',
+      copied: false,
+      error: false,
+      canEdit: editor ? editor.can({ type: 'insertText', text: '' }).ok : false,
+    });
+  }, [editor]);
+
+  // Register with the engine: a plain click on an external link opens the popover under it,
+  // Ctrl/Cmd+K opens insert-or-edit. The cleanup restores whatever was registered before, so
+  // nested hosts unwind in order.
+  useEffect(() => {
+    if (!editor || !active) return undefined;
+    return editor.setHyperlinkChrome({
+      onPopover: (activation) =>
+        open(activation.link, { left: activation.rect.left, top: activation.rect.bottom }),
+      onRequest: openAtCaret,
+    });
+  }, [editor, active, open, openAtCaret]);
+
+  // Dismiss when the CARET LEAVES the link the panel is describing — not on any state tick.
+  //
+  // "Something moved" is the wrong question, and asking it made the popover unusable: a
+  // click on a link queues a `selectionchange`, the surface adopts it a turn later, and that
+  // tick landed after the panel had opened and closed it again. The panel appeared and
+  // vanished on every click, and only a synthetic click (which skips the pointer path) ever
+  // seemed to work.
+  //
+  // The honest question is whether what the panel SAYS is still true. It is exactly as
+  // strict — an edit that removes the link, or a caret that moves out of it, still closes
+  // the panel — and it is immune to ticks that change nothing it shows. Editing mode is
+  // exempt: the user is mid-keystroke there, and the commit itself moves the caret.
+  useEffect(() => {
+    const current = stateRef.current;
+    if (current.mode !== 'reading' || !current.link) return;
+    const atCaret = editor?.surface?.hyperlinks.linkAtCaret() ?? null;
+    if (atCaret && atCaret.id === current.link.id) return;
+    setState(CLOSED);
+  }, [snapshot, editor]);
+
+  const copy = useCallback(async () => {
+    const href = stateRef.current.link?.href;
+    if (!href) return false;
+    try {
+      await navigator.clipboard.writeText(href);
+    } catch {
+      // A denied clipboard permission is not an error worth throwing at a user who clicked
+      // a copy button; the confirmation simply does not appear.
+      return false;
+    }
+    setState((previous) => ({ ...previous, copied: true }));
+    return true;
+  }, []);
+
+  const beginEdit = useCallback(() => {
+    setState((previous) => ({ ...previous, mode: 'editing', copied: false, error: false }));
+  }, []);
+
+  const setText = useCallback((text: string) => {
+    setState((previous) => ({ ...previous, text, copied: false, error: false }));
+  }, []);
+
+  const setUrl = useCallback((url: string) => {
+    setState((previous) => ({ ...previous, url, copied: false, error: false }));
+  }, []);
+
+  const commitEdit = useCallback(() => {
+    const current = stateRef.current;
+    const hyperlinks = editor?.surface?.hyperlinks;
+    if (!hyperlinks) return false;
+    const url = current.url.trim();
+    if (url.length === 0) {
+      setState((previous) => ({ ...previous, error: true }));
+      return false;
+    }
+    // `#name` is a bookmark in this document; anything else goes through the package's URL
+    // allowlist, which refuses what `sanitizeHref` refuses.
+    const internal = url.startsWith('#');
+    const applied = hyperlinks.applyHyperlink({
+      ...(internal ? { anchor: url.slice(1) } : { url }),
+      ...(current.text.trim().length > 0 ? { text: current.text } : {}),
+    });
+    if (!applied) {
+      // The engine refused: a scheme it will not write, a selection spanning paragraphs, or
+      // nothing to link. Stay open so the value can be corrected, and SAY so.
+      setState((previous) => ({ ...previous, error: true }));
+      return false;
+    }
+    setState(CLOSED);
+    return true;
+  }, [editor]);
+
+  const unlink = useCallback(() => {
+    const hyperlinks = editor?.surface?.hyperlinks;
+    const link = stateRef.current.link;
+    if (!hyperlinks) return false;
+    const removed = hyperlinks.removeHyperlink(link?.id);
+    if (removed) setState(CLOSED);
+    return removed;
+  }, [editor]);
+
+  const openTarget = useCallback(() => {
+    const navigation = editor?.surface?.navigation;
+    const link = stateRef.current.link;
+    if (!navigation || !link) return false;
+    // Internal links are a scroll, not a tab.
+    if (link.kind === 'internal') {
+      const jumped = link.anchor ? navigation.goToBookmark(link.anchor) : false;
+      if (jumped) setState(CLOSED);
+      return jumped;
+    }
+    // THE gate. `link.href` is the sanitized projection; an inert link carries null and is
+    // refused inside `openExternal` regardless of what is asked here.
+    const opened = navigation.openExternal(link.href);
+    if (opened) setState(CLOSED);
+    return opened;
+  }, [editor]);
+
+  return useMemo(
+    () => ({
+      state: state.mode === 'closed' ? CLOSED : { ...state, canEdit },
+      open,
+      openAtCaret,
+      close,
+      copy,
+      beginEdit,
+      setText,
+      setUrl,
+      commitEdit,
+      unlink,
+      openTarget,
+    }),
+    [
+      state,
+      canEdit,
+      open,
+      openAtCaret,
+      close,
+      copy,
+      beginEdit,
+      setText,
+      setUrl,
+      commitEdit,
+      unlink,
+      openTarget,
+    ]
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -43,6 +43,23 @@ export {
   DocxEditorPageSetupDialog,
   type DocxEditorPageSetupDialogProps,
 } from './editor/DocxEditorPageSetup';
+// The link popover (also reachable as `DocxEditor.HyperLink`) and its headless hook. The
+// parts live on the namespace statics; a host that wants a different panel takes the hook.
+export {
+  DocxEditorHyperLink,
+  type DocxEditorHyperLinkNamespace,
+  type HyperLinkActionProps,
+  type HyperLinkPartProps,
+  type HyperLinkProps,
+} from './editor/DocxEditorHyperLink';
+export {
+  useHyperlinkPopup,
+  useHyperlinkPopupInstance,
+  type HyperlinkPopupAnchor,
+  type HyperlinkPopupMode,
+  type HyperlinkPopupState,
+  type UseHyperlinkPopupResult,
+} from './editor/useHyperlinkPopup';
 export { useEditorState } from './editor/useEditorState';
 export { useEditorCommand, type EditorCommandState } from './editor/useEditorCommand';
 export { useEditorEvent } from './editor/useEditorEvent';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -74,6 +74,14 @@ export interface DocxEditorProps {
   onTitleChange?: (title: string) => void;
   /** Save handler for the chrome's save control. Runs `Editor.save()` at the host. */
   onSave?: () => void;
+  /**
+   * Render the packaged hyperlink popover (`false` removes it).
+   *
+   * The engine's link GESTURES stay wired either way — a click on a link and Ctrl/Cmd+K
+   * still reach `useHyperlinkPopup()` — so a host that turns this off to render its own
+   * panel loses the packaged UI and nothing else.
+   */
+  hyperlinkPopup?: boolean;
   /** A document to load: DOCX bytes or an existing handle. */
   document?: DocumentSource;
   /** 'edit' (default) or 'view' (read-only). Applied at mount only — not reactive; remount to change. */

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -192,7 +192,9 @@ describe('useEditorCommand', () => {
     let binding: EditorCommandState | null = null;
     let instance: DocxEditorInstance | null = null;
     function Probe() {
-      binding = useEditorCommand('text.link');
+      // `review.comments` has no command and no probe. (`text.link` used to be the
+      // example here; it is now chrome-driven, so it enables through the engine.)
+      binding = useEditorCommand('review.comments');
       return null;
     }
     render(

--- a/packages/react/test/hyperlink-popup.test.tsx
+++ b/packages/react/test/hyperlink-popup.test.tsx
@@ -1,0 +1,343 @@
+// DocxEditor.HyperLink against the REAL engine.
+//
+// The popover is chrome over an engine that already decides everything that matters: which
+// gestures mean "show the link UI", what a safe target is, and what a link edit does to the
+// document. These tests drive it the way a user does — click a link, press Ctrl/Cmd+K, type
+// a URL — and check the document, not the markup.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { zipSync, strToU8 } from 'fflate';
+import type { DocxEditorInstance } from '@docx-editor.dev/core-contract/editor';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorHyperLink } from '../src/editor/DocxEditorHyperLink.tsx';
+import { DocxEditorToolbar } from '../src/editor/toolbar/index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string, rels = ''): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(`<Relationships xmlns="${REL}">${rels}</Relationships>`),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const EXTERNAL_REL = `<Relationship Id="rId9" Type="${R}/hyperlink" Target="https://example.com" TargetMode="External"/>`;
+const LINKED = docx(
+  `<w:p><w:r><w:t>Visit </w:t></w:r>` +
+    `<w:hyperlink r:id="rId9"><w:r><w:t>Example</w:t></w:r></w:hyperlink>` +
+    `<w:r><w:t> today</w:t></w:r></w:p>`,
+  EXTERNAL_REL
+);
+const PLAIN = docx('<w:p><w:r><w:t>Visit example today</w:t></w:r></w:p>');
+const PID = '/word/document.xml#0.0.0';
+
+interface Mounted {
+  readonly view: ReturnType<typeof render>;
+  editor(): DocxEditorInstance;
+}
+
+function mount(source: Uint8Array, children?: React.ReactNode): Mounted {
+  let instance: DocxEditorInstance | null = null;
+  const view = render(
+    <DocxEditorRoot
+      document={source}
+      onReady={(editor) => {
+        instance = editor as DocxEditorInstance;
+      }}
+    >
+      <DocxEditorToolbar />
+      <DocxEditorViewport>
+        <DocxEditorContent />
+        <DocxEditorHyperLink>{children}</DocxEditorHyperLink>
+      </DocxEditorViewport>
+    </DocxEditorRoot>
+  );
+  return { view, editor: () => instance! };
+}
+
+function caret(mounted: Mounted, offset: number): void {
+  act(() => {
+    mounted.editor().surface!.setSelection({
+      anchor: { paragraphId: PID, offset },
+      head: { paragraphId: PID, offset },
+    });
+  });
+}
+
+function select(mounted: Mounted, start: number, end: number): void {
+  act(() => {
+    mounted.editor().surface!.setSelection({
+      anchor: { paragraphId: PID, offset: start },
+      head: { paragraphId: PID, offset: end },
+    });
+  });
+}
+
+/** Click the painted anchor whose text is `text`. */
+function clickLink(mounted: Mounted, text: string): void {
+  const anchors = [...mounted.view.container.querySelectorAll('a.docx-hyperlink')];
+  const anchor = anchors.find((element) => element.textContent === text);
+  if (!anchor) throw new Error(`no painted link ${JSON.stringify(text)}`);
+  act(() => {
+    fireEvent.click(anchor);
+  });
+}
+
+/** Press Ctrl/Cmd+K on the pages layer, the way the surface receives it. */
+function pressCommandK(mounted: Mounted): void {
+  const pages = mounted.view.container.querySelector('.docx-pages');
+  if (!pages) throw new Error('no pages layer');
+  act(() => {
+    fireEvent.keyDown(pages, { key: 'k', metaKey: true });
+  });
+}
+
+const bodyText = (mounted: Mounted): string => mounted.editor().surface!.session.bodyText();
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DocxEditor.HyperLink', () => {
+  test('is not rendered until a gesture opens it', () => {
+    const mounted = mount(LINKED);
+    expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
+  });
+
+  test('a click on a link opens the popover showing the target', () => {
+    const mounted = mount(LINKED);
+    caret(mounted, 8);
+    clickLink(mounted, 'Example');
+    const panel = mounted.view.getByTestId('hyperlink-popup');
+    expect(panel.dataset.mode).toBe('reading');
+    expect(mounted.view.getByTestId('hyperlink-popup-url').textContent).toContain(
+      'https://example.com'
+    );
+    // The Google-Docs three: copy, edit, unlink.
+    expect(mounted.view.getByTestId('hyperlink-popup-copy')).toBeTruthy();
+    expect(mounted.view.getByTestId('hyperlink-popup-edit')).toBeTruthy();
+    expect(mounted.view.getByTestId('hyperlink-popup-unlink')).toBeTruthy();
+  });
+
+  test('the host page never navigates when a link is clicked', () => {
+    const mounted = mount(LINKED);
+    caret(mounted, 8);
+    const anchor = [...mounted.view.container.querySelectorAll('a.docx-hyperlink')].find(
+      (element) => element.textContent === 'Example'
+    )!;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    act(() => {
+      anchor.dispatchEvent(event);
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('Escape dismisses it', () => {
+    const mounted = mount(LINKED);
+    caret(mounted, 8);
+    clickLink(mounted, 'Example');
+    expect(mounted.view.queryByTestId('hyperlink-popup')).not.toBeNull();
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
+  });
+
+  test('a mousedown outside dismisses it', () => {
+    const mounted = mount(LINKED);
+    caret(mounted, 8);
+    clickLink(mounted, 'Example');
+    act(() => {
+      fireEvent.mouseDown(document.body);
+    });
+    expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
+  });
+
+  test('unlink keeps the text and removes the link', () => {
+    const mounted = mount(LINKED);
+    caret(mounted, 8);
+    clickLink(mounted, 'Example');
+    act(() => {
+      fireEvent.click(mounted.view.getByTestId('hyperlink-popup-unlink'));
+    });
+    expect(bodyText(mounted)).toBe('Visit Example today');
+    expect(mounted.view.container.querySelectorAll('a.docx-hyperlink')).toHaveLength(0);
+    // Its own job done, the panel closes.
+    expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
+  });
+
+  test('edit mode seeds from the link and applies a new target', () => {
+    const mounted = mount(LINKED);
+    caret(mounted, 8);
+    clickLink(mounted, 'Example');
+    act(() => {
+      fireEvent.click(mounted.view.getByTestId('hyperlink-popup-edit'));
+    });
+    const url = mounted.view.getByTestId('hyperlink-popup-url-input') as HTMLInputElement;
+    const text = mounted.view.getByTestId('hyperlink-popup-text') as HTMLInputElement;
+    expect(url.value).toBe('https://example.com');
+    expect(text.value).toBe('Example');
+
+    act(() => {
+      fireEvent.change(url, { target: { value: 'https://example.org' } });
+    });
+    act(() => {
+      fireEvent.click(mounted.view.getByTestId('hyperlink-popup-apply'));
+    });
+    caret(mounted, 8);
+    expect(mounted.editor().surface!.hyperlinks.linkAtCaret()?.href).toBe('https://example.org');
+    expect(bodyText(mounted)).toBe('Visit Example today');
+  });
+
+  test('the URL input is typeable and Enter applies', () => {
+    const mounted = mount(PLAIN);
+    select(mounted, 6, 13);
+    pressCommandK(mounted);
+    const url = mounted.view.getByTestId('hyperlink-popup-url-input') as HTMLInputElement;
+    act(() => {
+      fireEvent.change(url, { target: { value: 'https://typed.example' } });
+    });
+    expect(url.value).toBe('https://typed.example');
+    act(() => {
+      fireEvent.keyDown(url, { key: 'Enter' });
+    });
+    caret(mounted, 8);
+    expect(mounted.editor().surface!.hyperlinks.linkAtCaret()?.href).toBe('https://typed.example');
+  });
+
+  test('a refused scheme is not applied and the document is untouched', () => {
+    const mounted = mount(PLAIN);
+    select(mounted, 6, 13);
+    pressCommandK(mounted);
+    const url = mounted.view.getByTestId('hyperlink-popup-url-input') as HTMLInputElement;
+    act(() => {
+      fireEvent.change(url, { target: { value: 'javascript:alert(1)' } });
+    });
+    act(() => {
+      fireEvent.click(mounted.view.getByTestId('hyperlink-popup-apply'));
+    });
+    expect(bodyText(mounted)).toBe('Visit example today');
+    expect(mounted.view.container.querySelectorAll('a.docx-hyperlink')).toHaveLength(0);
+    // Still open, so the user can correct the value rather than wondering what happened.
+    expect(mounted.view.queryByTestId('hyperlink-popup')).not.toBeNull();
+  });
+
+  test('an inert link shows its target with nothing to press', () => {
+    const mounted = mount(
+      docx(
+        `<w:p><w:hyperlink r:id="rId9"><w:r><w:t>Click</w:t></w:r></w:hyperlink></w:p>`,
+        `<Relationship Id="rId9" Type="${R}/hyperlink" Target="javascript:alert(1)" TargetMode="External"/>`
+      )
+    );
+    caret(mounted, 2);
+    clickLink(mounted, 'Click');
+    const readout = mounted.view.getByTestId('hyperlink-popup-url');
+    expect(readout.hasAttribute('data-inert')).toBe(true);
+    expect(readout.tagName).toBe('SPAN');
+    // Copy needs a safe target; there is none.
+    expect(mounted.view.queryByTestId('hyperlink-popup-copy')).toBeNull();
+  });
+});
+
+describe('Ctrl/Cmd+K', () => {
+  test('opens edit mode over the selection', () => {
+    const mounted = mount(PLAIN);
+    select(mounted, 6, 13);
+    pressCommandK(mounted);
+    const panel = mounted.view.getByTestId('hyperlink-popup');
+    expect(panel.dataset.mode).toBe('editing');
+    // Seeded with the selected text, so the user only has to supply the URL.
+    expect((mounted.view.getByTestId('hyperlink-popup-text') as HTMLInputElement).value).toBe(
+      'example'
+    );
+  });
+
+  test('on an existing link it opens edit pre-filled', () => {
+    const mounted = mount(LINKED);
+    caret(mounted, 8);
+    pressCommandK(mounted);
+    expect(mounted.view.getByTestId('hyperlink-popup').dataset.mode).toBe('editing');
+    expect((mounted.view.getByTestId('hyperlink-popup-url-input') as HTMLInputElement).value).toBe(
+      'https://example.com'
+    );
+    expect((mounted.view.getByTestId('hyperlink-popup-text') as HTMLInputElement).value).toBe(
+      'Example'
+    );
+  });
+});
+
+describe('the toolbar link control', () => {
+  test('is enabled, and opens the popover rather than running a bare command', () => {
+    const mounted = mount(PLAIN);
+    select(mounted, 6, 13);
+    const button = mounted.view.container.querySelector(
+      '[data-slot="text.link"]'
+    ) as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    expect(button.disabled).toBe(false);
+    act(() => {
+      fireEvent.click(button);
+    });
+    expect(mounted.view.getByTestId('hyperlink-popup').dataset.mode).toBe('editing');
+    // No link was created by the press itself — a link needs a target.
+    expect(bodyText(mounted)).toBe('Visit example today');
+  });
+});
+
+describe('the customization ladder', () => {
+  test('a part child replaces its slot in place, and `hidden` removes it', () => {
+    const mounted = mount(
+      LINKED,
+      <>
+        <DocxEditorHyperLink.Copy className="my-copy" />
+        <DocxEditorHyperLink.Unlink hidden />
+      </>
+    );
+    caret(mounted, 8);
+    clickLink(mounted, 'Example');
+    // The consumer's class landed, and there is still exactly ONE copy button.
+    const copies = mounted.view.container.querySelectorAll('[data-testid="hyperlink-popup-copy"]');
+    expect(copies).toHaveLength(1);
+    expect(copies[0]!.className).toContain('my-copy');
+    // Unlink is gone, and edit — which the consumer did not name — is untouched.
+    expect(mounted.view.queryByTestId('hyperlink-popup-unlink')).toBeNull();
+    expect(mounted.view.queryByTestId('hyperlink-popup-edit')).not.toBeNull();
+  });
+
+  test('a custom icon replaces the glyph without changing the wiring', () => {
+    const mounted = mount(
+      LINKED,
+      <DocxEditorHyperLink.Unlink icon={<span data-testid="my-glyph">x</span>} />
+    );
+    caret(mounted, 8);
+    clickLink(mounted, 'Example');
+    expect(mounted.view.getByTestId('my-glyph')).toBeTruthy();
+    act(() => {
+      fireEvent.click(mounted.view.getByTestId('hyperlink-popup-unlink'));
+    });
+    expect(mounted.view.container.querySelectorAll('a.docx-hyperlink')).toHaveLength(0);
+  });
+});

--- a/packages/react/test/toolbar-composition.test.tsx
+++ b/packages/react/test/toolbar-composition.test.tsx
@@ -652,7 +652,9 @@ describe('enabled state is the engine answer, not a registry constant', () => {
 
   test('a slot with no command is dead with the engine reason, inside the default bar', () => {
     const { view } = mountToolbar(<DocxEditorToolbar />);
-    for (const slot of ['text.link', 'script.super', 'script.sub', 'format.clear']) {
+    // `text.link` is deliberately absent: it graduated to a chrome-driven slot (enabled
+    // by the engine, dispatched by the popover), so it is no longer an example of one.
+    for (const slot of ['script.super', 'script.sub', 'format.clear']) {
       const button = view.container.querySelector(`[data-slot="${slot}"]`) as HTMLButtonElement;
       expect(button.disabled, slot).toBe(true);
       expect(button.title, slot).toBe('not wired to an editor command');

--- a/packages/vue/test/toolbar-engine-state.test.ts
+++ b/packages/vue/test/toolbar-engine-state.test.ts
@@ -155,7 +155,9 @@ describe('the Vue toolbar reads enabled state from the engine', () => {
     // Not wired in the shared command table: the control is visible, disabled, and says
     // WHY in the engine's own words — never an adapter paraphrase, never a claim that
     // the capability is missing when only the wiring is.
-    for (const id of ['text.link', 'script.super', 'script.sub', 'format.clear']) {
+    // `text.link` is deliberately absent: it graduated to a chrome-driven slot, so it is
+    // enabled in both adapters now — Vue's press reports what is missing (a target).
+    for (const id of ['script.super', 'script.sub', 'format.clear']) {
       const button = slot(toolbar, id) as HTMLButtonElement;
       expect(button.disabled, id).toBe(true);
       expect(button.title, id).toBe('not wired to an editor command');

--- a/scripts/check-editor-contract.mjs
+++ b/scripts/check-editor-contract.mjs
@@ -37,6 +37,13 @@ const REACT_PROPS_NOT_YET_IN_VUE = new Set([
   'title',
   'onTitleChange',
   'onSave',
+  // The link popover is part of the provider/hooks layer, which landed React-first: it is
+  // a context-backed hook plus a compound over it, and its Vue twin is the composable form
+  // that lands with the rest of that layer. The ENGINE half is already shared — typed
+  // links, sanitization, click classification, bookmark jumps, the ops, and Vue's
+  // `text.link` enabled state all come from core — so this gap is the panel, not the
+  // capability. Removed when the Vue provider/hooks twin lands.
+  'hyperlinkPopup',
 ]);
 
 function extractInterfaceBody(source, name) {

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -12,19 +12,20 @@
       "zoom"
     ],
     "deferredInVue": {
-      "className": "React takes an explicit className prop. Vue applies `class` as a native fallthrough attribute, so it is not a declared prop \u2014 the capability exists on both, the declaration only on React.",
+      "className": "React takes an explicit className prop. Vue applies `class` as a native fallthrough attribute, so it is not a declared prop — the capability exists on both, the declaration only on React.",
       "onChange": "React takes a callback prop. Vue exposes the same signal as a `change` EMIT, which is the idiomatic Vue form and does not appear in DocxEditorProps.",
       "onReady": "React takes a callback prop. Vue exposes the same signal as a `ready` EMIT.",
       "t": "M6V.1 chrome: React resolves chrome labels through this, defaulting to the bundled English catalogue. Vue's chrome port is task 10V.1, which MUST remove this entry.",
       "title": "M6V.1 chrome title. Deferred to 10V.1 with `t`.",
       "onTitleChange": "M6V.1 chrome title editing. Deferred to 10V.1 with `t`.",
       "onSave": "M6V.1 chrome save control. Deferred to 10V.1 with `t`.",
-      "chrome": "M6V.1 chrome toggle: React renders the packaged title bar + toolbar by default and `chrome={false}` opts out. Deferred to 10V.1 with `t`."
+      "chrome": "M6V.1 chrome toggle: React renders the packaged title bar + toolbar by default and `chrome={false}` opts out. Deferred to 10V.1 with `t`.",
+      "hyperlinkPopup": "The packaged link popover, part of the React-first provider/hooks layer: a context-backed hook plus a compound over it, whose Vue twin lands with the rest of that layer. The ENGINE half is already shared — typed links, the sanitized target projection, click classification, bookmark jumps, the insert/edit/unlink ops and hyperlinkAt all live in core, and Vue's `text.link` control enables from the same toolbarCommandState React's does — so this defers the panel, not the capability."
     },
     "vueExclusive": {}
   },
   "ref": {
-    "comment": "Greenfield DocxEditorRef is the SAME interface on both adapters \u2014 every member is declared directly on each side, so nothing is inherited and pairedViaInheritance is empty. Vue used to declare it as `type DocxEditorRef = EditorRefLike & { ... }`; it is now a plain interface matching React, which is stricter parity, not looser.",
+    "comment": "Greenfield DocxEditorRef is the SAME interface on both adapters — every member is declared directly on each side, so nothing is inherited and pairedViaInheritance is empty. Vue used to declare it as `type DocxEditorRef = EditorRefLike & { ... }`; it is now a plain interface matching React, which is stricter parity, not looser.",
     "paired": [
       "exec",
       "focus",


### PR DESCRIPTION
Link text is measured, painted and selectable instead of dropped: `w:hyperlink` and the bookmark markers are typed canonical nodes. Adds insert/retarget/unlink ops, the popover and Cmd+K in React, and bookmark navigation that resolves through the layout so it reaches pages the engine has not painted.

Targets are allowlisted at the bounded parse boundary and an external target must be absolute; anything else renders inert and still round-trips. `window.open` has one call site, which only ever sees the sanitized projection.

Two defects surfaced while building it, both fixed here with regression tests:

- Range run-formatting skipped a `w:hyperlink` without advancing past its characters, so every run after a link was addressed at the wrong offset — colouring a link wrote the *following* run's properties over its text, one character short. Nothing was added or lost, so no census, digest or fingerprint guard could see it. Formatting now descends exactly where `segmentsOf` does.
- `OoxmlHyperlinkNode`'s child union excluded a nested link that the reader in fact keeps typed. `CT_Hyperlink`'s content model is `EG_PContent` (ECMA-376 §17.16.22), which lists `w:hyperlink` among its members, so nesting is schema-legal; demoting the inner one would stop its runs painting.

`§17.16.22` declares six attributes. Three are modeled (`r:id`, `w:anchor`, `w:tooltip`); `w:tgtFrame`, `w:docLocation` and `w:history` are preserved but never interpreted, which is now stated as a requirement rather than left to the general preservation guarantee — `w:docLocation` names a location inside the target, so dropping it on a retarget would silently move the link.

Lossless editing is asserted against the real fixture: seven link edits, each saved and reopened, checked for element-census losses across every part, per-paragraph text, bookmark identity, relationship targets, and a digest that differs in at most one paragraph.

## Retained selection

A document has one selection, so focusing the panel's URL field moved it into that input and the highlighted words stopped looking highlighted — at the moment the panel was asking what they should link to. The surface now pins the range and draws it on its own overlay, which survives the focus move; the model selection is untouched, so the op still addresses the same characters.

The pin releases when the caret leaves the range, either edge counting as inside, so clicking within your own selection keeps the panel open. That rule lives in `PaginatedSurface` (`retainSelection`/`releaseSelection`/`retainedSelection`) rather than in an adapter, so "clicked somewhere else" has one definition instead of one per adapter.