### PR TITLE
fix(core): add repository field so npm can verify publish provenance

### DIFF
--- a/.changeset/core-repository-field.md
+++ b/.changeset/core-repository-field.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Add the `repository` field to the core package manifest so npm can verify its provenance statement on publish.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,6 +75,11 @@
     "typescript": "^5.3.3"
   },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eigenpal/docx-editor.git",
+    "directory": "packages/core"
+  },
   "dependencies": {
     "@docx-editor.dev/i18n": "^2.0.0",
     "bidi-js": "1.0.3",


### PR DESCRIPTION
`@docx-editor.dev/core@2.0.0` failed to publish with E422 "repository.url is \"\", expected to match https://github.com/eigenpal/docx-editor from provenance" while the other five packages shipped. Core's manifest was the only publishable one without a `repository` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788562126&installation_model_id=422592&pr_number=174&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F174&signature=8e1683828934ee652d5f80aa5e7f17ca0cb58a724d7e6f7b419bcca5cc01a6c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->