### PR TITLE
fix(core): load DOCX files with UTF-16 XML parts

### DIFF
--- a/.changeset/load-utf16-xml-parts.md
+++ b/.changeset/load-utf16-xml-parts.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Load DOCX files containing UTF-16 XML parts, including document-management metadata.

--- a/packages/core/src/store/__tests__/ooxml-package.test.ts
+++ b/packages/core/src/store/__tests__/ooxml-package.test.ts
@@ -39,6 +39,14 @@ function build(overrides: Record<string, string | Uint8Array> = {}): Uint8Array 
   return zipSync(entries);
 }
 
+function utf16Le(value: string): Uint8Array {
+  const bytes = new Uint8Array(2 + value.length * 2);
+  bytes.set([0xff, 0xfe]);
+  const view = new DataView(bytes.buffer);
+  for (let i = 0; i < value.length; i += 1) view.setUint16(2 + i * 2, value.charCodeAt(i), true);
+  return bytes;
+}
+
 describe('bounded OPC loading into canonical trees (task 4.4)', () => {
   test('loads parts as canonical trees and resolves the main document', () => {
     const result = readOoxmlPackage(build());
@@ -50,6 +58,25 @@ describe('bounded OPC loading into canonical trees (task 4.4)', () => {
     expect(JSON.stringify(main)).toContain('hello');
     // Relationship parts are XML and load as trees too; the root rels owner is `/`.
     expect([...(result.package.relationships.get('/') ?? [])].map((r) => r.id)).toEqual(['rId1']);
+  });
+
+  test('loads a UTF-16LE XML part with a byte-order mark', () => {
+    const types = CONTENT_TYPES.replace(
+      '</Types>',
+      '<Override PartName="/customXml/item1.xml" ContentType="application/xml"/></Types>'
+    );
+    const customXml = utf16Le(
+      '<?xml version="1.0" encoding="utf-16"?><properties><documentid>LEGAL!1</documentid></properties>'
+    );
+
+    const result = readOoxmlPackage(
+      build({ '[Content_Types].xml': types, 'customXml/item1.xml': customXml })
+    );
+
+    if (!result.ok)
+      throw new Error(`unexpected rejection: ${result.reason}: ${result.detail ?? ''}`);
+    expect(result.package.parts.get('/customXml/item1.xml')?.root.localName).toBe('properties');
+    expect(JSON.stringify(result.package.parts.get('/customXml/item1.xml'))).toContain('LEGAL!1');
   });
 
   test('a declared non-ASCII part name resolves through the canonical content-type key', () => {

--- a/packages/core/src/store/package/ooxml-package.ts
+++ b/packages/core/src/store/package/ooxml-package.ts
@@ -25,7 +25,13 @@ import {
   type ZipRejection,
   DEFAULT_ZIP_LIMITS,
 } from './zip.ts';
-import { readXml, type XmlLimits, type XmlNode } from './xml-reader.ts';
+import {
+  readXml,
+  XML_HARD_MAX_BYTES,
+  type XmlLimits,
+  type XmlNode,
+  type XmlRejection,
+} from './xml-reader.ts';
 import { normalizePartName, type NameRejection } from './opc-names.ts';
 import {
   buildRelationshipSet,
@@ -52,6 +58,50 @@ const OFFICE_DOCUMENT_REL_TYPE =
 
 /** MIME types read into canonical trees. Anything else stays bytes (media, fonts, ...). */
 const XML_CONTENT_TYPE_RE = /(?:\/xml|\+xml)$/i;
+
+type XmlBytesResult =
+  | { readonly ok: true; readonly xml: string }
+  | { readonly ok: false; readonly reason: XmlRejection };
+
+/**
+ * Decode the encodings XML processors are required to recognize without an encoding hint.
+ * The raw-byte ceiling is checked before decoding so UTF-16 input cannot allocate past the
+ * package reader's configured XML budget.
+ */
+function decodeXmlBytes(bytes: Uint8Array, limits?: XmlLimits): XmlBytesResult {
+  const configuredMax = limits?.maxBytes ?? XML_HARD_MAX_BYTES;
+  if (!Number.isFinite(configuredMax) || !Number.isInteger(configuredMax) || configuredMax < 0) {
+    return { ok: false, reason: 'invalid-limits' };
+  }
+  if (bytes.byteLength > Math.min(configuredMax, XML_HARD_MAX_BYTES)) {
+    return { ok: false, reason: 'too-large' };
+  }
+
+  try {
+    if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+      return {
+        ok: true,
+        xml: new TextDecoder('utf-16le', { fatal: true }).decode(bytes.subarray(2)),
+      };
+    }
+    if (bytes[0] === 0xfe && bytes[1] === 0xff) {
+      return {
+        ok: true,
+        xml: new TextDecoder('utf-16be', { fatal: true }).decode(bytes.subarray(2)),
+      };
+    }
+    if (bytes[0] === 0x3c && bytes[1] === 0x00 && bytes[2] === 0x3f && bytes[3] === 0x00) {
+      return { ok: true, xml: new TextDecoder('utf-16le', { fatal: true }).decode(bytes) };
+    }
+    if (bytes[0] === 0x00 && bytes[1] === 0x3c && bytes[2] === 0x00 && bytes[3] === 0x3f) {
+      return { ok: true, xml: new TextDecoder('utf-16be', { fatal: true }).decode(bytes) };
+    }
+    const offset = bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf ? 3 : 0;
+    return { ok: true, xml: strFromU8(bytes.subarray(offset)) };
+  } catch {
+    return { ok: false, reason: 'parse-error' };
+  }
+}
 
 export interface OoxmlPackageLimits {
   readonly zip?: ZipLimits;
@@ -204,7 +254,9 @@ export function readOoxmlPackage(
 
   const contentTypeBytes = zip.entries.get(CONTENT_TYPES_PART);
   if (!contentTypeBytes) return { ok: false, reason: 'no-content-types' };
-  const contentTypes = readContentTypes(strFromU8(contentTypeBytes), limits.xml);
+  const decodedContentTypes = decodeXmlBytes(contentTypeBytes, limits.xml);
+  if (!decodedContentTypes.ok) return { ok: false, reason: decodedContentTypes.reason };
+  const contentTypes = readContentTypes(decodedContentTypes.xml, limits.xml);
   if (!contentTypes) return { ok: false, reason: 'bad-content-types' };
 
   const maxRelationships = limits.maxRelationships ?? DEFAULT_OOXML_PACKAGE_LIMITS.maxRelationships;
@@ -215,7 +267,9 @@ export function readOoxmlPackage(
   for (const [partName, data] of zip.entries) {
     const owner = relsOwner(partName);
     if (owner === null) continue;
-    const parsed = readXml(strFromU8(data), limits.xml);
+    const decoded = decodeXmlBytes(data, limits.xml);
+    if (!decoded.ok) return { ok: false, reason: decoded.reason, detail: partName };
+    const parsed = readXml(decoded.xml, limits.xml);
     if (!parsed.ok) return { ok: false, reason: parsed.reason, detail: partName };
     for (const element of collectElements(parsed.nodes, 'Relationship')) {
       if (records.length >= maxRelationships) {
@@ -304,11 +358,9 @@ export function readOoxmlPackage(
         detail: `${partName}: ${normalized.reason}`,
       };
     }
-    const read = readOoxmlPart(
-      strFromU8(data),
-      { name: normalized.partName, contentType },
-      limits.xml
-    );
+    const decoded = decodeXmlBytes(data, limits.xml);
+    if (!decoded.ok) return { ok: false, reason: decoded.reason, detail: partName };
+    const read = readOoxmlPart(decoded.xml, { name: normalized.partName, contentType }, limits.xml);
     if (!read.ok) return { ok: false, reason: read.reason, detail: partName };
     parts.set(normalized.partName, read.part);
   }


### PR DESCRIPTION
## Summary
- Decode UTF-16 XML parts at the bounded package trust boundary so valid DOCX files with custom metadata load.

## Test plan
- [x] `bun test packages/core/src/store/__tests__/ooxml-package.test.ts`
- [x] `bun run --filter '@docx-editor.dev/core-contract' typecheck`
- [x] Open `toc-and-footer.docx` through `openTreeSession`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788440227&installation_model_id=422592&pr_number=111&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F111&signature=3399ea542e86df40157d8ec236a0c6fc070feaee27cde24a2b1748da9f759ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->