### PR TITLE
fix(core): compile the engine at ES2022, which its sources already need

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
@@ -32,9 +28,7 @@
       "@docx-editor.dev/core/editor": ["./src/editor/index.ts"]
     }
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "exclude": [
     "src/store/__tests__",
     "src/layout/__tests__",


### PR DESCRIPTION
`bun run --filter '@docx-editor.dev/core' build` fails on `docx-editor-v2`:

```
src/layout/shaped-run.ts(549,37): error TS2550: Property 'at' does not exist on
type 'Readonly<{ font: ResolvedFont; ... }>[]'. Do you need to change your target
library? Try changing the 'lib' compiler option to 'es2022' or later.
```

The declaration pass reads `packages/core/tsconfig.json`, which still says ES2020 while the sources use `Array.prototype.at`.

The requirement is already documented one directory over, at the top of `packages/editor-api/src/runtime/tsconfig.neutral.json`:

> ES2022 rather than ES2020 because core's sources use `Array.prototype.at`. That is a statement about the language level this code needs, which is a different axis from the platform.

This makes core's own config agree with that. `lib` keeps `DOM`, so the per-lane environment check in `core-lane-graph.test.ts` still reads what it expects.

Found because the docs site's sync builds the packages at a pinned ref, and the pin bump to this branch could not get past `build:packages`.

## Verification

`build:packages` builds all 6, `typecheck` clean across all 8, `bun test` 0 failures across 5951 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788558223&installation_model_id=422592&pr_number=169&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F169&signature=e6ebaeecc5ed063b37164bc48ca4adac54ee62e35ec3d1443cc547acdf6f1d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->