### PR TITLE
fix(core): sit line-spaced text on the baseline layout publishes

### DIFF
--- a/.changeset/line-spacing-text-sits-on-its-baseline.md
+++ b/.changeset/line-spacing-text-sits-on-its-baseline.md
@@ -1,0 +1,6 @@
+---
+'@docx-editor.dev/react': patch
+'@docx-editor.dev/vue': patch
+---
+
+Text on a line with spacing above single now sits on the baseline layout publishes, so the caret lands in the text instead of half a leading below it. Double-spaced lines were the most visible. List markers and dot leaders on those lines follow the same baseline.

--- a/packages/core/src/layout/__tests__/semantic-interaction.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-interaction.test.ts
@@ -92,6 +92,35 @@ describe('caret geometry for a model position', () => {
     expect(caretAt(lay(load(paragraph('hi'))), at(P0, 99))).toBeNull();
     expect(caretAt(lay(load(paragraph('hi'))), at('no-such-paragraph', 0))).toBeNull();
   });
+
+  test('an EMPTY spaced paragraph gets a text-height caret, not a line-box one', () => {
+    // There is no run to size the caret against, so the line box is all there is — and on a
+    // double-spaced paragraph that box is mostly leading. Taking it whole drew a caret twice
+    // the height of the text about to be typed, starting a full line above it.
+    const spaced = lay(
+      load(
+        '<w:p><w:pPr><w:spacing w:line="480" w:lineRule="auto"/></w:pPr></w:p>' +
+          '<w:p><w:r><w:t>reference</w:t></w:r></w:p>'
+      )
+    );
+    const emptyLine = spaced.pages[0]!.fragments[0]!;
+    if (emptyLine.kind !== 'paragraph') throw new Error('expected a paragraph');
+    const line = emptyLine.lines[0]!;
+    expect(line.leading).toBeGreaterThan(0);
+
+    const caret = caretAt(spaced, at(P0, 0))!;
+    expect(caret).not.toBeNull();
+    // The glyph band is what is left of the box once the leading is taken off, and it sits
+    // at the bottom — where the text will appear.
+    expect(caret.height).toBe(line.box.height - line.leading);
+    expect(caret.y).toBe(line.box.y + line.leading);
+    // Same height a single-spaced empty paragraph would get: the spacing changed the box,
+    // not the text.
+    const single = lay(load('<w:p/>'));
+    const singleFragment = single.pages[0]!.fragments[0]!;
+    if (singleFragment.kind !== 'paragraph') throw new Error('expected a paragraph');
+    expect(caret.height).toBe(singleFragment.lines[0]!.box.height);
+  });
 });
 
 describe('hit testing', () => {

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -191,6 +191,17 @@ export interface PendingLine {
   width: number;
   height: number;
   baseline: number;
+  /**
+   * How much of {@link height} is line-spacing leading rather than glyphs.
+   *
+   * PUBLISHED, not re-derived. `applyLineSpacing` decides where the leading goes, and the
+   * whole of it sits ABOVE the text, which is what moves `baseline` down. Paint used to
+   * recover this by subtracting the tallest span height from the line box — an identity
+   * that only holds while the spacing rule is the multiplying one, and that is already
+   * false for an `exact` box clipped below its glyphs. Every consumer reads the one number
+   * the spacing rule produced instead of guessing at it from the box.
+   */
+  leading: number;
   /** When true, layout must start a new page after this line is placed. */
   pageBreakAfter?: boolean;
 }
@@ -212,6 +223,7 @@ export function frozenLine(line: PendingLine): PendingLine {
     width: line.width,
     height: line.height,
     baseline: line.baseline,
+    leading: line.leading,
     ...(line.pageBreakAfter ? { pageBreakAfter: true } : {}),
   }) as PendingLine;
 }
