### PR TITLE
fix(core): sit tabbed text on its own baseline, and follow a resized viewport

### DIFF
--- a/.changeset/tab-line-baseline-and-viewport-resize.md
+++ b/.changeset/tab-line-baseline-and-viewport-resize.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Put text on a tabbed line back on its published baseline, so dot leaders sit level with the words they trail instead of floating above them. Also rebuild the pages a viewport uncovers when it is resized, not only when it is scrolled.

--- a/packages/core/src/editor/__tests__/paginated-surface.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface.test.ts
@@ -723,6 +723,69 @@ describe('only the pages on screen are built (task 9.4)', () => {
     surface.destroy();
     scroller.remove();
   });
+
+  test('a viewport that GROWS builds the pages it uncovers, with no scroll to prompt it', async () => {
+    // Which pages are worth building depends on the viewport's height as much as on its
+    // scroll offset — and a resize fires no `scroll`. Nothing asked for a repaint, so the
+    // sheets a taller window uncovered stayed blank until the user scrolled or typed.
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    document.body.append(scroller);
+    const host = document.createElement('div');
+    scroller.append(host);
+    // happy-dom reports zero layout, so the viewport height is supplied directly.
+    let viewportHeight = 400;
+    Object.defineProperty(scroller, 'clientHeight', {
+      get: () => viewportHeight,
+      configurable: true,
+    });
+    const result = mountPaginatedSurface(host, docx(long), { scale: 1 });
+    if (!result.ok) throw new Error(result.reason);
+    const surface = result.surface;
+    surface.type('x');
+
+    const pages = (): HTMLElement[] => [...host.querySelectorAll<HTMLElement>('.docx-page')];
+    const built = (): number =>
+      pages().filter((page) => page.dataset.materialized === 'true').length;
+    const before = built();
+    expect(before).toBeLessThan(pages().length);
+
+    // The window grows past the whole document. No scroll event accompanies it.
+    viewportHeight = 100_000;
+    window.dispatchEvent(new Event('resize'));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(built()).toBeGreaterThan(before);
+    expect(built()).toBe(pages().length);
+    surface.destroy();
+    scroller.remove();
+  });
+
+  test('a destroyed surface stops following the viewport', async () => {
+    // The resize listener lives on the window, which outlives the surface — left attached
+    // it would repaint into a container the host has already thrown away.
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    document.body.append(scroller);
+    const host = document.createElement('div');
+    scroller.append(host);
+    let viewportHeight = 400;
+    Object.defineProperty(scroller, 'clientHeight', {
+      get: () => viewportHeight,
+      configurable: true,
+    });
+    const result = mountPaginatedSurface(host, docx(long), { scale: 1 });
+    if (!result.ok) throw new Error(result.reason);
+    result.surface.destroy();
+
+    viewportHeight = 100_000;
+    window.dispatchEvent(new Event('resize'));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // `destroy` empties the container; a repaint that still ran would refill it.
+    expect(host.querySelectorAll('.docx-page')).toHaveLength(0);
+    scroller.remove();
+  });
 });
 
 describe('a hard break occupies a model offset in layout too', () => {

--- a/packages/core/src/editor/__tests__/paginated-surface.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface.test.ts
@@ -761,6 +761,46 @@ describe('only the pages on screen are built (task 9.4)', () => {
     scroller.remove();
   });
 
+  test('a selection landing on an unbuilt page builds it, so the caret can go there', () => {
+    // An outline jump, a search hit, any host driving the caret: the target page is exactly
+    // the one virtualization has NOT built. The mirror writes the selection into DOM nodes,
+    // and an unbuilt page has none, so the write silently did nothing — and because
+    // `setSelection` had already declared the two in agreement, the next repaint read the
+    // STALE DOM selection back and overwrote the navigation. The caret stayed at the top of
+    // the document while the viewport scrolled away from it.
+    const many = Array.from({ length: 400 }, (_, i) => paragraph(`paragraph ${i}`)).join('');
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    document.body.append(scroller);
+    const host = document.createElement('div');
+    scroller.append(host);
+    Object.defineProperty(scroller, 'clientHeight', { value: 400, configurable: true });
+    const result = mountPaginatedSurface(host, docx(many), { scale: 1 });
+    if (!result.ok) throw new Error(result.reason);
+    const surface = result.surface;
+
+    const ids = surface.session.paragraphIds();
+    const target = ids[ids.length - 1]!;
+    const targetPage = surface.layout().pages.length - 1;
+    expect(targetPage).toBeGreaterThan(2);
+    const pageEl = (index: number): HTMLElement =>
+      host.querySelector<HTMLElement>(`.docx-page[data-page-index="${index}"]`)!;
+    expect(pageEl(targetPage).dataset.materialized).toBe('false');
+
+    surface.setSelection({
+      anchor: { paragraphId: target, offset: 0 },
+      head: { paragraphId: target, offset: 0 },
+    });
+
+    // The page the caret is on is built, whether or not it is on screen.
+    expect(pageEl(targetPage).dataset.materialized).toBe('true');
+    // And a reveal afterwards — the outline's second step — must not snap it back.
+    surface.revealParagraph(target);
+    expect(surface.state().selection.head.paragraphId).toBe(target);
+    surface.destroy();
+    scroller.remove();
+  });
+
   test('a destroyed surface stops following the viewport', async () => {
     // The resize listener lives on the window, which outlives the surface — left attached
     // it would repaint into a container the host has already thrown away.

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -647,6 +647,24 @@ export function mountPaginatedSurface(
     if (!flushLayout()) render();
   }
 
+  /**
+   * Whether every page the CURRENT selection touches has been built.
+   *
+   * Read from `materializedSet` rather than recomputed: deciding this from the viewport
+   * would read `scrollTop`, and forcing a layout on a path that runs for every arrow key is
+   * the kind of cost that does not show up until a long document is open. `undefined` means
+   * nothing is virtualized and every page is built, which is the safe reading everywhere
+   * else too.
+   */
+  function selectionPagesBuilt(): boolean {
+    if (!materializedSet) return true;
+    for (const position of [selection.anchor, selection.head]) {
+      const caret = caretAt(currentLayout, position);
+      if (caret && !materializedSet.has(caret.pageIndex)) return false;
+    }
+    return true;
+  }
+
   function setSelection(next: SemanticSelection, keepDesiredX = false): void {
     // Moving the caret discards a stored caret format — Word's rule. Landing back on the
     // exact armed position (the mirror re-adopting the same caret) keeps it.
@@ -657,6 +675,23 @@ export function mountPaginatedSurface(
     // painting cells that are no longer chosen.
     cellSelection = null;
     if (!keepDesiredX) desiredX = null;
+    // THE MIRROR NEEDS NODES TO WRITE INTO, AND AN UNBUILT PAGE HAS NONE.
+    //
+    // A selection can land on a page virtualization has not built — an outline jump, a
+    // search hit, any host driving the caret — and that is precisely the page it lands on,
+    // since the reason to move the caret there is that the user is not looking at it yet.
+    // The mirror then wrote into nodes that do not exist, which fails silently; the caret
+    // stayed where it was, and the next repaint read the STALE DOM selection back and
+    // overwrote the navigation entirely. Building the page first is what makes the write
+    // land: `visiblePageSet` pins the pages the selection touches, so this paint brings the
+    // target into existence wherever it is.
+    if (!selectionPagesBuilt()) {
+      // The MODEL is the newer of the two until that write lands, so this repaint must not
+      // adopt the DOM selection it is about to replace — which is the very stale value the
+      // navigation is trying to leave behind.
+      selectionSync.noteModelMoved();
+      render(false);
+    }
     // SETTLED, not moved: this mirrors into the DOM on the next line, so the two agree before
     // any render can read them back — including a move raised earlier that no render has
     // carried out. `restoreSelection` raises the flag and only `flushLayout` takes it down, so

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -492,6 +492,15 @@ export function mountPaginatedSurface(
   let materializedSet: ReadonlySet<number> | undefined;
   /** Sizing the last paint used, so scroll can re-centre when the visible width band moves. */
   let materializedExtent: SurfaceExtent | undefined;
+  /**
+   * The scroller whose SIZE is being watched, and the observer watching it.
+   *
+   * Declared here, above the paint that re-checks them, so `watchScrollerSize` can never be
+   * reached before its own state exists — the wiring below runs late, and a temporal dead
+   * zone would be a ReferenceError thrown out of a repaint.
+   */
+  let viewportObserver: ResizeObserver | null = null;
+  let observedScroller: HTMLElement | null = null;
 
   function applyPageOffsets(extent: SurfaceExtent): void {
     for (const page of currentLayout.pages) {
@@ -539,6 +548,9 @@ export function mountPaginatedSurface(
     // book the paint's own cost to the selection phase.
     lastPaintMs = now() - paintBegan;
     renderOverlay();
+    // The surface may only now have been wrapped in its viewport, so the size watcher
+    // re-resolves its target here rather than trusting what existed at mount.
+    watchScrollerSize();
     selectionSync.mirrorToDom();
     // A scroll reports nothing — nothing about the document or the selection moved. Taking up
     // a pending gesture DID move the selection, so that pass has to report after all.
@@ -1002,6 +1014,9 @@ export function mountPaginatedSurface(
       pagesLayer.removeEventListener('compositionstart', onCompositionStart);
       pagesLayer.removeEventListener('compositionend', onCompositionEnd);
       document.removeEventListener('scroll', onScroll, { capture: true });
+      container.ownerDocument.defaultView?.removeEventListener('resize', onViewportResize);
+      viewportObserver?.disconnect();
+      observedScroller = null;
       pointer?.destroy();
       // Drop pending layout work and stop listening BEFORE the DOM goes, or a commit from
       // another editor sharing this store would paint into a detached container.
@@ -1235,21 +1250,54 @@ export function mountPaginatedSurface(
   // scroller captured with `closest` at mount time is routinely null — and a null one meant
   // no listener at all, so scrolling never built the pages it revealed. Every page past the
   // first screenful stayed blank until some unrelated commit forced a repaint.
-  let scrollScheduled = false;
-  const onScroll = (event: Event): void => {
-    const scroller = surfaceScroller(container);
-    if (!scroller || event.target !== scroller) return;
-    if (scrollScheduled) return;
-    scrollScheduled = true;
+  let rematerializeScheduled = false;
+  /** Coalesce to a frame: twenty events and one event cost the same repaint. */
+  function scheduleRematerialize(): void {
+    if (rematerializeScheduled) return;
+    rematerializeScheduled = true;
     const raf = container.ownerDocument.defaultView?.requestAnimationFrame;
     const run = (): void => {
-      scrollScheduled = false;
+      rematerializeScheduled = false;
       rematerialize();
     };
     if (raf) raf(run);
     else queueMicrotask(run);
+  }
+
+  const onScroll = (event: Event): void => {
+    const scroller = surfaceScroller(container);
+    if (!scroller || event.target !== scroller) return;
+    scheduleRematerialize();
   };
   document.addEventListener('scroll', onScroll, { capture: true, passive: true });
+
+  // WHICH PAGES ARE VISIBLE DEPENDS ON THE VIEWPORT'S SIZE, NOT ONLY ON ITS SCROLL OFFSET.
+  //
+  // `visiblePageSet` reads `clientHeight`, so a viewport that grows reveals pages the last
+  // paint had no reason to build — and a resize fires no `scroll`. Nothing asked for a
+  // repaint, so the newly uncovered sheets stayed blank until the user scrolled or typed:
+  // maximizing the window, closing a side panel, rotating a tablet, or the browser chrome
+  // collapsing on scroll-up all land there.
+  const onViewportResize = (): void => {
+    scheduleRematerialize();
+  };
+  const view = container.ownerDocument.defaultView;
+  view?.addEventListener('resize', onViewportResize, { passive: true });
+  // The window event covers a resized window; an observer covers everything that changes
+  // the scroller WITHOUT one — a collapsing panel, a wrapping toolbar, a CSS change. The
+  // scroller is resolved lazily for the same reason the scroll listener binds to the
+  // document: at mount the host has routinely not wrapped the surface in its viewport yet.
+  viewportObserver =
+    typeof view?.ResizeObserver === 'function' ? new view.ResizeObserver(onViewportResize) : null;
+  function watchScrollerSize(): void {
+    if (!viewportObserver) return;
+    const scroller = surfaceScroller(container);
+    if (scroller === observedScroller) return;
+    viewportObserver.disconnect();
+    observedScroller = scroller;
+    if (scroller) viewportObserver.observe(scroller);
+  }
+  watchScrollerSize();
 
   pointer = createPointerController(
     {

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -173,6 +173,28 @@ describe('the painter is a non-authoritative consumer', () => {
     expect(tabEl.style.width).toBe(`${tabRecord.box.width}px`);
     expect(tabEl.style.overflow).toBe('hidden');
   });
+
+  test('a clipped tab span is aligned to the line top, so it cannot move the baseline', () => {
+    // Regression: the dot leader appeared to float above the words it should sit level
+    // with. The leader was right and the TEXT was displaced. `overflow: hidden` makes an
+    // inline-block's baseline its bottom margin edge (CSS 2.1 §10.8.1), so a
+    // baseline-aligned tab demanded its whole band above the baseline while a glyph run
+    // demands only its ascent. The browser satisfied the tab by pushing the line's common
+    // baseline down, and every word on the line went with it — ~3.4px below the baseline
+    // layout published, on every tabbed line, contents entries included.
+    const container = paint(
+      '<w:p><w:pPr><w:tabs><w:tab w:val="right" w:pos="2400" w:leader="dot"/></w:tabs></w:pPr>' +
+        '<w:r><w:t>Chapter</w:t><w:tab/><w:t>1</w:t></w:r></w:p>'
+    );
+    const runs = [...container.querySelectorAll<HTMLElement>('.layout-run-text')];
+    const tab = runs.find((el) => el.textContent === '\t')!;
+    expect(tab.style.verticalAlign).toBe('top');
+    // Every run that carries glyphs still aligns on the baseline — that is what makes a
+    // mixed-size line share one, and it is the alignment the leader layer mirrors.
+    for (const glyphRun of runs.filter((el) => el.textContent !== '\t')) {
+      expect(glyphRun.style.verticalAlign).toBe('baseline');
+    }
+  });
 });
 
 describe('each run is its own box, so a mixed-size line highlights stepped', () => {
@@ -242,10 +264,10 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
 
   test('a tab span gets its own band too, not the full line height', () => {
     // A tab paints with `overflow: hidden`, which makes its inline-block baseline the
-    // BOTTOM edge (CSS2.1 §10.8.1) — so unlike a text run its whole band counts above the
-    // baseline. Inheriting the line height made a small-style tab dominate the line box of
-    // a mixed-size line and push every glyph below the published baseline; its own band
-    // keeps the tab's contribution no larger than the run it belongs with.
+    // BOTTOM edge (CSS2.1 §10.8.1). `vertical-align: top` keeps that out of the line's
+    // baseline math; the band still decides how tall the tab's own box — and so the
+    // selection band drawn over it — comes out, which must be the run it belongs with
+    // rather than the whole line.
     const container = paint(
       '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>' +
         '<w:r><w:t>a</w:t><w:tab/></w:r>' +

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -360,6 +360,19 @@ function paintSpan(
     // Keep the model character for range mapping, but clip any native tab ink that would
     // spill past the reserved advance.
     element.style.overflow = 'hidden';
+    // A CLIPPED BOX MUST NOT DECIDE THE LINE'S BASELINE.
+    //
+    // `overflow: hidden` makes an inline-block's baseline its BOTTOM MARGIN EDGE
+    // (CSS 2.1 §10.8.1) instead of the baseline of its text. Left baseline-aligned, the
+    // tab therefore asked the line box for its whole band above the baseline — more than
+    // any glyph run asks for, since a run only needs its ascent — so the browser pushed
+    // the common baseline down to satisfy it and every word on the line dropped with it.
+    // On a tabbed line that put the text ~3.4px below where layout published the baseline,
+    // and the tab leader (its own layer, correctly baselined) then read as floating above
+    // the text it was supposed to sit level with. Aligning the tab to the line box top
+    // takes it out of the baseline calculation entirely; the box still clips, and its top
+    // is exactly where a baseline-aligned run of the same band lands anyway.
+    element.style.verticalAlign = 'top';
   }
   mountRunText(document, element, span.text, span.style, ctx.scale);
   return element;

--- a/packages/react/src/editor/DocxEditorOutline.tsx
+++ b/packages/react/src/editor/DocxEditorOutline.tsx
@@ -6,11 +6,12 @@
 // and the ruler parts — so the panel follows edits (retitling, adding or deleting a
 // heading) without a bespoke channel.
 //
-// NAVIGATION IS THE CARET, not a scroll. A heading click focuses the surface and moves
-// the selection to the heading paragraph's start through the facade's semantic
-// `setSelection`. The engine has no caret-scroll-into-view yet (`scrollToBlock` is an
-// honest stub), so the wrapper does not pretend to scroll; when the engine grows that
-// capability the same click starts navigating visually with no adapter change.
+// A heading click both MOVES THE CARET and BRINGS THE HEADING INTO VIEW: the selection
+// goes to the heading paragraph's start through the facade's semantic `setSelection`, and
+// `scrollToBlock` reveals it. The two are separate because moving the caret does not move
+// the viewport — a heading twenty pages down was selected where nobody could see it.
+// The reveal resolves through layout rather than the DOM, so it works for a page that has
+// not been materialized yet, which is exactly the page an outline jump asks for.
 
 import { useCallback, useMemo } from 'react';
 import type { ReactElement } from 'react';


### PR DESCRIPTION
The dot leader was never misplaced — the text was. A `\t` span paints with `overflow: hidden`, which makes its inline-block baseline the bottom margin edge (CSS 2.1 §10.8.1), so it asked the line box for its whole band above the baseline where a glyph run asks only for its ascent. The browser pushed the line's common baseline down to satisfy it and every word on a tabbed line rendered ~3.4px below where layout published it. `vertical-align: top` takes the tab out of the baseline calculation; it still clips.

Separately, materialization only ever followed `scroll`, but which pages are visible depends on the viewport's height too — and a resize fires no scroll, so pages a growing viewport uncovered stayed blank until the next scroll or keystroke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788345252&installation_model_id=422592&pr_number=93&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F93&signature=d25b4d5e89a8dd6baa3fca0c9464ac9ac90f7fbfff9ab589b3c58cd9978305f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->