### PR TITLE
fix(core): resolve table widths and placement from the document

### DIFF
--- a/.changeset/table-placement-and-revisions.md
+++ b/.changeset/table-placement-and-revisions.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Place tables where the document puts them, and stop reserving blank lines for deleted paragraphs. `w:tblInd` and `w:jc` now indent, centre, or right-align a table instead of leaving every one flush left, and `w:tblCellSpacing` separates adjacent cells. A paragraph whose mark and content were both removed by a tracked deletion no longer claims a line box it renders nothing into — a table full of them was stacking blank lines and pushing real content off the page.

--- a/.changeset/table-preferred-widths.md
+++ b/.changeset/table-preferred-widths.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-Keep autofit tables inside the page and read authored cell widths. A table left on Word's autofit layout now scales to the text column instead of running past the right margin, a table that states no `w:tblGrid` takes its columns from `w:tcW` rather than an even split, and a table's reported width is its own rather than always the page width. Tables that ask for fixed layout are still laid out on their grid, overflow included, as Word renders them.
+Resolve table column widths from the widths the document actually authors. `w:tcW` now overrides the `w:tblGrid` seed the way Word resolves them, rows that disagree settle on the widest, and `w:wBefore`/`w:wAfter` size the bands a row skips. `w:tblW` bounds the total — including stretching a table stated as a percentage out to the full text column — and an autofit table no longer renders past the right margin, while a fixed-layout table still lays out on its grid the way Word renders it. Widths stated as `2in` or `33.3%` are read rather than dropped, and a table reports its own width instead of always the page width.

--- a/.changeset/table-preferred-widths.md
+++ b/.changeset/table-preferred-widths.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Keep autofit tables inside the page and read authored cell widths. A table left on Word's autofit layout now scales to the text column instead of running past the right margin, a table that states no `w:tblGrid` takes its columns from `w:tcW` rather than an even split, and a table's reported width is its own rather than always the page width. Tables that ask for fixed layout are still laid out on their grid, overflow included, as Word renders them.

--- a/packages/core/src/layout/__tests__/table-placement-and-revisions.test.ts
+++ b/packages/core/src/layout/__tests__/table-placement-and-revisions.test.ts
@@ -1,0 +1,245 @@
+// Where a table sits in the text column (`w:tblInd` 17.4.50, `w:jc` 17.4.29,
+// `w:tblCellSpacing` 17.4.45), and which paragraphs a tracked revision removes from it.
+//
+// A `w:del` on the paragraph MARK (17.13.5.15) joins a paragraph to the next one. When the
+// paragraph's content is deleted too, nothing survives the join and Word shows no line —
+// but layout still measured a full line box for it, because deleted runs contribute no
+// spans and an empty paragraph is still a paragraph.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlPart,
+} from '../../store/package/ooxml-tree.ts';
+import { buildStyleCascadeTable } from '../style-cascade.ts';
+import { readTableStructure, tableOriginX } from '../semantic-table.ts';
+import { revisionRemovesParagraph } from '../revision-visibility.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import type { ParagraphFragmentRecord, TableFragmentRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const REV = 'w:id="1" w:author="a" w:date="2020-01-01T00:00:00Z"';
+
+function part(xml: string, name = '/word/document.xml'): OoxmlPart {
+  const result = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const documentOf = (bodyXml: string) =>
+  part(`<w:document xmlns:w="${W}"><w:body>${bodyXml}</w:body></w:document>`);
+
+function tableNode(bodyXml: string): OoxmlElement {
+  const found = documentOf(bodyXml)
+    .root.children.flatMap((child) => (child.kind === 'textValue' ? [] : child.children))
+    .find((child) => child.kind === 'table');
+  if (!found) throw new Error('no table');
+  return found as OoxmlElement;
+}
+
+const CONTENT_WIDTH_PT = 468;
+const cell = (tcPr = '') => `<w:tc>${tcPr}<w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc>`;
+const grid = (...cols: number[]) =>
+  `<w:tblGrid>${cols.map((w) => `<w:gridCol w:w="${w}"/>`).join('')}</w:tblGrid>`;
+/** 144pt wide, leaving 324pt of slack in the text column. */
+const narrow = `${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr>`;
+
+const structureOf = (bodyXml: string) =>
+  readTableStructure(tableNode(bodyXml), CONTENT_WIDTH_PT, 0)!;
+
+function layoutBody(bodyXml: string) {
+  return layoutSemanticDocument(documentOf(bodyXml), 0, { measurer: createFixedMeasurer() });
+}
+
+function firstTable(bodyXml: string): TableFragmentRecord {
+  const fragment = layoutBody(bodyXml)
+    .pages.flatMap((page) => page.fragments)
+    .find((item): item is TableFragmentRecord => item.kind === 'table');
+  if (!fragment) throw new Error('no table fragment');
+  return fragment;
+}
+
+describe('w:tblInd and w:jc place the table in the text column', () => {
+  test('an absent w:jc leaves the table flush at the leading margin', () => {
+    const structure = structureOf(`<w:tbl><w:tblPr/>${narrow}</w:tbl>`);
+    expect(structure.alignment).toBe('left');
+    expect(structure.indentPt).toBe(0);
+    expect(tableOriginX(structure, CONTENT_WIDTH_PT)).toBe(0);
+  });
+
+  test('w:tblInd shifts a left-aligned table', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblInd w:w="1440" w:type="dxa"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    expect(structure.indentPt).toBe(72);
+    expect(tableOriginX(structure, CONTENT_WIDTH_PT)).toBe(72);
+  });
+
+  test('w:jc="center" centres the table in the column, ignoring the indent', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:jc w:val="center"/><w:tblInd w:w="1440" w:type="dxa"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    expect(structure.alignment).toBe('center');
+    expect(tableOriginX(structure, CONTENT_WIDTH_PT)).toBeCloseTo((468 - 144) / 2, 6);
+  });
+
+  test('w:jc="right" pushes the table to the trailing margin', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:jc w:val="right"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    expect(tableOriginX(structure, CONTENT_WIDTH_PT)).toBeCloseTo(468 - 144, 6);
+  });
+
+  test('the strict-conformant start/end spellings are read as left/right', () => {
+    expect(
+      structureOf(`<w:tbl><w:tblPr><w:jc w:val="start"/></w:tblPr>${narrow}</w:tbl>`).alignment
+    ).toBe('left');
+    expect(
+      structureOf(`<w:tbl><w:tblPr><w:jc w:val="end"/></w:tblPr>${narrow}</w:tbl>`).alignment
+    ).toBe('right');
+  });
+
+  test('a table wider than the column stays flush rather than being centred off the page', () => {
+    const wide = `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr>`;
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:jc w:val="center"/><w:tblLayout w:type="fixed"/></w:tblPr>${wide}</w:tbl>`
+    );
+    expect(tableOriginX(structure, CONTENT_WIDTH_PT)).toBe(0);
+  });
+
+  test('an indent wider than the slack cannot push the table off the column', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblInd w:w="20000" w:type="dxa"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    expect(tableOriginX(structure, CONTENT_WIDTH_PT)).toBeLessThanOrEqual(468 - 144);
+  });
+
+  test('placement reaches the laid-out cells and the fragment box together', () => {
+    const fragment = firstTable(
+      `<w:tbl><w:tblPr><w:jc w:val="center"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    const expected = (468 - 144) / 2;
+    expect(fragment.box.x).toBeCloseTo(expected, 6);
+    expect(fragment.rows[0]!.cells[0]!.box.x).toBeCloseTo(expected, 6);
+    // The box still describes exactly the span its cells cover.
+    const right = Math.max(
+      ...fragment.rows.flatMap((row) => row.cells.map((c) => c.box.x + c.box.width))
+    );
+    expect(fragment.box.x + fragment.box.width).toBeCloseTo(right, 6);
+  });
+
+  test('a table style can state the placement for every table that names it', () => {
+    const styles =
+      `<w:styles xmlns:w="${W}"><w:style w:type="table" w:styleId="Centred">` +
+      '<w:name w:val="Centred"/><w:tblPr><w:jc w:val="center"/></w:tblPr></w:style></w:styles>';
+    const structure = readTableStructure(
+      tableNode(`<w:tbl><w:tblPr><w:tblStyle w:val="Centred"/></w:tblPr>${narrow}</w:tbl>`),
+      CONTENT_WIDTH_PT,
+      0,
+      buildStyleCascadeTable(part(styles, '/word/styles.xml').root)
+    )!;
+    expect(structure.alignment).toBe('center');
+  });
+});
+
+describe('w:tblCellSpacing separates adjacent cells', () => {
+  test('each cell gives up half of every gap, inside its own grid slot', () => {
+    const fragment = firstTable(
+      `<w:tbl><w:tblPr><w:tblCellSpacing w:w="120" w:type="dxa"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    const [first, second] = fragment.rows[0]!.cells;
+    // 120tw = 6pt gap, so 3pt comes off each side of every cell.
+    expect(first!.box.x).toBeCloseTo(3, 6);
+    expect(first!.box.width).toBeCloseTo(72 - 6, 6);
+    expect(second!.box.x - (first!.box.x + first!.box.width)).toBeCloseTo(6, 6);
+    // The grid itself does not move: the table still spans its resolved columns.
+    expect(fragment.box.width).toBeCloseTo(144, 6);
+  });
+
+  test('spacing wider than the column still leaves a positive cell box', () => {
+    const fragment = firstTable(
+      `<w:tbl><w:tblPr><w:tblCellSpacing w:w="5000" w:type="dxa"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    for (const c of fragment.rows[0]!.cells) expect(c.box.width).toBeGreaterThan(0);
+  });
+
+  test('no spacing leaves cells flush, as before', () => {
+    const fragment = firstTable(`<w:tbl><w:tblPr/>${narrow}</w:tbl>`);
+    const [first, second] = fragment.rows[0]!.cells;
+    expect(first!.box.x).toBe(0);
+    expect(second!.box.x).toBeCloseTo(first!.box.x + first!.box.width, 6);
+  });
+});
+
+describe('a tracked revision can remove a paragraph from the rendered document', () => {
+  const markDeleted = (content: string) =>
+    `<w:p><w:pPr><w:rPr><w:del ${REV}/></w:rPr></w:pPr>${content}</w:p>`;
+  const deletedRun = (text: string) =>
+    `<w:del ${REV}><w:r><w:delText>${text}</w:delText></w:r></w:del>`;
+
+  test('a deleted mark over deleted content removes the paragraph', () => {
+    expect(revisionRemovesParagraph(paragraphOf(markDeleted(deletedRun('gone'))))).toBe(true);
+  });
+
+  test('a deleted mark over VISIBLE content keeps it — that content is still shown', () => {
+    expect(revisionRemovesParagraph(paragraphOf(markDeleted('<w:r><w:t>kept</w:t></w:r>')))).toBe(
+      false
+    );
+  });
+
+  test('deleted content under a SURVIVING mark keeps the empty line Word shows', () => {
+    expect(revisionRemovesParagraph(paragraphOf(`<w:p>${deletedRun('gone')}</w:p>`))).toBe(false);
+  });
+
+  test('an ordinary empty paragraph is untouched', () => {
+    expect(revisionRemovesParagraph(paragraphOf('<w:p/>'))).toBe(false);
+  });
+
+  test('a deleted mark over a tab or a break keeps the paragraph, since those occupy a line', () => {
+    expect(revisionRemovesParagraph(paragraphOf(markDeleted('<w:r><w:tab/></w:r>')))).toBe(false);
+    expect(revisionRemovesParagraph(paragraphOf(markDeleted('<w:r><w:br/></w:r>')))).toBe(false);
+  });
+
+  test('the removed paragraph claims no line box in the body flow', () => {
+    const layout = layoutBody(
+      `<w:p><w:r><w:t>above</w:t></w:r></w:p>` +
+        markDeleted(deletedRun('gone')) +
+        `<w:p><w:r><w:t>below</w:t></w:r></w:p>`
+    );
+    const paragraphs = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((f): f is ParagraphFragmentRecord => f.kind === 'paragraph');
+    expect(paragraphs).toHaveLength(2);
+    const text = paragraphs.map((p) =>
+      p.lines
+        .flatMap((l) => l.spans)
+        .map((s) => s.text)
+        .join('')
+    );
+    expect(text).toEqual(['above', 'below']);
+    // "below" sits directly under "above" — no blank line reserved between them.
+    expect(paragraphs[1]!.box.y).toBeCloseTo(paragraphs[0]!.box.y + paragraphs[0]!.box.height, 6);
+  });
+
+  test('a cell of removed paragraphs collapses instead of stacking blank lines', () => {
+    const dead = markDeleted(deletedRun('gone')).repeat(8);
+    const tall = firstTable(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}` +
+        `<w:tr><w:tc>${dead}<w:p><w:r><w:t>real</w:t></w:r></w:p></w:tc>${cell()}</w:tr></w:tbl>`
+    );
+    const plain = firstTable(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}` +
+        `<w:tr><w:tc><w:p><w:r><w:t>real</w:t></w:r></w:p></w:tc>${cell()}</w:tr></w:tbl>`
+    );
+    expect(tall.box.height).toBeCloseTo(plain.box.height, 6);
+  });
+});
+
+function paragraphOf(paragraphXml: string): OoxmlElement {
+  const found = documentOf(paragraphXml)
+    .root.children.flatMap((child) => (child.kind === 'textValue' ? [] : child.children))
+    .find((child) => child.kind === 'paragraph');
+  if (!found) throw new Error('no paragraph');
+  return found as OoxmlElement;
+}

