### PR TITLE
fix(react,pro): document-describing chrome renders nothing without a document

### DIFF
--- a/.changeset/review-rail-loading-gate.md
+++ b/.changeset/review-rail-loading-gate.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+The review rail renders nothing while the editor is still waiting for its document, instead of floating its empty state and host furniture over the loading screen. `useReview().ready` now reports false until a document is present, matching its documented meaning.

--- a/.changeset/review-rail-loading-gate.md
+++ b/.changeset/review-rail-loading-gate.md
@@ -1,5 +1,6 @@
 ---
 '@docx-editor.dev/pro': patch
+'@docx-editor.dev/react': patch
 ---
 
-The review rail renders nothing while the editor is still waiting for its document, instead of floating its empty state and host furniture over the loading screen. `useReview().ready` now reports false until a document is present, matching its documented meaning.
+Chrome that describes the document no longer renders before one is loaded. The review rail kept its empty state and host furniture off screen until bytes arrive instead of floating them over the loading screen, `useReview().ready` reports false until a document is present, and the ruler parts render nothing rather than default Letter-size ticks for a page that does not exist yet.

--- a/.changeset/review-rail-loading-gate.md
+++ b/.changeset/review-rail-loading-gate.md
@@ -3,4 +3,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Chrome that describes the document no longer renders before one is loaded. The review rail kept its empty state and host furniture off screen until bytes arrive instead of floating them over the loading screen, `useReview().ready` reports false until a document is present, and the ruler parts render nothing rather than default Letter-size ticks for a page that does not exist yet.
+Chrome that describes the document no longer renders before one is present. The review rail keeps its empty state and host furniture off screen until a document opens instead of floating them over the loading screen, the ruler parts render nothing rather than default Letter-size ticks for a page that does not exist, and the navigation pane and document outline no longer report "no headings" about an absent document. The same applies after a parse failure or a detach, not only while loading. `useReview().ready` reports false until a document is present and the hook now re-derives when a load fails.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -405,7 +405,7 @@ export interface DocxEditorHeaderFooterChromeProps {
 }
 
 // @public
-export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactElement;
+export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactElement | null;
 
 // @public (undocumented)
 export const DocxEditorHyperLink: DocxEditorHyperLinkNamespace;
@@ -833,7 +833,7 @@ export interface DocxEditorToolbarProps {
 }
 
 // @public
-export function DocxEditorVerticalRuler(props: DocxEditorRulerProps): ReactElement;
+export function DocxEditorVerticalRuler(props: DocxEditorRulerProps): ReactElement | null;
 
 // @public
 export function DocxEditorViewport(input: DocxEditorViewportProps): react.JSX.Element;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -376,7 +376,7 @@ export interface DocxEditorContextMenuProps {
 }
 
 // @public
