### PR TITLE
fix(core): keep empty line after column break

### DIFF
--- a/.changeset/column-break-empty-remainder.md
+++ b/.changeset/column-break-empty-remainder.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Keep the empty line Word shows at the top of a column after an explicit column break. A paragraph whose only content is `w:br w:type="column"` still occupies its remainder line in the next column; page breaks continue to open the next page flush with the following block.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -245,7 +245,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Existing tab stops render, including right/decimal tabs and dot, hyphen and underscore leaders. Positional tabs (w:ptab) render too, so a table-of-contents line reads as one: entry left, leader dots between, page number flush right. The document\'s own w:defaultTabStop is honoured, so a metric-locale grid lands where Word puts it, in headers and footers as well as the body. A tab-stop editing UI is not built yet.',
+      "Existing tab stops render, including right/decimal tabs and dot, hyphen and underscore leaders. Positional tabs (w:ptab) render too, so a table-of-contents line reads as one: entry left, leader dots between, page number flush right. The document's own w:defaultTabStop is honoured, so a metric-locale grid lands where Word puts it, in headers and footers as well as the body. A tab-stop editing UI is not built yet.",
   },
   {
     id: 'paragraphs.frames',
@@ -606,11 +606,11 @@ export const wordFeatures: WordFeature[] = [
     name: 'Multi-column layout',
     category: 'layout',
     editing: 'none',
-    rendering: 'none',
+    rendering: 'partial',
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'The section w:cols count and gap are read and round-trip, but text does not yet flow into columns: a three-column section renders as one full-width column.',
+      "Section w:cols count, gap, separator and equal/unequal widths paginate into columns; explicit column breaks leave the break paragraph's empty remainder at the top of the next column. Balancing continuous multi-column sections is supported. Column editing chrome is not exposed.",
   },
   {
     id: 'layout.page-borders',
@@ -641,7 +641,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'First, even, and default variants are selected by the page\'s number in the document (so the alternation carries across section breaks) and editable in an open furniture scope. Programmatic `editHeaderFooter({ variant: \'even\' })` (or `evenPage: true`) creates/opens the even story and enables `w:evenAndOddHeaders` in one undo unit. React header/footer chrome can toggle different even and odd pages; Vue chrome deferred.',
+      "First, even, and default variants are selected by the page's number in the document (so the alternation carries across section breaks) and editable in an open furniture scope. Programmatic `editHeaderFooter({ variant: 'even' })` (or `evenPage: true`) creates/opens the even story and enables `w:evenAndOddHeaders` in one undo unit. React header/footer chrome can toggle different even and odd pages; Vue chrome deferred.",
   },
   {
     id: 'layout.vertical-align',

--- a/packages/core/src/layout/__tests__/multi-column-layout.test.ts
+++ b/packages/core/src/layout/__tests__/multi-column-layout.test.ts
@@ -110,6 +110,8 @@ describe('multi-column section layout', () => {
     );
     expect(first?.box.x).toBe(0);
     expect(second?.box.x).toBe(120);
+    // Column one holds FIRST plus the break line; column two holds the empty remainder
+    // plus SECOND. Both columns therefore reach two line heights with this measurer.
     expect(
       (
         layout.pages[0] as (typeof layout.pages)[number] & {
@@ -117,6 +119,42 @@ describe('multi-column section layout', () => {
         }
       ).columnSeparators
     ).toEqual([{ x: 104.625, y: 0, width: 0.75, height: 25.454545454545453 }]);
+  });
+
+  test('a column break in an otherwise empty paragraph leaves an empty line in the next column', () => {
+    // Word authoring form for an explicit column cut: a paragraph whose only run is the
+    // break. After the break advances the flow, the paragraph's remainder still occupies a
+    // line at the top of the new column — the empty line visible above "After Column Break"
+    // in section 19 of the comprehensive fixture.
+    const part = packageWithBody(
+      paragraph('FIRST COLUMN') +
+        '<w:p><w:r><w:br w:type="column"/></w:r></w:p>' +
+        paragraph('SECOND COLUMN') +
+        '<w:sectPr>' +
+        '<w:pgSz w:w="7200" w:h="7200"/>' +
+        '<w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/>' +
+        '<w:cols w:num="2" w:space="600"/>' +
+        '</w:sectPr>'
+    );
+
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: createFixedMeasurer(6, 14),
+    });
+    const first = layout.pages[0]!.fragments.find((item) => fragmentText(item) === 'FIRST COLUMN');
+    const second = layout.pages[0]!.fragments.find(
+      (item) => fragmentText(item) === 'SECOND COLUMN'
+    );
+    const breakRemnant = layout.pages[0]!.fragments.find(
+      (item) =>
+        item.kind === 'paragraph' &&
+        item.box.x === second?.box.x &&
+        fragmentText(item) === '' &&
+        item.paragraphId !== second?.paragraphId
+    );
+    expect(breakRemnant).toBeDefined();
+    expect(breakRemnant!.box.y).toBe(first!.box.y);
+    expect(second!.box.y).toBeGreaterThan(breakRemnant!.box.y);
+    expect(second!.box.y - breakRemnant!.box.y).toBe(breakRemnant!.box.height);
   });
 
   test('inline content after a column break is rebroken in the new column', () => {
@@ -380,6 +418,9 @@ describe('multi-column section layout', () => {
     );
     expect(heading?.box.x).toBeLessThan(200);
     expect(afterBreak?.box.x).toBeGreaterThan(200);
+    // The break paragraph's empty remainder sits above "After Column Break" in column two,
+    // so that text starts one line below the heading rather than flush with it.
+    expect(afterBreak!.box.y).toBeGreaterThan(heading!.box.y);
     expect(
       (
         sectionPage as typeof sectionPage & {

--- a/packages/core/src/layout/__tests__/semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-layout.test.ts
@@ -169,7 +169,11 @@ describe('line breaking and pagination (task 7.3)', () => {
     const layout = lay(part, { ...SMALL, height: 1000 });
     expect(layout.pages).toHaveLength(2);
     expect(layout.pages[0]!.fragments[0]!.lines[0]!.spans[0]!.text).toBe('\f');
+    // Unlike a column break, a page break does NOT publish an empty remainder on the page
+    // it opens — the following block starts flush at the top (Word Online / fixture parity).
+    expect(layout.pages[1]!.fragments).toHaveLength(1);
     expect(layout.pages[1]!.fragments[0]!.lines[0]!.spans[0]!.text).toBe('after');
+    expect(layout.pages[1]!.fragments[0]!.box.y).toBe(0);
   });
 
   test('an ordinary w:br remains a line break', () => {

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -626,7 +626,13 @@ export function breakParagraph(
       line.end = piece.end;
       closeLine();
       lines[lines.length - 1]!.columnBreakAfter = true;
-      trailingLineBreak = false;
+      // Like a trailing hard break, NOT like a page break: Word still lays out the
+      // paragraph's remainder after the column advance. The common authoring form
+      // `<w:p><w:r><w:br w:type="column"/></w:r></w:p>` therefore opens one empty line
+      // at the top of the next column before the following block — the paragraph mark
+      // after the break. Suppressing that remainder put "After Column Break" flush with
+      // the prior column's first line.
+      trailingLineBreak = true;
       continue;
     }
     if (piece.text === PAGE_BREAK_CHAR) {
@@ -645,12 +651,13 @@ export function breakParagraph(
       line.end = piece.end;
       closeLine();
       lines[lines.length - 1]!.pageBreakAfter = true;
-      // NOT `trailingLineBreak`, unlike the hard break below. An empty remainder publishes
-      // no line on the page the break opened: Word Online puts the following block flush at
-      // the top of that page, which `paragraph-spacing-borders` and `section-aware-
-      // pagination` pin against the comprehensive fixture. The caret after such a break
-      // therefore has nowhere to go on the new page, which is why the click that lands in
-      // the blank space beside the mark resolves BEFORE it — see `hitTestSemantic`.
+      // NOT `trailingLineBreak`, unlike the hard break / column break above. An empty
+      // remainder publishes no line on the page the break opened: Word Online puts the
+      // following block flush at the top of that page, which `paragraph-spacing-borders`
+      // and `section-aware-pagination` pin against the comprehensive fixture. The caret
+      // after such a break therefore has nowhere to go on the new page, which is why the
+      // click that lands in the blank space beside the mark resolves BEFORE it — see
+      // `hitTestSemantic`.
       trailingLineBreak = false;
       continue;
     }


### PR DESCRIPTION
## Summary
- A column-break-only paragraph now publishes its empty remainder line at the top of the next column. Section 19 of the comprehensive fixture covers it.
- Page breaks stay flush at the top of the next page; both behaviors are pinned by tests.

## Test plan
- [ ] `bun test packages/core/src/layout/__tests__/multi-column-layout.test.ts`
- [ ] Confirm section 19 second column starts one line below the heading in the comprehensive fixture


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788515535&installation_model_id=422592&pr_number=134&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F134&signature=e208233dd3acc0528470f953487d96f3cd1ec577caed3c2d5699ab1c89358927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->