### PR TITLE
fix: support IME composition at offset 0 of an empty paragraph

### DIFF
--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -412,7 +412,17 @@ export function paintedTextOf(pagesLayer: HTMLElement, paragraphId: string): str
     if (!Number.isInteger(start)) continue;
     pieces.push({ start, text: element.textContent ?? '' });
   }
-  if (pieces.length === 0) return null;
+  if (pieces.length === 0) {
+    // Fallback: no [data-start] spans found (e.g., IME composition on an empty paragraph).
+    // Empty paragraphs are painted with a <br> that has no data-start attribute, so the
+    // query above finds nothing. When the IME writes text into the DOM, the text lives in
+    // a text node that also has no data-start. Read the paragraph fragment's text content
+    // directly and return it if it is non-empty.
+    const fragment = pagesLayer.querySelector(`[data-paragraph-id="${paragraphId}"]`);
+    if (!fragment) return null;
+    const text = fragment.textContent ?? '';
+    return text.length > 0 ? text : null;
+  }
   pieces.sort((a, b) => a.start - b.start);
   return pieces.map((piece) => piece.text).join('');
 }


### PR DESCRIPTION
## Summary

Chinese IME composition fails at offset 0 of an empty paragraph. The IME candidate window appears, but confirming the Chinese text does not insert anything.

## Root Cause

`paintedTextOf()` in `surface-input.ts` only queries for elements with both `data-paragraph-id` and `data-start` attributes. Empty paragraphs are painted with a `<br>` that has neither attribute. When the IME writes text directly into the DOM during composition, the reconciliation at `compositionend` calls `paintedTextOf()`, which returns `null` — causing `reconcileParagraphFromDom()` to skip the commit entirely.

## Fix

Added a fallback path in `paintedTextOf()`: when no `[data-start]` spans are found for the paragraph, read the paragraph fragment's `textContent` directly. If the fragment has text content (from IME composition), return it. This ensures IME-composed text in an empty paragraph is correctly committed to the model.

## Testing

- [ ] Place caret at offset 0 of an empty paragraph
- [ ] Switch to a Chinese IME (e.g., Pinyin)
- [ ] Type and confirm a Chinese character
- [ ] Character is inserted as expected
- [ ] Re-selecting the same position and typing English still works
- [ ] Non-empty paragraphs continue to work as before

Fixes #190

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788616852&installation_model_id=422592&pr_number=199&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F199&signature=dc03e76a418133cea442ed094825d7289e234a31739bd81ea1ac60d44d26a27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->