-export function DocxEditorDocumentOutline(props: DocxEditorDocumentOutlineProps): ReactElement;
+export function DocxEditorDocumentOutline(props: DocxEditorDocumentOutlineProps): ReactElement | null;
 
 // @public
 export interface DocxEditorDocumentOutlineProps {

--- a/examples/igloo/index.html
+++ b/examples/igloo/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Igloo Editor — customizing docx-editor</title>
-  <meta name="description" content="A fully themed docx-editor.dev, built to answer one question: how much of this is mine? Themed chrome, custom document nodes, and a re-cut review rail.">
+  <title>Igloo Editor: customizing docx-editor</title>
+  <meta name="description" content="A themed docx-editor demo. Custom toolbar, menus and document nodes, plus a restyled review rail, all on the public React API.">
   <meta name="theme-color" content="#0b2740">
   <link rel="icon" href="/icon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="any">
@@ -13,15 +13,15 @@
        the source, `igloo.png` the render. Relative, because the demo has no fixed home. -->
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="docx-editor.dev">
-  <meta property="og:title" content="Igloo Editor — a fully themed docx-editor">
-  <meta property="og:description" content="How much of this is mine? Themed chrome, custom document nodes, and a re-cut review rail — none of them reimplemented to be re-skinned.">
+  <meta property="og:title" content="Igloo Editor: a themed docx-editor">
+  <meta property="og:description" content="Custom toolbar, menus and document nodes, plus a restyled review rail, all on the public React API.">
   <meta property="og:image" content="/og/igloo.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="An iceberg carrying a Word page, over the title Igloo Editor.">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Igloo Editor — a fully themed docx-editor">
-  <meta name="twitter:description" content="How much of this is mine? Themed chrome, custom document nodes, and a re-cut review rail — none of them reimplemented to be re-skinned.">
+  <meta name="twitter:title" content="Igloo Editor: a themed docx-editor">
+  <meta name="twitter:description" content="Custom toolbar, menus and document nodes, plus a restyled review rail, all on the public React API.">
   <meta name="twitter:image" content="/og/igloo.png">
 
   <style>

--- a/examples/igloo/src/IglooEditor.tsx
+++ b/examples/igloo/src/IglooEditor.tsx
@@ -68,88 +68,90 @@ export function IglooEditor({ fixtureUrl }: IglooEditorProps) {
             the click popover and the notice strip, plus the actions the two menus call. It
             wraps the chrome because those menus are inside it. */}
         <SpecimenProvider>
-        <div className="igloo-chrome">
-          <header className="igloo-brand">
-            <IglooMark />
-            <div className="igloo-brand__text">
-              <h1>Igloo Editor</h1>
-              <p>Same editor. Colder.</p>
-            </div>
-          </header>
-          <IglooMenu />
-          <IglooToolbar blizzard={blizzard} onBlizzard={() => setBlizzard((on) => !on)} />
-        </div>
+          <div className="igloo-chrome">
+            <header className="igloo-brand">
+              <IglooMark />
+              <div className="igloo-brand__text">
+                <h1>Igloo Editor</h1>
+                <p>Same editor. Colder.</p>
+              </div>
+            </header>
+            <IglooMenu />
+            <IglooToolbar blizzard={blizzard} onBlizzard={() => setBlizzard((on) => !on)} />
+          </div>
 
-        {/* The rulers, context-fed: they read page setup from the editor and commit margin
+          {/* The rulers, context-fed: they read page setup from the editor and commit margin
             drags back to it. Restyled as icicle ticks, not reimplemented. */}
-        <div className="igloo-rulerbar">
-          <DocxEditor.HorizontalRuler className="igloo-ruler" />
-        </div>
+          <div className="igloo-rulerbar">
+            <DocxEditor.HorizontalRuler className="igloo-ruler" />
+          </div>
 
-        {/* The navigation pane is a SIBLING of the viewport inside a positioned row, not a
+          {/* The navigation pane is a SIBLING of the viewport inside a positioned row, not a
             column beside it — the same shape the packaged component uses. The pane floats
             over the gutter and absolutely positions against this box, so without the
             positioning context it would lay out in the flow and push the page down. */}
-        <div className="igloo-workspace">
-          {/* COMPOSED, not just re-themed. The pane's parts are statics, so the demo can
+          <div className="igloo-workspace">
+            {/* COMPOSED, not just re-themed. The pane's parts are statics, so the demo can
               hang its OWN class on each one rather than styling the library's internals —
               which is the difference between customizing the API and working around it. The
               parts still do all the work: the headings list is still `Navigation.Headings`,
               still fed by the engine's outline. */}
-          <DocxEditor.Navigation
-            className="igloo-nav"
-            t={iglooT}
-            toggle={{ className: 'igloo-nav__toggle' }}
-          >
-            <DocxEditor.Navigation.Header className="igloo-nav__header">
-              <DocxEditor.Navigation.Close className="igloo-nav__close" />
-              <DocxEditor.Navigation.Title className="igloo-nav__title" />
-            </DocxEditor.Navigation.Header>
-            <DocxEditor.Navigation.Tabs className="igloo-nav__tabs" />
-            <DocxEditor.Navigation.Headings className="igloo-nav__headings" />
-            <DocxEditor.Navigation.Find className="igloo-nav__find" />
-          </DocxEditor.Navigation>
+            <DocxEditor.Navigation
+              className="igloo-nav"
+              t={iglooT}
+              toggle={{ className: 'igloo-nav__toggle' }}
+            >
+              <DocxEditor.Navigation.Header className="igloo-nav__header">
+                <DocxEditor.Navigation.Close className="igloo-nav__close" />
+                <DocxEditor.Navigation.Title className="igloo-nav__title" />
+              </DocxEditor.Navigation.Header>
+              <DocxEditor.Navigation.Tabs className="igloo-nav__tabs" />
+              <DocxEditor.Navigation.Headings className="igloo-nav__headings" />
+              <DocxEditor.Navigation.Find className="igloo-nav__find" />
+            </DocxEditor.Navigation>
 
-          <DocxEditor.Viewport className="igloo-viewport">
-            {/* The vertical ruler sits at the EDITING AREA's left edge, where Word and Docs
+            <DocxEditor.Viewport className="igloo-viewport">
+              {/* The vertical ruler sits at the EDITING AREA's left edge, where Word and Docs
                 put it — not beside the page. It rides inside the scroll container as an
                 absolutely positioned child, so it scrolls with the document and its zero
                 stays on the first page's top edge; that offset is the stage's own top
                 padding, and the two have to agree or the inch marks describe a page they are
                 not level with. */}
-            <div className="igloo-vrulerbar" aria-hidden="true">
-              <DocxEditor.VerticalRuler className="igloo-ruler" />
-            </div>
-
-            {/* The loading screen, replaced: rendered only while there is no document. */}
-            <DocxEditor.Loading>
-              <div className="igloo-loading">
-                <IglooMark spinning />
-                <span>{error ? error.message : 'Carving the berg…'}</span>
+              <div className="igloo-vrulerbar" aria-hidden="true">
+                <DocxEditor.VerticalRuler className="igloo-ruler" />
               </div>
-            </DocxEditor.Loading>
-            {/* A parse failure CLEARS `isLoading` (a document that cannot open is not still
+
+              {/* The loading screen, replaced: rendered only while there is no document. */}
+              <DocxEditor.Loading>
+                {/* A failed fetch parks here for good (no bytes ever arrive), so the mark
+                  stops spinning — an error that keeps animating reads as progress. */}
+                <div className="igloo-loading">
+                  <IglooMark spinning={!error} />
+                  <span>{error ? error.message : 'Carving the berg…'}</span>
+                </div>
+              </DocxEditor.Loading>
+              {/* A parse failure CLEARS `isLoading` (a document that cannot open is not still
                 arriving), so the loading screen unmounts — this is the screen for that,
                 exactly where the docs say to report `snapshot().parseError`. Without it a
                 broken fixture left an empty sea and nothing to read. */}
-            <CarveFailure />
+              <CarveFailure />
 
-            {/* The berg the page rides on: art behind, page on top, both in one stage so the
+              {/* The berg the page rides on: art behind, page on top, both in one stage so the
                 berg tracks the page as it scrolls. */}
-            <div className="igloo-stage">
-              <Iceberg />
-              <DocxEditor.Content className="igloo-page" />
-            </div>
+              <div className="igloo-stage">
+                <Iceberg />
+                <DocxEditor.Content className="igloo-page" />
+              </div>
 
-            {/* The packaged link popover, restyled into an ice shard by class alone. */}
-            <DocxEditor.HyperLink className="igloo-shard" />
-            {/* The PRO review rail — comments, tracked changes AND this demo's own
+              {/* The packaged link popover, restyled into an ice shard by class alone. */}
+              <DocxEditor.HyperLink className="igloo-shard" />
+              {/* The PRO review rail — comments, tracked changes AND this demo's own
                 specimens, as cards beside the page. Enabled by `reviewModule()` on the
                 Root; `IglooReview.tsx` is where it is re-cut. */}
-            <IglooReview />
-            <IglooContextMenu />
-          </DocxEditor.Viewport>
-        </div>
+              <IglooReview />
+              <IglooContextMenu />
+            </DocxEditor.Viewport>
+          </div>
         </SpecimenProvider>
       </DocxEditor.Root>
     </div>

--- a/examples/igloo/src/IglooEditor.tsx
+++ b/examples/igloo/src/IglooEditor.tsx
@@ -11,7 +11,8 @@
 // in the chrome, in the sea behind, and in the berg the page rides on.
 
 import { useState } from 'react';
-import { DocxEditor, useDocxSource } from '@docx-editor.dev/react';
+import { DocxEditor, useDocxSource, useEditorState } from '@docx-editor.dev/react';
+import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { customNodesModule, reviewModule } from '@docx-editor.dev/pro';
 import { defaultFonts } from '@docx-editor.dev/fonts';
 
@@ -127,6 +128,11 @@ export function IglooEditor({ fixtureUrl }: IglooEditorProps) {
                 <span>{error ? error.message : 'Carving the berg…'}</span>
               </div>
             </DocxEditor.Loading>
+            {/* A parse failure CLEARS `isLoading` (a document that cannot open is not still
+                arriving), so the loading screen unmounts — this is the screen for that,
+                exactly where the docs say to report `snapshot().parseError`. Without it a
+                broken fixture left an empty sea and nothing to read. */}
+            <CarveFailure />
 
             {/* The berg the page rides on: art behind, page on top, both in one stage so the
                 berg tracks the page as it scrolls. */}
@@ -146,6 +152,20 @@ export function IglooEditor({ fixtureUrl }: IglooEditorProps) {
         </div>
         </SpecimenProvider>
       </DocxEditor.Root>
+    </div>
+  );
+}
+
+const selectParseError = (snapshot: EditorSnapshot) => snapshot.parseError;
+
+/** The document could not be opened: the loading screen's sibling, same ice, no spin. */
+function CarveFailure() {
+  const parseError = useEditorState(selectParseError);
+  if (parseError === null) return null;
+  return (
+    <div className="igloo-loading" role="alert">
+      <IglooMark />
+      <span>This one would not carve: {parseError}</span>
     </div>
   );
 }

--- a/examples/igloo/src/SpecimenDialog.tsx
+++ b/examples/igloo/src/SpecimenDialog.tsx
@@ -5,7 +5,7 @@
 // Attrs ride in the `w:tag`, which Word caps at 64 characters, so the fields collect one
 // number and a label rather than a payload.
 
-import { useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import {
   blocksOf,
   defaultAttrs,
@@ -55,7 +55,43 @@ export function SpecimenDialog({ form, onCommit, onClose }: SpecimenDialogProps)
   const [label, setLabel] = useState(form.label);
   const editing = form.mode === 'edit';
   const field = FIELD[kind];
-  const value = kind === 'iceberg' ? depthOf(attrs) : blocksOf(attrs);
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const titleId = useId();
+
+  // Escape and Tab containment on `document`, not the scrim: a click on the dialog's own
+  // non-focusable text moves focus to `body`, and a scrim-scoped keydown would never hear
+  // the Escape that follows. Tab wraps at the edges — the scrim only blocks the POINTER,
+  // and `aria-modal` promises assistive tech the background is not there, so the keyboard
+  // must not walk out into it. Capture phase, so the editor's keymap never sees these keys.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const root = formRef.current;
+      if (!root) return;
+      // `:disabled` also matches inputs inside the editing mode's disabled fieldset.
+      const focusable = [...root.querySelectorAll<HTMLElement>('input, button')].filter(
+        (element) => !element.matches(':disabled')
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !root.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (active === last || !root.contains(active))) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [onClose]);
 
   /** Switching kind switches which attr is meaningful, so the defaults come with it. */
   const chooseKind = (next: SpecimenKind): void => {
@@ -74,35 +110,42 @@ export function SpecimenDialog({ form, onCommit, onClose }: SpecimenDialogProps)
   };
 
   return (
+    // The scrim is presentation: it blocks the pointer and closes on a backdrop press.
+    // The dialog ROLE lives on the box itself, named by its own heading, so the
+    // accessibility tree matches what a sighted user sees as "the dialog".
     <div
       className="igloo-dialog__scrim"
-      role="dialog"
-      aria-modal="true"
-      aria-label={editing ? 'Re-carve this specimen' : 'Carve a specimen'}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
-      // Escape closes, like every packaged panel. Listening on the scrim is enough because
-      // the autofocused field below puts focus inside it the moment the dialog opens.
-      onKeyDown={(event) => {
-        if (event.key === 'Escape') onClose();
-      }}
     >
       <form
+        ref={formRef}
         className="igloo-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         onSubmit={(event) => {
           event.preventDefault();
+          // The field keeps whatever was typed, including a mid-edit empty string; the
+          // COMMIT is where it clamps back into range, through the same reads the
+          // recognition boundary uses.
+          const clamped = {
+            [field.key]: String(kind === 'iceberg' ? depthOf(attrs) : blocksOf(attrs)),
+          };
           onCommit(
             editing
-              ? { mode: 'edit', kind, nodeId: form.nodeId, attrs, label }
-              : { mode: 'insert', kind, attrs, label, at: form.at }
+              ? { mode: 'edit', kind, nodeId: form.nodeId, attrs: clamped, label }
+              : { mode: 'insert', kind, attrs: clamped, label, at: form.at }
           );
         }}
       >
-        <h2 className="igloo-dialog__title">{editing ? 'Re-carve it' : 'Carve a specimen'}</h2>
+        <h2 className="igloo-dialog__title" id={titleId}>
+          {editing ? 'Re-carve it' : 'Carve a specimen'}
+        </h2>
         <p className="igloo-dialog__lede">
-          The label is what the paragraph shows, in this editor and in Word. The number rides
-          in the control&rsquo;s tag and comes back typed on the chip, the card and the menu.
+          The label is what the paragraph shows, in this editor and in Word. The number rides in the
+          control&rsquo;s tag and comes back typed on the chip, the card and the menu.
         </p>
 
         {/* Fixed while editing: swapping the tag would be deleting one node and authoring
@@ -110,7 +153,11 @@ export function SpecimenDialog({ form, onCommit, onClose }: SpecimenDialogProps)
         <fieldset className="igloo-dialog__kinds" disabled={editing}>
           <legend className="igloo-dialog__legend">Specimen</legend>
           {(['iceberg', 'igloo'] as const).map((option) => (
-            <label key={option} className="igloo-dialog__kind" data-checked={kind === option ? '' : undefined}>
+            <label
+              key={option}
+              className="igloo-dialog__kind"
+              data-checked={kind === option ? '' : undefined}
+            >
               <input
                 type="radio"
                 name="igloo-specimen-kind"
@@ -126,16 +173,25 @@ export function SpecimenDialog({ form, onCommit, onClose }: SpecimenDialogProps)
           <span>Label (document text)</span>
           {/* A modal dialog is the one place initial focus belongs inside; the scrim's
               Escape handler depends on focus landing here. */}
-          <input autoFocus value={label} onChange={(event) => setLabel(event.target.value)} required />
+          <input
+            autoFocus
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            required
+          />
         </label>
 
         <label className="igloo-dialog__field">
           <span>{field.label}</span>
+          {/* The RAW string, not the clamped read: clamping while someone is still typing
+              turns backspace-to-clear into an instant "90", and the only way to enter a
+              number becomes select-all-overtype. Submit clamps; see onSubmit. */}
           <input
             type="number"
             min={1}
             max={field.max}
-            value={value}
+            required
+            value={attrs[field.key] ?? ''}
             onChange={(event) => setAttrs({ [field.key]: event.target.value })}
           />
           <small>{field.hint}</small>

--- a/examples/igloo/src/SpecimenDialog.tsx
+++ b/examples/igloo/src/SpecimenDialog.tsx
@@ -82,6 +82,11 @@ export function SpecimenDialog({ form, onCommit, onClose }: SpecimenDialogProps)
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
+      // Escape closes, like every packaged panel. Listening on the scrim is enough because
+      // the autofocused field below puts focus inside it the moment the dialog opens.
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose();
+      }}
     >
       <form
         className="igloo-dialog"
