### PR TITLE
feat(core): position floating tables at their anchor

### DIFF
--- a/.changeset/floating-table-position.md
+++ b/.changeset/floating-table-position.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Render floating tables at their anchored position. A table carrying `w:tblpPr` is placed against the text, margin or page box it names, so a centred callout table no longer renders flush against the left margin.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -397,6 +397,17 @@ export const wordFeatures: WordFeature[] = [
       'Table styles resolve through their basedOn chain: borders, cell margins, shading and the paragraph/run formatting a conditional format carries (so a header row comes out bold and centred) all come from styles.xml, gated by w:tblLook, with an explicit w:cnfStyle taking precedence. Conditional cell margins and switching table styles from the UI are not built yet.',
   },
   {
+    id: 'tables.floating',
+    name: 'Floating tables (tblpPr anchored position)',
+    category: 'tables',
+    editing: 'none',
+    rendering: 'partial',
+    roundTrip: 'full',
+    tier: 'community',
+    notes:
+      'An anchored table lands where Word puts it across the page: tblpXSpec/tblpX against the text, margin or page box, plus a tblpY offset from the text anchor. Text does not yet wrap beside it, and page- or margin-anchored vertical positions keep their place in the flow.',
+  },
+  {
     id: 'tables.text-direction',
     name: 'Vertical cell text (textDirection)',
     category: 'tables',

--- a/packages/core/src/layout/__tests__/table-float-position.test.ts
+++ b/packages/core/src/layout/__tests__/table-float-position.test.ts
@@ -1,0 +1,196 @@
+// `w:tblpPr` (17.4.57): a table positioned against an anchor box rather than at the point
+// in the text where it was authored.
+//
+// Word's floating table is also pulled out of the flow so text wraps beside it. That part
+// is not modelled — the table keeps its place in the flow and only its position within the
+// line of the page moves. A centred callout table therefore lands where Word draws it,
+// while the paragraphs around it still clear it top-to-bottom.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import {
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlPart,
+} from '../../store/package/ooxml-tree.ts';
+import { readTableStructure, tableFloatOriginX } from '../semantic-table.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import type { TableFragmentRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function part(xml: string, name = '/word/document.xml'): OoxmlPart {
+  const result = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const documentOf = (bodyXml: string) =>
+  part(`<w:document xmlns:w="${W}"><w:body>${bodyXml}</w:body></w:document>`);
+
+function tableNode(bodyXml: string): OoxmlElement {
+  const found = documentOf(bodyXml)
+    .root.children.flatMap((child) => (child.kind === 'textValue' ? [] : child.children))
+    .find((child) => child.kind === 'table');
+  if (!found) throw new Error('no table');
+  return found as OoxmlElement;
+}
+
+/** Letter portrait with 1" margins, the default `layoutSemanticDocument` geometry. */
+const CONTENT_WIDTH_PT = 468;
+const FRAMES = {
+  text: { left: 0, width: CONTENT_WIDTH_PT },
+  margin: { left: 0, width: CONTENT_WIDTH_PT },
+  page: { left: -72, width: 612 },
+} as const;
+
+const cell = () => `<w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc>`;
+/** 144pt wide, leaving 324pt of slack in the text column. */
+const narrow = `<w:tblGrid><w:gridCol w:w="1440"/><w:gridCol w:w="1440"/></w:tblGrid><w:tr>${cell()}${cell()}</w:tr>`;
+const TABLE_WIDTH_PT = 144;
+
+const structureOf = (bodyXml: string, depth = 0) =>
+  readTableStructure(tableNode(bodyXml), CONTENT_WIDTH_PT, depth)!;
+
+const floatingTable = (tblpPr: string) =>
+  `<w:tbl><w:tblPr>${tblpPr}<w:tblW w:type="dxa" w:w="2880"/></w:tblPr>${narrow}</w:tbl>`;
+
+function firstTable(bodyXml: string): TableFragmentRecord {
+  const fragment = layoutSemanticDocument(documentOf(bodyXml), 0, {
+    measurer: createFixedMeasurer(),
+  })
+    .pages.flatMap((page) => page.fragments)
+    .find((item): item is TableFragmentRecord => item.kind === 'table');
+  if (!fragment) throw new Error('no table fragment');
+  return fragment;
+}
+
+describe('w:tblpPr is read off the table', () => {
+  test('an absent w:tblpPr leaves the table unfloated', () => {
+    expect(structureOf(floatingTable('')).float).toBeUndefined();
+  });
+
+  test('anchors default to text and offsets convert to points', () => {
+    const float = structureOf(floatingTable('<w:tblpPr w:tblpX="720" w:tblpY="200"/>')).float;
+    expect(float).toEqual({ horzAnchor: 'text', vertAnchor: 'text', xPt: 36, yPt: 10 });
+  });
+
+  test('a negative offset survives — Word pulls a table into the margin with one', () => {
+    const float = structureOf(floatingTable('<w:tblpPr w:tblpX="-720"/>')).float;
+    expect(float?.xPt).toBe(-36);
+  });
+
+  test('an unrecognised spec is dropped, leaving the offset to place the table', () => {
+    const float = structureOf(
+      floatingTable('<w:tblpPr w:tblpXSpec="sideways" w:tblpX="720"/>')
+    ).float;
+    expect(float?.xSpec).toBeUndefined();
+    expect(float?.xPt).toBe(36);
+  });
+
+  test('a nested table stays in flow — Word floats only the top-level one', () => {
+    expect(structureOf(floatingTable('<w:tblpPr w:tblpXSpec="center"/>'), 1).float).toBeUndefined();
+  });
+});
+
+describe('tableFloatOriginX places the table against its anchor', () => {
+  const originOf = (tblpPr: string) => {
+    const structure = structureOf(floatingTable(tblpPr));
+    return tableFloatOriginX(structure.float!, TABLE_WIDTH_PT, FRAMES);
+  };
+
+  test('tblpXSpec="center" centres the table in the anchor box', () => {
+    expect(originOf('<w:tblpPr w:horzAnchor="margin" w:tblpXSpec="center"/>')).toBe(162);
+  });
+
+  test('tblpXSpec="right" puts the trailing edge on the anchor box edge', () => {
+    expect(originOf('<w:tblpPr w:horzAnchor="margin" w:tblpXSpec="right"/>')).toBe(324);
+  });
+
+  test('a spec supersedes tblpX (17.4.57)', () => {
+    expect(originOf('<w:tblpPr w:horzAnchor="margin" w:tblpXSpec="center" w:tblpX="2880"/>')).toBe(
+      162
+    );
+  });
+
+  test('inside/outside render as left/right without mirrored margins', () => {
+    expect(originOf('<w:tblpPr w:horzAnchor="margin" w:tblpXSpec="inside"/>')).toBe(0);
+    expect(originOf('<w:tblpPr w:horzAnchor="margin" w:tblpXSpec="outside"/>')).toBe(324);
+  });
+
+  test('the page anchor measures from the sheet edge, not the margin', () => {
+    // 1" from the sheet edge is 1" left of the text column, whose x is 0.
+    expect(originOf('<w:tblpPr w:horzAnchor="page" w:tblpX="1440"/>')).toBe(0);
+    expect(originOf('<w:tblpPr w:horzAnchor="page" w:tblpXSpec="left"/>')).toBe(-72);
+  });
+
+  test('a hostile offset keeps the leading edge on the sheet', () => {
+    expect(originOf('<w:tblpPr w:tblpX="999999999"/>')).toBe(540);
+    expect(originOf('<w:tblpPr w:tblpX="-999999999"/>')).toBe(-72);
+  });
+});
+
+describe('a floated table lays out at its anchored position', () => {
+  const paragraph = '<w:p><w:r><w:t>lead</w:t></w:r></w:p>';
+
+  test('the fragment box and every row share the floated origin', () => {
+    const fragment = firstTable(
+      paragraph + floatingTable('<w:tblpPr w:horzAnchor="margin" w:tblpXSpec="center"/>')
+    );
+    expect(fragment.box.x).toBeCloseTo(162, 3);
+    for (const row of fragment.rows) expect(row.box.x).toBeCloseTo(162, 3);
+    expect(fragment.rows[0]!.cells[0]!.box.x).toBeCloseTo(162, 3);
+  });
+
+  test('an unfloated table is unaffected', () => {
+    const fragment = firstTable(paragraph + floatingTable(''));
+    expect(fragment.box.x).toBeCloseTo(0, 3);
+  });
+
+  test('tblpY against the text anchor moves the table down the flow', () => {
+    const inFlow = firstTable(paragraph + floatingTable('')).box.y;
+    const floated = firstTable(paragraph + floatingTable('<w:tblpPr w:tblpY="200"/>')).box.y;
+    expect(floated - inFlow).toBeCloseTo(10, 3);
+  });
+
+  test('the comprehensive fixture §16 callout table centres on the margin', () => {
+    const bytes = readFileSync(
+      `${import.meta.dir}/../../../../../e2e/fixtures/comprehensive-word-element-test.docx`
+    );
+    const opened = readOoxmlPackage(bytes);
+    if (!opened.ok) throw new Error(opened.reason);
+    const main = opened.package.parts.get(opened.package.mainDocumentPart)!;
+    const layout = layoutSemanticDocument(main, 0, { measurer: createFixedMeasurer() });
+    const table = layout.pages
+      .flatMap((page) => page.fragments)
+      .find(
+        (fragment): fragment is TableFragmentRecord =>
+          fragment.kind === 'table' &&
+          fragment.rows.some((row) =>
+            row.cells.some((cellRecord) =>
+              cellRecord.blocks.some(
+                (block) =>
+                  block.kind === 'paragraph' &&
+                  block.lines.some((line) =>
+                    line.spans.some((span) => span.text.includes('Uptime'))
+                  )
+              )
+            )
+          )
+      );
+    if (!table) throw new Error('§16 floating table not found');
+    // `tblpXSpec="center"` with `horzAnchor="margin"` — the table sits centred in the text
+    // area, not flush left where an unfloated table lands.
+    expect(table.box.x).toBeCloseTo((CONTENT_WIDTH_PT - table.box.width) / 2, 3);
+    expect(table.box.x).toBeGreaterThan(1);
+  });
+
+  test('a page-anchored tblpY is not applied — the table stays in flow', () => {
+    const inFlow = firstTable(paragraph + floatingTable('')).box.y;
+    const floated = firstTable(
+      paragraph + floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="2880"/>')
+    ).box.y;
+    expect(floated).toBeCloseTo(inFlow, 3);
+  });
+});

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -59,7 +59,13 @@ import {
   type StyleCascadeTable,
 } from './style-cascade.ts';
 import { paragraphShadingBox } from './ooxml-shading.ts';
