### PR TITLE
fix(core): stop a section break mark from making a blank page

### DIFF
--- a/.changeset/section-break-mark-blank-page.md
+++ b/.changeset/section-break-mark-blank-page.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Stop an empty paragraph that carries a section break from producing a blank page. The paragraph mark holding a `w:sectPr` is the section break itself, so when it paints nothing it now stays on the page its section ended on instead of opening a sheet the following next-page section then leaves empty.

--- a/packages/core/src/layout/__tests__/semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-layout.test.ts
@@ -567,4 +567,58 @@ describe('per-section pagination (the per-section lane)', () => {
     expect(layout.pages).toHaveLength(1);
     expect([layout.pages[0]!.box.width, layout.pages[0]!.box.height]).toEqual([200, 300]);
   });
+
+  describe('a section break mark never manufactures a page', () => {
+    // 200x100pt sheets with 10pt margins: six lines fill the 80pt column exactly, so the
+    // seventh has nothing left. That seventh line is what a section boundary lands on in a
+    // real document, and whether it fits is a matter of a point or two.
+    const SHORT = sect(4000, 2000);
+    /** A paragraph that is nothing but the section break it carries. */
+    const breakMark = (pPr: string) => `<w:p><w:pPr>${pPr}</w:pPr></w:p>`;
+    const FILL = ['a', 'b', 'c', 'd', 'e', 'f'].map((text) => paragraph(text)).join('');
+    const pageTexts = (layout: ReturnType<typeof lay>) =>
+      layout.pages.map((page) =>
+        page.fragments
+          .flatMap((fragment) =>
+            fragment.kind === 'paragraph'
+              ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+              : []
+          )
+          .join('')
+      );
+
+    test('an unfittable break mark rides the page its section ended on', () => {
+      const part = load(FILL + breakMark(SHORT) + paragraph('two') + SHORT);
+      const layout = lay(part);
+      // Two sheets, not three: the mark paints nothing, so a sheet holding only the mark
+      // would be a blank page between two sections Word sets adjacent.
+      expect(layout.pages).toHaveLength(2);
+      expect(pageTexts(layout)).toEqual(['abcdef', 'two']);
+      // The mark is still laid out — it is the section's last paragraph and the caret has to
+      // reach it — and it is laid out on the page the section already filled.
+      expect(layout.pages[0]!.fragments).toHaveLength(7);
+      expect(layout.pages[1]!.fragments).toHaveLength(1);
+    });
+
+    test('a break mark WITH text is content, and moves to its own page when it must', () => {
+      const part = load(
+        FILL +
+          `<w:p><w:pPr>${SHORT}</w:pPr><w:r><w:t>tail</w:t></w:r></w:p>` +
+          paragraph('two') +
+          SHORT
+      );
+      const layout = lay(part);
+      expect(layout.pages).toHaveLength(3);
+      expect(pageTexts(layout)).toEqual(['abcdef', 'tail', 'two']);
+    });
+
+    test('an ordinary empty paragraph still paginates', () => {
+      // The exemption belongs to the break, not to emptiness: a plain empty paragraph is a
+      // line of the document and takes the next page when the column is full.
+      const part = load(FILL + '<w:p/>' + SHORT);
+      const layout = lay(part);
+      expect(layout.pages).toHaveLength(2);
+      expect(pageTexts(layout)).toEqual(['abcdef', '']);
+    });
+  });
 });

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -131,6 +131,7 @@ import {
   DEFAULT_SECTION_PROPERTIES,
   enumerateDocumentSections,
   geometryOfSection,
+  paragraphSectionNode,
   type SectionColumns,
 } from './section-properties.ts';
 import { resolveSectionColumns, type ResolvedSectionColumns } from './section-columns.ts';
@@ -1177,6 +1178,34 @@ function layoutBlocksPass(
     regionFragmentStart = 0;
   };
 
