### PR TITLE
fix(core): emit a change when a comment or reply is written

### DIFF
--- a/.changeset/comment-writes-emit-change.md
+++ b/.changeset/comment-writes-emit-change.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Emit a change event when a comment or reply is written, so a review rail refreshes on its own. Replies previously stayed invisible until an unrelated click moved the caret.

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -1082,6 +1082,8 @@ export function openTreeSession(
         // reply. `graftPackage` is the narrow lane for exactly this — a package write that is
         // not a user intent and publishes no revision.
         store.graftPackage(() => packageStore.currentPackage());
+        // The comment ITSELF is a user intent and does publish one — see the
+        // `publishStoryWrite` below.
         const result = addComment(store, {
           anchor: {
             paragraphId: anchor.paragraphId,
@@ -1106,6 +1108,10 @@ export function openTreeSession(
         // `currentPackage()` keeps answering with a package that has no comment part and the
         // reply reads back as never written.
         packageStore.replacePackageShell(store.package);
+        // Published LAST, so a subscriber that re-derives on the notification already sees the
+        // shell installed above. Publishing first handed the change to a rail whose next
+        // `reviewItems()` still read a package with no comment part in it.
+        packageStore.publishStoryWrite(result.change);
         return result.commentId;
       },
 
@@ -1118,6 +1124,8 @@ export function openTreeSession(
         const result = setCommentResolved(store, commentId, resolved);
         if (!result.ok) return false;
         packageStore.replacePackageShell(store.package);
+        // Resolving is a document change like any other — see `replyToComment`.
+        packageStore.publishStoryWrite(result.change);
         return true;
       },
 

--- a/packages/core/src/store/store/comment-writes.ts
+++ b/packages/core/src/store/store/comment-writes.ts
@@ -28,7 +28,7 @@ import {
 } from '../package/ooxml-tree.ts';
 import { W14_NAMESPACE_URI, XML_NAMESPACE_URI } from '../package/ooxml-shared.ts';
 import { isValidParaId, mintParaId, usedParaIds, w14RootPrefix } from '../package/para-id.ts';
-import type { TreeDocumentStore } from './tree-store.ts';
+import type { TreeDocumentStore, TreeModelChange } from './tree-store.ts';
 import type { TreeOpRejection } from './tree-op-validate.ts';
 
 const COMMENTS_PART = '/word/comments.xml';
@@ -63,7 +63,19 @@ export interface AddCommentRequest {
 }
 
 export type AddCommentResult =
-  | { readonly ok: true; readonly commentId: string }
+  | {
+      readonly ok: true;
+      readonly commentId: string;
+      /**
+       * The story transaction's own change, so the coordinator can publish it.
+       *
+       * A comment write commits straight on the story store rather than through
+       * `applyTreeOps`, and the change is what carries the dirty anchor paragraphs and the
+       * `text-local` impact. Dropping it here left the caller with nothing precise to
+       * publish and no way to tell a committed write from an identity no-op.
+       */
+      readonly change: TreeModelChange | null;
+    }
   | { readonly ok: false; readonly reason: TreeOpRejection | 'invalid-author' };
 
 function attribute(
@@ -582,11 +594,16 @@ export function addComment(store: TreeDocumentStore, request: AddCommentRequest)
   });
 
   if (!result.ok) return { ok: false, reason: result.reason };
-  return { ok: true, commentId };
+  return { ok: true, commentId, change: result.change };
 }
 
 export type SetCommentResolvedResult =
-  | { readonly ok: true; readonly changed: boolean }
+  | {
+      readonly ok: true;
+      readonly changed: boolean;
+      /** The story transaction's change, for the coordinator to publish — see {@link AddCommentResult}. */
+      readonly change: TreeModelChange | null;
+    }
   | { readonly ok: false; readonly reason: TreeOpRejection | 'unknown-comment' };
 
 /** Every `w15:commentEx` in the part, by the `w15:paraId` it records state for. */
@@ -730,7 +747,7 @@ export function setCommentResolved(
   });
 
   if (!result.ok) return { ok: false, reason: result.reason };
-  return { ok: true, changed: true };
+  return { ok: true, changed: true, change: result.change };
 }
 
 /** A comment part exists and declares the comment content type. */

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -736,6 +736,31 @@ export class TreePackageStore {
     );
   }
 
