### PR TITLE
feat: font picker offers the editor's font catalog, not just document fonts

### DIFF
--- a/.changeset/default-font-catalog.md
+++ b/.changeset/default-font-catalog.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+The font picker always offers a real catalog. A new or blank document used to open an empty picker ("no fonts declared") with an em-dash in the font box; the options are now the editor's configured font families — the default face, the Word-name families the substitution map covers, and any host-registered fonts — merged with what the document declares. The font box reports the default face (Calibri unless configured otherwise) for text with no authored font instead of showing nothing, while mixed selections still read as mixed. New `Editor.getAvailableFonts()` exposes the merged catalog; `getDocumentFonts()` is unchanged.

--- a/.changeset/default-font-catalog.md
+++ b/.changeset/default-font-catalog.md
@@ -3,3 +3,7 @@
 ---
 
 The font picker always offers a real catalog. A new or blank document used to open an empty picker ("no fonts declared") with an em-dash in the font box; the options are now the editor's configured font families — the default face, the Word-name families the substitution map covers, and any host-registered fonts — merged with what the document declares. The font box reports the default face (Calibri unless configured otherwise) for text with no authored font instead of showing nothing, while mixed selections still read as mixed. New `Editor.getAvailableFonts()` exposes the merged catalog; `getDocumentFonts()` is unchanged.