@@ -96,7 +101,7 @@ export function SpecimenDialog({ form, onCommit, onClose }: SpecimenDialogProps)
       >
         <h2 className="igloo-dialog__title">{editing ? 'Re-carve it' : 'Carve a specimen'}</h2>
         <p className="igloo-dialog__lede">
-          The label is what the paragraph shows — in this editor and in Word. The number rides
+          The label is what the paragraph shows, in this editor and in Word. The number rides
           in the control&rsquo;s tag and comes back typed on the chip, the card and the menu.
         </p>
 
@@ -119,7 +124,9 @@ export function SpecimenDialog({ form, onCommit, onClose }: SpecimenDialogProps)
 
         <label className="igloo-dialog__field">
           <span>Label (document text)</span>
-          <input value={label} onChange={(event) => setLabel(event.target.value)} required />
+          {/* A modal dialog is the one place initial focus belongs inside; the scrim's
+              Escape handler depends on focus landing here. */}
+          <input autoFocus value={label} onChange={(event) => setLabel(event.target.value)} required />
         </label>
 
         <label className="igloo-dialog__field">

--- a/examples/igloo/src/SpecimenPopover.tsx
+++ b/examples/igloo/src/SpecimenPopover.tsx
@@ -22,7 +22,9 @@ const PROBE_WIDTH = 260;
 
 export function SpecimenPopover({ probe, onClose }: SpecimenPopoverProps) {
   // Capture phase: the painted surface cancels its own pointer handling, so a bubbling
-  // listener never hears a press on the page.
+  // listener never hears a press on the page. Scroll closes too — the card is `fixed` and
+  // anchored to a rect captured at click, so a scrolled page would move the chip out from
+  // under it while the card stayed put, annotating open water.
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') onClose();
@@ -34,9 +36,11 @@ export function SpecimenPopover({ probe, onClose }: SpecimenPopoverProps) {
     };
     document.addEventListener('keydown', onKey);
     document.addEventListener('pointerdown', onDown, true);
+    document.addEventListener('scroll', onClose, { capture: true, passive: true });
     return () => {
       document.removeEventListener('keydown', onKey);
       document.removeEventListener('pointerdown', onDown, true);
+      document.removeEventListener('scroll', onClose, { capture: true });
     };
   }, [onClose]);
 