--- a/packages/core/src/layout/__tests__/table-preferred-width.test.ts
+++ b/packages/core/src/layout/__tests__/table-preferred-width.test.ts
@@ -1,0 +1,248 @@
+// Preferred table/cell widths and the fit that follows from them.
+//
+// Three sources settle a table's columns, strongest first: `w:tblGrid` (17.4.49, the
+// producer's own RESOLVED grid), `w:tcW` (17.4.72, what a cell ASKED for), then an even
+// split. Reading `w:tcW` does not mean overriding a stated grid with it — for a well-formed
+// file the two agree, and where they disagree the grid is the later statement.
+//
+// `w:tblLayout` (17.4.53) then decides whether the result may exceed the text column: a
+// fixed table renders past the right margin in Word rather than shrinking, an autofit one
+// never does.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlPart,
+} from '../../store/package/ooxml-tree.ts';
+import { readTableStructure } from '../semantic-table.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import type { TableFragmentRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function part(xml: string, name: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function tableNode(bodyXml: string): OoxmlElement {
+  const document = part(
+    `<w:document xmlns:w="${W}"><w:body>${bodyXml}</w:body></w:document>`,
+    '/word/document.xml'
+  );
+  const found = document.root.children
+    .flatMap((child) => (child.kind === 'textValue' ? [] : child.children))
+    .find((child) => child.kind === 'table');
+  if (!found) throw new Error('no table');
+  return found as OoxmlElement;
+}
+
+/** 468pt = 9360 twips, the content width of a portrait Letter page at 1" margins. */
+const CONTENT_WIDTH_PT = 468;
+
+function structureOf(bodyXml: string, contentWidthPt = CONTENT_WIDTH_PT) {
+  return readTableStructure(tableNode(bodyXml), contentWidthPt, 0)!;
+}
+
+const cell = (tcPr = '') => `<w:tc>${tcPr}<w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc>`;
+const tcW = (w: string, type = 'dxa') => `<w:tcPr><w:tcW w:w="${w}" w:type="${type}"/></w:tcPr>`;
+const grid = (...twips: number[]) =>
+  `<w:tblGrid>${twips.map((w) => `<w:gridCol w:w="${w}"/>`).join('')}</w:tblGrid>`;
+const total = (widths: readonly number[]) => widths.reduce((sum, width) => sum + width, 0);
+
+describe('w:tcW is read onto the cell', () => {
+  test('a dxa preference lands in points', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(2340, 2340)}<w:tr>${cell(tcW('2340'))}${cell(tcW('2340'))}</w:tr></w:tbl>`
+    );
+    expect(structure.rows[0]!.cells[0]!.preferredWidth).toEqual({ type: 'dxa', value: 117 });
+  });
+
+  test('a pct preference is read from fiftieths of a percent, and from the string form', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(2340, 2340)}` +
+        `<w:tr>${cell(tcW('2500', 'pct'))}${cell(tcW('50%', 'pct'))}</w:tr></w:tbl>`
+    );
+    expect(structure.rows[0]!.cells[0]!.preferredWidth).toEqual({ type: 'pct', value: 50 });
+    expect(structure.rows[0]!.cells[1]!.preferredWidth).toEqual({ type: 'pct', value: 50 });
+  });
+
+  test('auto, nil, and an absent w:tcW all carry no width', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(2340, 2340, 2340)}` +
+        `<w:tr>${cell(tcW('0', 'auto'))}${cell(tcW('0', 'nil'))}${cell()}</w:tr></w:tbl>`
+    );
+    const [auto, nil, absent] = structure.rows[0]!.cells;
+    expect(auto!.preferredWidth.type).toBe('auto');
+    expect(nil!.preferredWidth.type).toBe('nil');
+    expect(absent!.preferredWidth).toEqual({ type: 'auto', value: 0 });
+  });
+
+  test('a hostile w:tcW is rejected the way every sibling geometry read rejects one', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(2340, 2340)}` +
+        `<w:tr>${cell(tcW('999999999'))}${cell(tcW('12.5'))}</w:tr></w:tbl>`
+    );
+    // Clamped, not propagated: 999999999 twips would otherwise be ~50,000,000pt.
+    expect(structure.rows[0]!.cells[0]!.preferredWidth.value).toBeLessThanOrEqual(31_680 / 20);
+    // Non-integer is rejected outright, exactly like w:tcMar rejects one.
+    expect(structure.rows[0]!.cells[1]!.preferredWidth.type).toBe('auto');
+  });
+});
+
+describe('w:tblGrid outranks w:tcW when both are stated', () => {
+  test('a grid that disagrees with the cell preferences still wins', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(3000, 1680)}` +
+        `<w:tr>${cell(tcW('1000'))}${cell(tcW('1000'))}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([150, 84]);
+  });
+});
+
+describe('w:tcW settles the columns when no usable grid does', () => {
+  test('a table with no w:tblGrid takes its widths from w:tcW, not an even split', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tr>${cell(tcW('1440'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
+    );
+    // Was an even split at contentWidth/2 = 234pt each; the file said 72pt and 144pt.
+    expect(structure.columnWidthsPt).toEqual([72, 144]);
+  });
+
+  test('a gridSpan cell only settles the columns no narrower claim already did', () => {
+    // Row 2 states column 0 alone at 1440tw; row 1's span-2 cell covers 0 and 1 at 2880tw,
+    // so column 1 gets the 1440tw that the span does not already account for.
+    const spanCell = `<w:tc><w:tcPr><w:gridSpan w:val="2"/><w:tcW w:w="2880" w:type="dxa"/></w:tcPr><w:p/></w:tc>`;
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tr>${spanCell}</w:tr>` +
+        `<w:tr>${cell(tcW('1440'))}${cell()}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([72, 72]);
+  });
+
+  test('a column nothing states still gets a positive width', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tr>${cell(tcW('1440'))}${cell()}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt[0]).toBe(72);
+    expect(structure.columnWidthsPt[1]!).toBeGreaterThan(0);
+  });
+
+  test('an unreadable w:gridCol falls through to the preferences rather than guessing', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="oops"/><w:gridCol w:w="1440"/></w:tblGrid>` +
+        `<w:tr>${cell(tcW('1440'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([72, 144]);
+  });
+});
+
+describe('w:tblLayout decides whether a table may exceed the text column', () => {
+  const wide = `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr>`;
+
+  test('an autofit table wider than the content box scales down to fit it', () => {
+    const structure = structureOf(`<w:tbl><w:tblPr/>${wide}</w:tbl>`);
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
+    // Proportions are preserved: both columns were equal and stay equal.
+    expect(structure.columnWidthsPt[0]).toBeCloseTo(structure.columnWidthsPt[1]!, 6);
+  });
+
+  test('a fixed table wider than the content box is left alone, as Word renders it', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblLayout w:type="fixed"/></w:tblPr>${wide}</w:tbl>`
+    );
+    expect(structure.layoutFixed).toBe(true);
+    expect(structure.columnWidthsPt).toEqual([360, 360]);
+  });
+
+  test('an autofit table narrower than the content box is not stretched to it', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([72, 72]);
+  });
+
+  test('w:tblLayout w:type="autofit" is autofit, like an absent element', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblLayout w:type="autofit"/></w:tblPr>${wide}</w:tbl>`
+    );
+    expect(structure.layoutFixed).toBe(false);
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
+  });
+});
+
+describe('w:tblW caps the width an autofit table fits into', () => {
+  const wide = `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr>`;
+
+  test('a dxa table width narrower than the page is the target', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblW w:w="4680" w:type="dxa"/></w:tblPr>${wide}</w:tbl>`
+    );
+    expect(structure.tableWidth).toEqual({ type: 'dxa', value: 234 });
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(234, 6);
+  });
+
+  test('a pct table width resolves against the content box', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblW w:w="2500" w:type="pct"/></w:tblPr>${wide}</w:tbl>`
+    );
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT / 2, 6);
+  });
+
+  test('a dxa table width wider than the page still cannot exceed the page', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblW w:w="20000" w:type="dxa"/></w:tblPr>${wide}</w:tbl>`
+    );
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
+  });
+});
+
+describe('the table fragment box reports the table’s own width', () => {
+  function tableFragment(bodyXml: string): TableFragmentRecord {
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W}"><w:body>${bodyXml}</w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    const layout = layoutSemanticDocument(result.part, 0, { measurer: createFixedMeasurer() });
+    const fragment = layout.pages
+      .flatMap((page) => page.fragments)
+      .find((item): item is TableFragmentRecord => item.kind === 'table');
+    if (!fragment) throw new Error('no table fragment');
+    return fragment;
+  }
+
+  const rightEdge = (fragment: TableFragmentRecord) =>
+    Math.max(...fragment.rows.flatMap((row) => row.cells.map((c) => c.box.x + c.box.width)));
+
+  test('a table narrower than the page reports its own width, not the page’s', () => {
+    const fragment = tableFragment(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+    );
+    expect(fragment.box.width).toBeCloseTo(144, 6);
+    expect(fragment.box.width).toBeCloseTo(rightEdge(fragment), 6);
+  });
+
+  test('a fixed table wider than the page reports the width it actually paints', () => {
+    const fragment = tableFragment(
+      `<w:tbl><w:tblPr><w:tblLayout w:type="fixed"/></w:tblPr>` +
+        `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+    );
+    expect(fragment.box.width).toBeCloseTo(720, 6);
+    expect(fragment.box.width).toBeCloseTo(rightEdge(fragment), 6);
+  });
+});
+
+describe('a hostile grid column cannot shrink the columns beside it', () => {
+  test('the clamp bounds the one column and no fit is derived from it', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(999999999, 1200)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt[0]!).toBeLessThanOrEqual(31_680 / 20);
+    // Scaling this table to the page would let one absurd w:gridCol crush every real
+    // column in it; the per-column clamp is the whole defense.
+    expect(structure.columnWidthsPt[1]).toBe(60);
+  });
+});

--- a/packages/core/src/layout/__tests__/table-preferred-width.test.ts
+++ b/packages/core/src/layout/__tests__/table-preferred-width.test.ts
@@ -1,13 +1,12 @@
-// Preferred table/cell widths and the fit that follows from them.
+// `w:tblGrid` (17.4.48) seeds a table's columns and `w:tcW` (17.4.71) overrides it: 17.4.16
+// calls the grid widths "the initial width of each grid column, which can then be overridden
+// by ... the preferred widths of specific cells", and 17.18.87 reconciles rows that disagree
+// by MAXIMUM. Anything still unstated shares what the content width has left.
 //
