### PR TITLE
fix(core): wrap text around floating images correctly

### DIFF
--- a/.changeset/wide-donkeys-repeat.md
+++ b/.changeset/wide-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"@docx-editor.dev/react": patch
+---
+
+Fix text wrapping around floating images. Wrapped lines now use the full column instead of about half of it, tight and through wrap polygons exclude the whole picture, a top-and-bottom image sits above the text it displaces rather than on top of it, and text fills both sides of a centred float.

--- a/packages/core/src/layout/__tests__/drawing-exclusion-layout.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-exclusion-layout.test.ts
@@ -31,6 +31,8 @@ const PIC_URI = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
 
 const measurer = createFixedMeasurer(6, 14);
 const OWNER = '/word/document.xml';
+/** Default US-Letter content column these fixtures lay out into. */
+const CONTENT_WIDTH_PT = 468;
 
 const READY: ImageResourceState = Object.freeze({
   kind: 'ready',
@@ -128,6 +130,74 @@ describe('square wrap reflow integration (OpenSpec 4.3)', () => {
       if (!lastSpan) continue;
       expect(lastSpan.box.x + lastSpan.box.width).toBeLessThanOrEqual(imageWidth + 468 + 1);
     }
+  });
+
+  test('a wrapped line still fills the column to its right edge', () => {
+    const part = load(squareAnchorAtLeft({ text: 'word '.repeat(80) }));
+    const ctx = layoutContext(part);
+    const layout = layoutSemanticDocument(part, 1, { measurer, inlineDrawingLayout: ctx });
+    const lines = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines;
+    const rightEdge = (line: (typeof lines)[number]): number => {
+      const last = line.spans[line.spans.length - 1];
+      return last ? last.box.x + last.box.width : 0;
+    };
+    // The float narrows where a line STARTS, never how far it may run. A line that stopped
+    // near the column's midpoint meant the width budget was being consumed twice.
+    const widest = Math.max(...lines.map(rightEdge));
+    expect(widest).toBeGreaterThan(CONTENT_WIDTH_PT * 0.9);
+    expect(widest).toBeLessThanOrEqual(CONTENT_WIDTH_PT + 1);
+  });
+
+  test('lines clear of the anchor return to the full column width', () => {
+    const part = load(squareAnchorAtLeft({ text: 'word '.repeat(200) }));
+    const ctx = layoutContext(part);
+    const layout = layoutSemanticDocument(part, 1, { measurer, inlineDrawingLayout: ctx });
+    const lines = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines;
+    const imageHeight = emuToPoints(914400);
+    const belowImage = lines.filter((line) => line.box.y >= imageHeight);
+    expect(belowImage.length).toBeGreaterThan(0);
+    for (const line of belowImage) {
+      expect(line.spans[0]!.box.x).toBeCloseTo(0, 3);
+    }
+    const widestBelow = Math.max(
+      ...belowImage.map((line) => {
+        const last = line.spans[line.spans.length - 1]!;
+        return last.box.x + last.box.width;
+      })
+    );
+    expect(widestBelow).toBeGreaterThan(CONTENT_WIDTH_PT * 0.9);
+  });
+});
+
+describe('topAndBottom anchored in the paragraph it displaces', () => {
+  test('the picture keeps the paragraph origin and the text clears below it', () => {
+    const part = load(
+      `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}">` +
+        '<w:body>' +
+        '<w:p><w:r><w:t>lead</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:drawing>' +
+        '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" allowOverlap="1" layoutInCell="1" relativeHeight="1">' +
+        '<wp:simplePos x="0" y="0"/>' +
+        '<wp:positionH relativeFrom="column"><wp:align>center</wp:align></wp:positionH>' +
+        '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+        '<wp:extent cx="914400" cy="914400"/>' +
+        '<wp:wrapTopAndBottom/>' +
+        '<wp:docPr id="1" name="band"/>' +
+        `<a:graphic><a:graphicData uri="${PIC_URI}"><pic:pic><pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr><pic:blipFill><a:blip r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>` +
+        '<pic:spPr><a:xfrm><a:ext cx="914400" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr></pic:pic></a:graphicData></a:graphic>' +
+        '</wp:anchor></w:drawing></w:r>' +
+        '<w:r><w:t>banded text</w:t></w:r></w:p>' +
+        '</w:body></w:document>'
+    );
+    const ctx = layoutContext(part);
+    const layout = layoutSemanticDocument(part, 1, { measurer, inlineDrawingLayout: ctx });
+    const page = layout.pages[0]!;
+    const anchored = page.anchoredDrawings![0]!;
+    const banded = paragraphFragmentsOf(page)[1]!;
+    const bandBottom = anchored.y + anchored.height;
+    // Framing the anchor against the lines it pushed down chased its own displacement and
+    // painted the picture over them.
+    expect(banded.lines[0]!.box.y).toBeGreaterThanOrEqual(bandBottom - 0.001);
   });
 });
 

