### PR TITLE
perf(core): cut long-document pipeline cost ~30%

### DIFF
--- a/.changeset/long-document-pipeline-performance.md
+++ b/.changeset/long-document-pipeline-performance.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Speed up the document pipeline on long documents: opening, laying out, editing and saving a 500-page document is roughly a third faster end to end, and unchanged-document layout passes drop by more than half. Parsing, validation, layout keying and serialization now avoid recomputing facts already proven for unchanged, immutable nodes; no validation or security bound changed.

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ examples/vue/public/DC_Template_Descricao_Cargo_Controlado_Enterprise.docx
 tmp-preview/
 openspec/changes/*/notes/feature-parity-report.json
 dist-types/
+
+# Generated profiling fixture (scripts/create-sample-20x-fixture.mjs)
+examples/vite/public/sample-20x.docx

--- a/packages/core/src/layout/__tests__/layout-cache.test.ts
+++ b/packages/core/src/layout/__tests__/layout-cache.test.ts
@@ -258,3 +258,88 @@ describe('cached breaks are re-tagged for the paragraph that uses them (review r
     }
   });
 });
+
+describe('key memoization over immutable nodes', () => {
+  const firstParagraphOf = (part: OoxmlPart) => {
+    const body = part.root.children.find((child) => child.kind === 'body')!;
+    return (body as { children: readonly { kind: string }[] }).children.find(
+      (child) => child.kind === 'paragraph'
+    )! as never;
+  };
+
+  test('unchanged inputs return the SAME key string object, not just an equal one', () => {
+    // The key embeds the whole content token, so it is long — and a freshly joined string
+    // has no cached hash. Handing back the same object keeps every cache get on the
+    // engine's cached string hash, which is what makes the cache cheap to consult per pass.
+    const part = load(paragraph('memoized paragraph content'));
+    const node = firstParagraphOf(part);
+    const inputs = { paragraph: node, properties: [], width: 100, producer: 'p' } as const;
+    expect(paragraphLayoutKey(inputs)).toBe(paragraphLayoutKey(inputs));
+  });
+
+  test('a changed width recomputes, and recomputation is value-stable', () => {
+    const part = load(paragraph('memoized paragraph content'));
+    const node = firstParagraphOf(part);
+    const at100 = paragraphLayoutKey({
+      paragraph: node,
+      properties: [],
+      width: 100,
+      producer: 'p',
+    });
+    const at200 = paragraphLayoutKey({
+      paragraph: node,
+      properties: [],
+      width: 200,
+      producer: 'p',
+    });
+    expect(at200).not.toBe(at100);
+    // The memo holds one entry per node; alternating widths must still produce the same VALUE.
+    const at100again = paragraphLayoutKey({
+      paragraph: node,
+      properties: [],
+      width: 100,
+      producer: 'p',
+    });
+    expect(at100again).toEqual(at100);
+  });
+
+  test('a changed producer or drawing token recomputes the key', () => {
+    const part = load(paragraph('memoized paragraph content'));
+    const node = firstParagraphOf(part);
+    const base = paragraphLayoutKey({ paragraph: node, properties: [], width: 100, producer: 'p' });
+    const otherProducer = paragraphLayoutKey({
+      paragraph: node,
+      properties: [],
+      width: 100,
+      producer: 'q',
+    });
+    expect(otherProducer).not.toEqual(base);
+    const withDrawing = paragraphLayoutKey({
+      paragraph: node,
+      properties: [],
+      width: 100,
+      producer: 'p',
+      drawingToken: 'd1',
+    });
+    expect(withDrawing).not.toEqual(base);
+  });
+
+  test('a REPLACED paragraph node with identical content keys to the same value', () => {
+    // Two parses of the same XML are different node objects with the same structural ids;
+    // the memo must never let one node object's cached key answer for another object, and
+    // equal content at the same structural id must still produce an equal key value.
+    const a = paragraphLayoutKey({
+      paragraph: firstParagraphOf(load(paragraph('same content'))),
+      properties: [],
+      width: 100,
+      producer: 'p',
+    });
+    const b = paragraphLayoutKey({
+      paragraph: firstParagraphOf(load(paragraph('same content'))),
+      properties: [],
+      width: 100,
+      producer: 'p',
+    });
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/core/src/layout/__tests__/table-preferred-width.test.ts
+++ b/packages/core/src/layout/__tests__/table-preferred-width.test.ts
@@ -515,3 +515,40 @@ describe('store column resize lands in preferred-width readback', () => {
     expect(total(structure.columnWidthsPt)).toBeCloseTo(330, 6);
   });
 });
+
+describe('structure memoization over immutable table nodes', () => {
+  const TABLE =
+    '<w:tbl><w:tblGrid><w:gridCol w:w="2400"/><w:gridCol w:w="4200"/></w:tblGrid>' +
+    '<w:tr><w:tc><w:p/></w:tc><w:tc><w:p/></w:tc></w:tr></w:tbl>';
+
+  test('the same table under the same inputs returns the SAME structure object', () => {
+    // One layout pass reads a table more than once — document-order indexing, flow
+    // layout, row measurement — and the structure is deeply readonly, so the second
+    // read must be an identity hit, not a recompute.
+    const table = tableNode(TABLE);
+    const first = readTableStructure(table, CONTENT_WIDTH_PT, 0);
+    const second = readTableStructure(table, CONTENT_WIDTH_PT, 0);
+    expect(second).toBe(first);
+  });
+
+  test('a changed content width recomputes, and recomputation is value-stable', () => {
+    const table = tableNode(TABLE);
+    const wide = readTableStructure(table, CONTENT_WIDTH_PT, 0)!;
+    const narrow = readTableStructure(table, 200, 0)!;
+    expect(narrow).not.toBe(wide);
+    const wideAgain = readTableStructure(table, CONTENT_WIDTH_PT, 0)!;
+    expect(wideAgain.columnWidthsPt).toEqual(wide.columnWidthsPt);
+  });
+
+  test('a changed style cascade recomputes the structure', () => {
+    const table = tableNode(TABLE);
+    const bare = readTableStructure(table, CONTENT_WIDTH_PT, 0);
+    const styles = part(
+      `<w:styles xmlns:w="${W}"><w:style w:type="table" w:styleId="TableGrid"><w:tblPr/></w:style></w:styles>`,
+      '/word/styles.xml'
+    );
+    const cascade = buildStyleCascadeTable(styles.root);
+    const cascaded = readTableStructure(table, CONTENT_WIDTH_PT, 0, cascade);
+    expect(cascaded).not.toBe(bare);
+  });
+});

--- a/packages/core/src/layout/layout-cache.ts
+++ b/packages/core/src/layout/layout-cache.ts
@@ -80,6 +80,14 @@ function propertiesToken(properties: readonly OoxmlProperty[]): string {
  */
 const nodeTokens = new WeakMap<object, string>();
 
+/**
+ * Tokens longer than this are computed transiently instead of retained. A table token embeds
+ * its whole subtree, so a hostile document nesting a large payload inside ~50 table levels
+ * would otherwise retain depth × payload of strings for the document's lifetime; the ceiling
+ * bounds retention while leaving every realistic paragraph and table memoized.
+ */
+const MAX_MEMOIZED_TOKEN_LENGTH = 1 << 18;
+
 function nodeToken(node: OoxmlNode): string {
   if (node.kind === 'textValue') return `t:${node.value}`;
   const cacheable = node.kind === 'paragraph' || node.kind === 'table';
@@ -88,7 +96,7 @@ function nodeToken(node: OoxmlNode): string {
     if (cached !== undefined) return cached;
   }
   const token = computeNodeToken(node);
-  if (cacheable) nodeTokens.set(node, token);
+  if (cacheable && token.length <= MAX_MEMOIZED_TOKEN_LENGTH) nodeTokens.set(node, token);
   return token;
 }
 
