### PR TITLE
fix: underline tab advances for form blanks

### DIFF
--- a/.changeset/underlined-tab-advance.md
+++ b/.changeset/underlined-tab-advance.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Paint form-blank underlines across tab advances: an underlined `w:tab` now draws a rule for the reserved stop width instead of relying on CSS text-decoration on an invisible tab glyph.

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -270,6 +270,38 @@ describe('the painter is a non-authoritative consumer', () => {
       expect(glyphRun.style.verticalAlign).toBe('baseline');
     }
   });
+
+  test('an underlined tab paints a rule across its advance, not via text-decoration on \\t', () => {
+    // Form blanks are often `w:u` on a bare `w:tab`. Word underlines the stop advance;
+    // CSS text-decoration on a clipped `\t` draws no visible ink across that width.
+    const container = paint(
+      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>' +
+        '<w:r><w:t>[</w:t></w:r>' +
+        '<w:r><w:rPr><w:u w:val="thick"/></w:rPr><w:tab/></w:r>' +
+        '<w:r><w:t>]</w:t></w:r></w:p>'
+    );
+    const tab = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (el) => el.textContent === '\t'
+    )!;
+    expect(tab.dataset.docxTabUnderline).toBe('');
+    expect(tab.style.textDecorationLine).toBe('');
+    expect(tab.style.borderBottomStyle).toBe('solid');
+    expect(tab.style.borderBottomWidth).toBe('2px');
+    expect(Number.parseFloat(tab.style.width)).toBeGreaterThan(6);
+  });
+
+  test('a single underlined tab keeps a thinner advance rule and optional colour', () => {
+    const container = paint(
+      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="1800"/></w:tabs></w:pPr>' +
+        '<w:r><w:rPr><w:u w:val="single" w:color="C00000"/></w:rPr><w:tab/></w:r></w:p>'
+    );
+    const tab = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (el) => el.textContent === '\t'
+    )!;
+    expect(tab.dataset.docxTabUnderline).toBe('');
+    expect(tab.style.borderBottomColor.toLowerCase()).toBe('#c00000');
+    expect(tab.style.borderBottomWidth).toBe('1px');
+  });
 });
 
 describe('each run is its own box, so a mixed-size line highlights stepped', () => {

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -468,6 +468,27 @@ function applyUnderlineDecoration(
 }
 
 /**
+ * Underline a tab's reserved ADVANCE, not its invisible `\t` glyph.
+ *
+ * Form blanks are often authored as `w:u` on a bare `w:tab` (thick/single). Word draws the
+ * rule across the distance to the stop. CSS `text-decoration` on a clipped `\t` paints no
+ * visible ink over that width, so the advance box itself carries a bottom border instead.
+ * `wavy` is not a border style — fall back to solid rather than inventing a wave path.
+ */
+function applyTabAdvanceUnderline(
+  css: CSSStyleDeclaration,
+  underline: UnderlineDecoration,
+  scale: number
+): void {
+  const color = underline.color ? `#${underline.color}` : 'currentColor';
+  // Plain px widths — `max()` is fine on `text-decoration-thickness` but happy-dom (and
+  // some engines) drop it on `border-*-width`, which would erase the whole form blank.
+  css.borderBottomWidth = `${(underline.heavy ? 2 : 1) * scale}px`;
+  css.borderBottomStyle = underline.cssStyle === 'wavy' ? 'solid' : underline.cssStyle;
+  css.borderBottomColor = color;
+}
+
+/**
  * Face / box styles only — decorations are applied separately so underline and strike can
  * live on independent nested layers without sharing style/colour/thickness.
  */
@@ -545,6 +566,9 @@ function applyRunFaceStyle(element: HTMLElement, style: ResolvedRunStyle, ctx: P
  * The outer layout-run keeps geometry, model range, highlight and shading. When underline
  * and strike both apply, nested inert spans each own one decoration family so CSS cannot
  * leak `text-decoration-style` / colour / thickness across them.
+ *
+ * Tab advances apply underline via {@link applyTabAdvanceUnderline} on the outer run; this
+ * path must not also set `text-decoration` on `\t` or the two mechanisms fight.
  */
 function mountRunText(
   document: Document,
@@ -553,7 +577,7 @@ function mountRunText(
   style: ResolvedRunStyle,
   scale: number
 ): void {
-  const underline = underlineDecorationOf(style);
+  const underline = text === '\t' ? null : underlineDecorationOf(style);
   const strike = strikeKindOf(style);
   let host: HTMLElement = run;
 
@@ -843,6 +867,12 @@ function paintSpan(
     // takes it out of the baseline calculation entirely; the box still clips, and its top
     // is exactly where a baseline-aligned run of the same band lands anyway.
     element.style.verticalAlign = 'top';
+    // Form blanks: `w:u` on `w:tab` underlines the ADVANCE (Word), not the `\t` glyph.
+    const tabUnderline = underlineDecorationOf(span.style);
+    if (tabUnderline) {
+      element.dataset.docxTabUnderline = '';
+      applyTabAdvanceUnderline(element.style, tabUnderline, ctx.scale);
+    }
   }
   mountRunText(document, element, span.text, span.style, ctx.scale);
   if (span.projected) {


### PR DESCRIPTION
## Summary
- Form blanks authored as `w:u` on `w:tab` (Selection Notice fill-in lines) painted no rule because CSS `text-decoration` on a clipped `\t` has no visible ink across the reserved advance.
- Paint the underline as a bottom border on the tab advance box instead; add focused painter regression coverage.

## Test plan
- [x] `bun test packages/core/src/output/__tests__/semantic-paint.test.ts`
- [x] `bun run typecheck`
- [ ] Open a doc with underlined tabs (e.g. Selection Notice title blanks) and confirm thick/single rules span the tab stop width


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788601882&installation_model_id=422592&pr_number=189&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F189&signature=8a6a86973488b3ad3bf60d995b52a91eacf8b34dd169c36a141d366bddd87935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->