### PR TITLE
fix: reset document-open state — scroll, review rail, file name

### DIFF
--- a/.changeset/document-open-reset.md
+++ b/.changeset/document-open-reset.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Opening a document now starts it at the first page instead of the previous file's scroll position. The review rail hides the read-only "changed the document structure" cards by default (opt back in with `structural` on `DocxEditor.Review`) and spaces unmeasured cards so dense redlines no longer paint cards over each other. The packaged File › Open reports the opened file through the new `onOpenFile` menu prop and names the default Save download after it.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -17,6 +17,8 @@ import { ChromeSlotId } from '@docx-editor.dev/core-contract/editor';
 import { ColorValue } from '@docx-editor.dev/core-contract/contracts/editor';
 import { commandForSlot } from '@docx-editor.dev/core-contract/editor';
 import { composeFontConfiguration } from '@docx-editor.dev/core-contract/editor';
+import { ContentControlSummary } from '@docx-editor.dev/core-contract';
+import { ContentControlType } from '@docx-editor.dev/core-contract';
 import { createFontSource } from '@docx-editor.dev/core-contract/editor';
 import { CSSProperties } from 'react';
 import { DocumentChange } from '@docx-editor.dev/core-contract/contracts/editor';
@@ -104,11 +106,77 @@ export { commandForSlot }
 export { composeFontConfiguration }
 
 // @public
+export const CONTENT_CONTROL_SLOTS: {
+    readonly showAll: "contentControl.showAll";
+    readonly formFill: "contentControl.formFill";
+    readonly inspector: "contentControl.inspector";
+    readonly remove: "contentControl.remove";
+};
+
+// @public
+export interface ContentControlActionProps extends ContentControlPartProps {
+    // (undocumented)
+    icon?: ReactNode;
+}
+
+// @public
+export interface ContentControlInspectorState {
+    // (undocumented)
+    readonly alias: string | null;
+    // (undocumented)
+    readonly bound: boolean;
+    // (undocumented)
+    readonly controlType: ContentControlType;
+    // (undocumented)
+    readonly effectiveLock: ContentControlLock | null;
+    // (undocumented)
+    readonly id: string;
+    readonly locked: boolean;
+    // (undocumented)
+    readonly placeholder: boolean;
+    readonly removalLocked: boolean;
+    // (undocumented)
+    readonly tag: string | null;
+}
+
+// @public
+export type ContentControlLock = 'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked';
+
+// @public
+export interface ContentControlPartProps {
+    // (undocumented)
+    asChild?: boolean;
+    // (undocumented)
+    children?: ReactNode;
+    // (undocumented)
+    className?: string;
+    // (undocumented)
+    hidden?: boolean;
+}
+
+// @public
+export interface ContentControlProps extends ContentControlPartProps {
+    preset?: boolean;
+}
+
+// @public (undocumented)
+export type ContentControlSlotId = (typeof CONTENT_CONTROL_SLOTS)[keyof typeof CONTENT_CONTROL_SLOTS];
+
+// @public
 export interface ContextMenuAnchor {
     // (undocumented)
     readonly x: number;
     // (undocumented)
     readonly y: number;
+}
+
+// @public
+export function ContextMenuCellVerticalAlignment(input: ContextMenuCommandProps): react.JSX.Element | null;
+
+// @public (undocumented)
+export namespace ContextMenuCellVerticalAlignment {
+    var // (undocumented)
+    docxRow: "table.cellVerticalAlignment";
 }
 
 // @public
@@ -222,6 +290,21 @@ export const DocxEditor: DocxEditorNamespace;
 // @public
 export function DocxEditorContent(input: DocxEditorContentProps): react.JSX.Element;
 
