### PR TITLE
feat: review header/footer tracked changes and blank-band editing

### DIFF
--- a/.changeset/header-tracked-changes-review.md
+++ b/.changeset/header-tracked-changes-review.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+Tracked changes and comments in headers/footers now appear in the review rail with accept/reject, `getTrackedChanges()` reports them with a `story` field, and an empty header/footer margin highlights on hover and opens for editing on double-click.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -17,6 +17,8 @@ import { ChromeSlotId } from '@docx-editor.dev/core-contract/editor';
 import { ColorValue } from '@docx-editor.dev/core-contract/contracts/editor';
 import { commandForSlot } from '@docx-editor.dev/core-contract/editor';
 import { composeFontConfiguration } from '@docx-editor.dev/core-contract/editor';
+import { ContentControlSummary } from '@docx-editor.dev/core-contract';
+import { ContentControlType } from '@docx-editor.dev/core-contract';
 import { createFontSource } from '@docx-editor.dev/core-contract/editor';
 import { CSSProperties } from 'react';
 import { DocumentChange } from '@docx-editor.dev/core-contract/contracts/editor';
@@ -104,11 +106,77 @@ export { commandForSlot }
 export { composeFontConfiguration }
 
 // @public
+export const CONTENT_CONTROL_SLOTS: {
+    readonly showAll: "contentControl.showAll";
+    readonly formFill: "contentControl.formFill";
+    readonly inspector: "contentControl.inspector";
+    readonly remove: "contentControl.remove";
+};
+
+// @public
+export interface ContentControlActionProps extends ContentControlPartProps {
+    // (undocumented)
+    icon?: ReactNode;
+}
+
+// @public
+export interface ContentControlInspectorState {
+    // (undocumented)
+    readonly alias: string | null;
+    // (undocumented)
+    readonly bound: boolean;
+    // (undocumented)
+    readonly controlType: ContentControlType;
+    // (undocumented)
+    readonly effectiveLock: ContentControlLock | null;
+    // (undocumented)
+    readonly id: string;
+    readonly locked: boolean;
+    // (undocumented)
+    readonly placeholder: boolean;
+    readonly removalLocked: boolean;
+    // (undocumented)
+    readonly tag: string | null;
+}
+
+// @public
+export type ContentControlLock = 'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked';
+
+// @public
+export interface ContentControlPartProps {
+    // (undocumented)
+    asChild?: boolean;
+    // (undocumented)
+    children?: ReactNode;
+    // (undocumented)
+    className?: string;
+    // (undocumented)
+    hidden?: boolean;
+}
+
+// @public
+export interface ContentControlProps extends ContentControlPartProps {
+    preset?: boolean;
+}
+
+// @public (undocumented)
+export type ContentControlSlotId = (typeof CONTENT_CONTROL_SLOTS)[keyof typeof CONTENT_CONTROL_SLOTS];
+
+// @public
 export interface ContextMenuAnchor {
     // (undocumented)
     readonly x: number;
     // (undocumented)
     readonly y: number;
+}
+
+// @public
+export function ContextMenuCellVerticalAlignment(input: ContextMenuCommandProps): react.JSX.Element | null;
+
+// @public (undocumented)
+export namespace ContextMenuCellVerticalAlignment {
+    var // (undocumented)
+    docxRow: "table.cellVerticalAlignment";
 }
 
 // @public
@@ -222,6 +290,21 @@ export const DocxEditor: DocxEditorNamespace;
 // @public
 export function DocxEditorContent(input: DocxEditorContentProps): react.JSX.Element;
 
