### PR TITLE
fix(core): typing formatting, list indent precedence, and the per-keystroke review walk

### DIFF
--- a/.changeset/list-indent-precedence.md
+++ b/.changeset/list-indent-precedence.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Apply a numbering level's indent between the paragraph style and the paragraph's own formatting, per attribute. A lettered sub-item whose level overrides its style's indent now sits where Word puts it rather than a full indent step to the left.

--- a/.changeset/review-queue-per-keystroke.md
+++ b/.changeset/review-queue-per-keystroke.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Keep typing responsive on long documents: the review and comment queues now re-read only the paragraphs a commit touched instead of walking the whole document on every keystroke. On an 878-paragraph agreement that is 49ms of per-keystroke work down to 4ms, whether or not the document has tracked changes.

--- a/.changeset/typing-inherits-preceding-run.md
+++ b/.changeset/typing-inherits-preceding-run.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Typed text now takes the formatting of the character before the caret, the way Word does, instead of the run that starts at the caret. On documents converted from PDF — where every space is its own run carrying character spacing — typing after a word came out letter-spaced.

--- a/packages/core/src/editor/surface-hyperlinks.ts
+++ b/packages/core/src/editor/surface-hyperlinks.ts
@@ -389,9 +389,14 @@ function withinLink(
  * display text of an existing link silently unlinked it while reporting success. That is
  * the ordinary Ctrl+K-then-change-the-text flow.
  *
- * Inserting at `start` first puts the new text inside the link (the offset is a boundary of
- * the link's first run), and the old text — now shifted right by the inserted length — is
- * deleted after. The link is never empty at any point, so nothing sweeps it away.
+ * Inserting at `start` first puts the new text inside the link, and the old text — now
+ * shifted right by the inserted length — is deleted after. The link is never empty at any
+ * point, so nothing sweeps it away.
+ *
+ * `bias: 'right'` is what keeps the insert INSIDE the link. A boundary insert otherwise joins
+ * the run to its LEFT (Word's typing rule, see `applyInsertContent`), which at a link's start
+ * is whatever plain text precedes it. This caller is not typing — it is rewriting the link's
+ * own display text, so it names the run it means.
  */
 function replaceTextOps(
   paragraphId: string,
@@ -400,7 +405,7 @@ function replaceTextOps(
   text: string
 ): TreeDocOp[] | null {
   if (text.length === 0) return null;
-  const ops: TreeDocOp[] = [{ op: 'insertText', paragraphId, offset: start, text }];
+  const ops: TreeDocOp[] = [{ op: 'insertText', paragraphId, offset: start, text, bias: 'right' }];
   if (end > start) {
     ops.push({
       op: 'deleteText',

--- a/packages/core/src/layout/__tests__/numbering-indent-precedence.test.ts
+++ b/packages/core/src/layout/__tests__/numbering-indent-precedence.test.ts
@@ -1,0 +1,98 @@
+// Where a list paragraph's indent comes from: STYLE, then the numbering LEVEL, then DIRECT.
+//
+// Word applies a level's `w:pPr/w:ind` between the paragraph style and the paragraph's own
+// formatting, per attribute. Reading the flattened cascade as "the paragraph's indent" hands
+// the STYLE's value to a level that overrode it — which is what put every lettered sub-item
+// of a converted agreement a full indent step left of where Word draws it.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlPart,
+} from '@docx-editor.dev/core-contract/store';
+import { buildNumberingIndex } from '../numbering-index.ts';
+import { resolveStoryListItems } from '../list-resolve.ts';
+import { buildStyleCascadeTable } from '../style-cascade.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function part(name: string, xml: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function numbering(levelInd: string) {
+  return buildNumberingIndex(
+    part(
+      '/word/numbering.xml',
+      `<w:numbering xmlns:w="${W}">
+        <w:abstractNum w:abstractNumId="1">
+          <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/>
+            <w:lvlText w:val="(%1)"/><w:lvlJc w:val="left"/>
+            <w:pPr>${levelInd}</w:pPr></w:lvl>
+        </w:abstractNum>
+        <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+      </w:numbering>`
+    ).root
+  );
+}
+
+/** A `ListParagraph` style stating an indent of its own, the way a converted file writes it. */
+const STYLES = `<w:styles xmlns:w="${W}">
+  <w:style w:type="paragraph" w:styleId="ListParagraph">
+    <w:name w:val="List Paragraph"/>
+    <w:pPr><w:ind w:left="775" w:hanging="624"/></w:pPr>
+  </w:style>
+</w:styles>`;
+
+function listItem(directInd: string, levelInd: string) {
+  const document = part(
+    '/word/document.xml',
+    `<w:document xmlns:w="${W}"><w:body>
+      <w:p><w:pPr><w:pStyle w:val="ListParagraph"/>
+        <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+        ${directInd}</w:pPr><w:r><w:t>item</w:t></w:r></w:p>
+    </w:body></w:document>`
+  );
+  const body = document.root.children.find(
+    (child) => (child as OoxmlElement).localName === 'body'
+  ) as OoxmlElement;
+  const blocks = body.children.filter((child) => child.kind === 'paragraph') as OoxmlElement[];
+  const items = resolveStoryListItems(
+    blocks,
+    numbering(levelInd),
+    buildStyleCascadeTable(part('/word/styles.xml', STYLES).root)
+  );
+  return [...items.values()][0]!;
+}
+
+describe('list indent precedence (style → level → direct)', () => {
+  test("the level's left beats the style's, and the paragraph's own hanging beats the level's", () => {
+    // The shape a PDF-converted agreement writes: style left=775 hanging=624, level
+    // left=1512 hanging=738, paragraph states hanging="737" and nothing else.
+    const item = listItem('<w:ind w:hanging="737"/>', '<w:ind w:left="1512" w:hanging="738"/>');
+    expect(item.indent.left).toBe(1512 / 20);
+    expect(item.indent.hanging).toBe(737 / 20);
+  });
+
+  test("the paragraph's own left beats the level's", () => {
+    const item = listItem('<w:ind w:left="2000"/>', '<w:ind w:left="1512" w:hanging="738"/>');
+    expect(item.indent.left).toBe(100);
+    // Untouched by the direct `w:ind`, which states no first-line offset.
+    expect(item.indent.hanging).toBe(738 / 20);
+  });
+
+  test("a level that states no indent leaves the style's standing", () => {
+    const item = listItem('', '');
+    expect(item.indent.left).toBe(775 / 20);
+    expect(item.indent.hanging).toBe(624 / 20);
+  });
+
+  test('a level stating only left keeps the style first-line offset', () => {
+    const item = listItem('', '<w:ind w:left="1512"/>');
+    expect(item.indent.left).toBe(1512 / 20);
+    expect(item.indent.hanging).toBe(624 / 20);
+  });
+});

--- a/packages/core/src/layout/comment-anchors.ts
+++ b/packages/core/src/layout/comment-anchors.ts
@@ -118,7 +118,20 @@ interface MarkerPoint {
  * yielded no anchor at all and reported the comment orphaned; and it gave a note reference or
  * an atomic field nothing where the model gives them one unit each.
  */
-function markersInParagraph(paragraph: OoxmlParagraphNode): MarkerPoint[] {
+function markersInParagraph(paragraph: OoxmlParagraphNode): readonly MarkerPoint[] {
+  // Memoized on the immutable paragraph node: the markers in a paragraph the last commit did
+  // not touch sit where they sat. The anchors are stitched across paragraphs by the caller,
+  // so only this paragraph-local step is cached.
+  const cached = markerCache.get(paragraph);
+  if (cached) return cached;
+  const points = collectMarkers(paragraph);
+  markerCache.set(paragraph, points);
+  return points;
+}
+
+const markerCache = new WeakMap<OoxmlParagraphNode, readonly MarkerPoint[]>();
+
+function collectMarkers(paragraph: OoxmlParagraphNode): MarkerPoint[] {
   const offsets = paragraphOffsetIndex(paragraph);
   const points: MarkerPoint[] = [];
   const walk = (children: readonly OoxmlNode[], depth: number): void => {

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -130,10 +130,6 @@ export function withNumberingStyleLinks(
   return resolveNumberingStyleLinks(index, (styleId) => numIdForStyle(styleCascade, styleId));
 }
 
-function paragraphHasIndent(props: readonly OoxmlProperty[]): boolean {
-  return props.some((property) => property.localName === 'ind');
-}
-
 /** Bound a file-derived indent both ways — negative is legal, unbounded is not. */
 function clampIndentPt(pt: number): number {
   if (!Number.isFinite(pt)) return 0;
@@ -142,38 +138,93 @@ function clampIndentPt(pt: number): number {
   return pt;
 }
 
-/**
- * Merge level indent with paragraph indent.
- *
- * Level indent is the base for list paragraphs; an authored paragraph/style `w:ind`
- * replaces left/right (and hanging/firstLine when present on that `ind`).
- */
-export function mergeListIndent(
-  levelIndent: NumberingLevelIndent,
-  paragraphProps: readonly OoxmlProperty[]
-): NumberingLevelIndent {
-  if (!paragraphHasIndent(paragraphProps)) return levelIndent;
-  const para = paragraphIndent(paragraphProps);
-  let hanging = levelIndent.hanging;
-  let firstLine = levelIndent.firstLine;
-  for (const property of paragraphProps) {
+/** The first-line slot as one `w:ind` states it, or null when it states neither spelling. */
+function firstLineOffsetOf(
+  props: readonly OoxmlProperty[]
+): { hanging: number; firstLine: number } | null {
+  let found: { hanging: number; firstLine: number } | null = null;
+  for (const property of props) {
     if (property.localName !== 'ind') continue;
     const h = property.attributes?.hanging;
     const f = property.attributes?.firstLine;
     // Mutually exclusive (§17.3.1.10, §17.3.1.12): one signed first-line offset, two spellings,
     // so an `w:ind` stating either replaces both. `w:firstLine` is read SIGNED because Word
     // keeps a negative value as a hang. A bare `w:left` states neither and leaves them alone.
-    if (h !== undefined || f !== undefined) {
-      hanging = h !== undefined && /^\d{1,9}$/.test(h) ? clampIndentPt(Number(h) / 20) : 0;
-      firstLine = f !== undefined && /^-?\d{1,9}$/.test(f) ? clampIndentPt(Number(f) / 20) : 0;
-    }
+    if (h === undefined && f === undefined) continue;
+    found = {
+      hanging: h !== undefined && /^\d{1,9}$/.test(h) ? clampIndentPt(Number(h) / 20) : 0,
+      firstLine: f !== undefined && /^-?\d{1,9}$/.test(f) ? clampIndentPt(Number(f) / 20) : 0,
+    };
   }
-  return {
-    left: para.left,
-    right: para.right,
-    hanging,
-    firstLine,
+  return found;
+}
+
+/** Whether any `w:ind` in the list states left (or its `w:start` spelling). */
+function statesLeft(props: readonly OoxmlProperty[]): boolean {
+  return props.some(
+    (property) =>
+      property.localName === 'ind' &&
+      (property.attributes?.left !== undefined || property.attributes?.start !== undefined)
+  );
+}
+
+function statesRight(props: readonly OoxmlProperty[]): boolean {
+  return props.some(
+    (property) =>
+      property.localName === 'ind' &&
+      (property.attributes?.right !== undefined || property.attributes?.end !== undefined)
+  );
+}
+
+/**
+ * The effective indent of a list paragraph: STYLE, then the numbering LEVEL, then DIRECT.
+ *
+ * Word applies a level's `w:pPr/w:ind` between the paragraph style and the paragraph's own
+ * formatting, per attribute — and the ordering matters on real documents. A converted
+ * agreement numbers its `(a)` items with a level stating `left=1512 hanging=738` under a
+ * `ListParagraph` style stating `left=775 hanging=624`, and states only `hanging="737"` on
+ * the paragraph itself. Reading the flattened cascade as "the paragraph's indent" gave the
+ * STYLE's 775 to a level that had overridden it, so every lettered sub-item hung a full
+ * indent step to the left of where Word puts it.
+ *
+ * `inherited` is the cascade WITHOUT the paragraph's own `w:pPr` (defaults, table cell style,
+ * style chain); `direct` is that `w:pPr` alone.
+ */
+export function mergeListIndent(
+  levelIndent: NumberingLevelIndent,
+  inherited: readonly OoxmlProperty[],
+  direct: readonly OoxmlProperty[] = []
+): NumberingLevelIndent {
+  // A level built by hand (a unit test, not a file) carries no presence record; it then
+  // states nothing and the style still wins, which is the behaviour those callers had.
+  const levelStates = levelIndent.stated ?? {
+    left: false,
+    right: false,
+    firstLineOffset: false,
   };
+  const inheritedIndent = paragraphIndent(inherited);
+  const directIndent = paragraphIndent(direct);
+  const levelOffset = { hanging: levelIndent.hanging, firstLine: levelIndent.firstLine };
+
+  const left = statesLeft(direct)
+    ? directIndent.left
+    : levelStates.left
+      ? levelIndent.left
+      : statesLeft(inherited)
+        ? inheritedIndent.left
+        : levelIndent.left;
+  const right = statesRight(direct)
+    ? directIndent.right
+    : levelStates.right
+      ? levelIndent.right
+      : statesRight(inherited)
+        ? inheritedIndent.right
+        : levelIndent.right;
+  const firstLineOffset =
+    firstLineOffsetOf(direct) ??
+    (levelStates.firstLineOffset ? levelOffset : (firstLineOffsetOf(inherited) ?? levelOffset));
+
+  return { left, right, ...firstLineOffset };
 }
 
 /**
@@ -254,8 +305,14 @@ export function resolveStoryListItems(
     const advanced = counters.advance(numPr.numId, numPr.ilvl);
     if (!advanced) continue;
 
-    const indentProps = cascaded ? cascaded.paragraphProperties : propertiesOf(pPr);
-    const indent = mergeListIndent(advanced.level.indent, indentProps);
+    // Split, not flattened: the level's indent outranks the STYLE's and is outranked by the
+    // paragraph's OWN `w:pPr`, so the merge needs the two tiers apart.
+    const directProps = propertiesOf(pPr);
+    const indent = mergeListIndent(
+      advanced.level.indent,
+      cascaded?.inheritedParagraphProperties ?? [],
+      directProps
+    );
     const markerProps = cascadeRunProperties(
       cascaded?.runProperties ?? [],
       advanced.level.runProperties,

--- a/packages/core/src/layout/numbering-index.ts
+++ b/packages/core/src/layout/numbering-index.ts
@@ -36,6 +36,20 @@ export interface NumberingLevelIndent {
   readonly right: number;
   readonly hanging: number;
   readonly firstLine: number;
+  /**
+   * Which of these the LEVEL actually authored.
+   *
+   * A level's `w:pPr/w:ind` sits between the paragraph style and direct formatting, so the
+   * merge has to tell "the level says left = 0" from "the level says nothing about left and
+   * the style's value stands". Absent (the default) reads as "says nothing", which is what a
+   * hand-built level in a test means.
+   */
+  readonly stated?: {
+    readonly left: boolean;
+    readonly right: boolean;
+    /** `w:hanging`/`w:firstLine` are one mutually exclusive slot (§17.3.1.10, §17.3.1.12). */
+    readonly firstLineOffset: boolean;
+  };
 }
 
 export interface NumberingLevel {
@@ -165,6 +179,11 @@ function parseIndent(pPr: OoxmlElement | undefined): NumberingLevelIndent {
     right: rightTwips === null ? 0 : clampSignedPt(rightTwips),
     hanging: hangingTwips === null ? 0 : clampNonNegativePt(hangingTwips),
     firstLine: firstLineTwips === null ? 0 : clampSignedPt(firstLineTwips),
+    stated: {
+      left: leftTwips !== null,
+      right: rightTwips !== null,
+      firstLineOffset: hangingTwips !== null || firstLineTwips !== null,
+    },
   };
 }
 

--- a/packages/core/src/layout/review-model.ts
+++ b/packages/core/src/layout/review-model.ts
@@ -196,50 +196,22 @@ interface SiteLocation {
 function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
   const located = new Map<string, SiteLocation>();
   const walkParagraph = (paragraph: OoxmlParagraphNode): void => {
-    const offsets = paragraphOffsetIndex(paragraph);
-    const place = (node: OoxmlNode, start: number, end: number, depth: number): void => {
-      if (node.kind === 'textValue' || depth > 64) return;
-      located.set(node.id, { paragraphId: paragraph.id, start, end });
-      for (const child of node.children) place(child, start, end, depth + 1);
-    };
-    const visit = (node: OoxmlNode, depth: number): void => {
-      if (node.kind === 'textValue' || depth > 64) return;
-      const span = offsets.spanOf(node);
-      if (node.kind === 'run') {
-        if (!span) return;
-        located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
-        // A run's OWN properties anchor over the run. `w:rPrChange` is a revision that
-        // decorates no characters and lives in `w:rPr`, so stopping at the run left it with
-        // no geometry at all: its card sorted to the end of the rail, painted no band, and
-        // the caret in tracked-formatted text activated nothing while accept and reject
-        // stayed on offer.
-        for (const child of node.children) {
-          if (child.kind === 'runProperties') place(child, span.start, span.end, depth + 1);
-        }
-        return;
-      }
-      if (span)
-        located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
-      for (const child of node.children) visit(child, depth + 1);
-    };
-    for (const child of paragraph.children) {
-      if (child.kind === 'paragraphProperties') continue;
-      visit(child, 0);
+    // Paragraph-local by construction: every offset here is measured inside this paragraph,
+    // so an unchanged paragraph's answer is still true and is reused rather than re-walked.
+    // A keystroke otherwise re-derived the location of every node in the document.
+    const memo = paragraphLocationsCache.get(paragraph);
+    if (memo) {
+      for (const [id, location] of memo) located.set(id, location);
+      return;
     }
-    // The paragraph MARK is the pilcrow — it sits at the END of the paragraph, not at
-    // offset 0 where its `w:pPr` happens to be written. Anchored at 0, a tracked Enter's
-    // card never opened when the caret was at the break that made it, `setActiveReviewItem`
-    // threw the caret to the paragraph start, and the zero-width range painted no band.
-    const properties = paragraph.children.find((child) => child.kind === 'paragraphProperties');
-    if (properties) place(properties, offsets.length, offsets.length, 0);
+    const own = new Map<string, SiteLocation>();
+    locateInParagraph(paragraph, own);
+    paragraphLocationsCache.set(paragraph, own);
+    for (const [id, location] of own) located.set(id, location);
   };
   const walk = (node: OoxmlNode, depth: number): void => {
     if (node.kind === 'textValue' || depth > 64) return;
     if (node.kind === 'paragraph') {
-      // `walkParagraph` already places everything, the `w:pPr` subtree included: a property
-      // revision anchors at the paragraph's END, where its pilcrow is. A second pass used to
-      // collapse the whole subtree to offset 0 afterwards, which is what left every tracked
-      // Enter's card pointing at the start of the paragraph instead of at the break.
       walkParagraph(node);
       return;
     }
@@ -247,6 +219,50 @@ function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
   };
   walk(part.root, 0);
   return located;
+}
+
+/** Node id → paragraph-local offsets, memoized on the immutable paragraph node. */
+const paragraphLocationsCache = new WeakMap<OoxmlNode, ReadonlyMap<string, SiteLocation>>();
+
+function locateInParagraph(
+  paragraph: OoxmlParagraphNode,
+  located: Map<string, SiteLocation>
+): void {
+  const offsets = paragraphOffsetIndex(paragraph);
+  const place = (node: OoxmlNode, start: number, end: number, depth: number): void => {
+    if (node.kind === 'textValue' || depth > 64) return;
+    located.set(node.id, { paragraphId: paragraph.id, start, end });
+    for (const child of node.children) place(child, start, end, depth + 1);
+  };
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || depth > 64) return;
+    const span = offsets.spanOf(node);
+    if (node.kind === 'run') {
+      if (!span) return;
+      located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
+      // A run's OWN properties anchor over the run. `w:rPrChange` is a revision that
+      // decorates no characters and lives in `w:rPr`, so stopping at the run left it with
+      // no geometry at all: its card sorted to the end of the rail, painted no band, and
+      // the caret in tracked-formatted text activated nothing while accept and reject
+      // stayed on offer.
+      for (const child of node.children) {
+        if (child.kind === 'runProperties') place(child, span.start, span.end, depth + 1);
+      }
+      return;
+    }
+    if (span) located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of paragraph.children) {
+    if (child.kind === 'paragraphProperties') continue;
+    visit(child, 0);
+  }
+  // The paragraph MARK is the pilcrow — it sits at the END of the paragraph, not at
+  // offset 0 where its `w:pPr` happens to be written. Anchored at 0, a tracked Enter's
+  // card never opened when the caret was at the break that made it, `setActiveReviewItem`
+  // threw the caret to the paragraph start, and the zero-width range painted no band.
+  const properties = paragraph.children.find((child) => child.kind === 'paragraphProperties');
+  if (properties) place(properties, offsets.length, offsets.length, 0);
 }
 
 function addressKey(address: RevisionAddress): string {

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -91,6 +91,13 @@ export interface StyleCascadeTable {
 export interface CascadedParagraphFormatting {
   /** Flat paragraph properties in cascade order (defaults → bases → style → direct). */
   readonly paragraphProperties: readonly OoxmlProperty[];
+  /**
+   * The same list WITHOUT the paragraph's own `w:pPr` — everything it inherits.
+   *
+   * Numbering needs the two tiers apart: a level's `w:pPr/w:ind` outranks the style's and is
+   * outranked by the paragraph's own, and a flattened list cannot say which is which.
+   */
+  readonly inheritedParagraphProperties: readonly OoxmlProperty[];
   /** Matching `w:pPr` nodes for nested border resolution. */
   readonly paragraphPropertyNodes: readonly OoxmlNode[];
   /** Inherited run properties for every run in the paragraph (before direct run `rPr`). */
@@ -465,12 +472,12 @@ export function cascadeParagraphFormatting(
   const styleId = styleIdFromProps(directProps, 'pStyle') ?? table.defaultParagraphStyleId;
   const chain = styleId ? styleChain(table, styleId, 'paragraph') : [];
 
-  const paragraphProperties: OoxmlProperty[] = [
+  const inheritedParagraphProperties: OoxmlProperty[] = [
     ...table.docDefaultsParagraph,
     ...(tableCellStyle?.paragraphProperties ?? []),
     ...chain.flatMap((style) => style.paragraphProperties),
-    ...directProps,
   ];
+  const paragraphProperties: OoxmlProperty[] = [...inheritedParagraphProperties, ...directProps];
 
   const paragraphPropertyNodes: OoxmlNode[] = [];
   if (table.docDefaultsParagraphNode) paragraphPropertyNodes.push(table.docDefaultsParagraphNode);
@@ -491,7 +498,13 @@ export function cascadeParagraphFormatting(
     ...propertiesOf(directMarkRun),
   ];
 
-  return { paragraphProperties, paragraphPropertyNodes, runProperties, styleId: styleId ?? null };
+  return {
+    paragraphProperties,
+    inheritedParagraphProperties,
+    paragraphPropertyNodes,
+    runProperties,
+    styleId: styleId ?? null,
+  };
 }
 
 /**

--- a/packages/core/src/store/__tests__/tree-ops.test.ts
+++ b/packages/core/src/store/__tests__/tree-ops.test.ts
@@ -161,6 +161,63 @@ describe('text operations over UTF-16 offsets (task 5.1)', () => {
     expect(out).toContain('drawing');
   });
 
+  test('typing at a run boundary takes the LEFT run, the way Word does', () => {
+    // A PDF-converted document writes every inter-word space as its own run carrying
+    // `w:spacing` (character tracking). Joining the run that STARTS at the offset gave typed
+    // text that run's tracking, so typing after a word came out letter-spaced: "x x x x".
+    const part = load(
+      '<w:p><w:r><w:t>word</w:t></w:r>' +
+        '<w:r><w:rPr><w:spacing w:val="60"/></w:rPr><w:t xml:space="preserve"> </w:t></w:r>' +
+        '<w:r><w:t>next</w:t></w:r></w:p>'
+    );
+    const [id] = paragraphIds(part);
+    const typed = apply(part, { op: 'insertText', paragraphId: id!, offset: 4, text: 'xx' });
+    expect(paragraphTextOf(typed, id!)).toBe('wordxx next');
+    // The characters joined "word", which authors no spacing — not the tracked space run.
+    expect(serializeOoxmlPart(typed)).toContain('<w:r><w:t>word</w:t><w:t>xx</w:t></w:r>');
+  });
+
+  test('typing at the START of a paragraph takes the run to its right', () => {
+    const part = load('<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r></w:p>');
+    const [id] = paragraphIds(part);
+    const typed = apply(part, { op: 'insertText', paragraphId: id!, offset: 0, text: 'X' });
+    expect(paragraphTextOf(typed, id!)).toBe('Xbold');
+    // No run to the left, so the bold run to the right owns it — Word's rule at offset 0.
+    expect(serializeOoxmlPart(typed)).toContain(
+      '<w:r><w:rPr><w:b/></w:rPr><w:t>X</w:t><w:t>bold</w:t></w:r>'
+    );
+  });
+
+  test('typing at the end of a hyperlink stays OUTSIDE the link', () => {
+    const part = load(
+      '<w:p><w:hyperlink r:id="rId1" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+        '<w:r><w:t>link</w:t></w:r></w:hyperlink><w:r><w:t> after</w:t></w:r></w:p>'
+    );
+    const [id] = paragraphIds(part);
+    const typed = apply(part, { op: 'insertText', paragraphId: id!, offset: 4, text: 'X' });
+    expect(paragraphTextOf(typed, id!)).toBe('linkX after');
+    // The link's own text is unchanged; the new character landed in the run after it.
+    expect(serializeOoxmlPart(typed)).toContain('<w:t>link</w:t>');
+  });
+
+  test('bias right places text inside the run that starts at the offset', () => {
+    const part = load(
+      '<w:p><w:r><w:t>plain</w:t></w:r>' + '<w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r></w:p>'
+    );
+    const [id] = paragraphIds(part);
+    const typed = apply(part, {
+      op: 'insertText',
+      paragraphId: id!,
+      offset: 5,
+      text: 'X',
+      bias: 'right',
+    });
+    expect(paragraphTextOf(typed, id!)).toBe('plainXbold');
+    expect(serializeOoxmlPart(typed)).toContain(
+      '<w:r><w:rPr><w:b/></w:rPr><w:t>X</w:t><w:t>bold</w:t></w:r>'
+    );
+  });
+
   test('insertText at boundaries emits xml:space preserve on save/reopen', () => {
     const part = load('<w:p><w:r><w:t>Hello</w:t></w:r></w:p>');
     const [id] = paragraphIds(part);

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -208,7 +208,8 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
         paragraph,
         op.offset,
         [(mint) => textElement(mint, op.text)],
-        options
+        options,
+        op.bias
       );
     case 'insertTab':
       return applyInsertContent(
@@ -330,7 +331,8 @@ function applyInsertContent(
   paragraph: OoxmlParagraphNode,
   offset: number,
   builders: readonly ((mint: () => string) => OoxmlNode)[],
-  options?: EditOptions
+  options?: EditOptions,
+  bias: 'left' | 'right' = 'left'
 ): TreeOpResult {
   const nextId = createNodeIdAllocator(part);
   const nodes = builders.map((build) => build(nextId));
@@ -362,12 +364,40 @@ function applyInsertContent(
     return fromEdit(replaceChildren(part, run.id, rebuilt, options), effect);
   }
 
-  // At a boundary: append to the run holding the offset, or to the last run.
-  const boundary = segments.find((segment) => segment.start === offset);
-  if (boundary) {
-    const run = findNode(part, boundary.runId);
+  // AT A BOUNDARY, THE RUN TO THE LEFT WINS.
+  //
+  // Word types into the run holding the character BEFORE the caret; `authoredRunPropertiesAt`
+  // states the same rule for what the toolbar reports, and the two have to agree or the
+  // toolbar describes formatting the next keystroke will not use. Joining the run that
+  // STARTS at the offset gave typed text the FOLLOWING run's properties — which on a
+  // PDF-converted document, where every inter-word space is its own run carrying
+  // `w:spacing`, meant typing after a word came out letter-spaced ("x x x x x x").
+  //
+  // The left run is refused in the two cases where inheriting from it would move the text
+  // somewhere it does not belong rather than merely format it: an ATOM (a field or a note
+  // reference, whose nodes must stay together), and a run inside a hyperlink or field when
+  // the run on the right is not — typing at the end of a link extends the link's text
+  // otherwise. Both fall back to the previous rule.
+  const before = findLast(segments, (segment) => segment.end === offset);
+  const after = segments.find((segment) => segment.start === offset);
+  if (
+    bias === 'left' &&
+    before &&
+    before.removeNodeIds === undefined &&
+    !leavesContainer(paragraph, before, after)
+  ) {
+    const run = findNode(part, before.runId);
     if (!run || run.kind !== 'run') return { ok: false, reason: 'tree-invariant' };
-    const index = run.children.findIndex((child) => contains(child, boundary.node.id));
+    const index = run.children.findIndex((child) => contains(child, before.node.id));
+    return fromEdit(
+      insertChildren(part, run.id, index < 0 ? run.children.length : index + 1, nodes, options),
+      effect
+    );
+  }
+  if (after) {
+    const run = findNode(part, after.runId);
+    if (!run || run.kind !== 'run') return { ok: false, reason: 'tree-invariant' };
+    const index = run.children.findIndex((child) => contains(child, after.node.id));
     return fromEdit(insertChildren(part, run.id, Math.max(0, index), nodes, options), effect);
   }
 
@@ -387,6 +417,48 @@ function applyInsertContent(
     ),
     effect
   );
+}
+
+function findLast<T>(items: readonly T[], predicate: (item: T) => boolean): T | undefined {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index]!;
+    if (predicate(item)) return item;
+  }
+  return undefined;
+}
+
+/**
+ * Whether typing into `before`'s run would carry the text INTO a container the caret is
+ * leaving — a hyperlink or a field whose last character this is, with ordinary paragraph
+ * content on the other side of the boundary.
+ */
+function leavesContainer(
+  paragraph: OoxmlParagraphNode,
+  before: { readonly runId: string },
+  after: { readonly runId: string } | undefined
+): boolean {
+  const container = (runId: string): OoxmlNode | null => {
+    let held: OoxmlNode | null = null;
+    const visit = (node: OoxmlNode, inside: OoxmlNode | null): void => {
+      if (node.kind === 'textValue' || held) return;
+      if (node.id === runId) {
+        held = inside;
+        return;
+      }
+      const nested =
+        node.kind === 'hyperlink' ||
+        node.kind === 'fldSimple' ||
+        (node.kind === 'generic' && node.localName === 'fldSimple')
+          ? node
+          : inside;
+      for (const child of node.children) visit(child, nested);
+    };
+    for (const child of paragraph.children) visit(child, null);
+    return held;
+  };
+  const held = container(before.runId);
+  if (held === null) return false;
+  return after === undefined || container(after.runId) !== held;
 }
 
 function contains(node: OoxmlNode, id: string): boolean {

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -123,11 +123,15 @@ export function revisionGroupKey(address: RevisionAddress, localName: string): s
   return `${localName}\u0000${address.id}\u0000${address.author}\u0000${address.date ?? ''}`;
 }
 
+/** Revision sites of one paragraph subtree, memoized on the immutable paragraph node. */
+const paragraphSitesCache = new WeakMap<OoxmlNode, readonly RevisionSite[]>();
+
 /**
  * Every revision-bearing element in the part, with the classification that decides whether it
  * can be resolved.
  *
- * One walk, so accept-all does not pay a traversal per revision.
+ * One walk, so accept-all does not pay a traversal per revision — and paragraphs the last
+ * commit did not touch are answered from {@link paragraphSitesCache} rather than re-walked.
  */
 export function collectRevisionSites(part: OoxmlPart): RevisionSite[] {
   const sites: RevisionSite[] = [];
@@ -137,6 +141,25 @@ export function collectRevisionSites(part: OoxmlPart): RevisionSite[] {
     grandparent: OoxmlElement | null
   ): void => {
     if (node.kind === 'textValue') return;
+    // A PARAGRAPH's sites depend on nothing outside it. Classification reads the parent and
+    // grandparent, and every case that consults them (`w:rPr` under `w:pPr`, a structural
+    // parent) is at least two levels inside the paragraph — so the answer for a paragraph
+    // subtree is a pure function of that subtree, and an unchanged paragraph can hand back
+    // what it said last time. Without this, a document with no tracked changes at all still
+    // paid a full-tree walk per keystroke, on this path and on the review queue's.
+    if (node.kind === 'paragraph') {
+      const cached = paragraphSitesCache.get(node);
+      if (cached) {
+        sites.push(...cached);
+        return;
+      }
+      const own: RevisionSite[] = [];
+      const before = sites.length;
+      for (const child of node.children) visit(child, node, parent);
+      for (let index = before; index < sites.length; index += 1) own.push(sites[index]!);
+      paragraphSitesCache.set(node, own);
+      return;
+    }
     const parentName = parent?.namespaceUri === WML_NAMESPACE_URI ? parent.localName : undefined;
     const grandparentName =
       grandparent?.namespaceUri === WML_NAMESPACE_URI ? grandparent.localName : undefined;

--- a/packages/core/src/store/store/tree-op-segments.ts
+++ b/packages/core/src/store/store/tree-op-segments.ts
@@ -88,7 +88,27 @@ export interface ParagraphOffsetIndex {
   lengthOf(node: OoxmlNode | string): number;
 }
 
+/**
+ * MEMOIZED ON NODE IDENTITY. A paragraph node is immutable — a transaction rebuilds the path
+ * to what it edited and leaves every other paragraph object-identical — so the index derived
+ * from one can be reused until that paragraph itself changes.
+ *
+ * This is not a micro-optimization. Three whole-document readers call this per paragraph on
+ * every commit (the review queue, the comment anchors, the tracked-change writer), so on a
+ * long document one keystroke re-walked every paragraph in the file several times over, and
+ * the cost showed up as typing latency that grew with document length.
+ */
+const offsetIndexCache = new WeakMap<OoxmlParagraphNode, ParagraphOffsetIndex>();
+
 export function paragraphOffsetIndex(paragraph: OoxmlParagraphNode): ParagraphOffsetIndex {
+  const cached = offsetIndexCache.get(paragraph);
+  if (cached) return cached;
+  const index = buildParagraphOffsetIndex(paragraph);
+  offsetIndexCache.set(paragraph, index);
+  return index;
+}
+
+function buildParagraphOffsetIndex(paragraph: OoxmlParagraphNode): ParagraphOffsetIndex {
   const spans = new Map<string, OffsetSpan>();
   const segments = walkParagraph(paragraph, spans);
   const length = segments.length === 0 ? 0 : segments[segments.length - 1]!.end;

--- a/packages/core/src/store/store/tree-op-types.ts
+++ b/packages/core/src/store/store/tree-op-types.ts
@@ -106,6 +106,16 @@ export type TreeDocOp =
        * depend on state the op does not carry.
        */
       readonly revision?: RevisionAttributionInput;
+      /**
+       * Which side of a run BOUNDARY the text joins. Default `'left'` — Word's typing rule:
+       * the next character takes the formatting of the character before the caret.
+       *
+       * `'right'` is for a caller that is not typing but placing text inside the run that
+       * STARTS at the offset — the hyperlink editor rewriting a link's display text, where
+       * landing left of the boundary would put the new text outside the link. Ignored when
+       * the offset falls strictly inside a run, which has no boundary to choose.
+       */
+      readonly bias?: 'left' | 'right';
     }
   | {
       readonly op: 'deleteText';

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -267,6 +267,7 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
       }
       if (typeof op.text !== 'string' || !isValidXmlText(op.text)) return 'invalid-text';
       if (splitsSurrogate(paragraph, op.offset)) return 'splits-surrogate-pair';
+      if (op.bias !== undefined && op.bias !== 'left' && op.bias !== 'right') return 'invalidArgs';
       return null;
     }
     case 'setListLevel': {


### PR DESCRIPTION
Three fixes found on one PDF-converted agreement, where every inter-word space is its own run carrying `w:spacing` and lettered sub-items number through a level that overrides their style.

**Typing inherited the wrong run.** At a run boundary the insert joined the run that *starts* at the offset, so text typed after a word took the following space run's character spacing and rendered letter-spaced. Word inherits from the character before the caret — which is the rule `authoredRunPropertiesAt` already applied when telling the toolbar what the next keystroke would look like, so the two disagreed. The left run is still refused for an atom and when it would carry the text into a hyperlink or field the caret is leaving; the hyperlink display-text rewrite needs the other side and now says so with `bias: 'right'`.

**Numbering indent lost to the style.** A level's `w:ind` belongs between the paragraph style and the paragraph's own formatting, per attribute. It was read from the flattened cascade, so a style stating `left=775` beat a level stating `left=1512` and every lettered sub-item hung an indent step left of where Word draws it. Levels now record which attributes they authored, so "the level says left = 0" is distinct from "the level says nothing".

**The review queue walked the whole document per keystroke.** `reviewItems()` re-derived revision sites, comment markers and paragraph offsets across the entire part on every commit, even with no tracked changes and no comments. Those walks are paragraph-local and the tree is immutable, so they now reuse untouched paragraphs: 49ms to 4ms per keystroke on an 878-paragraph document.

Verified against the reporting document, which is not in the repo — the tests build the same shapes from synthetic XML.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788444754&installation_model_id=422592&pr_number=114&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F114&signature=fb00522c8626f21479f2c32d7fdd93f233f561fcf473a4b7fea5bdc110a53afa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->