### PR TITLE
fix(core): caret placement in all-caps text, and theme font resolution

### DIFF
--- a/.changeset/caps-caret-alignment.md
+++ b/.changeset/caps-caret-alignment.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Place the caret on the right letter in all-caps text. Runs with `w:caps` paint uppercase glyphs, but caret and click positions were measured from the lowercase source, so the caret drifted further left with every character and clicks landed an offset or two early.

--- a/.changeset/theme-font-resolution.md
+++ b/.changeset/theme-font-resolution.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Render documents in their theme fonts. A template that states its fonts through the theme (`w:asciiTheme="minorHAnsi"` in `w:docDefaults`, `majorHAnsi` on heading styles) names no concrete family anywhere, so every run fell back to the default face and the document rendered in the wrong font even when the author's fonts were installed.

--- a/packages/core/src/binding/document-run-defaults.ts
+++ b/packages/core/src/binding/document-run-defaults.ts
@@ -71,16 +71,22 @@ function themeFamilyOf(value: string | undefined, themeFonts: DocumentThemeFonts
 }
 
 /**
- * The family an `w:rFonts` element names: `ascii ?? hAnsi` (the spelling the engine
- * reads back), then the theme attributes through the font scheme.
+ * The family an `w:rFonts` element names: the theme attributes through the font scheme,
+ * then `ascii ?? hAnsi` (the spelling the engine reads back).
+ *
+ * Theme first, matching §17.3.2.26 and `resolveRunStyle` in the layout lane: Word writes
+ * both, the concrete name only so readers that cannot resolve a theme have something to
+ * use. Reading it in preference would make this answer a different font from the one the
+ * document is painted in, which is what the font box would then display.
  */
 function familyFromRFonts(rFonts: OoxmlElement, themeFonts: DocumentThemeFonts): string | null {
-  const direct = attributeValue(rFonts, 'ascii') ?? attributeValue(rFonts, 'hAnsi');
-  if (direct !== undefined) return FONT_NAME.test(direct) ? direct : null;
-  return (
+  const themed =
     themeFamilyOf(attributeValue(rFonts, 'asciiTheme'), themeFonts) ??
-    themeFamilyOf(attributeValue(rFonts, 'hAnsiTheme'), themeFonts)
-  );
+    themeFamilyOf(attributeValue(rFonts, 'hAnsiTheme'), themeFonts);
+  if (themed !== null) return themed;
+  const direct = attributeValue(rFonts, 'ascii') ?? attributeValue(rFonts, 'hAnsi');
+  if (direct === undefined) return null;
+  return FONT_NAME.test(direct) ? direct : null;
 }
 
 /** What one `w:rPr` container contributes: validated family and size, or nulls. */
