### PR TITLE
feat(react): Word-style hover balloon for tracked changes

### DIFF
--- a/.changeset/revision-hover-card.md
+++ b/.changeset/revision-hover-card.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Hovering a tracked change in the page now raises a Word-style balloon with the author, what changed, when, and accept/reject where the change is resolvable. Tracked table rows carry their revision attribution in the painted DOM, so structural changes hidden from the review rail stay one hover away.
+Hovering a tracked change in the page now raises a Word-style balloon with the author, what changed, when, and accept/reject where the change is resolvable. The balloon follows the pointer across changes, and clicking a change pins it until you press elsewhere. Tracked table rows carry their revision attribution in the painted DOM, so structural changes hidden from the review rail stay one hover away.

--- a/.changeset/revision-hover-card.md
+++ b/.changeset/revision-hover-card.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Hovering a tracked change in the page now raises a Word-style balloon with the author, what changed, when, and accept/reject where the change is resolvable. The balloon follows the pointer across changes, and clicking a change pins it until you press elsewhere. Tracked format changes mark their range with a quiet grey wash and dotted rule, tracked rows wear their insertion/deletion wash as a box, and rows carry their revision attribution in the painted DOM — so changes hidden from the review rail stay visible and one hover away.
+The review rail now shows only the decisions a reviewer reads in order — content changes and comments; "changed text formatting" and "changed the document structure" cards are hidden by default (opt back in with `formatting` / `structural` on `DocxEditor.Review`). Those changes stay marked in the page — format changes with a grey wash and dotted rule, tracked rows with their insertion/deletion wash — and clicking the marking opens a Word-style balloon with the author, the change, the date, and accept/reject where resolvable; the balloon stays until you press elsewhere.

--- a/.changeset/revision-hover-card.md
+++ b/.changeset/revision-hover-card.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Hovering a tracked change in the page now raises a Word-style balloon with the author, what changed, when, and accept/reject where the change is resolvable. Tracked table rows carry their revision attribution in the painted DOM, so structural changes hidden from the review rail stay one hover away.

