### PR TITLE
docs: accuracy and style pass over READMEs and docs site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,8 @@ Every code PR gets a changeset (`bun changeset`, or a correct hand-written
 - Default `patch`; `minor` for additive public API; `major` for breaks.
 - The summary lands verbatim in CHANGELOG: consumer-facing, what changed not how,
   `Fixes #N` at the end if relevant. No emojis, no marketing.
+- Keep the summary minimal: one sentence, two at most. No bullet lists, no
+  implementation detail.
 
 Never push the `chore: release` commit by hand, delete `.changeset/*.md` outside
 `changeset version`, or hand-edit `CHANGELOG.md` / `package.json#version`.

--- a/docs/site/content/core/architecture.mdx
+++ b/docs/site/content/core/architecture.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Architecture'
 description: 'How the editor renders DOCX with Word fidelity: one canonical OOXML tree, a DOM-free layout pass, and painted pages that are themselves the editable surface.'
-category: "Reference"
+category: 'Reference'
 ---
 
 There is one document model and one pipeline:
@@ -10,7 +10,7 @@ There is one document model and one pipeline:
 bytes → bounded OPC/XML read → canonical OOXML tree → layout → painted pages → serialize
 ```
 
-There is one document model. What you see painted and what an edit mutates are the same tree, so nothing has to be kept in sync.
+What you see painted and what an edit mutates are the same tree, so nothing has to be kept in sync.
 
 ## The canonical tree
 

--- a/docs/site/content/core/index.mdx
+++ b/docs/site/content/core/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: '@docx-editor.dev/core'
-description: "The framework-agnostic engine: OOXML read and write, the canonical document tree, layout, paint, and the Editor contract that adapters render."
-category: "Reference"
+description: 'The framework-agnostic engine: OOXML read and write, the canonical document tree, layout, paint, and the Editor contract that adapters render.'
+category: 'Reference'
 order: 70
 ---
 
@@ -26,25 +26,24 @@ import type { Editor, EditorSnapshot } from '@docx-editor.dev/core';
 
 Reach for a subpath when you need the canonical tree, the layout pass, or the paint step directly.
 
-| Subpath                   | What's there                                                                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `.`                       | Create an editor, the `Editor` contract, fonts, the chrome registry, the document model types.                               |
-| `./editor`                | Everything the root re-exports, plus the paginated surface, ruler geometry, and module resolution.                           |
+| Subpath                   | What's there                                                                                                                |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `.`                       | Create an editor, the `Editor` contract, fonts, the chrome registry, the document model types.                              |
+| `./editor`                | Everything the root re-exports, plus the paginated surface, ruler geometry, and module resolution.                          |
 | `./contracts/editor`      | `Editor`, `EditorCommand`, `EditorQuery`, `EditorSnapshot`, `DocumentSource`, `PageSetup`, the contract an adapter renders. |
-| `./contracts/types`       | Document model types.                                                                                                        |
-| `./contracts/modules`     | `EditorModule`, the shape [`@docx-editor.dev/pro`](/docs/2.x/pro) implements.                                                |
-| `./contracts/interaction` | Semantic addressing (`SemanticTarget`) and the `InteractionOutcome` an attempt answers with.                                 |
-| `./store`                 | The canonical tree and its transactional store.                                                                              |
-| `./layout`                | The DOM-free layout pass.                                                                                                    |
-| `./output`                | Paint: turning a laid-out document into page DOM, and the selection overlay over it.                                          |
-| `./automation`            | The document object model behind [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api).                                      |
-| `./styles/editor.css`     | The one editor stylesheet. The packaged chrome and your own chrome both use it.                                              |
+| `./contracts/document`    | The document-level edit and query vocabulary.                                                                               |
+| `./contracts/types`       | Document model types.                                                                                                       |
+| `./contracts/modules`     | `EditorModule`, the shape [`@docx-editor.dev/pro`](/docs/2.x/pro) implements.                                               |
+| `./contracts/interaction` | Semantic addressing (`SemanticTarget`) and the `InteractionOutcome` an attempt answers with.                                |
+| `./store`                 | The canonical tree and its transactional store.                                                                             |
+| `./layout`                | The DOM-free layout pass.                                                                                                   |
+| `./output`                | Paint: turning a laid-out document into page DOM, and the selection overlay over it.                                        |
+| `./automation`            | The document object model behind [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api).                                     |
+| `./styles/editor.css`     | The one editor stylesheet. The packaged chrome and your own chrome both use it.                                             |
 
 **Root or `./editor`?** Import from the root. `./editor` is the same engine with its
-internals attached — the paginated surface, ruler geometry, module resolution — and you want
-those only when you are building an adapter rather than using one. The rule is which side of
-the contract you are on, not which is shorter to type: everything the root exports is a
-promise, and `./editor` is the drawer underneath it.
+internals attached (the paginated surface, ruler geometry, module resolution), and you want
+those only when you are building an adapter rather than using one.
 
 ## The contract
 

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Overview'
 description: 'Office.js-compatible editing API: an object model that batches its work, running on a server over bytes or in a page against an editor already open.'
-category: "Editor API"
+category: 'Editing API'
 order: 50
 seoTitle: 'Office.js-compatible DOCX editing API'
 ---
@@ -16,7 +16,7 @@ You describe work against objects (paragraphs, ranges, comments, revisions, cont
 npm install @docx-editor.dev/editor-api
 ```
 
-## On a server, from bytes
+## On a server
 
 Runs headless: it takes bytes and returns bytes.
 
@@ -42,7 +42,7 @@ try {
 }
 ```
 
-## In a page, on a document already open
+## In the browser
 
 The browser entry takes an editor the host already created (from `@docx-editor.dev/react` or a plain page) and drives it in place. Edits land in the open document with the reader's undo stack intact, so there is no `save()`: the host saves the way it already did.
 
@@ -62,12 +62,12 @@ await runtime.run(async (context) => {
 
 Import it from `/browser` deliberately: reaching a live editor means reaching the painted engine, and a server holding bytes should not pay for that.
 
-## The four rules
+## Programming model
 
-- **Read what you asked for.** A property you did not `load()` throws instead of answering `undefined`, so a typo fails at the read rather than producing a wrong document three steps later.
-- **`sync()` is the only round trip.** Everything queued between two syncs is one ordered transaction. If any operation in it is refused, none of them happened.
-- **Objects live inside `run`.** They are proxies into a document the runtime owns. Keeping one past the callback, or past `dispose()`, is an error rather than a stale read: to keep one across syncs deliberately, hand it to `context.trackedObjects`.
-- **Ask before you assume.** `getFirstOrNullObject` and `getLastOrNullObject` answer an object whose `isNullObject` is `true` after the sync, which is the difference between "no such heading" and a crash.
+- A property you did not `load()` throws instead of answering `undefined`, so a typo fails at the read rather than producing a wrong document three steps later.
+- `sync()` is the only round trip. Everything queued between two syncs is one ordered transaction. If any operation in it is refused, none of them happened.
+- Objects are proxies into a document the runtime owns and live inside `run`. Keeping one past the callback, or past `dispose()`, is an error rather than a stale read: to keep one across syncs deliberately, hand it to `context.trackedObjects`.
+- `getFirstOrNullObject` and `getLastOrNullObject` answer an object whose `isNullObject` is `true` after the sync, which is the difference between "no such heading" and a crash.
 
 ## Capabilities
 
@@ -88,7 +88,7 @@ This package ships no model integration, no tool catalog and no chat UI. That is
 
 <Cards>
   <Card title="Office.js compatibility" href="/docs/2.x/editor-api/word-js-api">
-    The supported subset, how the shape is kept honest, and what it omits.
+    The supported subset, how compatibility is verified, and what it omits.
   </Card>
 </Cards>
 

--- a/docs/site/content/editor-api/word-js-api.mdx
+++ b/docs/site/content/editor-api/word-js-api.mdx
@@ -1,19 +1,19 @@
 ---
 title: 'Office.js compatibility'
-description: "The Office.js-compatible subset: which parts of the Word JavaScript object model are implemented, how the shape is verified in CI, and what it omits."
-category: "Editor API"
+description: 'The Office.js-compatible subset: which parts of the Word JavaScript object model are implemented, how compatibility is verified in CI, and what it omits.'
+category: 'Editing API'
 order: 53
 ---
 
 `@docx-editor.dev/editor-api` is Office.js-compatible: it implements the Word JavaScript object model, so `context.document.body.paragraphs`, `load()` then `sync()`, `search(text, options)`, `getFirstOrNullObject()` and `isNullObject` all mean here what they mean in an add-in. Word add-in code ports by changing how the batch is opened.
 
-Being exact about the scope of that claim:
+The exact scope of that claim:
 
 - **Compatible, not hosted.** It does not run inside an Office add-in host, so there is no `Office.onReady` and no `Word.run`: a batch is opened by a runtime you construct, with `DocxEditor.createServer(bytes)` or `DocxEditor.createBrowser(editor)`. Everything inside the callback is the same code.
 - **No Microsoft dependency.** Every type in the public surface is authored in this repository. Nothing is vendored, copied, or code-generated from Microsoft's declarations.
 - **A subset.** The omissions are listed below.
 
-## How the shape is kept honest
+## How compatibility is verified
 
 Microsoft's published declarations are used as reference-only conformance input, never as a dependency. A checked-in manifest allowlists which symbols and members the surface is measured against; a network-capable maintainer script reads a pinned `@types/office-js` release into a normalized fixture of names and call shapes; and the repository's own hand-authored declarations are compared against that fixture two independent ways: a strict per-overload comparison, and generated TypeScript assertions that the real compiler checks. Representative Word samples, rewritten only in their namespace, have to type-check against the authored declarations.
 
@@ -23,11 +23,11 @@ None of that runs at install, test or build time. Everything CI gates on reads f
 
 The document, its body, paragraphs, ranges and the collections over them; search with `matchCase` / `matchWholeWord`; character formatting through `font`; paragraph formatting (style, alignment, indents, spacing); lists and list items; bookmarks; sections and page setup; footnotes and endnotes; comments with replies and a resolved flag; revisions with accept and reject, individually or all at once; and content controls, addressed by id, tag or title.
 
-The lifecycle around them is the whole point: `load()` declares reads, `sync()` is the only round trip, `getFirstOrNullObject` / `getLastOrNullObject` answer an object rather than throwing, and `context.trackedObjects` keeps a proxy alive across syncs.
+The lifecycle around them carries over unchanged: `load()` declares reads, `sync()` is the only round trip, `getFirstOrNullObject` / `getLastOrNullObject` answer an object rather than throwing, and `context.trackedObjects` keeps a proxy alive across syncs.
 
 ## What is omitted
 
-Omitted means **absent**, not stubbed. There is no type in this surface shaped like the ones below, working or not, so a call site that needs one fails to compile rather than compiling and doing nothing.
+Omitted means absent rather than stubbed: there is no type in this surface shaped like the ones below, so a call site that needs one fails to compile rather than compiling and doing nothing.
 
 | Omitted                                                    | Why                                                                                                                                              |
 | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/site/content/examples.mdx
+++ b/docs/site/content/examples.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Examples'
-description: "Runnable DOCX editor starters for Vite, Next.js, Remix, and Astro, plus a fully themed editor and a headless editing script. Clone one and run it."
-category: "Getting Started"
+description: 'Runnable DOCX editor starters for Vite, Next.js, Remix, and Astro, plus a fully themed editor and a headless editing script. Clone one and run it.'
+category: 'Getting Started'
 order: 55
 ---
 
@@ -9,12 +9,12 @@ Two kinds of examples. The [starters](#runnable-starters) are complete apps in t
 
 ## Runnable starters
 
-Every starter lives under [`examples/`](https://github.com/eigenpal/docx-editor/tree/main/examples) in the repo and runs with `bun install` followed by the `bun run dev:*` script in its README. All of them resolve `@docx-editor.dev/*` from the monorepo workspace rather than from npm, so build the packages once first (`bun run build:packages` from the repo root); to run a starter against the published npm packages instead, replace the `workspace:*` versions in its `package.json`.
+Every starter lives under [`examples/`](https://github.com/eigenpal/docx-editor/tree/main/examples) in the repo and runs with `bun install` followed by the `bun run dev:*` script in its README. All of them resolve `@docx-editor.dev/*` from the monorepo workspace rather than from npm. Most need the packages built once first (`bun run build:packages` from the repo root); the Vite starter aliases package source directly and needs no build step. To run a starter against the published npm packages instead, replace the `workspace:*` versions in its `package.json`.
 
 <Cards>
   <Card title="Vite + React" href="https://github.com/eigenpal/docx-editor/tree/main/examples/vite">
-    Plain Vite + React SPA, and the fullest example in the repo: composed chrome, the review sidebar,
-    and a custom node, all on the public primitives.
+    Plain Vite + React SPA, and the fullest example in the repo: composed chrome, the review
+    sidebar, and a custom node, all on the public primitives.
   </Card>
   <Card title="Next.js" href="https://github.com/eigenpal/docx-editor/tree/main/examples/nextjs">
     App Router integration. One dynamic() import with ssr: false; the rest of the page stays
@@ -27,8 +27,14 @@ Every starter lives under [`examples/`](https://github.com/eigenpal/docx-editor/
     The editor as a React island with client:only="react", skipping Astro's SSR for the component.
   </Card>
   <Card title="Igloo" href="https://github.com/eigenpal/docx-editor/tree/main/examples/igloo">
-    A fully themed editor built to answer one question: how much of this is yours? Every control is
-    host markup over the hooks.
+    A fully themed editor. Every control is host markup over the hooks, so nothing of the packaged
+    look remains.
+  </Card>
+  <Card
+    title="Custom nodes"
+    href="https://github.com/eigenpal/docx-editor/tree/main/examples/custom-nodes"
+  >
+    Define, insert, edit, and round-trip a citation node stored as a Word content control.
   </Card>
   <Card
     title="Headless editing"

--- a/docs/site/content/frameworks/astro.mdx
+++ b/docs/site/content/frameworks/astro.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Astro'
 description: 'Run an Astro DOCX editor as a React island with client:only. Why client:load crashes, how styles load, and the path from file upload to .docx download.'
-category: "Frameworks"
+category: 'Frameworks'
 seoTitle: 'Astro DOCX editor setup'
 ---
 
@@ -85,7 +85,7 @@ export function Editor() {
 
 `client:only="react"` is the key directive. `client:load` would still server-render the component once to produce static HTML, and the editor crashes on `window` during that pass. `client:only` skips SSR for the island entirely and renders it in the browser only. The rest of the page stays zero-JS static HTML.
 
-Styles need no extra setup: the `styles.css` import sits inside the island component, and Astro's Vite pipeline bundles CSS imported from `client:only` components like any other module.
+Styles need no extra setup: the stylesheet import sits inside the island component, and Astro's Vite pipeline bundles CSS imported from `client:only` components like any other module.
 
 ## Run the example
 

--- a/docs/site/content/frameworks/nextjs.mdx
+++ b/docs/site/content/frameworks/nextjs.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Next.js'
 description: 'Set up a Next.js DOCX editor in the App Router. Dynamic import with ssr: false, the window is not defined fix, file upload, and saving back to .docx.'
-category: "Frameworks"
+category: 'Frameworks'
 seoTitle: 'Next.js DOCX editor setup'
 ---
 

--- a/docs/site/content/frameworks/remix.mdx
+++ b/docs/site/content/frameworks/remix.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Remix'
 description: 'Add a Remix DOCX editor with a mount check and React.lazy. Keeps server rendering and hydration intact while the editor loads in the browser only.'
-category: "Frameworks"
+category: 'Frameworks'
 seoTitle: 'Remix DOCX editor setup'
 ---
 

--- a/docs/site/content/frameworks/vite.mdx
+++ b/docs/site/content/frameworks/vite.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Vite'
-description: "Build a Vite DOCX editor with React. Install the package, mount the component, open a .docx from disk, edit it, and download the edited result."
-category: "Frameworks"
+description: 'Build a Vite DOCX editor with React. Install the package, mount the component, open a .docx from disk, edit it, and download the edited result.'
+category: 'Frameworks'
 seoTitle: 'Vite DOCX editor setup'
 ---
 

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Content controls'
-description: "Find and fill Word content controls by tag or id. Set text, dropdown, checkbox, and date values, from inside the editor or from a server-side script."
-category: "Guides"
+description: 'Find and fill Word content controls by tag or id. Set text, dropdown, checkbox, and date values, from inside the editor or from a server-side script.'
+category: 'Guides'
 seoTitle: 'Content controls (SDTs)'
 ---
 
@@ -10,7 +10,8 @@ Word content controls (`w:sdt`, Structured Document Tags) are labeled, bounded r
 The editor parses controls into the canonical tree, keeps them editable, renders their boundary, and round-trips them losslessly on save, including properties it does not model, such as `w:dataBinding` and `w15:repeatingSection`.
 
 <Callout>
-Content controls are addressed by `tag`, `title`, or `id`. They are not `{{mustache}}` template variables; the two systems can coexist in one document.
+  Content controls are addressed by `tag`, `title`, or `id`. They are not `{{ mustache }}` template
+  variables; the two systems can coexist in one document.
 </Callout>
 
 ## Filling a template from a server
@@ -49,12 +50,12 @@ try {
 
 `setValue` takes a discriminated value rather than a bare string, so a typed control cannot be filled with something it cannot hold:
 
-| Kind | Shape | For |
-|---|---|---|
-| `text` | `{ kind: 'text', text }` | Rich-text and plain-text controls. |
-| `listItem` | `{ kind: 'listItem', value }` | Dropdowns and combo boxes. Must match a declared item. |
-| `checkbox` | `{ kind: 'checkbox', checked }` | Checkbox controls. |
-| `date` | `{ kind: 'date', iso }` | Date pickers. `YYYY-MM-DD` or a full ISO-8601 instant. |
+| Kind       | Shape                           | For                                                    |
+| ---------- | ------------------------------- | ------------------------------------------------------ |
+| `text`     | `{ kind: 'text', text }`        | Rich-text and plain-text controls.                     |
+| `listItem` | `{ kind: 'listItem', value }`   | Dropdowns and combo boxes. Must match a declared item. |
+| `checkbox` | `{ kind: 'checkbox', checked }` | Checkbox controls.                                     |
+| `date`     | `{ kind: 'date', iso }`         | Date pickers. `YYYY-MM-DD` or a full ISO-8601 instant. |
 
 `insertText(text, 'Replace' | 'Start' | 'End')` writes free text where that is what you want, and `delete(keepContent)` either drops a control with its content or unwraps it and keeps the content in place.
 
@@ -86,11 +87,16 @@ function ControlInspector() {
     <div>
       <h4>{control.alias ?? control.tag ?? control.id}</h4>
       <p>{control.controlType}</p>
-      <button disabled={!canSetValue} title={setValueDisabledReason ?? undefined}
-        onClick={() => setValue('Acme GmbH')}>
+      <button
+        disabled={!canSetValue}
+        title={setValueDisabledReason ?? undefined}
+        onClick={() => setValue('Acme GmbH')}
+      >
         Fill
       </button>
-      <button disabled={!canRemove} onClick={() => remove()}>Remove</button>
+      <button disabled={!canRemove} onClick={() => remove()}>
+        Remove
+      </button>
     </div>
   );
 }
@@ -108,7 +114,7 @@ In the editor, typed controls get an interactive trigger at the top-right of the
 
 ## Current limits
 
-- A control that *wraps* a whole table cell or row is not supported (controls *inside* a cell are).
+- A control that _wraps_ a whole table cell or row is not supported (controls _inside_ a cell are).
 - A control inside a hyperlink is not surfaced.
 - `dataBinding` and repeating sections round-trip but have no live behavior: no bound-value resolution, no automatic repeat expansion.
 

--- a/docs/site/content/guides/custom-styles.mdx
+++ b/docs/site/content/guides/custom-styles.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Custom styles & branding'
 description: 'Use a branded DOCX template to control headings, fonts, and table styles. Documents inherit your styles automatically and preserve them when saved.'
-category: "Guides"
+category: 'Guides'
 seoTitle: 'Custom styles, fonts, and branded DOCX templates'
 ---
 
@@ -43,7 +43,7 @@ export function BrandedEditor() {
 ### Use a word processor
 
 1. Create a document with your desired styles.
-2. Configure a default table style (see [Tables](#tables)).
+2. Define any table styles you use (see [Tables](#tables)).
 3. Remove the document content.
 4. Save the file as your template.
 
@@ -55,36 +55,30 @@ Set `w:qFormat` to surface a style in the dropdown, and `w:semiHidden` or `w:hid
 
 ## Tables
 
-New tables use the document's default table style. To apply branded borders, shading, and header formatting automatically, define a table style and set it as the default:
+Table styles defined in the document (borders, shading, banded rows, header-row formatting) render through the style cascade, including `basedOn` inheritance, and survive a round trip.
 
-```xml
-<!-- word/settings.xml -->
-<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:defaultTableStyle w:val="BrandGrid"/>
-</w:settings>
-```
-
-If no default table style is configured, inserted tables use a basic single-border style.
+Newly inserted tables do not pick up a document default table style: Insert → Table authors an even grid with explicit single-line borders, so it renders the same in every document. Restyle it afterwards with the table border and fill controls.
 
 ## Fonts
 
-The recommended way to provide custom fonts is the editor's `fonts` prop. Each entry registers an `@font-face` rule, allowing the editor to render and measure the font without additional setup. The font picker offers the families the document declares plus the ones you configure.
+Provide brand fonts through the editor's `fonts` prop. `loadFonts` fetches the URLs you list and returns a fragment the editor both measures and paints with:
 
 ```tsx
-const FONTS = [
-  { family: 'Custom Sans', src: '/fonts/CustomSans-Regular.woff2' },
-  { family: 'Custom Sans', src: '/fonts/CustomSans-Bold.woff2', weight: 700 },
-];
+import { loadFonts } from '@docx-editor.dev/react';
 
-<DocxEditor
-  document={template}
-  fonts={FONTS}
-/>;
+const brand = await loadFonts({
+  sources: [
+    { url: '/fonts/CustomSans-Regular.ttf', family: 'Custom Sans', weight: 400, style: 'normal' },
+    { url: '/fonts/CustomSans-Bold.ttf', family: 'Custom Sans', weight: 700, style: 'normal' },
+  ],
+});
+
+<DocxEditor document={template} fonts={brand} />;
 ```
 
-See [React props: Fonts](/docs/2.x/react/props#fonts) for the full API.
+The font picker offers the families the document declares plus the ones you configure. See [React props: Fonts](/docs/2.x/react/props#fonts) for the prop and [Fonts and measurement](/docs/2.x/guides/fonts) for hashes, failure handling, and on-demand loading.
 
-Alternatively, fonts can be installed on the user's system or loaded using your own `@font-face` rules. The editor renders fonts by name, so any font available to the browser can be used.
+A font that is only installed on the user's system or registered through your own `@font-face` rules affects painting, not measurement: the editor measures with the bytes you hand it and falls back to estimated metrics for families it has no bytes for.
 
 Fonts embedded inside a `.docx` are loaded automatically: the editor de-obfuscates the embedded faces, renders with them, and lists them in the font picker. They are also preserved when saving.
 
@@ -92,9 +86,8 @@ Fonts embedded inside a `.docx` are loaded automatically: the editor de-obfuscat
 
 The editor preserves existing style files (`styles.xml`, `theme1.xml`, `settings.xml`) rather than regenerating them. Custom styles, themes, fonts, and table defaults survive a full edit-and-save round trip.
 
-
 ## Next steps
 
-- [Fonts and measurement](/docs/2.x/guides/fonts): the three font sources and how they compose
+- [Fonts and measurement](/docs/2.x/guides/fonts): font sources and how they compose
 - [Word fidelity](/docs/2.x/word-fidelity): what survives a round trip
 - [Props](/docs/2.x/react/props): `fonts` and the rest of the root props

--- a/docs/site/content/guides/dark-mode.mdx
+++ b/docs/site/content/guides/dark-mode.mdx
@@ -1,20 +1,20 @@
 ---
 title: 'Dark mode'
 description: 'Enable dark mode in the DOCX editor with the colorMode prop: theme the chrome, render the document canvas like Word dark view, and toggle from your own UI.'
-category: "Guides"
+category: 'Guides'
 seoTitle: 'Dark mode'
 ---
 
-The editor ships a native dark mode. One prop, `colorMode`, themes the whole UI and renders the document the way Word's dark view does. 
+The editor ships a native dark mode. One prop, `colorMode`, themes the whole UI and renders the document the way Word's dark view does.
 
 ## Enabling dark mode
 
 `colorMode` is a controlled prop. There is no internal toggle button; you set the value and the editor follows it.
 
-| Value | Behavior |
-|---|---|
-| `'light'` | Light theme (default). |
-| `'dark'` | Dark theme. |
+| Value      | Behavior                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| `'light'`  | Light theme (default).                                                                               |
+| `'dark'`   | Dark theme.                                                                                          |
 | `'system'` | Follows the operating system via `prefers-color-scheme`, and updates live when the OS theme changes. |
 
 ```tsx
@@ -36,14 +36,14 @@ const [colorMode, setColorMode] = useState<'light' | 'dark'>('light');
 
 To follow the operating system instead, pass `colorMode="system"`.
 
-## What changes, and what doesn't
+## What dark mode changes
 
 Dark mode has two layers:
 
 - **Editor chrome** (toolbar, title bar, dialogs, dropdowns, sidebar, menus) re-themes through the shared design tokens, so every surface tracks the theme.
 - **The document canvas** is rendered like Word's dark view: the page turns dark and text turns light. Rather than swapping two fixed colors, the canvas applies a perceptual transform that inverts each authored color's lightness while preserving its hue: black body text becomes near-white, a dark-navy heading becomes light blue, a dark red stays red. Nothing on the page becomes unreadable.
 
-It is a **display transform only.** Dark mode never changes the document itself:
+It is a display transform only. Dark mode never changes the document itself:
 
 - The saved DOCX is byte-for-byte unaffected; authored colors are preserved as written.
 - Printing always uses a white page with black text, regardless of `colorMode`.
@@ -54,7 +54,6 @@ The light theme is unchanged when `colorMode` is `'light'`.
 ## Reporting issues
 
 Dark mode covers a large surface, and the canvas transform is heuristic. If you find a control that doesn't theme correctly, text that's hard to read, or a color that transforms badly, please open an issue at [github.com/eigenpal/docx-editor/issues](https://github.com/eigenpal/docx-editor/issues). Mention `colorMode` and include a screenshot.
-
 
 ## Next steps
 

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Fonts and measurement'
 description: 'How the editor resolves fonts for Word-accurate line wrap and pagination: embedded DOCX fonts, metric-compatible substitutes, and app-supplied font URLs.'
-category: "Guides"
+category: 'Guides'
 seoTitle: 'Fonts and text measurement'
 ---
 
@@ -11,7 +11,7 @@ fixed-width estimate, but wrap and page-break points are then approximations rat
 than Word's. This guide covers the three ways fonts reach the editor, the two ways of
 timing them, and how they combine.
 
-## The three font sources
+## Font sources
 
 **1. Fonts embedded in the document, automatic.** A `.docx` can carry the faces it was
 written in. When it does, the editor extracts them on load and measures with them. No
@@ -30,11 +30,6 @@ fonts (Calibri, Cambria, Times New Roman, Arial, Courier New), which are proprie
 and cannot be bundled. The optional `@docx-editor.dev/fonts` package ships open-licensed
 faces built to match their metrics: identical advance widths, so lines wrap where Word
 wraps them:
-
-<Callout>
-  `@docx-editor.dev/fonts` is not published to npm yet. It ships with the v2 line. The API below is
-  stable; the package is workspace-only until then.
-</Callout>
 
 | Word font       | Substitute       | License |
 | --------------- | ---------------- | ------- |
@@ -65,7 +60,7 @@ function Editor({ bytes }: { bytes: Uint8Array }) {
       try {
         const fragment = await loadDefaultFonts(); // or { families: ['Calibri'] }
         // Optional: also register the substitutes with the browser under the Word family
-        // names, so painted glyphs use the same metrics layout measured with.
+        // names, so painted glyphs match the metrics layout measured with.
         void installDefaultFontFaces();
         if (!cancelled) setFonts({ settled: true, value: fragment });
       } catch {
@@ -141,7 +136,7 @@ if ('source' in made) {
 }
 ```
 
-## Upfront, or on demand
+## Loading upfront or on demand
 
 Every path above resolves fonts before a document opens. You pick the faces, load the
 bytes, and hand the editor a value. Keep this as your default: it is the only path that
@@ -216,7 +211,7 @@ one immutable configuration the editor samples per mount. Precedence is simple:
 3. **First fragment wins** among equals, and duplicate faces are deduplicated rather
    than erroring.
 
-## Degradation, not failure
+## Fallback behavior
 
 Fonts never block a document from opening. The document mounts immediately on the
 fixed measurer and swaps to shaped measurement in a single re-mount when fonts resolve.
@@ -252,7 +247,7 @@ editor?.fontMeasurement();
 `{ measurer: 'fixed', resolving: false }` is the steady state for a document with no
 usable font source; `resolving: true` means shaped resolution is still in flight.
 
-## Honesty notes
+## Caveats
 
 - **Metric-compatible is not identical.** Advance widths match, so wrap points match;
   rare kerning-pair differences can still move an edge case. Documents that must
@@ -261,7 +256,6 @@ usable font source; `resolving: true` means shaped resolution is still in flight
   resolver you pass run because your code asked for them. Embedded fonts come from inside
   the file. Opening a document makes no network request unless you passed a resolver that
   fetches, which is the one case where a font request happens on open.
-
 
 ## Next steps
 

--- a/docs/site/content/guides/headers-footers.mdx
+++ b/docs/site/content/guides/headers-footers.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Headers & footers'
 description: 'Edit DOCX headers and footers in place, insert PAGE and NUMPAGES fields, use per-section first-page and even-page variants, and add watermarks.'
-category: "Guides"
+category: 'Guides'
 seoTitle: 'Headers, footers, and watermarks'
 ---
 
@@ -23,7 +23,7 @@ Press Escape or click the close action to save and leave header/footer editing.
 
 Page-number fields are stored as real Word fields, not static text. The page view renders the resolved value on each page (page 3 of a 10-page document shows "3" and "10"), values update as the document reflows, and the fields round-trip to OOXML so Word keeps them live.
 
-A "Page X of Y" footer is the two inserts with literal text between them: type `Page `, insert the page number, type ` of `, insert the total page count.
+A "Page X of Y" footer is the two inserts with literal text between them: type the text "Page ", insert the page number, type " of " with the surrounding spaces, insert the total page count.
 
 ## Per-section headers and footers
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -1,20 +1,20 @@
 ---
 title: 'Images & drawings'
-description: "Inline and floating DrawingML pictures in DOCX: supported formats, wrap modes, authoring them from React, accessibility, and the security boundaries."
-category: "Guides"
+description: 'Inline and floating DrawingML pictures in DOCX: supported formats, wrap modes, authoring them from React, accessibility, and the security boundaries.'
+category: 'Guides'
 seoTitle: 'Images and floating pictures'
 ---
 
-DrawingML pictures (`w:drawing` with `pic:pic`) now layout, paint, and round-trip through the shared engine. React ships insert, wrap, properties, alt text, and selection-overlay authoring.
+DrawingML pictures (`w:drawing` with `pic:pic`) lay out, paint, and round-trip through the engine. React ships insert, wrap, properties, alt text, and selection-overlay authoring.
 
 ## Supported formats
 
-| Format | Insert (React) | Layout & paint | Round-trip |
-| --- | --- | --- | --- |
-| PNG, JPEG, GIF | Yes, `normalizeImageBytes` preflight | Full decode at authored `wp:extent` | Byte-identical media unless replaced |
-| SVG | No insert | Painted at authored `wp:extent` | Byte-identical media |
-| TIFF, EMF, WMF | No insert | Extent reserved; labelled placeholder | Preserved; no zero-click fetch |
-| External `r:link` / `TargetMode="External"` | No auto-load | Placeholder + preserved rel | Preserved; explicit user gesture to embed |
+| Format                                      | Insert (React)                       | Layout & paint                       | Round-trip                                |
+| ------------------------------------------- | ------------------------------------ | ------------------------------------ | ----------------------------------------- |
+| PNG, JPEG, GIF                              | Yes, `normalizeImageBytes` preflight | Full decode at authored `wp:extent`  | Byte-identical media unless replaced      |
+| SVG                                         | No insert                            | Painted at authored `wp:extent`      | Byte-identical media                      |
+| TIFF, EMF, WMF                              | No insert                            | Extent reserved; labeled placeholder | Preserved; no zero-click fetch            |
+| External `r:link` / `TargetMode="External"` | No auto-load                         | Placeholder + preserved rel          | Preserved; explicit user gesture to embed |
 
 Insert accepts PNG/JPEG/GIF only. Other payloads stay in the package and participate in pagination through their authored extent.
 
@@ -36,7 +36,7 @@ const image = useEditorState((s) => s.image);
 
 ```ts
 editor.getSelectedImage(); // same SelectedImageState shape
-editor.snapshot().image;   // reference-stable until selection or image fields move
+editor.snapshot().image; // reference-stable until selection or image fields move
 ```
 
 `SelectedImageState.wrap` reports all nine Word menu targets (`inline`, `square`, `squareLeft`, `squareRight`, `tight`, `through`, `topAndBottom`, `behind`, `inFront`). `behind` and `inFront` are both `wrapNone` with different `@behindDoc`.
@@ -45,12 +45,12 @@ editor.snapshot().image;   // reference-stable until selection or image fields m
 
 Default toolbar slots (contextual `image` group when a picture is selected):
 
-| Slot | Component / hook | Engine command |
-| --- | --- | --- |
-| `image.insert` | `ImageInsertProvider`, `ImageInsertTrigger` | `executeImageCommand({ type: 'insertImage', … })` |
-| `image.wrap` | `ImageWrap`, `useEditorValueCommand('image.wrap')` | `setImageWrapType` via `runToolbarCommand` |
-| `image.altText` | `ImageAltText` | `setImageAltText` |
-| `image.properties` | `ImagePropertiesTrigger`, `DocxEditorImagePropertiesDialog` | `setImageProperties` |
+| Slot               | Component / hook                                            | Engine command                                    |
+| ------------------ | ----------------------------------------------------------- | ------------------------------------------------- |
+| `image.insert`     | `ImageInsertProvider`, `ImageInsertTrigger`                 | `executeImageCommand({ type: 'insertImage', … })` |
+| `image.wrap`       | `ImageWrap`, `useEditorValueCommand('image.wrap')`          | `setImageWrapType` via `runToolbarCommand`        |
+| `image.altText`    | `ImageAltText`                                              | `setImageAltText`                                 |
+| `image.properties` | `ImagePropertiesTrigger`, `DocxEditorImagePropertiesDialog` | `setImageProperties`                              |
 
 Insert preflight:
 
@@ -90,11 +90,11 @@ Alt text uses `@descr`, then `@title`; `@name` is never announced. A picture wit
 
 Not edited or raster-rendered in this release:
 
-- VML (`w:pict`): follow-up `typed-vml-watermarks`
-- Charts, SmartArt, groups, canvases, text-box stories: extent + labelled placeholder
+- VML (`w:pict`), except watermarks
+- Charts, SmartArt, groups, canvases, text-box stories: extent + labeled placeholder
 - `w:object` / `w:altChunk`: generic preservation with diagnostics
-- Artistic effects (`a:effectLst`), TIFF/EMF/WMF converters
-- Tracked-change accept/reject on drawings: `typed-revisions-and-comments`
+- Artistic effects (`a:effectLst`), TIFF/EMF/WMF rasterization
+- Tracked-change accept/reject on drawings
 
 ## Next steps
 

--- a/docs/site/content/guides/loading-and-saving.mdx
+++ b/docs/site/content/guides/loading-and-saving.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Loading & saving'
-description: "Load DOCX bytes into the editor root, swap documents through the shared ref, and serialize the current state back out to a .docx file on demand."
-category: "Guides"
+description: 'Load DOCX bytes into the editor root, swap documents through the shared ref, and serialize the current state back out to a .docx file on demand.'
+category: 'Guides'
 seoTitle: 'Loading and saving DOCX documents'
 ---
 
@@ -9,7 +9,7 @@ The editor takes a `.docx` file in and gives a `.docx` file back. Everything hap
 
 ## Input formats
 
-The current adapters take the document through the `document` prop. The most common value is `Uint8Array` DOCX bytes:
+The editor takes the document through the `document` prop. The most common value is `Uint8Array` DOCX bytes:
 
 ```tsx
 <DocxEditor document={bytes} />
@@ -119,7 +119,7 @@ Debounce `ref.save()` when `onChange` fires:
 import { useRef } from 'react';
 import { DocxEditor, type DocxEditorRef } from '@docx-editor.dev/react';
 
-export function AutosaveEditor({ docId }: { docId: string }) {
+export function AutosaveEditor({ docId, bytes }: { docId: string; bytes: Uint8Array }) {
   const ref = useRef<DocxEditorRef>(null);
   const timer = useRef<number | null>(null);
 

--- a/docs/site/content/guides/toolbar.mdx
+++ b/docs/site/content/guides/toolbar.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Toolbar'
-description: "Customize the React editor chrome: keep the packaged toolbar, override single slots, or compose your own from DocxEditor.Toolbar and its parts."
-category: "Guides"
+description: 'Customize the React editor chrome: keep the packaged toolbar, override single slots, or compose your own from DocxEditor.Toolbar and its parts.'
+category: 'Guides'
 seoTitle: 'Toolbar customization'
 ---
 
@@ -64,7 +64,11 @@ import { useEditorCommand } from '@docx-editor.dev/react';
 function BoldButton() {
   const bold = useEditorCommand('text.bold');
   return (
-    <button onClick={() => bold.execute()} disabled={!bold.isEnabled}>
+    <button
+      onMouseDown={(e) => e.preventDefault()} // chrome must not steal the caret
+      onClick={() => bold.execute()}
+      disabled={!bold.isEnabled}
+    >
       Bold
     </button>
   );
@@ -75,16 +79,16 @@ function BoldButton() {
 
 When the caret or a rectangular cell selection is inside a table, the formatting toolbar shows contextual table controls:
 
-- **Resize**: hover a column divider or the table’s right edge; drag to commit Word-compatible twip widths (inner divider resize preserves total table width; outer-right resize changes table width).
+- **Resize**: hover a column divider or the table's right edge; drag to commit Word-compatible twip widths (inner divider resize preserves total table width; outer-right resize changes table width).
 - **Insert rows/columns**: hover the row band or column header band and click the `+` control, or use the table rows on the right-click menu.
-- **Borders and fill**: with one or more cells selected, choose a border target, style, width, and colour, then pick a cell fill (clear fill removes direct shading).
+- **Borders and fill**: with one or more cells selected, choose a border target, style, width, and color, then pick a cell fill (clear fill removes direct shading).
 
 These controls target the **innermost** nested table under the pointer or selection. Merge and split remain unsupported; tables with merged cells refuse column resize/insert/delete with an explicit disabled reason.
+
+The [Igloo demo](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) is a worked example of every point above: it hand-orders the bar, re-icons every packaged part, and adds two host actions.
 
 ## Next steps
 
 - [React package overview](/docs/2.x/react)
 - [React props](/docs/2.x/react/props)
 - [React examples](/docs/2.x/react/examples)
-
-A worked example of every point above: the [Igloo demo](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) hand-orders the bar, re-icons every packaged part, and adds two host actions.

--- a/docs/site/content/i18n/contributing.mdx
+++ b/docs/site/content/i18n/contributing.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Contributing a translation'
 description: 'Add a new editor language to @docx-editor.dev/i18n: scaffold the locale JSON, fill the strings, validate, and open a PR. Partial translations welcome.'
-category: "Reference"
+category: 'Reference'
 ---
 
 The editor UI ships in ten languages. Adding an eleventh is a single JSON file

--- a/docs/site/content/i18n/index.mdx
+++ b/docs/site/content/i18n/index.mdx
@@ -54,7 +54,7 @@ import { pl } from '@docx-editor.dev/i18n';
 </LocaleProvider>;
 ```
 
-`LocaleProvider` merges your catalog over English, so a locale that has not translated every key falls back per key rather than per language. Chrome you write yourself reads the same catalog through `useTranslation()`:
+`LocaleProvider` merges your catalog over English, so a locale that has not translated every key falls back per key rather than per language. It localizes the packaged editor and any chrome parts you compose yourself (`DocxEditor.Toolbar`, `DocxEditor.Menu`, …) alike. Chrome you write from scratch reads the same catalog through `useTranslation()`:
 
 ```tsx
 import { useTranslation } from '@docx-editor.dev/react';

--- a/docs/site/content/i18n/index.mdx
+++ b/docs/site/content/i18n/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "@docx-editor.dev/i18n"
-description: "Locale data for the editor chrome. Ships ten languages: English, Polish, German, French, Portuguese, Hebrew, Hindi, Indonesian, Turkish, and Chinese."
-category: "Reference"
+title: '@docx-editor.dev/i18n'
+description: 'Locale data for the editor chrome. Ships ten languages: English, Polish, German, French, Portuguese, Hebrew, Hindi, Indonesian, Turkish, and Chinese.'
+category: 'Reference'
 order: 60
 ---
 
@@ -17,18 +17,18 @@ You usually don't install this directly. `-react` pulls it in transitively. Inst
 
 ## Available locales
 
-| Code | Language | Named export |
-|---|---|---|
-| `en` | English | `en` |
-| `pl` | Polish | `pl` |
-| `de` | German | `de` |
-| `fr` | French | `fr` |
-| `pt-BR` | Brazilian Portuguese | `ptBR` |
-| `he` | Hebrew | `he` |
-| `hi` | Hindi | `hi` |
-| `id` | Indonesian | `id` |
-| `tr` | Turkish | `tr` |
-| `zh-CN` | Chinese (Simplified) | `zhCN` |
+| Code    | Language             | Named export |
+| ------- | -------------------- | ------------ |
+| `en`    | English              | `en`         |
+| `pl`    | Polish               | `pl`         |
+| `de`    | German               | `de`         |
+| `fr`    | French               | `fr`         |
+| `pt-BR` | Brazilian Portuguese | `ptBR`       |
+| `he`    | Hebrew               | `he`         |
+| `hi`    | Hindi                | `hi`         |
+| `id`    | Indonesian           | `id`         |
+| `tr`    | Turkish              | `tr`         |
+| `zh-CN` | Chinese (Simplified) | `zhCN`       |
 
 Two import shapes are supported:
 
@@ -54,7 +54,7 @@ import { pl } from '@docx-editor.dev/i18n';
 </LocaleProvider>;
 ```
 
-`LocaleProvider` merges your catalogue over English, so a locale that has not translated every key falls back per key rather than per language. Chrome you write yourself reads the same catalogue through `useTranslation()`:
+`LocaleProvider` merges your catalog over English, so a locale that has not translated every key falls back per key rather than per language. Chrome you write yourself reads the same catalog through `useTranslation()`:
 
 ```tsx
 import { useTranslation } from '@docx-editor.dev/react';

--- a/docs/site/content/index.mdx
+++ b/docs/site/content/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: 'Introduction'
-description: "Open source WYSIWYG DOCX editor for React. Runs in the browser: .docx in, .docx out, with tracked changes, comments, content controls, and custom nodes."
-category: "Getting Started"
+description: 'Open source WYSIWYG DOCX editor for React. Runs in the browser: .docx in, .docx out, with tracked changes, comments, content controls, and custom nodes.'
+category: 'Getting Started'
 order: 1
 seoTitle: 'DOCX Editor for React'
 ---
 
 `docx-editor` is an open-source WYSIWYG DOCX editor for React. It parses OOXML in the browser, paints real paginated pages, and serializes the current document back to `.docx`. You do not need an upload service or a conversion backend for normal browser editing.
 
-**It is lossless.** Everything you do not edit comes back byte for byte, including the parts the editor does not understand. Opening a document here cannot quietly destroy it.
+Saving is lossless. Everything you do not edit comes back byte for byte, including the parts the editor does not understand. Opening a document here cannot quietly destroy it.
 
 <Cards>
   <Card title="Get it running" href="/docs/2.x/quickstart">
@@ -37,7 +37,7 @@ All packages release together in a fixed version group. Everything is Apache 2.0
 
 ## Which package do I need?
 
-**React app.** Install `-react` and the engine it renders. The string catalogue comes with it.
+**React app.** Install `-react` and the engine it renders. The string catalog comes with it.
 
 ```bash
 npm install @docx-editor.dev/react @docx-editor.dev/core
@@ -70,7 +70,7 @@ The editor models common Word constructs and writes them back through OOXML:
 
 Feature-by-feature coverage and known limits: [Word fidelity](/docs/2.x/word-fidelity). You can also open one of your own documents in the [live demo](https://docx-editor.dev/editor).
 
-## Nothing is lost
+## Lossless round-trip
 
 Open a document, edit one word, save it. Everything you did not touch comes back byte for
 byte: custom XML, embedded fonts, macros, media, VBA, Smart Tags, and markup from add-ins the

--- a/docs/site/content/installation.mdx
+++ b/docs/site/content/installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Installation'
-description: "Install the DOCX editor in React, Next.js, Vite, Remix, or Astro. Covers the stylesheet import, the client-only SSR boundary, fonts, and which package to pick."
-category: "Getting Started"
+description: 'Install the DOCX editor in React, Next.js, Vite, Remix, or Astro. Covers the stylesheet import, the client-only SSR boundary, fonts, and which package to pick.'
+category: 'Getting Started'
 order: 2
 ---
 
@@ -9,7 +9,7 @@ order: 2
 
 ## Pick a package
 
-The adapter carries the engine and the string catalogue, so for most apps it is one install.
+The adapter holds the engine as a peer, so install both. The string catalog comes with the adapter.
 
 ```bash
 # React adapter: the editor, plus the engine it holds as a peer
@@ -44,7 +44,7 @@ export default function App() {
 }
 ```
 
-Two things that catch people out:
+Two details to get right:
 
 - Without the stylesheet the editor works but the chrome renders unstyled. The styles are scoped under `.ep-root` and do not leak into your app.
 - `<DocxEditor>` fills its parent. In a parent with no height it collapses and nothing appears.
@@ -54,10 +54,22 @@ Two things that catch people out:
 The editor measures text in the DOM at mount, so it must render client-side. Client-rendered apps (Vite) need nothing special; SSR frameworks need one client-only boundary. Each guide is a complete walkthrough backed by a runnable example:
 
 <Cards>
-  <Card href="/docs/2.x/frameworks/nextjs" title="Next.js" description="dynamic() with ssr: false; fixes 'window is not defined'." />
-  <Card href="/docs/2.x/frameworks/vite" title="Vite" description="Client-rendered React setup with no SSR boundary." />
+  <Card
+    href="/docs/2.x/frameworks/nextjs"
+    title="Next.js"
+    description="dynamic() with ssr: false; fixes 'window is not defined'."
+  />
+  <Card
+    href="/docs/2.x/frameworks/vite"
+    title="Vite"
+    description="Client-rendered React setup with no SSR boundary."
+  />
   <Card href="/docs/2.x/frameworks/remix" title="Remix" description="Mount check + React.lazy." />
-  <Card href="/docs/2.x/frameworks/astro" title="Astro" description="React island with client:only." />
+  <Card
+    href="/docs/2.x/frameworks/astro"
+    title="Astro"
+    description="React island with client:only."
+  />
 </Cards>
 
 ## Fonts
@@ -74,7 +86,7 @@ const fonts = await loadDefaultFonts();
 
 See [Fonts and measurement](/docs/2.x/guides/fonts) for how the sources compose.
 
-## No UI
+## Headless
 
 To read, edit, and write a `.docx` headlessly, on a server, in a worker, or in a script, use [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api). It opens bytes, edits them through an Office.js-compatible batching object model, and saves them back.
 

--- a/docs/site/content/pro/comments.mdx
+++ b/docs/site/content/pro/comments.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Comments'
-description: "Comment threads anchored to a range in a DOCX: read them, write them, reply and resolve, and render your own comment UI over the review hook."
-category: "Pro"
+description: 'Comment threads anchored to a range in a DOCX: read them, write them, reply and resolve, and render your own comment UI over the review hook.'
+category: 'Pro'
 order: 62
 ---
 

--- a/docs/site/content/pro/custom-nodes.mdx
+++ b/docs/site/content/pro/custom-nodes.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Custom nodes'
-description: "Define your own inline node types, such as citations, mentions, and merge fields, stored as Word content controls that survive a round trip through Word."
-category: "Pro"
+description: 'Define your own inline node types, such as citations, mentions, and merge fields, stored as Word content controls that survive a round trip through Word.'
+category: 'Pro'
 order: 63
 ---
 

--- a/docs/site/content/pro/index.mdx
+++ b/docs/site/content/pro/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: '@docx-editor.dev/pro'
-description: "Tracked changes, comments, and custom nodes for the React DOCX editor. Register a module on the editor root, then take the hook or the packaged sidebar."
-category: "Pro"
+description: 'Tracked changes, comments, and custom nodes for the React DOCX editor. Register a module on the editor root, then take the hook or the packaged sidebar.'
+category: 'Pro'
 order: 60
 ---
 
@@ -62,7 +62,7 @@ Write calls report whether they landed rather than throwing, so a reply written 
 
 ## Chrome or hooks
 
-Everything the packaged sidebar renders is reachable from `useReview()`. Take the sidebar when you want Word-like cards out of the box; take the hook when you want your own markup:
+Everything the packaged sidebar renders is reachable from `useReview()`. Use the sidebar for Word-like cards out of the box, or the hook to render your own markup:
 
 ```tsx
 import { useReview } from '@docx-editor.dev/pro/react';

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Tracked changes'
-description: "Suggesting mode records every edit as a Word revision. Render them, accept and reject them, from the packaged review sidebar or from your own UI."
-category: "Pro"
+description: 'Suggesting mode records every edit as a Word revision. Render them, accept and reject them, from the packaged review sidebar or from your own UI.'
+category: 'Pro'
 order: 61
 ---
 
@@ -87,9 +87,9 @@ Each card is a compound you can take apart:
 
 Every part takes `className`, `asChild`, and `hidden`. The action parts (`Accept`, `Reject`, `Delete`, `Reply`) also take `icon`.
 
-`Delete` is the destructive one, and it is on both kinds of card: on a comment it deletes the thread, and on a tracked change it discards the suggestion. `Replies` draws one per reply as well, so a single answer can be taken back without deleting the conversation it belongs to. It is absent on a card with nothing to discard.
+`Delete` is the destructive one, and it is on both kinds of card: on a comment it deletes the thread, and on a tracked change it discards the suggestion. `Replies` draws a Delete control per reply as well, so a single answer can be taken back without deleting the conversation it belongs to. Delete is absent on a card with nothing to discard.
 
-The stylesheet reveals it on hover of the one node it deletes, and on keyboard focus — a rail where every card offers to throw a remark away invites clicking one by mistake, and a reply that lit up its parent's control at the same time is how a reader deletes the wrong one. Restyle it like any other part; if you want it always visible, `visibility: visible` on `[data-testid='review-delete']` is the whole override.
+The stylesheet reveals it on hover of the one node it deletes, and on keyboard focus. A rail where every card offers to throw a remark away invites clicking one by mistake, and a reply that lit up its parent's control at the same time is how a reader deletes the wrong one. Restyle it like any other part; if you want it always visible, `visibility: visible` on `[data-testid='review-delete']` is the whole override.
 
 ## Choosing what the sidebar shows
 
@@ -111,7 +111,7 @@ The props on `DocxEditorReview` decide which decisions appear and how they stack
 <DocxEditorReview filter={(item) => item.kind === 'comment'} gap={12} furniture={<MyFilters />} />
 ```
 
-With `preset={false}` you keep the subscription and the anchoring and render the cards yourself. `useStackedReviewPositions(items, heights, { gap })` is the packaged stacking maths if you want the same behavior.
+With `preset={false}` you keep the subscription and the anchoring and render the cards yourself. `useStackedReviewPositions(items, heights, { gap })` is the packaged stacking math if you want the same behavior.
 
 ## Host content inside a card
 
@@ -162,17 +162,17 @@ function ChangeList() {
 }
 ```
 
-| Member                          | What it does                                                             |
-| ------------------------------- | ------------------------------------------------------------------------ |
-| `items`                         | Every pending decision, in reading order.                                |
-| `activeKey` / `setActive`       | Which item the caret is in; setting selects its range and scrolls to it. |
-| `accept(item)` / `reject(item)` | Resolve a revision. No-ops on an item whose `readOnly` is true.          |
-| `reply(item, text, author?)`    | Reply to a change. Returns whether it landed.                            |
+| Member                          | What it does                                                                 |
+| ------------------------------- | ---------------------------------------------------------------------------- |
+| `items`                         | Every pending decision, in reading order.                                    |
+| `activeKey` / `setActive`       | Which item the caret is in; setting selects its range and scrolls to it.     |
+| `accept(item)` / `reject(item)` | Resolve a revision. No-ops on an item whose `readOnly` is true.              |
+| `reply(item, text, author?)`    | Reply to a change. Returns whether it landed.                                |
 | `remove(item)`                  | Delete a comment thread, or discard a suggestion. Returns whether it landed. |
-| `comment(text, author?)`        | Comment on the current selection. Returns whether it landed.             |
-| `selectionAnchorY`              | Where a comment on the selection would sit, or `null`.                   |
-| `paneOpen` / `setPaneOpen`      | The same toggle the toolbar's comments button runs.                      |
-| `ready`                         | False while no document is loaded.                                       |
+| `comment(text, author?)`        | Comment on the current selection. Returns whether it landed.                 |
+| `selectionAnchorY`              | Where a comment on the selection would sit, or `null`.                       |
+| `paneOpen` / `setPaneOpen`      | The same toggle the toolbar's comments button runs.                          |
+| `ready`                         | False while no document is loaded.                                           |
 
 Each item carries `key`, `id`, `author`, `initials`, `date`, `text`, `replyIds`, `readOnly`, `anchorY`, `pageIndex`, and `isActive`. Revision items add `kind: 'revision'`, a `revisionKind`, and `replacedText` for replacements, so a card can say _Replaced "x" with "y"_.
 

--- a/docs/site/content/quickstart.mdx
+++ b/docs/site/content/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Quickstart'
-description: "Load, edit, and save a .docx in the browser with React. Copy-paste setup: a file input, the editor component, and a download button, in one file."
-category: "Getting Started"
+description: 'Load, edit, and save a .docx in the browser with React. Copy-paste setup: a file input, the editor component, and a download button, in one file.'
+category: 'Getting Started'
 ---
 
 This page builds a browser editor that opens a local `.docx` and downloads the edited document.
@@ -12,7 +12,7 @@ This page builds a browser editor that opens a local `.docx` and downloads the e
 
 ### Install
 
-The adapter carries the string catalogue and holds the engine as a peer, so install both.
+The adapter carries the string catalog and holds the engine as a peer, so install both.
 
 ```bash
 npm install @docx-editor.dev/react @docx-editor.dev/core

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Composition'
-description: "Build your own DOCX editor UI on unstyled primitives: provider, viewport, content, compound parts, asChild, slot overrides, and the escalation ladder."
-category: "React"
+description: 'Build your own DOCX editor UI on unstyled primitives: provider, viewport, content, compound parts, asChild, slot overrides, and the customization ladder.'
+category: 'React'
 order: 32
 ---
 
@@ -11,13 +11,13 @@ The packaged toolbar is built from the hooks and primitives on this page, so a c
 
 <Callout>
   The [Igloo example](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) is a fully
-  re-skinned editor built to answer one question: how much of this is yours? Every pattern below
-  appears in it, running. `bun run dev:igloo`.
+  re-skinned editor: every control is host markup over the hooks. Every pattern below appears in it,
+  running. `bun run dev:igloo`.
 </Callout>
 
-## The three primitives
+## Primitives
 
-Every editor is these three, in this order:
+Every editor is these three components, in this order:
 
 ```tsx
 import { DocxEditor } from '@docx-editor.dev/react';
@@ -39,7 +39,7 @@ export function Editor({ bytes }: { bytes: Uint8Array }) {
 
 Everything else (toolbar, menu, rulers, navigation pane, link popover, context menu) is optional and can be placed anywhere inside `Root`.
 
-## Escalation ladder
+## Customization ladder
 
 Start at the top and go down only as far as you need:
 
@@ -170,6 +170,9 @@ Put the hook in one file and share it across every surface that exposes the acti
 Every composition mode in one panel: packaged rows kept, a packaged row re-iconed, a packaged row removed, a chrome slot pulled in as a row, host rows, and a submenu.
 
 ```tsx
+{
+  /* `enabled` and `apply` come from useHighlightAction() above; `editor` from useDocxEditor(). */
+}
 <DocxEditor.ContextMenu className="my-menu" t={myLabels}>
   {/* Packaged rows, re-iconed. They still run the engine's commands and still carry the
       engine's reason when nothing is selected. */}