@@ -48,7 +52,16 @@ export function SpecimenPopover({ probe, onClose }: SpecimenPopoverProps) {
   };
 
   return (
-    <div className="igloo-probe" style={style} data-kind={probe.kind} role="dialog" aria-modal="false">
+    // Not a dialog: nothing in it takes focus and nothing in it acts. It is a transient
+    // readout the chip click revealed, so it carries no role — and its mousedown is
+    // prevented, per the chrome rule: a press that reaches the surface moves the caret,
+    // and reading two numbers must not do that.
+    <div
+      className="igloo-probe"
+      style={style}
+      data-kind={probe.kind}
+      onMouseDown={(event) => event.preventDefault()}
+    >
       {probe.kind === 'iceberg' ? (
         <>
           <p className="igloo-probe__title">There is more of it than that</p>

--- a/examples/igloo/src/igloo.css
+++ b/examples/igloo/src/igloo.css
@@ -75,8 +75,13 @@
   height: 100vh;
   overflow: hidden;
   /* The water itself: deep below, bright at the horizon. */
-  background:
-    radial-gradient(120% 70% at 50% -10%, #9fd9f2 0%, #4a9fc8 38%, #17547a 72%, #0b2740 100%);
+  background: radial-gradient(
+    120% 70% at 50% -10%,
+    #9fd9f2 0%,
+    #4a9fc8 38%,
+    #17547a 72%,
+    #0b2740 100%
+  );
   color: var(--doc-text);
 }
 
@@ -164,6 +169,9 @@
 
 .igloo-rulerbar {
   z-index: 4;
+  /* The ruler renders nothing until a document is open; the bar holds its height so the
+     workspace does not jump down when the ticks appear. */
+  min-height: 28px;
 }
 
 .igloo-brand {
@@ -913,11 +921,21 @@
  *
  * `insertCustomNode` and `updateCustomNode` return a typed result, and repeating that reason
  * verbatim beats a host inventing one. */
+/* The persistent live region the notices swap through. Fixed and sizeless, so an empty
+   region never takes part in the shell's layout. */
+.igloo-notice-region {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+}
+
 .igloo-notice {
   position: fixed;
   bottom: 24px;
   left: 50%;
   z-index: 80;
+  /* Informational only: a press on it would blur the editor for nothing. */
+  pointer-events: none;
   padding: 9px 16px;
   border: 1px solid rgba(255, 255, 255, 0.7);
   border-radius: 999px;

--- a/examples/igloo/src/main.tsx
+++ b/examples/igloo/src/main.tsx
@@ -17,12 +17,13 @@ const requested = new URLSearchParams(location.search).get('fixture') ?? '';
 const fixture = /^[\w.-]+\.docx$/.test(requested) ? requested : DEFAULT_FIXTURE;
 
 const container = document.getElementById('app');
-if (container) {
-  // StrictMode, because the library asks its hosts to survive it: `DocxEditor.Root`
-  // documents itself as StrictMode-safe, and a demo that skipped it would stop proving that.
-  createRoot(container).render(
-    <StrictMode>
-      <IglooEditor fixtureUrl={`${base}${fixture}`} />
-    </StrictMode>
-  );
-}
+// Throw, not an if: a missing mount point is a broken index.html, and a demo that
+// silently renders nothing hides it.
+if (!container) throw new Error('missing #app mount point');
+// StrictMode, because the library asks its hosts to survive it: `DocxEditor.Root`
+// documents itself as StrictMode-safe, and a demo that skipped it would stop proving that.
+createRoot(container).render(
+  <StrictMode>
+    <IglooEditor fixtureUrl={`${base}${fixture}`} />
+  </StrictMode>
+);

--- a/examples/igloo/src/main.tsx
+++ b/examples/igloo/src/main.tsx
@@ -1,4 +1,5 @@
 import './igloo.css';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { IglooEditor } from './IglooEditor';
 
@@ -17,5 +18,11 @@ const fixture = /^[\w.-]+\.docx$/.test(requested) ? requested : DEFAULT_FIXTURE;
 
 const container = document.getElementById('app');
 if (container) {
-  createRoot(container).render(<IglooEditor fixtureUrl={`${base}${fixture}`} />);
+  // StrictMode, because the library asks its hosts to survive it: `DocxEditor.Root`
+  // documents itself as StrictMode-safe, and a demo that skipped it would stop proving that.
+  createRoot(container).render(
+    <StrictMode>
+      <IglooEditor fixtureUrl={`${base}${fixture}`} />
+    </StrictMode>
+  );
 }

--- a/examples/igloo/src/specimens.ts
+++ b/examples/igloo/src/specimens.ts
@@ -68,7 +68,7 @@ export const ICEBERG = defineCustomNode({
   reviewCard: ({ attrs, text }) => {
     const depth = depthOf(attrs);
     return {
-      title: `Iceberg — ${tipHeight(depth)} m up, ${depth} m down`,
+      title: `Iceberg: ${tipHeight(depth)} m up, ${depth} m down`,
       detail: `“${text}” is all of it that surfaced. The other nine tenths are below the line.`,
     };
   },
@@ -87,7 +87,7 @@ export const IGLOO = defineCustomNode({
   reviewCard: ({ attrs }) => {
     const blocks = blocksOf(attrs);
     return {
-      title: `Igloo — ${blocks} blocks`,
+      title: `Igloo: ${blocks} blocks`,
       detail: `${insideTemperature(blocks)} °C in here, ${OUTSIDE} °C out there. Click it to lay another.`,
     };
   },

--- a/examples/igloo/src/useFrost.ts
+++ b/examples/igloo/src/useFrost.ts
@@ -9,6 +9,7 @@
 // round-trips to DOCX like any other formatting. A demo action that only moved local state
 // would look the same on screen and prove nothing about the API.
 
+import { useCallback, useMemo } from 'react';
 import { useDocxEditor, useEditorCommand, useEditorState } from '@docx-editor.dev/react';
 import type { EditorCommand } from '@docx-editor.dev/react';
 
@@ -46,10 +47,17 @@ export function useFrost(): FrostActions {
   const { isEnabled, disabledReason } = useEditorCommand(frostCommand('cyan'));
   const collapsed = useEditorState((snapshot) => snapshot.selectionCollapsed);
 
-  return {
-    freeze: () => editor?.exec(frostCommand('cyan')),
-    thaw: () => editor?.exec(frostCommand('none')),
-    enabled: isEnabled && !collapsed,
-    disabledReason: collapsed && isEnabled ? 'nothing is selected' : disabledReason,
-  };
+  // Memoized like the library's own hooks: three surfaces render from this return, and a
+  // fresh object per render would defeat any memo a consumer put between itself and it.
+  const freeze = useCallback(() => editor?.exec(frostCommand('cyan')), [editor]);
+  const thaw = useCallback(() => editor?.exec(frostCommand('none')), [editor]);
+  return useMemo(
+    () => ({
+      freeze,
+      thaw,
+      enabled: isEnabled && !collapsed,
+      disabledReason: collapsed && isEnabled ? 'nothing is selected' : disabledReason,
+    }),
+    [freeze, thaw, isEnabled, collapsed, disabledReason]
+  );
 }

--- a/examples/igloo/src/useSpecimens.tsx
+++ b/examples/igloo/src/useSpecimens.tsx
@@ -7,7 +7,16 @@
 // It also mounts `CustomNodeChrome`, which belongs inside `DocxEditor.Root` and drives its
 // `onNodeClick` from the state held here.
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useDocxEditor, useEditorCaret, useEditorState } from '@docx-editor.dev/react';
 import { insertCustomNode, updateCustomNode, type ActivatedCustomNode } from '@docx-editor.dev/pro';
 import { CustomNodeChrome } from '@docx-editor.dev/pro/react';
@@ -81,13 +90,28 @@ export function SpecimenProvider({ children }: { children: ReactNode }) {
   const [notice, setNotice] = useState<Notice | null>(null);
 
   // The caret at the moment a row is chosen. A dialog takes focus, so inserting at "wherever
-  // the selection is by then" lands the specimen wherever the last click left it. The value is
-  // reference-stable, so capturing it in a handler is safe.
+  // the selection is by then" lands the specimen wherever the last click left it.
+  //
+  // Read through a REF at call time, not closed over: the caret moves on every keystroke,
+  // and actions whose identities followed it rebuilt the context value — and with it the
+  // whole menu tree of every consumer — once per typed character. The handlers only need
+  // the caret at the moment they run, which is exactly what a ref carries.
   const caret = useEditorCaret();
+  const caretRef = useRef(caret);
+  caretRef.current = caret;
 
   const say = useCallback((text: string) => {
     setNotice((previous) => ({ id: (previous?.id ?? 0) + 1, text }));
   }, []);
+
+  // The fade animation's `onAnimationEnd` is the primary dismissal; this is the fallback
+  // for environments where it never fires (reduced motion, a hidden tab's throttled
+  // rendering) — a status pill must not outlive its moment.
+  useEffect(() => {
+    if (!notice) return undefined;
+    const timer = window.setTimeout(() => setNotice(null), 5000);
+    return () => window.clearTimeout(timer);
+  }, [notice]);
 
   const report = useCallback(
     (result: Refusable, done: string) => {
@@ -111,18 +135,15 @@ export function SpecimenProvider({ children }: { children: ReactNode }) {
     [editor, report]
   );
 
-  const compose = useCallback(
-    (kind: SpecimenKind) => {
-      const attrs = defaultAttrs(kind);
-      setForm({ mode: 'insert', kind, attrs, label: labelFor(kind, attrs), at: caret });
-    },
-    [caret]
-  );
+  const compose = useCallback((kind: SpecimenKind) => {
+    const attrs = defaultAttrs(kind);
+    setForm({ mode: 'insert', kind, attrs, label: labelFor(kind, attrs), at: caretRef.current });
+  }, []);
 
   const dropRandom = useCallback(() => {
     const picked = randomSpecimen();
-    place(picked.kind, picked.attrs, picked.label, caret);
-  }, [caret, place]);
+    place(picked.kind, picked.attrs, picked.label, caretRef.current);
+  }, [place]);
 
   const edit = useCallback(
     (node: ActivatedCustomNode) => {
@@ -199,36 +220,59 @@ export function SpecimenProvider({ children }: { children: ReactNode }) {
       if (!editor) return;
       if (next.mode === 'insert') {
         place(next.kind, next.attrs, next.label, next.at);
-        return;
+      } else {
+        const definition = definitionOf(next.kind);
+        report(
+          updateCustomNode(editor, definition, next.nodeId, next.attrs, next.label, {
+            alias: definition.label ?? definition.name,
+          }),
+          'Re-carved.'
+        );
       }
-      const definition = definitionOf(next.kind);
-      report(
-        updateCustomNode(editor, definition, next.nodeId, next.attrs, next.label, {
-          alias: definition.label ?? definition.name,
-        }),
-        'Re-carved.'
-      );
+      // Back to the document, the way the packaged compose box returns focus: the dialog
+      // took it, and without this the writer lands on `body` with Tab restarting at the top.
+      editor.focus();
     },
     [editor, place, report]
   );
+
+  // Stable, so the dialog's and popover's document-level listener effects bind once per
+  // open rather than re-subscribing on every provider render.
+  const closeDialog = useCallback(() => {
+    setForm(null);
+    editor?.focus();
+  }, [editor]);
+  const closePopover = useCallback(() => setProbe(null), []);
 
   return (
     <SpecimenContext.Provider value={value}>
       {/* Chip tint and click delegation. Defaults to the definitions registered on the Root. */}
       <CustomNodeChrome onNodeClick={activate} />
       {children}
-      {form ? <SpecimenDialog form={form} onCommit={commit} onClose={() => setForm(null)} /> : null}
-      {probe ? <SpecimenPopover probe={probe} onClose={() => setProbe(null)} /> : null}
-      {notice ? (
-        <div
-          key={notice.id}
-          className="igloo-notice"
-          role="status"
-          onAnimationEnd={() => setNotice(null)}
-        >
-          {notice.text}
-        </div>
+      {/* KEYED by what is being authored: the fields are seeded from `form` at mount, and
+          the key guarantees a different target never reuses a mounted dialog's state —
+          without it, an edit reached while another edit was open would show the previous
+          node's fields and save them to the new nodeId. */}
+      {form ? (
+        <SpecimenDialog
+          key={form.mode === 'edit' ? form.nodeId : 'insert'}
+          form={form}
+          onCommit={commit}
+          onClose={closeDialog}
+        />
       ) : null}
+      {probe ? <SpecimenPopover probe={probe} onClose={closePopover} /> : null}
+      {/* The live region is PERSISTENT and the notice swaps inside it: a `role="status"`
+          element inserted already holding its text is unreliably announced, and this one
+          was also remounted per notice to replay the fade. The inner key keeps the replay;
+          the region keeps the announcement. */}
+      <div role="status" className="igloo-notice-region">
+        {notice ? (
+          <div key={notice.id} className="igloo-notice" onAnimationEnd={() => setNotice(null)}>
+            {notice.text}
+          </div>
+        ) : null}
+      </div>
     </SpecimenContext.Provider>
   );
 }

--- a/examples/igloo/src/useSpecimens.tsx
+++ b/examples/igloo/src/useSpecimens.tsx
@@ -184,7 +184,7 @@ export function SpecimenProvider({ children }: { children: ReactNode }) {
       disabledReason: editable
         ? null
         : mode === 'viewing'
-          ? 'Viewing mode — switch to Editing or Suggesting'
+          ? 'Viewing mode: switch to Editing or Suggesting'
           : 'this document is read-only',
       compose,
       dropRandom,

--- a/examples/vite/src/styles.css
+++ b/examples/vite/src/styles.css
@@ -270,6 +270,9 @@
      navigation + review reservations force horizontal overflow. */
   justify-content: safe center;
   padding: 6px 0 2px;
+  /* The ruler renders nothing until a document is open; the row holds its height so the
+     page stack does not jump down when the ticks appear. */
+  min-height: 36px;
   overflow: hidden;
   flex: none;
 }

--- a/packages/pro/src/__tests__/review-sidebar.test.tsx
+++ b/packages/pro/src/__tests__/review-sidebar.test.tsx
@@ -492,5 +492,15 @@ describe('DocxEditor.Review while the document is loading', () => {
     expect(view.getByTestId('review-rail')).toBeDefined();
     expect(view.getByTestId('review-empty')).toBeDefined();
     expect(view.getByTestId('host-furniture')).toBeDefined();
+
+    // A parse failure clears `isLoading` (so a host can put its error screen up) while
+    // still leaving no document. The rail must read that as "nothing to review", not as
+    // a document — it floated its empty state over hosts' parse-error screens otherwise.
+    await act(async () => {
+      view.rerender(compose(strToU8('not a docx')));
+    });
+
+    expect(view.queryByTestId('review-rail')).toBeNull();
+    expect(view.queryByTestId('host-furniture')).toBeNull();
   });
 });

--- a/packages/pro/src/__tests__/review-sidebar.test.tsx
+++ b/packages/pro/src/__tests__/review-sidebar.test.tsx
@@ -466,3 +466,31 @@ describe('DocxEditor.Review query exclusions', () => {
     expect(view.getByTestId('review-rail').getAttribute('data-count')).toBe('2');
   });
 });
+
+describe('DocxEditor.Review while the document is loading', () => {
+  test('renders nothing — no rail, no empty state, no furniture — until bytes arrive', async () => {
+    const compose = (document?: Uint8Array) => (
+      <DocxEditorRoot {...(document ? { document } : {})} modules={[reviewModule()]}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview furniture={<div data-testid="host-furniture" />} />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    // The Root mounted before its document, the shape every fetching host has: the editor
+    // instance exists, but there is nothing to review — and nothing to say "no comments
+    // yet" about. The rail must not float its empty state over the host's loading screen.
+    const view = render(compose());
+    expect(view.queryByTestId('review-rail')).toBeNull();
+    expect(view.queryByTestId('review-empty')).toBeNull();
+    expect(view.queryByTestId('host-furniture')).toBeNull();
+
+    await act(async () => {
+      view.rerender(compose(SOURCE));
+    });
+
+    expect(view.getByTestId('review-rail')).toBeDefined();
+    expect(view.getByTestId('review-empty')).toBeDefined();
+    expect(view.getByTestId('host-furniture')).toBeDefined();
+  });
+});

--- a/packages/pro/src/__tests__/review-sidebar.test.tsx
+++ b/packages/pro/src/__tests__/review-sidebar.test.tsx
@@ -503,4 +503,33 @@ describe('DocxEditor.Review while the document is loading', () => {
     expect(view.queryByTestId('review-rail')).toBeNull();
     expect(view.queryByTestId('host-furniture')).toBeNull();
   });
+
+  test('a failed live load hides the rail — the failure emits only `error`', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={SOURCE}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    expect(view.getByTestId('review-rail')).toBeDefined();
+
+    // The SAME editor instance, handed bytes that will not parse: the surface is torn
+    // down and the facade emits ONLY `error` — no `change` fires for a failing load. The
+    // rail (and the raw hook's `ready`) must hear that event, or they keep the previous
+    // document's cards over a document that never opened.
+    await act(async () => {
+      instance!.load(strToU8('not a docx'));
+    });
+
+    expect(view.queryByTestId('review-rail')).toBeNull();
+  });
 });

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -62,12 +62,14 @@ import {
 import { useReview, type ReviewItemView } from './useReview';
 
 /**
- * True while the editor holds NO document: still loading one, or the one it was handed
- * would not parse. Not `isLoading` alone — a parse failure clears that flag (so hosts can
- * put their own error screen up), and the rail must not read the clearing as a document.
+ * True while the editor has NO painted document: still loading one, the one it was handed
+ * would not parse, or bytes are held but detached from any mount point. Not `isLoading`
+ * alone — a parse failure clears that flag (so hosts can put their own error screen up),
+ * and handed-over-but-detached bytes clear it too, while in both states there is nothing
+ * for a card to anchor to. `pageSetup` is null in exactly those states.
  */
 const selectDocumentAbsent = (snapshot: EditorSnapshot) =>
-  snapshot.isLoading || snapshot.parseError !== null;
+  snapshot.isLoading || snapshot.parseError !== null || snapshot.pageSetup == null;
 
 /** The rail's data, provided once by the Root so a card never re-subscribes. */
 const ReviewContext = createContext<ReviewRailValue | null>(null);
@@ -499,10 +501,10 @@ function ReviewRoot({
     if (surface) observer.observe(surface);
     return () => observer.disconnect();
     // Re-measured whenever the queue could have moved: a new page above an anchor changes
-    // where its card belongs, and zoom changes every anchor at once. `documentAbsent` because
-    // the rail element does not exist until loading ends, and a binding pass that ran
-    // against the null ref must run again once there is a rail to measure.
-  }, [editor, items, documentAbsent]);
+    // where its card belongs, and zoom changes every anchor at once. `documentAbsent` and
+    // `hidden` because the rail element does not exist while either holds, and a binding
+    // pass that ran against the null ref must run again once there is a rail to measure.
+  }, [editor, items, documentAbsent, hidden]);
 
   // Clicking the canvas AROUND the page closes the open item. The caret decides everything
   // else, but a click on the grey moves no caret, so nothing else would ever put a card away.
@@ -524,8 +526,9 @@ function ReviewRoot({
     // bubbling listener never sees a click that lands on the pages layer.
     document.addEventListener('mousedown', onMouseDown, true);
     return () => document.removeEventListener('mousedown', onMouseDown, true);
-    // `documentAbsent` for the same reason as the metrics effect: no rail element until it clears.
-  }, [editor, documentAbsent]);
+    // `documentAbsent` and `hidden` for the same reason as the metrics effect: no rail element
+    // exists while either holds.
+  }, [editor, documentAbsent, hidden]);
 
   // The visible band of the scroller, in the rail's own coordinates. Passive listener,
   // coalesced into a frame: the handler runs on every wheel tick and must do nothing but
@@ -568,8 +571,9 @@ function ReviewRoot({
       scroller.removeEventListener('scroll', onScroll);
       observer.disconnect();
     };
-    // `documentAbsent` for the same reason as the metrics effect: no rail element until it clears.
-  }, [editor, documentAbsent]);
+    // `documentAbsent` and `hidden` for the same reason as the metrics effect: no rail element
+    // exists while either holds.
+  }, [editor, documentAbsent, hidden]);
 
   // A comment being composed, before anything is written. Held here rather than committed
   // empty: an empty `w:comment` is a real comment in the file, and abandoning the box would

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -61,8 +61,13 @@ import {
 } from '@docx-editor.dev/react';
 import { useReview, type ReviewItemView } from './useReview';
 
