### PR TITLE
fix(core): leave Cmd+R to the browser instead of right-aligning

### DIFF
--- a/.changeset/keymap-cmd-r-reload.md
+++ b/.changeset/keymap-cmd-r-reload.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Stop binding Cmd+R for right alignment on macOS: the browser reserves that chord for reload, so the old binding re-aligned the paragraph and the page still reloaded. Right alignment stays on Ctrl+R on every platform.

--- a/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
+++ b/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
@@ -236,6 +236,27 @@ describe('the Word keymap', () => {
     expect(xml).toContain('auto');
   });
 
+  test('Cmd+R stays the browser reload; Ctrl+R right-aligns', () => {
+    // The browser reserves Cmd+R — preventDefault does not cancel the reload, so the
+    // keymap must not touch the document on that chord.
+    const surface = mount('<w:p><w:r><w:t>x</w:t></w:r></w:p>');
+    const handler = createKeyDownHandler(surface);
+    let prevented = false;
+    handler(
+      key({
+        key: 'r',
+        metaKey: true,
+        preventDefault: () => {
+          prevented = true;
+        },
+      })
+    );
+    expect(prevented).toBe(false);
+    expect(JSON.stringify(surface.session.part().root)).not.toContain('right');
+    handler(key({ key: 'r', ctrlKey: true }));
+    expect(JSON.stringify(surface.session.part().root)).toContain('right');
+  });
+
   test('Ctrl+Backspace deletes a word, not a character', () => {
     const surface = mount('<w:p><w:r><w:t>alpha beta</w:t></w:r></w:p>');
     const id = surface.session.paragraphIds()[0]!;

--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -240,6 +240,11 @@ export function createKeyDownHandler(
       return;
     }
     if (accel && !event.shiftKey && ALIGNMENT[event.key.toLowerCase()]) {
+      // Cmd+R is the browser's reload and the browser RESERVES it — preventDefault does
+      // not cancel the reload, so claiming the chord would right-align and then lose the
+      // page anyway. Right alignment stays on Ctrl+R, which pages may claim and which is
+      // an unused chord on macOS.
+      if (event.metaKey && event.key.toLowerCase() === 'r') return;
       surface.setParagraphProperty('jc', { val: ALIGNMENT[event.key.toLowerCase()]! });
       event.preventDefault();
       return;


### PR DESCRIPTION
macOS browsers reserve Cmd+R for reload, so `preventDefault()` never cancelled it: the chord right-aligned the paragraph and the page reloaded anyway. The keymap now yields any meta+R chord; right alignment stays on Ctrl+R, which pages may claim and which is unused on macOS. Windows behavior is unchanged (Ctrl+R right-aligns, matching desktop Word).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788593847&installation_model_id=422592&pr_number=181&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F181&signature=4c82d12580ba5f1e36ae249ced22b0de7ce3d2556d015aac0a7b7cebf3dbb878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->