+// @public (undocumented)
+export const DocxEditorContentControl: DocxEditorContentControlNamespace;
+
+// @public
+export interface DocxEditorContentControlNamespace {
+    // (undocumented)
+    (props: ContentControlProps): ReturnType<typeof ContentControlRoot>;
+    // (undocumented)
+    readonly Fields: typeof ContentControlFields;
+    // (undocumented)
+    readonly Header: typeof ContentControlHeader;
+    // (undocumented)
+    readonly Remove: typeof ContentControlRemove;
+}
+
 // @public
 export interface DocxEditorContentProps {
     className?: string;
@@ -234,6 +317,8 @@ export function DocxEditorContextMenu(input: DocxEditorContextMenuProps): react.
 export interface DocxEditorContextMenuNamespace {
     // (undocumented)
     (props: DocxEditorContextMenuProps): ReactElement;
+    // (undocumented)
+    readonly CellVerticalAlignment: typeof ContextMenuCellVerticalAlignment;
     // (undocumented)
     readonly Copy: typeof ContextMenuCopy;
     // (undocumented)
@@ -390,6 +475,7 @@ export interface DocxEditorMenuProps {
     className?: string;
     fileName?: string;
     onOpen?: () => void;
+    onOpenFile?: (file: File) => void;
     onPageSetup?: () => void;
     onReportIssue?: () => void;
     onSave?: () => void;
@@ -402,6 +488,7 @@ export interface DocxEditorMenuProps {
 export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEditorProps & RefAttributes<DocxEditorRef>> {
     // (undocumented)
     readonly Content: typeof DocxEditorContent;
+    readonly ContentControl: typeof DocxEditorContentControl;
     readonly ContextMenu: typeof ContextMenu;
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
     readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
@@ -412,6 +499,7 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEdito
     readonly Navigation: typeof Navigation;
     // (undocumented)
     readonly NotesChrome: typeof DocxEditorNotesChrome;
+    readonly PageNumber: typeof DocxEditorPageNumber;
     readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
     readonly Review: typeof DocxEditorReview;
     // (undocumented)
@@ -661,6 +749,14 @@ export interface DocxEditorToolbarNamespace {
     // (undocumented)
     readonly Comments: ToolbarPartComponent;
     // (undocumented)
+    readonly ContentControlFormFill: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlInspector: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlRemove: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlShowAll: ToolbarPartComponent;
+    // (undocumented)
     readonly EditingMode: ToolbarSlotPartComponent;
     // (undocumented)
     readonly FontColor: ToolbarColorSplitComponent;
@@ -721,6 +817,7 @@ export interface DocxEditorToolbarProps {
     children?: ReactNode;
     className?: string;
     onSave?: () => void;
+    overflow?: boolean;
     preset?: boolean;
     t?: ToolbarTranslate;
 }
@@ -1067,6 +1164,7 @@ export function navigationShift(input: NavigationShiftInput): number;
 
 // @public (undocumented)
 export interface NavigationShiftInput {
+    readonly inlineEndReservation?: number;
     readonly pageWidthPx: number;
     readonly reservation: number;
     readonly viewportWidth: number;
@@ -1284,6 +1382,7 @@ export interface ReviewProps extends ReviewPartProps {
     gap?: number;
     preset?: boolean;
     stack?: boolean;
+    structural?: boolean;
 }
 
 // @public (undocumented)
@@ -1531,6 +1630,41 @@ export interface ToolbarSlotPartProps {
 export type ToolbarTranslate = (key: string) => string;
 
 // @public
+export function useContentControl(): UseContentControlResult;
+
+// @public
+export function useContentControlInstance(): UseContentControlResult;
+
+// @public
+export interface UseContentControlResult {
+    readonly canRemove: boolean;
+    readonly canSetValue: boolean;
+    // (undocumented)
+    readonly closeInspector: () => void;
+    readonly control: ContentControlInspectorState | null;
+    readonly controls: readonly ContentControlSummary[];
+    readonly formFill: boolean;
+    readonly inspectorOpen: boolean;
+    // (undocumented)
+    readonly openInspector: () => void;
+    readonly remove: () => ExecResult;
+    readonly removeDisabledReason: string | null;
+    // (undocumented)
+    readonly setFormFill: (on: boolean) => void;
+    // (undocumented)
+    readonly setShowAll: (show: boolean) => void;
+    readonly setValue: (value: string) => ExecResult;
+    readonly setValueDisabledReason: string | null;
+    readonly showAll: boolean;
+    // (undocumented)
+    readonly toggleFormFill: () => void;
+    // (undocumented)
+    readonly toggleInspector: () => void;
+    // (undocumented)
+    readonly toggleShowAll: () => void;
+}
+
+// @public
 export function useDocumentOutline(): UseDocumentOutlineResult;
 
 // @public
@@ -1745,6 +1879,7 @@ export function useStackedReviewPositions(items: readonly {
 }[], heights: ReadonlyMap<string, number>, options?: {
     readonly gap?: number;
     readonly scale?: number;
+    readonly defaultHeight?: number;
 }): ReadonlyMap<string, number>;
 
 // @public

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -1080,8 +1080,8 @@ type: BooleanConstructor;
 default: boolean;
 };
 }>> & Readonly<{}>, {
-visible: boolean;
 editor: Editor | null;
+visible: boolean;
 }, {}, {}, {}, string, ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -367,6 +367,9 @@ function EditorChrome({
   const [showPageSetup, setShowPageSetup] = useState(false);
 
   const openFile = (file: File) => {
+    // The title follows the opened file, so the header names the document actually
+    // on screen — and the download the Save button writes names itself after it too.
+    onTitleChange(file.name.replace(/\.docx$/i, ''));
     void file.arrayBuffer().then((buffer) => {
       editor?.load(new Uint8Array(buffer));
     });
@@ -549,7 +552,10 @@ function RulerRow() {
 
 export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
   const [colorMode, setColorMode] = useState<'light' | 'dark'>('light');
-  const [title, setTitle] = useState('Sample Document');
+  // Named after the document it opens with, and after whichever file is opened later.
+  const [title, setTitle] = useState(
+    () => fixtureUrl.split('/').pop()?.replace(/\.docx$/i, '') ?? 'Document'
+  );
   const [showOutline, setShowOutline] = useState(false);
 
   // The whole boot in ONE call: fetch the fixture, load Word's default substitute faces

--- a/packages/core/src/editor/__tests__/docx-editor.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor.test.ts
@@ -240,6 +240,23 @@ describe('createDocxEditor', () => {
     expect(editor.surface!.session.bodyText()).toBe('second');
   });
 
+  test('load() with new bytes opens at the top, not at the previous scroll offset', () => {
+    // The scroller is the HOST's element and survives the remount, so without an explicit
+    // reset a reader ten pages into one file opened the next file ten pages in.
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    const container = document.createElement('div');
+    scroller.appendChild(container);
+    const editor = createDocxEditor({ container, document: docx(p('first')) });
+    expect(editor.surface).not.toBeNull();
+    scroller.scrollTop = 4321;
+    scroller.scrollLeft = 17;
+    editor.load(docx(p('second')));
+    expect(scroller.scrollTop).toBe(0);
+    expect(scroller.scrollLeft).toBe(0);
+    editor.destroy();
+  });
+
   test('load() with a DocumentHandle emits a typed error and keeps the document', () => {
     const { editor } = mount(p('hello'));
     const errors: { code?: string }[] = [];

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -148,6 +148,7 @@ import {
   type PaginatedSurfaceOptions,
   type PaginatedSurfaceState,
 } from './paginated-surface.ts';
+import { surfaceScroller } from './surface-pages.ts';
 import type {
   DocxEditorConfig,
   DocxEditorInstance,
@@ -437,6 +438,19 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // guard will refuse to touch state, so the flag must reset here or a load that
     // starts no font work of its own reports `resolving: true` forever.
     fontsResolving = false;
+    // A NEW document opens at its first page. The scroller is the host's element and
+    // survives the remount, so the previous document's scroll offset would otherwise
+    // carry over — a reader ten pages into one file opened the next file ten pages in.
+    // BEFORE the mount, so the initial paint materializes the pages actually in view.
+    // Only here, never in `mountBytes`: the font remount and `attach` re-enter that
+    // function for the SAME document and must keep the reader's place.
+    if (container) {
+      const scroller = surfaceScroller(container);
+      if (scroller) {
+        scroller.scrollTop = 0;
+        scroller.scrollLeft = 0;
+      }
+    }
     mountBytes(bytes);
   }
 

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -165,6 +165,13 @@ export interface ReviewProps extends ReviewPartProps {
   gap?: number;
   /** Show only some of the queue — comments in one rail, revisions in another. */
   filter?: (item: ReviewItemView) => boolean;
+  /**
+   * Show the read-only "changed the document structure" cards. Default `false`: a heavily
+   * revised document carries one per structural site, they cannot be accepted or rejected
+   * from the rail, and together they crowd out the cards a reviewer can act on. The
+   * revisions themselves stay in the document either way — this hides only their cards.
+   */
+  structural?: boolean;
 }
 
 // Inline SVG, like the toolbar's icons: this package ships no icon font.
@@ -198,8 +205,9 @@ function ReviewRoot({
   children,
   preset = true,
   stack = true,
-  gap = 6,
+  gap = 8,
   filter,
+  structural = false,
 }: ReviewProps) {
   const editor = useDocxEditor();
   const review = useReview();
@@ -214,10 +222,12 @@ function ReviewRoot({
   // the viewport shifts the page for it, so a flag kept here would be a third opinion.
   const open = review.paneOpen;
 
-  const items = useMemo(
-    () => (filter ? review.items.filter((entry) => filter(entry)) : review.items),
-    [review.items, filter]
-  );
+  const items = useMemo(() => {
+    const shown = structural
+      ? review.items
+      : review.items.filter((entry) => entry.revisionKind !== 'structural');
+    return filter ? shown.filter((entry) => filter(entry)) : shown;
+  }, [review.items, filter, structural]);
 
   // Word's rule: a colour per author by ORDER OF FIRST APPEARANCE. A hash of the name is
   // stable but collides, and two reviewers drawn in one colour tells the reader the wrong
@@ -400,16 +410,31 @@ function ReviewRoot({
   // card's anchor, so nothing about its own position could have avoided the collision. The
   // BUTTON does not stack — it sits against the page instead, where nothing else is.
   const composeAnchorY = draftAnchorY ?? review.selectionAnchorY;
+  // Only what the list RENDERS competes for the column: a threaded reply lives inside its
+  // parent's card, and letting it into the run advanced the cursor once per reply, spacing
+  // every card below a commented conversation by gaps nothing on screen accounted for.
+  const roots = useMemo(
+    () => items.filter((entry) => !(entry.kind === 'comment' && entry.parentId !== undefined)),
+    [items]
+  );
   const stackInput = useMemo(() => {
-    if (draftAnchorY === null) return items;
+    if (draftAnchorY === null) return roots;
     // In document order, AFTER anything already at that height: the comments already there
     // were made before this selection, and later is below.
-    const at = items.findIndex((entry) => entry.anchorY !== null && entry.anchorY > draftAnchorY);
+    const at = roots.findIndex((entry) => entry.anchorY !== null && entry.anchorY > draftAnchorY);
     const compose = { key: COMPOSE_KEY, anchorY: draftAnchorY };
-    return at === -1 ? [...items, compose] : [...items.slice(0, at), compose, ...items.slice(at)];
-  }, [items, draftAnchorY]);
+    return at === -1 ? [...roots, compose] : [...roots.slice(0, at), compose, ...roots.slice(at)];
+  }, [roots, draftAnchorY]);
 
-  const stacked = useStackedReviewPositions(stackInput, heights, { gap, scale: metrics.scale });
+  const stacked = useStackedReviewPositions(stackInput, heights, {
+    gap,
+    scale: metrics.scale,
+    // An unmeasured card — below the virtualization window, or in its first frame — still
+    // reserves a plausible card's worth of room. Without this the run advanced by the gap
+    // alone and a dense redline opened as a column of cards painted over each other until
+    // every one had reported its height.
+    defaultHeight: 72,
+  });
   const composeTop =
     composeAnchorY === null
       ? null

--- a/packages/react/src/editor/menu/DocxEditorMenu.tsx
+++ b/packages/react/src/editor/menu/DocxEditorMenu.tsx
@@ -79,6 +79,12 @@ export interface DocxEditorMenuProps {
    * `Editor.load` — a user-driven file READ, never a fetch.
    */
   onOpen?: () => void;
+  /**
+   * Fired when the packaged Open reads a file, before its bytes are loaded — so a host can
+   * reflect the file's name in its own title chrome. Not fired when `onOpen` replaced the
+   * packaged picker: the host is reading the file itself and already holds the name.
+   */
+  onOpenFile?: (file: File) => void;
   /** Replaces File › Save. The default runs `Editor.save()` and downloads the bytes. */
   onSave?: () => void;
   /** Replaces File › Page setup. The default opens the packaged Page Setup dialog. */
@@ -144,6 +150,7 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
     t,
     fileName,
     onOpen,
+    onOpenFile,
     onSave,
     onPageSetup,
     onReportIssue,
@@ -153,6 +160,10 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
   } = props;
   const editor = useDocxEditor();
   const [openMenu, setOpenMenu] = useState<MenuId | null>(null);
+  // The last file the packaged Open read. The default Save names its download after it
+  // when the host pinned no `fileName` — opening "contract-v2.docx" and saving must not
+  // produce "document.docx".
+  const [openedName, setOpenedName] = useState<string | null>(null);
   // The bar's single tab stop. Defaults to the first rendered menu; arrowing along the bar
   // moves it, and opening a menu takes it so Escape returns focus somewhere sensible.
   const [activeMenu, setActiveMenu] = useState<MenuId | null>(null);
@@ -197,11 +208,11 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
     // reported through the same channel a host's `onChange` uses.
     void editor
       .save()
-      .then((buffer) => download(buffer, downloadName(fileName)))
+      .then((buffer) => download(buffer, downloadName(fileName ?? openedName ?? undefined)))
       .catch((error: unknown) => {
         console.error('[docx-editor] save failed', error);
       });
-  }, [editor, fileName]);
+  }, [editor, fileName, openedName]);
 
   const packagedPageSetup = useCallback(() => setPageSetupOpen(true), []);
 
@@ -350,6 +361,8 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
           // Cleared so choosing the SAME file twice fires a change event again.
           event.target.value = '';
           if (!file || !editor) return;
+          setOpenedName(file.name);
+          onOpenFile?.(file);
           // A read or a parse can fail — a revoked file handle, or the package guards
           // refusing a zip bomb. Reporting it beats a silent no-op that leaves the previous
           // document painted and the user believing the new one opened.

--- a/packages/react/src/editor/useReview.ts
+++ b/packages/react/src/editor/useReview.ts
@@ -218,10 +218,15 @@ export function useReviewOf(editor: Editor | null): UseReviewReturn {
 export function useStackedReviewPositions(
   items: readonly { readonly key: string; readonly anchorY: number | null }[],
   heights: ReadonlyMap<string, number>,
-  options: { readonly gap?: number; readonly scale?: number } = {}
+  options: { readonly gap?: number; readonly scale?: number; readonly defaultHeight?: number } = {}
 ): ReadonlyMap<string, number> {
   const gap = options.gap ?? 8;
   const scale = options.scale ?? 1;
+  // What an entry with no measured height reserves, in CSS pixels. Zero keeps the historic
+  // behavior — unmeasured cards advance the run by the gap alone; the packaged rail passes
+  // an estimate so cards it has not measured yet (or has virtualized out of the DOM) still
+  // hold a card's worth of room instead of painting over each other.
+  const defaultHeight = options.defaultHeight ?? 0;
   return useMemo(() => {
     const positions = new Map<string, number>();
     let cursor = Number.NEGATIVE_INFINITY;
@@ -230,8 +235,8 @@ export function useStackedReviewPositions(
       const top = Math.max(entry.anchorY, cursor);
       positions.set(entry.key, top);
       // Pixels to points before they meet an anchor.
-      cursor = top + ((heights.get(entry.key) ?? 0) + gap) / scale;
+      cursor = top + ((heights.get(entry.key) ?? defaultHeight) + gap) / scale;
     }
     return positions;
-  }, [items, heights, gap, scale]);
+  }, [items, heights, gap, scale, defaultHeight]);
 }

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -287,6 +287,58 @@ describe('the review sidebar', () => {
 
     expect(view.queryByTestId('review-draft')).toBeNull();
   });
+
+  test('hides the read-only structural cards by default, and shows them on request', () => {
+    // One resolvable insertion plus one structural site (a tracked row insertion,
+    // `w:trPr/w:ins`) — the kind of markup a heavily revised contract carries by the dozen.
+    const TRACKED = docx(
+      '<w:p><w:r><w:t>base </w:t></w:r>' +
+        '<w:ins w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z"><w:r><w:t>added</w:t></w:r></w:ins></w:p>' +
+        '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>' +
+        '<w:tr><w:tc><w:tcPr/><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc></w:tr>' +
+        '<w:tr><w:trPr><w:ins w:id="2" w:author="A" w:date="2026-01-01T00:00:00Z"/></w:trPr>' +
+        '<w:tc><w:tcPr/><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc></w:tr>' +
+        '</w:tbl>'
+    );
+    const kindsOf = (root: HTMLElement) =>
+      [...root.querySelectorAll('[data-testid="review-card"]')].map(
+        (card) => (card as HTMLElement).dataset.kind
+      );
+
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={TRACKED}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    // The ENGINE still lists the structural revision — only its card is hidden.
+    expect(
+      instance!
+        .getReviewItems()
+        .some((item) => item.kind === 'revision' && item.revisionKind === 'structural')
+    ).toBe(true);
+    expect(kindsOf(view.container)).toContain('insert');
+    expect(kindsOf(view.container)).not.toContain('structural');
+    view.unmount();
+
+    const shown = render(
+      <DocxEditorRoot document={TRACKED}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview structural />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    expect(kindsOf(shown.container)).toContain('structural');
+  });
 });
 
 describe('useEditorEvent', () => {

--- a/packages/react/test/menu-composition.test.tsx
+++ b/packages/react/test/menu-composition.test.tsx
@@ -281,6 +281,30 @@ describe('rows carry the engine, not a paraphrase', () => {
     });
     expect(opened).toBe(1);
   });
+
+  test('the packaged Open loads the file and reports its name through `onOpenFile`', async () => {
+    const seen: string[] = [];
+    const { view, editor } = mountMenu(
+      <DocxEditorMenu onOpenFile={(file) => seen.push(file.name)} />
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const input = view.container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    const file = new File(
+      [docx('<w:p><w:r><w:t>reopened</w:t></w:r></w:p>')],
+      'contract-v2.docx',
+      { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+    );
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+      // `file.arrayBuffer()` resolves on a later microtask; give the load a turn to land.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(seen).toEqual(['contract-v2.docx']);
+    expect(editor().surface!.session.bodyText()).toBe('reopened');
+  });
 });
 
 describe('chrome contracts', () => {


### PR DESCRIPTION
Opening a new document previously kept the old file's scroll offset, and a dense redline crowded the review rail with overlapping cards — dominated by read-only "changed the document structure" entries.

- `Editor.load` resets the scroller to the top for a NEW document (font remount and `attach` keep the reader's place).
- `DocxEditor.Review` hides structural revision cards by default (`structural` prop opts back in; the engine still lists them), stacks only rendered root cards, and reserves an estimated height for unmeasured cards so they never paint over each other.
- The packaged File › Open reports the opened file via the new `onOpenFile` prop and names the default Save download after it; the Vite demo title follows the opened file.

Pre-existing on the base branch, unchanged here: 11 react + 13 core test failures (pointer/caret/table-chrome suites, verified identical with the diff stashed) and the `check:public-docs-surface` red. The refreshed React API snapshot also picks up previously-unextracted content-control symbols from earlier merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788504877&installation_model_id=422592&pr_number=124&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F124&signature=65dc1e0c59c0540c167883b547c5cfd96787de83253f97408b8187ac5c9c5ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->