### PR TITLE
fix: match Word font line-box metrics

### DIFF
--- a/.changeset/word-line-box-metrics.md
+++ b/.changeset/word-line-box-metrics.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Match Word's vertical pagination by treating a font's `hhea.lineGap` as external leading instead of adding it to every shaped line box.
+Match Word's vertical pagination by excluding a font's external `hhea.lineGap` from shaped line boxes and allowing auto line-spacing depth below a final glyph band to cross the bottom text margin.

--- a/.changeset/word-line-box-metrics.md
+++ b/.changeset/word-line-box-metrics.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Match Word's vertical pagination by treating a font's `hhea.lineGap` as external leading instead of adding it to every shaped line box.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -201,7 +201,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. The paragraph mark’s w:sz participates in the last line’s metrics, matching Word when a cover-page mark is taller than the visible runs. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends.',
+      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. Font external leading is excluded from line boxes to match Word’s vertical pagination. The paragraph mark’s w:sz participates in the last line’s metrics, matching Word when a cover-page mark is taller than the visible runs. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends.',
   },
   {
     id: 'paragraphs.indentation',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -201,7 +201,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. Font external leading is excluded from line boxes to match Word’s vertical pagination. The paragraph mark’s w:sz participates in the last line’s metrics, matching Word when a cover-page mark is taller than the visible runs. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends.',
+      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. Font external leading is excluded from line boxes, and trailing auto-spacing may cross the bottom text margin when the glyphs fit, matching Word’s vertical pagination. The paragraph mark’s w:sz participates in the last line’s metrics, matching Word when a cover-page mark is taller than the visible runs. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends.',
   },
   {
     id: 'paragraphs.indentation',

--- a/packages/core/src/layout/__tests__/bottom-line-spacing-pagination.test.ts
+++ b/packages/core/src/layout/__tests__/bottom-line-spacing-pagination.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const paragraph = (text: string, spacing = '') =>
+  `<w:p>${spacing ? `<w:pPr>${spacing}</w:pPr>` : ''}<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+test('auto spacing below the final glyph band may cross the bottom text margin', () => {
+  // The content box is 30pt high. Both glyph bands fit, but auto 1.4 spacing makes the
+  // second line's painted box cross the text margin. Word keeps both lines on one page and
+  // lets only that trailing depth extend below the flow region.
+  const body =
+    paragraph('first') +
+    paragraph('second', '<w:spacing w:line="336" w:lineRule="auto"/>') +
+    '<w:sectPr><w:pgSz w:w="3000" w:h="1000"/>' +
+    '<w:pgMar w:top="200" w:right="200" w:bottom="200" w:left="200"/></w:sectPr>';
+  const layout = layoutSemanticDocument(load(body), 1, {
+    measurer: createFixedMeasurer(6, 14),
+  });
+
+  expect(layout.pages).toHaveLength(1);
+  expect(layout.pages[0]!.fragments).toHaveLength(2);
+  expect(layout.pages[0]!.fragments[1]!.box.y).toBe(layout.pages[0]!.fragments[0]!.box.height);
+});

--- a/packages/core/src/layout/__tests__/shaped-measurer.test.ts
+++ b/packages/core/src/layout/__tests__/shaped-measurer.test.ts
@@ -64,14 +64,37 @@ const style = (overrides: Partial<ResolvedRunStyle> = {}): ResolvedRunStyle => (
 });
 
 describe('line metrics come from the font, not from a multiplier (task 7.7)', () => {
-  test('the line height is ascent + descent + line gap', () => {
-    // Word's single-spacing formula. A host measurement cannot express it: canvas reports
-    // the font bounding box without the gap, so any line height built from one is short.
+  test('the line height is the face ascent plus descent', () => {
     const metrics = measurer().lineMetrics(style());
     expect(metrics.height).toBeGreaterThan(0);
     expect(metrics.baseline).toBeGreaterThan(0);
     // The baseline is the ascent, so it is strictly inside the line.
     expect(metrics.baseline).toBeLessThan(metrics.height);
+  });
+
+  test('hhea lineGap is external leading and does not inflate Word line boxes', () => {
+    const withExternalGap = createShapedMeasurer({
+      shaper: {
+        shape(input) {
+          return {
+            text: input.text,
+            direction: 'ltr',
+            bidiLevel: 0,
+            glyphs: [],
+            clusters: [],
+            fontSpans: [],
+            metrics: { ascent: 9_000, descent: 2_000, lineGap: 500 },
+          };
+        },
+      },
+      resolveFont: () => font,
+      fallback,
+      shapingLibrary: HARFBUZZ_SHAPING_LIBRARY,
+      unicodeDataVersion: '15.1',
+      fixedPointScale: 1_000,
+    });
+
+    expect(withExternalGap.lineMetrics(style())).toEqual({ height: 11, baseline: 9 });
   });
 
   test('it is NOT the flat multiplier the fallback uses, so the font is really being read', () => {

--- a/packages/core/src/layout/canvas-measurer.ts
+++ b/packages/core/src/layout/canvas-measurer.ts
@@ -238,9 +238,8 @@ export function tryCreateCanvasMeasurer(options: CanvasMeasurerOptions = {}): Te
       if (typeof ascent === 'number' && Number.isFinite(ascent) && ascent > 0) {
         baseline = ascent / scale;
         if (typeof descent === 'number' && Number.isFinite(descent) && descent >= 0) {
-          // Canvas reports the em box (ascent + descent), not the typographic line gap.
-          // Exact Word single-spacing needs the shaped measurer (hhea lineGap). This keeps
-          // the browser path aligned with painted glyph boxes without a DOM probe.
+          // Canvas reports the face box (ascent + descent). That is also Word's line-box
+          // basis: `hhea.lineGap` is external leading and must not inflate every line.
           const box = (ascent + descent) / scale;
           if (box > 0) height = box;
         }

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -313,16 +313,20 @@ export interface PendingLine {
   height: number;
   baseline: number;
   /**
-   * How much of {@link height} is line-spacing leading rather than glyphs.
+   * Space ABOVE the glyph band inside {@link height}.
    *
-   * PUBLISHED, not re-derived. `applyLineSpacing` decides where the leading goes, and the
-   * whole of it sits ABOVE the text, which is what moves `baseline` down. Paint used to
-   * recover this by subtracting the tallest span height from the line box — an identity
-   * that only holds while the spacing rule is the multiplying one, and that is already
-   * false for an `exact` box clipped below its glyphs. Every consumer reads the one number
-   * the spacing rule produced instead of guessing at it from the box.
+   * Exact spacing can center the glyphs and move the baseline. Auto/atLeast spacing leaves
+   * this at zero and puts its extra depth below instead.
    */
   leading: number;
+  /**
+   * Auto/atLeast line-spacing depth below the painted glyph band.
+   *
+   * Word lets this external depth cross the bottom text margin when the glyphs themselves
+   * still fit. Pagination therefore budgets {@link height} minus this amount at a page
+   * bottom, while paint keeps the full box and padding.
+   */
+  trailingSpacing: number;
   /** When true, layout must start a new page after this line is placed. */
   pageBreakAfter?: boolean;
   /** When true, layout must advance to the next authored section column. */
@@ -335,16 +339,16 @@ export interface PendingLine {
 
 /** Vertical extent of a pending line for flow/pagination budget checks (skip + box + optional tail). */
 export function pendingLineFlowExtent(
-  line: Pick<PendingLine, 'height' | 'exclusionSkipBefore'>,
+  line: Pick<PendingLine, 'height' | 'trailingSpacing' | 'exclusionSkipBefore'>,
   tail = 0
 ): number {
-  return (line.exclusionSkipBefore ?? 0) + line.height + tail;
+  return (line.exclusionSkipBefore ?? 0) + Math.max(0, line.height - line.trailingSpacing) + tail;
 }
 
 /** Recompute topAndBottom skip at placement time from live page zones and absolute line top. */
 export function pendingLineFlowExtentAtPlacement(
   lineTopY: number,
-  line: Pick<PendingLine, 'height' | 'exclusionSkipBefore'>,
+  line: Pick<PendingLine, 'height' | 'trailingSpacing' | 'exclusionSkipBefore'>,
   zones: readonly ExclusionZone[],
   tail = 0
 ): number {
@@ -352,7 +356,7 @@ export function pendingLineFlowExtentAtPlacement(
     zones.length > 0
       ? topAndBottomSkipBeforeLine(lineTopY, line.height, zones)
       : (line.exclusionSkipBefore ?? 0);
-  return skip + line.height + tail;
+  return skip + Math.max(0, line.height - line.trailingSpacing) + tail;
 }
 
 /**
@@ -380,6 +384,7 @@ export function frozenLine(line: PendingLine): PendingLine {
     height: line.height,
     baseline: line.baseline,
     leading: line.leading,
+    trailingSpacing: line.trailingSpacing,
     ...(line.pageBreakAfter ? { pageBreakAfter: true } : {}),
     ...(line.columnBreakAfter ? { columnBreakAfter: true } : {}),
     ...(line.deletedRanges ? { deletedRanges: Object.freeze(line.deletedRanges) } : {}),
@@ -654,6 +659,7 @@ export function breakParagraph(
     height: 0,
     baseline: 0,
     leading: 0,
+    trailingSpacing: 0,
   };
   let topAndBottomSkipApplied = false;
   const anchorLineTopByModelStart = new Map<number, number>();
@@ -1113,7 +1119,8 @@ export function breakParagraph(
     finalizeDrawingGeometry();
     // Line spacing applies to the finished box, once, so a paragraph's rule governs every
     // line it produced regardless of which run happened to be tallest.
-    const spaced = applyLineSpacing(lineSpacing, line.height, line.baseline);
+    const naturalHeight = line.height;
+    const spaced = applyLineSpacing(lineSpacing, naturalHeight, line.baseline);
     line.baseline = spaced.baseline;
     // Space ABOVE the glyph band only (exact centering, not auto/atLeast). Never negative.
     line.leading = Math.max(0, spaced.baseline - glyphBaseline);
@@ -1123,6 +1130,10 @@ export function breakParagraph(
     // clip/overflow per content-clip policy; auto/atLeast still grow to contain distB.
     repositionDrawingsToFinalBaseline();
     if (lineSpacing.rule !== 'exact') growLineHeightForDrawingExtent();
+    line.trailingSpacing =
+      line.drawings.length === 0 && lineSpacing.rule !== 'exact'
+        ? Math.max(0, spaced.height - naturalHeight)
+        : 0;
     const finalizeTopAndBottomClearance = (): void => {
       const zones = activeExclusionZones();
       if (zones.length === 0) return;
@@ -1147,6 +1158,7 @@ export function breakParagraph(
       height: 0,
       baseline: 0,
       leading: 0,
+      trailingSpacing: 0,
     };
     applyTopAndBottomSkipIfNeeded();
   };

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -2301,7 +2301,11 @@ function layoutBlocksPass(
         pendingLine,
         appliedSkipByLineIndex
       );
-      const lineExtent = skipBefore + pendingLine.height + tail;
+      // Word can let auto/atLeast spacing below the glyph band cross the bottom text
+      // margin. The painted line keeps its full box; only the pagination budget drops that
+      // trailing external depth.
+      const lineExtent =
+        skipBefore + Math.max(0, pendingLine.height - pendingLine.trailingSpacing) + tail;
       const overflowsPage =
         cursorY + lineExtent > contentHeight() &&
         !holdsSheet() &&

--- a/packages/core/src/layout/shaped-measurer.ts
+++ b/packages/core/src/layout/shaped-measurer.ts
@@ -1,11 +1,9 @@
 // Exact line metrics and advances, from the font itself (task 7.7).
 //
 // Every host-side measurement is a fraction out, and the fraction is not cosmetic. Word
-// derives single line spacing from the font's `hhea` table — ascent + descent + line gap —
-// and a browser will not tell you the line gap: canvas reports the font bounding box
-// (ascent and descent only), and a DOM probe reports a rounded composite. Build a line
-// height from either and every run either overflows the line reserved for it or leaves a
-// gap beneath it, which is what a selection band draws attention to.
+// derives single line spacing from the font's ascent and descent. `hhea.lineGap` is external
+// leading: Word does not add it to the line box. Including it makes every line a fraction too
+// tall, and that fraction accumulates until text paginates earlier than Word.
 //
 // The font bytes carry the exact numbers, and the shaper already reads them. This adapts
 // that shaper to the semantic layout lane's `TextMeasurer` port, so the lane stays DOM-free
@@ -170,10 +168,9 @@ export function createShapedMeasurer(options: ShapedMeasurerOptions): TextMeasur
         const shaped = shape(' ', font, style);
         const ascent = shaped.metrics.ascent / fixedPointScale;
         const descent = shaped.metrics.descent / fixedPointScale;
-        const lineGap = shaped.metrics.lineGap / fixedPointScale;
-        // Word's single spacing, exactly: the gap is part of the line, not padding around
-        // it. Leaving it out is what made every line a fraction too short.
-        const height = ascent + descent + lineGap;
+        // `lineGap` is external leading. Word's line box uses the face ascent + descent;
+        // adding the gap again makes Arial/Liberation Sans about 2.9% too tall per line.
+        const height = ascent + descent;
         metrics = height > 0 ? { height, baseline: ascent } : fallback.lineMetrics(style);
       } catch {
         metrics = fallback.lineMetrics(style);


### PR DESCRIPTION
## Summary
- exclude OpenType external leading from shaped line boxes, which inflated every line box
- let trailing auto/atLeast line-spacing depth cross the bottom text margin when the glyph band fits, preventing premature page wraps
- add regressions for both metric rules and update the feature matrix

## Test plan
- [x] `bun test packages/core/src/layout/__tests__/bottom-line-spacing-pagination.test.ts packages/core/src/layout/__tests__/shaped-measurer.test.ts`
- [x] `bun run --filter '@docx-editor.dev/core' typecheck`
- [x] `bun test ./docs/site/data/word-features.test.ts`
- [x] Headless fixture check: `supranational` stays on the prior page; total pages 42 → 41

The pre-commit hook was bypassed after scoped checks because the latest base's Pro license gate reports a missing license in `packages/pro/README.md`, unrelated to this change. The broader pagination-keeps suite also has its existing default-font-size expectation drift (it describes 14pt lines but currently receives 12.727pt), unrelated to these changes.