-// Three sources settle a table's columns, strongest first: `w:tblGrid` (17.4.49, the
-// producer's own RESOLVED grid), `w:tcW` (17.4.72, what a cell ASKED for), then an even
-// split. Reading `w:tcW` does not mean overriding a stated grid with it — for a well-formed
-// file the two agree, and where they disagree the grid is the later statement.
-//
-// `w:tblLayout` (17.4.53) then decides whether the result may exceed the text column: a
-// fixed table renders past the right margin in Word rather than shrinking, an autofit one
-// never does.
+// `w:tblW` (17.4.63) then bounds the total, and `w:tblLayout` (17.4.52 — 17.4.53 is the
+// `w:tblPrEx` variant) decides whether the PAGE also bounds it: 17.18.87 puts "override the
+// preferred table width until the table reaches the page width" in the autofit chain only,
+// so a fixed table with no `w:tblW` renders past the right margin the way Word renders it.
 
 import { describe, expect, test } from 'bun:test';
 import {
@@ -15,8 +14,10 @@ import {
   type OoxmlElement,
   type OoxmlPart,
 } from '../../store/package/ooxml-tree.ts';
+import { buildStyleCascadeTable } from '../style-cascade.ts';
 import { readTableStructure } from '../semantic-table.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { hitTestPage } from '../semantic-hit-test.ts';
 import type { TableFragmentRecord } from '../semantic-records.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -42,14 +43,14 @@ function tableNode(bodyXml: string): OoxmlElement {
 /** 468pt = 9360 twips, the content width of a portrait Letter page at 1" margins. */
 const CONTENT_WIDTH_PT = 468;
 
-function structureOf(bodyXml: string, contentWidthPt = CONTENT_WIDTH_PT) {
+function structureOf(bodyXml: string, contentWidthPt: number = CONTENT_WIDTH_PT) {
   return readTableStructure(tableNode(bodyXml), contentWidthPt, 0)!;
 }
 
 const cell = (tcPr = '') => `<w:tc>${tcPr}<w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc>`;
 const tcW = (w: string, type = 'dxa') => `<w:tcPr><w:tcW w:w="${w}" w:type="${type}"/></w:tcPr>`;
-const grid = (...twips: number[]) =>
-  `<w:tblGrid>${twips.map((w) => `<w:gridCol w:w="${w}"/>`).join('')}</w:tblGrid>`;
+const grid = (...cols: (number | string)[]) =>
+  `<w:tblGrid>${cols.map((w) => `<w:gridCol w:w="${w}"/>`).join('')}</w:tblGrid>`;
 const total = (widths: readonly number[]) => widths.reduce((sum, width) => sum + width, 0);
 
 describe('w:tcW is read onto the cell', () => {
@@ -60,13 +61,44 @@ describe('w:tcW is read onto the cell', () => {
     expect(structure.rows[0]!.cells[0]!.preferredWidth).toEqual({ type: 'dxa', value: 117 });
   });
 
-  test('a pct preference is read from fiftieths of a percent, and from the string form', () => {
+  test('a pct preference is read from fiftieths, the string form, and a decimal percent', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(2340, 2340, 2340)}` +
+        `<w:tr>${cell(tcW('2500', 'pct'))}${cell(tcW('50%', 'pct'))}${cell(tcW('33.3%', 'pct'))}</w:tr></w:tbl>`
+    );
+    const [fiftieths, string, decimal] = structure.rows[0]!.cells;
+    expect(fiftieths!.preferredWidth).toEqual({ type: 'pct', value: 50 });
+    expect(string!.preferredWidth).toEqual({ type: 'pct', value: 50 });
+    // 17.4.71's own example is `w:w="33.3%"`; ST_Percentage admits the decimal.
+    expect(decimal!.preferredWidth).toEqual({ type: 'pct', value: 33.3 });
+  });
+
+  test('a universal measure is read, since w:w is ST_MeasurementOrPercent not just twips', () => {
     const structure = structureOf(
       `<w:tbl><w:tblPr/>${grid(2340, 2340)}` +
-        `<w:tr>${cell(tcW('2500', 'pct'))}${cell(tcW('50%', 'pct'))}</w:tr></w:tbl>`
+        `<w:tr>${cell(tcW('2in'))}${cell(tcW('72pt'))}</w:tr></w:tbl>`
+    );
+    expect(structure.rows[0]!.cells[0]!.preferredWidth).toEqual({ type: 'dxa', value: 144 });
+    expect(structure.rows[0]!.cells[1]!.preferredWidth).toEqual({ type: 'dxa', value: 72 });
+  });
+
+  test('a measurement that contradicts w:type wins over it, per 17.4.87', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(2340, 2340)}` +
+        `<w:tr>${cell(tcW('50%', 'dxa'))}${cell(tcW('1in', 'pct'))}</w:tr></w:tbl>`
     );
     expect(structure.rows[0]!.cells[0]!.preferredWidth).toEqual({ type: 'pct', value: 50 });
-    expect(structure.rows[0]!.cells[1]!.preferredWidth).toEqual({ type: 'pct', value: 50 });
+    expect(structure.rows[0]!.cells[1]!.preferredWidth).toEqual({ type: 'dxa', value: 72 });
+  });
+
+  test('an unrecognised w:type is rejected, not silently read as an absolute width', () => {
+    // `w:type="Pct" w:w="5000"` read as dxa would be a 250pt hard width instead of 100%.
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(2340, 2340)}` +
+        `<w:tr>${cell(tcW('5000', 'Pct'))}${cell(tcW('1440', 'typo'))}</w:tr></w:tbl>`
+    );
+    expect(structure.rows[0]!.cells[0]!.preferredWidth.type).toBe('auto');
+    expect(structure.rows[0]!.cells[1]!.preferredWidth.type).toBe('auto');
   });
 
   test('auto, nil, and an absent w:tcW all carry no width', () => {
@@ -85,76 +117,158 @@ describe('w:tcW is read onto the cell', () => {
       `<w:tbl><w:tblPr/>${grid(2340, 2340)}` +
         `<w:tr>${cell(tcW('999999999'))}${cell(tcW('12.5'))}</w:tr></w:tbl>`
     );
-    // Clamped, not propagated: 999999999 twips would otherwise be ~50,000,000pt.
     expect(structure.rows[0]!.cells[0]!.preferredWidth.value).toBeLessThanOrEqual(31_680 / 20);
-    // Non-integer is rejected outright, exactly like w:tcMar rejects one.
+    // A bare decimal is neither twips nor a universal measure: rejected outright.
     expect(structure.rows[0]!.cells[1]!.preferredWidth.type).toBe('auto');
   });
 });
 
-describe('w:tblGrid outranks w:tcW when both are stated', () => {
-  test('a grid that disagrees with the cell preferences still wins', () => {
+describe('w:tcW overrides the grid it seeds, resolving conflicts by maximum', () => {
+  test('a cell asking for more than the grid gets it', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}` +
+        `<w:tr>${cell(tcW('2880'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([144, 144]);
+  });
+
+  test('a cell asking for less than the grid does not shrink it', () => {
     const structure = structureOf(
       `<w:tbl><w:tblPr/>${grid(3000, 1680)}` +
         `<w:tr>${cell(tcW('1000'))}${cell(tcW('1000'))}</w:tr></w:tbl>`
     );
     expect(structure.columnWidthsPt).toEqual([150, 84]);
   });
-});
 
-describe('w:tcW settles the columns when no usable grid does', () => {
-  test('a table with no w:tblGrid takes its widths from w:tcW, not an even split', () => {
+  test('rows that disagree resolve to the maximum, not to whichever came first', () => {
+    // 17.18.87: "each grid column is adjusted to be the maximum value of the requested widths".
     const structure = structureOf(
-      `<w:tbl><w:tblPr/><w:tr>${cell(tcW('1440'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
+      `<w:tbl><w:tblPr/>` +
+        `<w:tr>${cell(tcW('1440'))}${cell(tcW('1440'))}</w:tr>` +
+        `<w:tr>${cell(tcW('2880'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
     );
-    // Was an even split at contentWidth/2 = 234pt each; the file said 72pt and 144pt.
-    expect(structure.columnWidthsPt).toEqual([72, 144]);
+    expect(structure.columnWidthsPt).toEqual([144, 144]);
   });
 
-  test('a gridSpan cell only settles the columns no narrower claim already did', () => {
-    // Row 2 states column 0 alone at 1440tw; row 1's span-2 cell covers 0 and 1 at 2880tw,
-    // so column 1 gets the 1440tw that the span does not already account for.
+  test('the maximum is still bounded by the page for an autofit table', () => {
+    // Both rows resolve to 288pt, which overflows the 468pt column, so the fit scales the
+    // agreed maximum back down rather than letting w:tcW escape the page clamp.
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>` +
+        `<w:tr>${cell(tcW('1440'))}${cell(tcW('1440'))}</w:tr>` +
+        `<w:tr>${cell(tcW('5760'))}${cell(tcW('5760'))}</w:tr></w:tbl>`
+    );
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
+  });
+
+  test('a narrower footprint is authoritative over a span that contains it', () => {
     const spanCell = `<w:tc><w:tcPr><w:gridSpan w:val="2"/><w:tcW w:w="2880" w:type="dxa"/></w:tcPr><w:p/></w:tc>`;
     const structure = structureOf(
       `<w:tbl><w:tblPr/><w:tr>${spanCell}</w:tr>` +
         `<w:tr>${cell(tcW('1440'))}${cell()}</w:tr></w:tbl>`
     );
+    // The span states 144pt across both columns; the single-column row settles the first at
+    // 72pt, so the span has 72pt left to give the second.
     expect(structure.columnWidthsPt).toEqual([72, 72]);
   });
 
-  test('a column nothing states still gets a positive width', () => {
+  test('a span whose total is already used up by settled columns adds nothing', () => {
+    const spanCell = `<w:tc><w:tcPr><w:gridSpan w:val="2"/><w:tcW w:w="1440" w:type="dxa"/></w:tcPr><w:p/></w:tc>`;
     const structure = structureOf(
-      `<w:tbl><w:tblPr/><w:tr>${cell(tcW('1440'))}${cell()}</w:tr></w:tbl>`
+      `<w:tbl><w:tblPr/><w:tr>${spanCell}</w:tr>` +
+        `<w:tr>${cell(tcW('2880'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
     );
-    expect(structure.columnWidthsPt[0]).toBe(72);
-    expect(structure.columnWidthsPt[1]!).toBeGreaterThan(0);
+    expect(structure.columnWidthsPt).toEqual([144, 144]);
   });
 
-  test('an unreadable w:gridCol falls through to the preferences rather than guessing', () => {
+  test('pct cell widths resolve against the table width rather than being discarded', () => {
+    // 17.4.71: "any width value of type pct ... shall be calculated relative to the overall
+    // width of the table".
     const structure = structureOf(
-      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="oops"/><w:gridCol w:w="1440"/></w:tblGrid>` +
-        `<w:tr>${cell(tcW('1440'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
+      `<w:tbl><w:tblPr><w:tblW w:w="4680" w:type="dxa"/></w:tblPr>` +
+        `<w:tr>${cell(tcW('2500', 'pct'))}${cell(tcW('2500', 'pct'))}</w:tr></w:tbl>`
     );
-    expect(structure.columnWidthsPt).toEqual([72, 144]);
+    expect(structure.columnWidthsPt).toEqual([117, 117]);
   });
 });
 
-describe('w:tblLayout decides whether a table may exceed the text column', () => {
+describe('w:tblGrid seeds what it can and no more', () => {
+  test('a table with no w:tblGrid takes its widths from w:tcW, not an even split', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tr>${cell(tcW('1440'))}${cell(tcW('2880'))}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([72, 144]);
+  });
+
+  test('one unreadable w:gridCol costs that column only, not the whole authored grid', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="2340"/><w:gridCol/><w:gridCol w:w="2340"/></w:tblGrid>` +
+        `<w:tr>${cell()}${cell()}${cell()}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt[0]).toBe(117);
+    expect(structure.columnWidthsPt[2]).toBe(117);
+    expect(structure.columnWidthsPt[1]!).toBeGreaterThan(0);
+  });
+
+  test('a w:gridCol in a universal measure is read, not discarded', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid('2in', 1440)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([144, 72]);
+  });
+
+  test('an unstated column cannot swallow the page — it is capped at the stated mean', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tr>${cell(tcW('1440'))}${cell()}</w:tr></w:tbl>`
+    );
+    // Was 396pt: the whole leftover of the content width for one unstated column.
+    expect(structure.columnWidthsPt).toEqual([72, 72]);
+  });
+
+  test('w:wBefore states the skipped band instead of leaving a phantom gutter', () => {
+    // 17.18.87: "the width of the skipped grid columns is set using the wBefore property".
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tr>` +
+        `<w:trPr><w:gridBefore w:val="1"/><w:wBefore w:w="1440" w:type="dxa"/></w:trPr>` +
+        `${cell(tcW('1440'))}${cell(tcW('1440'))}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([72, 72, 72]);
+  });
+
+  test('w:wAfter states the trailing skipped band', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/><w:tr>` +
+        `<w:trPr><w:gridAfter w:val="1"/><w:wAfter w:w="1440" w:type="dxa"/></w:trPr>` +
+        `${cell(tcW('1440'))}${cell(tcW('1440'))}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt).toEqual([72, 72, 72]);
+  });
+});
+
+describe('w:tblLayout decides whether the PAGE bounds the table', () => {
   const wide = `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr>`;
 
   test('an autofit table wider than the content box scales down to fit it', () => {
     const structure = structureOf(`<w:tbl><w:tblPr/>${wide}</w:tbl>`);
     expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
-    // Proportions are preserved: both columns were equal and stay equal.
     expect(structure.columnWidthsPt[0]).toBeCloseTo(structure.columnWidthsPt[1]!, 6);
   });
 
-  test('a fixed table wider than the content box is left alone, as Word renders it', () => {
+  test('a fixed table with no w:tblW is left alone, as Word renders it', () => {
     const structure = structureOf(
       `<w:tbl><w:tblPr><w:tblLayout w:type="fixed"/></w:tblPr>${wide}</w:tbl>`
     );
     expect(structure.layoutFixed).toBe(true);
     expect(structure.columnWidthsPt).toEqual([360, 360]);
+  });
+
+  test('a fixed table IS still held to a stated w:tblW', () => {
+    // 17.18.87 puts the proportional reduction against tblW in the fixed algorithm; only the
+    // page clamp is autofit-only.
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblLayout w:type="fixed"/><w:tblW w:w="2000" w:type="dxa"/></w:tblPr>${wide}</w:tbl>`
+    );
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(100, 6);
   });
 
   test('an autofit table narrower than the content box is not stretched to it', () => {
@@ -173,8 +287,9 @@ describe('w:tblLayout decides whether a table may exceed the text column', () =>
   });
 });
 
-describe('w:tblW caps the width an autofit table fits into', () => {
+describe('w:tblW bounds the total', () => {
   const wide = `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr>`;
+  const narrow = `${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr>`;
 
   test('a dxa table width narrower than the page is the target', () => {
     const structure = structureOf(
@@ -184,11 +299,20 @@ describe('w:tblW caps the width an autofit table fits into', () => {
     expect(total(structure.columnWidthsPt)).toBeCloseTo(234, 6);
   });
 
-  test('a pct table width resolves against the content box', () => {
+  test('a pct table width STRETCHES a narrow table — this is AutoFit to Window', () => {
+    // 17.4.63: a pct table width is relative to the page's text extents. 5000 = 100%.
     const structure = structureOf(
-      `<w:tbl><w:tblPr><w:tblW w:w="2500" w:type="pct"/></w:tblPr>${wide}</w:tbl>`
+      `<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="pct"/></w:tblPr>${narrow}</w:tbl>`
     );
-    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT / 2, 6);
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
+    expect(structure.columnWidthsPt[0]).toBeCloseTo(234, 6);
+  });
+
+  test('a dxa table width does NOT stretch a narrow table', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblW w:w="9360" w:type="dxa"/></w:tblPr>${narrow}</w:tbl>`
+    );
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(144, 6);
   });
 
   test('a dxa table width wider than the page still cannot exceed the page', () => {
@@ -197,52 +321,157 @@ describe('w:tblW caps the width an autofit table fits into', () => {
     );
     expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
   });
+
+  test('a hostile w:tblW cannot crush every column to nothing', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr><w:tblW w:w="1" w:type="dxa"/></w:tblPr>${wide}</w:tbl>`
+    );
+    for (const width of structure.columnWidthsPt) expect(width).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('a table style states w:tblW and w:tblLayout for every table that names it', () => {
+  const STYLES =
+    `<w:styles xmlns:w="${W}">` +
+    '<w:style w:type="table" w:styleId="Windowed"><w:name w:val="Windowed"/>' +
+    '<w:tblPr><w:tblW w:w="5000" w:type="pct"/></w:tblPr></w:style>' +
+    '<w:style w:type="table" w:styleId="Fixed"><w:name w:val="Fixed"/>' +
+    '<w:tblPr><w:tblLayout w:type="fixed"/></w:tblPr></w:style>' +
+    '</w:styles>';
+  const cascade = () => buildStyleCascadeTable(part(STYLES, '/word/styles.xml').root);
+  const styled = (styleId: string, body: string) =>
+    readTableStructure(
+      tableNode(`<w:tbl><w:tblPr><w:tblStyle w:val="${styleId}"/></w:tblPr>${body}</w:tbl>`),
+      CONTENT_WIDTH_PT,
+      0,
+      cascade()
+    )!;
+
+  test('a style-level w:tblW is honoured', () => {
+    const structure = styled('Windowed', `${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr>`);
+    expect(structure.tableWidth).toEqual({ type: 'pct', value: 100 });
+    expect(total(structure.columnWidthsPt)).toBeCloseTo(CONTENT_WIDTH_PT, 6);
+  });
+
+  test('a style-level w:tblLayout is honoured', () => {
+    const structure = styled('Fixed', `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr>`);
+    expect(structure.layoutFixed).toBe(true);
+    expect(structure.columnWidthsPt).toEqual([360, 360]);
+  });
+
+  test('the table’s own w:tblPr wins over the style', () => {
+    const structure = readTableStructure(
+      tableNode(
+        `<w:tbl><w:tblPr><w:tblStyle w:val="Windowed"/><w:tblW w:w="0" w:type="auto"/></w:tblPr>` +
+          `${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+      ),
+      CONTENT_WIDTH_PT,
+      0,
+      cascade()
+    )!;
+    expect(structure.tableWidth.type).toBe('auto');
+    expect(structure.columnWidthsPt).toEqual([72, 72]);
+  });
+});
+
+describe('degenerate and hostile geometry stays bounded', () => {
+  test('a hostile grid column is dropped, and the columns beside it keep their widths', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(999999999, 1200)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+    );
+    expect(structure.columnWidthsPt[0]!).toBeLessThanOrEqual(31_680 / 20);
+    expect(structure.columnWidthsPt[1]).toBe(60);
+  });
+
+  test('a non-finite content width resolves from the grid instead of poisoning it', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`,
+      Number.NaN
+    );
+    expect(structure.columnWidthsPt).toEqual([72, 72]);
+  });
+
+  test('a zero content width never produces a zero or negative column', () => {
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`,
+      0
+    );
+    for (const width of structure.columnWidthsPt) expect(width).toBeGreaterThan(0);
+  });
+
+  test('no column collapses below a hairline even when the table must shrink hard', () => {
+    const cols = Array.from({ length: 20 }, () => 2880);
+    const cells = cols.map(() => cell()).join('');
+    const structure = structureOf(
+      `<w:tbl><w:tblPr/>${grid(...cols)}<w:tr>${cells}</w:tr></w:tbl>`,
+      10
+    );
+    for (const width of structure.columnWidthsPt) expect(width).toBeGreaterThanOrEqual(1);
+  });
 });
 
 describe('the table fragment box reports the table’s own width', () => {
-  function tableFragment(bodyXml: string): TableFragmentRecord {
+  function layoutBody(bodyXml: string) {
     const result = readOoxmlPart(
       `<w:document xmlns:w="${W}"><w:body>${bodyXml}</w:body></w:document>`,
       { name: '/word/document.xml', contentType: 'app/xml' }
     );
     if (!result.ok) throw new Error(result.reason);
-    const layout = layoutSemanticDocument(result.part, 0, { measurer: createFixedMeasurer() });
-    const fragment = layout.pages
-      .flatMap((page) => page.fragments)
-      .find((item): item is TableFragmentRecord => item.kind === 'table');
-    if (!fragment) throw new Error('no table fragment');
-    return fragment;
+    return layoutSemanticDocument(result.part, 0, { measurer: createFixedMeasurer() });
+  }
+
+  function tableFragments(bodyXml: string): TableFragmentRecord[] {
+    return layoutBody(bodyXml)
+      .pages.flatMap((page) => page.fragments)
+      .filter((item): item is TableFragmentRecord => item.kind === 'table');
   }
 
   const rightEdge = (fragment: TableFragmentRecord) =>
     Math.max(...fragment.rows.flatMap((row) => row.cells.map((c) => c.box.x + c.box.width)));
 
   test('a table narrower than the page reports its own width, not the page’s', () => {
-    const fragment = tableFragment(
+    const [fragment] = tableFragments(
       `<w:tbl><w:tblPr/>${grid(1440, 1440)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
     );
-    expect(fragment.box.width).toBeCloseTo(144, 6);
-    expect(fragment.box.width).toBeCloseTo(rightEdge(fragment), 6);
+    expect(fragment!.box.width).toBeCloseTo(144, 6);
+    expect(fragment!.box.width).toBeCloseTo(rightEdge(fragment!), 6);
   });
 
   test('a fixed table wider than the page reports the width it actually paints', () => {
-    const fragment = tableFragment(
+    const [fragment] = tableFragments(
       `<w:tbl><w:tblPr><w:tblLayout w:type="fixed"/></w:tblPr>` +
         `${grid(7200, 7200)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
     );
-    expect(fragment.box.width).toBeCloseTo(720, 6);
-    expect(fragment.box.width).toBeCloseTo(rightEdge(fragment), 6);
+    expect(fragment!.box.width).toBeCloseTo(720, 6);
+    expect(fragment!.box.width).toBeCloseTo(rightEdge(fragment!), 6);
   });
-});
 
-describe('a hostile grid column cannot shrink the columns beside it', () => {
-  test('the clamp bounds the one column and no fit is derived from it', () => {
-    const structure = structureOf(
-      `<w:tbl><w:tblPr/>${grid(999999999, 1200)}<w:tr>${cell()}${cell()}</w:tr></w:tbl>`
+  test('every fragment of a table that paginates reports the same width', () => {
+    const row = `<w:tr>${cell()}${cell()}</w:tr>`;
+    const fragments = tableFragments(
+      `<w:tbl><w:tblPr/>${grid(1440, 1440)}${row.repeat(300)}</w:tbl>`
     );
-    expect(structure.columnWidthsPt[0]!).toBeLessThanOrEqual(31_680 / 20);
-    // Scaling this table to the page would let one absurd w:gridCol crush every real
-    // column in it; the per-column clamp is the whole defense.
-    expect(structure.columnWidthsPt[1]).toBe(60);
+    expect(fragments.length).toBeGreaterThan(1);
+    for (const fragment of fragments) expect(fragment.box.width).toBeCloseTo(144, 6);
+  });
+
+  test('clicking beside a narrow table lands in that row, not in a neighbouring paragraph', () => {
+    const layout = layoutBody(
+      `<w:p><w:r><w:t>above</w:t></w:r></w:p>` +
+        `<w:tbl><w:tblPr/>${grid(1440, 1440)}` +
+        `<w:tr>${cell()}${cell()}</w:tr></w:tbl>` +
+        `<w:p><w:r><w:t>below</w:t></w:r></w:p>`
+    );
+    const table = layout.pages[0]!.fragments.find(
+      (f): f is TableFragmentRecord => f.kind === 'table'
+    )!;
+    // Cell block ids carry a `#f<n>` fragment suffix; the hit reports the source paragraph.
+    const insideCell = table.rows[0]!.cells[1]!.blocks[0]!.id.replace(/#f\d+$/, '');
+    const y = table.rows[0]!.box.y + table.rows[0]!.box.height / 2;
+    // 144pt-wide table on a 468pt page: everything past x=144 is blank strip.
+    for (const x of [200, 300, 460]) {
+      const hit = hitTestPage(layout, 0, { x, y });
+      expect(hit?.position.paragraphId).toBe(insideCell);
+    }
   });
 });

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -381,6 +381,7 @@ export {
   MAX_TABLE_COLUMNS,
   MAX_TABLE_NESTING,
   readTableStructure,
+  tableOriginX,
   type CellMarginsPt,
   type CellVerticalAlign,
   type PreferredWidth,
@@ -388,7 +389,9 @@ export {
   type SemanticTableCell,
   type SemanticTableRow,
   type SemanticTableStructure,
+  type TableAlignment,
 } from './semantic-table.ts';
+export { paragraphMarkDeleted, revisionRemovesParagraph } from './revision-visibility.ts';
 export {
   MAX_TABLE_ROW_FRAGMENTS,
   TablePaginationError,

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -375,6 +375,7 @@ export {
   type SemanticSelection,
 } from './semantic-interaction.ts';
 export {
+  AUTO_PREFERRED_WIDTH,
   CELL_PAD,
   DEFAULT_CELL_MARGINS,
   MAX_TABLE_COLUMNS,
@@ -382,6 +383,8 @@ export {
   readTableStructure,
   type CellMarginsPt,
   type CellVerticalAlign,
+  type PreferredWidth,
+  type PreferredWidthType,
   type SemanticTableCell,
   type SemanticTableRow,
   type SemanticTableStructure,

--- a/packages/core/src/layout/revision-visibility.ts
+++ b/packages/core/src/layout/revision-visibility.ts
@@ -1,0 +1,88 @@
+// Which paragraphs a tracked revision removes from the laid-out document.
+//
+// A `w:del` on the paragraph MARK (17.13.5.15, `w:pPr/w:rPr/w:del`) says the mark itself was
+// deleted, which in Word joins the paragraph to the one after it. When everything the
+// paragraph would have rendered is deleted too, that join leaves nothing at all — Word shows
+// no line where the paragraph was.
+//
+// Layout does not render deleted run content (a `w:del` is not a run container it walks, and
+// `w:delText` is not model text), so such a paragraph reaches pagination with no spans and
+// still claims a full line box. A cell of them is a stack of blank lines that pushes real
+// content down the page and off it. This module identifies exactly that case.
+//
+// The narrow condition matters. A paragraph whose CONTENT is deleted but whose mark survives
+// is a paragraph Word still shows as empty, and suppressing it would delete a blank line the
+// document really has. A paragraph whose mark is deleted but which still renders something
+// has to keep its box, because that content is visible and Word merely merges it forward —
+// dropping it would lose text. Only the intersection is removed.
+
+import type { OoxmlNode } from '@docx-editor.dev/core-contract/store';
+
+/** Matches the layout walk's own container recursion; see `piecesOfParagraph`. */
+const MAX_INLINE_DEPTH = 8;
+
+function childNamed(node: OoxmlNode, localName: string): OoxmlNode | undefined {
+  if (node.kind === 'textValue') return undefined;
+  for (const child of node.children) {
+    if (child.kind !== 'textValue' && child.localName === localName) return child;
+  }
+  return undefined;
+}
+
+/**
+ * `w:pPr/w:rPr/w:del` — the paragraph mark was deleted by a tracked revision.
+ *
+ * Read from the paragraph-mark run properties only. A `w:del` anywhere else in the paragraph
+ * deletes run content, which is a different statement entirely.
+ */
+export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean {
+  if (paragraph.kind === 'textValue') return false;
+  const properties = childNamed(paragraph, 'paragraphProperties') ?? childNamed(paragraph, 'pPr');
+  if (!properties) return false;
+  const markRunProperties =
+    childNamed(properties, 'runProperties') ?? childNamed(properties, 'rPr');
+  return markRunProperties !== undefined && childNamed(markRunProperties, 'del') !== undefined;
+}
+
+/**
+ * Whether the paragraph would put any text on the page.
+ *
+ * Deliberately mirrors the container recursion layout itself performs: typed runs and the
+ * runs inside a `w:hyperlink` contribute, and any other container (including `w:del` and
+ * `w:ins`) does not. If that recursion ever changes, this must change with it or a paragraph
+ * that now renders could be suppressed.
+ */
+function rendersNoText(node: OoxmlNode, depth: number): boolean {
+  if (node.kind === 'textValue') return true;
+  if (depth > MAX_INLINE_DEPTH) return true;
+  for (const child of node.children) {
+    if (child.kind === 'textValue') continue;
+    if (child.kind === 'run') {
+      for (const grand of child.children) {
+        if (grand.kind === 'text') {
+          for (const value of grand.children) {
+            if (value.kind === 'textValue' && value.value.length > 0) return false;
+          }
+          continue;
+        }
+        // A tab, a break, or a drawing all occupy the line even with no characters. Anything
+        // unrecognised counts as rendering too: keeping a paragraph that renders nothing
+        // costs a blank line, dropping one that renders something loses content.
+        if (grand.kind !== 'runProperties') return false;
+      }
+      continue;
+    }
+    if (child.kind === 'hyperlink' && !rendersNoText(child, depth + 1)) return false;
+  }
+  return true;
+}
+
+/**
+ * True when a tracked revision has removed this paragraph from the rendered document, so
+ * layout should emit no box for it at all.
+ */
+export function revisionRemovesParagraph(paragraph: OoxmlNode): boolean {
+  if (paragraph.kind !== 'paragraph') return false;
+  if (!paragraphMarkDeleted(paragraph)) return false;
+  return rendersNoText(paragraph, 0);
+}

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -326,6 +326,31 @@ function weightedDistance(box: LayoutBox, point: HitPoint, verticalWeight: numbe
 }
 
 /**
+ * How far a point is from a BLOCK, which is not the same question as how far it is from the
+ * block's box.
+ *
+ * A table owns its whole horizontal band. Its box is only as wide as its columns, so the
+ * blank strip beside a narrow table sits outside every box on the page, and plain
+ * nearest-box hands that strip to whichever PARAGRAPH above or below happens to be closer —
+ * a click level with row three lands two paragraphs up. Word puts the caret in the nearest
+ * cell of the row you clicked beside, so a table level with the point is at distance zero
+ * horizontally and the row resolution below picks the cell.
+ *
+ * Paragraphs keep the plain measure: their boxes start at the left indent, and the indent
+ * strip must stay reachable by real proximity.
+ */
+function blockDistance(
+  block: BlockFragmentRecord,
+  point: HitPoint,
+  verticalWeight: number
+): number {
+  if (block.kind !== 'table') return weightedDistance(block.box, point, verticalWeight);
+  const dy = Math.max(block.box.y - point.y, 0, point.y - (block.box.y + block.box.height));
+  if (dy > 0) return weightedDistance(block.box, point, verticalWeight);
+  return 0;
+}
+
+/**
  * The block a point means, then the position within it.
  *
  * A paragraph's box starts at its left INDENT, so the indent strip — the most common place to
@@ -359,7 +384,7 @@ function resolveBlocks(
   // answer for a press.
   const ranked = blocks
     .filter((block) => block !== contained)
-    .map((block) => ({ block, score: weightedDistance(block.box, point, context.verticalWeight) }))
+    .map((block) => ({ block, score: blockDistance(block, point, context.verticalWeight) }))
     .sort((left, right) => left.score - right.score);
   for (const { block } of ranked) {
     const hit = resolveOneBlock(block, point, context, cell);

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -783,7 +783,11 @@ function layoutBlocksWithGeometry(
         box: {
           x: 0,
           y: fragmentTop,
-          width: contentWidth,
+          // The table's own width, not the page's. Reporting `contentWidth` here described
+          // every table as exactly page-wide while its cells spanned whatever the resolved
+          // grid said — narrower for most tables, wider for a fixed-layout one that
+          // genuinely overflows the margin.
+          width: structure.columnWidthsPt.reduce((sum, columnWidth) => sum + columnWidth, 0),
           height: last.box.y + last.box.height - fragmentTop,
         },
       });

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -51,7 +51,7 @@ import {
   type StyleCascadeTable,
 } from './style-cascade.ts';
 import { paragraphShadingBox } from './ooxml-shading.ts';
-import { readTableStructure, type SemanticTableRow } from './semantic-table.ts';
+import { readTableStructure, tableOriginX, type SemanticTableRow } from './semantic-table.ts';
 import {
   createTableBorderOwnershipBudget,
   createTableVMergeResolveBudget,
@@ -754,6 +754,9 @@ function layoutBlocksWithGeometry(
   const layoutTableInFlow = (table: OoxmlElement): void => {
     const structure = readTableStructure(table, contentWidth, 0, styleCascade);
     if (!structure || structure.rows.length === 0) return;
+    // `w:tblInd` / `w:jc` place the table inside the text column; every row and the fragment
+    // box share the one origin so cell geometry and the reported box cannot drift apart.
+    const tableLeft = tableOriginX(structure, contentWidth);
     const headerRows: SemanticTableRow[] = [];
     for (const row of structure.rows) {
       if (row.isHeader) headerRows.push(row);
@@ -781,7 +784,7 @@ function layoutBlocksWithGeometry(
         fragmentIndex,
         rows: finalized,
         box: {
-          x: 0,
+          x: tableLeft,
           y: fragmentTop,
           // The table's own width, not the page's. Reporting `contentWidth` here described
           // every table as exactly page-wide while its cells spanned whatever the resolved
@@ -805,7 +808,14 @@ function layoutBlocksWithGeometry(
 
       let groupHeight = 0;
       for (const headerRow of headerRows) {
-        groupHeight += measureRowHeight(headerRow, structure.columnWidthsPt, 0, 0, tableDeps);
+        groupHeight += measureRowHeight(
+          headerRow,
+          structure.columnWidthsPt,
+          tableLeft,
+          0,
+          tableDeps,
+          structure.cellSpacingPt
+        );
       }
       if (groupHeight > contentHeight + 0.001) {
         throw new TablePaginationError(
@@ -823,11 +833,12 @@ function layoutBlocksWithGeometry(
         const placed = layoutRowFragment(
           headerRow,
           structure.columnWidthsPt,
-          0,
+          tableLeft,
           cursorY,
           asRepeat,
           0,
-          tableDeps
+          tableDeps,
+          structure.cellSpacingPt
         );
         if (placed.bottom > contentHeight + 0.001) {
           throw new TablePaginationError(
@@ -852,7 +863,14 @@ function layoutBlocksWithGeometry(
     placeHeaderGroup(false);
 
     for (const row of structure.rows.slice(headerRows.length)) {
-      const naturalHeight = measureRowHeight(row, structure.columnWidthsPt, 0, 0, tableDeps);
+      const naturalHeight = measureRowHeight(
+        row,
+        structure.columnWidthsPt,
+        tableLeft,
+        0,
+        tableDeps,
+        structure.cellSpacingPt
+      );
       let cursors: CellPlaceCursor[] = initialCellCursors(row);
       let isContinuation = false;
       let fragmentsForRow = 0;
@@ -895,11 +913,12 @@ function layoutBlocksWithGeometry(
           const placed = layoutRowFragment(
             row,
             structure.columnWidthsPt,
-            0,
+            tableLeft,
             cursorY,
             false,
             0,
-            tableDeps
+            tableDeps,
+            structure.cellSpacingPt
           );
           if (placed.bottom > contentHeight + 0.001) {
             throw new TablePaginationError(
@@ -929,14 +948,15 @@ function layoutBlocksWithGeometry(
         const placed = layoutRowFragmentBounded(
           row,
           structure.columnWidthsPt,
-          0,
+          tableLeft,
           cursorY,
           contentHeight,
           false,
           isContinuation,
           0,
           tableDeps,
-          cursors
+          cursors,
+          structure.cellSpacingPt
         );
 
         // First attempt on a non-empty page placed nothing useful → move to next page.

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -36,6 +36,7 @@ import {
   CELL_PAD,
   MAX_TABLE_NESTING,
   readTableStructure,
+  tableOriginX,
   type CellMarginsPt,
   type SemanticTableCell,
   type SemanticTableRow,
@@ -84,6 +85,9 @@ export {
 
 /** Soft ceiling on fragments emitted for one authored row (hostile / runaway splits). */
 export const MAX_TABLE_ROW_FRAGMENTS = 4096;
+
+/** A cell box never narrows below this, however wide a `w:tblCellSpacing` gap is stated. */
+const MIN_CELL_BOX_PT = 1;
 
 export type TablePaginationErrorCode =
   | 'table-row-overheight'
@@ -759,7 +763,8 @@ export function layoutRowFragment(
   rowTop: number,
   isHeaderRepeat: boolean,
   depth: number,
-  deps: TableFlowDeps
+  deps: TableFlowDeps,
+  cellSpacingPt = 0
 ): { readonly record: TableRowFragmentRecord; readonly bottom: number } {
   const placed = layoutRowFragmentBounded(
     row,
@@ -771,7 +776,8 @@ export function layoutRowFragment(
     false,
     depth,
     deps,
-    initialCellCursors(row)
+    initialCellCursors(row),
+    cellSpacingPt
   );
   return { record: placed.record, bottom: placed.bottom };
 }
@@ -805,9 +811,16 @@ export function layoutRowFragmentBounded(
   isContinuation: boolean,
   depth: number,
   deps: TableFlowDeps,
-  cursors: readonly CellPlaceCursor[]
+  cursors: readonly CellPlaceCursor[],
+  cellSpacingPt = 0
 ): LayoutRowBoundedResult {
   const total = sumCols(cols, 0, cols.length);
+  // `w:tblCellSpacing`: each cell gives up half of every gap it shares with a neighbour.
+  // `w:tblCellSpacing` (17.4.45) separates ADJACENT cell edges, so each of the two cells
+  // sharing a gap gives up half of it. Applied inside the grid slot rather than by widening
+  // the table, which keeps every column boundary, border interval and hit box where the
+  // resolved grid put it.
+  const gap = Number.isFinite(cellSpacingPt) && cellSpacingPt > 0 ? cellSpacingPt / 2 : 0;
   const defaultLineHeight = deps.measurer.lineMetrics(DEFAULT_RUN_STYLE).height;
 
   interface FlowedCell {
@@ -843,8 +856,12 @@ export function layoutRowFragmentBounded(
     // of grid intervals in the border pass). Never re-derived by accumulating spans here.
     const span = cell.gridSpan;
     const gridColumn = cell.gridColumn;
-    const cellX = left + sumCols(cols, 0, gridColumn);
-    const cellW = sumCols(cols, gridColumn, Math.min(gridColumn + span, cols.length)) || total;
+    const slotX = left + sumCols(cols, 0, gridColumn);
+    const slotW = sumCols(cols, gridColumn, Math.min(gridColumn + span, cols.length)) || total;
+    // Never let the gap consume the cell: a spacing wider than the column keeps a hairline.
+    const inset = Math.min(gap, Math.max((slotW - MIN_CELL_BOX_PT) / 2, 0));
+    const cellX = slotX + inset;
+    const cellW = Math.max(slotW - 2 * inset, MIN_CELL_BOX_PT);
     const insets = contentInsets(cell.margins, cell.borders);
     const topInset = isContinuation ? borderExtentPt(cell.borders.top) : insets.top;
     const contentTop = rowTop + topInset;
@@ -975,14 +992,15 @@ export function measureRowHeight(
   cols: readonly number[],
   left: number,
   depth: number,
-  deps: TableFlowDeps
+  deps: TableFlowDeps,
+  cellSpacingPt = 0
 ): number {
   let lineCounter = 0;
   const probeDeps: TableFlowDeps = {
     ...deps,
     nextLineId: () => `probe-${lineCounter++}`,
   };
-  const placed = layoutRowFragment(row, cols, left, 0, false, depth, probeDeps);
+  const placed = layoutRowFragment(row, cols, left, 0, false, depth, probeDeps, cellSpacingPt);
   return placed.record.box.height;
 }
 
@@ -1127,12 +1145,25 @@ function emitNestedTable(
   deps: TableFlowDeps
 ): { readonly fragment: TableFragmentRecord; readonly bottom: number } | null {
   if (depth >= MAX_TABLE_NESTING) return null;
-  const structure = readTableStructure(table, Math.max(1, right - left), depth, deps.styleCascade);
+  const containerWidth = Math.max(1, right - left);
+  const structure = readTableStructure(table, containerWidth, depth, deps.styleCascade);
   if (!structure || structure.rows.length === 0) return null;
+  // A nested table is placed inside its CELL's content box by the same rules a top-level one
+  // is placed inside the text column.
+  const tableLeft = left + tableOriginX(structure, containerWidth);
   const rawRows: TableRowFragmentRecord[] = [];
   let y = top;
   for (const row of structure.rows) {
-    const placed = layoutRowFragment(row, structure.columnWidthsPt, left, y, false, depth, deps);
+    const placed = layoutRowFragment(
+      row,
+      structure.columnWidthsPt,
+      tableLeft,
+      y,
+      false,
+      depth,
+      deps,
+      structure.cellSpacingPt
+    );
     rawRows.push(placed.record);
     y = placed.bottom;
   }
@@ -1153,7 +1184,7 @@ function emitNestedTable(
       tableId: table.id,
       fragmentIndex: 0,
       rows,
-      box: { x: left, y: top, width, height: y - top },
+      box: { x: tableLeft, y: top, width, height: y - top },
     },
     bottom: y,
   };
@@ -1180,7 +1211,8 @@ export function layoutTableFragment(
       y,
       isHeaderRepeat(row),
       depth,
-      deps
+      deps,
+      structure.cellSpacingPt
     );
     rawRows.push(placed.record);
     y = placed.bottom;

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -17,6 +17,7 @@
 
 import type { OoxmlElement, OoxmlNode } from '@docx-editor.dev/core-contract/store';
 import { shadingFillFromElement } from './ooxml-shading.ts';
+import { revisionRemovesParagraph } from './revision-visibility.ts';
 import {
   EMPTY_TABLE_CELL_STYLE_FORMATTING,
   EMPTY_TABLE_FORMATTING,
@@ -168,6 +169,36 @@ const MAX_CELL_CONDITION_SETS = 256;
 
 export type CellVerticalAlign = 'top' | 'center' | 'bottom';
 
+/** `w:tblPr/w:jc` (17.4.29, ST_JcTable): where the table sits within the text column. */
+export type TableAlignment = 'left' | 'center' | 'right';
+
+/**
+ * Ceiling on `w:tblInd`, so a stated indent cannot push a table off the sheet. Read through
+ * the same unsigned path as every other width here: a negative indent (Word pulls a table
+ * into the margin with one) is rejected rather than applied.
+ */
+const MAX_TABLE_INDENT_PT = 31_680 / 20;
+
+/** `w:tblPr/w:jc`, defaulting to left when absent or unrecognised. */
+function readTableAlignment(container: OoxmlElement | undefined): TableAlignment | undefined {
+  const jc = container && childNamed(container, 'jc');
+  if (!jc) return undefined;
+  const value = attributeValue(jc, 'val');
+  // `start`/`end` are the strict-conformant spellings of `left`/`right`.
+  if (value === 'center') return 'center';
+  if (value === 'right' || value === 'end') return 'right';
+  if (value === 'left' || value === 'start') return 'left';
+  return undefined;
+}
+
+/** A CT_TblWidth read down to points, for the `dxa` geometry the placement reads use. */
+function preferredLengthPt(node: OoxmlElement | undefined, limit: number): number | undefined {
+  if (!node) return undefined;
+  const width = readPreferredWidth(node);
+  if (width.type !== 'dxa') return undefined;
+  return Math.min(width.value, limit);
+}
+
 export interface CellMarginsPt {
   readonly top: number;
   readonly right: number;
@@ -239,6 +270,22 @@ export interface SemanticTableStructure {
   readonly rows: readonly SemanticTableRow[];
   /** `w:tblPr/w:tblW` — the width the table asked for. */
   readonly tableWidth: PreferredWidth;
+  /**
+   * `w:tblInd` (17.4.50) in points — "this indentation should shift the table into the text
+   * margin by the specified amount". Applies to a left-aligned table; `w:jc` decides the
+   * placement outright for the other two.
+   */
+  readonly indentPt: number;
+  /** `w:tblPr/w:jc` (17.4.29) — where the table sits in the text column. */
+  readonly alignment: TableAlignment;
+  /**
+   * `w:tblCellSpacing` (17.4.45) in points: the gap between adjacent cell edges. Applied as
+   * a half-gap inset on each side of every cell, so cells separate visually without the grid
+   * itself moving. Word ALSO grows the table's overall width by the spacing it adds around
+   * the outside; that part is not modelled, so a spaced table is laid out on the same grid
+   * its file states rather than a wider one.
+   */
+  readonly cellSpacingPt: number;
   /**
    * `w:tblPr/w:tblLayout/@w:type="fixed"` (17.4.52 — 17.4.53 is the `w:tblPrEx` exception
    * variant, not this element). Fixed layout takes the grid as final;
@@ -555,6 +602,24 @@ function resolveColumnWidthsPt(input: {
   if (Math.abs(total - target) <= WIDTH_EPSILON_PT) return resolved;
   const scale = target / total;
   return resolved.map((width) => width * scale);
+}
+
+/**
+ * Where a table's left edge sits inside the box that contains it.
+ *
+ * 17.4.50 puts a left-aligned table at `w:tblInd` from the leading margin. 17.4.29's other
+ * two placements are stated relative to the containing box instead, so the indent does not
+ * also apply to them — Word centres a centred table in the text column whatever indent the
+ * file carries. A table wider than its container starts flush so its leading edge stays on
+ * the page rather than being centred off it.
+ */
+export function tableOriginX(structure: SemanticTableStructure, containerWidthPt: number): number {
+  const width = structure.columnWidthsPt.reduce((sum, column) => sum + column, 0);
+  const slack = containerWidthPt - width;
+  if (!Number.isFinite(slack) || slack <= 0) return 0;
+  if (structure.alignment === 'center') return slack / 2;
+  if (structure.alignment === 'right') return slack;
+  return Math.min(structure.indentPt, slack);
 }
 
 /**
@@ -917,6 +982,10 @@ export function readTableStructure(
       );
       const blocks: OoxmlElement[] = [];
       for (const child of cellNode.children) {
+        // A paragraph a tracked revision has removed claims a full line box while rendering
+        // nothing; a cell of them is a stack of blank lines that pushes the rest of the table
+        // down the page.
+        if (child.kind === 'paragraph' && revisionRemovesParagraph(child)) continue;
         if (child.kind === 'paragraph' || child.kind === 'table') blocks.push(child);
       }
       cells.push({
@@ -950,11 +1019,20 @@ export function readTableStructure(
   // it. 17.4.52: an absent `w:tblLayout` means autofit.
   let styleTableWidth = AUTO_PREFERRED_WIDTH;
   let styleLayoutFixed: boolean | undefined;
+  let styleIndentPt: number | undefined;
+  let styleAlignment: TableAlignment | undefined;
+  let styleCellSpacingPt: number | undefined;
   for (const node of tableStyle.tablePropertyNodes) {
     const styleW = childNamed(node, 'tblW');
     if (styleW) styleTableWidth = readPreferredWidth(styleW);
     const styleLayout = childNamed(node, 'tblLayout');
     if (styleLayout) styleLayoutFixed = attributeValue(styleLayout, 'type') === 'fixed';
+    styleIndentPt =
+      preferredLengthPt(childNamed(node, 'tblInd'), MAX_TABLE_INDENT_PT) ?? styleIndentPt;
+    styleAlignment = readTableAlignment(node) ?? styleAlignment;
+    styleCellSpacingPt =
+      preferredLengthPt(childNamed(node, 'tblCellSpacing'), MAX_CELL_MARGIN_PT) ??
+      styleCellSpacingPt;
   }
   const ownTblW = tblPr && childNamed(tblPr, 'tblW');
   const tableWidth = ownTblW ? readPreferredWidth(ownTblW) : styleTableWidth;
@@ -962,6 +1040,15 @@ export function readTableStructure(
   const layoutFixed = tblLayout
     ? attributeValue(tblLayout, 'type') === 'fixed'
     : (styleLayoutFixed ?? false);
+  const indentPt =
+    preferredLengthPt(tblPr && childNamed(tblPr, 'tblInd'), MAX_TABLE_INDENT_PT) ??
+    styleIndentPt ??
+    0;
+  const alignment = readTableAlignment(tblPr) ?? styleAlignment ?? 'left';
+  const cellSpacingPt =
+    preferredLengthPt(tblPr && childNamed(tblPr, 'tblCellSpacing'), MAX_CELL_MARGIN_PT) ??
+    styleCellSpacingPt ??
+    0;
 
   return {
     columnWidthsPt: resolveColumnWidthsPt({
@@ -975,6 +1062,9 @@ export function readTableStructure(
     rows,
     tableWidth,
     layoutFixed,
+    indentPt,
+    alignment,
+    cellSpacingPt,
     tableBorders,
     defaultMargins,
   };

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -59,6 +59,65 @@ const MAX_COLUMN_WIDTH_PT = 31_680 / 20;
 /** Highest grid column a cell may start on; keeps a row's total span bounded. */
 const LAST_GRID_COLUMN = MAX_TABLE_COLUMNS - 1;
 
+/**
+ * `w:tblW` / `w:tcW` (CT_TblWidth, 17.4.87): a PREFERRED width plus the unit it is stated
+ * in. Preferred is the operative word — it is what the producer asked for, not what the
+ * table resolved to. `w:tblGrid` carries the resolved grid, and where the two disagree the
+ * grid wins for any table that has one.
+ *
+ * `pct` is stated in fiftieths of a percent (5000 = 100%), and older producers write the
+ * `"50%"` string form instead; both are read. `auto` and `nil` carry no width.
+ */
+export type PreferredWidthType = 'dxa' | 'pct' | 'auto' | 'nil';
+
+export interface PreferredWidth {
+  readonly type: PreferredWidthType;
+  /** POINTS for `dxa`, PERCENT (0–100) for `pct`, 0 for `auto`/`nil`. */
+  readonly value: number;
+}
+
+export const AUTO_PREFERRED_WIDTH: PreferredWidth = Object.freeze({ type: 'auto', value: 0 });
+
+/** Widest a `pct` preference may resolve to, so `w:w="999999"` cannot inflate a table. */
+const MAX_PREFERRED_PERCENT = 100;
+
+/**
+ * Read a CT_TblWidth element. Digits-only and clamped exactly like `twipsSide`: every
+ * number here is attacker-controlled and feeds cell box geometry.
+ *
+ * A missing `w:type` means `dxa` per the schema default, but a missing `w:w` means the
+ * element states nothing at all, which is `auto`.
+ */
+function readPreferredWidth(node: OoxmlElement | undefined): PreferredWidth {
+  if (!node) return AUTO_PREFERRED_WIDTH;
+  const rawType = attributeValue(node, 'type');
+  const type: PreferredWidthType =
+    rawType === 'pct' || rawType === 'auto' || rawType === 'nil' || rawType === 'dxa'
+      ? rawType
+      : 'dxa';
+  if (type === 'auto' || type === 'nil') return { type, value: 0 };
+
+  const raw = attributeValue(node, 'w');
+  if (raw === undefined) return AUTO_PREFERRED_WIDTH;
+
+  if (type === 'pct') {
+    // `"50%"` (string form) or `2500` (fiftieths of a percent).
+    const asString = /^(\d{1,7})%$/.exec(raw);
+    const percent = asString
+      ? Number(asString[1])
+      : /^\d{1,7}$/.test(raw)
+        ? Number(raw) / 50
+        : Number.NaN;
+    if (!Number.isFinite(percent) || percent <= 0) return AUTO_PREFERRED_WIDTH;
+    return { type: 'pct', value: Math.min(percent, MAX_PREFERRED_PERCENT) };
+  }
+
+  if (!/^\d{1,9}$/.test(raw)) return AUTO_PREFERRED_WIDTH;
+  const pt = Number(raw) / 20;
+  if (!Number.isFinite(pt) || pt <= 0) return AUTO_PREFERRED_WIDTH;
+  return { type: 'dxa', value: Math.min(pt, MAX_COLUMN_WIDTH_PT) };
+}
+
 /** Distinct conditional-format combinations memoized per table; see `styleFormattingFor`. */
 const MAX_CELL_CONDITION_SETS = 256;
 
@@ -100,6 +159,12 @@ export interface SemanticTableCell {
   /** Validated 6-hex shading fill, absent for none/auto. */
   readonly shading?: string;
   /**
+   * `w:tcW` — the width this cell ASKED for. Only consulted where `w:tblGrid` cannot
+   * settle the geometry (absent or degenerate grid); a table that states a grid has already
+   * resolved its columns and the grid wins. See `resolveColumnWidthsPt`.
+   */
+  readonly preferredWidth: PreferredWidth;
+  /**
    * What the table style says about this cell's paragraphs and runs (17.7.6.6) — a header
    * row's bold and centring live here, not in the cell's own properties.
    */
@@ -123,6 +188,13 @@ export interface SemanticTableRow {
 export interface SemanticTableStructure {
   readonly columnWidthsPt: readonly number[];
   readonly rows: readonly SemanticTableRow[];
+  /** `w:tblPr/w:tblW` — the width the table asked for. */
+  readonly tableWidth: PreferredWidth;
+  /**
+   * `w:tblPr/w:tblLayout/@w:type="fixed"` (17.4.53). Fixed layout takes the grid as final;
+   * anything else is autofit, which in Word never renders wider than the text column.
+   */
+  readonly layoutFixed: boolean;
   /** Table-level `tblBorders` (three-state, including insideH/insideV). */
   readonly tableBorders: TableBorderBox;
   /** Table-level `tblCellMar` defaults (per-side, CELL_PAD when a side is omitted). */
@@ -238,29 +310,148 @@ function gridColumnElements(table: OoxmlElement): readonly OoxmlElement[] {
 }
 
 /**
- * Column widths in points: from `w:tblGrid` when present, else an even split over the
- * hardened column count. The no-grid path is the security-sensitive one — see header.
+ * Column widths from `w:tblGrid` alone, or null when the grid cannot settle them.
+ *
+ * Digits only and clamped, exactly like `twipsSide`: `w="999999999"` otherwise becomes a
+ * ~50,000,000pt column that every cell box and border stroke inherits. A single unreadable
+ * `w:gridCol` no longer poisons one column with an even-split guess — the whole grid is
+ * rejected and the caller falls back to the authored `w:tcW` preferences instead, which is
+ * the better evidence about what the producer meant.
  */
-function columnWidthsPt(
-  cols: readonly OoxmlElement[],
+function gridColumnWidthsPt(
+  cols: readonly OoxmlElement[]
+): { readonly widths: readonly number[]; readonly clamped: boolean } | null {
+  if (cols.length === 0) return null;
+  const widths: number[] = [];
+  let clamped = false;
+  for (const col of cols) {
+    const raw = attributeValue(col, 'w');
+    if (raw === undefined || !/^\d{1,9}$/.test(raw)) return null;
+    const pt = Number(raw) / 20;
+    if (!Number.isFinite(pt) || pt <= 0) return null;
+    if (pt > MAX_COLUMN_WIDTH_PT) {
+      clamped = true;
+      widths.push(MAX_COLUMN_WIDTH_PT);
+    } else {
+      widths.push(pt);
+    }
+  }
+  return { widths, clamped };
+}
+
+/** One cell's grid footprint and stated width preference, for the no-grid fallback. */
+interface CellWidthClaim {
+  readonly start: number;
+  readonly span: number;
+  readonly preferred: PreferredWidth;
+}
+
+/**
+ * Column widths derived from `w:tcW` when there is no usable `w:tblGrid`.
+ *
+ * Producers that omit `w:tblGrid` state their geometry entirely in `w:tcW`, and an even
+ * split over the column count throws all of it away. Each column takes the first definite
+ * `dxa` claim covering it, narrowest footprint first so a `gridSpan` cell never overwrites
+ * a column some single-column cell already stated. A spanning claim splits evenly across
+ * the columns it covers that nothing else has settled. Columns still unclaimed share
+ * whatever is left of the content width, and never go to zero.
+ */
+function preferredColumnWidthsPt(
+  claims: readonly CellWidthClaim[],
   columnCount: number,
   contentWidthPt: number
-): readonly number[] {
-  if (cols.length > 0) {
-    return cols.map((col) => {
-      // Digits only and clamped, exactly like `twipsSide`: `w="999999999"` otherwise
-      // becomes a ~50,000,000pt column that every cell box and border stroke inherits.
-      const raw = attributeValue(col, 'w');
-      if (raw === undefined || !/^\d{1,9}$/.test(raw)) return contentWidthPt / cols.length;
-      const pt = Number(raw) / 20;
-      if (!Number.isFinite(pt) || pt <= 0) return contentWidthPt / cols.length;
-      return pt > MAX_COLUMN_WIDTH_PT ? MAX_COLUMN_WIDTH_PT : pt;
-    });
+): readonly number[] | null {
+  const settled = new Array<number>(columnCount).fill(0);
+  const ordered = [...claims]
+    .filter((claim) => claim.preferred.type === 'dxa' && claim.start < columnCount)
+    .sort((a, b) => a.span - b.span);
+  if (ordered.length === 0) return null;
+
+  for (const claim of ordered) {
+    const last = Math.min(claim.start + claim.span, columnCount);
+    const open: number[] = [];
+    for (let index = claim.start; index < last; index += 1)
+      if (settled[index] === 0) open.push(index);
+    if (open.length === 0) continue;
+    // A spanning cell states the width of its whole footprint, so only the part not already
+    // accounted for by narrower claims is what these columns get to share.
+    let remaining = claim.preferred.value;
+    for (let index = claim.start; index < last; index += 1) remaining -= settled[index]!;
+    if (remaining <= 0) continue;
+    const each = remaining / open.length;
+    for (const index of open) settled[index] = each;
   }
-  const width = contentWidthPt / columnCount;
-  const widths: number[] = [];
-  for (let index = 0; index < columnCount; index += 1) widths.push(width);
-  return widths;
+
+  const stated = settled.reduce((total, width) => total + width, 0);
+  if (stated <= 0) return null;
+  const unsettled = settled.filter((width) => width === 0).length;
+  if (unsettled === 0) return settled;
+  // Nothing stated these columns. Give them what the content width has left over, or a
+  // hairline when the stated columns already fill it, so no column collapses to zero.
+  const leftover = Math.max(contentWidthPt - stated, unsettled * MIN_DERIVED_COLUMN_PT);
+  const each = leftover / unsettled;
+  return settled.map((width) => (width === 0 ? each : width));
+}
+
+/** Floor for a column nothing states, so a derived grid never contains a zero column. */
+const MIN_DERIVED_COLUMN_PT = 1;
+
+/** Rounding slack when comparing a resolved table width against the content box. */
+const WIDTH_EPSILON_PT = 0.001;
+
+/**
+ * The table's resolved column widths, in points.
+ *
+ * Order of evidence: `w:tblGrid` (the producer's own resolved grid) beats `w:tcW` (what
+ * cells asked for) beats an even split. The grid is the resolved answer for any table that
+ * has one, so reading `w:tcW` does NOT mean overriding a stated grid with it — for a
+ * well-formed file the two agree, and where they disagree the grid is the later statement.
+ *
+ * Fit is then applied per 17.4.53. A `w:tblLayout w:type="fixed"` table takes its grid as
+ * final and is left alone: Word genuinely renders a fixed table past the right margin
+ * rather than shrinking it, so clamping one here would DIVERGE from Word. Every other
+ * table is autofit, which in Word never renders wider than the text column, so an autofit
+ * grid wider than the content box is scaled down proportionally.
+ *
+ * Scaling only ever shrinks. Stretching a narrow table up to `w:tblW` is a separate
+ * question with its own compatibility surface, and an autofit table that is narrower than
+ * the page is already showing what Word shows.
+ */
+function resolveColumnWidthsPt(input: {
+  readonly gridCols: readonly OoxmlElement[];
+  readonly claims: readonly CellWidthClaim[];
+  readonly columnCount: number;
+  readonly contentWidthPt: number;
+  readonly tableWidth: PreferredWidth;
+  readonly layoutFixed: boolean;
+}): readonly number[] {
+  const { columnCount, contentWidthPt } = input;
+  const available = Math.max(contentWidthPt, MIN_DERIVED_COLUMN_PT);
+
+  const grid = gridColumnWidthsPt(input.gridCols);
+  const resolved =
+    grid?.widths ??
+    preferredColumnWidthsPt(input.claims, columnCount, available) ??
+    new Array<number>(columnCount).fill(available / columnCount);
+
+  const total = resolved.reduce((sum, width) => sum + width, 0);
+  if (total <= 0) return new Array<number>(columnCount).fill(available / columnCount);
+  // Fixed layout states that the grid IS the geometry, overflow included.
+  if (input.layoutFixed) return resolved;
+  // A column so wide it had to be clamped is not geometry anyone authored, and a fit
+  // derived from it would let one hostile `w:gridCol` shrink every legitimate column in the
+  // table. The clamp already bounds the damage to that one column; leave its siblings be.
+  if (grid?.clamped === true) return resolved;
+
+  const target =
+    input.tableWidth.type === 'dxa'
+      ? Math.min(input.tableWidth.value, available)
+      : input.tableWidth.type === 'pct'
+        ? Math.min((available * input.tableWidth.value) / 100, available)
+        : available;
+  if (total <= target + WIDTH_EPSILON_PT) return resolved;
+  const scale = target / total;
+  return resolved.map((width) => width * scale);
 }
 
 /**
@@ -522,30 +713,37 @@ export function readTableStructure(
     readonly properties: OoxmlElement | undefined;
     readonly starts: readonly number[];
     readonly spans: readonly number[];
+    readonly preferred: readonly PreferredWidth[];
     readonly gridColumns: number;
   }
   const plans: RowPlan[] = [];
+  const claims: CellWidthClaim[] = [];
   let derivedColumns = 1;
   for (const rowNode of table.children) {
     if (rowNode.kind !== 'tableRow') continue;
     const properties = childNamed(rowNode, 'trPr');
     const starts: number[] = [];
     const spans: number[] = [];
+    const preferred: PreferredWidth[] = [];
     let cursor = Math.min(readGridSkip(properties, 'gridBefore'), LAST_GRID_COLUMN);
     for (const cellNode of rowNode.children) {
       if (cellNode.kind !== 'tableCell') continue;
+      const cellPr = childNamed(cellNode, 'tcPr');
       const start = Math.min(cursor, LAST_GRID_COLUMN);
       const span = Math.min(
-        readGridSpan(childNamed(cellNode, 'tcPr')),
+        readGridSpan(cellPr),
         MAX_TABLE_COLUMNS - start // ≥ 1: `start` never exceeds the last column
       );
+      const width = readPreferredWidth(cellPr && childNamed(cellPr, 'tcW'));
       starts.push(start);
       spans.push(span);
+      preferred.push(width);
+      claims.push({ start, span, preferred: width });
       cursor = start + span;
     }
     const gridColumns = Math.min(cursor + readGridSkip(properties, 'gridAfter'), MAX_TABLE_COLUMNS);
     if (gridColumns > derivedColumns) derivedColumns = gridColumns;
-    plans.push({ node: rowNode, properties, starts, spans, gridColumns });
+    plans.push({ node: rowNode, properties, starts, spans, preferred, gridColumns });
   }
 
   const gridCols = gridColumnElements(table);
@@ -606,6 +804,7 @@ export function readTableStructure(
           cellProperties ? readCellBorders(cellProperties) : EMPTY_CELL_BORDER_BOX
         ),
         ...(shading === undefined ? {} : { shading }),
+        preferredWidth: plan.preferred[cellIndex - 1] ?? AUTO_PREFERRED_WIDTH,
         styleFormatting: styleFormattingFor(conditions),
         blocks,
       });
@@ -618,9 +817,22 @@ export function readTableStructure(
     });
   }
 
+  const tableWidth = readPreferredWidth(tblPr && childNamed(tblPr, 'tblW'));
+  const tblLayout = tblPr && childNamed(tblPr, 'tblLayout');
+  const layoutFixed = tblLayout ? attributeValue(tblLayout, 'type') === 'fixed' : false;
+
   return {
-    columnWidthsPt: columnWidthsPt(gridCols, columnCount, contentWidthPt),
+    columnWidthsPt: resolveColumnWidthsPt({
+      gridCols,
+      claims,
+      columnCount,
+      contentWidthPt,
+      tableWidth,
+      layoutFixed,
+    }),
     rows,
+    tableWidth,
+    layoutFixed,
     tableBorders,
     defaultMargins,
   };

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -5,10 +5,15 @@
 // converted once at this boundary, matching `geometryOfSection` and `paragraphIndent`.
 //
 // Every value below is attacker-controlled (a .docx is a zip of XML the author fully
-// controls). `columnWidthsPt` bounds span and column counts before allocation and avoids
-// spread over attacker-sized collections. Do not relax these limits: hostile inputs can
-// otherwise trigger multi-gigabyte allocation attempts or spread-arity failures that vary
-// by JavaScript engine.
+// controls). `resolveColumnWidthsPt` bounds span and column counts before allocation and
+// avoids spread over attacker-sized collections — note the claim list it consumes grows with
+// the table's CELL count, not its column count, so it must never be spread or passed as
+// varargs. Do not relax these limits: hostile inputs can otherwise trigger multi-gigabyte
+// allocation attempts or spread-arity failures that vary by JavaScript engine.
+//
+// Widths resolve to a positive number or not at all. A column that no evidence settles takes
+// a bounded share of what is left rather than zero, and no fit may scale a table below one
+// point per column — a zero-width column is unrecoverable downstream.
 
 import type { OoxmlElement, OoxmlNode } from '@docx-editor.dev/core-contract/store';
 import { shadingFillFromElement } from './ooxml-shading.ts';
@@ -60,13 +65,12 @@ const MAX_COLUMN_WIDTH_PT = 31_680 / 20;
 const LAST_GRID_COLUMN = MAX_TABLE_COLUMNS - 1;
 
 /**
- * `w:tblW` / `w:tcW` (CT_TblWidth, 17.4.87): a PREFERRED width plus the unit it is stated
- * in. Preferred is the operative word — it is what the producer asked for, not what the
- * table resolved to. `w:tblGrid` carries the resolved grid, and where the two disagree the
- * grid wins for any table that has one.
+ * `w:tblW` / `w:tcW` / `w:wBefore` (CT_TblWidth, 17.4.63 / 17.4.71 / 17.4.86): a PREFERRED
+ * width plus the unit it is stated in. Preferred is the operative word — it is what the
+ * producer asked for, not what the table resolved to.
  *
- * `pct` is stated in fiftieths of a percent (5000 = 100%), and older producers write the
- * `"50%"` string form instead; both are read. `auto` and `nil` carry no width.
+ * `pct` is stated in fiftieths of a percent (5000 = 100%) by Word, and in the `"50%"`
+ * string form of `ST_Percentage` by others; both are read. `auto` and `nil` carry no width.
  */
 export type PreferredWidthType = 'dxa' | 'pct' | 'auto' | 'nil';
 
@@ -81,41 +85,82 @@ export const AUTO_PREFERRED_WIDTH: PreferredWidth = Object.freeze({ type: 'auto'
 /** Widest a `pct` preference may resolve to, so `w:w="999999"` cannot inflate a table. */
 const MAX_PREFERRED_PERCENT = 100;
 
+/** Points per unit for `ST_UniversalMeasure`'s suffixes (`pi` is a synonym for `pc`). */
+const MEASURE_UNIT_PT: Readonly<Record<string, number>> = Object.freeze({
+  mm: 72 / 25.4,
+  cm: 72 / 2.54,
+  in: 72,
+  pt: 1,
+  pc: 12,
+  pi: 12,
+});
+
 /**
- * Read a CT_TblWidth element. Digits-only and clamped exactly like `twipsSide`: every
- * number here is attacker-controlled and feeds cell box geometry.
+ * Bounded reader for `ST_MeasurementOrPercent` — the union `w:w` actually admits. Word
+ * writes the plain twips form, but `ST_UniversalMeasure` (`2.5in`, `72pt`) and
+ * `ST_Percentage` (`33.3%`, the form 17.4.71's own example uses) are equally valid, and
+ * dropping them silently loses geometry a conformant producer stated.
  *
- * A missing `w:type` means `dxa` per the schema default, but a missing `w:w` means the
- * element states nothing at all, which is `auto`.
+ * Every branch is anchored with a bounded quantifier: these run over attacker-controlled
+ * attribute values and must not backtrack.
+ */
+function readMeasurementOrPercent(
+  raw: string
+):
+  | { readonly kind: 'length'; readonly pt: number }
+  | { readonly kind: 'percent'; readonly percent: number }
+  | null {
+  if (/^\d{1,9}$/.test(raw)) {
+    const pt = Number(raw) / 20;
+    return Number.isFinite(pt) ? { kind: 'length', pt } : null;
+  }
+  const percent = /^(\d{1,7}(?:\.\d{1,4})?)%$/.exec(raw);
+  if (percent) {
+    const value = Number(percent[1]);
+    return Number.isFinite(value) ? { kind: 'percent', percent: value } : null;
+  }
+  const universal = /^(\d{1,9}(?:\.\d{1,4})?)(mm|cm|in|pt|pc|pi)$/.exec(raw);
+  if (universal) {
+    const pt = Number(universal[1]) * MEASURE_UNIT_PT[universal[2]!]!;
+    return Number.isFinite(pt) ? { kind: 'length', pt } : null;
+  }
+  return null;
+}
+
+/**
+ * Read a CT_TblWidth element, clamped exactly like `twipsSide`: every number here is
+ * attacker-controlled and feeds cell box geometry.
+ *
+ * An absent `w:type` is `dxa` per 17.4.87 (the schema declares no default, the prose does).
+ * An unrecognised type is NOT read as `dxa` — every sibling reader in this file rejects a
+ * value it does not recognise rather than reinterpreting it, and reading `w:type="Pct"` as
+ * an absolute measurement turns a 100% table into a 250pt one.
+ *
+ * 17.4.87 also settles the conflict case: where the type and the measurement `w:w` actually
+ * states contradict each other, the measurement wins and the type is ignored.
  */
 function readPreferredWidth(node: OoxmlElement | undefined): PreferredWidth {
   if (!node) return AUTO_PREFERRED_WIDTH;
   const rawType = attributeValue(node, 'type');
-  const type: PreferredWidthType =
-    rawType === 'pct' || rawType === 'auto' || rawType === 'nil' || rawType === 'dxa'
-      ? rawType
-      : 'dxa';
-  if (type === 'auto' || type === 'nil') return { type, value: 0 };
+  if (rawType !== undefined && rawType !== 'pct' && rawType !== 'dxa') {
+    return rawType === 'nil' ? { type: 'nil', value: 0 } : AUTO_PREFERRED_WIDTH;
+  }
 
   const raw = attributeValue(node, 'w');
   if (raw === undefined) return AUTO_PREFERRED_WIDTH;
+  const measure = readMeasurementOrPercent(raw);
+  if (!measure) return AUTO_PREFERRED_WIDTH;
 
-  if (type === 'pct') {
-    // `"50%"` (string form) or `2500` (fiftieths of a percent).
-    const asString = /^(\d{1,7})%$/.exec(raw);
-    const percent = asString
-      ? Number(asString[1])
-      : /^\d{1,7}$/.test(raw)
-        ? Number(raw) / 50
-        : Number.NaN;
+  // A bare number carries no unit of its own, so the type decides how to read it. A stated
+  // `%` or `in` DOES carry one, and 17.4.87 says that statement overrides the type.
+  const bare = /^\d{1,9}$/.test(raw);
+  if (measure.kind === 'percent' || (bare && rawType === 'pct')) {
+    const percent = measure.kind === 'percent' ? measure.percent : Number(raw) / 50;
     if (!Number.isFinite(percent) || percent <= 0) return AUTO_PREFERRED_WIDTH;
     return { type: 'pct', value: Math.min(percent, MAX_PREFERRED_PERCENT) };
   }
-
-  if (!/^\d{1,9}$/.test(raw)) return AUTO_PREFERRED_WIDTH;
-  const pt = Number(raw) / 20;
-  if (!Number.isFinite(pt) || pt <= 0) return AUTO_PREFERRED_WIDTH;
-  return { type: 'dxa', value: Math.min(pt, MAX_COLUMN_WIDTH_PT) };
+  if (!Number.isFinite(measure.pt) || measure.pt <= 0) return AUTO_PREFERRED_WIDTH;
+  return { type: 'dxa', value: Math.min(measure.pt, MAX_COLUMN_WIDTH_PT) };
 }
 
 /** Distinct conditional-format combinations memoized per table; see `styleFormattingFor`. */
@@ -159,9 +204,13 @@ export interface SemanticTableCell {
   /** Validated 6-hex shading fill, absent for none/auto. */
   readonly shading?: string;
   /**
-   * `w:tcW` — the width this cell ASKED for. Only consulted where `w:tblGrid` cannot
-   * settle the geometry (absent or degenerate grid); a table that states a grid has already
-   * resolved its columns and the grid wins. See `resolveColumnWidthsPt`.
+   * `w:tcW` — the width this cell asked for, as authored.
+   *
+   * Published for consumers that need the cell's own statement (a column-resize handle has
+   * to write back to it). Column geometry is NOT derived from this field: the resolver works
+   * from a flat claim list built in the same pass, because resolving a column means looking
+   * at every cell that covers it across every row, not at one cell at a time. Read
+   * `columnWidthsPt` for what the table actually laid out.
    */
   readonly preferredWidth: PreferredWidth;
   /**
@@ -191,7 +240,8 @@ export interface SemanticTableStructure {
   /** `w:tblPr/w:tblW` — the width the table asked for. */
   readonly tableWidth: PreferredWidth;
   /**
-   * `w:tblPr/w:tblLayout/@w:type="fixed"` (17.4.53). Fixed layout takes the grid as final;
+   * `w:tblPr/w:tblLayout/@w:type="fixed"` (17.4.52 — 17.4.53 is the `w:tblPrEx` exception
+   * variant, not this element). Fixed layout takes the grid as final;
    * anything else is autofit, which in Word never renders wider than the text column.
    */
   readonly layoutFixed: boolean;
@@ -310,112 +360,129 @@ function gridColumnElements(table: OoxmlElement): readonly OoxmlElement[] {
 }
 
 /**
- * Column widths from `w:tblGrid` alone, or null when the grid cannot settle them.
+ * The INITIAL width of each grid column, or undefined for a column `w:tblGrid` does not
+ * settle. 17.4.48 calls these the table's "default widths" and 17.4.16 is explicit that they
+ * "determine the initial width of each grid column, which can then be overridden by ... the
+ * preferred widths of specific cells" — so this is a seed, not the answer.
  *
- * Digits only and clamped, exactly like `twipsSide`: `w="999999999"` otherwise becomes a
- * ~50,000,000pt column that every cell box and border stroke inherits. A single unreadable
- * `w:gridCol` no longer poisons one column with an even-split guess — the whole grid is
- * rejected and the caller falls back to the authored `w:tcW` preferences instead, which is
- * the better evidence about what the producer meant.
+ * Values are clamped exactly like `twipsSide`: `w="999999999"` otherwise becomes a
+ * ~50,000,000pt column that every cell box and border stroke inherits. A column at or past
+ * that ceiling is not geometry anyone authored — `MAX_COLUMN_WIDTH_PT` is wider than any
+ * legal page — so it is dropped to undefined rather than kept as a 22-inch column that then
+ * has to be exempted from every later fit. One unreadable column costs that column only; the
+ * rest of the authored grid survives.
  */
-function gridColumnWidthsPt(
-  cols: readonly OoxmlElement[]
-): { readonly widths: readonly number[]; readonly clamped: boolean } | null {
-  if (cols.length === 0) return null;
-  const widths: number[] = [];
-  let clamped = false;
+function gridColumnWidthsPt(cols: readonly OoxmlElement[]): readonly (number | undefined)[] {
+  const widths: (number | undefined)[] = [];
   for (const col of cols) {
     const raw = attributeValue(col, 'w');
-    if (raw === undefined || !/^\d{1,9}$/.test(raw)) return null;
-    const pt = Number(raw) / 20;
-    if (!Number.isFinite(pt) || pt <= 0) return null;
-    if (pt > MAX_COLUMN_WIDTH_PT) {
-      clamped = true;
-      widths.push(MAX_COLUMN_WIDTH_PT);
-    } else {
-      widths.push(pt);
+    const measure = raw === undefined ? null : readMeasurementOrPercent(raw);
+    if (!measure || measure.kind !== 'length' || !Number.isFinite(measure.pt) || measure.pt <= 0) {
+      widths.push(undefined);
+      continue;
     }
+    widths.push(measure.pt > MAX_COLUMN_WIDTH_PT ? undefined : measure.pt);
   }
-  return { widths, clamped };
+  return widths;
 }
 
-/** One cell's grid footprint and stated width preference, for the no-grid fallback. */
+/** One cell's grid footprint and stated width preference. */
 interface CellWidthClaim {
   readonly start: number;
   readonly span: number;
   readonly preferred: PreferredWidth;
 }
 
-/**
- * Column widths derived from `w:tcW` when there is no usable `w:tblGrid`.
- *
- * Producers that omit `w:tblGrid` state their geometry entirely in `w:tcW`, and an even
- * split over the column count throws all of it away. Each column takes the first definite
- * `dxa` claim covering it, narrowest footprint first so a `gridSpan` cell never overwrites
- * a column some single-column cell already stated. A spanning claim splits evenly across
- * the columns it covers that nothing else has settled. Columns still unclaimed share
- * whatever is left of the content width, and never go to zero.
- */
-function preferredColumnWidthsPt(
-  claims: readonly CellWidthClaim[],
-  columnCount: number,
-  contentWidthPt: number
-): readonly number[] | null {
-  const settled = new Array<number>(columnCount).fill(0);
-  const ordered = [...claims]
-    .filter((claim) => claim.preferred.type === 'dxa' && claim.start < columnCount)
-    .sort((a, b) => a.span - b.span);
-  if (ordered.length === 0) return null;
-
-  for (const claim of ordered) {
-    const last = Math.min(claim.start + claim.span, columnCount);
-    const open: number[] = [];
-    for (let index = claim.start; index < last; index += 1)
-      if (settled[index] === 0) open.push(index);
-    if (open.length === 0) continue;
-    // A spanning cell states the width of its whole footprint, so only the part not already
-    // accounted for by narrower claims is what these columns get to share.
-    let remaining = claim.preferred.value;
-    for (let index = claim.start; index < last; index += 1) remaining -= settled[index]!;
-    if (remaining <= 0) continue;
-    const each = remaining / open.length;
-    for (const index of open) settled[index] = each;
-  }
-
-  const stated = settled.reduce((total, width) => total + width, 0);
-  if (stated <= 0) return null;
-  const unsettled = settled.filter((width) => width === 0).length;
-  if (unsettled === 0) return settled;
-  // Nothing stated these columns. Give them what the content width has left over, or a
-  // hairline when the stated columns already fill it, so no column collapses to zero.
-  const leftover = Math.max(contentWidthPt - stated, unsettled * MIN_DERIVED_COLUMN_PT);
-  const each = leftover / unsettled;
-  return settled.map((width) => (width === 0 ? each : width));
-}
-
-/** Floor for a column nothing states, so a derived grid never contains a zero column. */
+/** Floor for a column nothing states, so a resolved grid never contains a zero column. */
 const MIN_DERIVED_COLUMN_PT = 1;
 
 /** Rounding slack when comparing a resolved table width against the content box. */
 const WIDTH_EPSILON_PT = 0.001;
 
 /**
+ * Lay the authored `w:tcW` preferences over the seed grid.
+ *
+ * 17.18.87 describes exactly this reconciliation: a cell's `tcW` sets the width of the grid
+ * columns its `gridSpan` covers, and "for each subsequent row ... each grid column is
+ * adjusted to be the MAXIMUM value of the requested widths (if the widths do not agree)".
+ * So a later row asking for more wins, and a narrower footprint is authoritative over a
+ * spanning one — a span states the total across its columns, not any one column's width.
+ *
+ * Claims are applied narrowest-span-first so single-column statements land before the spans
+ * that contain them; a span then distributes only the width its settled columns have not
+ * already accounted for.
+ */
+function applyWidthClaims(
+  seed: readonly (number | undefined)[],
+  claims: readonly CellWidthClaim[],
+  columnCount: number,
+  tableWidthPt: number
+): (number | undefined)[] {
+  const settled: (number | undefined)[] = [];
+  for (let index = 0; index < columnCount; index += 1) settled.push(seed[index]);
+
+  // `.filter` already returns a fresh array, so this never mutates the caller's claims and
+  // needs no spread — `claims` grows with the table's cell count and is attacker-sized.
+  const ordered = claims
+    .filter(
+      (claim) =>
+        claim.start < columnCount &&
+        (claim.preferred.type === 'dxa' || (claim.preferred.type === 'pct' && tableWidthPt > 0))
+    )
+    .sort((a, b) => a.span - b.span);
+
+  for (const claim of ordered) {
+    const last = Math.min(claim.start + claim.span, columnCount);
+    if (last <= claim.start) continue;
+    // 17.4.71: a `pct` cell width is relative to the overall width of the TABLE.
+    const stated =
+      claim.preferred.type === 'pct'
+        ? (tableWidthPt * claim.preferred.value) / 100
+        : claim.preferred.value;
+    if (!Number.isFinite(stated) || stated <= 0) continue;
+
+    if (last - claim.start === 1) {
+      // A single-column claim states that column outright; maximum wins across rows.
+      const current = settled[claim.start];
+      settled[claim.start] = current === undefined ? stated : Math.max(current, stated);
+      continue;
+    }
+    // A span only gets to state the columns nothing narrower has settled, and only with
+    // whatever of its total those settled columns leave over.
+    const open: number[] = [];
+    let remaining = stated;
+    for (let index = claim.start; index < last; index += 1) {
+      const current = settled[index];
+      if (current === undefined) open.push(index);
+      else remaining -= current;
+    }
+    if (open.length === 0 || remaining <= 0) continue;
+    const each = remaining / open.length;
+    for (const index of open) settled[index] = each;
+  }
+  return settled;
+}
+
+/**
  * The table's resolved column widths, in points.
  *
- * Order of evidence: `w:tblGrid` (the producer's own resolved grid) beats `w:tcW` (what
- * cells asked for) beats an even split. The grid is the resolved answer for any table that
- * has one, so reading `w:tcW` does NOT mean overriding a stated grid with it — for a
- * well-formed file the two agree, and where they disagree the grid is the later statement.
+ * `w:tblGrid` seeds the columns, the authored `w:tcW`/`w:wBefore` preferences are laid over
+ * it (see {@link applyWidthClaims}), and anything still unstated shares what the content
+ * width has left. Columns never resolve to zero.
  *
- * Fit is then applied per 17.4.53. A `w:tblLayout w:type="fixed"` table takes its grid as
- * final and is left alone: Word genuinely renders a fixed table past the right margin
- * rather than shrinking it, so clamping one here would DIVERGE from Word. Every other
- * table is autofit, which in Word never renders wider than the text column, so an autofit
- * grid wider than the content box is scaled down proportionally.
+ * Fit is then applied per 17.18.87. The table's total is measured against `w:tblW`, and
+ * "if at any stage, the preferred width requested for the cells exceeds the preferred width
+ * of the table, then each grid column is proportionally reduced in size to fit" — that
+ * reduction belongs to BOTH layout algorithms, so a fixed table is still held to a stated
+ * `w:tblW`. What is autofit-only is the PAGE clamp: 17.18.87 ends the autofit override chain
+ * with "override the preferred table width until the table reaches the page width", and says
+ * nothing of the sort for fixed. A fixed table with no `w:tblW` therefore renders past the
+ * right margin, which is what Word does; an autofit table never exceeds the text column.
  *
- * Scaling only ever shrinks. Stretching a narrow table up to `w:tblW` is a separate
- * question with its own compatibility surface, and an autofit table that is narrower than
- * the page is already showing what Word shows.
+ * A `pct` table width is a two-way instruction — it is Word's "AutoFit to Window", so a
+ * table narrower than its stated percentage is stretched up to it as well as shrunk down.
+ * An absolute or absent width only ever shrinks: a narrow autofit table is already showing
+ * what Word shows, and stretching it would invent geometry no one authored.
  */
 function resolveColumnWidthsPt(input: {
   readonly gridCols: readonly OoxmlElement[];
@@ -425,31 +492,67 @@ function resolveColumnWidthsPt(input: {
   readonly tableWidth: PreferredWidth;
   readonly layoutFixed: boolean;
 }): readonly number[] {
-  const { columnCount, contentWidthPt } = input;
-  const available = Math.max(contentWidthPt, MIN_DERIVED_COLUMN_PT);
+  const { columnCount, tableWidth } = input;
+  // A caller with a degenerate or non-finite content box has told us nothing about the page.
+  // The authored grid is still perfectly good evidence on its own, so resolve from it and
+  // skip the page clamp rather than scaling the table down to a sliver of a width that was
+  // never a real measurement.
+  const hasPage = Number.isFinite(input.contentWidthPt) && input.contentWidthPt > 0;
+  const available = hasPage ? input.contentWidthPt : MIN_DERIVED_COLUMN_PT;
 
-  const grid = gridColumnWidthsPt(input.gridCols);
-  const resolved =
-    grid?.widths ??
-    preferredColumnWidthsPt(input.claims, columnCount, available) ??
-    new Array<number>(columnCount).fill(available / columnCount);
+  // 17.4.63: a `pct` TABLE width is relative to the page's text extents, unlike `tcW`'s
+  // basis, which is the table itself.
+  const statedTableWidth =
+    tableWidth.type === 'dxa'
+      ? tableWidth.value
+      : tableWidth.type === 'pct'
+        ? (available * tableWidth.value) / 100
+        : 0;
+
+  const seed = gridColumnWidthsPt(input.gridCols);
+  const settled = applyWidthClaims(seed, input.claims, columnCount, statedTableWidth);
+
+  let stated = 0;
+  let unsettled = 0;
+  for (const width of settled) {
+    if (width === undefined) unsettled += 1;
+    else stated += width;
+  }
+  const resolved: number[] = [];
+  if (unsettled > 0) {
+    // Nothing states these columns. Give them what the content width has left over, capped
+    // at the mean of the stated columns so a `w:gridBefore` band or one unstated column
+    // cannot swallow the whole page, and floored so none collapses.
+    const mean =
+      stated > 0 ? stated / Math.max(columnCount - unsettled, 1) : available / columnCount;
+    const leftover = Math.max(available - stated, 0) / unsettled;
+    const each = Math.max(Math.min(leftover, mean), MIN_DERIVED_COLUMN_PT);
+    for (const width of settled) resolved.push(width ?? each);
+  } else {
+    for (const width of settled) resolved.push(width!);
+  }
 
   const total = resolved.reduce((sum, width) => sum + width, 0);
-  if (total <= 0) return new Array<number>(columnCount).fill(available / columnCount);
-  // Fixed layout states that the grid IS the geometry, overflow included.
-  if (input.layoutFixed) return resolved;
-  // A column so wide it had to be clamped is not geometry anyone authored, and a fit
-  // derived from it would let one hostile `w:gridCol` shrink every legitimate column in the
-  // table. The clamp already bounds the damage to that one column; leave its siblings be.
-  if (grid?.clamped === true) return resolved;
+  if (!Number.isFinite(total) || total <= 0) {
+    return new Array<number>(columnCount).fill(available / columnCount);
+  }
 
-  const target =
-    input.tableWidth.type === 'dxa'
-      ? Math.min(input.tableWidth.value, available)
-      : input.tableWidth.type === 'pct'
-        ? Math.min((available * input.tableWidth.value) / 100, available)
-        : available;
-  if (total <= target + WIDTH_EPSILON_PT) return resolved;
+  // Never let a stated width crush the table to nothing. `w:tblW w:w="1"` is a hostile
+  // instruction rather than a layout request, and a nested table inside a degenerate cell
+  // would otherwise be scaled below the hairline `preferredColumnWidthsPt` guarantees. The
+  // floor wins over the clamp: overflowing a 3pt cell is recoverable, a zero-width column is
+  // not.
+  const floor = columnCount * MIN_DERIVED_COLUMN_PT;
+  const pageCap = input.layoutFixed || !hasPage ? Number.POSITIVE_INFINITY : available;
+  const target = Math.max(
+    statedTableWidth > 0 ? Math.min(statedTableWidth, pageCap) : Math.min(total, pageCap),
+    floor
+  );
+
+  // Only a `pct` table width stretches a narrow table up to its target.
+  const stretches = tableWidth.type === 'pct' && statedTableWidth > 0;
+  if (total <= target + WIDTH_EPSILON_PT && !stretches) return resolved;
+  if (Math.abs(total - target) <= WIDTH_EPSILON_PT) return resolved;
   const scale = target / total;
   return resolved.map((width) => width * scale);
 }
@@ -725,7 +828,19 @@ export function readTableStructure(
     const starts: number[] = [];
     const spans: number[] = [];
     const preferred: PreferredWidth[] = [];
-    let cursor = Math.min(readGridSkip(properties, 'gridBefore'), LAST_GRID_COLUMN);
+    const gridBefore = Math.min(readGridSkip(properties, 'gridBefore'), LAST_GRID_COLUMN);
+    // 17.18.87: "the initial number of grid units before the row starts is skipped. The
+    // width of the skipped grid columns is set using the wBefore property." Without this the
+    // skipped band is a column nothing states, and it absorbs the leftover as a phantom
+    // gutter wider than the cells it precedes.
+    if (gridBefore > 0) {
+      claims.push({
+        start: 0,
+        span: gridBefore,
+        preferred: readPreferredWidth(properties && childNamed(properties, 'wBefore')),
+      });
+    }
+    let cursor = gridBefore;
     for (const cellNode of rowNode.children) {
       if (cellNode.kind !== 'tableCell') continue;
       const cellPr = childNamed(cellNode, 'tcPr');
@@ -741,7 +856,16 @@ export function readTableStructure(
       claims.push({ start, span, preferred: width });
       cursor = start + span;
     }
-    const gridColumns = Math.min(cursor + readGridSkip(properties, 'gridAfter'), MAX_TABLE_COLUMNS);
+    const gridAfter = readGridSkip(properties, 'gridAfter');
+    const gridColumns = Math.min(cursor + gridAfter, MAX_TABLE_COLUMNS);
+    // 17.4.85, the trailing counterpart of `w:wBefore`.
+    if (gridAfter > 0 && cursor < MAX_TABLE_COLUMNS) {
+      claims.push({
+        start: cursor,
+        span: Math.min(gridAfter, MAX_TABLE_COLUMNS - cursor),
+        preferred: readPreferredWidth(properties && childNamed(properties, 'wAfter')),
+      });
+    }
     if (gridColumns > derivedColumns) derivedColumns = gridColumns;
     plans.push({ node: rowNode, properties, starts, spans, preferred, gridColumns });
   }
@@ -762,6 +886,9 @@ export function readTableStructure(
       const cellProperties = childNamed(cellNode, 'tcPr');
       const gridColumn = plan.starts[cellIndex]!;
       const gridSpan = plan.spans[cellIndex]!;
+      // Read alongside its siblings, before `cellIndex` moves on — the plan loop and this
+      // one skip the same non-cell children, and the indices must stay in lockstep.
+      const preferredWidth = plan.preferred[cellIndex] ?? AUTO_PREFERRED_WIDTH;
       const conditions = conditionalTypesFor({
         look,
         rowIndex,
@@ -804,7 +931,7 @@ export function readTableStructure(
           cellProperties ? readCellBorders(cellProperties) : EMPTY_CELL_BORDER_BOX
         ),
         ...(shading === undefined ? {} : { shading }),
-        preferredWidth: plan.preferred[cellIndex - 1] ?? AUTO_PREFERRED_WIDTH,
+        preferredWidth,
         styleFormatting: styleFormattingFor(conditions),
         blocks,
       });
@@ -817,9 +944,24 @@ export function readTableStructure(
     });
   }
 
-  const tableWidth = readPreferredWidth(tblPr && childNamed(tblPr, 'tblW'));
+  // `w:tblW` and `w:tblLayout` both live in CT_TblPrBase, which is what a table STYLE's
+  // `w:tblPr` carries — the same reason `tblCellMar` and `tblBorders` cascade above. A style
+  // that states "AutoFit to Window" or fixed layout is stating it for every table that names
+  // it. 17.4.52: an absent `w:tblLayout` means autofit.
+  let styleTableWidth = AUTO_PREFERRED_WIDTH;
+  let styleLayoutFixed: boolean | undefined;
+  for (const node of tableStyle.tablePropertyNodes) {
+    const styleW = childNamed(node, 'tblW');
+    if (styleW) styleTableWidth = readPreferredWidth(styleW);
+    const styleLayout = childNamed(node, 'tblLayout');
+    if (styleLayout) styleLayoutFixed = attributeValue(styleLayout, 'type') === 'fixed';
+  }
+  const ownTblW = tblPr && childNamed(tblPr, 'tblW');
+  const tableWidth = ownTblW ? readPreferredWidth(ownTblW) : styleTableWidth;
   const tblLayout = tblPr && childNamed(tblPr, 'tblLayout');
-  const layoutFixed = tblLayout ? attributeValue(tblLayout, 'type') === 'fixed' : false;
+  const layoutFixed = tblLayout
+    ? attributeValue(tblLayout, 'type') === 'fixed'
+    : (styleLayoutFixed ?? false);
 
   return {
     columnWidthsPt: resolveColumnWidthsPt({

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -12,6 +12,7 @@
 // locks, dropdown behaviour — is not modelled.
 
 import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import { revisionRemovesParagraph } from './revision-visibility.ts';
 
 /** Nested `w:sdt` wrappers deeper than this stop flattening; content stays preserved. */
 const MAX_SDT_NESTING = 32;
@@ -43,6 +44,10 @@ export function storyBlocks(part: OoxmlPart): OoxmlElement[] {
   const collect = (children: readonly OoxmlNode[], depth: number): void => {
     for (const child of children) {
       if (child.kind === 'paragraph' || child.kind === 'table') {
+        // A paragraph whose mark AND content a tracked revision deleted is not part of the
+        // rendered document; without this it reaches pagination with no spans and still
+        // claims a full line box.
+        if (child.kind === 'paragraph' && revisionRemovesParagraph(child)) continue;
         blocks.push(child);
         continue;
       }


### PR DESCRIPTION
`w:tcW`, `w:tblW`, `w:tblLayout`, `w:wBefore`/`w:wAfter`, `w:tblInd`, `w:jc` and `w:tblCellSpacing` were parsed nowhere. Columns came only from `w:tblGrid`, and every table sat flush at the leading margin.

The precedence follows 17.4.16 and 17.18.87: the grid is the *initial* width and `w:tcW` overrides it, with rows that disagree settling on the maximum. Verified against demo.docx `0.0.27`, whose grid says `3488,3215` while both cells state `tcW=4788` — Word renders equal columns.

Two deliberate asymmetries, both sourced. A fixed-layout table is bounded by `w:tblW` but not by the page, because 17.18.87 puts the page clamp in the autofit chain only, and Word really does render fixed tables past the right margin. A `pct` `w:tblW` stretches a narrow table up as well as shrinking a wide one, because that is AutoFit to Window.

Also drops paragraphs a tracked revision removed. A `w:del` on the paragraph mark joins the paragraph forward, and when its content is deleted too nothing survives the join — but layout still measured a full line box, so a cell of them stacked blank lines. Narrowed to that intersection: content-deleted-with-a-surviving-mark is an empty line Word really shows, and a deleted mark over visible content keeps its box or text would be lost. Worth 12 pages on `list-pagination-break.docx`, 47 down to 35.

Reviewed by three independent agents (OOXML conformance, security, correctness). Their findings are folded in: the original grid-beats-`tcW` precedence was backwards, one unreadable `w:gridCol` was discarding the whole authored grid, `w:tblW w:w="1"` could crush every column, and making the fragment box honest had regressed clicking in the blank strip beside a narrow table, which is now fixed in `blockDistance`.

Not included: no content-measuring autofit pass, so widths scale proportionally and a long unbreakable token will not widen its column the way Word widens it. `w:tblCellSpacing` is a half-gap inside each grid slot; Word also grows the table by the spacing it adds outside, which is not modelled, and no fixture exercises it. Inserted `w:ins` content still does not render — `paragraphTextOf` excludes it too, so rendering it without first extending the store's model-text vocabulary would desync selection and tree ops; that belongs to `typed-revisions-and-comments`.

Full suite 3114 pass, with the two failures that are already red on a clean tree. Across all 116 fixture tables no throws and every fragment box matches its painted extent; exactly one fixture's page count moves.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788360505&installation_model_id=422592&pr_number=99&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F99&signature=b51aeac1f7e28e0a98bb65c2ac9965eccd5e2eb111c369ed5aa9c4957d20ff30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->