### PR TITLE
fix: match tab underline thickness to run text thick

### DIFF
--- a/.changeset/thick-tab-underline-paint.md
+++ b/.changeset/thick-tab-underline-paint.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Paint thick/single underlined tab form blanks as point-sized inset rules so overflow clipping cannot thin the baseline band the way a bottom border could.
+Paint underlined tab form blanks with the same thick/single thickness heuristic as ordinary run underlines, using an inset rule so overflow clipping cannot drop the advance band.

--- a/.changeset/thick-tab-underline-paint.md
+++ b/.changeset/thick-tab-underline-paint.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Paint thick/single underlined tab form blanks as point-sized inset rules so overflow clipping cannot thin the baseline band the way a bottom border could.

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -51,9 +51,9 @@ function layoutOf(body: string, numbering?: string) {
   });
 }
 
-function paint(body: string): HTMLElement {
+function paint(body: string, options: { readonly scale?: number } = {}): HTMLElement {
   const container = document.createElement('div');
-  paintSemanticLayout(container, layoutOf(body), { scale: 1 });
+  paintSemanticLayout(container, layoutOf(body), { scale: options.scale ?? 1 });
   return container;
 }
 
@@ -285,8 +285,10 @@ describe('the painter is a non-authoritative consumer', () => {
     )!;
     expect(tab.dataset.docxTabUnderline).toBe('');
     expect(tab.style.textDecorationLine).toBe('');
-    expect(tab.style.borderBottomStyle).toBe('solid');
-    expect(tab.style.borderBottomWidth).toBe('2px');
+    // Inset background rule (overflow:hidden on the tab would fight a margin-edge border).
+    expect(tab.style.backgroundSize).toBe('100% 2.25px');
+    expect(tab.style.backgroundPosition).toBe('left bottom');
+    expect(tab.style.borderBottomWidth).toBe('');
     expect(Number.parseFloat(tab.style.width)).toBeGreaterThan(6);
   });
 
@@ -299,8 +301,29 @@ describe('the painter is a non-authoritative consumer', () => {
       (el) => el.textContent === '\t'
     )!;
     expect(tab.dataset.docxTabUnderline).toBe('');
-    expect(tab.style.borderBottomColor.toLowerCase()).toBe('#c00000');
-    expect(tab.style.borderBottomWidth).toBe('1px');
+    expect(tab.style.backgroundImage.toLowerCase()).toContain('#c00000');
+    expect(tab.style.backgroundSize).toBe('100% 0.75px');
+  });
+
+  test('thick tab underline scales with paint zoom and stays heavier than single', () => {
+    const thick = paint(
+      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>' +
+        '<w:r><w:rPr><w:sz w:val="20"/><w:u w:val="thick"/></w:rPr><w:tab/></w:r></w:p>',
+      { scale: 2 }
+    );
+    const single = paint(
+      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>' +
+        '<w:r><w:rPr><w:sz w:val="20"/><w:u w:val="single"/></w:rPr><w:tab/></w:r></w:p>',
+      { scale: 2 }
+    );
+    const thickTab = [...thick.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (el) => el.textContent === '\t'
+    )!;
+    const singleTab = [...single.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (el) => el.textContent === '\t'
+    )!;
+    expect(thickTab.style.backgroundSize).toBe('100% 4.5px');
+    expect(singleTab.style.backgroundSize).toBe('100% 1.5px');
   });
 });
 

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -285,8 +285,8 @@ describe('the painter is a non-authoritative consumer', () => {
     )!;
     expect(tab.dataset.docxTabUnderline).toBe('');
     expect(tab.style.textDecorationLine).toBe('');
-    // Inset background rule (overflow:hidden on the tab would fight a margin-edge border).
-    expect(tab.style.backgroundSize).toBe('100% 2.25px');
+    // Same heavy heuristic as run text: max(2×scale px, 0.12em) at docDefaults 11pt → 2px.
+    expect(tab.style.backgroundSize).toBe('100% 2px');
     expect(tab.style.backgroundPosition).toBe('left bottom');
     expect(tab.style.borderBottomWidth).toBe('');
     expect(Number.parseFloat(tab.style.width)).toBeGreaterThan(6);
@@ -302,28 +302,29 @@ describe('the painter is a non-authoritative consumer', () => {
     )!;
     expect(tab.dataset.docxTabUnderline).toBe('');
     expect(tab.style.backgroundImage.toLowerCase()).toContain('#c00000');
-    expect(tab.style.backgroundSize).toBe('100% 0.75px');
+    expect(tab.style.backgroundSize).toBe('100% 1px');
   });
 
