### PR TITLE
fix: place auto line-spacing extras below the glyph band

### DIFF
--- a/.changeset/paragraph-mark-line-height.md
+++ b/.changeset/paragraph-mark-line-height.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-The paragraph mark's font size now contributes to the last line's height, so cover-page party names that author a taller mark than their visible text no longer pack tighter than Word.
+The paragraph mark's font size now contributes to the last line's ascent and published leading, so cover-page party names that author a taller mark than their visible text get Word's gap above the glyphs instead of packing tight underneath the previous line.

--- a/.changeset/paragraph-mark-line-height.md
+++ b/.changeset/paragraph-mark-line-height.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-The paragraph mark's font size now contributes to the last line's ascent and published leading, so cover-page party names that author a taller mark than their visible text get Word's gap above the glyphs instead of packing tight underneath the previous line.
+Auto and at-least line spacing now grow the line box below the glyphs, matching Word, so cover-page connectors like "between" no longer open a large gap above themselves while sitting tight on the next line. A taller paragraph mark still deepens the last line without shifting the text baseline.

--- a/.changeset/paragraph-mark-line-height.md
+++ b/.changeset/paragraph-mark-line-height.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+The paragraph mark's font size now contributes to the last line's height, so cover-page party names that author a taller mark than their visible text no longer pack tighter than Word.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -201,7 +201,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends.',
+      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. The paragraph mark’s w:sz participates in the last line’s metrics, matching Word when a cover-page mark is taller than the visible runs. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends.',
   },
   {
     id: 'paragraphs.indentation',

--- a/packages/core/src/layout/__tests__/line-spacing-indent.test.ts
+++ b/packages/core/src/layout/__tests__/line-spacing-indent.test.ts
@@ -90,24 +90,30 @@ describe('paragraphLineSpacing reads w:line and w:lineRule', () => {
   });
 });
 
