### PR TITLE
fix(react): keep navigation clear of review pane

### DIFF
--- a/.changeset/fix-navigation-review-overflow.md
+++ b/.changeset/fix-navigation-review-overflow.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Keep the document clear of navigation when the review pane is open, with horizontal scrolling on narrow screens.

--- a/examples/vite/src/styles.css
+++ b/examples/vite/src/styles.css
@@ -266,8 +266,10 @@
    no pane-aware padding of its own. */
 .demo-ruler-row {
   display: flex;
-  justify-content: center;
-  padding: 6px 20px 2px;
+  /* Match the page stack: centre while it fits, then pin to the inline start when the
+     navigation + review reservations force horizontal overflow. */
+  justify-content: safe center;
+  padding: 6px 0 2px;
   overflow: hidden;
   flex: none;
 }

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -10,18 +10,17 @@
 // no relayout storm at mousemove frequency. Editability follows what the engine reports
 // (`usePageSetup().isEnabled`), so against a read-only document the handles stay inert.
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactElement } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core-contract/contracts/editor';
 import type { RulerIndent } from '@docx-editor.dev/core-contract/editor';
 import { HorizontalRuler, type RulerPageSetup } from '../components/ui/HorizontalRuler';
 import { VerticalRuler } from '../components/ui/VerticalRuler';
-import { useContext } from 'react';
 import { ReviewRailContext, useDocxEditor } from './context';
 import { useEditorState } from './useEditorState';
 import { usePageSetup } from './usePageSetup';
 import { useParagraphIndent } from './useParagraphIndent';
-import { useNavigationShift } from './navigation/navigation-layout';
+import { useNavigationShift, useNavigationViewportElement } from './navigation/navigation-layout';
 
 const selectZoom = (snapshot: EditorSnapshot): number => snapshot.zoom;
 
@@ -149,6 +148,25 @@ function useIndentDrag(): IndentDrag {
   );
 }
 
+/** Horizontal viewport movement shared by the painted page and the ruler above it. */
+function useViewportScrollLeft(): number {
+  const viewport = useNavigationViewportElement();
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  useEffect(() => {
+    if (!viewport) {
+      setScrollLeft(0);
+      return undefined;
+    }
+    const sync = () => setScrollLeft(viewport.scrollLeft);
+    sync();
+    viewport.addEventListener('scroll', sync, { passive: true });
+    return () => viewport.removeEventListener('scroll', sync);
+  }, [viewport]);
+
+  return scrollLeft;
+}
+
 /**
  * The horizontal ruler as a context-fed part (`DocxEditor.HorizontalRuler`): page
  * width, margins and zoom straight from the editor. Left/right margin handles are
@@ -168,6 +186,7 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
   // the right. Same values, same easing, so the ticks stay over the page they measure.
   const shift = useNavigationShift();
   const reserved = useReviewGutter();
+  const scrollLeft = useViewportScrollLeft();
   return (
     <HorizontalRuler
       pageSetup={previewed(pageSetup, pending)}
@@ -196,6 +215,8 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
         // `margin`, not one edge: the review pane moves the other side, and animating only
         // `margin-inline-start` left the ruler snapping while the page glided.
         transition: 'margin 0.2s ease',
+        // The ruler lives above the scroller, so mirror its horizontal movement explicitly.
+        transform: `${props.style?.transform ? `${props.style.transform} ` : ''}translateX(${-scrollLeft}px)`,
       }}
     />
   );

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -217,6 +217,10 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
         transition: 'margin 0.2s ease',
         // The ruler lives above the scroller, so mirror its horizontal movement explicitly.
         transform: `${props.style?.transform ? `${props.style.transform} ` : ''}translateX(${-scrollLeft}px)`,
+        // Navigation is below this row and cannot physically cover the ruler. Clip the
+        // scrolled portion at the same boundary so ticks never show above the pane.
+        clipPath:
+          shift > 0 && scrollLeft > 0 ? `inset(0 0 0 ${scrollLeft}px)` : props.style?.clipPath,
       }}
     />
   );

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -184,6 +184,9 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
       unit={props.unit ?? 'inch'}
       className={props.className ?? ''}
       style={{
+        // A ruler always represents the full page width. In a narrow host its surrounding
+        // row overflows; shrinking the ruler would move its ticks off the document.
+        flexShrink: 0,
         marginRight: reserved,
         ...props.style,
         // The ruler is centred by its host row, so the same rule applies as to the page:

--- a/packages/react/src/editor/navigation/navigation-geometry.ts
+++ b/packages/react/src/editor/navigation/navigation-geometry.ts
@@ -38,6 +38,8 @@ export interface NavigationShiftInput {
   readonly pageWidthPx: number;
   /** Space the open pane needs, from {@link navigationPaneReservation}. */
   readonly reservation: number;