--- a/.changeset/revision-hover-card.md
+++ b/.changeset/revision-hover-card.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Hovering a tracked change in the page now raises a Word-style balloon with the author, what changed, when, and accept/reject where the change is resolvable. The balloon follows the pointer across changes, and clicking a change pins it until you press elsewhere. Tracked table rows carry their revision attribution in the painted DOM, so structural changes hidden from the review rail stay one hover away.
+Hovering a tracked change in the page now raises a Word-style balloon with the author, what changed, when, and accept/reject where the change is resolvable. The balloon follows the pointer across changes, and clicking a change pins it until you press elsewhere. Tracked format changes mark their range with a quiet grey wash and dotted rule, tracked rows wear their insertion/deletion wash as a box, and rows carry their revision attribution in the painted DOM — so changes hidden from the review rail stay visible and one hover away.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -645,12 +645,12 @@ export interface DocxEditorReviewNamespace {
     readonly Author: typeof ReviewAuthor;
     // (undocumented)
     readonly Avatar: typeof ReviewAvatar;
+    readonly Balloon: typeof ReviewBalloon;
     // (undocumented)
     readonly Card: typeof ReviewCard;
     readonly Draft: typeof ReviewDraft;
     // (undocumented)
     readonly Empty: typeof ReviewEmpty;
-    readonly Hover: typeof ReviewHover;
     // (undocumented)
     readonly List: typeof ReviewList;
     readonly Markers: typeof ReviewMarkers;
@@ -1396,6 +1396,7 @@ export interface ReviewPartProps {
 // @public
 export interface ReviewProps extends ReviewPartProps {
     filter?: (item: ReviewItemView) => boolean;
+    formatting?: boolean;
     gap?: number;
     preset?: boolean;
     stack?: boolean;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -650,6 +650,7 @@ export interface DocxEditorReviewNamespace {
     readonly Draft: typeof ReviewDraft;
     // (undocumented)
     readonly Empty: typeof ReviewEmpty;
+    readonly Hover: typeof ReviewHover;
     // (undocumented)
     readonly List: typeof ReviewList;
     readonly Markers: typeof ReviewMarkers;

--- a/packages/core/src/layout/__tests__/style-cascade.test.ts
+++ b/packages/core/src/layout/__tests__/style-cascade.test.ts
@@ -12,6 +12,7 @@ import {
   isValidStyleId,
 } from '../style-cascade.ts';
 import { resolveRunStyle } from '../run-style.ts';
+import { formatRevisionOf } from '../revision-projection.ts';
 import { paragraphSpacing } from '../paragraph-style.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
 import { linesOf } from '../semantic-records.ts';
@@ -76,6 +77,41 @@ describe('isValidStyleId guards attacker-controlled ids', () => {
     expect(isValidStyleId('__proto__')).toBe(false);
     expect(isValidStyleId('constructor')).toBe(false);
     expect(isValidStyleId('Heading1')).toBe(true);
+  });
+});
+
+describe('a restyled STYLE definition is not a format change on every span', () => {
+  test("the style's rPrChange record stays out of the cascade; a run's own survives", () => {
+    // Editing a style with tracking on writes `w:rPrChange` INSIDE the style's `rPr`.
+    // Cascaded into span property lists it read as "this text's formatting is a pending
+    // decision" on every span of every paragraph using the style — a whole document marked
+    // grey over one style edit. The record is about the STYLE; only the formatting flows.
+    const table = buildStyleCascadeTable(
+      loadStyles(
+        `<w:style w:type="paragraph" w:styleId="Normal" w:default="1">` +
+          `<w:name w:val="Normal"/>` +
+          `<w:rPr><w:b/><w:rPrChange w:id="0" w:author="Author" ` +
+          `w:date="2026-07-07T20:18:00Z"><w:rPr/></w:rPrChange></w:rPr></w:style>`
+      )
+    );
+    const part = loadDocument(
+      `<w:p><w:r><w:t xml:space="preserve">plain </w:t></w:r>` +
+        `<w:r><w:rPr><w:i/><w:rPrChange w:id="77" w:author="Author" ` +
+        `w:date="2026-07-07T20:18:00Z"><w:rPr/></w:rPrChange></w:rPr>` +
+        `<w:t>changed</w:t></w:r></w:p>`
+    );
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: createFixedMeasurer(6, 14),
+      styleCascade: table,
+    });
+    const spans = linesOf(layout).flatMap((line) => line.spans);
+    const marks = spans.map((span) => formatRevisionOf(span.props));
+    // The plain run inherits the style but is NOT a tracked format change…
+    expect(marks[0]).toBeNull();
+    // …while the style's actual FORMATTING still cascades.
+    expect(spans[0]!.style.bold).toBe(true);
+    // A run's own rPrChange keeps its own attribution, not the style's.
+    expect(marks[1]?.id).toBe('77');
   });
 });
 

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -372,6 +372,13 @@ export interface TableRowFragmentRecord {
   readonly id: string;
   /** Pending tracked row insertion/deletion, when authored in `w:trPr`. */
   readonly revisionKind?: 'insert' | 'delete';
+  /**
+   * The `w:trPr/w:ins|w:del` attribution — the `(id, author, date)` triple the review model
+   * addresses this decision by, so painted rows can carry it the way revision spans do.
+   */
+  readonly revisionId?: string;
+  readonly revisionAuthor?: string;
+  readonly revisionDate?: string;
   /** Authored row ordinal within the table; repeats share the original row's index. */
   readonly rowIndex: number;
   /**

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -1037,6 +1037,9 @@ export function layoutRowFragmentBounded(
     record: {
       id: row.id,
       ...(row.revisionKind ? { revisionKind: row.revisionKind } : {}),
+      ...(row.revisionId !== undefined ? { revisionId: row.revisionId } : {}),
+      ...(row.revisionAuthor !== undefined ? { revisionAuthor: row.revisionAuthor } : {}),
+      ...(row.revisionDate !== undefined ? { revisionDate: row.revisionDate } : {}),
       rowIndex: 0,
       isHeaderRepeat,
       ...(isContinuation ? { isContinuation: true as const } : {}),

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -233,6 +233,15 @@ export interface SemanticTableRow {
   readonly id: string;
   /** Pending Word row insertion/deletion authored in `w:trPr`. */
   readonly revisionKind?: 'insert' | 'delete';
+  /**
+   * The `w:trPr/w:ins|w:del` attribution, carried with the kind so a painted row can say
+   * WHOSE pending decision it is — the review model addresses the decision by exactly this
+   * `(id, author, date)` triple, and a surface with only the kind could highlight the row
+   * but never open its card.
+   */
+  readonly revisionId?: string;
+  readonly revisionAuthor?: string;
+  readonly revisionDate?: string;
   /** `w:trPr/w:tblHeader` — the row repeats atop each page the table continues onto. */
   readonly isHeader: boolean;
   /**
@@ -891,13 +900,23 @@ export function readTableStructure(
         blocks,
       });
     }
+    const rowRevision = rowProperties
+      ? (childNamed(rowProperties, 'ins') ?? childNamed(rowProperties, 'del'))
+      : undefined;
+    const rowRevisionKind = rowRevision
+      ? rowRevision.localName === 'ins'
+        ? ('insert' as const)
+        : ('delete' as const)
+      : undefined;
+    const rowRevisionId = rowRevision && attributeValue(rowRevision, 'id');
+    const rowRevisionAuthor = rowRevision && attributeValue(rowRevision, 'author');
+    const rowRevisionDate = rowRevision && attributeValue(rowRevision, 'date');
     rows.push({
       id: rowNode.id,
-      ...(rowProperties && childNamed(rowProperties, 'ins')
-        ? { revisionKind: 'insert' as const }
-        : rowProperties && childNamed(rowProperties, 'del')
-          ? { revisionKind: 'delete' as const }
-          : {}),
+      ...(rowRevisionKind ? { revisionKind: rowRevisionKind } : {}),
+      ...(rowRevisionId !== undefined ? { revisionId: rowRevisionId } : {}),
+      ...(rowRevisionAuthor !== undefined ? { revisionAuthor: rowRevisionAuthor } : {}),
+      ...(rowRevisionDate !== undefined ? { revisionDate: rowRevisionDate } : {}),
       isHeader: readFlag(rowProperties, 'tblHeader'),
       cantSplit: readFlag(rowProperties, 'cantSplit'),
       height: readRowHeight(rowProperties),

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -173,6 +173,31 @@ function findParagraphProperties(container: OoxmlElement | undefined): OoxmlElem
   return undefined;
 }
 
+/**
+ * Tracked-change RECORDS a style definition's property lists can carry: editing a style
+ * with tracking on writes `w:rPrChange`/`w:pPrChange` (and `w:ins`/`w:del` for the
+ * definition itself) INSIDE the style's `rPr`/`pPr`. They are decisions about the STYLE,
+ * not formatting, and none of the property resolvers read them — but cascaded into span
+ * property lists they made `formatRevisionOf` mark EVERY span of every paragraph using
+ * the style as one tracked format change, painting a whole document grey over a single
+ * restyled style definition.
+ */
+const STYLE_CHANGE_RECORDS: ReadonlySet<string> = new Set([
+  'rPrChange',
+  'pPrChange',
+  'ins',
+  'del',
+  'moveFrom',
+  'moveTo',
+]);
+
+function withoutChangeRecords(props: OoxmlProperty[]): OoxmlProperty[] {
+  // The common style carries none; keep the allocated array in that case.
+  return props.some((property) => STYLE_CHANGE_RECORDS.has(property.localName))
+    ? props.filter((property) => !STYLE_CHANGE_RECORDS.has(property.localName))
+    : props;
+}
+
 function readDocDefaults(stylesRoot: OoxmlElement): {
   run: readonly OoxmlProperty[];
   paragraph: readonly OoxmlProperty[];
@@ -185,8 +210,8 @@ function readDocDefaults(stylesRoot: OoxmlElement): {
   const runNode = findRunProperties(rPrDefault);
   const paragraphNode = findParagraphProperties(pPrDefault);
   return {
-    run: propertiesOf(runNode),
-    paragraph: propertiesOf(paragraphNode),
+    run: withoutChangeRecords(propertiesOf(runNode)),
+    paragraph: withoutChangeRecords(propertiesOf(paragraphNode)),
     paragraphNode,
   };
 }
@@ -222,8 +247,8 @@ function readStyleDefinition(
     type,
     basedOn,
     isDefault: isDefaultFlag(attributeValue(node, 'default')),
-    paragraphProperties: propertiesOf(paragraphPropertiesNode),
-    runProperties: propertiesOf(runPropertiesNode),
+    paragraphProperties: withoutChangeRecords(propertiesOf(paragraphPropertiesNode)),
+    runProperties: withoutChangeRecords(propertiesOf(runPropertiesNode)),
     paragraphPropertiesNode,
     tablePropertiesNode: childNamed(node, 'tblPr'),
     conditionalTableFormats,
@@ -326,10 +351,10 @@ export function tableCellStyleFormatting(
     const conditionPPr = findParagraphProperties(format);
     if (conditionPPr) {
       paragraphPropertyNodes.push(conditionPPr);
-      paragraphProperties.push(...propertiesOf(conditionPPr));
+      paragraphProperties.push(...withoutChangeRecords(propertiesOf(conditionPPr)));
     }
     const conditionRPr = findRunProperties(format);
-    if (conditionRPr) runProperties.push(...propertiesOf(conditionRPr));
+    if (conditionRPr) runProperties.push(...withoutChangeRecords(propertiesOf(conditionRPr)));
   }
   if (
     paragraphPropertyNodes.length === 0 &&

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -473,14 +473,13 @@ function applyRevisionPresentation(
     return;
   }
 
-  // A tracked FORMAT change gets its provenance and NO inline decoration.
-  //
-  // Marking it inline reads as noise rather than signal at the density real documents carry:
-  // this fixture has 18,284 of them, so a rule under each one drew a dotted line beneath
-  // nearly every line on the page, competing with the insertions and deletions that are the
-  // decisions a reviewer actually has to make. The attributes stay, so the review surface can
-  // still list the change and highlight its range on demand — which is where Word puts it too,
-  // as a "Formatted:" note rather than a mark on the words.
+  // A tracked FORMAT change gets its provenance and NO inline decoration — its marking
+  // (a grey wash and a faint dotted rule) comes from the STYLESHEET's
+  // `.docx-revision-format`, not from style written here. The split is deliberate: an
+  // authored underline or strike is painted as inline style and so outranks the stylesheet,
+  // keeping the author's own decoration intact, and a host that finds even the quiet grey
+  // too loud at its documents' density (a real fixture carries 18,284 of these) can silence
+  // it with one CSS override instead of forking the painter.
   element.classList.add('docx-revision', 'docx-revision-format');
   element.dataset.revisionKind = 'format';
   element.dataset.revisionId = format!.id;

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1407,6 +1407,13 @@ function paintTableFragment(
         'docx-table-row--revision',
         row.revisionKind === 'insert' ? 'layout-revision-ins' : 'layout-revision-del'
       );
+      // The same attribution datasets revision SPANS carry, so chrome that maps a hovered
+      // element to its review decision treats a tracked row like any other tracked change.
+      // Dataset assignment escapes; the values are attacker-controlled and never markup.
+      rowElement.dataset.revisionKind = row.revisionKind;
+      if (row.revisionId !== undefined) rowElement.dataset.revisionId = row.revisionId;
+      if (row.revisionAuthor !== undefined) rowElement.dataset.revisionAuthor = row.revisionAuthor;
+      if (row.revisionDate !== undefined) rowElement.dataset.revisionDate = row.revisionDate;
     }
     rowElement.dataset.rowId = row.id;
     if (row.isHeaderRepeat) rowElement.dataset.headerRepeat = 'true';

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -136,9 +136,11 @@
   --doc-revision-insertion-wash: rgba(46, 125, 50, 0.05);
   --doc-revision-deletion-wash: rgba(198, 40, 40, 0.05);
   /* A tracked FORMAT change: the words are unchanged, so it takes neither the insertion nor
-     the deletion colour, and it carries no fill — a document can be almost entirely
-     reformatted, and tinting all of it says nothing. The rule alone marks it. */
+     the deletion colour — grey says "the appearance is the decision". The wash plus a faint
+     dotted rule make the range findable (it is the hover balloon's target); both are quiet
+     enough that a heavily restyled page reads as text, not as marking. */
   --doc-revision-format: #6b7f8c;
+  --doc-revision-format-wash: rgba(107, 127, 140, 0.1);
   /* Word's tracked-change palette. Deletions read as removal, insertions as addition, and the
      margin rules take the same two colours so the margin says WHAT happened, not only that
      something did. */
@@ -1897,6 +1899,31 @@ a.docx-hyperlink:focus-visible {
 .docx-table-row--revision.layout-revision-del .layout-run-text {
   color: var(--doc-revision-deletion);
   text-decoration: line-through;
+}
+
+/* The row is a BOX, so it gets the box treatment text changes get from their wash: a tracked
+   row reads as one pending decision at a glance, and gives the hover balloon a visibly
+   bounded target. Directional, not grey — a row is added or removed, and the wash should say
+   which the way the struck/underlined text inside it already does. */
+.docx-table-row--revision.layout-revision-ins {
+  background-color: var(--doc-revision-insertion-wash);
+}
+
+.docx-table-row--revision.layout-revision-del {
+  background-color: var(--doc-revision-deletion-wash);
+}
+
+/* A tracked FORMAT change: grey, because nothing was added or removed — the appearance
+   itself is the pending decision. A stylesheet rule rather than painter inline style on
+   purpose: an authored underline or strike arrives as inline style and therefore WINS over
+   the dotted rule here, and a host that finds even this too loud for its documents can
+   silence it with one override. */
+.docx-revision-format {
+  background-color: var(--doc-revision-format-wash);
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 1px;
+  text-decoration-color: var(--doc-revision-format);
 }
 
 .layout-revision-pmark {

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4985,6 +4985,25 @@ a.docx-hyperlink:focus-visible {
   transition: none;
 }
 
+/* An INACTIVE card keeps its summary to a few lines: the rail is a queue, not the reading
+   surface, and one long insertion was a full viewport of card pushing everything after it
+   pages below its text. The active card renders in full. */
+.docx-review__card:not([data-active]) .docx-review__summary {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+/* A card the stacking pass pushed too far from its own text collapses to its header —
+   a full summary there reads as annotating whatever text happens to be beside it.
+   Clicking still works, and the active card never collapses. */
+.docx-review__slot[data-collapsed] .docx-review__summary,
+.docx-review__slot[data-collapsed] .docx-review__replies,
+.docx-review__slot[data-collapsed] .docx-review__reply-box {
+  display: none;
+}
+
 .docx-review__card {
   display: flex;
   flex-direction: column;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4995,15 +4995,6 @@ a.docx-hyperlink:focus-visible {
   overflow: hidden;
 }
 
-/* A card the stacking pass pushed too far from its own text collapses to its header —
-   a full summary there reads as annotating whatever text happens to be beside it.
-   Clicking still works, and the active card never collapses. */
-.docx-review__slot[data-collapsed] .docx-review__summary,
-.docx-review__slot[data-collapsed] .docx-review__replies,
-.docx-review__slot[data-collapsed] .docx-review__reply-box {
-  display: none;
-}
-
 .docx-review__card {
   display: flex;
   flex-direction: column;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4599,16 +4599,16 @@ a.docx-hyperlink:focus-visible {
   border-color: var(--doc-primary, #1a73e8);
 }
 
-/* The Word-style hover balloon: pointing at a tracked change in the page raises its
-   decision card beside the text. The wrapper is a zero-size positioning origin only —
+/* The Word-style decision balloon: clicking a format or structural change in the page
+   raises its card beside the text. The wrapper is a zero-size positioning origin only —
    the balloon positions in rail coordinates, so it scrolls with the text it annotates. */
-.docx-review__hover-root {
+.docx-review__balloon-root {
   position: absolute;
   top: 0;
   left: 0;
 }
 
-.docx-review__hover {
+.docx-review__balloon {
   position: absolute;
   width: 280px;
   pointer-events: auto;
@@ -4616,7 +4616,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Raised harder than a rail card: it floats OVER the sheet, not beside it. */
-.docx-review__hover .docx-review__card {
+.docx-review__balloon .docx-review__card {
   margin: 0;
   box-shadow: 0 6px 20px rgb(0 0 0 / 18%);
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4572,6 +4572,28 @@ a.docx-hyperlink:focus-visible {
   border-color: var(--doc-primary, #1a73e8);
 }
 
+/* The Word-style hover balloon: pointing at a tracked change in the page raises its
+   decision card beside the text. The wrapper is a zero-size positioning origin only —
+   the balloon positions in rail coordinates, so it scrolls with the text it annotates. */
+.docx-review__hover-root {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.docx-review__hover {
+  position: absolute;
+  width: 280px;
+  pointer-events: auto;
+  z-index: 6;
+}
+
+/* Raised harder than a rail card: it floats OVER the sheet, not beside it. */
+.docx-review__hover .docx-review__card {
+  margin: 0;
+  box-shadow: 0 6px 20px rgb(0 0 0 / 18%);
+}
+
 .docx-review__markers {
   position: relative;
   height: 100%;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4977,6 +4977,14 @@ a.docx-hyperlink:focus-visible {
   transition: top 120ms ease-out;
 }
 
+/* While the reader scrolls, restacks snap instead of animating. The transition exists for
+   accept/reject collapses; during a scroll it animated the height-correction shifts of
+   every card below a newly measured one, and the moving cards over the moving page read
+   as a second scroll. The rail sets the attribute at scroll frequency without React. */
+.docx-review[data-scrolling] .docx-review__slot {
+  transition: none;
+}
+
 .docx-review__card {
   display: flex;
   flex-direction: column;

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -45,7 +45,7 @@ import type { TranslationKey } from '@docx-editor.dev/i18n';
 import { useTranslation } from '../i18n';
 import { ReviewRailContext, useDocxEditor } from './context';
 import { Slot } from './toolbar/Slot';
-import { useReview, useStackedReviewPositions, type ReviewItemView } from './useReview';
+import { useReview, type ReviewItemView } from './useReview';
 
 /** The rail's data, provided once by the Root so a card never re-subscribes. */
 const ReviewContext = createContext<ReviewRailValue | null>(null);
@@ -102,6 +102,17 @@ const RAIL_OVERSCAN = 600;
 
 /** How many author slots the token ramp defines; past it, colours repeat. */
 const AUTHOR_SLOTS = 8;
+
+/** What an unmeasured, uncollapsed card reserves in the stacking run, in CSS px. */
+const DEFAULT_CARD_HEIGHT = 72;
+/** A collapsed card: the head row and its padding, in CSS px. */
+const COLLAPSED_CARD_HEIGHT = 54;
+/**
+ * How far (CSS px) a card may be pushed below its own text before it collapses to a
+ * header. Roughly half a viewport: nearer than that the eye still connects card to text;
+ * further, a full card reads as annotating whatever happens to be beside it.
+ */
+const COLLAPSE_DISPLACEMENT_PX = 480;
 
 /** Keeps the caret: a mousedown that bubbles to the editor moves it. Inputs are exempt. */
 function guardMousedown(event: React.MouseEvent): void {
@@ -470,12 +481,37 @@ function ReviewRoot({
     return merged;
   }, [heights, roots]);
 
-  const stacked = useStackedReviewPositions(stackInput, estimatedHeights, {
-    gap,
-    scale: metrics.scale,
-    // The compose box, the one stacked key that is not a root card.
-    defaultHeight: 72,
-  });
+  // Stacking with CROWDING COLLAPSE, one deterministic pass. Push-down stacking cannot be
+  // cheated: a cluster of tall cards needs more room than its text region has, and the
+  // overflow used to spill page after page — the reader at the bottom of the document saw
+  // full cards whose text lived pages earlier. A card pushed further than the threshold
+  // from its own text renders COLLAPSED (header only), which both bounds how misleading a
+  // displaced card can be and shrinks the pressure that displaces everything after it.
+  // The ACTIVE card and the compose box never collapse. Collapse decisions feed the cursor
+  // with the collapsed height, so the pass is stable: each decision depends only on the
+  // cards before it.
+  const { stacked, collapsedKeys } = useMemo(() => {
+    const scale = metrics.scale;
+    const positions = new Map<string, number>();
+    const collapsed = new Set<string>();
+    let cursor = Number.NEGATIVE_INFINITY;
+    for (const entry of stackInput) {
+      if (entry.anchorY === null) continue;
+      const top = Math.max(entry.anchorY, cursor);
+      positions.set(entry.key, top);
+      const displacedPx = (top - entry.anchorY) * scale;
+      const isActive = 'isActive' in entry && entry.isActive;
+      const collapse =
+        displacedPx > COLLAPSE_DISPLACEMENT_PX && !isActive && entry.key !== COMPOSE_KEY;
+      if (collapse) collapsed.add(entry.key);
+      const height = collapse
+        ? COLLAPSED_CARD_HEIGHT
+        : (estimatedHeights.get(entry.key) ?? DEFAULT_CARD_HEIGHT);
+      // Pixels to points before they meet an anchor.
+      cursor = top + (height + gap) / scale;
+    }
+    return { stacked: positions, collapsedKeys: collapsed };
+  }, [stackInput, estimatedHeights, gap, metrics.scale]);
   const composeTop =
     composeAnchorY === null
       ? null
@@ -539,6 +575,7 @@ function ReviewRoot({
           <ReviewList
             stack={stack}
             positions={stacked}
+            collapsed={collapsedKeys}
             scale={metrics.scale}
             offset={metrics.top}
             window={window_}
@@ -570,6 +607,7 @@ function ReviewRoot({
               <ReviewList
                 stack={stack}
                 positions={stacked}
+                collapsed={collapsedKeys}
                 scale={metrics.scale}
                 offset={metrics.top}
                 window={window_}
@@ -591,6 +629,8 @@ function ReviewRoot({
 interface ReviewListProps {
   stack?: boolean;
   positions?: ReadonlyMap<string, number>;
+  /** Cards the stacking pass collapsed to a header — pushed too far from their text. */
+  collapsed?: ReadonlySet<string>;
   scale?: number;
   offset?: number;
   /** Visible band of the scroller; cards outside it are not mounted. Null renders all. */
@@ -615,6 +655,7 @@ interface ReviewListProps {
 function ReviewList({
   stack = true,
   positions,
+  collapsed,
   scale = 1,
   offset = 0,
   window: visible = null,
@@ -647,6 +688,10 @@ function ReviewList({
             <div
               className="docx-review__slot"
               style={style}
+              // Header-only, because the card sits far from the text it annotates and a
+              // full summary there reads as annotating the wrong text. Clicking it makes
+              // the item active, and the active card always renders in full.
+              {...(collapsed?.has(entry.key) ? { 'data-collapsed': '' } : {})}
               ref={(node) => {
                 measure(node, entry.key);
               }}

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -54,6 +54,12 @@ const ReviewItemContext = createContext<ReviewItemView | null>(null);
 
 interface ReviewRailValue {
   readonly review: ReturnType<typeof useReview>;
+  /**
+   * The UNFILTERED queue. The rail's cards render `review.items`, which the `structural`
+   * default and the host's `filter` have already narrowed — but the hover balloon exists
+   * precisely for the items those filters hide, so it matches against everything.
+   */
+  readonly allItems: readonly ReviewItemView[];
   /** Author colour slot per author, by order of first appearance — Word's own rule. */
   readonly authorSlots: ReadonlyMap<string, number>;
   /** Comment items by id, so a card can render its replies without walking the list. */
@@ -126,6 +132,7 @@ const INERT_RAIL: ReviewRailValue = {
     setPaneOpen: () => {},
     ready: false,
   },
+  allItems: [],
   authorSlots: new Map(),
   byId: new Map(),
   measure: () => {},
@@ -443,6 +450,7 @@ function ReviewRoot({
   const value = useMemo<ReviewRailValue>(
     () => ({
       review: { ...review, items },
+      allItems: review.items,
       authorSlots,
       byId,
       measure: observeSlot,
@@ -483,6 +491,9 @@ function ReviewRoot({
       {!open || draftAnchorY === null || composeTop === null
         ? null
         : takeRoot('Draft', <ReviewDraft top={composeTop} />)}
+      {/* Mounted open OR closed: the balloon is how a reader inspects a change whose rail
+          card is filtered away, and a closed pane filters ALL of them away. */}
+      {takeRoot('Hover', <ReviewHover />)}
     </>
   ) : null;
 
@@ -828,6 +839,254 @@ function ReviewDraft({ top, className, hidden }: ReviewPartProps & { top: number
   );
 }
 ReviewDraft.docxReviewPart = 'Draft' as const;
+
+/** What a hovered tracked change tells us before any item matching — straight off its DOM. */
+interface HoverAnchor {
+  readonly revisionId: string;
+  readonly author: string;
+  readonly date?: string;
+  readonly kind?: string;
+  /** Rail-relative CSS px of the hovered element's box. */
+  readonly left: number;
+  readonly top: number;
+  readonly bottom: number;
+  /** True when the balloon opens upward — the target sits low in the window. */
+  readonly above: boolean;
+}
+
+/** Word's own delays, near enough: deliberate hover opens, a passing pointer does not. */
+const HOVER_SHOW_MS = 250;
+const HOVER_HIDE_MS = 200;
+
+/**
+ * The hover balloon: pointing at a tracked change in the PAGE raises its decision card
+ * beside the text — author, what changed, when, and accept/reject where the engine can
+ * resolve it. This is how Word presents a change, and it is what makes hiding noisy card
+ * kinds from the rail safe: the information moves from a permanent column to a gesture.
+ *
+ * Matches the painted element's `data-revision-*` attribution against the UNFILTERED
+ * queue, so it answers for kinds the rail's `structural` default or a host `filter` hid.
+ * An element whose attribution matches nothing (mid-edit staleness) still shows what the
+ * DOM itself carries — author, kind, date — just without actions.
+ *
+ * @public
+ */
+function ReviewHover({ className, hidden }: ReviewPartProps) {
+  const { review, allItems, authorSlots } = useRail();
+  const { t } = useTranslation();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [anchor, setAnchor] = useState<HoverAnchor | null>(null);
+
+  useEffect(() => {
+    const host = rootRef.current;
+    const rail = host?.closest('.docx-review') as HTMLElement | null;
+    // The engine's own scroll-container class first: `offsetParent` needs layout, which a
+    // DOM without a renderer (happy-dom) does not do, and the viewport always carries it.
+    const scroller = (rail?.closest('.docx-editor__scroll-container') ??
+      rail?.offsetParent) as HTMLElement | null;
+    if (!host || !rail || !scroller) return undefined;
+    let showTimer = 0;
+    let hideTimer = 0;
+    let current: HTMLElement | null = null;
+
+    const show = (element: HTMLElement): void => {
+      const railRect = rail.getBoundingClientRect();
+      const rect = element.getBoundingClientRect();
+      const viewportBottom = element.ownerDocument.defaultView?.innerHeight ?? Infinity;
+      setAnchor({
+        revisionId: element.dataset.revisionId!,
+        author: element.dataset.revisionAuthor ?? '',
+        ...(element.dataset.revisionDate !== undefined
+          ? { date: element.dataset.revisionDate }
+          : {}),
+        ...(element.dataset.revisionKind !== undefined
+          ? { kind: element.dataset.revisionKind }
+          : {}),
+        left: rect.left - railRect.left,
+        top: rect.top - railRect.top,
+        bottom: rect.bottom - railRect.top,
+        // Opens upward when there is no room below — a change on the last visible line
+        // would otherwise push its balloon under the fold.
+        above: rect.bottom + 220 > viewportBottom,
+      });
+    };
+
+    const onOver = (event: MouseEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      // Travelling INTO the balloon keeps it open — that is how its buttons get clicked.
+      if (host.contains(target)) {
+        window.clearTimeout(hideTimer);
+        return;
+      }
+      const element = target.closest('[data-revision-id]');
+      if (element instanceof HTMLElement && scroller.contains(element)) {
+        window.clearTimeout(hideTimer);
+        if (element === current) return;
+        current = element;
+        window.clearTimeout(showTimer);
+        showTimer = window.setTimeout(() => show(element), HOVER_SHOW_MS);
+      } else {
+        current = null;
+        window.clearTimeout(showTimer);
+        window.clearTimeout(hideTimer);
+        hideTimer = window.setTimeout(() => setAnchor(null), HOVER_HIDE_MS);
+      }
+    };
+    const onLeave = (): void => {
+      current = null;
+      window.clearTimeout(showTimer);
+      window.clearTimeout(hideTimer);
+      hideTimer = window.setTimeout(() => setAnchor(null), HOVER_HIDE_MS);
+    };
+    scroller.addEventListener('mouseover', onOver, true);
+    scroller.addEventListener('mouseleave', onLeave);
+    return () => {
+      window.clearTimeout(showTimer);
+      window.clearTimeout(hideTimer);
+      scroller.removeEventListener('mouseover', onOver, true);
+      scroller.removeEventListener('mouseleave', onLeave);
+    };
+  }, []);
+
+  // The decision the hovered SITE belongs to. Sites coalesce into decisions by the
+  // `(id, author, date)` triple, which is exactly what the painted element carries.
+  const entry = useMemo(() => {
+    if (!anchor) return null;
+    return (
+      allItems.find(
+        (candidate) =>
+          candidate.kind === 'revision' &&
+          candidate.item.kind === 'revision' &&
+          candidate.item.addresses.some(
+            (address) =>
+              address.id === anchor.revisionId &&
+              address.author === anchor.author &&
+              address.date === anchor.date
+          )
+      ) ?? null
+    );
+  }, [allItems, anchor]);
+
+  // Resolving the decision removes it from the queue; the balloon it was resolved from
+  // must not linger over the text the accept just changed.
+  const hadEntry = useRef(false);
+  useEffect(() => {
+    if (entry) {
+      hadEntry.current = true;
+      return;
+    }
+    if (hadEntry.current) {
+      hadEntry.current = false;
+      setAnchor(null);
+    }
+  }, [entry]);
+
+  if (hidden) return null;
+  const fallbackKind =
+    anchor?.kind === 'insert' ||
+    anchor?.kind === 'delete' ||
+    anchor?.kind === 'moveFrom' ||
+    anchor?.kind === 'moveTo' ||
+    anchor?.kind === 'format'
+      ? (anchor.kind as ReviewRevisionKind)
+      : ('structural' as const);
+
+  return (
+    // The wrapper always mounts — it is what the wiring effect climbs from — and carries
+    // no box of its own until there is a balloon to show.
+    <div ref={rootRef} className={`docx-review__hover-root${className ? ` ${className}` : ''}`}>
+      {anchor === null ? null : (
+        <div
+          className="docx-review__hover"
+          data-testid="review-hover"
+          style={{
+            left: anchor.left,
+            top: anchor.above ? anchor.top - 6 : anchor.bottom + 6,
+            transform: anchor.above ? 'translateY(-100%)' : undefined,
+          }}
+          onMouseDown={guardMousedown}
+        >
+          {entry ? (
+            <ReviewItemContext.Provider value={entry}>
+              <div
+                className="docx-review__card"
+                data-testid="review-hover-card"
+                data-kind={entry.revisionKind ?? 'revision'}
+                style={
+                  {
+                    '--doc-review-author': `var(--doc-review-author-${(authorSlots.get(entry.author) ?? 0) % AUTHOR_SLOTS})`,
+                  } as CSSProperties
+                }
+                onClick={() => review.setActive(entry.key)}
+              >
+                <div className="docx-review__head">
+                  <ReviewAvatar />
+                  <div className="docx-review__meta">
+                    <ReviewAuthor />
+                    <ReviewTime />
+                  </div>
+                  {entry.kind === 'revision' && !entry.readOnly ? (
+                    <div className="docx-review__actions">
+                      <ReviewAccept />
+                      <ReviewReject />
+                    </div>
+                  ) : null}
+                </div>
+                <ReviewSummary />
+              </div>
+            </ReviewItemContext.Provider>
+          ) : (
+            <div
+              className="docx-review__card"
+              data-testid="review-hover-card"
+              data-kind={fallbackKind}
+            >
+              <div className="docx-review__head">
+                <span className="docx-review__avatar" aria-hidden="true">
+                  {initialsOf(anchor.author)}
+                </span>
+                <div className="docx-review__meta">
+                  <span className="docx-review__author">
+                    {anchor.author || t('comments.unknown')}
+                  </span>
+                  {anchor.date ? <HoverTime raw={anchor.date} /> : null}
+                </div>
+              </div>
+              <div className="docx-review__summary">
+                <span className="docx-review__label" data-kind={fallbackKind}>
+                  {t(revisionLabelKey(fallbackKind))}
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+ReviewHover.docxReviewPart = 'Hover' as const;
+
+/** Initials for the dataset-only fallback, matching the engine's own derivation. */
+function initialsOf(author: string): string {
+  const words = author.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '?';
+  return words
+    .slice(0, 2)
+    .map((word) => word[0]!.toUpperCase())
+    .join('');
+}
+
+/** `ReviewTime` for a raw dataset date, outside any item context. */
+function HoverTime({ raw }: { raw: string }) {
+  const when = new Date(raw);
+  if (Number.isNaN(when.getTime())) return null;
+  return (
+    <time className="docx-review__time" dateTime={raw} title={when.toLocaleString()}>
+      {REVIEW_DATE_FORMAT.format(when)}
+    </time>
+  );
+}
 
 /** Shown when nothing is pending. @public */
 function ReviewEmpty({ className, hidden, children }: ReviewPartProps) {
@@ -1314,6 +1573,8 @@ export interface DocxEditorReviewNamespace {
   readonly AddComment: typeof ReviewAddComment;
   /** The compose box a new comment is written in. */
   readonly Draft: typeof ReviewDraft;
+  /** The Word-style balloon raised by hovering a tracked change in the page. */
+  readonly Hover: typeof ReviewHover;
 }
 
 export const DocxEditorReview: DocxEditorReviewNamespace = Object.assign(ReviewRoot, {
@@ -1331,4 +1592,5 @@ export const DocxEditorReview: DocxEditorReviewNamespace = Object.assign(ReviewR
   Markers: ReviewMarkers,
   AddComment: ReviewAddComment,
   Draft: ReviewDraft,
+  Hover: ReviewHover,
 });

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -55,9 +55,9 @@ const ReviewItemContext = createContext<ReviewItemView | null>(null);
 interface ReviewRailValue {
   readonly review: ReturnType<typeof useReview>;
   /**
-   * The UNFILTERED queue. The rail's cards render `review.items`, which the `structural`
-   * default and the host's `filter` have already narrowed — but the hover balloon exists
-   * precisely for the items those filters hide, so it matches against everything.
+   * The UNFILTERED queue. The rail's cards render `review.items`, which the structural and
+   * formatting defaults and the host's `filter` have already narrowed — but the balloon
+   * exists precisely for the items those filters hide, so it matches against everything.
    */
   readonly allItems: readonly ReviewItemView[];
   /** Author colour slot per author, by order of first appearance — Word's own rule. */
@@ -173,12 +173,19 @@ export interface ReviewProps extends ReviewPartProps {
   /** Show only some of the queue — comments in one rail, revisions in another. */
   filter?: (item: ReviewItemView) => boolean;
   /**
-   * Show the read-only "changed the document structure" cards. Default `false`: a heavily
-   * revised document carries one per structural site, they cannot be accepted or rejected
-   * from the rail, and together they crowd out the cards a reviewer can act on. The
-   * revisions themselves stay in the document either way — this hides only their cards.
+   * Show the "changed the document structure" cards. Default `false`: a heavily revised
+   * document carries one per structural site and together they crowd out the cards a
+   * reviewer can act on. The revisions stay marked in the document, where clicking one
+   * opens its balloon — this hides only their rail cards.
    */
   structural?: boolean;
+  /**
+   * Show the "changed text formatting" cards. Default `false`, same reasoning as
+   * {@link structural}: a restyled document mints one per run, and the decision is
+   * reachable by clicking the grey-marked text instead. The rail keeps the decisions a
+   * reviewer reads in order — content changes and comments.
+   */
+  formatting?: boolean;
 }
 
 // Inline SVG, like the toolbar's icons: this package ships no icon font.
@@ -215,6 +222,7 @@ function ReviewRoot({
   gap = 8,
   filter,
   structural = false,
+  formatting = false,
 }: ReviewProps) {
   const editor = useDocxEditor();
   const review = useReview();
@@ -230,11 +238,13 @@ function ReviewRoot({
   const open = review.paneOpen;
 
   const items = useMemo(() => {
-    const shown = structural
-      ? review.items
-      : review.items.filter((entry) => entry.revisionKind !== 'structural');
+    const shown = review.items.filter(
+      (entry) =>
+        (structural || entry.revisionKind !== 'structural') &&
+        (formatting || entry.revisionKind !== 'format')
+    );
     return filter ? shown.filter((entry) => filter(entry)) : shown;
-  }, [review.items, filter, structural]);
+  }, [review.items, filter, structural, formatting]);
 
   // Word's rule: a colour per author by ORDER OF FIRST APPEARANCE. A hash of the name is
   // stable but collides, and two reviewers drawn in one colour tells the reader the wrong
@@ -493,7 +503,7 @@ function ReviewRoot({
         : takeRoot('Draft', <ReviewDraft top={composeTop} />)}
       {/* Mounted open OR closed: the balloon is how a reader inspects a change whose rail
           card is filtered away, and a closed pane filters ALL of them away. */}
-      {takeRoot('Hover', <ReviewHover />)}
+      {takeRoot('Balloon', <ReviewBalloon />)}
     </>
   ) : null;
 
@@ -840,64 +850,54 @@ function ReviewDraft({ top, className, hidden }: ReviewPartProps & { top: number
 }
 ReviewDraft.docxReviewPart = 'Draft' as const;
 
-/** What a hovered tracked change tells us before any item matching — straight off its DOM. */
-interface HoverAnchor {
+/** What a clicked tracked change tells us before any item matching — straight off its DOM. */
+interface BalloonAnchor {
   readonly revisionId: string;
   readonly author: string;
   readonly date?: string;
   readonly kind?: string;
-  /** Rail-relative CSS px of the hovered element's box. */
+  /** True when the pressed element is a tracked table ROW — a structural site. */
+  readonly structuralSite: boolean;
+  /** The pressed span's own range, for the position rung of the match. */
+  readonly paragraphId?: string;
+  readonly start?: number;
+  readonly end?: number;
+  /** Rail-relative CSS px of the pressed element's box. */
   readonly left: number;
   readonly top: number;
   readonly bottom: number;
   /** True when the balloon opens upward — the target sits low in the window. */
   readonly above: boolean;
-  /**
-   * True when a CLICK opened it. A pinned balloon stops following the pointer and stays
-   * until a press lands somewhere that is neither a tracked change nor the balloon.
-   */
-  readonly pinned: boolean;
 }
 
-/** Word's own delays, near enough: deliberate hover opens, a passing pointer does not. */
-const HOVER_SHOW_MS = 250;
-const HOVER_HIDE_MS = 200;
 /**
- * Retarget delay while a balloon is ALREADY up. Much shorter than the opening delay: the
- * reader is plainly working through the changes, and making each one wait the full
- * deliberate-hover pause reads as the balloon failing to follow.
- */
-const HOVER_RETARGET_MS = 80;
-
-/**
- * The hover balloon: pointing at a tracked change in the PAGE raises its decision card
+ * The decision balloon: CLICKING a format or structural change in the PAGE opens its card
  * beside the text — author, what changed, when, and accept/reject where the engine can
- * resolve it. This is how Word presents a change, and it is what makes hiding noisy card
- * kinds from the rail safe: the information moves from a permanent column to a gesture.
+ * resolve it — and the card stays until a press lands somewhere that is neither a tracked
+ * change nor the balloon itself. Click-opened on purpose: a hover-opened card vanished
+ * under the pointer travelling toward its own buttons.
  *
- * Matches the painted element's `data-revision-*` attribution against the UNFILTERED
- * queue, so it answers for kinds the rail's `structural` default or a host `filter` hid.
- * An element whose attribution matches nothing (mid-edit staleness) still shows what the
- * DOM itself carries — author, kind, date — just without actions.
+ * ONLY the kinds whose rail cards are hidden by default. Content changes and comments are
+ * the rail's — a balloon over "added" text repeats a card already beside the page — while
+ * a format or structural change has nothing but its grey/washed marking, so the click on
+ * that marking is where its decision lives.
  *
- * FOLLOW, THEN PIN. With a balloon up, moving onto another change retargets it after a
- * short beat — the reader is walking the redline and the balloon walks with them.
- * CLICKING a change pins its balloon in place; it ignores the pointer until a press lands
- * somewhere that is neither a tracked change nor the balloon itself.
+ * Matches the pressed element against the UNFILTERED queue, attribution first and POSITION
+ * last: the `(id, author, date)` triple, then `(id, author)`, then the id, then the span's
+ * own paragraph range against the items' ranges — real files drift on attribution, and the
+ * range is the one thing the painter and the review model cannot disagree about. An
+ * element matching nothing still shows what its DOM carries, just without actions.
  *
  * @public
  */
-function ReviewHover({ className, hidden }: ReviewPartProps) {
+function ReviewBalloon({ className, hidden }: ReviewPartProps) {
   const { review, allItems, authorSlots } = useRail();
   const { t } = useTranslation();
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const [anchor, setAnchor] = useState<HoverAnchor | null>(null);
-  // What the LISTENERS need to know about the state they cannot read: whether a balloon
-  // is up (retarget fast) and whether it is pinned (ignore hover altogether).
+  const [anchor, setAnchor] = useState<BalloonAnchor | null>(null);
+  // Whether a balloon is up, readable from the listener without re-binding it.
   const openRef = useRef(false);
-  const pinnedRef = useRef(false);
   openRef.current = anchor !== null;
-  pinnedRef.current = anchor?.pinned ?? false;
 
   useEffect(() => {
     const host = rootRef.current;
@@ -907,14 +907,13 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
     const scroller = (rail?.closest('.docx-editor__scroll-container') ??
       rail?.offsetParent) as HTMLElement | null;
     if (!host || !rail || !scroller) return undefined;
-    let showTimer = 0;
-    let hideTimer = 0;
-    let current: HTMLElement | null = null;
 
-    const show = (element: HTMLElement, pinned: boolean): void => {
+    const open = (element: HTMLElement, structuralSite: boolean): void => {
       const railRect = rail.getBoundingClientRect();
       const rect = element.getBoundingClientRect();
       const viewportBottom = element.ownerDocument.defaultView?.innerHeight ?? Infinity;
+      const start = Number(element.dataset.start);
+      const end = Number(element.dataset.end);
       setAnchor({
         revisionId: element.dataset.revisionId!,
         author: element.dataset.revisionAuthor ?? '',
@@ -924,91 +923,45 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
         ...(element.dataset.revisionKind !== undefined
           ? { kind: element.dataset.revisionKind }
           : {}),
+        structuralSite,
+        ...(element.dataset.paragraphId !== undefined
+          ? { paragraphId: element.dataset.paragraphId }
+          : {}),
+        ...(Number.isFinite(start) ? { start } : {}),
+        ...(Number.isFinite(end) ? { end } : {}),
         left: rect.left - railRect.left,
         top: rect.top - railRect.top,
         bottom: rect.bottom - railRect.top,
         // Opens upward when there is no room below — a change on the last visible line
         // would otherwise push its balloon under the fold.
         above: rect.bottom + 220 > viewportBottom,
-        pinned,
       });
     };
 
-    const onOver = (event: MouseEvent): void => {
-      // A pinned balloon holds still: the reader clicked THIS change, and having the card
-      // wander off while they reach for its buttons is the failure pinning exists to stop.
-      if (pinnedRef.current) return;
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      // Travelling INTO the balloon keeps it open — that is how its buttons get clicked.
-      if (host.contains(target)) {
-        window.clearTimeout(hideTimer);
-        return;
-      }
-      const element = target.closest('[data-revision-id]');
-      if (element instanceof HTMLElement && scroller.contains(element)) {
-        window.clearTimeout(hideTimer);
-        if (element === current) return;
-        current = element;
-        window.clearTimeout(showTimer);
-        // With a balloon already up the pointer is FOLLOWED: retargeting waits only long
-        // enough to skip changes the pointer merely crosses.
-        showTimer = window.setTimeout(
-          () => show(element, false),
-          openRef.current ? HOVER_RETARGET_MS : HOVER_SHOW_MS
-        );
-      } else if (openRef.current || current !== null) {
-        // Only when there is something to put away. This branch is the one ordinary mouse
-        // movement lands in — every element crossing on a page with no balloon up — and
-        // unconditionally cancelling and re-arming a timer per crossing is allocation at
-        // pointer frequency for nothing.
-        current = null;
-        window.clearTimeout(showTimer);
-        window.clearTimeout(hideTimer);
-        hideTimer = window.setTimeout(() => setAnchor(null), HOVER_HIDE_MS);
-      }
-    };
-    const onLeave = (): void => {
-      if (pinnedRef.current || (!openRef.current && current === null)) return;
-      current = null;
-      window.clearTimeout(showTimer);
-      window.clearTimeout(hideTimer);
-      hideTimer = window.setTimeout(() => setAnchor(null), HOVER_HIDE_MS);
-    };
-    // Clicking a change PINS its balloon — Word's own gesture for "I am deciding this
-    // one". Observation only: the press still moves the caret and opens the rail card,
-    // exactly as it did before the balloon existed. A press anywhere else lets go —
-    // including the pinned change's own text, where the reader is now placing a caret.
+    // ONE capture-phase mousedown listener; nothing runs at pointer-movement frequency.
+    // Observation only: the press still moves the caret exactly as it did before the
+    // balloon existed. A press anywhere that is not a qualifying change closes the card —
+    // including on an insertion or deletion, whose decision lives in the rail.
     const onDown = (event: MouseEvent): void => {
       const target = event.target;
       if (!(target instanceof Element)) return;
       // Pressing the balloon itself (accept, reject) is not a dismissal.
       if (host.contains(target)) return;
       const element = target.closest('[data-revision-id]');
-      window.clearTimeout(showTimer);
-      window.clearTimeout(hideTimer);
       if (element instanceof HTMLElement && scroller.contains(element)) {
-        // Pressing a change pins it — including one whose balloon hover already opened.
-        current = element;
-        show(element, true);
-      } else {
-        current = null;
-        setAnchor(null);
+        const structuralSite = element.classList.contains('docx-table-row--revision');
+        if (element.dataset.revisionKind === 'format' || structuralSite) {
+          open(element, structuralSite);
+          return;
+        }
       }
+      if (openRef.current) setAnchor(null);
     };
-    scroller.addEventListener('mouseover', onOver, true);
-    scroller.addEventListener('mouseleave', onLeave);
     scroller.addEventListener('mousedown', onDown, true);
-    return () => {
-      window.clearTimeout(showTimer);
-      window.clearTimeout(hideTimer);
-      scroller.removeEventListener('mouseover', onOver, true);
-      scroller.removeEventListener('mouseleave', onLeave);
-      scroller.removeEventListener('mousedown', onDown, true);
-    };
+    return () => scroller.removeEventListener('mousedown', onDown, true);
   }, []);
 
-  // The decision the hovered SITE belongs to. Sites coalesce into decisions by the
+  // The decision the pressed SITE belongs to. Sites coalesce into decisions by the
   // `(id, author, date)` triple, which is what the painted element carries — but real
   // files drift: producers reuse ids, omit dates on one wrapper and not another, and a
   // strict triple left the balloon informational over changes the rail could resolve. So
@@ -1019,13 +972,18 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
   // tick while a balloon is up, and the queue behind a heavy redline runs to thousands.
   // The exact triple returns the FIRST hit immediately (Word reuses ids across an editing
   // burst, and reading order picks the right one); the relaxed rungs each keep a single
-  // candidate and disqualify themselves on a second distinct hit.
+  // candidate and disqualify themselves on a second distinct hit. The POSITION rung runs
+  // over the same pass: the pressed span's own paragraph range against the item's ranges,
+  // restricted to the balloon's kinds — attribution can drift between the painter's read
+  // and the review model's, but both took the range from the same characters.
   const entry = useMemo(() => {
     if (!anchor) return null;
     let byAuthor: ReviewItemView | null = null;
     let byAuthorAmbiguous = false;
     let byId: ReviewItemView | null = null;
     let byIdAmbiguous = false;
+    let byRange: ReviewItemView | null = null;
+    let byRangeAmbiguous = false;
     for (const candidate of allItems) {
       if (candidate.kind !== 'revision' || candidate.item.kind !== 'revision') continue;
       for (const address of candidate.item.addresses) {
@@ -1038,17 +996,43 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
         if (byId === null) byId = candidate;
         else if (byId !== candidate) byIdAmbiguous = true;
       }
+      if (
+        anchor.paragraphId !== undefined &&
+        anchor.start !== undefined &&
+        anchor.end !== undefined &&
+        (candidate.revisionKind === 'format' || candidate.revisionKind === 'structural')
+      ) {
+        for (const range of candidate.item.ranges) {
+          if (
+            range.start.paragraphId === anchor.paragraphId &&
+            range.start.offset < anchor.end &&
+            range.end.offset > anchor.start
+          ) {
+            if (byRange === null) byRange = candidate;
+            else if (byRange !== candidate) byRangeAmbiguous = true;
+            break;
+          }
+        }
+      }
     }
     if (byAuthor !== null && !byAuthorAmbiguous) return byAuthor;
     if (byId !== null && !byIdAmbiguous) return byId;
+    if (byRange !== null && !byRangeAmbiguous) return byRange;
     return null;
   }, [allItems, anchor]);
+
+  // The balloon serves the kinds the rail does not; a drifted id that happened to land on
+  // a CONTENT decision must not raise a balloon over text whose card is beside the page.
+  const served =
+    entry && (entry.revisionKind === 'format' || entry.revisionKind === 'structural')
+      ? entry
+      : null;
 
   // Resolving the decision removes it from the queue; the balloon it was resolved from
   // must not linger over the text the accept just changed.
   const hadEntry = useRef(false);
   useEffect(() => {
-    if (entry) {
+    if (served) {
       hadEntry.current = true;
       return;
     }
@@ -1056,26 +1040,19 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
       hadEntry.current = false;
       setAnchor(null);
     }
-  }, [entry]);
+  }, [served]);
 
   if (hidden) return null;
-  const fallbackKind =
-    anchor?.kind === 'insert' ||
-    anchor?.kind === 'delete' ||
-    anchor?.kind === 'moveFrom' ||
-    anchor?.kind === 'moveTo' ||
-    anchor?.kind === 'format'
-      ? (anchor.kind as ReviewRevisionKind)
-      : ('structural' as const);
+  const fallbackKind = anchor?.kind === 'format' ? ('format' as const) : ('structural' as const);
 
   return (
     // The wrapper always mounts — it is what the wiring effect climbs from — and carries
     // no box of its own until there is a balloon to show.
-    <div ref={rootRef} className={`docx-review__hover-root${className ? ` ${className}` : ''}`}>
+    <div ref={rootRef} className={`docx-review__balloon-root${className ? ` ${className}` : ''}`}>
       {anchor === null ? null : (
         <div
-          className="docx-review__hover"
-          data-testid="review-hover"
+          className="docx-review__balloon"
+          data-testid="review-balloon"
           style={{
             left: anchor.left,
             top: anchor.above ? anchor.top - 6 : anchor.bottom + 6,
@@ -1083,18 +1060,18 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
           }}
           onMouseDown={guardMousedown}
         >
-          {entry ? (
-            <ReviewItemContext.Provider value={entry}>
+          {served ? (
+            <ReviewItemContext.Provider value={served}>
               <div
                 className="docx-review__card"
-                data-testid="review-hover-card"
-                data-kind={entry.revisionKind ?? 'revision'}
+                data-testid="review-balloon-card"
+                data-kind={served.revisionKind ?? 'revision'}
                 style={
                   {
-                    '--doc-review-author': `var(--doc-review-author-${(authorSlots.get(entry.author) ?? 0) % AUTHOR_SLOTS})`,
+                    '--doc-review-author': `var(--doc-review-author-${(authorSlots.get(served.author) ?? 0) % AUTHOR_SLOTS})`,
                   } as CSSProperties
                 }
-                onClick={() => review.setActive(entry.key)}
+                onClick={() => review.setActive(served.key)}
               >
                 <div className="docx-review__head">
                   <ReviewAvatar />
@@ -1102,7 +1079,7 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
                     <ReviewAuthor />
                     <ReviewTime />
                   </div>
-                  {entry.kind === 'revision' && !entry.readOnly ? (
+                  {served.kind === 'revision' && !served.readOnly ? (
                     <div className="docx-review__actions">
                       <ReviewAccept />
                       <ReviewReject />
@@ -1115,7 +1092,7 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
           ) : (
             <div
               className="docx-review__card"
-              data-testid="review-hover-card"
+              data-testid="review-balloon-card"
               data-kind={fallbackKind}
             >
               <div className="docx-review__head">
@@ -1126,7 +1103,7 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
                   <span className="docx-review__author">
                     {anchor.author || t('comments.unknown')}
                   </span>
-                  {anchor.date ? <HoverTime raw={anchor.date} /> : null}
+                  {anchor.date ? <BalloonTime raw={anchor.date} /> : null}
                 </div>
               </div>
               <div className="docx-review__summary">
@@ -1141,7 +1118,7 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
     </div>
   );
 }
-ReviewHover.docxReviewPart = 'Hover' as const;
+ReviewBalloon.docxReviewPart = 'Balloon' as const;
 
 /** Initials for the dataset-only fallback, matching the engine's own derivation. */
 function initialsOf(author: string): string {
@@ -1154,7 +1131,7 @@ function initialsOf(author: string): string {
 }
 
 /** `ReviewTime` for a raw dataset date, outside any item context. */
-function HoverTime({ raw }: { raw: string }) {
+function BalloonTime({ raw }: { raw: string }) {
   const when = new Date(raw);
   if (Number.isNaN(when.getTime())) return null;
   return (
@@ -1649,8 +1626,8 @@ export interface DocxEditorReviewNamespace {
   readonly AddComment: typeof ReviewAddComment;
   /** The compose box a new comment is written in. */
   readonly Draft: typeof ReviewDraft;
-  /** The Word-style balloon raised by hovering a tracked change in the page. */
-  readonly Hover: typeof ReviewHover;
+  /** The decision balloon opened by clicking a format or structural change in the page. */
+  readonly Balloon: typeof ReviewBalloon;
 }
 
 export const DocxEditorReview: DocxEditorReviewNamespace = Object.assign(ReviewRoot, {
@@ -1668,5 +1645,5 @@ export const DocxEditorReview: DocxEditorReviewNamespace = Object.assign(ReviewR
   Markers: ReviewMarkers,
   AddComment: ReviewAddComment,
   Draft: ReviewDraft,
-  Hover: ReviewHover,
+  Balloon: ReviewBalloon,
 });

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -103,16 +103,8 @@ const RAIL_OVERSCAN = 600;
 /** How many author slots the token ramp defines; past it, colours repeat. */
 const AUTHOR_SLOTS = 8;
 
-/** What an unmeasured, uncollapsed card reserves in the stacking run, in CSS px. */
+/** What an unmeasured card reserves in the stacking run, in CSS px. */
 const DEFAULT_CARD_HEIGHT = 72;
-/** A collapsed card: the head row and its padding, in CSS px. */
-const COLLAPSED_CARD_HEIGHT = 54;
-/**
- * How far (CSS px) a card may be pushed below its own text before it collapses to a
- * header. Roughly half a viewport: nearer than that the eye still connects card to text;
- * further, a full card reads as annotating whatever happens to be beside it.
- */
-const COLLAPSE_DISPLACEMENT_PX = 480;
 
 /** Keeps the caret: a mousedown that bubbles to the editor moves it. Inputs are exempt. */
 function guardMousedown(event: React.MouseEvent): void {
@@ -278,6 +270,10 @@ function ReviewRoot({
   // a rail that guessed would overlap the moment a comment ran to three lines.
   const [heights, setHeights] = useState<ReadonlyMap<string, number>>(() => new Map());
   const measure = useCallback((key: string, height: number) => {
+    // A real card is never 0px tall — zero is a layout-less read (a DOM without a
+    // renderer, or a mid-transition detach), and recording it collapses the stacking run
+    // to gaps. The content-derived estimate keeps standing in until a real height lands.
+    if (height <= 0) return;
     setHeights((previous) => {
       if (previous.get(key) === height) return previous;
       const next = new Map(previous);
@@ -481,36 +477,78 @@ function ReviewRoot({
     return merged;
   }, [heights, roots]);
 
-  // Stacking with CROWDING COLLAPSE, one deterministic pass. Push-down stacking cannot be
-  // cheated: a cluster of tall cards needs more room than its text region has, and the
-  // overflow used to spill page after page — the reader at the bottom of the document saw
-  // full cards whose text lived pages earlier. A card pushed further than the threshold
-  // from its own text renders COLLAPSED (header only), which both bounds how misleading a
-  // displaced card can be and shrinks the pressure that displaces everything after it.
-  // The ACTIVE card and the compose box never collapse. Collapse decisions feed the cursor
-  // with the collapsed height, so the pass is stable: each decision depends only on the
-  // cards before it.
-  const { stacked, collapsedKeys } = useMemo(() => {
+  // CLUSTERED stacking, the way Google Docs places its cards. Push-down alone cannot be
+  // cheated: a dense cluster of cards needs more room than its text region has, and
+  // one-directional overflow marched full cards page after page below their text. Here
+  // colliding cards merge into a CLUSTER that centres on its members' anchors — spreading
+  // the overflow both up and down, so every card stays a full card and sits as close to
+  // its text as geometry allows. A cluster holding the ACTIVE card shifts so that card
+  // sits exactly at its own text, which is what makes click-to-review feel anchored.
+  // One deterministic pass over document-ordered entries: each entry opens a cluster, and
+  // clusters merge while they collide, the standard 1-D label-placement algorithm.
+  const stacked = useMemo(() => {
     const scale = metrics.scale;
-    const positions = new Map<string, number>();
-    const collapsed = new Set<string>();
-    let cursor = Number.NEGATIVE_INFINITY;
+    interface ClusterEntry {
+      readonly key: string;
+      readonly anchorY: number;
+      /** This entry's offset from the cluster top, in LAYOUT points. */
+      offset: number;
+      readonly heightPt: number;
+      readonly isActive: boolean;
+    }
+    interface Cluster {
+      entries: ClusterEntry[];
+      /** Sum over entries of (anchor − offset): the numerator of the centred top. */
+      desiredSum: number;
+      heightPt: number;
+      top: number;
+    }
+    const clusters: Cluster[] = [];
+    const place = (cluster: Cluster): void => {
+      // Centred on its members' anchors; the active member overrides the centre so ITS
+      // card aligns with its text; never above the document.
+      const active = cluster.entries.find((entry) => entry.isActive);
+      const centred = cluster.desiredSum / cluster.entries.length;
+      cluster.top = Math.max(0, active ? active.anchorY - active.offset : centred);
+    };
     for (const entry of stackInput) {
       if (entry.anchorY === null) continue;
-      const top = Math.max(entry.anchorY, cursor);
-      positions.set(entry.key, top);
-      const displacedPx = (top - entry.anchorY) * scale;
-      const isActive = 'isActive' in entry && entry.isActive;
-      const collapse =
-        displacedPx > COLLAPSE_DISPLACEMENT_PX && !isActive && entry.key !== COMPOSE_KEY;
-      if (collapse) collapsed.add(entry.key);
-      const height = collapse
-        ? COLLAPSED_CARD_HEIGHT
-        : (estimatedHeights.get(entry.key) ?? DEFAULT_CARD_HEIGHT);
-      // Pixels to points before they meet an anchor.
-      cursor = top + (height + gap) / scale;
+      const heightPt = ((estimatedHeights.get(entry.key) ?? DEFAULT_CARD_HEIGHT) + gap) / scale;
+      const member: ClusterEntry = {
+        key: entry.key,
+        anchorY: entry.anchorY,
+        offset: 0,
+        heightPt,
+        isActive: 'isActive' in entry && entry.isActive === true,
+      };
+      clusters.push({
+        entries: [member],
+        desiredSum: entry.anchorY,
+        heightPt,
+        top: Math.max(0, entry.anchorY),
+      });
+      place(clusters[clusters.length - 1]!);
+      // Merge while the new cluster overlaps the one before it; merging can push the
+      // combined cluster up into ITS predecessor, so the loop continues until clear.
+      while (clusters.length > 1) {
+        const previous = clusters[clusters.length - 2]!;
+        const current = clusters[clusters.length - 1]!;
+        if (previous.top + previous.heightPt <= current.top) break;
+        for (const moved of current.entries) {
+          moved.offset += previous.heightPt;
+          previous.desiredSum += moved.anchorY - moved.offset;
+          previous.entries.push(moved);
+        }
+        previous.heightPt += current.heightPt;
+        clusters.pop();
+        place(previous);
+      }
     }
-    return { stacked: positions, collapsedKeys: collapsed };
+    const positions = new Map<string, number>();
+    for (const cluster of clusters) {
+      for (const entry of cluster.entries) positions.set(entry.key, cluster.top + entry.offset);
+    }
+    return positions;
   }, [stackInput, estimatedHeights, gap, metrics.scale]);
   const composeTop =
     composeAnchorY === null
@@ -575,7 +613,6 @@ function ReviewRoot({
           <ReviewList
             stack={stack}
             positions={stacked}
-            collapsed={collapsedKeys}
             scale={metrics.scale}
             offset={metrics.top}
             window={window_}
@@ -607,7 +644,6 @@ function ReviewRoot({
               <ReviewList
                 stack={stack}
                 positions={stacked}
-                collapsed={collapsedKeys}
                 scale={metrics.scale}
                 offset={metrics.top}
                 window={window_}
@@ -629,8 +665,6 @@ function ReviewRoot({
 interface ReviewListProps {
   stack?: boolean;
   positions?: ReadonlyMap<string, number>;
-  /** Cards the stacking pass collapsed to a header — pushed too far from their text. */
-  collapsed?: ReadonlySet<string>;
   scale?: number;
   offset?: number;
   /** Visible band of the scroller; cards outside it are not mounted. Null renders all. */
@@ -655,7 +689,6 @@ interface ReviewListProps {
 function ReviewList({
   stack = true,
   positions,
-  collapsed,
   scale = 1,
   offset = 0,
   window: visible = null,
@@ -688,10 +721,6 @@ function ReviewList({
             <div
               className="docx-review__slot"
               style={style}
-              // Header-only, because the card sits far from the text it annotates and a
-              // full summary there reads as annotating the wrong text. Clicking it makes
-              // the item active, and the active card always renders in full.
-              {...(collapsed?.has(entry.key) ? { 'data-collapsed': '' } : {})}
               ref={(node) => {
                 measure(node, entry.key);
               }}

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -852,11 +852,22 @@ interface HoverAnchor {
   readonly bottom: number;
   /** True when the balloon opens upward — the target sits low in the window. */
   readonly above: boolean;
+  /**
+   * True when a CLICK opened it. A pinned balloon stops following the pointer and stays
+   * until a press lands somewhere that is neither a tracked change nor the balloon.
+   */
+  readonly pinned: boolean;
 }
 
 /** Word's own delays, near enough: deliberate hover opens, a passing pointer does not. */
 const HOVER_SHOW_MS = 250;
 const HOVER_HIDE_MS = 200;
+/**
+ * Retarget delay while a balloon is ALREADY up. Much shorter than the opening delay: the
+ * reader is plainly working through the changes, and making each one wait the full
+ * deliberate-hover pause reads as the balloon failing to follow.
+ */
+const HOVER_RETARGET_MS = 80;
 
 /**
  * The hover balloon: pointing at a tracked change in the PAGE raises its decision card
@@ -869,6 +880,11 @@ const HOVER_HIDE_MS = 200;
  * An element whose attribution matches nothing (mid-edit staleness) still shows what the
  * DOM itself carries — author, kind, date — just without actions.
  *
+ * FOLLOW, THEN PIN. With a balloon up, moving onto another change retargets it after a
+ * short beat — the reader is walking the redline and the balloon walks with them.
+ * CLICKING a change pins its balloon in place; it ignores the pointer until a press lands
+ * somewhere that is neither a tracked change nor the balloon itself.
+ *
  * @public
  */
 function ReviewHover({ className, hidden }: ReviewPartProps) {
@@ -876,6 +892,12 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
   const { t } = useTranslation();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [anchor, setAnchor] = useState<HoverAnchor | null>(null);
+  // What the LISTENERS need to know about the state they cannot read: whether a balloon
+  // is up (retarget fast) and whether it is pinned (ignore hover altogether).
+  const openRef = useRef(false);
+  const pinnedRef = useRef(false);
+  openRef.current = anchor !== null;
+  pinnedRef.current = anchor?.pinned ?? false;
 
   useEffect(() => {
     const host = rootRef.current;
@@ -889,7 +911,7 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
     let hideTimer = 0;
     let current: HTMLElement | null = null;
 
-    const show = (element: HTMLElement): void => {
+    const show = (element: HTMLElement, pinned: boolean): void => {
       const railRect = rail.getBoundingClientRect();
       const rect = element.getBoundingClientRect();
       const viewportBottom = element.ownerDocument.defaultView?.innerHeight ?? Infinity;
@@ -908,10 +930,14 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
         // Opens upward when there is no room below — a change on the last visible line
         // would otherwise push its balloon under the fold.
         above: rect.bottom + 220 > viewportBottom,
+        pinned,
       });
     };
 
     const onOver = (event: MouseEvent): void => {
+      // A pinned balloon holds still: the reader clicked THIS change, and having the card
+      // wander off while they reach for its buttons is the failure pinning exists to stop.
+      if (pinnedRef.current) return;
       const target = event.target;
       if (!(target instanceof Element)) return;
       // Travelling INTO the balloon keeps it open — that is how its buttons get clicked.
@@ -925,7 +951,12 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
         if (element === current) return;
         current = element;
         window.clearTimeout(showTimer);
-        showTimer = window.setTimeout(() => show(element), HOVER_SHOW_MS);
+        // With a balloon already up the pointer is FOLLOWED: retargeting waits only long
+        // enough to skip changes the pointer merely crosses.
+        showTimer = window.setTimeout(
+          () => show(element, false),
+          openRef.current ? HOVER_RETARGET_MS : HOVER_SHOW_MS
+        );
       } else {
         current = null;
         window.clearTimeout(showTimer);
@@ -934,37 +965,89 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
       }
     };
     const onLeave = (): void => {
+      if (pinnedRef.current) return;
       current = null;
       window.clearTimeout(showTimer);
       window.clearTimeout(hideTimer);
       hideTimer = window.setTimeout(() => setAnchor(null), HOVER_HIDE_MS);
     };
+    // Clicking a change PINS its balloon — Word's own gesture for "I am deciding this
+    // one". Observation only: the press still moves the caret and opens the rail card,
+    // exactly as it did before the balloon existed. A press anywhere else lets go —
+    // including the pinned change's own text, where the reader is now placing a caret.
+    const onDown = (event: MouseEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      // Pressing the balloon itself (accept, reject) is not a dismissal.
+      if (host.contains(target)) return;
+      const element = target.closest('[data-revision-id]');
+      window.clearTimeout(showTimer);
+      window.clearTimeout(hideTimer);
+      if (element instanceof HTMLElement && scroller.contains(element)) {
+        // Pressing a change pins it — including one whose balloon hover already opened.
+        current = element;
+        show(element, true);
+      } else {
+        current = null;
+        setAnchor(null);
+      }
+    };
     scroller.addEventListener('mouseover', onOver, true);
     scroller.addEventListener('mouseleave', onLeave);
+    scroller.addEventListener('mousedown', onDown, true);
     return () => {
       window.clearTimeout(showTimer);
       window.clearTimeout(hideTimer);
       scroller.removeEventListener('mouseover', onOver, true);
       scroller.removeEventListener('mouseleave', onLeave);
+      scroller.removeEventListener('mousedown', onDown, true);
     };
   }, []);
 
   // The decision the hovered SITE belongs to. Sites coalesce into decisions by the
-  // `(id, author, date)` triple, which is exactly what the painted element carries.
+  // `(id, author, date)` triple, which is what the painted element carries — but real
+  // files drift: producers reuse ids, omit dates on one wrapper and not another, and a
+  // strict triple left the balloon informational over changes the rail could resolve. So
+  // the match RELAXES in steps, taking the strictest interpretation with a single answer:
+  // the full triple, then `(id, author)`, then the id alone — and never a guess between
+  // two candidates.
   const entry = useMemo(() => {
     if (!anchor) return null;
+    const revisions = allItems.filter(
+      (candidate) => candidate.kind === 'revision' && candidate.item.kind === 'revision'
+    );
+    const only = (matches: readonly ReviewItemView[]): ReviewItemView | null =>
+      matches.length === 1 ? matches[0]! : null;
+    const byTriple = revisions.filter(
+      (candidate) =>
+        candidate.item.kind === 'revision' &&
+        candidate.item.addresses.some(
+          (address) =>
+            address.id === anchor.revisionId &&
+            address.author === anchor.author &&
+            address.date === anchor.date
+        )
+    );
+    // The exact triple may legitimately match SEVERAL decisions (Word reuses ids across
+    // an editing burst); reading order put the right one first often enough before, so
+    // the first stays the answer at this rung.
+    if (byTriple.length > 0) return byTriple[0]!;
+    const byAuthor = revisions.filter(
+      (candidate) =>
+        candidate.item.kind === 'revision' &&
+        candidate.item.addresses.some(
+          (address) => address.id === anchor.revisionId && address.author === anchor.author
+        )
+    );
     return (
-      allItems.find(
-        (candidate) =>
-          candidate.kind === 'revision' &&
-          candidate.item.kind === 'revision' &&
-          candidate.item.addresses.some(
-            (address) =>
-              address.id === anchor.revisionId &&
-              address.author === anchor.author &&
-              address.date === anchor.date
-          )
-      ) ?? null
+      only(byAuthor) ??
+      only(
+        revisions.filter(
+          (candidate) =>
+            candidate.item.kind === 'revision' &&
+            candidate.item.addresses.some((address) => address.id === anchor.revisionId)
+        )
+      )
     );
   }, [allItems, anchor]);
 

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -1168,7 +1168,7 @@ function BalloonTime({ raw }: { raw: string }) {
   const when = new Date(raw);
   if (Number.isNaN(when.getTime())) return null;
   return (
-    <time className="docx-review__time" dateTime={raw} title={when.toLocaleString()}>
+    <time className="docx-review__time" dateTime={raw}>
       {REVIEW_DATE_FORMAT.format(when)}
     </time>
   );
@@ -1363,11 +1363,12 @@ function ReviewTime({ className, asChild, hidden, children }: ReviewPartProps) {
   if (!raw) return null;
   const when = new Date(raw);
   if (Number.isNaN(when.getTime())) return null;
+  // No `title`: the visible text already carries the date and time, and the native tooltip
+  // popped over the author's name in the balloon, reading as a mystery grey box.
   const shared = {
     className: `docx-review__time${className ? ` ${className}` : ''}`,
     'data-testid': 'review-time',
     dateTime: raw,
-    title: when.toLocaleString(),
   };
   if (asChild) return <Slot {...shared}>{children}</Slot>;
   // Month, day and time — what Word shows, and what a reviewer actually needs: two comments

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -381,8 +381,17 @@ function ReviewRoot({
           : { top, bottom };
       });
     };
+    // While the reader scrolls, the slots' `top` transition is suppressed (a DOM attribute
+    // so no React work happens at scroll frequency). Restacks DURING a scroll come from
+    // cards entering the window and correcting an estimated height to a measured one; each
+    // correction shifts every card below it, and ANIMATING those shifts while the page
+    // itself moves read as a second, faster scroll layered over the document.
+    let settle = 0;
     const onScroll = (): void => {
       if (frame === 0) frame = requestAnimationFrame(sync);
+      rail?.setAttribute('data-scrolling', '');
+      window.clearTimeout(settle);
+      settle = window.setTimeout(() => rail?.removeAttribute('data-scrolling'), 150);
     };
     sync();
     scroller.addEventListener('scroll', onScroll, { passive: true });
@@ -390,6 +399,7 @@ function ReviewRoot({
     observer.observe(scroller);
     return () => {
       if (frame !== 0) cancelAnimationFrame(frame);
+      window.clearTimeout(settle);
       scroller.removeEventListener('scroll', onScroll);
       observer.disconnect();
     };
@@ -443,13 +453,27 @@ function ReviewRoot({
     return at === -1 ? [...roots, compose] : [...roots.slice(0, at), compose, ...roots.slice(at)];
   }, [roots, draftAnchorY]);
 
-  const stacked = useStackedReviewPositions(stackInput, heights, {
+  // An unmeasured card — below the virtualization window, or in its first frame — reserves
+  // an estimate derived from ITS OWN text, not a flat constant. The estimate's error is the
+  // distance every card below it jumps at the moment the real measurement lands, and with
+  // hundreds of cards those corrections during a scroll compounded into the rail visibly
+  // sliding against the page. Card chrome (padding, head, gaps) is ~64px; summary lines
+  // wrap at roughly 36 characters of 20px line height.
+  const estimatedHeights = useMemo(() => {
+    const merged = new Map(heights);
+    for (const entry of roots) {
+      if (merged.has(entry.key)) continue;
+      const textLength = entry.text.length + (entry.replacedText?.length ?? 0);
+      const lines = Math.min(6, Math.max(1, Math.ceil(textLength / 36)));
+      merged.set(entry.key, 64 + lines * 20);
+    }
+    return merged;
+  }, [heights, roots]);
+
+  const stacked = useStackedReviewPositions(stackInput, estimatedHeights, {
     gap,
     scale: metrics.scale,
-    // An unmeasured card — below the virtualization window, or in its first frame — still
-    // reserves a plausible card's worth of room. Without this the run advanced by the gap
-    // alone and a dense redline opened as a column of cards painted over each other until
-    // every one had reported its height.
+    // The compose box, the one stacked key that is not a root card.
     defaultHeight: 72,
   });
   const composeTop =
@@ -938,11 +962,11 @@ function ReviewBalloon({ className, hidden }: ReviewPartProps) {
       });
     };
 
-    // ONE capture-phase mousedown listener; nothing runs at pointer-movement frequency.
+    // Capture-phase press listeners; nothing runs at pointer-movement frequency.
     // Observation only: the press still moves the caret exactly as it did before the
     // balloon existed. A press anywhere that is not a qualifying change closes the card —
     // including on an insertion or deletion, whose decision lives in the rail.
-    const onDown = (event: MouseEvent): void => {
+    const onDown = (event: Event): void => {
       const target = event.target;
       if (!(target instanceof Element)) return;
       // Pressing the balloon itself (accept, reject) is not a dismissal.
@@ -957,8 +981,17 @@ function ReviewBalloon({ className, hidden }: ReviewPartProps) {
       }
       if (openRef.current) setAnchor(null);
     };
+    // BOTH press events, not mousedown alone. The surface cancels `pointerdown` when it
+    // places the caret, and a cancelled pointerdown SUPPRESSES the compatibility mousedown
+    // outright — a mousedown-only listener never heard a real click on the page, only
+    // synthetic ones, which is exactly how that bug shipped. The rare double delivery
+    // (chrome areas cancel nothing) re-runs a handler that converges on the same state.
+    scroller.addEventListener('pointerdown', onDown, true);
     scroller.addEventListener('mousedown', onDown, true);
-    return () => scroller.removeEventListener('mousedown', onDown, true);
+    return () => {
+      scroller.removeEventListener('pointerdown', onDown, true);
+      scroller.removeEventListener('mousedown', onDown, true);
+    };
   }, []);
 
   // The decision the pressed SITE belongs to. Sites coalesce into decisions by the

--- a/packages/react/src/editor/DocxEditorReview.tsx
+++ b/packages/react/src/editor/DocxEditorReview.tsx
@@ -957,7 +957,11 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
           () => show(element, false),
           openRef.current ? HOVER_RETARGET_MS : HOVER_SHOW_MS
         );
-      } else {
+      } else if (openRef.current || current !== null) {
+        // Only when there is something to put away. This branch is the one ordinary mouse
+        // movement lands in — every element crossing on a page with no balloon up — and
+        // unconditionally cancelling and re-arming a timer per crossing is allocation at
+        // pointer frequency for nothing.
         current = null;
         window.clearTimeout(showTimer);
         window.clearTimeout(hideTimer);
@@ -965,7 +969,7 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
       }
     };
     const onLeave = (): void => {
-      if (pinnedRef.current) return;
+      if (pinnedRef.current || (!openRef.current && current === null)) return;
       current = null;
       window.clearTimeout(showTimer);
       window.clearTimeout(hideTimer);
@@ -1011,44 +1015,33 @@ function ReviewHover({ className, hidden }: ReviewPartProps) {
   // the match RELAXES in steps, taking the strictest interpretation with a single answer:
   // the full triple, then `(id, author)`, then the id alone — and never a guess between
   // two candidates.
+  // ONE allocation-free pass, not one filter per rung: this re-derives on every review
+  // tick while a balloon is up, and the queue behind a heavy redline runs to thousands.
+  // The exact triple returns the FIRST hit immediately (Word reuses ids across an editing
+  // burst, and reading order picks the right one); the relaxed rungs each keep a single
+  // candidate and disqualify themselves on a second distinct hit.
   const entry = useMemo(() => {
     if (!anchor) return null;
-    const revisions = allItems.filter(
-      (candidate) => candidate.kind === 'revision' && candidate.item.kind === 'revision'
-    );
-    const only = (matches: readonly ReviewItemView[]): ReviewItemView | null =>
-      matches.length === 1 ? matches[0]! : null;
-    const byTriple = revisions.filter(
-      (candidate) =>
-        candidate.item.kind === 'revision' &&
-        candidate.item.addresses.some(
-          (address) =>
-            address.id === anchor.revisionId &&
-            address.author === anchor.author &&
-            address.date === anchor.date
-        )
-    );
-    // The exact triple may legitimately match SEVERAL decisions (Word reuses ids across
-    // an editing burst); reading order put the right one first often enough before, so
-    // the first stays the answer at this rung.
-    if (byTriple.length > 0) return byTriple[0]!;
-    const byAuthor = revisions.filter(
-      (candidate) =>
-        candidate.item.kind === 'revision' &&
-        candidate.item.addresses.some(
-          (address) => address.id === anchor.revisionId && address.author === anchor.author
-        )
-    );
-    return (
-      only(byAuthor) ??
-      only(
-        revisions.filter(
-          (candidate) =>
-            candidate.item.kind === 'revision' &&
-            candidate.item.addresses.some((address) => address.id === anchor.revisionId)
-        )
-      )
-    );
+    let byAuthor: ReviewItemView | null = null;
+    let byAuthorAmbiguous = false;
+    let byId: ReviewItemView | null = null;
+    let byIdAmbiguous = false;
+    for (const candidate of allItems) {
+      if (candidate.kind !== 'revision' || candidate.item.kind !== 'revision') continue;
+      for (const address of candidate.item.addresses) {
+        if (address.id !== anchor.revisionId) continue;
+        if (address.author === anchor.author) {
+          if (address.date === anchor.date) return candidate;
+          if (byAuthor === null) byAuthor = candidate;
+          else if (byAuthor !== candidate) byAuthorAmbiguous = true;
+        }
+        if (byId === null) byId = candidate;
+        else if (byId !== candidate) byIdAmbiguous = true;
+      }
+    }
+    if (byAuthor !== null && !byAuthorAmbiguous) return byAuthor;
+    if (byId !== null && !byIdAmbiguous) return byId;
+    return null;
   }, [allItems, anchor]);
 
   // Resolving the decision removes it from the queue; the balloon it was resolved from

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -388,6 +388,25 @@ describe('the review sidebar', () => {
       await new Promise((resolve) => setTimeout(resolve, 260));
     });
     expect(view.queryByTestId('review-hover')).toBeNull();
+
+    // CLICKING a change pins its balloon: it opens at once, ignores the pointer moving to
+    // other changes, and lets go when a press lands outside any tracked change.
+    const pinSpan = view.container.querySelector(
+      '.docx-paginated-surface [data-revision-id][data-revision-kind="insert"]'
+    )!;
+    await act(async () => {
+      fireEvent.mouseDown(pinSpan);
+    });
+    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe('insert');
+    await act(async () => {
+      fireEvent.mouseOver(view.container.querySelector('.docx-table-row--revision')!);
+      await new Promise((resolve) => setTimeout(resolve, 320));
+    });
+    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe('insert');
+    await act(async () => {
+      fireEvent.mouseDown(view.container.querySelector('.docx-editor__scroll-container')!);
+    });
+    expect(view.queryByTestId('review-hover')).toBeNull();
   });
 });
 

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -405,6 +405,71 @@ describe('the review sidebar', () => {
     });
     expect(view.queryByTestId('review-balloon')).toBeNull();
   });
+
+  test('a crowded cluster spreads around its text instead of spilling below it', async () => {
+    // Many changes packed line-on-line: their cards cannot all fit beside the text.
+    // Push-down alone marched the tail pages below; the cluster instead CENTRES on its
+    // anchors, so cards spread up as well as down and every card stays a full card.
+    const CROWDED = docx(
+      // Plain paragraphs first, so the cluster has room ABOVE it to spread into — enough
+      // that aligning a mid-cluster member to its text never hits the top of the document.
+      Array.from({ length: 60 }, (_, index) => `<w:p><w:r><w:t>plain ${index}</w:t></w:r></w:p>`)
+        .join('') +
+        Array.from(
+          { length: 16 },
+          (_, index) =>
+            `<w:p><w:ins w:id="${index + 1}" w:author="A${index}" ` +
+            `w:date="2026-01-01T00:00:${String(index).padStart(2, '0')}Z">` +
+            `<w:r><w:t>change ${index}</w:t></w:r></w:ins></w:p>`
+        ).join('')
+    );
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={CROWDED}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    // EVERY decision renders as a full card — nothing is minimized or demoted.
+    const slots = [...view.container.querySelectorAll('.docx-review__slot')];
+    expect(slots.length).toBe(16);
+    const items = instance!.getReviewItems();
+    const anchors = new Map(items.map((item) => [item.key, item.anchorY] as const));
+    const tops = slots.map((slot) => parseFloat((slot as HTMLElement).style.top));
+    // Ordered and non-overlapping (estimates space them; happy-dom measures no heights).
+    for (let index = 1; index < tops.length; index += 1) {
+      expect(tops[index]!).toBeGreaterThan(tops[index - 1]!);
+    }
+    // Centred: the run starts ABOVE the first anchor (spread went upward too, in CSS px —
+    // slot tops are layout points times the render scale), and the last card sits closer
+    // to its text than pure push-down would have put it.
+    const SCALE = 96 / 72;
+    const firstAnchorPx = ([...anchors.values()][0] as number) * SCALE;
+    const lastAnchorPx = ([...anchors.values()].at(-1) as number) * SCALE;
+    expect(tops[0]!).toBeLessThan(firstAnchorPx);
+    const pushDownLastTop = firstAnchorPx + (tops.length - 1) * (tops[1]! - tops[0]!);
+    expect(tops.at(-1)! - lastAnchorPx).toBeLessThan(pushDownLastTop - lastAnchorPx);
+
+    // Activating a member shifts the cluster so THAT card aligns with its own text.
+    const target = items[7]!;
+    await act(async () => {
+      instance!.setActiveReviewItem(target.key);
+    });
+    const activeSlot = view.container
+      .querySelector('[data-testid="review-card"][data-active]')
+      ?.closest('.docx-review__slot') as HTMLElement | null;
+    expect(activeSlot).not.toBeNull();
+    expect(
+      Math.abs(parseFloat(activeSlot!.style.top) - (target.anchorY as number) * SCALE)
+    ).toBeLessThan(2);
+  });
 });
 
 describe('useEditorEvent', () => {

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -337,10 +337,12 @@ describe('the review sidebar', () => {
     expect(kindsOf(shown.container)).toContain('structural');
   });
 
-  test('hovering a tracked change raises its balloon — including a structural row whose rail card is hidden', async () => {
+  test('clicking a format or structural change opens its balloon; content changes stay rail-only', async () => {
     const TRACKED = docx(
       '<w:p><w:r><w:t>base </w:t></w:r>' +
-        '<w:ins w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z"><w:r><w:t>added</w:t></w:r></w:ins></w:p>' +
+        '<w:ins w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z"><w:r><w:t>added</w:t></w:r></w:ins>' +
+        '<w:r><w:rPr><w:b/><w:rPrChange w:id="3" w:author="A" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange></w:rPr>' +
+        '<w:t>restyled</w:t></w:r></w:p>' +
         '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>' +
         '<w:tr><w:tc><w:tcPr/><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc></w:tr>' +
         '<w:tr><w:trPr><w:ins w:id="2" w:author="A" w:date="2026-01-01T00:00:00Z"/></w:trPr>' +
@@ -355,58 +357,53 @@ describe('the review sidebar', () => {
         </DocxEditorViewport>
       </DocxEditorRoot>
     );
-    const hoverAndWait = async (element: Element) => {
-      await act(async () => {
-        fireEvent.mouseOver(element);
-        // Past the balloon's deliberate-hover delay.
-        await new Promise((resolve) => setTimeout(resolve, 320));
-      });
-    };
-
-    // A revision SPAN: the balloon carries the decision's card, actions included.
-    const span = view.container.querySelector(
-      '.docx-paginated-surface [data-revision-id][data-revision-kind="insert"]'
+    // FORMAT cards are out of the rail by default, like structural ones; the balloon —
+    // not a hover — is where their decision lives.
+    const railKinds = [...view.container.querySelectorAll('[data-testid="review-card"]')].map(
+      (card) => (card as HTMLElement).dataset.kind
     );
-    expect(span).not.toBeNull();
-    await hoverAndWait(span!);
-    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe('insert');
-    expect(view.getByTestId('review-hover').textContent).toContain('added');
+    expect(railKinds).toContain('insert');
+    expect(railKinds).not.toContain('format');
+    expect(railKinds).not.toContain('structural');
 
-    // A tracked ROW: its rail card is hidden by default, so the balloon is the only way
-    // to read the decision — the painted row carries the attribution to find it.
+    // Clicking the format-marked text opens its balloon, actions included, and it STAYS.
+    const formatSpan = view.container.querySelector(
+      '.docx-paginated-surface [data-revision-kind="format"]'
+    )!;
+    await act(async () => {
+      fireEvent.mouseDown(formatSpan);
+    });
+    const balloon = view.getByTestId('review-balloon-card') as HTMLElement;
+    expect(balloon.dataset.kind).toBe('format');
+    expect(view.getByTestId('review-balloon').querySelector('[data-testid="review-accept"]'))
+      .not.toBeNull();
+
+    // A CONTENT change opens no balloon — its card is beside the page — and the press
+    // closes whatever balloon was up.
+    await act(async () => {
+      fireEvent.mouseDown(
+        view.container.querySelector(
+          '.docx-paginated-surface [data-revision-id][data-revision-kind="insert"]'
+        )!
+      );
+    });
+    expect(view.queryByTestId('review-balloon')).toBeNull();
+
+    // A tracked ROW is a structural site: its balloon opens on click, with actions.
     const row = view.container.querySelector('.docx-table-row--revision') as HTMLElement;
     expect(row.dataset.revisionId).toBe('2');
-    expect(row.dataset.revisionAuthor).toBe('A');
-    await hoverAndWait(row);
-    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe(
+    await act(async () => {
+      fireEvent.mouseDown(row);
+    });
+    expect((view.getByTestId('review-balloon-card') as HTMLElement).dataset.kind).toBe(
       'structural'
     );
 
-    // Leaving the page puts the balloon away.
-    await act(async () => {
-      fireEvent.mouseOver(view.container.querySelector('.docx-editor__scroll-container')!);
-      await new Promise((resolve) => setTimeout(resolve, 260));
-    });
-    expect(view.queryByTestId('review-hover')).toBeNull();
-
-    // CLICKING a change pins its balloon: it opens at once, ignores the pointer moving to
-    // other changes, and lets go when a press lands outside any tracked change.
-    const pinSpan = view.container.querySelector(
-      '.docx-paginated-surface [data-revision-id][data-revision-kind="insert"]'
-    )!;
-    await act(async () => {
-      fireEvent.mouseDown(pinSpan);
-    });
-    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe('insert');
-    await act(async () => {
-      fireEvent.mouseOver(view.container.querySelector('.docx-table-row--revision')!);
-      await new Promise((resolve) => setTimeout(resolve, 320));
-    });
-    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe('insert');
+    // A press outside any tracked change lets go.
     await act(async () => {
       fireEvent.mouseDown(view.container.querySelector('.docx-editor__scroll-container')!);
     });
-    expect(view.queryByTestId('review-hover')).toBeNull();
+    expect(view.queryByTestId('review-balloon')).toBeNull();
   });
 });
 

--- a/packages/react/test/editor-composition.test.tsx
+++ b/packages/react/test/editor-composition.test.tsx
@@ -16,7 +16,7 @@ import './dom-setup.ts';
 import { afterEach, describe, expect, test } from 'bun:test';
 import { StrictMode, createRef } from 'react';
 import { renderToString } from 'react-dom/server';
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
 import type {
   Editor,
@@ -335,6 +335,59 @@ describe('the review sidebar', () => {
       </DocxEditorRoot>
     );
     expect(kindsOf(shown.container)).toContain('structural');
+  });
+
+  test('hovering a tracked change raises its balloon — including a structural row whose rail card is hidden', async () => {
+    const TRACKED = docx(
+      '<w:p><w:r><w:t>base </w:t></w:r>' +
+        '<w:ins w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z"><w:r><w:t>added</w:t></w:r></w:ins></w:p>' +
+        '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>' +
+        '<w:tr><w:tc><w:tcPr/><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc></w:tr>' +
+        '<w:tr><w:trPr><w:ins w:id="2" w:author="A" w:date="2026-01-01T00:00:00Z"/></w:trPr>' +
+        '<w:tc><w:tcPr/><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc></w:tr>' +
+        '</w:tbl>'
+    );
+    const view = render(
+      <DocxEditorRoot document={TRACKED}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const hoverAndWait = async (element: Element) => {
+      await act(async () => {
+        fireEvent.mouseOver(element);
+        // Past the balloon's deliberate-hover delay.
+        await new Promise((resolve) => setTimeout(resolve, 320));
+      });
+    };
+
+    // A revision SPAN: the balloon carries the decision's card, actions included.
+    const span = view.container.querySelector(
+      '.docx-paginated-surface [data-revision-id][data-revision-kind="insert"]'
+    );
+    expect(span).not.toBeNull();
+    await hoverAndWait(span!);
+    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe('insert');
+    expect(view.getByTestId('review-hover').textContent).toContain('added');
+
+    // A tracked ROW: its rail card is hidden by default, so the balloon is the only way
+    // to read the decision — the painted row carries the attribution to find it.
+    const row = view.container.querySelector('.docx-table-row--revision') as HTMLElement;
+    expect(row.dataset.revisionId).toBe('2');
+    expect(row.dataset.revisionAuthor).toBe('A');
+    await hoverAndWait(row);
+    expect((view.getByTestId('review-hover-card') as HTMLElement).dataset.kind).toBe(
+      'structural'
+    );
+
+    // Leaving the page puts the balloon away.
+    await act(async () => {
+      fireEvent.mouseOver(view.container.querySelector('.docx-editor__scroll-container')!);
+      await new Promise((resolve) => setTimeout(resolve, 260));
+    });
+    expect(view.queryByTestId('review-hover')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Hovering a tracked change in the page raises a Word-style balloon: author, what changed, when, and accept/reject where the engine can resolve it (screenshot pattern from Word's own "Accept or reject suggestion?" card).

- `DocxEditor.Review` gains a `Hover` part, mounted by default whether the pane is open or closed. It matches the hovered element's `data-revision-*` attribution against the UNFILTERED review queue, so kinds hidden from the rail — structural by default, or a host `filter` — stay one hover away instead of gone.
- Tracked table rows (`w:trPr/w:ins|w:del`) now thread their `(id, author, date)` attribution from the semantic table model through the row fragment record into painted DOM datasets, the same contract revision spans already had. Fragment signatures pick the new fields up automatically (`rows` is hashed wholesale).
- Balloon opens after a deliberate-hover delay, stays open while the pointer travels into it, flips above the anchor near the viewport bottom, and closes when the decision it shows is resolved.

Stacked on #124 (shares the review-rail changes); its commit shows in this diff until #124 merges. Pre-existing on the base branch, unchanged here: the 11 core paint-test failures (verified identical with the diff stashed) and the `check:public-docs-surface` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788506523&installation_model_id=422592&pr_number=125&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F125&signature=0c628374bef121e3340e92c5233e5b2f3b5e9afec866c4fd4b639efcd3fe7d60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->