-/** The same scalar slice `DocxEditor.Loading` reads, so the two can never disagree. */
-const selectIsLoading = (snapshot: EditorSnapshot) => snapshot.isLoading;
+/**
+ * True while the editor holds NO document: still loading one, or the one it was handed
+ * would not parse. Not `isLoading` alone — a parse failure clears that flag (so hosts can
+ * put their own error screen up), and the rail must not read the clearing as a document.
+ */
+const selectDocumentAbsent = (snapshot: EditorSnapshot) =>
+  snapshot.isLoading || snapshot.parseError !== null;
 
 /** The rail's data, provided once by the Root so a card never re-subscribes. */
 const ReviewContext = createContext<ReviewRailValue | null>(null);
@@ -352,11 +357,11 @@ function ReviewRoot({
   formatting = false,
 }: ReviewProps) {
   const editor = useDocxEditor();
-  // While the editor is still waiting for its document, the rail renders NOTHING — not its
-  // empty state, not the host's furniture. The instance exists before any bytes arrive, so
-  // without this gate "no comments yet" and the furniture floated over the host's loading
+  // While the editor holds no document, the rail renders NOTHING — not its empty state,
+  // not the host's furniture. The instance exists before any bytes arrive, so without
+  // this gate "no comments yet" and the furniture floated over the host's loading
   // screen, describing a document that was not there.
-  const isLoading = useEditorState(selectIsLoading);
+  const documentAbsent = useEditorState(selectDocumentAbsent);
   const excludeRevisionKinds = useMemo((): readonly ReviewRevisionKind[] | undefined => {
     const excluded: ReviewRevisionKind[] = [];
     if (!structural) excluded.push('structural');
@@ -494,10 +499,10 @@ function ReviewRoot({
     if (surface) observer.observe(surface);
     return () => observer.disconnect();
     // Re-measured whenever the queue could have moved: a new page above an anchor changes
-    // where its card belongs, and zoom changes every anchor at once. `isLoading` because
+    // where its card belongs, and zoom changes every anchor at once. `documentAbsent` because
     // the rail element does not exist until loading ends, and a binding pass that ran
     // against the null ref must run again once there is a rail to measure.
-  }, [editor, items, isLoading]);
+  }, [editor, items, documentAbsent]);
 
   // Clicking the canvas AROUND the page closes the open item. The caret decides everything
   // else, but a click on the grey moves no caret, so nothing else would ever put a card away.
@@ -519,8 +524,8 @@ function ReviewRoot({
     // bubbling listener never sees a click that lands on the pages layer.
     document.addEventListener('mousedown', onMouseDown, true);
     return () => document.removeEventListener('mousedown', onMouseDown, true);
-    // `isLoading` for the same reason as the metrics effect: no rail element until it clears.
-  }, [editor, isLoading]);
+    // `documentAbsent` for the same reason as the metrics effect: no rail element until it clears.
+  }, [editor, documentAbsent]);
 
   // The visible band of the scroller, in the rail's own coordinates. Passive listener,
   // coalesced into a frame: the handler runs on every wheel tick and must do nothing but