+// @public (undocumented)
+export const DocxEditorContentControl: DocxEditorContentControlNamespace;
+
+// @public
+export interface DocxEditorContentControlNamespace {
+    // (undocumented)
+    (props: ContentControlProps): ReturnType<typeof ContentControlRoot>;
+    // (undocumented)
+    readonly Fields: typeof ContentControlFields;
+    // (undocumented)
+    readonly Header: typeof ContentControlHeader;
+    // (undocumented)
+    readonly Remove: typeof ContentControlRemove;
+}
+
 // @public
 export interface DocxEditorContentProps {
     className?: string;
@@ -234,6 +317,8 @@ export function DocxEditorContextMenu(input: DocxEditorContextMenuProps): react.
 export interface DocxEditorContextMenuNamespace {
     // (undocumented)
     (props: DocxEditorContextMenuProps): ReactElement;
+    // (undocumented)
+    readonly CellVerticalAlignment: typeof ContextMenuCellVerticalAlignment;
     // (undocumented)
     readonly Copy: typeof ContextMenuCopy;
     // (undocumented)
@@ -402,6 +487,7 @@ export interface DocxEditorMenuProps {
 export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEditorProps & RefAttributes<DocxEditorRef>> {
     // (undocumented)
     readonly Content: typeof DocxEditorContent;
+    readonly ContentControl: typeof DocxEditorContentControl;
     readonly ContextMenu: typeof ContextMenu;
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
     readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
@@ -412,6 +498,7 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEdito
     readonly Navigation: typeof Navigation;
     // (undocumented)
     readonly NotesChrome: typeof DocxEditorNotesChrome;
+    readonly PageNumber: typeof DocxEditorPageNumber;
     readonly PageSetupDialog: typeof DocxEditorPageSetupDialog;
     readonly Review: typeof DocxEditorReview;
     // (undocumented)
@@ -661,6 +748,14 @@ export interface DocxEditorToolbarNamespace {
     // (undocumented)
     readonly Comments: ToolbarPartComponent;
     // (undocumented)
+    readonly ContentControlFormFill: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlInspector: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlRemove: ToolbarPartComponent;
+    // (undocumented)
+    readonly ContentControlShowAll: ToolbarPartComponent;
+    // (undocumented)
     readonly EditingMode: ToolbarSlotPartComponent;
     // (undocumented)
     readonly FontColor: ToolbarColorSplitComponent;
@@ -721,6 +816,7 @@ export interface DocxEditorToolbarProps {
     children?: ReactNode;
     className?: string;
     onSave?: () => void;
+    overflow?: boolean;
     preset?: boolean;
     t?: ToolbarTranslate;
 }
@@ -1067,6 +1163,7 @@ export function navigationShift(input: NavigationShiftInput): number;
 
 // @public (undocumented)
 export interface NavigationShiftInput {
+    readonly inlineEndReservation?: number;
     readonly pageWidthPx: number;
     readonly reservation: number;
     readonly viewportWidth: number;
@@ -1529,6 +1626,41 @@ export interface ToolbarSlotPartProps {
 
 // @public
 export type ToolbarTranslate = (key: string) => string;
+
+// @public
+export function useContentControl(): UseContentControlResult;
+
+// @public
+export function useContentControlInstance(): UseContentControlResult;
+
+// @public
+export interface UseContentControlResult {
+    readonly canRemove: boolean;
+    readonly canSetValue: boolean;
+    // (undocumented)
+    readonly closeInspector: () => void;
+    readonly control: ContentControlInspectorState | null;
+    readonly controls: readonly ContentControlSummary[];
+    readonly formFill: boolean;
+    readonly inspectorOpen: boolean;
+    // (undocumented)
+    readonly openInspector: () => void;
+    readonly remove: () => ExecResult;
+    readonly removeDisabledReason: string | null;
+    // (undocumented)
+    readonly setFormFill: (on: boolean) => void;
+    // (undocumented)
+    readonly setShowAll: (show: boolean) => void;
+    readonly setValue: (value: string) => ExecResult;
+    readonly setValueDisabledReason: string | null;
+    readonly showAll: boolean;
+    // (undocumented)
+    readonly toggleFormFill: () => void;
+    // (undocumented)
+    readonly toggleInspector: () => void;
+    // (undocumented)
+    readonly toggleShowAll: () => void;
+}
 
 // @public
 export function useDocumentOutline(): UseDocumentOutlineResult;

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -529,6 +529,7 @@ export interface Editor {
         readonly id: string;
         readonly kind: string;
         readonly author?: string;
+        readonly story?: 'body' | 'header' | 'footer';
     }[];
     getWatermark(): { readonly kind: 'text' | 'image'; readonly text?: string } | null;
     // (undocumented)
@@ -1080,8 +1081,8 @@ type: BooleanConstructor;
 default: boolean;
 };
 }>> & Readonly<{}>, {
-visible: boolean;
 editor: Editor | null;
+visible: boolean;
 }, {}, {}, {}, string, ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -408,7 +408,7 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
     readonly resolution: readonly HeaderFooterSectionResolution[];
   } | null = null;
   /** Memoized per package revision: the queue only changes when the document does. */
-  let reviewCache: { revision: number; items: readonly ReviewItem[] } | null = null;
+  let reviewCache: { revision: string; items: readonly ReviewItem[] } | null = null;
   let lastChange: TreeModelChange | null = null;
   packageStore.subscribe((change) => {
     lastChange = change;
@@ -881,16 +881,36 @@ export function openTreeSession(bytes: Uint8Array): OpenTreeSessionResult {
 
       reviewItems() {
         const store = bodyStore();
-        if (!reviewCache || reviewCache.revision !== store.revision) {
+        // Keyed on BOTH revisions. The body store's alone missed a tracked change typed
+        // into a header (only the package revision moves); the package revision alone
+        // missed a comment written straight through the body store (`replyToComment`
+        // commits on the story store, which moves only the body revision).
+        const revisionKey = `${packageStore.packageRevision}:${store.revision}`;
+        if (!reviewCache || reviewCache.revision !== revisionKey) {
           const pkg = currentPackage();
+          // Every header/footer story that any section resolves to, deduped by part
+          // identity — the same pattern `documentFonts` walks, and for the same reason:
+          // a shared part must contribute its cards once.
+          const furnitureParts: OoxmlPart[] = [];
+          const seenFurniture = new Set<OoxmlPart>();
+          for (const section of resolvedHeaderFooterBySection().parts) {
+            for (const slots of [section.headers, section.footers]) {
+              for (const part of slots.values()) {
+                if (seenFurniture.has(part)) continue;
+                seenFurniture.add(part);
+                furnitureParts.push(part);
+              }
+            }
+          }
           // Resolved through the story's own relationships, exactly as the WRITE side
           // resolves them. Hardcoding `/word/comments.xml` here made the reader disagree
           // with the writer for any package that names its comment part something else —
           // the comment was written and then never read back.
           reviewCache = {
-            revision: store.revision,
+            revision: revisionKey,
             items: collectReviewItems({
               storyPart: store.part,
+              furnitureParts,
               commentsPart: pkg.parts.get(commentPartNameOf(pkg, store.part.name)),
               commentsExtendedPart: pkg.parts.get(commentsExtendedPartNameOf(pkg, store.part.name)),
             }),

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -407,11 +407,13 @@ export interface Editor {
   /** Plain-text note preview for hover chrome. */
   getNotePreviewText(scopeId: string): string | null;
 
-  /** Tracked changes in the document, for the review sidebar. */
+  /** Tracked changes in the document — body AND header/footer stories. */
   getTrackedChanges(): readonly {
     readonly id: string;
     readonly kind: string;
     readonly author?: string;
+    /** Which story holds the change, so a consumer can group or filter by region. */
+    readonly story?: 'body' | 'header' | 'footer';
   }[];
 
   /**

--- a/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
@@ -208,9 +208,20 @@ describe('headers and footers, read-only', () => {
     expect(surface.session.paragraphIds()).toHaveLength(3);
   });
 
-  test('a document without furniture renders none', () => {
+  test('a document without furniture renders no story, only the blank-band affordance', () => {
     const { container } = mount(docx({}));
-    expect(container.querySelector('[data-docx-hf]')).toBeNull();
+    // No STORY furniture — nothing carries a relationship id and nothing has content.
+    expect(container.querySelector('[data-docx-hf][data-docx-r-id]')).toBeNull();
+    // The empty margin bands are painted so hover can invite and double-click can create.
+    const placeholders = [...container.querySelectorAll('.docx-hf--placeholder')];
+    expect(placeholders.map((band) => band.getAttribute('data-docx-hf')).sort()).toEqual([
+      'footer',
+      'header',
+    ]);
+    for (const band of placeholders) {
+      expect(band.getAttribute('contenteditable')).toBe('false');
+      expect(band.textContent).toBe('');
+    }
   });
 
   test('comprehensive fixture: HF right tabs reach the authored stop on the surface', () => {
@@ -273,7 +284,7 @@ describe('headers and footers, read-only', () => {
     // Page index 1 is the first body sheet with header1/footer1 (cover is index 0).
     const cover = pages[0]!;
     const sheet = pages[1]!;
-    expect(cover.querySelector('[data-docx-hf]')).toBeNull();
+    expect(cover.querySelector('[data-docx-hf][data-docx-r-id]')).toBeNull();
     expect(sheet.querySelector('[data-docx-hf="header"]')).not.toBeNull();
     expect(sheet.querySelector('[data-docx-hf="footer"]')).not.toBeNull();
     // Cover must not visually host body furniture: relative story Y is authored distance,

--- a/packages/core/src/editor/__tests__/review-facade.test.ts
+++ b/packages/core/src/editor/__tests__/review-facade.test.ts
@@ -24,29 +24,46 @@ const COMMENTS_CT = 'application/vnd.openxmlformats-officedocument.wordprocessin
 interface DocxParts {
   readonly body: string;
   readonly comments?: string;
+  /** Default-header content; wires the part, its relationship and the section reference. */
+  readonly header?: string;
 }
 
-function docx({ body, comments }: DocxParts): Uint8Array {
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+function docx({ body, comments, header }: DocxParts): Uint8Array {
   const files: Record<string, Uint8Array> = {
     '[Content_Types].xml': strToU8(
       `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
         `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
         (comments ? `<Override PartName="/word/comments.xml" ContentType="${COMMENTS_CT}"/>` : '') +
+        (header
+          ? `<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>`
+          : '') +
         `</Types>`
     ),
     '_rels/.rels': strToU8(
       `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
     ),
     'word/document.xml': strToU8(
-      `<w:document xmlns:w="${W}" xmlns:w15="${W15}"><w:body>${body}</w:body></w:document>`
+      `<w:document xmlns:w="${W}" xmlns:w15="${W15}" xmlns:r="${R}"><w:body>${body}` +
+        (header ? `<w:sectPr><w:headerReference w:type="default" r:id="rIdH"/></w:sectPr>` : '') +
+        `</w:body></w:document>`
     ),
   };
+  const documentRels: string[] = [];
   if (comments) {
-    files['word/_rels/document.xml.rels'] = strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rIdC" Type="${COMMENTS_REL}" Target="comments.xml"/></Relationships>`
-    );
+    documentRels.push(`<Relationship Id="rIdC" Type="${COMMENTS_REL}" Target="comments.xml"/>`);
     files['word/comments.xml'] = strToU8(
       `<w:comments xmlns:w="${W}" xmlns:w15="${W15}">${comments}</w:comments>`
+    );
+  }
+  if (header) {
+    documentRels.push(`<Relationship Id="rIdH" Type="${R}/header" Target="header1.xml"/>`);
+    files['word/header1.xml'] = strToU8(`<w:hdr xmlns:w="${W}">${header}</w:hdr>`);
+  }
+  if (documentRels.length > 0) {
+    files['word/_rels/document.xml.rels'] = strToU8(
+      `<Relationships xmlns="${REL}">${documentRels.join('')}</Relationships>`
     );
   }
   return zipSync(files);
@@ -861,5 +878,88 @@ describe('activating a card', () => {
     expect(bodyTextOf(editor)).toContain('added text');
     editor.setActiveReviewItem(null);
     expect(editor.getReviewItems()[0]!.isActive).toBe(false);
+  });
+});
+
+// A tracked change in a header is a pending decision like any other: it must reach the
+// queue, carry real geometry, resolve against ITS story, and tell a programmatic consumer
+// which story holds it. A queue that only walked the body hid all of that.
+const HEADER_INSERTION =
+  `<w:p><w:r><w:t xml:space="preserve">Confidential </w:t></w:r>` +
+  `<w:ins w:id="7" w:author="Margaret Hamilton" w:date="2026-03-04T05:06:07Z">` +
+  `<w:r><w:t>draft</w:t></w:r></w:ins></w:p>`;
+
+describe('tracked changes in headers', () => {
+  test('a header revision gets a card, with geometry from the furniture layout', () => {
+    const editor = mount({ body: INSERTION, header: HEADER_INSERTION });
+    const cards = editor.getReviewItems();
+    expect(cards).toHaveLength(2);
+    const header = cards.find((card) => card.author === 'Margaret Hamilton');
+    expect(header).toBeDefined();
+    expect(header!.text).toBe('draft');
+    expect(header!.readOnly).toBe(false);
+    expect(header!.pageIndex).toBe(0);
+    expect(header!.anchorY).not.toBeNull();
+    // The header sits ABOVE the body content on the sheet, and its card rides before the
+    // body's in the rail: the rail stacks top-down and never lifts a card past its anchor.
+    const body = cards.find((card) => card.author === 'Ada Lovelace')!;
+    expect(cards.indexOf(header!)).toBeLessThan(cards.indexOf(body));
+    expect(header!.anchorY!).toBeLessThan(body.anchorY!);
+  });
+
+  test('getTrackedChanges names the story each change lives in', () => {
+    const editor = mount({ body: INSERTION, header: HEADER_INSERTION });
+    const stories = editor
+      .getTrackedChanges()
+      .map((change) => change.story)
+      .sort();
+    expect(stories).toEqual(['body', 'header']);
+  });
+
+  test('accepting a header revision resolves it inside the header story', () => {
+    const editor = mount({ body: INSERTION, header: HEADER_INSERTION });
+    const header = editor.getReviewItems().find((card) => card.author === 'Margaret Hamilton')!;
+    expect(editor.acceptReviewItem(header.key)).toEqual({ ok: true, changed: true });
+    // The card is gone, the body's card is untouched, and the header kept the words.
+    const remaining = editor.getReviewItems();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.author).toBe('Ada Lovelace');
+    const storyText =
+      editor.surface!.session.storyText({ kind: 'headerFooter', rId: 'rIdH' }) ?? '';
+    expect(storyText).toContain('draft');
+  });
+
+  test('rejecting a header insertion removes its words from the header story', () => {
+    const editor = mount({ body: INSERTION, header: HEADER_INSERTION });
+    const header = editor.getReviewItems().find((card) => card.author === 'Margaret Hamilton')!;
+    expect(editor.rejectReviewItem(header.key)).toEqual({ ok: true, changed: true });
+    const storyText =
+      editor.surface!.session.storyText({ kind: 'headerFooter', rId: 'rIdH' }) ?? '';
+    expect(storyText).not.toContain('draft');
+    expect(bodyTextOf(editor)).toContain('added text');
+  });
+
+  test('undoing a header accept brings the card back, with the tick moving each time', () => {
+    const editor = mount({ body: INSERTION, header: HEADER_INSERTION });
+    const header = editor.getReviewItems().find((card) => card.author === 'Margaret Hamilton')!;
+    const before = editor.getReviewRevision();
+    expect(editor.acceptReviewItem(header.key)).toEqual({ ok: true, changed: true });
+    const afterAccept = editor.getReviewRevision();
+    // An accept inside a header moves only the PACKAGE revision; a tick watching the body
+    // alone froze the rail, so undoing the accept restored the change with no card beside it.
+    expect(afterAccept).not.toBe(before);
+    editor.surface!.undo();
+    expect(editor.getReviewRevision()).not.toBe(afterAccept);
+    expect(
+      editor.getReviewItems().filter((card) => card.author === 'Margaret Hamilton')
+    ).toHaveLength(1);
+  });
+
+  test('opening a header card enters the header scope, like Word', () => {
+    const editor = mount({ body: INSERTION, header: HEADER_INSERTION });
+    const header = editor.getReviewItems().find((card) => card.author === 'Margaret Hamilton')!;
+    editor.setActiveReviewItem(header.key);
+    expect(editor.surface!.activeScope()).toEqual({ kind: 'headerFooter', rId: 'rIdH' });
+    expect(editor.getHeaderFooterState()?.editing).toBe('header');
   });
 });

--- a/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
+++ b/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
@@ -749,6 +749,55 @@ describe('surface-root pointer delegation for HF / notes', () => {
     surface.destroy();
   });
 
+  test('root listener: double press in the BLANK header margin creates the header and opens it', () => {
+    const { surface, container } = mount(docx({ body: `${p('One')}${p('Two')}` }));
+    const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+    stubPagesRect(pages);
+    pages.focus();
+
+    // No story, but the blank-band affordance is painted so hover can invite the press.
+    expect(container.querySelector('[data-docx-hf][data-docx-r-id]')).toBeNull();
+    expect(container.querySelector('.docx-hf--placeholder[data-docx-hf="header"]')).not.toBeNull();
+
+    const page = surface.layout().pages[0]!;
+    const clientX = page.contentBox.x + 8;
+    const clientY = page.box.y + 2;
+
+    // A single press stays a body gesture: margin clicks place the nearest body caret.
+    const first = pressAt(pages, pages, clientX, clientY);
+    expect(first.defaultPrevented).toBe(true);
+    expect(surface.activeScope()).toEqual({ kind: 'body' });
+    expect(surface.session.headerFooterResolutionBySection()[0]?.headers.size ?? 0).toBe(0);
+
+    const second = pressAt(pages, pages, clientX, clientY);
+    expect(second.defaultPrevented).toBe(true);
+    // The part was created — one committed package op — and its scope opened for editing.
+    const slot = surface.session.headerFooterResolutionBySection()[0]!.headers.get('default');
+    expect(slot).toBeDefined();
+    expect(surface.activeScope()).toEqual({ kind: 'headerFooter', rId: slot!.rId });
+    expect(surface.headerFooterState()?.editing).toBe('header');
+    expect(surface.session.canUndo()).toBe(true);
+    surface.destroy();
+  });
+
+  test('root listener: viewing mode refuses to create a header from the blank band', () => {
+    const { surface, container } = mount(docx({ body: p('Body') }));
+    const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+    stubPagesRect(pages);
+    pages.focus();
+    surface.setEditingMode('view');
+
+    const page = surface.layout().pages[0]!;
+    const clientX = page.contentBox.x + 8;
+    const clientY = page.box.y + 2;
+    pressAt(pages, pages, clientX, clientY);
+    pressAt(pages, pages, clientX, clientY);
+
+    expect(surface.activeScope()).toEqual({ kind: 'body' });
+    expect(surface.session.headerFooterResolutionBySection()[0]?.headers.size ?? 0).toBe(0);
+    surface.destroy();
+  });
+
   test('root listener: DOM furniture hit without layout miss still enters via data-docx-r-id', () => {
     const { surface, container } = mount(docx({ header: p('HDR'), body: p('Body') }));
     const pages = container.querySelector<HTMLElement>('.docx-pages')!;

--- a/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
+++ b/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
@@ -780,6 +780,60 @@ describe('surface-root pointer delegation for HF / notes', () => {
     surface.destroy();
   });
 
+  test('root listener: blank-band create works on a minimal document with no sectPr and no rels', () => {
+    // The shape a host's "new document" produces: one paragraph, no `w:sectPr`, no
+    // `document.xml.rels`, and no `xmlns:r` on the root. The minted `w:headerReference`
+    // carries `r:id`, and without a root binding the whole create refused `invalid-qname` —
+    // double-clicking the blank band on a fresh document did nothing at all.
+    const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+    const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+    const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+    const bytes = zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}">` +
+          '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '</Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t></w:t></w:r></w:p></w:body></w:document>`
+      ),
+    });
+    const container = document.createElement('div');
+    const result = mountPaginatedSurface(container, bytes, { scale: 1 });
+    if (!result.ok) throw new Error(String(result.reason));
+    const surface = result.surface;
+    const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+    stubPagesRect(pages);
+    pages.focus();
+
+    const page = surface.layout().pages[0]!;
+    const clientX = page.contentBox.x + 8;
+    const clientY = page.box.y + 2;
+    pressAt(pages, pages, clientX, clientY);
+    pressAt(pages, pages, clientX, clientY);
+
+    const slot = surface.session.headerFooterResolutionBySection()[0]!.headers.get('default');
+    expect(slot).toBeDefined();
+    expect(surface.activeScope()).toEqual({ kind: 'headerFooter', rId: slot!.rId });
+    expect(surface.headerFooterState()?.editing).toBe('header');
+
+    // The minted root `xmlns:r` binding survives save: reopening the bytes still resolves
+    // the header reference.
+    const reopened = mountPaginatedSurface(document.createElement('div'), surface.session.save(), {
+      scale: 1,
+    });
+    if (!reopened.ok) throw new Error(String(reopened.reason));
+    expect(
+      reopened.surface.session.headerFooterResolutionBySection()[0]!.headers.get('default')
+    ).toBeDefined();
+    reopened.surface.destroy();
+    surface.destroy();
+  });
+
   test('root listener: viewing mode refuses to create a header from the blank band', () => {
     const { surface, container } = mount(docx({ body: p('Body') }));
     const pages = container.querySelector<HTMLElement>('.docx-pages')!;

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -54,6 +54,7 @@ import {
   commentInitials,
   documentOrder,
   paragraphFragmentsOf,
+  paragraphFragmentsOfBlocks,
   reviewAnchorIndex,
   reviewItemGeometry,
   reviewItemKey,
@@ -794,13 +795,18 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
    */
   let reviewTick = 0;
   let reviewSurface: unknown = null;
-  let reviewSeenRevision = -1;
+  let reviewSeenRevision = '';
   let reviewSeenActive: string | null = null;
   let reviewSeenPaneOpen = true;
   let reviewSeenSelectionAnchor: number | null = null;
 
   function reviewRevision(): number {
-    const revision = surface?.session.revision() ?? -1;
+    // BOTH revisions, like the session's own queue cache: an accept inside a header moves
+    // only the package revision, and a tick watching the body alone left the rail frozen —
+    // undoing that accept put the tracked change back with no card beside it.
+    const revision = `${surface?.session.packageRevision() ?? -1}:${
+      surface?.session.revision() ?? -1
+    }`;
     const active = activeReviewKeyNow();
     // The selection is an input too: the "comment on this" affordance appears and moves with
     // it, and a counter blind to it left the button absent no matter what was selected.
@@ -846,8 +852,49 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     const cached = anchorIndexCache.get(layout);
     if (cached) return cached;
     const index = reviewAnchorIndex(layout, (page) => paragraphFragmentsOf(page));
+    // Header/footer stories join the same index so their cards get real geometry. A story's
+    // box is sheet-absolute like a page's content box, and its fragments are story-relative
+    // like body fragments are content-relative — the same two-space sum `reviewItemGeometry`
+    // performs. FIRST page wins, matching the body rule: a shared part painted on every
+    // page anchors its card where the reader first meets it.
+    for (const page of layout.pages) {
+      for (const story of [page.header, page.footer]) {
+        if (!story) continue;
+        for (const fragment of paragraphFragmentsOfBlocks(story.fragments)) {
+          if (index.has(fragment.paragraphId)) continue;
+          index.set(fragment.paragraphId, {
+            pageIndex: page.index,
+            contentY: story.box.y,
+            fragmentY: fragment.box.y,
+            ...(fragment.lines ? { lines: fragment.lines } : {}),
+          });
+        }
+      }
+    }
     anchorIndexCache.set(layout, index);
     return index;
+  }
+
+  /**
+   * Which story a review item lives in, from the part name its ranges carry.
+   *
+   * `null` rId means the part is not a header/footer this document's sections resolve —
+   * i.e. the body (or an unknown part, which is treated as body rather than guessed at).
+   */
+  function furnitureHomeOf(
+    item: ReviewItem
+  ): { readonly kind: 'header' | 'footer'; readonly rId: string } | null {
+    const partName = firstReviewRange(item)?.partName;
+    if (!partName || !surface || partName === surface.session.part().name) return null;
+    for (const section of surface.session.headerFooterResolutionBySection()) {
+      for (const kind of ['header', 'footer'] as const) {
+        const slots = kind === 'header' ? section.headers : section.footers;
+        for (const slot of slots.values()) {
+          if (slot.partName === partName) return { kind, rId: slot.rId };
+        }
+      }
+    }
+    return null;
   }
 
   /** Word writes `@w:date` to the second; milliseconds group with nothing. */
@@ -922,7 +969,30 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     const layout = surface?.publishedLayout() ?? null;
     const anchors = layout ? anchorIndexOf(layout) : null;
     const activeReviewKey = activeReviewKeyNow();
-    return items.map((item) => {
+    // The queue ranks furniture stories after the whole body (tree order), but the rail
+    // stacks cards top-down and never moves one UP past its anchor — a header card sorted
+    // after page 40's cards would render at the rail's bottom, pages away from the header
+    // it annotates. Reorder by the page a card sits beside; within a page, header cards
+    // first, then body cards in document order, then footer cards. The sort is stable, so
+    // body cards keep the tree order the queue promised.
+    const groupOf = (item: ReviewItem): number => {
+      const home = furnitureHomeOf(item);
+      return home === null ? 1 : home.kind === 'header' ? 0 : 2;
+    };
+    const ranked = items.map((item, position) => ({
+      item,
+      position,
+      pageIndex: anchors ? (reviewItemGeometry(item, anchors)?.pageIndex ?? null) : null,
+      group: groupOf(item),
+    }));
+    ranked.sort((a, b) => {
+      const aPage = a.pageIndex ?? Number.MAX_SAFE_INTEGER;
+      const bPage = b.pageIndex ?? Number.MAX_SAFE_INTEGER;
+      if (aPage !== bPage) return aPage - bPage;
+      if (a.group !== b.group) return a.group - b.group;
+      return a.position - b.position;
+    });
+    return ranked.map(({ item }) => {
       const key = reviewItemKey(item);
       const geometry = anchors ? reviewItemGeometry(item, anchors) : null;
       const comment = item.kind === 'comment' ? item.comment : null;
@@ -1037,13 +1107,20 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // accepted, the replacement text still pending — is a state nobody asked for and one
     // undo would not take back.
     let applied: { committed: boolean; reason?: unknown } | undefined;
+    // A revision in a header/footer resolves against ITS story store, not the body's. The
+    // default body scope simply failed to find the address, so an Accept on a header card
+    // reported "refused" over a change the queue itself had listed.
+    const home = furnitureHomeOf(item);
     surface?.commitReviewOps(() => {
       applied = surface!.session.applyTreeOps(
         item.addresses.map((revision) =>
           action === 'accept'
             ? ({ op: 'acceptRevision', revision } as const)
             : ({ op: 'rejectRevision', revision } as const)
-        )
+        ),
+        undefined,
+        undefined,
+        home === null ? undefined : { kind: 'headerFooter', rId: home.rId }
       );
       return applied;
     });
@@ -1359,11 +1436,15 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     getTrackedChanges: () =>
       (surface?.session.reviewItems() ?? [])
         .filter((item) => item.kind === 'revision')
-        .map((item) => ({
-          id: item.id,
-          kind: item.kind === 'revision' ? item.revisionKind : 'revision',
-          ...(item.kind === 'revision' && item.author ? { author: item.author } : {}),
-        })),
+        .map((item) => {
+          const home = furnitureHomeOf(item);
+          return {
+            id: item.id,
+            kind: item.kind === 'revision' ? item.revisionKind : 'revision',
+            ...(item.kind === 'revision' && item.author ? { author: item.author } : {}),
+            story: home === null ? ('body' as const) : home.kind,
+          };
+        }),
 
     getReviewItems: () => reviewPlacements(),
 
@@ -1431,6 +1512,18 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       const item = placement?.item;
       const range = item ? firstReviewRange(item) : null;
       if (!range || !surface) return;
+      // A card whose range lives in a header/footer opens that scope, exactly as Word does:
+      // the body selection cannot address a furniture paragraph, so setting it would only
+      // clamp the caret to some unrelated body position.
+      const home = item ? furnitureHomeOf(item) : null;
+      if (home !== null) {
+        surface.enterHeaderFooter?.({
+          rId: home.rId,
+          kind: home.kind,
+          position: { paragraphId: range.start.paragraphId, offset: range.start.offset },
+        });
+        return;
+      }
       // Card to document: put the CARET at the range's start. Selecting the whole range
       // instead turned the text grey and — because a range selection is what the "comment on
       // this" affordance keys on — offered to add a second comment on top of the one the

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1421,6 +1421,9 @@ export function mountPaginatedSurface(
       ...(contentControlChrome ? { contentControlChrome } : {}),
     });
     setHeaderFooterEditingChrome(container, pagesLayer, activeHf != null);
+    // Viewing mode hides write affordances the painter cannot know about — today the
+    // blank header/footer "double-click to add" band.
+    container.classList.toggle('docx-paginated-surface--viewing', editingMode === 'view');
     // The pages are absolutely positioned, so the layer has no intrinsic size and the
     // surface would collapse to zero — pages then escape whatever centres or scrolls it.
     // Size it from the records, which is the only place the extent is known.
@@ -3038,6 +3041,55 @@ export function mountPaginatedSurface(
         noteOps?.exitNote(restoreBody);
       },
       exitHeaderFooter: () => hfScope?.exitHeaderFooter(),
+      enterEmptyHeaderFooter: (kind, pageIndex) => {
+        // Creating the part is a WRITE — viewing mode refuses it like every other lane.
+        if (editingMode === 'view') return;
+        // Which section owns the page, from the multi-section spans; a single-section
+        // document has no spans and every page belongs to section 0.
+        const spans = layoutSession.multi?.spans;
+        let sectionIndex = 0;
+        let sectionStart = 0;
+        if (spans && spans.length > 0) {
+          for (let index = 0; index < spans.length; index += 1) {
+            const span = spans[index]!;
+            sectionIndex = index;
+            sectionStart = span.startIndex;
+            if (pageIndex < span.startIndex + span.pageCount) break;
+          }
+        }
+        const bySection = session.headerFooterResolutionBySection();
+        const section = bySection[Math.min(sectionIndex, Math.max(0, bySection.length - 1))];
+        // The variant this page would DISPLAY, which is the one Word creates on a blank
+        // double-click: `even` on an even page only when the document separates them,
+        // `first` on a section's first page only when it declares a title page.
+        const pageNumber =
+          currentLayout.pages[pageIndex]?.pageFieldSource?.pageNumber ?? pageIndex + 1;
+        const variant: 'default' | 'first' | 'even' =
+          section?.evenAndOddHeaders && pageNumber % 2 === 0
+            ? 'even'
+            : section?.titlePage && pageIndex === sectionStart
+              ? 'first'
+              : 'default';
+        const slotsOf = (resolution: typeof bySection) => {
+          const target = resolution[Math.min(sectionIndex, Math.max(0, resolution.length - 1))];
+          return kind === 'header' ? target?.headers : target?.footers;
+        };
+        let rId = slotsOf(bySection)?.get(variant)?.rId;
+        if (!rId) {
+          const created = surface.applyHeaderFooterLifecycle?.({
+            op: 'createHeaderFooter',
+            sectionIndex,
+            kind,
+            variant,
+            ...(variant === 'first' ? { titlePage: true } : {}),
+            ...(variant === 'even' ? { evenAndOddHeaders: true } : {}),
+          });
+          if (!created?.ok) return;
+          rId = slotsOf(session.headerFooterResolutionBySection())?.get(variant)?.rId;
+        }
+        if (!rId) return;
+        hfScope?.enterHeaderFooter({ rId, pageIndex, sectionIndex, kind, variant });
+      },
       onContentControlWidget: (controlId, kind) => openContentControlWidget(controlId, kind),
     },
     options.pointer ? { mode: options.pointer } : {}

--- a/packages/core/src/editor/surface-pointer.ts
+++ b/packages/core/src/editor/surface-pointer.ts
@@ -41,6 +41,7 @@ import type {
 } from '../layout/semantic-records.ts';
 import { MAX_TABLE_NESTING } from '../layout/semantic-table.ts';
 import {
+  findEmptyFurnitureBandAtSheetPoint,
   findNoteAtSheetPoint,
   findStoryAtSheetPoint,
   hitTestStoryAtLocalPoint,
@@ -97,6 +98,13 @@ export interface PointerHost {
   activeNote?(): { readonly scopeId: string; readonly pageIndex: number | null } | null;
   /** Double-click enter on painted furniture. */
   enterHeaderFooter?(info: EnterHeaderFooterPointerRequest): void;
+  /**
+   * Double-click in the blank header/footer margin band of a page with no story there.
+   *
+   * The host decides what that means — typically create the part and open it for editing,
+   * refusing in view mode. The pointer only reports the gesture.
+   */
+  enterEmptyHeaderFooter?(kind: 'header' | 'footer', pageIndex: number): void;
   /** Enter a painted note story for scoped editing. */
   enterNote?(
     scopeId: string,
@@ -845,6 +853,17 @@ export function createPointerController(
         host.focus();
         return;
       } else {
+        // While a header is open, double-clicking the blank footer band (or vice versa)
+        // creates and opens that story — Word's behaviour — instead of swallowing the press.
+        const empty =
+          clicks() >= 2
+            ? findEmptyFurnitureBandAtSheetPoint(layout, sheet, host.pageOffsetX)
+            : null;
+        if (empty) {
+          event.preventDefault();
+          host.focus();
+          host.enterEmptyHeaderFooter?.(empty.kind, empty.pageIndex);
+        }
         return;
       }
     } else if (onFurniture && clicks() >= 2) {
@@ -863,25 +882,41 @@ export function createPointerController(
         const kindAttr = furnitureDom.dataset.docxHf;
         const pageAttr = furnitureDom.closest('[data-page-index]')?.getAttribute('data-page-index');
         const pageIndex = pageAttr != null ? Number(pageAttr) : NaN;
-        if (
-          rId &&
-          (kindAttr === 'header' || kindAttr === 'footer') &&
-          Number.isInteger(pageIndex)
-        ) {
-          const page = layout.pages[pageIndex];
-          const story = page?.[kindAttr];
-          event.preventDefault();
-          host.focus();
-          host.enterHeaderFooter?.({
-            rId,
-            pageIndex,
-            kind: kindAttr,
-            partName: story?.partName ?? '',
-            variant: story?.variant ?? 'default',
-          });
+        if ((kindAttr === 'header' || kindAttr === 'footer') && Number.isInteger(pageIndex)) {
+          if (rId) {
+            const page = layout.pages[pageIndex];
+            const story = page?.[kindAttr];
+            event.preventDefault();
+            host.focus();
+            host.enterHeaderFooter?.({
+              rId,
+              pageIndex,
+              kind: kindAttr,
+              partName: story?.partName ?? '',
+              variant: story?.variant ?? 'default',
+            });
+          } else if (!layout.pages[pageIndex]?.[kindAttr]) {
+            // The painted PLACEHOLDER band: `data-docx-hf` with no relationship id marks a
+            // page with no story of that kind — create and open it.
+            event.preventDefault();
+            host.focus();
+            host.enterEmptyHeaderFooter?.(kindAttr, pageIndex);
+          }
         }
       }
       return;
+    } else if (clicks() >= 2) {
+      // No painted furniture under the press: a double click in the blank header/footer
+      // margin band creates that story and opens it, matching Word. Single presses keep
+      // falling through to body hit-testing — a click in the top margin still just places
+      // the caret in the nearest body line.
+      const empty = findEmptyFurnitureBandAtSheetPoint(layout, sheet, host.pageOffsetX);
+      if (empty) {
+        event.preventDefault();
+        host.focus();
+        host.enterEmptyHeaderFooter?.(empty.kind, empty.pageIndex);
+        return;
+      }
     }
 
     const hit = resolve(event.clientX, event.clientY);

--- a/packages/core/src/editor/surface-scope.ts
+++ b/packages/core/src/editor/surface-scope.ts
@@ -397,6 +397,38 @@ export function furnitureActivationBox(
   };
 }
 
+/**
+ * The header/footer margin band of a page that has NO story of that kind, or null.
+ *
+ * The counterpart of {@link findStoryAtSheetPoint} for blank furniture: Word lets a reader
+ * double-click the empty top margin to create and open a header, and the hit test has to
+ * answer from geometry because there is nothing painted to hit.
+ */
+export function findEmptyFurnitureBandAtSheetPoint(
+  layout: SemanticLayout,
+  sheet: { readonly x: number; readonly y: number },
+  pageOffsetX: (pageIndex: number) => number
+): { pageIndex: number; kind: 'header' | 'footer' } | null {
+  for (const page of layout.pages) {
+    const ox = pageOffsetX(page.index);
+    for (const kind of ['header', 'footer'] as const) {
+      if (page[kind]) continue;
+      const band = furnitureActivationBox(page, kind);
+      if (!band) continue;
+      const left = band.x + ox;
+      if (
+        sheet.x >= left &&
+        sheet.x < left + band.width &&
+        sheet.y >= band.y &&
+        sheet.y < band.y + band.height
+      ) {
+        return { pageIndex: page.index, kind };
+      }
+    }
+  }
+  return null;
+}
+
 export function findStoryAtSheetPoint(
   layout: SemanticLayout,
   sheet: { readonly x: number; readonly y: number },

--- a/packages/core/src/layout/__tests__/review-model.test.ts
+++ b/packages/core/src/layout/__tests__/review-model.test.ts
@@ -624,3 +624,48 @@ describe('the offset model has ONE authority', () => {
     expect(item.ranges[0]!.end.offset).toBe(5);
   });
 });
+
+describe('furniture stories join the queue', () => {
+  function headerStory(body: string): OoxmlPart {
+    const result = readOoxmlPart(`<w:hdr xmlns:w="${W}" xmlns:w14="${W14}">${body}</w:hdr>`, {
+      name: '/word/header1.xml',
+      contentType: 'app/xml',
+    });
+    if (!result.ok) throw new Error(result.reason);
+    return result.part;
+  }
+
+  test('a header revision is listed beside body items, its ranges naming the header part', () => {
+    const body = story(`<w:p>${run('keep ')}${ins('1', run('body add'))}</w:p>`);
+    const header = headerStory(`<w:p>${run('title ')}${ins('9', run('hdr add'), 'HF')}</w:p>`);
+    const items = revisionsOf(collectReviewItems({ storyPart: body, furnitureParts: [header] }));
+    expect(items).toHaveLength(2);
+    const fromHeader = items.find((item) => item.author === 'HF')!;
+    expect(fromHeader.ranges[0]!.partName).toBe('/word/header1.xml');
+    // Body items rank first: furniture paragraphs join the merged order AFTER the body's.
+    expect(items[0]!.author).toBe('QA');
+  });
+
+  test('the same part passed twice contributes its cards once', () => {
+    const body = story(`<w:p>${run('keep')}</w:p>`);
+    const header = headerStory(`<w:p>${ins('9', run('shared'), 'HF')}</w:p>`);
+    const items = collectReviewItems({ storyPart: body, furnitureParts: [header, header] });
+    expect(items).toHaveLength(1);
+  });
+
+  test('a comment anchored in a header stops being an orphan', () => {
+    const body = story(`<w:p>${run('body')}</w:p>`);
+    const header = headerStory(`<w:p>${cStart('1')}${run('marked')}${cEnd('1')}</w:p>`);
+    const comments = commentsPart(comment('1', 'about the header'));
+    const without = collectReviewItems({ storyPart: body, commentsPart: comments });
+    expect(without.some((item) => item.kind === 'comment' && item.orphaned)).toBe(true);
+    const withHeader = collectReviewItems({
+      storyPart: body,
+      furnitureParts: [header],
+      commentsPart: comments,
+    });
+    const card = withHeader.find((item) => item.kind === 'comment');
+    expect(card && card.kind === 'comment' && card.orphaned).toBe(false);
+    expect(card && card.kind === 'comment' && card.range?.partName).toBe('/word/header1.xml');
+  });
+});

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -135,6 +135,7 @@ export {
   lineAtPosition,
   linesOf,
   paragraphFragmentsOf,
+  paragraphFragmentsOfBlocks,
   unionLayoutBoxes,
   type BlockFragmentRecord,
   type ContentControlBoundaryRecord,

--- a/packages/core/src/layout/review-model.ts
+++ b/packages/core/src/layout/review-model.ts
@@ -681,6 +681,12 @@ export function commentItemsOf(
 export interface ReviewModelInput {
   /** The story the ranges live in — the main document, a header, a note. */
   readonly storyPart: OoxmlPart;
+  /**
+   * Header/footer story parts, in section order. Their revisions and comment anchors join
+   * the queue: a tracked change in a header is a pending decision like any other, and a
+   * queue that only walked the body silently hid it from the rail AND from Accept All.
+   */
+  readonly furnitureParts?: readonly OoxmlPart[] | undefined;
   /** `word/comments.xml`, absent when the package has none. */
   readonly commentsPart?: OoxmlPart | undefined;
   /** `word/commentsExtended.xml`, absent when the package has none. */
@@ -691,17 +697,41 @@ export interface ReviewModelInput {
  * Everything the review surface lists, in document order.
  *
  * Order is by paragraph position within the story, then by offset. A comment and the revision
- * it covers therefore arrive together, which is what lets a surface group them.
+ * it covers therefore arrive together, which is what lets a surface group them. Furniture
+ * stories rank after the body in one merged order — their geometry (the page they first paint
+ * on) is a layout question the queue deliberately does not answer.
  */
 export function collectReviewItems(input: ReviewModelInput): ReviewItem[] {
-  const revisions = revisionItemsOf(input.storyPart);
+  // The body part deduped against the furniture list, so a caller passing a part twice —
+  // or the same shared header under two sections — cannot double every card in it.
+  const parts: OoxmlPart[] = [input.storyPart];
+  const seen = new Set<string>([input.storyPart.name]);
+  for (const part of input.furnitureParts ?? []) {
+    if (seen.has(part.name)) continue;
+    seen.add(part.name);
+    parts.push(part);
+  }
+
   const comments = input.commentsPart ? commentsOfPart(input.commentsPart) : [];
-  const anchors = commentAnchorsOfStory(input.storyPart);
   const threadState = input.commentsExtendedPart
     ? threadStateOfPart(input.commentsExtendedPart)
     : new Map<string, CommentThreadState>();
 
-  const order = paragraphOrderOfPart(input.storyPart);
+  // ONE anchor set across every story, then ONE pass over `comments.xml`. Collecting
+  // per-story and concatenating listed each comment once per story — anchored in one,
+  // orphaned in all the others.
+  const revisions: ReviewRevisionItem[] = [];
+  const anchors: ReturnType<typeof commentAnchorsOfStory> = [];
+  const order = new Map<string, number>();
+  for (const part of parts) {
+    revisions.push(...revisionItemsOf(part));
+    anchors.push(...commentAnchorsOfStory(part));
+    const base = order.size;
+    for (const [id, position] of paragraphOrderOfPart(part)) {
+      if (!order.has(id)) order.set(id, base + position);
+    }
+  }
+
   const items: ReviewItem[] = [...revisions, ...commentItemsOf(comments, anchors, threadState)];
   return items.sort((a, b) => positionRank(a, order) - positionRank(b, order));
 }

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -677,9 +677,22 @@ export function paragraphFragmentsOf(
   page: PageRecord,
   includeHeaderRepeats = false
 ): ParagraphFragmentRecord[] {
+  return paragraphFragmentsOfBlocks(page.fragments, includeHeaderRepeats);
+}
+
+/**
+ * Depth-first paragraph fragments of one block list, in reading order.
+ *
+ * The same walk as {@link paragraphFragmentsOf} for fragment lists that do not sit on the
+ * page directly — a header/footer story's fragments, a note story's.
+ */
+export function paragraphFragmentsOfBlocks(
+  blocks: readonly BlockFragmentRecord[],
+  includeHeaderRepeats = false
+): ParagraphFragmentRecord[] {
   const found: ParagraphFragmentRecord[] = [];
-  const visitBlocks = (blocks: readonly BlockFragmentRecord[]): void => {
-    for (const block of blocks) {
+  const visitBlocks = (list: readonly BlockFragmentRecord[]): void => {
+    for (const block of list) {
       if (block.kind === 'paragraph') {
         found.push(block);
         continue;
@@ -690,7 +703,7 @@ export function paragraphFragmentsOf(
       }
     }
   };
-  visitBlocks(page.fragments);
+  visitBlocks(blocks);
   return found;
 }
 

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1342,20 +1342,21 @@ function paintPage(
     band.className = 'docx-hf docx-hf--placeholder';
     band.dataset.docxHf = kind;
     band.setAttribute('contenteditable', 'false');
-    // A SLIM strip beside the content edge, not the whole margin: a section with a deep
-    // top margin painted an invitation taller than the heading under it. Word's header
-    // area is a couple of lines; the pointer still accepts the full margin band, so the
-    // visual can stay modest without shrinking the target.
+    // A SLIM strip where a real header/footer would FLOW — the default furniture distance
+    // from the sheet edge — not the whole margin and not the content edge: anchored to
+    // content, a cover page with a deep top area drew the invitation halfway down the
+    // page, glued to its own heading. Word's header area is a couple of lines near the
+    // edge; the pointer still accepts the full margin band, so the visual stays modest
+    // without shrinking the target.
     const marginHeight =
       kind === 'header'
         ? page.contentBox.y - page.box.y
         : page.box.y + page.box.height - (page.contentBox.y + page.contentBox.height);
     const height = Math.min(marginHeight, PLACEHOLDER_BAND_PT);
     if (height <= 0) continue;
-    const top =
-      kind === 'header'
-        ? page.contentBox.y - page.box.y - height
-        : page.contentBox.y + page.contentBox.height - page.box.y;
+    // Squeezed toward the content edge when the margin is too tight for distance + band.
+    const edgeOffset = Math.max(0, Math.min(PLACEHOLDER_DISTANCE_PT, marginHeight - height));
+    const top = kind === 'header' ? edgeOffset : page.box.height - edgeOffset - height;
     band.style.position = 'absolute';
     band.style.left = `${(page.contentBox.x - page.box.x) * options.scale}px`;
     band.style.top = `${top * options.scale}px`;
@@ -1426,6 +1427,8 @@ function paintPage(
 
 /** Height of the blank header/footer invitation band, in points (~two text lines). */
 const PLACEHOLDER_BAND_PT = 30;
+/** Where the band starts from the sheet edge — `w:pgMar` header/footer default (720 twips). */
+const PLACEHOLDER_DISTANCE_PT = 36;
 
 /** Widget kinds the painted surface can activate without adapter chrome. */
 const WIDGET_TYPES = new Set<ContentControlMappedType>([

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1332,6 +1332,30 @@ function paintPage(
   // Page furniture (phase 2, read-only): painted inside the sheet but OUTSIDE the content
   // box, inert to editing. `data-docx-hf` is what dom-selection uses to refuse mapping a
   // browser caret inside the furniture back to a model position.
+  // Blank furniture affordance: a page with no header (or footer) paints an EMPTY band over
+  // that margin — `data-docx-hf` with no relationship id — so hover can invite and a double
+  // click can create the story. Geometry mirrors the pointer's activation band: the full
+  // margin strip at content width. Never printed (CSS hides it), never editable.
+  for (const kind of ['header', 'footer'] as const) {
+    if (page[kind]) continue;
+    const band = document.createElement('div');
+    band.className = 'docx-hf docx-hf--placeholder';
+    band.dataset.docxHf = kind;
+    band.setAttribute('contenteditable', 'false');
+    const top = kind === 'header' ? 0 : page.contentBox.y + page.contentBox.height - page.box.y;
+    const height =
+      kind === 'header'
+        ? page.contentBox.y - page.box.y
+        : page.box.y + page.box.height - (page.contentBox.y + page.contentBox.height);
+    if (height <= 0) continue;
+    band.style.position = 'absolute';
+    band.style.left = `${(page.contentBox.x - page.box.x) * options.scale}px`;
+    band.style.top = `${top * options.scale}px`;
+    band.style.width = `${page.contentBox.width * options.scale}px`;
+    band.style.height = `${height * options.scale}px`;
+    element.append(band);
+  }
+
   for (const story of [page.header, page.footer]) {
     if (!story) continue;
     const container = document.createElement('div');

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1342,12 +1342,20 @@ function paintPage(
     band.className = 'docx-hf docx-hf--placeholder';
     band.dataset.docxHf = kind;
     band.setAttribute('contenteditable', 'false');
-    const top = kind === 'header' ? 0 : page.contentBox.y + page.contentBox.height - page.box.y;
-    const height =
+    // A SLIM strip beside the content edge, not the whole margin: a section with a deep
+    // top margin painted an invitation taller than the heading under it. Word's header
+    // area is a couple of lines; the pointer still accepts the full margin band, so the
+    // visual can stay modest without shrinking the target.
+    const marginHeight =
       kind === 'header'
         ? page.contentBox.y - page.box.y
         : page.box.y + page.box.height - (page.contentBox.y + page.contentBox.height);
+    const height = Math.min(marginHeight, PLACEHOLDER_BAND_PT);
     if (height <= 0) continue;
+    const top =
+      kind === 'header'
+        ? page.contentBox.y - page.box.y - height
+        : page.contentBox.y + page.contentBox.height - page.box.y;
     band.style.position = 'absolute';
     band.style.left = `${(page.contentBox.x - page.box.x) * options.scale}px`;
     band.style.top = `${top * options.scale}px`;
@@ -1393,11 +1401,31 @@ function paintPage(
       );
     }
     element.append(container);
+    // Hover invitation for an EXISTING band: a pill just outside the story box, shown by
+    // CSS only while the adjacent band is hovered (`.docx-hf:hover + .docx-hf-edit-hint`).
+    // Outside the band because the band clips (`overflow: hidden`) and its content would
+    // sit under the pill. Adjacency is load-bearing — keep this append right here.
+    const hint = document.createElement('div');
+    hint.className = 'docx-hf-edit-hint';
+    hint.dataset.docxHfHint = story.kind;
+    hint.setAttribute('contenteditable', 'false');
+    hint.style.position = 'absolute';
+    hint.style.left = container.style.left;
+    hint.style.width = container.style.width;
+    hint.style.top =
+      story.kind === 'header'
+        ? `${(story.box.y + story.box.height - page.box.y) * options.scale}px`
+        : `${(story.box.y - page.box.y) * options.scale}px`;
+    if (story.kind === 'footer') hint.style.transform = 'translateY(-100%)';
+    element.append(hint);
   }
 
   paintContentControlChrome(document, element, page, options);
   return element;
 }
+
+/** Height of the blank header/footer invitation band, in points (~two text lines). */
+const PLACEHOLDER_BAND_PT = 30;
 
 /** Widget kinds the painted surface can activate without adapter chrome. */
 const WIDGET_TYPES = new Set<ContentControlMappedType>([

--- a/packages/core/src/store/package/hf-lifecycle.ts
+++ b/packages/core/src/store/package/hf-lifecycle.ts
@@ -496,6 +496,27 @@ function cloneNodeIds(node: OoxmlNode, nextId: () => string): OoxmlNode {
 // sectPr reference mutation
 // ---------------------------------------------------------------------------
 
+/**
+ * The main part with `xmlns:r` guaranteed on its root, or null when the prefix is taken.
+ *
+ * A minted `w:headerReference` carries `r:id`, and a minimal document that never declared
+ * the relationships namespace fails the invariant validator with `invalid-qname` — the
+ * whole create refused over a missing binding. Same discipline as the `w14:paraId` root
+ * binding: add it at the root, in the same mutation that needs it.
+ */
+function withRelationshipRootBinding(main: OoxmlPart): OoxmlPart | null {
+  const bound = main.root.namespaceBindings.find((binding) => binding.prefix === 'r');
+  if (bound) return bound.namespaceUri === R_NS ? main : null;
+  const root = {
+    ...main.root,
+    namespaceBindings: Object.freeze([
+      ...main.root.namespaceBindings,
+      Object.freeze({ prefix: 'r', namespaceUri: R_NS }),
+    ]),
+  } as typeof main.root;
+  return { ...main, root };
+}
+
 function setSectionReference(
   pkg: OoxmlPackage,
   sectionIndex: number,
@@ -504,7 +525,9 @@ function setSectionReference(
   rId: string
 ): OoxmlPackage | null {
   if (!/^rId\d{1,9}$/.test(rId)) return null;
-  const main = pkg.parts.get(pkg.mainDocumentPart);
+  const located = pkg.parts.get(pkg.mainDocumentPart);
+  if (!located) return null;
+  const main = withRelationshipRootBinding(located);
   if (!main) return null;
   const sectPrNodes = collectSectionPropertyNodes(main.root);
   if (sectionIndex >= sectPrNodes.length) return null;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3019,7 +3019,8 @@ a.docx-hyperlink:focus-visible {
 }
 
 .docx-pages .docx-hf--placeholder:hover {
-  background: var(--doc-bg-hover);
+  background: var(--doc-primary-light);
+  border-radius: 4px;
 }
 
 .docx-pages .docx-hf--placeholder:hover::after {
@@ -3029,7 +3030,7 @@ a.docx-hyperlink:focus-visible {
     -apple-system,
     sans-serif;
   font-size: 12px;
-  color: var(--doc-text-subtle);
+  color: var(--doc-primary);
   user-select: none;
   -webkit-user-select: none;
 }
@@ -3038,9 +3039,58 @@ a.docx-hyperlink:focus-visible {
   content: 'Double-click to add footer';
 }
 
+/* Hovering an EXISTING inactive band tints it and floats an edit invitation beside it —
+ * without this the enterable header answered a hover with nothing at all. The pill is a
+ * sibling because the band clips its own overflow. */
+.docx-pages .docx-hf:not([data-docx-hf-active]):not(.docx-hf--placeholder):hover {
+  background: var(--doc-primary-light);
+  border-radius: 4px;
+}
+
+.docx-pages .docx-hf-edit-hint {
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.docx-pages .docx-hf:not([data-docx-hf-active]):hover + .docx-hf-edit-hint {
+  opacity: 1;
+}
+
+.docx-pages .docx-hf-edit-hint::after {
+  content: 'Double-click to edit header';
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--doc-primary);
+  background: var(--doc-primary-light);
+  border-radius: 10px;
+  padding: 0 10px;
+  margin-top: 4px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.docx-pages .docx-hf-edit-hint[data-docx-hf-hint='footer'] {
+  align-items: flex-end;
+}
+
+.docx-pages .docx-hf-edit-hint[data-docx-hf-hint='footer']::after {
+  content: 'Double-click to edit footer';
+  margin-top: 0;
+  margin-bottom: 4px;
+}
+
 /* No affordance while another furniture scope is open, in view mode, or in print. */
 .docx-pages--hf-editing .docx-hf--placeholder:hover,
-.docx-paginated-surface--viewing .docx-hf--placeholder:hover {
+.docx-paginated-surface--viewing .docx-hf--placeholder:hover,
+.docx-pages--hf-editing .docx-hf:not([data-docx-hf-active]):hover,
+.docx-paginated-surface--viewing .docx-hf:not([data-docx-hf-active]):hover {
   background: none;
 }
 
@@ -3049,8 +3099,14 @@ a.docx-hyperlink:focus-visible {
   content: none;
 }
 
+.docx-pages--hf-editing .docx-hf-edit-hint,
+.docx-paginated-surface--viewing .docx-hf-edit-hint {
+  display: none;
+}
+
 @media print {
-  .docx-hf--placeholder {
+  .docx-hf--placeholder,
+  .docx-hf-edit-hint {
     display: none !important;
   }
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3008,6 +3008,53 @@ a.docx-hyperlink:focus-visible {
   cursor: text;
 }
 
+/* Blank furniture: a page with no header/footer paints an empty band over that margin.
+ * Invisible until hovered; the hover invites the double-click that creates the story.
+ * The hint text stays in CSS (like the band itself it is screen-only chrome), and the
+ * document canvas stays Word-faithful because nothing shows until the pointer asks. */
+.docx-pages .docx-hf--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.docx-pages .docx-hf--placeholder:hover {
+  background: var(--doc-bg-hover);
+}
+
+.docx-pages .docx-hf--placeholder:hover::after {
+  content: 'Double-click to add header';
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 12px;
+  color: var(--doc-text-subtle);
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.docx-pages .docx-hf--placeholder[data-docx-hf='footer']:hover::after {
+  content: 'Double-click to add footer';
+}
+
+/* No affordance while another furniture scope is open, in view mode, or in print. */
+.docx-pages--hf-editing .docx-hf--placeholder:hover,
+.docx-paginated-surface--viewing .docx-hf--placeholder:hover {
+  background: none;
+}
+
+.docx-pages--hf-editing .docx-hf--placeholder:hover::after,
+.docx-paginated-surface--viewing .docx-hf--placeholder:hover::after {
+  content: none;
+}
+
+@media print {
+  .docx-hf--placeholder {
+    display: none !important;
+  }
+}
+
 .docx-pages--hf-editing .docx-page-content {
   opacity: var(--doc-hf-dim-opacity);
   pointer-events: none;


### PR DESCRIPTION
Tracked changes and comments in header/footer stories now join the review queue: cards render in the rail with real geometry, accept/reject resolve against the owning story, opening a card enters the header/footer scope, and `getTrackedChanges()` tags each change with the story it lives in. A page with no header or footer paints a hover-only margin band that creates and opens the story on double-click (refused in viewing mode).

Pre-existing at base and unchanged: 13 core test failures (pointer/caret/marker suites under happy-dom) and the `check:public-docs-surface` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788507675&installation_model_id=422592&pr_number=127&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F127&signature=573f2d36c2724925b5edaf9c852221be847686ac554fd6fc0986ff6e3f8073cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->