### PR TITLE
feat(react): add responsive toolbar overflow

### DIFF
--- a/.changeset/responsive-toolbar-overflow.md
+++ b/.changeset/responsive-toolbar-overflow.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+The default toolbar now stays on one row: when the bar runs out of width it collapses whole chrome groups into a keyboard-accessible More menu, with the review controls pinned at every size. Pass `overflow={false}` to restore wrapping; `preset={false}` is unchanged.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -17,8 +17,6 @@ import { ChromeSlotId } from '@docx-editor.dev/core-contract/editor';
 import { ColorValue } from '@docx-editor.dev/core-contract/contracts/editor';
 import { commandForSlot } from '@docx-editor.dev/core-contract/editor';
 import { composeFontConfiguration } from '@docx-editor.dev/core-contract/editor';
-import { ContentControlSummary } from '@docx-editor.dev/core-contract';
-import { ContentControlType } from '@docx-editor.dev/core-contract';
 import { createFontSource } from '@docx-editor.dev/core-contract/editor';
 import { CSSProperties } from 'react';
 import { DocumentChange } from '@docx-editor.dev/core-contract/contracts/editor';
@@ -105,63 +103,6 @@ export { commandForSlot }
 export { composeFontConfiguration }
 
 // @public
-export const CONTENT_CONTROL_SLOTS: {
-    readonly showAll: "contentControl.showAll";
-    readonly formFill: "contentControl.formFill";
-    readonly inspector: "contentControl.inspector";
-    readonly remove: "contentControl.remove";
-};
-
-// @public
-export interface ContentControlActionProps extends ContentControlPartProps {
-    // (undocumented)
-    icon?: ReactNode;
-}
-
-// @public
-export interface ContentControlInspectorState {
-    // (undocumented)
-    readonly alias: string | null;
-    // (undocumented)
-    readonly bound: boolean;
-    // (undocumented)
-    readonly controlType: ContentControlType;
-    // (undocumented)
-    readonly effectiveLock: ContentControlLock | null;
-    // (undocumented)
-    readonly id: string;
-    readonly locked: boolean;
-    // (undocumented)
-    readonly placeholder: boolean;
-    readonly removalLocked: boolean;
-    // (undocumented)
-    readonly tag: string | null;
-}
-
-// @public
-export type ContentControlLock = 'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked';
-
-// @public
-export interface ContentControlPartProps {
-    // (undocumented)
-    asChild?: boolean;
-    // (undocumented)
-    children?: ReactNode;
-    // (undocumented)
-    className?: string;
-    // (undocumented)
-    hidden?: boolean;
-}
-
-// @public
-export interface ContentControlProps extends ContentControlPartProps {
-    preset?: boolean;
-}
-
-// @public (undocumented)
-export type ContentControlSlotId = (typeof CONTENT_CONTROL_SLOTS)[keyof typeof CONTENT_CONTROL_SLOTS];
-
-// @public
 export interface ContextMenuAnchor {
     // (undocumented)
     readonly x: number;
@@ -239,21 +180,6 @@ export const DocxEditor: DocxEditorNamespace;
 
 // @public
 export function DocxEditorContent(input: DocxEditorContentProps): react.JSX.Element;
-
-// @public (undocumented)
-export const DocxEditorContentControl: DocxEditorContentControlNamespace;
-
-// @public
-export interface DocxEditorContentControlNamespace {
-    // (undocumented)
-    (props: ContentControlProps): ReturnType<typeof ContentControlRoot>;
-    // (undocumented)
-    readonly Fields: typeof ContentControlFields;
-    // (undocumented)
-    readonly Header: typeof ContentControlHeader;
-    // (undocumented)
-    readonly Remove: typeof ContentControlRemove;
-}
 
 // @public
 export interface DocxEditorContentProps {
@@ -421,7 +347,6 @@ export interface DocxEditorMenuProps {
 export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEditorProps & RefAttributes<DocxEditorRef>> {
     // (undocumented)
     readonly Content: typeof DocxEditorContent;
-    readonly ContentControl: typeof DocxEditorContentControl;
     readonly ContextMenu: typeof ContextMenu;
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
     readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
@@ -681,14 +606,6 @@ export interface DocxEditorToolbarNamespace {
     // (undocumented)
     readonly Comments: ToolbarPartComponent;
     // (undocumented)
-    readonly ContentControlFormFill: ToolbarPartComponent;
-    // (undocumented)
-    readonly ContentControlInspector: ToolbarPartComponent;
-    // (undocumented)
-    readonly ContentControlRemove: ToolbarPartComponent;
-    // (undocumented)
-    readonly ContentControlShowAll: ToolbarPartComponent;
-    // (undocumented)
     readonly EditingMode: ToolbarSlotPartComponent;
     // (undocumented)
     readonly FontColor: ToolbarColorSplitComponent;
@@ -744,6 +661,7 @@ export interface DocxEditorToolbarProps {
     children?: ReactNode;
     className?: string;
     onSave?: () => void;
+    overflow?: boolean;
     preset?: boolean;
     t?: ToolbarTranslate;
 }
@@ -1489,41 +1407,6 @@ export interface ToolbarSlotPartProps {
 
 // @public
 export type ToolbarTranslate = (key: string) => string;
-
-// @public
-export function useContentControl(): UseContentControlResult;
-
-// @public
-export function useContentControlInstance(): UseContentControlResult;
-
-// @public
-export interface UseContentControlResult {
-    readonly canRemove: boolean;
-    readonly canSetValue: boolean;
-    // (undocumented)
-    readonly closeInspector: () => void;
-    readonly control: ContentControlInspectorState | null;
-    readonly controls: readonly ContentControlSummary[];
-    readonly formFill: boolean;
-    readonly inspectorOpen: boolean;
-    // (undocumented)
-    readonly openInspector: () => void;
-    readonly remove: () => ExecResult;
-    readonly removeDisabledReason: string | null;
-    // (undocumented)
-    readonly setFormFill: (on: boolean) => void;
-    // (undocumented)
-    readonly setShowAll: (show: boolean) => void;
-    readonly setValue: (value: string) => ExecResult;
-    readonly setValueDisabledReason: string | null;
-    readonly showAll: boolean;
-    // (undocumented)
-    readonly toggleFormFill: () => void;
-    // (undocumented)
-    readonly toggleInspector: () => void;
-    // (undocumented)
-    readonly toggleShowAll: () => void;
-}
 
 // @public
 export function useDocumentOutline(): UseDocumentOutlineResult;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -17,6 +17,8 @@ import { ChromeSlotId } from '@docx-editor.dev/core-contract/editor';
 import { ColorValue } from '@docx-editor.dev/core-contract/contracts/editor';
 import { commandForSlot } from '@docx-editor.dev/core-contract/editor';
 import { composeFontConfiguration } from '@docx-editor.dev/core-contract/editor';
+import { ContentControlSummary } from '@docx-editor.dev/core-contract';
+import { ContentControlType } from '@docx-editor.dev/core-contract';
 import { createFontSource } from '@docx-editor.dev/core-contract/editor';
 import { CSSProperties } from 'react';
 import { DocumentChange } from '@docx-editor.dev/core-contract/contracts/editor';
@@ -103,6 +105,63 @@ export { commandForSlot }
 export { composeFontConfiguration }
 
 // @public
+export const CONTENT_CONTROL_SLOTS: {
+    readonly showAll: "contentControl.showAll";
+    readonly formFill: "contentControl.formFill";
+    readonly inspector: "contentControl.inspector";
+    readonly remove: "contentControl.remove";
+};
+
+// @public
+export interface ContentControlActionProps extends ContentControlPartProps {
+    // (undocumented)
+    icon?: ReactNode;
+}
+
+// @public
+export interface ContentControlInspectorState {
+    // (undocumented)
+    readonly alias: string | null;
+    // (undocumented)
+    readonly bound: boolean;
+    // (undocumented)
+    readonly controlType: ContentControlType;
+    // (undocumented)
+    readonly effectiveLock: ContentControlLock | null;
+    // (undocumented)
+    readonly id: string;
+    readonly locked: boolean;
+    // (undocumented)
+    readonly placeholder: boolean;
+    readonly removalLocked: boolean;
+    // (undocumented)
+    readonly tag: string | null;
+}
+
+// @public
+export type ContentControlLock = 'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked';
+
+// @public
+export interface ContentControlPartProps {
+    // (undocumented)
+    asChild?: boolean;
+    // (undocumented)
+    children?: ReactNode;
+    // (undocumented)
+    className?: string;
+    // (undocumented)
+    hidden?: boolean;
+}
+
+// @public
+export interface ContentControlProps extends ContentControlPartProps {
+    preset?: boolean;
+}
+
+// @public (undocumented)
+export type ContentControlSlotId = (typeof CONTENT_CONTROL_SLOTS)[keyof typeof CONTENT_CONTROL_SLOTS];
+
+// @public
 export interface ContextMenuAnchor {
     // (undocumented)
     readonly x: number;
@@ -180,6 +239,21 @@ export const DocxEditor: DocxEditorNamespace;
 
 // @public
 export function DocxEditorContent(input: DocxEditorContentProps): react.JSX.Element;
+
+// @public (undocumented)
+export const DocxEditorContentControl: DocxEditorContentControlNamespace;
+
+// @public
+export interface DocxEditorContentControlNamespace {
+    // (undocumented)
+    (props: ContentControlProps): ReturnType<typeof ContentControlRoot>;
+    // (undocumented)
+    readonly Fields: typeof ContentControlFields;
+    // (undocumented)
+    readonly Header: typeof ContentControlHeader;
+    // (undocumented)
+    readonly Remove: typeof ContentControlRemove;
+}
 
 // @public
 export interface DocxEditorContentProps {
@@ -347,6 +421,7 @@ export interface DocxEditorMenuProps {
 export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEditorProps & RefAttributes<DocxEditorRef>> {
     // (undocumented)
     readonly Content: typeof DocxEditorContent;
+    readonly ContentControl: typeof DocxEditorContentControl;
     readonly ContextMenu: typeof ContextMenu;
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
     readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
@@ -605,6 +680,14 @@ export interface DocxEditorToolbarNamespace {
     readonly ClearFormatting: ToolbarPartComponent;
     // (undocumented)
     readonly Comments: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlFormFill: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlInspector: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlRemove: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlShowAll: ToolbarPartComponent;
     // (undocumented)
     readonly EditingMode: ToolbarSlotPartComponent;
     // (undocumented)
@@ -1407,6 +1490,41 @@ export interface ToolbarSlotPartProps {
 
 // @public
 export type ToolbarTranslate = (key: string) => string;
+
+// @public
+export function useContentControl(): UseContentControlResult;
+
+// @public
+export function useContentControlInstance(): UseContentControlResult;
+
+// @public
+export interface UseContentControlResult {
+    readonly canRemove: boolean;
+    readonly canSetValue: boolean;
+    // (undocumented)
+    readonly closeInspector: () => void;
+    readonly control: ContentControlInspectorState | null;
+    readonly controls: readonly ContentControlSummary[];
+    readonly formFill: boolean;
+    readonly inspectorOpen: boolean;
+    // (undocumented)
+    readonly openInspector: () => void;
+    readonly remove: () => ExecResult;
+    readonly removeDisabledReason: string | null;
+    // (undocumented)
+    readonly setFormFill: (on: boolean) => void;
+    // (undocumented)
+    readonly setShowAll: (show: boolean) => void;
+    readonly setValue: (value: string) => ExecResult;
+    readonly setValueDisabledReason: string | null;
+    readonly showAll: boolean;
+    // (undocumented)
+    readonly toggleFormFill: () => void;
+    // (undocumented)
+    readonly toggleInspector: () => void;
+    // (undocumented)
+    readonly toggleShowAll: () => void;
+}
 
 // @public
 export function useDocumentOutline(): UseDocumentOutlineResult;

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -7,6 +7,9 @@
 import { ComponentOptionsMixin } from 'vue';
 import { ComponentProvideOptions } from 'vue';
 import { DefineComponent } from 'vue';
+import { DisplayItem } from '../../core/src/contracts/geometry';
+import { DisplayPage } from '../../core/src/contracts/geometry';
+import { DocPoint } from '../../core/src/contracts/geometry';
 import { ExtractPropTypes } from 'vue';
 import { PropType } from 'vue';
 import { PublicProps } from 'vue';
@@ -184,6 +187,12 @@ export const DEFERRED_DIALOGS: readonly ["findReplace", "hyperlink", "insertImag
 // @public (undocumented)
 export type DeferredDialogId = (typeof DEFERRED_DIALOGS)[number];
 
+export { DisplayItem }
+
+export { DisplayPage }
+
+export { DocPoint }
+
 // @public
 export interface DocxDocument {
     // (undocumented)
@@ -260,9 +269,9 @@ onChange?: ((_change: DocumentChange) => any) | undefined;
 onReady?: ((_editor: Editor) => any) | undefined;
 onFontError?: ((_error: EditorFontError) => any) | undefined;
 }>, {
-fonts: FontConfiguration | FontConfigurationFragment;
-document: DocumentSource;
 author: string;
+document: DocumentSource;
+fonts: FontConfiguration | FontConfigurationFragment;
 zoom: number;
 mode: EditorMode;
 locale: string;

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -7,9 +7,6 @@
 import { ComponentOptionsMixin } from 'vue';
 import { ComponentProvideOptions } from 'vue';
 import { DefineComponent } from 'vue';
-import { DisplayItem } from '../../core/src/contracts/geometry';
-import { DisplayPage } from '../../core/src/contracts/geometry';
-import { DocPoint } from '../../core/src/contracts/geometry';
 import { ExtractPropTypes } from 'vue';
 import { PropType } from 'vue';
 import { PublicProps } from 'vue';
@@ -187,12 +184,6 @@ export const DEFERRED_DIALOGS: readonly ["findReplace", "hyperlink", "insertImag
 // @public (undocumented)
 export type DeferredDialogId = (typeof DEFERRED_DIALOGS)[number];
 
-export { DisplayItem }
-
-export { DisplayPage }
-
-export { DocPoint }
-
 // @public
 export interface DocxDocument {
     // (undocumented)
@@ -269,9 +260,9 @@ onChange?: ((_change: DocumentChange) => any) | undefined;
 onReady?: ((_editor: Editor) => any) | undefined;
 onFontError?: ((_error: EditorFontError) => any) | undefined;
 }>, {
-author: string;
-document: DocumentSource;
 fonts: FontConfiguration | FontConfigurationFragment;
+document: DocumentSource;
+author: string;
 zoom: number;
 mode: EditorMode;
 locale: string;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -2803,8 +2803,9 @@ a.docx-hyperlink:focus-visible {
   align-items: center;
   /* NOT overflow-scroll like the chrome spec's pill: this toolbar hosts LIVE popups
    * (font menu, swatch grids) positioned absolutely inside their parts, and any
-   * overflow clipping on the bar would cut them off. Narrow viewports wrap to a
-   * second row instead. */
+   * overflow clipping on the bar would cut them off. A bar that does not measure
+   * itself wraps to a second row instead; one that does collapses groups into the
+   * "⋯" menu and stays on one row (`[data-overflow]` below). */
   flex-wrap: wrap;
   flex-shrink: 0;
   gap: 2px;
@@ -2859,6 +2860,148 @@ a.docx-hyperlink:focus-visible {
 .docx-toolbar__button:disabled {
   opacity: 0.3;
   cursor: default;
+}
+
+/* ── Overflow ("⋯") ────────────────────────────────────────────────────────────────
+ *
+ * The bar that measures itself is ONE ROW: groups that do not fit move into the menu
+ * rather than wrapping. The adapter sets `data-overflow` only while it is actually
+ * measuring, so a hand-composed bar (or `overflow={false}`) keeps the wrapping above
+ * and nothing about it changes. */
+.docx-toolbar[data-overflow] {
+  flex-wrap: nowrap;
+}
+
+/* The collapse unit: one registry group. Rendered even when nothing overflows, so the
+ * measured width of a group is the width it will have when it comes back. */
+.docx-toolbar__group {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  gap: 2px;
+}
+
+/* The trigger sits at the row's end, whatever is in front of it. */
+.docx-toolbar__more {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  margin-inline-start: auto;
+}
+
+/* The panel SCROLLS when it is taller than the room under the bar. That does clip a
+ * popup opened from a control inside it (a font list, a swatch grid) — the same
+ * trade every scrolling menu makes — and the alternative, a panel that runs off the
+ * bottom of a short window, loses the rows entirely. */
+.docx-toolbar__more-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  inset-inline-end: 0;
+  z-index: 60;
+  box-sizing: border-box;
+  inline-size: min(340px, calc(100vw - 16px));
+  min-inline-size: min(260px, calc(100vw - 16px));
+  max-inline-size: min(340px, calc(100vw - 16px));
+  max-height: min(72vh, 560px);
+  overflow-y: auto;
+  padding: 6px;
+  background: var(--doc-surface);
+  border: 1px solid var(--doc-border);
+  border-radius: 8px;
+  box-shadow: var(--doc-shadow-lg);
+}
+
+.docx-toolbar__more-section + .docx-toolbar__more-section {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--doc-border-light);
+}
+
+.docx-toolbar__more-heading {
+  display: block;
+  padding: 6px 10px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--doc-text-muted);
+  user-select: none;
+}
+
+/* A control row: the registry's name on the left, the real control on the right. */
+.docx-toolbar__more-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 2px 6px 2px 10px;
+}
+
+.docx-toolbar__more-control-label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  font-size: 13px;
+  line-height: 18px;
+  color: var(--doc-text);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.docx-toolbar__more-control-body {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  gap: 2px;
+}
+
+/* One command row in the overflow dialog: ordinary button, shared chrome vocabulary. */
+.docx-toolbar__more-command {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 32px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--doc-text);
+  cursor: pointer;
+  font: inherit;
+  text-align: start;
+}
+
+.docx-toolbar__more-command:hover:not(:disabled) {
+  background: var(--doc-border);
+}
+
+.docx-toolbar__more-command[data-active],
+.docx-toolbar__more-command[data-active]:hover {
+  background: var(--doc-toggle-active-bg);
+  color: var(--doc-toggle-active-fg);
+}
+
+.docx-toolbar__more-command:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.docx-toolbar__more-command-icon {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  color: var(--doc-text-muted);
+}
+
+.docx-toolbar__more-command-label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  font-size: 13px;
+  line-height: 18px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 /* Separator: `w-px h-6 bg-border mx-1.5`. */

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -88,7 +88,8 @@
     "clearFormatting": "Formatierung löschen",
     "commentsAndChanges": "Kommentare & Änderungen",
     "moreItems": "{count, plural, one {# weiteres Element} other {# weitere Elemente}}",
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "Linksbündig",

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -90,6 +90,7 @@
     "imagePropertiesShortcut": "Image properties (alt text, border)...",
     "clearFormatting": "Clear formatting",
     "commentsAndChanges": "Comments & Changes",
+    "more": "More",
     "moreItems": "{count, plural, one {# more item} other {# more items}}",
     "unavailableInPreview": "Not available in this preview build"
   },

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -88,7 +88,8 @@
     "clearFormatting": "Effacer la mise en forme",
     "commentsAndChanges": null,
     "moreItems": null,
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "Aligner à gauche",

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -88,7 +88,8 @@
     "clearFormatting": "נקה עיצוב",
     "commentsAndChanges": null,
     "moreItems": null,
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "יישור לשמאל",

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -88,7 +88,8 @@
     "clearFormatting": "प्रारूपण साफ करें",
     "commentsAndChanges": null,
     "moreItems": null,
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "बाएं संरेखित करें",

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -88,7 +88,8 @@
     "clearFormatting": "Hapus Pemformatan",
     "commentsAndChanges": "Komentar & Perubahan",
     "moreItems": "{count} item lainnya",
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "Rata Kiri",

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -88,7 +88,8 @@
     "clearFormatting": "Wyczyść formatowanie",
     "commentsAndChanges": null,
     "moreItems": null,
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "Wyrównaj do lewej",

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -88,7 +88,8 @@
     "clearFormatting": "Limpar formatação",
     "commentsAndChanges": null,
     "moreItems": null,
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "Alinhar à esquerda",

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -88,7 +88,8 @@
     "clearFormatting": "Biçimlendirmeyi temizle",
     "commentsAndChanges": null,
     "moreItems": null,
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "Sola hizala",

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -88,7 +88,8 @@
     "clearFormatting": "清除格式",
     "commentsAndChanges": null,
     "moreItems": null,
-    "unavailableInPreview": null
+    "unavailableInPreview": null,
+    "more": null
   },
   "alignment": {
     "alignLeft": "左对齐",

--- a/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
+++ b/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
@@ -19,6 +19,14 @@
 // whole toolbar with one customized button. A part child with `hidden` removes its
 // slot (the part renders null where it stands). Non-part children append after the
 // default set. `preset={false}` opts out entirely: children render verbatim.
+//
+// ONE ROW, MEASURED. The bar used to wrap to a second and third row when it ran out of
+// width, which on a laptop beside an open navigation pane cost more vertical space than the
+// first page of the document. Now it measures itself and moves whole GROUPS into a "⋯"
+// menu (`useToolbarOverflow` for the measurement, `toolbar-overflow.ts` for the policy).
+// That is why the default arrangement below is a list of groups rather than a flat list of
+// slots: a group is the unit that collapses, and its registry label becomes the panel's
+// section heading. `overflow={false}` restores wrapping.
 
 import { ToolbarEditingMode } from './EditingMode';
 import { Children, Fragment, isValidElement, useMemo } from 'react';
@@ -29,7 +37,15 @@ import {
   type ChromeSlotId,
 } from '@docx-editor.dev/core-contract/editor';
 import { ToolbarContext, type ToolbarTranslate } from './toolbar-context';
-import { ToolbarButton, guardToolbarMousedown } from './ToolbarButton';
+import { ToolbarButton, chromeControlForSlot, guardToolbarMousedown } from './ToolbarButton';
+import {
+  ToolbarOverflow,
+  ToolbarOverflowControl,
+  ToolbarOverflowItem,
+  type ToolbarOverflowSection,
+} from './ToolbarOverflow';
+import { collapseOrder, TOOLBAR_PINNED_GROUPS } from './toolbar-overflow';
+import { FIXED_ATTRIBUTE, GROUP_ATTRIBUTE, useToolbarOverflow } from './useToolbarOverflow';
 import {
   ToolbarAlignCenter,
   ToolbarAlignJustify,
@@ -79,8 +95,19 @@ import {
  */
 type ArrangementKey = ChromeSlotId | 'alignment';
 
-/** The default arrangement, as slot entries with separators between groups. */
-type DefaultEntry = { kind: 'slot'; slot: ArrangementKey; Part: PartLike } | { kind: 'separator' };
+/** One default-arrangement entry: the slot and the part that draws it. */
+interface DefaultEntry {
+  readonly slot: ArrangementKey;
+  readonly Part: PartLike;
+}
+
+/** A registry group as the toolbar renders it: the collapse unit and a panel section. */
+interface DefaultGroup {
+  readonly id: string;
+  readonly labelKey: string;
+  readonly entries: readonly DefaultEntry[];
+}
+
 type PartLike = (props: { hidden?: boolean }) => ReactNode;
 
 /**
@@ -126,20 +153,39 @@ function iconPart(slot: ChromeSlotId): PartLike {
  * editing-mode picker (contextual slots stay available for composition) — with the
  * alignment group merged into ONE dropdown under the `'alignment'` key.
  */
-const DEFAULT_ARRANGEMENT: readonly DefaultEntry[] = defaultChromeGroups().flatMap(
-  (group, index) => {
-    const entries: DefaultEntry[] = index > 0 ? [{ kind: 'separator' }] : [];
-    if (group.id === 'alignment') {
-      entries.push({ kind: 'slot', slot: 'alignment', Part: ToolbarAlignment });
-      return entries;
-    }
-    for (const control of group.controls) {
-      const slot = chromeSlotId(group, control);
-      entries.push({ kind: 'slot', slot, Part: SHAPED_PARTS[slot] ?? iconPart(slot) });
-    }
-    return entries;
+const DEFAULT_GROUPS: readonly DefaultGroup[] = defaultChromeGroups().map((group) => {
+  if (group.id === 'alignment') {
+    return {
+      id: group.id,
+      labelKey: group.labelKey,
+      entries: [{ slot: 'alignment' as ArrangementKey, Part: ToolbarAlignment }],
+    };
   }
+  return {
+    id: group.id,
+    labelKey: group.labelKey,
+    entries: group.controls.map((control) => {
+      const slot = chromeSlotId(group, control);
+      return { slot: slot as ArrangementKey, Part: SHAPED_PARTS[slot] ?? iconPart(slot) };
+    }),
+  };
+});
+
+/** Every slot the default arrangement draws, for recognizing an override child. */
+const DEFAULT_SLOTS: ReadonlySet<ArrangementKey> = new Set(
+  DEFAULT_GROUPS.flatMap((group) => group.entries.map((entry) => entry.slot))
 );
+
+/** Collapsible group ids in bar order, and the order they collapse in. */
+const COLLAPSIBLE = DEFAULT_GROUPS.map((group) => group.id).filter(
+  (id) => !TOOLBAR_PINNED_GROUPS.has(id)
+);
+const COLLAPSE_ORDER = collapseOrder(COLLAPSIBLE);
+
+/** Slots whose panel row is the CONTROL itself, because it shows a value. */
+function isValueSlot(slot: ArrangementKey): boolean {
+  return slot === 'alignment' || slot in SHAPED_PARTS;
+}
 
 /** The slot one child element drives, or null for a non-part child. */
 function slotOfChild(child: ReactNode): ArrangementKey | null {
@@ -171,12 +217,23 @@ export interface DocxEditorToolbarProps {
    * part children override their slots in place, others append.
    */
   preset?: boolean;
+  /**
+   * `false` lets the bar WRAP to more rows instead of collapsing groups into the "⋯"
+   * menu when it runs out of width. Default `true`.
+   */
+  overflow?: boolean;
   children?: ReactNode;
 }
 
 function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
-  const { className, t, onSave, preset = true, children } = props;
+  const { className, t, onSave, preset = true, overflow: overflowEnabled = true, children } = props;
   const context = useMemo(() => ({ t, onSave }), [t, onSave]);
+
+  // Only the preset arrangement has groups to collapse; `preset={false}` is the host's own
+  // markup, and moving pieces of it into a menu would be the library rearranging a bar it
+  // does not own.
+  const measuring = preset && overflowEnabled;
+  const { attach, overflow } = useToolbarOverflow(measuring, COLLAPSIBLE, COLLAPSE_ORDER);
 
   let content: ReactNode;
   if (!preset) {
@@ -187,28 +244,70 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
     const appended: ReactNode[] = [];
     for (const child of kids) {
       const slot = slotOfChild(child);
-      if (slot && DEFAULT_ARRANGEMENT.some((e) => e.kind === 'slot' && e.slot === slot)) {
+      if (slot && DEFAULT_SLOTS.has(slot)) {
         // Last override for a slot wins, matching how later props win in a spread.
         overrides.set(slot, child as ReactElement);
       } else {
         appended.push(child);
       }
     }
+
+    const render = (entry: DefaultEntry): ReactNode => {
+      // A `hidden` override renders null where it stands, removing the slot.
+      const override = overrides.get(entry.slot);
+      if (override) return override;
+      const Part = entry.Part;
+      return <Part />;
+    };
+
+    const bar: ReactNode[] = [];
+    const sections: ToolbarOverflowSection[] = [];
+    let drawn = 0;
+    for (const group of DEFAULT_GROUPS) {
+      if (overflow.has(group.id)) {
+        const rows = group.entries.flatMap((entry) => {
+          const row = overflowRow(entry, overrides, t, group.labelKey, render);
+          if (row === null) return [];
+          return [<Fragment key={entry.slot}>{row}</Fragment>];
+        });
+        if (rows.length === 0) continue;
+        sections.push({
+          id: group.id,
+          labelKey: group.labelKey,
+          children: rows,
+        });
+        continue;
+      }
+      // The separator belongs BETWEEN what is on screen. Keyed on the group so a collapse
+      // does not renumber the ones that stayed.
+      if (drawn > 0) bar.push(<ToolbarSeparator key={`separator-${group.id}`} />);
+      drawn += 1;
+      const pinned = TOOLBAR_PINNED_GROUPS.has(group.id);
+      bar.push(
+        <div
+          key={group.id}
+          className="docx-toolbar__group"
+          // Pinned groups are costed as fixed width rather than offered to the fit.
+          {...(pinned ? { [FIXED_ATTRIBUTE]: '' } : { [GROUP_ATTRIBUTE]: group.id })}
+        >
+          {group.entries.map((entry) => (
+            <Fragment key={entry.slot}>{render(entry)}</Fragment>
+          ))}
+        </div>
+      );
+    }
+
     content = (
       <>
-        {DEFAULT_ARRANGEMENT.map((entry, index) => {
-          if (entry.kind === 'separator') return <ToolbarSeparator key={`separator-${index}`} />;
-          const override = overrides.get(entry.slot);
-          // A `hidden` override renders null where it stands, removing the slot.
-          if (override) return <Fragment key={entry.slot}>{override}</Fragment>;
-          const Part = entry.Part;
-          return (
-            <Fragment key={entry.slot}>
-              <Part />
-            </Fragment>
-          );
-        })}
-        {appended}
+        {bar}
+        {appended.length > 0 ? (
+          // Host children never collapse — the library does not own them — so they are
+          // costed as fixed width like a pinned group.
+          <div className="docx-toolbar__group" {...{ [FIXED_ATTRIBUTE]: '' }}>
+            {appended}
+          </div>
+        ) : null}
+        {sections.length > 0 ? <ToolbarOverflow sections={sections} /> : null}
       </>
     );
   }
@@ -216,9 +315,13 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
   return (
     <ToolbarContext.Provider value={context}>
       <div
+        ref={attach}
         role="toolbar"
         data-testid="docx-toolbar"
         className={`docx-toolbar${className ? ` ${className}` : ''}`}
+        // One row when the bar measures itself, wrapping when it does not: the stylesheet
+        // reads this rather than guessing from a breakpoint.
+        {...(measuring ? { 'data-overflow': '' } : {})}
         // Container-level caret guard (CLAUDE.md focus-stealing pitfall): a disabled
         // button never receives mousedown, so per-button handlers cannot cover it.
         // Form fields are exempt inside the guard itself.
@@ -228,6 +331,43 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
       </div>
     </ToolbarContext.Provider>
   );
+}
+
+/** True when an override child removes its slot from the arrangement. */
+function isHiddenOverride(override: ReactElement | undefined): boolean {
+  if (!override) return false;
+  return Boolean((override.props as { hidden?: boolean }).hidden);
+}
+
+/** One row in a collapsed group's overflow panel, or null when hidden. */
+function overflowRow(
+  entry: DefaultEntry,
+  overrides: Map<ArrangementKey, ReactElement>,
+  t: ToolbarTranslate | undefined,
+  groupLabelKey: string,
+  render: (entry: DefaultEntry) => ReactNode
+): ReactNode {
+  const override = overrides.get(entry.slot);
+  if (isHiddenOverride(override)) return null;
+  if (override || isValueSlot(entry.slot)) {
+    return (
+      <ToolbarOverflowControl label={labelOf(t, entry, groupLabelKey)}>
+        {render(entry)}
+      </ToolbarOverflowControl>
+    );
+  }
+  return <ToolbarOverflowItem slot={entry.slot as ChromeSlotId} />;
+}
+
+/** A panel control row's label: the slot's own registry label, else its group's. */
+function labelOf(
+  t: ToolbarTranslate | undefined,
+  entry: DefaultEntry,
+  groupLabelKey: string
+): string {
+  const control = entry.slot === 'alignment' ? null : chromeControlForSlot(entry.slot);
+  const key = control?.labelKey ?? groupLabelKey;
+  return t?.(key) ?? key;
 }
 
 /** The toolbar with its parts attached as statics. @public */

--- a/packages/react/src/editor/toolbar/ToolbarOverflow.tsx
+++ b/packages/react/src/editor/toolbar/ToolbarOverflow.tsx
@@ -1,0 +1,223 @@
+// The "⋯" control: everything the row could not hold, one press away.
+//
+// COMMAND ROWS REUSE ENGINE STATE. Each command row goes through `useEditorCommand` and
+// the chrome registry for icon, label, enabled/active, and disabled reason — the same
+// source as `ToolbarButton` and `Menu.Item`. They render as ordinary buttons inside a
+// non-modal dialog popover so value-bearing controls (font pickers, steppers) can keep
+// their combobox/input semantics and natural Tab traversal.
+//
+// VALUE CONTROLS STAY CONTROLS. Font family, size, colour splits, zoom, line spacing,
+// the style picker and editing-mode pill render in labelled rows with their real parts.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { commandForSlot, type ChromeSlotId } from '@docx-editor.dev/core-contract/editor';
+import { useEditorCommand } from '../useEditorCommand';
+import { useToolbarLabel } from './toolbar-context';
+import { chromeControlForSlot, chromeIcon, guardToolbarMousedown } from './ToolbarButton';
+import { MORE_ATTRIBUTE } from './useToolbarOverflow';
+
+/**
+ * `more_horiz`. Here rather than in the registry for the reason the context menu's icons
+ * are: the trigger is not a chrome slot, and giving it one would put a dead control in the
+ * default arrangement. Material Symbols (Google, Apache-2.0), viewBox "0 -960 960 960".
+ */
+const MORE_PATHS: readonly string[] = [
+  'M240-400q-33 0-56.5-23.5T160-480q0-33 23.5-56.5T240-560q33 0 56.5 23.5T320-480q0 33-23.5 56.5T240-400Zm240 0q-33 0-56.5-23.5T400-480q0-33 23.5-56.5T480-560q33 0 56.5 23.5T560-480q0 33-23.5 56.5T480-400Zm240 0q-33 0-56.5-23.5T640-480q0-33 23.5-56.5T720-560q33 0 56.5 23.5T800-480q0 33-23.5 56.5T720-400Z',
+];
+
+/** One collapsed group in the panel: the registry's label, and the group's rows. */
+export interface ToolbarOverflowSection {
+  readonly id: string;
+  readonly labelKey: string;
+  readonly children: ReactNode;
+}
+
+export interface ToolbarOverflowProps {
+  readonly sections: readonly ToolbarOverflowSection[];
+  readonly className?: string;
+}
+
+interface OverflowPanelContextValue {
+  readonly close: (focusTrigger: boolean) => void;
+}
+
+const OverflowPanelContext = createContext<OverflowPanelContextValue>({
+  close: () => {},
+});
+
+/** Focus the first tabbable control inside the panel. */
+function focusFirstInteractive(panel: HTMLElement): void {
+  const selector =
+    'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  panel.querySelector<HTMLElement>(selector)?.focus();
+}
+
+/**
+ * A labelled row for a control that shows a value: the part itself, with the name the
+ * registry gives it, because a font picker with no label in a vertical list is a mystery.
+ */
+export function ToolbarOverflowControl({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="docx-toolbar__more-control">
+      <span className="docx-toolbar__more-control-label">{label}</span>
+      <span className="docx-toolbar__more-control-body">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * One chrome command in the overflow panel: ordinary button semantics, shared engine state.
+ */
+export function ToolbarOverflowItem({ slot }: { readonly slot: ChromeSlotId }) {
+  const label = useToolbarLabel();
+  const { close } = useContext(OverflowPanelContext);
+  const { execute, isActive, isEnabled, disabledReason } = useEditorCommand(slot);
+  const control = chromeControlForSlot(slot);
+  const command = commandForSlot(slot);
+  const isToggle = command?.type === 'toggleMark' || command?.type === 'setAlignment';
+  const text = label(control?.labelKey ?? slot);
+
+  return (
+    <button
+      type="button"
+      className="docx-toolbar__more-command"
+      data-slot={slot}
+      disabled={!isEnabled}
+      {...(disabledReason ? { title: disabledReason } : {})}
+      {...(isToggle ? { 'aria-pressed': isActive } : {})}
+      {...(isActive ? { 'data-active': '' } : {})}
+      onMouseDown={guardToolbarMousedown}
+      onClick={(event) => {
+        execute();
+        // Keyboard activation unmounts the focused row, so return focus to the trigger.
+        // A pointer click keeps the editor selection focused through the mousedown guard.
+        close(event.detail === 0);
+      }}
+    >
+      <span className="docx-toolbar__more-command-icon" aria-hidden="true">
+        {chromeIcon(control?.paths)}
+      </span>
+      <span className="docx-toolbar__more-command-label">{text}</span>
+    </button>
+  );
+}
+
+/** The trigger and its panel. Rendered by the toolbar only when something overflowed. */
+export function ToolbarOverflow({ sections, className }: ToolbarOverflowProps) {
+  const label = useToolbarLabel();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const focusOnOpenRef = useRef(false);
+  const panelId = useId();
+  const text = label('formattingBar.more');
+
+  const close = useCallback((focusTrigger: boolean) => {
+    setOpen(false);
+    if (focusTrigger) triggerRef.current?.focus();
+  }, []);
+
+  const panelContext = useMemo<OverflowPanelContextValue>(() => ({ close }), [close]);
+
+  // Outside press closes. Capture, for the same reason the review rail listens in capture:
+  // the painted surface calls `preventDefault` on its own pointer handling and a bubbling
+  // listener never sees a press that landed on the pages.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onPointerDown = (event: MouseEvent): void => {
+      const target = event.target;
+      if (target instanceof Node && rootRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown, true);
+    return () => document.removeEventListener('mousedown', onPointerDown, true);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !focusOnOpenRef.current) return;
+    focusOnOpenRef.current = false;
+    const panel = panelRef.current;
+    if (panel) focusFirstInteractive(panel);
+  }, [open]);
+
+  const onPanelKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+    if (event.key !== 'Escape' || event.defaultPrevented) return;
+    event.preventDefault();
+    close(true);
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      className={`docx-toolbar__more${className ? ` ${className}` : ''}`}
+      {...{ [MORE_ATTRIBUTE]: '' }}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        className="docx-toolbar__button docx-toolbar__more-trigger"
+        data-slot="toolbar.more"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        aria-label={text}
+        title={text}
+        {...(open ? { 'data-active': '' } : {})}
+        onMouseDown={guardToolbarMousedown}
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={(event) => {
+          if (event.key !== 'ArrowDown') return;
+          event.preventDefault();
+          focusOnOpenRef.current = true;
+          setOpen(true);
+        }}
+      >
+        {chromeIcon(MORE_PATHS)}
+      </button>
+      {open ? (
+        <OverflowPanelContext.Provider value={panelContext}>
+          <div
+            ref={panelRef}
+            id={panelId}
+            role="dialog"
+            aria-label={text}
+            className="docx-toolbar__more-panel"
+            data-testid="toolbar-overflow-panel"
+            onKeyDown={onPanelKeyDown}
+          >
+            {sections.map((section) => (
+              <div
+                key={section.id}
+                className="docx-toolbar__more-section"
+                role="group"
+                aria-label={label(section.labelKey)}
+              >
+                <span className="docx-toolbar__more-heading" aria-hidden="true">
+                  {label(section.labelKey)}
+                </span>
+                {section.children}
+              </div>
+            ))}
+          </div>
+        </OverflowPanelContext.Provider>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/react/src/editor/toolbar/toolbar-context.ts
+++ b/packages/react/src/editor/toolbar/toolbar-context.ts
@@ -20,6 +20,11 @@ export const ToolbarContext = createContext<ToolbarContextValue>({
   onSave: undefined,
 });
 
+/** The toolbar root's published value. Internal: parts read it, hosts pass props. */
+export function useToolbarContext(): ToolbarContextValue {
+  return useContext(ToolbarContext);
+}
+
 /** The label for an i18n key: the host's translation, or the key itself. */
 export function useToolbarLabel(): (key: string) => string {
   const { t } = useContext(ToolbarContext);

--- a/packages/react/src/editor/toolbar/toolbar-measure.ts
+++ b/packages/react/src/editor/toolbar/toolbar-measure.ts
@@ -1,0 +1,57 @@
+// Pure width accounting for the measured toolbar row.
+//
+// Collapsible groups are costed with the separator slot that precedes them on the bar:
+// separator border-box width, inline margins, and flex gaps on both sides. That
+// overstates the first group by one separator — the safe direction — but must not
+// undercount margins or the bar clips before it collapses.
+//
+// Fixed groups and the More trigger never receive that separator allowance: More sits
+// after flex content with margin-inline-start: auto, not after a rule.
+
+/** Leading separator slot cost for one collapsible group (px). */
+export function separatorLeadingCost(
+  separatorWidth: number,
+  marginInlineStart: number,
+  marginInlineEnd: number,
+  gap: number
+): number {
+  return separatorWidth + marginInlineStart + marginInlineEnd + gap * 2;
+}
+
+/** Total width charged for one collapsible group on the bar. */
+export function collapsibleGroupCost(groupWidth: number, separatorLeading: number): number {
+  return groupWidth + separatorLeading;
+}
+
+/** Flex gap charged after a fixed group or the More trigger. */
+export function trailingGapCost(width: number, gap: number): number {
+  return width + gap;
+}
+
+/** Read inline margins from computed style (px). */
+export function readInlineMargins(style: CSSStyleDeclaration): {
+  readonly start: number;
+  readonly end: number;
+} {
+  const start = Number.parseFloat(style.marginInlineStart || style.marginLeft);
+  const end = Number.parseFloat(style.marginInlineEnd || style.marginRight);
+  return {
+    start: Number.isFinite(start) ? start : 0,
+    end: Number.isFinite(end) ? end : 0,
+  };
+}
+
+function px(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Parse column gap from toolbar computed style. */
+export function readColumnGap(style: CSSStyleDeclaration): number {
+  return px(style.columnGap);
+}
+
+/** Content width inside toolbar horizontal padding. */
+export function readAvailableWidth(bar: HTMLElement, style: CSSStyleDeclaration): number {
+  return bar.clientWidth - px(style.paddingLeft) - px(style.paddingRight);
+}

--- a/packages/react/src/editor/toolbar/toolbar-overflow.ts
+++ b/packages/react/src/editor/toolbar/toolbar-overflow.ts
@@ -1,0 +1,138 @@
+// Which toolbar groups give up their place to the "⋯" menu when the bar runs out of room.
+//
+// THE BAR IS ONE ROW. Wrapping to a second and third row was the old answer, and on a
+// laptop beside an open navigation pane it ate a third of the window before a single line
+// of the document was visible. So the row measures itself and moves whole groups into an
+// overflow menu instead.
+//
+// TWO RULES DECIDE WHAT GOES:
+//
+// - WHOLE GROUPS, never half of one. Half a group leaves a separator standing between
+//   nothing and something, and splits capabilities that were put together on purpose.
+// - A DECLARED ORDER, not "whatever is last". Registry order is bar order, and its tail is
+//   the review controls — the comments toggle and the editing-mode pill, the two things
+//   Word keeps at every width. The order below is the collapse policy of THIS arrangement,
+//   which is the same layer that merges the four alignment slots into one dropdown; the
+//   registry stays free of layout policy.
+//
+// The fit itself is arithmetic over measured widths, so it is a pure function and tests
+// without a DOM.
+
+/**
+ * Collapse order: the first id here is the first group to leave the bar.
+ *
+ * Zoom goes first (a document you cannot format is worse than one you cannot scale), then
+ * the small standalone groups, then the paragraph controls, and text formatting and history
+ * last. A group the registry has but this list does not is collapsed before all of these,
+ * in reverse bar order — a host-added group has no declared standing, and the alternative
+ * is a new group that silently never collapses.
+ */
+export const TOOLBAR_COLLAPSE_ORDER: readonly string[] = [
+  'zoom',
+  'script',
+  'format',
+  'list',
+  'alignment',
+  'styles',
+  'font',
+  'text',
+  'history',
+];
+
+/**
+ * Groups that never move into the overflow menu.
+ *
+ * `review` holds the comments toggle and the editing-mode pill. The comments rail is
+ * reached through that toggle and nothing else, and a narrow window is exactly where a
+ * reader needs it, so burying it one menu deep is the wrong trade.
+ */
+export const TOOLBAR_PINNED_GROUPS: ReadonlySet<string> = new Set(['review']);
+
+/**
+ * Px of surplus a group must find before it comes back OUT of the overflow menu.
+ *
+ * Without it a value control that widens with its own value (font family going from
+ * "Arial" to "Times New Roman") pushes itself out, which frees the width that pulled it
+ * back in, forever. One-directional slack breaks the loop.
+ */
+export const TOOLBAR_OVERFLOW_HYSTERESIS = 24;
+
+/** No group overflows. Shared so an unmeasured toolbar returns a stable identity. */
+const NONE: ReadonlySet<string> = new Set<string>();
+
+/** What {@link toolbarOverflowGroups} measures against. */
+export interface ToolbarFitInput {
+  /** Content width of the bar, in px. `0` or less means "not measured yet". */
+  readonly available: number;
+  /** Group id -> measured width, separator and gaps included. */
+  readonly widths: ReadonlyMap<string, number>;
+  /** Collapsible groups, in bar order. */
+  readonly groups: readonly string[];
+  /** Collapse order; ids missing from it collapse first, in reverse bar order. */
+  readonly order: readonly string[];
+  /** Width of everything that never collapses: pinned groups, appended children, padding. */
+  readonly fixed: number;
+  /** Width the "⋯" trigger takes once it is shown. */
+  readonly more: number;
+  /** The previous answer, for the one-directional slack. */
+  readonly previous?: ReadonlySet<string> | undefined;
+  readonly hysteresis?: number;
+}
+
+/** The collapse order actually used: the declared one, with undeclared groups first. */
+export function collapseOrder(
+  groups: readonly string[],
+  order: readonly string[] = TOOLBAR_COLLAPSE_ORDER
+): readonly string[] {
+  const declared = order.filter((id) => groups.includes(id));
+  const undeclared = groups.filter((id) => !order.includes(id)).reverse();
+  return [...undeclared, ...declared];
+}
+
+function fit(input: ToolbarFitInput, available: number): ReadonlySet<string> {
+  const { widths, groups, order, fixed, more } = input;
+  let total = fixed;
+  for (const id of groups) total += widths.get(id) ?? 0;
+  if (total <= available) return NONE;
+
+  // Showing the trigger costs width of its own, so it joins the total the moment the bar
+  // is known not to fit. Ignoring it collapsed one group too few at every threshold.
+  total += more;
+  const overflow = new Set<string>();
+  for (const id of order) {
+    if (total <= available) break;
+    const width = widths.get(id);
+    if (width === undefined || overflow.has(id)) continue;
+    overflow.add(id);
+    total -= width;
+  }
+  return overflow;
+}
+
+function sameIds(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a === b) return true;
+  if (a.size !== b.size) return false;
+  for (const id of a) if (!b.has(id)) return false;
+  return true;
+}
+
+/** True when two answers describe the same bar, so a re-render can be skipped. */
+export const sameOverflow = sameIds;
+
+/**
+ * The groups that must leave the bar for the rest of it to fit in one row.
+ *
+ * An unmeasured bar (`available <= 0`, which is every server render and every jsdom test)
+ * overflows nothing: the full toolbar is the honest answer when nothing is known about the
+ * space, and it is also what a host that opted out of overflow renders.
+ */
+export function toolbarOverflowGroups(input: ToolbarFitInput): ReadonlySet<string> {
+  if (!(input.available > 0)) return NONE;
+  const next = fit(input, input.available);
+  const previous = input.previous;
+  // Growing the overflow is immediate; shrinking it has to clear the slack, or a control
+  // whose width follows its own value oscillates across the threshold.
+  if (!previous || previous.size === 0 || next.size >= previous.size) return next;
+  const relaxed = fit(input, input.available - (input.hysteresis ?? TOOLBAR_OVERFLOW_HYSTERESIS));
+  return sameIds(relaxed, previous) ? previous : relaxed;
+}

--- a/packages/react/src/editor/toolbar/useToolbarOverflow.ts
+++ b/packages/react/src/editor/toolbar/useToolbarOverflow.ts
@@ -1,0 +1,183 @@
+// The toolbar's own measurement: how wide each group is, and how much room the bar has.
+//
+// MEASURED, NOT BREAKPOINTED. A media query knows the window's width and nothing about the
+// bar: the same 1200px window holds a different toolbar with a navigation pane open, at
+// 150% zoom, in German, or with a host that appended two buttons of its own. The bar reads
+// its own children instead, so all four cases land on the same rule.
+//
+// MEASUREMENT IS FREE HERE. Everything is read inside a ResizeObserver callback, which the
+// browser delivers after layout has already been computed — so nothing in this file
+// forces a reflow. The one exception is the mount pass, which reads once against the fully
+// rendered bar to learn every group's width; that is also what makes a group that has been
+// in the overflow menu since the first frame still have a known width to come back on.
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  sameOverflow,
+  toolbarOverflowGroups,
+  TOOLBAR_OVERFLOW_HYSTERESIS,
+  type ToolbarFitInput,
+} from './toolbar-overflow';
+import {
+  collapsibleGroupCost,
+  readAvailableWidth,
+  readColumnGap,
+  readInlineMargins,
+  separatorLeadingCost,
+  trailingGapCost,
+} from './toolbar-measure';
+
+/** Marks a collapsible group wrapper; the value is the group id. */
+export const GROUP_ATTRIBUTE = 'data-toolbar-group';
+/** Marks anything that stays in the bar at every width (pinned groups, host children). */
+export const FIXED_ATTRIBUTE = 'data-toolbar-fixed';
+/** Marks the "⋯" trigger. */
+export const MORE_ATTRIBUTE = 'data-toolbar-more';
+
+/** Assumed trigger width before one has ever been rendered: the icon-button size. */
+const ASSUMED_MORE_WIDTH = 34;
+
+const NONE: ReadonlySet<string> = new Set<string>();
+
+export interface UseToolbarOverflowResult {
+  /** Attach to the bar element. */
+  readonly attach: (element: HTMLDivElement | null) => void;
+  /** Group ids that must render in the "⋯" menu instead of the bar. */
+  readonly overflow: ReadonlySet<string>;
+}
+
+/**
+ * Measures the bar and answers which groups have to move into the overflow menu.
+ *
+ * `enabled` false is inert: no observer, no reads, and an empty answer, which renders the
+ * complete bar exactly as it did before overflow existed.
+ */
+export function useToolbarOverflow(
+  enabled: boolean,
+  groups: readonly string[],
+  order: readonly string[]
+): UseToolbarOverflowResult {
+  const barRef = useRef<HTMLDivElement | null>(null);
+  // Widths SURVIVE a group leaving the bar. A group in the overflow menu renders nothing to
+  // measure, and forgetting its width would mean never knowing whether it could come back.
+  const widths = useRef(new Map<string, number>());
+  const moreWidth = useRef(ASSUMED_MORE_WIDTH);
+  const [overflow, setOverflow] = useState<ReadonlySet<string>>(NONE);
+  const overflowRef = useRef(overflow);
+  overflowRef.current = overflow;
+
+  // Latest inputs, read inside the measure callback without re-creating it (and with it the
+  // observer) whenever a parent re-renders with a fresh array literal.
+  const inputs = useRef({ groups, order });
+  inputs.current = { groups, order };
+
+  const measure = useCallback(() => {
+    const bar = barRef.current;
+    if (!bar || !enabled) return;
+    const style = getComputedStyle(bar);
+    const gap = readColumnGap(style);
+    const available = readAvailableWidth(bar, style);
+    // Every collapsible group is costed WITH a leading separator slot — width, inline
+    // margins, and flex gaps — including the first one, which does not have a separator.
+    // That overstates the row by one separator and makes the bar collapse a few px early,
+    // the safe direction, since the other one clips.
+    const separator = bar.querySelector<HTMLElement>('.docx-toolbar__separator');
+    let separatorLeading = gap * 2;
+    if (separator) {
+      const sepStyle = getComputedStyle(separator);
+      const margins = readInlineMargins(sepStyle);
+      separatorLeading = separatorLeadingCost(
+        separator.offsetWidth,
+        margins.start,
+        margins.end,
+        gap
+      );
+    }
+
+    for (const element of bar.querySelectorAll<HTMLElement>(`[${GROUP_ATTRIBUTE}]`)) {
+      const id = element.getAttribute(GROUP_ATTRIBUTE);
+      // A group mid-transition can measure zero; keeping the last real width beats
+      // recording a zero that would make it look free forever.
+      if (id && element.offsetWidth > 0) {
+        widths.current.set(id, collapsibleGroupCost(element.offsetWidth, separatorLeading));
+      }
+    }
+    let fixed = 0;
+    for (const element of bar.querySelectorAll<HTMLElement>(`[${FIXED_ATTRIBUTE}]`)) {
+      if (element.offsetWidth > 0) fixed += trailingGapCost(element.offsetWidth, gap);
+    }
+    const more = bar.querySelector<HTMLElement>(`[${MORE_ATTRIBUTE}]`);
+    if (more && more.offsetWidth > 0) {
+      // More follows flex content; it is not preceded by a separator rule.
+      moreWidth.current = trailingGapCost(more.offsetWidth, gap);
+    }
+
+    const input: ToolbarFitInput = {
+      available,
+      widths: widths.current,
+      groups: inputs.current.groups,
+      order: inputs.current.order,
+      fixed,
+      more: moreWidth.current,
+      previous: overflowRef.current,
+      hysteresis: TOOLBAR_OVERFLOW_HYSTERESIS,
+    };
+    const next = toolbarOverflowGroups(input);
+    if (!sameOverflow(next, overflowRef.current)) {
+      overflowRef.current = next;
+      setOverflow(next);
+    }
+  }, [enabled]);
+
+  const attach = useCallback((element: HTMLDivElement | null) => {
+    barRef.current = element;
+  }, []);
+
+  // The mount pass, against the complete bar: the only forced read in the file, and the one
+  // that gives every group a width before any of them can be hidden. In a layout effect so
+  // the collapsed bar is what the browser paints — measuring after paint shows the user one
+  // frame of the three-row toolbar this exists to remove.
+  useLayoutEffect(() => {
+    if (!enabled) {
+      if (overflowRef.current.size > 0) {
+        overflowRef.current = NONE;
+        setOverflow(NONE);
+      }
+      return;
+    }
+    measure();
+  }, [enabled, measure]);
+
+  // Width changes come from two directions and both are observed: the bar's own box (window
+  // resize, a navigation pane opening) and each group's content (a longer font name, a
+  // locale with longer labels, a host restyling a control).
+  useEffect(() => {
+    const bar = barRef.current;
+    if (!enabled || !bar || typeof ResizeObserver === 'undefined') return undefined;
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      // Coalesced: a window drag delivers a callback per frame per observed element, and
+      // the answer only ever depends on the final geometry of the frame.
+      if (frame !== 0) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        measure();
+      });
+    });
+    observer.observe(bar);
+    for (const element of bar.querySelectorAll<HTMLElement>(
+      `[${GROUP_ATTRIBUTE}], [${FIXED_ATTRIBUTE}]`
+    )) {
+      observer.observe(element);
+    }
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+    // Re-observes when the composition changes: a group that just came back into the bar is
+    // a new element, and an unobserved one stops reporting the growth that would push it out
+    // again. `overflow` in the deps is what makes that re-attachment happen.
+  }, [enabled, measure, overflow]);
+
+  return { attach, overflow };
+}

--- a/packages/react/test/toolbar-composition.test.tsx
+++ b/packages/react/test/toolbar-composition.test.tsx
@@ -102,12 +102,41 @@ function toolbarElement(view: ReturnType<typeof render>): HTMLElement {
   return view.getByTestId('docx-toolbar');
 }
 
-/** Toolbar children flattened to comparable identities, for order assertions. */
-function childIdentities(toolbar: HTMLElement): string[] {
-  return [...toolbar.children].map((child) => {
+function entryIdentity(entry: Element): string {
+  if (entry.getAttribute('role') === 'separator') return 'separator';
+  return entry.getAttribute('data-slot') ?? entry.getAttribute('aria-label') ?? entry.className;
+}
+
+/** Flatten intentional top-level group wrappers; keep separators and direct children. */
+function toolbarArrangement(toolbar: HTMLElement): string[] {
+  return [...toolbar.children].flatMap((child) => {
     if (child.getAttribute('role') === 'separator') return 'separator';
-    return child.getAttribute('data-slot') ?? child.getAttribute('aria-label') ?? child.className;
+    if (child.classList.contains('docx-toolbar__group')) {
+      return [...child.children].map(entryIdentity);
+    }
+    return entryIdentity(child);
   });
+}
+
+function entryRootAtFlatIndex(toolbar: HTMLElement, index: number): Element | null {
+  let flat = 0;
+  for (const child of toolbar.children) {
+    if (child.getAttribute('role') === 'separator') {
+      if (flat === index) return child;
+      flat += 1;
+      continue;
+    }
+    if (child.classList.contains('docx-toolbar__group')) {
+      for (const entry of child.children) {
+        if (flat === index) return entry;
+        flat += 1;
+      }
+      continue;
+    }
+    if (flat === index) return child;
+    flat += 1;
+  }
+  return null;
 }
 
 afterEach(() => {
@@ -121,7 +150,7 @@ describe('the default arrangement', () => {
     // The arrangement is derived from the registry on both sides of this assertion —
     // the 10 non-contextual groups, alignment merged — so a registry change updates
     // both in lockstep.
-    expect(childIdentities(toolbar)).toEqual([...EXPECTED_ARRANGEMENT]);
+    expect(toolbarArrangement(toolbar)).toEqual([...EXPECTED_ARRANGEMENT]);
     // Every slot is present exactly once.
     for (const slot of EXPECTED_ARRANGEMENT) {
       if (slot === 'separator') continue;
@@ -145,15 +174,19 @@ describe('the default arrangement', () => {
     );
     const toolbar = toolbarElement(view);
     // Same full arrangement (plus the appended extra), with Bold still in its place.
-    const identities = childIdentities(toolbar);
+    const identities = toolbarArrangement(toolbar);
     expect(identities.slice(0, EXPECTED_ARRANGEMENT.length)).toEqual([...EXPECTED_ARRANGEMENT]);
-    expect(toolbar.children.length).toBe(EXPECTED_ARRANGEMENT.length + 1);
     // The Bold in the arrangement IS the override (its className landed).
     const bold = view.container.querySelector('[aria-label="formattingBar.boldShortcut"]')!;
     expect(bold.className).toContain('custom-bold');
-    expect(toolbar.children[EXPECTED_ARRANGEMENT.indexOf('text.bold')]).toBe(bold);
-    // The non-part child appended after the default set.
-    expect(toolbar.lastElementChild).toBe(view.getByTestId('extra'));
+    const boldIndex = EXPECTED_ARRANGEMENT.indexOf('text.bold');
+    expect(identities[boldIndex]).toBe('text.bold');
+    expect(entryRootAtFlatIndex(toolbar, boldIndex)!.contains(bold)).toBe(true);
+    // The non-part child appended in a fixed group after the default set.
+    const appended = toolbar.querySelector(
+      ':scope > .docx-toolbar__group[data-toolbar-fixed]:last-of-type'
+    )!;
+    expect(appended.contains(view.getByTestId('extra'))).toBe(true);
   });
 
   test('a hidden part child removes its slot from the arrangement', () => {
@@ -164,7 +197,7 @@ describe('the default arrangement', () => {
     );
     const toolbar = toolbarElement(view);
     expect(view.container.querySelector('[aria-label="formattingBar.strikethrough"]')).toBeNull();
-    expect(toolbar.children.length).toBe(EXPECTED_ARRANGEMENT.length - 1);
+    expect(toolbarArrangement(toolbar).length).toBe(EXPECTED_ARRANGEMENT.length - 1);
     // Neighbours unaffected: underline still present, alignment group intact.
     expect(
       view.container.querySelector('[aria-label="formattingBar.underlineShortcut"]')
@@ -180,7 +213,7 @@ describe('the default arrangement', () => {
       </DocxEditorToolbar>
     );
     const toolbar = toolbarElement(view);
-    expect(childIdentities(toolbar)).toEqual(['text.bold', 'separator', 'history.undo']);
+    expect(toolbarArrangement(toolbar)).toEqual(['text.bold', 'separator', 'history.undo']);
   });
 });
 
@@ -239,7 +272,10 @@ describe('live button state', () => {
     )!;
     // Appended after the whole default arrangement — it drives no slot.
     const toolbar = toolbarElement(view);
-    expect(toolbar.lastElementChild).toBe(action);
+    const appended = toolbar.querySelector(
+      ':scope > .docx-toolbar__group[data-toolbar-fixed]:last-of-type'
+    )!;
+    expect(appended.contains(action)).toBe(true);
     expect(action.className).toContain('docx-toolbar__button');
 
     // The caret guard is the reason this is a component and not a documented class name.

--- a/packages/react/test/toolbar-measure.test.ts
+++ b/packages/react/test/toolbar-measure.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  collapsibleGroupCost,
+  separatorLeadingCost,
+  trailingGapCost,
+} from '../src/editor/toolbar/toolbar-measure.ts';
+
+describe('toolbar width accounting', () => {
+  test('separator leading cost includes width, inline margins, and both flex gaps', () => {
+    // 1px rule + 6px margins each side + 2px gap twice (toolbar gap: 2px).
+    expect(separatorLeadingCost(1, 6, 6, 2)).toBe(17);
+  });
+
+  test('collapsible group cost adds the group width to the leading separator slot', () => {
+    expect(collapsibleGroupCost(90, 17)).toBe(107);
+  });
+
+  test('fixed and More widths use trailing gap only, not a separator allowance', () => {
+    expect(trailingGapCost(140, 2)).toBe(142);
+    expect(trailingGapCost(34, 2)).toBe(36);
+  });
+
+  test('old undercount (width + 2 gaps only) is 12px short of the separator slot', () => {
+    const legacy = 1 + 2 * 2;
+    const corrected = separatorLeadingCost(1, 6, 6, 2);
+    expect(corrected - legacy).toBe(12);
+  });
+});

--- a/packages/react/test/toolbar-overflow-react.test.tsx
+++ b/packages/react/test/toolbar-overflow-react.test.tsx
@@ -1,0 +1,371 @@
+// Responsive toolbar overflow: measured one-row collapse, More dialog, and opt-outs.
+//
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import type { ReactNode } from 'react';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { zipSync, strToU8 } from 'fflate';
+import type { DocxEditorInstance } from '@docx-editor.dev/core-contract/editor';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorToolbar } from '../src/editor/toolbar/index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
+
+/** Shared ResizeObserver harness for overflow measurement tests in this file only. */
+class MockResizeObserver {
+  static readonly instances: MockResizeObserver[] = [];
+  private readonly callback: ResizeObserverCallback;
+  readonly observed: Element[] = [];
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    MockResizeObserver.instances.push(this);
+  }
+
+  observe(element: Element): void {
+    this.observed.push(element);
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {
+    const index = MockResizeObserver.instances.indexOf(this);
+    if (index >= 0) MockResizeObserver.instances.splice(index, 1);
+  }
+
+  flush(): void {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+const RealResizeObserver = global.ResizeObserver;
+
+/** Same selector as `focusFirstInteractive` in ToolbarOverflow.tsx. */
+const OVERFLOW_FIRST_INTERACTIVE =
+  'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function installResizeObserverMock(): void {
+  MockResizeObserver.instances.length = 0;
+  global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+}
+
+function mockBarGeometry(
+  toolbar: HTMLElement,
+  options: { barWidth: number; groupWidth: number; fixedWidth?: number }
+): void {
+  toolbar.style.width = `${options.barWidth}px`;
+  toolbar.style.boxSizing = 'border-box';
+  Object.defineProperty(toolbar, 'clientWidth', {
+    configurable: true,
+    get: () => options.barWidth,
+  });
+  for (const group of toolbar.querySelectorAll('[data-toolbar-group]')) {
+    const width = options.groupWidth;
+    Object.defineProperty(group, 'offsetWidth', { configurable: true, get: () => width });
+  }
+  for (const fixed of toolbar.querySelectorAll('[data-toolbar-fixed]')) {
+    const width = options.fixedWidth ?? options.groupWidth;
+    Object.defineProperty(fixed, 'offsetWidth', { configurable: true, get: () => width });
+  }
+  const separator = toolbar.querySelector('.docx-toolbar__separator');
+  if (separator) {
+    Object.defineProperty(separator, 'offsetWidth', { configurable: true, get: () => 1 });
+  }
+}
+
+async function collapseToolbar(
+  view: ReturnType<typeof render>,
+  options: { barWidth: number; groupWidth?: number; fixedWidth?: number } = {
+    barWidth: 280,
+    groupWidth: 90,
+    fixedWidth: 140,
+  }
+): Promise<HTMLElement> {
+  const toolbar = view.getByTestId('docx-toolbar');
+  mockBarGeometry(toolbar, {
+    barWidth: options.barWidth,
+    groupWidth: options.groupWidth ?? 90,
+    fixedWidth: options.fixedWidth ?? 140,
+  });
+  await act(async () => {
+    for (const observer of MockResizeObserver.instances) observer.flush();
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+  return toolbar;
+}
+
+function mountToolbar(
+  toolbar: ReactNode,
+  source: Uint8Array = SOURCE
+): { view: ReturnType<typeof render>; editor: () => DocxEditorInstance } {
+  let instance: DocxEditorInstance | null = null;
+  const view = render(
+    <DocxEditorRoot
+      document={source}
+      onReady={(editor) => {
+        instance = editor as DocxEditorInstance;
+      }}
+    >
+      {toolbar}
+      <DocxEditorViewport>
+        <DocxEditorContent />
+      </DocxEditorViewport>
+    </DocxEditorRoot>
+  );
+  return { view, editor: () => instance! };
+}
+
+beforeEach(() => {
+  MockResizeObserver.instances.length = 0;
+});
+
+afterEach(() => {
+  cleanup();
+  global.ResizeObserver = RealResizeObserver;
+});
+
+describe('toolbar overflow integration', () => {
+  test('overflow={false} keeps wrapping and does not measure', () => {
+    const { view } = mountToolbar(<DocxEditorToolbar overflow={false} />);
+    const toolbar = view.getByTestId('docx-toolbar');
+    expect(toolbar.hasAttribute('data-overflow')).toBe(false);
+    expect(view.queryByLabelText('formattingBar.more')).toBeNull();
+    expect(MockResizeObserver.instances.length).toBe(0);
+  });
+
+  test('preset={false} renders verbatim markup without group wrappers or measurement', () => {
+    const { view } = mountToolbar(
+      <DocxEditorToolbar preset={false}>
+        <DocxEditorToolbar.Bold />
+        <DocxEditorToolbar.Undo />
+      </DocxEditorToolbar>
+    );
+    const toolbar = view.getByTestId('docx-toolbar');
+    expect(toolbar.querySelector('.docx-toolbar__group')).toBeNull();
+    expect(toolbar.hasAttribute('data-overflow')).toBe(false);
+    expect(MockResizeObserver.instances.length).toBe(0);
+  });
+
+  test('collapses groups into More in collapse order and keeps review pinned', async () => {
+    installResizeObserverMock();
+    const { view } = mountToolbar(
+      <DocxEditorToolbar t={(key) => (key === 'formattingBar.more' ? 'More' : key)} />
+    );
+    const toolbar = await collapseToolbar(view, { barWidth: 360 });
+
+    expect(
+      MockResizeObserver.instances.some((observer) =>
+        observer.observed.some((element) => element.hasAttribute('data-toolbar-fixed'))
+      )
+    ).toBe(true);
+    expect(toolbar.querySelector('[data-slot="zoom.level"]')).toBeNull();
+    expect(toolbar.querySelector('[data-slot="review.comments"]')).not.toBeNull();
+    expect(toolbar.querySelector('[data-slot="review.editingMode"]')).not.toBeNull();
+
+    const trigger = view.getByLabelText('More');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('dialog');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    await act(async () => {
+      trigger.click();
+    });
+    const panel = view.getByTestId('toolbar-overflow-panel');
+    expect(panel.getAttribute('role')).toBe('dialog');
+    expect(panel.hasAttribute('aria-modal')).toBe(false);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(panel.querySelector('[data-slot="zoom.level"]')).not.toBeNull();
+    expect(
+      panel.querySelector('[role="group"][aria-label="formattingBar.groups.zoom"]')
+    ).not.toBeNull();
+    expect(panel.querySelector('[role="menuitem"]')).toBeNull();
+    expect(panel.querySelector('.docx-toolbar__more-command')).not.toBeNull();
+  });
+
+  test('More dialog closes on Escape, outside click, and command selection', async () => {
+    installResizeObserverMock();
+    const { view } = mountToolbar(
+      <DocxEditorToolbar t={(key) => (key === 'formattingBar.more' ? 'More' : key)} />
+    );
+    await collapseToolbar(view, { barWidth: 280 });
+
+    const trigger = view.getByLabelText('More') as HTMLButtonElement;
+    await act(async () => {
+      trigger.click();
+    });
+    expect(view.queryByTestId('toolbar-overflow-panel')).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.keyDown(view.getByTestId('toolbar-overflow-panel'), { key: 'Escape' });
+    });
+    expect(view.queryByTestId('toolbar-overflow-panel')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+
+    await act(async () => {
+      trigger.click();
+    });
+    await act(async () => {
+      fireEvent.mouseDown(document.body, { bubbles: true });
+    });
+    expect(view.queryByTestId('toolbar-overflow-panel')).toBeNull();
+  });
+
+  test('a command in the overflow dialog executes through shared engine state', async () => {
+    installResizeObserverMock();
+    const { view, editor } = mountToolbar(
+      <DocxEditorToolbar t={(key) => (key === 'formattingBar.more' ? 'More' : key)} />
+    );
+    await waitFor(() => {
+      expect(editor().surface).not.toBeNull();
+    });
+    await act(async () => {
+      editor().surface!.selectAll();
+    });
+
+    const toolbar = await collapseToolbar(view, { barWidth: 240 });
+
+    const trigger = view.getByLabelText('More');
+    expect(toolbar.querySelector('[data-slot="text.bold"]')).toBeNull();
+    await act(async () => {
+      trigger.click();
+    });
+
+    const bold = view.container.querySelector(
+      '[data-testid="toolbar-overflow-panel"] [data-slot="text.bold"]'
+    ) as HTMLButtonElement;
+    expect(bold.className).toContain('docx-toolbar__more-command');
+    expect(bold.getAttribute('role')).toBeNull();
+    expect(bold.disabled).toBe(false);
+
+    await act(async () => {
+      bold.click();
+    });
+    expect(editor().snapshot().formatting?.bold).toBe(true);
+    expect(view.queryByTestId('toolbar-overflow-panel')).toBeNull();
+  });
+
+  test('hidden override is absent when its group collapses into More', async () => {
+    installResizeObserverMock();
+    const { view } = mountToolbar(
+      <DocxEditorToolbar t={(key) => (key === 'formattingBar.more' ? 'More' : key)}>
+        <DocxEditorToolbar.Strike hidden />
+      </DocxEditorToolbar>
+    );
+    await collapseToolbar(view, { barWidth: 240 });
+
+    await act(async () => {
+      view.getByLabelText('More').click();
+    });
+    const panel = view.getByTestId('toolbar-overflow-panel');
+    expect(panel.querySelector('[data-slot="text.strike"]')).toBeNull();
+    expect(panel.querySelector('[aria-label="formattingBar.strikethrough"]')).toBeNull();
+  });
+
+  test('ArrowDown on the trigger opens the dialog and focuses the first control', async () => {
+    installResizeObserverMock();
+    const { view } = mountToolbar(
+      <DocxEditorToolbar t={(key) => (key === 'formattingBar.more' ? 'More' : key)} />
+    );
+    await collapseToolbar(view, { barWidth: 280 });
+
+    const trigger = view.getByLabelText('More') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    });
+
+    const panel = view.getByTestId('toolbar-overflow-panel');
+    const firstControl = panel.querySelector<HTMLElement>(OVERFLOW_FIRST_INTERACTIVE);
+    expect(firstControl).not.toBeNull();
+    await waitFor(() => {
+      const active = document.activeElement;
+      expect(active).not.toBeNull();
+      expect(active).not.toBe(trigger);
+      expect(panel.contains(active)).toBe(true);
+      expect(active instanceof HTMLElement && active.matches(OVERFLOW_FIRST_INTERACTIVE)).toBe(
+        true
+      );
+      expect(
+        Array.from(panel.querySelectorAll<HTMLElement>(OVERFLOW_FIRST_INTERACTIVE)).indexOf(
+          active as HTMLElement
+        )
+      ).toBe(0);
+    });
+  });
+
+  test('ArrowDown inside a value control is not hijacked by the dialog', async () => {
+    installResizeObserverMock();
+    const { view, editor } = mountToolbar(
+      <DocxEditorToolbar t={(key) => (key === 'formattingBar.more' ? 'More' : key)} />
+    );
+    await waitFor(() => {
+      expect(view.container.querySelectorAll('.docx-page').length).toBeGreaterThan(0);
+    });
+    await act(async () => {
+      editor().surface!.selectAll();
+    });
+    await collapseToolbar(view, { barWidth: 200, groupWidth: 100, fixedWidth: 160 });
+
+    await act(async () => {
+      view.getByLabelText('More').click();
+    });
+    const panel = view.getByTestId('toolbar-overflow-panel');
+    const fontTrigger = panel.querySelector(
+      '.docx-toolbar__font-family-trigger'
+    ) as HTMLButtonElement;
+    expect(fontTrigger).not.toBeNull();
+    fontTrigger.focus();
+
+    let defaultPrevented = false;
+    await act(async () => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        bubbles: true,
+        cancelable: true,
+      });
+      event.preventDefault = () => {
+        defaultPrevented = true;
+      };
+      fontTrigger.dispatchEvent(event);
+    });
+    expect(defaultPrevented).toBe(false);
+  });
+
+  test('the overflow panel uses viewport-bounded logical sizing', () => {
+    const css = readFileSync(new URL('../../core/src/styles/editor.css', import.meta.url), 'utf8');
+    const rule = css.match(/\.docx-toolbar__more-panel\s*\{[^}]+\}/)?.[0] ?? '';
+    expect(rule).toContain('box-sizing: border-box');
+    expect(rule).toContain('inline-size: min(340px, calc(100vw - 16px))');
+    expect(rule).toContain('min-inline-size: min(260px, calc(100vw - 16px))');
+    expect(rule).toContain('max-height: min(72vh, 560px)');
+  });
+});

--- a/packages/react/test/toolbar-overflow.test.ts
+++ b/packages/react/test/toolbar-overflow.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  TOOLBAR_COLLAPSE_ORDER,
+  TOOLBAR_OVERFLOW_HYSTERESIS,
+  TOOLBAR_PINNED_GROUPS,
+  collapseOrder,
+  sameOverflow,
+  toolbarOverflowGroups,
+  type ToolbarFitInput,
+} from '../src/editor/toolbar/toolbar-overflow.ts';
+
+function fit(
+  available: number,
+  widths: Record<string, number>,
+  groups: readonly string[],
+  order: readonly string[],
+  fixed = 0,
+  more = 34,
+  previous?: ReadonlySet<string>,
+  hysteresis?: number
+): ReadonlySet<string> {
+  const input: ToolbarFitInput = {
+    available,
+    widths: new Map(Object.entries(widths)),
+    groups,
+    order,
+    fixed,
+    more,
+    previous,
+    hysteresis,
+  };
+  return toolbarOverflowGroups(input);
+}
+
+const BAR_GROUPS = [
+  'history',
+  'zoom',
+  'styles',
+  'font',
+  'text',
+  'script',
+  'alignment',
+  'list',
+  'format',
+] as const;
+
+describe('toolbar overflow policy', () => {
+  test('collapseOrder puts undeclared groups first, in reverse bar order', () => {
+    const groups = ['history', 'zoom', 'custom', 'text'];
+    expect(collapseOrder(groups)).toEqual(['custom', 'zoom', 'text', 'history']);
+  });
+
+  test('collapseOrder follows the declared order for known groups', () => {
+    expect(collapseOrder([...BAR_GROUPS])).toEqual([...TOOLBAR_COLLAPSE_ORDER]);
+  });
+
+  test('an unmeasured bar overflows nothing', () => {
+    expect(fit(0, { zoom: 100 }, ['zoom'], TOOLBAR_COLLAPSE_ORDER).size).toBe(0);
+    expect(fit(-10, { zoom: 100 }, ['zoom'], TOOLBAR_COLLAPSE_ORDER).size).toBe(0);
+  });
+
+  test('collapses in declared order, zoom first', () => {
+    const widths = Object.fromEntries(BAR_GROUPS.map((id) => [id, 100]));
+    const order = collapseOrder(BAR_GROUPS);
+    const overflow = fit(400, widths, BAR_GROUPS, order, 120, 34);
+    expect(overflow.has('zoom')).toBe(true);
+    expect(overflow.has('history')).toBe(false);
+    expect(overflow.has('text')).toBe(false);
+    expect([...overflow][0]).toBe('zoom');
+  });
+
+  test('accounts for the More trigger width once overflow is needed', () => {
+    const widths = { keep: 100, drop: 50 };
+    const groups = ['keep', 'drop'];
+    const order = ['drop', 'keep'];
+    expect(fit(150, widths, groups, order, 0, 34).size).toBe(0);
+    expect(fit(149, widths, groups, order, 0, 34)).toEqual(new Set(['drop']));
+  });
+
+  test('hysteresis keeps a group in overflow until surplus clears the slack', () => {
+    const widths = { keep: 100, drop: 100 };
+    const groups = ['keep', 'drop'];
+    const order = ['drop', 'keep'];
+    const previous = new Set(['drop']);
+    expect(fit(200, widths, groups, order, 0, 34, previous, TOOLBAR_OVERFLOW_HYSTERESIS)).toEqual(
+      previous
+    );
+    expect(fit(224, widths, groups, order, 0, 34, previous, TOOLBAR_OVERFLOW_HYSTERESIS).size).toBe(
+      0
+    );
+  });
+
+  test('pinned review is excluded from collapsible groups at the toolbar layer', () => {
+    expect(TOOLBAR_PINNED_GROUPS.has('review')).toBe(true);
+    expect(BAR_GROUPS.includes('review' as (typeof BAR_GROUPS)[number])).toBe(false);
+  });
+
+  test('sameOverflow compares set contents', () => {
+    const a = new Set(['zoom']);
+    const b = new Set(['zoom']);
+    expect(sameOverflow(a, b)).toBe(true);
+    expect(sameOverflow(a, new Set(['text']))).toBe(false);
+    expect(sameOverflow(a, a)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the preset React toolbar on one row by collapsing complete control groups into an accessible overflow dialog
- preserve pinned review controls, custom composition, wrapping opt-out, and shared command state

## Test plan
- [x] `bun test packages/react/test/toolbar-composition.test.tsx packages/react/test/toolbar-overflow.test.ts packages/react/test/toolbar-measure.test.ts packages/react/test/toolbar-overflow-react.test.tsx` (53 passed)
- [x] `bun run typecheck`
- [x] `bun run check:parity-contract && bun run check:adapter-css-thin && bun run i18n:validate`
- [ ] Full suite on the current base: 3553 passed, 34 existing review/tracked-edit and CSS-token failures
- [ ] Full docs parity: existing public-docs surface drift

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788452086&installation_model_id=422592&pr_number=115&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F115&signature=ec9d743ec53874c78391ad7644025161e570e04decda7fbe1a0db8d2536360aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->