-import { readTableStructure, tableOriginX, type SemanticTableRow } from './semantic-table.ts';
+import {
+  readTableStructure,
+  tableFloatOriginX,
+  tableOriginX,
+  type SemanticTableRow,
+  type TableAnchorFrames,
+} from './semantic-table.ts';
 import {
   createTableBorderOwnershipBudget,
   createTableVMergeResolveBudget,
@@ -646,6 +652,15 @@ function layoutBlocksWithGeometry(
   let regionFragmentStart = 0;
   const columnLeft = (): number => columns.lefts[columnIndex]!;
   const columnWidth = (): number => columns.widths[columnIndex]!;
+  /**
+   * The boxes `w:horzAnchor` can name, in the content-box coordinates every fragment box is
+   * reported in: x=0 is the left margin, so the sheet starts one left margin before it.
+   */
+  const anchorFrames = (): TableAnchorFrames => ({
+    text: { left: columnLeft(), width: columnWidth() },
+    margin: { left: 0, width: pageContentWidth },
+    page: { left: -geometry.margin.left, width: geometry.width },
+  });
   const regionHasFragments = (): boolean => pageFragments.length > regionFragmentStart;
   // A continuous section resumes the previous section's column rather than opening a
   // sheet, so its first block starts at that column's used height and its first paragraph
@@ -870,9 +885,21 @@ function layoutBlocksWithGeometry(
     const regionWidth = columnWidth();
     const structure = readTableStructure(table, regionWidth, 0, styleCascade, displayMode);
     if (!structure || structure.rows.length === 0) return;
-    // `w:tblInd` / `w:jc` place the table inside the text column; every row and the fragment
-    // box share the one origin so cell geometry and the reported box cannot drift apart.
-    let tableLeft = columnLeft() + tableOriginX(structure, regionWidth);
+    // `w:tblInd` / `w:jc` place the table inside the text column, `w:tblpPr` against a wider
+    // anchor box; every row and the fragment box share the one origin so cell geometry and
+    // the reported box cannot drift apart.
+    const tableWidthPt = structure.columnWidthsPt.reduce((sum, column) => sum + column, 0);
+    const originX = (): number =>
+      structure.float
+        ? tableFloatOriginX(structure.float, tableWidthPt, anchorFrames())
+        : columnLeft() + tableOriginX(structure, columnWidth());
+    let tableLeft = originX();
+    // `w:tblpY` against the text anchor is an offset from where the table would otherwise
+    // sit, so it moves the table within the flow. The page and margin anchors state an
+    // absolute position on the sheet, which this layout does not model — those stay in flow.
+    if (structure.float && structure.float.vertAnchor === 'text' && !structure.float.ySpec) {
+      cursorY = Math.max(0, Math.min(cursorY + structure.float.yPt, contentHeight()));
+    }
     const headerRows: SemanticTableRow[] = [];
     for (const row of structure.rows) {
       if (row.isHeader) headerRows.push(row);
@@ -946,7 +973,7 @@ function layoutBlocksWithGeometry(
       if (cursorY + groupHeight > contentHeight() + 0.001 && cursorY > 0) {
         closeTableFragment();
         advanceColumn();
-        tableLeft = columnLeft() + tableOriginX(structure, columnWidth());
+        tableLeft = originX();
         fragmentTop = 0;
       }
 
@@ -976,7 +1003,7 @@ function layoutBlocksWithGeometry(
     const breakForContinuation = (emitHeaders: boolean): void => {
       closeTableFragment();
       advanceColumn();
-      tableLeft = columnLeft() + tableOriginX(structure, columnWidth());
+      tableLeft = originX();
       fragmentTop = 0;
       if (emitHeaders) placeHeaderGroup(true);
     };

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -120,6 +120,59 @@ function readTableAlignment(container: OoxmlElement | undefined): TableAlignment
   return undefined;
 }
 
+/**
+ * `w:tblpPr/@w:horzAnchor` (17.4.58) and `@w:vertAnchor` (17.4.66): the box a floated
+ * table's offsets are measured from. Absent means `text` for both.
+ */
+export type TableFloatAnchor = 'text' | 'margin' | 'page';
+
+/** `w:tblpPr/@w:tblpXSpec` (17.4.63, ST_XAlign). */
+export type TableFloatXSpec = 'left' | 'center' | 'right' | 'inside' | 'outside';
+
+/** `w:tblpPr/@w:tblpYSpec` (17.4.65, ST_YAlign). */
+export type TableFloatYSpec = 'inline' | 'top' | 'center' | 'bottom' | 'inside' | 'outside';
+
+/**
+ * `w:tblPr/w:tblpPr` (17.4.57) — a table positioned against an anchor box rather than at
+ * the point in the text where it was authored.
+ *
+ * A spec (`tblpXSpec`/`tblpYSpec`) supersedes the matching offset when both are present:
+ * 17.4.57 states the alignment outright, and the offset only answers "how far from the
+ * anchor" for the case where no alignment was stated.
+ */
+export interface TableFloatPosition {
+  readonly horzAnchor: TableFloatAnchor;
+  readonly vertAnchor: TableFloatAnchor;
+  readonly xSpec?: TableFloatXSpec;
+  /** `w:tblpX` in points; signed, so a table can be pulled into the margin. */
+  readonly xPt: number;
+  readonly ySpec?: TableFloatYSpec;
+  /** `w:tblpY` in points; signed. */
+  readonly yPt: number;
+}
+
+/** One anchor box, in the same coordinates layout reports fragment boxes in. */
+export interface TableAnchorFrame {
+  readonly left: number;
+  readonly width: number;
+}
+
+/** The three boxes `w:horzAnchor` can name, resolved for the region being laid out. */
+export interface TableAnchorFrames {
+  /** The text column the table was authored in. */
+  readonly text: TableAnchorFrame;
+  /** The page's text area between the left and right margins. */
+  readonly margin: TableAnchorFrame;
+  /** The whole sheet, margins included. */
+  readonly page: TableAnchorFrame;
+}
+
+/**
+ * Ceiling on a `w:tblpX`/`w:tblpY` offset (~22"), matching the other bounded geometry
+ * reads here. Both are signed, so the clamp is two-sided.
+ */
+const MAX_TABLE_FLOAT_OFFSET_PT = 31_680 / 20;
+
 export interface CellMarginsPt {
   readonly top: number;
   readonly right: number;
@@ -205,6 +258,11 @@ export interface SemanticTableStructure {
   readonly indentPt: number;
   /** `w:tblPr/w:jc` (17.4.29) — where the table sits in the text column. */
   readonly alignment: TableAlignment;
+  /**
+   * `w:tblPr/w:tblpPr` (17.4.57) — present when the table is positioned against an anchor
+   * box. Placement then comes from {@link tableFloatOriginX} rather than `w:jc`/`w:tblInd`.
+   */
+  readonly float?: TableFloatPosition;
   /**
    * `w:tblCellSpacing` (17.4.45) in points: the gap between adjacent cell edges. Applied as
    * a half-gap inset on each side of every cell, so cells separate visually without the grid
@@ -361,6 +419,87 @@ export function tableOriginX(structure: SemanticTableStructure, containerWidthPt
   if (structure.alignment === 'center') return slack / 2;
   if (structure.alignment === 'right') return slack;
   return Math.min(structure.indentPt, slack);
+}
+
+function readFloatAnchor(raw: string | undefined): TableFloatAnchor | undefined {
+  if (raw === 'page') return 'page';
+  if (raw === 'margin') return 'margin';
+  if (raw === 'text') return 'text';
+  return undefined;
+}
+
+function readSignedTwipsPt(raw: string | undefined): number | undefined {
+  if (raw === undefined || !/^-?\d{1,9}$/.test(raw)) return undefined;
+  const twips = Number(raw);
+  if (!Number.isFinite(twips)) return undefined;
+  const pt = twips / 20;
+  return Math.max(-MAX_TABLE_FLOAT_OFFSET_PT, Math.min(MAX_TABLE_FLOAT_OFFSET_PT, pt));
+}
+
+/**
+ * Read `w:tblpPr`. Absent anchors default to `text` (17.4.58/17.4.66); an unrecognised
+ * spec is dropped rather than guessed at, which leaves the offset to place the table.
+ */
+function readTableFloatPosition(
+  container: OoxmlElement | undefined
+): TableFloatPosition | undefined {
+  const tblpPr = container && childNamed(container, 'tblpPr');
+  if (!tblpPr) return undefined;
+  const rawXSpec = attributeValue(tblpPr, 'tblpXSpec');
+  const xSpec: TableFloatXSpec | undefined =
+    rawXSpec === 'left' ||
+    rawXSpec === 'center' ||
+    rawXSpec === 'right' ||
+    rawXSpec === 'inside' ||
+    rawXSpec === 'outside'
+      ? rawXSpec
+      : undefined;
+  const rawYSpec = attributeValue(tblpPr, 'tblpYSpec');
+  const ySpec: TableFloatYSpec | undefined =
+    rawYSpec === 'inline' ||
+    rawYSpec === 'top' ||
+    rawYSpec === 'center' ||
+    rawYSpec === 'bottom' ||
+    rawYSpec === 'inside' ||
+    rawYSpec === 'outside'
+      ? rawYSpec
+      : undefined;
+  return {
+    horzAnchor: readFloatAnchor(attributeValue(tblpPr, 'horzAnchor')) ?? 'text',
+    vertAnchor: readFloatAnchor(attributeValue(tblpPr, 'vertAnchor')) ?? 'text',
+    ...(xSpec ? { xSpec } : {}),
+    xPt: readSignedTwipsPt(attributeValue(tblpPr, 'tblpX')) ?? 0,
+    ...(ySpec ? { ySpec } : {}),
+    yPt: readSignedTwipsPt(attributeValue(tblpPr, 'tblpY')) ?? 0,
+  };
+}
+
+/**
+ * Where a floated table's left edge sits, in the coordinates layout reports boxes in.
+ *
+ * `w:tblpXSpec` aligns the table inside its anchor box; `w:tblpX` offsets it from that
+ * box's leading edge instead. `inside`/`outside` are the mirrored-margin spellings of
+ * `left`/`right` and render as those — the odd/even page flip they ask for only exists in
+ * a document with mirrored margins, which this layout does not model.
+ *
+ * The result keeps the table's leading edge on the sheet whatever the file states, so a
+ * hostile offset moves the table rather than painting it off the page entirely.
+ */
+export function tableFloatOriginX(
+  float: TableFloatPosition,
+  tableWidthPt: number,
+  frames: TableAnchorFrames
+): number {
+  const frame = frames[float.horzAnchor];
+  const slack = frame.width - tableWidthPt;
+  let x: number;
+  if (float.xSpec === 'center') x = frame.left + slack / 2;
+  else if (float.xSpec === 'right' || float.xSpec === 'outside') x = frame.left + slack;
+  else if (float.xSpec) x = frame.left;
+  else x = frame.left + float.xPt;
+  if (!Number.isFinite(x)) return frame.left;
+  const pageRight = frames.page.left + frames.page.width;
+  return Math.max(frames.page.left, Math.min(x, pageRight));
 }
 
 /**
@@ -775,6 +914,7 @@ export function readTableStructure(
   let styleIndentPt: number | undefined;
   let styleAlignment: TableAlignment | undefined;
   let styleCellSpacingPt: number | undefined;
+  let styleFloat: TableFloatPosition | undefined;
   for (const node of tableStyle.tablePropertyNodes) {
     const styleW = childNamed(node, 'tblW');
     if (styleW) styleTableWidth = readPreferredWidth(styleW);
@@ -786,6 +926,7 @@ export function readTableStructure(
     styleCellSpacingPt =
       preferredLengthPt(childNamed(node, 'tblCellSpacing'), MAX_CELL_MARGIN_PT) ??
       styleCellSpacingPt;
+    styleFloat = readTableFloatPosition(node) ?? styleFloat;
   }
   const ownTblW = tblPr && childNamed(tblPr, 'tblW');
   const tableWidth = ownTblW ? readPreferredWidth(ownTblW) : styleTableWidth;
@@ -798,6 +939,9 @@ export function readTableStructure(
     styleIndentPt ??
     0;
   const alignment = readTableAlignment(tblPr) ?? styleAlignment ?? 'left';
+  // A nested table's position is stated against its cell, not the page — `w:tblpPr` inside
+  // one is honoured by Word only for the top-level table, so deeper tables stay in flow.
+  const float = depth === 0 ? (readTableFloatPosition(tblPr) ?? styleFloat) : undefined;
   const cellSpacingPt =
     preferredLengthPt(tblPr && childNamed(tblPr, 'tblCellSpacing'), MAX_CELL_MARGIN_PT) ??
     styleCellSpacingPt ??
@@ -817,6 +961,7 @@ export function readTableStructure(
     layoutFixed,
     indentPt,
     alignment,
+    ...(float ? { float } : {}),
     cellSpacingPt,
     tableBorders,
     defaultMargins,


### PR DESCRIPTION
A table carrying `w:tblpPr` had no reader, so it fell to the default left alignment. The comprehensive fixture's §16 callout table (`tblpXSpec="center" horzAnchor="margin"`) rendered flush at the margin where Word centres it.

Placement resolves against the three anchor boxes (`text` / `margin` / `page`), a spec supersedes the offset per §17.4.57, and a `tblpY` against the text anchor shifts the table down the flow.

Text does not wrap beside a floating table, and page- or margin-anchored vertical positions keep their place in the flow rather than pinning to the sheet. Both are recorded in the feature matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788502171&installation_model_id=422592&pr_number=122&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F122&signature=5b83070eddde03bc49d1c9d7f6528ff62f032a46175979547e7b1ba76b538ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->