@@ -563,8 +568,8 @@ function ReviewRoot({
       scroller.removeEventListener('scroll', onScroll);
       observer.disconnect();
     };
-    // `isLoading` for the same reason as the metrics effect: no rail element until it clears.
-  }, [editor, isLoading]);
+    // `documentAbsent` for the same reason as the metrics effect: no rail element until it clears.
+  }, [editor, documentAbsent]);
 
   // A comment being composed, before anything is written. Held here rather than committed
   // empty: an empty `w:comment` is a real comment in the file, and abandoning the box would
@@ -694,7 +699,7 @@ function ReviewRoot({
     ]
   );
 
-  if (hidden || isLoading) return null;
+  if (hidden || documentAbsent) return null;
 
   const shared = {
     ref: railRef as React.Ref<HTMLElement>,

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -45,16 +45,24 @@ import {
   useState,
 } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
-import type { ReviewItemQuery, ReviewRevisionKind } from '@docx-editor.dev/core/contracts/editor';
+import type {
+  EditorSnapshot,
+  ReviewItemQuery,
+  ReviewRevisionKind,
+} from '@docx-editor.dev/core/contracts/editor';
 import type { TranslationKey } from '@docx-editor.dev/i18n';
 import {
   ReviewRailContext,
   Slot,
   useDocxEditor,
+  useEditorState,
   useTranslation,
   type ToolbarTranslate,
 } from '@docx-editor.dev/react';
 import { useReview, type ReviewItemView } from './useReview';
+
+/** The same scalar slice `DocxEditor.Loading` reads, so the two can never disagree. */
+const selectIsLoading = (snapshot: EditorSnapshot) => snapshot.isLoading;
 
 /** The rail's data, provided once by the Root so a card never re-subscribes. */
 const ReviewContext = createContext<ReviewRailValue | null>(null);
@@ -344,6 +352,11 @@ function ReviewRoot({
   formatting = false,
 }: ReviewProps) {
   const editor = useDocxEditor();
+  // While the editor is still waiting for its document, the rail renders NOTHING — not its
+  // empty state, not the host's furniture. The instance exists before any bytes arrive, so
+  // without this gate "no comments yet" and the furniture floated over the host's loading
+  // screen, describing a document that was not there.
+  const isLoading = useEditorState(selectIsLoading);
   const excludeRevisionKinds = useMemo((): readonly ReviewRevisionKind[] | undefined => {
     const excluded: ReviewRevisionKind[] = [];
     if (!structural) excluded.push('structural');
@@ -481,8 +494,10 @@ function ReviewRoot({
     if (surface) observer.observe(surface);
     return () => observer.disconnect();
     // Re-measured whenever the queue could have moved: a new page above an anchor changes
-    // where its card belongs, and zoom changes every anchor at once.
-  }, [editor, items]);
+    // where its card belongs, and zoom changes every anchor at once. `isLoading` because
+    // the rail element does not exist until loading ends, and a binding pass that ran
+    // against the null ref must run again once there is a rail to measure.
+  }, [editor, items, isLoading]);
 
   // Clicking the canvas AROUND the page closes the open item. The caret decides everything
   // else, but a click on the grey moves no caret, so nothing else would ever put a card away.
@@ -504,7 +519,8 @@ function ReviewRoot({
     // bubbling listener never sees a click that lands on the pages layer.
     document.addEventListener('mousedown', onMouseDown, true);
     return () => document.removeEventListener('mousedown', onMouseDown, true);
-  }, [editor]);
+    // `isLoading` for the same reason as the metrics effect: no rail element until it clears.
+  }, [editor, isLoading]);
 
   // The visible band of the scroller, in the rail's own coordinates. Passive listener,
   // coalesced into a frame: the handler runs on every wheel tick and must do nothing but