+
+Text with no authored font is now also painted in the default face it was measured in, instead of the page's inherited CSS font — visible glyphs no longer drift from wrap points and caret geometry in documents that never declare a font.
+
+New `blankDocumentBytes()` returns a Word-faithful blank document — Calibri 11pt and Word's Normal paragraph spacing authored in `docDefaults`, US Letter with one-inch margins — so a "New document" behaves like Word's and saves to a file Word opens identically.

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -84,10 +84,11 @@ function downloadDocx(buffer: ArrayBuffer, name: string): void {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Custom items for the FontFamily popup: each document font as a single-line row
+ * Custom items for the FontFamily popup: each offerable font as a single-line row
  * rendered in its own typeface, reference-picker style (the selected row gets the
- * library's right-aligned check). Options come from `useFontFamily()`, i.e. from
- * the DOCUMENT's font catalog — the list follows edits.
+ * library's right-aligned check). Options come from `useFontFamily()` — the editor's
+ * configured catalog merged with the document's declared fonts, so a brand-new
+ * document still lists real choices; the list follows edits.
  */
 function FontPreviewItems() {
   const { options } = useFontFamily();

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -14,7 +14,6 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import { zipSync, strToU8 } from 'fflate';
 import {
   DocxEditor,
   useDocxEditor,
@@ -22,6 +21,7 @@ import {
   useEditorEvent,
   useFontFamily,
 } from '@docx-editor.dev/react';
+import { blankDocumentBytes } from '@docx-editor.dev/core-contract/editor';
 import { defaultFonts } from '@docx-editor.dev/fonts';
 import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
 import { BrandLogo } from '../../shared/BrandLogo';
@@ -41,29 +41,6 @@ const translate = (key: string): string => tEnglish(key as TranslationKey);
 /** Keep the caret: chrome mousedown must never move focus out of the document. */
 function keepCaret(event: ReactMouseEvent): void {
   event.preventDefault();
-}
-
-const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
-const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
-const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
-
-/** A minimal empty document, built the same way the adapter test suite builds one. */
-function emptyDocx(): Uint8Array {
-  return zipSync({
-    '[Content_Types].xml': strToU8(
-      `<Types xmlns="${CT}">` +
-        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
-        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
-        '</Types>'
-    ),
-    '_rels/.rels': strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
-    ),
-    'word/document.xml': strToU8(
-      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t></w:t></w:r></w:p></w:body></w:document>`
-    ),
-  });
 }
 
 /** Hand DOCX bytes to the browser as a download. */
@@ -375,7 +352,7 @@ function EditorChrome({
       editor?.load(new Uint8Array(buffer));
     });
   };
-  const newDocument = () => editor?.load(emptyDocx());
+  const newDocument = () => editor?.load(blankDocumentBytes());
   const saveDocument = () => {
     void editor?.save().then((buffer) => {
       const base = title.trim() || 'document';

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -317,6 +317,14 @@ export interface Editor {
   getDocumentFonts(): readonly string[];
 
   /**
+   * Every font family the editor can offer: the configured catalog (the default face,
+   * the Word-name families the substitution map stands in for, and host-registered
+   * source families) merged with {@link getDocumentFonts}. Never empty — a brand-new
+   * document offers the configured catalog rather than a dead picker.
+   */
+  getAvailableFonts(): readonly string[];
+
+  /**
    * The document theme's ten picker colours (`a:clrScheme`) in Word's column order
    * (Background 1, Text 1, Background 2, Text 2, Accent 1-6), each a six-digit hex
    * without '#'. Empty when the document has no complete scheme — the picker then

--- a/packages/core/src/editor/__tests__/docx-editor.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { blankDocumentBytes } from '../blank-document.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -870,6 +871,37 @@ describe('setMarkAttr (value-typed run formatting)', () => {
     editor.exec({ type: 'setSelection', range: caret('/word/document.xml#0.0.1', 3) });
     expect(editor.snapshot().formatting?.fontFamily).toBe('Calibri');
     expect(editor.snapshot().formatting?.fontSizePt).toBe(11);
+  });
+
+  test('a run with no authored font PAINTS in the default face it was measured in', () => {
+    // Measurement falls back to the default face; paint must fall back to the SAME face,
+    // or the browser draws the page's inherited font over Calibri-computed geometry.
+    const { container } = mount(p('hello'));
+    const span = container.querySelector<HTMLElement>('[data-paragraph-id][data-start]');
+    expect(span).not.toBeNull();
+    // happy-dom normalizes away the quotes; the family itself is the contract.
+    expect(span!.style.fontFamily).toContain('Calibri');
+  });
+
+  test('the blank-document template is Word: Calibri 11, Normal, Letter', () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({ container, document: blankDocumentBytes() });
+    expect(editor.surface).not.toBeNull();
+    // The toolbar's boxes read Word's blank-template defaults, authored in docDefaults —
+    // not the format's 10pt floor.
+    expect(editor.snapshot().formatting?.fontFamily).toBe('Calibri');
+    expect(editor.snapshot().formatting?.fontSizePt).toBe(11);
+    expect(editor.snapshot().formatting?.styleId).toBe('Normal');
+    expect(editor.getAvailableFonts()).toContain('Calibri');
+    // Layout measures the same 11pt the box shows (22 half-points through the cascade).
+    const span = container.querySelector<HTMLElement>('[data-paragraph-id]');
+    expect(span).not.toBeNull();
+    // US Letter at one-inch margins.
+    expect(editor.getPageSetup()?.pageWidthTwips).toBe(12240);
+    expect(editor.getPageSetup()?.pageHeightTwips).toBe(15840);
+    // Typing works and the saved bytes round-trip.
+    editor.exec({ type: 'insertText', text: 'hello' });
+    expect(editor.snapshot().pages?.length ?? editor.getTotalPages()).toBeGreaterThan(0);
   });
 
   test('a blank document still reports the default face, and offers a catalog', () => {

--- a/packages/core/src/editor/__tests__/docx-editor.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor.test.ts
@@ -872,6 +872,32 @@ describe('setMarkAttr (value-typed run formatting)', () => {
     expect(editor.snapshot().formatting?.fontSizePt).toBe(11);
   });
 
+  test('a blank document still reports the default face, and offers a catalog', () => {
+    // No styles part, no theme, no rFonts anywhere: the document derivation is empty,
+    // but the run is measured in the configured default face — the font box must say
+    // so, and the picker must offer something to change it to.
+    const { editor } = mount(p('hello'));
+    editor.surface!.selectAll();
+    expect(editor.getDocumentFonts()).toEqual([]);
+    expect(editor.snapshot().formatting?.fontFamily).toBe('Calibri');
+    expect(editor.getAvailableFonts()).toEqual(['Calibri']);
+    // Declaring a font in the document joins the catalog without displacing it.
+    editor.exec({ type: 'setMarkAttr', mark: 'fontFamily', attr: 'family', value: 'Georgia' });
+    expect(editor.getDocumentFonts()).toEqual(['Georgia']);
+    expect(editor.getAvailableFonts()).toEqual(['Calibri', 'Georgia']);
+  });
+
+  test('a mixed-font selection still reports no agreed family', () => {
+    // The default-face fallback is per span; it must not launder a real disagreement
+    // into the default font.
+    const { editor } = mount(
+      '<w:p><w:r><w:rPr><w:rFonts w:ascii="Georgia"/></w:rPr><w:t>serif</w:t></w:r>' +
+        '<w:r><w:t>plain</w:t></w:r></w:p>'
+    );
+    editor.surface!.selectAll();
+    expect(editor.snapshot().formatting?.fontFamily).toBeUndefined();
+  });
+
   test('invalid values are refused as invalidArgs before touching the document', () => {
     const { editor } = mount(p('hello'));
     editor.surface!.selectAll();

--- a/packages/core/src/editor/__tests__/font-catalog.test.ts
+++ b/packages/core/src/editor/__tests__/font-catalog.test.ts
@@ -1,0 +1,78 @@
+// The offerable font catalog: configured families merged with document-declared ones.
+//
+// What these tests pin down: the catalog is never empty (the default face is always
+// offerable), substitution WORD-names are offered while their stand-in faces are not,
+// host-registered families join, document fonts merge with configuration-first casing,
+// and invalid names drop at this boundary like every other catalog derivation.
+
+import { describe, expect, test } from 'bun:test';
+import { availableFontFamilies, configuredDefaultFontFamily } from '../font-catalog.ts';
+
+const face = (family: string, weight = 400, style: 'normal' | 'italic' = 'normal') => ({
+  family,
+  weight,
+  style,
+});
+
+const source = (family: string) => ({
+  request: face(family),
+  id: `test:${family}`,
+  bytes: new Uint8Array(0),
+  hash: 'x',
+  faceIndex: 0,
+});
+
+describe('configuredDefaultFontFamily', () => {
+  test('answers Word default when nothing is configured', () => {
+    expect(configuredDefaultFontFamily(undefined)).toBe('Calibri');
+    expect(configuredDefaultFontFamily({})).toBe('Calibri');
+  });
+
+  test('answers the configured face, but never an invalid name', () => {
+    expect(
+      configuredDefaultFontFamily({ defaultFont: { family: 'Aptos', sizeHalfPoints: 24 } })
+    ).toBe('Aptos');
+    expect(
+      configuredDefaultFontFamily({
+        defaultFont: { family: 'bad"family;url(', sizeHalfPoints: 24 },
+      })
+    ).toBe('Calibri');
+  });
+});
+
+describe('availableFontFamilies', () => {
+  test('a blank document with no configuration still offers the default face', () => {
+    expect(availableFontFamilies(undefined, [])).toEqual(['Calibri']);
+  });
+
+  test('substitution Word-names are offered; their stand-in faces are not', () => {
+    const catalog = availableFontFamilies(
+      {
+        sources: [source('Carlito'), source('Liberation Serif')],
+        substitutions: [
+          { from: face('Calibri'), to: face('Carlito') },
+          { from: face('Times New Roman'), to: face('Liberation Serif') },
+        ],
+      },
+      []
+    );
+    expect(catalog).toEqual(['Calibri', 'Times New Roman']);
+  });
+
+  test('host-registered families that stand in for nothing are offered', () => {
+    expect(availableFontFamilies({ sources: [source('Inter')] }, [])).toEqual(['Calibri', 'Inter']);
+  });
+
+  test('document fonts merge, dedup case-insensitively with configured casing winning', () => {
+    const catalog = availableFontFamilies(
+      { substitutions: [{ from: face('Arial'), to: face('Liberation Sans') }] },
+      ['arial', 'Georgia', 'CALIBRI']
+    );
+    expect(catalog).toEqual(['Arial', 'Calibri', 'Georgia']);
+  });
+
+  test('invalid document names are dropped, never repaired', () => {
+    const catalog = availableFontFamilies(undefined, ['Georgia', 'x'.repeat(65), 'bad;name']);
+    expect(catalog).toEqual(['Calibri', 'Georgia']);
+  });
+});

--- a/packages/core/src/editor/blank-document.ts
+++ b/packages/core/src/editor/blank-document.ts
@@ -1,0 +1,94 @@
+// The bytes a "New document" gesture loads — Word's own blank template, not a bare shell.
+//
+// A minimal document.xml with no styles part falls to the FORMAT's defaults (10pt, no
+// font authored anywhere), which is not what a user who pressed New expects: Word's
+// blank template authors its defaults explicitly — Calibri at 11pt with the Normal
+// style's paragraph spacing — in `w:docDefaults`. This template does the same, so the
+// engine measures, paints and reports exactly what the toolbar shows, and the saved
+// file opens in Word looking identical.
+//
+// The font family is authored DIRECTLY (`w:ascii="Calibri"`), not as a theme reference:
+// no theme part ships here, and layout's theme-font resolution is a separate lane. The
+// name is the Word name; rendering resolves through the host's font configuration
+// (metric substitutes or real bytes) like any other document.
+
+import { strToU8, zipSync } from 'fflate';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OFFICE_DOCUMENT =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const STYLES_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+const CONTENT_TYPES =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<Types xmlns="${CT}">` +
+  `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+  `<Default Extension="xml" ContentType="application/xml"/>` +
+  `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+  `<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>` +
+  `</Types>`;
+
+const ROOT_RELS =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<Relationships xmlns="${REL}">` +
+  `<Relationship Id="rId1" Type="${OFFICE_DOCUMENT}" Target="word/document.xml"/>` +
+  `</Relationships>`;
+
+const DOCUMENT_RELS =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<Relationships xmlns="${REL}">` +
+  `<Relationship Id="rId1" Type="${STYLES_REL}" Target="styles.xml"/>` +
+  `</Relationships>`;
+
+// Word's blank-template defaults: Calibri 11pt run defaults, and the Normal paragraph
+// rhythm (8pt space after, 1.08-line spacing) in the paragraph defaults — the values
+// Word writes, so a save/reopen in Word shows the same text metrics.
+const STYLES =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<w:styles xmlns:w="${W}">` +
+  `<w:docDefaults>` +
+  `<w:rPrDefault><w:rPr>` +
+  `<w:rFonts w:ascii="Calibri" w:hAnsi="Calibri" w:eastAsia="Calibri" w:cs="Calibri"/>` +
+  `<w:sz w:val="22"/><w:szCs w:val="22"/>` +
+  `</w:rPr></w:rPrDefault>` +
+  `<w:pPrDefault><w:pPr>` +
+  `<w:spacing w:after="160" w:line="259" w:lineRule="auto"/>` +
+  `</w:pPr></w:pPrDefault>` +
+  `</w:docDefaults>` +
+  `<w:style w:type="paragraph" w:default="1" w:styleId="Normal">` +
+  `<w:name w:val="Normal"/><w:qFormat/>` +
+  `</w:style>` +
+  `</w:styles>`;
+
+// US Letter with one-inch margins — the geometry Word's own blank template carries.
+const DOCUMENT =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<w:document xmlns:w="${W}">` +
+  `<w:body>` +
+  `<w:p/>` +
+  `<w:sectPr>` +
+  `<w:pgSz w:w="12240" w:h="15840"/>` +
+  `<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>` +
+  `</w:sectPr>` +
+  `</w:body>` +
+  `</w:document>`;
+
+/**
+ * A Word-faithful blank document, freshly zipped per call (the caller may hand the
+ * bytes to a loader that takes ownership). Calibri 11pt and Word's Normal paragraph
+ * spacing are authored in `w:docDefaults`, US Letter geometry in the section — a New
+ * document behaves like Word's, and saving it produces a file Word opens identically.
+ *
+ * @public
+ */
+export function blankDocumentBytes(): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(CONTENT_TYPES),
+    '_rels/.rels': strToU8(ROOT_RELS),
+    'word/_rels/document.xml.rels': strToU8(DOCUMENT_RELS),
+    'word/document.xml': strToU8(DOCUMENT),
+    'word/styles.xml': strToU8(STYLES),
+  });
+}

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -145,6 +145,7 @@ import {
   toEditorFontError,
 } from './font-configuration.ts';
 import { composeFontConfiguration } from './font-composition.ts';
+import { availableFontFamilies, configuredDefaultFontFamily } from './font-catalog.ts';
 import { embeddedFontSources } from './embedded-font-sources.ts';
 import { createLocalFontProbe, detectFontSubstitutions } from './font-availability.ts';
 import { tryCreateBrowserCanvasContext } from './browser-canvas-context.ts';
@@ -392,6 +393,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     teardownSurface();
     const result = mountPaginatedSurface(container, bytes, {
       scale: scaleOf(),
+      // What a run with no authored font is REPORTED as, matching what it is measured
+      // as (`resolveFont`'s fallback below) — so a blank document's font box reads
+      // "Calibri", not an em-dash.
+      defaultFontFamily: configuredDefaultFontFamily(config.fonts),
       // Suggesting needs both: an author to attribute a proposal to, and the mode itself,
       // which survives a document reload because the reader chose it, not the file.
       ...(config.author ? { author: config.author } : {}),
@@ -1464,6 +1469,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // Real derivations from the canonical trees (session-memoized), no longer stubs.
     getDocumentStyles: () => surface?.session.documentStyles() ?? [],
     getDocumentFonts: () => surface?.session.documentFonts() ?? [],
+    // The picker's list: the configured catalog is offerable with no document at all,
+    // and the document's declared families join it once one is mounted.
+    getAvailableFonts: () =>
+      availableFontFamilies(config.fonts, surface?.session.documentFonts() ?? []),
     getDocumentThemeColors: () => surface?.session.documentThemeColors() ?? [],
     getOutline: () => surface?.session.documentOutline() ?? [],
     getComments: () => [],

--- a/packages/core/src/editor/font-catalog.ts
+++ b/packages/core/src/editor/font-catalog.ts
@@ -1,0 +1,69 @@
+// The font catalog a picker offers: the families the editor can honour, not just the
+// families the document happens to declare.
+//
+// A brand-new document declares no `w:rFonts` anywhere, so a picker fed only the
+// document derivation opens empty — a dead control on the commonest document there is.
+// The editor, however, always has fonts: the configured default face, every Word-name
+// family its substitution map can stand in for, and any family the host registered
+// bytes for directly. Those are offerable regardless of what the file says, and the
+// document's own declared families join them.
+//
+// Substitution TARGETS are deliberately excluded: `Carlito` exists to render "Calibri",
+// and listing both would offer the same metrics twice under two names — the stand-in is
+// an implementation face, not a choice.
+
+import type { FontConfiguration } from '../contracts/editor.ts';
+import { WORD_DEFAULT_FONT, type FontConfigurationBase } from './font-composition.ts';
+
+/**
+ * The same family-name bound `document-catalog.ts` and the paint sink enforce: kept in
+ * sync by value because each module re-validates at its own boundary (see the note
+ * there). Every name this module emits can end up in a CSS `font-family` declaration.
+ */
+const FONT_NAME = /^[\p{L}\p{N}\p{M} \-.+_]{1,64}$/u;
+
+/** A configuration in either public spelling — full or fragment-with-defaults. */
+export type FontCatalogConfiguration = FontConfiguration | FontConfigurationBase;
+
+/**
+ * The face a run with no authored font is measured and reported as: the configured
+ * default when it names a valid family, Word's own (Calibri) otherwise.
+ */
+export function configuredDefaultFontFamily(configuration?: FontCatalogConfiguration): string {
+  const family = configuration?.defaultFont?.family;
+  return family !== undefined && FONT_NAME.test(family) ? family : WORD_DEFAULT_FONT.family;
+}
+
+/**
+ * Every family a font picker can offer: the configured catalog (default face,
+ * substitution Word-names, host-registered source families) merged with the document's
+ * declared families. Deduplicated case-insensitively — configuration first, so its
+ * casing wins over a document respelling — and sorted by code point for the same
+ * deterministic order as the document derivation. Invalid names are dropped, never
+ * repaired, exactly like `collectDocumentFonts`.
+ */
+export function availableFontFamilies(
+  configuration: FontCatalogConfiguration | undefined,
+  documentFonts: readonly string[]
+): readonly string[] {
+  const byFold = new Map<string, string>();
+  const add = (family: string | undefined): void => {
+    if (family === undefined || !FONT_NAME.test(family)) return;
+    const fold = family.toLowerCase();
+    if (!byFold.has(fold)) byFold.set(fold, family);
+  };
+
+  add(configuredDefaultFontFamily(configuration));
+  const substitutions = configuration?.substitutions ?? [];
+  const standIns = new Set(substitutions.map((entry) => entry.to.family.toLowerCase()));
+  for (const entry of substitutions) add(entry.from.family);
+  for (const source of configuration?.sources ?? []) {
+    if (standIns.has(source.request.family.toLowerCase())) continue;
+    add(source.request.family);
+  }
+  for (const family of documentFonts) add(family);
+
+  const fonts = [...byFold.values()];
+  fonts.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return fonts;
+}

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -19,6 +19,7 @@ export {
   type FontConfigurationBase,
   type FontConfigurationFragment,
 } from './font-composition.ts';
+export { blankDocumentBytes } from './blank-document.ts';
 export {
   createFontSource,
   loadFonts,

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -92,9 +92,10 @@ export interface PaginatedSurfaceOptions {
   /** Points to CSS pixels. */
   readonly scale?: number;
   /**
-   * The family a run with no authored font is reported as by `formatting()` — the face
-   * the measurer falls back to. Absent, such a run reports `fontFamily: null` and a
-   * font box shows its placeholder even though the text renders in a real face.
+   * The family a run with no authored font is reported as by `formatting()` AND painted
+   * in — the face the measurer falls back to. Absent, such a run reports
+   * `fontFamily: null` and paints in whatever font the page inherits, which the measurer
+   * did not measure: visible glyphs drift from wrap points and caret geometry.
    */
   readonly defaultFontFamily?: string;
   /**

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -92,6 +92,12 @@ export interface PaginatedSurfaceOptions {
   /** Points to CSS pixels. */
   readonly scale?: number;
   /**
+   * The family a run with no authored font is reported as by `formatting()` — the face
+   * the measurer falls back to. Absent, such a run reports `fontFamily: null` and a
+   * font box shows its placeholder even though the text renders in a real face.
+   */
+  readonly defaultFontFamily?: string;
+  /**
    * Who resolves a pointer to a caret.
    *
    * `'engine'` (the default) answers from the layout records, which is what makes a click in

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -553,6 +553,7 @@ export function mountPaginatedSurface(
     textOf: (paragraphId) => textOf(paragraphId),
     selectedCells: () => cellSelection?.cellIds,
     defaultParagraphStyleId: () => styleCascade?.defaultParagraphStyleId ?? null,
+    defaultFontFamily: () => options.defaultFontFamily ?? null,
     pendingFormats: () => pendingAtCaret(),
     setPendingFormats: (next) => {
       if (next === null || next.length === 0) {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1664,6 +1664,7 @@ export function mountPaginatedSurface(
       readOnlyParagraphIds: tocParagraphIds(),
       ...(emptyTocIds.size > 0 ? { emptyTocPlaceholderIds: emptyTocIds } : {}),
       ...(options.fontAlias ? { fontAlias: options.fontAlias } : {}),
+      ...(options.defaultFontFamily ? { defaultFontFamily: options.defaultFontFamily } : {}),
       materialize: materializedSet,
       ariaHidden: false,
       ...(activeHf

--- a/packages/core/src/editor/surface-format.ts
+++ b/packages/core/src/editor/surface-format.ts
@@ -67,6 +67,11 @@ export interface SurfaceFormatDeps {
    * style it is actually written in rather than nothing.
    */
   defaultParagraphStyleId?(): string | null;
+  /**
+   * The face a run with no authored font is measured in, so `formatting()` reports it
+   * instead of null (the run-defaults twin of `defaultParagraphStyleId`).
+   */
+  defaultFontFamily?(): string | null;
 }
 
 type FormatMethods = Pick<
@@ -324,8 +329,16 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
         formattingAt(
           currentLayout.value,
           selectionNow.value,
-          (paragraphId: string, runProperties) =>
-            session.effectiveRunDefaults(paragraphId, runProperties),
+          (paragraphId: string, runProperties) => {
+            const resolved = session.effectiveRunDefaults(paragraphId, runProperties);
+            // A run whose chain authored NOTHING is still measured in the surface's
+            // default face; report that face rather than null, per span — so a blank
+            // document reads "Calibri" while a genuinely mixed selection still
+            // disagrees its way to null.
+            if (resolved.fontFamily !== null) return resolved;
+            const fallback = deps.defaultFontFamily?.() ?? null;
+            return fallback === null ? resolved : { ...resolved, fontFamily: fallback };
+          },
           deps.selectedCells?.(),
           deps.defaultParagraphStyleId?.() ?? null
         ),

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -52,6 +52,13 @@ export interface PaintContext {
    */
   readonly fontAlias?: (family: string) => string | undefined;
   /**
+   * The family painted for a run whose cascade authors no font — the SAME face the
+   * measurer falls back to. Without it such a run inherits the page's CSS font, and the
+   * browser draws one face over geometry measured for another: wrap points, caret and
+   * selection rectangles all drift from the visible glyphs.
+   */
+  readonly defaultFontFamily?: string;
+  /**
    * Paint hyperlinks without an `href` and out of the tab order.
    *
    * Set while painting page furniture: headers and footers are read-only in this slice, so
@@ -109,6 +116,8 @@ export interface PaintOptions {
    * family, so a file can never shadow a family name the host page uses.
    */
   readonly fontAlias?: (family: string) => string | undefined;
+  /** See {@link PaintContext.defaultFontFamily}. */
+  readonly defaultFontFamily?: string;
   /**
    * Relationship id of the header/footer story currently open for editing.
    *
@@ -301,19 +310,27 @@ function applyRunFaceStyle(element: HTMLElement, style: ResolvedRunStyle, ctx: P
   if (style.bold) css.fontWeight = 'bold';
   if (style.italic) css.fontStyle = 'italic';
   // Re-validated here even though the resolver already checked: this is the sink, and a
-  // sink that trusts its caller is one refactor away from being the hole.
-  if (style.fontFamily && FONT_NAME.test(style.fontFamily)) {
+  // sink that trusts its caller is one refactor away from being the hole. A run with no
+  // resolved family paints in the surface's default face — the face it was MEASURED in —
+  // never in whatever font the page happens to inherit.
+  const family =
+    style.fontFamily && FONT_NAME.test(style.fontFamily)
+      ? style.fontFamily
+      : ctx.defaultFontFamily && FONT_NAME.test(ctx.defaultFontFamily)
+        ? ctx.defaultFontFamily
+        : null;
+  if (family) {
     // An alias names bytes the host registered for THIS document under a family a file
     // cannot collide with. It leads, with the declared family behind it: document text
     // gets the embedded glyphs while the page-global CSS font namespace keeps its own
     // meaning for the declared name. `FONT_NAME` gates the declared family; the alias is
     // engine-minted, never file-derived.
-    const alias = ctx.fontAlias?.(style.fontFamily);
-    // The measurer's fallback stack trails the declared family so an unresolvable name
-    // falls back to the SAME face measurement fell back to — not to the inherited font.
+    const alias = ctx.fontAlias?.(family);
+    // The measurer's fallback stack trails the family so an unresolvable name falls
+    // back to the SAME face measurement fell back to — not to the inherited font.
     css.fontFamily = alias
-      ? `"${alias}", "${style.fontFamily}", ${DEFAULT_CANVAS_FONT_STACK}`
-      : `"${style.fontFamily}", ${DEFAULT_CANVAS_FONT_STACK}`;
+      ? `"${alias}", "${family}", ${DEFAULT_CANVAS_FONT_STACK}`
+      : `"${family}", ${DEFAULT_CANVAS_FONT_STACK}`;
   }
   if (style.color && HEX.test(style.color)) css.color = `#${style.color}`;
   const highlight = style.highlight ? HIGHLIGHT.get(style.highlight) : undefined;
@@ -1731,6 +1748,7 @@ export function paintSemanticLayout(
     ...(options.emptyTocPlaceholderIds
       ? { emptyTocPlaceholderIds: options.emptyTocPlaceholderIds }
       : {}),
+    ...(options.defaultFontFamily ? { defaultFontFamily: options.defaultFontFamily } : {}),
     authorSlots: authorSlotsOf(layout),
     ...(options.activeHeaderFooterRId
       ? { activeHeaderFooterRId: options.activeHeaderFooterRId }
@@ -1747,7 +1765,7 @@ export function paintSemanticLayout(
   // Content-control chrome is furniture only, but toggling it must rebuild painted pages
   // so show-all / caret chrome appear. Hover is the one exception: it is applied to the
   // painted nodes in place, because a pointer crossing a region may not move it.
-  const parameters = `${resolved.scale}|${resolved.ariaHidden}|${resolved.fontAlias ? aliasIdentity(resolved.fontAlias) : ''}|${resolved.activeHeaderFooterRId ?? ''}|${resolved.activeHeaderFooterPageIndex ?? ''}|cc:${chromeKey}:${additionalKey}|toc:${tocKey}|ro:${readOnlyKey}|tocEmpty:${emptyTocKey}`;
+  const parameters = `${resolved.scale}|${resolved.ariaHidden}|${resolved.fontAlias ? aliasIdentity(resolved.fontAlias) : ''}|${resolved.defaultFontFamily ?? ''}|${resolved.activeHeaderFooterRId ?? ''}|${resolved.activeHeaderFooterPageIndex ?? ''}|cc:${chromeKey}:${additionalKey}|toc:${tocKey}|ro:${readOnlyKey}|tocEmpty:${emptyTocKey}`;
   const previous = retainedPaints.get(container);
   const reusable =
     previous && previous.parameters === parameters

--- a/packages/react/src/editor/toolbar/FontFamily.tsx
+++ b/packages/react/src/editor/toolbar/FontFamily.tsx
@@ -5,10 +5,12 @@
 // different picker UI takes the hook and ignores the compound parts. The compound
 // `FontFamily` (Trigger / Content / Item) is that hook plus open-state plumbing.
 //
-// Every option string comes from `Editor.getDocumentFonts()`, which validates font
-// names at the derivation boundary (length-bounded, control characters dropped), so
-// rendering an option in its own typeface via a React `style` object is styling an
-// already-sanitized name — and a style OBJECT, never a CSS string sink.
+// Every option string comes from `Editor.getAvailableFonts()` — the configured font
+// catalog merged with the document's declared families, so a brand-new document still
+// offers a real list. The derivation validates font names at its boundary
+// (length-bounded, control characters dropped), so rendering an option in its own
+// typeface via a React `style` object is styling an already-sanitized name — and a
+// style OBJECT, never a CSS string sink.
 
 import {
   createContext,
@@ -39,7 +41,10 @@ export interface UseFontFamilyResult {
   readonly value: string | null;
   /** Apply a family through the can-before-exec path; a refusal is a safe no-op. */
   readonly setValue: (family: string) => void;
-  /** The document's font catalog (validated, deduplicated, sorted). */
+  /**
+   * The offerable font catalog (validated, deduplicated, sorted): the editor's
+   * configured families merged with the document's declared ones.
+   */
   readonly options: readonly string[];
   /** Whether the engine would honour a font change right now. */
   readonly isEnabled: boolean;
@@ -56,14 +61,14 @@ export function useFontFamily(): UseFontFamilyResult {
   // OPTIONS SUBSCRIPTION: the options list must follow edits (typing a run with a new
   // `w:rFonts`, undo, load), and the change signal for ALL document state is the
   // version-cached snapshot's IDENTITY. So this selects the snapshot itself — a new
-  // reference exactly when observable state moved — and re-reads `getDocumentFonts()`
-  // keyed on it. The read is cheap: the session memoizes the derivation per revision,
-  // so an unchanged document answers from cache. The cost accepted here is a re-render
-  // of the consuming component on every state move, which for a single toolbar picker
-  // is the right trade against a bespoke second subscription channel.
+  // reference exactly when observable state moved — and re-reads `getAvailableFonts()`
+  // keyed on it. The read is cheap: the session memoizes the document half per
+  // revision, so an unchanged document answers from cache. The cost accepted here is a
+  // re-render of the consuming component on every state move, which for a single
+  // toolbar picker is the right trade against a bespoke second subscription channel.
   const snapshot = useEditorState(selectSnapshot);
   const options = useMemo(
-    () => (editor && !snapshot.isLoading ? editor.getDocumentFonts() : EMPTY_FONTS),
+    () => (editor && !snapshot.isLoading ? editor.getAvailableFonts() : EMPTY_FONTS),
     [editor, snapshot]
   );
   const { isEnabled } = useEditorCommand('font.family');

--- a/packages/react/test/toolbar-composition.test.tsx
+++ b/packages/react/test/toolbar-composition.test.tsx
@@ -8,7 +8,8 @@
 // place (and `hidden` removes it); `preset={false}` verbatim rendering; live Bold
 // state through a click; asChild prop merging; the wired font-size stepper, zoom
 // stepper, and colour split buttons; the undriven pickers rendering disabled; that
-// FontFamily's options come from the DOCUMENT'S fonts and selecting one applies it;
+// FontFamily's options are the editor's offerable catalog (configured families merged
+// with the document's) and selecting one applies it;
 // and the caret-preserving mousedown contract.
 
 // MUST be first: happy-dom registration happens on import.
@@ -803,9 +804,12 @@ describe('the shaped parts', () => {
 });
 
 describe('the FontFamily compound', () => {
-  test('options come from the DOCUMENT fonts; selecting applies and closes', async () => {
+  test('options are the offerable catalog; selecting applies and closes', async () => {
     const { view, editor } = mountToolbar(<DocxEditorToolbar />, FONTED_SOURCE);
     expect(editor().getDocumentFonts()).toEqual(['Courier New', 'Georgia']);
+    // The catalog never collapses to the document alone: with no `fonts` configured,
+    // the default face is still offerable alongside the declared families.
+    expect(editor().getAvailableFonts()).toEqual(['Calibri', 'Courier New', 'Georgia']);
     await act(async () => {
       editor().surface!.selectAll();
     });
@@ -824,30 +828,35 @@ describe('the FontFamily compound', () => {
     // headings in the chrome spec's group order (serif before monospace), not one flat
     // alphabetical list.
     const options = [...listbox.querySelectorAll('[role="option"]')];
-    expect(options.map((option) => option.textContent)).toEqual(['Georgia', 'Courier New']);
+    expect(options.map((option) => option.textContent)).toEqual([
+      'Calibri',
+      'Georgia',
+      'Courier New',
+    ]);
     expect(
       [...listbox.querySelectorAll('.docx-toolbar__menu-label')].map((label) => label.textContent)
-    ).toEqual(['font.serif', 'font.monospace']);
+    ).toEqual(['font.sansSerif', 'font.serif', 'font.monospace']);
 
     await act(async () => {
-      (options[0] as HTMLButtonElement).click();
+      (options[1] as HTMLButtonElement).click();
     });
     // Applied through can-before-exec, popup closed, trigger shows the new value.
     expect(editor().snapshot().formatting?.fontFamily).toBe('Georgia');
     expect(view.container.querySelector('[role="listbox"]')).toBeNull();
     expect(trigger.textContent).toBe('Georgia');
     // Reopened, the OPTIONS FOLLOWED THE EDIT: applying Georgia to the whole selection
-    // rewrote both runs' rFonts, so Courier New left the document's font catalog — the
-    // list re-derives from the document, not from a mount-time snapshot. And the one
-    // remaining option is marked selected.
+    // rewrote both runs' rFonts, so Courier New left the document half of the catalog —
+    // the list re-derives from the document, not from a mount-time snapshot. The
+    // configured default face stays offerable, and the applied option is marked
+    // selected.
     await act(async () => {
       trigger.click();
     });
     const reopened = [...view.container.querySelectorAll('[role="option"]')];
     // The selected row carries the right-edge ✓ (part of its text content).
-    expect(reopened.map((option) => option.textContent)).toEqual(['Georgia✓']);
-    expect(reopened[0]!.hasAttribute('data-selected')).toBe(true);
-    expect(reopened[0]!.querySelector('.docx-toolbar__menu-check')).not.toBeNull();
+    expect(reopened.map((option) => option.textContent)).toEqual(['Calibri', 'Georgia✓']);
+    expect(reopened[1]!.hasAttribute('data-selected')).toBe(true);
+    expect(reopened[1]!.querySelector('.docx-toolbar__menu-check')).not.toBeNull();
   });
 
   test('custom Item children render inside a composed FontFamily', async () => {


### PR DESCRIPTION
A brand-new document declares no `w:rFonts`, so the font picker opened empty ("no fonts declared") and the font box showed an em-dash. Two follow-on defects surfaced in review: font-less runs painted in the page's inherited CSS font while being measured in the default face (visible glyphs drifted from wrap points and caret geometry), and a blank document fell to the format's 10pt floor instead of Word's 11pt.

- `Editor.getAvailableFonts()`: the configured catalog (default face, substitution Word-names, host-registered families, stand-in faces excluded) merged with the document's declared fonts; `getDocumentFonts()` unchanged. React `useFontFamily` options come from it.
- The formatting read reports the configured default face (Calibri unless overridden) for runs whose style chain authors no font, per span — mixed selections still read as mixed.
- Paint falls back to the same default face the measurer uses, so glyphs, wrap points and caret geometry agree even in documents that never declare a font.
- `blankDocumentBytes()`: Word's blank template (Calibri 11pt + Normal paragraph rhythm in `docDefaults`, US Letter, one-inch margins); the demo's New button uses it.

Verified in the demo: New shows Calibri 11, text paints in the metric substitute with the caret flush to the glyphs, the picker offers Arial/Calibri/Cambria/Courier New/Times New Roman, and applying one works. Test failure sets are byte-identical to the base branch (13 editor + 11 paint core, 11 react — all pre-existing); `check:parity`/`api:check` drift pre-exists on base and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)