### PR TITLE
fix(core): stop table cells wrapping around a float they sit below

### DIFF
--- a/.changeset/tidy-hounds-repeat.md
+++ b/.changeset/tidy-hounds-repeat.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Stop table cells wrapping around a floating image they sit far below. Text in the affected cells broke into fragments that jumped to the picture's edge and ran past the cell border.

--- a/packages/core/src/layout/__tests__/drawing-exclusion-layout.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-exclusion-layout.test.ts
@@ -21,7 +21,14 @@ import { createLayoutSession } from '../layout-session.ts';
 import { breakParagraph } from '../paragraph-flow.ts';
 import type { PendingLine } from '../paragraph-flow.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
-import { linesOf, paragraphFragmentsOf, type PageGeometry } from '../semantic-records.ts';
+import {
+  linesOf,
+  paragraphFragmentsOf,
+  paragraphFragmentsOfBlocks,
+  type LayoutBox,
+  type LineRecord,
+  type PageGeometry,
+} from '../semantic-records.ts';
 
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
@@ -394,5 +401,114 @@ describe('paint order on page record (OpenSpec 4.5)', () => {
     expect(anchors).toHaveLength(2);
     expect(anchors[0]!.behindDocument).toBe(true);
     expect(anchors[1]!.behindDocument).toBe(false);
+  });
+});
+
+describe('a table clear of a float does not inherit its wrap band', () => {
+  const CELL_TEXT = 'alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima';
+  /** Column-relative left edge of the square anchor these fixtures place. */
+  const FLOAT_LEFT = emuToPoints(3000000);
+  const FLOAT_RIGHT = FLOAT_LEFT + emuToPoints(1828800);
+
+  /**
+   * A square-wrapped picture at the top of the page and a table pushed well past its band.
+   * `withFloat: false` keeps the same paragraph and only drops the drawing, so the table
+   * lands in the same flow with nothing to wrap around.
+   */
+  function floatAboveTable(withFloat: boolean): string {
+    const anchor =
+      '<w:r><w:drawing>' +
+      '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" allowOverlap="1" layoutInCell="1" relativeHeight="1">' +
+      '<wp:simplePos x="0" y="0"/>' +
+      '<wp:positionH relativeFrom="column"><wp:posOffset>3000000</wp:posOffset></wp:positionH>' +
+      '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+      '<wp:extent cx="1828800" cy="914400"/>' +
+      '<wp:wrapSquare wrapText="bothSides" distT="0" distB="0" distL="0" distR="0"/>' +
+      '<wp:docPr id="1" name="pic"/>' +
+      `<a:graphic><a:graphicData uri="${PIC_URI}"><pic:pic><pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr><pic:blipFill><a:blip r:embed="rId1"/><a:srcRect/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>` +
+      '<pic:spPr><a:xfrm><a:ext cx="1828800" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr></pic:pic></a:graphicData></a:graphic>' +
+      '</wp:anchor></w:drawing></w:r>';
+    const cell = (width: string, text: string): string =>
+      `<w:tc><w:tcPr><w:tcW w:w="${width}" w:type="dxa"/></w:tcPr>` +
+      '<w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>' +
+      `<w:r><w:t>${text}</w:t></w:r></w:p></w:tc>`;
+    return (
+      `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}">` +
+      '<w:body>' +
+      `<w:p>${withFloat ? anchor : ''}<w:r><w:t>lead</w:t></w:r></w:p>` +
+      fillerParagraphs(6) +
+      '<w:tbl>' +
+      '<w:tblPr><w:tblW w:w="9000" w:type="dxa"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="7000"/></w:tblGrid>' +
+      `<w:tr>${cell('2000', 'label')}${cell('7000', CELL_TEXT)}</w:tr>` +
+      '</w:tbl>' +
+      '</w:body></w:document>'
+    );
+  }
+
+  interface WideCell {
+    readonly lines: readonly LineRecord[];
+    readonly box: LayoutBox;
+    readonly tableTop: number;
+    readonly bandBottom: number;
+  }
+
+  /**
+   * A paragraph cache is what makes this observable: the row is laid out twice, once by the
+   * natural-height probe and once where it lands, and the cache is what carries a break
+   * between them.
+   */
+  function wideCell(withFloat: boolean): WideCell {
+    const part = load(floatAboveTable(withFloat));
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      cache: createParagraphLayoutCache(),
+      inlineDrawingLayout: layoutContext(part),
+    });
+    const page = layout.pages[0]!;
+    const anchor = (page.anchoredDrawings ?? [])[0];
+    const table = page.fragments.find((fragment) => fragment.kind === 'table');
+    if (table?.kind !== 'table') throw new Error('missing table fragment');
+    const cell = table.rows[0]!.cells[1]!;
+    return {
+      lines: paragraphFragmentsOfBlocks(cell.blocks).flatMap((paragraph) => paragraph.lines),
+      box: cell.box,
+      tableTop: table.box.y,
+      bandBottom: anchor ? anchor.y + anchor.height : 0,
+    };
+  }
+
+  test('no cell line steps over the float to resume at its far edge', () => {
+    const floated = wideCell(true);
+    // The premise: the table sits entirely below the picture, so nothing in it may wrap.
+    expect(floated.tableTop).toBeGreaterThan(floated.bandBottom);
+    expect(floated.lines.length).toBeGreaterThan(1);
+
+    for (const line of floated.lines) {
+      for (const span of line.spans) {
+        // Resuming exactly at the picture's right edge is the signature of a line that
+        // thought it had to step over it.
+        expect(Math.abs(span.box.x - FLOAT_RIGHT)).toBeGreaterThan(0.5);
+      }
+      const last = line.spans[line.spans.length - 1]!;
+      expect(last.box.x + last.box.width).toBeLessThanOrEqual(
+        floated.box.x + floated.box.width + 1
+      );
+    }
+  });
+
+  test('the cell breaks exactly as it does with no float in the document at all', () => {
+    const floated = wideCell(true);
+    const plain = wideCell(false);
+    const shape = (cell: WideCell): readonly string[][] =>
+      cell.lines.map((line) =>
+        line.spans.map((span) => `${span.text}@${(span.box.x - cell.box.x).toFixed(2)}`)
+      );
+    // The natural-height probe places the row at y=0 to keep its height free of any page
+    // position. Wrap zones ARE page positions, so consulting them there breaks the cell
+    // around a picture hundreds of points above it, and the placed row used to inherit that
+    // break through a cache keyed on zone geometry alone.
+    expect(shape(floated)).toEqual(shape(plain));
+    expect(floated.box.height).toBeCloseTo(plain.box.height, 3);
   });
 });

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1290,7 +1290,13 @@ function layoutBlocksPass(
               width: available,
               producer,
               ...(drawingKeyed ? { drawingToken: drawingKeyed } : {}),
-              ...(exclusionToken ? { exclusionToken: `${flowColumnIndex}|${exclusionToken}` } : {}),
+              // `cursorY` belongs in the key: the zones are page-content bands, so the same
+              // text at the same width breaks differently depending on where down the page
+              // it starts. Keying on zone geometry alone lets a paragraph clear of the float
+              // reuse the wrapped break of an identical one that crosses it.
+              ...(exclusionToken
+                ? { exclusionToken: `${flowColumnIndex}|${cursorY.toFixed(3)}|${exclusionToken}` }
+                : {}),
               ...(startOffset > 0 ? { startOffset } : {}),
             })
           : startOffset === 0

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -148,7 +148,9 @@ export const MAX_TABLE_ROW_FRAGMENTS = 4096;
 const MIN_CELL_BOX_PT = 1;
 
 export type TablePaginationErrorCode =
