### PR TITLE
fix: keep paragraph-mark rPr off content run size

### DIFF
--- a/.changeset/paragraph-mark-rpr-not-content.md
+++ b/.changeset/paragraph-mark-rpr-not-content.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Stop applying paragraph-mark `w:pPr/w:rPr` font size to content runs that inherit the paragraph style. Mark formatting still sizes empty lines and last-line mark height.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -204,6 +204,7 @@ export function cascadedParagraphBorders(paragraphPropertyNodes: readonly OoxmlN
 // @public
 export interface CascadedParagraphFormatting {
     readonly inheritedParagraphProperties: readonly OoxmlProperty[];
+    readonly markRunProperties: readonly OoxmlProperty[];
     readonly paragraphProperties: readonly OoxmlProperty[];
     readonly paragraphPropertyNodes: readonly OoxmlNode[];
     readonly runProperties: readonly OoxmlProperty[];
@@ -1806,6 +1807,7 @@ export interface ParagraphLayoutInputs {
     readonly inheritedRunProperties: readonly OoxmlProperty[];
     readonly lineSpacing: ParagraphLineSpacing;
     readonly listItem?: ResolvedListItem;
+    readonly markRunProperties: readonly OoxmlProperty[];
     // (undocumented)
     readonly props: OoxmlProperty[];
     readonly shading: string | undefined;

--- a/packages/core/src/layout/__tests__/style-cascade.test.ts
+++ b/packages/core/src/layout/__tests__/style-cascade.test.ts
@@ -275,6 +275,42 @@ describe('character rStyle cascade and default character style', () => {
   });
 });
 
+describe('paragraph-mark rPr does not size content runs', () => {
+  test('direct w:pPr/w:rPr sz stays on the mark cascade only', () => {
+    const styles =
+      DOC_DEFAULTS +
+      `<w:style w:type="paragraph" w:styleId="BodyText"><w:basedOn w:val="Normal"/>` +
+      `<w:rPr><w:sz w:val="20"/></w:rPr></w:style>`;
+    const table = buildStyleCascadeTable(loadStyles(styles));
+    const cascaded = cascadeParagraphFormatting(
+      table,
+      paragraphPPr(
+        `<w:p><w:pPr><w:pStyle w:val="BodyText"/><w:rPr><w:sz w:val="13"/></w:rPr></w:pPr>` +
+          `<w:r><w:t>next Interest Period</w:t></w:r></w:p>`
+      )
+    );
+    expect(resolveRunStyle(cascaded.runProperties).fontSizePt).toBe(10);
+    expect(resolveRunStyle(cascaded.markRunProperties).fontSizePt).toBe(6.5);
+  });
+
+  test('layout paints BodyText size when content runs omit sz and the mark is 13 half-points', () => {
+    const styles =
+      DOC_DEFAULTS +
+      `<w:style w:type="paragraph" w:styleId="BodyText"><w:basedOn w:val="Normal"/>` +
+      `<w:rPr><w:sz w:val="20"/></w:rPr></w:style>`;
+    const table = buildStyleCascadeTable(loadStyles(styles));
+    const part = loadDocument(
+      `<w:p><w:pPr><w:pStyle w:val="BodyText"/><w:rPr><w:sz w:val="13"/></w:rPr></w:pPr>` +
+        `<w:r><w:t>[We request that the next Interest Period</w:t></w:r></w:p>`
+    );
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: createFixedMeasurer(6, 14),
+      styleCascade: table,
+    });
+    expect(linesOf(layout)[0]!.spans[0]!.style.fontSizePt).toBe(10);
+  });
+});
+
 describe('cascadeParagraphFormatting basedOn, cycles, depth, overrides', () => {
   test('basedOn inherits parent size while own color wins', () => {
     const styles =

--- a/packages/core/src/layout/__tests__/style-cascade.test.ts
+++ b/packages/core/src/layout/__tests__/style-cascade.test.ts
@@ -17,6 +17,8 @@ import { paragraphSpacing } from '../paragraph-style.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
 import { linesOf } from '../semantic-records.ts';
 import { createParagraphLayoutCache } from '../layout-cache.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
+import { resolveStoryListItems } from '../list-resolve.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -308,6 +310,46 @@ describe('paragraph-mark rPr does not size content runs', () => {
       styleCascade: table,
     });
     expect(linesOf(layout)[0]!.spans[0]!.style.fontSizePt).toBe(10);
+  });
+
+  test('list marker resolution reads markRunProperties and keeps level rPr last', () => {
+    const numberingBody =
+      `<w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">` +
+      `<w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/>` +
+      `<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr>`;
+    const numberingWithLevelRpr = (rPr: string) => {
+      const result = readOoxmlPart(
+        `<w:numbering xmlns:w="${W}">${numberingBody}${rPr}</w:lvl></w:abstractNum>` +
+          `<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>`,
+        { name: '/word/numbering.xml', contentType: 'app/xml' }
+      );
+      if (!result.ok) throw new Error(result.reason);
+      return buildNumberingIndex(result.part.root);
+    };
+    const styles =
+      DOC_DEFAULTS +
+      `<w:style w:type="paragraph" w:styleId="BodyText"><w:basedOn w:val="Normal"/>` +
+      `<w:rPr><w:sz w:val="20"/></w:rPr></w:style>`;
+    const table = buildStyleCascadeTable(loadStyles(styles));
+    const listParagraph =
+      `<w:p><w:pPr><w:pStyle w:val="BodyText"/><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>` +
+      `<w:rPr><w:sz w:val="52"/><w:b/></w:rPr></w:pPr><w:r><w:t>BIG</w:t></w:r></w:p>`;
+    const part = loadDocument(listParagraph);
+    const paragraph = part.root.children.find((child) => child.localName === 'body')!.children[0]!;
+
+    const fromMark = resolveStoryListItems([paragraph], numberingWithLevelRpr(''), table).get(
+      paragraph.id
+    )!;
+    expect(fromMark.markerStyle.fontSizePt).toBe(26);
+    expect(fromMark.markerStyle.bold).toBe(true);
+
+    const fromLevel = resolveStoryListItems(
+      [paragraph],
+      numberingWithLevelRpr('<w:rPr><w:sz w:val="20"/></w:rPr>'),
+      table
+    ).get(paragraph.id)!;
+    expect(fromLevel.markerStyle.fontSizePt).toBe(10);
+    expect(fromLevel.markerStyle.bold).toBe(true);
   });
 });
 

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -309,8 +309,11 @@ export function resolveStoryListItems(
       cascaded?.inheritedParagraphProperties ?? [],
       directProps
     );
