### PR TITLE
fix: paint common paragraph border styles including thin doubles

### DIFF
--- a/.changeset/paragraph-border-styles.md
+++ b/.changeset/paragraph-border-styles.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Paragraph borders honour common OOXML line styles. A thin `w:val="double"` rule (including the end-of-document separator in the comprehensive fixture) now paints as two parallel lines instead of collapsing to a single hairline, and dashed/dotted/3-D approximations follow the same layout-owned thickness as table borders.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -234,7 +234,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Paragraph shading (w:shd) is editable. Borders render and round-trip but cannot be added, changed or removed from the editor yet.',
+      'Paragraph shading (w:shd) is editable. Borders render common ST_Border line styles (single, double, dashed, dotted, and CSS approximations for thick/3-D/inset/outset); decorative art borders paint as a solid rule. Thin doubles inflate to a visible compound band in layout, matching table borders. Borders round-trip but cannot be added, changed or removed from the editor yet.',
   },
   {
     id: 'paragraphs.tabs',
@@ -245,7 +245,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Existing tab stops render, including right/decimal tabs and dot, hyphen and underscore leaders. Positional tabs (w:ptab) render too, so a table-of-contents line reads as one: entry left, leader dots between, page number flush right. The document\'s own w:defaultTabStop is honoured, so a metric-locale grid lands where Word puts it, in headers and footers as well as the body. A tab-stop editing UI is not built yet.',
+      "Existing tab stops render, including right/decimal tabs and dot, hyphen and underscore leaders. Positional tabs (w:ptab) render too, so a table-of-contents line reads as one: entry left, leader dots between, page number flush right. The document's own w:defaultTabStop is honoured, so a metric-locale grid lands where Word puts it, in headers and footers as well as the body. A tab-stop editing UI is not built yet.",
   },
   {
     id: 'paragraphs.frames',
@@ -641,7 +641,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'First, even, and default variants are selected by the page\'s number in the document (so the alternation carries across section breaks) and editable in an open furniture scope. Programmatic `editHeaderFooter({ variant: \'even\' })` (or `evenPage: true`) creates/opens the even story and enables `w:evenAndOddHeaders` in one undo unit. React header/footer chrome can toggle different even and odd pages; Vue chrome deferred.',
+      "First, even, and default variants are selected by the page's number in the document (so the alternation carries across section breaks) and editable in an open furniture scope. Programmatic `editHeaderFooter({ variant: 'even' })` (or `evenPage: true`) creates/opens the even story and enables `w:evenAndOddHeaders` in one undo unit. React header/footer chrome can toggle different even and odd pages; Vue chrome deferred.",
   },
   {
     id: 'layout.vertical-align',

--- a/packages/core/src/layout/__tests__/paragraph-border-styles.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-border-styles.test.ts
@@ -1,0 +1,175 @@
+// Paragraph `ST_Border` style mapping: layout extent + painted appearance.
+//
+// Kept separate from `paragraph-borders.test.ts` (placement / grouping / PR #133 orphans)
+// so style regressions do not collide with that worktree.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import {
+  computeDoubleBorderMetricsPt,
+  paragraphBorderExtentPt,
+  paragraphBorderStrokeWidthPt,
+  paragraphBorders,
+} from '../index.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import type { ParagraphFragmentRecord } from '../semantic-records.ts';
+import { paintSemanticLayout } from '../../output/semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const measurer = createFixedMeasurer(6, 14);
+const lay = (body: string) => layoutSemanticDocument(load(body), 1, { measurer });
+
+const paragraph = (text: string, pPr: string) =>
+  `<w:p><w:pPr>${pPr}</w:pPr>${text ? `<w:r><w:t>${text}</w:t></w:r>` : ''}</w:p>`;
+
+function paragraphsOf(layout: ReturnType<typeof lay>): ParagraphFragmentRecord[] {
+  const fragments: ParagraphFragmentRecord[] = [];
+  for (const fragment of layout.pages[0]!.fragments) {
+    if (fragment.kind === 'paragraph') fragments.push(fragment);
+  }
+  return fragments;
+}
+
+function painted(body: string): HTMLElement {
+  const container = document.createElement('div');
+  paintSemanticLayout(container, lay(body), { scale: 1 });
+  return container;
+}
+
+function propertiesNodeOf(part: OoxmlPart, paragraphIndex = 0) {
+  return part.root.children[0]!.children[paragraphIndex]!.children.find(
+    (child) => child.kind === 'paragraphProperties'
+  );
+}
+
+describe('paragraph ST_Border styles — layout geometry', () => {
+  test('single uses authored w:sz; double inflates thin bands like table borders', () => {
+    const single = paragraphBorders(
+      propertiesNodeOf(
+        load(paragraph('x', '<w:pBdr><w:top w:val="single" w:sz="3" w:space="8"/></w:pBdr>'))
+      )
+    ).top!;
+    const dbl = paragraphBorders(
+      propertiesNodeOf(
+        load(paragraph('x', '<w:pBdr><w:top w:val="double" w:sz="3" w:space="8"/></w:pBdr>'))
+      )
+    ).top!;
+
+    expect(single.widthPt).toBe(0.375);
+    expect(paragraphBorderStrokeWidthPt(single)).toBe(0.375);
+    expect(paragraphBorderExtentPt(single)).toBe(8.375);
+
+    expect(dbl.widthPt).toBe(0.375);
+    expect(paragraphBorderStrokeWidthPt(dbl)).toBe(computeDoubleBorderMetricsPt(0.375).extentPt);
+    expect(paragraphBorderStrokeWidthPt(dbl)).toBe(3);
+    expect(paragraphBorderExtentPt(dbl)).toBe(11);
+  });
+
+  test('fixture-shaped thin double top publishes a 3pt stroke box', () => {
+    // Verbatim from comprehensive-word-element-test.docx end paragraph:
+    // <w:top w:val="double" w:color="1B3A5C" w:sz="3" w:space="8"/>
+    const body = paragraph(
+      'END',
+      '<w:pBdr><w:top w:val="double" w:color="1B3A5C" w:sz="3" w:space="8"/></w:pBdr>'
+    );
+    const fragment = paragraphsOf(lay(body))[0]!;
+    const top = fragment.borders?.find((s) => s.side === 'top');
+    expect(top).toBeDefined();
+    expect(top!.edge.val).toBe('double');
+    expect(top!.edge.color).toBe('1B3A5C');
+    expect(top!.box.height).toBe(3);
+  });
+
+  test('a thick double splits the authored band into equal thirds without inflation', () => {
+    const edge = paragraphBorders(
+      propertiesNodeOf(
+        load(paragraph('x', '<w:pBdr><w:bottom w:val="double" w:sz="24" w:space="2"/></w:pBdr>'))
+      )
+    ).bottom!;
+    expect(edge.widthPt).toBe(3);
+    expect(paragraphBorderStrokeWidthPt(edge)).toBe(3);
+    expect(computeDoubleBorderMetricsPt(3)).toEqual({
+      strokePt: 1,
+      gapPt: 1,
+      extentPt: 3,
+      insetPt: 0,
+    });
+  });
+});
+
+describe('paragraph ST_Border styles — paint', () => {
+  test('single stays a solid fill; double paints two borders inside the published box', () => {
+    const singleBody = paragraph(
+      's',
+      '<w:pBdr><w:top w:val="single" w:sz="8" w:space="1" w:color="C00000"/></w:pBdr>'
+    );
+    const doubleBody = paragraph(
+      'd',
+      '<w:pBdr><w:top w:val="double" w:sz="3" w:space="8" w:color="1B3A5C"/></w:pBdr>'
+    );
+
+    const singleRule = painted(singleBody).querySelector<HTMLElement>(
+      '.docx-paragraph-border-top'
+    )!;
+    expect(singleRule.style.backgroundColor.toLowerCase()).toBe('#c00000');
+    expect(singleRule.style.borderTop).toBe('');
+    expect(singleRule.style.borderBottom).toBe('');
+
+    const doubleRule = painted(doubleBody).querySelector<HTMLElement>(
+      '.docx-paragraph-border-top'
+    )!;
+    expect(doubleRule.style.height).toBe('3px');
+    expect(doubleRule.style.backgroundColor).toBe('transparent');
+    expect(doubleRule.style.borderTop).toBe('1px solid #1B3A5C');
+    expect(doubleRule.style.borderBottom).toBe('1px solid #1B3A5C');
+    expect(doubleRule.style.boxSizing).toBe('border-box');
+  });
+
+  test('dashed and dotted rules keep directional patterns', () => {
+    const dashed = painted(
+      paragraph('x', '<w:pBdr><w:bottom w:val="dashed" w:sz="8" w:space="2"/></w:pBdr>')
+    ).querySelector<HTMLElement>('.docx-paragraph-border-bottom')!;
+    expect(dashed.style.backgroundImage).toContain('to right');
+
+    const dotted = painted(
+      paragraph('x', '<w:pBdr><w:left w:val="dotted" w:sz="8" w:space="4"/></w:pBdr>')
+    ).querySelector<HTMLElement>('.docx-paragraph-border-left')!;
+    expect(dotted.style.backgroundImage).toContain('to bottom');
+  });
+
+  test('dashSmallGap and dotDash alias to the dashed pattern', () => {
+    for (const val of ['dashSmallGap', 'dotDash'] as const) {
+      const rule = painted(
+        paragraph('x', `<w:pBdr><w:bottom w:val="${val}" w:sz="8"/></w:pBdr>`)
+      ).querySelector<HTMLElement>('.docx-paragraph-border-bottom')!;
+      expect(rule.style.backgroundImage).toContain('to right');
+    }
+  });
+
+  test('threeDEmboss approximates as ridge; art borders stay solid', () => {
+    const emboss = painted(
+      paragraph('x', '<w:pBdr><w:top w:val="threeDEmboss" w:sz="16" w:color="808080"/></w:pBdr>')
+    ).querySelector<HTMLElement>('.docx-paragraph-border-top')!;
+    expect(emboss.style.borderTop).toContain('ridge');
+    expect(emboss.style.backgroundColor).toBe('transparent');
+
+    const art = painted(
+      paragraph('x', '<w:pBdr><w:top w:val="apples" w:sz="8" w:color="00AA00"/></w:pBdr>')
+    ).querySelector<HTMLElement>('.docx-paragraph-border-top')!;
+    expect(art.style.backgroundColor.toLowerCase()).toBe('#00aa00');
+    expect(art.style.borderTop).toBe('');
+  });
+});

