### PR TITLE
feat(react): composed chrome resolves labels from the locale catalogue and self-scopes ep-root

### DIFF
--- a/.changeset/composed-chrome-catalogue-defaults.md
+++ b/.changeset/composed-chrome-catalogue-defaults.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+Composed chrome is legible and styled with zero configuration. Bare `DocxEditor.Toolbar`, `DocxEditor.Menu`, and `DocxEditor.ContextMenu` now resolve labels through the active locale catalogue (so `LocaleProvider` localizes them) instead of rendering raw i18n keys, and emit the `ep-root` styling scope on their own root — matching `DocxEditor.Loading` — so they render styled wherever the host mounts them. New `useChromeTranslate(overrides?)` returns a catalogue-backed resolver assignable to every part's `t` prop, with a `Map` of key-level overrides consulted first. The `<DocxEditor>` `t` prop now also receives interpolation params, so host resolvers can format parameterized labels like the navigation match counter.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -108,6 +108,9 @@ export { ChromeMenuSubmenuEntry }
 
 export { ChromeSlotId }
 
+// @public
+export type ChromeTranslate = (key: string, params?: Record<string, string | number>) => string;
+
 export { commandForSlot }
 
 export { composeFontConfiguration }
@@ -633,7 +636,7 @@ export interface DocxEditorProps {
     readonly renderTitleBarLeft?: () => ReactNode;
     // (undocumented)
     readonly renderTitleBarRight?: () => ReactNode;
-    t?: (key: string) => string;
+    t?: (key: string, params?: Record<string, string | number>) => string;
     title?: string;
     // (undocumented)
     zoom?: number;
@@ -1732,6 +1735,9 @@ export interface ToolbarSlotPartProps {
 
 // @public
 export type ToolbarTranslate = (key: string) => string;
+
+// @public
+export function useChromeTranslate(overrides?: ReadonlyMap<string, string>): ChromeTranslate;
 
 // @public
 export function useContentControl(): UseContentControlResult;

--- a/examples/igloo/src/IglooContextMenu.tsx
+++ b/examples/igloo/src/IglooContextMenu.tsx
@@ -14,12 +14,12 @@
 // library's own element (and therefore its roles, its keyboard handling and its placement),
 // and the SVG sits behind at `z-index: 0` with no hit test of its own.
 
-import { DocxEditor, useDocxEditor } from '@docx-editor.dev/react';
+import { DocxEditor, useChromeTranslate, useDocxEditor } from '@docx-editor.dev/react';
 import { CustomNodeContextMenu } from '@docx-editor.dev/pro/react';
 import { BergPanel } from './art/Iceberg';
 import { useFrost } from './useFrost';
 import { useSpecimens } from './useSpecimens';
-import { iglooT } from './labels';
+import { ICE_LABELS } from './labels';
 import {
   IceBerg,
   IceCarve,
@@ -34,6 +34,8 @@ import {
 
 export function IglooContextMenu() {
   const editor = useDocxEditor();
+  // Ice vocabulary first, then the active locale catalogue — the packaged fallback chain.
+  const iglooT = useChromeTranslate(ICE_LABELS);
   // The SAME hook the toolbar's Freeze action uses, so the two surfaces cannot disagree
   // about when the demo's own edit is available.
   const { freeze, thaw, enabled, disabledReason } = useFrost();

--- a/examples/igloo/src/IglooEditor.tsx
+++ b/examples/igloo/src/IglooEditor.tsx
@@ -11,7 +11,7 @@
 // in the chrome, in the sea behind, and in the berg the page rides on.
 
 import { useState } from 'react';
-import { DocxEditor, useDocxSource, useEditorState } from '@docx-editor.dev/react';
+import { DocxEditor, useChromeTranslate, useDocxSource, useEditorState } from '@docx-editor.dev/react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { customNodesModule, reviewModule } from '@docx-editor.dev/pro';
 import { defaultFonts } from '@docx-editor.dev/fonts';
@@ -23,7 +23,7 @@ import { IglooMenu } from './IglooMenu';
 import { IglooReview } from './IglooReview';
 import { IglooToolbar } from './IglooToolbar';
 import { Blizzard } from './art/Blizzard';
-import { iglooT } from './labels';
+import { ICE_LABELS } from './labels';
 import { SPECIMENS } from './specimens';
 import { SpecimenProvider } from './useSpecimens';
 
@@ -45,6 +45,7 @@ export interface IglooEditorProps {
 
 export function IglooEditor({ fixtureUrl }: IglooEditorProps) {
   const [blizzard, setBlizzard] = useState(false);
+  const iglooT = useChromeTranslate(ICE_LABELS);
 
   // The whole boot: fetch the bytes, load Word's default faces, register them for paint,
   // compose the configuration, and cancel both if this unmounts. `defaultFonts` is passed

--- a/examples/igloo/src/IglooMenu.tsx
+++ b/examples/igloo/src/IglooMenu.tsx
@@ -13,10 +13,10 @@
 // it (a page break belongs under Insert), and the product's own menu is for what the product
 // added.
 
-import { DocxEditor, useDocxEditor } from '@docx-editor.dev/react';
+import { DocxEditor, useChromeTranslate, useDocxEditor } from '@docx-editor.dev/react';
 import { useFrost } from './useFrost';
 import { useSpecimens } from './useSpecimens';
-import { iglooT } from './labels';
+import { ICE_LABELS } from './labels';
 import {
   IceBerg,
   IceCarve,
@@ -33,6 +33,7 @@ import {
 
 export function IglooMenu() {
   const editor = useDocxEditor();
+  const iglooT = useChromeTranslate(ICE_LABELS);
   const { freeze, thaw, enabled, disabledReason } = useFrost();
   // `editable` is the engine's answer: a view-only document greys these out like it does Bold.
   const { compose, dropRandom, editable, disabledReason: nodeReason } = useSpecimens();

--- a/examples/igloo/src/IglooReview.tsx
+++ b/examples/igloo/src/IglooReview.tsx
@@ -9,7 +9,8 @@ import { DocxEditorReview, useReview, useReviewItem } from '@docx-editor.dev/pro
 import type { ReviewRevisionKind } from '@docx-editor.dev/core/contracts/editor';
 import { BergGlyph, DomeGlyph } from './art/Specimen';
 import { Stats } from './SpecimenPopover';
-import { iglooT } from './labels';
+import { useChromeTranslate } from '@docx-editor.dev/react';
+import { ICE_LABELS } from './labels';
 import { IceMelt, IceRefreeze } from './icons/review';
 import { blocksOf, depthOf, insideTemperature, OUTSIDE, tipHeight } from './specimens';
 
@@ -31,6 +32,7 @@ const FLOE_WORDS: Record<ReviewRevisionKind, string> = {
 };
 
 export function IglooReview() {
+  const iglooT = useChromeTranslate(ICE_LABELS);
   return (
     <DocxEditorReview
       className="igloo-rail"

--- a/examples/igloo/src/IglooToolbar.tsx
+++ b/examples/igloo/src/IglooToolbar.tsx
@@ -9,9 +9,9 @@
 // Every packaged part still drives its chrome slot: the enabled state, the pressed state
 // and the command all still come from the engine. Only the glyph is the demo's.
 
-import { DocxEditor } from '@docx-editor.dev/react';
+import { DocxEditor, useChromeTranslate } from '@docx-editor.dev/react';
 import { useFrost } from './useFrost';
-import { iglooT } from './labels';
+import { ICE_LABELS } from './labels';
 import {
   IceAlignCenter,
   IceAlignLeft,
@@ -62,6 +62,7 @@ function FreezeAction() {
 }
 
 export function IglooToolbar({ blizzard, onBlizzard }: IglooActionsProps) {
+  const iglooT = useChromeTranslate(ICE_LABELS);
   return (
     <DocxEditor.Toolbar preset={false} className="igloo-toolbar" t={iglooT}>
       <DocxEditor.Toolbar.Undo icon={IceUndo} />

--- a/examples/igloo/src/labels.ts
+++ b/examples/igloo/src/labels.ts
@@ -1,28 +1,22 @@
-// The demo's own label catalogue.
+// The demo's own label overrides.
 //
-// Every packaged part takes a `t`, and this is what a host passes it. The mechanism is
-// exactly the one a real product uses for a real locale — resolve a key to a string — so
-// exercising it with ice vocabulary proves the same path a French catalogue would take.
-//
-// It DELEGATES rather than replaces: overrides come first, then the bundled English
-// catalogue, then the key itself. A host that renamed six things should not have to restate
-// the other four hundred, and a key that falls through to its own name is a visible bug
-// rather than a blank control.
-
-import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
-
-const english = createT(en);
+// Every packaged part takes a `t`, and `useChromeTranslate(ICE_LABELS)` builds the one a
+// host passes: overrides first, then the active locale catalogue (bundled English by
+// default). A host that renamed six things should not have to restate the other four
+// hundred, and a key that falls through to its own name is a visible bug rather than a
+// blank control — both of which the hook already guarantees, so this file is left holding
+// only the theme's actual vocabulary.
 
 /**
  * Just the labels the Igloo theme renames — ROWS and CONTROLS, never the menu bar itself.
- * Everything else falls through to English.
+ * Everything else falls through to the catalogue.
  *
  * A `Map`, not an object literal, because the key is CALLER input: an object answers
- * `constructor` and `toString` off the prototype chain, so `iglooT('constructor')` would
- * return a function rather than a string. Core spells `MARKS` and `HIGHLIGHT_NAMES` this way
- * for exactly that reason; an example that teaches the API should teach that too.
+ * `constructor` and `toString` off the prototype chain, so `t('constructor')` would
+ * return a function rather than a string. `useChromeTranslate` takes a `ReadonlyMap` for
+ * exactly that reason; an example that teaches the API should teach that too.
  */
-const ICE_LABELS = new Map<string, string>(Object.entries({
+export const ICE_LABELS = new Map<string, string>(Object.entries({
   // The clipboard rows, in the theme's own vocabulary.
   'contextMenu.cut': 'Carve out',
   'contextMenu.copy': 'Cast a replica',
@@ -72,12 +66,3 @@ const ICE_LABELS = new Map<string, string>(Object.entries({
   // out, which is exactly what it is.
 }));
 
-/**
- * The resolver handed to every packaged part.
- *
- * Typed as `(key: string) => string` because that is what the parts take — a host's
- * catalogue is its own, and the library does not require it to be keyed by our union.
- */
-export function iglooT(key: string): string {
-  return ICE_LABELS.get(key) ?? english(key as TranslationKey);
-}

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -42,7 +42,6 @@ import {
 } from '@docx-editor.dev/pro/react';
 import { blankDocumentBytes } from '@docx-editor.dev/core/editor';
 import { defaultFonts } from '@docx-editor.dev/fonts';
-import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
 import { BrandLogo } from '../../shared/BrandLogo';
 // import { AdapterSwitcher } from '../../shared/AdapterSwitcher';
 import { ExampleSwitcher } from '../../shared/ExampleSwitcher';
@@ -80,10 +79,6 @@ const DEMO_CITATION = defineCustomNode({
 });
 
 const PRO_MODULES = [reviewModule(), customNodesModule({ nodes: [DEMO_CITATION] })];
-
-/** English labels for the library toolbar's i18n keys. Demos are apps: English is fine. */
-const tEnglish = createT(en);
-const translate = (key: string): string => tEnglish(key as TranslationKey);
 
 /** Keep the caret: chrome mousedown must never move focus out of the document. */
 function keepCaret(event: ReactMouseEvent): void {
@@ -696,7 +691,6 @@ function EditorChrome({
             spellCheck={false}
           />
           <DocxEditor.Menu
-            t={translate}
             onOpen={() => fileInputRef.current?.click()}
             onSave={saveDocument}
             onPageSetup={() => setShowPageSetup(true)}
@@ -810,7 +804,7 @@ function EditorChrome({
           customized IN PLACE to show override semantics: FontFamily renders each
           document-derived family in its own typeface. Save is
           live because the toolbar was given an onSave handler. */}
-      <DocxEditor.Toolbar t={translate} className="demo-toolbar" onSave={saveDocument}>
+      <DocxEditor.Toolbar className="demo-toolbar" onSave={saveDocument}>
         <DocxEditor.Toolbar.FontFamily>
           <DocxEditor.Toolbar.FontFamily.Trigger className="demo-font-trigger" />
           <DocxEditor.Toolbar.FontFamily.Content className="demo-font-menu">
@@ -820,7 +814,7 @@ function EditorChrome({
       </DocxEditor.Toolbar>
 
       {/* Word-style compatibility bar when document fonts render in substitutes. */}
-      <DocxEditor.FontNotice t={translate} />
+      <DocxEditor.FontNotice />
 
       {/* File > Page setup: the library dialog, applied as one undo step. */}
       <DocxEditor.PageSetupDialog open={showPageSetup} onClose={() => setShowPageSetup(false)} />
@@ -934,7 +928,7 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
               {/* The right-click menu, with the PRO custom-node section on top: pointing
                   at a citation chip shows its data and "Edit Citation" above the packaged
                   rows. Chips are content-locked, so the menu is the editing entry point. */}
-              <DocxEditor.ContextMenu t={translate}>
+              <DocxEditor.ContextMenu>
                 <CustomNodeContextMenu
                   onEditNode={(node) =>
                     node.nodeId
@@ -958,7 +952,7 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
                   `@docx-editor.dev/pro/react` and enabled by the `reviewModule()` on the
                   Root. Inside the viewport for the same reason as the popover — it
                   scrolls with the document rather than chasing it. */}
-              <DocxEditorReview t={translate} card={{ className: 'demo-review-card' }}>
+              <DocxEditorReview card={{ className: 'demo-review-card' }}>
                 {/* Host content inside every card: `useReviewItem()` scopes it to
                     citation cards, the packaged parts stay. A custom node's card carries
                     `data-node-name`, so `demo-review-card[data-node-name='citation']`

--- a/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
+++ b/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
@@ -209,6 +209,10 @@ not the contract. Publishing retain/release on `Editor` is the prerequisite.
 - `SlotProps`
 - `LocaleProvider`
 - `useTranslation`
+- `useChromeTranslate` — the catalogue-backed resolver a composing host passes as any
+  part's `t` (override-Map-first); rides the same locale binding, so its Vue twin lands
+  with `LocaleProvider`/`useTranslation`.
+- `ChromeTranslate`
 
 The font-fallback notice is React chrome with no Vue twin yet, same lane as the
 rest of the notice/banner chrome:

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -187,7 +187,7 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
   const { t: catalogT } = useTranslation();
   const translate = useCallback(
     (key: string, params?: Record<string, string | number>) =>
-      t ? t(key) : catalogT(key as TranslationKey, params),
+      t ? t(key, params) : catalogT(key as TranslationKey, params),
     [t, catalogT]
   );
 

--- a/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
+++ b/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
@@ -28,6 +28,8 @@ import {
 import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import { mergeArrangement, unwrapFragment } from '../merge-arrangement';
 import { useDocxEditor } from '../context';
+import { useTranslation } from '../../i18n';
+import type { TranslationKey } from '../../i18n';
 import type { ToolbarTranslate } from '../toolbar/toolbar-context';
 import { MenuContext, type MenuContextValue } from '../menu/menu-context';
 import { focusBy, focusEdge, panelItems } from '../menu/menu-keyboard';
@@ -250,6 +252,7 @@ export function DocxEditorContextMenu({
   children,
 }: DocxEditorContextMenuProps) {
   const editor = useDocxEditor();
+  const { t: catalogT } = useTranslation();
   const tableContextVisible = useTableContextMenuVisible();
   const hostRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -445,13 +448,15 @@ export function DocxEditorContextMenu({
             <div
               ref={panelRef}
               role="menu"
-              // Resolved through the host's `t` like every row label. A hardcoded English
-              // string here would be the one piece of the panel a locale could not reach.
-              aria-label={t?.('contextMenu.ariaLabel') ?? 'contextMenu.ariaLabel'}
+              // Resolved through the host's `t` like every row label, else the locale
+              // catalogue — matching the rows' own fallback.
+              aria-label={
+                t?.('contextMenu.ariaLabel') ?? catalogT('contextMenu.ariaLabel' as TranslationKey)
+              }
               // One tab stop for the whole panel, which is the menu pattern: rows are
               // reached with the arrows, never with Tab.
               tabIndex={-1}
-              className={`docx-toolbar__menu docx-contextmenu${className ? ` ${className}` : ''}`}
+              className={`ep-root docx-toolbar__menu docx-contextmenu${className ? ` ${className}` : ''}`}
               style={style}
               onKeyDown={(event) => {
                 const panel = panelRef.current;

--- a/packages/react/src/editor/editor-scope.ts
+++ b/packages/react/src/editor/editor-scope.ts
@@ -1,0 +1,29 @@
+// The editor-instance scope, distinct from the styling scope.
+//
+// `.ep-root` is the STYLING scope: it carries the chrome CSS variables, and since the
+// composed parts self-emit it (toolbar, menu bar, context menu, navigation — like
+// `Loading` and `Viewport` before them), `closest('.ep-root')` from inside a chrome part
+// now matches that part's own root first. `closest()` starts at the element itself, so
+// the class stopped being a proxy for "the wrapper around this whole editor instance".
+//
+// Code that needs the INSTANCE — the box containing both the chrome and the painted
+// pages — climbs instead: past every self-scoped chrome root, to the nearest `.ep-root`
+// that actually contains the pages layer. In the packaged `<DocxEditor>` that is its
+// wrapper div; in a composed host it is whatever the host wrapped the parts in; a bare
+// composition with no such wrapper resolves to null and callers keep their old narrow
+// fallbacks.
+
+/**
+ * The nearest ancestor `.ep-root` that contains the painted pages, or null.
+ *
+ * Skips styling-only roots (a toolbar or menu bar's own `ep-root`) by requiring the
+ * `.docx-pages` layer inside, so the answer is the editor instance's container rather
+ * than the first element that happens to carry the class.
+ */
+export function editorScopeFor(from: Element | null): Element | null {
+  let root = from?.closest('.ep-root') ?? null;
+  while (root && !root.querySelector('.docx-pages')) {
+    root = root.parentElement?.closest('.ep-root') ?? null;
+  }
+  return root;
+}

--- a/packages/react/src/editor/menu/DocxEditorMenu.tsx
+++ b/packages/react/src/editor/menu/DocxEditorMenu.tsx
@@ -30,6 +30,8 @@ import {
 import type { ReactElement, ReactNode } from 'react';
 import { CHROME_MENUS, type ChromeMenuId } from '@docx-editor.dev/core/editor';
 import { useDocxEditor } from '../context';
+import { useTranslation } from '../../i18n';
+import type { TranslationKey } from '../../i18n';
 import { DocxEditorPageSetupDialog } from '../DocxEditorPageSetup';
 import type { ToolbarTranslate } from '../toolbar/toolbar-context';
 import { guardToolbarMousedown } from '../toolbar/ToolbarButton';
@@ -160,6 +162,7 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
     children,
   } = props;
   const editor = useDocxEditor();
+  const { t: catalogT } = useTranslation();
   const [openMenu, setOpenMenu] = useState<MenuId | null>(null);
   // The last file the packaged Open read. The default Save names its download after it
   // when the host pinned no `fileName` — opening "contract-v2.docx" and saving must not
@@ -321,9 +324,14 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
         role="menubar"
         // Named, because a host page can carry its own menubar beside the editor's and
         // "menu bar" twice tells a screen-reader user nothing about which is which.
-        aria-label={(t ?? ((key: string) => key))('titleBar.menuBarAriaLabel')}
+        aria-label={
+          t?.('titleBar.menuBarAriaLabel') ??
+          catalogT('titleBar.menuBarAriaLabel' as TranslationKey)
+        }
         data-testid="docx-menubar"
-        className={`docx-menubar${className ? ` ${className}` : ''}`}
+        // `ep-root` self-emitted so a composed menu bar is styled outside the packaged
+        // wrapper, as `DocxEditorLoading` and `DocxEditorViewport` already do.
+        className={`ep-root docx-menubar${className ? ` ${className}` : ''}`}
         // Container-level caret guard (CLAUDE.md focus-stealing pitfall): a disabled row
         // never receives mousedown, so per-row handlers cannot cover it.
         onMouseDown={guardToolbarMousedown}

--- a/packages/react/src/editor/menu/DocxEditorMenu.tsx
+++ b/packages/react/src/editor/menu/DocxEditorMenu.tsx
@@ -30,6 +30,7 @@ import {
 import type { ReactElement, ReactNode } from 'react';
 import { CHROME_MENUS, type ChromeMenuId } from '@docx-editor.dev/core/editor';
 import { useDocxEditor } from '../context';
+import { editorScopeFor } from '../editor-scope';
 import { useTranslation } from '../../i18n';
 import type { TranslationKey } from '../../i18n';
 import { DocxEditorPageSetupDialog } from '../DocxEditorPageSetup';
@@ -239,12 +240,12 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
       // an unrelated field, and two mounted editors both answer one keypress. The shortcut
       // belongs to the editor the user is actually in: the chrome, the painted surface, or
       // anything else under this instance's root.
-      // `.ep-root` is the library's own scope class and wraps the whole editor — chrome,
-      // viewport and painted pages — so one containment test covers the bar AND the
-      // document. A composition that does not use it falls back to the bar's own subtree,
-      // which is narrow but never wrong.
+      // `editorScopeFor` finds the instance container — the `.ep-root` that holds the
+      // painted pages, NOT the bar's own self-emitted styling root — so one containment
+      // test covers the bar AND the document. A composition with no such container falls
+      // back to the bar's own subtree, which is narrow but never wrong.
       const target = event.target as Node | null;
-      const scope = rootRef.current?.closest('.ep-root') ?? rootRef.current;
+      const scope = editorScopeFor(rootRef.current) ?? rootRef.current;
       if (!target || !scope?.contains(target)) return;
       if (key === 's' && resolvedSave) {
         event.preventDefault();

--- a/packages/react/src/editor/menu/menu-context.ts
+++ b/packages/react/src/editor/menu/menu-context.ts
@@ -7,9 +7,13 @@
 // never decides policy; it renders what the context gives it.
 //
 // Like the toolbar context, no user-facing English lives here: labels are i18n keys from
-// the chrome registry, resolved through the host's `t` or falling back to the KEY.
+// the chrome registry, resolved through the host's `t` or the active `LocaleContext`
+// catalogue — the same default the packaged `<DocxEditor>` uses. The context menu's rows
+// resolve through `useMenuLabel` too, so this one fallback covers both surfaces.
 
 import { createContext, useContext } from 'react';
+import { useTranslation } from '../../i18n';
+import type { TranslationKey } from '../../i18n';
 import type { ChromeMenuId } from '@docx-editor.dev/core/editor';
 import type { ToolbarTranslate } from '../toolbar/toolbar-context';
 
@@ -63,8 +67,9 @@ export function useMenuContext(): MenuContextValue {
   return useContext(MenuContext);
 }
 
-/** The label for an i18n key: the host's translation, or the key itself. */
+/** The label for an i18n key: the host's translation, else the locale catalogue. */
 export function useMenuLabel(): (key: string) => string {
   const { t } = useMenuContext();
-  return (key: string) => t?.(key) ?? key;
+  const { t: catalogT } = useTranslation();
+  return (key: string) => t?.(key) ?? catalogT(key as TranslationKey);
 }

--- a/packages/react/src/editor/navigation/DocxEditorNavigation.tsx
+++ b/packages/react/src/editor/navigation/DocxEditorNavigation.tsx
@@ -98,7 +98,7 @@ export function DocxEditorNavigation(props: DocxEditorNavigationProps): ReactEle
   return (
     <NavigationContext.Provider value={value}>
       <div
-        className={`docx-nav${pane.open ? ' docx-nav--open' : ''}${className ? ` ${className}` : ''}`}
+        className={`ep-root docx-nav${pane.open ? ' docx-nav--open' : ''}${className ? ` ${className}` : ''}`}
         data-open={pane.open ? 'true' : 'false'}
         style={
           {

--- a/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
+++ b/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
@@ -387,7 +387,11 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
         ref={attach}
         role="toolbar"
         data-testid="docx-toolbar"
-        className={`docx-toolbar${className ? ` ${className}` : ''}`}
+        // `ep-root` self-emitted: chrome CSS and --doc-* tokens are scoped under it, and
+        // `Root` renders no DOM — same pattern as `DocxEditorLoading`/`DocxEditorViewport`,
+        // so a composed toolbar is styled wherever the host puts it. Nesting under the
+        // packaged wrapper is fine; the stylesheet re-applies dark tokens to nested roots.
+        className={`ep-root docx-toolbar${className ? ` ${className}` : ''}`}
         // One row when the bar measures itself, wrapping when it does not: the stylesheet
         // reads this rather than guessing from a breakpoint.
         {...(measuring ? { 'data-overflow': '' } : {})}

--- a/packages/react/src/editor/toolbar/steppers.tsx
+++ b/packages/react/src/editor/toolbar/steppers.tsx
@@ -16,6 +16,7 @@ import type { ReactNode } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { commandForSlotValue } from '@docx-editor.dev/core/editor';
 import { useDocxEditor } from '../context';
+import { editorScopeFor } from '../editor-scope';
 import { useEditorState } from '../useEditorState';
 import { useEditorCommand } from '../useEditorCommand';
 import { useToolbarLabel } from './toolbar-context';
@@ -302,7 +303,9 @@ function ToolbarFontSizeImpl({ className, hidden }: ToolbarSlotPartProps) {
  * in the toolbar, so the next keystroke went to the box rather than the document.
  */
 function editorFocus(from: HTMLElement | null): void {
-  const root = from?.closest('.ep-root') ?? from?.ownerDocument?.body;
+  // NOT a bare `closest('.ep-root')`: the toolbar's own root self-emits that class and
+  // contains no pages, so the scope must be the instance container around both.
+  const root = editorScopeFor(from) ?? from?.ownerDocument?.body;
   const pages = root?.querySelector<HTMLElement>('.docx-pages');
   pages?.focus();
 }

--- a/packages/react/src/editor/toolbar/table-chrome-shared.tsx
+++ b/packages/react/src/editor/toolbar/table-chrome-shared.tsx
@@ -1,12 +1,14 @@
 // Shared a11y and keyboard helpers for contextual table toolbar compounds.
 
 import { useEffect, useId, type ReactNode, type RefObject } from 'react';
+import { editorScopeFor } from '../editor-scope';
 import { focusBy, focusEdge } from '../menu/menu-keyboard';
 import { guardToolbarMousedown } from './ToolbarButton';
 
 /** Return focus to the painted pages layer after a table colour dialog applies. */
 export function restoreToolbarDocumentFocus(from: HTMLElement | null): void {
-  const root = from?.closest('.ep-root') ?? from?.ownerDocument?.body;
+  // NOT a bare `closest('.ep-root')`: the toolbar's own root self-emits that class.
+  const root = editorScopeFor(from) ?? from?.ownerDocument?.body;
   root?.querySelector<HTMLElement>('.docx-pages')?.focus();
 }
 

--- a/packages/react/src/editor/toolbar/toolbar-context.ts
+++ b/packages/react/src/editor/toolbar/toolbar-context.ts
@@ -2,9 +2,13 @@
 //
 // The adapter ships NO hardcoded user-facing English (repo i18n rule): every label is
 // an i18n key from the chrome registry, resolved through the host's `t` when one is
-// provided and falling back to the KEY STRING — never to an English literal — when not.
+// provided and otherwise through the active `LocaleContext` catalogue — matching
+// `<DocxEditor>`'s own default, so a bare `DocxEditor.Toolbar` is legible and
+// `LocaleProvider` localizes composed chrome exactly like the packaged entry point.
 
 import { createContext, useContext } from 'react';
+import { useTranslation } from '../../i18n';
+import type { TranslationKey } from '../../i18n';
 
 /** Resolves an i18n key to display text. @public */
 export type ToolbarTranslate = (key: string) => string;
@@ -25,8 +29,9 @@ export function useToolbarContext(): ToolbarContextValue {
   return useContext(ToolbarContext);
 }
 
-/** The label for an i18n key: the host's translation, or the key itself. */
+/** The label for an i18n key: the host's translation, else the locale catalogue. */
 export function useToolbarLabel(): (key: string) => string {
   const { t } = useContext(ToolbarContext);
-  return (key: string) => t?.(key) ?? key;
+  const { t: catalogT } = useTranslation();
+  return (key: string) => t?.(key) ?? catalogT(key as TranslationKey);
 }

--- a/packages/react/src/i18n/index.ts
+++ b/packages/react/src/i18n/index.ts
@@ -1,5 +1,6 @@
 export { LocaleProvider, useTranslation } from './LocaleContext';
 export type { LocaleProviderProps } from './LocaleContext';
+export { useChromeTranslate, type ChromeTranslate } from './useChromeTranslate';
 
 // Re-exported from the i18n package so ported controls can type their `labelKey` fields
 // against the real key union derived from `en.json`, exactly as legacy did.

--- a/packages/react/src/i18n/useChromeTranslate.ts
+++ b/packages/react/src/i18n/useChromeTranslate.ts
@@ -23,9 +23,15 @@ export type ChromeTranslate = (key: string, params?: Record<string, string | num
  * English by default), with `overrides` consulted first for key-level renames.
  *
  * ```tsx
- * const t = useChromeTranslate(new Map([['toolbar.bold', 'Heavy']]));
+ * const MY_LABELS = new Map([['toolbar.bold', 'Heavy']]); // module-level: stable identity
+ *
+ * const t = useChromeTranslate(MY_LABELS);
  * <DocxEditor.Toolbar t={t} />
  * ```
+ *
+ * Keep the `overrides` Map identity stable (module-level or memoized) — the returned
+ * resolver is memoized on it, and an inline `new Map(...)` re-creates the resolver, and
+ * with it every consuming part's props, on each render.
  *
  * `overrides` is a `Map` on purpose: the key is caller input, and an object literal
  * would answer `constructor` and `toString` off the prototype chain. Parts pass no

--- a/packages/react/src/i18n/useChromeTranslate.ts
+++ b/packages/react/src/i18n/useChromeTranslate.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import type { TranslationKey } from '@docx-editor.dev/i18n';
+import { useTranslation } from './LocaleContext';
+
+/**
+ * A chrome-part label resolver: plain string keys, optional interpolation params.
+ *
+ * This is the shape every packaged part's `t` prop accepts. It takes `string` rather
+ * than the `TranslationKey` union so a host can route its own extra keys through the
+ * same resolver.
+ *
+ * @public
+ */
+export type ChromeTranslate = (key: string, params?: Record<string, string | number>) => string;
+
+/**
+ * The catalogue-backed resolver for composed chrome, ready to pass as any part's `t`.
+ *
+ * `useTranslation().t` is keyed by the strict `TranslationKey` union, which does not
+ * assign to the parts' plain-`string` `t` props — so before this hook, every composing
+ * host hand-wrote the same cast wrapper `<DocxEditor>` builds internally. This is that
+ * wrapper, exported: it resolves through the active `LocaleContext` catalogue (bundled
+ * English by default), with `overrides` consulted first for key-level renames.
+ *
+ * ```tsx
+ * const t = useChromeTranslate(new Map([['toolbar.bold', 'Heavy']]));
+ * <DocxEditor.Toolbar t={t} />
+ * ```
+ *
+ * `overrides` is a `Map` on purpose: the key is caller input, and an object literal
+ * would answer `constructor` and `toString` off the prototype chain. Parts pass no
+ * `params` today for overridden keys, so override values are literal strings.
+ *
+ * @public
+ */
+export function useChromeTranslate(overrides?: ReadonlyMap<string, string>): ChromeTranslate {
+  const { t } = useTranslation();
+  return useCallback(
+    (key: string, params?: Record<string, string | number>) =>
+      overrides?.get(key) ?? t(key as TranslationKey, params),
+    [overrides, t]
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -54,6 +54,7 @@ export {
 export { ReviewRailContext, type ReviewRailRegistry } from './editor/context';
 export { Slot, type SlotProps } from './editor/toolbar/Slot';
 export { LocaleProvider, useTranslation } from './i18n';
+export { useChromeTranslate, type ChromeTranslate } from './i18n';
 // The navigation pane (also reachable as `DocxEditor.Navigation`): the compound over the
 // left gutter, its parts, and the three hooks a custom pane is built from. The pane FLOATS
 // — it displaces the page only when the gutter is too narrow to hold it, and

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -65,8 +65,12 @@ export interface DocxEditorProps {
    * Strings still come from `packages/i18n/en.json` rather than literals in components;
    * this only chooses who resolves the key. For another language, pass
    * `createT(locale)` from `@docx-editor.dev/i18n`.
+   *
+   * `params` carries interpolation values for parameterized keys (for example the
+   * navigation pane's `{current} of {total}` match counter) — a resolver that ignores
+   * them renders the raw placeholders for those labels.
    */
-  t?: (key: string) => string;
+  t?: (key: string, params?: Record<string, string | number>) => string;
   /**
    * Renders the packaged chrome — title bar and toolbar — around the document.
    * Default `true`. Set `false` for the painted surface alone when the host supplies

--- a/packages/react/test/editor-scope.test.ts
+++ b/packages/react/test/editor-scope.test.ts
@@ -1,0 +1,47 @@
+// `editorScopeFor`: the instance scope, distinct from the styling scope.
+//
+// The chrome parts self-emit `.ep-root` (styling), so a bare `closest('.ep-root')` from
+// inside the toolbar or menu bar matches the part's own root — which contains no pages —
+// and Cmd+S scoping and focus-return silently broke. This pins the climb: past
+// styling-only roots to the container that actually holds the painted pages.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { editorScopeFor } from '../src/editor/editor-scope';
+
+function el(className: string, parent: Element): HTMLElement {
+  const node = document.createElement('div');
+  node.className = className;
+  parent.appendChild(node);
+  return node;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('editorScopeFor', () => {
+  test('climbs past a self-scoped chrome root to the instance container', () => {
+    // The packaged arrangement: wrapper(.ep-root) > [toolbar(.ep-root), viewport(.ep-root) > pages]
+    const wrapper = el('ep-root', document.body);
+    const toolbar = el('ep-root docx-toolbar', wrapper);
+    const button = el('docx-toolbar__button', toolbar);
+    const viewport = el('ep-root docx-editor-viewport', wrapper);
+    el('docx-pages', viewport);
+
+    // From inside the toolbar: NOT the toolbar's own styling root — the wrapper.
+    expect(editorScopeFor(button)).toBe(wrapper);
+    expect(editorScopeFor(toolbar)).toBe(wrapper);
+    // From inside the viewport the viewport itself qualifies; it contains the pages.
+    expect(editorScopeFor(viewport)).toBe(viewport);
+  });
+
+  test('a bare composition with no instance container resolves to null', () => {
+    const toolbar = el('ep-root docx-toolbar', document.body);
+    const button = el('docx-toolbar__button', toolbar);
+    expect(editorScopeFor(button)).toBeNull();
+    expect(editorScopeFor(null)).toBeNull();
+  });
+});

--- a/packages/react/test/menu-composition.test.tsx
+++ b/packages/react/test/menu-composition.test.tsx
@@ -20,7 +20,8 @@ import type { ReactNode } from 'react';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
 import { CHROME_MENUS, type DocxEditorInstance } from '@docx-editor.dev/core/editor';
-import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
+import { createT, en, type TranslationKey, type Translations } from '@docx-editor.dev/i18n';
+import { LocaleProvider } from '../src/i18n/index.ts';
 import { DocxEditor } from '../src/components/DocxEditor.tsx';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
@@ -323,6 +324,26 @@ describe('chrome contracts', () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  test('LocaleProvider localizes a bare composed menu', () => {
+    // The bug the catalogue fallback fixed: composed chrome ignored `LocaleProvider`
+    // entirely, so the documented i18n path silently did nothing for it.
+    const de = { _lang: 'de', toolbar: { file: 'Datei' } } as Translations;
+    const { view } = mountMenu(
+      <LocaleProvider i18n={de}>
+        <DocxEditorMenu />
+      </LocaleProvider>
+    );
+    expect(view.container.textContent).toContain('Datei');
+    expect(view.container.textContent).not.toContain('toolbar.file');
+    // A key the locale leaves out falls through to English, not to the raw key.
+    expect(view.container.textContent).toContain('Insert');
+  });
+
+  test('the bar self-emits the ep-root styling scope', () => {
+    const { view } = mountMenu(<DocxEditorMenu />);
+    expect(bar(view).classList.contains('ep-root')).toBe(true);
+  });
+
   test('labels resolve through `t`, and fall back to the CATALOGUE, never to the key', () => {
     const { view } = mountMenu(<DocxEditorMenu t={(key) => `[${key}]`} />);
     expect(view.container.textContent).toContain('[toolbar.file]');
@@ -427,6 +448,24 @@ describe('chrome contracts', () => {
     });
     expect(saved).toBe(1);
     outside.remove();
+  });
+
+  test('Ctrl/Cmd+S fires with focus in the DOCUMENT, not only on the bar', async () => {
+    // The regression this pins: the menubar self-emits `.ep-root` (styling scope), so a
+    // naive closest('.ep-root') resolves to the bar itself and a keypress from the
+    // painted pages — the normal case — falls outside the containment test, handing
+    // Cmd+S back to the browser. The scope must be the instance container.
+    let saved = 0;
+    const view = render(<DocxEditor document={SOURCE} onSave={() => (saved += 1)} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const pages = view.container.querySelector('.docx-pages')!;
+    expect(pages).not.toBeNull();
+    act(() => {
+      fireEvent.keyDown(pages, { key: 's', ctrlKey: true });
+    });
+    expect(saved).toBe(1);
   });
 
   test('Help › Report issue is addressable: `reportIssue={false}` drops it and Help', () => {

--- a/packages/react/test/menu-composition.test.tsx
+++ b/packages/react/test/menu-composition.test.tsx
@@ -20,6 +20,7 @@ import type { ReactNode } from 'react';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
 import { CHROME_MENUS, type DocxEditorInstance } from '@docx-editor.dev/core/editor';
+import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
 import { DocxEditor } from '../src/components/DocxEditor.tsx';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
@@ -85,11 +86,15 @@ function menuIds(element: HTMLElement): string[] {
   );
 }
 
-/** Open one menu by its trigger's visible label (the raw i18n key without a `t`). */
+/** Bare parts resolve labels through the locale catalogue; tests address them by key. */
+const label = createT(en);
+
+/** Open one menu by its i18n key — matched against the catalogue label it renders. */
 function openMenu(view: ReturnType<typeof render>, labelKey: string): void {
+  const text = label(labelKey as TranslationKey);
   const match = [...view.container.querySelectorAll<HTMLButtonElement>('.docx-menubar__trigger')] //
-    .find((button) => button.textContent === labelKey);
-  if (!match) throw new Error(`no trigger labelled ${labelKey}`);
+    .find((button) => button.textContent === text);
+  if (!match) throw new Error(`no trigger labelled ${text}`);
   act(() => {
     fireEvent.click(match);
   });
@@ -97,9 +102,10 @@ function openMenu(view: ReturnType<typeof render>, labelKey: string): void {
 
 /** Reveal a submenu's panel — the parent opens on hover, as it does for a pointer. */
 function openSubmenu(view: ReturnType<typeof render>, labelKey: string): void {
+  const text = label(labelKey as TranslationKey);
   const parent = [...view.container.querySelectorAll<HTMLElement>('.docx-menubar__submenu')] //
-    .find((element) => element.textContent?.includes(labelKey));
-  if (!parent) throw new Error(`no submenu labelled ${labelKey}`);
+    .find((element) => element.textContent?.includes(text));
+  if (!parent) throw new Error(`no submenu labelled ${text}`);
   act(() => {
     fireEvent.mouseEnter(parent);
   });
@@ -145,7 +151,7 @@ describe('the default bar', () => {
       element.getAttribute('data-slot')
     );
     expect(slots).toEqual(['file.open', 'file.save', 'file.pageSetup']);
-    expect(view.container.textContent).not.toContain('toolbar.print');
+    expect(view.container.textContent).not.toContain(label('toolbar.print' as TranslationKey));
   });
 
   test('a menu child overrides its menu IN PLACE; `hidden` removes it', () => {
@@ -205,7 +211,7 @@ describe('rows carry the engine, not a paraphrase', () => {
     const toc = row(view, 'insert.toc');
     expect(toc.disabled).toBe(false);
     expect(toc.getAttribute('aria-disabled')).toBeNull();
-    expect(toc.textContent).toContain('toolbar.tableOfContents');
+    expect(toc.textContent).toContain(label('toolbar.tableOfContents' as TranslationKey));
     act(() => {
       fireEvent.click(toc);
     });
@@ -253,7 +259,7 @@ describe('rows carry the engine, not a paraphrase', () => {
     expect(row(view, 'file.save').getAttribute('aria-disabled')).toBeNull();
     expect(row(view, 'file.pageSetup').getAttribute('aria-disabled')).toBeNull();
     // The shortcut column is filled from the registry's keys.
-    expect(row(view, 'file.save').textContent).toContain('toolbar.saveShortcut');
+    expect(row(view, 'file.save').textContent).toContain(label('toolbar.saveShortcut' as TranslationKey));
   });
 
   test('a host `onSave` replaces the packaged download', async () => {
@@ -317,15 +323,17 @@ describe('chrome contracts', () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  test('labels resolve through `t`, and fall back to the KEY, never to English', () => {
+  test('labels resolve through `t`, and fall back to the CATALOGUE, never to the key', () => {
     const { view } = mountMenu(<DocxEditorMenu t={(key) => `[${key}]`} />);
     expect(view.container.textContent).toContain('[toolbar.file]');
     expect(view.container.textContent).toContain('[toolbar.insert]');
 
+    // A bare part matches `<DocxEditor>`'s own default — legible with zero configuration.
+    // A RAW KEY on screen is the bug this pins against, in both directions.
     cleanup();
     const bare = mountMenu(<DocxEditorMenu />);
-    expect(bare.view.container.textContent).toContain('toolbar.file');
-    expect(bare.view.container.textContent).not.toContain('File');
+    expect(bare.view.container.textContent).toContain(label('toolbar.file' as TranslationKey));
+    expect(bare.view.container.textContent).not.toContain('toolbar.file');
   });
 
   test('`<DocxEditor>` mounts the bar by default, and `menu={false}` removes it', () => {
@@ -348,7 +356,7 @@ describe('chrome contracts', () => {
     const { view } = mountMenu(<DocxEditorMenu />);
     openMenu(view, 'toolbar.file');
     const insert = [...view.container.querySelectorAll<HTMLButtonElement>('.docx-menubar__trigger')] //
-      .find((button) => button.textContent === 'toolbar.insert')!;
+      .find((button) => button.textContent === label('toolbar.insert' as TranslationKey))!;
     act(() => {
       fireEvent.mouseEnter(insert);
     });
@@ -374,7 +382,7 @@ describe('chrome contracts', () => {
     openSubmenu(view, 'toolbar.break');
     expect(row(view, 'insert.pageBreak')).toBeDefined();
     const parent = [...view.container.querySelectorAll<HTMLElement>('.docx-menubar__submenu')] //
-      .find((element) => element.textContent?.includes('toolbar.break'))!;
+      .find((element) => element.textContent?.includes(label('toolbar.break' as TranslationKey)))!;
     act(() => {
       fireEvent.click(parent.querySelector('button')!);
     });
@@ -387,7 +395,7 @@ describe('chrome contracts', () => {
     const { view } = mountMenu(<DocxEditorMenu />);
     openMenu(view, 'toolbar.insert');
     const parent = [...view.container.querySelectorAll<HTMLElement>('.docx-menubar__submenu')] //
-      .find((element) => element.textContent?.includes('toolbar.break'))!;
+      .find((element) => element.textContent?.includes(label('toolbar.break' as TranslationKey)))!;
     act(() => {
       fireEvent.focus(parent.querySelector('button')!);
     });
@@ -592,7 +600,7 @@ describe('chrome contracts', () => {
   test('ARIA containment: the menubar owns its items through role="none" wrappers', () => {
     const { view } = mountMenu(<DocxEditorMenu />);
     const menubar = bar(view);
-    expect(menubar.getAttribute('aria-label')).toBe('titleBar.menuBarAriaLabel');
+    expect(menubar.getAttribute('aria-label')).toBe(label('titleBar.menuBarAriaLabel' as TranslationKey));
     // `menubar` -> unrole'd div -> menuitem breaks the required-owned-elements
     // relationship AT derives item counts and "x of y" announcements from.
     for (const child of menubar.children) {

--- a/packages/react/test/toolbar-composition.test.tsx
+++ b/packages/react/test/toolbar-composition.test.tsx
@@ -21,7 +21,8 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import type { ReactNode } from 'react';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
-import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
+import { createT, en, type TranslationKey, type Translations } from '@docx-editor.dev/i18n';
+import { LocaleProvider } from '../src/i18n/index.ts';
 import {
   chromeSlotId,
   defaultChromeGroups,
@@ -171,6 +172,27 @@ describe('the default arrangement', () => {
     expect(
       view.container.querySelector(byLabel('formattingBar.undoShortcut'))
     ).not.toBeNull();
+    // No raw key ever reaches the screen — the guard the resolved-label helpers cannot
+    // provide, since they resolve through the same catalogue as the code under test.
+    expect(toolbar.textContent).not.toContain('toolbar.');
+    expect(toolbar.textContent).not.toContain('formattingBar.');
+    // The bar self-emits the ep-root styling scope, like Loading and Viewport.
+    expect(toolbar.classList.contains('ep-root')).toBe(true);
+  });
+
+  test('LocaleProvider localizes a bare composed toolbar', () => {
+    const de = {
+      _lang: 'de',
+      formattingBar: { boldShortcut: 'Fett (Strg+B)' },
+    } as Translations;
+    const { view } = mountToolbar(
+      <LocaleProvider i18n={de}>
+        <DocxEditorToolbar />
+      </LocaleProvider>
+    );
+    expect(view.container.querySelector('[aria-label="Fett (Strg+B)"]')).not.toBeNull();
+    // A key the locale leaves out falls through to English, not to the raw key.
+    expect(view.container.querySelector(byLabel('formattingBar.undoShortcut'))).not.toBeNull();
   });
 
   test('a part child overrides its slot IN PLACE; non-part children append', () => {

--- a/packages/react/test/toolbar-composition.test.tsx
+++ b/packages/react/test/toolbar-composition.test.tsx
@@ -21,6 +21,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import type { ReactNode } from 'react';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
+import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
 import {
   chromeSlotId,
   defaultChromeGroups,
@@ -142,6 +143,10 @@ function entryRootAtFlatIndex(toolbar: HTMLElement, index: number): Element | nu
   return null;
 }
 
+/** Bare parts resolve labels through the locale catalogue; tests address them by key. */
+const label = createT(en);
+const byLabel = (key: string): string => `[aria-label=${JSON.stringify(label(key as TranslationKey))}]`;
+
 afterEach(() => {
   cleanup();
 });
@@ -161,10 +166,10 @@ describe('the default arrangement', () => {
     }
     // Wired controls are live buttons; the labels come from the registry keys.
     expect(
-      view.container.querySelector('[aria-label="formattingBar.boldShortcut"]')
+      view.container.querySelector(byLabel('formattingBar.boldShortcut'))
     ).not.toBeNull();
     expect(
-      view.container.querySelector('[aria-label="formattingBar.undoShortcut"]')
+      view.container.querySelector(byLabel('formattingBar.undoShortcut'))
     ).not.toBeNull();
   });
 
@@ -180,7 +185,7 @@ describe('the default arrangement', () => {
     const identities = toolbarArrangement(toolbar);
     expect(identities.slice(0, EXPECTED_ARRANGEMENT.length)).toEqual([...EXPECTED_ARRANGEMENT]);
     // The Bold in the arrangement IS the override (its className landed).
-    const bold = view.container.querySelector('[aria-label="formattingBar.boldShortcut"]')!;
+    const bold = view.container.querySelector(byLabel('formattingBar.boldShortcut'))!;
     expect(bold.className).toContain('custom-bold');
     const boldIndex = EXPECTED_ARRANGEMENT.indexOf('text.bold');
     expect(identities[boldIndex]).toBe('text.bold');
@@ -199,11 +204,11 @@ describe('the default arrangement', () => {
       </DocxEditorToolbar>
     );
     const toolbar = toolbarElement(view);
-    expect(view.container.querySelector('[aria-label="formattingBar.strikethrough"]')).toBeNull();
+    expect(view.container.querySelector(byLabel('formattingBar.strikethrough'))).toBeNull();
     expect(toolbarArrangement(toolbar).length).toBe(EXPECTED_ARRANGEMENT.length - 1);
     // Neighbours unaffected: underline still present, alignment group intact.
     expect(
-      view.container.querySelector('[aria-label="formattingBar.underlineShortcut"]')
+      view.container.querySelector(byLabel('formattingBar.underlineShortcut'))
     ).not.toBeNull();
   });
 
@@ -227,7 +232,7 @@ describe('live button state', () => {
       editor().surface!.selectAll();
     });
     const bold = view.container.querySelector(
-      '[aria-label="formattingBar.boldShortcut"]'
+      byLabel('formattingBar.boldShortcut')
     ) as HTMLButtonElement;
     expect(bold.disabled).toBe(false);
     expect(bold.hasAttribute('data-active')).toBe(false);
@@ -247,7 +252,7 @@ describe('live button state', () => {
       </DocxEditorToolbar>
     );
     const button = view.container.querySelector(
-      '[aria-label="toolbar.image"]'
+      byLabel('toolbar.image')
     ) as HTMLButtonElement;
     expect(button.disabled).toBe(false);
     expect(button.hasAttribute('data-disabled')).toBe(false);
@@ -347,7 +352,7 @@ describe('the shaped parts', () => {
     const stepper = view.container.querySelector('[data-slot="font.size"]')!;
     const value = stepper.querySelector('.docx-toolbar__stepper-value') as HTMLInputElement;
     expect(value.value).toBe('12');
-    const increase = stepper.querySelector('[aria-label="fontSize.increase"]') as HTMLButtonElement;
+    const increase = stepper.querySelector(byLabel('fontSize.increase')) as HTMLButtonElement;
     expect(increase.disabled).toBe(false);
     await act(async () => {
       increase.click();
@@ -356,7 +361,7 @@ describe('the shaped parts', () => {
     // increment: 12pt steps to 14pt, read back from the engine's snapshot.
     expect(editor().snapshot().formatting?.fontSizePt).toBe(14);
     expect(value.value).toBe('14');
-    const decrease = stepper.querySelector('[aria-label="fontSize.decrease"]') as HTMLButtonElement;
+    const decrease = stepper.querySelector(byLabel('fontSize.decrease')) as HTMLButtonElement;
     await act(async () => {
       decrease.click();
     });
@@ -498,8 +503,8 @@ describe('the shaped parts', () => {
       trigger.click();
     });
     expect(rows().map((row) => row.textContent)).toEqual([
-      'lineSpacing.addSpaceBefore',
-      'lineSpacing.addSpaceAfter',
+      label('lineSpacing.addSpaceBefore' as TranslationKey),
+      label('lineSpacing.addSpaceAfter' as TranslationKey),
     ]);
 
     await act(async () => {
@@ -511,7 +516,7 @@ describe('the shaped parts', () => {
       trigger.click();
     });
     // Word never offers to add space that is already there.
-    expect(rows()[0]!.textContent).toBe('lineSpacing.removeSpaceBefore');
+    expect(rows()[0]!.textContent).toBe(label('lineSpacing.removeSpaceBefore' as TranslationKey));
     await act(async () => {
       rows()[0]!.click();
     });
@@ -571,7 +576,7 @@ describe('the shaped parts', () => {
     await act(async () => {
       (value as HTMLButtonElement).click();
     });
-    const zoomIn = stepper.querySelector('[aria-label="zoom.zoomIn"]') as HTMLButtonElement;
+    const zoomIn = stepper.querySelector(byLabel('zoom.zoomIn')) as HTMLButtonElement;
     await act(async () => {
       zoomIn.click();
     });
@@ -584,7 +589,7 @@ describe('the shaped parts', () => {
     expect(pageWidth()).toBeCloseTo(widthBefore * 1.25);
     expect(view.container.textContent).toContain('hello world!');
     expect(editor().can({ type: 'undo' }).ok).toBe(true);
-    const zoomOut = stepper.querySelector('[aria-label="zoom.zoomOut"]') as HTMLButtonElement;
+    const zoomOut = stepper.querySelector(byLabel('zoom.zoomOut')) as HTMLButtonElement;
     await act(async () => {
       zoomOut.click();
     });
@@ -832,7 +837,7 @@ describe('the FontFamily compound', () => {
     ]);
     expect(
       [...listbox.querySelectorAll('.docx-toolbar__menu-label')].map((label) => label.textContent)
-    ).toEqual(['font.sansSerif', 'font.serif', 'font.monospace']);
+    ).toEqual([label('font.sansSerif' as TranslationKey), label('font.serif' as TranslationKey), label('font.monospace' as TranslationKey)]);
 
     await act(async () => {
       (options[1] as HTMLButtonElement).click();
@@ -894,7 +899,7 @@ describe('the caret-preserving mousedown contract', () => {
         </select>
       </DocxEditorToolbar>
     );
-    const bold = view.container.querySelector('[aria-label="formattingBar.boldShortcut"]')!;
+    const bold = view.container.querySelector(byLabel('formattingBar.boldShortcut'))!;
     const buttonEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
     bold.dispatchEvent(buttonEvent);
     expect(buttonEvent.defaultPrevented).toBe(true);
@@ -1238,7 +1243,7 @@ describe('enabled state is the engine answer, not a registry constant', () => {
     ) as HTMLButtonElement;
     expect(underline.disabled).toBe(false);
     // The label, not an "unavailable" apology.
-    expect(underline.title).toBe('formattingBar.underlineShortcut');
+    expect(underline.title).toBe(label('formattingBar.underlineShortcut' as TranslationKey));
     await act(async () => {
       underline.click();
     });

--- a/packages/react/test/use-chrome-translate.test.tsx
+++ b/packages/react/test/use-chrome-translate.test.tsx
@@ -1,0 +1,78 @@
+// `useChromeTranslate`: the catalogue-backed resolver a composing host passes as any
+// part's `t`. Pins the override-first chain, the catalogue fallback, params
+// interpolation, prototype-safety of the override Map, and that `LocaleProvider`
+// drives the fallback — the guarantees the deleted hand-written wrappers used to
+// carry in comments.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { ReactNode } from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { createT, en, type TranslationKey, type Translations } from '@docx-editor.dev/i18n';
+import { LocaleProvider, useChromeTranslate, type ChromeTranslate } from '../src/i18n';
+
+const english = createT(en);
+
+/** Renders nothing; hands the hook's resolver to the test. */
+function Probe({
+  overrides,
+  onT,
+}: {
+  overrides?: ReadonlyMap<string, string>;
+  onT: (t: ChromeTranslate) => void;
+}) {
+  onT(useChromeTranslate(overrides));
+  return null;
+}
+
+function resolve(overrides?: ReadonlyMap<string, string>, wrap?: (node: ReactNode) => ReactNode) {
+  let t: ChromeTranslate | null = null;
+  const probe = <Probe overrides={overrides} onT={(value) => (t = value)} />;
+  render(<>{wrap ? wrap(probe) : probe}</>);
+  return t!;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useChromeTranslate', () => {
+  test('an override wins; everything else falls back to the catalogue, never the key', () => {
+    const t = resolve(new Map([['toolbar.bold', 'Heavy']]));
+    expect(t('toolbar.bold')).toBe('Heavy');
+    // Not overridden: the bundled English catalogue, pinned to the LITERAL string so a
+    // broken catalogue (which would fall back to the key) cannot pass silently.
+    expect(t('toolbar.file')).toBe('File');
+    expect(t('toolbar.file')).toBe(english('toolbar.file' as TranslationKey));
+  });
+
+  test('params interpolate through the catalogue path', () => {
+    const t = resolve();
+    const counter = t('dialogs.findReplace.matchCount', { current: 3, total: 15 });
+    expect(counter).toBe('3 of 15 matches');
+    expect(counter).not.toContain('{current}');
+  });
+
+  test('prototype-chain keys resolve to themselves, never to functions', () => {
+    // The override Map is the proto-safe layer, and `createT`'s lookup only returns
+    // string leaves — so a hostile or accidental key can never surface a function.
+    const t = resolve(new Map([['toolbar.bold', 'Heavy']]));
+    for (const key of ['constructor', 'toString', '__proto__', 'constructor.name']) {
+      const result = t(key);
+      expect(typeof result).toBe('string');
+      expect(result).toBe(key);
+    }
+  });
+
+  test('LocaleProvider drives the fallback catalogue', () => {
+    const de = { _lang: 'de', toolbar: { file: 'Datei' } } as Translations;
+    const t = resolve(undefined, (probe) => <LocaleProvider i18n={de}>{probe}</LocaleProvider>);
+    expect(t('toolbar.file')).toBe('Datei');
+    // Keys the locale leaves out fall through to English, not to the raw key.
+    expect(t('toolbar.insert')).toBe('Insert');
+  });
+});


### PR DESCRIPTION
Bare DocxEditor.Toolbar/Menu/ContextMenu rendered raw i18n keys unless handed a t and rendered unstyled outside the packaged wrapper — and LocaleProvider never reached them. They now default to the active locale catalogue and emit the ep-root styling scope themselves, matching Loading and Viewport. New useChromeTranslate(overrides?) replaces the cast wrapper every composing host hand-wrote; the sugar t prop forwards interpolation params. Because the chrome roots now match .ep-root, instance scoping (Cmd+S containment, focus return to the pages) moved off bare closest('.ep-root') onto editorScopeFor, which climbs to the container that holds the painted pages. Vite and igloo examples drop their label glue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788595999&installation_model_id=422592&pr_number=183&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F183&signature=ba448e441a75cdf95bc848c8ddfbf47e65e29906e0927e786232df661f0d2dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->