### PR TITLE
perf(core): memoize review-queue derivations for heavily reviewed documents

### DIFF
--- a/.changeset/review-queue-scale-performance.md
+++ b/.changeset/review-queue-scale-performance.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Speed up comment and tracked-change derivation on heavily reviewed long documents: re-deriving the review queue over an unchanged tree is ~25x faster and the re-derive after an accept, reject, comment write or undo drops by more than half, on a 540-page document carrying ~1,900 review items. The per-keystroke content-control gate also no longer re-walks the whole document. Derivation semantics are unchanged.
+Speed up comment and tracked-change derivation on heavily reviewed long documents: re-reading the review queue over an unchanged document is ~25x faster, and the re-derive after an accept, reject, comment write or undo drops by more than half. Derivation semantics are unchanged.

--- a/.changeset/review-queue-scale-performance.md
+++ b/.changeset/review-queue-scale-performance.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Speed up comment and tracked-change derivation on heavily reviewed long documents: re-deriving the review queue over an unchanged tree is ~25x faster and the re-derive after an accept, reject, comment write or undo drops by more than half, on a 540-page document carrying ~1,900 review items. The per-keystroke content-control gate also no longer re-walks the whole document. Derivation semantics are unchanged.

--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,8 @@ tmp-preview/
 openspec/changes/*/notes/feature-parity-report.json
 dist-types/
 
-# Generated profiling fixture (scripts/create-sample-20x-fixture.mjs)
+# Generated profiling fixtures (scripts/create-sample-20x-fixture.mjs,
+# scripts/create-review-20x-fixture.mjs)
 examples/vite/public/sample-20x.docx
+examples/vite/public/sample-review.docx
+examples/vite/public/sample-review-20x.docx

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1836,7 +1836,7 @@ export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean;
 export function paragraphMarkRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null;
 
 // @public
-export function paragraphOrderOfPart(part: OoxmlPart): Map<string, number>;
+export function paragraphOrderOfPart(part: OoxmlPart): ReadonlyMap<string, number>;
 
 // @public
 export function paragraphSectionNode(paragraph: OoxmlElement): OoxmlElement | undefined;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -1696,7 +1696,7 @@ export type ListKind = 'bullet' | 'ordered';
 export function liveDrawingReferenceCount(pkg: OoxmlPackage, partName: string): number;
 
 // @public
-export function locateSites(part: OoxmlPart): Map<string, SiteLocation>;
+export function locateSites(part: OoxmlPart): ReadonlyMap<string, SiteLocation>;
 
 // @public
 export function lockForbidsEdit(lock: ContentControlLock): boolean;
@@ -2692,7 +2692,7 @@ export interface ParagraphOffsetIndex {
 export function paragraphOffsetIndex(paragraph: OoxmlParagraphNode): ParagraphOffsetIndex;
 
 // @public
-export function paragraphOrderOfPart(part: OoxmlPart): Map<string, number>;
+export function paragraphOrderOfPart(part: OoxmlPart): ReadonlyMap<string, number>;
 
 // @public
 export function paragraphTextOf(part: OoxmlPart, paragraphId: string): string | null;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3174,7 +3174,7 @@ export interface RevisionAddress {
 }
 
 // @public
-export function revisionItemsOf(part: OoxmlPart): ReviewRevisionItem[];
+export function revisionItemsOf(part: OoxmlPart): readonly ReviewRevisionItem[];
 
 // @public
 export function runAddressRanges(paragraph: Extract<OoxmlNode, {

--- a/packages/core/src/layout/review-support.ts
+++ b/packages/core/src/layout/review-support.ts
@@ -286,20 +286,9 @@ export function commentInitials(comment: CommentRecord): string {
     .join('');
 }
 
-/** Paragraph node id → document position, from the TREE rather than from a layout. */
-export function paragraphOrderOfPart(part: OoxmlPart): Map<string, number> {
-  const order = new Map<string, number>();
-  const walk = (node: OoxmlNode, depth: number): void => {
-    if (node.kind === 'textValue' || depth > 64) return;
-    if (node.kind === 'paragraph') {
-      if (!order.has(node.id)) order.set(node.id, order.size);
-      return;
-    }
-    for (const child of node.children) walk(child, depth + 1);
-  };
-  walk(part.root, 0);
-  return order;
-}
+// The store's derivation, re-exported rather than copied: it is memoized on the part root,
+// and a second implementation here paid a full-tree walk per call and shared nothing.
+export { paragraphOrderOfPart } from '@docx-editor.dev/core/store';
 
 /** Every range a decision touches. One card can cover several, in different paragraphs. */
 export function reviewItemRanges(item: ReviewItem): readonly ReviewRange[] {

--- a/packages/core/src/store/__tests__/review-reads.test.ts
+++ b/packages/core/src/store/__tests__/review-reads.test.ts
@@ -17,7 +17,10 @@ import {
   commentBodyText,
   commentPartNameOf,
   commentsExtendedPartNameOf,
+  locateSites,
   readOoxmlPackage,
+  readOoxmlPart,
+  revisionItemsOf,
   TreeDocumentStore,
   type OoxmlPackage,
   type OoxmlPart,
@@ -85,5 +88,57 @@ describe('the store lane answers the review queue', () => {
     expect(comment.orphaned).toBe(false);
     expect(comment.range?.start).toEqual({ paragraphId, offset: 0 });
     expect(comment.range?.end).toEqual({ paragraphId, offset: 5 });
+  });
+});
+
+describe('tracked rows inside a textbox keep their anchors', () => {
+  // A paragraph CAN hold table rows: a textbox in a run carries block content, tables
+  // included. The site walk memoizes paragraph subtrees rather than pruning them — a
+  // prune here silently turned the row's card rangeless (no band, no local patch).
+  test('a tracked row deletion in a textbox table gets a range', () => {
+    const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W_NS}" xmlns:v="urn:schemas-microsoft-com:vml"><w:body>` +
+        `<w:p><w:r><w:pict><v:textbox><w:txbxContent>` +
+        `<w:tbl><w:tr>` +
+        `<w:trPr><w:del w:id="9" w:author="Ada Reviewer" w:date="2026-01-01T00:00:00Z"/></w:trPr>` +
+        `<w:tc><w:tcPr><w:cellDel w:id="9" w:author="Ada Reviewer" w:date="2026-01-01T00:00:00Z"/></w:tcPr>` +
+        `<w:p><w:r><w:t>in the box</w:t></w:r></w:p></w:tc>` +
+        `</w:tr></w:tbl>` +
+        `</w:txbxContent></v:textbox></w:pict></w:r></w:p>` +
+        `</w:body></w:document>`,
+      {
+        name: '/word/document.xml',
+        contentType:
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+      }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+    const part = result.part;
+
+    const boxParagraphId = (() => {
+      let inCell: string | null = null;
+      const visit = (node: (typeof part)['root'], insideCell: boolean): void => {
+        if (node.kind === 'textValue') return;
+        if (node.kind === 'paragraph' && insideCell && inCell === null) {
+          inCell = node.id;
+          return;
+        }
+        for (const child of node.children) visit(child, insideCell || node.kind === 'tableCell');
+      };
+      visit(part.root, false);
+      if (inCell === null) throw new Error('no textbox cell paragraph');
+      return inCell;
+    })();
+
+    const located = locateSites(part);
+    const cards = revisionItemsOf(part);
+    const card = cards.find((item) => item.revisionKind === 'structural');
+    expect(card).toBeDefined();
+    expect(card!.ranges.length).toBeGreaterThan(0);
+    expect(card!.ranges[0]!.start.paragraphId).toBe(boxParagraphId);
+    // The memoized index answers repeat reads with the same instance.
+    expect(locateSites(part)).toBe(located);
   });
 });

