### PR TITLE
fix(react): align scoped story chrome with scrollbar gutter

### DIFF
--- a/.changeset/hf-chrome-scrollbar-gutter.md
+++ b/.changeset/hf-chrome-scrollbar-gutter.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Align header, footer, and note editing chrome with the painted story when the scroller reserves a left scrollbar gutter.
+Align header, footer, footnote, endnote, and hyperlink chrome with the painted page when the scroller reserves a left scrollbar gutter.

--- a/.changeset/hf-chrome-scrollbar-gutter.md
+++ b/.changeset/hf-chrome-scrollbar-gutter.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Align header, footer, and note editing chrome with the painted story when the scroller reserves a left scrollbar gutter.

--- a/packages/react/src/editor/DocxEditorHyperLink.tsx
+++ b/packages/react/src/editor/DocxEditorHyperLink.tsx
@@ -31,6 +31,7 @@ import {
 } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import { useTranslation } from '../i18n';
+import { absolutePointInScroller } from './scroller-geometry.ts';
 import { HyperlinkPopupContext, type UseHyperlinkPopupResult } from './useHyperlinkPopup';
 import { Slot } from './toolbar/Slot';
 
@@ -141,9 +142,9 @@ function HyperLinkRoot({ className, asChild, hidden, children, preset = true }: 
       setPlacement(null);
       return;
     }
-    const box = container.getBoundingClientRect();
-    const left = anchor.left - box.left + container.scrollLeft;
-    const top = anchor.top - box.top + container.scrollTop;
+    // Same padding-edge correction as scoped story chrome: the popover is absolute inside
+    // the scroller, and `scrollbar-gutter: stable both-edges` inflates `clientLeft`.
+    const { left, top } = absolutePointInScroller(container, anchor.left, anchor.top);
     // Clamped horizontally so a link near the right edge does not push the panel off it.
     const maxLeft = Math.max(0, container.scrollWidth - panel.offsetWidth);
     setPlacement({ left: Math.max(0, Math.min(left, maxLeft)), top });

--- a/packages/react/src/editor/scroller-geometry.ts
+++ b/packages/react/src/editor/scroller-geometry.ts
@@ -1,0 +1,19 @@
+/**
+ * Convert a client-space point into coordinates for `position: absolute` inside a scroller.
+ *
+ * Absolute children resolve against the scroller's padding edge. `getBoundingClientRect` is
+ * the border box, so a reserved gutter (`scrollbar-gutter: stable both-edges` → non-zero
+ * `clientLeft` / `clientTop` in Chromium) must be subtracted or the overlay drifts by that
+ * gutter relative to painted content.
+ */
+export function absolutePointInScroller(
+  scroller: HTMLElement,
+  clientX: number,
+  clientY: number
+): { left: number; top: number } {
+  const box = scroller.getBoundingClientRect();
+  return {
+    left: clientX - box.left - scroller.clientLeft + scroller.scrollLeft,
+    top: clientY - box.top - scroller.clientTop + scroller.scrollTop,
+  };
+}

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -1,5 +1,6 @@
 import { useCallback, useLayoutEffect, useState } from 'react';
 import type { CSSProperties, RefCallback } from 'react';
+import { absolutePointInScroller } from './scroller-geometry.ts';
 
 type AnchorPlacement = 'before' | 'after' | 'story-label';
 
@@ -49,29 +50,19 @@ export function useScopedChromeAnchor(
         return;
       }
 
-      const viewportRect = viewport.getBoundingClientRect();
       const anchorRect = anchor.getBoundingClientRect();
       const chromeHeight =
         placement === 'story-label' ? Math.max(chrome.offsetHeight, 28) : chrome.offsetHeight;
       const clearance = placement === 'story-label' ? 6 : 4;
       const attachedInsideViewport = containingViewport === viewport;
