### PR TITLE
fix(react): attach scoped editing controls to stories

### DIFF
--- a/.changeset/scoped-editing-chrome-polish.md
+++ b/.changeset/scoped-editing-chrome-polish.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Keep header, footer, footnote, and endnote editing controls attached to the active story, replace misleading insert icons with an explicit page-number menu, and reveal notes when their references are opened.

--- a/packages/core/src/editor/__tests__/scoped-note-editing.test.ts
+++ b/packages/core/src/editor/__tests__/scoped-note-editing.test.ts
@@ -257,6 +257,28 @@ describe('scoped note editing', () => {
     surface.destroy();
   });
 
+  test('entering a citation reveals its note instead of leaving an off-screen scope open', () => {
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    document.body.append(scroller);
+    const { container, surface } = mount(noteDoc());
+    scroller.append(container);
+    Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true });
+    Object.defineProperty(scroller, 'scrollHeight', { value: 10_000, configurable: true });
+    let revealedTop: number | null = null;
+    scroller.scrollTo = ((options: ScrollToOptions) => {
+      revealedTop = options.top ?? null;
+    }) as typeof scroller.scrollTo;
+
+    expect(surface.enterNote('footnote:1')).toBe(true);
+    expect(revealedTop).not.toBeNull();
+    expect(revealedTop!).toBeGreaterThan(0);
+    expect(surface.activeScope()).toEqual({ kind: 'note', id: 'footnote:1' });
+
+    surface.destroy();
+    scroller.remove();
+  });
+
   test('note hyperlink owns footnotes rels; undo restores; no stray body relationship', () => {
     const { surface } = mount(noteDoc('Note text'));
     expect(surface.enterNote('footnote:1')).toBe(true);

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1040,6 +1040,20 @@ export function mountPaginatedSurface(
     setSelection: (next) => setSelection(next),
     noteModelMoved: () => selectionSync.noteModelMoved(),
     render: () => render(),
+    revealNote: (scopeId) => {
+      for (const page of currentLayout.pages) {
+        const note = [...(page.footnotes?.notes ?? []), ...(page.endnotes?.notes ?? [])].find(
+          (candidate) => candidate.scopeId === scopeId
+        );
+        if (!note) continue;
+        scrollToContentY(note.box.y, note.box.height, {
+          block: 'nearest',
+          offsetPx: 48,
+        });
+        return page.index;
+      }
+      return null;
+    },
     notify: () => options.onChange?.(currentState()),
     lastRejection: () => lastRejection,
     setLastRejection: (reason) => {

--- a/packages/core/src/editor/surface-note-ops.ts
+++ b/packages/core/src/editor/surface-note-ops.ts
@@ -80,6 +80,7 @@ export function createNoteOps(deps: {
   setSelection: (next: SemanticSelection) => void;
   noteModelMoved: () => void;
   render: () => void;
+  revealNote: (scopeId: string) => number | null;
   notify: () => void;
   lastRejection: () => string | null;
   setLastRejection: (reason: string | null) => void;
@@ -147,6 +148,7 @@ export function createNoteOps(deps: {
     }
     deps.noteModelMoved();
     deps.render();
+    activeNotePageIndex ??= deps.revealNote(activeNote.id);
     deps.notify();
     return true;
   };

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3194,83 +3194,74 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* ── Scoped story chrome ──────────────────────────────────────────────────────────────
- * Compact controls follow the active header/footer/note story. React keeps them outside
- * the engine-painted subtree, while useScopedChromeAnchor places them beside its boundary. */
-.docx-context-chip {
+ * A quiet label rail follows the active header/footer/note story. React keeps it outside
+ * the engine-painted subtree, while useScopedChromeAnchor places it at the story boundary. */
+.docx-context-bar {
   position: absolute;
   display: flex;
   align-items: center;
-  gap: 6px;
-  min-height: 30px;
-  padding: 4px 5px 4px 10px;
-  background: var(--doc-surface);
-  border: 1px solid var(--doc-border);
-  border-radius: 8px;
-  box-shadow: 0 4px 14px var(--doc-shadow);
-  color: var(--doc-text);
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 24px;
+  box-sizing: border-box;
+  padding: 0 2px 5px;
+  color: var(--doc-primary);
+  background: transparent;
+  border-bottom: 1px dotted var(--doc-primary);
   font-size: 12px;
   white-space: nowrap;
   pointer-events: auto;
 }
 
-.docx-context-chip__title {
+.docx-context-bar__label {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.docx-context-bar__title {
   min-width: 0;
   overflow: hidden;
   font-weight: 600;
   text-overflow: ellipsis;
 }
 
-.docx-context-chip__status {
+.docx-context-bar__status {
   max-width: 150px;
   overflow: hidden;
-  padding: 2px 6px;
   color: var(--doc-text-muted);
-  background: var(--doc-bg-subtle);
-  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 400;
   text-overflow: ellipsis;
 }
 
-.docx-context-chip__button {
-  min-height: 24px;
-  padding: 3px 8px;
+.docx-context-bar__options-trigger {
+  padding: 2px 0 2px 8px;
   font: inherit;
-  color: var(--doc-text);
+  font-weight: 500;
+  color: var(--doc-primary);
   background: transparent;
-  border: 1px solid transparent;
-  border-radius: 5px;
+  border: 0;
   cursor: pointer;
 }
 
-.docx-context-chip__button:hover:not(:disabled) {
-  background: var(--doc-bg-hover);
-  border-color: var(--doc-border);
+.docx-context-bar__options-trigger::after {
+  content: ' ▾';
+  font-size: 9px;
 }
 
-.docx-context-chip__button--primary {
-  color: var(--doc-on-primary);
-  background: var(--doc-primary);
-  border-color: var(--doc-primary);
+.docx-context-bar__options-trigger:hover {
+  text-decoration: underline;
 }
 
-.docx-context-chip__button--primary:hover:not(:disabled) {
-  background: var(--doc-primary-hover);
-  border-color: var(--doc-primary-hover);
-}
-
-.docx-context-chip__button:disabled {
-  opacity: 0.45;
-  cursor: default;
+.docx-context-bar__options-trigger:focus-visible {
+  outline: 2px solid var(--doc-focus-ring);
+  outline-offset: 2px;
 }
 
 .docx-hf-chrome__options {
   position: relative;
-}
-
-.docx-hf-chrome__actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  flex: none;
 }
 
 .docx-hf-chrome__options-menu {
@@ -3497,11 +3488,11 @@ a.docx-hyperlink:focus-visible {
 }
 
 @media (max-width: 640px) {
-  .docx-context-chip__status {
+  .docx-context-bar__status {
     display: none;
   }
 
-  .docx-context-chip {
+  .docx-context-bar {
     max-width: calc(100vw - 16px) !important;
   }
 
@@ -3520,7 +3511,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 @media print {
-  .docx-context-chip {
+  .docx-context-bar {
     display: none !important;
   }
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3193,89 +3193,84 @@ a.docx-hyperlink:focus-visible {
   cursor: default;
 }
 
-/* ── Header/footer scope chrome (`docx-hf-chrome` family) — React overlay while editing
- * page furniture. UI-only; no document canvas geometry. */
-.docx-hf-chrome {
-  position: sticky;
-  top: 0;
+/* ── Scoped story chrome ──────────────────────────────────────────────────────────────
+ * Compact controls follow the active header/footer/note story. React keeps them outside
+ * the engine-painted subtree, while useScopedChromeAnchor places them beside its boundary. */
+.docx-context-chip {
+  position: absolute;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 8px 12px;
-  padding: 8px 12px;
-  margin: 0 auto 8px;
-  max-width: 100%;
+  gap: 6px;
+  min-height: 30px;
+  padding: 4px 5px 4px 10px;
   background: var(--doc-surface);
   border: 1px solid var(--doc-border);
-  border-radius: 6px;
-  box-shadow: 0 1px 4px var(--doc-shadow);
+  border-radius: 8px;
+  box-shadow: 0 4px 14px var(--doc-shadow);
   color: var(--doc-text);
-}
-
-.docx-hf-chrome__title-block {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-  flex: 1 1 160px;
-}
-
-.docx-hf-chrome__title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--doc-text);
-}
-
-.docx-hf-chrome__inheritance {
   font-size: 12px;
+  white-space: nowrap;
+  pointer-events: auto;
+}
+
+.docx-context-chip__title {
+  min-width: 0;
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.docx-context-chip__status {
+  max-width: 150px;
+  overflow: hidden;
+  padding: 2px 6px;
   color: var(--doc-text-muted);
+  background: var(--doc-bg-subtle);
+  border-radius: 9999px;
+  text-overflow: ellipsis;
 }
 
-.docx-hf-chrome__inheritance-hint {
-  display: block;
-  font-size: 11px;
-  color: var(--doc-text-subtle);
+.docx-context-chip__button {
+  min-height: 24px;
+  padding: 3px 8px;
+  font: inherit;
+  color: var(--doc-text);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  cursor: pointer;
 }
 
-.docx-hf-chrome__inserts {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  flex: none;
+.docx-context-chip__button:hover:not(:disabled) {
+  background: var(--doc-bg-hover);
+  border-color: var(--doc-border);
 }
 
-.docx-hf-chrome__actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  flex: none;
+.docx-context-chip__button--primary {
+  color: var(--doc-on-primary);
+  background: var(--doc-primary);
+  border-color: var(--doc-primary);
+}
+
+.docx-context-chip__button--primary:hover:not(:disabled) {
+  background: var(--doc-primary-hover);
+  border-color: var(--doc-primary-hover);
+}
+
+.docx-context-chip__button:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .docx-hf-chrome__options {
   position: relative;
 }
 
-.docx-hf-chrome__options-trigger,
-.docx-hf-chrome__close {
-  font: inherit;
-  font-size: 13px;
-  color: var(--doc-text);
-  background: var(--doc-bg-input);
-  border: 1px solid var(--doc-border-input);
-  border-radius: 4px;
-  padding: 4px 10px;
-  cursor: pointer;
-}
-
-.docx-hf-chrome__options-trigger:hover:not(:disabled),
-.docx-hf-chrome__close:hover:not(:disabled) {
-  background: var(--doc-bg-hover);
-}
-
-.docx-hf-chrome__options-trigger:disabled,
-.docx-hf-chrome__close:disabled {
-  opacity: 0.5;
-  cursor: default;
+.docx-hf-chrome__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex: none;
 }
 
 .docx-hf-chrome__options-menu {
@@ -3357,6 +3352,22 @@ a.docx-hyperlink:focus-visible {
 .docx-hf-chrome__unit {
   font-size: 11px;
   color: var(--doc-text-muted);
+}
+
+@media (max-width: 640px) {
+  .docx-context-chip__status {
+    display: none;
+  }
+
+  .docx-context-chip {
+    max-width: calc(100vw - 16px) !important;
+  }
+}
+
+@media print {
+  .docx-context-chip {
+    display: none !important;
+  }
 }
 
 /* ── Vue registry-toolbar (`ep-toolbar` family) additions for the same shapes:

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3354,6 +3354,148 @@ a.docx-hyperlink:focus-visible {
   color: var(--doc-text-muted);
 }
 
+.docx-note-properties {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  box-sizing: border-box;
+  padding: 20px;
+  background: var(--doc-overlay);
+}
+
+.docx-note-properties__panel {
+  width: min(620px, 100%);
+  max-height: calc(100vh - 40px);
+  overflow: auto;
+  color: var(--doc-text);
+  background: var(--doc-surface);
+  border: 1px solid var(--doc-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 36px var(--doc-shadow-strong);
+}
+
+.docx-note-properties__title {
+  margin: 0;
+  padding: 18px 20px 14px;
+  font-size: 16px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--doc-border);
+}
+
+.docx-note-properties__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 20px;
+}
+
+.docx-note-properties__scope {
+  display: grid;
+  grid-template-columns: 130px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.docx-note-properties__section {
+  min-width: 0;
+  margin: 0;
+  padding: 14px 16px 16px;
+  background: var(--doc-bg-subtle);
+  border: 1px solid var(--doc-border);
+  border-radius: 8px;
+}
+
+.docx-note-properties__legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 5px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.docx-note-properties__badge {
+  padding: 2px 7px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--doc-text-muted);
+  background: var(--doc-surface);
+  border: 1px solid var(--doc-border);
+  border-radius: 9999px;
+}
+
+.docx-note-properties__fields {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.docx-note-properties__field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--doc-text-muted);
+}
+
+.docx-note-properties__select {
+  width: 100%;
+  min-height: 34px;
+  box-sizing: border-box;
+  padding: 6px 30px 6px 9px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--doc-text);
+  background: var(--doc-surface);
+  border: 1px solid var(--doc-border-input);
+  border-radius: 5px;
+}
+
+.docx-note-properties__select:focus-visible {
+  border-color: var(--doc-primary);
+  outline: 2px solid var(--doc-focus-ring);
+  outline-offset: 1px;
+}
+
+.docx-note-properties__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px 16px;
+  border-top: 1px solid var(--doc-border);
+}
+
+.docx-note-properties__button {
+  min-height: 32px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--doc-text);
+  background: var(--doc-surface);
+  border: 1px solid var(--doc-border);
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.docx-note-properties__button:hover {
+  background: var(--doc-bg-hover);
+}
+
+.docx-note-properties__button--primary {
+  color: var(--doc-on-primary);
+  background: var(--doc-primary);
+  border-color: var(--doc-primary);
+}
+
+.docx-note-properties__button--primary:hover {
+  background: var(--doc-primary-hover);
+  border-color: var(--doc-primary-hover);
+}
+
 @media (max-width: 640px) {
   .docx-context-chip__status {
     display: none;
@@ -3361,6 +3503,19 @@ a.docx-hyperlink:focus-visible {
 
   .docx-context-chip {
     max-width: calc(100vw - 16px) !important;
+  }
+
+  .docx-note-properties {
+    padding: 12px;
+  }
+
+  .docx-note-properties__panel {
+    max-height: calc(100vh - 24px);
+  }
+
+  .docx-note-properties__scope,
+  .docx-note-properties__fields {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -869,7 +869,8 @@
     "insertSectionPages": "Abschnittsseitenzahl einfügen",
     "insertPageXofY": "Seite X von Y einfügen",
     "pageXofYLabel": "Seite",
-    "pageXofYSeparator": "von"
+    "pageXofYSeparator": "von",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "Bildplatzhalter",

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -916,6 +916,7 @@
     "footerDistance": "Footer distance from edge",
     "removeHeader": "Remove header",
     "removeFooter": "Remove footer",
+    "pageNumbers": "Page numbers",
     "insertPageNumber": "Insert current page number",
     "insertTotalPages": "Insert total page count",
     "insertSectionPages": "Insert section page count",

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -872,7 +872,8 @@
     "insertSectionPages": "Insérer le nombre de pages de la section",
     "insertPageXofY": "Insérer page X sur Y",
     "pageXofYLabel": "Page",
-    "pageXofYSeparator": "sur"
+    "pageXofYSeparator": "sur",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "Insérer une image",

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -869,7 +869,8 @@
     "insertSectionPages": "הוסף מספר עמודים במקטע",
     "insertPageXofY": "הוסף עמוד X מתוך Y",
     "pageXofYLabel": "עמוד",
-    "pageXofYSeparator": "מתוך"
+    "pageXofYSeparator": "מתוך",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "מיקום תמונה",

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -872,7 +872,8 @@
     "insertSectionPages": "अनुभाग पृष्ठ संख्या डालें",
     "insertPageXofY": "पृष्ठ X of Y डालें",
     "pageXofYLabel": "पृष्ठ",
-    "pageXofYSeparator": "में से"
+    "pageXofYSeparator": "में से",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "चित्र प्लेसहोल्डर",

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -888,7 +888,8 @@
     "insertSectionPages": "Sisipkan jumlah halaman bagian",
     "insertPageXofY": "Sisipkan halaman X dari Y",
     "pageXofYLabel": "Halaman",
-    "pageXofYSeparator": "dari"
+    "pageXofYSeparator": "dari",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "Placeholder gambar",

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -869,7 +869,8 @@
     "insertSectionPages": "Wstaw liczbę stron sekcji",
     "insertPageXofY": "Wstaw stronę X z Y",
     "pageXofYLabel": "Strona",
-    "pageXofYSeparator": "z"
+    "pageXofYSeparator": "z",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "Symbol zastępczy obrazu",

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -869,7 +869,8 @@
     "insertSectionPages": "Inserir contagem de páginas da seção",
     "insertPageXofY": "Inserir página X de Y",
     "pageXofYLabel": "Página",
-    "pageXofYSeparator": "de"
+    "pageXofYSeparator": "de",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "Espaço reservado para imagem",

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -872,7 +872,8 @@
     "insertSectionPages": "Bölüm sayfa sayısını ekle",
     "insertPageXofY": "X / Y sayfasını ekle",
     "pageXofYLabel": "Sayfa",
-    "pageXofYSeparator": "/"
+    "pageXofYSeparator": "/",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "Görsel yer tutucu",

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -869,7 +869,8 @@
     "insertSectionPages": "插入本节页数",
     "insertPageXofY": "插入第 X 页，共 Y 页",
     "pageXofYLabel": "第",
-    "pageXofYSeparator": "页，共"
+    "pageXofYSeparator": "页，共",
+    "pageNumbers": null
   },
   "image": {
     "placeholder": "图片占位符",

--- a/packages/react/src/editor/DocxEditorHeaderFooter.tsx
+++ b/packages/react/src/editor/DocxEditorHeaderFooter.tsx
@@ -8,23 +8,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, MouseEvent, ReactElement } from 'react';
 import type { EditorCommand } from '@docx-editor.dev/core-contract/contracts/editor';
-import { CHROME_GROUPS, chromeSlotId } from '@docx-editor.dev/core-contract/editor';
 import { useTranslation } from '../i18n';
 import type { TranslationKey } from '../i18n';
 import { Z_INDEX } from '../styles/zIndex';
 import { useDocxEditor } from './context';
 import { guardToolbarMousedown } from './toolbar/ToolbarButton';
-import { ToolbarButton } from './toolbar/ToolbarButton';
-import { ToolbarContext } from './toolbar/toolbar-context';
 import { inchesToTwips, twipsToInches } from './header-footer-units';
 import { useHeaderFooterState } from './useHeaderFooterState';
+import { useScopedChromeAnchor } from './useScopedChromeAnchor';
 
 /** Props for `DocxEditor.HeaderFooterChrome`. @public */
 export interface DocxEditorHeaderFooterChromeProps {
   className?: string;
 }
-
-const INSERT_GROUP = CHROME_GROUPS.find((group) => group.id === 'insert')!;
 
 function regionLabelKey(
   editing: 'header' | 'footer',
@@ -37,6 +33,73 @@ function regionLabelKey(
     return editing === 'header' ? 'headerFooter.evenPageHeader' : 'headerFooter.evenPageFooter';
   }
   return editing === 'header' ? 'headerFooter.header' : 'headerFooter.footer';
+}
+
+const PAGE_FIELDS = [
+  { field: 'PAGE', labelKey: 'headerFooter.insertPageNumber' },
+  { field: 'NUMPAGES', labelKey: 'headerFooter.insertTotalPages' },
+  { field: 'SECTIONPAGES', labelKey: 'headerFooter.insertSectionPages' },
+  { field: 'PAGE_X_OF_Y', labelKey: 'headerFooter.insertPageXofY' },
+] as const;
+
+function PageFieldsMenu(props: {
+  readonly onMouseDown: (event: MouseEvent) => void;
+}): ReactElement {
+  const { onMouseDown } = props;
+  const { t } = useTranslation();
+  const editor = useDocxEditor();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocMouseDown = (event: globalThis.MouseEvent) => {
+      if (menuRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocMouseDown);
+    return () => document.removeEventListener('mousedown', onDocMouseDown);
+  }, [open]);
+
+  return (
+    <div ref={menuRef} className="docx-hf-chrome__options" onMouseDown={onMouseDown}>
+      <button
+        type="button"
+        className="docx-context-chip__button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => setOpen((value) => !value)}
+        onMouseDown={onMouseDown}
+      >
+        {t('headerFooter.pageNumbers')}
+      </button>
+      {open ? (
+        <div className="docx-hf-chrome__options-menu" role="menu" onMouseDown={onMouseDown}>
+          {PAGE_FIELDS.map((item) => {
+            const command: EditorCommand = { type: 'insertPageField', field: item.field };
+            const gate = editor?.can(command);
+            return (
+              <button
+                key={item.field}
+                type="button"
+                role="menuitem"
+                className="docx-hf-chrome__menu-item"
+                disabled={!gate?.ok}
+                title={gate && !gate.ok ? gate.reason : undefined}
+                onClick={() => {
+                  editor?.exec(command);
+                  setOpen(false);
+                }}
+                onMouseDown={onMouseDown}
+              >
+                {t(item.labelKey)}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function useCommandGate(command: EditorCommand): { enabled: boolean; reason: string | null } {
@@ -119,7 +182,7 @@ function OptionsMenu(props: {
     <div ref={menuRef} className="docx-hf-chrome__options" onMouseDown={onMouseDown}>
       <button
         type="button"
-        className="docx-hf-chrome__options-trigger"
+        className="docx-context-chip__button"
         aria-expanded={open}
         aria-haspopup="menu"
         onClick={() => setOpen((value) => !value)}
@@ -239,6 +302,14 @@ export function DocxEditorHeaderFooterChrome({
   const { t } = useTranslation();
   const editor = useDocxEditor();
   const state = useHeaderFooterState();
+  const findActiveFurniture = useCallback(
+    (viewport: HTMLElement) => viewport.querySelector<HTMLElement>('[data-docx-hf-active]'),
+    []
+  );
+  const anchor = useScopedChromeAnchor(
+    findActiveFurniture,
+    state?.editing === 'footer' ? 'before' : 'after'
+  );
 
   const onChromeMouseDown = guardToolbarMousedown;
 
@@ -256,43 +327,36 @@ export function DocxEditorHeaderFooterChrome({
 
   return (
     <div
-      className={`docx-hf-chrome${className ? ` ${className}` : ''}`}
+      ref={anchor.ref}
+      className={`docx-context-chip docx-hf-chrome${className ? ` ${className}` : ''}`}
       role="region"
       aria-label={t('headerFooter.chromeAriaLabel')}
       data-testid="docx-hf-chrome"
       onMouseDown={onChromeMouseDown}
-      style={{ zIndex: Z_INDEX.hfInlineEditor } as CSSProperties}
+      style={{ ...anchor.style, zIndex: Z_INDEX.hfInlineEditor } as CSSProperties}
     >
-      <div className="docx-hf-chrome__title-block">
-        <span className="docx-hf-chrome__title">{title}</span>
-        {state.inherited ? (
-          <span className="docx-hf-chrome__inheritance" data-testid="docx-hf-inherited">
-            {t('headerFooter.sameAsPrevious')}
-            <span className="docx-hf-chrome__inheritance-hint">
-              {t('headerFooter.sameAsPreviousHint')}
-            </span>
-          </span>
-        ) : null}
-      </div>
-      <ToolbarContext.Provider value={{ t: (key) => t(key as TranslationKey), onSave: undefined }}>
-        <div className="docx-hf-chrome__inserts" aria-label={t('formattingBar.groups.insert')}>
-          {INSERT_GROUP.controls.map((control) => {
-            const slot = chromeSlotId(INSERT_GROUP, control);
-            return <ToolbarButton key={slot} slot={slot} />;
-          })}
-        </div>
-      </ToolbarContext.Provider>
+      <span className="docx-context-chip__title">{title}</span>
+      {state.inherited ? (
+        <span
+          className="docx-context-chip__status"
+          data-testid="docx-hf-inherited"
+          title={t('headerFooter.sameAsPreviousHint')}
+        >
+          {t('headerFooter.sameAsPrevious')}
+        </span>
+      ) : null}
       <div className="docx-hf-chrome__actions">
+        <PageFieldsMenu onMouseDown={onChromeMouseDown} />
         <OptionsMenu state={state} onMouseDown={onChromeMouseDown} />
         <button
           type="button"
-          className="docx-hf-chrome__close"
+          className="docx-context-chip__button docx-context-chip__button--primary"
           data-testid="docx-hf-close"
           aria-label={t('headerFooter.closeEditing', { label: t(regionKey) })}
           onClick={close}
           onMouseDown={onChromeMouseDown}
         >
-          {t('headerFooter.closeEditing', { label: t(regionKey) })}
+          {t('common.close')}
         </button>
       </div>
     </div>

--- a/packages/react/src/editor/DocxEditorHeaderFooter.tsx
+++ b/packages/react/src/editor/DocxEditorHeaderFooter.tsx
@@ -42,66 +42,6 @@ const PAGE_FIELDS = [
   { field: 'PAGE_X_OF_Y', labelKey: 'headerFooter.insertPageXofY' },
 ] as const;
 
-function PageFieldsMenu(props: {
-  readonly onMouseDown: (event: MouseEvent) => void;
-}): ReactElement {
-  const { onMouseDown } = props;
-  const { t } = useTranslation();
-  const editor = useDocxEditor();
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return undefined;
-    const onDocMouseDown = (event: globalThis.MouseEvent) => {
-      if (menuRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
-    };
-    document.addEventListener('mousedown', onDocMouseDown);
-    return () => document.removeEventListener('mousedown', onDocMouseDown);
-  }, [open]);
-
-  return (
-    <div ref={menuRef} className="docx-hf-chrome__options" onMouseDown={onMouseDown}>
-      <button
-        type="button"
-        className="docx-context-chip__button"
-        aria-expanded={open}
-        aria-haspopup="menu"
-        onClick={() => setOpen((value) => !value)}
-        onMouseDown={onMouseDown}
-      >
-        {t('headerFooter.pageNumbers')}
-      </button>
-      {open ? (
-        <div className="docx-hf-chrome__options-menu" role="menu" onMouseDown={onMouseDown}>
-          {PAGE_FIELDS.map((item) => {
-            const command: EditorCommand = { type: 'insertPageField', field: item.field };
-            const gate = editor?.can(command);
-            return (
-              <button
-                key={item.field}
-                type="button"
-                role="menuitem"
-                className="docx-hf-chrome__menu-item"
-                disabled={!gate?.ok}
-                title={gate && !gate.ok ? gate.reason : undefined}
-                onClick={() => {
-                  editor?.exec(command);
-                  setOpen(false);
-                }}
-                onMouseDown={onMouseDown}
-              >
-                {t(item.labelKey)}
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 function useCommandGate(command: EditorCommand): { enabled: boolean; reason: string | null } {
   const editor = useDocxEditor();
   return useMemo(() => {
@@ -182,7 +122,7 @@ function OptionsMenu(props: {
     <div ref={menuRef} className="docx-hf-chrome__options" onMouseDown={onMouseDown}>
       <button
         type="button"
-        className="docx-context-chip__button"
+        className="docx-context-bar__options-trigger"
         aria-expanded={open}
         aria-haspopup="menu"
         onClick={() => setOpen((value) => !value)}
@@ -192,6 +132,28 @@ function OptionsMenu(props: {
       </button>
       {open ? (
         <div className="docx-hf-chrome__options-menu" role="menu" onMouseDown={onMouseDown}>
+          {PAGE_FIELDS.map((item) => {
+            const command: EditorCommand = { type: 'insertPageField', field: item.field };
+            const gate = editor?.can(command);
+            return (
+              <button
+                key={item.field}
+                type="button"
+                role="menuitem"
+                className="docx-hf-chrome__menu-item"
+                disabled={!gate?.ok}
+                title={gate && !gate.ok ? gate.reason : undefined}
+                onClick={() => {
+                  editor?.exec(command);
+                  setOpen(false);
+                }}
+                onMouseDown={onMouseDown}
+              >
+                {t(item.labelKey)}
+              </button>
+            );
+          })}
+          <div className="docx-hf-chrome__menu-separator" role="separator" />
           <label className="docx-hf-chrome__menu-row">
             <input
               type="checkbox"
@@ -284,6 +246,20 @@ function OptionsMenu(props: {
               ? t('headerFooter.removeHeader')
               : t('headerFooter.removeFooter')}
           </button>
+          <div className="docx-hf-chrome__menu-separator" role="separator" />
+          <button
+            type="button"
+            role="menuitem"
+            className="docx-hf-chrome__menu-item"
+            data-testid="docx-hf-close"
+            onClick={() => {
+              editor?.exec({ type: 'exitHeaderFooter' });
+              setOpen(false);
+            }}
+            onMouseDown={onMouseDown}
+          >
+            {t('common.close')}
+          </button>
         </div>
       ) : null}
     </div>
@@ -291,8 +267,8 @@ function OptionsMenu(props: {
 }
 
 /**
- * Thin overlay while a header or footer scope is open: region label, inheritance warning,
- * page-number insert slots, options menu, and close. Mount beside `DocxEditor.Content`.
+ * Thin overlay while a header or footer scope is open: region label and contextual options.
+ * Mount beside `DocxEditor.Content`.
  *
  * @public
  */
@@ -300,65 +276,42 @@ export function DocxEditorHeaderFooterChrome({
   className,
 }: DocxEditorHeaderFooterChromeProps): ReactElement | null {
   const { t } = useTranslation();
-  const editor = useDocxEditor();
   const state = useHeaderFooterState();
   const findActiveFurniture = useCallback(
     (viewport: HTMLElement) => viewport.querySelector<HTMLElement>('[data-docx-hf-active]'),
     []
   );
-  const anchor = useScopedChromeAnchor(
-    findActiveFurniture,
-    state?.editing === 'footer' ? 'before' : 'after'
-  );
+  const anchor = useScopedChromeAnchor(findActiveFurniture, 'story-label');
 
   const onChromeMouseDown = guardToolbarMousedown;
-
-  const close = useCallback(() => {
-    editor?.exec({ type: 'exitHeaderFooter' });
-  }, [editor]);
 
   if (!state?.editing) return null;
 
   const regionKey = regionLabelKey(state.editing, state.variant);
-  const title = t('headerFooter.regionSection', {
-    region: t(regionKey),
-    section: state.sectionIndex + 1,
-  });
 
   return (
     <div
       ref={anchor.ref}
-      className={`docx-context-chip docx-hf-chrome${className ? ` ${className}` : ''}`}
+      className={`docx-context-bar docx-hf-chrome${className ? ` ${className}` : ''}`}
       role="region"
       aria-label={t('headerFooter.chromeAriaLabel')}
       data-testid="docx-hf-chrome"
       onMouseDown={onChromeMouseDown}
       style={{ ...anchor.style, zIndex: Z_INDEX.hfInlineEditor } as CSSProperties}
     >
-      <span className="docx-context-chip__title">{title}</span>
-      {state.inherited ? (
-        <span
-          className="docx-context-chip__status"
-          data-testid="docx-hf-inherited"
-          title={t('headerFooter.sameAsPreviousHint')}
-        >
-          {t('headerFooter.sameAsPrevious')}
-        </span>
-      ) : null}
-      <div className="docx-hf-chrome__actions">
-        <PageFieldsMenu onMouseDown={onChromeMouseDown} />
-        <OptionsMenu state={state} onMouseDown={onChromeMouseDown} />
-        <button
-          type="button"
-          className="docx-context-chip__button docx-context-chip__button--primary"
-          data-testid="docx-hf-close"
-          aria-label={t('headerFooter.closeEditing', { label: t(regionKey) })}
-          onClick={close}
-          onMouseDown={onChromeMouseDown}
-        >
-          {t('common.close')}
-        </button>
+      <div className="docx-context-bar__label">
+        <span className="docx-context-bar__title">{t(regionKey)}</span>
+        {state.inherited ? (
+          <span
+            className="docx-context-bar__status"
+            data-testid="docx-hf-inherited"
+            title={t('headerFooter.sameAsPreviousHint')}
+          >
+            {t('headerFooter.sameAsPrevious')}
+          </span>
+        ) : null}
       </div>
+      <OptionsMenu state={state} onMouseDown={onChromeMouseDown} />
     </div>
   );
 }

--- a/packages/react/src/editor/DocxEditorNotes.tsx
+++ b/packages/react/src/editor/DocxEditorNotes.tsx
@@ -52,6 +52,74 @@ function useCommandGate(command: EditorCommand): { enabled: boolean; reason: str
   }, [editor, command]);
 }
 
+function NoteStoryOptions(props: {
+  readonly onOpenProperties: () => void;
+  readonly onClose: () => void;
+}): ReactElement {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocumentMouseDown = (event: globalThis.MouseEvent) => {
+      if (menuRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocumentMouseDown);
+    return () => document.removeEventListener('mousedown', onDocumentMouseDown);
+  }, [open]);
+
+  return (
+    <div ref={menuRef} className="docx-hf-chrome__options">
+      <button
+        type="button"
+        className="docx-context-bar__options-trigger"
+        data-testid="docx-notes-options"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onMouseDown={guardToolbarMousedown}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {t('headerFooter.options')}
+      </button>
+      {open ? (
+        <div
+          className="docx-hf-chrome__options-menu"
+          role="menu"
+          onMouseDown={guardToolbarMousedown}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="docx-hf-chrome__menu-item"
+            data-testid="docx-notes-properties"
+            onClick={() => {
+              props.onOpenProperties();
+              setOpen(false);
+            }}
+          >
+            {t('dialogs.footnoteProperties.title')}
+          </button>
+          <div className="docx-hf-chrome__menu-separator" role="separator" />
+          <button
+            type="button"
+            role="menuitem"
+            className="docx-hf-chrome__menu-item"
+            data-testid="docx-notes-close"
+            onClick={() => {
+              props.onClose();
+              setOpen(false);
+            }}
+          >
+            {t('common.close')}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function DocxEditorNotesChrome({
   className,
 }: DocxEditorNotesChromeProps): ReactElement | null {
@@ -80,7 +148,7 @@ export function DocxEditorNotesChrome({
     },
     [noteScope]
   );
-  const anchor = useScopedChromeAnchor(findActiveNote, 'before');
+  const anchor = useScopedChromeAnchor(findActiveNote, 'story-label');
 
   const clearPreview = useCallback(() => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
@@ -255,32 +323,18 @@ export function DocxEditorNotesChrome({
       {noteScope && parsedActive ? (
         <div
           ref={anchor.ref}
-          className="docx-context-chip docx-notes-chrome__banner"
+          className="docx-context-bar docx-notes-chrome__banner"
           role="region"
           aria-label={t('notes.chromeAriaLabel')}
           data-testid="docx-notes-banner"
           data-note-scope={noteScope.id}
           style={{ ...anchor.style, zIndex: Z_INDEX.chrome }}
         >
-          <span className="docx-context-chip__title">{regionLabel}</span>
-          <button
-            type="button"
-            className="docx-context-chip__button"
-            data-testid="docx-notes-properties"
-            onMouseDown={guardToolbarMousedown}
-            onClick={() => setPropsOpen(true)}
-          >
-            {t('headerFooter.options')}
-          </button>
-          <button
-            type="button"
-            className="docx-context-chip__button docx-context-chip__button--primary"
-            data-testid="docx-notes-close"
-            onMouseDown={guardToolbarMousedown}
-            onClick={() => editor.setActiveScope({ kind: 'body' })}
-          >
-            {t('common.close')}
-          </button>
+          <span className="docx-context-bar__title">{regionLabel}</span>
+          <NoteStoryOptions
+            onOpenProperties={() => setPropsOpen(true)}
+            onClose={() => editor.setActiveScope({ kind: 'body' })}
+          />
         </div>
       ) : null}
 

--- a/packages/react/src/editor/DocxEditorNotes.tsx
+++ b/packages/react/src/editor/DocxEditorNotes.tsx
@@ -7,18 +7,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, MouseEvent, ReactElement } from 'react';
 import type { EditorCommand } from '@docx-editor.dev/core-contract/contracts/editor';
-import { CHROME_GROUPS, chromeSlotId } from '@docx-editor.dev/core-contract/editor';
 import { useTranslation } from '../i18n';
-import type { TranslationKey } from '../i18n';
 import { Z_INDEX } from '../styles/zIndex';
 import { useDocxEditor } from './context';
 import { guardToolbarMousedown } from './toolbar/ToolbarButton';
-import { ToolbarButton } from './toolbar/ToolbarButton';
-import { ToolbarContext } from './toolbar/toolbar-context';
 import { useNotePropertiesState, useNoteScopeState } from './useNoteScopeState';
+import { useScopedChromeAnchor } from './useScopedChromeAnchor';
 
 const NOTE_SCOPE_RE = /^(footnote|endnote):(-?\d{1,10})$/;
-const INSERT_GROUP = CHROME_GROUPS.find((group) => group.id === 'insert')!;
 
 function parseNoteScopeId(
   id: string
@@ -70,6 +66,21 @@ export function DocxEditorNotesChrome({
   } | null>(null);
   const [propsOpen, setPropsOpen] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const findActiveNote = useCallback(
+    (viewport: HTMLElement) => {
+      if (!noteScope) return null;
+      const candidates = viewport.querySelectorAll<HTMLElement>('[data-docx-note-scope]');
+      return (
+        [...candidates].find(
+          (candidate) =>
+            candidate.matches('[data-docx-note]') &&
+            candidate.dataset.docxNoteScope === noteScope.id
+        ) ?? null
+      );
+    },
+    [noteScope]
+  );
+  const anchor = useScopedChromeAnchor(findActiveNote, 'before');
 
   const clearPreview = useCallback(() => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
@@ -88,12 +99,16 @@ export function DocxEditorNotesChrome({
       const ref = target.closest<HTMLElement>('[data-docx-note-ref]');
       if (ref?.dataset.docxNoteScope) {
         event.preventDefault();
+        clearPreview();
+        setMenu(null);
         editor.setActiveScope({ kind: 'note', id: ref.dataset.docxNoteScope });
         return;
       }
       const mark = target.closest<HTMLElement>('[data-docx-note-mark-back]');
       if (mark) {
         event.preventDefault();
+        clearPreview();
+        setMenu(null);
         editor.setActiveScope({ kind: 'body' });
       }
     };
@@ -239,54 +254,32 @@ export function DocxEditorNotesChrome({
     >
       {noteScope && parsedActive ? (
         <div
-          className="docx-notes-chrome__banner"
+          ref={anchor.ref}
+          className="docx-context-chip docx-notes-chrome__banner"
           role="region"
           aria-label={t('notes.chromeAriaLabel')}
           data-testid="docx-notes-banner"
           data-note-scope={noteScope.id}
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            zIndex: Z_INDEX.chrome,
-            display: 'flex',
-            gap: 8,
-            alignItems: 'center',
-            padding: '4px 8px',
-            background: 'var(--doc-banner-bg, #f5f5f5)',
-            borderBottom: '1px solid var(--doc-border, #ddd)',
-            fontSize: 12,
-          }}
+          style={{ ...anchor.style, zIndex: Z_INDEX.chrome }}
         >
-          <span>{regionLabel}</span>
-          <ToolbarContext.Provider
-            value={{ t: (key) => t(key as TranslationKey), onSave: undefined }}
-          >
-            <div aria-label={t('formattingBar.groups.insert')}>
-              {INSERT_GROUP.controls
-                .filter((control) => control.id === 'footnote' || control.id === 'endnote')
-                .map((control) => {
-                  const slot = chromeSlotId(INSERT_GROUP, control);
-                  return <ToolbarButton key={slot} slot={slot} />;
-                })}
-            </div>
-          </ToolbarContext.Provider>
+          <span className="docx-context-chip__title">{regionLabel}</span>
           <button
             type="button"
-            data-testid="docx-notes-close"
-            onMouseDown={guardToolbarMousedown}
-            onClick={() => editor.setActiveScope({ kind: 'body' })}
-          >
-            {t('notes.closeNote')}
-          </button>
-          <button
-            type="button"
+            className="docx-context-chip__button"
             data-testid="docx-notes-properties"
             onMouseDown={guardToolbarMousedown}
             onClick={() => setPropsOpen(true)}
           >
-            {t('dialogs.footnoteProperties.title')}
+            {t('headerFooter.options')}
+          </button>
+          <button
+            type="button"
+            className="docx-context-chip__button docx-context-chip__button--primary"
+            data-testid="docx-notes-close"
+            onMouseDown={guardToolbarMousedown}
+            onClick={() => editor.setActiveScope({ kind: 'body' })}
+          >
+            {t('common.close')}
           </button>
         </div>
       ) : null}

--- a/packages/react/src/editor/DocxEditorNotes.tsx
+++ b/packages/react/src/editor/DocxEditorNotes.tsx
@@ -400,135 +400,161 @@ function NotePropertiesDialog(props: {
 
   return (
     <div
+      className="docx-note-properties"
       role="dialog"
+      aria-modal="true"
       aria-label={t('dialogs.footnoteProperties.title')}
       data-testid="docx-notes-properties-dialog"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: Z_INDEX.modal,
-        display: 'grid',
-        placeItems: 'center',
-        background: 'rgba(0,0,0,.32)',
+      style={{ zIndex: Z_INDEX.modal }}
+      onClick={props.onClose}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') props.onClose();
       }}
-      onMouseDown={guardToolbarMousedown}
     >
       <div
-        style={{
-          background: 'var(--doc-popover-bg, #fff)',
-          padding: 16,
-          minWidth: 280,
-          borderRadius: 4,
-        }}
+        className="docx-note-properties__panel"
+        onClick={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
       >
-        <h2 style={{ margin: '0 0 12px', fontSize: 14 }}>
-          {t('dialogs.footnoteProperties.title')}
-        </h2>
-        <label>
-          {t('notes.scope')}
-          <select
-            value={scope}
-            onChange={(e) => setScope(e.target.value as 'document' | 'section')}
-          >
-            <option value="document">{t('notes.scopeDocument')}</option>
-            <option value="section">{t('notes.scopeSection')}</option>
-          </select>
-        </label>
-        <fieldset style={{ marginTop: 8 }}>
-          <legend>
-            {t('dialogs.footnoteProperties.footnotes')}
-            {footnoteInherited ? ` ${t('notes.inheritedValue')}` : ''}
-          </legend>
-          <label>
-            {t('dialogs.footnoteProperties.numberFormat')}
-            <select value={footnoteFmt} onChange={(e) => setFootnoteFmt(e.target.value)}>
-              <option value="decimal">{t('dialogs.footnoteProperties.formats.decimal')}</option>
-              <option value="lowerRoman">
-                {t('dialogs.footnoteProperties.formats.lowerRoman')}
-              </option>
-              <option value="upperRoman">
-                {t('dialogs.footnoteProperties.formats.upperRoman')}
-              </option>
-            </select>
-          </label>
-          <label>
-            {t('dialogs.footnoteProperties.numbering')}
-            <select value={footnoteRestart} onChange={(e) => setFootnoteRestart(e.target.value)}>
-              <option value="continuous">
-                {t('dialogs.footnoteProperties.numberingOptions.continuous')}
-              </option>
-              <option value="eachSect">
-                {t('dialogs.footnoteProperties.numberingOptions.restartSection')}
-              </option>
-              <option value="eachPage">
-                {t('dialogs.footnoteProperties.numberingOptions.restartPage')}
-              </option>
-            </select>
-          </label>
-          <label>
-            {t('dialogs.footnoteProperties.position')}
-            <select value={footnotePosition} onChange={(e) => setFootnotePosition(e.target.value)}>
-              <option value="pageBottom">
-                {t('dialogs.footnoteProperties.footnotePositions.bottomOfPage')}
-              </option>
-              <option value="beneathText">
-                {t('dialogs.footnoteProperties.footnotePositions.belowText')}
-              </option>
-            </select>
-          </label>
-        </fieldset>
-        <fieldset style={{ marginTop: 8 }}>
-          <legend>
-            {t('dialogs.footnoteProperties.endnotes')}
-            {endnoteInherited ? ` ${t('notes.inheritedValue')}` : ''}
-          </legend>
-          <label>
-            {t('dialogs.footnoteProperties.numberFormat')}
-            <select value={endnoteFmt} onChange={(e) => setEndnoteFmt(e.target.value)}>
-              <option value="decimal">{t('dialogs.footnoteProperties.formats.decimal')}</option>
-              <option value="lowerRoman">
-                {t('dialogs.footnoteProperties.formats.lowerRoman')}
-              </option>
-              <option value="upperRoman">
-                {t('dialogs.footnoteProperties.formats.upperRoman')}
-              </option>
-            </select>
-          </label>
-          <label>
-            {t('dialogs.footnoteProperties.numbering')}
-            <select value={endnoteRestart} onChange={(e) => setEndnoteRestart(e.target.value)}>
-              <option value="continuous">
-                {t('dialogs.footnoteProperties.numberingOptions.continuous')}
-              </option>
-              <option value="eachSect">
-                {t('dialogs.footnoteProperties.numberingOptions.restartSection')}
-              </option>
-              <option value="eachPage">
-                {t('dialogs.footnoteProperties.numberingOptions.restartPage')}
-              </option>
-            </select>
-          </label>
-          <label>
-            {t('dialogs.footnoteProperties.position')}
+        <h2 className="docx-note-properties__title">{t('dialogs.footnoteProperties.title')}</h2>
+        <div className="docx-note-properties__body">
+          <label className="docx-note-properties__scope">
+            <span>{t('notes.scope')}</span>
             <select
-              value={endnotePosition}
-              data-testid="docx-notes-endnote-position"
-              onChange={(e) => setEndnotePosition(e.target.value)}
+              className="docx-note-properties__select"
+              value={scope}
+              onChange={(e) => setScope(e.target.value as 'document' | 'section')}
             >
-              <option value="docEnd">
-                {t('dialogs.footnoteProperties.endnotePositions.endOfDocument')}
-              </option>
-              <option value="sectEnd">
-                {t('dialogs.footnoteProperties.endnotePositions.endOfSection')}
-              </option>
+              <option value="document">{t('notes.scopeDocument')}</option>
+              <option value="section">{t('notes.scopeSection')}</option>
             </select>
           </label>
-        </fieldset>
-        <div style={{ display: 'flex', gap: 8, marginTop: 12, justifyContent: 'flex-end' }}>
-          <button type="button" onClick={props.onClose}>
+          <fieldset className="docx-note-properties__section">
+            <legend className="docx-note-properties__legend">
+              <span>{t('dialogs.footnoteProperties.footnotes')}</span>
+              {footnoteInherited ? (
+                <span className="docx-note-properties__badge">{t('notes.inheritedValue')}</span>
+              ) : null}
+            </legend>
+            <div className="docx-note-properties__fields">
+              <label className="docx-note-properties__field">
+                <span>{t('dialogs.footnoteProperties.numberFormat')}</span>
+                <select
+                  className="docx-note-properties__select"
+                  value={footnoteFmt}
+                  onChange={(e) => setFootnoteFmt(e.target.value)}
+                >
+                  <option value="decimal">{t('dialogs.footnoteProperties.formats.decimal')}</option>
+                  <option value="lowerRoman">
+                    {t('dialogs.footnoteProperties.formats.lowerRoman')}
+                  </option>
+                  <option value="upperRoman">
+                    {t('dialogs.footnoteProperties.formats.upperRoman')}
+                  </option>
+                </select>
+              </label>
+              <label className="docx-note-properties__field">
+                <span>{t('dialogs.footnoteProperties.numbering')}</span>
+                <select
+                  className="docx-note-properties__select"
+                  value={footnoteRestart}
+                  onChange={(e) => setFootnoteRestart(e.target.value)}
+                >
+                  <option value="continuous">
+                    {t('dialogs.footnoteProperties.numberingOptions.continuous')}
+                  </option>
+                  <option value="eachSect">
+                    {t('dialogs.footnoteProperties.numberingOptions.restartSection')}
+                  </option>
+                  <option value="eachPage">
+                    {t('dialogs.footnoteProperties.numberingOptions.restartPage')}
+                  </option>
+                </select>
+              </label>
+              <label className="docx-note-properties__field">
+                <span>{t('dialogs.footnoteProperties.position')}</span>
+                <select
+                  className="docx-note-properties__select"
+                  value={footnotePosition}
+                  onChange={(e) => setFootnotePosition(e.target.value)}
+                >
+                  <option value="pageBottom">
+                    {t('dialogs.footnoteProperties.footnotePositions.bottomOfPage')}
+                  </option>
+                  <option value="beneathText">
+                    {t('dialogs.footnoteProperties.footnotePositions.belowText')}
+                  </option>
+                </select>
+              </label>
+            </div>
+          </fieldset>
+          <fieldset className="docx-note-properties__section">
+            <legend className="docx-note-properties__legend">
+              <span>{t('dialogs.footnoteProperties.endnotes')}</span>
+              {endnoteInherited ? (
+                <span className="docx-note-properties__badge">{t('notes.inheritedValue')}</span>
+              ) : null}
+            </legend>
+            <div className="docx-note-properties__fields">
+              <label className="docx-note-properties__field">
+                <span>{t('dialogs.footnoteProperties.numberFormat')}</span>
+                <select
+                  className="docx-note-properties__select"
+                  value={endnoteFmt}
+                  onChange={(e) => setEndnoteFmt(e.target.value)}
+                >
+                  <option value="decimal">{t('dialogs.footnoteProperties.formats.decimal')}</option>
+                  <option value="lowerRoman">
+                    {t('dialogs.footnoteProperties.formats.lowerRoman')}
+                  </option>
+                  <option value="upperRoman">
+                    {t('dialogs.footnoteProperties.formats.upperRoman')}
+                  </option>
+                </select>
+              </label>
+              <label className="docx-note-properties__field">
+                <span>{t('dialogs.footnoteProperties.numbering')}</span>
+                <select
+                  className="docx-note-properties__select"
+                  value={endnoteRestart}
+                  onChange={(e) => setEndnoteRestart(e.target.value)}
+                >
+                  <option value="continuous">
+                    {t('dialogs.footnoteProperties.numberingOptions.continuous')}
+                  </option>
+                  <option value="eachSect">
+                    {t('dialogs.footnoteProperties.numberingOptions.restartSection')}
+                  </option>
+                  <option value="eachPage">
+                    {t('dialogs.footnoteProperties.numberingOptions.restartPage')}
+                  </option>
+                </select>
+              </label>
+              <label className="docx-note-properties__field">
+                <span>{t('dialogs.footnoteProperties.position')}</span>
+                <select
+                  className="docx-note-properties__select"
+                  value={endnotePosition}
+                  data-testid="docx-notes-endnote-position"
+                  onChange={(e) => setEndnotePosition(e.target.value)}
+                >
+                  <option value="docEnd">
+                    {t('dialogs.footnoteProperties.endnotePositions.endOfDocument')}
+                  </option>
+                  <option value="sectEnd">
+                    {t('dialogs.footnoteProperties.endnotePositions.endOfSection')}
+                  </option>
+                </select>
+              </label>
+            </div>
+          </fieldset>
+        </div>
+        <div className="docx-note-properties__footer">
+          <button className="docx-note-properties__button" type="button" onClick={props.onClose}>
             {t('common.cancel')}
           </button>
           <button
+            className="docx-note-properties__button docx-note-properties__button--primary"
             type="button"
             data-testid="docx-notes-properties-apply"
             onClick={() => {

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -51,7 +51,8 @@ export function useScopedChromeAnchor(
 
       const viewportRect = viewport.getBoundingClientRect();
       const anchorRect = anchor.getBoundingClientRect();
-      const chromeHeight = chrome.offsetHeight;
+      const chromeHeight =
+        placement === 'story-label' ? Math.max(chrome.offsetHeight, 28) : chrome.offsetHeight;
       const attachedInsideViewport = containingViewport === viewport;
       const documentLeft = attachedInsideViewport
         ? anchorRect.left - viewportRect.left + viewport.scrollLeft

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -1,7 +1,7 @@
 import { useCallback, useLayoutEffect, useState } from 'react';
 import type { CSSProperties, RefCallback } from 'react';
 
-type AnchorPlacement = 'before' | 'after';
+type AnchorPlacement = 'before' | 'after' | 'story-label';
 
 export interface ScopedChromeAnchor {
   readonly ref: RefCallback<HTMLDivElement>;
@@ -57,18 +57,26 @@ export function useScopedChromeAnchor(
         ? anchorRect.left - viewportRect.left + viewport.scrollLeft
         : anchorRect.left;
       const documentTop = attachedInsideViewport
-        ? (placement === 'after' ? anchorRect.bottom + 6 : anchorRect.top - chromeHeight - 6) -
+        ? (placement === 'after' ? anchorRect.bottom + 6 : anchorRect.top - chromeHeight - 4) -
           viewportRect.top +
           viewport.scrollTop
         : placement === 'after'
           ? anchorRect.bottom + 6
-          : anchorRect.top - chromeHeight - 6;
+          : anchorRect.top - chromeHeight - 4;
+      const viewportEdge = attachedInsideViewport ? viewport.scrollLeft + 8 : 8;
 
       setStyle({
         position: attachedInsideViewport ? 'absolute' : 'fixed',
-        left: Math.max(attachedInsideViewport ? viewport.scrollLeft + 8 : 8, documentLeft + 8),
-        top: Math.max(8, documentTop),
-        maxWidth: Math.max(240, Math.min(anchorRect.width - 16, viewport.clientWidth - 16)),
+        left:
+          placement === 'story-label'
+            ? Math.max(viewportEdge, documentLeft)
+            : Math.max(viewportEdge, documentLeft + 8),
+        top: Math.max(attachedInsideViewport ? viewport.scrollTop + 8 : 8, documentTop),
+        ...(placement === 'story-label'
+          ? { width: Math.max(240, Math.min(anchorRect.width, viewport.clientWidth - 16)) }
+          : {
+              maxWidth: Math.max(240, Math.min(anchorRect.width - 16, viewport.clientWidth - 16)),
+            }),
         visibility: 'visible',
       });
     };

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -1,0 +1,119 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import type { CSSProperties, RefObject } from 'react';
+
+type AnchorPlacement = 'before' | 'after';
+
+export interface ScopedChromeAnchor {
+  readonly ref: RefObject<HTMLDivElement | null>;
+  readonly style: CSSProperties;
+}
+
+/**
+ * Attach contextual chrome to a painted story instead of the top of the editor viewport.
+ *
+ * The engine owns and may replace everything inside the paginated surface, so React cannot
+ * portal controls into a header, footer, or note node. This hook keeps the controls as a
+ * sibling overlay and derives only their screen placement from the current painted host.
+ */
+export function useScopedChromeAnchor(
+  findAnchor: (viewport: HTMLElement) => HTMLElement | null,
+  placement: AnchorPlacement
+): ScopedChromeAnchor {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [style, setStyle] = useState<CSSProperties>({
+    position: 'absolute',
+    left: 8,
+    top: 8,
+    visibility: 'visible',
+  });
+
+  useLayoutEffect(() => {
+    const chrome = ref.current;
+    const containingViewport = chrome?.closest<HTMLElement>('.docx-editor__scroll-container');
+    const viewport =
+      containingViewport ??
+      chrome?.parentElement?.querySelector<HTMLElement>('.docx-editor__scroll-container');
+    const surface = viewport?.querySelector<HTMLElement>('.docx-paginated-surface');
+    if (!chrome || !viewport || !surface) return undefined;
+
+    let frame = 0;
+    let missingAnchorRetries = 0;
+    let disposed = false;
+    let observedAnchor: HTMLElement | null = null;
+    const resizeObserver = new ResizeObserver(() => schedule());
+
+    const update = () => {
+      frame = 0;
+      const anchor = findAnchor(viewport);
+      if (anchor !== observedAnchor) {
+        resizeObserver.disconnect();
+        resizeObserver.observe(viewport);
+        resizeObserver.observe(chrome);
+        if (anchor) resizeObserver.observe(anchor);
+        observedAnchor = anchor;
+      }
+      if (!anchor || !anchor.isConnected) {
+        if (missingAnchorRetries < 2) {
+          missingAnchorRetries += 1;
+          queueMicrotask(() => {
+            if (!disposed) update();
+          });
+        }
+        return;
+      }
+      missingAnchorRetries = 0;
+
+      const viewportRect = viewport.getBoundingClientRect();
+      const anchorRect = anchor.getBoundingClientRect();
+      const chromeHeight = chrome.offsetHeight;
+      const attachedInsideViewport = containingViewport === viewport;
+      const documentLeft = attachedInsideViewport
+        ? anchorRect.left - viewportRect.left + viewport.scrollLeft
+        : anchorRect.left;
+      const documentTop = attachedInsideViewport
+        ? (placement === 'after' ? anchorRect.bottom + 6 : anchorRect.top - chromeHeight - 6) -
+          viewportRect.top +
+          viewport.scrollTop
+        : placement === 'after'
+          ? anchorRect.bottom + 6
+          : anchorRect.top - chromeHeight - 6;
+
+      setStyle({
+        position: attachedInsideViewport ? 'absolute' : 'fixed',
+        left: Math.max(attachedInsideViewport ? viewport.scrollLeft + 8 : 8, documentLeft + 8),
+        top: Math.max(8, documentTop),
+        maxWidth: Math.max(240, Math.min(anchorRect.width - 16, viewport.clientWidth - 16)),
+        visibility: 'visible',
+      });
+    };
+
+    const schedule = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(update);
+    };
+
+    resizeObserver.observe(viewport);
+    resizeObserver.observe(chrome);
+    const mutationObserver = new MutationObserver(schedule);
+    mutationObserver.observe(surface, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ['data-docx-hf-active', 'data-docx-note-scope'],
+    });
+    viewport.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    update();
+
+    return () => {
+      disposed = true;
+      if (frame) cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      viewport.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+    };
+  }, [findAnchor, placement]);
+
+  return { ref, style };
+}

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -1,10 +1,10 @@
-import { useLayoutEffect, useRef, useState } from 'react';
-import type { CSSProperties, RefObject } from 'react';
+import { useCallback, useLayoutEffect, useState } from 'react';
+import type { CSSProperties, RefCallback } from 'react';
 
 type AnchorPlacement = 'before' | 'after';
 
 export interface ScopedChromeAnchor {
-  readonly ref: RefObject<HTMLDivElement | null>;
+  readonly ref: RefCallback<HTMLDivElement>;
   readonly style: CSSProperties;
 }
 
@@ -19,26 +19,18 @@ export function useScopedChromeAnchor(
   findAnchor: (viewport: HTMLElement) => HTMLElement | null,
   placement: AnchorPlacement
 ): ScopedChromeAnchor {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const [style, setStyle] = useState<CSSProperties>({
-    position: 'absolute',
-    left: 8,
-    top: 8,
-    visibility: 'visible',
-  });
+  const [chrome, setChrome] = useState<HTMLDivElement | null>(null);
+  const ref = useCallback<RefCallback<HTMLDivElement>>((node) => setChrome(node), []);
+  const [style, setStyle] = useState<CSSProperties>({ visibility: 'hidden' });
 
   useLayoutEffect(() => {
-    const chrome = ref.current;
     const containingViewport = chrome?.closest<HTMLElement>('.docx-editor__scroll-container');
     const viewport =
       containingViewport ??
       chrome?.parentElement?.querySelector<HTMLElement>('.docx-editor__scroll-container');
-    const surface = viewport?.querySelector<HTMLElement>('.docx-paginated-surface');
-    if (!chrome || !viewport || !surface) return undefined;
+    if (!chrome || !viewport) return undefined;
 
     let frame = 0;
-    let missingAnchorRetries = 0;
-    let disposed = false;
     let observedAnchor: HTMLElement | null = null;
     const resizeObserver = new ResizeObserver(() => schedule());
 
@@ -53,15 +45,9 @@ export function useScopedChromeAnchor(
         observedAnchor = anchor;
       }
       if (!anchor || !anchor.isConnected) {
-        if (missingAnchorRetries < 2) {
-          missingAnchorRetries += 1;
-          queueMicrotask(() => {
-            if (!disposed) update();
-          });
-        }
+        setStyle({ visibility: 'hidden' });
         return;
       }
-      missingAnchorRetries = 0;
 
       const viewportRect = viewport.getBoundingClientRect();
       const anchorRect = anchor.getBoundingClientRect();
@@ -95,7 +81,7 @@ export function useScopedChromeAnchor(
     resizeObserver.observe(viewport);
     resizeObserver.observe(chrome);
     const mutationObserver = new MutationObserver(schedule);
-    mutationObserver.observe(surface, {
+    mutationObserver.observe(viewport, {
       subtree: true,
       childList: true,
       attributes: true,
@@ -106,14 +92,13 @@ export function useScopedChromeAnchor(
     update();
 
     return () => {
-      disposed = true;
       if (frame) cancelAnimationFrame(frame);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
       viewport.removeEventListener('scroll', schedule);
       window.removeEventListener('resize', schedule);
     };
-  }, [findAnchor, placement]);
+  }, [chrome, findAnchor, placement]);
 
   return { ref, style };
 }

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -67,11 +67,11 @@ export function useScopedChromeAnchor(
 
       setStyle({
         position: attachedInsideViewport ? 'absolute' : 'fixed',
-        left:
+        left: placement === 'story-label' ? documentLeft : Math.max(viewportEdge, documentLeft + 8),
+        top:
           placement === 'story-label'
-            ? Math.max(viewportEdge, documentLeft)
-            : Math.max(viewportEdge, documentLeft + 8),
-        top: Math.max(attachedInsideViewport ? viewport.scrollTop + 8 : 8, documentTop),
+            ? documentTop
+            : Math.max(attachedInsideViewport ? viewport.scrollTop + 8 : 8, documentTop),
         ...(placement === 'story-label'
           ? { width: Math.max(240, Math.min(anchorRect.width, viewport.clientWidth - 16)) }
           : {

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -96,9 +96,9 @@ function mountChrome(
         instance = editor as DocxEditorInstance;
       }}
     >
-      <DocxEditorHeaderFooterChrome />
       {extra}
       <DocxEditorViewport>
+        <DocxEditorHeaderFooterChrome />
         <DocxEditorContent />
       </DocxEditorViewport>
     </DocxEditorRoot>
@@ -145,7 +145,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     expect(view.getByTestId('docx-hf-inherited').textContent).toContain('Same as previous');
   });
 
-  test('insert slots disabled in body, enabled in scope', async () => {
+  test('page fields are explicit menu items enabled in furniture scope', async () => {
     const { view, editor } = mountChrome(docxWithHeader());
     const pageNumber = () => view.queryByRole('button', { name: 'Insert current page number' });
     expect(pageNumber()).toBeNull();
@@ -153,8 +153,17 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     await act(async () => {
       editor().exec({ type: 'editHeaderFooter', position: 'header' });
     });
-    const button = view.getByRole('button', { name: 'Insert current page number' });
-    expect(button.disabled).toBe(false);
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    const trigger = view.getByRole('button', { name: 'Page numbers', hidden: true });
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+    fireEvent.click(trigger);
+    const menuItem = view.getByRole('menuitem', {
+      name: 'Insert current page number',
+      hidden: true,
+    }) as HTMLButtonElement;
+    expect(menuItem.disabled).toBe(false);
     const disabled = editor().can({ type: 'insertPageField', field: 'PAGE' });
     expect(disabled.ok).toBe(true);
   });

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -41,6 +41,14 @@ function rect(left: number, top: number, width: number, height: number): DOMRect
 const findActiveProbe = (viewport: HTMLElement): HTMLElement | null =>
   viewport.querySelector<HTMLElement>('[data-docx-hf-active]');
 
+function setStoryRect(node: HTMLDivElement | null, left: number, top: number, width: number): void {
+  if (!node) return;
+  node.getBoundingClientRect = () => {
+    const viewport = node.closest<HTMLElement>('.docx-editor__scroll-container');
+    return rect(left - (viewport?.scrollLeft ?? 0), top - (viewport?.scrollTop ?? 0), width, 30);
+  };
+}
+
 function AnchorProbe({ active }: { active: 'first' | 'second' }): ReactNode {
   const anchor = useScopedChromeAnchor(findActiveProbe, 'story-label');
   return (
@@ -57,17 +65,13 @@ function AnchorProbe({ active }: { active: 'first' | 'second' }): ReactNode {
           <div
             key="first"
             data-docx-hf-active=""
-            ref={(node) => {
-              if (node) node.getBoundingClientRect = () => rect(120, 80, 500, 30);
-            }}
+            ref={(node) => setStoryRect(node, 120, 80, 500)}
           />
         ) : (
           <div
             key="second"
             data-docx-hf-active=""
-            ref={(node) => {
-              if (node) node.getBoundingClientRect = () => rect(420, 280, 320, 30);
-            }}
+            ref={(node) => setStoryRect(node, 420, 280, 320)}
           />
         )}
       </div>
@@ -191,6 +195,27 @@ describe('DocxEditor.HeaderFooterChrome', () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
     expect(view.getByTestId('anchor-probe').style.left).toBe('420px');
+  });
+
+  test('story bar scrolls away with its focused occurrence', async () => {
+    const view = render(<AnchorProbe active="first" />);
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    const bar = view.getByTestId('anchor-probe');
+    const initialLeft = bar.style.left;
+    const initialTop = bar.style.top;
+    const viewport = view.container.querySelector('.docx-editor__scroll-container') as HTMLElement;
+
+    viewport.scrollLeft = 50;
+    viewport.scrollTop = 200;
+    await act(async () => {
+      fireEvent.scroll(viewport);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    expect(bar.style.left).toBe(initialLeft);
+    expect(bar.style.top).toBe(initialTop);
   });
 
   test('shows the active region after editHeaderFooter', async () => {

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -186,6 +186,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
     expect(view.getByTestId('anchor-probe').style.left).toBe('120px');
+    expect(view.getByTestId('anchor-probe').style.top).toBe('48px');
 
     await act(async () => {
       view.rerender(<AnchorProbe active="second" />);

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -15,6 +15,7 @@ import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
 import { DocxEditorHeaderFooterChrome } from '../src/editor/DocxEditorHeaderFooter.tsx';
 import { useHeaderFooterState } from '../src/editor/useHeaderFooterState.ts';
+import { useScopedChromeAnchor } from '../src/editor/useScopedChromeAnchor.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -22,6 +23,58 @@ const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
 const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
 
 const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+const findActiveProbe = (viewport: HTMLElement): HTMLElement | null =>
+  viewport.querySelector<HTMLElement>('[data-docx-hf-active]');
+
+function AnchorProbe({ active }: { active: 'first' | 'second' }): ReactNode {
+  const anchor = useScopedChromeAnchor(findActiveProbe, 'story-label');
+  return (
+    <div
+      className="docx-editor__scroll-container"
+      ref={(node) => {
+        if (!node) return;
+        node.getBoundingClientRect = () => rect(0, 0, 800, 600);
+        Object.defineProperty(node, 'clientWidth', { value: 800, configurable: true });
+      }}
+    >
+      <div className="docx-paginated-surface">
+        {active === 'first' ? (
+          <div
+            key="first"
+            data-docx-hf-active=""
+            ref={(node) => {
+              if (node) node.getBoundingClientRect = () => rect(120, 80, 500, 30);
+            }}
+          />
+        ) : (
+          <div
+            key="second"
+            data-docx-hf-active=""
+            ref={(node) => {
+              if (node) node.getBoundingClientRect = () => rect(420, 280, 320, 30);
+            }}
+          />
+        )}
+      </div>
+      <div ref={anchor.ref} data-testid="anchor-probe" style={anchor.style} />
+    </div>
+  );
+}
 
 function docxWithHeader(headerText = 'Hdr'): Uint8Array {
   return zipSync({
@@ -123,7 +176,24 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     expect(view.queryByTestId('docx-hf-chrome')).toBeNull();
   });
 
-  test('shows region and section after editHeaderFooter', async () => {
+  test('story bar follows the focused furniture occurrence', async () => {
+    const view = render(<AnchorProbe active="first" />);
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    expect(view.getByTestId('anchor-probe').style.left).toBe('120px');
+
+    await act(async () => {
+      view.rerender(<AnchorProbe active="second" />);
+    });
+    await act(async () => {
+      fireEvent.scroll(view.container.querySelector('.docx-editor__scroll-container')!);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    expect(view.getByTestId('anchor-probe').style.left).toBe('420px');
+  });
+
+  test('shows the active region after editHeaderFooter', async () => {
     const { view, editor } = mountChrome(docxWithHeader());
     await act(async () => {
       const opened = editor().exec({ type: 'editHeaderFooter', position: 'header' });
@@ -135,7 +205,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     expect(chrome.style.visibility).toBe('visible');
     expect(chrome.style.position).toBe('absolute');
     expect(chrome.textContent).toContain('Header');
-    expect(chrome.textContent).toContain('Section 1');
+    expect(chrome.textContent).not.toContain('Section 1');
     expect(chrome.getAttribute('aria-label')).toBe('Header and footer editing');
   });
 
@@ -148,7 +218,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     expect(view.getByTestId('docx-hf-inherited').textContent).toContain('Same as previous');
   });
 
-  test('page fields are explicit menu items enabled in furniture scope', async () => {
+  test('options exposes page fields enabled in furniture scope', async () => {
     const { view, editor } = mountChrome(docxWithHeader());
     const pageNumber = () => view.queryByRole('button', { name: 'Insert current page number' });
     expect(pageNumber()).toBeNull();
@@ -159,7 +229,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     await act(async () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
-    const trigger = view.getByRole('button', { name: 'Page numbers', hidden: true });
+    const trigger = view.getByRole('button', { name: 'Options', hidden: true });
     expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
     fireEvent.click(trigger);
     const menuItem = view.getByRole('menuitem', {
@@ -193,6 +263,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     await act(async () => {
       editor().exec({ type: 'editHeaderFooter', position: 'header' });
     });
+    fireEvent.click(view.getByText('Options'));
     await act(async () => {
       fireEvent.click(view.getByTestId('docx-hf-close'));
     });
@@ -205,6 +276,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     await act(async () => {
       editor().exec({ type: 'editHeaderFooter', position: 'header' });
     });
+    fireEvent.click(view.getByText('Options'));
     const close = view.getByTestId('docx-hf-close');
     const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
     let prevented = false;

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -128,9 +128,12 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     await act(async () => {
       const opened = editor().exec({ type: 'editHeaderFooter', position: 'header' });
       expect(opened.ok).toBe(true);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
     const chrome = view.getByTestId('docx-hf-chrome');
     expect(chrome).toBeTruthy();
+    expect(chrome.style.visibility).toBe('visible');
+    expect(chrome.style.position).toBe('absolute');
     expect(chrome.textContent).toContain('Header');
     expect(chrome.textContent).toContain('Section 1');
     expect(chrome.getAttribute('aria-label')).toBe('Header and footer editing');

--- a/packages/react/test/notes-chrome.test.tsx
+++ b/packages/react/test/notes-chrome.test.tsx
@@ -114,9 +114,9 @@ function mountChrome(
         <DocxEditorToolbar.Button slot="insert.footnote" />
         <DocxEditorToolbar.Button slot="insert.endnote" />
       </DocxEditorToolbar>
-      <DocxEditorNotesChrome />
       {extra}
       <DocxEditorViewport>
+        <DocxEditorNotesChrome />
         <DocxEditorContent />
       </DocxEditorViewport>
     </DocxEditorRoot>
@@ -174,7 +174,7 @@ describe('DocxEditor.NotesChrome', () => {
     expect(banner.textContent).toContain('Endnote');
   });
 
-  test('insert.footnote / insert.endnote enabled in body, disabled in note scope', async () => {
+  test('note scope keeps insertion in the main toolbar instead of duplicating disabled icons', async () => {
     const { view, editor } = mountChrome(footnoteDoc());
     const footnoteSlot = () =>
       view.container.querySelector('[data-slot="insert.footnote"]') as HTMLButtonElement | null;
@@ -186,14 +186,9 @@ describe('DocxEditor.NotesChrome', () => {
     expect(editor().can({ type: 'insertNote', noteKind: 'footnote' }).ok).toBe(true);
 
     await enterFootnote(editor());
-    const bannerFootnote = view
-      .getByTestId('docx-notes-banner')
-      .querySelector('[data-slot="insert.footnote"]') as HTMLButtonElement;
-    const bannerEndnote = view
-      .getByTestId('docx-notes-banner')
-      .querySelector('[data-slot="insert.endnote"]') as HTMLButtonElement;
-    expect(bannerFootnote.disabled).toBe(true);
-    expect(bannerEndnote.disabled).toBe(true);
+    expect(view.getByTestId('docx-notes-banner').querySelector('[data-slot]')).toBeNull();
+    expect(footnoteSlot()?.disabled).toBe(true);
+    expect(endnoteSlot()?.disabled).toBe(true);
     expect(editor().can({ type: 'insertNote', noteKind: 'footnote' }).ok).toBe(false);
     expect(editor().can({ type: 'insertNote', noteKind: 'footnote' }).reason).toContain(
       'body scope'
@@ -261,6 +256,11 @@ describe('DocxEditor.NotesChrome', () => {
     };
     preview.dispatchEvent(event);
     expect(prevented).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(ref);
+    });
+    expect(view.queryByTestId('docx-notes-preview')).toBeNull();
   });
 
   test('touch primary skips hover preview', async () => {
@@ -378,9 +378,13 @@ describe('DocxEditor.NotesChrome', () => {
     await act(async () => {
       fireEvent.click(view.getByTestId('docx-notes-properties-apply'));
     });
-    expect(editor().can({ type: 'setNoteProperties', scope: 'document', footnote: { numFmt: 'decimal' } }).ok).toBe(
-      true
-    );
+    expect(
+      editor().can({
+        type: 'setNoteProperties',
+        scope: 'document',
+        footnote: { numFmt: 'decimal' },
+      }).ok
+    ).toBe(true);
   });
 
   test('engine refuses endnote pageBottom for setNoteProperties', () => {

--- a/packages/react/test/notes-chrome.test.tsx
+++ b/packages/react/test/notes-chrome.test.tsx
@@ -219,6 +219,9 @@ describe('DocxEditor.NotesChrome', () => {
     expect(editor().getActiveScope().kind).toBe('note');
 
     await act(async () => {
+      fireEvent.click(view.getByTestId('docx-notes-options'));
+    });
+    await act(async () => {
       fireEvent.click(view.getByTestId('docx-notes-close'));
     });
     expect(editor().getActiveScope()).toEqual({ kind: 'body' });
@@ -363,6 +366,9 @@ describe('DocxEditor.NotesChrome', () => {
     expect(props!.footnote.resolved.numFmt).toBe('decimal');
 
     await enterFootnote(editor());
+    await act(async () => {
+      fireEvent.click(view.getByTestId('docx-notes-options'));
+    });
     await act(async () => {
       fireEvent.click(view.getByTestId('docx-notes-properties'));
     });

--- a/packages/react/test/notes-chrome.test.tsx
+++ b/packages/react/test/notes-chrome.test.tsx
@@ -368,6 +368,9 @@ describe('DocxEditor.NotesChrome', () => {
     });
     const dialog = view.getByTestId('docx-notes-properties-dialog');
     expect(dialog.getAttribute('aria-label')).toBe('Footnote & Endnote Properties');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.querySelectorAll('.docx-note-properties__section')).toHaveLength(2);
+    expect(dialog.querySelector('.docx-note-properties__button--primary')).toBeTruthy();
     expect(dialog.textContent).toContain('(inherited)');
 
     const positionSelect = view.getByTestId('docx-notes-endnote-position') as HTMLSelectElement;


### PR DESCRIPTION
## Summary
- attach a subtle story-width label and Options rail to the actively focused header, footer, footnote, or endnote occurrence
- keep page fields, furniture settings, note properties, and scope exit actions in contextual dropdowns
- reveal off-screen notes when references are opened and clear hover previews when entering note scope
- restyle note properties as a responsive, token-based dialog with clear footnote/endnote sections

## Test plan
- [x] `bun test packages/react/test/header-footer-chrome.test.tsx packages/react/test/notes-chrome.test.tsx packages/core/src/editor/__tests__/scoped-note-editing.test.ts`
- [x] focused-occurrence anchoring regression coverage
- [x] React and core typechecks
- [x] i18n validation and diff whitespace check
- [ ] Full pre-commit parity gate is currently blocked by pre-existing public docs surface drift on `docx-editor-v2`