--- a/packages/core/src/store/package/content-control-nodes.ts
+++ b/packages/core/src/store/package/content-control-nodes.ts
@@ -600,7 +600,8 @@ const defaultContentControlsInCache = new WeakMap<OoxmlNode, readonly ContentCon
 function collectContentControlsIn(
   root: OoxmlNode,
   maxDepth: number,
-  limit: number
+  limit: number,
+  composeFromSubtrees = false
 ): ContentControlEntry[] {
   const entries: ContentControlEntry[] = [];
   const walk = (node: OoxmlNode, depth: number, ancestors: OoxmlContentControlNode[]): void => {
@@ -611,6 +612,23 @@ function collectContentControlsIn(
         if (depth >= maxDepth) continue;
         entries.push({ node: child, depth, ancestors: [...ancestors] });
         walk(child, depth + 1, [...ancestors, child]);
+        continue;
+      }
+      // OUTSIDE any control, a paragraph's or table's entries are a pure function of that
+      // subtree — same depths, same ancestor lists — so an unchanged block hands back its
+      // memoized answer through the per-root cache below instead of being re-descended.
+      // Every transaction gate otherwise re-walked the whole document per keystroke.
+      // Only for the default bounds, which is what the memoized entry point uses; inside a
+      // control the depths and ancestors differ, so composition stops applying there.
+      if (
+        composeFromSubtrees &&
+        depth === 0 &&
+        (child.kind === 'paragraph' || child.kind === 'table')
+      ) {
+        for (const entry of contentControlsIn(child)) {
+          if (entries.length >= limit) return;
+          entries.push(entry);
+        }
         continue;
       }
       walk(child, depth, ancestors);
@@ -646,7 +664,12 @@ export function contentControlsIn(
     const cached = defaultContentControlsInCache.get(root);
     if (cached !== undefined) return cached;
     const entries = freezeContentControlEntries(
-      collectContentControlsIn(root, MAX_CONTENT_CONTROL_NESTING, MAX_CONTENT_CONTROLS_PER_PART)
+      collectContentControlsIn(
+        root,
+        MAX_CONTENT_CONTROL_NESTING,
+        MAX_CONTENT_CONTROLS_PER_PART,
+        true
+      )
     );
     defaultContentControlsInCache.set(root, entries);
     return entries;

--- a/packages/core/src/store/store/comment-reads.ts
+++ b/packages/core/src/store/store/comment-reads.ts
@@ -37,6 +37,7 @@ import {
 import { isContentRevisionKind } from '../package/ooxml-shared.ts';
 import { collectStoryParagraphs, storyRootsOf } from '../package/story-blocks.ts';
 import { paragraphOffsetIndex } from './tree-op-segments.ts';
+import { createRecentRootCache } from './recent-root-cache.ts';
 
 /** The `w15` namespace: `commentsExtended.xml` — thread parent and resolved state. */
 export const W15_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2012/wordml';
@@ -256,8 +257,12 @@ function storyParagraphsOfPart(part: OoxmlPart): readonly OoxmlParagraphNode[] {
   return paragraphs;
 }
 
-/** Story paragraphs per immutable part root. */
-const storyParagraphsCache = new WeakMap<OoxmlNode, readonly OoxmlParagraphNode[]>();
+/**
+ * Story paragraphs per part root, bounded to recent roots: the undo history retains old
+ * roots by reference, and a plain WeakMap would keep one O(document) array alive per
+ * retained root.
+ */
+const storyParagraphsCache = createRecentRootCache<readonly OoxmlParagraphNode[]>(8);
 
 /**
  * The comments in `word/comments.xml`, in authored order.

--- a/packages/core/src/store/store/comment-reads.ts
+++ b/packages/core/src/store/store/comment-reads.ts
@@ -127,7 +127,21 @@ interface MarkerPoint {
  * yielded no anchor at all and reported the comment orphaned; and it gave a note reference or
  * an atomic field nothing where the model gives them one unit each.
  */
-function markersInParagraph(paragraph: OoxmlParagraphNode): MarkerPoint[] {
+function markersInParagraph(paragraph: OoxmlParagraphNode): readonly MarkerPoint[] {
+  // Paragraph-local by construction, like the offset index it reads — an unchanged
+  // paragraph's markers sit at the offsets they sat at last time. Every full anchor pass
+  // otherwise re-walked all paragraphs of the story, comments or none.
+  const cached = markerPointsCache.get(paragraph);
+  if (cached) return cached;
+  const points = computeMarkersInParagraph(paragraph);
+  markerPointsCache.set(paragraph, points);
+  return points;
+}
+
+/** Marker points per immutable paragraph node. */
+const markerPointsCache = new WeakMap<OoxmlParagraphNode, readonly MarkerPoint[]>();
+
+function computeMarkersInParagraph(paragraph: OoxmlParagraphNode): MarkerPoint[] {
   const offsets = paragraphOffsetIndex(paragraph);
   const points: MarkerPoint[] = [];
   const walk = (children: readonly OoxmlNode[], depth: number): void => {
@@ -228,13 +242,22 @@ export function commentAnchorsOfStory(part: OoxmlPart): CommentAnchor[] {
  * offsets these anchors carry are the offsets the ops and the caret use.
  */
 function storyParagraphsOfPart(part: OoxmlPart): readonly OoxmlParagraphNode[] {
+  // Memoized on the immutable root: the enumeration is a pure function of the tree, and the
+  // anchor pass runs once per story part per derivation.
+  const cached = storyParagraphsCache.get(part.root);
+  if (cached) return cached;
   const found: OoxmlNode[] = [];
   for (const story of storyRootsOf(part)) {
     if (story.root.kind === 'textValue') continue;
     collectStoryParagraphs(story.root.children, found, 0);
   }
-  return found.filter((node): node is OoxmlParagraphNode => node.kind === 'paragraph');
+  const paragraphs = found.filter((node): node is OoxmlParagraphNode => node.kind === 'paragraph');
+  storyParagraphsCache.set(part.root, paragraphs);
+  return paragraphs;
 }
+
+/** Story paragraphs per immutable part root. */
+const storyParagraphsCache = new WeakMap<OoxmlNode, readonly OoxmlParagraphNode[]>();
 
 /**
  * The comments in `word/comments.xml`, in authored order.

--- a/packages/core/src/store/store/recent-root-cache.ts
+++ b/packages/core/src/store/store/recent-root-cache.ts
@@ -13,9 +13,19 @@ interface RecentRootCache<V> {
   set(root: object, value: V): void;
 }
 
+/**
+ * `WeakRef` is ES2021 and the workspace tsconfigs pin `lib` at ES2020, so the global is
+ * declared here rather than raising every package's lib: every supported runtime (Node
+ * 14.6+, all evergreen browsers) ships it.
+ */
+interface RootWeakRef {
+  deref(): object | undefined;
+}
+declare const WeakRef: new (target: object) => RootWeakRef;
+
 export function createRecentRootCache<V>(limit: number): RecentRootCache<V> {
   const values = new WeakMap<object, V>();
-  const recent: WeakRef<object>[] = [];
+  const recent: RootWeakRef[] = [];
   return {
     get: (root) => values.get(root),
     set(root, value) {

--- a/packages/core/src/store/store/recent-root-cache.ts
+++ b/packages/core/src/store/store/recent-root-cache.ts
@@ -1,0 +1,37 @@
+// A WeakMap memo for values derived per part ROOT, bounded to the most recent roots.
+//
+// Why not a plain WeakMap: the undo history retains up to 200 package snapshots by
+// reference, and every root it keeps alive would keep its O(document) derived map alive
+// with it — an accept/reject-heavy session on a long document would hold hundreds of full
+// site indexes that were transient before memoization. The ring holds WeakRefs, so it
+// never extends a root's lifetime; it only decides how many still-living roots keep their
+// derived value. An evicted root that comes back (an undo past the window) simply
+// recomputes.
+
+interface RecentRootCache<V> {
+  get(root: object): V | undefined;
+  set(root: object, value: V): void;
+}
+
+export function createRecentRootCache<V>(limit: number): RecentRootCache<V> {
+  const values = new WeakMap<object, V>();
+  const recent: WeakRef<object>[] = [];
+  return {
+    get: (root) => values.get(root),
+    set(root, value) {
+      if (!values.has(root)) {
+        recent.push(new WeakRef(root));
+        while (recent.length > limit) {
+          const evicted = recent.shift()!.deref();
+          // Evict only when no fresher ring slot names the same root — a root re-cached
+          // after eviction sits in the ring twice, and deleting on the stale slot would
+          // drop a live entry.
+          if (evicted && !recent.some((ref) => ref.deref() === evicted)) {
+            values.delete(evicted);
+          }
+        }
+      }
+      values.set(root, value);
+    },
+  };
+}

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -225,6 +225,12 @@ interface SiteLocation {
  * range the caret and the ops disagreed with.
  */
 export function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
+  // Memoized on the immutable root: the merged index is a pure function of the tree, and
+  // every caller in one derivation pass — the revision cards, the pro custom-node cards, an
+  // automation read — asks for the same one. Rebuilding it merged 80k+ entries per call on
+  // a long document. The instance is SHARED; callers must treat it as read-only.
+  const merged = locatedSitesCache.get(part.root);
+  if (merged) return merged;
   const located = new Map<string, SiteLocation>();
   const walkParagraph = (paragraph: OoxmlParagraphNode): void => {
     // Paragraph-local by construction: every offset here is measured inside this paragraph,
@@ -252,49 +258,83 @@ export function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
 
   const anchorTrackedRows = (node: OoxmlNode, depth: number): void => {
     if (node.kind === 'textValue' || depth > 64) return;
+    // A table is block-level content: a row can sit inside a cell, a body or an SDT, never
+    // inside a paragraph — so the subtrees holding almost every node in the document have
+    // nothing for this walk, and descending into them cost more than the rest of it.
+    if (node.kind === 'paragraph') return;
     if (node.kind === 'tableRow') {
-      let paragraph: OoxmlParagraphNode | null = null;
-      const firstParagraph = (candidate: OoxmlNode, nestedDepth: number): void => {
-        if (paragraph || candidate.kind === 'textValue' || nestedDepth > 64) return;
-        if (candidate.kind === 'paragraph') {
-          paragraph = candidate;
-          return;
-        }
-        for (const child of candidate.children) firstParagraph(child, nestedDepth + 1);
-      };
-      firstParagraph(node, 0);
-      if (paragraph) {
-        const placeMarkers = (
-          candidate: OoxmlNode,
-          parentName: string | undefined,
-          nestedDepth: number
-        ): void => {
-          if (candidate.kind === 'textValue' || nestedDepth > 64) return;
-          if (candidate.kind === 'paragraph') return;
-          const rowMarker =
-            parentName === 'trPr' &&
-            (candidate.localName === 'ins' || candidate.localName === 'del');
-          const cellMarker =
-            parentName === 'tcPr' &&
-            (candidate.localName === 'cellIns' || candidate.localName === 'cellDel');
-          if (rowMarker || cellMarker) {
-            located.set(candidate.id, { paragraphId: paragraph!.id, start: 0, end: 0 });
-          }
-          for (const child of candidate.children) {
-            placeMarkers(child, candidate.localName, nestedDepth + 1);
-          }
-        };
-        placeMarkers(node, undefined, 0);
+      // Row-local by the same argument as the paragraph memo: the markers and the first
+      // paragraph that anchors them all live inside the row subtree. A nested row's
+      // markers are recorded by the OUTER row's walk too, anchored to the outer row's
+      // first paragraph — and then overwritten when the walk below reaches the nested row
+      // itself, whose own anchor wins. The per-row entries replay in that same order.
+      let entries = rowMarkerAnchorsCache.get(node);
+      if (!entries) {
+        entries = computeRowMarkerAnchors(node);
+        rowMarkerAnchorsCache.set(node, entries);
       }
+      for (const [markerId, location] of entries) located.set(markerId, location);
     }
     for (const child of node.children) anchorTrackedRows(child, depth + 1);
   };
   anchorTrackedRows(part.root, 0);
+  locatedSitesCache.set(part.root, located);
   return located;
 }
 
+/** Tracked row/cell marker anchors of one row subtree, memoized on the immutable row. */
+function computeRowMarkerAnchors(row: OoxmlNode): readonly (readonly [string, SiteLocation])[] {
+  let paragraph: OoxmlParagraphNode | null = null;
+  const firstParagraph = (candidate: OoxmlNode, nestedDepth: number): void => {
+    if (paragraph || candidate.kind === 'textValue' || nestedDepth > 64) return;
+    if (candidate.kind === 'paragraph') {
+      paragraph = candidate;
+      return;
+    }
+    for (const child of candidate.children) firstParagraph(child, nestedDepth + 1);
+  };
+  firstParagraph(row, 0);
+  if (!paragraph) return EMPTY_ROW_ANCHORS;
+  const anchor: SiteLocation = {
+    paragraphId: (paragraph as OoxmlParagraphNode).id,
+    start: 0,
+    end: 0,
+  };
+  const entries: (readonly [string, SiteLocation])[] = [];
+  const placeMarkers = (
+    candidate: OoxmlNode,
+    parentName: string | undefined,
+    nestedDepth: number
+  ): void => {
+    if (candidate.kind === 'textValue' || nestedDepth > 64) return;
+    if (candidate.kind === 'paragraph') return;
+    const rowMarker =
+      parentName === 'trPr' && (candidate.localName === 'ins' || candidate.localName === 'del');
+    const cellMarker =
+      parentName === 'tcPr' &&
+      (candidate.localName === 'cellIns' || candidate.localName === 'cellDel');
+    if (rowMarker || cellMarker) entries.push([candidate.id, anchor]);
+    for (const child of candidate.children) {
+      placeMarkers(child, candidate.localName, nestedDepth + 1);
+    }
+  };
+  placeMarkers(row, undefined, 0);
+  return entries;
+}
+
+const EMPTY_ROW_ANCHORS: readonly (readonly [string, SiteLocation])[] = [];
+
 /** Node id → paragraph-local offsets, memoized on the immutable paragraph node. */
 const paragraphLocationsCache = new WeakMap<OoxmlNode, ReadonlyMap<string, SiteLocation>>();
+
+/** The merged site index, memoized on the immutable part root. */
+const locatedSitesCache = new WeakMap<OoxmlNode, Map<string, SiteLocation>>();
+
+/** Marker anchors per immutable table row. */
+const rowMarkerAnchorsCache = new WeakMap<
+  OoxmlNode,
+  readonly (readonly [string, SiteLocation])[]
+>();
 
 function locateInParagraph(
   paragraph: OoxmlParagraphNode,
@@ -511,18 +551,37 @@ function pairReplacements(
   const taken = new Set<string>();
   const replacements = new Map<string, ReviewRevisionItem>();
 
+  // Insertions indexed by where their FIRST range starts. Pairing is exact end-to-start
+  // position equality — DELETION FIRST, same paragraph only. The cross-paragraph case is
+  // gone deliberately: it checked that the insertion's paragraph followed the deletion's,
+  // never that the deletion sat at the END of its own, so routine mid-paragraph edits
+  // folded into one card. Order matters too: this engine only ever writes
+  // delete-then-insert, so an insertion FOLLOWED by a deletion is a foreign file where
+  // pairing them would be an invention. The index makes the lookup exact rather than a
+  // scan of every insertion per deletion, which was quadratic in a heavily edited document.
+  const insertionsByStart = new Map<string, ReviewRevisionItem[]>();
+  for (const insertion of pairable) {
+    if (insertion.revisionKind !== 'insert') continue;
+    const start = insertion.ranges[0]!.start;
+    const key = `${start.paragraphId} ${start.offset}`;
+    const bucket = insertionsByStart.get(key);
+    if (bucket) bucket.push(insertion);
+    else insertionsByStart.set(key, [insertion]);
+  }
+
   for (const deletion of pairable) {
     if (deletion.revisionKind !== 'delete' || taken.has(deletion.id)) continue;
-    for (const insertion of pairable) {
-      if (insertion.revisionKind !== 'insert' || taken.has(insertion.id)) continue;
+    // The deletion's LAST range end: the end that actually meets the insertion's first
+    // start when the halves span more than one range each.
+    const end = deletion.ranges[deletion.ranges.length - 1]!.end;
+    const candidates = insertionsByStart.get(`${end.paragraphId} ${end.offset}`) ?? [];
+    for (const insertion of candidates) {
+      if (taken.has(insertion.id)) continue;
       if (insertion.author !== deletion.author) continue;
       // Same MOMENT, not just the same author. Adjacency alone folded two edits an hour
       // apart into one card, and accepting it then resolved a revision the reviewer was not
       // looking at. The window matches the write side's.
       if (!sameMoment(deletion.date, insertion.date)) continue;
-      // The deletion's LAST range against the insertion's FIRST: the two ends that actually
-      // meet when the halves span more than one range each.
-      if (!touching(deletion.ranges[deletion.ranges.length - 1]!, insertion.ranges[0]!)) continue;
       taken.add(deletion.id);
       taken.add(insertion.id);
       // Anchored at whichever half comes FIRST, so the card sits where the edit starts.
@@ -558,21 +617,6 @@ function pairReplacements(
     if (!taken.has(item.id)) out.push(item);
   }
   return out;
-}
-
-/**
- * Two ranges meet end-to-start, in the same paragraph.
- *
- * DELETION FIRST, and same paragraph only. The cross-paragraph case is gone: it checked that
- * the insertion's paragraph followed the deletion's, never that the deletion sat at the END
- * of its own — so "deleted something mid-paragraph, then inserted at the start of the next",
- * which is routine in a reviewed document, folded into one card, and one Accept then
- * resolved a revision the reviewer was not looking at. Order matters too: this engine only
- * ever writes delete-then-insert, so an insertion FOLLOWED by a deletion is a foreign file
- * where pairing them would be an invention.
- */
-function touching(a: ReviewRange, b: ReviewRange): boolean {
-  return a.end.paragraphId === b.start.paragraphId && a.end.offset === b.start.offset;
 }
 
 /** Two addresses naming one revision. */
@@ -756,13 +800,18 @@ export function collectReviewItems(input: ReviewModelInput): ReviewItem[] {
   // orphaned in all the others.
   const revisions: ReviewRevisionItem[] = [];
   const anchors: ReturnType<typeof commentAnchorsOfStory> = [];
-  const order = new Map<string, number>();
+  // With one story there is nothing to merge: the memoized per-part order IS the order,
+  // and copying it entry-by-entry was a measurable slice of every full derivation.
+  const order: ReadonlyMap<string, number> =
+    parts.length === 1 ? paragraphOrderOfPart(parts[0]!) : new Map<string, number>();
   for (const part of parts) {
     revisions.push(...revisionItemsOf(part));
     anchors.push(...commentAnchorsOfStory(part));
-    const base = order.size;
+    if (parts.length === 1) continue;
+    const merged = order as Map<string, number>;
+    const base = merged.size;
     for (const [id, position] of paragraphOrderOfPart(part)) {
-      if (!order.has(id)) order.set(id, base + position);
+      if (!merged.has(id)) merged.set(id, base + position);
     }
   }
 
@@ -898,8 +947,17 @@ export function linkRevisionReplies<T extends LinkableReviewItem>(items: readonl
   });
 }
 
-/** Paragraph node id → document position, from the TREE rather than from a layout. */
+/**
+ * Paragraph node id → document position, from the TREE rather than from a layout.
+ *
+ * Memoized on the immutable root: one full derivation pass asks this question three times
+ * (replacement pairing, the queue's merged order, the session's cached order), and each
+ * answer was a fresh full-tree walk. The instance is SHARED; callers must treat it as
+ * read-only.
+ */
 export function paragraphOrderOfPart(part: OoxmlPart): Map<string, number> {
+  const cached = paragraphOrderCache.get(part.root);
+  if (cached) return cached;
   const order = new Map<string, number>();
   const walk = (node: OoxmlNode, depth: number): void => {
     if (node.kind === 'textValue' || depth > 64) return;
@@ -907,11 +965,42 @@ export function paragraphOrderOfPart(part: OoxmlPart): Map<string, number> {
       if (!order.has(node.id)) order.set(node.id, order.size);
       return;
     }
+    // A table's paragraph sequence is a pure function of the table subtree, so an unchanged
+    // table hands back its list instead of being re-descended — an edit outside any table
+    // otherwise re-walked every cell of every table in the document.
+    if (node.kind === 'table') {
+      let ids = tableParagraphIdsCache.get(node);
+      if (!ids) {
+        const found: string[] = [];
+        const collect = (candidate: OoxmlNode, nestedDepth: number): void => {
+          if (candidate.kind === 'textValue' || nestedDepth > 64) return;
+          if (candidate.kind === 'paragraph') {
+            found.push(candidate.id);
+            return;
+          }
+          for (const child of candidate.children) collect(child, nestedDepth + 1);
+        };
+        for (const child of node.children) collect(child, 0);
+        ids = found;
+        tableParagraphIdsCache.set(node, ids);
+      }
+      for (const id of ids) {
+        if (!order.has(id)) order.set(id, order.size);
+      }
+      return;
+    }
     for (const child of node.children) walk(child, depth + 1);
   };
   walk(part.root, 0);
+  paragraphOrderCache.set(part.root, order);
   return order;
 }
+
+/** The paragraph order index, memoized on the immutable part root. */
+const paragraphOrderCache = new WeakMap<OoxmlNode, Map<string, number>>();
+
+/** Paragraph ids of one table subtree, in reading order, per immutable table node. */
+const tableParagraphIdsCache = new WeakMap<OoxmlNode, readonly string[]>();
 
 /**
  * Every range a decision touches. One card can cover several, in different paragraphs.

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -222,8 +222,29 @@ const CONTENT_KINDS: Readonly<Record<string, ReviewRevisionKind>> = {
  * `w:trPr/w:ins` plus `w:cellIns` on every cell — so they coalesce into one card listing every
  * range it touches. Keying per site would show the reviewer four decisions where there is one,
  * and accepting any of them would make the other three vanish.
+ *
+ * Memoized per part root like the indexes it reads, and for the same reason: a heavily
+ * tracked document produces tens of thousands of cards, and rebuilding them per read cost
+ * more than everything the memos above saved. The paragraph-scoped view the local review
+ * patch derives (`revisionItemsOfParagraph`'s synthetic paragraph-root part) is NOT cached:
+ * each keystroke would insert a fresh root and churn the bounded ring. The instance is
+ * SHARED, so the return type is readonly.
  */
-export function revisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
+export function revisionItemsOf(part: OoxmlPart): readonly ReviewRevisionItem[] {
+  const cacheable = part.root.kind !== 'paragraph';
+  if (cacheable) {
+    const cached = revisionItemsCache.get(part.root);
+    if (cached) return cached;
+  }
+  const items = computeRevisionItemsOf(part);
+  if (cacheable) revisionItemsCache.set(part.root, items);
+  return items;
+}
+
+/** Revision cards per part root, bounded like the site index above. */
+const revisionItemsCache = createRecentRootCache<readonly ReviewRevisionItem[]>(8);
+
+function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
   const located = locateSites(part);
   const byAddress = new Map<
     string,

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -14,14 +14,8 @@
 // beside the page, which is the one thing the tree cannot answer.
 
 import { WML_NAMESPACE_URI } from '../package/ooxml-tree.ts';
-import type {
-  OoxmlElement,
-  OoxmlNode,
-  OoxmlParagraphNode,
-  OoxmlPart,
-} from '../package/ooxml-tree.ts';
+import type { OoxmlElement, OoxmlNode, OoxmlPart } from '../package/ooxml-tree.ts';
 import { collectRevisionSites } from './tree-op-revisions.ts';
-import { paragraphOffsetIndex } from './tree-op-segments.ts';
 import type { RevisionAddress } from './tree-op-types.ts';
 import {
   commentAnchorsOfStory,
@@ -30,7 +24,10 @@ import {
   type CommentRecord,
   type CommentThreadState,
 } from './comment-reads.ts';
+import { locateSites } from './review-site-locations.ts';
 import { createRecentRootCache } from './recent-root-cache.ts';
+
+export { locateSites } from './review-site-locations.ts';
 
 /** A position in the model offset space of one story. */
 export interface ReviewPosition {
@@ -205,221 +202,6 @@ function textUnder(node: OoxmlNode): string {
   let text = '';
   for (const child of node.children) text += textUnder(child);
   return text;
-}
-
-/** The `w:p` a node sits inside, and the model offset it starts at within that paragraph. */
-interface SiteLocation {
-  readonly paragraphId: string;
-  readonly start: number;
-  readonly end: number;
-}
-
-/**
- * Locate every revision site in one walk.
- *
- * One walk rather than a lookup per site: `resolveRevisions` learned the same lesson the hard
- * way, where a per-site tree walk inside a per-site loop made accept-all quadratic.
- *
- * Offsets come from `paragraphOffsetIndex`, which is `segmentsOf`'s walk. A private one here
- * measured a run by summing its text and gave a note reference, an atomic field and a field's
- * instruction text the wrong lengths, so every card in a paragraph holding one reported a
- * range the caret and the ops disagreed with.
- */
-export function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
-  // Memoized on the immutable root: the merged index is a pure function of the tree, and
-  // every caller in one derivation pass — the revision cards, the pro custom-node cards, an
-  // automation read — asks for the same one. Rebuilding it merged 80k+ entries per call on
-  // a long document. The instance is SHARED; callers must treat it as read-only.
-  const merged = locatedSitesCache.get(part.root);
-  if (merged) return merged;
-  const located = new Map<string, SiteLocation>();
-  const walkParagraph = (paragraph: OoxmlParagraphNode): void => {
-    // Paragraph-local by construction: every offset here is measured inside this paragraph,
-    // so an unchanged paragraph's answer is still true and is reused rather than re-walked.
-    // A keystroke otherwise re-derived the location of every node in the document.
-    const memo = paragraphLocationsCache.get(paragraph);
-    if (memo) {
-      for (const [id, location] of memo) located.set(id, location);
-      return;
-    }
-    const own = new Map<string, SiteLocation>();
-    locateInParagraph(paragraph, own);
-    paragraphLocationsCache.set(paragraph, own);
-    for (const [id, location] of own) located.set(id, location);
-  };
-  const walk = (node: OoxmlNode, depth: number): void => {
-    if (node.kind === 'textValue' || depth > 64) return;
-    if (node.kind === 'paragraph') {
-      walkParagraph(node);
-      return;
-    }
-    for (const child of node.children) walk(child, depth + 1);
-  };
-  walk(part.root, 0);
-
-  const anchorTrackedRows = (node: OoxmlNode, depth: number): void => {
-    if (node.kind === 'textValue' || depth > 64) return;
-    // A paragraph CAN hold table rows — a textbox in a run holds block content, tables
-    // included — so paragraph subtrees are walked, not pruned. Memoized per paragraph
-    // like the location walk above: the ordinary paragraph with no textbox costs one
-    // cached empty answer instead of a descent through every run.
-    if (node.kind === 'paragraph') {
-      let entries = paragraphRowAnchorsCache.get(node);
-      if (!entries) {
-        const own: (readonly [string, SiteLocation])[] = [];
-        collectRowAnchorEntries(node, 0, own);
-        entries = own;
-        paragraphRowAnchorsCache.set(node, entries);
-      }
-      for (const [markerId, location] of entries) located.set(markerId, location);
-      return;
-    }
-    if (node.kind === 'tableRow') {
-      // Row-local by the same argument as the paragraph memo: the markers and the first
-      // paragraph that anchors them all live inside the row subtree. A nested row's
-      // markers are recorded by the OUTER row's walk too, anchored to the outer row's
-      // first paragraph — and then overwritten when the walk below reaches the nested row
-      // itself, whose own anchor wins. The per-row entries replay in that same order.
-      let entries = rowMarkerAnchorsCache.get(node);
-      if (!entries) {
-        entries = computeRowMarkerAnchors(node);
-        rowMarkerAnchorsCache.set(node, entries);
-      }
-      for (const [markerId, location] of entries) located.set(markerId, location);
-    }
-    for (const child of node.children) anchorTrackedRows(child, depth + 1);
-  };
-  anchorTrackedRows(part.root, 0);
-  locatedSitesCache.set(part.root, located);
-  return located;
-}
-
-/**
- * Every row-marker anchor under a node, in the same emit order the outer walk uses —
- * outer rows first, nested rows after, so a later entry for the same marker wins.
- */
-function collectRowAnchorEntries(
-  node: OoxmlNode,
-  depth: number,
-  out: (readonly [string, SiteLocation])[]
-): void {
-  if (node.kind === 'textValue' || depth > 64) return;
-  if (node.kind === 'tableRow') {
-    let entries = rowMarkerAnchorsCache.get(node);
-    if (!entries) {
-      entries = computeRowMarkerAnchors(node);
-      rowMarkerAnchorsCache.set(node, entries);
-    }
-    for (const entry of entries) out.push(entry);
-  }
-  for (const child of node.children) collectRowAnchorEntries(child, depth + 1, out);
-}
-
-/** Tracked row/cell marker anchors of one row subtree, memoized on the immutable row. */
-function computeRowMarkerAnchors(row: OoxmlNode): readonly (readonly [string, SiteLocation])[] {
-  let paragraph: OoxmlParagraphNode | null = null;
-  const firstParagraph = (candidate: OoxmlNode, nestedDepth: number): void => {
-    if (paragraph || candidate.kind === 'textValue' || nestedDepth > 64) return;
-    if (candidate.kind === 'paragraph') {
-      paragraph = candidate;
-      return;
-    }
-    for (const child of candidate.children) firstParagraph(child, nestedDepth + 1);
-  };
-  firstParagraph(row, 0);
-  if (!paragraph) return EMPTY_ROW_ANCHORS;
-  const anchor: SiteLocation = {
-    paragraphId: (paragraph as OoxmlParagraphNode).id,
-    start: 0,
-    end: 0,
-  };
-  const entries: (readonly [string, SiteLocation])[] = [];
-  const placeMarkers = (
-    candidate: OoxmlNode,
-    parentName: string | undefined,
-    nestedDepth: number
-  ): void => {
-    if (candidate.kind === 'textValue' || nestedDepth > 64) return;
-    if (candidate.kind === 'paragraph') return;
-    const rowMarker =
-      parentName === 'trPr' && (candidate.localName === 'ins' || candidate.localName === 'del');
-    const cellMarker =
-      parentName === 'tcPr' &&
-      (candidate.localName === 'cellIns' || candidate.localName === 'cellDel');
-    if (rowMarker || cellMarker) entries.push([candidate.id, anchor]);
-    for (const child of candidate.children) {
-      placeMarkers(child, candidate.localName, nestedDepth + 1);
-    }
-  };
-  placeMarkers(row, undefined, 0);
-  return entries;
-}
-
-const EMPTY_ROW_ANCHORS: readonly (readonly [string, SiteLocation])[] = [];
-
-/** Node id → paragraph-local offsets, memoized on the immutable paragraph node. */
-const paragraphLocationsCache = new WeakMap<OoxmlNode, ReadonlyMap<string, SiteLocation>>();
-
-/**
- * The merged site index per part root, bounded to recent roots.
- *
- * Bounded because the undo history retains old roots by reference: a plain WeakMap would
- * keep one O(document) index alive per retained root. Per-NODE memos above are exempt —
- * unchanged nodes are shared across roots, so those caches stay O(document) in total.
- */
-const locatedSitesCache = createRecentRootCache<Map<string, SiteLocation>>(8);
-
-/** Marker anchors per immutable table row. */
-const rowMarkerAnchorsCache = new WeakMap<
-  OoxmlNode,
-  readonly (readonly [string, SiteLocation])[]
->();
-
-/** Row-marker anchors under one immutable paragraph (a textbox can hold a table). */
-const paragraphRowAnchorsCache = new WeakMap<
-  OoxmlNode,
-  readonly (readonly [string, SiteLocation])[]
->();
-
-function locateInParagraph(
-  paragraph: OoxmlParagraphNode,
-  located: Map<string, SiteLocation>
-): void {
-  const offsets = paragraphOffsetIndex(paragraph);
-  const place = (node: OoxmlNode, start: number, end: number, depth: number): void => {
-    if (node.kind === 'textValue' || depth > 64) return;
-    located.set(node.id, { paragraphId: paragraph.id, start, end });
-    for (const child of node.children) place(child, start, end, depth + 1);
-  };
-  const visit = (node: OoxmlNode, depth: number): void => {
-    if (node.kind === 'textValue' || depth > 64) return;
-    const span = offsets.spanOf(node);
-    if (node.kind === 'run') {
-      if (!span) return;
-      located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
-      // A run's OWN properties anchor over the run. `w:rPrChange` is a revision that
-      // decorates no characters and lives in `w:rPr`, so stopping at the run left it with
-      // no geometry at all: its card sorted to the end of the rail, painted no band, and
-      // the caret in tracked-formatted text activated nothing while accept and reject
-      // stayed on offer.
-      for (const child of node.children) {
-        if (child.kind === 'runProperties') place(child, span.start, span.end, depth + 1);
-      }
-      return;
-    }
-    if (span) located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
-    for (const child of node.children) visit(child, depth + 1);
-  };
-  for (const child of paragraph.children) {
-    if (child.kind === 'paragraphProperties') continue;
-    visit(child, 0);
-  }
-  // The paragraph MARK is the pilcrow — it sits at the END of the paragraph, not at
-  // offset 0 where its `w:pPr` happens to be written. Anchored at 0, a tracked Enter's
-  // card never opened when the caret was at the break that made it, `setActiveReviewItem`
-  // threw the caret to the paragraph start, and the zero-width range painted no band.
-  const properties = paragraph.children.find((child) => child.kind === 'paragraphProperties');
-  if (properties) place(properties, offsets.length, offsets.length, 0);
 }
 
 function addressKey(address: RevisionAddress): string {

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -30,6 +30,7 @@ import {
   type CommentRecord,
   type CommentThreadState,
 } from './comment-reads.ts';
+import { createRecentRootCache } from './recent-root-cache.ts';
 
 /** A position in the model offset space of one story. */
 export interface ReviewPosition {
@@ -258,10 +259,21 @@ export function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
 
   const anchorTrackedRows = (node: OoxmlNode, depth: number): void => {
     if (node.kind === 'textValue' || depth > 64) return;
-    // A table is block-level content: a row can sit inside a cell, a body or an SDT, never
-    // inside a paragraph — so the subtrees holding almost every node in the document have
-    // nothing for this walk, and descending into them cost more than the rest of it.
-    if (node.kind === 'paragraph') return;
+    // A paragraph CAN hold table rows — a textbox in a run holds block content, tables
+    // included — so paragraph subtrees are walked, not pruned. Memoized per paragraph
+    // like the location walk above: the ordinary paragraph with no textbox costs one
+    // cached empty answer instead of a descent through every run.
+    if (node.kind === 'paragraph') {
+      let entries = paragraphRowAnchorsCache.get(node);
+      if (!entries) {
+        const own: (readonly [string, SiteLocation])[] = [];
+        collectRowAnchorEntries(node, 0, own);
+        entries = own;
+        paragraphRowAnchorsCache.set(node, entries);
+      }
+      for (const [markerId, location] of entries) located.set(markerId, location);
+      return;
+    }
     if (node.kind === 'tableRow') {
       // Row-local by the same argument as the paragraph memo: the markers and the first
       // paragraph that anchors them all live inside the row subtree. A nested row's
@@ -280,6 +292,27 @@ export function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
   anchorTrackedRows(part.root, 0);
   locatedSitesCache.set(part.root, located);
   return located;
+}
+
+/**
+ * Every row-marker anchor under a node, in the same emit order the outer walk uses —
+ * outer rows first, nested rows after, so a later entry for the same marker wins.
+ */
+function collectRowAnchorEntries(
+  node: OoxmlNode,
+  depth: number,
+  out: (readonly [string, SiteLocation])[]
+): void {
+  if (node.kind === 'textValue' || depth > 64) return;
+  if (node.kind === 'tableRow') {
+    let entries = rowMarkerAnchorsCache.get(node);
+    if (!entries) {
+      entries = computeRowMarkerAnchors(node);
+      rowMarkerAnchorsCache.set(node, entries);
+    }
+    for (const entry of entries) out.push(entry);
+  }
+  for (const child of node.children) collectRowAnchorEntries(child, depth + 1, out);
 }
 
 /** Tracked row/cell marker anchors of one row subtree, memoized on the immutable row. */
@@ -327,11 +360,23 @@ const EMPTY_ROW_ANCHORS: readonly (readonly [string, SiteLocation])[] = [];
 /** Node id → paragraph-local offsets, memoized on the immutable paragraph node. */
 const paragraphLocationsCache = new WeakMap<OoxmlNode, ReadonlyMap<string, SiteLocation>>();
 
-/** The merged site index, memoized on the immutable part root. */
-const locatedSitesCache = new WeakMap<OoxmlNode, Map<string, SiteLocation>>();
+/**
+ * The merged site index per part root, bounded to recent roots.
+ *
+ * Bounded because the undo history retains old roots by reference: a plain WeakMap would
+ * keep one O(document) index alive per retained root. Per-NODE memos above are exempt —
+ * unchanged nodes are shared across roots, so those caches stay O(document) in total.
+ */
+const locatedSitesCache = createRecentRootCache<Map<string, SiteLocation>>(8);
 
 /** Marker anchors per immutable table row. */
 const rowMarkerAnchorsCache = new WeakMap<
+  OoxmlNode,
+  readonly (readonly [string, SiteLocation])[]
+>();
+
+/** Row-marker anchors under one immutable paragraph (a textbox can hold a table). */
+const paragraphRowAnchorsCache = new WeakMap<
   OoxmlNode,
   readonly (readonly [string, SiteLocation])[]
 >();
@@ -996,8 +1041,8 @@ export function paragraphOrderOfPart(part: OoxmlPart): Map<string, number> {
   return order;
 }
 
-/** The paragraph order index, memoized on the immutable part root. */
-const paragraphOrderCache = new WeakMap<OoxmlNode, Map<string, number>>();
+/** The paragraph order index per part root, bounded like {@link locatedSitesCache}. */
+const paragraphOrderCache = createRecentRootCache<Map<string, number>>(8);
 
 /** Paragraph ids of one table subtree, in reading order, per immutable table node. */
 const tableParagraphIdsCache = new WeakMap<OoxmlNode, readonly string[]>();

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -779,10 +779,10 @@ export function linkRevisionReplies<T extends LinkableReviewItem>(items: readonl
  *
  * Memoized on the immutable root: one full derivation pass asks this question three times
  * (replacement pairing, the queue's merged order, the session's cached order), and each
- * answer was a fresh full-tree walk. The instance is SHARED; callers must treat it as
- * read-only.
+ * answer was a fresh full-tree walk. The instance is SHARED, so the return type is
+ * ReadonlyMap: a caller mutating it would poison every later reader of this root.
  */
-export function paragraphOrderOfPart(part: OoxmlPart): Map<string, number> {
+export function paragraphOrderOfPart(part: OoxmlPart): ReadonlyMap<string, number> {
   const cached = paragraphOrderCache.get(part.root);
   if (cached) return cached;
   const order = new Map<string, number>();

--- a/packages/core/src/store/store/review-site-locations.ts
+++ b/packages/core/src/store/store/review-site-locations.ts
@@ -1,0 +1,224 @@
+// Where every node of a story sits, in the model offset space its paragraph defines.
+//
+// Split from `review-reads.ts` (which stays the review QUEUE derivation) purely along the
+// "where is this node" seam: this module owns the site index, its per-paragraph and
+// per-row memos, and the tracked-row anchors; the queue asks it for ranges.
+
+import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../package/ooxml-tree.ts';
+import { paragraphOffsetIndex } from './tree-op-segments.ts';
+import { createRecentRootCache } from './recent-root-cache.ts';
+
+/** The `w:p` a node sits inside, and the model offset it starts at within that paragraph. */
+export interface SiteLocation {
+  readonly paragraphId: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * Locate every revision site in one walk.
+ *
+ * One walk rather than a lookup per site: `resolveRevisions` learned the same lesson the hard
+ * way, where a per-site tree walk inside a per-site loop made accept-all quadratic.
+ *
+ * Offsets come from `paragraphOffsetIndex`, which is `segmentsOf`'s walk. A private one here
+ * measured a run by summing its text and gave a note reference, an atomic field and a field's
+ * instruction text the wrong lengths, so every card in a paragraph holding one reported a
+ * range the caret and the ops disagreed with.
+ */
+export function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
+  // Memoized on the immutable root: the merged index is a pure function of the tree, and
+  // every caller in one derivation pass — the revision cards, the pro custom-node cards, an
+  // automation read — asks for the same one. Rebuilding it merged 80k+ entries per call on
+  // a long document. The instance is SHARED; callers must treat it as read-only.
+  const merged = locatedSitesCache.get(part.root);
+  if (merged) return merged;
+  const located = new Map<string, SiteLocation>();
+  const walkParagraph = (paragraph: OoxmlParagraphNode): void => {
+    // Paragraph-local by construction: every offset here is measured inside this paragraph,
+    // so an unchanged paragraph's answer is still true and is reused rather than re-walked.
+    // A keystroke otherwise re-derived the location of every node in the document.
+    const memo = paragraphLocationsCache.get(paragraph);
+    if (memo) {
+      for (const [id, location] of memo) located.set(id, location);
+      return;
+    }
+    const own = new Map<string, SiteLocation>();
+    locateInParagraph(paragraph, own);
+    paragraphLocationsCache.set(paragraph, own);
+    for (const [id, location] of own) located.set(id, location);
+  };
+  const walk = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || depth > 64) return;
+    if (node.kind === 'paragraph') {
+      walkParagraph(node);
+      return;
+    }
+    for (const child of node.children) walk(child, depth + 1);
+  };
+  walk(part.root, 0);
+
+  const anchorTrackedRows = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || depth > 64) return;
+    // A paragraph CAN hold table rows — a textbox in a run holds block content, tables
+    // included — so paragraph subtrees are walked, not pruned. Memoized per paragraph
+    // like the location walk above: the ordinary paragraph with no textbox costs one
+    // cached empty answer instead of a descent through every run.
+    if (node.kind === 'paragraph') {
+      let entries = paragraphRowAnchorsCache.get(node);
+      if (!entries) {
+        const own: (readonly [string, SiteLocation])[] = [];
+        collectRowAnchorEntries(node, 0, own);
+        entries = own;
+        paragraphRowAnchorsCache.set(node, entries);
+      }
+      for (const [markerId, location] of entries) located.set(markerId, location);
+      return;
+    }
+    if (node.kind === 'tableRow') {
+      // Row-local by the same argument as the paragraph memo: the markers and the first
+      // paragraph that anchors them all live inside the row subtree. A nested row's
+      // markers are recorded by the OUTER row's walk too, anchored to the outer row's
+      // first paragraph — and then overwritten when the walk below reaches the nested row
+      // itself, whose own anchor wins. The per-row entries replay in that same order.
+      let entries = rowMarkerAnchorsCache.get(node);
+      if (!entries) {
+        entries = computeRowMarkerAnchors(node);
+        rowMarkerAnchorsCache.set(node, entries);
+      }
+      for (const [markerId, location] of entries) located.set(markerId, location);
+    }
+    for (const child of node.children) anchorTrackedRows(child, depth + 1);
+  };
+  anchorTrackedRows(part.root, 0);
+  locatedSitesCache.set(part.root, located);
+  return located;
+}
+
+/**
+ * Every row-marker anchor under a node, in the same emit order the outer walk uses —
+ * outer rows first, nested rows after, so a later entry for the same marker wins.
+ */
+function collectRowAnchorEntries(
+  node: OoxmlNode,
+  depth: number,
+  out: (readonly [string, SiteLocation])[]
+): void {
+  if (node.kind === 'textValue' || depth > 64) return;
+  if (node.kind === 'tableRow') {
+    let entries = rowMarkerAnchorsCache.get(node);
+    if (!entries) {
+      entries = computeRowMarkerAnchors(node);
+      rowMarkerAnchorsCache.set(node, entries);
+    }
+    for (const entry of entries) out.push(entry);
+  }
+  for (const child of node.children) collectRowAnchorEntries(child, depth + 1, out);
+}
+
+/** Tracked row/cell marker anchors of one row subtree, memoized on the immutable row. */
+function computeRowMarkerAnchors(row: OoxmlNode): readonly (readonly [string, SiteLocation])[] {
+  let paragraph: OoxmlParagraphNode | null = null;
+  const firstParagraph = (candidate: OoxmlNode, nestedDepth: number): void => {
+    if (paragraph || candidate.kind === 'textValue' || nestedDepth > 64) return;
+    if (candidate.kind === 'paragraph') {
+      paragraph = candidate;
+      return;
+    }
+    for (const child of candidate.children) firstParagraph(child, nestedDepth + 1);
+  };
+  firstParagraph(row, 0);
+  if (!paragraph) return EMPTY_ROW_ANCHORS;
+  const anchor: SiteLocation = {
+    paragraphId: (paragraph as OoxmlParagraphNode).id,
+    start: 0,
+    end: 0,
+  };
+  const entries: (readonly [string, SiteLocation])[] = [];
+  const placeMarkers = (
+    candidate: OoxmlNode,
+    parentName: string | undefined,
+    nestedDepth: number
+  ): void => {
+    if (candidate.kind === 'textValue' || nestedDepth > 64) return;
+    if (candidate.kind === 'paragraph') return;
+    const rowMarker =
+      parentName === 'trPr' && (candidate.localName === 'ins' || candidate.localName === 'del');
+    const cellMarker =
+      parentName === 'tcPr' &&
+      (candidate.localName === 'cellIns' || candidate.localName === 'cellDel');
+    if (rowMarker || cellMarker) entries.push([candidate.id, anchor]);
+    for (const child of candidate.children) {
+      placeMarkers(child, candidate.localName, nestedDepth + 1);
+    }
+  };
+  placeMarkers(row, undefined, 0);
+  return entries;
+}
+
+const EMPTY_ROW_ANCHORS: readonly (readonly [string, SiteLocation])[] = [];
+
+/** Node id → paragraph-local offsets, memoized on the immutable paragraph node. */
+const paragraphLocationsCache = new WeakMap<OoxmlNode, ReadonlyMap<string, SiteLocation>>();
+
+/**
+ * The merged site index per part root, bounded to recent roots.
+ *
+ * Bounded because the undo history retains old roots by reference: a plain WeakMap would
+ * keep one O(document) index alive per retained root. Per-NODE memos above are exempt —
+ * unchanged nodes are shared across roots, so those caches stay O(document) in total.
+ */
+const locatedSitesCache = createRecentRootCache<Map<string, SiteLocation>>(8);
+
+/** Marker anchors per immutable table row. */
+const rowMarkerAnchorsCache = new WeakMap<
+  OoxmlNode,
+  readonly (readonly [string, SiteLocation])[]
+>();
+
+/** Row-marker anchors under one immutable paragraph (a textbox can hold a table). */
+const paragraphRowAnchorsCache = new WeakMap<
+  OoxmlNode,
+  readonly (readonly [string, SiteLocation])[]
+>();
+
+function locateInParagraph(
+  paragraph: OoxmlParagraphNode,
+  located: Map<string, SiteLocation>
+): void {
+  const offsets = paragraphOffsetIndex(paragraph);
+  const place = (node: OoxmlNode, start: number, end: number, depth: number): void => {
+    if (node.kind === 'textValue' || depth > 64) return;
+    located.set(node.id, { paragraphId: paragraph.id, start, end });
+    for (const child of node.children) place(child, start, end, depth + 1);
+  };
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || depth > 64) return;
+    const span = offsets.spanOf(node);
+    if (node.kind === 'run') {
+      if (!span) return;
+      located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
+      // A run's OWN properties anchor over the run. `w:rPrChange` is a revision that
+      // decorates no characters and lives in `w:rPr`, so stopping at the run left it with
+      // no geometry at all: its card sorted to the end of the rail, painted no band, and
+      // the caret in tracked-formatted text activated nothing while accept and reject
+      // stayed on offer.
+      for (const child of node.children) {
+        if (child.kind === 'runProperties') place(child, span.start, span.end, depth + 1);
+      }
+      return;
+    }
+    if (span) located.set(node.id, { paragraphId: paragraph.id, start: span.start, end: span.end });
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of paragraph.children) {
+    if (child.kind === 'paragraphProperties') continue;
+    visit(child, 0);
+  }
+  // The paragraph MARK is the pilcrow — it sits at the END of the paragraph, not at
+  // offset 0 where its `w:pPr` happens to be written. Anchored at 0, a tracked Enter's
+  // card never opened when the caret was at the break that made it, `setActiveReviewItem`
+  // threw the caret to the paragraph start, and the zero-width range painted no band.
+  const properties = paragraph.children.find((child) => child.kind === 'paragraphProperties');
+  if (properties) place(properties, offsets.length, offsets.length, 0);
+}

--- a/packages/core/src/store/store/review-site-locations.ts
+++ b/packages/core/src/store/store/review-site-locations.ts
@@ -26,11 +26,12 @@ export interface SiteLocation {
  * instruction text the wrong lengths, so every card in a paragraph holding one reported a
  * range the caret and the ops disagreed with.
  */
-export function locateSites(part: OoxmlPart): Map<string, SiteLocation> {
+export function locateSites(part: OoxmlPart): ReadonlyMap<string, SiteLocation> {
   // Memoized on the immutable root: the merged index is a pure function of the tree, and
   // every caller in one derivation pass — the revision cards, the pro custom-node cards, an
   // automation read — asks for the same one. Rebuilding it merged 80k+ entries per call on
-  // a long document. The instance is SHARED; callers must treat it as read-only.
+  // a long document. The instance is SHARED, so the return type is ReadonlyMap: a caller
+  // mutating it would poison every later reader of this root, undo included.
   const merged = locatedSitesCache.get(part.root);
   if (merged) return merged;
   const located = new Map<string, SiteLocation>();

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -170,7 +170,10 @@ export function collectRevisionSites(part: OoxmlPart): RevisionSite[] {
     if (node.kind === 'paragraph' || node.kind === 'table') {
       const cached = subtreeSitesCache.get(node);
       if (cached) {
-        sites.push(...cached);
+        // A plain loop, not a spread: spreading is bounded by the engine's argument-count
+        // limit, and one adversarial table can legally hold more tracked markers than that
+        // — the first walk would succeed and every cache hit after it would throw.
+        for (const site of cached) sites.push(site);
         return;
       }
       const before = sites.length;

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -140,8 +140,8 @@ export function revisionGroupKey(address: RevisionAddress, localName: string): s
   return `${localName}\u0000${address.id}\u0000${address.author}\u0000${address.date ?? ''}`;
 }
 
-/** Revision sites of one paragraph subtree, memoized on the immutable paragraph node. */
-const paragraphSitesCache = new WeakMap<OoxmlNode, readonly RevisionSite[]>();
+/** Revision sites of one paragraph or table subtree, memoized on the immutable node. */
+const subtreeSitesCache = new WeakMap<OoxmlNode, readonly RevisionSite[]>();
 
 /**
  * Every revision-bearing element in the part, with the classification that decides whether it
@@ -158,23 +158,25 @@ export function collectRevisionSites(part: OoxmlPart): RevisionSite[] {
     grandparent: OoxmlElement | null
   ): void => {
     if (node.kind === 'textValue') return;
-    // A PARAGRAPH's sites depend on nothing outside it. Classification reads the parent and
-    // grandparent, and every case that consults them (`w:rPr` under `w:pPr`, a structural
-    // parent) is at least two levels inside the paragraph — so the answer for a paragraph
-    // subtree is a pure function of that subtree, and an unchanged paragraph can hand back
-    // what it said last time. Without this, a document with no tracked changes at all still
-    // paid a full-tree walk per keystroke, on this path and on the review queue's.
-    if (node.kind === 'paragraph') {
-      const cached = paragraphSitesCache.get(node);
+    // A PARAGRAPH's — or a TABLE's — sites depend on nothing outside it. Classification
+    // reads the parent and grandparent, and every case that consults them (`w:rPr` under
+    // `w:pPr`, a structural `w:trPr`/`w:tcPr` parent) is at least two levels inside the
+    // memoized subtree — so the answer for that subtree is a pure function of it, and an
+    // unchanged one can hand back what it said last time. Without this, a document with no
+    // tracked changes at all still paid a full-tree walk per keystroke, on this path and on
+    // the review queue's. Tables are memoized as a unit because their row and cell markers
+    // live OUTSIDE any paragraph: a long document of tables otherwise re-walked every
+    // `w:trPr`/`w:tcPr` per derivation even though only one paragraph had changed.
+    if (node.kind === 'paragraph' || node.kind === 'table') {
+      const cached = subtreeSitesCache.get(node);
       if (cached) {
         sites.push(...cached);
         return;
       }
-      const own: RevisionSite[] = [];
       const before = sites.length;
       for (const child of node.children) visit(child, node, parent);
-      for (let index = before; index < sites.length; index += 1) own.push(sites[index]!);
-      paragraphSitesCache.set(node, own);
+      const own = sites.slice(before);
+      subtreeSitesCache.set(node, own);
       return;
     }
     const parentName = parent?.namespaceUri === WML_NAMESPACE_URI ? parent.localName : undefined;

--- a/packages/pro/src/review/review-model.ts
+++ b/packages/pro/src/review/review-model.ts
@@ -69,7 +69,7 @@ import {
 export function revisionItemsOfParagraph(
   part: OoxmlPart,
   paragraphId: string
-): ReviewRevisionItem[] {
+): readonly ReviewRevisionItem[] {
   const paragraph = findNode(part, paragraphId);
   if (!paragraph || paragraph.kind !== 'paragraph') return [];
   return revisionItemsOf({

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -98,23 +98,27 @@ The review fixture is `sample.docx` with 50 comments (10 of them replies anchore
 exactly the parent's range) and 40 tracked changes (15 insertions, 15 deletions, 5
 delete+insert replacement pairs) injected, then the body repeated 20 times with comment
 and revision ids uniquified per copy: ~1,080 comments and ~800 tracked-change sites over
-540 pages — the "long reviewed contract" shape. Medians of 3 runs, Apple Silicon,
-Bun 1.3.14.
+540 pages — the "long reviewed contract" shape. Before and after are the SAME bench
+script (its stage names below) run against the pre- and post-change engine; medians of 3
+runs, Apple Silicon, Bun 1.3.14.
 
-| Path                                              | Before  | After  | Change |
-| ------------------------------------------------- | ------- | ------ | ------ |
-| Full queue re-derive, unchanged tree              | 117 ms  | 4.5 ms | −96%   |
-| Full queue re-derive after an edit (fresh root)   | 116 ms  | 47 ms  | −59%   |
-| `revisionItemsOf` (repeat read)                   | 86 ms   | 3 ms   | −96%   |
-| `locateSites` (repeat read)                       | 54 ms   | ~0 ms  | —      |
-| `commentAnchorsOfStory` (repeat read)             | 12 ms   | 0.5 ms | −96%   |
-| `paragraphOrderOfPart` (repeat read)              | 13 ms   | ~0 ms  | —      |
-| Session `reviewItems()` cold (document open)      | 192 ms  | 148 ms | −23%   |
-| `reviewItems()` after keystroke (local patch)     | 6–7 ms  | 4–6 ms | —      |
+| Stage                                            | Before | After | Change |
+| ------------------------------------------------ | ------ | ----- | ------ |
+| `collectReviewItems` (repeat, unchanged tree)    | 116 ms | 5 ms  | −96%   |
+| `collectReviewItems` (fresh root, after an edit) | 117 ms | 52 ms | −55%   |
+| `revisionItemsOf` (repeat read)                  | 86 ms  | 3 ms  | −96%   |
+| `locateSites` (repeat read)                      | 54 ms  | ~0 ms | —      |
+| `commentAnchorsOfStory` (repeat read)            | 12 ms  | 0.5 ms | −96%  |
+| `paragraphOrderOfPart` (repeat read)             | 13 ms  | ~0 ms | —      |
+| `hasReviewContent` (after the queue was read)    | 17 ms  | 1 ms  | −94%   |
+| `reviewItems()` after keystroke (local patch)    | 7.5 ms | 6 ms  | —      |
+| `reviewItems()` cold (document open)             | 207 ms | 197 ms | ~same |
 
 The fresh-root path is what an accept, reject, comment write or undo pays before the rail
 repaints; the unchanged-tree path is what any second reader (automation, a re-render, the
-geometry pass) pays. What the profiler found, and what changed:
+geometry pass) pays. The cold document-open read is deliberately reported as unchanged:
+the first derivation builds the per-node memos either way, and the win is every read
+after it. What the profiler found, and what changed:
 
 1. **Every full-tree review fact was re-derived per call** even though each is a pure
    function of immutable nodes. `locateSites` merged 82,800 entries into a fresh `Map` per
@@ -127,8 +131,10 @@ geometry pass) pays. What the profiler found, and what changed:
 2. **`collectRevisionSites` memoized per paragraph only**, so a document of tables
    re-walked every `w:trPr`/`w:tcPr` per derivation. The memo now covers table subtrees
    too, which also feeds `hasReviewContent` and accept-all.
-3. **`anchorTrackedRows` descended into every paragraph** looking for table rows, which
-   can never sit inside one — the walk now prunes paragraph subtrees.
+3. **`anchorTrackedRows` re-descended every paragraph** looking for table rows. A
+   paragraph CAN hold one — a textbox in a run holds block content, tables included — so
+   the subtrees are memoized per paragraph rather than pruned: the ordinary paragraph
+   costs one cached empty answer, and a textbox table keeps its anchors.
 4. **Replacement pairing scanned every insertion per deletion.** Pairing is exact
    end-to-start position equality, so insertions are indexed by their start position and
    the scan is one lookup.
@@ -144,4 +150,12 @@ validation and security bound, and the derivation SEMANTICS — the queue, its o
 threading and pairing rules are byte-for-byte the same, only recomputation of
 already-proven facts was removed. The shared memoized `Map` instances (`locateSites`,
 `paragraphOrderOfPart`) keep their public signatures; callers must treat them as
-read-only, which every in-repo caller already did.
+read-only, which every in-repo caller already did (declaring them `ReadonlyMap` is a
+follow-up, being a public signature change).
+
+Two bounds keep the memos honest under adversarial input and long sessions: cached site
+arrays replay through a plain loop (a spread would hit the engine's argument-count limit
+on a table holding tens of thousands of tracked markers), and the per-ROOT caches are
+bounded to recent roots (`recent-root-cache.ts`) so the undo history's retained snapshots
+do not each pin an O(document) derived index — per-NODE memos are exempt, because
+unchanged nodes are shared across revisions.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -16,6 +16,11 @@ bun scripts/bench/pipeline-bench.ts --json     # machine-readable
 
 # Attribute time to functions
 bun --cpu-prof scripts/bench/pipeline-bench.ts # writes CPU.*.cpuprofile
+
+# Review-path benchmark: the same document carrying ~1,080 comments and ~800
+# tracked-change sites (gitignored fixture)
+node scripts/create-review-20x-fixture.mjs
+bun scripts/bench/review-bench.ts
 ```
 
 The fixture is the demo `sample.docx` with its body repeated 20 times (bookmark ids,
@@ -86,3 +91,57 @@ shrank (item 4), but dev-mode React overhead and per-revision whole-document der
 (content-control walk, revision projection, note references, drawing projection — each a
 full-tree scan per edit) dominate the interactive path. Making those derivations
 incremental is the next lever, and it is a design change, not a micro-optimization.
+
+## 2026-08-06 review-scale pass — results
+
+The review fixture is `sample.docx` with 50 comments (10 of them replies anchored over
+exactly the parent's range) and 40 tracked changes (15 insertions, 15 deletions, 5
+delete+insert replacement pairs) injected, then the body repeated 20 times with comment
+and revision ids uniquified per copy: ~1,080 comments and ~800 tracked-change sites over
+540 pages — the "long reviewed contract" shape. Medians of 3 runs, Apple Silicon,
+Bun 1.3.14.
+
+| Path                                              | Before  | After  | Change |
+| ------------------------------------------------- | ------- | ------ | ------ |
+| Full queue re-derive, unchanged tree              | 117 ms  | 4.5 ms | −96%   |
+| Full queue re-derive after an edit (fresh root)   | 116 ms  | 47 ms  | −59%   |
+| `revisionItemsOf` (repeat read)                   | 86 ms   | 3 ms   | −96%   |
+| `locateSites` (repeat read)                       | 54 ms   | ~0 ms  | —      |
+| `commentAnchorsOfStory` (repeat read)             | 12 ms   | 0.5 ms | −96%   |
+| `paragraphOrderOfPart` (repeat read)              | 13 ms   | ~0 ms  | —      |
+| Session `reviewItems()` cold (document open)      | 192 ms  | 148 ms | −23%   |
+| `reviewItems()` after keystroke (local patch)     | 6–7 ms  | 4–6 ms | —      |
+
+The fresh-root path is what an accept, reject, comment write or undo pays before the rail
+repaints; the unchanged-tree path is what any second reader (automation, a re-render, the
+geometry pass) pays. What the profiler found, and what changed:
+
+1. **Every full-tree review fact was re-derived per call** even though each is a pure
+   function of immutable nodes. `locateSites` merged 82,800 entries into a fresh `Map` per
+   call on warm per-paragraph memos; `paragraphOrderOfPart` walked the whole tree three
+   times per derivation (replacement pairing, the queue's merged order, the session's
+   cached order); `commentAnchorsOfStory` re-walked every paragraph's markers. All are now
+   memoized on the immutable node they are a function of — the part root for merged
+   indexes, the paragraph for marker points, the table row for tracked-row anchors — the
+   same pattern the 2026-08-06 layout pass established.
+2. **`collectRevisionSites` memoized per paragraph only**, so a document of tables
+   re-walked every `w:trPr`/`w:tcPr` per derivation. The memo now covers table subtrees
+   too, which also feeds `hasReviewContent` and accept-all.
+3. **`anchorTrackedRows` descended into every paragraph** looking for table rows, which
+   can never sit inside one — the walk now prunes paragraph subtrees.
+4. **Replacement pairing scanned every insertion per deletion.** Pairing is exact
+   end-to-start position equality, so insertions are indexed by their start position and
+   the scan is one lookup.
+5. **The content-control gate re-walked the whole document per keystroke**
+   (`contentControlsIn` was cached per root, and every transaction makes a new root).
+   Outside any control, a block's entries are a pure function of the block subtree, so the
+   walk now composes memoized per-paragraph/per-table answers instead of descending.
+6. **The layout lane carried its own `paragraphOrderOfPart` copy**, unmemoized; it now
+   re-exports the store's.
+
+Not changed, deliberately: the local-patch keystroke path (already sub-10 ms), every
+validation and security bound, and the derivation SEMANTICS — the queue, its order, its
+threading and pairing rules are byte-for-byte the same, only recomputation of
+already-proven facts was removed. The shared memoized `Map` instances (`locateSites`,
+`paragraphOrderOfPart`) keep their public signatures; callers must treat them as
+read-only, which every in-repo caller already did.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -144,6 +144,13 @@ after it. What the profiler found, and what changed:
    walk now composes memoized per-paragraph/per-table answers instead of descending.
 6. **The layout lane carried its own `paragraphOrderOfPart` copy**, unmemoized; it now
    re-exports the store's.
+7. **The revision CARDS were rebuilt per read even when every index hit.** A real
+   heavily-tracked document (Word mints an id per editing burst) produces tens of
+   thousands of cards from a few thousand wrappers, and assembling them cost ~40 ms per
+   unchanged-tree read — more than everything the index memos saved. `revisionItemsOf`
+   is memoized per part root now, bounded like the indexes; on such a document the
+   unchanged-tree re-derive drops from ~48 ms to ~6 ms. The paragraph-scoped view the
+   local patch derives is deliberately uncached (each keystroke would churn the ring).
 
 Not changed, deliberately: the local-patch keystroke path (already sub-10 ms), every
 validation and security bound, and the derivation SEMANTICS — the queue, its order, its

--- a/scripts/bench/review-bench.ts
+++ b/scripts/bench/review-bench.ts
@@ -64,13 +64,17 @@ if (!opened.ok) throw new Error(`open failed: ${opened.reason}`);
 const session = opened.session;
 
 // ── the review queue ──
-stage('hasReviewContent', () => session.hasReviewContent());
-const items = stage('reviewItems (cold)', () => session.reviewItems(), (list) => {
-  const comments = list.filter((item) => item.kind === 'comment').length;
-  const revisions = list.filter((item) => item.kind === 'revision').length;
-  return `${list.length} items (${comments} comments, ${revisions} revisions)`;
-});
+const items = stage(
+  'reviewItems (cold, document open)',
+  () => session.reviewItems(),
+  (list) => {
+    const comments = list.filter((item) => item.kind === 'comment').length;
+    const revisions = list.filter((item) => item.kind === 'revision').length;
+    return `${list.length} items (${comments} comments, ${revisions} revisions)`;
+  }
+);
 stage('reviewItems (cached)', () => session.reviewItems());
+stage('hasReviewContent', () => session.hasReviewContent());
 
 // ── keystroke paths ──
 const paragraphs = (() => {
@@ -137,9 +141,25 @@ const commentsPart = [...pkg.parts.values()].find((candidate) =>
   candidate.name.endsWith('comments.xml')
 );
 
-stage('collectReviewItems (full, cold-ish)', () =>
-  collectReviewItems({ storyPart: part, commentsPart })
-);
+// The keystroke rounds above local-patched without a full derivation, so the root-level
+// memos are cold for the CURRENT tree: this is the re-derive an accept, reject, comment
+// write or undo pays.
+stage('collectReviewItems (fresh root)', () => collectReviewItems({ storyPart: part, commentsPart }));
+// And this is what any second reader of the same revision pays.
+{
+  const timings: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const t0 = performance.now();
+    collectReviewItems({ storyPart: part, commentsPart });
+    timings.push(performance.now() - t0);
+  }
+  timings.sort((a, b) => a - b);
+  results.push({
+    stage: 'collectReviewItems (repeat, unchanged tree)',
+    ms: timings[2]!,
+    note: 'median of 5 repeats',
+  });
+}
 stage('revisionItemsOf', () => revisionItemsOf(part), (list) => `${list.length} cards`);
 stage('locateSites', () => locateSites(part), (map) => `${map.size} sites`);
 stage('commentAnchorsOfStory', () => commentAnchorsOfStory(part), (list) => `${list.length} anchors`);

--- a/scripts/bench/review-bench.ts
+++ b/scripts/bench/review-bench.ts
@@ -1,0 +1,170 @@
+// Review-path benchmark: what the comment / tracked-change derivations cost at scale.
+//
+// Runs against the review-heavy fixture built by scripts/create-review-20x-fixture.mjs
+// (~1080 comments + ~800 tracked-change sites at 20x) and measures the paths a review
+// document actually exercises: session open, the full queue derivation, the per-keystroke
+// cached / locally-patched reads, the store-lane sub-derivations, and layout with markup.
+//
+// The review-model hooks come from the pro review module, exactly as `createDocxEditor`
+// receives them. Pro's `@docx-editor.dev/core/*` imports resolve to core SRC through its
+// tsconfig `paths` when bun runs this from the workspace, so the whole bench is one engine
+// copy (consumer installs resolve the same specifiers to dist through the export maps).
+//
+// Usage: bun scripts/bench/review-bench.ts [fixturePath] [--json]
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  collectReviewItems,
+  commentAnchorsOfStory,
+  locateSites,
+  paragraphOrderOfPart,
+  revisionItemsOf,
+  type OoxmlNode,
+  type OoxmlParagraphNode,
+} from '../../packages/core/src/store/index.ts';
+import { reviewModule } from '../../packages/pro/src/index.ts';
+import { commentsOfPart } from '../../packages/core/src/store/store/comment-reads.ts';
+import { openTreeSession } from '../../packages/core/src/binding/tree-session.ts';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+} from '../../packages/core/src/layout/index.ts';
+
+const fixture = resolve(
+  process.argv[2] && !process.argv[2].startsWith('--')
+    ? process.argv[2]
+    : 'examples/vite/public/sample-review-20x.docx'
+);
+const asJson = process.argv.includes('--json');
+
+interface StageResult {
+  stage: string;
+  ms: number;
+  note?: string;
+}
+const results: StageResult[] = [];
+function stage<T>(name: string, fn: () => T, note?: (value: T) => string): T {
+  const t0 = performance.now();
+  const value = fn();
+  const ms = performance.now() - t0;
+  results.push({ stage: name, ms, ...(note ? { note: note(value) } : {}) });
+  return value;
+}
+
+const bytes = new Uint8Array(readFileSync(fixture));
+results.push({ stage: 'fixture', ms: 0, note: `${fixture} (${(bytes.length / 1024) | 0} KB)` });
+
+const reviewModel = reviewModule().review!;
+
+// ── session open (parse + identity + store) ──
+const opened = stage('openTreeSession', () => openTreeSession(bytes, { reviewModel }));
+if (!opened.ok) throw new Error(`open failed: ${opened.reason}`);
+const session = opened.session;
+
+// ── the review queue ──
+stage('hasReviewContent', () => session.hasReviewContent());
+const items = stage('reviewItems (cold)', () => session.reviewItems(), (list) => {
+  const comments = list.filter((item) => item.kind === 'comment').length;
+  const revisions = list.filter((item) => item.kind === 'revision').length;
+  return `${list.length} items (${comments} comments, ${revisions} revisions)`;
+});
+stage('reviewItems (cached)', () => session.reviewItems());
+
+// ── keystroke paths ──
+const paragraphs = (() => {
+  const found: OoxmlParagraphNode[] = [];
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.kind === 'paragraph') {
+      found.push(node);
+      return;
+    }
+    for (const child of node.children) walk(child);
+  };
+  walk(session.part().root);
+  return found;
+})();
+
+const reviewedParagraphIds = new Set<string>();
+for (const item of items) {
+  if (item.kind === 'comment' && item.range) reviewedParagraphIds.add(item.range.start.paragraphId);
+  if (item.kind === 'revision') {
+    for (const range of item.ranges) reviewedParagraphIds.add(range.start.paragraphId);
+  }
+}
+const plainParagraph = paragraphs.find(
+  (paragraph) => !reviewedParagraphIds.has(paragraph.id)
+);
+const revisionParagraphId = items.find((item) => item.kind === 'revision' && item.ranges.length > 0)
+  ?.ranges?.[0]?.start.paragraphId;
+const revisionParagraph = paragraphs.find((paragraph) => paragraph.id === revisionParagraphId);
+
+function keystrokeRound(name: string, paragraph: OoxmlParagraphNode | undefined, rounds: number) {
+  if (!paragraph) {
+    results.push({ stage: name, ms: 0, note: 'no target paragraph found' });
+    return;
+  }
+  const timings: number[] = [];
+  for (let i = 0; i < rounds; i++) {
+    const applied = session.applyTreeOps([
+      { op: 'insertText', paragraphId: paragraph.id, offset: 0, text: 'X' },
+    ]);
+    if (!applied.committed) {
+      results.push({ stage: name, ms: 0, note: `apply refused` });
+      return;
+    }
+    const t0 = performance.now();
+    session.reviewItems();
+    timings.push(performance.now() - t0);
+  }
+  timings.sort((a, b) => a - b);
+  results.push({
+    stage: name,
+    ms: timings[timings.length >> 1]!,
+    note: `median of ${rounds} keystrokes (min ${timings[0]!.toFixed(1)}, max ${timings[timings.length - 1]!.toFixed(1)})`,
+  });
+}
+
+keystrokeRound('reviewItems after keystroke (plain ¶)', plainParagraph, 10);
+keystrokeRound('reviewItems after keystroke (revision ¶)', revisionParagraph, 10);
+
+// ── store-lane sub-derivations, on the current part ──
+const part = session.part();
+const pkg = session.currentPackage();
+const commentsPart = [...pkg.parts.values()].find((candidate) =>
+  candidate.name.endsWith('comments.xml')
+);
+
+stage('collectReviewItems (full, cold-ish)', () =>
+  collectReviewItems({ storyPart: part, commentsPart })
+);
+stage('revisionItemsOf', () => revisionItemsOf(part), (list) => `${list.length} cards`);
+stage('locateSites', () => locateSites(part), (map) => `${map.size} sites`);
+stage('commentAnchorsOfStory', () => commentAnchorsOfStory(part), (list) => `${list.length} anchors`);
+stage('paragraphOrderOfPart', () => paragraphOrderOfPart(part), (map) => `${map.size} paragraphs`);
+if (commentsPart) {
+  stage('commentsOfPart', () => commentsOfPart(commentsPart), (list) => `${list.length} records`);
+}
+
+// ── layout with markup (the painted view of a reviewed document) ──
+const measurer = createFixedMeasurer(6, 14);
+const layoutSession = createLayoutSession();
+const layout = stage(
+  'layoutSemanticDocument (cold)',
+  () => layoutSemanticDocument(part, 1, { measurer, session: layoutSession, producer: 'bench' }),
+  (l) => `${l.pages.length} pages`
+);
+stage('layout (no-change, warm)', () =>
+  layoutSemanticDocument(part, 2, { measurer, session: layoutSession, producer: 'bench' })
+);
+
+if (asJson) {
+  console.log(JSON.stringify(results, null, 2));
+} else {
+  for (const r of results) {
+    console.log(`${r.stage.padEnd(44)} ${r.ms.toFixed(1).padStart(9)} ms  ${r.note ?? ''}`);
+  }
+  console.log(`pages: ${layout.pages.length}`);
+}

--- a/scripts/create-review-20x-fixture.mjs
+++ b/scripts/create-review-20x-fixture.mjs
@@ -1,0 +1,247 @@
+// Builds a review-heavy copy of examples/vite/public/sample.docx for profiling the
+// comment / tracked-change derivations at scale.
+//
+// Two steps:
+//   1. Inject review markup into the base body: 50 comments (10 of them replies, anchored
+//      over exactly the parent's range, which is the Part 1 threading evidence) and 40
+//      tracked changes (15 w:ins, 15 w:del, 5 delete+insert replacement pairs by one
+//      author in one editing moment, so the queue folds each pair into one card).
+//   2. Repeat the body N times, uniquifying per copy exactly like
+//      create-sample-20x-fixture.mjs — bookmarks, anchors, drawing ids — plus comment ids
+//      and revision ids, and duplicating word/comments.xml entries per copy so every
+//      range marker still names a defined comment.
+//
+// At 20x the result holds ~1080 comments and ~800 tracked changes: the "long reviewed
+// contract" shape where review derivation cost shows up.
+//
+// Usage: node scripts/create-review-20x-fixture.mjs [multiplier] [outPath]
+// Default: 20x -> examples/vite/public/sample-review-20x.docx
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { unzipSync, zipSync, strToU8, strFromU8 } from 'fflate';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const multiplier = Number(process.argv[2] ?? 20);
+const outPath = resolve(
+  root,
+  process.argv[3] ??
+    (multiplier === 1
+      ? 'examples/vite/public/sample-review.docx'
+      : 'examples/vite/public/sample-review-20x.docx')
+);
+const srcPath = resolve(root, 'examples/vite/public/sample.docx');
+
+const AUTHORS = ['Ada Reviewer', 'Ben Editor', 'Chris Legal', 'Dana PM'];
+const COMMENT_TEXTS = [
+  'Please double-check this figure against the appendix.',
+  'Wording is ambiguous, suggest tightening the clause.',
+  'Approved as written.',
+  'This paragraph duplicates the section above, consider removing.',
+  'Needs a citation for this claim.',
+];
+const REPLY_TEXTS = [
+  'Agreed, will update in the next pass.',
+  'Checked, the figure is correct.',
+  'Done in the latest revision.',
+];
+const INSERT_TEXTS = [
+  ' (as amended)',
+  ' subject to the conditions below',
+  ' effective immediately',
+];
+
+// Injected ids start clear of the sample's own comment ids (0-3) and of each other;
+// copies then offset by copy*100000, matching the bookmark scheme.
+const COMMENT_ID_BASE = 1000;
+const REVISION_ID_BASE = 5000;
+
+const zip = unzipSync(readFileSync(srcPath));
+const doc = strFromU8(zip['word/document.xml']);
+
+const bodyOpen = doc.indexOf('<w:body>');
+const bodyClose = doc.lastIndexOf('</w:body>');
+if (bodyOpen === -1 || bodyClose === -1) throw new Error('no w:body');
+const prefix = doc.slice(0, bodyOpen + '<w:body>'.length);
+const body = doc.slice(bodyOpen + '<w:body>'.length, bodyClose);
+const suffix = doc.slice(bodyClose);
+
+const sectPrStart = body.lastIndexOf('<w:sectPr');
+if (sectPrStart === -1) throw new Error('no trailing sectPr');
+const finalSectPr = body.slice(sectPrStart);
+
+// ── step 1: inject review markup into the base body ──────────────────────────────────
+
+/** Comment entries to append to word/comments.xml, built alongside the body injection. */
+const newComments = [];
+
+function isoDate(minute) {
+  return `2026-04-0${1 + (minute % 5)}T${String(9 + (minute % 8)).padStart(2, '0')}:${String(minute % 60).padStart(2, '0')}:00Z`;
+}
+
+/**
+ * The plan: which eligible paragraph (by index) gets which review markup.
+ * Spread evenly so the review load is uniform across the document (and across pages).
+ */
+function buildPlan(eligibleCount) {
+  const plan = new Map();
+  const actions = [];
+  for (let i = 0; i < 40; i++) actions.push({ kind: 'comment', reply: i % 4 === 3 }); // 40 anchors, 10 carry a reply
+  for (let i = 0; i < 15; i++) actions.push({ kind: 'ins' });
+  for (let i = 0; i < 15; i++) actions.push({ kind: 'del' });
+  for (let i = 0; i < 5; i++) actions.push({ kind: 'replace' });
+  const step = eligibleCount / actions.length;
+  actions.forEach((action, index) => {
+    let at = Math.floor(index * step);
+    while (plan.has(at)) at++;
+    plan.set(at, action);
+  });
+  return plan;
+}
+
+/** A paragraph a marker can safely wrap: has a text run, no fields/links/drawings/comments. */
+function isEligible(paragraph) {
+  return (
+    paragraph.includes('<w:t') &&
+    !paragraph.includes('<w:drawing') &&
+    !paragraph.includes('<w:hyperlink') &&
+    !paragraph.includes('commentRange') &&
+    !paragraph.includes('<w:fldChar') &&
+    !paragraph.includes('<w:instrText') &&
+    !paragraph.includes('<w:ins') &&
+    !paragraph.includes('<w:del')
+  );
+}
+
+/** The first `<w:r>...</w:r>` that holds visible text, as [start, end) in the paragraph. */
+function firstTextRun(paragraph) {
+  const runPattern = /<w:r>[\s\S]*?<\/w:r>/g;
+  let match;
+  while ((match = runPattern.exec(paragraph)) !== null) {
+    if (match[0].includes('<w:t')) return { start: match.index, end: match.index + match[0].length, xml: match[0] };
+  }
+  return null;
+}
+
+function toDeletedRun(runXml) {
+  return runXml.replaceAll('<w:t>', '<w:delText>').replaceAll('<w:t ', '<w:delText ').replaceAll('</w:t>', '</w:delText>');
+}
+
+let commentSerial = 0;
+let revisionSerial = 0;
+
+function injectIntoParagraph(paragraph, action) {
+  const run = firstTextRun(paragraph);
+  if (!run) return paragraph;
+  const before = paragraph.slice(0, run.start);
+  const after = paragraph.slice(run.end);
+  const author = AUTHORS[(commentSerial + revisionSerial) % AUTHORS.length];
+
+  if (action.kind === 'comment') {
+    const id = COMMENT_ID_BASE + commentSerial;
+    const minute = commentSerial;
+    commentSerial++;
+    newComments.push({ id, author, date: isoDate(minute), text: COMMENT_TEXTS[id % COMMENT_TEXTS.length] });
+    let starts = `<w:commentRangeStart w:id="${id}"/>`;
+    let ends = `<w:commentRangeEnd w:id="${id}"/><w:r><w:commentReference w:id="${id}"/></w:r>`;
+    if (action.reply) {
+      // The reply anchors over EXACTLY the parent's characters — coincident ranges are the
+      // Part 1 threading evidence the queue reads when no extension part states a parent.
+      const replyId = COMMENT_ID_BASE + commentSerial;
+      commentSerial++;
+      newComments.push({
+        id: replyId,
+        author: AUTHORS[(id + 1) % AUTHORS.length],
+        date: isoDate(minute + 2),
+        text: REPLY_TEXTS[replyId % REPLY_TEXTS.length],
+      });
+      starts += `<w:commentRangeStart w:id="${replyId}"/>`;
+      ends += `<w:commentRangeEnd w:id="${replyId}"/><w:r><w:commentReference w:id="${replyId}"/></w:r>`;
+    }
+    return before + starts + run.xml + ends + after;
+  }
+
+  const id = REVISION_ID_BASE + revisionSerial;
+  const date = isoDate(revisionSerial * 7); // minutes apart, so unrelated edits never pair
+  revisionSerial++;
+  if (action.kind === 'ins') {
+    return `${before}<w:ins w:id="${id}" w:author="${author}" w:date="${date}">${run.xml}</w:ins>${after}`;
+  }
+  if (action.kind === 'del') {
+    return `${before}<w:del w:id="${id}" w:author="${author}" w:date="${date}">${toDeletedRun(run.xml)}</w:del>${after}`;
+  }
+  // replace: a deletion and an adjacent insertion by one author in one editing moment.
+  const insId = REVISION_ID_BASE + revisionSerial;
+  revisionSerial++;
+  const insText = INSERT_TEXTS[id % INSERT_TEXTS.length];
+  return (
+    `${before}<w:del w:id="${id}" w:author="${author}" w:date="${date}">${toDeletedRun(run.xml)}</w:del>` +
+    `<w:ins w:id="${insId}" w:author="${author}" w:date="${date}"><w:r><w:t xml:space="preserve">${insText}</w:t></w:r></w:ins>${after}`
+  );
+}
+
+function injectReviewMarkup(chunk) {
+  const paragraphs = chunk.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? [];
+  const eligible = paragraphs.filter(isEligible).length;
+  const plan = buildPlan(eligible);
+  let eligibleIndex = 0;
+  return chunk.replace(/<w:p>[\s\S]*?<\/w:p>/g, (paragraph) => {
+    if (!isEligible(paragraph)) return paragraph;
+    const action = plan.get(eligibleIndex);
+    eligibleIndex++;
+    return action ? injectIntoParagraph(paragraph, action) : paragraph;
+  });
+}
+
+const content = injectReviewMarkup(body.slice(0, sectPrStart));
+
+// ── step 2: repeat, uniquifying per copy ──────────────────────────────────────────────
+
+function uniquify(chunk, copy) {
+  const offset = copy * 100000;
+  const bumpId = (_, a, id, b) => a + (Number(id) + offset) + b;
+  return chunk
+    .replace(/(<w:bookmark(?:Start|End)[^>]*w:id=")(\d+)(")/g, bumpId)
+    .replace(/(<w:bookmarkStart[^>]*w:name=")([^"]+)(")/g, (_, a, name, b) => a + name + '_c' + copy + b)
+    .replace(/(<w:hyperlink[^>]*w:anchor=")([^"]+)(")/g, (_, a, name, b) => a + name + '_c' + copy + b)
+    .replace(/(<wp:docPr[^>]*id=")(\d+)(")/g, bumpId)
+    .replace(/(<w:commentRange(?:Start|End)[^>]*w:id=")(\d+)(")/g, bumpId)
+    .replace(/(<w:commentReference[^>]*w:id=")(\d+)(")/g, bumpId)
+    .replace(/(<w:(?:ins|del) [^>]*w:id=")(\d+)(")/g, bumpId);
+}
+
+let repeated = content;
+for (let copy = 1; copy < multiplier; copy++) repeated += uniquify(content, copy);
+
+zip['word/document.xml'] = strToU8(prefix + repeated + finalSectPr + suffix);
+
+// ── comments.xml: append injected comments, then duplicate every entry per copy ───────
+
+const commentsXml = strFromU8(zip['word/comments.xml']);
+const commentsClose = commentsXml.lastIndexOf('</w:comments>');
+if (commentsClose === -1) throw new Error('no w:comments');
+
+const injectedEntries = newComments
+  .map(
+    (comment) =>
+      `<w:comment w:id="${comment.id}" w:author="${comment.author}" w:date="${comment.date}">` +
+      `<w:p><w:r><w:t xml:space="preserve">${comment.text}</w:t></w:r></w:p></w:comment>`
+  )
+  .join('');
+
+const baseComments = commentsXml.slice(0, commentsClose) + injectedEntries;
+const commentEntries = (baseComments.match(/<w:comment [\s\S]*?<\/w:comment>/g) ?? []).join('');
+let copiedEntries = '';
+for (let copy = 1; copy < multiplier; copy++) {
+  copiedEntries += commentEntries.replace(/(<w:comment [^>]*w:id=")(\d+)(")/g, (_, a, id, b) => a + (Number(id) + copy * 100000) + b);
+}
+zip['word/comments.xml'] = strToU8(baseComments + copiedEntries + '</w:comments>');
+
+writeFileSync(outPath, zipSync(zip, { level: 6 }));
+const totalComments = (4 + newComments.length) * multiplier;
+const totalRevisions = revisionSerial * multiplier;
+console.log(
+  `wrote ${outPath}: x${multiplier}, ${totalComments} comments, ${totalRevisions} tracked-change sites, ` +
+    `document.xml ${((prefix.length + repeated.length + finalSectPr.length + suffix.length) / 1e6).toFixed(1)}MB`
+);

--- a/scripts/create-review-20x-fixture.mjs
+++ b/scripts/create-review-20x-fixture.mjs
@@ -53,7 +53,8 @@ const INSERT_TEXTS = [
 ];
 
 // Injected ids start clear of the sample's own comment ids (0-3) and of each other;
-// copies then offset by copy*100000, matching the bookmark scheme.
+// copies then offset by copy*1,000,000 — above the sample's largest id family (the
+// ~900,000 TOC bookmarks), so no copy's bumped id can collide with another copy's.
 const COMMENT_ID_BASE = 1000;
 const REVISION_ID_BASE = 5000;
 
@@ -199,7 +200,7 @@ const content = injectReviewMarkup(body.slice(0, sectPrStart));
 // ── step 2: repeat, uniquifying per copy ──────────────────────────────────────────────
 
 function uniquify(chunk, copy) {
-  const offset = copy * 100000;
+  const offset = copy * 1000000;
   const bumpId = (_, a, id, b) => a + (Number(id) + offset) + b;
   return chunk
     .replace(/(<w:bookmark(?:Start|End)[^>]*w:id=")(\d+)(")/g, bumpId)
@@ -234,7 +235,10 @@ const baseComments = commentsXml.slice(0, commentsClose) + injectedEntries;
 const commentEntries = (baseComments.match(/<w:comment [\s\S]*?<\/w:comment>/g) ?? []).join('');
 let copiedEntries = '';
 for (let copy = 1; copy < multiplier; copy++) {
-  copiedEntries += commentEntries.replace(/(<w:comment [^>]*w:id=")(\d+)(")/g, (_, a, id, b) => a + (Number(id) + copy * 100000) + b);
+  copiedEntries += commentEntries.replace(
+    /(<w:comment [^>]*w:id=")(\d+)(")/g,
+    (_, a, id, b) => a + (Number(id) + copy * 1000000) + b
+  );
 }
 zip['word/comments.xml'] = strToU8(baseComments + copiedEntries + '</w:comments>');
 

--- a/scripts/create-sample-20x-fixture.mjs
+++ b/scripts/create-sample-20x-fixture.mjs
@@ -38,7 +38,9 @@ const content = body.slice(0, sectPrStart);
 const finalSectPr = body.slice(sectPrStart);
 
 function uniquify(chunk, copy) {
-  const offset = copy * 100000;
+  // 1,000,000 per copy: above the sample's largest id family (the ~900,000 TOC
+  // bookmarks), so no copy's bumped id can collide with another copy's original.
+  const offset = copy * 1000000;
   let out = chunk
     .replace(/(<w:bookmark(?:Start|End)[^>]*w:id=")(\d+)(")/g, (_, a, id, b) => a + (Number(id) + offset) + b)
     .replace(/(<w:bookmarkStart[^>]*w:name=")([^"]+)(")/g, (_, a, name, b) => a + name + '_c' + copy + b)


### PR DESCRIPTION
On a 540-page document carrying ~1,080 comments and ~800 tracked-change sites, re-reading the review queue over an unchanged tree drops from 116ms to 5ms and the full re-derive after an accept, reject, comment write or undo from 117ms to 52ms; the per-keystroke content-control gate no longer re-walks the whole document. The full-tree facts the derivation reads are pure functions of immutable nodes and are now memoized on those nodes; replacement pairing indexes insertions by position instead of scanning quadratically. Semantics unchanged; per-root caches are bounded so undo snapshots don't pin O(document) indexes, and cached site arrays replay without spread so an adversarial table can't hit the argument-count limit.

`locateSites` and `paragraphOrderOfPart` now return their shared memoized instances typed `ReadonlyMap` (they previously minted a fresh mutable `Map` per call; every in-repo caller was already read-only).

New: `scripts/create-review-20x-fixture.mjs` (sample.docx + 90 injected review items, multiplied 20x with per-copy uniquified ids, gitignored output) and `scripts/bench/review-bench.ts`; before/after measured with the same script against the pre-change engine, recorded in `scripts/bench/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)