@@ -201,7 +204,7 @@ Every composition mode in one panel: packaged rows kept, a packaged row re-icone
   {/* A chrome slot as a row: label, icon and enabled state all from the registry, so it
       cannot disagree with its toolbar twin. */}
   <DocxEditor.ContextMenu.Slot slot="format.clear" />
-</DocxEditor.ContextMenu>
+</DocxEditor.ContextMenu>;
 ```
 
 A child the compound does not recognize is appended rather than wrapping the rows, so decorative markup lands after them in DOM order and the library keeps its own panel element, roles, keyboard handling, and placement.
@@ -211,6 +214,9 @@ A child the compound does not recognize is appended rather than wrapping the row
 The default bar derives from `CHROME_MENUS`, so it is already correct without you writing anything. What a product adds on top is usually a menu of its own and a replacement for Help:
 
 ```tsx
+{
+  /* `enabled` and `apply` come from useHighlightAction() above; `editor` from useDocxEditor(). */
+}
 <DocxEditor.Menu className="my-menubar" t={myLabels}>
   {/* The registry's menus, re-iconed in place. Each still derives its rows from the
       registry, so a row added upstream still appears here. */}
@@ -219,7 +225,7 @@ The default bar derives from `CHROME_MENUS`, so it is already correct without yo
   <DocxEditor.Menu.Insert icon={MyInsert} />
 
   {/* A menu the library has never heard of. `MenuId` accepts any string. `label` rather
-      than `labelKey`, because its name will never be in our catalogue. */}
+      than `labelKey`, because its name will never be in our catalog. */}
   <DocxEditor.Menu.Menu id="review" label="Review" icon={MyReview} preset={false}>
     <DocxEditor.Menu.Row disabled={!enabled} onSelect={apply}>
       Highlight passage
