### PR TITLE
fix: keep sub-1pt drawing paint bounds full height

### DIFF
--- a/.changeset/hairline-vector-shape-bounds.md
+++ b/.changeset/hairline-vector-shape-bounds.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep sub-1pt drawing extents at full paint height so Word's hairline form-rule bars stay visible instead of shrinking to a sub-pixel clip.

--- a/packages/core/src/layout/__tests__/drawing-geometry.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-geometry.test.ts
@@ -155,6 +155,26 @@ describe('computeDrawingGeometry', () => {
     expect(geometry.hitBounds).toEqual(geometry.paintBounds);
   });
 
+  test('sub-1pt extents keep full paintBounds (hairline form-rule bars)', () => {
+    // Regression: cropLocalPoints used Math.max(dim, 1) as the normalization divisor, so a
+    // 0.75pt-tall wp:extent (Word's ~9525 EMU solid fill bars) painted at 0.5625pt and
+    // disappeared as a sub-pixel SVG clip. The floor must only avoid divide-by-zero.
+    const geometry = computeDrawingGeometry({
+      extentWidth: 55.35,
+      extentHeight: 0.75,
+      anchorX: 289.5,
+      anchorY: 16.428,
+      effectExtentEmu: { top: 0, right: 0, bottom: 0, left: 0 },
+      crop: { left: 0, top: 0, right: 0, bottom: 0 },
+      transform: identityTransform,
+      presetGeometry: null,
+    });
+    expect(geometry.contentBounds.height).toBe(0.75);
+    expect(geometry.paintBounds.height).toBeCloseTo(0.75, 6);
+    expect(geometry.paintBounds.width).toBeCloseTo(55.35, 6);
+    expect(geometry.paintBounds.height).not.toBeCloseTo(0.5625, 6);
+  });
+
   test('90-degree rotation moves transformed corners without changing content bounds', () => {
     const geometry = computeDrawingGeometry({
       extentWidth: 40,

--- a/packages/core/src/layout/drawing-geometry.ts
+++ b/packages/core/src/layout/drawing-geometry.ts
@@ -231,8 +231,12 @@ function cropLocalPoints(
   const visible = visibleCropRect(sourceWidth, sourceHeight, crop);
   const visibleWidth = visible.right - visible.left;
   const visibleHeight = visible.bottom - visible.top;
-  const safeWidth = Math.max(sourceWidth, 1);
-  const safeHeight = Math.max(sourceHeight, 1);
+  // Guard division by zero only. `Math.max(dim, 1)` used to force a 1pt floor, which
+  // silently scaled every sub-1pt source axis (Word's ~0.75pt form-rule bars) down by
+  // `dim/1` — paintBounds came out 0.5625pt tall for a 0.75pt extent and the SVG clipped
+  // to a sub-pixel box that disappeared on screen.
+  const safeWidth = sourceWidth > 0 ? sourceWidth : 1;
+  const safeHeight = sourceHeight > 0 ? sourceHeight : 1;
   const out: DrawingPoint[] = [];
   const limit = Math.min(points.length, MAX_IMAGE_POLYGON_POINTS);
   for (let index = 0; index < limit; index += 1) {


### PR DESCRIPTION
## Summary
- Word form-rule bars are ~0.75pt-tall `wps:wsp` fills. `cropLocalPoints` normalized coordinates with `Math.max(dim, 1)`, so a 0.75pt axis became 0.5625pt paintBounds and clipped to a disappearing sub-pixel SVG.
- Guard divide-by-zero only; keep full paint height for sub-1pt extents. Focused geometry regression test + patch changeset.

## Test plan
- [x] `bun test packages/core/src/layout/__tests__/drawing-geometry.test.ts`
- [x] `bun run typecheck` / pre-commit api:check
- [ ] Open Selection Notice (or any doc with ~9525 EMU solid bars) and confirm the thin black rules remain visible


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788603008&installation_model_id=422592&pr_number=191&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F191&signature=8516da004829d25743b2146db5d2d91cac6e78e624a3fd417a1eabdc4d4a558f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->