@@ -547,7 +563,8 @@ function ReviewRoot({
       scroller.removeEventListener('scroll', onScroll);
       observer.disconnect();
     };
-  }, [editor]);
+    // `isLoading` for the same reason as the metrics effect: no rail element until it clears.
+  }, [editor, isLoading]);
 
   // A comment being composed, before anything is written. Held here rather than committed
   // empty: an empty `w:comment` is a real comment in the file, and abandoning the box would
@@ -677,7 +694,7 @@ function ReviewRoot({
     ]
   );
 
-  if (hidden) return null;
+  if (hidden || isLoading) return null;
 
   const shared = {
     ref: railRef as React.Ref<HTMLElement>,

--- a/packages/pro/src/react/useReview.ts
+++ b/packages/pro/src/react/useReview.ts
@@ -217,8 +217,11 @@ export function useReviewOf(editor: Editor | null, query?: ReviewItemQuery): Use
       setPaneOpen,
       // Not merely "an editor exists": the instance is constructed before any bytes arrive,
       // and a `ready` that reported true then invited surfaces to draw an empty state over
-      // the host's loading screen. Re-derived with the queue — the load emits `change`.
-      ready: editor !== null && !editor.snapshot().isLoading,
+      // the host's loading screen. A parse failure clears `isLoading` while still leaving
+      // no document, so it must stay false then too. Re-derived with the queue — the load
+      // emits `change`.
+      ready:
+        editor !== null && !editor.snapshot().isLoading && editor.snapshot().parseError === null,
     }),
     [
       items,

--- a/packages/pro/src/react/useReview.ts
+++ b/packages/pro/src/react/useReview.ts
@@ -81,7 +81,7 @@ export interface UseReviewReturn {
   readonly paneOpen: boolean;
   /** Open or close the pane — the same toggle the toolbar button runs. */
   readonly setPaneOpen: (open: boolean) => void;
-  /** True while the engine has no document, so a surface can render nothing rather than empty. */
+  /** False until the engine has a document, so a surface can render nothing rather than empty. */
   readonly ready: boolean;
 }
 
@@ -215,7 +215,10 @@ export function useReviewOf(editor: Editor | null, query?: ReviewItemQuery): Use
       comment,
       paneOpen,
       setPaneOpen,
-      ready: editor !== null,
+      // Not merely "an editor exists": the instance is constructed before any bytes arrive,
+      // and a `ready` that reported true then invited surfaces to draw an empty state over
+      // the host's loading screen. Re-derived with the queue — the load emits `change`.
+      ready: editor !== null && !editor.snapshot().isLoading,
     }),
     [
       items,

--- a/packages/pro/src/react/useReview.ts
+++ b/packages/pro/src/react/useReview.ts
@@ -103,9 +103,15 @@ export function useReviewOf(editor: Editor | null, query?: ReviewItemQuery): Use
       if (!editor) return () => undefined;
       const offDocument = editor.on('change', onChange);
       const offSelection = editor.on('selectionChange', onChange);
+      // `error` too: a load that fails to parse tears the surface down and emits ONLY an
+      // error — no `change` fires for it. Without this, a surface built on the raw hook
+      // kept the previous document's cards (and `ready: true`) over a document that never
+      // opened, until some unrelated event happened to re-render it.
+      const offError = editor.on('error', onChange);
       return () => {
         offDocument();
         offSelection();
+        offError();
       };
     },
     [editor]
@@ -218,8 +224,9 @@ export function useReviewOf(editor: Editor | null, query?: ReviewItemQuery): Use
       // Not merely "an editor exists": the instance is constructed before any bytes arrive,
       // and a `ready` that reported true then invited surfaces to draw an empty state over
       // the host's loading screen. A parse failure clears `isLoading` while still leaving
-      // no document, so it must stay false then too. Re-derived with the queue — the load
-      // emits `change`.
+      // no document, so it must stay false then too. Re-derived with the queue: a
+      // successful load emits `change`, a failed one emits `error`, and `subscribe` above
+      // listens to both.
       ready:
         editor !== null && !editor.snapshot().isLoading && editor.snapshot().parseError === null,
     }),

--- a/packages/react/src/editor/DocxEditorOutline.tsx
+++ b/packages/react/src/editor/DocxEditorOutline.tsx
@@ -18,6 +18,7 @@ import type { ReactElement } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { DocumentOutline, type OutlineHeading } from '../components/DocumentOutline';
 import { useDocxEditor } from './context';
+import { selectDocumentAbsent } from './document-presence';
 import { useEditorState } from './useEditorState';
 
 const selectSnapshot = (snapshot: EditorSnapshot) => snapshot;