@@ -240,7 +246,7 @@ The default bar derives from `CHROME_MENUS`, so it is already correct without yo
       Documentation
     </DocxEditor.Menu.Row>
   </DocxEditor.Menu.Help>
-</DocxEditor.Menu>
+</DocxEditor.Menu>;
 ```
 
 ## Navigation pane
@@ -277,7 +283,7 @@ The pane's parts are statics, so you can hang your own class on each one instead
 
 ## Labels
 
-Every packaged part takes a `t`. Delegate to the bundled English catalogue rather than replacing it, so renaming six things does not mean restating the other four hundred:
+Every packaged part takes a `t`. Delegate to the bundled English catalog rather than replacing it, so renaming six things does not mean restating the other four hundred:
 
 ```ts
 import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
@@ -312,8 +318,8 @@ The library's chrome is built on the `--doc-*` palette, so restating that palett
 
 Two rules worth keeping:
 
-- **Do not style `docx-*` classes and do not use `!important`.** Those names are implementation details. Every visual change should go through a prop, a `--doc-*` token, or an element you own. Where that was not possible the library grew a prop instead: trigger icons, colour-split icons, and the page's centring margin all came out of building the Igloo demo.
-- **The document canvas is not themed, on purpose.** Painter output stays Word-faithful. A page rendered in your brand colours would be a lie about what the file contains, so the theme lives in the chrome around it.
+- **Do not style `docx-*` classes and do not use `!important`.** Those names are implementation details. Every visual change should go through a prop, a `--doc-*` token, or an element you own. Where that was not possible the library grew a prop instead: trigger icons, color-split icons, and the page's centering margin all came out of building the Igloo demo.
+- **The document canvas is not themed, on purpose.** Painter output stays Word-faithful. A page rendered in your brand colors would be a lie about what the file contains, so the theme lives in the chrome around it.
 
 ## Pro surfaces
 
