### PR TITLE
fix(react): stabilize note editing controls

### DIFF
--- a/.changeset/stable-note-story-controls.md
+++ b/.changeset/stable-note-story-controls.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Keep note editing controls above the note area without moving between notes or blocking note selection.

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3206,11 +3206,12 @@ a.docx-hyperlink:focus-visible {
   box-sizing: border-box;
   padding: 0 2px 5px;
   color: var(--doc-primary);
-  background: transparent;
-  border-bottom: 1px dotted var(--doc-primary);
+  background: var(--doc-page-bg-rendered);
+  border: 0;
+  border-bottom: 1px dashed var(--doc-primary);
   font-size: 12px;
   white-space: nowrap;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .docx-context-bar__label {
@@ -3262,6 +3263,7 @@ a.docx-hyperlink:focus-visible {
 
 .docx-hf-chrome__options {
   position: relative;
+  pointer-events: auto;
 }
 
 .docx-hf-chrome__options-menu {

--- a/packages/react/src/editor/DocxEditorNotes.tsx
+++ b/packages/react/src/editor/DocxEditorNotes.tsx
@@ -134,21 +134,21 @@ export function DocxEditorNotesChrome({
   } | null>(null);
   const [propsOpen, setPropsOpen] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const findActiveNote = useCallback(
+  const findActiveNoteArea = useCallback(
     (viewport: HTMLElement) => {
       if (!noteScope) return null;
       const candidates = viewport.querySelectorAll<HTMLElement>('[data-docx-note-scope]');
-      return (
+      const active =
         [...candidates].find(
           (candidate) =>
             candidate.matches('[data-docx-note]') &&
             candidate.dataset.docxNoteScope === noteScope.id
-        ) ?? null
-      );
+        ) ?? null;
+      return active?.closest<HTMLElement>('[data-docx-notes]') ?? active;
     },
     [noteScope]
   );
-  const anchor = useScopedChromeAnchor(findActiveNote, 'story-label');
+  const anchor = useScopedChromeAnchor(findActiveNoteArea, 'story-label');
 
   const clearPreview = useCallback(() => {
     if (hideTimer.current) clearTimeout(hideTimer.current);

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -53,17 +53,20 @@ export function useScopedChromeAnchor(
       const anchorRect = anchor.getBoundingClientRect();
       const chromeHeight =
         placement === 'story-label' ? Math.max(chrome.offsetHeight, 28) : chrome.offsetHeight;
+      const clearance = placement === 'story-label' ? 6 : 4;
       const attachedInsideViewport = containingViewport === viewport;
       const documentLeft = attachedInsideViewport
         ? anchorRect.left - viewportRect.left + viewport.scrollLeft
         : anchorRect.left;
       const documentTop = attachedInsideViewport
-        ? (placement === 'after' ? anchorRect.bottom + 6 : anchorRect.top - chromeHeight - 4) -
+        ? (placement === 'after'
+            ? anchorRect.bottom + 6
+            : anchorRect.top - chromeHeight - clearance) -
           viewportRect.top +
           viewport.scrollTop
         : placement === 'after'
           ? anchorRect.bottom + 6
-          : anchorRect.top - chromeHeight - 4;
+          : anchorRect.top - chromeHeight - clearance;
       const viewportEdge = attachedInsideViewport ? viewport.scrollLeft + 8 : 8;
 
       setStyle({

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -186,7 +186,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
     expect(view.getByTestId('anchor-probe').style.left).toBe('120px');
-    expect(view.getByTestId('anchor-probe').style.top).toBe('48px');
+    expect(view.getByTestId('anchor-probe').style.top).toBe('46px');
 
     await act(async () => {
       view.rerender(<AnchorProbe active="second" />);

--- a/packages/react/test/notes-chrome.test.tsx
+++ b/packages/react/test/notes-chrome.test.tsx
@@ -59,7 +59,8 @@ function dualNoteDoc(): Uint8Array {
   const body =
     `<w:p><w:r><w:t>Body</w:t></w:r>` +
     `<w:r><w:footnoteReference w:id="1"/></w:r>` +
-    `<w:r><w:endnoteReference w:id="1"/></w:r></w:p>`;
+    `<w:r><w:endnoteReference w:id="1"/></w:r>` +
+    `<w:r><w:endnoteReference w:id="2"/></w:r></w:p>`;
   const footnotes =
     `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
     `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
@@ -67,7 +68,8 @@ function dualNoteDoc(): Uint8Array {
   const endnotes =
     `<w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>` +
     `<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>` +
-    `<w:endnote w:id="1"><w:p><w:r><w:endnoteRef/><w:t>En</w:t></w:r></w:p></w:endnote>`;
+    `<w:endnote w:id="1"><w:p><w:r><w:endnoteRef/><w:t>En one</w:t></w:r></w:p></w:endnote>` +
+    `<w:endnote w:id="2"><w:p><w:r><w:endnoteRef/><w:t>En two</w:t></w:r></w:p></w:endnote>`;
   return zipSync({
     '[Content_Types].xml': strToU8(
       `<Types xmlns="${CT}">` +
@@ -172,6 +174,26 @@ describe('DocxEditor.NotesChrome', () => {
     const banner = view.getByTestId('docx-notes-banner');
     expect(banner.getAttribute('data-note-scope')).toBe('endnote:1');
     expect(banner.textContent).toContain('Endnote');
+  });
+
+  test('endnote bar stays above its note area when selection changes', async () => {
+    const { view, editor } = mountChrome(dualNoteDoc());
+    await act(async () => {
+      editor().setActiveScope({ kind: 'note', id: 'endnote:1' });
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    const banner = view.getByTestId('docx-notes-banner');
+    const initialLeft = banner.style.left;
+    const initialTop = banner.style.top;
+
+    await act(async () => {
+      editor().setActiveScope({ kind: 'note', id: 'endnote:2' });
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    expect(banner.getAttribute('data-note-scope')).toBe('endnote:2');
+    expect(banner.style.left).toBe(initialLeft);
+    expect(banner.style.top).toBe(initialTop);
   });
 
   test('note scope keeps insertion in the main toolbar instead of duplicating disabled icons', async () => {


### PR DESCRIPTION
## Summary
- anchor footnote and endnote controls to their note area so switching notes does not move the controls
- keep the rail above selectable note text with a compact white-backed dashed treatment
- make the rail pointer-transparent except for its Options menu

## Test plan
- [x] `bun test packages/react/test/header-footer-chrome.test.tsx packages/react/test/notes-chrome.test.tsx packages/core/src/editor/__tests__/scoped-note-editing.test.ts`
- [x] React typecheck, scoped lint, formatting, and whitespace checks
- [ ] Full pre-commit parity gate is currently blocked by pre-existing public docs surface drift on `docx-editor-v2`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788440123&installation_model_id=422592&pr_number=110&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F110&signature=6e61f745a2bb2c428aa28211a6b849dfbbc2a3aed8dc36551b3157b99e214b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->