### PR TITLE
fix: let suggesting mode type into a new paragraph

### DIFF
--- a/.changeset/suggesting-enter-then-type.md
+++ b/.changeset/suggesting-enter-then-type.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix suggesting mode dropping text typed at the start of a paragraph that carries properties, which made the keyboard look dead in the item Enter had just opened. An empty list item's marker also no longer paints over the item above it.

--- a/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
@@ -1,0 +1,135 @@
+// Typing in SUGGESTING mode, through the surface rather than the store.
+//
+// The store's own markup rules live in `store/__tests__/tracked-edits.test.ts`. What is
+// pinned here is the keystroke sequence a reviewer actually performs: Enter opens a
+// paragraph, and the next character has to land in it. Enter leaves a paragraph carrying
+// `w:pPr` and nothing else — the shape a tracked insertion has to be able to write into —
+// so a rule that only held for a paragraph with runs in it looked like a dead keyboard.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { serializeOoxmlPart, type OoxmlNode } from '@docx-editor.dev/core/store';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const NUM = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
+
+const NUMBERING =
+  `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">` +
+  '<w:start w:val="1"/><w:numFmt w:val="upperRoman"/><w:lvlText w:val="%1."/>' +
+  '<w:lvlJc w:val="left"/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>' +
+  '</w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${NUM}" Target="numbering.xml"/></Relationships>`
+    ),
+    'word/numbering.xml': strToU8(NUMBERING),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const listItem = (text: string) =>
+  '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+  `<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+const styledParagraph = (text: string) =>
+  `<w:p><w:pPr><w:ind w:left="720"/></w:pPr><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+function withSurface(body: string, run: (surface: PaginatedSurface) => void): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(body), { author: 'Ada Lovelace' });
+  if (!opened.ok) throw new Error(opened.reason);
+  try {
+    opened.surface.setEditingMode('suggest');
+    run(opened.surface);
+  } finally {
+    opened.surface.destroy();
+    container.remove();
+  }
+}
+
+/** Every paragraph's text, in document order. */
+function paragraphTexts(surface: PaginatedSurface): string[] {
+  const out: string[] = [];
+  const collect = (node: OoxmlNode, into: string[]): void => {
+    if (node.kind === 'textValue') {
+      into.push(node.value);
+      return;
+    }
+    for (const child of node.children) collect(child, into);
+  };
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.kind === 'paragraph') {
+      const parts: string[] = [];
+      collect(node, parts);
+      out.push(parts.join(''));
+      return;
+    }
+    for (const child of node.children) walk(child);
+  };
+  walk(surface.session.part().root);
+  return out;
+}
+
+function caretTo(surface: PaginatedSurface, index: number, offset: number): void {
+  const paragraphId = surface.session.paragraphIds()[index]!;
+  surface.setSelection({
+    anchor: { paragraphId, offset },
+    head: { paragraphId, offset },
+  });
+}
+
+describe('Enter then type, in suggesting mode', () => {
+  test('the character lands in the list item Enter just opened', () => {
+    withSurface(listItem('Introduction') + listItem('Analysis'), (surface) => {
+      caretTo(surface, 0, 'Introduction'.length);
+      surface.splitParagraph();
+      surface.insertPlainText('Findings');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Introduction', 'Findings', 'Analysis']);
+    });
+  });
+
+  test('and in a plain paragraph that only carries an indent', () => {
+    withSurface(styledParagraph('first'), (surface) => {
+      caretTo(surface, 0, 'first'.length);
+      surface.splitParagraph();
+      surface.insertPlainText('second');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['first', 'second']);
+    });
+  });
+
+  test('the typed run is a proposal, and the properties stay ahead of it', () => {
+    withSurface(listItem('Introduction'), (surface) => {
+      caretTo(surface, 0, 'Introduction'.length);
+      surface.splitParagraph();
+      surface.insertPlainText('Findings');
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:ins[^>]*w:author="Ada Lovelace"[^>]*>/);
+      // `w:pPr` first (§17.3.1.26). The insertion landing ahead of it is markup the
+      // paragraph invariant refuses, which is how the keystroke came to be dropped.
+      expect(xml).toMatch(/<\/w:pPr><w:ins[^>]*><w:r><w:t[^>]*>Findings<\/w:t><\/w:r><\/w:ins>/);
+    });
+  });
+});

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -851,4 +851,31 @@ describe('list marker paint', () => {
     expect(run?.textContent).toBe('Item');
     expect(run?.dataset.start).toBe('0');
   });
+
+  test('an EMPTY item still gets a glyph band, so its marker stays on its own line', () => {
+    // The paragraph Enter has just opened has no spans to take the band from. With the band
+    // collapsed to zero the browser centred the glyph on a zero-height line box and drew it
+    // half a line above its own row, over the item before it. `paintLine` already falls back
+    // to the paragraph mark's own depth for an empty line; the marker reads the same number.
+    const layout = layoutOf(
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+        '<w:r><w:t>Item</w:t></w:r></w:p>' +
+        '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr></w:p>',
+      NUM
+    );
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const markers = [...container.querySelectorAll<HTMLElement>('.docx-list-marker')];
+    expect(markers).toHaveLength(2);
+    const empty = markers[1]!;
+    const glyph = empty.firstElementChild as HTMLElement;
+    // The empty item's band matches the one beside text, and nothing is pushed above it.
+    expect(parseFloat(glyph.style.height)).toBeCloseTo(
+      parseFloat((markers[0]!.firstElementChild as HTMLElement).style.height),
+      5
+    );
+    expect(parseFloat(glyph.style.height)).toBeGreaterThan(0);
+    expect(parseFloat(empty.style.lineHeight)).toBeGreaterThan(0);
+    expect(parseFloat(empty.style.paddingBottom)).toBe(0);
+  });
 });

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1337,10 +1337,19 @@ function paintListMarker(
   // Mirror `paintLine`: content band at the top (plus any above-leading), auto extras as
   // padding-bottom so the marker shares the text baseline on spaced lines.
   const firstLine = fragment.lines[0];
-  const maxSpanH = firstLine
-    ? Math.max(0, ...firstLine.spans.map((span) => span.box.height))
+  // The same band `paintLine` gives the text beside it, including its EMPTY-line arm: a list
+  // item with no runs — the one Enter has just opened, and every blank item in a list — has
+  // no spans to take a height from, and `Math.max` over none collapsed the band to zero. The
+  // browser then centred the marker glyph on a zero-height line box and drew it half a line
+  // ABOVE its own row, overlapping the item before it until the next edit repainted.
+  const band = firstLine
+    ? Math.max(
+        leading,
+        ...firstLine.spans.map((span) => span.box.height + leading),
+        firstLine.spans.length === 0 ? firstLine.box.height - (firstLine.trailingSpacing ?? 0) : 0
+      )
     : marker.box.height;
-  const glyphBand = Math.min(Math.max(leading + maxSpanH, leading), marker.box.height);
+  const glyphBand = Math.min(band, marker.box.height);
   const trailing = Math.max(0, marker.box.height - glyphBand);
   element.style.fontSize = '0';
   element.style.boxSizing = 'border-box';

--- a/packages/core/src/store/__tests__/tracked-edits.test.ts
+++ b/packages/core/src/store/__tests__/tracked-edits.test.ts
@@ -99,6 +99,46 @@ describe('a tracked insertion', () => {
     expect(xml(after)).toMatch(/<w:p><w:ins[^>]*><w:r><w:t>first<\/w:t><\/w:r><\/w:ins><\/w:p>/);
   });
 
+  test('an empty paragraph WITH properties keeps w:pPr first', () => {
+    // §17.3.1.26 puts `w:pPr` first, and the paragraph invariant enforces it — so an
+    // insertion placed before it took the whole transaction down. Every keystroke in an
+    // empty paragraph that carries properties was refused: the list item Enter has just
+    // opened, a styled blank line, an indented one. Suggesting mode looked dead from the
+    // moment the caret landed in a new paragraph.
+    const before = part(
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr></w:p>'
+    );
+    const after = apply(before, {
+      op: 'insertText',
+      paragraphId: paragraphId(before),
+      offset: 0,
+      text: 'first',
+      revision: ADA,
+    });
+    const out = xml(after);
+    expect(out.indexOf('<w:pPr>')).toBeLessThan(out.indexOf('<w:ins'));
+    expect(out).toMatch(/<\/w:pPr><w:ins[^>]*><w:r><w:t>first<\/w:t><\/w:r><\/w:ins><\/w:p>/);
+  });
+
+  test('and so does the head of a paragraph that HAS runs', () => {
+    // Offset 0 is the properties' offset too, so this is the same refusal without an empty
+    // paragraph anywhere near it: Home and type, in any indented, aligned or numbered
+    // paragraph.
+    const before = part(
+      '<w:p><w:pPr><w:ind w:left="720"/></w:pPr><w:r><w:t>tail</w:t></w:r></w:p>'
+    );
+    const after = apply(before, {
+      op: 'insertText',
+      paragraphId: paragraphId(before),
+      offset: 0,
+      text: 'head',
+      revision: ADA,
+    });
+    expect(xml(after)).toMatch(
+      /<\/w:pPr><w:ins[^>]*><w:r><w:t>head<\/w:t><\/w:r><\/w:ins><w:r><w:t>tail/
+    );
+  });
+
   test('typing inside your OWN insertion extends it instead of nesting a second', () => {
     const before = part(
       `<w:p><w:ins w:id="1" w:author="Ada Lovelace"><w:r><w:t>abcd</w:t></w:r></w:ins></w:p>`

--- a/packages/core/src/store/store/tree-op-tracked.ts
+++ b/packages/core/src/store/store/tree-op-tracked.ts
@@ -378,6 +378,18 @@ export function applyInsertTracked(
         out.push(node);
         continue;
       }
+      // `w:pPr` IS a child of the paragraph, it measures nothing, and §17.3.1.26 requires it
+      // FIRST — so it is never a place to put words. Without this it took every insertion
+      // aimed at offset 0 (the boundary rule below fires for anything that is not a run) and
+      // wrote `<w:p><w:ins/><w:pPr/></w:p>`, which the paragraph invariant refuses. Every
+      // keystroke in an empty paragraph that carries properties — the one Enter has just
+      // made, a list item, a styled blank line — was rejected, so suggesting mode looked
+      // dead from the moment the caret landed in a new paragraph.
+      if (node.kind !== 'textValue' && node.kind === 'paragraphProperties') {
+        out.push(node);
+        continue;
+      }
+
       const length = offsets.lengthOf(node);
       const start = cursor.offset;
       const end = start + length;


### PR DESCRIPTION
Two unrelated bugs from the same keystroke.

A tracked insertion aimed at offset 0 was emitted ahead of `w:pPr`, which the paragraph invariant refuses, so the transaction was rejected and the character never landed. Enter always leaves a paragraph carrying only its properties, which is why the keyboard looked dead in the item it had just opened.

The list marker's glyph band came from the first line's span heights, and an empty paragraph has none — so the browser centred the marker on a zero-height line box and drew it over the item above until the next edit repainted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788623347&installation_model_id=422592&pr_number=200&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F200&signature=74465ce794da4b49855951edd6238b093b8351d73d9b312a42d54fbca0f6d260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->