-      // Absolute children resolve against the scroller's padding edge. `getBoundingClientRect`
-      // is the border box, so a reserved left/top gutter (`scrollbar-gutter: stable both-edges`
-      // sets a non-zero `clientLeft` in Chromium) must be subtracted or the rail sits that
-      // many pixels to the right/below the painted story.
-      const documentLeft = attachedInsideViewport
-        ? anchorRect.left - viewportRect.left - viewport.clientLeft + viewport.scrollLeft
-        : anchorRect.left;
-      const documentTop = attachedInsideViewport
-        ? (placement === 'after'
-            ? anchorRect.bottom + 6
-            : anchorRect.top - chromeHeight - clearance) -
-          viewportRect.top -
-          viewport.clientTop +
-          viewport.scrollTop
-        : placement === 'after'
-          ? anchorRect.bottom + 6
-          : anchorRect.top - chromeHeight - clearance;
+      // Header/footer AND footnote/endnote chrome both use this hook (`story-label`).
+      const anchorTop =
+        placement === 'after' ? anchorRect.bottom + 6 : anchorRect.top - chromeHeight - clearance;
+      const documentPoint = attachedInsideViewport
+        ? absolutePointInScroller(viewport, anchorRect.left, anchorTop)
+        : { left: anchorRect.left, top: anchorTop };
+      const documentLeft = documentPoint.left;
+      const documentTop = documentPoint.top;
       const viewportEdge = attachedInsideViewport ? viewport.scrollLeft + 8 : 8;
 
       setStyle({

--- a/packages/react/src/editor/useScopedChromeAnchor.ts
+++ b/packages/react/src/editor/useScopedChromeAnchor.ts
@@ -55,14 +55,19 @@ export function useScopedChromeAnchor(
         placement === 'story-label' ? Math.max(chrome.offsetHeight, 28) : chrome.offsetHeight;
       const clearance = placement === 'story-label' ? 6 : 4;
       const attachedInsideViewport = containingViewport === viewport;
+      // Absolute children resolve against the scroller's padding edge. `getBoundingClientRect`
+      // is the border box, so a reserved left/top gutter (`scrollbar-gutter: stable both-edges`
+      // sets a non-zero `clientLeft` in Chromium) must be subtracted or the rail sits that
+      // many pixels to the right/below the painted story.
       const documentLeft = attachedInsideViewport
-        ? anchorRect.left - viewportRect.left + viewport.scrollLeft
+        ? anchorRect.left - viewportRect.left - viewport.clientLeft + viewport.scrollLeft
         : anchorRect.left;
       const documentTop = attachedInsideViewport
         ? (placement === 'after'
             ? anchorRect.bottom + 6
             : anchorRect.top - chromeHeight - clearance) -
-          viewportRect.top +
+          viewportRect.top -
+          viewport.clientTop +
           viewport.scrollTop
         : placement === 'after'
           ? anchorRect.bottom + 6

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -49,7 +49,15 @@ function setStoryRect(node: HTMLDivElement | null, left: number, top: number, wi
   };
 }
 
-function AnchorProbe({ active }: { active: 'first' | 'second' }): ReactNode {
+function AnchorProbe({
+  active,
+  clientLeft = 0,
+  clientTop = 0,
+}: {
+  active: 'first' | 'second';
+  clientLeft?: number;
+  clientTop?: number;
+}): ReactNode {
   const anchor = useScopedChromeAnchor(findActiveProbe, 'story-label');
   return (
     <div
@@ -58,6 +66,8 @@ function AnchorProbe({ active }: { active: 'first' | 'second' }): ReactNode {
         if (!node) return;
         node.getBoundingClientRect = () => rect(0, 0, 800, 600);
         Object.defineProperty(node, 'clientWidth', { value: 800, configurable: true });
+        Object.defineProperty(node, 'clientLeft', { value: clientLeft, configurable: true });
+        Object.defineProperty(node, 'clientTop', { value: clientTop, configurable: true });
       }}
     >
       <div className="docx-paginated-surface">
@@ -196,6 +206,19 @@ describe('DocxEditor.HeaderFooterChrome', () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
     expect(view.getByTestId('anchor-probe').style.left).toBe('420px');
+  });
+
+  test('story bar subtracts the scroller padding-edge gutter (scrollbar-gutter both-edges)', async () => {
+    // Chromium reports clientLeft ≈ 15 when `scrollbar-gutter: stable both-edges` reserves
+    // a left gutter. Absolute `left` is relative to that padding edge, not the border box
+    // from getBoundingClientRect — without subtracting clientLeft the rail sits 15px right
+    // of the painted header/footer box (visible on Chrome, often invisible on Safari).
+    const view = render(<AnchorProbe active="first" clientLeft={15} clientTop={0} />);
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    expect(view.getByTestId('anchor-probe').style.left).toBe('105px');
+    expect(view.getByTestId('anchor-probe').style.top).toBe('46px');
   });
 
   test('story bar scrolls away with its focused occurrence', async () => {

--- a/packages/react/test/header-footer-chrome.test.tsx
+++ b/packages/react/test/header-footer-chrome.test.tsx
@@ -212,7 +212,7 @@ describe('DocxEditor.HeaderFooterChrome', () => {
     // Chromium reports clientLeft ≈ 15 when `scrollbar-gutter: stable both-edges` reserves
     // a left gutter. Absolute `left` is relative to that padding edge, not the border box
     // from getBoundingClientRect — without subtracting clientLeft the rail sits 15px right
-    // of the painted header/footer box (visible on Chrome, often invisible on Safari).
+    // of the painted story. Header/footer and footnote/endnote chrome share this hook.
     const view = render(<AnchorProbe active="first" clientLeft={15} clientTop={0} />);
     await act(async () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));

--- a/packages/react/test/notes-chrome.test.tsx
+++ b/packages/react/test/notes-chrome.test.tsx
@@ -152,6 +152,22 @@ afterEach(() => {
 });
 
 describe('DocxEditor.NotesChrome', () => {
+  test('note banner anchors through the shared story-label chrome hook', async () => {
+    // Footnote/endnote chrome uses `useScopedChromeAnchor(..., 'story-label')` — the same
+    // path as header/footer. Gutter regression coverage lives with that hook; this pins the
+    // notes banner to the shared placement mode so a future fork cannot silently diverge.
+    const { view, editor } = mountChrome(footnoteDoc());
+    await enterFootnote(editor());
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    const banner = view.getByTestId('docx-notes-banner');
+    expect(banner.style.position).toBe('absolute');
+    expect(banner.style.visibility).toBe('visible');
+    expect(banner.style.left).toMatch(/^\d+(\.\d+)?px$/);
+    expect(banner.style.width).toMatch(/^\d+(\.\d+)?px$/);
+  });
+
   test('banner hidden in body, visible in note scope with label and scope id', async () => {
     const { view, editor } = mountChrome(footnoteDoc());
     expect(view.getByTestId('docx-notes-chrome')).toBeTruthy();

--- a/packages/react/test/scroller-geometry.test.ts
+++ b/packages/react/test/scroller-geometry.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { absolutePointInScroller } from '../src/editor/scroller-geometry.ts';
+
+describe('absolutePointInScroller', () => {
+  test('subtracts the scroller padding-edge gutter from border-box client coords', () => {
+    const scroller = {
+      getBoundingClientRect: () =>
+        ({
+          left: 10,
+          top: 20,
+          right: 810,
+          bottom: 620,
+          width: 800,
+          height: 600,
+          x: 10,
+          y: 20,
+          toJSON: () => ({}),
+        }) as DOMRect,
+      clientLeft: 15,
+      clientTop: 0,
+      scrollLeft: 40,
+      scrollTop: 80,
+    } as HTMLElement;
+
+    expect(absolutePointInScroller(scroller, 265, 146)).toEqual({ left: 280, top: 206 });
+  });
+});


### PR DESCRIPTION
## Summary
- Scoped header/footer/footnote/endnote chrome (and the hyperlink popover) placed absolute overlays from the scroller border box while CSS resolves against the padding edge, so `scrollbar-gutter: stable both-edges` shifted rails ~15px right of the painted story.
- The omission was latent in #108; it became the visible dashed-rail bug when that PR turned the chrome into a story-width rail. `scrollbar-gutter: stable both-edges` was already present from the v2 stylesheet (#72), not added afterward.
- Extract `absolutePointInScroller`, use it from the shared story-label hook and the hyperlink popover. Vue has no furniture/notes chrome (deferred).

## Test plan
- [x] `bun test packages/react/test/header-footer-chrome.test.tsx packages/react/test/notes-chrome.test.tsx packages/react/test/scroller-geometry.test.ts packages/react/test/hyperlink-popup.test.tsx`
- [x] `bun run --filter '@docx-editor.dev/react' typecheck`
- [x] Browser: header and footnote rails at leftΔ=0 under `stable both-edges`; old formula reproduces leftΔ=15
- [ ] Double-click header/footer or click a footnote ref — chrome is absent until that scope opens