--- a/packages/core/src/layout/drawing-wrap.ts
+++ b/packages/core/src/layout/drawing-wrap.ts
@@ -24,6 +24,14 @@ export interface ScanlineInterval {
 
 export type WrapTextSide = 'bothSides' | 'left' | 'right' | 'largest';
 
+/**
+ * Edge length of the square `wp:wrapPolygon` coordinates address (ECMA-376 §20.4.2.16).
+ *
+ * The polygon is authored against the drawing's own extent in this fixed unit space, so the
+ * same point list describes the same outline at any picture size.
+ */
+const WRAP_POLYGON_UNITS = 21600;
+
 export interface WrapExclusionInput {
   readonly mode: 'square' | 'tight' | 'through' | 'topAndBottom';
   readonly contentBounds: LayoutBox;
@@ -391,13 +399,19 @@ export function normalizeWrapPolygonToPage(options: {
     });
   }
 
+  // `wp:wrapPolygon` points are NOT EMU despite their schema type: they address a fixed
+  // 21600-unit square spanning the drawing's own extent, so (21600, 21600) is its far
+  // corner whatever size it is. Reading them as EMU collapses a full-rectangle polygon to a
+  // 1.7pt sliver at the origin, and text walks straight over the picture.
+  const scaleX = frame.width / WRAP_POLYGON_UNITS;
+  const scaleY = frame.height / WRAP_POLYGON_UNITS;
   const local: DrawingPoint[] = [];
   for (let index = 0; index < limit; index += 1) {
     const point = options.polygonEmu[index]!;
     local.push(
       Object.freeze({
-        x: finite(point.x) / EMU_PER_POINT,
-        y: finite(point.y) / EMU_PER_POINT,
+        x: finite(point.x) * scaleX,
+        y: finite(point.y) * scaleY,
       })
     );
   }

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -808,7 +808,11 @@ export function breakParagraph(
     }
   };
 