+  /**
+   * Publish a story transaction the coordinator did not run.
+   *
+   * Comment writes commit straight on the story store and hand the new shell back through
+   * {@link replacePackageShell}, so they never pass through `applyTreeOps` — the one place
+   * every other edit bumps the revision and publishes. The subscriber channel therefore
+   * stayed silent for a comment: `Editor.on('change')` never fired, and a review rail keyed
+   * on it only caught up on the next unrelated caret move, so a reply someone had just
+   * written was invisible until they clicked elsewhere.
+   *
+   * The STORY's own change is published rather than a synthetic one, because it carries the
+   * dirty anchor paragraphs and the `text-local` impact the marker ops computed; a synthetic
+   * `global` would make every comment cost a full relayout. History is deliberately
+   * untouched — the story transaction already recorded its undo entry, exactly as
+   * `applyTreeOps` leaves a non-cascading story edit.
+   *
+   * A `null` change is an identity no-op (nothing was written), and publishes nothing.
+   */
+  publishStoryWrite(change: TreeModelChange | null): TreeModelChange | null {
+    if (!change) return null;
+    this.packageRev += 1;
+    this.publish(change);
+    return change;
+  }
+
   /** Install a full package snapshot (public seam for post-fetch cleanup). */
   installPackageSnapshot(snapshot: OoxmlPackage): void {
     this.installPackageSnapshotInternal(snapshot);

--- a/packages/pro/src/__tests__/review-facade.test.ts
+++ b/packages/pro/src/__tests__/review-facade.test.ts
@@ -354,6 +354,41 @@ describe('comments in the queue', () => {
     if (!result.ok) expect(result.code).toBe('invalidArgs');
   });
 
+  // PUSH, not pull. `getReviewRevision()` moving proves only that a re-derivation WOULD see
+  // the reply; it cannot see that nobody was told to re-derive. A rail subscribes through
+  // `useSyncExternalStore` on this event, so with no emit the reply stayed invisible until an
+  // unrelated click moved the caret and fired `selectionChange` by accident.
+  test('replying emits a change, so a subscribed rail re-derives without another gesture', () => {
+    const editor = mount({ body: COMMENTED_BODY, comments: COMMENTS });
+    const [card] = editor.getReviewItems();
+    const seen: number[] = [];
+    editor.on('change', () => seen.push(editor.getReviewItems().length));
+
+    expect(editor.replyToReviewItem(card!.key, 'Yes, checked.').ok).toBe(true);
+
+    expect(seen).toHaveLength(1);
+    // The handler must already see the reply: an emit that fires before the write lands is
+    // the same freeze one notification later.
+    expect(seen[0]).toBe(2);
+  });
+
+  test('a refused reply emits nothing — there is no change to report', () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      document: docx({ body: COMMENTED_BODY, comments: COMMENTS }),
+      modules: [testReviewModule()],
+    });
+    const [card] = editor.getReviewItems();
+    let emits = 0;
+    editor.on('change', () => {
+      emits += 1;
+    });
+    // No author anywhere, so `CT_Comment` cannot be satisfied and nothing is written.
+    expect(editor.replyToReviewItem(card!.key, 'anonymous').ok).toBe(false);
+    expect(emits).toBe(0);
+  });
+
   test('replying to a REVISION comments on its range — `w:ins` has no thread of its own', () => {
     const editor = mount({ body: INSERTION });
     const [card] = editor.getReviewItems();
@@ -398,6 +433,20 @@ describe('commenting on a selection', () => {
     const range = (card!.item as { range: { start: { offset: number }; end: { offset: number } } })
       .range;
     expect([range.start.offset, range.end.offset]).toEqual([6, 10]);
+  });
+
+  // The same emit `replyToReviewItem` owes, on the same lane. It only LOOKED right in the
+  // packaged compose box, which returns focus to the document afterwards and so moved the
+  // caret — a host that composes its own box got nothing.
+  test('adding a comment emits a change', () => {
+    const editor = mount({ body: PARAGRAPH });
+    select(editor, 6, 10);
+    let emits = 0;
+    editor.on('change', () => {
+      emits += 1;
+    });
+    expect(editor.addComment('why this word?').ok).toBe(true);
+    expect(emits).toBe(1);
   });
 
   test('a backwards drag anchors the same range as a forwards one', () => {


### PR DESCRIPTION
Replying to a comment wrote the reply but showed nothing until you clicked elsewhere.

Comment writes commit on the story store and hand the coordinator a new package shell, so they never pass through `applyTreeOps` — the one place an edit bumps the revision and publishes. Nothing reached the subscriber channel, so a rail subscribed to `Editor.on('change')` never re-derived; the next unrelated caret move fired `selectionChange` and the reply appeared. `addComment` and `setCommentResolved` share the lane — the compose box only looked right because it returns focus to the document afterwards.

The fix publishes the story transaction's own change, which carries the dirty anchor paragraphs and the `text-local` impact the marker ops computed, rather than a synthetic `global` that would cost a full relayout per comment. History is untouched: the story transaction already recorded its undo entry.

The existing test asserted `getReviewRevision()` moved — a pull, which cannot see that nobody was told to re-derive. The new tests assert on the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788531301&installation_model_id=422592&pr_number=148&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F148&signature=2818c72c2dd295251c7b5b78fc788dc3192ee1a3d6c5259bfdd205f19adce679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->