### PR TITLE
test: pin page-relative Selection Notice form-bar geometry

### DIFF
--- a/packages/core/src/layout/__tests__/drawing-layout.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-layout.test.ts
@@ -861,4 +861,60 @@ describe('page clip for page-relative anchors', () => {
     expect(drawing!.paintBounds.height).toBeGreaterThan(1);
     expect(drawing!.x).toBeGreaterThan(120);
   });
+
+  test('Selection Notice form bar: page posOffset maps to content x = pagePt − marginLeft', () => {
+    // shapes-and-page-breaks Selection Notice item 3 (Graphic 14): page-H bar whose RIGHT
+    // edge meets the tab at 6896 twips. VML fallback margin-left:338.5pt; section left=980.
+    const posOffsetEmu = 4298950;
+    const extentCx = 702945;
+    const extentCy = 9525;
+    const shapeDrawing =
+      '<w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" ' +
+      'relativeHeight="1" behindDoc="1" locked="0" layoutInCell="1" allowOverlap="1">' +
+      '<wp:simplePos x="0" y="0"/>' +
+      `<wp:positionH relativeFrom="page"><wp:posOffset>${posOffsetEmu}</wp:posOffset></wp:positionH>` +
+      '<wp:positionV relativeFrom="paragraph"><wp:posOffset>208632</wp:posOffset></wp:positionV>' +
+      `<wp:extent cx="${extentCx}" cy="${extentCy}"/><wp:effectExtent l="0" t="0" r="0" b="0"/>` +
+      '<wp:wrapNone/><wp:docPr id="14" name="Graphic 14"/>' +
+      `<a:graphic><a:graphicData uri="${WPS_URI}">` +
+      '<wps:wsp><wps:cNvSpPr/><wps:spPr>' +
+      `<a:xfrm><a:off x="0" y="0"/><a:ext cx="${extentCx}" cy="${extentCy}"/></a:xfrm>` +
+      '<a:custGeom><a:avLst/><a:gdLst/><a:ahLst/><a:cxnLst/><a:rect l="l" t="t" r="r" b="b"/>' +
+      `<a:pathLst><a:path w="${extentCx}" h="${extentCy}">` +
+      `<a:moveTo><a:pt x="${extentCx - 382}" y="0"/></a:moveTo>` +
+      '<a:lnTo><a:pt x="0" y="0"/></a:lnTo>' +
+      `<a:lnTo><a:pt x="0" y="${extentCy - 508}"/></a:lnTo>` +
+      `<a:lnTo><a:pt x="${extentCx - 382}" y="${extentCy - 508}"/></a:lnTo>` +
+      '<a:close/></a:path></a:pathLst></a:custGeom>' +
+      '<a:solidFill><a:srgbClr val="000000"/></a:solidFill>' +
+      '</wps:spPr><wps:bodyPr/></wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing>';
+    const xml =
+      `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+      `xmlns:wps="${WPS}" xmlns:mc="${MC}"><w:body>` +
+      '<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="6896"/></w:tabs></w:pPr>' +
+      `<w:r><mc:AlternateContent><mc:Choice Requires="wps">${shapeDrawing}</mc:Choice>` +
+      '<mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>' +
+      '<w:r><w:t>divided into [</w:t></w:r><w:r><w:tab/></w:r><w:r><w:t>] Loans</w:t></w:r></w:p>' +
+      '<w:sectPr>' +
+      '<w:pgSz w:w="11910" w:h="16840"/>' +
+      '<w:pgMar w:top="980" w:right="0" w:bottom="1120" w:left="980"/>' +
+      '</w:sectPr></w:body></w:document>';
+    const part = load(xml);
+    const layout = lay(part, layoutContext(part));
+    const page = layout.pages[0]!;
+    const drawing = page.anchoredDrawings?.[0];
+    expect(drawing).toBeDefined();
+    const marginLeft = page.contentBox.x;
+    const pageXPt = emuToPoints(posOffsetEmu);
+    const widthPt = emuToPoints(extentCx);
+    expect(marginLeft).toBe(49);
+    expect(drawing!.horizontalFrame).toBe('page');
+    expect(drawing!.horizontalFrameOrigin).toBe(-marginLeft);
+    expect(drawing!.x).toBeCloseTo(pageXPt - marginLeft, 5);
+    expect(drawing!.width).toBeCloseTo(widthPt, 5);
+    // Right edge of the bar meets the authored tab stop (6896 twips ≈ 344.8pt).
+    expect(drawing!.x + drawing!.width).toBeCloseTo(6896 / 20, 0);
+    // Paint origin on the page element is −margin; CSS left must equal page posOffset.
+    expect(drawing!.x - drawing!.horizontalFrameOrigin).toBeCloseTo(pageXPt, 5);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a synthetic regression that pins Selection Notice item-3 geometry: `positionH relativeFrom=page` posOffset 4298950 with section `left=980` → content x = 289.5pt, right edge at the 6896-twip tab.
- **No production fix:** layout + paint already place the bar at page x = 338.5pt (verified). The left/short visual vs Word is the sub-1pt paint-bounds height (0.5625pt vs authored 0.75pt) tracked in #191, plus wrap differences — not a wrong page-H origin.

## Test plan
- [x] `bun test packages/core/src/layout/__tests__/drawing-layout.test.ts -t "Selection Notice form bar"`

## Preview / related
Land #191 so the 0.75pt bar paints at full height at this (already correct) X. Private DOCX not committed.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788609583&installation_model_id=422592&pr_number=198&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F198&signature=d45e25aaa1f2e8f261143b4c06ff095b4195f6ce5e0f1c3276d98014391ea593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->