### PR TITLE
docs: keep changeset summaries to one or two sentences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,8 @@ Every code PR gets a changeset (`bun changeset`, or a correct hand-written
 - Default `patch`; `minor` for additive public API; `major` for breaks.
 - The summary lands verbatim in CHANGELOG: consumer-facing, what changed not how,
   `Fixes #N` at the end if relevant. No emojis, no marketing.
+- Keep the summary minimal: one sentence, two at most. No bullet lists, no
+  implementation detail.
 
 Never push the `chore: release` commit by hand, delete `.changeset/*.md` outside
 `changeset version`, or hand-edit `CHANGELOG.md` / `package.json#version`.


### PR DESCRIPTION
Adds a CLAUDE.md rule that changeset summaries stay minimal: one sentence, two at most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788594300&installation_model_id=422592&pr_number=182&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F182&signature=b582ed757f39c4e3c464b161df58cf92334fbce05577d7f504dd56262f002b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->