@@ -368,7 +380,15 @@ export function breakParagraph(
       : resolveRunStyle(inheritedRunProperties);
   const rightEdge = indentLeft + available;
   const lines: PendingLine[] = [];
-  let line: PendingLine = { spans: [], start: 0, end: 0, width: 0, height: 0, baseline: 0 };
+  let line: PendingLine = {
+    spans: [],
+    start: 0,
+    end: 0,
+    width: 0,
+    height: 0,
+    baseline: 0,
+    leading: 0,
+  };
 
   // Where the line being built starts, and how much room it has. Only the first differs.
   const lineOffset = (): number => (lines.length === 0 ? firstLineOffset : 0);
@@ -383,9 +403,14 @@ export function breakParagraph(
     }
     // Line spacing applies to the finished box, once, so a paragraph's rule governs every
     // line it produced regardless of which run happened to be tallest.
+    const natural = line.height;
     const spaced = applyLineSpacing(lineSpacing, line.height, line.baseline);
     line.height = spaced.height;
     line.baseline = spaced.baseline;
+    // Never negative: an `exact` box clipped below its glyphs adds no leading, it removes
+    // box. Paint keys its baseline correction off this, and a negative would push the text
+    // the wrong way rather than leaving the clipped line alone.
+    line.leading = Math.max(0, spaced.height - natural);
     lines.push(line);
     line = {
       spans: [],
@@ -394,6 +419,7 @@ export function breakParagraph(
       width: 0,
       height: 0,
       baseline: 0,
+      leading: 0,
     };
   };
 

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -646,7 +646,17 @@ export function caretBoxOnLine(
 ): { x: number; y: number; height: number } {
   const spans = line.spans;
   if (spans.length === 0) {
-    return { x: line.box.x, y: line.box.y, height: line.box.height };
+    // An empty paragraph paints no run to size the caret against, so the LINE is all there
+    // is — but the line box on a spaced paragraph is mostly leading, and taking it whole
+    // drew a double-spaced empty line a caret twice the height of the text it would type.
+    // The leading is published, so the glyph band is exactly what is left of the box, and
+    // it sits at the bottom because that is where the text will appear.
+    const leading = line.leading ?? 0;
+    return {
+      x: line.box.x,
+      y: line.box.y + leading,
+      height: Math.max(0, line.box.height - leading),
+    };
   }
   let chosen = spans[0]!;
   for (const span of spans) {

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1363,6 +1363,7 @@ function layoutBlocksWithGeometry(
         ),
         box: { x: indent.left, y: cursorY, width: available, height: pendingLine.height },
         baseline: pendingLine.baseline,
+        leading: pendingLine.leading,
       };
       lineCounter += 1;
       pending.push(record);

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -151,6 +151,19 @@ export interface LineRecord {
   readonly box: LayoutBox;
   /** Distance from the line box top to the text baseline. */
   readonly baseline: number;
+  /**
+   * How much of the box is line-spacing leading rather than glyphs, and therefore how far
+   * below the box top the text sits: `w:line` above single puts the WHOLE leading above the
+   * text, so the glyphs are bottom-anchored in the box and {@link baseline} already carries
+   * it.
+   *
+   * Published by the spacing rule rather than recovered by paint. Subtracting the tallest
+   * span height from the box gives the same answer only while the rule is the multiplying
+   * one — it is already wrong for an `exact` box clipped below its glyphs — and three paint
+   * sites each deriving it separately is how they came to disagree about where a line's
+   * text sits.
+   */
+  readonly leading: number;
 }
 
 /**

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -383,6 +383,7 @@ function placeCellParagraph(
         height: pendingLine.height,
       },
       baseline: pendingLine.baseline,
+      leading: pendingLine.leading,
     });
     y += pendingLine.height;
     nextLineIndex = lineIndex + 1;

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -267,17 +267,26 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
     expect(small!.style.height).toBe('42px'); // 14 own + 28 leading
     expect(big!.style.height).toBe('56px'); // 28 own + 28 leading = the line height
 
-    // THE INVARIANT, not the four numbers. Asserting the constants only re-states what the
-    // source computes: `band + 2 × leading` would satisfy them just as well. What has to
-    // hold is that EVERY run overshoots its band by the SAME leading — that is what puts
-    // them all on one baseline, and what puts that baseline where layout published it.
-    const overshoot = (run: HTMLElement): number =>
-      parseFloat(run.style.lineHeight) - parseFloat(run.style.height);
-    expect(overshoot(small!)).toBe(28);
-    expect(overshoot(big!)).toBe(28);
-    // And the leading is the line's own, not something re-derived per run: the tallest run
-    // fills the line box exactly, so its overshoot IS line height − its own glyph height.
-    expect(overshoot(big!)).toBe(parseFloat(line.style.height) - 28);
+    // THE INVARIANTS, not the numbers. Asserting constants only re-states what the source
+    // computes. Three things have to hold, and each one is a bug this went through:
+    //
+    // 1. Every run is padded by the SAME leading — that is what keeps them on one baseline.
+    // 2. Padding plus inner line box equals the band exactly. Any slack here is highlight
+    //    the browser paints outside the run's own box, which bled a leading of selection
+    //    into the line below when the leading was spent on `line-height` instead.
+    // 3. The leading is the LINE's, not something re-derived per run.
+    const padding = (run: HTMLElement): number => parseFloat(run.style.paddingTop);
+    const inner = (run: HTMLElement): number => parseFloat(run.style.lineHeight);
+    const band = (run: HTMLElement): number => parseFloat(run.style.height);
+
+    expect(padding(small!)).toBe(28);
+    expect(padding(big!)).toBe(28);
+    for (const run of [small!, big!]) {
+      expect(run.style.boxSizing).toBe('border-box');
+      expect(padding(run) + inner(run)).toBe(band(run));
+    }
+    // The tallest run fills the line box, so its padding IS line height − its glyph height.
+    expect(padding(big!)).toBe(parseFloat(line.style.height) - 28);
   });
 
   test('the list marker sits on the same baseline as the text beside it', () => {
@@ -298,11 +307,15 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
     paintSemanticLayout(container, layout, { scale: 1 });
     const run = container.querySelector<HTMLElement>('.layout-run-text')!;
     const markerGlyph = container.querySelector<HTMLElement>('[data-docx-marker] span')!;
-    const overshoot = (el: HTMLElement): number =>
-      parseFloat(el.style.lineHeight) - parseFloat(el.style.height);
     // 14 natural, doubled to 28, so 14 of leading — all of it above the text.
-    expect(overshoot(run)).toBe(14);
-    expect(overshoot(markerGlyph)).toBe(overshoot(run));
+    const leading = parseFloat(run.style.paddingTop);
+    expect(leading).toBe(14);
+    // The marker reserves the SAME leading above its glyph. It gets there by a different
+    // route (its box is the whole line, not a run band), so what is pinned is the one
+    // number both sinks read — not the CSS either of them writes.
+    expect(parseFloat(markerGlyph.style.lineHeight) - parseFloat(markerGlyph.style.height)).toBe(
+      leading
+    );
   });
 
   test('a tab span gets its own band too, not the full line height', () => {

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -249,7 +249,13 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
   test('line spacing above single joins the stepped bands with the extra leading', () => {
     // Double spacing doubles the line box. Word still paints the leading, so every run's
     // band grows by the same extra leading — capped at the line height, which the tallest
-    // run reaches exactly.
+    // run reaches exactly. The band is the run's HEIGHT.
+    //
+    // `line-height` is a leading TALLER than the band, and that is deliberate: the extra
+    // leading of a spaced line sits ABOVE the text (17.3.1.33), so the glyphs belong at the
+    // bottom of the box. CSS centres content in its line box, so a `line-height` equal to
+    // the band would put the text half a leading too HIGH — off the baseline layout
+    // published, and off the caret, which reads that baseline.
     const container = paint(
       '<w:p><w:pPr><w:spacing w:line="480" w:lineRule="auto"/></w:pPr>' +
         '<w:r><w:t>small</w:t></w:r>' +
@@ -258,8 +264,45 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
     const line = container.querySelector<HTMLElement>('.docx-line')!;
     expect(line.style.height).toBe('56px'); // 28 natural × 480/240
     const [small, big] = [...line.querySelectorAll<HTMLElement>('.layout-run-text')];
-    expect(small!.style.lineHeight).toBe('42px'); // 14 own + 28 leading
-    expect(big!.style.lineHeight).toBe('56px'); // 28 own + 28 leading = the line height
+    expect(small!.style.height).toBe('42px'); // 14 own + 28 leading
+    expect(big!.style.height).toBe('56px'); // 28 own + 28 leading = the line height
+
+    // THE INVARIANT, not the four numbers. Asserting the constants only re-states what the
+    // source computes: `band + 2 × leading` would satisfy them just as well. What has to
+    // hold is that EVERY run overshoots its band by the SAME leading — that is what puts
+    // them all on one baseline, and what puts that baseline where layout published it.
+    const overshoot = (run: HTMLElement): number =>
+      parseFloat(run.style.lineHeight) - parseFloat(run.style.height);
+    expect(overshoot(small!)).toBe(28);
+    expect(overshoot(big!)).toBe(28);
+    // And the leading is the line's own, not something re-derived per run: the tallest run
+    // fills the line box exactly, so its overshoot IS line height − its own glyph height.
+    expect(overshoot(big!)).toBe(parseFloat(line.style.height) - 28);
+  });
+
+  test('the list marker sits on the same baseline as the text beside it', () => {
+    // These drifted apart once: only the text was taught that a spaced line's leading sits
+    // ABOVE it, so the bullet floated half a leading over its own sentence. One baseline
+    // means one overshoot, pinned together here because no unit test in this file can
+    // observe a rendered baseline — happy-dom does no layout.
+    const layout = layoutOf(
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>' +
+        '<w:spacing w:line="480" w:lineRule="auto"/></w:pPr>' +
+        '<w:r><w:t>numbered and double spaced</w:t></w:r></w:p>',
+      `<w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:start w:val="1"/>` +
+        `<w:numFmt w:val="bullet"/><w:lvlText w:val="•"/><w:lvlJc w:val="left"/>` +
+        `<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>` +
+        `<w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>`
+    );
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const run = container.querySelector<HTMLElement>('.layout-run-text')!;
+    const markerGlyph = container.querySelector<HTMLElement>('[data-docx-marker] span')!;
+    const overshoot = (el: HTMLElement): number =>
+      parseFloat(el.style.lineHeight) - parseFloat(el.style.height);
+    // 14 natural, doubled to 28, so 14 of leading — all of it above the text.
+    expect(overshoot(run)).toBe(14);
+    expect(overshoot(markerGlyph)).toBe(overshoot(run));
   });
 
   test('a tab span gets its own band too, not the full line height', () => {

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -323,7 +323,8 @@ function paintSpan(
   document: Document,
   span: StyleSpanRecord,
   ctx: PaintContext,
-  bandHeightPt: number
+  bandHeightPt: number,
+  extraLeadingPt: number
 ): HTMLElement {
   const element = document.createElement('span');
   element.className = 'layout-run layout-run-text';
@@ -335,11 +336,23 @@ function paintSpan(
   // own size, which is how Word draws it: the band steps with the text.
   element.style.display = 'inline-block';
   element.style.verticalAlign = 'baseline';
-  // The box is only its own size if the run does NOT inherit the line's pixel line-height:
-  // inherited, every run's inner line box is the full line height and the band is one
-  // uniform slab again. The caller passes the height this run's band should be (its own
-  // published height, plus the line's extra leading, capped at the line height).
-  element.style.lineHeight = `${bandHeightPt * ctx.scale}px`;
+  // THE BAND IS THE BOX; THE LEADING DECIDES WHERE THE TEXT SITS IN IT.
+  //
+  // `w:line` above single puts ALL the extra leading ABOVE the text — observed Word
+  // behaviour, not a spec rule; 17.3.1.33 defines the VALUES and says nothing about where
+  // the leading lands, and `applyLineSpacing` is where that decision is made. So the
+  // glyphs sit at the BOTTOM of the line box and `line.baseline` is measured from the line
+  // top with the whole leading already added. Sizing the run by `line-height` alone leaves
+  // the browser to place the glyphs, and CSS always splits leading in HALF — so the text
+  // was painted half a leading ABOVE the baseline layout published, while the caret (which
+  // reads `line.baseline`) was drawn on it. On a double-spaced line that is half a line
+  // apart, and the insertion point sat under the text instead of in it.
+  //
+  // The box keeps the band height; the inner line box is one leading taller, which pushes
+  // the baseline down by exactly the half-leading CSS took off. Glyph bottom then lands on
+  // the box bottom, so the band still tiles from the line top with no overflow.
+  element.style.height = `${bandHeightPt * ctx.scale}px`;
+  element.style.lineHeight = `${(bandHeightPt + extraLeadingPt) * ctx.scale}px`;
   // ADDRESSABLE ONLY IF IT OWNS OFFSETS. Selection maps through `data-paragraph-id` +
   // `data-start` and reads an endpoint as `start + textContent.length`, so a span whose
   // painted text is wider than its model range hands back an offset the paragraph does not
@@ -515,9 +528,12 @@ function paintLine(document: Document, line: LineRecord, ctx: PaintContext): HTM
   // unchanged. Smaller runs get their own published height plus the line's extra
   // leading (spacing above single keeps a contiguous band, as Word draws it), capped
   // at the line height so an `exact`-spaced line cannot grow past its box.
-  let tallest = 0;
-  for (const span of line.spans) tallest = Math.max(tallest, span.box.height);
-  const leading = Math.max(0, line.box.height - tallest);
+  //
+  // The leading is READ, not recovered from the box. The marker and the tab leader place
+  // their furniture against this same number, and when each of the three derived it for
+  // itself they drifted: the text moved onto the published baseline while the marker
+  // beside it stayed half a leading higher.
+  const leading = line.leading;
   // Consecutive spans of the SAME link share one anchor, so a link that spans several
   // formatting runs on one line is one `<a>` — one focus stop, one hover target, one thing
   // a screen reader announces. A link that WRAPS gets one anchor per line, which is the
@@ -526,7 +542,7 @@ function paintLine(document: Document, line: LineRecord, ctx: PaintContext): HTM
   let anchorLinkId: string | null = null;
   for (const span of line.spans) {
     const band = Math.min(span.box.height + leading, line.box.height);
-    const painted = paintSpan(document, span, ctx, band);
+    const painted = paintSpan(document, span, ctx, band, leading);
     const link = span.link;
     if (!link) {
       anchor = null;
@@ -638,6 +654,8 @@ function paintListMarker(
 ): HTMLElement {
   const marker = fragment.marker!;
   const scale = ctx.scale;
+  // The marker belongs to the paragraph's FIRST line, which is the line it is drawn beside.
+  const leading = fragment.lines[0]?.leading ?? 0;
   const element = positioned(document, 'span', marker.box, scale);
   element.className = 'docx-list-marker';
   element.dataset.docxMarker = '';
@@ -656,11 +674,19 @@ function paintListMarker(
   // `paintLine` gives a line fixes it: kill the anonymous strut with `font-size: 0`,
   // apply the published box height as an explicit line-height, and let the glyph align on
   // `baseline` inside it — which is exactly how every run on that line is aligned.
+  //
+  // INCLUDING THE LEADING. `marker.box.height` is the whole post-spacing line box, so on a
+  // spaced line the glyph would centre in it while the text it numbers is bottom-anchored,
+  // and the number floated half a leading above its own sentence. The run treatment is the
+  // whole treatment: an inner line box one leading taller drops the glyph onto the same
+  // baseline `paintSpan` puts the text on.
   element.style.fontSize = '0';
   element.style.lineHeight = `${marker.box.height * scale}px`;
   const glyph = document.createElement('span');
   glyph.style.display = 'inline-block';
   glyph.style.verticalAlign = 'baseline';
+  glyph.style.height = `${marker.box.height * scale}px`;
+  glyph.style.lineHeight = `${(marker.box.height + leading) * scale}px`;
   applyRunFaceStyle(glyph, marker.style, ctx);
   mountRunText(document, glyph, marker.text, marker.style, scale);
   element.append(glyph);
@@ -732,21 +758,27 @@ function paintTabLeader(
   // to and no arithmetic here can second-guess it: strut killed with `font-size: 0`, the
   // published line height as an explicit line-height, and the glyphs as a baseline-aligned
   // inline-block carrying their own BAND height — the run's own height plus the line's
-  // extra leading, capped at the line box. Leaving the band off let the glyphs inherit the
-  // whole line height, and their inner line box then centred them; putting the face on the
-  // container instead gave the strut different metrics from the dots and floated them.
+  // extra leading, capped at the line box — over an inner line box one leading taller, so
+  // a spaced line's leading sits above the dots exactly as it sits above the text. Leaving
+  // the band off let the glyphs inherit the whole line height, and their inner line box
+  // then centred them; putting the face on the container instead gave the strut different
+  // metrics from the dots and floated them.
+  //
+  // The mirror is literal, so it has to be MAINTAINED as one: both sides read `line.leading`
+  // and neither recomputes it. This structure and `paintSpan`'s drifted apart once already,
+  // when only one of them was taught that the leading sits above the text.
   layer.style.fontSize = '0';
   layer.style.lineHeight = `${line.box.height * scale}px`;
 
-  let tallest = 0;
-  for (const entry of line.spans) tallest = Math.max(tallest, entry.box.height);
-  const band = Math.min(span.box.height + Math.max(0, line.box.height - tallest), line.box.height);
+  const leading = line.leading;
+  const band = Math.min(span.box.height + leading, line.box.height);
 
   const glyphs = document.createElement('span');
   glyphs.style.display = 'inline-block';
   glyphs.style.verticalAlign = 'baseline';
   applyRunFaceStyle(glyphs, span.style, ctx);
-  glyphs.style.lineHeight = `${band * scale}px`;
+  glyphs.style.height = `${band * scale}px`;
+  glyphs.style.lineHeight = `${(band + leading) * scale}px`;
   if (span.tabLeader === 'heavy') glyphs.style.fontWeight = 'bold';
   // ONE GLYPH PER ITS OWN ADVANCE — the leader is the same character typed over and over,
   // and Word spaces it exactly as typing it would. Layout measured that advance in this

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -348,11 +348,19 @@ function paintSpan(
   // reads `line.baseline`) was drawn on it. On a double-spaced line that is half a line
   // apart, and the insertion point sat under the text instead of in it.
   //
-  // The box keeps the band height; the inner line box is one leading taller, which pushes
-  // the baseline down by exactly the half-leading CSS took off. Glyph bottom then lands on
-  // the box bottom, so the band still tiles from the line top with no overflow.
+  // So the leading is PADDING, not line-height. The box is the band, the leading is padded
+  // off the top of it, and what remains is an inner line box exactly as tall as the glyphs —
+  // no half-leading left for CSS to split, and the baseline lands where layout put it.
+  //
+  // Growing the line-height instead lands the same baseline and is wrong for a reason that
+  // does not show up in a geometry test: the browser paints the native selection to the
+  // INNER LINE BOX, so a box one leading shorter than its own line-height bled a leading's
+  // worth of highlight into the line below. Double-spaced text selected as overlapping
+  // stripes, darker where they met, running past the end of the paragraph.
+  element.style.boxSizing = 'border-box';
   element.style.height = `${bandHeightPt * ctx.scale}px`;
-  element.style.lineHeight = `${(bandHeightPt + extraLeadingPt) * ctx.scale}px`;
+  element.style.paddingTop = `${extraLeadingPt * ctx.scale}px`;
+  element.style.lineHeight = `${(bandHeightPt - extraLeadingPt) * ctx.scale}px`;
   // ADDRESSABLE ONLY IF IT OWNS OFFSETS. Selection maps through `data-paragraph-id` +
   // `data-start` and reads an endpoint as `start + textContent.length`, so a span whose
   // painted text is wider than its model range hands back an offset the paragraph does not
@@ -533,7 +541,7 @@ function paintLine(document: Document, line: LineRecord, ctx: PaintContext): HTM
   // their furniture against this same number, and when each of the three derived it for
   // itself they drifted: the text moved onto the published baseline while the marker
   // beside it stayed half a leading higher.
-  const leading = line.leading;
+  const leading = line.leading ?? 0;
   // Consecutive spans of the SAME link share one anchor, so a link that spans several
   // formatting runs on one line is one `<a>` — one focus stop, one hover target, one thing
   // a screen reader announces. A link that WRAPS gets one anchor per line, which is the
@@ -759,26 +767,29 @@ function paintTabLeader(
   // published line height as an explicit line-height, and the glyphs as a baseline-aligned
   // inline-block carrying their own BAND height — the run's own height plus the line's
   // extra leading, capped at the line box — over an inner line box one leading taller, so
-  // a spaced line's leading sits above the dots exactly as it sits above the text. Leaving
-  // the band off let the glyphs inherit the whole line height, and their inner line box
-  // then centred them; putting the face on the container instead gave the strut different
-  // metrics from the dots and floated them.
+  // a spaced line's leading is padded off the top of the dots exactly as it is off the text.
+  // Leaving the band off let the glyphs inherit the whole line height, and their inner line
+  // box then centred them; putting the face on the container instead gave the strut
+  // different metrics from the dots and floated them.
   //
-  // The mirror is literal, so it has to be MAINTAINED as one: both sides read `line.leading`
-  // and neither recomputes it. This structure and `paintSpan`'s drifted apart once already,
-  // when only one of them was taught that the leading sits above the text.
+  // The mirror is literal, so it has to be MAINTAINED as one: both sides read `line.leading`,
+  // neither recomputes it, and both spend it as padding rather than line-height. This
+  // structure and `paintSpan`'s drifted apart once already, when only one of them was taught
+  // that the leading sits above the text.
   layer.style.fontSize = '0';
   layer.style.lineHeight = `${line.box.height * scale}px`;
 
-  const leading = line.leading;
+  const leading = line.leading ?? 0;
   const band = Math.min(span.box.height + leading, line.box.height);
 
   const glyphs = document.createElement('span');
   glyphs.style.display = 'inline-block';
   glyphs.style.verticalAlign = 'baseline';
   applyRunFaceStyle(glyphs, span.style, ctx);
+  glyphs.style.boxSizing = 'border-box';
   glyphs.style.height = `${band * scale}px`;
-  glyphs.style.lineHeight = `${(band + leading) * scale}px`;
+  glyphs.style.paddingTop = `${leading * scale}px`;
+  glyphs.style.lineHeight = `${(band - leading) * scale}px`;
   if (span.tabLeader === 'heavy') glyphs.style.fontWeight = 'bold';
   // ONE GLYPH PER ITS OWN ADVANCE — the leader is the same character typed over and over,
   // and Word spaces it exactly as typing it would. Layout measured that advance in this


### PR DESCRIPTION
The caret sat half a leading below the text on any paragraph with line spacing above single. Most visible at double spacing, where it was half a line out.

`applyLineSpacing` puts the whole extra leading above the text and moves `baseline` down by it, so the glyphs are bottom-anchored in the line box. Paint never placed the glyphs though: it set a CSS `line-height` and let the browser do it, and CSS splits leading in half. The text rendered half a leading high; the caret, which reads `line.baseline`, was drawn where layout actually said.

Each run now spends the leading as `padding-top` over a border-box band, so the inner line box is exactly as tall as the glyphs and there is no half-leading left for CSS to split. Growing `line-height` instead lands the same baseline but bleeds a leading of native selection highlight into the line below, because the browser paints the highlight to the inner line box.

The leading is published on the line record instead of being recovered from the box. Three paint sites were each subtracting the tallest span height to get it, which only agrees with the spacing rule while that rule is the multiplying one and is already wrong for an `exact` box clipped below its glyphs. The list marker and the tab leader now read the same number the text does.

Two further symptoms of the same cause:

- **List markers** sat half a leading above their own text on every spaced list paragraph.
- **Empty paragraphs** had no run to size the caret against, so `caretBoxOnLine` took the whole line box — twice the text height on a double-spaced line, starting a full line too high.

Measured in Chromium against the demo, glyph top minus line top:

| spacing | leading | before | after |
| --- | --- | --- | --- |
| single | 0 | 0 | 0 |
| 1.5x | 8.43px | 4.2px | 8.5px |
| double | 16.87px | 8.4px | 17px |

Selection overflow past the run's own box is 0 at every spacing; marker ink and text ink agree to 0.1px.

Word's own behaviour was checked against a probe document in Word Online before picking a direction: the extra leading of an `auto`-spaced line goes above the text, so layout was right and paint was the broken side.

### Known trade-off

The native selection band now covers the glyph rows rather than the full line box, so double-spaced selection has gaps between lines where Word draws it contiguous. `::selection` height *is* the inner line box, and that same box fixes the baseline, so both cannot be had at once — a contiguous band needs selection painted from layout (as `semantic-selection-overlay.ts` already does for cells) with `::selection` suppressed. Left out of scope here.

### Verification

2240 core tests pass; `bun run typecheck` clean. Two OpenSpec governance tests fail identically on `docx-editor-v2` at `3a1b1bd8e` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)