### PR TITLE
fix: open review sidebar for new review items

### DIFF
--- a/.changeset/open-review-sidebar.md
+++ b/.changeset/open-review-sidebar.md
@@ -2,4 +2,5 @@
 '@docx-editor.dev/react': patch
 ---
 
-Open the review sidebar when starting a comment or recording a tracked change.
+Open the review sidebar when starting a comment or recording a tracked change, use the editor's
+primary blue for comment controls, and dismiss uncommitted drafts when the sidebar closes.

--- a/.changeset/open-review-sidebar.md
+++ b/.changeset/open-review-sidebar.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Open the review sidebar when starting a comment or recording a tracked change.

--- a/packages/core/src/editor/__tests__/review-facade.test.ts
+++ b/packages/core/src/editor/__tests__/review-facade.test.ts
@@ -669,6 +669,17 @@ describe('the review pane', () => {
     expect(editor.snapshot().reviewPaneOpen).toBe(false);
   });
 
+  test('reopens when suggesting commits another tracked change', () => {
+    const editor = mount({ body: '<w:p><w:r><w:t>plain text</w:t></w:r></w:p>' });
+    editor.setEditingMode('suggesting');
+    editor.exec({ type: 'toggleReviewPane' });
+    expect(editor.isReviewPaneOpen()).toBe(false);
+
+    editor.surface!.type('X');
+
+    expect(editor.isReviewPaneOpen()).toBe(true);
+  });
+
   test('the queue counter moves on a toggle, so a subscriber re-renders', () => {
     const editor = mount({ body: INSERTION });
     const before = editor.getReviewRevision();

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -135,6 +135,7 @@ import {
 import {
   mountPaginatedSurface,
   type PaginatedSurface,
+  type PaginatedSurfaceOptions,
   type PaginatedSurfaceState,
 } from './paginated-surface.ts';
 import type {
@@ -336,6 +337,12 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // host's chrome wired to the surface it replaced.
       onHyperlinkPopover: (activation) => liveHyperlinkChrome().onPopover?.(activation),
       onRequestHyperlink: () => liveHyperlinkChrome().onRequest?.(),
+      onTrackedChange: () => {
+        if (reviewPaneOpen) return;
+        reviewPaneOpen = true;
+        bump();
+        emitSelectionChange();
+      },
       onChange: (state) => {
         // The mount-time render reports before `surface` is assigned; nothing observable
         // has changed at that point, so it is not a selection change.
@@ -363,7 +370,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         lastSelection = state.selection;
         emitSelectionChange();
       },
-    });
+    } as PaginatedSurfaceOptions & { readonly onTrackedChange?: () => void });
     if (!result.ok) {
       parseError = result.detail ? `${result.reason}: ${result.detail}` : result.reason;
       // Failure is observable state too: `snapshot().parseError` moved.

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -121,6 +121,9 @@ export function mountPaginatedSurface(
   bytes: Uint8Array,
   options: PaginatedSurfaceOptions = {}
 ): OpenPaginatedResult {
+  const runtimeOptions = options as PaginatedSurfaceOptions & {
+    readonly onTrackedChange?: () => void;
+  };
   const opened = openTreeSession(bytes);
   if (!opened.ok) {
     return {
@@ -787,7 +790,12 @@ export function mountPaginatedSurface(
 
     // `storyScope()` so an edit inside a header, a footer or a note is applied to that story
     // rather than to the body.
-    return session.applyTreeOps(trackedOps(ops), selectionBefore, selectionAfter, storyScope());
+    const attributed = trackedOps(ops);
+    const result = session.applyTreeOps(attributed, selectionBefore, selectionAfter, storyScope());
+    if (result.committed && editingMode === 'suggest' && attributed.some(isTrackedEdit)) {
+      runtimeOptions.onTrackedChange?.();
+    }
+    return result;
   }
 
   /** Ops that change the DOCUMENT, as opposed to reading or resolving it. */
@@ -798,6 +806,20 @@ export function mountPaginatedSurface(
       op.op !== 'acceptAllRevisions' &&
       op.op !== 'rejectAllRevisions'
     );
+  }
+
+  /** Ops that create or extend a reviewable proposal. */
+  function isTrackedEdit(op: TreeDocOp): boolean {
+    switch (op.op) {
+      case 'insertText':
+      case 'deleteText':
+        return op.revision !== undefined;
+      case 'setParagraphMarkRevision':
+      case 'proposeParagraphMerge':
+        return true;
+      default:
+        return false;
+    }
   }
 
   /** Text ops become tracked ones while suggesting; everything else is untouched. */

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3830,7 +3830,7 @@ a.docx-hyperlink:focus-visible {
   border-radius: 8px;
   background: var(--doc-surface, #fff);
   box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
-  color: var(--doc-accent, #1a73e8);
+  color: var(--doc-primary, #1a73e8);
   cursor: pointer;
   pointer-events: auto;
 }
@@ -3841,14 +3841,14 @@ a.docx-hyperlink:focus-visible {
    through its right, split down the middle. Mixed into the surface colour it stays one
    solid shape wherever it sits. */
 .docx-review__add:hover {
-  background: color-mix(in srgb, var(--doc-accent, #1a73e8) 8%, var(--doc-surface, #fff));
-  border-color: color-mix(in srgb, var(--doc-accent, #1a73e8) 35%, var(--doc-border, #e3e5e8));
+  background: color-mix(in srgb, var(--doc-primary, #1a73e8) 8%, var(--doc-surface, #fff));
+  border-color: color-mix(in srgb, var(--doc-primary, #1a73e8) 35%, var(--doc-border, #e3e5e8));
   box-shadow: 0 2px 6px rgb(0 0 0 / 14%);
 }
 
 /* A card being composed reads as unfinished until it is committed. */
 .docx-review__card[data-draft] {
-  border-color: var(--doc-accent, #1a73e8);
+  border-color: var(--doc-primary, #1a73e8);
 }
 
 .docx-review__markers {
@@ -4413,7 +4413,7 @@ a.docx-hyperlink:focus-visible {
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: var(--doc-accent, #1a73e8);
+  color: var(--doc-primary, #1a73e8);
   font: inherit;
   font-weight: 500;
   cursor: pointer;
@@ -4427,7 +4427,7 @@ a.docx-hyperlink:focus-visible {
   padding: 6px 14px;
   border: 0;
   border-radius: 999px;
-  background: var(--doc-accent, #1a73e8);
+  background: var(--doc-primary, #1a73e8);
   color: #fff;
   font: inherit;
   font-weight: 500;

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -203,6 +203,7 @@ function ReviewRoot({
 }: ReviewProps) {
   const editor = useDocxEditor();
   const review = useReview();
+  const setReviewPaneOpen = review.setPaneOpen;
   const { t } = useTranslation();
   const railRef = useRef<HTMLElement | null>(null);
   // Claim the gutter. Without this the viewport reserved it for every consumer, mounted
@@ -376,8 +377,9 @@ function ReviewRoot({
     // Pin the range before the compose box takes focus, or the browser drops the highlight
     // off the very words the comment is about.
     editor.surface?.retainSelection();
+    setReviewPaneOpen(true);
     setDraftAnchorY(editor.getSelectionPlacement()?.anchorY ?? null);
-  }, [editor]);
+  }, [editor, setReviewPaneOpen]);
   const endDraft = useCallback(() => {
     editor?.surface?.releaseSelection();
     setDraftAnchorY(null);

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -387,6 +387,13 @@ function ReviewRoot({
     // `<body>` with Tab restarting at the top of the page.
     editor?.focus();
   }, [editor]);
+  useEffect(() => {
+    if (open || draftAnchorY === null) return;
+    // Closing the pane abandons its uncommitted draft. Release the pinned range without
+    // moving focus away from the toolbar control that closed it.
+    editor?.surface?.releaseSelection();
+    setDraftAnchorY(null);
+  }, [open, draftAnchorY, editor]);
 
   // The compose CARD stacks with the cards, because it is one: rendered outside the run it
   // landed on top of the card whose text had just been re-selected, and its anchor IS that
@@ -448,7 +455,7 @@ function ReviewRoot({
         'AddComment',
         <ReviewAddComment top={composeTop} drafting={draftAnchorY !== null} />
       )}
-      {draftAnchorY === null || composeTop === null
+      {!open || draftAnchorY === null || composeTop === null
         ? null
         : takeRoot('Draft', <ReviewDraft top={composeTop} />)}
     </>

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -29,6 +29,7 @@ import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
 import { DocxEditorPageNumber } from '../src/editor/DocxEditorPageNumber.tsx';
+import { DocxEditorReview } from '../src/editor/DocxEditorReview.tsx';
 import { useDocxEditor } from '../src/editor/context.ts';
 import { useEditorState } from '../src/editor/useEditorState.ts';
 import { useEditorCommand, type EditorCommandState } from '../src/editor/useEditorCommand.ts';
@@ -222,6 +223,38 @@ describe('useEditorCommand', () => {
       })
     ).not.toThrow();
     expect(instance!.surface!.session.bodyText()).toBe(before);
+  });
+});
+
+describe('the review sidebar', () => {
+  test('opens when the add-comment affordance starts a draft', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={SOURCE}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const editor = instance!;
+    await act(async () => {
+      editor.surface!.selectAll();
+      editor.exec({ type: 'toggleReviewPane' });
+    });
+    expect(editor.isReviewPaneOpen()).toBe(false);
+
+    await act(async () => {
+      view.getByTestId('review-add-comment').click();
+    });
+
+    expect(editor.isReviewPaneOpen()).toBe(true);
+    expect(view.getByTestId('review-draft')).toBeDefined();
   });
 });
 

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -256,6 +256,37 @@ describe('the review sidebar', () => {
     expect(editor.isReviewPaneOpen()).toBe(true);
     expect(view.getByTestId('review-draft')).toBeDefined();
   });
+
+  test('removes an open comment draft when the sidebar closes', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={SOURCE}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const editor = instance!;
+    await act(async () => {
+      editor.surface!.selectAll();
+    });
+    await act(async () => {
+      view.getByTestId('review-add-comment').click();
+    });
+    expect(view.getByTestId('review-draft')).toBeDefined();
+
+    await act(async () => {
+      editor.exec({ type: 'toggleReviewPane' });
+    });
+
+    expect(view.queryByTestId('review-draft')).toBeNull();
+  });
 });
 
 describe('useEditorEvent', () => {


### PR DESCRIPTION
## Summary
- Open the review sidebar when starting a comment or committing a tracked edit.

## Test plan
- [x] `bun test`
- [x] Core and React typechecks
- [x] React API snapshot check


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454199&installation_model_id=422592&pr_number=116&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F116&signature=8204bc7733a05cc084f0119d7826d555364fea35a5020f8414e428b1176d2f6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->