### PR TITLE
fix(core): type the setSelection forms the engine actually accepts

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,11 @@
+---
+'@docx-editor.dev/core': major
+---
+
+`setSelection` now types the forms it actually accepts. `EditorSelection` gained the
+`{ anchor, head }` paragraph-id pair the engine honours, and lost the `SemanticTarget` and
+`DocLocation` arms it never accepted, so the outline and any other caller can move the caret
+without a cast.
+
+Breaking if you passed a `SemanticTarget` or a `DocLocation`-ended range to `setSelection`:
+both were refused at runtime with `unsupported`, so working code is unaffected.

--- a/bun.lock
+++ b/bun.lock
@@ -318,7 +318,6 @@
       "name": "@docx-editor.dev/react",
       "version": "1.0.0",
       "dependencies": {
-        "@docx-editor.dev/core": "workspace:*",
         "@docx-editor.dev/i18n": "workspace:*",
         "@radix-ui/react-select": "^2.3.3",
         "class-variance-authority": "^0.7.1",
@@ -327,9 +326,11 @@
         "harfbuzzjs": "1.4.0",
       },
       "devDependencies": {
+        "@docx-editor.dev/core": "workspace:*",
         "fflate": "^0.8.2",
       },
       "peerDependencies": {
+        "@docx-editor.dev/core": "workspace:*",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
       },

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -775,9 +775,8 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
         beforePt?: number | null;
         afterPt?: number | null;
     };
-    // (undocumented)
     setSelection: {
-        anchor: EditorPosition;
+        anchor: DocAnchor;
     } | {
         range: EditorSelection;
     };
@@ -932,7 +931,7 @@ export interface EditorNoteCommands {
 }
 
 // @public