+  /**
+   * Whether a laid-out paragraph would put nothing on the sheet.
+   *
+   * Asked of a section break mark before letting it skip pagination, so the exemption covers
+   * only a mark with nothing to show: any glyph, marker, drawing, rule or shading makes the
+   * paragraph content, and content paginates.
+   */
+  const paintsNothing = (entry: PreparedBlock, lines: readonly PendingLine[]): boolean => {
+    if (entry.kind !== 'paragraph') return false;
+    if (entry.listItem !== undefined || entry.shading !== undefined) return false;
+    const { top, bottom, left, right, between } = entry.borders;
+    if (top ?? bottom ?? left ?? right ?? between) return false;
+    const drawingContext = options.inlineDrawingLayout;
+    if (
+      drawingContext &&
+      anchoredDrawingAtomsInParagraph(entry.paragraph, drawingContext).length > 0
+    ) {
+      return false;
+    }
+    return lines.every(
+      (line) =>
+        line.drawings.length === 0 &&
+        !line.pageBreakAfter &&
+        !line.columnBreakAfter &&
+        line.spans.every((span) => span.text.length === 0)
+    );
+  };
+
   const advanceColumn = (): void => {
     if (columnIndex + 1 < columns.count) {
       columnIndex += 1;
@@ -1864,6 +1893,22 @@ function layoutBlocksPass(
       // Cross-paragraph TOC field chrome: tree preserved, no painted row or flow height.
       continue;
     }
+    // A SECTION BREAK IS NOT CONTENT. The paragraph mark that carries a paragraph-level
+    // `w:sectPr` (ECMA-376 §17.6.18) IS the section break; `w:type` (§17.6.22) says where the
+    // NEXT section starts, never that the mark itself claims a sheet. So a mark that paints
+    // nothing may not OPEN A SHEET: it rides out the bottom of the page its section already
+    // ended on. Without this a mark missing the bottom margin by a point flushed a sheet, the
+    // following `nextPage` section started after it, and the document rendered a wholly blank
+    // page between two sections Word sets adjacent.
+    //
+    // Only the sheet. Moving into the next COLUMN of the same sheet manufactures nothing, and
+    // the mark is part of what a balanced multi-column section distributes (§17.6.4) — so a
+    // balance trial, which asks how short the region can be while still holding one sheet,
+    // has to see the mark's own demand for room or it converges on a band too tight for it.
+    const marksSectionBreak =
+      paragraphSectionNode(paragraph) !== undefined && paintsNothing(entry, lines);
+    const holdsSheet = (): boolean =>
+      marksSectionBreak && columnRegionBottom === undefined && columnIndex + 1 >= columns.count;
     const rebreakInCurrentColumn = (startOffset: number): void => {
       const next = prepareBlock(paragraph, columnWidth());
       if (next.kind !== 'paragraph') return;
@@ -1909,7 +1954,7 @@ function layoutBlocksPass(
           needed = Math.max(needed, group + topExtent);
         }
       }
-      if (cursorY + needed > contentHeight() && cursorY > 0) {
+      if (cursorY + needed > contentHeight() && cursorY > 0 && !holdsSheet()) {
         advanceColumn();
         previousSpaceAfter = 0;
         rebreakInCurrentColumn(0);
@@ -2259,6 +2304,7 @@ function layoutBlocksPass(
       const lineExtent = skipBefore + pendingLine.height + tail;
       const overflowsPage =
         cursorY + lineExtent > contentHeight() &&
+        !holdsSheet() &&
         (pending.length > 0 || pageFragments.length > 0 || pages.length > 0);
       if (overflowsPage) {
         // `w:widowControl` (§17.3.1.44) / `w:keepLines` (§17.3.1.16) change where a paragraph


### PR DESCRIPTION
The paragraph mark that carries a paragraph-level `w:sectPr` is the section break (ECMA-376 §17.6.18); `w:type` (§17.6.22) says where the next section starts, not that the mark claims a sheet of its own. We laid it out as ordinary flow content, so a mark that missed the bottom margin by a point or two flushed a page, the following `nextPage` section then started after it, and a wholly blank page appeared between two sections Word sets adjacent.

A mark that paints nothing no longer opens a sheet. It still opens a column, and it still demands room inside a `columnRegionBottom` balance trial, so balanced multi-column sections are unchanged.

Reported against `shapes-and-page-breaks.docx`, which rendered six such blank pages; this removes all six and shifts nothing else on the page. The bug predates and survives #141 — that change only moved which page index the first blank one landed on.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788532892&installation_model_id=422592&pr_number=150&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F150&signature=3ae77515c58affc74dcd552184bd995d50bc32e17fa0fb40508780905e2efc20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->