+  /** Padding already reserved at the inline end, for example by the review rail. */
+  readonly inlineEndReservation?: number;
 }
 
 /**
@@ -52,12 +54,17 @@ export function navigationShift({
   viewportWidth,
   pageWidthPx,
   reservation,
+  inlineEndReservation = 0,
 }: NavigationShiftInput): number {
   if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return 0;
   if (!Number.isFinite(pageWidthPx) || pageWidthPx <= 0) return 0;
   if (!Number.isFinite(reservation) || reservation <= 0) return 0;
+  if (!Number.isFinite(inlineEndReservation) || inlineEndReservation < 0) return 0;
 
-  const gutter = (viewportWidth - pageWidthPx) / 2;
+  // A review rail (or other inline-end chrome) reduces the box in which the page centres.
+  // Ignoring it makes the left gutter look wider than it is, so navigation can cover the
+  // page instead of pushing the combined layout into horizontal overflow.
+  const gutter = (viewportWidth - inlineEndReservation - pageWidthPx) / 2;
   // Already room to the left of the page: the pane overlays empty space, the page holds
   // still. This is the common case on any reasonably wide window, and it is the whole
   // point of computing a shift instead of hard-coding one.

--- a/packages/react/src/editor/navigation/useNavigationPane.ts
+++ b/packages/react/src/editor/navigation/useNavigationPane.ts
@@ -10,9 +10,10 @@
 // setup and zoom, NOT a DOM query for a painted page: a pane opened before the first paint
 // would otherwise measure nothing and settle a frame later, which reads as a flinch.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { EditorSnapshot, PageSetup } from '@docx-editor.dev/core-contract/contracts/editor';
 import { twipsToPixels } from '../../lib/units';
+import { ReviewRailContext } from '../context';
 import { useEditorState } from '../useEditorState';
 import {
   NAVIGATION_PANE_WIDTH,
@@ -26,15 +27,19 @@ export type NavigationTab = 'headings' | 'find';
 
 const selectPageGeometry = (
   snapshot: EditorSnapshot
-): { pageSetup: PageSetup | null; zoom: number } => ({
+): { pageSetup: PageSetup | null; zoom: number; reviewPaneOpen: boolean } => ({
   pageSetup: snapshot.pageSetup ?? null,
   zoom: snapshot.zoom,
+  reviewPaneOpen: snapshot.reviewPaneOpen ?? true,
 });
 
 const samePageGeometry = (
-  a: { pageSetup: PageSetup | null; zoom: number },
-  b: { pageSetup: PageSetup | null; zoom: number }
-) => a.zoom === b.zoom && a.pageSetup?.pageWidthTwips === b.pageSetup?.pageWidthTwips;
+  a: { pageSetup: PageSetup | null; zoom: number; reviewPaneOpen: boolean },
+  b: { pageSetup: PageSetup | null; zoom: number; reviewPaneOpen: boolean }
+) =>
+  a.zoom === b.zoom &&
+  a.reviewPaneOpen === b.reviewPaneOpen &&
+  a.pageSetup?.pageWidthTwips === b.pageSetup?.pageWidthTwips;
 
 /** How `useNavigationPane` is configured. @public */
 export interface UseNavigationPaneOptions {
@@ -111,8 +116,10 @@ export function useNavigationPane(options: UseNavigationPaneOptions = {}): UseNa
   // ── Displacement ────────────────────────────────────────────────────────────────────
   const store = useNavigationLayoutStore();
   const viewport = useNavigationViewportElement();
-  const { pageSetup, zoom } = useEditorState(selectPageGeometry, samePageGeometry);
+  const rail = useContext(ReviewRailContext);
+  const { pageSetup, zoom, reviewPaneOpen } = useEditorState(selectPageGeometry, samePageGeometry);
   const [viewportWidth, setViewportWidth] = useState(0);
+  const [inlineEndReservation, setInlineEndReservation] = useState(0);
 
   // `open` is a dependency as well as `viewport`: a window resized while the pane was
   // closed leaves no observation to react to (a hidden or throttled tab delivers no
@@ -121,14 +128,20 @@ export function useNavigationPane(options: UseNavigationPaneOptions = {}): UseNa
   useEffect(() => {
     if (!viewport) {
       setViewportWidth(0);
+      setInlineEndReservation(0);
       return undefined;
     }
-    setViewportWidth(viewport.clientWidth);
+    const measure = () => {
+      setViewportWidth(viewport.clientWidth);
+      const padding = Number.parseFloat(getComputedStyle(viewport).paddingInlineEnd);
+      setInlineEndReservation(Number.isFinite(padding) ? padding : 0);
+    };
+    measure();
     if (typeof ResizeObserver === 'undefined') return undefined;
-    const observer = new ResizeObserver(() => setViewportWidth(viewport.clientWidth));
+    const observer = new ResizeObserver(measure);
     observer.observe(viewport);
     return () => observer.disconnect();
-  }, [viewport, open]);
+  }, [viewport, open, reviewPaneOpen, rail?.mounted]);
 
   // The snapshot reports `pageSetup` as null on some ticks even with a document loaded,
   // and a shift derived from one of those would collapse to zero and snap the page
