### PR TITLE
fix(core): align the caret on an empty paragraph

### DIFF
--- a/.changeset/empty-line-alignment-caret.md
+++ b/.changeset/empty-line-alignment-caret.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Put the caret in the right place on an empty centred or right-aligned paragraph. It sat at the left margin and only jumped to the correct position once a character was typed.

--- a/.changeset/empty-line-alignment-caret.md
+++ b/.changeset/empty-line-alignment-caret.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
-Put the caret in the right place on an empty centred or right-aligned paragraph. It sat at the left margin and only jumped to the correct position once a character was typed.
+Put the caret in the right place on an empty paragraph. A centred or right-aligned one drew it at the left margin, and one with a first-line indent ignored the indent; in both cases it only jumped to the correct position once a character was typed. Lines now publish their aligned content origin as `LineRecord.contentX`.

--- a/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
@@ -88,6 +88,35 @@ describe('a click beside a line', () => {
     const layout = lay('<w:p/>');
     expect(hit(layout, 300, 5)!.position).toEqual({ paragraphId: P0, offset: 0 });
   });
+
+  test('an EMPTY centred paragraph puts its caret in the middle, not at the margin', () => {
+    // The line has no spans to carry the alignment offset, so the caret used to be drawn at
+    // the left edge of the column and only jumped to the centre once a character was typed.
+    const empty = lay('<w:p><w:pPr><w:jc w:val="center"/></w:pPr></w:p>');
+    const emptyLine = paragraphFragmentsOf(empty.pages[0]!)[0]!.lines[0]!;
+    const middle = emptyLine.box.x + emptyLine.box.width / 2;
+    expect(emptyLine.spans).toHaveLength(0);
+    expect(caretBoxOnLine(emptyLine, 0, measurer).x).toBeCloseTo(middle, 5);
+
+    // ...and the first keystroke barely moves it — half a glyph, not half a page.
+    const typed = lay(`<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>a</w:t></w:r></w:p>`);
+    const typedLine = paragraphFragmentsOf(typed.pages[0]!)[0]!.lines[0]!;
+    expect(Math.abs(caretBoxOnLine(typedLine, 0, measurer).x - middle)).toBeLessThan(6);
+  });
+
+  test('an EMPTY right-aligned paragraph puts its caret at the right edge', () => {
+    const layout = lay('<w:p><w:pPr><w:jc w:val="right"/></w:pPr></w:p>');
+    const line = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!;
+    expect(caretBoxOnLine(line, 0, measurer).x).toBeCloseTo(line.box.x + line.box.width, 5);
+  });
+
+  test('a click anywhere on an empty centred line lands on the aligned caret x', () => {
+    const layout = lay('<w:p><w:pPr><w:jc w:val="center"/></w:pPr></w:p>');
+    const line = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!;
+    const found = hit(layout, 20, 5)!;
+    expect(found.position).toEqual({ paragraphId: P0, offset: 0 });
+    expect(caretAt(layout, found.position, { measurer })!.x).toBeCloseTo(line.contentX, 5);
+  });
 });
 
 describe('a click above or below the lines', () => {

--- a/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
@@ -111,11 +111,48 @@ describe('a click beside a line', () => {
   });
 
   test('a click anywhere on an empty centred line lands on the aligned caret x', () => {
+    // The band still spans the whole column — a click in the left margin belongs to this
+    // paragraph — but the position it resolves to is the centred one.
     const layout = lay('<w:p><w:pPr><w:jc w:val="center"/></w:pPr></w:p>');
     const line = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!;
     const found = hit(layout, 20, 5)!;
     expect(found.position).toEqual({ paragraphId: P0, offset: 0 });
-    expect(caretAt(layout, found.position, { measurer })!.x).toBeCloseTo(line.contentX, 5);
+    expect(caretAt(layout, found.position, { measurer })!.x).toBeCloseTo(
+      line.box.x + line.box.width / 2,
+      5
+    );
+  });
+
+  test('an empty JUSTIFIED paragraph stays flush left', () => {
+    // `w:jc both` sets its last line flush left, and an empty paragraph is all last line.
+    const layout = lay('<w:p><w:pPr><w:jc w:val="both"/></w:pPr></w:p>');
+    const line = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!;
+    expect(caretBoxOnLine(line, 0, measurer).x).toBeCloseTo(line.box.x, 5);
+  });
+
+  test('an empty paragraph takes its FIRST-LINE indent, the way a filled one does', () => {
+    // `box.x` is the column edge and does not carry `w:firstLine`, so reading it put the
+    // caret a whole indent left of where the first character would land.
+    const ind = (attr: string) =>
+      paragraphFragmentsOf(lay(`<w:p><w:pPr><w:ind ${attr}/></w:pPr></w:p>`).pages[0]!)[0]!
+        .lines[0]!;
+    const withText = paragraphFragmentsOf(
+      lay(`<w:p><w:pPr><w:ind w:firstLine="720"/></w:pPr><w:r><w:t>a</w:t></w:r></w:p>`).pages[0]!
+    )[0]!.lines[0]!;
+    expect(caretBoxOnLine(ind('w:firstLine="720"'), 0, measurer).x).toBeCloseTo(36, 5);
+    expect(caretBoxOnLine(withText, 0, measurer).x).toBeCloseTo(36, 5);
+    // A hanging indent is the same rule with the opposite sign: the first line pulls back.
+    expect(caretBoxOnLine(ind('w:left="720" w:hanging="720"'), 0, measurer).x).toBeCloseTo(0, 5);
+  });
+
+  test('an empty centred paragraph in a TABLE CELL centres in the cell', () => {
+    // Table layout carries its own copy of the alignment maths; it drifts silently otherwise.
+    const layout = lay(
+      `<w:tbl>${tr(tc('<w:p><w:pPr><w:jc w:val="center"/></w:pPr></w:p>'))}</w:tbl>`
+    );
+    const line = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!;
+    expect(line.spans).toHaveLength(0);
+    expect(caretBoxOnLine(line, 0, measurer).x).toBeCloseTo(line.box.x + line.box.width / 2, 5);
   });
 });
 

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -500,9 +500,12 @@ function withCaretEdges(
  * Shift a line's spans to satisfy the paragraph alignment.
  *
  * Layout is the only geometry authority: hit testing and the caret read published span boxes
- * (and {@link StyleSpanRecord.caretEdges}). Paint starts the line at the first span's x and
- * flows inline — justification slack must therefore land on the same inter-word spaces
- * `word-spacing` expands, not on every style-span boundary.
+ * (and {@link StyleSpanRecord.caretEdges}). Paint starts the line at `LineRecord.contentX` —
+ * the first span's x whenever there is one — and flows inline, so justification slack must
+ * land on the same inter-word spaces `word-spacing` expands, not on every style-span boundary.
+ *
+ * A line with NO spans returns unchanged; its alignment is published as `contentX` by the
+ * callers, which is the only place an empty paragraph's caret x can come from.
  */
 export function alignSpans(
   spans: readonly StyleSpanRecord[],

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -49,7 +49,16 @@ export function fragmentSignature(fragment: BlockFragmentRecord): string {
           fragment.shading,
           fragment.shadingBox,
           fragment.marker,
-          fragment.lines.map((line) => [line.id, line.box, line.baseline, line.spans]),
+          // `contentX` as well as `box`: on a span-less line the alignment lives ONLY there,
+          // so an empty paragraph re-aligned from left to centre changes no other hashed
+          // field and would converge against the stale fragment.
+          fragment.lines.map((line) => [
+            line.id,
+            line.box,
+            line.contentX,
+            line.baseline,
+            line.spans,
+          ]),
         ]);
   signatures.set(fragment, signature);
   return signature;

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -49,9 +49,9 @@ export function fragmentSignature(fragment: BlockFragmentRecord): string {
           fragment.shading,
           fragment.shadingBox,
           fragment.marker,
-          // `contentX` as well as `box`: on a span-less line the alignment lives ONLY there,
-          // so an empty paragraph re-aligned from left to centre changes no other hashed
-          // field and would converge against the stale fragment.
+          // `contentX` as well as `box`, because it is published geometry and everything
+          // published participates. It is the ONLY field carrying alignment on a span-less
+          // line, and nothing here guarantees a mover of it also moves `box` or `spans`.
           fragment.lines.map((line) => [
             line.id,
             line.box,

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -660,7 +660,8 @@ function hitBoundsContainDrawing(
  *
  * SPAN boxes are the authority, never `line.box.x`: alignment is baked into the span boxes, so
  * a centred or right-aligned line starts well right of its line box and using the line box
- * would report every such click as "left of the line".
+ * would report every such click as "left of the line". With no spans to read, the aligned
+ * origin comes from {@link LineRecord.contentX}, which obeys the same rule.
  */
 function offsetOnLine(line: LineRecord, x: number, y: number, context: HitContext): LineOffset {
   const spans = line.spans;
@@ -694,8 +695,9 @@ function offsetOnLine(line: LineRecord, x: number, y: number, context: HitContex
     }
   }
   if (spans.length === 0) {
-    // An empty paragraph still has a position to click into.
-    return { offset: line.range.start, x: line.box.x, withinSpan: false };
+    // An empty paragraph still has a position to click into, and it is the line's ALIGNED
+    // origin: clicking a centred empty paragraph must not park the caret at the left margin.
+    return { offset: line.range.start, x: line.contentX, withinSpan: false };
   }
 
   const first = spans[0]!;
@@ -743,7 +745,7 @@ function offsetOnLine(line: LineRecord, x: number, y: number, context: HitContex
           drawing,
         };
       }
-      if (x < drawing.hitBounds.x && x >= (spans[index - 1]?.box.x ?? line.box.x)) {
+      if (x < drawing.hitBounds.x && x >= (spans[index - 1]?.box.x ?? line.contentX)) {
         return { offset: drawing.start, x: drawing.hitBounds.x, withinSpan: false, drawing };
       }
     }
@@ -971,7 +973,7 @@ export function caretBoxOnLine(
     // it sits at the bottom because that is where the text will appear.
     const leading = line.leading ?? 0;
     return {
-      x: line.box.x,
+      x: line.contentX,
       y: line.box.y + leading,
       height: Math.max(0, line.box.height - leading),
     };

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -134,7 +134,7 @@ function xWithinLine(
     if (offset === drawing.start) return drawing.advanceStart;
     if (offset === drawing.start + 1) return drawing.advanceEnd;
   }
-  let x = line.box.x;
+  let x = line.contentX;
   for (const span of line.spans) {
     if (offset <= span.range.start) return span.box.x;
     if (offset >= span.range.end) {

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -2227,6 +2227,12 @@ function layoutBlocksPass(
                 width: available,
                 height: brokenLine.height,
               },
+              // Synthetic frame geometry only — these lines are never aligned, painted or
+              // caret-tested, so the content origin is just where their spans were placed.
+              contentX:
+                brokenLine.spans.length > 0
+                  ? brokenLine.spans[0]!.box.x + origin.columnX
+                  : origin.columnX + indent.left,
               baseline: brokenLine.baseline,
               leading: brokenLine.leading,
               spans: brokenLine.spans.map((span) => ({
@@ -2370,10 +2376,12 @@ function layoutBlocksPass(
         isLastLine,
         alignment === 'center' || alignment === 'right' ? pendingLine.width : undefined
       );
+      // A line with no spans still aligns: an empty centred paragraph puts its (zero width)
+      // content — and so the caret — at the middle of the measure, not at the left edge.
       const alignOffset =
         placedSpans.length > 0 && alignedSpans.length > 0
           ? alignedSpans[0]!.box.x - placedSpans[0]!.box.x
-          : pendingLine.drawings.length > 0 && alignment !== 'left' && alignment !== 'both'
+          : alignment !== 'left' && alignment !== 'both'
             ? (() => {
                 const slack = lineAvailableWidth - pendingLine.width;
                 if (slack <= 0) return 0;
@@ -2418,6 +2426,7 @@ function layoutBlocksPass(
           width: available,
           height: pendingLine.height,
         },
+        contentX: alignedSpans[0]?.box.x ?? lineIndent + alignOffset,
         baseline: pendingLine.baseline,
         leading: pendingLine.leading,
         ...(pendingLine.deletedRanges ? { deletedRanges: pendingLine.deletedRanges } : {}),

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -202,6 +202,20 @@ export interface LineRecord {
   readonly range: SourceRange;
   readonly spans: readonly StyleSpanRecord[];
   readonly box: LayoutBox;
+  /**
+   * Where the line's content actually starts, after alignment and the first-line indent.
+   *
+   * {@link box} is the content BAND the line was broken against — its `x` is the indented
+   * column edge and its `width` the available measure, neither of which moves with
+   * `w:jc`. Alignment is otherwise expressed only as x offsets on the span boxes, so a line
+   * with no spans (an empty paragraph) had no aligned origin at all: paint, hit testing and
+   * the caret each fell back to `box.x` and drew a centred empty paragraph's caret hard
+   * against the left margin, where it stayed until the first character was typed.
+   *
+   * Equal to the first span's x whenever there is one, so it is the single origin every
+   * consumer can read without a spans-or-box fallback of its own.
+   */
+  readonly contentX: number;
   /** Distance from the line box top to the text baseline. */
   readonly baseline: number;
   /**

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -681,10 +681,11 @@ function placeCellParagraph(
       isLastLine,
       alignment === 'center' || alignment === 'right' ? pendingLine.width : undefined
     );
+    // Empty lines align too — see the body-flow twin in `semantic-layout.ts`.
     const alignOffset =
       placedSpans.length > 0 && alignedSpans.length > 0
         ? alignedSpans[0]!.box.x - placedSpans[0]!.box.x
-        : pendingLine.drawings.length > 0 && alignment !== 'left' && alignment !== 'both'
+        : alignment !== 'left' && alignment !== 'both'
           ? (() => {
               const slack = lineAvailableWidth - pendingLine.width;
               if (slack <= 0) return 0;
@@ -734,6 +735,7 @@ function placeCellParagraph(
         width: available,
         height: pendingLine.height,
       },
+      contentX: alignedSpans[0]?.box.x ?? lineIndent + alignOffset,
       baseline: pendingLine.baseline,
       leading: pendingLine.leading,
       ...(pendingLine.deletedRanges ? { deletedRanges: pendingLine.deletedRanges } : {}),

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -963,10 +963,10 @@ function paintLine(
   element.dataset.paragraphId = line.range.paragraphId;
   element.style.position = 'absolute';
   element.style.top = `${line.box.y * scale}px`;
-  // Alignment is already baked into the span boxes, so the first span's x IS the line's
-  // left edge — centred and right-aligned lines start where layout put them.
-  const left = line.spans[0]?.box.x ?? line.box.x;
-  element.style.left = `${left * scale}px`;
+  // Alignment is baked into the geometry, not re-derived here: `contentX` IS the line's left
+  // edge, so centred and right-aligned lines start where layout put them — including an empty
+  // one, whose <br> caret anchor would otherwise sit at the margin.
+  element.style.left = `${line.contentX * scale}px`;
   element.style.height = `${line.box.height * scale}px`;
   // Each run keeps its OWN box, which is how a mixed-size line should highlight: an 8pt
   // run gets an 8pt band and a 36pt run a 36pt one, stepped, the way Word draws it.
@@ -1102,7 +1102,7 @@ function paintLine(
   }
 
   const lineOrigin = Object.freeze({
-    x: line.spans[0]?.box.x ?? line.box.x,
+    x: line.contentX,
     y: line.box.y,
     width: line.box.width,
     height: line.box.height,
@@ -1206,8 +1206,7 @@ function paintFragment(
     // BOTH axes. The fragment box already carries the x origin (indent, or a table cell's
     // content edge), so an absolute left here would count that origin twice.
     painted.style.top = `${(line.box.y - fragment.box.y) * scale}px`;
-    const left = line.spans[0]?.box.x ?? line.box.x;
-    painted.style.left = `${(left - fragment.box.x) * scale}px`;
+    painted.style.left = `${(line.contentX - fragment.box.x) * scale}px`;
     element.append(painted);
   }
   // Layout owns border geometry. Side rules sit OUTSIDE the text column — Word draws them

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1196,7 +1196,9 @@ function paintFragment(
       // At the end of the last line's text, which is where the mark itself sits.
       const end = last.spans[last.spans.length - 1];
       glyph.style.top = `${(last.box.y - fragment.box.y) * scale}px`;
-      glyph.style.left = `${((end ? end.box.x + end.box.width : last.box.x) - fragment.box.x) * scale}px`;
+      // No spans means an empty paragraph, whose mark sits at the ALIGNED origin — the same
+      // place the caret goes. Reading the line box drew a centred one against the margin.
+      glyph.style.left = `${((end ? end.box.x + end.box.width : last.contentX) - fragment.box.x) * scale}px`;
       element.append(glyph);
     }
   }


### PR DESCRIPTION
Alignment was expressed only as x offsets on span boxes, so a line with no spans had no aligned origin. Paint, hit testing and the caret each fell back to the line box's left edge: a centred empty paragraph drew its caret at the margin and only moved it once a character was typed. One with a first-line indent ignored the indent the same way.

Lines now publish `contentX`, the aligned content origin, and every consumer reads it instead of its own `spans[0]?.box.x ?? box.x` fallback. `box` keeps its meaning as the content band the line was broken against, so the clickable band still spans the column.

Also covers table cells (their copy of the alignment maths had no test of its own) and the tracked-change paragraph mark, which had the same fallback.

Known remaining sink of this class: `anchorCharacterXOnLine` in `drawing-layout.ts` still frames a `positionH relativeFrom="character"` anchor from the column edge on a span-less line. Its parameter is a structural type shared with pre-placement lines that have no `contentX`, so it needs its own change.

Verified: `bun test` failure sets diff-identical to base (106 pre-existing), +7 passing tests; reverting the two producer lines makes 5 of them fail. `typecheck`, `check:parity`, `i18n:validate` pass. Confirmed in the browser on the demo document.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788543709&installation_model_id=422592&pr_number=157&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F157&signature=a4ad027e2356d319ad941b9d451d4ea47d9940ab94078823c467dcc17edbb5b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->