### PR TITLE
feat(react): add viewport page indicator

### DIFF
--- a/.changeset/page-number-indicator.md
+++ b/.changeset/page-number-indicator.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+Add `DocxEditor.PageNumber`, a localized viewport page indicator that appears while scrolling multi-page documents and is included in the default editor.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -357,6 +357,7 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEdito
     readonly Navigation: typeof Navigation;
     // (undocumented)
     readonly NotesChrome: typeof DocxEditorNotesChrome;
+    readonly PageNumber: typeof DocxEditorPageNumber;
     readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
     readonly Review: typeof DocxEditorReview;
     // (undocumented)

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -626,6 +626,7 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
                   the popover — it scrolls with the document rather than chasing it. */}
               <DocxEditor.Review />
             </DocxEditor.Viewport>
+            <DocxEditor.PageNumber />
             {/* Floating diagnostics chrome, above the overlay panels. */}
             <PerfHud />
           </div>

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -503,6 +503,10 @@ export interface Editor {
   snapshot(options?: { scope?: EditorScope }): EditorSnapshot;
 
   getTotalPages(): number;
+  /**
+   * One-based page at the caret (default), or at the centre of the mounted scroll viewport.
+   * Viewport mode falls back to the caret when no measurable viewport is attached.
+   */
   getCurrentPage(mode?: 'viewport' | 'caret'): number;
 
   /**

--- a/packages/core/src/editor/__tests__/page-geometry.test.ts
+++ b/packages/core/src/editor/__tests__/page-geometry.test.ts
@@ -34,6 +34,7 @@ function docx(body: string): Uint8Array {
 }
 
 const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const pageBreak = '<w:p><w:r><w:br w:type="page"/></w:r></w:p>';
 
 function mount(body: string, options: { mode?: 'edit' | 'view' } = {}): DocxEditorInstance {
   const container = document.createElement('div');
@@ -84,6 +85,55 @@ describe('getPageGeometry', () => {
   test('is empty with no document rather than inventing a page', () => {
     const editor = createDocxEditor({});
     expect(editor.getPageGeometry()).toEqual([]);
+  });
+});
+
+describe('getCurrentPage', () => {
+  test('viewport mode reports the page at the viewport center while caret mode stays put', () => {
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    const positionedWrapper = document.createElement('div');
+    const container = document.createElement('div');
+    positionedWrapper.append(container);
+    scroller.append(positionedWrapper);
+    document.body.append(scroller);
+    Object.defineProperty(scroller, 'clientHeight', { value: 300, configurable: true });
+    Object.defineProperty(container, 'offsetTop', { value: 40, configurable: true });
+    const surfaceTop = 1_000;
+    scroller.getBoundingClientRect = () =>
+      ({ top: 20, left: 0, right: 800, bottom: 320, width: 800, height: 300 }) as DOMRect;
+    container.getBoundingClientRect = () =>
+      ({
+        top: 20 + surfaceTop - scroller.scrollTop,
+        left: 0,
+        right: 800,
+        bottom: 20 + surfaceTop - scroller.scrollTop + 3_000,
+        width: 800,
+        height: 3_000,
+      }) as DOMRect;
+
+    const editor = createDocxEditor({
+      container,
+      document: docx(p('first') + pageBreak + p('second') + pageBreak + p('third')),
+      zoom: 1.5,
+    });
+    if (!editor.surface) throw new Error('surface failed to mount');
+    const second = editor.surface.layout().pages[1]!;
+    const scale = 1.5 * (96 / 72);
+    scroller.scrollTop =
+      surfaceTop + (second.box.y + second.box.height / 2) * scale - scroller.clientHeight / 2;
+
+    expect(editor.getCurrentPage('viewport')).toBe(2);
+    expect(editor.getCurrentPage('caret')).toBe(1);
+
+    editor.destroy();
+    scroller.remove();
+  });
+
+  test('viewport mode falls back to the caret page without a measurable scroller', () => {
+    const editor = mount(p('first') + pageBreak + p('second'));
+    expect(editor.getCurrentPage('viewport')).toBe(editor.getCurrentPage('caret'));
+    editor.destroy();
   });
 });
 

--- a/packages/core/src/editor/docx-editor-derive.ts
+++ b/packages/core/src/editor/docx-editor-derive.ts
@@ -20,7 +20,7 @@ import { classifyCommand } from './docx-editor-support.ts';
 
 /** Whether a command may run, and the engine's own refusal when it may not. */
 export type CommandGate = { ok: true } | { ok: false; refusal: Exclude<ExecResult, { ok: true }> };
-import { caretAt, tableContextAt } from '@docx-editor.dev/core-contract/layout';
+import { tableContextAt } from '@docx-editor.dev/core-contract/layout';
 import { paragraphTextOf } from '@docx-editor.dev/core-contract/store';
 import { allParagraphs } from '../binding/tree-binding.ts';
 import { paragraphStyleId } from '../binding/document-outline.ts';
@@ -165,12 +165,11 @@ export function totalPages(surface: PaginatedSurface | null): number {
   return surface ? surface.state().pageCount : 0;
 }
 
-export function currentPage(surface: PaginatedSurface | null): number {
-  // Caret page from the layout records. There is no viewport tracking on this facade yet,
-  // so `'viewport'` honestly answers with the caret's page as the nearest derivable value.
-  if (!surface) return 1;
-  const caret = caretAt(surface.layout(), surface.state().selection.head);
-  return caret ? caret.pageIndex + 1 : 1;
+export function currentPage(
+  surface: PaginatedSurface | null,
+  mode: 'viewport' | 'caret' = 'caret'
+): number {
+  return surface ? surface.currentPage(mode) : 1;
 }
 
 export function gateCommand(

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -1490,7 +1490,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     snapshot: () => snapshotNow(),
 
     getTotalPages: () => totalPagesOf(surface),
-    getCurrentPage: () => currentPageOf(surface),
+    getCurrentPage: (mode) => currentPageOf(surface, mode),
 
     // Page NUMBERS are 1-based in this contract; the layout indexes from 0.
     scrollToPage: (pageNumber: number) =>

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -192,6 +192,8 @@ export interface PaginatedSurface {
   readonly session: TreeDocxSession;
   layout(): SemanticLayout;
   state(): PaginatedSurfaceState;
+  /** One-based page at the caret, or at the centre of the mounted viewport. */
+  currentPage(mode?: 'viewport' | 'caret'): number;
   type(text: string): void;
   /**
    * Insert text whose newlines are PARAGRAPH BOUNDARIES, in one commit.

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -70,6 +70,7 @@ import {
   surfaceExtent,
   surfaceScroller,
   visiblePageSet,
+  viewportPage,
   type SurfaceExtent,
 } from './surface-pages.ts';
 import { createSurfaceCaret } from './surface-caret.ts';
@@ -1326,6 +1327,15 @@ export function mountPaginatedSurface(
       return currentLayout;
     },
     state: currentState,
+    currentPage: (mode = 'caret') => {
+      flushLayout();
+      if (mode === 'viewport') {
+        const page = viewportPage(container, currentLayout, scale);
+        if (page !== null) return page;
+      }
+      const caret = caretAt(currentLayout, selection.head);
+      return caret ? caret.pageIndex + 1 : 1;
+    },
 
     type(text) {
       // Insert at the selection's START, not at its head. Deleting a selection removes the

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -236,6 +236,46 @@ export function surfaceScroller(container: HTMLElement): HTMLElement | null {
   return container.closest('.docx-editor__scroll-container') as HTMLElement | null;
 }
 
+function viewportInLayout(
+  container: HTMLElement,
+  scroller: HTMLElement,
+  scale: number
+): { top: number; height: number } {
+  const containerRect = container.getBoundingClientRect();
+  const scrollerRect = scroller.getBoundingClientRect();
+  // Real browsers move the container rect as the ancestor scrolls. happy-dom leaves both
+  // rects at zero, so retain the offset fallback for DOM-free geometry tests.
+  const topPx =
+    scroller.scrollTop !== 0 && containerRect.top === 0 && scrollerRect.top === 0
+      ? scroller.scrollTop - container.offsetTop
+      : scrollerRect.top + scroller.clientTop - containerRect.top;
+  return { top: topPx / scale, height: scroller.clientHeight / scale };
+}
+
+/**
+ * The one-based page under the viewport centre, derived from semantic page records.
+ *
+ * `null` means there is no measurable viewport, so a caller can fall back to the caret
+ * rather than inventing a scroll position. A centre in a page gap belongs to the following
+ * page, matching the page a reader is scrolling toward.
+ */
+export function viewportPage(
+  container: HTMLElement,
+  layout: SemanticLayout,
+  scale: number
+): number | null {
+  const scroller = surfaceScroller(container);
+  if (!scroller || scroller.clientHeight <= 0 || layout.pages.length === 0 || scale <= 0) {
+    return null;
+  }
+  const viewport = viewportInLayout(container, scroller, scale);
+  const centerY = viewport.top + viewport.height / 2;
+  for (const page of layout.pages) {
+    if (centerY < page.box.y + page.box.height) return page.index + 1;
+  }
+  return layout.pages.length;
+}
+
 export function visiblePageSet(
   container: HTMLElement,
   layout: SemanticLayout,
@@ -244,6 +284,7 @@ export function visiblePageSet(
 ): ReadonlySet<number> | undefined {
   const scroller = surfaceScroller(container);
   if (!scroller || scroller.clientHeight === 0) return undefined;
+  const viewport = viewportInLayout(container, scroller, scale);
   const pinned: number[] = [];
   for (const position of [selection.anchor, selection.head]) {
     const caret = caretAt(layout, position);
@@ -251,12 +292,9 @@ export function visiblePageSet(
   }
   return pagesToMaterialize({
     layout,
-    // Surface coordinates back to layout units: the records are in points and the scroll
-    // offset is in CSS pixels.
-    viewport: {
-      top: (scroller.scrollTop - container.offsetTop) / scale,
-      height: scroller.clientHeight / scale,
-    },
+    // Surface coordinates back to layout units: the records are in points and the viewport
+    // may be nested below positioned wrappers inside the scroller.
+    viewport,
     overscanPages: 1,
     pinnedPages: pinned,
   });

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -1896,6 +1896,21 @@ a.docx-hyperlink:focus-visible {
   pointer-events: none;
 }
 
+/* Public React page-number primitive. It is an overlay sibling of the viewport inside the
+ * positioned workspace, so scrolling the document never moves the readout itself. */
+.docx-editor__page-number {
+  position: absolute;
+  right: 24px;
+  top: 50%;
+  z-index: 1000;
+  opacity: 0;
+  transform: translateY(-50%);
+}
+
+.docx-editor__page-number[data-visible='true'] {
+  opacity: 1;
+}
+
 /* Display-only rulers (interactive-paginated-editing M4.4). No margin or tab
  * markers and no drag handles: this change owns no section-geometry contract,
  * so a draggable handle would be a control that silently does nothing. */

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -14,6 +14,7 @@ import { DocxEditorHorizontalRuler, DocxEditorVerticalRuler } from '../editor/Do
 import { DocxEditorDocumentOutline } from '../editor/DocxEditorOutline';
 import { Navigation as DocxEditorNavigationCompound } from '../editor/navigation';
 import { DocxEditorPageSetupDialog } from '../editor/DocxEditorPageSetup';
+import { DocxEditorPageNumber, PageNumberTranslationContext } from '../editor/DocxEditorPageNumber';
 import { DocxEditorReview } from '../editor/DocxEditorReview';
 import { DocxEditorHeaderFooterChrome } from '../editor/DocxEditorHeaderFooter';
 import { DocxEditorHyperLink } from '../editor/DocxEditorHyperLink';
@@ -278,6 +279,9 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
       <div style={WORKSPACE_STYLE}>
         {navigation ? <DocxEditorNavigationCompound t={translate} /> : null}
         {viewport}
+        <PageNumberTranslationContext.Provider value={translate}>
+          <DocxEditorPageNumber />
+        </PageNumberTranslationContext.Provider>
       </div>
     </div>
   ) : (
@@ -340,6 +344,8 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<
   readonly Navigation: typeof DocxEditorNavigationCompound;
   /** Page Setup dialog — size, orientation, margins — applied as one undo step. */
   readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
+  /** Floating localized page readout for the active viewport. */
+  readonly PageNumber: typeof DocxEditorPageNumber;
   /** Header/footer scope chrome while editing page furniture. */
   readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
   readonly NotesChrome: typeof DocxEditorNotesChrome;
@@ -374,6 +380,7 @@ export const DocxEditor: DocxEditorNamespace = Object.assign(DocxEditorImpl, {
   DocumentOutline: DocxEditorDocumentOutline,
   Navigation: DocxEditorNavigationCompound,
   PageSetupDialog: DocxEditorPageSetupDialog,
+  PageNumber: DocxEditorPageNumber,
   HeaderFooterChrome: DocxEditorHeaderFooterChrome,
   NotesChrome: DocxEditorNotesChrome,
   HyperLink: DocxEditorHyperLink,

--- a/packages/react/src/editor/DocxEditorPageNumber.tsx
+++ b/packages/react/src/editor/DocxEditorPageNumber.tsx
@@ -1,0 +1,77 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { EditorSnapshot } from '@docx-editor.dev/core-contract/contracts/editor';
+import { useTranslation } from '../i18n';
+import { useDocxEditor } from './context';
+import { useNavigationViewportElement } from './navigation/navigation-layout';
+import { useEditorState } from './useEditorState';
+
+const HIDE_DELAY_MS = 600;
+const selectTotalPages = (snapshot: EditorSnapshot): number => snapshot.page.total;
+
+/** Internal bridge from the batteries-included editor's `t` prop to this composition part. */
+export const PageNumberTranslationContext = createContext<((key: string) => string) | null>(null);
+
+/** Props for `DocxEditor.PageNumber`. @public */
+export interface DocxEditorPageNumberProps {
+  /** Appended after the default page-number classes. */
+  className?: string;
+  /** Inline presentation overrides for the indicator element. */
+  style?: CSSProperties;
+}
+
+/**
+ * Floating localized page readout for the active `DocxEditor.Viewport`.
+ *
+ * Render it as a sibling of the viewport inside a positioned wrapper. It appears while a
+ * multi-page document scrolls and fades after 600 ms of inactivity.
+ *
+ * @public
+ */
+export function DocxEditorPageNumber({ className, style }: DocxEditorPageNumberProps) {
+  const editor = useDocxEditor();
+  const viewport = useNavigationViewportElement();
+  const total = useEditorState(selectTotalPages);
+  const { t } = useTranslation();
+  const translate = useContext(PageNumberTranslationContext);
+  const [current, setCurrent] = useState(1);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(false);
+    if (!editor || !viewport || total <= 1) return undefined;
+    setCurrent(editor.getCurrentPage('viewport'));
+    let hideTimer: ReturnType<typeof setTimeout> | null = null;
+    const onScroll = () => {
+      setCurrent(editor.getCurrentPage('viewport'));
+      setVisible(true);
+      if (hideTimer) clearTimeout(hideTimer);
+      hideTimer = setTimeout(() => setVisible(false), HIDE_DELAY_MS);
+    };
+    viewport.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      viewport.removeEventListener('scroll', onScroll);
+      if (hideTimer) clearTimeout(hideTimer);
+    };
+  }, [editor, total, viewport]);
+
+  if (total <= 1) return null;
+  const label = translate
+    ? translate('viewer.pageIndicator')
+        .replace(/\{current\}/g, String(current))
+        .replace(/\{total\}/g, String(total))
+    : t('viewer.pageIndicator', { current, total });
+  return (
+    <div
+      className={`ep-root ep-shell__page-indicator-chip docx-editor__page-number${
+        className ? ` ${className}` : ''
+      }`}
+      style={style}
+      data-visible={visible ? 'true' : 'false'}
+      role="status"
+      aria-live="polite"
+    >
+      {label}
+    </div>
+  );
+}

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -28,6 +28,7 @@ import { DocxEditor } from '../src/components/DocxEditor.tsx';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorPageNumber } from '../src/editor/DocxEditorPageNumber.tsx';
 import { useDocxEditor } from '../src/editor/context.ts';
 import { useEditorState } from '../src/editor/useEditorState.ts';
 import { useEditorCommand, type EditorCommandState } from '../src/editor/useEditorCommand.ts';
@@ -260,6 +261,7 @@ describe('the sugar <DocxEditor> (namespace + ref parity)', () => {
     expect(DocxEditor.Root).toBe(DocxEditorRoot);
     expect(DocxEditor.Viewport).toBe(DocxEditorViewport);
     expect(DocxEditor.Content).toBe(DocxEditorContent);
+    expect(DocxEditor.PageNumber).toBe(DocxEditorPageNumber);
   });
 
   test('the target provider-first usage works through the namespace', async () => {

--- a/packages/react/test/page-number.test.tsx
+++ b/packages/react/test/page-number.test.tsx
@@ -1,0 +1,120 @@
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, render } from '@testing-library/react';
+import { zipSync, strToU8 } from 'fflate';
+import type { Editor } from '@docx-editor.dev/core-contract/contracts/editor';
+import { DocxEditor } from '../src/components/DocxEditor.tsx';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorPageNumber } from '../src/editor/DocxEditorPageNumber.tsx';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const pageBreak = '<w:p><w:r><w:br w:type="page"/></w:r></w:p>';
+const ONE_PAGE = docx(paragraph('one'));
+const THREE_PAGES = docx(
+  paragraph('one') + pageBreak + paragraph('two') + pageBreak + paragraph('three')
+);
+
+afterEach(cleanup);
+
+describe('DocxEditor.PageNumber', () => {
+  test('renders nothing for a one-page document', () => {
+    const view = render(
+      <DocxEditorRoot document={ONE_PAGE}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+        <DocxEditorPageNumber />
+      </DocxEditorRoot>
+    );
+
+    expect(view.queryByRole('status')).toBeNull();
+  });
+
+  test('reports the viewport page while scrolling, then fades after 600ms idle', async () => {
+    let editor: Editor | null = null;
+    const view = render(
+      <DocxEditorRoot document={THREE_PAGES} onReady={(instance) => (editor = instance)}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+        <DocxEditorPageNumber className="host-page-number" style={{ right: 32 }} />
+      </DocxEditorRoot>
+    );
+    const viewport = view.getByTestId('docx-editor-scroll');
+    const surface = view.container.querySelector<HTMLElement>('.docx-paginated-surface')!;
+    Object.defineProperty(viewport, 'clientHeight', { value: 300, configurable: true });
+    Object.defineProperty(surface, 'offsetTop', { value: 0, configurable: true });
+    const second = editor!.getPageGeometry()[1]!;
+    viewport.scrollTop = second.box.y + second.box.height / 2 - viewport.clientHeight / 2;
+
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+
+    const status = view.getByRole('status');
+    expect(status.textContent).toBe('2 of 3');
+    expect(status.getAttribute('data-visible')).toBe('true');
+    expect(status.classList.contains('ep-root')).toBe(true);
+    expect(status.classList.contains('host-page-number')).toBe(true);
+    expect((status as HTMLElement).style.right).toBe('32px');
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 650));
+    });
+    expect(status.getAttribute('data-visible')).toBe('false');
+  });
+
+  test('is included in the batteries-included editor', () => {
+    const view = render(
+      <DocxEditor
+        document={THREE_PAGES}
+        t={(key) => (key === 'viewer.pageIndicator' ? 'Page {current} / {total}' : key)}
+      />
+    );
+    expect(view.getByRole('status').textContent).toBe('Page 1 / 3');
+  });
+
+  test('returns to hidden when the editor document changes', () => {
+    const tree = (document: Uint8Array) => (
+      <DocxEditorRoot document={document}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+        <DocxEditorPageNumber />
+      </DocxEditorRoot>
+    );
+    const view = render(tree(THREE_PAGES));
+    const viewport = view.getByTestId('docx-editor-scroll');
+    Object.defineProperty(viewport, 'clientHeight', { value: 300, configurable: true });
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+    expect(view.getByRole('status').getAttribute('data-visible')).toBe('true');
+
+    view.rerender(tree(ONE_PAGE));
+    expect(view.queryByRole('status')).toBeNull();
+    view.rerender(tree(THREE_PAGES));
+    expect(view.getByRole('status').getAttribute('data-visible')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary
- add a localized `DocxEditor.PageNumber` overlay backed by viewport geometry
- include the indicator in the default React editor with scroll-idle fading

## Test plan
- [x] `bun test packages/core packages/react`
- [x] core and React typechecks
- [x] React build and scoped API check
- [x] i18n and editor-contract validation

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788442248&installation_model_id=422592&pr_number=112&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F112&signature=863e51aa132a56f540f15ca1b09897712071138ea4ba01dfce5a25afd9cc8b9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->