-export type EditorPosition = DocAnchor | DocLocation | SemanticTarget;
+export type EditorPosition = DocAnchor | SemanticPosition;
 
 // @public
 export interface EditorQueries extends DocQueries {
@@ -1028,10 +1027,10 @@ export type EditorScope = {
 };
 
 // @public
-export type EditorSelection = DocRange | {
-    from: EditorPosition;
-    to: EditorPosition;
-} | SemanticTarget;
+export type EditorSelection = SemanticSelection | {
+    from: DocAnchor;
+    to: DocAnchor;
+};
 
 // @public
 export interface EditorSnapshot {
@@ -1706,6 +1705,22 @@ export interface SemanticIdentity {
     readonly blockId: string;
     // (undocumented)
     readonly storyId: string;
+}
+
+// @public
+export interface SemanticPosition {
+    // (undocumented)
+    readonly offset: number;
+    // (undocumented)
+    readonly paragraphId: string;
+}
+
+// @public
+export interface SemanticSelection {
+    // (undocumented)
+    readonly anchor: SemanticPosition;
+    // (undocumented)
+    readonly head: SemanticPosition;
 }
 
 // @public

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1388,9 +1388,8 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
         beforePt?: number | null;
         afterPt?: number | null;
     };
-    // (undocumented)
     setSelection: {
-        anchor: EditorPosition;
+        anchor: DocAnchor;
     } | {
         range: EditorSelection;
     };
@@ -1552,7 +1551,7 @@ export interface EditorNoteCommands {
 }
 
 // @public
-export type EditorPosition = DocAnchor | DocLocation | SemanticTarget;
+export type EditorPosition = DocAnchor | SemanticPosition;
 
 // @public
 export interface EditorQueries extends DocQueries {
@@ -1648,10 +1647,10 @@ export type EditorScope = {
 };
 
 // @public
-export type EditorSelection = DocRange | {
-    from: EditorPosition;
-    to: EditorPosition;
-} | SemanticTarget;
+export type EditorSelection = SemanticSelection | {
+    from: DocAnchor;
+    to: DocAnchor;
+};
 
 // @public
 export interface EditorSnapshot {
@@ -2458,6 +2457,22 @@ export interface SemanticIdentity {
     readonly blockId: string;
     // (undocumented)
     readonly storyId: string;
+}
+
+// @public
+export interface SemanticPosition {
+    // (undocumented)
+    readonly offset: number;
+    // (undocumented)
+    readonly paragraphId: string;
+}
+
+// @public
+export interface SemanticSelection {
+    // (undocumented)
+    readonly anchor: SemanticPosition;
+    // (undocumented)
+    readonly head: SemanticPosition;
 }
 
 // @public

--- a/packages/core/src/__tests__/consumer.test-d.ts
+++ b/packages/core/src/__tests__/consumer.test-d.ts
@@ -136,6 +136,38 @@ const rightEdgeTargetMissingRepeat: TableRightEdgeResizeTarget = {
 declare const target: SemanticTarget;
 void target;
 
+// Every form `can()` says it accepts must be CONSTRUCTIBLE without a cast, and nothing else
+// should be. Both adapter call sites and the facade's own test used to write
+// `{ anchor, head } as never` against a union that named a `SemanticTarget` the engine
+// refuses and omitted the paragraph-id form it honours — the cast was load-bearing, which is
+// how the contract stayed wrong. These four lines are the gate in
+// `editor/docx-editor-support.ts`, spelled as types.
+const semanticCaret: EditorCommand = {
+  type: 'setSelection',
+  range: { anchor: { paragraphId: 'p1', offset: 0 }, head: { paragraphId: 'p1', offset: 0 } },
+};
+const semanticRange: EditorCommand = {
+  type: 'setSelection',
+  range: { anchor: { paragraphId: 'p1', offset: 1 }, head: { paragraphId: 'p2', offset: 4 } },
+};
+const anchorRange: EditorCommand = {
+  type: 'setSelection',
+  range: { from: { paraId: 'A1B2C3D4' }, to: { paraId: 'E5F6A7B8' } },
+};
+const collapsedAnchor: EditorCommand = { type: 'setSelection', anchor: { paraId: 'A1B2C3D4' } };
+
+const mixedEndpoints: EditorCommand = {
+  type: 'setSelection',
+  // @ts-expect-error the two endpoint vocabularies do not mix; `can()` refuses this pair
+  range: { from: { paraId: 'A1B2C3D4' }, to: { paragraphId: 'p2', offset: 0 } },
+};
+
+void semanticCaret;
+void semanticRange;
+void anchorRange;
+void collapsedAnchor;
+void mixedEndpoints;
+
 export function exercise(editor: Editor, doc: DocxDocument): void {
   // Writes return a result that narrows.
   const result = editor.exec(boldCmd);

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -21,12 +21,15 @@ import type {
   ReviewRevisionItem,
   ReviewRevisionKind,
 } from '../layout/review-support.ts';
-import type { InteractionOutcome, SemanticTarget } from './interaction';
+import type { InteractionOutcome } from './interaction';
+// The selection vocabulary the painted surface actually speaks. Type-only, and re-exported
+// below for the same reason the review types are: an adapter is not allowed to import the
+// layout lane, so a form it must construct has to be nameable from this contract.
+import type { SemanticPosition, SemanticSelection } from '../layout/semantic-interaction.ts';
 import type {
   ColorValue,
   ContentControlFilter,
   DocAnchor,
-  DocLocation,
   DocRange,
   Rect,
   Revision,
@@ -70,6 +73,7 @@ export type {
   ReviewRevisionItem,
 } from '../layout/review-support.ts';
 export type { RevisionAddress } from '@docx-editor.dev/core/store';
+export type { SemanticPosition, SemanticSelection } from '../layout/semantic-interaction.ts';
 export type {
   DrawingHorizontalReferenceFrame,
   DrawingKind,
@@ -244,17 +248,28 @@ export type EditorScope =
 export type ViewScope = Exclude<EditorScope, { kind: 'all' }>;
 
 /**
- * A position the engine can resolve. Kept deliberately open: any accepted address form,
- * including a {@link SemanticTarget}. New forms may be added without breaking callers, so do
- * not treat this as a closed set.
+ * A selection endpoint, in either vocabulary the engine resolves.
+ *
+ * {@link DocAnchor} addresses a paragraph by its `w14:paraId`, which is what an LLM or an
+ * automation script can name in a payload. {@link SemanticPosition} addresses it by the
+ * paragraph id the painted surface and the ops already use, with a UTF-16 offset inside it.
+ *
+ * Neither subsumes the other. A paraId survives being written to a file and read back, so it
+ * is the one an out-of-process caller can hold; but it is OPTIONAL in the document, and
+ * `ParagraphSummary.paraId` says so — a paragraph the file gave no `w14:paraId` cannot be
+ * reached by a `DocAnchor` at all. The paragraph id reaches every paragraph.
  */
-export type EditorPosition = DocAnchor | DocLocation | SemanticTarget;
+export type EditorPosition = DocAnchor | SemanticPosition;
 
-/** A selection expressed with any accepted position form. */
-export type EditorSelection =
-  | DocRange
-  | { from: EditorPosition; to: EditorPosition }
-  | SemanticTarget;
+/**
+ * A selection, in one endpoint vocabulary or the other.
+ *
+ * The two do NOT mix: a range is a pair of paraId anchors, or a semantic anchor/head pair,
+ * and `can()` refuses anything else with the engine's own reason. Spelled as two arms rather
+ * than `{ from: EditorPosition; to: EditorPosition }` for exactly that reason — the looser
+ * shape would type a mixed pair the engine rejects at runtime.
+ */
+export type EditorSelection = SemanticSelection | { from: DocAnchor; to: DocAnchor };
 
 /**
  * Whether a command would be accepted, and why not when it would not.
@@ -1153,7 +1168,15 @@ export interface EditorCommands
 
   undo: Record<never, never>;
   redo: Record<never, never>;
-  setSelection: { anchor: EditorPosition } | { range: EditorSelection };
+  /**
+   * Move the selection. Three accepted forms, and `can()` names all three when it refuses:
+   * a collapsed paraId anchor, a range of two paraId anchors, or a semantic anchor/head pair.
+   *
+   * `{ anchor }` takes a {@link DocAnchor} rather than an {@link EditorPosition} because a
+   * collapsed SEMANTIC position is spelled as a range whose anchor and head are equal, which
+   * is what a caret already is.
+   */
+  setSelection: { anchor: DocAnchor } | { range: EditorSelection };
 
   // ── Selection and clipboard ─────────────────────────────────────────────────────────
   //

--- a/packages/core/src/editor/__tests__/docx-editor.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor.test.ts
@@ -267,11 +267,47 @@ describe('createDocxEditor', () => {
       range: {
         anchor: { paragraphId: id, offset: 1 },
         head: { paragraphId: id, offset: 4 },
-      } as never,
+      },
     });
     expect(result).toEqual({ ok: true, changed: false });
     expect(editor.query({ type: 'selectedText' })).toBe('ell');
     expect(editor.surface!.selectedText()).toBe('ell');
+  });
+
+  test('every setSelection form the contract types is a form can() accepts', () => {
+    // The contract used to type a `SemanticTarget` the gate refuses and omit the paragraph-id
+    // pair it honours, so both adapter call sites cast `as never` to reach the working form.
+    // A type that admits what the gate rejects is not checkable by the compiler alone; this
+    // is the runtime half, and `consumer.test-d.ts` is the compile-time half.
+    const { editor } = mount(p('hello'));
+    const [first] = editor.surface!.session.paragraphIds();
+    const paraId = (editor.snapshot().selection?.from as { paraId?: string } | undefined)?.paraId;
+    expect(paraId).toMatch(/^[0-9A-F]{8}$/);
+
+    expect(
+      editor.can({
+        type: 'setSelection',
+        range: {
+          anchor: { paragraphId: first!, offset: 0 },
+          head: { paragraphId: first!, offset: 2 },
+        },
+      })
+    ).toEqual({ ok: true });
+    expect(editor.can({ type: 'setSelection', anchor: { paraId: paraId! } })).toEqual({ ok: true });
+    expect(
+      editor.can({
+        type: 'setSelection',
+        range: { from: { paraId: paraId! }, to: { paraId: paraId! } },
+      })
+    ).toEqual({ ok: true });
+
+    // And the arms the contract dropped are still refused, so removing them narrowed the
+    // type to what was already true rather than removing capability.
+    const refused = editor.can({
+      type: 'setSelection',
+      range: { from: { path: [0] }, to: { path: [0] } },
+    } as never);
+    expect(refused.ok).toBe(false);
   });
 
   test('load() with new bytes replaces the document', () => {

--- a/packages/react/src/editor/DocxEditorOutline.tsx
+++ b/packages/react/src/editor/DocxEditorOutline.tsx
@@ -54,13 +54,12 @@ export function DocxEditorDocumentOutline(props: DocxEditorDocumentOutlineProps)
       if (!editor) return;
       // Focus first, so the surface owns the selection it is about to paint.
       editor.focus();
+      // Anchor and head equal is what a caret is, so this collapses the selection at the
+      // start of the heading rather than selecting it.
       const position = { paragraphId: blockId, offset: 0 };
-      // The paragraph-id/offset endpoints are the ONE selection form the tree surface
-      // honours; the declared `EditorSelection` union does not spell it yet, so this
-      // casts exactly the way the facade's own setSelection test does.
       editor.exec({
         type: 'setSelection',
-        range: { anchor: position, head: position } as never,
+        range: { anchor: position, head: position },
       });
       // Moving the caret does not move the VIEWPORT — a heading twenty pages down was
       // selected where the user could not see it. The engine knows which page the block

--- a/packages/react/src/editor/navigation/useDocumentOutline.ts
+++ b/packages/react/src/editor/navigation/useDocumentOutline.ts
@@ -84,11 +84,10 @@ export function useDocumentOutline(): UseDocumentOutlineResult {
       if (!editor || typeof blockId !== 'string' || blockId.length === 0) return;
       // Focus first, so the surface owns the selection it is about to paint.
       editor.focus();
+      // Anchor and head equal is what a caret is, so this collapses the selection at the
+      // start of the heading rather than selecting it.
       const position = { paragraphId: blockId, offset: 0 };
-      // The paragraph-id/offset endpoints are the ONE selection form the tree surface
-      // honours; the declared `EditorSelection` union does not spell it yet, so this casts
-      // exactly the way the facade's own setSelection test does.
-      editor.exec({ type: 'setSelection', range: { anchor: position, head: position } as never });
+      editor.exec({ type: 'setSelection', range: { anchor: position, head: position } });
       editor.scrollToBlock(blockId);
       setSelectedBlockId(blockId);
     },


### PR DESCRIPTION
`EditorSelection` named a `SemanticTarget` the gate refuses and omitted the `{ anchor, head }` paragraph-id pair it honours, so the one working form could only be reached by a cast. Both outline call sites and the facade's own test carried `as never`, each with a comment saying the union did not spell it. The cast was load-bearing, which is how the contract stayed wrong.

```ts
export type EditorPosition = DocAnchor | SemanticPosition;
export type EditorSelection = SemanticSelection | { from: DocAnchor; to: DocAnchor };

setSelection: { anchor: DocAnchor } | { range: EditorSelection };
```

That is `editor/docx-editor-support.ts:633` spelled as types, and it matches the refusal message that entry already writes out in prose.

**Not a third vocabulary.** `SemanticPosition` and `SemanticSelection` already exist in `layout/semantic-interaction.ts`, and #165 deleted the contract's fake `SemanticSelection`, so those names are now unique in the package. This re-exports them from the contract for the same reason the review and drawing types are re-exported there: an adapter cannot import the layout lane.

**Both vocabularies stay, because neither subsumes the other.** `w14:paraId` is optional in the file and `ParagraphSummary.paraId` documents that a paragraph without one "cannot be reached by a `DocAnchor`". The paragraph id reaches every paragraph. A paraId survives a save/reopen, so it stays the form an out-of-process caller holds.

**`DocLocation` goes too**, beyond what I originally proposed. `isDocAnchor`/`isDocAnchorRange` require paraId endpoints, so a `DocLocation` was refused at both `can` and `exec` exactly like a `SemanticTarget`. Leaving it would have shipped a contract that still lied. Narrowing removes no capability, and the facade test asserts that.

The two endpoint vocabularies are spelled as separate arms rather than `{ from: EditorPosition; to: EditorPosition }`, since the looser shape types a mixed pair the engine rejects.

Covered on both sides: `consumer.test-d.ts` constructs all four accepted forms without a cast and `@ts-expect-error`s a mixed pair; the facade test asserts `can()` accepts the same four and still refuses a `DocLocation` range.

Verified locally (no CI runs on v2 PRs): `bun run typecheck` clean, `bun test` 5950 pass / 0 fail, `check:parity` and `check:lane-boundaries` green, `api:extract` 0 errors with the two expected snapshot diffs.

Follow-up, not done here: with `EditorPosition` no longer using it, `SemanticTarget` (and `SemanticIdentity`/`InteractionAffinity` under it) is referenced by no signature in the package. `contracts/interaction.ts` is then live only for `InteractionOutcome`. Worth deciding whether that addressing vocabulary is reserved or dead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788557459&installation_model_id=422592&pr_number=167&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F167&signature=8ac13cd2fb21f6c7270aa4292ea99f80d62aa28d38fec68a17f22e4533683d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->