@@ -355,7 +361,7 @@ import { DocxEditorReview } from '@docx-editor.dev/pro/react';
 
 Every part takes `className`, `asChild`, and `hidden`; the action parts also take `icon`. `furniture` is host content above the cards, for filters or a legend.
 
-`preset={false}` mounts the rail and its context without the packaged arrangement, so you can lay the cards out yourself and keep the subscription and the anchoring. `useStackedReviewPositions(items, heights, { gap })` is the packaged stacking maths if you want it.
+`preset={false}` mounts the rail and its context without the packaged arrangement, so you can lay the cards out yourself and keep the subscription and the anchoring. `useStackedReviewPositions(items, heights, { gap })` is the packaged stacking math if you want it.
 
 Below that, `useReview()` gives you the queue with no chrome at all. See [Tracked changes](/docs/2.x/pro/tracked-changes).
 
@@ -440,11 +446,11 @@ export function Workspace({ bytes }: { bytes: Uint8Array }) {
 
 Composing gets you every part by name. Parts you do not place have no UI, which is the work `<DocxEditor>` does for you.
 
-## Two layout traps
+## Layout pitfalls
 
-**The navigation pane needs a positioning context.** It is a sibling of the viewport inside a positioned row, not a column beside it. The pane floats over the gutter and absolutely positions against that box, so without `position: relative` on the row it lays out in the flow and pushes the page down.
+The navigation pane needs a positioning context. It is a sibling of the viewport inside a positioned row, not a column beside it. The pane floats over the gutter and absolutely positions against that box, so without `position: relative` on the row it lays out in the flow and pushes the page down.
 
-**Do not set `z-index` on the workspace row or the viewport.** Either opens a stacking context around the context menu, and a `position: fixed` panel cannot escape the context it is declared in. It renders under the chrome bar however high its own `z-index` goes.
+Do not set `z-index` on the workspace row or the viewport. Either opens a stacking context around the context menu, and a `position: fixed` panel cannot escape the context it is declared in. It renders under the chrome bar however high its own `z-index` goes.
 
 ## Keep the caret
 

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -80,7 +80,7 @@ A part child replaces the slot of the same name and leaves the rest of the defau
 `preset={false}` opts out of the registry's default arrangement, so the order in your JSX is the order on screen. Every packaged part still drives its chrome slot: enabled state, pressed state, and the command all still come from the engine. Only the glyph is yours.
 
 ```tsx
-<DocxEditor.Toolbar preset={false} className="my-toolbar" t={myLabels}>
+<DocxEditor.Toolbar preset={false} className="my-toolbar">
   <DocxEditor.Toolbar.Undo icon={MyUndo} />
   <DocxEditor.Toolbar.Redo icon={MyRedo} />
   <DocxEditor.Toolbar.Separator />
@@ -173,7 +173,7 @@ Every composition mode in one panel: packaged rows kept, a packaged row re-icone
 {
   /* `enabled` and `apply` come from useHighlightAction() above; `editor` from useDocxEditor(). */
 }
-<DocxEditor.ContextMenu className="my-menu" t={myLabels}>
+<DocxEditor.ContextMenu className="my-menu">
   {/* Packaged rows, re-iconed. They still run the engine's commands and still carry the
       engine's reason when nothing is selected. */}
   <DocxEditor.ContextMenu.Cut icon={MyCut} />
@@ -217,7 +217,7 @@ The default bar derives from `CHROME_MENUS`, so it is already correct without yo
 {
   /* `enabled` and `apply` come from useHighlightAction() above; `editor` from useDocxEditor(). */
 }
-<DocxEditor.Menu className="my-menubar" t={myLabels}>
+<DocxEditor.Menu className="my-menubar">
   {/* The registry's menus, re-iconed in place. Each still derives its rows from the
       registry, so a row added upstream still appears here. */}
   <DocxEditor.Menu.File icon={MyFile} />
@@ -281,28 +281,88 @@ The pane's parts are statics, so you can hang your own class on each one instead
 </DocxEditor.Viewport>
 ```
 
+To keep the packaged spinner and restyle only it, `DocxEditor.Loading.Spinner` takes a `className`.
+
+## The link popover
+
+`DocxEditor.HyperLink` is the popover that opens on a link: the URL, edit fields, apply, copy, unlink. Its parts follow the same contract as every other compound (`className`, `asChild`, `hidden`; action parts take `icon`), so restyling it is the same work as restyling the toolbar:
+
+```tsx
+<DocxEditor.HyperLink className="my-popover">
+  <DocxEditor.HyperLink.Copy hidden />
+  <DocxEditor.HyperLink.Unlink icon={MyUnlink} />
+</DocxEditor.HyperLink>
+```
+
+The parts are `Url`, `Fields`, `Edit`, `Apply`, `Cancel`, `Copy`, `Unlink`, and `Error`. For a popover that shares no markup with the packaged one, `useHyperlinkPopup()` is the state behind it.
+
+## Rulers
+
+`DocxEditor.HorizontalRuler` and `DocxEditor.VerticalRuler` read page setup and zoom from the snapshot, so they stay correct across section changes and zoom. Dragging a margin previews live and commits once on release: one transaction, one undo entry. Against a read-only document the handles are inert.
+
+```tsx
+<DocxEditor.Root document={bytes}>
+  <DocxEditor.HorizontalRuler />
+  <DocxEditor.Viewport>
+    {/* Absolutely positioned at the editing area's left edge, so it scrolls with the pages. */}
+    <DocxEditor.VerticalRuler />
+    <DocxEditor.Content />
+  </DocxEditor.Viewport>
+</DocxEditor.Root>
+```
+
+## Page setup dialog
+
+`DocxEditor.PageSetupDialog` is controlled: you own `open` and it reports `onClose`. The packaged menu wires it to Format → Page setup; a composed host wires it to its own trigger:
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<button onClick={() => setOpen(true)}>Page setup…</button>
+<DocxEditor.PageSetupDialog open={open} onClose={() => setOpen(false)} />
+```
+
+It reads and writes through the same engine command as `usePageSetup()`, so a dialog of your own markup is the hook plus a form.
+
+## Content-control panel
+
+`DocxEditor.ContentControl` is the inspector for the control at the caret, with `Header`, `Fields`, and `Remove` parts that compose like every other compound. What the panel reports (locks, data bindings, fill-only mode) is covered in [Content controls](/docs/2.x/guides/content-controls).
+
+## Page furniture
+
+The smaller parts place individually; a part you do not mount has no UI:
+
+- `DocxEditor.PageNumber`: the "page n of m" indicator that appears while the document scrolls and fades after.
+- `DocxEditor.FontNotice`: a dismissible notice listing the fonts the document asked for that were substituted.
+- `DocxEditor.DocumentOutline`: the headings list on its own, outside the navigation pane. Clicking a heading moves the caret and scrolls it into view.
+- `DocxEditor.HeaderFooterChrome`: the header/footer editing overlay: region label, inheritance warning, field inserts, and the options menu.
+- `DocxEditor.NotesChrome`: footnote and endnote chrome: hover preview, context menu, and the numbering properties dialog.
+
 ## Labels
 
-Every packaged part takes a `t`. Delegate to the bundled English catalog rather than replacing it, so renaming six things does not mean restating the other four hundred:
+Composed chrome resolves its labels through the active locale catalog on its own: a bare `<DocxEditor.Toolbar />` renders real labels with no `t` handed to it, localized by `LocaleProvider` like everything else. The same goes for `Menu`, `ContextMenu`, and the rest.
 
-```ts
-import { createT, en, type TranslationKey } from '@docx-editor.dev/i18n';
+Pass a `t` only to rename labels. `useChromeTranslate(overrides?)` returns the catalog-backed resolver every part's `t` prop accepts, with your overrides consulted first:
 
-const english = createT(en);
+```tsx
+import { DocxEditor, useChromeTranslate } from '@docx-editor.dev/react';
 
+// Module level: the resolver is memoized on the Map's identity, so an inline
+// `new Map(...)` would re-create it, and every consuming part's props, per render.
 // A Map, not an object literal: the key is caller input, and an object answers
 // `constructor` and `toString` off the prototype chain.
-const OVERRIDES = new Map<string, string>([
+const OVERRIDES = new Map([
   ['contextMenu.cut', 'Cut text'],
   ['toolbar.bold', 'Heavy'],
 ]);
 
-export function myLabels(key: string): string {
-  return OVERRIDES.get(key) ?? english(key as TranslationKey) ?? key;
+function MyToolbar() {
+  const t = useChromeTranslate(OVERRIDES);
+  return <DocxEditor.Toolbar t={t} />;
 }
 ```
 
-A key that falls through to its own name is a visible bug rather than a blank control.
+Keys you do not override fall through to the catalog, so renaming two labels does not mean restating the other four hundred.
 
 ## Theming
 

--- a/docs/site/content/react/examples.mdx
+++ b/docs/site/content/react/examples.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'React examples'
 description: 'Concrete patterns for the current React root surface: mount bytes, save through the ref, compose custom chrome, and automate an open editor.'
-category: "React"
-order: 32
+category: 'React'
+order: 34
 ---
 
 Each example uses the current root exports only.
@@ -64,7 +64,11 @@ import { DocxEditor, useEditorCommand } from '@docx-editor.dev/react';
 function BoldButton() {
   const bold = useEditorCommand('text.bold');
   return (
-    <button onClick={() => bold.execute()} disabled={!bold.isEnabled}>
+    <button
+      onMouseDown={(e) => e.preventDefault()} // chrome must not steal the caret
+      onClick={() => bold.execute()}
+      disabled={!bold.isEnabled}
+    >
       Bold
     </button>
   );
@@ -119,4 +123,4 @@ export function AutomateButton() {
 - [React package overview](/docs/2.x/react)
 - [Props reference](/docs/2.x/react/props)
 - [Toolbar guide](/docs/2.x/guides/toolbar)
-- [DocxEditor API](/docs/2.x/editor-api)
+- [Editing API](/docs/2.x/editor-api)

--- a/docs/site/content/react/hooks.mdx
+++ b/docs/site/content/react/hooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Hooks'
-description: "The React API the packaged chrome is built on: subscribe to editor state, run commands, read the document outline, search, and drive page setup."
-category: "React"
+description: 'The React API the packaged chrome is built on: subscribe to editor state, run commands, read the document outline, search, and drive page setup.'
+category: 'React'
 order: 33
 ---
 
@@ -223,25 +223,25 @@ function Find() {
 
 `matchCase` / `setMatchCase` and `wholeWord` / `setWholeWord` are on the same object.
 
-## The rest
+## Other hooks
 
-| Hook                              | Returns                                                                  |
-| --------------------------------- | ------------------------------------------------------------------------ |
-| `useDocxSource(source, options?)` | Fetches bytes and fonts for a URL, `File`, or `Blob`, with cancellation. |
-| `useEditorValueCommand(slotId)`   | Value-taking commands: `'image.wrap'`, `'image.altText'`.                |
-| `useParagraphIndent()`            | Current indents plus an `apply` for ruler-style editing.                 |
-| `useHyperlinkPopup()`             | State behind the link popover, for a custom panel.                       |
-| `useContentControl()`             | The content-control inspector: locks, value writes, form fill.           |
-| `useHeaderFooterState()`          | Which header/footer scope is being edited, or `null`.                    |
-| `useNoteScopeState()`             | The same for footnotes and endnotes.                                     |
-| `useContextMenuTarget()`          | The element the last right-click landed on.                              |
-| `useNavigationPane(options?)`     | Open state and width for the navigation pane.                            |
-| `useTranslation()`                | `{ t }` bound to the active locale catalogue.                            |
+| Hook                              | Returns                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `useDocxSource(source, options?)` | Fetches bytes and fonts for a URL, `File`, or `Blob`, with cancellation.                   |
+| `useEditorValueCommand(slotId)`   | Value-taking commands: `'image.wrap'`, `'image.altText'`.                                  |
+| `useParagraphIndent()`            | Current indents plus an `apply` for ruler-style editing.                                   |
+| `useHyperlinkPopup()`             | State behind the link popover, for a custom panel.                                         |
+| `useContentControl()`             | The content-control inspector: locks, value writes, form fill.                             |
+| `useHeaderFooterState()`          | Which header/footer scope is being edited, or `null`.                                      |
+| `useNoteScopeState()`             | The same for footnotes and endnotes.                                                       |
+| `useContextMenuTarget()`          | The element the last right-click landed on.                                                |
+| `useNavigationPane(options?)`     | Open state and width for the navigation pane.                                              |
+| `useTranslation()`                | `{ t }` bound to the active locale catalog.                                                |
 | `useFonts(source, ...fragments)`  | Builds a `FontResolver` from a source plus fragments. See [Fonts](/docs/2.x/guides/fonts). |
-| `useNotePropertiesState()`        | Footnote and endnote numbering properties for the current scope.        |
-| `useEditorSnapshot(editor)`       | Revision counter for an editor, for your own `useSyncExternalStore`.    |
-| `useNavigationShift()`            | Horizontal offset the open navigation pane pushes the page by.          |
-| `useTableBorderTargetLabel()`     | Label for the active table border target, for a custom border control.  |
+| `useNotePropertiesState()`        | Footnote and endnote numbering properties for the current scope.                           |
+| `useEditorSnapshot(editor)`       | Revision counter for an editor, for your own `useSyncExternalStore`.                       |
+| `useNavigationShift()`            | Horizontal offset the open navigation pane pushes the page by.                             |
+| `useTableBorderTargetLabel()`     | Label for the active table border target, for a custom border control.                     |
 
 `useContentControlInstance()` and `useHyperlinkPopupInstance()` are the context-free variants of `useContentControl()` and `useHyperlinkPopup()`, for a control mounted outside the part that owns the state.
 

--- a/docs/site/content/react/hooks.mdx
+++ b/docs/site/content/react/hooks.mdx
@@ -237,6 +237,7 @@ function Find() {
 | `useContextMenuTarget()`          | The element the last right-click landed on.                                                |
 | `useNavigationPane(options?)`     | Open state and width for the navigation pane.                                              |
 | `useTranslation()`                | `{ t }` bound to the active locale catalog.                                                |
+| `useChromeTranslate(overrides?)`  | Catalog-backed label resolver for chrome `t` props; an overrides `Map` is consulted first. |
 | `useFonts(source, ...fragments)`  | Builds a `FontResolver` from a source plus fragments. See [Fonts](/docs/2.x/guides/fonts). |
 | `useNotePropertiesState()`        | Footnote and endnote numbering properties for the current scope.                           |
 | `useEditorSnapshot(editor)`       | Revision counter for an editor, for your own `useSyncExternalStore`.                       |

--- a/docs/site/content/react/index.mdx
+++ b/docs/site/content/react/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: '@docx-editor.dev/react'
-description: "React adapter for the DOCX editor: the packaged root component, provider primitives, shared hooks, and compound chrome, all from the package root."
-category: "React"
+description: 'React adapter for the DOCX editor: the packaged root component, provider primitives, shared hooks, and compound chrome, all from the package root.'
+category: 'React'
 order: 30
 ---
 
@@ -13,7 +13,7 @@ order: 30
 npm install @docx-editor.dev/react @docx-editor.dev/core
 ```
 
-Carries the engine and the string catalogue. Add [`@docx-editor.dev/pro`](/docs/2.x/pro) for tracked changes, comments, and custom nodes, or [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) to automate the document from code.
+The adapter holds the engine as a peer, so install both; the string catalog comes with it. Add [`@docx-editor.dev/pro`](/docs/2.x/pro) for tracked changes, comments, and custom nodes, or [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) to automate the document from code.
 
 ## Quickstart
 
@@ -25,7 +25,7 @@ export default function App() {
 }
 ```
 
-`<DocxEditor>` is the batteries-included host: title bar, menu, toolbar, navigation pane, hyperlink popover, context menu, and the painted editable document. On Next.js App Router, render it inside a `"use client"` component; the editor has nothing to SSR.
+`<DocxEditor>` is the full packaged editor: title bar, menu, toolbar, navigation pane, hyperlink popover, context menu, and the painted editable document. On Next.js App Router, render it inside a `"use client"` component; the editor has nothing to SSR.
 
 <DemoPlayground />
 
@@ -71,7 +71,11 @@ import { DocxEditor, useEditorCommand } from '@docx-editor.dev/react';
 function BoldButton() {
   const bold = useEditorCommand('text.bold');
   return (
-    <button onClick={() => bold.execute()} disabled={!bold.isEnabled}>
+    <button
+      onMouseDown={(e) => e.preventDefault()} // chrome must not steal the caret
+      onClick={() => bold.execute()}
+      disabled={!bold.isEnabled}
+    >
       Bold
     </button>
   );
@@ -93,7 +97,7 @@ export function ToolbarOnly({ bytes }: { bytes: Uint8Array }) {
 
 The lower-level helpers (`useEditorCommand`, `useEditorState`, `useFontFamily`) also come from the root package.
 
-## DocxEditor API
+## Editing API
 
 Drive the open document from code with the Office.js-compatible `@docx-editor.dev/editor-api/browser`, which takes the editor instance this adapter created:
 

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Props'
 description: 'Reference for the current React root props and ref: document source, chrome toggles, menu integration, callbacks, and the shared imperative handle.'
-category: "React"
+category: 'React'
 order: 31
 ---
 
-`<DocxEditor>` is the packaged host over the v2 provider primitives. The full generated reference is at [/docs/2.x/api/react](/docs/2.x/api/react); this page groups the current root props by how you actually wire the editor.
+`<DocxEditor>` is the packaged host over the provider primitives. The full generated reference is at [/docs/2.x/api/react](/docs/2.x/api/react); this page groups the current root props by how you actually wire the editor.
 
 ## Document and mount state
 
@@ -30,9 +30,9 @@ const bytes = new Uint8Array(await fetch('/template.docx').then((r) => r.arrayBu
 
 `modules` registers capability modules at construction. It is how [`@docx-editor.dev/pro`](/docs/2.x/pro) adds tracked changes, comments, and custom nodes.
 
-| Prop      | Type              | Description                                             |
-| --------- | ----------------- | ------------------------------------------------------- |
-| `modules` | `EditorModule[]`  | Capability modules, read once when the editor is built. |
+| Prop      | Type             | Description                                             |
+| --------- | ---------------- | ------------------------------------------------------- |
+| `modules` | `EditorModule[]` | Capability modules, read once when the editor is built. |
 
 Registration happens at construction, like `mode`, so the array identity has to be stable. Build it outside the component or memoize it, or the editor rebuilds on every render:
 
@@ -57,7 +57,7 @@ These props control the packaged frame around the painted document.
 | `title`                                      | `string`                                | Document title shown in the title bar.                                                          |
 | `onTitleChange`                              | `(title) => void`                       | Makes the title editable.                                                                       |
 | `renderTitleBarLeft` / `renderTitleBarRight` | `() => ReactNode`                       | Host-owned title-bar slots.                                                                     |
-| `colorMode`                                  | `'light' \| 'dark' \| 'system'`         | Chrome-only theming mode.                                                                       |
+| `colorMode`                                  | `'light' \| 'dark' \| 'system'`         | Light, dark, or OS-following theme.                                                             |
 | `menu`                                       | `boolean \| DocxEditorMenuProps`        | Toggle or customize the packaged menu bar.                                                      |
 | `navigation`                                 | `boolean`                               | Toggle the packaged navigation pane.                                                            |
 | `hyperlinkPopup`                             | `boolean`                               | Toggle the packaged link popover.                                                               |
@@ -65,7 +65,7 @@ These props control the packaged frame around the painted document.
 
 ## Appearance (dark mode)
 
-`colorMode` controls the editor chrome only; the document canvas stays Word-faithful. Drive it from your own UI:
+`colorMode` themes the editor chrome and renders the document canvas the way Word's dark view does. It never changes the document itself: saving and printing are unaffected. Drive it from your own UI:
 
 ```tsx
 const [colorMode, setColorMode] = useState<'light' | 'dark'>('light');
@@ -111,16 +111,17 @@ keep the prop's identity stable, or the editor rebuilds on every render:
 import { DocxEditor, useFonts } from '@docx-editor.dev/react';
 import { googleFonts } from '@docx-editor.dev/fonts/google';
 
-const fonts = useFonts(googleFonts());
-
-<DocxEditor document={bytes} fonts={fonts} />;
+function Editor({ bytes }: { bytes: Uint8Array }) {
+  const fonts = useFonts(googleFonts());
+  return <DocxEditor document={bytes} fonts={fonts} />;
+}
 ```
 
 A resolver that fetches makes opening a document perform network requests, which the
 editor never does on its own. Read the guide before reaching for one.
 
-See the [Fonts and measurement](/docs/2.x/guides/fonts) guide for the three font
-sources, on-demand resolution, how they compose, and how to supply your own faces with
+See the [Fonts and measurement](/docs/2.x/guides/fonts) guide for the font sources,
+on-demand resolution, how they compose, and how to supply your own faces with
 `loadFonts`.
 
 ## Title bar customization

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -51,17 +51,18 @@ Without a module the editor still opens a document that carries revisions and co
 
 These props control the packaged frame around the painted document.
 
-| Prop                                         | Type                                    | Description                                                                                     |
-| -------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `chrome`                                     | `boolean`                               | Render the packaged title bar, menu, toolbar, and navigation. Set `false` for the bare surface. |
-| `title`                                      | `string`                                | Document title shown in the title bar.                                                          |
-| `onTitleChange`                              | `(title) => void`                       | Makes the title editable.                                                                       |
-| `renderTitleBarLeft` / `renderTitleBarRight` | `() => ReactNode`                       | Host-owned title-bar slots.                                                                     |
-| `colorMode`                                  | `'light' \| 'dark' \| 'system'`         | Light, dark, or OS-following theme.                                                             |
-| `menu`                                       | `boolean \| DocxEditorMenuProps`        | Toggle or customize the packaged menu bar.                                                      |
-| `navigation`                                 | `boolean`                               | Toggle the packaged navigation pane.                                                            |
-| `hyperlinkPopup`                             | `boolean`                               | Toggle the packaged link popover.                                                               |
-| `contextMenu`                                | `boolean \| DocxEditorContextMenuProps` | Toggle or customize the packaged context menu.                                                  |
+| Prop                                         | Type                                    | Description                                                                                      |
+| -------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `chrome`                                     | `boolean`                               | Render the packaged title bar, menu, toolbar, and navigation. Set `false` for the bare surface.  |
+| `title`                                      | `string`                                | Document title shown in the title bar.                                                           |
+| `onTitleChange`                              | `(title) => void`                       | Makes the title editable.                                                                        |
+| `renderTitleBarLeft` / `renderTitleBarRight` | `() => ReactNode`                       | Host-owned title-bar slots.                                                                      |
+| `colorMode`                                  | `'light' \| 'dark' \| 'system'`         | Light, dark, or OS-following theme.                                                              |
+| `menu`                                       | `boolean \| DocxEditorMenuProps`        | Toggle or customize the packaged menu bar.                                                       |
+| `navigation`                                 | `boolean`                               | Toggle the packaged navigation pane.                                                             |
+| `hyperlinkPopup`                             | `boolean`                               | Toggle the packaged link popover.                                                                |
+| `contextMenu`                                | `boolean \| DocxEditorContextMenuProps` | Toggle or customize the packaged context menu.                                                   |
+| `t`                                          | `(key, params?) => string`              | Label resolver for the packaged chrome; receives interpolation params for counters and the like. |
 
 ## Appearance (dark mode)
 

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Word fidelity'
-description: "Word feature support matrix for the DOCX editor: what renders, what edits, what round-trips unchanged, plus the security model and API stability policy."
-category: "Getting Started"
+description: 'Word feature support matrix for the DOCX editor: what renders, what edits, what round-trips unchanged, plus the security model and API stability policy.'
+category: 'Getting Started'
 seoTitle: 'Word feature support and fidelity'
 ---
 
@@ -73,14 +73,14 @@ losslessly without rendering · Planned = on the roadmap · No = not supported.
 
 ## Rendering fidelity
 
-The editor runs two renderers at once. A hidden ProseMirror instance owns the editing state (document, selection,
-undo history, keyboard and IME input) and is never shown. On every change, a
-layout painter rebuilds the visible pages from that state using Word's own
-metrics: twips, the document's fonts and themes, its section and margin
-geometry. The browser never decides where a line or page breaks; the painter does.
-The output stays plain DOM text rather than a canvas bitmap.
+The editor does not let the browser lay out the document. A DOM-free layout
+pass positions every line and page break from Word's own metrics (twips, the
+document's fonts and themes, its section and margin geometry) and the visible
+pages are painted from that result. The browser never decides where a line or
+page breaks; the layout pass does. The output is plain DOM text rather than a
+canvas bitmap.
 
-The full comparison with contenteditable and canvas approaches is in
+How the pipeline achieves this is in
 [Architecture](/docs/2.x/core/architecture). To judge fidelity yourself, open
 one of your own documents in the [live demo](https://docx-editor.dev/editor)
 next to Word.
@@ -113,10 +113,11 @@ media, relationships, custom XML. Concretely:
 - References stay intact: relationship IDs, bookmark names, field codes, style IDs and numbering definitions are not renamed or renumbered.
 - Output is canonical OOXML, not merely valid: tracked changes are real `w:ins`/`w:del` revisions Word's review pane understands, theme colors stay theme references, numbering keeps its definitions.
 
-How it's tested: a parity corpus of real documents is round-tripped in CI
-and compared structurally; serializer unit tests assert revision markup,
-conditional table formatting and section properties survive; 500+ Playwright
-tests drive the editor against Word-derived expectations.
+How it's tested: CI round-trips a corpus of real documents through two
+oracles, a canonical fingerprint over the tree and a save-and-reopen semantic
+digest; serializer tests assert specific constructs (revisions, fields,
+hyperlinks, content controls) survive; and browser end-to-end tests drive the
+painted editor.
 
 What this does not mean: bit-identical files. The ZIP container is
 rebuilt and XML is re-serialized, so whitespace and part ordering can differ.
@@ -133,7 +134,7 @@ breaks this behavior is a bug; attach it to a
 ## Bundle and performance
 
 - `-core` ships subpath exports that tree-shake independently.
-- ProseMirror packages are peers so your package manager can share one copy.
+- The engine is a peer dependency of the adapters, so one copy resolves for the whole tree.
 - Lazy-load the editor (`next/dynamic`, `React.lazy`) to keep it out of the initial bundle.
 - The layout engine caches per-block measurements; an edit doesn't re-measure the document.
 
@@ -142,11 +143,10 @@ No published benchmarks; test with your own documents in the
 
 ## Stability, license and support
 
-- **Apache 2.0**, every package except `@docx-editor.dev/editor-api`. Contributions need a one-time [CLA](https://github.com/eigenpal/docx-editor/blob/main/CLA.md).
+- **Apache 2.0**, every package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`, which ship under the EigenPal Pro Evaluation License 1.0: free to evaluate internally, production use under a written agreement from [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
 - **SemVer** via changesets; all packages share one version number.
 - The public API is tracked by [API Extractor snapshots](https://github.com/eigenpal/docx-editor/tree/main/docs/api); CI fails on drift.
-- `pagination-model`, `painter-model`, `flow-model` and `plugin-api` are `@experimental`.
-- The editor packages stay Apache 2.0. `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro` ship commercially under the EigenPal Pro Evaluation License 1.0, free to evaluate internally, with production use under a written agreement from [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
+- Contributions need a one-time [CLA](https://github.com/eigenpal/docx-editor/blob/main/CLA.md).
 
 If a feature you need is Partial or missing, [open an issue](https://github.com/eigenpal/docx-editor/issues/new/choose)
 with a sample `.docx`, or email [docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com)
@@ -155,5 +155,5 @@ for priority features and support contracts.
 ## Next steps
 
 - [Quickstart](/docs/2.x/quickstart): the load, edit, save loop
-- [Architecture](/docs/2.x/core/architecture): the dual-renderer design in depth
+- [Architecture](/docs/2.x/core/architecture): the pipeline in depth
 - [Tracked changes](/docs/2.x/pro/tracked-changes): the review model in practice

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -25,38 +25,33 @@ types to write a function signature.
 npm install @docx-editor.dev/core
 ```
 
-## The root is the 80% path
+## Entry points
 
 ```ts
 import { createDocxEditor, loadFonts, WORD_DEFAULT_FONT } from '@docx-editor.dev/core';
 import type { Editor, EditorSnapshot } from '@docx-editor.dev/core';
 ```
 
-Create an editor, the `Editor` contract it implements, fonts, the chrome registry, and the
-document model types. Reach for a subpath when you need the canonical tree, the layout pass,
-or the paint step directly.
+The root covers most uses: creating an editor, the `Editor` contract it implements, fonts,
+the chrome registry, and the document model types. Subpaths expose the canonical tree, the
+layout pass, and the paint step directly.
 
-| Subpath                | What's there                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------- |
-| `.`                    | Create an editor, the contract, fonts, the chrome registry, the document model. |
-| `./editor`             | Everything the root re-exports, plus the paginated surface and ruler geometry.  |
-| `./contracts/editor`   | `Editor`, `EditorCommand`, `EditorQuery`, `EditorSnapshot`, `PageSetup`.        |
-| `./contracts/document` | The document-level edit and query vocabulary.                                   |
-| `./contracts/types`    | Document model types.                                                           |
-| `./contracts/modules`  | `EditorModule` — the shape `@docx-editor.dev/pro` implements.                   |
-| `./store`              | The canonical tree and its transactional store.                                 |
-| `./layout`             | The DOM-free layout pass.                                                       |
-| `./output`             | Serialization.                                                                  |
-| `./automation`         | The object model behind `@docx-editor.dev/editor-api`.                          |
-| `./styles/editor.css`  | The one editor stylesheet, shared by packaged and custom chrome.                |
+| Subpath                   | What's there                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------------- |
+| `.`                       | Create an editor, the contract, fonts, the chrome registry, the document model.              |
+| `./editor`                | Everything the root re-exports, plus the paginated surface and ruler geometry.               |
+| `./contracts/editor`      | `Editor`, `EditorCommand`, `EditorQuery`, `EditorSnapshot`, `PageSetup`.                     |
+| `./contracts/document`    | The document-level edit and query vocabulary.                                                |
+| `./contracts/interaction` | Semantic addressing (`SemanticTarget`) and the `InteractionOutcome` an attempt answers with. |
+| `./contracts/types`       | Document model types.                                                                        |
+| `./contracts/modules`     | `EditorModule` — the shape `@docx-editor.dev/pro` implements.                                |
+| `./store`                 | The canonical tree and its transactional store.                                              |
+| `./layout`                | The DOM-free layout pass.                                                                    |
+| `./output`                | Serialization.                                                                               |
+| `./automation`            | The object model behind `@docx-editor.dev/editor-api`.                                       |
+| `./styles/editor.css`     | The one editor stylesheet, shared by packaged and custom chrome.                             |
 
-## Nothing is lost
-
-Everything you do not edit comes back byte for byte, including parts the engine does not
-model — custom XML, embedded fonts, macros, media, unknown extensions. Two oracles gate it in
-CI: a canonical fingerprint over the tree, and a save-and-reopen semantic digest.
-
-## One pipeline
+## Architecture
 
 ```
 bytes → bounded OPC/XML read → canonical OOXML tree → layout → painted pages → serialize
@@ -66,18 +61,22 @@ There is one document model. The painted pages are the editable surface: they ar
 `contenteditable`, but the DOM is a picture. Browser mutations are prevented and re-expressed
 as tree operations, so the browser never invents markup inside your document.
 
-Nodes are **typed** where layout needs them and **generic** everywhere else, preserving the
-element verbatim. So content the engine does not model is carried rather than dropped, and a
-document full of unknown extensions still opens, edits, and saves.
+Nodes are typed where layout needs them and generic everywhere else, preserving the element
+verbatim. Content the engine does not model is carried rather than dropped, so a document full
+of unknown extensions still opens, edits, and saves.
 
-On save, modeled parts are re-emitted normalized; everything else — custom XML, embedded fonts,
-media — is repacked from the original file untouched. Two oracles gate that in CI: a canonical
-fingerprint over the tree, and a save-and-reopen semantic digest.
+## Fidelity
+
+Everything you do not edit comes back byte for byte, including parts the engine does not model:
+custom XML, embedded fonts, macros, media, unknown extensions. On save, modeled parts are
+re-emitted normalized; everything else is repacked from the original file untouched. Two
+oracles gate this in CI: a canonical fingerprint over the tree, and a save-and-reopen semantic
+digest.
 
 ## Untrusted input
 
 A `.docx` is a zip of XML that whoever sent it controls end to end. The engine sanitizes at the
-parse boundary — URL allowlisting, entity and zip-bomb limits, recursion and element caps, no
+parse boundary: URL allowlisting, entity and zip-bomb limits, recursion and element caps, no
 zero-click external fetches, escaping on the way back out.
 
 Anything you render from document data (a font name, a hyperlink target, a comment body) is

--- a/packages/editor-api/README.md
+++ b/packages/editor-api/README.md
@@ -26,10 +26,10 @@ already has open in a page.
 npm install @docx-editor.dev/editor-api
 ```
 
-## On a server, from bytes
+## On a server
 
-No browser, no framework, nothing to mount. This half of the package opens DOCX bytes, edits
-them, and hands them back.
+The default entry needs no browser and nothing to mount. It opens DOCX bytes, edits them, and
+hands them back.
 
 ```ts
 import { readFile, writeFile } from 'node:fs/promises';
@@ -55,12 +55,11 @@ try {
 }
 ```
 
-## In a page, on a document already open
+## In the browser
 
-The browser entry takes an editor the host already created — from `@docx-editor.dev/react`,
-`@docx-editor.dev/react` or a plain page — and drives it in place, so edits land in the open
-document with the reader's undo stack intact. There is no `save()`: the host saves as it already
-did.
+The browser entry takes an editor the host already created, from `@docx-editor.dev/react` or a
+plain page, and drives it in place. Edits land in the open document with the reader's undo
+stack intact. There is no `save()`: the host saves as it already did.
 
 ```ts
 import { DocxEditor } from '@docx-editor.dev/editor-api/browser';
@@ -79,20 +78,20 @@ await runtime.run(async (context) => {
 Import it from `/browser` deliberately: reaching a live editor means reaching the painted engine,
 and a server holding bytes should not pay for that.
 
-## The four rules
+## Programming model
 
-- **Read what you asked for.** A property you did not `load()` throws instead of answering
-  `undefined`, so a typo fails at the read rather than producing a wrong document later.
-- **`sync()` is the only round trip.** Everything queued between two syncs is one ordered batch,
+- A property you did not `load()` throws instead of answering `undefined`, so a typo fails at
+  the read rather than producing a wrong document later.
+- `sync()` is the only round trip. Everything queued between two syncs is one ordered batch,
   applied atomically.
-- **Objects live inside `run`.** They are proxies into a document the runtime owns. Keeping one
-  past the callback, or past `dispose()`, is an error rather than a stale read — to keep one
-  across syncs deliberately, hand it to `context.trackedObjects`.
-- **Ask before you assume.** `getFirstOrNullObject` / `getLastOrNullObject` answer an object whose
-  `isNullObject` is `true`, which is the difference between "no such heading" and a crash.
+- Objects are proxies into a document the runtime owns and live inside `run`. Keeping one past
+  the callback, or past `dispose()`, is an error rather than a stale read; to keep one across
+  syncs deliberately, hand it to `context.trackedObjects`.
+- `getFirstOrNullObject` / `getLastOrNullObject` answer an object whose `isNullObject` is
+  `true`, which is the difference between "no such heading" and a crash.
 
-`runtime.capabilities` says what the host behind a runtime can do — `save` is false in the
-browser; `selection`, `scrolling` and `layout` are false on a server — and it is frozen for the
+`runtime.capabilities` says what the host behind a runtime can do: `save` is false in the
+browser; `selection`, `scrolling` and `layout` are false on a server. It is frozen for the
 life of the runtime, so one read stays true.
 
 ## Entries
@@ -105,15 +104,15 @@ life of the runtime, so one read stays true.
 Both entries export the same vocabulary — the lifecycle types, the object model and the error
 type — so consumer code compiles against either. They differ by one member: `createBrowser`.
 
-## What this is, and is not
+## Office.js compatibility
 
-The Office.js Word-shaped DocxEditor API is compatible with a documented subset of Word's
-JavaScript object model, so a call site written against that vocabulary compiles here. It is not
-Office.js, does not run in an Office add-in host, and depends on no Microsoft package. Every type
-in the surface is authored in this repository.
+The API is compatible with a documented subset of Word's JavaScript object model, so a call
+site written against that vocabulary compiles here. It is not Office.js: it does not run in an
+Office add-in host and depends on no Microsoft package. Every type in the surface is authored
+in this repository.
 
-The supported subset and its documented omissions — tables, images, repeating sections, custom
-XML mapping — are listed in
+The supported subset and its documented omissions (tables, images, repeating sections, custom
+XML mapping) are listed in
 [the Word API compatibility page](https://www.docx-editor.dev/docs/1.x/editor-api/word-js-api).
 
 Upgrading from the reviewer/bridge/MCP/chat surfaces this package used to ship? See

--- a/packages/fonts/README.md
+++ b/packages/fonts/README.md
@@ -41,10 +41,10 @@ Font binaries ship as separate files (`assets/*.ttf`) fetched lazily per request
 family. Each face's `sha256:` hash is baked at packaging time
 (`src/manifest.generated.ts`) and CI-verified against the shipped bytes.
 
-## On demand, from Google's catalog
+## Google Fonts, on demand
 
-`@docx-editor.dev/fonts/google` inverts both halves: nothing ships in the bundle, and
-nothing is fetched until a document turns out to name a family the catalog covers.
+`@docx-editor.dev/fonts/google` ships nothing in the bundle and fetches nothing until a
+document names a family the catalog covers.
 
 ```ts
 import { googleFonts } from '@docx-editor.dev/fonts/google';
@@ -55,21 +55,21 @@ import { googleFonts } from '@docx-editor.dev/fonts/google';
 ```
 
 Open a file that uses only Calibri and one family is fetched (Carlito, its
-metric-compatible stand-in). Open one that names nothing catalogued and no request is
+metric-compatible stand-in). Open one that names nothing cataloged and no request is
 made at all.
 
 The catalog is generated, closed and pinned to a single google/fonts commit
 (`src/google-catalog.generated.ts`, 105 families). A family a document names is only
-ever a lookup key — nothing is interpolated into a URL — and every entry carries a
-baked `sha256:` that the engine re-derives on admission. Families are included by rule:
+ever a lookup key, never interpolated into a URL, and every entry carries a baked
+`sha256:` that the engine re-derives on admission. Families are included by rule:
 all four static faces present, and the shaper's table checks passed. Variable-only
 families (Roboto, Arimo, Open Sans, …) are excluded, because the shaper refuses
 variation axes and a variable file would render bold at regular weight.
 
-Be deliberate about this: a fetching resolver makes opening a document perform network
-requests, and the CDN learns which families a document uses. The engine never supplies
-one, so it stays your call. `loadDefaultFonts()` remains the zero-network answer. Narrow
-what may ever be fetched with `googleFonts({ allow: ['Tinos', 'Lato'] })`.
+A fetching resolver makes opening a document perform network requests, and the CDN learns
+which families a document uses. The engine never supplies one, so opting in stays your call.
+`loadDefaultFonts()` remains the zero-network answer, and
+`googleFonts({ allow: ['Tinos', 'Lato'] })` narrows what may ever be fetched.
 
 Regenerate the catalog with `bun run google:catalog` (downloads ~90 MB, pins hashes);
 `google:check` guards the committed file offline, `google:verify` re-checks it against

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -33,7 +33,7 @@ import { de } from '@docx-editor.dev/i18n';
 </LocaleProvider>;
 ```
 
-Chrome you write yourself reads the same catalogue through `useTranslation()`.
+Chrome you write yourself reads the same catalog through `useTranslation()`.
 
 Mix a community locale with custom overrides:
 
@@ -66,7 +66,10 @@ Keys set to `null` in any locale fall back to English.
 | ------- | ------ | ------------------- |
 | `en`    | `en`   | English (source)    |
 | `de`    | `de`   | German              |
+| `fr`    | `fr`   | French              |
 | `he`    | `he`   | Hebrew              |
+| `hi`    | `hi`   | Hindi               |
+| `id`    | `id`   | Indonesian          |
 | `pl`    | `pl`   | Polish              |
 | `pt-BR` | `ptBR` | Portuguese (Brazil) |
 | `tr`    | `tr`   | Turkish             |
@@ -74,9 +77,12 @@ Keys set to `null` in any locale fall back to English.
 
 BCP-47 codes (`pt-BR`, `zh-CN`) use camelCase JS identifiers (`ptBR`, `zhCN`). For runtime lookup by tag:
 
-```ts
+```tsx
 import { locales } from '@docx-editor.dev/i18n';
-<DocxEditor i18n={locales[userPreferredLocale]} />
+
+<LocaleProvider i18n={locales[userPreferredLocale]}>
+  <DocxEditor document={bytes} />
+</LocaleProvider>;
 ```
 
 > Importing `locales` pulls every locale into your bundle. For a smaller bundle, import only the ones you need by name; `sideEffects: false` lets the rest tree-shake.
@@ -93,7 +99,7 @@ import pl from '@docx-editor.dev/i18n/pl';
 const pl = (await import('@docx-editor.dev/i18n/pl')).default;
 ```
 
-Subpaths ship for every locale: `/en`, `/de`, `/he`, `/pl`, `/pt-BR`, `/tr`, `/zh-CN`. Each also exports its locale as a named binding (`import { pl } from '@docx-editor.dev/i18n/pl'`) for callers that prefer non-default imports.
+Subpaths ship for every locale: `/en`, `/de`, `/fr`, `/he`, `/hi`, `/id`, `/pl`, `/pt-BR`, `/tr`, `/zh-CN`. Each also exports its locale as a named binding (`import { pl } from '@docx-editor.dev/i18n/pl'`) for callers that prefer non-default imports.
 
 ## Types
 

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -47,7 +47,7 @@ async function loadFile(e: Event) {
 </template>
 ```
 
-That's the whole integration. The module registers `<DocxEditor>` as **client-only** — the editor drives a hidden ProseMirror instance and browser DOM APIs, so it never runs during SSR. Nuxt renders a placeholder on the server and hydrates the editor in the browser. The module also pushes the editor stylesheet into Nuxt's CSS pipeline, so the toolbar is styled without a manual `import`.
+That's the whole integration. The module registers `<DocxEditor>` as client-only: the editor measures text and paints pages in the browser DOM, so it never runs during SSR. Nuxt renders a placeholder on the server and hydrates the editor in the browser. The module also pushes the editor stylesheet into Nuxt's CSS pipeline, so the toolbar is styled without a manual `import`.
 
 ## Options
 
@@ -68,14 +68,14 @@ export default defineNuxtConfig({
 
 ## Packages
 
-| Package                                                                                    | Description                                                                                                                                |
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`@docx-editor.dev/react`](https://www.npmjs.com/package/@docx-editor.dev/react)           | <img src="https://cdn.simpleicons.org/react/61DAFB" width="20" align="middle" /> &nbsp; React adapter. Toolbar, paged editor, plugins.     |
-| [`@docx-editor.dev/vue`](https://www.npmjs.com/package/@docx-editor.dev/vue)               | <img src="https://cdn.simpleicons.org/vuedotjs/4FC08D" width="20" align="middle" /> &nbsp; Vue 3 adapter. Toolbar, paged editor, plugins.  |
-| [`@docx-editor.dev/nuxt`](https://www.npmjs.com/package/@docx-editor.dev/nuxt)             | <img src="https://cdn.simpleicons.org/nuxt/00DC82" width="20" align="middle" /> &nbsp; Nuxt 3 & 4 module wrapping the Vue adapter.         |
-| [`@docx-editor.dev/core`](https://www.npmjs.com/package/@docx-editor.dev/core)             | Framework-agnostic core: OOXML parser, serializer, layout engine, ProseMirror schema. Depend on this if you fork the React or Vue adapter. |
-| [`@docx-editor.dev/i18n`](https://www.npmjs.com/package/@docx-editor.dev/i18n)             | Shared locale strings and types consumed by both adapters.                                                                                 |
-| [`@docx-editor.dev/editor-api`](https://www.npmjs.com/package/@docx-editor.dev/editor-api) | Document automation: a batching object model that drives a document from a server or from an editor already open in a page.                |
+| Package                                                                                    | Description                                                                                                                               |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@docx-editor.dev/react`](https://www.npmjs.com/package/@docx-editor.dev/react)           | <img src="https://cdn.simpleicons.org/react/61DAFB" width="20" align="middle" /> &nbsp; React adapter. Toolbar, paged editor, plugins.    |
+| [`@docx-editor.dev/vue`](https://www.npmjs.com/package/@docx-editor.dev/vue)               | <img src="https://cdn.simpleicons.org/vuedotjs/4FC08D" width="20" align="middle" /> &nbsp; Vue 3 adapter. Toolbar, paged editor, plugins. |
+| [`@docx-editor.dev/nuxt`](https://www.npmjs.com/package/@docx-editor.dev/nuxt)             | <img src="https://cdn.simpleicons.org/nuxt/00DC82" width="20" align="middle" /> &nbsp; Nuxt 3 & 4 module wrapping the Vue adapter.        |
+| [`@docx-editor.dev/core`](https://www.npmjs.com/package/@docx-editor.dev/core)             | Framework-agnostic engine: OOXML read/write, canonical document tree, layout, paint. Depend on this if you fork the React or Vue adapter. |
+| [`@docx-editor.dev/i18n`](https://www.npmjs.com/package/@docx-editor.dev/i18n)             | Shared locale strings and types consumed by both adapters.                                                                                |
+| [`@docx-editor.dev/editor-api`](https://www.npmjs.com/package/@docx-editor.dev/editor-api) | Document automation: a batching object model that drives a document from a server or from an editor already open in a page.               |
 
 ## Component API
 

--- a/packages/pro/README.md
+++ b/packages/pro/README.md
@@ -60,8 +60,8 @@ UI; the module is what makes them visible and actionable.
 
 ## Chrome or hooks
 
-Everything the packaged sidebar renders is reachable from `useReview()`. Take the sidebar for
-Word-like cards out of the box; take the hook for your own markup.
+Everything the packaged sidebar renders is reachable from `useReview()`. Use the sidebar for
+Word-like cards out of the box, or the hook to render your own markup.
 
 ```tsx
 import { useReview } from '@docx-editor.dev/pro/react';
@@ -95,7 +95,7 @@ repaint behind the page or break during pagination.
 
 ## Custom nodes
 
-An inline node type you define — a citation, a mention, a merge field — stored as a Word content
+An inline node type you define (a citation, a mention, a merge field) stored as a Word content
 control whose `w:tag` carries your identity and attributes. Word opens the document, shows the
 node's text, and gives it back unchanged.
 
@@ -120,10 +120,10 @@ Every value reaching `fromDocx` came out of a `.docx`, so treat `attrs` and `tex
 
 ## Licensing
 
-Not Apache 2.0 like the editor packages. Licensed under the
+Unlike the editor packages, this one is not Apache 2.0. It is licensed under the
 [EigenPal Pro Evaluation License 1.0](https://github.com/eigenpal/docx-editor/blob/main/packages/pro/LICENSE.md):
-free to read, run, and modify internally to evaluate. Production use — a live or customer-facing
-environment, business-operational data, or this package inside something you offer to others —
+free to read, run, and modify internally to evaluate. Production use (a live or customer-facing
+environment, business-operational data, or this package inside something you offer to others)
 requires a written commercial agreement, and so does redistribution.
 
 Commercial licensing: [licensing@eigenpal.com](mailto:licensing@eigenpal.com)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -18,7 +18,7 @@ WYSIWYG `.docx` editor for React. Opens a Word file in the browser, paints the r
 layout, edits it in place, and writes a `.docx` back out. No upload service, no conversion
 backend: parsing and serialization both happen client-side.
 
-**It is lossless.** Everything you do not edit comes back byte for byte, including the parts
+Saving is lossless. Everything you do not edit comes back byte for byte, including the parts
 the editor does not understand: custom XML, embedded fonts, macros, unknown extensions. Two
 oracles gate that in CI, so opening a document here cannot quietly destroy it.
 
@@ -54,17 +54,17 @@ export function App() {
 }
 ```
 
-`<DocxEditor>` is the batteries-included host: title bar, menu, toolbar, navigation pane,
-context menu, and the painted document. Two things catch people out: it fills its parent, so
-give it a box with a real height, and the stylesheet import is required once.
+`<DocxEditor>` is the full packaged editor: title bar, menu, toolbar, navigation pane,
+context menu, and the painted document. It fills its parent, so give it a box with a real
+height, and import the stylesheet once.
 
 > **Next.js / SSR:** the editor measures text in the DOM at mount, so render it client-side
 > (`dynamic(..., { ssr: false })`).
 
 ## Build your own UI
 
-The packaged chrome is one arrangement of parts that are all public. There is no private API
-behind it. Every packaged control is a consumer of the same hooks you would use.
+The packaged chrome is one arrangement of public parts. Every packaged control uses the same
+hooks you would; there is no private API behind it.
 
 ```tsx
 import { DocxEditor, useEditorCommand } from '@docx-editor.dev/react';
@@ -96,7 +96,7 @@ export function Editor({ bytes }: { bytes: Uint8Array }) {
 ```
 
 `Root` owns the editor instance, `Viewport` is the scroll container, `Content` is where pages
-are painted. Everything else — toolbar, menu, rulers, navigation, link popover, context menu —
+are painted. Everything else (toolbar, menu, rulers, navigation, link popover, context menu)
 is optional and placed by name.
 
 The customization ladder, in order: `className` and `data-active` → the `icon` prop →


### PR DESCRIPTION
Corrects stale claims against the code (old dual-renderer description, unimplemented defaultTableStyle recipe, wrong fonts prop shape, 7-of-10 locale list, chrome-only colorMode), fixes code samples (caret guard, hook-in-component, lost literal spaces), and replaces essay-style headings with descriptive ones. The composition page now covers every compound part and teaches useChromeTranslate per #183 instead of the hand-written resolver.

Docs-only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788598107&installation_model_id=422592&pr_number=185&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F185&signature=d7acaeaefb4c72fd43d1259fbb9d85b0f1658893f35874ae89c291f2e798b95e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->