@@ -39,9 +40,14 @@ export interface DocxEditorDocumentOutlineProps {
  * from `Editor.getOutline()`, in document order; clicking one moves the caret to that
  * heading. The panel positions absolutely — give it a `position: relative` container.
  *
+ * Renders nothing while the editor has no document — a floating panel saying "no
+ * headings" about a document that is not there is the same false claim the rulers made.
+ *
  * @public
  */
-export function DocxEditorDocumentOutline(props: DocxEditorDocumentOutlineProps): ReactElement {
+export function DocxEditorDocumentOutline(
+  props: DocxEditorDocumentOutlineProps
+): ReactElement | null {
   const editor = useDocxEditor();
   const snapshot = useEditorState(selectSnapshot);
   const headings = useMemo(
@@ -69,6 +75,7 @@ export function DocxEditorDocumentOutline(props: DocxEditorDocumentOutlineProps)
     [editor]
   );
 
+  if (selectDocumentAbsent(snapshot)) return null;
   return (
     <DocumentOutline
       headings={headings}

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -24,6 +24,17 @@ import { useNavigationShift, useNavigationViewportElement } from './navigation/n
 
 const selectZoom = (snapshot: EditorSnapshot): number => snapshot.zoom;
 
+/**
+ * True while the editor holds NO document: still loading one, or the one it was handed
+ * would not parse. A ruler MEASURES the page, and without a document there is no page —
+ * `pageSetup` is null and the ruler fell back to drawing default Letter ticks over a
+ * document that was not there. Render nothing instead; a host that wants the bar to hold
+ * its height sizes the row it put the ruler in. Not `isLoading` alone, because a parse
+ * failure clears that flag while still leaving nothing to measure.
+ */
+const selectDocumentAbsent = (snapshot: EditorSnapshot): boolean =>
+  snapshot.isLoading || snapshot.parseError !== null;
+
 /** Props for the context-fed ruler parts. @public */
 export interface DocxEditorRulerProps {
   /** Measurement unit for tick labels. Defaults to inches. */
@@ -173,9 +184,13 @@ function useViewportScrollLeft(): number {
  * draggable when the engine supports page-setup writes; the drag previews locally and
  * commits one undoable step on release.
  *
+ * Renders nothing while the editor holds no document — see
+ * {@link selectDocumentAbsent}.
+ *
  * @public
  */
-export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactElement {
+export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactElement | null {
+  const documentAbsent = useEditorState(selectDocumentAbsent);
   const { pageSetup, isEnabled } = usePageSetup();
   const zoom = useEditorState(selectZoom);
   const { pending, preview, commit } = useMarginDrag();
@@ -187,6 +202,7 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
   const shift = useNavigationShift();
   const reserved = useReviewGutter();
   const scrollLeft = useViewportScrollLeft();
+  if (documentAbsent) return null;
   return (
     <HorizontalRuler
       pageSetup={previewed(pageSetup, pending)}
@@ -253,12 +269,17 @@ const REVIEW_MARKERS_GUTTER = 44;
  * margins and zoom straight from the editor. Top/bottom margin handles are draggable
  * when the engine supports page-setup writes, committing one undoable step on release.
  *
+ * Renders nothing while the editor holds no document — see
+ * {@link selectDocumentAbsent}.
+ *
  * @public
  */
-export function DocxEditorVerticalRuler(props: DocxEditorRulerProps): ReactElement {
+export function DocxEditorVerticalRuler(props: DocxEditorRulerProps): ReactElement | null {
+  const documentAbsent = useEditorState(selectDocumentAbsent);
   const { pageSetup, isEnabled } = usePageSetup();
   const zoom = useEditorState(selectZoom);
   const { pending, preview, commit } = useMarginDrag();
+  if (documentAbsent) return null;
   return (
     <VerticalRuler
       pageSetup={previewed(pageSetup, pending)}

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -17,23 +17,17 @@ import type { RulerIndent } from '@docx-editor.dev/core/editor';
 import { HorizontalRuler, type RulerPageSetup } from '../components/ui/HorizontalRuler';
 import { VerticalRuler } from '../components/ui/VerticalRuler';
 import { ReviewRailContext, useDocxEditor } from './context';
+// A ruler MEASURES the page, and while the document is absent there is no page — the
+// primitive fell back to drawing default Letter ticks over a document that was not
+// there. Render nothing instead; a host that wants the bar to hold its height sizes the
+// row it put the ruler in.
+import { selectDocumentAbsent } from './document-presence';
 import { useEditorState } from './useEditorState';
 import { usePageSetup } from './usePageSetup';
 import { useParagraphIndent } from './useParagraphIndent';
 import { useNavigationShift, useNavigationViewportElement } from './navigation/navigation-layout';
 
 const selectZoom = (snapshot: EditorSnapshot): number => snapshot.zoom;
-
-/**
- * True while the editor holds NO document: still loading one, or the one it was handed
- * would not parse. A ruler MEASURES the page, and without a document there is no page —
- * `pageSetup` is null and the ruler fell back to drawing default Letter ticks over a
- * document that was not there. Render nothing instead; a host that wants the bar to hold
- * its height sizes the row it put the ruler in. Not `isLoading` alone, because a parse
- * failure clears that flag while still leaving nothing to measure.
- */
-const selectDocumentAbsent = (snapshot: EditorSnapshot): boolean =>
-  snapshot.isLoading || snapshot.parseError !== null;
 
 /** Props for the context-fed ruler parts. @public */
 export interface DocxEditorRulerProps {

--- a/packages/react/src/editor/document-presence.ts
+++ b/packages/react/src/editor/document-presence.ts
@@ -1,0 +1,17 @@
+// The one predicate for "is there a document to describe?", shared by every part whose
+// content is a STATEMENT ABOUT THE DOCUMENT (rulers, outline, navigation empty states).
+// Chrome that merely acts on the document (toolbar buttons, menu rows) disables through
+// `toolbarCommandState` instead — disabled is honest for an action, but "no headings" or
+// a page-width ruler is a claim, and a claim about a document that is not there is false.
+
+import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
+
+/**
+ * True while the editor has NO painted document: still loading one, the one it was
+ * handed would not parse, or bytes are held but detached from any mount point. Not
+ * `isLoading` alone — a parse failure clears that flag (so hosts can put their own error
+ * screen up), and a detach never sets it, while both leave nothing to describe.
+ * `pageSetup` is null in exactly those states (it is derived from the mounted surface).
+ */
+export const selectDocumentAbsent = (snapshot: EditorSnapshot): boolean =>
+  snapshot.isLoading || snapshot.parseError !== null || snapshot.pageSetup == null;

--- a/packages/react/src/editor/navigation/parts.tsx
+++ b/packages/react/src/editor/navigation/parts.tsx
@@ -15,6 +15,8 @@ import { useCallback, useMemo, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactElement, ReactNode } from 'react';
 import type { TextMatch } from '@docx-editor.dev/core/contracts/editor';
 import { MaterialSymbol } from '../../components/ui/Icons';
+import { selectDocumentAbsent } from '../document-presence';
+import { useEditorState } from '../useEditorState';
 import { useNavigationContext } from './navigation-context';
 // Aliased: this module also EXPORTS a component called `NavigationTab`, and the two
 // declarations would collide in the generated .d.ts.
@@ -212,6 +214,9 @@ function SearchBox({
 export function NavigationHeadings({ className, style }: NavigationPartProps): ReactElement {
   const { pane, outline, t } = useNavigationContext('Headings');
   const [filter, setFilter] = useState('');
+  // "This document has no headings" is a claim about the document; while there is none
+  // (loading, parse failure, detached) the panel shows neither the claim nor the list.
+  const documentAbsent = useEditorState(selectDocumentAbsent);
 
   const items = useMemo(() => {
     const needle = filter.trim().toLowerCase();
@@ -238,7 +243,7 @@ export function NavigationHeadings({ className, style }: NavigationPartProps): R
         label={t('navigation.find.inputAriaLabel')}
         clearLabel={t('navigation.find.clearAriaLabel')}
       />
-      {outline.isEmpty ? (
+      {documentAbsent ? null : outline.isEmpty ? (
         <p className="docx-nav__empty">{t('navigation.headings.noHeadings')}</p>
       ) : items.length === 0 ? (
         <p className="docx-nav__empty">{t('navigation.find.noResults')}</p>

--- a/packages/react/test/chrome-parts.test.tsx
+++ b/packages/react/test/chrome-parts.test.tsx
@@ -186,6 +186,40 @@ describe('the context-fed ruler parts', () => {
     expect(ruler).not.toBeNull();
     expect(ruler.style.height).toBe('1056px');
   });
+
+  test('both rulers render nothing until the document arrives', async () => {
+    // A ruler measures the page; before the document there is no page, and the primitive's
+    // Letter-size fallback drew ticks for a page that was not there — over the host's
+    // loading screen.
+    const compose = (source?: Uint8Array) => (
+      <DocxEditorRoot {...(source ? { document: source } : {})}>
+        <DocxEditorHorizontalRuler />
+        <DocxEditorVerticalRuler />
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const view = render(compose());
+    expect(view.container.querySelector('.docx-horizontal-ruler')).toBeNull();
+    expect(view.container.querySelector('.docx-vertical-ruler')).toBeNull();
+
+    await act(async () => {
+      view.rerender(compose(PLAIN_SOURCE));
+    });
+
+    expect(view.container.querySelector('.docx-horizontal-ruler')).not.toBeNull();
+    expect(view.container.querySelector('.docx-vertical-ruler')).not.toBeNull();
+
+    // A parse failure clears `isLoading` while still leaving nothing to measure; the
+    // rulers must not read the clearing as a page.
+    await act(async () => {
+      view.rerender(compose(strToU8('not a docx')));
+    });
+
+    expect(view.container.querySelector('.docx-horizontal-ruler')).toBeNull();
+    expect(view.container.querySelector('.docx-vertical-ruler')).toBeNull();
+  });
 });
 
 describe('the context-fed outline part', () => {


### PR DESCRIPTION
Chrome whose content is a statement about the document rendered before any document existed. The review rail floated its empty state and furniture over the loading screen, the rulers drew default Letter ticks for a page that was not there, and navigation claimed "no headings" about nothing.

All of it now gates on one predicate — `isLoading || parseError || pageSetup == null` — which also covers the parse-failure and detached states, where `isLoading` is false by design. `useReview` additionally subscribes to `error` (a failing live load emits nothing else) and its `ready` flag now matches its documented meaning. The igloo demo picks up the matching polish: parse-error notice, StrictMode, dialog focus containment and Escape, a caret ref that stops per-keystroke menu re-renders, and a persistent live region for notices.

Verified with new tests for the loading, parse-failure and failed-live-load states in both packages, plus browser screenshots of all three states in the igloo demo. Three parallel review agents ran over the branch; every confirmed finding is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)