### PR TITLE
chore(examples): deploy the Igloo demo, and stop serving an e2e fixture

### DIFF
--- a/examples/igloo/README.md
+++ b/examples/igloo/README.md
@@ -180,6 +180,27 @@ Full reference: [`docs/CUSTOMIZING.md`](../../docs/CUSTOMIZING.md).
   `rsvg-convert -w 1200 -h 630 public/og/igloo-card.svg -o public/og/igloo.png`.
 - The default document is `public/sample-igloo.docx` — the shared sample with an iceberg and
   an igloo already saved into it, so the custom nodes and their rail cards are on screen
-  before anyone touches a menu. `?fixture=<name>.docx` swaps in the Vite example's
-  `sample.docx` or any e2e fixture, mapped onto the real path by a vite plugin so a second
-  copy of somebody else's file cannot drift.
+  before anyone touches a menu. `?fixture=sample.docx` swaps in the Vite example's copy,
+  mapped onto the real path by a vite plugin so a second copy of somebody else's file cannot
+  drift. That is the only fixture the plugin serves; `e2e/fixtures/` is off limits, because
+  those files change to suit a test run and this demo is deployed.
+
+## Deploying
+
+`vercel.json` covers the build. It is its own Vercel project, separate from the parity demo
+the repo root deploys, with **Root Directory** set to `examples/igloo`.
+
+Two settings live in the project rather than the file, and it does not build without either:
+
+- **Include source files outside of the Root Directory: on.** `vite.config.ts` aliases the
+  library to `../../packages/*/src`, and the fixture plugin reads
+  `../../examples/vite/public/sample.docx` and emits it into the bundle.
+- **Production Branch: `docx-editor-v2`.** This directory does not exist on `main`.
+
+`build:packages:demo` runs first because only `react`, `i18n` and the `core/*` subpaths are
+aliased to source. `pro` and `fonts` resolve through node_modules to their `dist/`, which a
+clean clone does not have. The install step clears `node_modules` for the reason the root
+`vercel.json` does: the build cache and a symlinked workspace disagree.
+
+An **Ignored Build Step** of `git diff --quiet HEAD^ HEAD -- examples/igloo packages` keeps
+docs and spec commits from rebuilding it.

--- a/examples/igloo/src/main.tsx
+++ b/examples/igloo/src/main.tsx
@@ -6,8 +6,8 @@ const base = import.meta.env.BASE_URL;
 
 // This demo's own copy of the sample, with an iceberg and an igloo already in it, so the
 // custom nodes and their rail cards are on screen before anyone touches a menu. It lives in
-// `public/` rather than behind the fixture plugin because nothing else reads it — the shared
-// `sample.docx` and the e2e fixtures still come through the plugin, under `?fixture=`.
+// `public/` rather than behind the fixture plugin because nothing else reads it. The shared
+// `sample.docx` still comes through the plugin, under `?fixture=`.
 const DEFAULT_FIXTURE = 'sample-igloo.docx';
 
 // `?fixture=<name>.docx` picks which same-origin fixture loads. Sanitized to a bare `.docx`

--- a/examples/igloo/vercel.json
+++ b/examples/igloo/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "cd ../.. && rm -rf node_modules && bun install --frozen-lockfile",
+  "buildCommand": "cd ../.. && bun run build:packages:demo && cd examples/igloo && bun run build",
+  "outputDirectory": "dist"
+}

--- a/examples/igloo/vite.config.ts
+++ b/examples/igloo/vite.config.ts
@@ -9,20 +9,20 @@ import type { Plugin } from 'vite';
 const monorepoRoot = path.resolve(__dirname, '../..');
 
 /**
- * Serve the SHARED documents from one byte source, the way the Vite example does.
+ * Serve the SHARED document from one byte source, the way the Vite example does.
  *
  * This demo's own default lives in `public/` (it has an iceberg and an igloo in it, and
- * nothing else reads it). Everything reachable through `?fixture=` is somebody else's file —
- * the Vite example's `sample.docx`, or an e2e fixture — so it is mapped onto the real path
- * rather than copied here, where a second copy would silently drift.
+ * nothing else reads it). The one thing reachable through `?fixture=` is somebody else's
+ * file, the Vite example's `sample.docx`, so it is mapped onto the real path rather than
+ * copied here, where a second copy would silently drift.
+ *
+ * Nothing under `e2e/fixtures/` belongs here. Those files exist to make assertions fail,
+ * they change whenever a test needs them to, and this demo is deployed: a fixture edit made
+ * for a test run would ship as a demo document nobody meant to publish.
  */
 function canonicalFixturePlugin(): Plugin {
   const fixtures = new Map([
     ['/sample.docx', path.join(monorepoRoot, 'examples/vite/public/sample.docx')],
-    [
-      '/comprehensive-word-element-test.docx',
-      path.join(monorepoRoot, 'e2e/fixtures/comprehensive-word-element-test.docx'),
-    ],
   ]);
   return {
     name: 'igloo-canonical-fixture',


### PR DESCRIPTION
`examples/igloo/vercel.json` builds the demo as its own Vercel project. Two settings live in the project rather than the file and it does not build without either: **Include source files outside of the Root Directory** (the vite aliases and the fixture plugin both reach into `../..`), and **Production Branch `docx-editor-v2`** (this directory does not exist on `main`). Both are written down in the README.



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788556662&installation_model_id=422592&pr_number=166&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F166&signature=57c9eb35f1a6f9e256202a37e220e8f107a860ae4175a05587092421d55ff364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->