### PR TITLE
fix(core): type where the click landed beside a page break

### DIFF
--- a/.changeset/click-beside-page-break.md
+++ b/.changeset/click-beside-page-break.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Clicking the blank space beside a page break now puts the caret before the break, so typing appears on the page that was clicked instead of the next one.

--- a/packages/core/src/layout/__tests__/positional-tab-and-trailing-break.test.ts
+++ b/packages/core/src/layout/__tests__/positional-tab-and-trailing-break.test.ts
@@ -336,3 +336,54 @@ describe('a w:ptab owns no model offsets', () => {
     expect(tab.box.width).toBeGreaterThan(0);
   });
 });
+
+describe('a PAGE break carries the caret onto the page it opened', () => {
+  // Same story as the trailing hard break above, one level up. The page break ends a line
+  // AND a page, so the offset after it belongs to the continuation — the place the text
+  // typed there will actually appear. Reporting the end of the line the break closed put
+  // the caret on the page before the one it was writing to, which reads as a dead caret:
+  // you click below the last line, type, and the letters land on the next page.
+  const ALPHA = '<w:p><w:r><w:t>Alpha</w:t></w:r></w:p>';
+  const BETA = '<w:p><w:r><w:t>Beta</w:t></w:r></w:p>';
+  const pageOfCaret = (body: string, offset: number): number | null => {
+    const layout = lay(body);
+    const paragraphId = paragraphs(layout)[1]!.paragraphId;
+    return caretAt(layout, { paragraphId, offset }, measurer)?.pageIndex ?? null;
+  };
+
+  test('the offset after the break reports the continuation page', () => {
+    const body = `${ALPHA}<w:p><w:r><w:br w:type="page"/></w:r><w:r><w:t>tail</w:t></w:r></w:p>${BETA}`;
+    expect(pageOfCaret(body, 0)).toBe(0);
+    expect(pageOfCaret(body, 1)).toBe(1);
+  });
+
+  test('a break in the middle of a paragraph does the same', () => {
+    const body =
+      `${ALPHA}<w:p><w:r><w:t>head</w:t></w:r><w:r><w:br w:type="page"/></w:r>` +
+      `<w:r><w:t>tail</w:t></w:r></w:p>${BETA}`;
+    expect(pageOfCaret(body, 4)).toBe(0);
+    expect(pageOfCaret(body, 5)).toBe(1);
+  });
+
+  test('a click in the blank space beside the mark stays on the page it landed on', () => {
+    // `<w:p><w:r><w:br w:type="page"/></w:r></w:p>` is the commonest way to end a page, and
+    // its line is one break wide with the rest of the column blank. Resolving that blank to
+    // the position AFTER the break sent the caret to a page the click never touched — and
+    // the typing with it. Word stops in front of the mark, so the click types where it is.
+    const body = `${ALPHA}<w:p><w:r><w:br w:type="page"/></w:r></w:p>${BETA}`;
+    const layout = lay(body);
+    const fragment = paragraphs(layout).find(
+      (entry) => entry.paragraphId === paragraphs(layout)[1]!.paragraphId
+    )!;
+    // Well to the right of the zero-width mark, in blank column space.
+    const hit = hitTestSemantic(layout, {
+      x: fragment.box.x + fragment.box.width - 1,
+      y: fragment.box.y + fragment.box.height / 2,
+      pageIndex: 0,
+    })!;
+    expect(hit.position.paragraphId).toBe(fragment.paragraphId);
+    expect(hit.position.offset).toBe(0);
+    // And the caret for what the click resolved to is on the page that was clicked.
+    expect(caretAt(layout, hit.position, measurer)?.pageIndex).toBe(0);
+  });
+});

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -589,6 +589,12 @@ export function breakParagraph(
       line.end = piece.end;
       closeLine();
       lines[lines.length - 1]!.pageBreakAfter = true;
+      // NOT `trailingLineBreak`, unlike the hard break below. An empty remainder publishes
+      // no line on the page the break opened: Word Online puts the following block flush at
+      // the top of that page, which `paragraph-spacing-borders` and `section-aware-
+      // pagination` pin against the comprehensive fixture. The caret after such a break
+      // therefore has nowhere to go on the new page, which is why the click that lands in
+      // the blank space beside the mark resolves BEFORE it — see `hitTestSemantic`.
       trailingLineBreak = false;
       continue;
     }

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -21,6 +21,7 @@
 // Refusing to answer is never right: a click has to put the caret somewhere, and returning
 // null makes it do nothing at all.
 
+import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
 import { graphemeBoundaryEpoch, segmentGraphemes } from './grapheme.ts';
 import { baselineShiftPtOf } from './run-style.ts';
 import type { CaretGeometry, SemanticPosition } from './semantic-interaction.ts';
