### PR TITLE
fix: honour continuous section w:type for TOC body flow

### DIFF
--- a/.changeset/continuous-section-type-ownership.md
+++ b/.changeset/continuous-section-type-ownership.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Continuous section breaks now honour `w:type` on the section being started (ECMA-376), so a next-page section followed by a continuous TOC body no longer inserts a spurious page break. Mid-page margin changes on the same paper size stay on the shared sheet.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -464,7 +464,8 @@ export const wordFeatures: WordFeature[] = [
     rendering: 'preserved',
     roundTrip: 'preserved',
     tier: 'community',
-    notes: 'Revision wrappers preserved inertly; accept/reject and suggesting-mode delete owned by typed-revisions-and-comments.',
+    notes:
+      'Revision wrappers preserved inertly; accept/reject and suggesting-mode delete owned by typed-revisions-and-comments.',
   },
   {
     id: 'images.textboxes',
@@ -499,7 +500,8 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     docsLink: '/docs/1.x/guides/images',
-    notes: 'Crop renders and round-trips; React properties dialog edits crop in UI percent. Vue deferred.',
+    notes:
+      'Crop renders and round-trips; React properties dialog edits crop in UI percent. Vue deferred.',
   },
   {
     id: 'images.adjustments',
@@ -531,7 +533,8 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'preserved',
     tier: 'community',
     docsLink: '/docs/1.x/guides/images',
-    notes: 'Extent reserved with labelled placeholder; chart payload preserved generically, not semantically edited.',
+    notes:
+      'Extent reserved with labelled placeholder; chart payload preserved generically, not semantically edited.',
   },
   {
     id: 'images.smartart',
@@ -780,7 +783,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Allowlisted complex PAGE, NUMPAGES, and SECTIONPAGES project in headers/footers at layout time (PAGE respects section pgNumType start/fmt). Insertable from React header/footer chrome (including Page X of Y). Other field instructions stay inert; body field evaluation is deferred.',
+      'Allowlisted complex PAGE, NUMPAGES, and SECTIONPAGES project in headers/footers at layout time (PAGE respects section pgNumType start/fmt). Insertable from React header/footer chrome (including Page X of Y). PAGE fields hosted inside drawing text boxes remain deferred with text-box story rendering. Other field instructions stay inert; body field evaluation is deferred.',
   },
   {
     id: 'fields.toc',

--- a/packages/core/src/layout/__tests__/semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-layout.test.ts
@@ -444,6 +444,58 @@ describe('per-section pagination (the per-section lane)', () => {
     expect(lay(part).pages).toHaveLength(2);
   });
 
+  test('w:type on the CONTINUED section decides sharing (ECMA-376 §17.6.22)', () => {
+    // `w:type` describes how THIS section starts relative to the previous one. A nextPage
+    // section followed by an explicit continuous one must share; the reverse must not.
+    const nextThenContinuous = load(
+      paragraph('SECTION', sect(4000, 6000)) + paragraph('entry') + sect(4000, 6000, 'continuous')
+    );
+    const continuousLayout = lay(nextThenContinuous);
+    expect(continuousLayout.pages).toHaveLength(1);
+    const continuousText = continuousLayout.pages[0]!.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph'
+        ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+        : []
+    ).join('');
+    expect(continuousText).toContain('SECTION');
+    expect(continuousText).toContain('entry');
+
+    const continuousThenNext = load(
+      paragraph('one', sect(4000, 6000, 'continuous')) + paragraph('two') + PORTRAIT
+    );
+    expect(lay(continuousThenNext).pages).toHaveLength(2);
+  });
+
+  test('continuous sharing tolerates mid-page margin changes on the same page size', () => {
+    // Word TOC galleries often restyle margins on a continuous section without starting a
+    // sheet. Only paper size / orientation must force a break.
+    const withMargins = (topTwips: number, type: string) =>
+      `<w:sectPr><w:type w:val="${type}"/>` +
+      '<w:pgSz w:w="4000" w:h="6000"/>' +
+      `<w:pgMar w:top="${topTwips}" w:right="200" w:bottom="200" w:left="200" ` +
+      'w:header="0" w:footer="0" w:gutter="0"/></w:sectPr>';
+    const part = load(
+      paragraph('CONTENTS', withMargins(200, 'nextPage')) +
+        '<w:sdt><w:sdtPr><w:docPartObj>' +
+        '<w:docPartGallery w:val="Table of Contents"/><w:docPartUnique/>' +
+        '</w:docPartObj></w:sdtPr><w:sdtContent>' +
+        paragraph('Definitions') +
+        paragraph('The Facility') +
+        '</w:sdtContent></w:sdt>' +
+        withMargins(900, 'continuous')
+    );
+    const layout = lay(part);
+    expect(layout.pages).toHaveLength(1);
+    const text = layout.pages[0]!.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph'
+        ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+        : []
+    ).join(' ');
+    expect(text).toContain('CONTENTS');
+    expect(text).toContain('Definitions');
+    expect(text).toMatch(/The\s+Facility/);
+  });
+
   test('continuous chains: three sections flow down one sheet in order', () => {
     const part = load(
       paragraph('one', sect(4000, 6000, 'continuous')) +
@@ -457,16 +509,13 @@ describe('per-section pagination (the per-section lane)', () => {
   });
 
   test('a continuous section that does not fit overflows to a new sheet', () => {
-    // 80pt of content column at 14pt a line is 5 lines. Six paragraphs cannot share it.
+    // Short sheet: 80pt content column. Enough fixed-height lines must overflow whether the
+    // measurer reports 14pt or the slightly-shorter shaped fallback used in this package.
     const short = sect(4000, 2000);
-    const filled = 'a\n'.repeat(0) + 'a';
+    const filled = 'a';
     const part = load(
       paragraph(filled, short) +
-        paragraph(filled) +
-        paragraph(filled) +
-        paragraph(filled) +
-        paragraph(filled) +
-        paragraph(filled) +
+        Array.from({ length: 10 }, () => paragraph(filled)).join('') +
         sect(4000, 2000, 'continuous')
     );
     const layout = lay(part);

--- a/packages/core/src/layout/multi-section-layout.ts
+++ b/packages/core/src/layout/multi-section-layout.ts
@@ -175,23 +175,15 @@ export function emptySectionNeedsBlankPage(
 }
 
 /**
- * Whether two sections could occupy one sheet: identical page box and margins.
+ * Whether two sections could occupy one sheet: identical page box (size / orientation).
  *
  * A sheet has ONE size. Word honours `continuous` by continuing the column on the current
- * page, which it cannot do when the new section restates the page — a continuous break that
- * also changes paper size or orientation starts a new page in Word too.
+ * page; a continuous break that also changes paper size or orientation starts a new page.
+ * Mid-page margin / header-distance changes stay on the sheet — Word applies the new
+ * content column below the resumed cursor, and the host sheet keeps its furniture.
  */
-function sameGeometry(a: PageGeometry, b: PageGeometry): boolean {
-  return (
-    a.width === b.width &&
-    a.height === b.height &&
-    a.margin.top === b.margin.top &&
-    a.margin.right === b.margin.right &&
-    a.margin.bottom === b.margin.bottom &&
-    a.margin.left === b.margin.left &&
-    (a.headerDistance ?? 36) === (b.headerDistance ?? 36) &&
-    (a.footerDistance ?? 36) === (b.footerDistance ?? 36)
-  );
+function samePageSize(a: PageGeometry, b: PageGeometry): boolean {
+  return a.width === b.width && a.height === b.height;
 }
 
 /**
@@ -309,19 +301,20 @@ export function layoutMultiSectionDocument(
       continue;
     }
 
-    // CONTINUOUS: Word keeps the new section on the page the last one ended, resuming the
-    // column immediately below its final paragraph. Only possible when the sheet does not
-    // change under it — same page box and margins, and the same furniture push-down, since
-    // both fix the content column this section would be flowing into.
+    // CONTINUOUS: `w:type` on THIS section's trailing `w:sectPr` says how the section starts
+    // relative to the previous one (ECMA-376 §17.6.22 / ST_SectionMark). Absent type is
+    // nextPage. When continuous, Word keeps the section on the page the last one ended,
+    // resuming the column immediately below its final paragraph — only when the sheet size
+    // and furniture push-down are unchanged (furniture belongs to the host sheet).
     const continues =
       sectionIndex > 0 &&
-      sections[sectionIndex - 1]!.properties.breakType === 'continuous' &&
+      section.properties.breakType === 'continuous' &&
       pages.length > 0 &&
       // A trailing page break already ended the previous sheet. Word puts the continued
       // section after that break, not on top of the page it closed.
       flowOpenPage &&
       previousGeometry !== null &&
-      sameGeometry(previousGeometry, geometry) &&
+      samePageSize(previousGeometry, geometry) &&
       previousFurnitureKey === furnitureKey;
 
     // Empty nextPage/even/odd: lay out zero blocks so the section still flushes one blank


### PR DESCRIPTION
## Summary
- Continuous section breaks now read `w:type` from the section being started (ECMA-376), so a next-page CONTENTS header followed by a continuous TOC body no longer invents an extra page.
- Same-size continuous sections may change mid-page margins without forcing a new sheet.

## Test plan
- [ ] Open `shapes-and-page-breaks.docx` and confirm CONTENTS + SECTION 1 + clause entries share one page
- [ ] Confirm footer PAGE-in-textbox numbers remain deferred (not this PR)
- [ ] `bun test packages/core/src/layout/__tests__/semantic-layout.test.ts -t "w:type on the CONTINUED|mid-page margin|does not fit overflows"`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788524075&installation_model_id=422592&pr_number=141&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F141&signature=03d7adbf00a8cdd393ec1d8ca8bf7c97446ea980a4ae28305fa159a48d1af8c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->