+    const directMarkRun = pPr && isElement(pPr) ? childNamed(pPr, 'rPr') : undefined;
+    const markOnly = propertiesOf(directMarkRun);
+    const inheritedMarkProps = cascaded ? cascaded.markRunProperties : markOnly;
     const markerProps = cascadeRunProperties(
-      cascaded?.runProperties ?? [],
+      inheritedMarkProps,
       advanced.level.runProperties,
       styleCascade
     );

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -154,6 +154,11 @@ export interface ParagraphFlowOptions {
    * would need `cacheToken` folded into those producers too.
    */
   readonly themeFonts?: ThemeFonts;
+  /**
+   * Paragraph-mark cascade for empty-line metrics and last-line mark height.
+   * When omitted, falls back to the content `inheritedRunProperties` argument.
+   */
+  readonly markRunProperties?: readonly OoxmlProperty[];
 }
 
 /** One measurable piece of a paragraph: text carrying one property set. */
@@ -644,10 +649,11 @@ export function breakParagraph(
   /** Carried onto every span so paint and the review surface read one attribution. */
   const revisionsOf = (piece: FieldAwarePiece): { revisions?: readonly RevisionAttribution[] } =>
     piece.revisions === undefined ? {} : { revisions: piece.revisions };
+  // Mark face (CT_PPr/rPr), not content inheritance — a taller mark grows the last line
+  // without shrinking BodyText runs that only inherit the paragraph style.
+  const markProps = flow?.markRunProperties ?? inheritedRunProperties;
   const emptyStyle =
-    inheritedRunProperties.length === 0
-      ? DEFAULT_RUN_STYLE
-      : resolveRunStyle(inheritedRunProperties, flow?.themeFonts);
+    markProps.length === 0 ? DEFAULT_RUN_STYLE : resolveRunStyle(markProps, flow?.themeFonts);
   const rightEdge = indentLeft + available;
   const contentLeft = flow?.contentLeft ?? indentLeft;
   const contentRight = flow?.contentRight ?? rightEdge;

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -356,6 +356,7 @@ type PreparedBlock =
       readonly borderGroupKey: string;
       readonly shading: string | undefined;
       readonly inheritedRunProperties: readonly OoxmlProperty[];
+      readonly markRunProperties: readonly OoxmlProperty[];
       readonly tabStops: ResolvedTabStops;
       /** `w:widowControl` / `w:keepNext` / `w:keepLines`, after the style cascade. */
       readonly keeps: ParagraphKeeps;
@@ -815,6 +816,7 @@ function layoutBlocksPass(
         styleId,
         shading,
         inheritedRunProperties,
+        markRunProperties,
       } = preparedParagraph;
       const borders = resolveParagraphBorders(
         block.children.find((child) => child.kind === 'paragraphProperties'),
@@ -843,6 +845,7 @@ function layoutBlocksPass(
           bordersToken === '' ? '' : `${bordersToken}@${indent.left},${indent.left + available}`,
         shading,
         inheritedRunProperties,
+        markRunProperties,
         tabStops,
         keeps: paragraphKeeps(props),
         ...(listItem ? { listItem } : {}),
@@ -851,6 +854,7 @@ function layoutBlocksPass(
           properties: [
             ...props,
             ...inheritedRunProperties,
+            ...markRunProperties,
             { localName: 'tabStops', attributes: { token: tabStopsCacheToken } },
             ...(listItem
               ? [{ localName: 'list', attributes: { token: listItem.cacheToken } }]
@@ -1400,6 +1404,7 @@ function layoutBlocksPass(
         ...(pageZones.length > 0 ? { pageExclusionZones: pageZones } : {}),
         ...(suppressChrome ? { suppressEmptyPlaceholderLine: true } : {}),
         ...(styleCascade ? { themeFonts: styleCascade.themeFonts } : {}),
+        markRunProperties: entry.markRunProperties,
       }
     );
   };
@@ -1875,7 +1880,7 @@ function layoutBlocksPass(
       shading,
       keeps,
     } = entry;
-    let { indent, alignment, inheritedRunProperties } = entry;
+    let { indent, alignment, markRunProperties } = entry;
     let available = entry.available;
     // `w:contextualSpacing` (17.3.1.9) drops the gap between paragraphs of the SAME style.
     // Word's own ListParagraph sets it, so without this every Word-authored list carries a
@@ -1948,7 +1953,7 @@ function layoutBlocksPass(
       indent = next.indent;
       alignment = next.alignment;
       available = next.available;
-      inheritedRunProperties = next.inheritedRunProperties;
+      markRunProperties = next.markRunProperties;
       firstLineOffset = startOffset === 0 ? firstLineOffsetOf(next) : 0;
       lines = [...breakBlock(next, index, startOffset)];
     };
@@ -1957,9 +1962,9 @@ function layoutBlocksPass(
     {
       const lead = collapsedSpaceBefore(spacing.before, previousSpaceAfter);
       const emptyStyle =
-        inheritedRunProperties.length === 0
+        markRunProperties.length === 0
           ? DEFAULT_RUN_STYLE
-          : resolveRunStyle(inheritedRunProperties, styleCascade?.themeFonts);
+          : resolveRunStyle(markRunProperties, styleCascade?.themeFonts);
       const firstTail = lines.length <= 1 ? borderExtent + spacing.after : 0;
       const prospectiveFirstTop = cursorY + lead + topExtent;
       const firstZones = placementZonesForLine(

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -551,6 +551,7 @@ function placeCellParagraph(
     borders,
     shading,
     inheritedRunProperties,
+    markRunProperties,
     tabStops: cascadedTabStops,
     tabStopsCacheToken: cascadedTabStopsCacheToken,
   } = resolveParagraphLayoutInputs(
@@ -594,6 +595,7 @@ function placeCellParagraph(
     properties: [
       ...props,
       ...inheritedRunProperties,
+      ...markRunProperties,
       { localName: 'tabStops', attributes: { token: tabStopsCacheToken } },
       ...(listItem ? [{ localName: 'list', attributes: { token: listItem.cacheToken } }] : []),
     ],
@@ -640,6 +642,7 @@ function placeCellParagraph(
       }),
       ...(pageZones.length > 0 ? { pageExclusionZones: pageZones } : {}),
       ...(deps.styleCascade ? { themeFonts: deps.styleCascade.themeFonts } : {}),
+      markRunProperties,
     }
   );
 

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -125,8 +125,18 @@ export interface CascadedParagraphFormatting {
   readonly inheritedParagraphProperties: readonly OoxmlProperty[];
   /** Matching `w:pPr` nodes for nested border resolution. */
   readonly paragraphPropertyNodes: readonly OoxmlNode[];
-  /** Inherited run properties for every run in the paragraph (before direct run `rPr`). */
+  /**
+   * Inherited run properties for CONTENT runs (before direct run `rPr`).
+   *
+   * Does NOT include direct `w:pPr/w:rPr` — that formats the paragraph MARK only
+   * (ECMA-376 §17.3.1.36). Folding mark `w:sz` into content made BodyText runs with no
+   * direct size paint at the mark's size (Selection Notice "or" alternative → 6.5pt).
+   */
   readonly runProperties: readonly OoxmlProperty[];
+  /**
+   * Content cascade plus direct `w:pPr/w:rPr` — empty-line metrics and last-line mark height.
+   */
+  readonly markRunProperties: readonly OoxmlProperty[];
   /**
    * The style this paragraph resolved to, or null when it names none and there is no
    * document default. `w:contextualSpacing` compares neighbours by exactly this.
@@ -550,19 +560,23 @@ export function cascadeParagraphFormatting(
   const directMarkRun = findRunProperties(
     directPPr && isElement(directPPr) ? directPPr : undefined
   );
+  const markProps = propertiesOf(directMarkRun);
 
+  // Content runs: defaults → table → paragraph style. Mark `w:pPr/w:rPr` is NOT content.
   const runProperties: OoxmlProperty[] = [
     ...table.docDefaultsRun,
     ...(tableCellStyle?.runProperties ?? []),
     ...chain.flatMap((style) => style.runProperties),
-    ...propertiesOf(directMarkRun),
   ];
+  const markRunProperties: OoxmlProperty[] =
+    markProps.length === 0 ? runProperties : [...runProperties, ...markProps];
 
   return {
     paragraphProperties,
     inheritedParagraphProperties,
     paragraphPropertyNodes,
     runProperties,
+    markRunProperties,
     styleId: styleId ?? null,
   };
 }
@@ -647,6 +661,11 @@ export interface ParagraphLayoutInputs {
   /** Validated 6-hex paragraph shading fill from cascaded `w:pPr/w:shd`, absent for none. */
   readonly shading: string | undefined;
   readonly inheritedRunProperties: readonly OoxmlProperty[];
+  /**
+   * Paragraph-mark cascade (`inheritedRunProperties` + direct `w:pPr/w:rPr`).
+   * Empty-line sizing and last-line mark height — never content-run face.
+   */
+  readonly markRunProperties: readonly OoxmlProperty[];
   /** Cascaded custom tab stops + default interval for paragraph-flow breaking. */
   readonly tabStops: ResolvedTabStops;
   /**
@@ -681,12 +700,12 @@ export function resolveParagraphLayoutInputs(
     ? cascadeParagraphFormatting(styleCascade, pPr, tableCellStyle)
     : null;
   const props = cascaded ? [...cascaded.paragraphProperties] : propertiesOf(pPr);
-  // Direct `w:pPr/w:rPr` (paragraph mark) must reach empty-line / last-line metrics even
-  // when there is no styles part — cascadeParagraphFormatting already folds it in when a
-  // table is present.
-  const inheritedRunProperties = cascaded
-    ? cascaded.runProperties
-    : propertiesOf(findRunProperties(pPr && isElement(pPr) ? pPr : undefined));
+  // Content vs mark: with a styles table, `cascaded.runProperties` is content-only and
+  // `markRunProperties` carries direct `w:pPr/w:rPr`. Without styles, there is no style
+  // face to inherit — content stays empty and the mark props size empty lines alone.
+  const markOnly = propertiesOf(findRunProperties(pPr && isElement(pPr) ? pPr : undefined));
+  const inheritedRunProperties = cascaded ? cascaded.runProperties : [];
+  const markRunProperties = cascaded ? cascaded.markRunProperties : markOnly;
   const baseIndent = paragraphIndent(props);
   let hanging = 0;
   let firstLine = 0;
@@ -751,6 +770,7 @@ export function resolveParagraphLayoutInputs(
       : paragraphBorders(pPr),
     shading: paragraphShading(props),
     inheritedRunProperties,
+    markRunProperties,
     tabStops,
     tabStopsCacheToken: tabStopsFingerprint(tabStops),
     ...(listItem ? { listItem } : {}),


### PR DESCRIPTION
## Summary
- Stop folding direct `w:pPr/w:rPr` into content `runProperties`; keep it on a separate `markRunProperties` cascade for empty-line / last-line mark metrics only.
- Fixes Selection Notice helper text after italic “or” (`BodyText` + mark `sz=13`, content runs with no `sz`) rendering at 6.5pt instead of BodyText 10pt.

## Test plan
- [x] `bun test packages/core/src/layout/__tests__/style-cascade.test.ts packages/core/src/layout/__tests__/paragraph-mark-line-height.test.ts`
- [x] `bun run --filter @docx-editor.dev/core typecheck`
- [ ] Spot-check Selection Notice Interest Period line vs Word after merge


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788607325&installation_model_id=422592&pr_number=194&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F194&signature=a89cc39a8ab6950a0122bf81384cbbd18c4888154e3e43aa1681580071eeaec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->