-  const exclusionProbeY = (): number => currentLineTopY() + 0.001;
+  // Where the line will actually sit. A band that pushed this line down has already been
+  // recorded on it, so probing must ask about the shifted position — probing the unshifted
+  // top reports the line as still inside the band it just cleared, which leaves it with no
+  // room and strands its first character on a line of its own.
+  const exclusionProbeY = (): number => currentLineTopY() + (line.exclusionSkipBefore ?? 0) + 0.001;
 
   const snapLineToAvailableInterval = (): boolean => {
     const zones = activeExclusionZones();
@@ -829,6 +833,14 @@ export function breakParagraph(
     return true;
   };
 
+  /**
+   * Total capacity of the line being built, in the same units as `line.width` — how far the
+   * pen may travel from `lineOrigin()`, not how much room is left from where it stands.
+   *
+   * Callers compare `line.width + width` against this, so it MUST stay a capacity. Returning
+   * the room remaining ahead of the pen makes the test `line.width + width > remaining`, which
+   * halves the usable width of every line on a page that carries any exclusion zone.
+   */
   const lineAvailable = (): number => {
     const base = baseLineAvailable();
     const zones = activeExclusionZones();
@@ -844,16 +856,23 @@ export function breakParagraph(
     const origin = lineOrigin() + line.width;
     const remaining = remainingWidthAtX(origin, intervals);
     if (remaining <= 0.001) return 0;
-    return Math.min(base, remaining);
+    return Math.min(base, line.width + remaining);
   };
+
+  /** Room left ahead of the pen on the current line. */
+  const remainingLineWidth = (): number => Math.max(0, lineAvailable() - line.width);
 
   const tryAdvanceToNextPassage = (): boolean => {
     const zones = activeExclusionZones();
     if (zones.length === 0) return false;
-    const pastAnchorOnLine = zones.some(
-      (zone) => zone.anchorParagraphId === paragraphId && line.end > zone.anchorModelStart
+    // A float anchored in an EARLIER paragraph has no offset in this one to be "past" — its
+    // zone applies to every line here. Requiring a same-paragraph anchor left those lines
+    // stranded in the first passage: they stopped at the picture's near edge and broke,
+    // never resuming in the column beside it.
+    const zoneIsOpen = zones.some(
+      (zone) => zone.anchorParagraphId !== paragraphId || line.end > zone.anchorModelStart
     );
-    if (!pastAnchorOnLine) return false;
+    if (!zoneIsOpen) return false;
     const intervals = mergeAvailableIntervalsAtY(
       exclusionProbeY(),
       zones,
@@ -904,11 +923,10 @@ export function breakParagraph(
         break;
       }
     }
-    if (containingIndex >= 0 && containingIndex + 1 < intervals.length) {
-      const next = intervals[containingIndex + 1]!;
-      line.width = next.start - lineOrigin();
-      return;
-    }
+    // Only move a pen standing INSIDE the picture. Skipping to the next passage whenever one
+    // existed emptied the near column of a centred float: every word after the anchor hopped
+    // the picture, so the space beside it took one word per line and the rest piled up on the
+    // far side. Filling the near passage first, then advancing on overflow, is what Word does.
     if (containingIndex >= 0) return;
     const snap = snapXToAvailableInterval(currentX, intervals);
     if (snap && snap.x > currentX + 0.001) {
@@ -929,7 +947,7 @@ export function breakParagraph(
   };
 
   const ensurePlacementWidth = (width: number, depth = 0): boolean => {
-    if (depth > 64) return lineAvailable() >= width;
+    if (depth > 64) return remainingLineWidth() >= width;
     applyTopAndBottomSkipIfNeeded();
     if (!snapLineToAvailableInterval()) {
       if (line.spans.length > 0 || line.drawings.length > 0) {
@@ -938,13 +956,18 @@ export function breakParagraph(
       }
       return true;
     }
-    if (width <= lineAvailable() + 0.001) return true;
+    if (width <= remainingLineWidth() + 0.001) return true;
     if (line.spans.length > 0 || line.drawings.length > 0) {
-      if (tryAdvanceToNextPassage() && width <= lineAvailable() + 0.001) return true;
+      if (tryAdvanceToNextPassage() && width <= remainingLineWidth() + 0.001) return true;
       closeLine();
       return ensurePlacementWidth(width, depth + 1);
     }
-    // Empty line still too narrow — place anyway (overflow) rather than stacking blank lines.
+    // An EMPTY line that cannot hold the word may still have room beside the float. A picture
+    // offset a few points from the margin leaves a sliver of a passage in front of it; without
+    // this the word was chopped at the character to fill that sliver, one letter per line,
+    // while the usable column to its right stayed empty.
+    if (tryAdvanceToNextPassage()) return ensurePlacementWidth(width, depth + 1);
+    // Nowhere wider left on this line — place anyway (overflow) rather than stacking blanks.
     return true;
   };
 
@@ -1028,6 +1051,29 @@ export function breakParagraph(
     growLineHeightForDrawingExtent();
   };
 
+  /**
+   * Record the jumps a float's wrap zone forced between this line's spans.
+   *
+   * Spans are laid contiguously as the pen advances, so at close time the ONLY horizontal
+   * gaps between them are advances the pen skipped: an inline drawing's own reserved slot,
+   * which paint already fills, and a wrap exclusion the line stepped over to resume in the
+   * next passage. Justification has not run yet, so nothing here can be confused with slack.
+   */
+  const markWrapAdvances = (): void => {
+    if (line.spans.length < 2) return;
+    for (let index = 1; index < line.spans.length; index += 1) {
+      const previous = line.spans[index - 1]!;
+      const current = line.spans[index]!;
+      const gap = current.box.x - (previous.box.x + previous.box.width);
+      if (gap <= 0.001) continue;
+      const drawingFillsGap = line.drawings.some(
+        (drawing) => drawing.start >= previous.range.end && drawing.start < current.range.start
+      );
+      if (drawingFillsGap) continue;
+      line.spans[index] = { ...current, wrapAdvanceBefore: gap };
+    }
+  };
+
   const closeLine = (): void => {
     const metrics = measurer.lineMetrics(emptyStyle);
     if (line.height === 0) {
@@ -1058,6 +1104,7 @@ export function breakParagraph(
       else delete (line as { exclusionSkipBefore?: number }).exclusionSkipBefore;
     };
     finalizeTopAndBottomClearance();
+    markWrapAdvances();
     const deleted = deletedWithin(line.start, line.end);
     if (deleted.length > 0) line.deletedRanges = deleted;
     lines.push(line);

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1281,21 +1281,22 @@ function layoutBlocksPass(
       options.drawingTokenForParagraph?.(entry.paragraph) ??
       options.drawingLayoutToken ??
       (options.inlineDrawingLayout ? 'drawing' : undefined);
-    const cacheKey = cache && !suppressChrome
-      ? exclusionToken || drawingKeyed
-        ? paragraphLayoutKey({
-            paragraph: entry.paragraph,
-            properties: entry.props,
-            width: available,
-            producer,
-            ...(drawingKeyed ? { drawingToken: drawingKeyed } : {}),
-            ...(exclusionToken ? { exclusionToken: `${flowColumnIndex}|${exclusionToken}` } : {}),
-            ...(startOffset > 0 ? { startOffset } : {}),
-          })
-        : startOffset === 0
-          ? entry.key
-          : `${entry.key}|from:${startOffset}`
-      : null;
+    const cacheKey =
+      cache && !suppressChrome
+        ? exclusionToken || drawingKeyed
+          ? paragraphLayoutKey({
+              paragraph: entry.paragraph,
+              properties: entry.props,
+              width: available,
+              producer,
+              ...(drawingKeyed ? { drawingToken: drawingKeyed } : {}),
+              ...(exclusionToken ? { exclusionToken: `${flowColumnIndex}|${exclusionToken}` } : {}),
+              ...(startOffset > 0 ? { startOffset } : {}),
+            })
+          : startOffset === 0
+            ? entry.key
+            : `${entry.key}|from:${startOffset}`
+        : null;
     const usePageColumnCoords = columnCount > 1;
     return breakParagraph(
       entry.paragraph,
@@ -1932,6 +1933,8 @@ function layoutBlocksPass(
     let fragmentTopExtent = topExtent;
     let endedWithPageBreak = false;
     let fragmentParagraphStartY = cursorY;
+    /** Clearance applied above the fragment's first placed line, for anchor framing. */
+    let fragmentFirstLineSkip = 0;
     const appliedSkipByLineIndex = new Map<number, number>();
     previousSpaceAfter = 0;
     const paragraphHasAnchors =
@@ -1945,6 +1948,28 @@ function layoutBlocksPass(
     }> | null = null;
 
     const markRevision = paragraphMarkRevisionOf(entry.paragraph);
+
+    /**
+     * How much of the first placed line's topAndBottom skip this paragraph's own anchor caused.
+     *
+     * The placement skip mixes two sources: bands inherited from earlier paragraphs, which
+     * genuinely move this paragraph down the page, and a band from an anchor inside it, which
+     * only moves its text away from a picture pinned to the paragraph origin. Re-running the
+     * clearance with the inherited zones alone isolates the second.
+     */
+    const ownTopAndBottomSkipOnFirstLine = (): number => {
+      const firstLine = pending[0];
+      if (!firstLine) return 0;
+      const applied = fragmentFirstLineSkip;
+      if (applied <= 0.001) return 0;
+      const inherited = topAndBottomSkipBeforeLine(
+        fragmentParagraphStartY,
+        firstLine.box.height,
+        pageExclusionZonesForEntry(entry, index)
+      );
+      return Math.max(0, applied - inherited);
+    };
+
     const flushFragment = (isLast: boolean): void => {
       if (pending.length === 0) return;
       const regionX = columnLeft();
@@ -2113,11 +2138,23 @@ function layoutBlocksPass(
         let publishParagraphBox: LayoutBox;
         let publishColumnBox: LayoutBox;
         if (pendingCoversAnchors) {
+          // A `wrapTopAndBottom` anchor pushed its OWN paragraph's lines down to clear the
+          // band. Framing the anchor against those lines chases the displacement it caused —
+          // the picture lands on the text it just moved. `positionV relativeFrom="paragraph"`
+          // means where the paragraph would begin without its own band, so that skip comes
+          // back off here. A band inherited from an earlier paragraph is NOT removed: it
+          // moved this paragraph for real, and the anchor travels with it.
+          const anchorTop = top - ownTopAndBottomSkipOnFirstLine();
           publishLines = pending;
-          publishParagraphBox = { x: columnX + indent.left, y: top, width: available, height };
+          publishParagraphBox = {
+            x: columnX + indent.left,
+            y: anchorTop,
+            width: available,
+            height,
+          };
           publishColumnBox = anchorColumnBox({
             x: columnX + indent.left,
-            y: top,
+            y: anchorTop,
             width: available,
             height,
           });
@@ -2334,6 +2371,7 @@ function layoutBlocksPass(
         ...(alignedDrawings.length > 0 ? { drawings: alignedDrawings } : {}),
       };
       lineCounter += 1;
+      if (pending.length === 0) fragmentFirstLineSkip = skipBefore;
       pending.push(record);
       cursorY += pendingLine.height;
       if (pendingLine.columnBreakAfter) {

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -161,6 +161,16 @@ export interface StyleSpanRecord {
    */
   readonly link?: SpanLinkRecord;
   /**
+   * Horizontal jump, in points, that a floating object's wrap zone forced before this span.
+   *
+   * A line that resumes on the far side of a float is still ONE line: its spans keep running
+   * model offsets and share a selection band. Only layout knows the jump is an obstacle
+   * rather than justification slack, so it publishes it here. Paint reserves it with an inert
+   * advance and excludes it from the word spacing it reconstructs — inferring the difference
+   * from the gap alone spread the float's whole width across every space on the line.
+   */
+  readonly wrapAdvanceBefore?: number;
+  /**
    * The revision wrappers this text sits inside, outermost first, absent when untracked.
    *
    * Carried on the span for the same reason `style` is: paint and the review surface must read

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1049,8 +1049,33 @@ function paintLine(
       anchorLinkId = null;
     }
   };
+  /**
+   * Reserve the horizontal jump a float's wrap zone forced, so the line resumes in the next
+   * passage instead of flowing straight across the picture.
+   */
+  const appendWrapAdvance = (span: StyleSpanRecord): void => {
+    const advance = span.wrapAdvanceBefore ?? 0;
+    if (advance <= 0.001) return;
+    const spacer = document.createElement('span');
+    spacer.className = 'docx-wrap-advance';
+    spacer.dataset.docxMarker = '';
+    spacer.setAttribute('contenteditable', 'false');
+    spacer.setAttribute('aria-hidden', 'true');
+    spacer.style.display = 'inline-block';
+    spacer.style.width = `${advance * scale}px`;
+    spacer.style.height = '0';
+    spacer.style.lineHeight = '0';
+    spacer.style.pointerEvents = 'none';
+    spacer.style.verticalAlign = 'baseline';
+    element.append(spacer);
+    // The gap is not part of any link's text, so an anchor cannot span it.
+    anchor = null;
+    anchorLinkId = null;
+  };
+
   for (const span of line.spans) {
     appendDrawingAdvancesBefore(span.range.start);
+    appendWrapAdvance(span);
     const band = Math.min(span.box.height + leading, line.box.height);
     const painted = paintSpan(document, span, ctx, band, leading);
     const link = span.link;
@@ -1114,7 +1139,10 @@ function interSpanGap(line: LineRecord): number {
       (drawing) => drawing.start >= previous.range.end && drawing.start < current.range.start
     );
     if (drawingOccupiesGap) continue;
-    const gap = current.box.x - (previous.box.x + previous.box.width);
+    // A float's wrap zone is an obstacle the line stepped over, not slack to redistribute.
+    // Averaging it in turned the picture's whole width into word spacing on every space.
+    const gap =
+      current.box.x - (previous.box.x + previous.box.width) - (current.wrapAdvanceBefore ?? 0);
     if (gap > 0.25) gaps.push(gap);
   }
   if (gaps.length === 0) return 0;
@@ -2214,7 +2242,10 @@ export function paintSemanticLayout(
     const kept = reusable?.get(page);
     if (kept && kept.materialized === materialized) return kept;
     const priorShell = materialized ? null : previousByIndex?.get(page.index);
-    if (priorShell && virtualPageShellMatches(priorShell, page, resolved.scale, resolved.ariaHidden)) {
+    if (
+      priorShell &&
+      virtualPageShellMatches(priorShell, page, resolved.scale, resolved.ariaHidden)
+    ) {
       return { record: page, materialized: false, element: priorShell.element };
     }
     return {

--- a/packages/core/src/store/__tests__/drawing-fixture-oracles.ts
+++ b/packages/core/src/store/__tests__/drawing-fixture-oracles.ts
@@ -50,7 +50,7 @@ export const FIXTURE_ORACLES: Readonly<Record<string, FixtureLayoutPaintOracle>>
   },
   'float-wrap-comprehensive-test.docx': {
     drawingCount: 26,
-    pageCount: 7,
+    pageCount: 5,
     readyCount: 26,
     placeholderCount: 0,
     assertProjections: (projections) => {
@@ -60,6 +60,57 @@ export const FIXTURE_ORACLES: Readonly<Record<string, FixtureLayoutPaintOracle>>
       expect(projections.some((p) => p.wrap === 'squareLeft')).toBe(true);
       expect(projections.some((p) => p.wrap === 'squareRight')).toBe(true);
       expect(projections.some((p) => p.wrap === 'behind')).toBe(true);
+    },
+    // The page count alone is a weak gate: it moved from 7 to 5 only because every wrapped
+    // line used to break at roughly half the column. These pin the geometry that decides it.
+    assertLayout: (layout) => {
+      const columnRight = layout.pages[0]!.contentBox.width;
+      let widest = 0;
+
+      for (const page of layout.pages) {
+        // Anchors and lines are page-local coordinates — never compare across pages.
+        const lines = page.fragments.flatMap((fragment) =>
+          fragment.kind === 'paragraph' ? fragment.lines : []
+        );
+        const anchors = page.anchoredDrawings ?? [];
+        for (const line of lines) {
+          for (const span of line.spans) {
+            widest = Math.max(widest, span.box.x + span.box.width);
+          }
+        }
+
+        for (const anchor of anchors) {
+          const top = anchor.y;
+          const bottom = anchor.y + anchor.height;
+          const overlappingLines = lines.filter(
+            (line) => line.box.y < bottom - 0.001 && line.box.y + line.box.height > top + 0.001
+          );
+
+          // A tight/through polygon excludes the whole picture, not a sliver of its left
+          // edge: no glyph may sit inside one.
+          if (anchor.wrap === 'tight' || anchor.wrap === 'through') {
+            for (const line of overlappingLines) {
+              for (const span of line.spans) {
+                const overlaps =
+                  span.box.x < anchor.x + anchor.width - 0.001 &&
+                  span.box.x + span.box.width > anchor.x + 0.001;
+                expect(overlaps).toBe(false);
+              }
+            }
+          }
+
+          // A topAndBottom band sits ABOVE the text it displaced — the anchor's own paragraph
+          // clears it rather than being painted over by it.
+          if (anchor.wrap === 'topAndBottom') {
+            for (const line of overlappingLines) expect(line.spans).toHaveLength(0);
+          }
+        }
+      }
+
+      // A line clear of every wrap zone reaches the full column, not a halved one, and
+      // nothing overhangs the column either.
+      expect(widest).toBeGreaterThan(columnRight * 0.9);
+      expect(widest).toBeLessThanOrEqual(columnRight + 1);
     },
   },
   'image-layout-modes-demo.docx': {


### PR DESCRIPTION
`image-layout-modes-demo.docx` and `float-wrap-comprehensive-test.docx` did not wrap text around floating images correctly. Six defects, each reproduced headless before fixing:

- `lineAvailable()` returned the room ahead of the pen while its callers compare `line.width + width` against it, so every line on a page carrying any wrap zone broke at roughly half the column — including paragraphs nowhere near a float.
- `wp:wrapPolygon` points address a 21600-unit square over the drawing's extent (§20.4.2.16), not EMU. Read as EMU, a full-rectangle tight/through polygon collapsed to a 1.7pt sliver and text walked over the picture.
- The exclusion probe read the line's unshifted top, so a line a top-and-bottom band had just pushed clear still reported itself inside the band and stranded its first character on a line of its own.
- An anchor framed against the lines its own band displaced chased that displacement, painting the picture on top of the text it had moved.
- Paint rebuilt justification slack from inter-span gaps, so the width of a float a line stepped over became word spacing on every space and pushed glyphs off the page. Layout now publishes the jump (`wrapAdvanceBefore`) and paint reserves it with an inert advance.
- Text after a same-paragraph anchor hopped to the far passage unconditionally, an inherited float's line never resumed beside it, and a passage too narrow for a word got the word chopped per character. All three now fill the near passage and advance only on overflow.

The `float-wrap-comprehensive-test.docx` oracle drops 7 -> 5 pages. Page count alone was a weak gate — it moved only because lines were half width — so `assertLayout` now pins the geometry that decides it: no glyph inside a tight/through polygon, no text inside a top-and-bottom band, and the widest line reaching the column without overhanging it.

Verified against the branch-point baseline: identical failure set (87 pre-existing). The two `list-pagination-break` tests flip run to run — they swap `globalThis.fetch` and shell out to `unzip`, and both pass in isolation. Each new regression test was confirmed to fail with its fix reverted.

Not addressed, both outside this bug: `<wp:wrapTopAndBottom/>` with no `distT`/`distB` of its own falls back to zero rather than the anchor's values (band ~3.6pt tighter than Word on that fixture), and cell-scoped anchor framing in Section 4 was not audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788526730&installation_model_id=422592&pr_number=144&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F144&signature=5ae00fdbc7193dd8abb88f5d025403607ed4f47d01d51c2cc81d0f2c2e6dc4b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->