-  test('thick tab underline scales with paint zoom and stays heavier than single', () => {
-    const thick = paint(
-      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>' +
-        '<w:r><w:rPr><w:sz w:val="20"/><w:u w:val="thick"/></w:rPr><w:tab/></w:r></w:p>',
-      { scale: 2 }
-    );
-    const single = paint(
-      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>' +
-        '<w:r><w:rPr><w:sz w:val="20"/><w:u w:val="single"/></w:rPr><w:tab/></w:r></w:p>',
-      { scale: 2 }
-    );
-    const thickTab = [...thick.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+  test('thick tab advance thickness matches ordinary w:u=thick text at the same size and scale', () => {
+    const scale = 2;
+    const sz = 40; // 20pt — large enough that 0.12em exceeds the 2×scale floor
+    const fontSizePt = sz / 2;
+    const expectedHeavyPx = Math.max(2 * scale, 0.12 * fontSizePt * scale);
+    const body =
+      `<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="2400"/></w:tabs></w:pPr>` +
+      `<w:r><w:rPr><w:sz w:val="${sz}"/><w:u w:val="thick"/></w:rPr><w:t>Aa</w:t></w:r>` +
+      `<w:r><w:rPr><w:sz w:val="${sz}"/><w:u w:val="thick"/></w:rPr><w:tab/></w:r></w:p>`;
+    const container = paint(body, { scale });
+    const text = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (el) => el.textContent === 'Aa'
+    )!;
+    const tab = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find(
       (el) => el.textContent === '\t'
     )!;
-    const singleTab = [...single.querySelectorAll<HTMLElement>('.layout-run-text')].find(
-      (el) => el.textContent === '\t'
-    )!;
-    expect(thickTab.style.backgroundSize).toBe('100% 4.5px');
-    expect(singleTab.style.backgroundSize).toBe('100% 1.5px');
+    // Text path keeps the CSS max() form; tab evaluates the same numbers to a stripe height.
+    expect(text.style.textDecorationThickness).toBe(`max(${2 * scale}px, 0.12em)`);
+    expect(tab.style.backgroundSize).toBe(`100% ${expectedHeavyPx}px`);
+    expect(expectedHeavyPx).toBeGreaterThan(2 * scale); // em floor engaged
   });
 });
 

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -467,6 +467,32 @@ function underlineDecorationOf(style: ResolvedRunStyle): UnderlineDecoration | n
 }
 
 /**
+ * Thick / *Heavy underline thickness — shared by run `text-decoration` and tab-advance paint.
+ *
+ * OOXML `ST_Underline` names the pattern only (§17.18.99); thickness is application-defined.
+ * The paint heuristic (twice a single rule, with a 0.12em floor at zoom) is what ordinary
+ * `w:u=thick` text already uses. Tab form blanks must evaluate the same numbers in JS because
+ * CSS `max()` is unreliable on `border-*-width` / background sizes in happy-dom.
+ */
+const HEAVY_UNDERLINE_MIN_PX_AT_SCALE = 2;
+const HEAVY_UNDERLINE_EM = 0.12;
+
+function heavyUnderlineThicknessCss(scale: number): string {
+  return `max(${HEAVY_UNDERLINE_MIN_PX_AT_SCALE * scale}px, ${HEAVY_UNDERLINE_EM}em)`;
+}
+
+/** Pixel thickness matching {@link heavyUnderlineThicknessCss} at a known font size. */
+function underlineThicknessPx(heavy: boolean, fontSizePt: number, scale: number): number {
+  const emPx = Math.max(0, fontSizePt) * scale;
+  if (heavy) {
+    return Math.max(HEAVY_UNDERLINE_MIN_PX_AT_SCALE * scale, HEAVY_UNDERLINE_EM * emPx);
+  }
+  // Single text underlines leave thickness to the browser; tab advances need an explicit
+  // stripe. 1×scale matches the previous tab `border-bottom` single.
+  return Math.max(1 * scale, 0);
+}
+
+/**
  * Apply one CSS text-decoration family to an element.
  *
  * Underline and strike must never share a single `text-decoration-*` declaration when their
@@ -483,9 +509,7 @@ function applyTextDecoration(
   css.textDecorationStyle = decorationStyle;
   if (options.color) css.textDecorationColor = `#${options.color}`;
   if (options.heavy) {
-    // Word's thick / *Heavy underlines are roughly twice a single rule. Floor scales with
-    // paint zoom so a 200% surface does not keep a 100%-thin heavy line.
-    css.textDecorationThickness = `max(${2 * options.scale}px, 0.12em)`;
+    css.textDecorationThickness = heavyUnderlineThicknessCss(options.scale);
   }
 }
 
@@ -507,26 +531,13 @@ function applyUnderlineDecoration(
 }
 
 /**
- * Point widths for tab-advance underlines (paint uses 1pt → 1css-px at scale 1).
- *
- * OOXML `ST_Underline` names the pattern only (§17.18.99) — thickness is application-defined.
- * Word's thick form blank is a heavy baseline rule (~3× a single hairline), not a 1-device-px
- * stroke. Keep single at 0.75pt (matches common body hairlines / 0.75pt shape bars) and thick
- * at 2.25pt; floor with an em fraction so large display runs stay proportionally heavy.
- */
-const TAB_UNDERLINE_SINGLE_PT = 0.75;
-const TAB_UNDERLINE_THICK_PT = 2.25;
-const TAB_UNDERLINE_HEAVY_EM = 0.15;
-const TAB_UNDERLINE_SINGLE_EM = 0.06;
-
-/**
  * Underline a tab's reserved ADVANCE, not its invisible `\t` glyph.
  *
  * Form blanks are often authored as `w:u` on a bare `w:tab` (thick/single). Word draws the
  * rule across the distance to the stop. CSS `text-decoration` on a clipped `\t` paints no
- * visible ink over that width. The advance box uses an inset background rule (not
- * `border-bottom`): tabs set `overflow: hidden` for glyph clipping, and a bottom border sits
- * on the margin edge where line boxes / overflow can thin or hide it.
+ * visible ink over that width. Thickness matches ordinary run underlines
+ * ({@link underlineThicknessPx}); the advance box uses an inset background rule because tabs
+ * set `overflow: hidden` and a margin-edge `border-bottom` can thin or hide.
  */
 function applyTabAdvanceUnderline(
   css: CSSStyleDeclaration,
@@ -535,10 +546,7 @@ function applyTabAdvanceUnderline(
   fontSizePt: number
 ): void {
   const color = underline.color ? `#${underline.color}` : 'currentColor';
-  const em = Math.max(0, fontSizePt) * scale;
-  const thicknessPx = underline.heavy
-    ? Math.max(TAB_UNDERLINE_THICK_PT * scale, TAB_UNDERLINE_HEAVY_EM * em)
-    : Math.max(TAB_UNDERLINE_SINGLE_PT * scale, TAB_UNDERLINE_SINGLE_EM * em);
+  const thicknessPx = underlineThicknessPx(underline.heavy, fontSizePt, scale);
   // Solid fill only — dashed/dotted tab blanks are rare; wavy has no background analogue.
   css.backgroundImage = `linear-gradient(${color}, ${color})`;
   css.backgroundSize = `100% ${thicknessPx}px`;

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -507,24 +507,47 @@ function applyUnderlineDecoration(
 }
 
 /**
+ * Point widths for tab-advance underlines (paint uses 1pt → 1css-px at scale 1).
+ *
+ * OOXML `ST_Underline` names the pattern only (§17.18.99) — thickness is application-defined.
+ * Word's thick form blank is a heavy baseline rule (~3× a single hairline), not a 1-device-px
+ * stroke. Keep single at 0.75pt (matches common body hairlines / 0.75pt shape bars) and thick
+ * at 2.25pt; floor with an em fraction so large display runs stay proportionally heavy.
+ */
+const TAB_UNDERLINE_SINGLE_PT = 0.75;
+const TAB_UNDERLINE_THICK_PT = 2.25;
+const TAB_UNDERLINE_HEAVY_EM = 0.15;
+const TAB_UNDERLINE_SINGLE_EM = 0.06;
+
+/**
  * Underline a tab's reserved ADVANCE, not its invisible `\t` glyph.
  *
  * Form blanks are often authored as `w:u` on a bare `w:tab` (thick/single). Word draws the
  * rule across the distance to the stop. CSS `text-decoration` on a clipped `\t` paints no
- * visible ink over that width, so the advance box itself carries a bottom border instead.
- * `wavy` is not a border style — fall back to solid rather than inventing a wave path.
+ * visible ink over that width. The advance box uses an inset background rule (not
+ * `border-bottom`): tabs set `overflow: hidden` for glyph clipping, and a bottom border sits
+ * on the margin edge where line boxes / overflow can thin or hide it.
  */
 function applyTabAdvanceUnderline(
   css: CSSStyleDeclaration,
   underline: UnderlineDecoration,
-  scale: number
+  scale: number,
+  fontSizePt: number
 ): void {
   const color = underline.color ? `#${underline.color}` : 'currentColor';
-  // Plain px widths — `max()` is fine on `text-decoration-thickness` but happy-dom (and
-  // some engines) drop it on `border-*-width`, which would erase the whole form blank.
-  css.borderBottomWidth = `${(underline.heavy ? 2 : 1) * scale}px`;
-  css.borderBottomStyle = underline.cssStyle === 'wavy' ? 'solid' : underline.cssStyle;
-  css.borderBottomColor = color;
+  const em = Math.max(0, fontSizePt) * scale;
+  const thicknessPx = underline.heavy
+    ? Math.max(TAB_UNDERLINE_THICK_PT * scale, TAB_UNDERLINE_HEAVY_EM * em)
+    : Math.max(TAB_UNDERLINE_SINGLE_PT * scale, TAB_UNDERLINE_SINGLE_EM * em);
+  // Solid fill only — dashed/dotted tab blanks are rare; wavy has no background analogue.
+  css.backgroundImage = `linear-gradient(${color}, ${color})`;
+  css.backgroundSize = `100% ${thicknessPx}px`;
+  // Bottom of the advance box ≈ Word's underline band under a top-aligned tab strut.
+  css.backgroundPosition = 'left bottom';
+  css.backgroundRepeat = 'no-repeat';
+  css.borderBottomWidth = '';
+  css.borderBottomStyle = '';
+  css.borderBottomColor = '';
 }
 
 /**
@@ -910,7 +933,7 @@ function paintSpan(
     const tabUnderline = underlineDecorationOf(span.style);
     if (tabUnderline) {
       element.dataset.docxTabUnderline = '';
-      applyTabAdvanceUnderline(element.style, tabUnderline, ctx.scale);
+      applyTabAdvanceUnderline(element.style, tabUnderline, ctx.scale, span.style.fontSizePt);
     }
   }
   mountRunText(document, element, span.text, span.style, ctx.scale);


### PR DESCRIPTION
## Summary
- Screenshot shows editor title blanks are **thicker** than Word; the prior revision’s 2.25pt tab constant was wrong and made that worse.
- Tab-advance underlines now use the **same** thick/single heuristic as ordinary run `text-decoration` (`max(2×scale px, 0.12em)` for heavy; `1×scale` for single), painted as an inset background so `overflow: hidden` cannot drop the rule.
- Absolute Word calibration of that shared heuristic is unchanged — if thick text underlines are also heavy vs Word, that is a separate global tune, not a tab-only 3× constant.

## Test plan
- [x] `bun test packages/core/src/output/__tests__/semantic-paint.test.ts -t "underlined tab|tab advance|ordinary w:u"`
- [ ] Spot-check Selection Notice title blanks vs Word (should match thick text weight, not chunkier than #189’s 2px)

## Preview
Compare a `w:u=thick` text run and a thick underlined tab at the same `w:sz` / paint scale — stripe height must equal `max(2×scale, 0.12em)`.