-describe('applyLineSpacing puts the extra leading above the text', () => {
-  test('auto scales the natural box', () => {
+describe('applyLineSpacing places auto extras below the text', () => {
+  test('auto scales the box downward without moving the baseline', () => {
     expect(applyLineSpacing({ rule: 'auto', value: 480 }, 14, 11)).toEqual({
       height: 28,
-      baseline: 25,
+      baseline: 11,
     });
   });
 
-  test('atLeast is a floor, never a ceiling', () => {
+  test('atLeast is a floor, never a ceiling, and grows downward', () => {
     expect(applyLineSpacing({ rule: 'atLeast', value: 10 }, 14, 11).height).toBe(14);
     expect(applyLineSpacing({ rule: 'atLeast', value: 20 }, 14, 11)).toEqual({
       height: 20,
-      baseline: 17,
+      baseline: 11,
     });
   });
 
-  test('exact fixes the box and keeps the baseline inside it when it clips', () => {
-    expect(applyLineSpacing({ rule: 'exact', value: 20 }, 14, 11).height).toBe(20);
+  test('exact taller than the glyphs centers the text', () => {
+    expect(applyLineSpacing({ rule: 'exact', value: 20 }, 14, 11)).toEqual({
+      height: 20,
+      baseline: 14,
+    });
+  });
+
+  test('exact smaller than the glyphs keeps the baseline inside the box', () => {
     const clipped = applyLineSpacing({ rule: 'exact', value: 8 }, 14, 11);
     expect(clipped.height).toBe(8);
     expect(clipped.baseline).toBeLessThanOrEqual(8);

--- a/packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts
@@ -1,0 +1,67 @@
+// The paragraph mark (`w:pPr/w:rPr`, CT_PPr / ECMA-376 17.3.1.29) sits on the last line of
+// a paragraph and participates in that line's metrics. Cover pages often author a larger
+// mark `w:sz` than the visible runs (e.g. 16pt mark, 10pt party name) — Word's line box
+// follows the mark; ignoring it packs the title block too tight.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import { layoutSemanticDocument, linesOf, type TextMeasurer } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+/** Size-aware measurer so mark `w:sz` and run `w:sz` produce different line boxes. */
+const measurer: TextMeasurer = {
+  measure(text, style) {
+    return text.length * style.fontSizePt * 0.5;
+  },
+  lineMetrics(style) {
+    return { height: style.fontSizePt * 1.15, baseline: style.fontSizePt * 0.9 };
+  },
+};
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const lay = (body: string) => layoutSemanticDocument(load(body), 1, { measurer });
+
+describe('paragraph mark w:sz contributes to last-line height', () => {
+  test('a taller mark grows a single-line paragraph past its run size', () => {
+    const markTall = lay(
+      '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
+        '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>'
+    );
+    const plain = lay('<w:p><w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>');
+    // 16pt mark → 18.4; 10pt run alone → 11.5.
+    expect(linesOf(markTall)[0]!.box.height).toBeCloseTo(16 * 1.15, 5);
+    expect(linesOf(plain)[0]!.box.height).toBeCloseTo(10 * 1.15, 5);
+  });
+
+  test('only the last wrapped line inherits the tall mark', () => {
+    const words = Array.from({ length: 40 }, (_, index) => `w${index}`).join(' ');
+    const lines = linesOf(
+      lay(
+        '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
+          `<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>${words}</w:t></w:r></w:p>` +
+          '<w:sectPr><w:pgSz w:w="3000" w:h="9000"/>' +
+          '<w:pgMar w:top="200" w:right="200" w:bottom="200" w:left="200"/></w:sectPr>'
+      )
+    );
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines.slice(0, -1)) {
+      expect(line.box.height).toBeCloseTo(10 * 1.15, 5);
+    }
+    expect(lines[lines.length - 1]!.box.height).toBeCloseTo(16 * 1.15, 5);
+  });
+
+  test('an empty paragraph still uses the mark size for its placeholder line', () => {
+    const lines = linesOf(lay('<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr></w:p>'));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.box.height).toBeCloseTo(16 * 1.15, 5);
+  });
+});

--- a/packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts
@@ -1,11 +1,15 @@
 // The paragraph mark (`w:pPr/w:rPr`, CT_PPr / ECMA-376 17.3.1.29) sits on the last line of
 // a paragraph and participates in that line's metrics. Cover pages often author a larger
 // mark `w:sz` than the visible runs (e.g. 16pt mark, 10pt party name) — Word's line box
-// follows the mark; ignoring it packs the title block too tight.
+// follows max-ascent/max-descent across the mark, so the extra space lands ABOVE the text.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
 import { layoutSemanticDocument, linesOf, type TextMeasurer } from '../index.ts';
+import { paintSemanticLayout } from '../../output/semantic-paint.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -42,6 +46,51 @@ describe('paragraph mark w:sz contributes to last-line height', () => {
     expect(linesOf(plain)[0]!.box.height).toBeCloseTo(10 * 1.15, 5);
   });
 
+  test('taller mark pushes baseline down and publishes leading above the glyphs', () => {
+    // Height-only growth (the first PR #140 attempt) left `leading` at 0, so paint kept the
+    // 10pt glyphs at the top of an 18.4pt box and the gap appeared BELOW the party name —
+    // "between" sat tight against "MERIDIAN". Word's max-ascent puts that gap ABOVE.
+    const between =
+      '<w:p><w:pPr><w:spacing w:before="202" w:line="460" w:lineRule="auto"/></w:pPr>' +
+      '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>between</w:t></w:r></w:p>';
+    const meridian =
+      '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
+      '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>';
+    const layout = lay(between + meridian);
+    const lines = linesOf(layout);
+    const betweenLine = lines[0]!;
+    const meridianLine = lines[1]!;
+
+    const runH = 10 * 1.15;
+    const runBaseline = 10 * 0.9;
+    const markH = 16 * 1.15;
+    const markBaseline = 16 * 0.9;
+
+    expect(betweenLine.spans[0]!.text).toBe('between');
+    expect(meridianLine.spans[0]!.text).toBe('MERIDIAN');
+
+    // MERIDIAN owns the tall mark — height and ascent come from the mark, not the prior para.
+    expect(meridianLine.box.height).toBeCloseTo(markH, 5);
+    expect(meridianLine.baseline).toBeCloseTo(markBaseline, 5);
+    expect(meridianLine.leading).toBeCloseTo(markBaseline - runBaseline, 5);
+    // Paint pads `leading` above the run band; without this, height alone still clumps.
+    expect(meridianLine.leading).toBeGreaterThan(runH * 0.2);
+    expect(meridianLine.baseline).toBeGreaterThan(runBaseline + 1);
+
+    // "between" is a separate paragraph: its own auto line box, no mark-driven leading.
+    expect(betweenLine.box.height).toBeCloseTo(runH * (460 / 240), 5);
+    expect(betweenLine.leading).toBeCloseTo(betweenLine.box.height - runH, 5);
+
+    // Gap between the two line tops equals between's full box (mark height stays on MERIDIAN).
+    expect(meridianLine.box.y - betweenLine.box.y).toBeCloseTo(betweenLine.box.height, 5);
+    // Space ABOVE MERIDIAN's glyphs (= its leading) is the visible gap under "between".
+    // A height-only fix left leading at 0, so this gap collapsed and the words clumped.
+    const betweenBottom = betweenLine.box.y + betweenLine.box.height;
+    const meridianGlyphTop = meridianLine.box.y + meridianLine.leading;
+    expect(meridianGlyphTop - betweenBottom).toBeCloseTo(meridianLine.leading, 5);
+    expect(meridianGlyphTop - betweenBottom).toBeGreaterThan(4);
+  });
+
   test('only the last wrapped line inherits the tall mark', () => {
     const words = Array.from({ length: 40 }, (_, index) => `w${index}`).join(' ');
     const lines = linesOf(
@@ -55,13 +104,37 @@ describe('paragraph mark w:sz contributes to last-line height', () => {
     expect(lines.length).toBeGreaterThan(1);
     for (const line of lines.slice(0, -1)) {
       expect(line.box.height).toBeCloseTo(10 * 1.15, 5);
+      expect(line.leading).toBeCloseTo(0, 5);
     }
-    expect(lines[lines.length - 1]!.box.height).toBeCloseTo(16 * 1.15, 5);
+    const last = lines[lines.length - 1]!;
+    expect(last.box.height).toBeCloseTo(16 * 1.15, 5);
+    expect(last.leading).toBeCloseTo(16 * 0.9 - 10 * 0.9, 5);
   });
 
   test('an empty paragraph still uses the mark size for its placeholder line', () => {
     const lines = linesOf(lay('<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr></w:p>'));
     expect(lines).toHaveLength(1);
     expect(lines[0]!.box.height).toBeCloseTo(16 * 1.15, 5);
+    // Empty line: the mark IS the glyph band, so mark growth adds no extra leading.
+    expect(lines[0]!.leading).toBeCloseTo(0, 5);
+  });
+
+  test('paint pads mark leading above the party-name glyphs', () => {
+    // IDE browser MCP was unavailable for the live 5190 check; pin the paint sink instead.
+    // Height-only mark growth left paddingTop at 0 while the line box was 18.4pt tall.
+    const layout = lay(
+      '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
+        '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>'
+    );
+    const line = linesOf(layout)[0]!;
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const run = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find((el) =>
+      (el.textContent ?? '').includes('MERIDIAN')
+    );
+    expect(run).toBeDefined();
+    expect(parseFloat(run!.style.paddingTop)).toBeCloseTo(line.leading, 5);
+    expect(parseFloat(run!.style.paddingTop)).toBeCloseTo(16 * 0.9 - 10 * 0.9, 5);
+    expect(parseFloat(run!.style.paddingTop)).toBeGreaterThan(4);
   });
 });

--- a/packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts
@@ -1,19 +1,33 @@
-// The paragraph mark (`w:pPr/w:rPr`, CT_PPr / ECMA-376 17.3.1.29) sits on the last line of
-// a paragraph and participates in that line's metrics. Cover pages often author a larger
-// mark `w:sz` than the visible runs (e.g. 16pt mark, 10pt party name) — Word's line box
-// follows max-ascent/max-descent across the mark, so the extra space lands ABOVE the text.
+// Cover-page vertical rhythm: auto line spacing extras sit BELOW each line (Word), and a
+// taller paragraph mark grows the last line's box without pushing the glyph baseline down.
+// The shapes-and-page-breaks title block is the oracle — the full inter-glyph gap sequence
+// must match Word's arithmetic (not a single padding assertion).
 
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
-import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
-import { layoutSemanticDocument, linesOf, type TextMeasurer } from '../index.ts';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { readOoxmlPart, readOoxmlPackage, type OoxmlPart } from '@docx-editor.dev/core-contract/store';
+import {
+  applyLineSpacing,
+  buildStyleCascadeTable,
+  layoutSemanticDocument,
+  linesOf,
+  type TextMeasurer,
+} from '../index.ts';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
 import { paintSemanticLayout } from '../../output/semantic-paint.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const OWNER = '/word/document.xml';
 
-/** Size-aware measurer so mark `w:sz` and run `w:sz` produce different line boxes. */
+/** Size-aware metrics (~Arial): height ≈ 1.15em, baseline ≈ 0.9em. */
 const measurer: TextMeasurer = {
   measure(text, style) {
     return text.length * style.fontSizePt * 0.5;
@@ -25,7 +39,7 @@ const measurer: TextMeasurer = {
 
 function load(body: string): OoxmlPart {
   const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
-    name: '/word/document.xml',
+    name: OWNER,
     contentType: 'app/xml',
   });
   if (!result.ok) throw new Error(result.reason);
@@ -34,107 +48,203 @@ function load(body: string): OoxmlPart {
 
 const lay = (body: string) => layoutSemanticDocument(load(body), 1, { measurer });
 
-describe('paragraph mark w:sz contributes to last-line height', () => {
-  test('a taller mark grows a single-line paragraph past its run size', () => {
-    const markTall = lay(
-      '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
-        '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>'
-    );
-    const plain = lay('<w:p><w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>');
-    // 16pt mark → 18.4; 10pt run alone → 11.5.
-    expect(linesOf(markTall)[0]!.box.height).toBeCloseTo(16 * 1.15, 5);
-    expect(linesOf(plain)[0]!.box.height).toBeCloseTo(10 * 1.15, 5);
+const RUN_H = 10 * 1.15;
+const RUN_BL = 10 * 0.9;
+const MARK_H = 16 * 1.15;
+/** Auto 460/240 extras on a 10pt run line. */
+const AUTO_460_EXTRA = RUN_H * (460 / 240) - RUN_H;
+const MARK_EXTRA = MARK_H - RUN_H;
+
+describe('auto line spacing and paragraph-mark height', () => {
+  test('auto extras leave the baseline put (space falls below)', () => {
+    expect(applyLineSpacing({ rule: 'auto', value: 460 }, RUN_H, RUN_BL)).toEqual({
+      height: RUN_H * (460 / 240),
+      baseline: RUN_BL,
+    });
   });
 
-  test('taller mark pushes baseline down and publishes leading above the glyphs', () => {
-    // Height-only growth (the first PR #140 attempt) left `leading` at 0, so paint kept the
-    // 10pt glyphs at the top of an 18.4pt box and the gap appeared BELOW the party name —
-    // "between" sat tight against "MERIDIAN". Word's max-ascent puts that gap ABOVE.
-    const between =
-      '<w:p><w:pPr><w:spacing w:before="202" w:line="460" w:lineRule="auto"/></w:pPr>' +
-      '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>between</w:t></w:r></w:p>';
-    const meridian =
-      '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
-      '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>';
-    const layout = lay(between + meridian);
-    const lines = linesOf(layout);
-    const betweenLine = lines[0]!;
-    const meridianLine = lines[1]!;
-
-    const runH = 10 * 1.15;
-    const runBaseline = 10 * 0.9;
-    const markH = 16 * 1.15;
-    const markBaseline = 16 * 0.9;
-
-    expect(betweenLine.spans[0]!.text).toBe('between');
-    expect(meridianLine.spans[0]!.text).toBe('MERIDIAN');
-
-    // MERIDIAN owns the tall mark — height and ascent come from the mark, not the prior para.
-    expect(meridianLine.box.height).toBeCloseTo(markH, 5);
-    expect(meridianLine.baseline).toBeCloseTo(markBaseline, 5);
-    expect(meridianLine.leading).toBeCloseTo(markBaseline - runBaseline, 5);
-    // Paint pads `leading` above the run band; without this, height alone still clumps.
-    expect(meridianLine.leading).toBeGreaterThan(runH * 0.2);
-    expect(meridianLine.baseline).toBeGreaterThan(runBaseline + 1);
-
-    // "between" is a separate paragraph: its own auto line box, no mark-driven leading.
-    expect(betweenLine.box.height).toBeCloseTo(runH * (460 / 240), 5);
-    expect(betweenLine.leading).toBeCloseTo(betweenLine.box.height - runH, 5);
-
-    // Gap between the two line tops equals between's full box (mark height stays on MERIDIAN).
-    expect(meridianLine.box.y - betweenLine.box.y).toBeCloseTo(betweenLine.box.height, 5);
-    // Space ABOVE MERIDIAN's glyphs (= its leading) is the visible gap under "between".
-    // A height-only fix left leading at 0, so this gap collapsed and the words clumped.
-    const betweenBottom = betweenLine.box.y + betweenLine.box.height;
-    const meridianGlyphTop = meridianLine.box.y + meridianLine.leading;
-    expect(meridianGlyphTop - betweenBottom).toBeCloseTo(meridianLine.leading, 5);
-    expect(meridianGlyphTop - betweenBottom).toBeGreaterThan(4);
-  });
-
-  test('only the last wrapped line inherits the tall mark', () => {
-    const words = Array.from({ length: 40 }, (_, index) => `w${index}`).join(' ');
-    const lines = linesOf(
+  test('a taller mark grows height without raising leading above the glyphs', () => {
+    const markTall = linesOf(
       lay(
         '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
-          `<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>${words}</w:t></w:r></w:p>` +
-          '<w:sectPr><w:pgSz w:w="3000" w:h="9000"/>' +
-          '<w:pgMar w:top="200" w:right="200" w:bottom="200" w:left="200"/></w:sectPr>'
+          '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>'
       )
+    )[0]!;
+    expect(markTall.box.height).toBeCloseTo(MARK_H, 5);
+    expect(markTall.baseline).toBeCloseTo(RUN_BL, 5);
+    expect(markTall.leading).toBeCloseTo(0, 5);
+  });
+
+  test('title-block inter-glyph gaps match Word arithmetic line-by-line', () => {
+    // Verbatim spacing from shapes-and-page-breaks.docx title region.
+    // "as Borrower and" keeps the authored left/right indents so it wraps; every wrap line
+    // must appear in the gap table (skipping a wrap line previously hid a 30pt false gap).
+    const body =
+      '<w:p><w:pPr><w:pStyle w:val="BodyText"/><w:spacing w:before="182"/>' +
+      '<w:jc w:val="center"/></w:pPr><w:r><w:t>LOAN FACILITY</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="BodyText"/><w:spacing w:before="202" w:line="460" w:lineRule="auto"/>' +
+      '<w:jc w:val="center"/></w:pPr><w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>between</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="TableParagraph"/><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
+      '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN HOLDINGS PLC</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="BodyText"/><w:spacing w:before="22" w:line="460" w:lineRule="auto"/>' +
+      '<w:ind w:left="4816" w:right="4838"/><w:jc w:val="center"/></w:pPr>' +
+      '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>as Borrower and</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="TableParagraph"/><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
+      '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>APEX CAPITAL PARTNERS LIMITED</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="BodyText"/><w:spacing w:line="218" w:lineRule="exact"/>' +
+      '<w:jc w:val="center"/></w:pPr><w:r><w:t>as Lender</w:t></w:r></w:p>' +
+      '<w:sectPr><w:pgSz w:w="11900" w:h="16840"/>' +
+      '<w:pgMar w:top="600" w:right="540" w:bottom="440" w:left="560"/></w:sectPr>';
+
+    const styles = readOoxmlPart(
+      `<w:styles xmlns:w="${W}">` +
+        '<w:docDefaults><w:rPrDefault><w:rPr><w:sz w:val="20"/></w:rPr></w:rPrDefault></w:docDefaults>' +
+        '<w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal"/>' +
+        '<w:rPr><w:rFonts w:ascii="Arial"/><w:sz w:val="20"/></w:rPr></w:style>' +
+        '<w:style w:type="paragraph" w:styleId="BodyText"><w:basedOn w:val="Normal"/>' +
+        '<w:rPr><w:sz w:val="20"/></w:rPr></w:style>' +
+        '<w:style w:type="paragraph" w:customStyle="1" w:styleId="TableParagraph">' +
+        '<w:basedOn w:val="Normal"/></w:style></w:styles>',
+      { name: '/word/styles.xml', contentType: 'app/xml' }
     );
-    expect(lines.length).toBeGreaterThan(1);
-    for (const line of lines.slice(0, -1)) {
-      expect(line.box.height).toBeCloseTo(10 * 1.15, 5);
-      expect(line.leading).toBeCloseTo(0, 5);
+    if (!styles.ok) throw new Error(styles.reason);
+    const layout = layoutSemanticDocument(load(body), 1, {
+      measurer,
+      styleCascade: buildStyleCascadeTable(styles.part.root),
+    });
+
+    // First page body lines in order through "as Lender" — no regex that drops wrap lines.
+    const focus: ReturnType<typeof linesOf> = [];
+    for (const line of linesOf(layout)) {
+      focus.push(line);
+      const text = line.spans.map((span) => span.text).join('');
+      if (text.includes('as Lender')) break;
     }
-    const last = lines[lines.length - 1]!;
-    expect(last.box.height).toBeCloseTo(16 * 1.15, 5);
-    expect(last.leading).toBeCloseTo(16 * 0.9 - 10 * 0.9, 5);
+    expect(focus.length).toBeGreaterThanOrEqual(7);
+
+    const glyphTop = (line: (typeof focus)[number]) => line.box.y + line.leading;
+    const glyphBottom = (line: (typeof focus)[number]) => {
+      const spanH = Math.max(0, ...line.spans.map((span) => span.box.height), RUN_H);
+      return line.box.y + line.leading + spanH;
+    };
+
+    const labels = focus.map((line) => line.spans.map((span) => span.text).join(''));
+    const gaps = focus.slice(0, -1).map((_, index) => glyphTop(focus[index + 1]!) - glyphBottom(focus[index]!));
+
+    // Word expected with this measurer (auto/atLeast extras BELOW; mark deepens below):
+    //   LOAN→between     = before 202twip = 10.1
+    //   between→MERIDIAN = auto460 extra ≈ 10.5417
+    //   MERIDIAN→(wrap0) = mark extra 6.9 + before 22twip 1.1 = 8.0
+    //   wrap→wrap        = auto460 extra ≈ 10.5417 each
+    //   last wrap→APEX   = auto460 extra ≈ 10.5417
+    //   APEX→Lender      = mark extra 6.9
+    // Rejected above-leading model produced ~20.6 then ~5.4 (clumps).
+    expect(labels[0]).toContain('LOAN');
+    expect(labels[1]).toContain('between');
+    expect(labels[2]).toContain('MERIDIAN');
+    expect(labels.at(-2)).toContain('APEX');
+    expect(labels.at(-1)).toContain('Lender');
+
+    const expected = [
+      202 / 20, // LOAN → between
+      AUTO_460_EXTRA, // between → MERIDIAN
+      MARK_EXTRA + 22 / 20, // MERIDIAN → first wrap of "as Borrower and"
+      ...Array.from({ length: gaps.length - 4 }, () => AUTO_460_EXTRA), // wraps + → APEX
+      MARK_EXTRA, // APEX → as Lender
+    ];
+    expect(gaps.length).toBe(expected.length);
+    for (let index = 0; index < gaps.length; index += 1) {
+      expect(gaps[index]!).toBeCloseTo(expected[index]!, 1);
+    }
+    // Old bug: max/min ratio ~20.6/5.4 ≈ 3.8. Uniform band stays under 2.
+    const max = Math.max(...gaps);
+    const min = Math.min(...gaps);
+    expect(max / min).toBeLessThan(2);
   });
 
-  test('an empty paragraph still uses the mark size for its placeholder line', () => {
-    const lines = linesOf(lay('<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr></w:p>'));
-    expect(lines).toHaveLength(1);
-    expect(lines[0]!.box.height).toBeCloseTo(16 * 1.15, 5);
-    // Empty line: the mark IS the glyph band, so mark growth adds no extra leading.
-    expect(lines[0]!.leading).toBeCloseTo(0, 5);
-  });
-
-  test('paint pads mark leading above the party-name glyphs', () => {
-    // IDE browser MCP was unavailable for the live 5190 check; pin the paint sink instead.
-    // Height-only mark growth left paddingTop at 0 while the line box was 18.4pt tall.
+  test('paint puts auto trailing depth in padding-bottom, not padding-top', () => {
     const layout = lay(
-      '<w:p><w:pPr><w:rPr><w:sz w:val="32"/></w:rPr></w:pPr>' +
-        '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>MERIDIAN</w:t></w:r></w:p>'
+      '<w:p><w:pPr><w:spacing w:line="480" w:lineRule="auto"/></w:pPr>' +
+        '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>between</w:t></w:r></w:p>'
     );
     const line = linesOf(layout)[0]!;
+    expect(line.leading).toBeCloseTo(0, 5);
+    expect(line.box.height).toBeCloseTo(RUN_H * 2, 5);
     const container = document.createElement('div');
     paintSemanticLayout(container, layout, { scale: 1 });
-    const run = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find((el) =>
-      (el.textContent ?? '').includes('MERIDIAN')
+    const painted = container.querySelector<HTMLElement>('.docx-line')!;
+    const run = container.querySelector<HTMLElement>('.layout-run-text')!;
+    expect(parseFloat(run.style.paddingTop)).toBeCloseTo(0, 5);
+    expect(parseFloat(painted.style.paddingBottom)).toBeCloseTo(RUN_H, 5);
+  });
+});
+
+describe('second case: BodyText line=336 extras stay below (same fixture family)', () => {
+  test('definition-style auto-336 does not invert inter-line gaps', () => {
+    // Independent of the cover: BodyText clauses in the same package use line=336.
+    const layout = lay(
+      '<w:p><w:pPr><w:pStyle w:val="BodyText"/>' +
+        '<w:spacing w:before="210" w:line="336" w:lineRule="auto"/></w:pPr>' +
+        '<w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:t>First definition line that is long enough to wrap onto a second line in this narrow column xx</w:t></w:r></w:p>' +
+        '<w:sectPr><w:pgSz w:w="5000" w:h="16840"/>' +
+        '<w:pgMar w:top="600" w:right="200" w:bottom="440" w:left="200"/></w:sectPr>'
     );
-    expect(run).toBeDefined();
-    expect(parseFloat(run!.style.paddingTop)).toBeCloseTo(line.leading, 5);
-    expect(parseFloat(run!.style.paddingTop)).toBeCloseTo(16 * 0.9 - 10 * 0.9, 5);
-    expect(parseFloat(run!.style.paddingTop)).toBeGreaterThan(4);
+    const wrapped = linesOf(layout);
+    expect(wrapped.length).toBeGreaterThan(1);
+    for (const line of wrapped) {
+      expect(line.leading).toBe(0);
+      expect(line.box.height).toBeCloseTo(RUN_H * (336 / 240), 5);
+    }
+    const gap =
+      wrapped[1]!.box.y + wrapped[1]!.leading - (wrapped[0]!.box.y + wrapped[0]!.leading + RUN_H);
+    const extra336 = RUN_H * (336 / 240) - RUN_H;
+    expect(gap).toBeCloseTo(extra336, 5);
+  });
+});
+
+describe('real package smoke (optional geometry)', () => {
+  test('pr140 fixture title lines expose below-band extras on line=460 paras', () => {
+    const fixture = resolve(
+      import.meta.dir,
+      '../../../../../e2e/fixtures/pr140-shapes-and-page-breaks.docx'
+    );
+    const loaded = readOoxmlPackage(new Uint8Array(readFileSync(fixture)));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const main = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+    const cascade = buildStyleCascadeTable(loaded.package.parts.get('/word/styles.xml')!.root);
+    const atoms = indexInlineDrawingProjectionsInPart(main);
+    const ready = Object.freeze({
+      kind: 'ready' as const,
+      partName: '/word/media/image1.png',
+      contentId: 'image1',
+      resourceKey: 'k1',
+      mime: 'image/png',
+      pixelWidth: 100,
+      pixelHeight: 100,
+      dpiX: 96,
+      dpiY: 96,
+    });
+    const layout = layoutSemanticDocument(main, 1, {
+      measurer,
+      styleCascade: cascade,
+      inlineDrawingLayout: {
+        ownerPartName: OWNER,
+        projectionForAtom: (id) => atoms.get(id) ?? null,
+        project: (node) =>
+          atoms.get(node.id) ??
+          projectDrawing(node, {
+            ownerPartName: OWNER,
+            limits: DEFAULT_DRAWING_PROJECTION_LIMITS,
+          }),
+        resourceOf: () => ready,
+      },
+    });
+    const between = linesOf(layout).find((line) =>
+      line.spans.some((span) => span.text.includes('between'))
+    );
+    expect(between).toBeDefined();
+    expect(between!.leading).toBeCloseTo(0, 5);
+    expect(between!.box.height).toBeGreaterThan(between!.baseline + 2);
   });
 });

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1100,27 +1100,37 @@ export function breakParagraph(
 
   const closeLine = (options?: { readonly includeParagraphMark?: boolean }): void => {
     const metrics = measurer.lineMetrics(emptyStyle);
+    // Glyph band before the paragraph mark joins the line. Paint pads `leading` above this
+    // band; if mark growth only raises `height`/`baseline` and leaves `leading` at 0, the
+    // extra space lands BELOW the text (cover-page "between"/"MERIDIAN" clump).
+    let glyphBaseline = line.baseline;
     if (line.height === 0) {
       line.height = metrics.height;
       line.baseline = metrics.baseline;
+      glyphBaseline = metrics.baseline;
     } else if (options?.includeParagraphMark) {
       // The paragraph mark (`w:pPr/w:rPr`, CT_PPr / ECMA-376 17.3.1.29) sits on the LAST
-      // line and participates in its metrics. Cover-page party names often author a larger
-      // mark `w:sz` than the visible runs; without the mark the line collapses to the run
-      // size and the title block packs tighter than Word.
-      line.height = Math.max(line.height, metrics.height);
-      line.baseline = Math.max(line.baseline, metrics.baseline);
+      // line and participates in max-ascent / max-descent, like Word: a taller mark pushes
+      // the baseline down so the gap appears ABOVE the visible runs.
+      const glyphAscent = line.baseline;
+      const glyphDescent = Math.max(0, line.height - line.baseline);
+      const markAscent = metrics.baseline;
+      const markDescent = Math.max(0, metrics.height - metrics.baseline);
+      const ascent = Math.max(glyphAscent, markAscent);
+      const descent = Math.max(glyphDescent, markDescent);
+      line.height = ascent + descent;
+      line.baseline = ascent;
     }
     finalizeDrawingGeometry();
     // Line spacing applies to the finished box, once, so a paragraph's rule governs every
     // line it produced regardless of which run happened to be tallest.
-    const natural = line.height;
     const spaced = applyLineSpacing(lineSpacing, line.height, line.baseline);
     line.baseline = spaced.baseline;
-    // Never negative: an `exact` box clipped below its glyphs adds no leading, it removes
-    // box. Paint keys its baseline correction off this, and a negative would push the text
-    // the wrong way rather than leaving the clipped line alone.
-    line.leading = Math.max(0, spaced.height - natural);
+    // Leading is space ABOVE the glyph band (mark growth + `w:line` extras). Paint reads
+    // this as padding-top; deriving it from `spaced.height - natural` after folding the
+    // mark into `natural` hid mark growth from paint and inverted the title-page gaps.
+    // Never negative: an `exact` box clipped below its glyphs adds no leading.
+    line.leading = Math.max(0, spaced.baseline - glyphBaseline);
     line.height = spaced.height;
     // Baseline shifts from line spacing must move inline drawings too, or authored distT/distB
     // and the text baseline drift apart. For `exact`, keep the authored box — tall drawings

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1098,11 +1098,18 @@ export function breakParagraph(
     }
   };
 
-  const closeLine = (): void => {
+  const closeLine = (options?: { readonly includeParagraphMark?: boolean }): void => {
     const metrics = measurer.lineMetrics(emptyStyle);
     if (line.height === 0) {
       line.height = metrics.height;
       line.baseline = metrics.baseline;
+    } else if (options?.includeParagraphMark) {
+      // The paragraph mark (`w:pPr/w:rPr`, CT_PPr / ECMA-376 17.3.1.29) sits on the LAST
+      // line and participates in its metrics. Cover-page party names often author a larger
+      // mark `w:sz` than the visible runs; without the mark the line collapses to the run
+      // size and the title block packs tighter than Word.
+      line.height = Math.max(line.height, metrics.height);
+      line.baseline = Math.max(line.baseline, metrics.baseline);
     }
     finalizeDrawingGeometry();
     // Line spacing applies to the finished box, once, so a paragraph's rule governs every
@@ -1513,8 +1520,11 @@ export function breakParagraph(
   // there was and left nothing after it — the caret fell back to the end of the line the
   // break had just terminated, sitting a break's width to the right of the last glyph,
   // and the new line only appeared once something was typed into it.
+  //
+  // Only this final close includes the paragraph mark: intermediate wraps must not inherit
+  // a tall mark size onto every line of a multi-line paragraph.
   if (line.spans.length > 0 || line.drawings.length > 0 || lines.length === 0 || trailingLineBreak)
-    closeLine();
+    closeLine({ includeParagraphMark: true });
   if (cacheKey !== null && cache) cache.set(cacheKey, lines.map(frozenLine));
   return lines;
 }

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1100,36 +1100,26 @@ export function breakParagraph(
 
   const closeLine = (options?: { readonly includeParagraphMark?: boolean }): void => {
     const metrics = measurer.lineMetrics(emptyStyle);
-    // Glyph band before the paragraph mark joins the line. Paint pads `leading` above this
-    // band; if mark growth only raises `height`/`baseline` and leaves `leading` at 0, the
-    // extra space lands BELOW the text (cover-page "between"/"MERIDIAN" clump).
+    // Baseline of the visible glyph band before mark / spacing. Paint's padding-top is
+    // `spaced.baseline - glyphBaseline` (space above); auto extras grow BELOW instead.
     let glyphBaseline = line.baseline;
     if (line.height === 0) {
       line.height = metrics.height;
       line.baseline = metrics.baseline;
       glyphBaseline = metrics.baseline;
     } else if (options?.includeParagraphMark) {
-      // The paragraph mark (`w:pPr/w:rPr`, CT_PPr / ECMA-376 17.3.1.29) sits on the LAST
-      // line and participates in max-ascent / max-descent, like Word: a taller mark pushes
-      // the baseline down so the gap appears ABOVE the visible runs.
-      const glyphAscent = line.baseline;
-      const glyphDescent = Math.max(0, line.height - line.baseline);
-      const markAscent = metrics.baseline;
-      const markDescent = Math.max(0, metrics.height - metrics.baseline);
-      const ascent = Math.max(glyphAscent, markAscent);
-      const descent = Math.max(glyphDescent, markDescent);
-      line.height = ascent + descent;
-      line.baseline = ascent;
+      // Paragraph mark `w:sz` (CT_PPr/rPr) can be taller than the visible runs. Grow the
+      // line box to the mark height but keep the glyph baseline — the spare depth sits
+      // below the text, matching Word's cover-page party-name rhythm. Pushing the baseline
+      // down (max-ascent) made "between"/"MERIDIAN" clump while inflating other gaps.
+      line.height = Math.max(line.height, metrics.height);
     }
     finalizeDrawingGeometry();
     // Line spacing applies to the finished box, once, so a paragraph's rule governs every
     // line it produced regardless of which run happened to be tallest.
     const spaced = applyLineSpacing(lineSpacing, line.height, line.baseline);
     line.baseline = spaced.baseline;
-    // Leading is space ABOVE the glyph band (mark growth + `w:line` extras). Paint reads
-    // this as padding-top; deriving it from `spaced.height - natural` after folding the
-    // mark into `natural` hid mark growth from paint and inverted the title-page gaps.
-    // Never negative: an `exact` box clipped below its glyphs adds no leading.
+    // Space ABOVE the glyph band only (exact centering, not auto/atLeast). Never negative.
     line.leading = Math.max(0, spaced.baseline - glyphBaseline);
     line.height = spaced.height;
     // Baseline shifts from line spacing must move inline drawings too, or authored distT/distB

--- a/packages/core/src/layout/paragraph-style.ts
+++ b/packages/core/src/layout/paragraph-style.ts
@@ -216,9 +216,12 @@ export function paragraphLineSpacing(props: readonly OoxmlProperty[]): Paragraph
 /**
  * Apply resolved line spacing to a line's natural (glyph-derived) box.
  *
- * Extra leading goes ABOVE the text — the baseline moves down by the whole delta — which
- * is what Word does for `auto` and `atLeast`. An `exact` box smaller than the glyphs keeps
- * the baseline inside the box so the clipped text still sits on it.
+ * Word places `auto` / `atLeast` extras BELOW the line (the last line's multiple spacing
+ * still separates it from the next paragraph). Putting that delta above inverted cover-page
+ * rhythm: `w:line="460"` on "between" opened a large gap above the word and almost none
+ * before "MERIDIAN". `exact` taller than the glyphs centers the text (ECMA-376 17.3.1.33).
+ * An `exact` box smaller than the glyphs keeps the baseline inside so clipped text still
+ * sits on it.
  */
 export function applyLineSpacing(
   spacing: ParagraphLineSpacing,
@@ -232,8 +235,14 @@ export function applyLineSpacing(
         ? spacing.value
         : Math.max(naturalHeight, spacing.value);
   const delta = height - naturalHeight;
-  if (delta >= 0) return { height, baseline: naturalBaseline + delta };
-  return { height, baseline: Math.max(0, Math.min(naturalBaseline, height)) };
+  if (delta < 0) {
+    return { height, baseline: Math.max(0, Math.min(naturalBaseline, height)) };
+  }
+  if (spacing.rule === 'exact') {
+    return { height, baseline: naturalBaseline + delta / 2 };
+  }
+  // auto / atLeast: grow the box downward; baseline stays put.
+  return { height, baseline: naturalBaseline };
 }
 
 /**

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -205,16 +205,14 @@ export interface LineRecord {
   /** Distance from the line box top to the text baseline. */
   readonly baseline: number;
   /**
-   * How much of the box is line-spacing leading rather than glyphs, and therefore how far
-   * below the box top the text sits: `w:line` above single puts the WHOLE leading above the
-   * text, so the glyphs are bottom-anchored in the box and {@link baseline} already carries
-   * it.
+   * Space ABOVE the glyph band inside {@link box} (exact centering, not auto/atLeast).
    *
-   * Published by the spacing rule rather than recovered by paint. Subtracting the tallest
-   * span height from the box gives the same answer only while the rule is the multiplying
-   * one — it is already wrong for an `exact` box clipped below its glyphs — and three paint
-   * sites each deriving it separately is how they came to disagree about where a line's
-   * text sits.
+   * `auto` / `atLeast` extras grow the box BELOW the glyphs — paint puts that depth in
+   * padding-bottom. {@link baseline} is measured from the line top and already includes
+   * this above-band when present.
+   *
+   * Published by layout rather than recovered by paint: three paint sites each deriving it
+   * separately is how they came to disagree about where a line's text sits.
    */
   readonly leading: number;
   /**

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -666,7 +666,12 @@ export function resolveParagraphLayoutInputs(
     ? cascadeParagraphFormatting(styleCascade, pPr, tableCellStyle)
     : null;
   const props = cascaded ? [...cascaded.paragraphProperties] : propertiesOf(pPr);
-  const inheritedRunProperties = cascaded?.runProperties ?? [];
+  // Direct `w:pPr/w:rPr` (paragraph mark) must reach empty-line / last-line metrics even
+  // when there is no styles part — cascadeParagraphFormatting already folds it in when a
+  // table is present.
+  const inheritedRunProperties = cascaded
+    ? cascaded.runProperties
+    : propertiesOf(findRunProperties(pPr && isElement(pPr) ? pPr : undefined));
   const baseIndent = paragraphIndent(props);
   let hanging = 0;
   let firstLine = 0;

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -305,54 +305,38 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
     expect(big!.style.lineHeight).toBe('28px');
   });
 
-  test('line spacing above single joins the stepped bands with the extra leading', () => {
-    // Double spacing doubles the line box. Word still paints the leading, so every run's
-    // band grows by the same extra leading — capped at the line height, which the tallest
-    // run reaches exactly. The band is the run's HEIGHT.
-    //
-    // `line-height` is a leading TALLER than the band, and that is deliberate: the extra
-    // leading of a spaced line sits ABOVE the text (17.3.1.33), so the glyphs belong at the
-    // bottom of the box. CSS centres content in its line box, so a `line-height` equal to
-    // the band would put the text half a leading too HIGH — off the baseline layout
-    // published, and off the caret, which reads that baseline.
+  test('auto line spacing puts the extra depth below the glyph band', () => {
+    // Double spacing doubles the line box. Word adds that extra BELOW the glyphs, so run
+    // padding-top stays 0 and the line carries padding-bottom.
+    // Fixed measurer: height scales from 11pt base — default 10pt → 14*(10/11), 22pt → 28.
+    const h10 = 14 * (10 / 11);
+    const h22 = 14 * (22 / 11);
     const container = paint(
       '<w:p><w:pPr><w:spacing w:line="480" w:lineRule="auto"/></w:pPr>' +
         '<w:r><w:t>small</w:t></w:r>' +
         '<w:r><w:rPr><w:sz w:val="44"/></w:rPr><w:t>big</w:t></w:r></w:p>'
     );
     const line = container.querySelector<HTMLElement>('.docx-line')!;
-    expect(line.style.height).toBe('56px'); // 28 natural × 480/240
+    expect(parseFloat(line.style.height)).toBeCloseTo(h22 * 2, 5);
+    expect(parseFloat(line.style.paddingBottom)).toBeCloseTo(h22, 5);
     const [small, big] = [...line.querySelectorAll<HTMLElement>('.layout-run-text')];
-    expect(small!.style.height).toBe('42px'); // 14 own + 28 leading
-    expect(big!.style.height).toBe('56px'); // 28 own + 28 leading = the line height
-
-    // THE INVARIANTS, not the numbers. Asserting constants only re-states what the source
-    // computes. Three things have to hold, and each one is a bug this went through:
-    //
-    // 1. Every run is padded by the SAME leading — that is what keeps them on one baseline.
-    // 2. Padding plus inner line box equals the band exactly. Any slack here is highlight
-    //    the browser paints outside the run's own box, which bled a leading of selection
-    //    into the line below when the leading was spent on `line-height` instead.
-    // 3. The leading is the LINE's, not something re-derived per run.
-    const padding = (run: HTMLElement): number => parseFloat(run.style.paddingTop);
-    const inner = (run: HTMLElement): number => parseFloat(run.style.lineHeight);
-    const band = (run: HTMLElement): number => parseFloat(run.style.height);
-
-    expect(padding(small!)).toBe(28);
-    expect(padding(big!)).toBe(28);
+    expect(parseFloat(small!.style.height)).toBeCloseTo(h10, 5);
+    expect(parseFloat(big!.style.height)).toBeCloseTo(h22, 5);
+    expect(parseFloat(small!.style.paddingTop)).toBe(0);
+    expect(parseFloat(big!.style.paddingTop)).toBe(0);
     for (const run of [small!, big!]) {
       expect(run.style.boxSizing).toBe('border-box');
-      expect(padding(run) + inner(run)).toBe(band(run));
+      expect(parseFloat(run.style.paddingTop) + parseFloat(run.style.lineHeight)).toBeCloseTo(
+        parseFloat(run.style.height),
+        5
+      );
     }
-    // The tallest run fills the line box, so its padding IS line height − its glyph height.
-    expect(padding(big!)).toBe(parseFloat(line.style.height) - 28);
   });
 
   test('the list marker sits on the same baseline as the text beside it', () => {
-    // These drifted apart once: only the text was taught that a spaced line's leading sits
-    // ABOVE it, so the bullet floated half a leading over its own sentence. One baseline
-    // means one overshoot, pinned together here because no unit test in this file can
-    // observe a rendered baseline — happy-dom does no layout.
+    // Marker and text must share the glyph band at the top of an auto-spaced line; the
+    // below-extra is padding-bottom on both sinks.
+    const h10 = 14 * (10 / 11);
     const layout = layoutOf(
       '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>' +
         '<w:spacing w:line="480" w:lineRule="auto"/></w:pPr>' +
@@ -365,16 +349,12 @@ describe('each run is its own box, so a mixed-size line highlights stepped', () 
     const container = document.createElement('div');
     paintSemanticLayout(container, layout, { scale: 1 });
     const run = container.querySelector<HTMLElement>('.layout-run-text')!;
-    const markerGlyph = container.querySelector<HTMLElement>('[data-docx-marker] span')!;
-    // 14 natural, doubled to 28, so 14 of leading — all of it above the text.
-    const leading = parseFloat(run.style.paddingTop);
-    expect(leading).toBe(14);
-    // The marker reserves the SAME leading above its glyph. It gets there by a different
-    // route (its box is the whole line, not a run band), so what is pinned is the one
-    // number both sinks read — not the CSS either of them writes.
-    expect(parseFloat(markerGlyph.style.lineHeight) - parseFloat(markerGlyph.style.height)).toBe(
-      leading
-    );
+    const marker = container.querySelector<HTMLElement>('[data-docx-marker]')!;
+    expect(parseFloat(run.style.paddingTop)).toBe(0);
+    expect(parseFloat(marker.style.paddingBottom)).toBeCloseTo(h10, 5);
+    expect(
+      parseFloat(container.querySelector<HTMLElement>('.docx-line')!.style.paddingBottom)
+    ).toBeCloseTo(h10, 5);
   });
 
   test('a tab span gets its own band too, not the full line height', () => {

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -782,27 +782,15 @@ function paintSpan(
   // own size, which is how Word draws it: the band steps with the text.
   element.style.display = 'inline-block';
   element.style.verticalAlign = 'baseline';
-  // THE BAND IS THE BOX; THE LEADING DECIDES WHERE THE TEXT SITS IN IT.
+  // THE BAND IS THE BOX; `extraLeadingPt` IS SPACE ABOVE THE GLYPHS INSIDE IT.
   //
-  // `w:line` above single puts ALL the extra leading ABOVE the text — observed Word
-  // behaviour, not a spec rule; 17.3.1.33 defines the VALUES and says nothing about where
-  // the leading lands, and `applyLineSpacing` is where that decision is made. So the
-  // glyphs sit at the BOTTOM of the line box and `line.baseline` is measured from the line
-  // top with the whole leading already added. Sizing the run by `line-height` alone leaves
-  // the browser to place the glyphs, and CSS always splits leading in HALF — so the text
-  // was painted half a leading ABOVE the baseline layout published, while the caret (which
-  // reads `line.baseline`) was drawn on it. On a double-spaced line that is half a line
-  // apart, and the insertion point sat under the text instead of in it.
+  // Auto/atLeast extras live BELOW the glyph band (line padding-bottom in `paintLine`).
+  // Exact centering (and any other above-band) is padding-top here. Sizing the run by
+  // `line-height` alone leaves CSS to split leading in half and drift off `line.baseline`.
   //
-  // So the leading is PADDING, not line-height. The box is the band, the leading is padded
-  // off the top of it, and what remains is an inner line box exactly as tall as the glyphs —
-  // no half-leading left for CSS to split, and the baseline lands where layout put it.
-  //
-  // Growing the line-height instead lands the same baseline and is wrong for a reason that
-  // does not show up in a geometry test: the browser paints the native selection to the
-  // INNER LINE BOX, so a box one leading shorter than its own line-height bled a leading's
-  // worth of highlight into the line below. Double-spaced text selected as overlapping
-  // stripes, darker where they met, running past the end of the paragraph.
+  // Growing the line-height instead of padding is wrong for selection too: the browser
+  // paints the native selection to the INNER LINE BOX, so a box shorter than its own
+  // line-height bled highlight into the line below.
   element.style.boxSizing = 'border-box';
   element.style.height = `${bandHeightPt * ctx.scale}px`;
   element.style.paddingTop = `${extraLeadingPt * ctx.scale}px`;
@@ -991,7 +979,6 @@ function paintLine(
   // explicit pixel line-height. Child runs keep their own font sizes and `vertical-align:
   // baseline`, so mixed-size and superscript/subscript (relative offset) still work.
   element.style.fontSize = '0';
-  element.style.lineHeight = `${line.box.height * scale}px`;
   element.style.whiteSpace = 'pre';
   // A raised superscript or a tall glyph draws outside the line box rather than being
   // clipped at it; the box governs spacing and the selection band, not what is visible.
@@ -1003,17 +990,28 @@ function paintLine(
   if (gap > 0) element.style.wordSpacing = `${gap * scale}px`;
 
   // Per-run band heights, chosen so the browser's line-box math cannot move a glyph:
-  // the tallest run's band is exactly the line height — the same value every run
-  // inherited before — so the box that decides where the common baseline sits is
-  // unchanged. Smaller runs get their own published height plus the line's extra
-  // leading (spacing above single keeps a contiguous band, as Word draws it), capped
-  // at the line height so an `exact`-spaced line cannot grow past its box.
+  // the tallest run's band is the glyph band (own height + space-above leading), and any
+  // remaining line-box depth is padding-bottom — Word's auto/atLeast extras sit BELOW the
+  // text. Capped at the line height so an `exact`-spaced line cannot grow past its box.
   //
   // The leading is READ, not recovered from the box. The marker and the tab leader place
   // their furniture against this same number, and when each of the three derived it for
   // itself they drifted: the text moved onto the published baseline while the marker
   // beside it stayed half a leading higher.
   const leading = line.leading ?? 0;
+  const glyphBand = Math.min(
+    Math.max(
+      leading,
+      ...line.spans.map((span) => span.box.height + leading),
+      // Empty lines still need a content band so the caret has a strut.
+      line.spans.length === 0 ? line.box.height : 0
+    ),
+    line.box.height
+  );
+  const trailing = Math.max(0, line.box.height - glyphBand);
+  element.style.boxSizing = 'border-box';
+  element.style.paddingBottom = `${trailing * scale}px`;
+  element.style.lineHeight = `${(line.box.height - trailing) * scale}px`;
   // Consecutive spans of the SAME link share one anchor, so a link that spans several
   // formatting runs on one line is one `<a>` — one focus stop, one hover target, one thing
   // a screen reader announces. A link that WRAPS gets one anchor per line, which is the
@@ -1258,27 +1256,25 @@ function paintListMarker(
   element.style.display = 'block';
   element.style.overflow = 'visible';
   element.style.whiteSpace = 'pre';
-  // The marker sits on the FIRST LINE'S BASELINE, not at the top of its box.
-  //
-  // Painting the glyph directly into this block let it inherit the block's own default
-  // line-height at the marker's font size, so a `1.` in a smaller marker face landed
-  // below the text it numbers and a bullet floated above it. The same treatment
-  // `paintLine` gives a line fixes it: kill the anonymous strut with `font-size: 0`,
-  // apply the published box height as an explicit line-height, and let the glyph align on
-  // `baseline` inside it — which is exactly how every run on that line is aligned.
-  //
-  // INCLUDING THE LEADING. `marker.box.height` is the whole post-spacing line box, so on a
-  // spaced line the glyph would centre in it while the text it numbers is bottom-anchored,
-  // and the number floated half a leading above its own sentence. The run treatment is the
-  // whole treatment: an inner line box one leading taller drops the glyph onto the same
-  // baseline `paintSpan` puts the text on.
+  // Mirror `paintLine`: content band at the top (plus any above-leading), auto extras as
+  // padding-bottom so the marker shares the text baseline on spaced lines.
+  const firstLine = fragment.lines[0];
+  const maxSpanH = firstLine
+    ? Math.max(0, ...firstLine.spans.map((span) => span.box.height))
+    : marker.box.height;
+  const glyphBand = Math.min(Math.max(leading + maxSpanH, leading), marker.box.height);
+  const trailing = Math.max(0, marker.box.height - glyphBand);
   element.style.fontSize = '0';
-  element.style.lineHeight = `${marker.box.height * scale}px`;
+  element.style.boxSizing = 'border-box';
+  element.style.paddingBottom = `${trailing * scale}px`;
+  element.style.lineHeight = `${glyphBand * scale}px`;
   const glyph = document.createElement('span');
   glyph.style.display = 'inline-block';
   glyph.style.verticalAlign = 'baseline';
-  glyph.style.height = `${marker.box.height * scale}px`;
-  glyph.style.lineHeight = `${(marker.box.height + leading) * scale}px`;
+  glyph.style.boxSizing = 'border-box';
+  glyph.style.height = `${glyphBand * scale}px`;
+  glyph.style.paddingTop = `${leading * scale}px`;
+  glyph.style.lineHeight = `${(glyphBand - leading) * scale}px`;
   applyRunFaceStyle(glyph, marker.style, ctx);
   mountRunText(document, glyph, marker.text, marker.style, scale);
   element.append(glyph);
@@ -1360,11 +1356,13 @@ function paintTabLeader(
   // neither recomputes it, and both spend it as padding rather than line-height. This
   // structure and `paintSpan`'s drifted apart once already, when only one of them was taught
   // that the leading sits above the text.
-  layer.style.fontSize = '0';
-  layer.style.lineHeight = `${line.box.height * scale}px`;
-
   const leading = line.leading ?? 0;
   const band = Math.min(span.box.height + leading, line.box.height);
+  const trailing = Math.max(0, line.box.height - band);
+  layer.style.fontSize = '0';
+  layer.style.boxSizing = 'border-box';
+  layer.style.paddingBottom = `${trailing * scale}px`;
+  layer.style.lineHeight = `${(line.box.height - trailing) * scale}px`;
 
   const glyphs = document.createElement('span');
   glyphs.style.display = 'inline-block';


### PR DESCRIPTION
## Summary
- Auto/atLeast `w:line` extras now grow the line box **below** the glyphs (Word), instead of shifting the baseline down — that was what opened a large gap above "between"/"and" and clumped them onto the party names.
- Taller paragraph marks still deepen the last line, but without the max-ascent baseline push from the prior attempt on this PR.
- Regression pins the full title-block inter-glyph gap sequence plus a second BodyText `line=336` wrap case from the same document family.

## Test plan
- [x] `bun test packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts`
- [x] `bun test` applyLineSpacing + paint below-band cases
- [ ] Visual check of cover page on review server (port 5173) against Word