@@ -145,8 +158,9 @@ export function useNavigationPane(options: UseNavigationPaneOptions = {}): UseNa
       viewportWidth,
       pageWidthPx: twipsToPixels(pageWidthTwips) * zoom,
       reservation: navigationPaneReservation(paneWidth),
+      inlineEndReservation,
     });
-  }, [open, pageWidthTwips, zoom, viewportWidth, paneWidth]);
+  }, [open, pageWidthTwips, zoom, viewportWidth, paneWidth, inlineEndReservation]);
 
   useEffect(() => {
     if (!store) return undefined;

--- a/packages/react/test/chrome-parts.test.tsx
+++ b/packages/react/test/chrome-parts.test.tsx
@@ -119,6 +119,17 @@ describe('the context-fed ruler parts', () => {
     expect(view.container.querySelectorAll('.docx-ruler-indent').length).toBe(4);
   });
 
+  test('HorizontalRuler follows the document viewport horizontally', () => {
+    const { view } = mountWith(<DocxEditorHorizontalRuler />, PLAIN_SOURCE);
+    const viewport = view.container.querySelector('.docx-editor__scroll-container') as HTMLElement;
+    const ruler = view.container.querySelector('.docx-horizontal-ruler') as HTMLElement;
+
+    viewport.scrollLeft = 125;
+    fireEvent.scroll(viewport);
+
+    expect(ruler.style.transform).toBe('translateX(-125px)');
+  });
+
   test('dragging the left margin zone commits ONE setPageSetup step on release', async () => {
     const { view, editor } = mountWith(<DocxEditorHorizontalRuler />, PLAIN_SOURCE);
     const ruler = view.container.querySelector('.docx-horizontal-ruler') as HTMLElement;

--- a/packages/react/test/chrome-parts.test.tsx
+++ b/packages/react/test/chrome-parts.test.tsx
@@ -114,6 +114,7 @@ describe('the context-fed ruler parts', () => {
     const ruler = view.container.querySelector('.docx-horizontal-ruler') as HTMLElement;
     expect(ruler).not.toBeNull();
     expect(ruler.style.width).toBe('816px');
+    expect(ruler.style.flexShrink).toBe('0');
     // Word's four indent handles: first-line, hanging, left, right.
     expect(view.container.querySelectorAll('.docx-ruler-indent').length).toBe(4);
   });

--- a/packages/react/test/navigation-pane.test.tsx
+++ b/packages/react/test/navigation-pane.test.tsx
@@ -88,13 +88,28 @@ describe('navigationShift', () => {
     );
   });
 
+  test('accounts for an open review rail and overflows instead of covering the page', () => {
+    // The review rail reserves 316px on the right. Ignoring that padding returns 272px,
+    // leaving the page 40px underneath the navigation pane. With both panes included the
+    // page pins immediately after navigation and the combined layout overflows horizontally.
+    const viewportWidth = 1200;
+    const reviewReservation = 316;
+    const shift = navigationShift({
+      viewportWidth,
+      pageWidthPx: PAGE,
+      reservation: RESERVATION,
+      inlineEndReservation: reviewReservation,
+    });
+    expect(shift).toBe(RESERVATION);
+    expect(shift + PAGE + reviewReservation).toBeGreaterThan(viewportWidth);
+  });
+
   test('never moves the page further than it must, at any width', () => {
     for (let viewportWidth = 500; viewportWidth <= 2400; viewportWidth += 17) {
       const shift = navigationShift({ viewportWidth, pageWidthPx: PAGE, reservation: RESERVATION });
       const gutter = (viewportWidth - PAGE) / 2;
       // Where the page ends up, in the two regimes the painted surface actually has.
-      const pageLeft =
-        viewportWidth - shift >= PAGE ? gutter + shift / 2 : shift;
+      const pageLeft = viewportWidth - shift >= PAGE ? gutter + shift / 2 : shift;
       // Always clears the pane...
       expect(pageLeft).toBeGreaterThanOrEqual(RESERVATION - 1);
       // ...and never overshoots it by more than the rounding to a whole pixel.


### PR DESCRIPTION
## Summary
- account for the review gutter when positioning open navigation on narrow screens
- keep the horizontal ruler aligned with the horizontally overflowing document

## Test plan
- [x] `bun test packages/react/test/navigation-pane.test.tsx packages/react/test/chrome-parts.test.tsx`
- [x] `bun run typecheck`
- [x] verify ruler and page edges remain aligned at 1200px with both panes open


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454274&installation_model_id=422592&pr_number=117&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F117&signature=3e375feea651f790baccd5da69714cda2075547c056b6743dc35223392fac259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->