@@ -624,12 +625,23 @@ function endOfLine(line: LineRecord, rightEdge: number, context: HitContext): Li
  * it belongs to the line the break opened (`caretAt` places it there), so a click in the
  * right margin of the line the break ENDED has to stop in front of it or the caret appears
  * a row below the click.
+ *
+ * A PAGE break is discounted even on the paragraph's LAST line, which is the one case the
+ * last-line shortcut got wrong. The position after such a break is on the next page — and
+ * when the remainder is empty it has no line anywhere, because Word Online starts the
+ * following block flush at the top of that page. So the caret for it stays behind on the
+ * line the break ended, and a click in the wide blank space beside the mark resolved to a
+ * position a page away from where it landed: the caret appeared under the pointer and the
+ * typing came out on the next page. `<w:p><w:r><w:br w:type="page"/></w:r></w:p>` is the
+ * commonest way to end a page, so that blank space is most of a page wide.
  */
 export function lineEndOffset(layout: SemanticLayout, line: LineRecord): number {
+  const end = line.range.end;
+  if (end > line.range.start && characterAt(line, end - 1) === PAGE_BREAK_CHAR) return end - 1;
   if (hitIndex(layout).lastLineIdOfParagraph.get(line.range.paragraphId) === line.id) {
-    return line.range.end;
+    return end;
   }
-  let offset = line.range.end;
+  let offset = end;
   if (offset > line.range.start && characterAt(line, offset - 1) === '\n') offset -= 1;
   while (offset > line.range.start && characterAt(line, offset - 1) === ' ') offset -= 1;
   return offset;

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -23,6 +23,7 @@ import type {
   TextMeasurer,
 } from './semantic-records.ts';
 import { contentControlsOfLayout, paragraphFragmentsOf } from './semantic-records.ts';
+import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
 
 /** A caret position in the model. */
 export interface SemanticPosition {
@@ -198,16 +199,24 @@ function isNonNavigableInterior(line: LineRecord, offset: number): boolean {
 }
 
 /**
- * Whether a hard line break is what ended this line.
+ * Whether an authored break is what ended this line.
  *
  * The break OCCUPIES a model offset and is published as a zero-width span, so a line that a
  * Shift+Enter terminated carries it as its last span. That is the one case where a position
  * shared by two lines is not ambiguous — see `caretAt`.
+ *
+ * A PAGE break counts for exactly the same reason, and leaving it out was worse than the
+ * hard-break case rather than milder: the line it opens is on the NEXT PAGE, so reporting
+ * the end of the line the break closed put the caret on a different page from the text that
+ * would be typed at it. Click below the last line, type, and the letters appear a page
+ * later. A column break already arrives here as `\n` — only `w:type="page"` projects its
+ * own character.
  */
 function endsWithLineBreak(line: {
   readonly spans: readonly { readonly text: string }[];
 }): boolean {
-  return line.spans[line.spans.length - 1]?.text === '\n';
+  const last = line.spans[line.spans.length - 1]?.text;
+  return last === '\n' || last === PAGE_BREAK_CHAR;
 }
 
 function pushLineCaretStops(


### PR DESCRIPTION
A paragraph that is only a page break lays out as one zero-width mark with the rest of the column blank, and a click anywhere in that blank resolved to the position after the break. The caret drew under the pointer and the text came out on the next page. Below a table of contents, where such a paragraph usually sits, that blank is most of a page — the editor reads as refusing to type at all, while a bullet still applies, because a paragraph property does not care which side of the break the caret is on.

`lineEndOffset` already discounts a trailing hard break for this exact reason. It now discounts a page break too, including on the paragraph's last line, which its last-line shortcut skipped. `caretAt` also treats a page break as a break, so an offset genuinely after one reports the continuation's page rather than the end of the line the break closed; column breaks already arrived as `\n`.

Worth knowing before reading the diff: the first attempt was to give the break-only paragraph a mark line on the page the break opens, since Word keeps the paragraph mark after the break. That fails four tests, two of which pin the opposite against the comprehensive fixture and cite Word Online — `section-aware-pagination` asserts the heading after this shape sits at `box.y === 0` with its 18pt space-before suppressed. So the empty remainder publishes no line, the caret cannot follow it, and the click has to stop in front of the mark instead. That reasoning is left as a comment at the site.

`bun test packages/core` fails the same 70 tests as `docx-editor-v2`, with no test newly failing and none newly passing beyond the three added here — each confirmed failing before the fix. `bun test packages/react packages/vue` is 417/0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788510581&installation_model_id=422592&pr_number=128&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F128&signature=e620ffe9cb5d8738ed8ae245e0939c61789c69fbedeae8f374a67d5e530d4710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->