--- a/packages/core/src/layout/border-metrics.ts
+++ b/packages/core/src/layout/border-metrics.ts
@@ -1,0 +1,73 @@
+// Layout-owned compound border metrics shared by paragraph `w:pBdr` and table borders.
+//
+// Word's `w:sz` for a multi-line style is the TOTAL band including gaps. Thin authored
+// doubles (e.g. sz="3" → 0.375pt) still paint as a visible double, so layout inflates to a
+// minimum stroke/gap band. Paint only scales these points — it must not re-derive mins.
+
+/** Minimum stroke width for a compound (double/triple) band, in points. */
+export const COMPOUND_BORDER_MIN_STROKE_PT = 1;
+/** Minimum gap between compound strokes, in points. */
+export const COMPOUND_BORDER_MIN_GAP_PT = 1;
+
+export interface CompoundBorderMetrics {
+  readonly strokePt: number;
+  readonly gapPt: number;
+  readonly extentPt: number;
+  /** Centers the compound band on the authored width; negative extends outward. */
+  readonly insetPt: number;
+}
+
+/**
+ * Deterministic double stroke / gap / extent in layout points (scale-independent).
+ *
+ * Thin authored widths inflate to a 1+1+1 point compound so a `w:sz="3"` double remains
+ * visible at paint scale 1 — matching Word's hairline-double floor.
+ */
+export function computeDoubleBorderMetricsPt(widthPt: number): CompoundBorderMetrics {
+  const bandPt = Math.max(widthPt, COMPOUND_BORDER_MIN_STROKE_PT);
+  const minExtent = 2 * COMPOUND_BORDER_MIN_STROKE_PT + COMPOUND_BORDER_MIN_GAP_PT;
+  if (bandPt >= minExtent) {
+    const unit = bandPt / 3;
+    if (unit >= COMPOUND_BORDER_MIN_STROKE_PT) {
+      return { strokePt: unit, gapPt: unit, extentPt: bandPt, insetPt: 0 };
+    }
+  }
+  const strokePt = COMPOUND_BORDER_MIN_STROKE_PT;
+  const gapPt = COMPOUND_BORDER_MIN_GAP_PT;
+  const extentPt = Math.max(bandPt, minExtent);
+  return { strokePt, gapPt, extentPt, insetPt: (bandPt - extentPt) / 2 };
+}
+
+/**
+ * OOXML `ST_Border` values whose painted band is wider than a single `w:sz` hairline.
+ *
+ * Decorative art borders are out of scope — callers treat them as a solid single.
+ */
+const COMPOUND_BORDER_VALS = new Set([
+  'double',
+  'triple',
+  'thinThickSmallGap',
+  'thickThinSmallGap',
+  'thinThickThinSmallGap',
+  'thinThickMediumGap',
+  'thickThinMediumGap',
+  'thinThickThinMediumGap',
+  'thinThickLargeGap',
+  'thickThinLargeGap',
+  'thinThickThinLargeGap',
+  'doubleWave',
+]);
+
+/** True when `ST_Border` paints as more than one parallel stroke. */
+export function isCompoundBorderVal(val: string): boolean {
+  return COMPOUND_BORDER_VALS.has(val);
+}
+
+/**
+ * Visual thickness of one border edge in points — the stroke box height/width layout
+ * publishes. Compound styles use the inflated double band; everything else uses `w:sz`.
+ */
+export function borderStrokeWidthPt(val: string, widthPt: number): number {
+  if (isCompoundBorderVal(val)) return computeDoubleBorderMetricsPt(widthPt).extentPt;
+  return widthPt;
+}

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -174,6 +174,7 @@ export {
   appliedSpaceBefore,
   applyLineSpacing,
   paragraphBorderExtentPt,
+  paragraphBorderStrokeWidthPt,
   bottomBorderExtentPt,
   cascadedParagraphBorders,
   collapsedSpaceBefore,

--- a/packages/core/src/layout/paragraph-style.ts
+++ b/packages/core/src/layout/paragraph-style.ts
@@ -5,6 +5,7 @@
 // guessed — a wrong before-spacing moves every subsequent page break.
 
 import type { OoxmlElement, OoxmlNode, OoxmlProperty } from '@docx-editor.dev/core-contract/store';
+import { borderStrokeWidthPt } from './border-metrics.ts';
 
 /** Whether a paragraph must start a new page (`w:pageBreakBefore`). */
 export function paragraphBreaksBefore(props: readonly OoxmlProperty[]): boolean {
@@ -335,6 +336,16 @@ export function cascadedParagraphBorders(
 }
 
 /**
+ * Visual stroke thickness layout publishes for one edge (points).
+ *
+ * Compound `ST_Border` values (`double`, …) use the shared inflated band so a thin
+ * `w:sz="3"` double still occupies a visible double-line box — matching table borders.
+ */
+export function paragraphBorderStrokeWidthPt(edge: ParagraphBorderEdge): number {
+  return borderStrokeWidthPt(edge.val, edge.widthPt);
+}
+
+/**
  * Extent one border edge occupies away from the text it decorates: gap plus rule, in points.
  *
  * Vertically that is flow height — a top rule pushes the first line down, a bottom rule holds
@@ -344,7 +355,7 @@ export function cascadedParagraphBorders(
  */
 export function paragraphBorderExtentPt(edge: ParagraphBorderEdge | undefined): number {
   if (!edge) return 0;
-  return edge.spacePt + edge.widthPt;
+  return edge.spacePt + paragraphBorderStrokeWidthPt(edge);
 }
 
 /** Vertical extent a bottom border adds below the last line (gap + rule). */

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -31,6 +31,7 @@ import {
 import {
   appliedSpaceBefore,
   paragraphBorderExtentPt,
+  paragraphBorderStrokeWidthPt,
   collapsedSpaceBefore,
   paragraphBordersFingerprint,
   paragraphBreaksBefore,
@@ -1427,36 +1428,42 @@ function layoutBlocksPass(
       // frame reads as two horizontal rules with two detached vertical bars beside it —
       // which is what a callout looked like. Word closes the rectangle, so the horizontal
       // rules span from the left rule's outer edge to the right rule's.
+      // Stroke thickness uses the inflated compound band for `double`/etc. so thin authored
+      // doubles still publish a box paint can draw as two lines (shared with table borders).
+      const leftStroke = borders.left ? paragraphBorderStrokeWidthPt(borders.left) : 0;
+      const rightStroke = borders.right ? paragraphBorderStrokeWidthPt(borders.right) : 0;
       const boxLeft = borders.left
-        ? regionX + indent.left - borders.left.spacePt - borders.left.widthPt
+        ? regionX + indent.left - borders.left.spacePt - leftStroke
         : regionX + indent.left;
       const boxRight = borders.right
-        ? regionX + indent.left + available + borders.right.spacePt + borders.right.widthPt
+        ? regionX + indent.left + available + borders.right.spacePt + rightStroke
         : regionX + indent.left + available;
       const boxWidth = Math.max(boxRight - boxLeft, 0);
       if (fragmentTopExtent > 0 && topEdge) {
-        const ruleY = linesTop - topEdge.spacePt - topEdge.widthPt;
+        const topStroke = paragraphBorderStrokeWidthPt(topEdge);
+        const ruleY = linesTop - topEdge.spacePt - topStroke;
         strokes.push({
           side: 'top',
           edge: topEdge,
-          box: { x: boxLeft, y: ruleY, width: boxWidth, height: topEdge.widthPt },
+          box: { x: boxLeft, y: ruleY, width: boxWidth, height: topStroke },
         });
         contentTop = ruleY;
       }
       if (isLast && closingEdge) {
+        const closeStroke = paragraphBorderStrokeWidthPt(closingEdge);
         const ruleY = linesBottom + closingEdge.spacePt;
         const box = {
           x: boxLeft,
           y: ruleY,
           width: boxWidth,
-          height: closingEdge.widthPt,
+          height: closeStroke,
         };
         strokes.push({ side: continuesBelow ? 'between' : 'bottom', edge: closingEdge, box });
         // `bottomBorder` stays the BOTTOM rule alone: a `between` rule closing a grouped
         // paragraph is a different edge, and a consumer reading it as the box's bottom would
         // draw the block's frame at every interior boundary.
         if (!continuesBelow) bottomBorderRecord = { edge: closingEdge, box };
-        contentBottom = ruleY + closingEdge.widthPt;
+        contentBottom = ruleY + closeStroke;
       }
       if (isLast) cursorY = Math.max(cursorY, contentBottom + appliedAfter);
       const height = Math.max(contentBottom + appliedAfter - top, 0);
@@ -1470,9 +1477,9 @@ function layoutBlocksPass(
           side: 'left',
           edge: borders.left,
           box: {
-            x: regionX + indent.left - borders.left.spacePt - borders.left.widthPt,
+            x: regionX + indent.left - borders.left.spacePt - leftStroke,
             y: sideTop,
-            width: borders.left.widthPt,
+            width: leftStroke,
             height: sideHeight,
           },
         });
@@ -1484,7 +1491,7 @@ function layoutBlocksPass(
           box: {
             x: regionX + indent.left + available + borders.right.spacePt,
             y: sideTop,
-            width: borders.right.widthPt,
+            width: rightStroke,
             height: sideHeight,
           },
         });
@@ -1492,13 +1499,14 @@ function layoutBlocksPass(
       // `w:bar` is the change-bar rule beside the paragraph. It belongs to the paragraph, not
       // to the block, so it neither opens nor closes with the group.
       if (borders.bar) {
+        const barStroke = paragraphBorderStrokeWidthPt(borders.bar);
         strokes.push({
           side: 'bar',
           edge: borders.bar,
           box: {
-            x: regionX + indent.left - borders.bar.spacePt - borders.bar.widthPt,
+            x: regionX + indent.left - borders.bar.spacePt - barStroke,
             y: linesTop,
-            width: borders.bar.widthPt,
+            width: barStroke,
             height: Math.max(linesBottom - linesTop, 0),
           },
         });

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -23,7 +23,11 @@ import type { FieldPageContext, HyperlinkProjector } from './field-projection.ts
 import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
 import { alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
-import { collapsedSpaceBefore, paragraphBorderExtentPt } from './paragraph-style.ts';
+import {
+  collapsedSpaceBefore,
+  paragraphBorderExtentPt,
+  paragraphBorderStrokeWidthPt,
+} from './paragraph-style.ts';
 import { tabStopsFingerprint, withDefaultTabInterval } from './paragraph-tabs.ts';
 import { DEFAULT_RUN_STYLE } from './run-style.ts';
 import {
@@ -91,9 +95,7 @@ export const MAX_TABLE_ROW_FRAGMENTS = 4096;
 const MIN_CELL_BOX_PT = 1;
 
 export type TablePaginationErrorCode =
-  | 'table-row-overheight'
-  | 'table-row-split-unsupported'
-  | 'table-row-fragment-limit';
+  'table-row-overheight' | 'table-row-split-unsupported' | 'table-row-fragment-limit';
 
 /**
  * Bounded table pagination failure. Prefer this over emitting a fragment that overflows
@@ -368,9 +370,7 @@ function placeCellParagraph(
     const pendingLine = lines[lineIndex]!;
     const isLastLine = lineIndex === lines.length - 1;
     const borderExtra =
-      isLastLine && includeBottomBorder && bottomBorder
-        ? bottomBorder.spacePt + bottomBorder.widthPt
-        : 0;
+      isLastLine && includeBottomBorder && bottomBorder ? paragraphBorderExtentPt(bottomBorder) : 0;
     const afterExtra = isLastLine && includeAfter ? spacing.after : 0;
     const lineBottom = y + pendingLine.height + borderExtra + afterExtra;
     if (lineBottom > maxBottom + 0.001) {
@@ -434,33 +434,36 @@ function placeCellParagraph(
   // same here or one document paints the identical callout two ways depending on whether it
   // sits in a table cell or a header. The side rules stand outside the text column by their
   // own `w:space`, so horizontals drawn only across the column leave the frame open.
-  const boxLeft = borders.left
-    ? fragmentX - borders.left.spacePt - borders.left.widthPt
-    : fragmentX;
+  // Stroke thickness uses the inflated compound band for `double`/etc. (shared with body).
+  const leftStroke = borders.left ? paragraphBorderStrokeWidthPt(borders.left) : 0;
+  const rightStroke = borders.right ? paragraphBorderStrokeWidthPt(borders.right) : 0;
+  const boxLeft = borders.left ? fragmentX - borders.left.spacePt - leftStroke : fragmentX;
   const boxRight = borders.right
-    ? fragmentX + available + borders.right.spacePt + borders.right.widthPt
+    ? fragmentX + available + borders.right.spacePt + rightStroke
     : fragmentX + available;
   const boxWidth = Math.max(boxRight - boxLeft, 0);
   if (topExtent > 0 && borders.top) {
-    const ruleY = linesTop - borders.top.spacePt - borders.top.widthPt;
+    const topStroke = paragraphBorderStrokeWidthPt(borders.top);
+    const ruleY = linesTop - borders.top.spacePt - topStroke;
     strokes.push({
       side: 'top',
       edge: borders.top,
-      box: { x: boxLeft, y: ruleY, width: boxWidth, height: borders.top.widthPt },
+      box: { x: boxLeft, y: ruleY, width: boxWidth, height: topStroke },
     });
     contentTop = ruleY;
   }
   if (complete && includeBottomBorder && bottomBorder) {
+    const closeStroke = paragraphBorderStrokeWidthPt(bottomBorder);
     const ruleY = linesBottom + bottomBorder.spacePt;
     const box = {
       x: boxLeft,
       y: ruleY,
       width: boxWidth,
-      height: bottomBorder.widthPt,
+      height: closeStroke,
     };
     bottomBorderRecord = { edge: bottomBorder, box };
     strokes.push({ side: 'bottom', edge: bottomBorder, box });
-    contentBottom = ruleY + bottomBorder.widthPt;
+    contentBottom = ruleY + closeStroke;
   }
   // Side rules run corner to corner of THIS fragment's frame. Horizontally they are
   // publish-only: Word draws them outside the text column and never re-breaks the lines for
@@ -471,9 +474,9 @@ function placeCellParagraph(
       side: 'left',
       edge: borders.left,
       box: {
-        x: fragmentX - borders.left.spacePt - borders.left.widthPt,
+        x: fragmentX - borders.left.spacePt - leftStroke,
         y: contentTop,
-        width: borders.left.widthPt,
+        width: leftStroke,
         height: sideHeight,
       },
     });
@@ -485,7 +488,7 @@ function placeCellParagraph(
       box: {
         x: fragmentX + available + borders.right.spacePt,
         y: contentTop,
-        width: borders.right.widthPt,
+        width: rightStroke,
         height: sideHeight,
       },
     });
@@ -494,13 +497,14 @@ function placeCellParagraph(
   // text only and adds no flow height, so a barred cell paragraph is exactly as tall as a
   // bare one.
   if (borders.bar) {
+    const barStroke = paragraphBorderStrokeWidthPt(borders.bar);
     strokes.push({
       side: 'bar',
       edge: borders.bar,
       box: {
-        x: fragmentX - borders.bar.spacePt - borders.bar.widthPt,
+        x: fragmentX - borders.bar.spacePt - barStroke,
         y: linesTop,
-        width: borders.bar.widthPt,
+        width: barStroke,
         height: Math.max(linesBottom - linesTop, 0),
       },
     });

--- a/packages/core/src/layout/table-borders.ts
+++ b/packages/core/src/layout/table-borders.ts
@@ -9,6 +9,11 @@
 
 import type { OoxmlElement } from '@docx-editor.dev/core-contract/store';
 import type { TableBorderStyle } from '@docx-editor.dev/core-contract/store';
+import {
+  COMPOUND_BORDER_MIN_GAP_PT,
+  computeDoubleBorderMetricsPt,
+  type CompoundBorderMetrics,
+} from './border-metrics.ts';
 import { MAX_BORDER_WIDTH_PT } from './paragraph-style.ts';
 import { resolveStrictHexFill } from './ooxml-shading.ts';
 import { effectiveBorderSide } from './table-border-cascade.ts';
@@ -26,6 +31,12 @@ export {
   createTableBorderOwnershipBudget,
   MAX_BORDER_OWNERSHIP_INTERVALS,
 } from './table-border-ownership.ts';
+export {
+  COMPOUND_BORDER_MIN_GAP_PT,
+  COMPOUND_BORDER_MIN_STROKE_PT,
+  computeDoubleBorderMetricsPt,
+  type CompoundBorderMetrics,
+} from './border-metrics.ts';
 
 export type TableBorderSideName = 'top' | 'right' | 'bottom' | 'left';
 
@@ -113,44 +124,8 @@ export interface ResolvedCellBorders {
   readonly strokes?: readonly TableBorderStrokeRecord[];
 }
 
-/**
- * Minimum compound stroke/gap in layout points.
- *
- * Chosen so that at paint scale `1` (1pt = 1 CSS px) the visible band matches the prior
- * 1px stroke + 1px gap heuristic. Paint must not re-derive mins.
- */
-export const COMPOUND_BORDER_MIN_STROKE_PT = 1;
-export const COMPOUND_BORDER_MIN_GAP_PT = 1;
-
 /** Soft cap on published stroke rectangles per cell (security / pathological spans). */
 export const MAX_TABLE_BORDER_STROKES = 256;
-
-export interface CompoundBorderMetrics {
-  readonly strokePt: number;
-  readonly gapPt: number;
-  readonly extentPt: number;
-  /** Centers the compound band on the authored width; negative extends outward. */
-  readonly insetPt: number;
-}
-
-/** Deterministic double stroke / gap / extent in layout points (scale-independent). */
-export function computeDoubleBorderMetricsPt(widthPt: number): CompoundBorderMetrics {
-  // Inflate sub-minimum authored widths to the configured minimum band so thin OOXML
-  // doubles still resolve to a visible 1+1+1 point compound at paint scale 1 — matching
-  // the prior paint-side `Math.max(1px, widthPx)` band without leaving that heuristic in paint.
-  const bandPt = Math.max(widthPt, COMPOUND_BORDER_MIN_STROKE_PT);
-  const minExtent = 2 * COMPOUND_BORDER_MIN_STROKE_PT + COMPOUND_BORDER_MIN_GAP_PT;
-  if (bandPt >= minExtent) {
-    const unit = bandPt / 3;
-    if (unit >= COMPOUND_BORDER_MIN_STROKE_PT) {
-      return { strokePt: unit, gapPt: unit, extentPt: bandPt, insetPt: 0 };
-    }
-  }
-  const strokePt = COMPOUND_BORDER_MIN_STROKE_PT;
-  const gapPt = COMPOUND_BORDER_MIN_GAP_PT;
-  const extentPt = Math.max(bandPt, minExtent);
-  return { strokePt, gapPt, extentPt, insetPt: (bandPt - extentPt) / 2 };
-}
 
 const OMITTED: TableBorderSide = { state: 'omitted' };
 const NONE: TableBorderSide = { state: 'none' };

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1175,6 +1175,10 @@ function paintParagraphShading(
  * Size, colour and position come from the record — never from computed style or
  * getBoundingClientRect. Colour is re-validated at the sink like every other file-derived
  * style value, and `side` is a closed union so it can safely reach a class name.
+ *
+ * `ST_Border` mapping (ECMA-376): common line styles get a CSS approximation; decorative
+ * art borders fall through to a solid rule. Compound styles (`double`, …) rely on layout
+ * having published the inflated band — paint must not re-derive mins.
  */
 function paintParagraphBorder(
   document: Document,
@@ -1187,12 +1191,13 @@ function paintParagraphBorder(
   rule.setAttribute('aria-hidden', 'true');
   const publishedLeft = (stroke.box.x - fragment.box.x) * scale;
   const publishedTop = (stroke.box.y - fragment.box.y) * scale;
-  // Preserve layout geometry, but snap a very thin rule to a visible screen hairline. Word's
-  // 1/4pt header rules otherwise become 0.33 CSS px at 96dpi and effectively disappear. Keep
-  // closing edges inside the published box so a header ending at that edge does not clip them.
+  // Preserve layout geometry, but snap a very thin SINGLE rule to a visible screen hairline.
+  // Word's 1/4pt header rules otherwise become 0.33 CSS px at 96dpi and effectively disappear.
+  // Compound styles already inflate in layout, so they keep the published thickness.
   const vertical = stroke.side === 'left' || stroke.side === 'right' || stroke.side === 'bar';
   const publishedThickness = (vertical ? stroke.box.width : stroke.box.height) * scale;
-  const paintedThickness = Math.max(1, publishedThickness);
+  const compound = isCompoundParagraphBorder(stroke.edge.val);
+  const paintedThickness = compound ? publishedThickness : Math.max(1, publishedThickness);
   rule.style.left = `${
     stroke.side === 'right'
       ? publishedLeft - (paintedThickness - publishedThickness)
@@ -1209,41 +1214,121 @@ function paintParagraphBorder(
   const color = stroke.edge.color && HEX.test(stroke.edge.color) ? stroke.edge.color : '000000';
   rule.style.backgroundColor = `#${color}`;
   // A side rule is a tall thin box, so its dash/double pattern runs down it rather than across.
-  // `val` selects a CSS approximation; unknown styles fall back to a solid rule so a
+  // `val` selects a CSS approximation; unknown / art styles fall back to a solid rule so a
   // recognised thickness is never silently dropped.
-  switch (stroke.edge.val) {
+  applyParagraphBorderStyle(rule, stroke.edge.val, color, vertical, paintedThickness, scale);
+  return rule;
+}
+
+/** Compound `ST_Border` values that layout already inflated — do not hairline-snap. */
+function isCompoundParagraphBorder(val: string): boolean {
+  return (
+    val === 'double' ||
+    val === 'triple' ||
+    val === 'doubleWave' ||
+    val.startsWith('thinThick') ||
+    val.startsWith('thickThin')
+  );
+}
+
+/**
+ * Map authored `ST_Border` onto the painted rule.
+ *
+ * CSS gives `double` / `dashed` / `dotted` / `groove` / `ridge` / `inset` / `outset` almost
+ * for free. Decorative art borders (apples, bats, …) stay solid — a deliberate approximation.
+ */
+function applyParagraphBorderStyle(
+  rule: HTMLElement,
+  val: string,
+  color: string,
+  vertical: boolean,
+  thicknessPx: number,
+  scale: number
+): void {
+  switch (val) {
     case 'dashed':
-    case 'dashSmallGap': {
+    case 'dashSmallGap':
+    case 'dotDash':
+    case 'dotDotDash':
+    case 'dashDotStroked': {
       const period = Math.max(4, 4 * scale);
       rule.style.backgroundImage = `linear-gradient(to ${vertical ? 'bottom' : 'right'}, #${color} 60%, transparent 60%)`;
       rule.style.backgroundSize = vertical ? `100% ${period}px` : `${period}px 100%`;
-      break;
+      return;
     }
     case 'dotted': {
       const period = Math.max(3, 3 * scale);
       rule.style.backgroundImage = `linear-gradient(to ${vertical ? 'bottom' : 'right'}, #${color} 35%, transparent 35%)`;
       rule.style.backgroundSize = vertical ? `100% ${period}px` : `${period}px 100%`;
-      break;
+      return;
     }
-    case 'double': {
-      // Two hairlines inside the published box thickness — still layout-owned geometry.
-      const thickness = (vertical ? stroke.box.width : stroke.box.height) * scale;
-      const half = Math.max(1, thickness / 3);
+    case 'double':
+    case 'doubleWave':
+    case 'triple':
+    case 'thinThickSmallGap':
+    case 'thickThinSmallGap':
+    case 'thinThickThinSmallGap':
+    case 'thinThickMediumGap':
+    case 'thickThinMediumGap':
+    case 'thinThickThinMediumGap':
+    case 'thinThickLargeGap':
+    case 'thickThinLargeGap':
+    case 'thinThickThinLargeGap': {
+      // Two hairlines inside the published box — layout owns the band (incl. thin-double floor).
+      // Triple and thinThick* compound vals approximate as double; decorative art stays solid.
+      const line = Math.max(1, thicknessPx / 3);
       rule.style.backgroundColor = 'transparent';
       if (vertical) {
-        rule.style.borderLeft = `${half}px solid #${color}`;
-        rule.style.borderRight = `${half}px solid #${color}`;
+        rule.style.borderLeft = `${line}px solid #${color}`;
+        rule.style.borderRight = `${line}px solid #${color}`;
       } else {
-        rule.style.borderTop = `${half}px solid #${color}`;
-        rule.style.borderBottom = `${half}px solid #${color}`;
+        rule.style.borderTop = `${line}px solid #${color}`;
+        rule.style.borderBottom = `${line}px solid #${color}`;
       }
       rule.style.boxSizing = 'border-box';
-      break;
+      return;
     }
+    case 'threeDEmboss':
+    case 'ridge': {
+      rule.style.backgroundColor = 'transparent';
+      const side = vertical ? 'borderLeft' : 'borderTop';
+      rule.style[side] = `${Math.max(1, thicknessPx)}px ridge #${color}`;
+      if (vertical) rule.style.width = '0px';
+      else rule.style.height = '0px';
+      return;
+    }
+    case 'threeDEngrave':
+    case 'groove': {
+      rule.style.backgroundColor = 'transparent';
+      const side = vertical ? 'borderLeft' : 'borderTop';
+      rule.style[side] = `${Math.max(1, thicknessPx)}px groove #${color}`;
+      if (vertical) rule.style.width = '0px';
+      else rule.style.height = '0px';
+      return;
+    }
+    case 'inset': {
+      rule.style.backgroundColor = 'transparent';
+      const side = vertical ? 'borderLeft' : 'borderTop';
+      rule.style[side] = `${Math.max(1, thicknessPx)}px inset #${color}`;
+      if (vertical) rule.style.width = '0px';
+      else rule.style.height = '0px';
+      return;
+    }
+    case 'outset': {
+      rule.style.backgroundColor = 'transparent';
+      const side = vertical ? 'borderLeft' : 'borderTop';
+      rule.style[side] = `${Math.max(1, thicknessPx)}px outset #${color}`;
+      if (vertical) rule.style.width = '0px';
+      else rule.style.height = '0px';
+      return;
+    }
+    case 'single':
+    case 'thick':
+    case 'wave':
     default:
-      break;
+      // Solid fill already set. Art borders and unrecognised vals stay solid.
+      return;
   }
-  return rule;
 }
 
 import { applyCellBorders } from './semantic-paint-table-borders.ts';


### PR DESCRIPTION
## Summary
- Thin `w:pBdr` doubles (e.g. the comprehensive fixture end rule, `w:val="double" w:sz="3"`) now publish an inflated compound band in layout and paint as two parallel lines, on the existing table-border metrics.
- Common `ST_Border` line styles map to CSS approximations; decorative art borders stay solid.

## Test plan
- [x] New `paragraph-border-styles.test.ts` covers single vs thin double geometry/paint, dashed/dotted, and art/3-D approximations
- [x] Existing table-border + paragraph-border placement suites still pass (known float-rounding asserts in paint remain pre-existing)
- [x] `bun run typecheck` clean

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788515993&installation_model_id=422592&pr_number=135&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F135&signature=ca9f2fe8309f6e442402573310dbf5b587088f79312653fe67a069fd5b401c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->