-  'table-row-overheight' | 'table-row-split-unsupported' | 'table-row-fragment-limit';
+  | 'table-row-overheight'
+  | 'table-row-split-unsupported'
+  | 'table-row-fragment-limit';
 
 /**
  * Bounded table pagination failure. Prefer this over emitting a fragment that overflows
@@ -568,7 +570,13 @@ function placeCellParagraph(
     left: 0,
     right: indent.left + available + indent.right,
   });
+  // Zone geometry alone does NOT identify the break: these zones stay in page-content Y
+  // (only x is localized to the cell), so which band a line crosses depends on where the
+  // paragraph starts. Two cells of the same text and width under the same float would
+  // otherwise share a cache entry and the one that sits clear of the picture would inherit
+  // the wrapped break of the one that does not.
   const exclusionToken = exclusionLayoutToken(pageZones);
+  const positionedExclusionToken = exclusionToken ? `${top.toFixed(3)}|${exclusionToken}` : '';
   const key = paragraphLayoutKey({
     paragraph,
     properties: [
@@ -584,7 +592,7 @@ function placeCellParagraph(
       : deps.drawingLayoutToken
         ? { drawingToken: deps.drawingLayoutToken }
         : {}),
-    ...(exclusionToken ? { exclusionToken } : {}),
+    ...(positionedExclusionToken ? { exclusionToken: positionedExclusionToken } : {}),
   });
   const lines = breakParagraph(
     paragraph,
@@ -1442,6 +1450,17 @@ function stripAnchorSinksForProbe(deps: TableFlowDeps): TableFlowDeps {
   };
 }
 
+/**
+ * The row's height on its own, with no page position — what the caller compares against a
+ * fresh content box to decide whether the row fits where it stands or has to move.
+ *
+ * The probe places the row at y=0 because that height must not depend on where the row
+ * currently sits. Wrap exclusions are the opposite: they are page-content bands, so at y=0
+ * a float near the top of the page covers a row that really sits far below it, and every
+ * cell paragraph breaks around a picture it never touches. The probe therefore measures
+ * free of them — the placing pass runs at the row's true top and applies whichever bands
+ * actually cross it.
+ */
 export function measureRowHeight(
   row: SemanticTableRow,
   cols: readonly number[],
@@ -1453,6 +1472,7 @@ export function measureRowHeight(
   let lineCounter = 0;
   const probeDeps: TableFlowDeps = {
     ...stripAnchorSinksForProbe(deps),
+    pageExclusionZones: undefined,
     nextLineId: () => `probe-${lineCounter++}`,
   };
   const placed = layoutRowFragment(row, cols, left, 0, false, depth, probeDeps, cellSpacingPt);


### PR DESCRIPTION
Cells in a table hundreds of points below a square-wrapped picture broke around it: text jumped to the picture's right edge mid-line and ran past the cell border. Reproduced on `e2e/fixtures/stacked-floats-with-floating-table.docx`.

`measureRowHeight` places a row at `y = 0` so its natural height carries no page position, but wrap exclusions are page-content bands — at `y = 0` a float near the top of the page covers a row that sits far below it. That break then reached the placed row, because the paragraph cache key encodes zone geometry but not the paragraph's Y, so the probe pass and the real pass collided. The body flow had the same hole between two identical paragraphs at different heights.

The probe now measures free of wrap zones, and both cache keys carry the paragraph's start Y.

Regression tests need a paragraph cache to reproduce — that is the mechanism that carries the bad break between the two passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788529239&installation_model_id=422592&pr_number=146&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F146&signature=4d15bfb20b160b3e0a191cc2345132625c08d6bf30faee84c045be107b851036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->