@@ -198,14 +206,16 @@ export function paragraphLayoutKey(inputs: ParagraphKeyInputs): ParagraphLayoutK
     properties,
     nodeToken(inputs.paragraph),
   ].join('\0');
-  paragraphKeyMemos.set(inputs.paragraph, {
-    producer: inputs.producer,
-    width,
-    drawingToken,
-    exclusionToken,
-    propertiesToken: properties,
-    key,
-  });
+  if (key.length <= MAX_MEMOIZED_TOKEN_LENGTH) {
+    paragraphKeyMemos.set(inputs.paragraph, {
+      producer: inputs.producer,
+      width,
+      drawingToken,
+      exclusionToken,
+      propertiesToken: properties,
+      key,
+    });
+  }
   return key;
 }
 

--- a/packages/core/src/layout/layout-cache.ts
+++ b/packages/core/src/layout/layout-cache.ts
@@ -70,7 +70,29 @@ function propertiesToken(properties: readonly OoxmlProperty[]): string {
  * Walks the tree rather than reading text alone: a run property changes advances without
  * changing a character, and an unknown child changes the ordering of what surrounds it.
  */
+/**
+ * Canonical-tree nodes are immutable (deep-frozen at construction; edits replace nodes), so a
+ * node's token can never change — memoizing per object turns the per-pass key computation for
+ * an unchanged paragraph into a single WeakMap hit instead of a full subtree walk.
+ *
+ * Only paragraph and table nodes are stored (the granularity `paragraphLayoutKey` is called
+ * at): caching every descendant would hold one string per nesting level of the same content.
+ */
+const nodeTokens = new WeakMap<object, string>();
+
 function nodeToken(node: OoxmlNode): string {
+  if (node.kind === 'textValue') return `t:${node.value}`;
+  const cacheable = node.kind === 'paragraph' || node.kind === 'table';
+  if (cacheable) {
+    const cached = nodeTokens.get(node);
+    if (cached !== undefined) return cached;
+  }
+  const token = computeNodeToken(node);
+  if (cacheable) nodeTokens.set(node, token);
+  return token;
+}
+
+function computeNodeToken(node: OoxmlNode): string {
   if (node.kind === 'textValue') return `t:${node.value}`;
   // The node's OWN identity, not just its shape. Ids are structural paths, so inserting a
   // table above a paragraph renumbers every paragraph below it while nothing about their
@@ -130,19 +152,61 @@ export interface ParagraphKeyInputs {
  * Folds in the content, the available width, and the measurement producer. Anything that changes
  * where lines fall must be in here, or the cache serves a break taken under different conditions.
  */
+interface ParagraphKeyMemo {
+  readonly producer: string;
+  readonly width: number;
+  readonly drawingToken: string;
+  readonly exclusionToken: string;
+  readonly propertiesToken: string;
+  readonly key: ParagraphLayoutKey;
+}
+
+/**
+ * Single-entry memo of the assembled key per (immutable) paragraph node.
+ *
+ * The key embeds the whole content token, so it is a LONG string — and a freshly joined
+ * string has no cached hash, which made every cache `get` re-hash kilobytes per paragraph
+ * per pass. Handing back the SAME string object keeps the engine on V8's cached string
+ * hash, which is what makes the paragraph cache cheap to consult on every keystroke.
+ */
+const paragraphKeyMemos = new WeakMap<object, ParagraphKeyMemo>();
+
 export function paragraphLayoutKey(inputs: ParagraphKeyInputs): ParagraphLayoutKey {
   // Width is quantized to a thousandth of a point: a width that differs by less than that
   // cannot move a break, and keying on the raw float would miss on every scroll that
   // recomputes it.
   const width = Math.round(inputs.width * 1000);
-  return [
+  const drawingToken = inputs.drawingToken ?? '';
+  const exclusionToken = inputs.exclusionToken ?? '';
+  const properties = propertiesToken(inputs.properties);
+  const memo = paragraphKeyMemos.get(inputs.paragraph);
+  if (
+    memo &&
+    memo.producer === inputs.producer &&
+    memo.width === width &&
+    memo.drawingToken === drawingToken &&
+    memo.exclusionToken === exclusionToken &&
+    memo.propertiesToken === properties
+  ) {
+    return memo.key;
+  }
+  const key = [
     inputs.producer,
     width,
-    inputs.drawingToken ?? '',
-    inputs.exclusionToken ?? '',
-    propertiesToken(inputs.properties),
+    drawingToken,
+    exclusionToken,
+    properties,
     nodeToken(inputs.paragraph),
   ].join('\0');
+  paragraphKeyMemos.set(inputs.paragraph, {
+    producer: inputs.producer,
+    width,
+    drawingToken,
+    exclusionToken,
+    propertiesToken: properties,
+    key,
+  });
+  return key;
 }
 
 /** How large the paragraph cache grows before least-recently-used eviction. */

--- a/packages/core/src/layout/layout-cache.ts
+++ b/packages/core/src/layout/layout-cache.ts
@@ -146,12 +146,6 @@ export interface ParagraphKeyInputs {
   readonly exclusionToken?: string;
 }
 
-/**
- * The cache key for one paragraph's measured break.
- *
- * Folds in the content, the available width, and the measurement producer. Anything that changes
- * where lines fall must be in here, or the cache serves a break taken under different conditions.
- */
 interface ParagraphKeyMemo {
   readonly producer: string;
   readonly width: number;
@@ -171,6 +165,12 @@ interface ParagraphKeyMemo {
  */
 const paragraphKeyMemos = new WeakMap<object, ParagraphKeyMemo>();
 
+/**
+ * The cache key for one paragraph's measured break.
+ *
+ * Folds in the content, the available width, and the measurement producer. Anything that changes
+ * where lines fall must be in here, or the cache serves a break taken under different conditions.
+ */
 export function paragraphLayoutKey(inputs: ParagraphKeyInputs): ParagraphLayoutKey {
   // Width is quantized to a thousandth of a point: a width that differs by less than that
   // cannot move a break, and keying on the raw float would miss on every scroll that

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -2790,6 +2790,19 @@ function controlLevelOf(control: OoxmlElement): ContentControlLevel {
  * changes this token, which is folded into the layout producer.
  */
 export function contentControlContextToken(part: OoxmlPart): string {
+  // Parts are immutable (edits publish a new part object), so the token is a pure function
+  // of the part reference. Without the memo this whole-tree walk ran on EVERY layout pass —
+  // including no-change passes that reuse every page.
+  const cached = contentControlContextTokens.get(part);
+  if (cached !== undefined) return cached;
+  const token = computeContentControlContextToken(part);
+  contentControlContextTokens.set(part, token);
+  return token;
+}
+
+const contentControlContextTokens = new WeakMap<OoxmlPart, string>();
+
+function computeContentControlContextToken(part: OoxmlPart): string {
   const parts: string[] = [];
   const walk = (node: OoxmlNode, depth: number): void => {
     if (node.kind === 'textValue') return;

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -759,6 +759,8 @@ export function readTableStructure(
     memo &&
     memo.contentWidthPt === contentWidthPt &&
     memo.depth === depth &&
+    // Identity compare is sound because a cascade table is built once per styles part and
+    // never mutated; a fresh-but-equal cascade only misses the memo, never lies to it.
     memo.styleCascade === styleCascade &&
     memo.displayMode === displayMode
   ) {

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -727,6 +727,21 @@ function conditionalTypesFor(input: {
   return ordered;
 }
 
+interface TableStructureMemo {
+  readonly contentWidthPt: number;
+  readonly depth: number;
+  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly displayMode: RevisionDisplayMode;
+  readonly structure: SemanticTableStructure | null;
+}
+
+/**
+ * Single-entry memo per (immutable) table node. One layout pass reads the same table under
+ * the same inputs more than once — document-order indexing, flow layout, row measurement —
+ * and the structure is deeply readonly, so the last read can be handed back by identity.
+ */
+const tableStructureMemos = new WeakMap<object, TableStructureMemo>();
+
 /**
  * Read one typed table node into a bounded structure, or null when the node is not a
  * typed table or sits beyond the nesting ceiling.
@@ -738,6 +753,34 @@ export function readTableStructure(
   styleCascade?: StyleCascadeTable,
   /** Which revisions the view resolves away; only the proposed result performs the join. */
   displayMode: RevisionDisplayMode = 'all-markup'
+): SemanticTableStructure | null {
+  const memo = tableStructureMemos.get(table);
+  if (
+    memo &&
+    memo.contentWidthPt === contentWidthPt &&
+    memo.depth === depth &&
+    memo.styleCascade === styleCascade &&
+    memo.displayMode === displayMode
+  ) {
+    return memo.structure;
+  }
+  const structure = readTableStructureUncached(
+    table,
+    contentWidthPt,
+    depth,
+    styleCascade,
+    displayMode
+  );
+  tableStructureMemos.set(table, { contentWidthPt, depth, styleCascade, displayMode, structure });
+  return structure;
+}
+
+function readTableStructureUncached(
+  table: OoxmlNode,
+  contentWidthPt: number,
+  depth: number,
+  styleCascade: StyleCascadeTable | undefined,
+  displayMode: RevisionDisplayMode
 ): SemanticTableStructure | null {
   if (depth >= MAX_TABLE_NESTING) return null;
   if (table.kind !== 'table') return null;

--- a/packages/core/src/layout/toc-layout.ts
+++ b/packages/core/src/layout/toc-layout.ts
@@ -36,13 +36,23 @@ function tocHasVisibleResultContent(part: OoxmlPart, toc: DetectedToc): boolean 
   return false;
 }
 
+// Parts are immutable (edits publish a new part object), so each of these id sets is a pure
+// function of the part reference. Memoized because layout recomputes them on EVERY pass —
+// including no-change passes — and `tocHasVisibleResultContent` walks result paragraphs.
+const chromeIdsByPart = new WeakMap<OoxmlPart, ReadonlySet<string>>();
+const placeholderIdsByPart = new WeakMap<OoxmlPart, ReadonlySet<string>>();
+const suppressedIdsByPart = new WeakMap<OoxmlPart, ReadonlySet<string>>();
+
 /** Paragraph ids for TOC field begin/end chrome that must not reserve vertical flow when empty. */
 export function tocFieldChromeParagraphIds(part: OoxmlPart): ReadonlySet<string> {
+  const cached = chromeIdsByPart.get(part);
+  if (cached) return cached;
   const ids = new Set<string>();
   for (const toc of detectBodyTocs(part)) {
     ids.add(toc.beginParagraphId);
     ids.add(toc.endParagraphId);
   }
+  chromeIdsByPart.set(part, ids);
   return ids;
 }
 
@@ -53,10 +63,13 @@ export function tocFieldChromeParagraphIds(part: OoxmlPart): ReadonlySet<string>
  * empty-TOC furniture placeholder; ordinary field chrome on the same ids stays suppressed.
  */
 export function emptyTocPlaceholderParagraphIds(part: OoxmlPart): ReadonlySet<string> {
+  const cached = placeholderIdsByPart.get(part);
+  if (cached) return cached;
   const ids = new Set<string>();
   for (const toc of detectBodyTocs(part)) {
     if (!tocHasVisibleResultContent(part, toc)) ids.add(toc.beginParagraphId);
   }
+  placeholderIdsByPart.set(part, ids);
   return ids;
 }
 
@@ -66,10 +79,13 @@ export function emptyTocPlaceholderParagraphIds(part: OoxmlPart): ReadonlySet<st
  * Suppressed like field chrome so blank cached rows do not stack under the empty placeholder.
  */
 export function emptyTocSuppressedResultParagraphIds(part: OoxmlPart): ReadonlySet<string> {
+  const cached = suppressedIdsByPart.get(part);
+  if (cached) return cached;
   const ids = new Set<string>();
   for (const toc of detectBodyTocs(part)) {
     if (tocHasVisibleResultContent(part, toc)) continue;
     for (const paragraphId of toc.resultParagraphIds) ids.add(paragraphId);
   }
+  suppressedIdsByPart.set(part, ids);
   return ids;
 }

--- a/packages/core/src/store/package/ooxml-package.ts
+++ b/packages/core/src/store/package/ooxml-package.ts
@@ -506,7 +506,11 @@ export function writeOoxmlPackage(pkg: OoxmlPackage): Uint8Array {
 
 /** Replace one part's tree, returning a new package. Pure, like the tree edits themselves. */
 export function withPart(pkg: OoxmlPackage, part: OoxmlPart): OoxmlPackage {
-  return Object.freeze({ ...pkg, parts: new Map([...pkg.parts, [part.name, part]]) });
+  // Copy the map directly instead of spreading through an intermediate entry array; this
+  // runs on every staged op of every transaction.
+  const parts = new Map(pkg.parts);
+  parts.set(part.name, part);
+  return Object.freeze({ ...pkg, parts });
 }
 
 export {

--- a/packages/core/src/store/package/ooxml-serialize.ts
+++ b/packages/core/src/store/package/ooxml-serialize.ts
@@ -79,8 +79,14 @@ function collectNonEmptyPrefixUris(
   uris: Set<string>
 ): void {
   if (node.kind === 'textValue') return;
-  const bindings = new Map(inheritedBindings);
-  for (const binding of node.namespaceBindings) bindings.set(binding.prefix, binding.namespaceUri);
+  // Copy-on-write: most nodes declare no namespaces, and copying the inherited map per node
+  // dominated the cost of this whole-tree walk on long documents.
+  let bindings = inheritedBindings;
+  if (node.namespaceBindings.length > 0) {
+    const own = new Map(inheritedBindings);
+    for (const binding of node.namespaceBindings) own.set(binding.prefix, binding.namespaceUri);
+    bindings = own;
+  }
   for (const attribute of node.attributes) {
     if (attribute.namespaceUri !== '') uris.add(attribute.namespaceUri);
     if (typeof attribute.value !== 'string') continue;
@@ -244,10 +250,13 @@ function controlledQualifiedName(
 }
 
 function sortedAttributes(attributes: readonly OoxmlAttribute[]): readonly OoxmlAttribute[] {
-  const seen = new Set<string>();
+  if (attributes.length === 0) return attributes;
+  // A single attribute cannot collide or need ordering; skip the set and the sort copy.
+  const seen = attributes.length > 1 ? new Set<string>() : null;
   for (const attribute of attributes) {
     assertSerializableName(attribute.localName);
     assertSerializableNamespace(attribute.namespaceUri);
+    if (!seen) continue;
     const key = expandedKey(attribute.namespaceUri, attribute.localName);
     if (seen.has(key))
       throw new Error(
@@ -255,6 +264,7 @@ function sortedAttributes(attributes: readonly OoxmlAttribute[]): readonly Ooxml
       );
     seen.add(key);
   }
+  if (attributes.length === 1) return attributes;
   return [...attributes].sort((left, right) => {
     const leftKey = expandedKey(left.namespaceUri, left.localName);
     const rightKey = expandedKey(right.namespaceUri, right.localName);
@@ -319,33 +329,49 @@ function serializeNode(
   prefixes: ControlledPrefixes,
   inheritedBindings: ReadonlyMap<string, string>,
   inheritedPreserve: boolean,
-  rootDeclarations: string
-): string {
-  if (node.kind === 'textValue') return escapeXmlChecked(node.value, 'OOXML text');
-  const bindings = new Map(inheritedBindings);
-  const seenDeclarationPrefixes = new Set<string>();
-  const declarations = [...node.namespaceBindings]
-    .sort((left, right) => {
-      const prefixOrder = left.prefix.localeCompare(right.prefix);
-      return prefixOrder !== 0 ? prefixOrder : left.namespaceUri.localeCompare(right.namespaceUri);
-    })
-    .map((binding) => {
-      if (
-        (binding.prefix !== '' && !isValidNCName(binding.prefix)) ||
-        binding.prefix === 'xmlns' ||
-        seenDeclarationPrefixes.has(binding.prefix)
-      )
-        throw new Error(`invalid or duplicate namespace prefix ${JSON.stringify(binding.prefix)}`);
-      assertSerializableNamespace(binding.namespaceUri);
-      seenDeclarationPrefixes.add(binding.prefix);
-      const declaredByControlledRoot =
-        rootDeclarations !== '' && controlledRootDeclares(binding, bindings, prefixes);
-      bindings.set(binding.prefix, binding.namespaceUri);
-      if (declaredByControlledRoot) return '';
-      const declarationName = binding.prefix === '' ? 'xmlns' : `xmlns:${binding.prefix}`;
-      return ` ${declarationName}="${escapeXmlChecked(binding.namespaceUri, declarationName)}"`;
-    })
-    .join('');
+  rootDeclarations: string,
+  /** Output accumulator — one flat join at the end beats per-element string assembly. */
+  out: string[]
+): void {
+  if (node.kind === 'textValue') {
+    out.push(escapeXmlChecked(node.value, 'OOXML text'));
+    return;
+  }
+  // Copy-on-write: most nodes declare no namespaces, and copying the inherited map (plus the
+  // sort/dedup scaffolding) per node dominated serialization cost on long documents.
+  let bindings = inheritedBindings;
+  let declarations = '';
+  if (node.namespaceBindings.length > 0) {
+    const own = new Map(inheritedBindings);
+    const seenDeclarationPrefixes = new Set<string>();
+    declarations = [...node.namespaceBindings]
+      .sort((left, right) => {
+        const prefixOrder = left.prefix.localeCompare(right.prefix);
+        return prefixOrder !== 0
+          ? prefixOrder
+          : left.namespaceUri.localeCompare(right.namespaceUri);
+      })
+      .map((binding) => {
+        if (
+          (binding.prefix !== '' && !isValidNCName(binding.prefix)) ||
+          binding.prefix === 'xmlns' ||
+          seenDeclarationPrefixes.has(binding.prefix)
+        )
+          throw new Error(
+            `invalid or duplicate namespace prefix ${JSON.stringify(binding.prefix)}`
+          );
+        assertSerializableNamespace(binding.namespaceUri);
+        seenDeclarationPrefixes.add(binding.prefix);
+        const declaredByControlledRoot =
+          rootDeclarations !== '' && controlledRootDeclares(binding, own, prefixes);
+        own.set(binding.prefix, binding.namespaceUri);
+        if (declaredByControlledRoot) return '';
+        const declarationName = binding.prefix === '' ? 'xmlns' : `xmlns:${binding.prefix}`;
+        return ` ${declarationName}="${escapeXmlChecked(binding.namespaceUri, declarationName)}"`;
+      })
+      .join('');
+    bindings = own;
+  }
   const elementAttributes =
     // `w:delText` is `CT_Text` exactly as `w:t` is (§17.3.3.7), so it needs the same
     // `xml:space` normalization. Without it, striking " b " wrote `<w:delText> b </w:delText>`
@@ -359,24 +385,25 @@ function serializeNode(
   const preserve =
     ownSpace === 'preserve' ? true : ownSpace === 'default' ? false : inheritedPreserve;
   const name = controlledQualifiedName(node.namespaceUri, node.localName, prefixes, false);
-  const attributes = sortedAttributes(elementAttributes)
-    .map((attribute) => {
-      const attributeName = controlledQualifiedName(
-        attribute.namespaceUri,
-        attribute.localName,
-        prefixes,
-        true
-      );
-      const value = controlledQNameValue(attribute, node, bindings, prefixes);
-      return ` ${attributeName}="${escapeXmlChecked(value, `attribute ${attributeName}`)}"`;
-    })
-    .join('');
-  const open = `<${name}${rootDeclarations}${declarations}${attributes}`;
+  out.push(`<${name}${rootDeclarations}${declarations}`);
+  for (const attribute of sortedAttributes(elementAttributes)) {
+    const attributeName = controlledQualifiedName(
+      attribute.namespaceUri,
+      attribute.localName,
+      prefixes,
+      true
+    );
+    const value = controlledQNameValue(attribute, node, bindings, prefixes);
+    out.push(` ${attributeName}="${escapeXmlChecked(value, `attribute ${attributeName}`)}"`);
+  }
   const children = significantChildren(node, preserve);
-  if (children.length === 0) return `${open}/>`;
-  return `${open}>${children
-    .map((child) => serializeNode(child, prefixes, bindings, preserve, ''))
-    .join('')}</${name}>`;
+  if (children.length === 0) {
+    out.push('/>');
+    return;
+  }
+  out.push('>');
+  for (const child of children) serializeNode(child, prefixes, bindings, preserve, '', out);
+  out.push(`</${name}>`);
 }
 
 function formatNamespaceDeclaration(namespaceUri: string, prefix: string): string {
@@ -409,7 +436,9 @@ export function serializeOoxmlPart(part: OoxmlPart): string {
       return formatNamespaceDeclaration(namespaceUri, prefix);
     })
     .join('');
-  return serializeNode(part.root, prefixes, rootBindings, false, declarations);
+  const out: string[] = [];
+  serializeNode(part.root, prefixes, rootBindings, false, declarations, out);
+  return out.join('');
 }
 
 type FingerprintValue =
@@ -429,6 +458,9 @@ function xmlSpaceValue(attributes: readonly OoxmlAttribute[]): string | undefine
 }
 
 function significantChildren(node: OoxmlElement, preserve: boolean): readonly OoxmlNode[] {
+  // Whitespace stripping only ever drops TEXT children; a child list without any is
+  // returned as-is, which skips the filter allocation for the structural bulk of a part.
+  if (!node.children.some((child) => child.kind === 'textValue')) return node.children;
   const hasElementChild = node.children.some((child) => child.kind !== 'textValue');
   const hasNonWhitespaceText = node.children.some(
     (child) => child.kind === 'textValue' && !/^\s*$/.test(child.value)

--- a/packages/core/src/store/package/ooxml-tree.ts
+++ b/packages/core/src/store/package/ooxml-tree.ts
@@ -1613,10 +1613,13 @@ function namespaceDeclarations(
   readonly bindings: ReadonlyMap<string, string>;
   readonly authored: readonly OoxmlNamespaceBinding[];
 } {
-  const bindings = new Map(inherited);
+  // Copy-on-write: most elements declare nothing, and copying the inherited map per element
+  // dominated parse allocation on long documents.
+  let bindings: Map<string, string> | null = null;
   const authored: OoxmlNamespaceBinding[] = [];
   for (const [name, namespaceUri] of Object.entries(element.attributes)) {
     if (name !== 'xmlns' && !name.startsWith('xmlns:')) continue;
+    bindings ??= new Map(inherited);
     const prefix = name === 'xmlns' ? '' : name.slice('xmlns:'.length);
     if (
       (prefix !== '' && !isValidNCName(prefix)) ||
@@ -1630,7 +1633,7 @@ function namespaceDeclarations(
     bindings.set(prefix, namespaceUri);
     authored.push({ prefix, namespaceUri });
   }
-  return { bindings, authored };
+  return { bindings: bindings ?? inherited, authored };
 }
 
 function resolveElementName(
@@ -1727,6 +1730,10 @@ function canonicalLegacyChildren(
   preserve: boolean,
   isWmlText: boolean
 ): readonly XmlNode[] {
+  // Whitespace stripping and adjacent-text merging only apply to TEXT children; the
+  // structural bulk of a part has none, and skipping the filter/merge allocation there
+  // is a measurable parse win on long documents.
+  if (!children.some((child) => child.type === 'text')) return children;
   const hasElement = children.some((child) => child.type === 'element');
   const hasNonWhitespaceText = children.some(
     (child) => child.type === 'text' && !/^\s*$/.test(child.value)

--- a/packages/core/src/store/package/ooxml-validate.ts
+++ b/packages/core/src/store/package/ooxml-validate.ts
@@ -185,13 +185,21 @@ export function validateOoxmlPartDelta(previous: OoxmlPart, part: OoxmlPart): Oo
 function runValidation(part: OoxmlPart, previous: OoxmlPart | null): OoxmlInvariantResult {
   const issues: OoxmlInvariantIssue[] = [];
   const ids = new Set<string>();
-  const report = (code: OoxmlInvariantIssueCode, path: string, nodeId?: string): void => {
-    issues.push({ code, path, ...(nodeId === undefined ? {} : { nodeId }) });
+  // The child-index trail of the node currently being visited. Issue paths are derived from
+  // it ON REPORT — building a `root.children[i]…` string for every node visited made path
+  // assembly a measurable cost of validating a long, overwhelmingly valid part.
+  const indexTrail: number[] = [];
+  const pathHere = (): string => {
+    let path = 'root';
+    for (const index of indexTrail) path += `.children[${index}]`;
+    return path;
+  };
+  const report = (code: OoxmlInvariantIssueCode, nodeId?: string): void => {
+    issues.push({ code, path: pathHere(), ...(nodeId === undefined ? {} : { nodeId }) });
   };
   const walk = (
     node: OoxmlNode,
     inheritedBindings: ReadonlyMap<string, string>,
-    path: string,
     priorNode: OoxmlNode | undefined,
     priorContext: boolean,
     parent?: DrawingParentContext
@@ -200,62 +208,72 @@ function runValidation(part: OoxmlPart, previous: OoxmlPart | null): OoxmlInvari
     // context proven identical — nothing in the subtree can have changed.
     if (priorContext && priorNode === node) return;
 
-    if (typeof node.id !== 'string' || node.id.length === 0) report('invalid-id', path, node.id);
-    else if (ids.has(node.id)) report('duplicate-id', path, node.id);
+    if (typeof node.id !== 'string' || node.id.length === 0) report('invalid-id', node.id);
+    else if (ids.has(node.id)) report('duplicate-id', node.id);
     else ids.add(node.id);
 
     if (node.kind === 'textValue') {
-      if (!isValidXmlText(node.value)) report('invalid-xml-value', path, node.id);
+      if (!isValidXmlText(node.value)) report('invalid-xml-value', node.id);
       return;
     }
 
-    const bindings = new Map(inheritedBindings);
-    const localPrefixes = new Set<string>();
-    for (const binding of node.namespaceBindings) {
-      const valid =
-        !localPrefixes.has(binding.prefix) &&
-        (binding.prefix === '' || isValidNCName(binding.prefix)) &&
-        binding.prefix !== 'xmlns' &&
-        isValidXmlText(binding.namespaceUri) &&
-        binding.namespaceUri !== XMLNS_NAMESPACE_URI &&
-        !(binding.prefix === 'xml' && binding.namespaceUri !== XML_NAMESPACE_URI) &&
-        !(binding.prefix !== 'xml' && binding.namespaceUri === XML_NAMESPACE_URI) &&
-        !(binding.prefix !== '' && binding.namespaceUri === '');
-      if (!valid) report('invalid-namespace', path, node.id);
-      localPrefixes.add(binding.prefix);
-      bindings.set(binding.prefix, binding.namespaceUri);
+    // Copy-on-write: most nodes declare no namespaces, and copying the inherited map per
+    // node made this walk the dominant cost of validating a long part.
+    let bindings: ReadonlyMap<string, string> = inheritedBindings;
+    if (node.namespaceBindings.length > 0) {
+      const own = new Map(inheritedBindings);
+      const localPrefixes = new Set<string>();
+      for (const binding of node.namespaceBindings) {
+        const valid =
+          !localPrefixes.has(binding.prefix) &&
+          (binding.prefix === '' || isValidNCName(binding.prefix)) &&
+          binding.prefix !== 'xmlns' &&
+          isValidXmlText(binding.namespaceUri) &&
+          binding.namespaceUri !== XMLNS_NAMESPACE_URI &&
+          !(binding.prefix === 'xml' && binding.namespaceUri !== XML_NAMESPACE_URI) &&
+          !(binding.prefix !== 'xml' && binding.namespaceUri === XML_NAMESPACE_URI) &&
+          !(binding.prefix !== '' && binding.namespaceUri === '');
+        if (!valid) report('invalid-namespace', node.id);
+        localPrefixes.add(binding.prefix);
+        own.set(binding.prefix, binding.namespaceUri);
+      }
+      bindings = own;
     }
 
-    if (!isValidNCName(node.localName)) report('invalid-name', path, node.id);
+    if (!isValidNCName(node.localName)) report('invalid-name', node.id);
     if (!isValidXmlText(node.namespaceUri) || node.namespaceUri === XMLNS_NAMESPACE_URI)
-      report('invalid-namespace', path, node.id);
+      report('invalid-namespace', node.id);
     const elementPrefixValid =
       node.prefix === undefined
         ? (bindings.get('') ?? '') === node.namespaceUri
         : isValidNCName(node.prefix) && bindings.get(node.prefix) === node.namespaceUri;
-    if (!elementPrefixValid) report('invalid-qname', path, node.id);
+    if (!elementPrefixValid) report('invalid-qname', node.id);
 
-    const expandedAttributes = new Set<string>();
+    // A single attribute cannot collide with itself, so the duplicate-tracking set is only
+    // allocated once a second attribute exists.
+    const expandedAttributes = node.attributes.length > 1 ? new Set<string>() : null;
     for (const attribute of node.attributes) {
-      if (!isValidNCName(attribute.localName)) report('invalid-name', path, node.id);
+      if (!isValidNCName(attribute.localName)) report('invalid-name', node.id);
       if (!isValidXmlText(attribute.namespaceUri) || attribute.namespaceUri === XMLNS_NAMESPACE_URI)
-        report('invalid-namespace', path, node.id);
-      if (!isValidXmlText(attribute.value)) report('invalid-xml-value', path, node.id);
+        report('invalid-namespace', node.id);
+      if (!isValidXmlText(attribute.value)) report('invalid-xml-value', node.id);
       const attributePrefixValid =
         attribute.prefix === undefined
           ? attribute.namespaceUri === ''
           : isValidNCName(attribute.prefix) &&
             bindings.get(attribute.prefix) === attribute.namespaceUri;
-      if (!attributePrefixValid) report('invalid-qname', path, node.id);
-      const key = expandedKey(attribute.namespaceUri, attribute.localName);
-      if (expandedAttributes.has(key)) report('duplicate-expanded-attribute', path, node.id);
-      expandedAttributes.add(key);
+      if (!attributePrefixValid) report('invalid-qname', node.id);
+      if (expandedAttributes) {
+        const key = expandedKey(attribute.namespaceUri, attribute.localName);
+        if (expandedAttributes.has(key)) report('duplicate-expanded-attribute', node.id);
+        expandedAttributes.add(key);
+      }
     }
 
     try {
       validateQNameAttributeValues(node.attributes, bindings, node.namespaceUri, node.localName);
     } catch {
-      report('invalid-qname', path, node.id);
+      report('invalid-qname', node.id);
     }
 
     if (node.kind !== 'generic') {
@@ -276,7 +294,7 @@ function runValidation(part: OoxmlPart, previous: OoxmlPart | null): OoxmlInvari
           : !knownAttributesAreValid(node.kind, node.attributes) ||
             !validKnownKind(node.kind, node.children))
       )
-        report('known-node-invariant', path, node.id);
+        report('known-node-invariant', node.id);
     }
 
     // Children may prune only when THIS node's paired predecessor declares the very same
@@ -303,16 +321,12 @@ function runValidation(part: OoxmlPart, previous: OoxmlPart | null): OoxmlInvari
       localName: node.localName,
       attributes: node.attributes,
     };
-    node.children.forEach((child, index) =>
-      walk(
-        child,
-        bindings,
-        `${path}.children[${index}]`,
-        priorChildren?.get(child.id),
-        childContext,
-        childParent
-      )
-    );
+    for (let index = 0; index < node.children.length; index += 1) {
+      const child = node.children[index]!;
+      indexTrail.push(index);
+      walk(child, bindings, priorChildren?.get(child.id), childContext, childParent);
+      indexTrail.pop();
+    }
   };
 
   walk(
@@ -321,7 +335,6 @@ function runValidation(part: OoxmlPart, previous: OoxmlPart | null): OoxmlInvari
       ['xml', XML_NAMESPACE_URI],
       ['xmlns', XMLNS_NAMESPACE_URI],
     ]),
-    'root',
     previous?.root,
     previous !== null,
     undefined

--- a/packages/core/src/store/package/para-id.ts
+++ b/packages/core/src/store/package/para-id.ts
@@ -331,6 +331,8 @@ export function normalizeParagraphIdentity(part: OoxmlPart): OoxmlPart {
     root = freezeElement({ ...root, namespaceBindings: bindings, attributes } as OoxmlElement);
   }
 
-  const normalized: OoxmlPart = { ...part, root };
+  // Frozen like every part the edit primitives publish — layout memos key on part identity,
+  // and the freeze discipline is what makes that identity trustworthy.
+  const normalized: OoxmlPart = Object.freeze({ ...part, root });
   return validateOoxmlPart(normalized).ok ? normalized : part;
 }

--- a/packages/core/src/store/package/xml-reader.ts
+++ b/packages/core/src/store/package/xml-reader.ts
@@ -109,7 +109,7 @@ export type XmlResult =
   | { readonly ok: true; readonly nodes: readonly XmlNode[] }
   | { readonly ok: false; readonly reason: XmlRejection };
 
-const CUSTOM_ENTITY_REF_AT_RE = /^&(?!(amp|lt|gt|quot|apos);)[A-Za-z_][\w.-]*;/;
+const CUSTOM_ENTITY_REF_STICKY_RE = /&(?!(amp|lt|gt|quot|apos);)[A-Za-z_][\w.-]*;/y;
 
 function validLimit(value: number): boolean {
   return Number.isFinite(value) && Number.isInteger(value) && value >= 0;
@@ -118,6 +118,15 @@ function validLimit(value: number): boolean {
 /** Reject active declarations/references while treating CDATA, comments, and PIs as literal. */
 function preflightForbiddenXml(xml: string): XmlRejection | undefined {
   for (let i = 0; i < xml.length; i += 1) {
+    // Everything this preflight can object to starts at '<' or '&'; skipping every other
+    // character keeps the scan linear without per-character slicing on multi-megabyte parts.
+    const ch = xml.charCodeAt(i);
+    if (ch !== 0x3c /* '<' */ && ch !== 0x26 /* '&' */) continue;
+    if (ch === 0x26) {
+      CUSTOM_ENTITY_REF_STICKY_RE.lastIndex = i;
+      if (CUSTOM_ENTITY_REF_STICKY_RE.test(xml)) return 'entity-forbidden';
+      continue;
+    }
     if (xml.startsWith('<![CDATA[', i)) {
       const end = xml.indexOf(']]>', i + 9);
       if (end < 0) return 'parse-error';
@@ -136,10 +145,11 @@ function preflightForbiddenXml(xml: string): XmlRejection | undefined {
       i = end + 1;
       continue;
     }
-    const declaration = xml.slice(i, i + 10).toUpperCase();
-    if (declaration.startsWith('<!DOCTYPE')) return 'dtd-forbidden';
-    if (declaration.startsWith('<!ENTITY')) return 'entity-forbidden';
-    if (xml[i] === '&' && CUSTOM_ENTITY_REF_AT_RE.test(xml.slice(i))) return 'entity-forbidden';
+    if (xml.startsWith('<!', i)) {
+      const declaration = xml.slice(i, i + 10).toUpperCase();
+      if (declaration.startsWith('<!DOCTYPE')) return 'dtd-forbidden';
+      if (declaration.startsWith('<!ENTITY')) return 'entity-forbidden';
+    }
   }
   return undefined;
 }

--- a/packages/core/src/store/package/xml-reader.ts
+++ b/packages/core/src/store/package/xml-reader.ts
@@ -109,6 +109,9 @@ export type XmlResult =
   | { readonly ok: true; readonly nodes: readonly XmlNode[] }
   | { readonly ok: false; readonly reason: XmlRejection };
 
+// Sticky (`y`) so the scan can anchor at an ampersand without slicing the tail of a
+// multi-megabyte part. `lastIndex` is shared mutable state: every caller MUST assign it
+// immediately before `test`, as `preflightForbiddenXml` does.
 const CUSTOM_ENTITY_REF_STICKY_RE = /&(?!(amp|lt|gt|quot|apos);)[A-Za-z_][\w.-]*;/y;
 
 function validLimit(value: number): boolean {

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,88 @@
+# Pipeline benchmark
+
+Measures each stage of the one pipeline — bytes → parse → identity → store → layout →
+edit/relayout → save — on a long document, so stage-level regressions show up as numbers
+instead of anecdotes.
+
+## Running it
+
+```bash
+# Build the 20x-length profiling fixture (gitignored; ~420 KB zip, 6 MB document.xml)
+node scripts/create-sample-20x-fixture.mjs
+
+# Run the staged benchmark
+bun scripts/bench/pipeline-bench.ts            # table output
+bun scripts/bench/pipeline-bench.ts --json     # machine-readable
+
+# Attribute time to functions
+bun --cpu-prof scripts/bench/pipeline-bench.ts # writes CPU.*.cpuprofile
+```
+
+The fixture is the demo `sample.docx` with its body repeated 20 times (bookmark ids,
+hyperlink anchors and drawing ids uniquified per copy): ~12,700 paragraphs, 300 tables,
+~1,800 bookmarks, 100 sections — 521 pages. The bench uses the fixed measurer so numbers
+are font-independent; browser-side costs (canvas measurement, paint, React) are profiled
+separately in Chrome.
+
+## 2026-08-06 optimization pass — results
+
+Medians of 3 runs, Apple Silicon, Bun 1.3.14, 20x fixture (521 pages).
+
+| Stage                          | Before  | After   | Change |
+| ------------------------------ | ------- | ------- | ------ |
+| `readOoxmlPackage` (parse)     | 1244 ms | 770 ms  | −38%   |
+| `normalizeParagraphIdentity`   | 480 ms  | 330 ms  | −31%   |
+| Layout, cold                   | 911 ms  | 755 ms  | −17%   |
+| Layout, no-change warm pass    | 124 ms  | 53 ms   | −57%   |
+| `transact` insertText (1 char) | 30 ms   | 26 ms   | −15%   |
+| Layout, incremental after edit | 125 ms  | 78 ms   | −38%   |
+| `writeOoxmlPackage` (save)     | 726 ms  | 475 ms  | −35%   |
+| **Total**                      | 3691 ms | 2510 ms | −32%   |
+
+What the profiler found, and what changed:
+
+1. **XML preflight scanned per character** (`xml-reader.ts`): `preflightForbiddenXml` did a
+   `slice(i, i+10).toUpperCase()` at every index of a multi-megabyte part and re-sliced the
+   whole tail for the entity regex at every `&`. Everything it can object to starts at `<`
+   or `&`, so the scan now skips every other character and anchors the entity check with a
+   sticky regex. ~350 ms of parse.
+2. **Namespace maps copied per element** (`ooxml-tree.ts`, `ooxml-validate.ts`,
+   `ooxml-serialize.ts`): parse, validate and serialize each copied the inherited
+   prefix→URI map for every node, though almost no node declares namespaces. All three
+   walks are copy-on-write now. This was the single largest allocation source (~400 ms of
+   `new Map` in parse alone) and also speeds up every `transact`, which re-validates the
+   touched part.
+3. **Validation path strings built eagerly** (`ooxml-validate.ts`): issue paths are now
+   derived from a shared index trail only when an issue is reported; a valid document
+   reports none.
+4. **Paragraph cache keys rebuilt and re-hashed per pass** (`layout-cache.ts`): `nodeToken`
+   walked every paragraph subtree on every layout pass, and the joined key was a fresh
+   multi-kilobyte string whose hash the JS engine had to recompute on every cache `get`.
+   Tokens are now memoized per immutable paragraph/table node, and the assembled key is
+   memoized per node so unchanged paragraphs hand the SAME string object back to the cache.
+   In a Chrome keystroke trace on the 20x document, `ParagraphLayoutCache.get` went from
+   ~129 ms per keystroke of self-time to unmeasurable.
+5. **Whole-tree scans repeated per layout pass** (`semantic-layout.ts`, `toc-layout.ts`):
+   `contentControlContextToken` and the three TOC paragraph-id scans ran on every pass,
+   including no-change passes that reuse every page. All four are memoized per immutable
+   part reference.
+6. **Tables read twice per pass** (`semantic-table.ts`): `readTableStructure` is a pure
+   function of an immutable node and scalar inputs, called by document-order indexing, flow
+   layout and row measurement. It now carries a single-entry memo per table node.
+7. **Serializer assembled strings bottom-up** (`ooxml-serialize.ts`): `serializeNode`
+   builds into a shared accumulator with one final join, and `significantChildren`
+   short-circuits for the (dominant) element-only child lists.
+8. **Package copy per staged op** (`ooxml-package.ts`): `withPart` copies the parts map
+   directly instead of spreading it through an intermediate entries array.
+
+Not changed, deliberately: deep-freezing of the canonical tree (an invariant the store's
+immutability contract and these very memos rely on), the full fail-open revalidation in
+`normalizeParagraphIdentity` (kept; made cheaper by items 2–3), and every validation or
+security bound — no rule was weakened, only recomputation of already-proven facts removed.
+
+Browser (Chrome, dev server, same fixture): load-to-521-pages ≈ 7.5 s wall including Vite
+module loading; keystroke-to-paint median ~300 ms before AND after — the engine's share
+shrank (item 4), but dev-mode React overhead and per-revision whole-document derivations
+(content-control walk, revision projection, note references, drawing projection — each a
+full-tree scan per edit) dominate the interactive path. Making those derivations
+incremental is the next lever, and it is a design change, not a micro-optimization.

--- a/scripts/bench/pipeline-bench.ts
+++ b/scripts/bench/pipeline-bench.ts
@@ -1,0 +1,162 @@
+// Headless pipeline benchmark: bytes → parse → store → layout → edit/relayout → save.
+//
+// Measures each stage of the one pipeline on a fixture (default: the 20x sample doc built by
+// scripts/create-sample-20x-fixture.mjs). Uses the fixed measurer so numbers are font-independent
+// and reproducible; browser paint cost is profiled separately in Chrome.
+//
+// Usage: bun scripts/bench/pipeline-bench.ts [fixturePath] [--json]
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  readOoxmlPackage,
+  writeOoxmlPackage,
+  resolveHeaderFooterPartsBySection,
+  TreePackageStore,
+  normalizeParagraphIdentity,
+  type OoxmlPart,
+  type OoxmlPackage,
+} from '../../packages/core/src/store/index.ts';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  enumerateDocumentSections,
+  geometryOfSection,
+  layoutHeaderFooterStory,
+  layoutSemanticDocument,
+  type PageFurniture,
+} from '../../packages/core/src/layout/index.ts';
+
+const fixture = resolve(
+  process.argv[2] && !process.argv[2].startsWith('--')
+    ? process.argv[2]
+    : 'examples/vite/public/sample-20x.docx'
+);
+const asJson = process.argv.includes('--json');
+
+const measurer = createFixedMeasurer(6, 14);
+
+function furnitureFor(pkg: OoxmlPackage, part: OoxmlPart): readonly (PageFurniture | undefined)[] {
+  const sections = enumerateDocumentSections(part);
+  const bySection = resolveHeaderFooterPartsBySection(pkg);
+  return sections.map((section, index) => {
+    const parts = bySection[index];
+    if (!parts || (parts.headers.size === 0 && parts.footers.size === 0)) return undefined;
+    const geometry = geometryOfSection(section.properties);
+    const width = geometry.width - geometry.margin.left - geometry.margin.right;
+    const mapStories = (source: typeof parts.headers) => {
+      const laid = new Map();
+      for (const [variant, hfPart] of source) {
+        laid.set(variant, layoutHeaderFooterStory(hfPart, width, measurer, 'bench'));
+      }
+      return laid;
+    };
+    return {
+      titlePage: parts.titlePage,
+      evenAndOddHeaders: parts.evenAndOddHeaders,
+      headers: mapStories(parts.headers),
+      footers: mapStories(parts.footers),
+    };
+  });
+}
+
+interface StageResult {
+  stage: string;
+  ms: number;
+  note?: string;
+}
+const results: StageResult[] = [];
+function stage<T>(name: string, fn: () => T, note?: (value: T) => string): T {
+  const t0 = performance.now();
+  const value = fn();
+  const ms = performance.now() - t0;
+  results.push({ stage: name, ms, ...(note ? { note: note(value) } : {}) });
+  return value;
+}
+
+const bytes = new Uint8Array(readFileSync(fixture));
+results.push({ stage: 'fixture', ms: 0, note: `${fixture} (${(bytes.length / 1024) | 0} KB)` });
+
+// ── parse ──
+const loaded = stage('readOoxmlPackage', () => readOoxmlPackage(bytes));
+if (!loaded.ok) throw new Error(`parse failed: ${loaded.reason}`);
+const pkg = loaded.package;
+const main = pkg.parts.get(pkg.mainDocumentPart)!;
+
+// ── identity + store ──
+const normalized = stage('normalizeParagraphIdentity', () => normalizeParagraphIdentity(main));
+const store = stage('new TreePackageStore', () => new TreePackageStore(pkg, normalized));
+const bodyStore = store.bodyStore();
+const part = () => bodyStore.part;
+
+// ── furniture + full layout ──
+const furniture = stage('furniture (hf layout)', () => furnitureFor(pkg, part()));
+const session = createLayoutSession();
+const layout = stage(
+  'layoutSemanticDocument (cold)',
+  () =>
+    layoutSemanticDocument(part(), 1, {
+      measurer,
+      sectionFurniture: furniture,
+      session,
+      producer: 'bench',
+    }),
+  (l) => `${l.pages.length} pages`
+);
+
+// ── no-change incremental pass ──
+stage('layout (no-change, warm session)', () =>
+  layoutSemanticDocument(part(), 2, {
+    measurer,
+    sectionFurniture: furniture,
+    session,
+    producer: 'bench',
+  })
+);
+
+// ── single edit + incremental relayout (keystroke path) ──
+const firstParagraph = (() => {
+  const body = part();
+  const walk = (node: any): any => {
+    if (node.kind === 'paragraph') return node;
+    for (const child of node.children ?? []) {
+      const hit = walk(child);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  return walk(body.root);
+})();
+if (firstParagraph) {
+  stage('transact insertText(1 char)', () =>
+    bodyStore.transact((ctx) =>
+      ctx.apply({ op: 'insertText', paragraphId: firstParagraph.id, offset: 0, text: 'X' })
+    )
+  );
+  stage('layout (incremental after edit)', () =>
+    layoutSemanticDocument(part(), 3, {
+      measurer,
+      sectionFurniture: furniture,
+      session,
+      producer: 'bench',
+    })
+  );
+}
+
+// ── save ──
+stage(
+  'writeOoxmlPackage (save)',
+  () => writeOoxmlPackage(store.currentPackage()),
+  (b) => `${((b as Uint8Array).length / 1024) | 0} KB`
+);
+
+if (asJson) {
+  console.log(JSON.stringify(results, null, 2));
+} else {
+  const total = results.reduce((sum, r) => sum + r.ms, 0);
+  for (const r of results) {
+    console.log(`${r.stage.padEnd(40)} ${r.ms.toFixed(1).padStart(9)} ms  ${r.note ?? ''}`);
+  }
+  console.log(`${'TOTAL'.padEnd(40)} ${total.toFixed(1).padStart(9)} ms`);
+  console.log(`pages: ${layout.pages.length}`);
+}

--- a/scripts/bench/roundtrip-check.ts
+++ b/scripts/bench/roundtrip-check.ts
@@ -1,0 +1,38 @@
+// Save/reopen stability oracle for the bench fixture: opening the saved bytes and saving
+// again must be byte-identical, and the reopened main part must fingerprint identically.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  readOoxmlPackage,
+  writeOoxmlPackage,
+  normalizeParagraphIdentity,
+  canonicalOoxmlFingerprint,
+} from '../../packages/core/src/store/index.ts';
+
+const fixture = resolve(process.argv[2] ?? 'examples/vite/public/sample-20x.docx');
+const bytes = new Uint8Array(readFileSync(fixture));
+
+const first = readOoxmlPackage(bytes);
+if (!first.ok) throw new Error(`open failed: ${first.reason}`);
+const main1 = normalizeParagraphIdentity(first.package.parts.get(first.package.mainDocumentPart)!);
+const parts1 = new Map(first.package.parts);
+parts1.set(main1.name, main1);
+const saved1 = writeOoxmlPackage({ ...first.package, parts: parts1 });
+
+const second = readOoxmlPackage(saved1);
+if (!second.ok) throw new Error(`reopen failed: ${second.reason}`);
+const main2 = normalizeParagraphIdentity(
+  second.package.parts.get(second.package.mainDocumentPart)!
+);
+const parts2 = new Map(second.package.parts);
+parts2.set(main2.name, main2);
+const saved2 = writeOoxmlPackage({ ...second.package, parts: parts2 });
+
+const fp1 = canonicalOoxmlFingerprint(main1);
+const fp2 = canonicalOoxmlFingerprint(main2);
+console.log('fingerprint stable:', fp1 === fp2);
+console.log(
+  'bytes stable:',
+  saved1.length === saved2.length && saved1.every((b, i) => b === saved2[i])
+);
+if (fp1 !== fp2 || saved1.length !== saved2.length) process.exit(1);

--- a/scripts/create-sample-20x-fixture.mjs
+++ b/scripts/create-sample-20x-fixture.mjs
@@ -1,0 +1,62 @@
+// Builds a 20x-length copy of examples/vite/public/sample.docx for pipeline profiling.
+//
+// The body content (everything before the trailing <w:sectPr>) is repeated N times.
+// Copies after the first are uniquified so the result is still a valid document:
+//   - bookmark ids and drawing docPr ids are offset per copy
+//   - bookmark names and hyperlink anchors get a per-copy suffix (kept consistent so
+//     internal links still resolve within their own copy)
+//   - comment ranges/references are stripped from copies (a comment is one range in
+//     the review model, not twenty)
+//
+// Usage: node scripts/create-sample-20x-fixture.mjs [multiplier] [outPath]
+// Default: 20x -> examples/vite/public/sample-20x.docx
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { unzipSync, zipSync, strToU8, strFromU8 } from 'fflate';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const multiplier = Number(process.argv[2] ?? 20);
+const outPath = resolve(root, process.argv[3] ?? 'examples/vite/public/sample-20x.docx');
+const srcPath = resolve(root, 'examples/vite/public/sample.docx');
+
+const zip = unzipSync(readFileSync(srcPath));
+const doc = strFromU8(zip['word/document.xml']);
+
+const bodyOpen = doc.indexOf('<w:body>');
+const bodyClose = doc.lastIndexOf('</w:body>');
+if (bodyOpen === -1 || bodyClose === -1) throw new Error('no w:body');
+const prefix = doc.slice(0, bodyOpen + '<w:body>'.length);
+const body = doc.slice(bodyOpen + '<w:body>'.length, bodyClose);
+const suffix = doc.slice(bodyClose);
+
+// The final <w:sectPr> is a direct child of <w:body>; everything before it repeats.
+const sectPrStart = body.lastIndexOf('<w:sectPr');
+if (sectPrStart === -1) throw new Error('no trailing sectPr');
+const content = body.slice(0, sectPrStart);
+const finalSectPr = body.slice(sectPrStart);
+
+function uniquify(chunk, copy) {
+  const offset = copy * 100000;
+  let out = chunk
+    .replace(/(<w:bookmark(?:Start|End)[^>]*w:id=")(\d+)(")/g, (_, a, id, b) => a + (Number(id) + offset) + b)
+    .replace(/(<w:bookmarkStart[^>]*w:name=")([^"]+)(")/g, (_, a, name, b) => a + name + '_c' + copy + b)
+    .replace(/(<w:hyperlink[^>]*w:anchor=")([^"]+)(")/g, (_, a, name, b) => a + name + '_c' + copy + b)
+    .replace(/(<wp:docPr[^>]*id=")(\d+)(")/g, (_, a, id, b) => a + (Number(id) + offset) + b);
+  // Strip duplicate comment machinery: range markers and the reference runs.
+  out = out
+    .replace(/<w:commentRangeStart[^>]*\/>/g, '')
+    .replace(/<w:commentRangeEnd[^>]*\/>/g, '')
+    .replace(/<w:r>(?:(?!<\/w:r>)[\s\S])*?<w:commentReference[^>]*\/>(?:(?!<\/w:r>)[\s\S])*?<\/w:r>/g, '');
+  return out;
+}
+
+let repeated = content;
+for (let copy = 1; copy < multiplier; copy++) repeated += uniquify(content, copy);
+
+zip['word/document.xml'] = strToU8(prefix + repeated + finalSectPr + suffix);
+writeFileSync(outPath, zipSync(zip, { level: 6 }));
+console.log(
+  `wrote ${outPath}: document.xml ${(prefix.length + repeated.length + finalSectPr.length + suffix.length) / 1e6}MB, x${multiplier}`
+);


### PR DESCRIPTION
Profiled the pipeline on a 20x-length copy of the demo document (521 pages, 6 MB document.xml) and removed recomputation of facts already proven for unchanged immutable nodes: character-skip XML preflight, copy-on-write namespace maps in the parse/validate/serialize walks, lazy validation issue paths, per-node memoized layout tokens and cache keys, per-part memoized whole-tree scans, single-entry table-structure memo, and an accumulator-based serializer. No validation or security bound changed; serialized output is byte-identical.

Measured on the 20x fixture (medians of 3, full table and methodology in `scripts/bench/README.md`): open 1.24s→0.77s, no-change layout pass 124ms→53ms, incremental relayout after an edit 125ms→78ms, save 726ms→475ms, end-to-end 3.7s→2.5s. Reproduce with `node scripts/create-sample-20x-fixture.mjs && bun scripts/bench/pipeline-bench.ts`.

Verified: full suite (5981 pass), typecheck, api:check, check:parity, i18n:validate, save/reopen byte-stability on the 1x and 20x fixtures, and three independent adversarial reviews (semantic-equivalence differential against the old code, memo-soundness audit, security preflight fuzzing) — review hardening applied in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788565397&installation_model_id=422592&pr_number=176&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F176&signature=4fe59e53e93e62e523e806bbca0484e03394a471482f3bd416f50c7db6e825bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->