@@ -163,8 +169,8 @@ export function createRunDefaultsResolver(
 
   return (styleId, runProperties) => {
     const chain = chainOf(styleId);
-    // A run-level `w:rFonts` that names only THEME slots resolves through the font
-    // scheme here — the layout's direct resolution leaves it null (deferred lane).
+    // A run-level `w:rFonts` naming a THEME slot outranks the whole style chain, the same
+    // precedence `familyFromRFonts` applies within one element.
     const rFonts = runProperties?.find((property) => property.localName === 'rFonts');
     const runTheme = rFonts
       ? (themeFamilyOf(rFonts.attributes?.asciiTheme, themeFonts) ??

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -75,6 +75,7 @@ import {
   collectDocumentThemeColors,
   collectDocumentThemeFonts,
   type DocumentThemeColorEntry,
+  type DocumentThemeFonts,
 } from './document-theme.ts';
 import {
   createRunDefaultsResolver,
@@ -218,6 +219,14 @@ export interface TreeDocxSession {
    * for the session.
    */
   stylesRoot(): OoxmlElement | null;
+  /**
+   * The theme part's Latin typefaces, for resolving `w:rFonts` theme references in layout.
+   *
+   * Memoized once: theme editing is a later slice. A document with no theme part answers
+   * `{ major: null, minor: null }`, which leaves every theme reference on the explicit
+   * font name beside it.
+   */
+  documentThemeFonts(): DocumentThemeFonts;
   /**
    * Root of the numbering part tree (`w:numbering`), for list layout. Memoized once;
    * `null` when the package has no numbering part. Numbering editing is a later slice.
@@ -630,6 +639,7 @@ export function openTreeSession(
   let fontsCache: { readonly revision: number; readonly fonts: readonly string[] } | null = null;
   let stylesCache: readonly DocumentStyleEntry[] | null = null;
   let themeColorsCache: readonly DocumentThemeColorEntry[] | null = null;
+  let themeFontsCache: DocumentThemeFonts | null = null;
   let runDefaultsResolver:
     | ((styleId: string | null, runProperties?: readonly RunPropertyLike[]) => StyleRunDefaults)
     | null = null;
@@ -853,6 +863,11 @@ export function openTreeSession(
       },
 
       stylesRoot: () => resolveStylesRoot(),
+
+      documentThemeFonts() {
+        themeFontsCache ??= collectDocumentThemeFonts(resolveThemeRoot());
+        return themeFontsCache;
+      },
 
       numberingRoot: () => resolveNumberingRoot(),
 

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -285,7 +285,7 @@ export function createSurfaceStyleDeps(session: TreeDocxSession): {
   let root: OoxmlElement | null | undefined;
   let index: NumberingIndex | undefined;
   return {
-    styleCascade: buildStyleCascadeTable(session.stylesRoot()),
+    styleCascade: buildStyleCascadeTable(session.stylesRoot(), session.documentThemeFonts()),
     defaultTabStopPt: defaultTabIntervalFromSettings(session.settingsRoot()),
     numberingIndex() {
       const current = session.numberingRoot();

--- a/packages/core/src/layout/__tests__/run-style.test.ts
+++ b/packages/core/src/layout/__tests__/run-style.test.ts
@@ -14,7 +14,7 @@ describe('every D8 run property resolves', () => {
   test('font family from ascii, falling back to hAnsi', () => {
     expect(resolve('rFonts', { ascii: 'Calibri' }).fontFamily).toBe('Calibri');
     expect(resolve('rFonts', { hAnsi: 'Georgia' }).fontFamily).toBe('Georgia');
-    // A theme-only reference resolves through the theme part, a deferred lane.
+    // Without a theme there is nothing to resolve a theme-only reference against.
     expect(resolve('rFonts', { asciiTheme: 'minorHAnsi' }).fontFamily).toBeNull();
   });
 
@@ -114,6 +114,41 @@ describe('every D8 run property resolves', () => {
       { localName: 'sz', attributes: { val: '44' } },
     ]);
     expect(style.fontSizePt).toBe(22);
+  });
+});
+
+describe('a w:rFonts theme reference resolves against the theme part', () => {
+  // Word writes the body font as `w:asciiTheme="minorHAnsi"`, usually in `w:docDefaults`,
+  // so in a themed document EVERY run reaches here with no explicit family. Leaving those
+  // unresolved put the whole document on the surface's fallback face.
+  const theme = { major: 'Aharoni', minor: 'Grandview' };
+  const themed = (attributes: Record<string, string>) =>
+    resolveRunStyle([{ localName: 'rFonts', attributes }], theme).fontFamily;
+
+  test('minor is body text, major is headings', () => {
+    expect(themed({ asciiTheme: 'minorHAnsi' })).toBe('Grandview');
+    expect(themed({ asciiTheme: 'majorHAnsi' })).toBe('Aharoni');
+    // The `*Ascii` spellings name the same two slots.
+    expect(themed({ asciiTheme: 'minorAscii' })).toBe('Grandview');
+    expect(themed({ hAnsiTheme: 'majorAscii' })).toBe('Aharoni');
+  });
+
+  test('the theme attribute overrides the explicit name beside it', () => {
+    // Word writes both: the concrete name is there for readers that cannot resolve a
+    // theme, and following it would ignore a retheme the author can see (§17.3.2.26).
+    expect(themed({ ascii: 'Calibri', asciiTheme: 'minorHAnsi' })).toBe('Grandview');
+  });
+
+  test('an unresolvable slot falls back to the explicit name, not to nothing', () => {
+    // `minorBidi` / `minorEastAsia` name the `a:cs` / `a:ea` faces this lane does not read.
+    expect(themed({ ascii: 'Calibri', asciiTheme: 'minorBidi' })).toBe('Calibri');
+    // A theme whose slot is empty leaves the run inheriting rather than naming null.
+    expect(
+      resolveRunStyle([{ localName: 'rFonts', attributes: { asciiTheme: 'minorHAnsi' } }], {
+        major: null,
+        minor: null,
+      }).fontFamily
+    ).toBeNull();
   });
 });
 

--- a/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
@@ -592,6 +592,40 @@ describe('the caret sits at a glyph edge', () => {
   });
 });
 
+describe('a w:caps run is measured as it is DRAWN', () => {
+  // `w:caps` paints uppercase glyphs while the model keeps the source text. Line breaking
+  // always measured the drawn form, so the span box was right — but the caret edges were
+  // taken from the source, so the caret drifted further left with every letter and a click
+  // resolved to an earlier offset than the one under the pointer.
+  /** Uppercase is wider than lowercase, as it is in any proportional face. */
+  const cased: TextMeasurer = {
+    measure: (text) => [...text].reduce((sum, ch) => sum + (ch === ch.toUpperCase() ? 10 : 6), 0),
+    lineMetrics: () => ({ height: 14, baseline: 11 }),
+  };
+  const caps = (text: string) => `<w:p><w:r><w:rPr><w:caps/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
+
+  test('caret edges follow the uppercase glyphs, not the source text', () => {
+    const layout = lay(caps('abcdef'), cased);
+    const span = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!.spans[0]!;
+    // Drawn as "ABCDEF": six wide glyphs, and the reserved advance already said so.
+    expect(span.box.width).toBe(60);
+    // Measuring the source "abc" would publish 18 here and disagree with that box.
+    expect(span.caretEdges?.[3]).toBe(30);
+    expect(spanOffsetX(span, 3, cased)).toBe(span.box.x + 30);
+  });
+
+  test('so a click lands on the letter it was aimed at', () => {
+    const layout = lay(caps('abcdef'), cased);
+    const caret = caretAt(layout, { paragraphId: P0, offset: 3 }, cased)!;
+    expect(caret.x).toBe(30);
+    // Clicking where the caret is drawn resolves back to the offset it was drawn for.
+    expect(hit(layout, caret.x, 5, cased)!.position.offset).toBe(3);
+    // A point inside the fourth glyph is offset 4, not the earlier offset source-text
+    // metrics would have interpolated it to.
+    expect(hit(layout, 44, 5, cased)!.position.offset).toBe(4);
+  });
+});
+
 describe('the caret is as tall as the run it sits in', () => {
   // A line is as tall as its LARGEST run, so a caret in small text on a line that also
   // carries large text was drawn several times the height of the text it was in.

--- a/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
@@ -620,9 +620,35 @@ describe('a w:caps run is measured as it is DRAWN', () => {
     expect(caret.x).toBe(30);
     // Clicking where the caret is drawn resolves back to the offset it was drawn for.
     expect(hit(layout, caret.x, 5, cased)!.position.offset).toBe(3);
-    // A point inside the fourth glyph is offset 4, not the earlier offset source-text
+    // A point inside the fifth glyph is offset 4, not the earlier offset source-text
     // metrics would have interpolated it to.
     expect(hit(layout, 44, 5, cased)!.position.offset).toBe(4);
+  });
+
+  test('a JUSTIFIED caps line is not over-stretched by phantom trailing whitespace', () => {
+    // `alignSpans` prices a line's trailing whitespace as `box.width - measure(visible)`.
+    // The box was reserved from the DRAWN text, so measuring the visible part from the
+    // SOURCE made almost the whole span look like whitespace, inflating the slack justify
+    // then distributes. Centre and right pass `lineUsedWidth` and never read it; a
+    // justified NON-LAST line is the only path that does — hence enough words to wrap.
+    const words = Array.from({ length: 40 }, (_, index) => `w${index}`).join(' ');
+    const layout = lay(
+      `<w:p><w:pPr><w:jc w:val="both"/></w:pPr>` +
+        `<w:r><w:rPr><w:caps/></w:rPr><w:t>${words}</w:t></w:r></w:p>`,
+      cased
+    );
+    const fragment = paragraphFragmentsOf(layout.pages[0]!)[0]!;
+    expect(fragment.lines.length).toBeGreaterThan(1); // or the rule is untested
+    const line = fragment.lines[0]!;
+    const last = line.spans[line.spans.length - 1]!;
+    expect(last.text.endsWith(' ')).toBe(true);
+    // Only the trailing space may hang into the margin. The GLYPHS must stop at the column
+    // edge; measuring the source text pushed them past it.
+    const visible = last.text.replace(/\s+$/, '');
+    const drawnVisible = cased.measure(visible.toUpperCase(), last.style);
+    expect(last.box.x + drawnVisible).toBeLessThanOrEqual(
+      layout.pages[0]!.contentBox.width + 0.001
+    );
   });
 });
 

--- a/packages/core/src/layout/__tests__/theme-fonts.test.ts
+++ b/packages/core/src/layout/__tests__/theme-fonts.test.ts
@@ -14,7 +14,8 @@ import {
 } from '@docx-editor.dev/core-contract/store';
 import { buildStyleCascadeTable } from '../style-cascade.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
-import { paragraphFragmentsOf } from '../semantic-records.ts';
+import { layoutHeaderFooterStory } from '../hf-layout.ts';
+import { paragraphFragmentsOf, type BlockFragmentRecord } from '../semantic-records.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -68,6 +69,29 @@ describe('a themed document lays out in its theme fonts', () => {
   test('without a theme every run falls through to the surface default', () => {
     // The regression this guards: the document renders, and renders entirely wrong.
     expect(familiesOf({ major: null, minor: null })).toEqual([null, null]);
+  });
+
+  test('a header resolves the same theme the body does', () => {
+    // Headers and footers do not go through the body block pass — they reach the shared
+    // cell-paragraph path instead. A refactor that stopped handing them the style cascade
+    // would put the page furniture on a different face from the body with every other test
+    // in this file still green.
+    const header = part(
+      '/word/header1.xml',
+      `<w:hdr xmlns:w="${W}"><w:p><w:r><w:t>Letterhead</w:t></w:r></w:p></w:hdr>`
+    );
+    const story = layoutHeaderFooterStory(
+      header,
+      468,
+      createFixedMeasurer(6, 14),
+      'test',
+      undefined,
+      buildStyleCascadeTable(STYLES, THEME)
+    );
+    const families = story.fragments
+      .filter((block: BlockFragmentRecord) => block.kind === 'paragraph')
+      .map((block) => block.lines[0]?.spans[0]?.style.fontFamily ?? null);
+    expect(families).toEqual(['Grandview']);
   });
 
   test('retheming changes the cascade token, so cached breaks are not reused', () => {

--- a/packages/core/src/layout/__tests__/theme-fonts.test.ts
+++ b/packages/core/src/layout/__tests__/theme-fonts.test.ts
@@ -1,0 +1,80 @@
+// Where a themed document's font comes from: the theme part, through `w:rFonts`.
+//
+// Word states the body face once, as `w:asciiTheme="minorHAnsi"` in `w:docDefaults`, and the
+// heading face as `majorHAnsi` on the heading styles. A template built that way names no
+// concrete font anywhere, so a lane that reads only `w:ascii`/`w:hAnsi` resolves EVERY run to
+// no family and measures and paints the whole document in the surface's fallback face — the
+// author's theme is invisible even when the reader has both fonts installed.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlPart,
+} from '@docx-editor.dev/core-contract/store';
+import { buildStyleCascadeTable } from '../style-cascade.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { paragraphFragmentsOf } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function part(name: string, xml: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/** Body font by theme reference in `w:docDefaults`; heading font by theme on the style. */
+const STYLES: OoxmlElement = part(
+  '/word/styles.xml',
+  `<w:styles xmlns:w="${W}">
+    <w:docDefaults>
+      <w:rPrDefault>
+        <w:rPr><w:rFonts w:asciiTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi"/></w:rPr>
+      </w:rPrDefault>
+    </w:docDefaults>
+    <w:style w:type="paragraph" w:styleId="Heading2">
+      <w:name w:val="heading 2"/>
+      <w:rPr><w:rFonts w:asciiTheme="majorHAnsi" w:hAnsiTheme="majorHAnsi"/></w:rPr>
+    </w:style>
+  </w:styles>`
+).root;
+
+const THEME = { major: 'Aharoni', minor: 'Grandview' };
+
+const BODY =
+  `<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Experience</w:t></w:r></w:p>` +
+  `<w:p><w:r><w:t>Body text</w:t></w:r></w:p>`;
+
+function familiesOf(themeFonts: { major: string | null; minor: string | null }) {
+  const document = part(
+    '/word/document.xml',
+    `<w:document xmlns:w="${W}"><w:body>${BODY}</w:body></w:document>`
+  );
+  const layout = layoutSemanticDocument(document, 1, {
+    measurer: createFixedMeasurer(6, 14),
+    styleCascade: buildStyleCascadeTable(STYLES, themeFonts),
+  });
+  return paragraphFragmentsOf(layout.pages[0]!).map(
+    (fragment) => fragment.lines[0]?.spans[0]?.style.fontFamily ?? null
+  );
+}
+
+describe('a themed document lays out in its theme fonts', () => {
+  test('major for headings, minor for body — neither named anywhere but the theme', () => {
+    expect(familiesOf(THEME)).toEqual(['Aharoni', 'Grandview']);
+  });
+
+  test('without a theme every run falls through to the surface default', () => {
+    // The regression this guards: the document renders, and renders entirely wrong.
+    expect(familiesOf({ major: null, minor: null })).toEqual([null, null]);
+  });
+
+  test('retheming changes the cascade token, so cached breaks are not reused', () => {
+    // The faces change while no style material moves; a token blind to the theme would
+    // hand back lines measured in the old font.
+    const before = buildStyleCascadeTable(STYLES, THEME).cacheToken;
+    const after = buildStyleCascadeTable(STYLES, { major: 'Georgia', minor: 'Verdana' }).cacheToken;
+    expect(before).not.toBe(after);
+  });
+});

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -74,7 +74,7 @@ import {
   type RevisionAttribution,
   type RevisionDisplayMode,
 } from './revision-projection.ts';
-import { resolveRunStyle, type ResolvedRunStyle } from './run-style.ts';
+import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
 import type {
   HeaderFooterStoryRecord,
   SemanticLayout,
@@ -382,7 +382,8 @@ export function piecesOfParagraph(
   noteMarks?: NoteMarkContext,
   displayMode: RevisionDisplayMode = DEFAULT_REVISION_DISPLAY_MODE,
   deletedRanges?: MutableModelRange[],
-  inlineDrawingLayout?: InlineDrawingLayoutContext
+  inlineDrawingLayout?: InlineDrawingLayoutContext,
+  themeFonts?: ThemeFonts
 ): FieldAwarePiece[] {
   if (paragraph.kind === 'textValue') return [];
   if (paragraph.kind !== 'paragraph') return [];
@@ -646,7 +647,7 @@ export function piecesOfParagraph(
   const processRun = (run: OoxmlNode, runDepth: number): void => {
     if (run.kind !== 'run') return;
     const props = runPropertiesOf(run, inheritedRunProperties, cascadeRuns);
-    const style = resolveRunStyle(props);
+    const style = resolveRunStyle(props, themeFonts);
 
     for (const grand of run.children) {
       if (!consumeScanNode(budget)) {

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -308,7 +308,7 @@ export function resolveStoryListItems(
       advanced.level.runProperties,
       styleCascade
     );
-    const markerStyle = resolveRunStyle(markerProps);
+    const markerStyle = resolveRunStyle(markerProps, styleCascade?.themeFonts);
     // Word writes a Symbol/Wingdings bullet as font-byte + 0xF000 (`` = U+F0B7 in
     // Symbol), which is a private-use codepoint no other font can draw. Mapping it here —
     // where the marker's FAMILY is finally known — keeps measurement and paint on the same

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -601,7 +601,7 @@ function effectiveNoteMarkStyle(
     [{ localName: 'rStyle', attributes: { val: styleId } }],
     styleCascade
   );
-  return resolveRunStyle(props);
+  return resolveRunStyle(props, styleCascade.themeFonts);
 }
 
 /**

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -42,8 +42,10 @@ import {
 import {
   DEFAULT_RUN_STYLE,
   displayText,
+  measureDisplayText,
   resolveRunStyle,
   type ResolvedRunStyle,
+  type ThemeFonts,
 } from './run-style.ts';
 import type { LayoutBox, StyleSpanRecord, TextMeasurer } from './semantic-records.ts';
 import {
@@ -144,6 +146,14 @@ export interface ParagraphFlowOptions {
    * layout does not reserve the caret placeholder row ordinary empty paragraphs need.
    */
   readonly suppressEmptyPlaceholderLine?: boolean;
+  /**
+   * The theme's Latin typefaces, resolving `w:rFonts` theme references.
+   *
+   * A different theme measures every `+Body`/`+Headings` run in a different face, so this
+   * belongs in the caller's cache key — `StyleCascadeTable.cacheToken`, which carries it,
+   * is already there.
+   */
+  readonly themeFonts?: ThemeFonts;
 }
 
 /** One measurable piece of a paragraph: text carrying one property set. */
@@ -469,7 +479,10 @@ function caretEdgesForSpan(span: StyleSpanRecord, measurer: TextMeasurer): reado
   }
   const edges: number[] = [0];
   for (let index = 1; index <= span.text.length; index += 1) {
-    edges.push(measurer.measure(span.text.slice(0, index), span.style));
+    // Measured as DRAWN, exactly as `breakParagraph` reserved the advance: `w:caps` paints
+    // uppercase glyphs, which are wider, so edges taken from the source text put the caret
+    // progressively further left of the glyphs the reader is clicking on.
+    edges.push(measureDisplayText(span.text.slice(0, index), span.style, measurer));
   }
   return Object.freeze(edges);
 }
@@ -507,8 +520,11 @@ export function alignSpans(
   // is what Word does and what stops a line ending in a space from looking misaligned.
   const last = spans[spans.length - 1]!;
   const visible = last.text.replace(/\s+$/, '');
+  // `box.width` was reserved from the DRAWN text, so the visible part has to be measured the
+  // same way or a `w:caps` run reports trailing whitespace it does not have and shifts the
+  // whole centred/right-aligned line.
   const trailing =
-    visible === last.text ? 0 : last.box.width - measurer.measure(visible, last.style);
+    visible === last.text ? 0 : last.box.width - measureDisplayText(visible, last.style, measurer);
   const used = lineUsedWidth ?? last.box.x - indentLeft + last.box.width - trailing;
   const slack = available - used;
   if (slack <= 0) return withCaretEdges(spans, measurer);
@@ -595,7 +611,8 @@ export function breakParagraph(
     flow?.noteMarks,
     flow?.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE,
     deletedRanges,
-    flow?.inlineDrawingLayout
+    flow?.inlineDrawingLayout,
+    flow?.themeFonts
   );
   const startOffset = Math.max(0, flow?.startOffset ?? 0);
   const pieces = allPieces.flatMap((piece): FieldAwarePiece[] => {
@@ -619,7 +636,7 @@ export function breakParagraph(
   const emptyStyle =
     inheritedRunProperties.length === 0
       ? DEFAULT_RUN_STYLE
-      : resolveRunStyle(inheritedRunProperties);
+      : resolveRunStyle(inheritedRunProperties, flow?.themeFonts);
   const rightEdge = indentLeft + available;
   const contentLeft = flow?.contentLeft ?? indentLeft;
   const contentRight = flow?.contentRight ?? rightEdge;

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -149,9 +149,13 @@ export interface ParagraphFlowOptions {
   /**
    * The theme's Latin typefaces, resolving `w:rFonts` theme references.
    *
-   * A different theme measures every `+Body`/`+Headings` run in a different face, so this
-   * belongs in the caller's cache key — `StyleCascadeTable.cacheToken`, which carries it,
-   * is already there.
+   * A different theme measures every `+Body`/`+Headings` run in a different face, so it
+   * belongs in the caller's cache key. The BODY lane has that: `semantic-layout` folds
+   * `StyleCascadeTable.cacheToken` into its producer. The header/footer and note lanes pass
+   * the raw surface producer instead, so their keys carry the cascaded `w:rFonts` property
+   * but not the theme it resolves through. That is safe only because the theme is memoized
+   * per session and every reload rebuilds the surface with a fresh cache — a live retheme
+   * would need `cacheToken` folded into those producers too.
    */
   readonly themeFonts?: ThemeFonts;
 }
@@ -521,8 +525,11 @@ export function alignSpans(
   const last = spans[spans.length - 1]!;
   const visible = last.text.replace(/\s+$/, '');
   // `box.width` was reserved from the DRAWN text, so the visible part has to be measured the
-  // same way or a `w:caps` run reports trailing whitespace it does not have and shifts the
-  // whole centred/right-aligned line.
+  // same way: the difference is what the trailing whitespace measures, and mixing a drawn
+  // total with a source-measured visible part reports nearly the whole span as whitespace.
+  // Centre and right pass `lineUsedWidth` and never read this; the path that does is a
+  // JUSTIFIED non-last line, where an over-reported `trailing` inflates `slack` and
+  // over-stretches the line.
   const trailing =
     visible === last.text ? 0 : last.box.width - measureDisplayText(visible, last.style, measurer);
   const used = lineUsedWidth ?? last.box.x - indentLeft + last.box.width - trailing;

--- a/packages/core/src/layout/run-style.ts
+++ b/packages/core/src/layout/run-style.ts
@@ -112,13 +112,46 @@ function hexColor(raw: string | undefined): string | null {
 }
 
 /**
+ * The theme part's two Latin typefaces, for resolving `w:rFonts` theme attributes.
+ *
+ * Structurally identical to the binding lane's `DocumentThemeFonts` and assignable from it.
+ * Declared here so this lane reads two validated strings rather than the theme tree.
+ */
+export interface ThemeFonts {
+  /** `a:majorFont` latin typeface — headings. */
+  readonly major: string | null;
+  /** `a:minorFont` latin typeface — body text. */
+  readonly minor: string | null;
+}
+
+/**
+ * A `w:rFonts` theme attribute resolved to a typeface.
+ *
+ * Only the LATIN slots resolve: `minorEastAsia`/`minorBidi` (and major) name the `a:ea`/
+ * `a:cs` faces this lane does not read, and an honest null — which falls back to the
+ * explicit attribute beside it — beats the wrong font.
+ */
+function themeFamilyOf(value: string | undefined, themeFonts: ThemeFonts): string | null {
+  if (value === 'minorAscii' || value === 'minorHAnsi') return themeFonts.minor;
+  if (value === 'majorAscii' || value === 'majorHAnsi') return themeFonts.major;
+  return null;
+}
+
+/**
  * Resolve one run's direct formatting.
  *
  * Unrecognised values are DROPPED rather than guessed: a `w:sz` of `"large"` leaves the
  * default size rather than inventing one, because a wrong measurement moves every glyph
  * after it and a missing one is visible immediately.
+ *
+ * `themeFonts` resolves `w:rFonts` theme references. Absent, a theme-only `rFonts` leaves
+ * the family inherited — which is what every run of a theme-fonted document does, so the
+ * whole document falls back to the surface default face.
  */
-export function resolveRunStyle(props: readonly OoxmlProperty[]): ResolvedRunStyle {
+export function resolveRunStyle(
+  props: readonly OoxmlProperty[],
+  themeFonts?: ThemeFonts
+): ResolvedRunStyle {
   const style: {
     -readonly [K in keyof ResolvedRunStyle]: ResolvedRunStyle[K];
   } = { ...DEFAULT_RUN_STYLE };
@@ -127,9 +160,17 @@ export function resolveRunStyle(props: readonly OoxmlProperty[]): ResolvedRunSty
     switch (property.localName) {
       case 'rFonts': {
         // `w:ascii` is the Latin face; `w:hAnsi` is the fallback this lane uses when it is
-        // the only one authored. Theme fonts resolve through the theme part, which is a
-        // deferred lane, so a theme-only rFonts leaves the family inherited.
-        const family = property.attributes?.ascii ?? property.attributes?.hAnsi;
+        // the only one authored. A theme attribute OVERRIDES the explicit one beside it
+        // (§17.3.2.26): Word writes both, the concrete name only so legacy readers have
+        // something to use, and following it would ignore a retheme the author can see.
+        // An unresolvable theme slot falls back to that explicit name rather than to
+        // nothing, because a stale face still beats no face at all.
+        const attributes = property.attributes;
+        const themed = themeFonts
+          ? (themeFamilyOf(attributes?.asciiTheme, themeFonts) ??
+            themeFamilyOf(attributes?.hAnsiTheme, themeFonts))
+          : null;
+        const family = themed ?? attributes?.ascii ?? attributes?.hAnsi;
         if (family && family.length <= 128) style.fontFamily = family;
         break;
       }

--- a/packages/core/src/layout/run-style.ts
+++ b/packages/core/src/layout/run-style.ts
@@ -267,8 +267,11 @@ export function resolveRunStyle(
 /** The text as it is DRAWN, after case transforms. Measurement must use this, not the source. */
 export function displayText(text: string, style: ResolvedRunStyle): string {
   if (style.caps) return text.toUpperCase();
-  // Small caps changes glyph selection rather than the characters; the shaper handles it,
-  // and uppercasing here would corrupt the text a copy would produce.
+  // Small caps changes glyph selection rather than the characters, so uppercasing here would
+  // corrupt the text a copy produces. Resolving it belongs to the shaper — which does not do
+  // it yet: no `smcp` feature is requested, so a small-caps run measures as plain lowercase
+  // while paint asks the browser to synthesize it. That leaves the span the wrong WIDTH, but
+  // breaking and caret edges agree with each other, so nothing drifts inside a run.
   return text;
 }
 

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -881,6 +881,8 @@ function prefixWidth(span: StyleSpanRecord, utf16: number, measurer: TextMeasure
   }
   const cached = widths.get(utf16);
   if (cached !== undefined) return cached;
+  // As DRAWN, matching `caretEdges` and the advance `breakParagraph` reserved: a `w:caps`
+  // run paints uppercase, and measuring the source text would disagree with both.
   const width =
     utf16 <= 0 ? 0 : measureDisplayText(span.text.slice(0, utf16), span.style, measurer);
   widths.set(utf16, width);

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1331,6 +1331,7 @@ function layoutBlocksPass(
         paragraphStartY: cursorY,
         ...(pageZones.length > 0 ? { pageExclusionZones: pageZones } : {}),
         ...(suppressChrome ? { suppressEmptyPlaceholderLine: true } : {}),
+        ...(styleCascade ? { themeFonts: styleCascade.themeFonts } : {}),
       }
     );
   };
@@ -1874,7 +1875,7 @@ function layoutBlocksPass(
       const emptyStyle =
         inheritedRunProperties.length === 0
           ? DEFAULT_RUN_STYLE
-          : resolveRunStyle(inheritedRunProperties);
+          : resolveRunStyle(inheritedRunProperties, styleCascade?.themeFonts);
       const firstTail = lines.length <= 1 ? borderExtent + spacing.after : 0;
       const prospectiveFirstTop = cursorY + lead + topExtent;
       const firstZones = placementZonesForLine(

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -619,6 +619,7 @@ function placeCellParagraph(
         height: Math.max(1, available),
       }),
       ...(pageZones.length > 0 ? { pageExclusionZones: pageZones } : {}),
+      ...(deps.styleCascade ? { themeFonts: deps.styleCascade.themeFonts } : {}),
     }
   );
 

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -41,6 +41,7 @@ import {
   tabStopsFingerprint,
   type ResolvedTabStops,
 } from './paragraph-tabs.ts';
+import type { ThemeFonts } from './run-style.ts';
 
 /** Soft ceiling on `basedOn` chain length — enough for real templates, refuses hostile graphs. */
 export const MAX_STYLE_BASED_ON_DEPTH = 32;
@@ -85,8 +86,18 @@ export interface StyleCascadeTable {
   readonly defaultParagraphStyleId: string | null;
   /** `w:style[@w:default='1'][@w:type='character']` — last wins among defaults of that type. */
   readonly defaultCharacterStyleId: string | null;
+  /**
+   * The theme part's Latin typefaces, for `w:rFonts` theme references.
+   *
+   * Lives on the cascade because it is document-level style material with the same
+   * lifetime, and because every site that resolves run properties already holds this table.
+   */
+  readonly themeFonts: ThemeFonts;
   readonly styles: ReadonlyMap<string, StyleDefinition>;
 }
+
+/** A document with no theme part: every theme reference falls back to its explicit name. */
+export const NO_THEME_FONTS: ThemeFonts = { major: null, minor: null };
 
 export interface CascadedParagraphFormatting {
   /** Flat paragraph properties in cascade order (defaults → bases → style → direct). */
@@ -373,16 +384,22 @@ export function tableCellStyleFormatting(
  * `styleId` values keep the last definition, matching Word's reader for this fixture class.
  * Default paragraph/character style ids track `w:default="1"` with the same last-wins rule.
  */
-export function buildStyleCascadeTable(stylesRoot: OoxmlElement | null): StyleCascadeTable {
+export function buildStyleCascadeTable(
+  stylesRoot: OoxmlElement | null,
+  themeFonts: ThemeFonts = NO_THEME_FONTS
+): StyleCascadeTable {
   const styles = new Map<string, StyleDefinition>();
   if (!stylesRoot) {
     return {
-      cacheToken: stableHash({ empty: true }),
+      // Still keyed on the theme: a document with no styles part can carry a theme, and
+      // its runs resolve `+Body` through it.
+      cacheToken: stableHash({ empty: true, theme: themeFonts }),
       docDefaultsRun: [],
       docDefaultsParagraph: [],
       docDefaultsParagraphNode: undefined,
       defaultParagraphStyleId: null,
       defaultCharacterStyleId: null,
+      themeFonts,
       styles,
     };
   }
@@ -415,6 +432,9 @@ export function buildStyleCascadeTable(stylesRoot: OoxmlElement | null): StyleCa
     dP: propertiesFingerprint(defaults.paragraph),
     defP: defaultParagraphStyleId,
     defC: defaultCharacterStyleId,
+    // Retheming changes the face every theme-fonted run measures in while no style
+    // material moves, so a break cached under the old theme must not be reused.
+    theme: themeFonts,
     styles: [...styles.values()].map((style) => ({
       id: style.styleId,
       type: style.type,
@@ -431,6 +451,7 @@ export function buildStyleCascadeTable(stylesRoot: OoxmlElement | null): StyleCa
     docDefaultsParagraphNode: defaults.paragraphNode,
     defaultParagraphStyleId,
     defaultCharacterStyleId,
+    themeFonts,
     styles,
   };
 }


### PR DESCRIPTION
Two measure/paint disagreements found while opening a Word resume template whose fonts come entirely from its theme.

**All-caps caret.** A `w:caps` run paints uppercase glyphs while the model keeps the source text. Line breaking already measured the drawn text, so span boxes were right, but `caretEdgesForSpan` measured the lowercase source — so the caret drifted further left with every character (0px at offset 0, -9.65px by offset 9 on the sample document) and clicks landed an offset or two early. The same mismatch inflated the trailing-whitespace price on justified lines, over-stretching them past the column edge.

`prefixWidth` was already correct on this base; the primary path, published `caretEdges`, was not, and it wins whenever it is present.

**Theme fonts.** `w:rFonts` theme references (`w:asciiTheme="minorHAnsi"` in `w:docDefaults`, `majorHAnsi` on heading styles) were not resolved by the layout lane, so a template that names no concrete family anywhere rendered entirely in the fallback face. The theme now travels on `StyleCascadeTable` — document-level style material with the same lifetime, already threaded to every site that resolves run properties — and folds into its cache token. Per §17.3.2.26 a theme attribute supersedes the explicit name beside it, falling back to that name when the slot is absent or names a non-Latin face. The binding lane's `familyFromRFonts` had the opposite precedence and is aligned here, so the toolbar font box cannot name a face the document is not painted in.

Verified on the sample document: every run now resolves through the theme, and caret-to-glyph agreement holds across 1372 offsets (worst 1.44px, a pre-existing kerning artifact from measuring a prefix in isolation).

`bun test packages/core`: 4753 pass / 86 fail against a base of 4743 / 86 — same failures, ten new tests.

Known gaps left alone: list markers inherit `w:caps` and are still measured from the source text, so a caps heading style with roman markers sizes its marker box wrong; and the header/footer and note lanes do not fold the cascade token into their producers, which is safe only because a retheme cannot happen without rebuilding the surface. Both are noted in comments.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788528646&installation_model_id=422592&pr_number=145&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F145&signature=4a830ea06dd31758e073ee3aa1055912a62286712cbaf23722843a5b8fa62955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->