### PR TITLE
fix(core): coalesce adjacent same-author tracked changes into single review cards

### DIFF
--- a/.changeset/replacement-pairing-adjacency.md
+++ b/.changeset/replacement-pairing-adjacency.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Tracked changes from other editors now coalesce the way Word shows them: adjacent same-author deletions or insertions merge into one review card, and a deletion meeting an insertion pairs into a single Replaced card regardless of how far apart their timestamps are.

--- a/packages/core/src/store/__tests__/review-reads.test.ts
+++ b/packages/core/src/store/__tests__/review-reads.test.ts
@@ -142,3 +142,27 @@ describe('tracked rows inside a textbox keep their anchors', () => {
     expect(locateSites(part)).toBe(located);
   });
 });
+
+describe('the revision-card memo is keyed on the part, not just its root', () => {
+  test('two parts sharing one root under different names each get their own part name', () => {
+    const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+        `<w:p><w:ins w:id="1" w:author="QA" w:date="2024-01-01T00:00:00Z">` +
+        `<w:r><w:t>alpha</w:t></w:r></w:ins></w:p>` +
+        `</w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    const part = result.part;
+    // The items embed `ranges[*].partName`; a root-only cache key would hand the second
+    // part the first part's stamped ranges.
+    const first = revisionItemsOf(part);
+    expect(first[0]!.ranges[0]!.partName).toBe('/word/document.xml');
+    const renamed = revisionItemsOf({ ...part, name: '/word/header1.xml' });
+    expect(renamed[0]!.ranges[0]!.partName).toBe('/word/header1.xml');
+    // And the original still answers with its own name (recomputed or re-cached — either
+    // way, never the other part's).
+    expect(revisionItemsOf(part)[0]!.ranges[0]!.partName).toBe('/word/document.xml');
+  });
+});

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -234,15 +234,21 @@ export function revisionItemsOf(part: OoxmlPart): readonly ReviewRevisionItem[] 
   const cacheable = part.root.kind !== 'paragraph';
   if (cacheable) {
     const cached = revisionItemsCache.get(part.root);
-    if (cached) return cached;
+    // The name rides along because the items embed it (`ranges[*].partName`): a root is
+    // the cache key, and serving one part's items to another part that shares the root
+    // under a different name would stamp every range with the wrong part.
+    if (cached && cached.name === part.name) return cached.items;
   }
   const items = computeRevisionItemsOf(part);
-  if (cacheable) revisionItemsCache.set(part.root, items);
+  if (cacheable) revisionItemsCache.set(part.root, { name: part.name, items });
   return items;
 }
 
 /** Revision cards per part root, bounded like the site index above. */
-const revisionItemsCache = createRecentRootCache<readonly ReviewRevisionItem[]>(8);
+const revisionItemsCache = createRecentRootCache<{
+  readonly name: string;
+  readonly items: readonly ReviewRevisionItem[];
+}>(8);
 
 function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
   const located = locateSites(part);
@@ -378,13 +384,19 @@ function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
  * mints separate ids for the halves — so the pairing is done on ADJACENCY here rather than
  * on identity, which is the only thing that works for a file this engine did not write.
  *
- * Both addresses ride along, so accept and reject resolve the pair in one transaction.
+ * The same argument folds runs of one KIND first: a word struck in three gestures is three
+ * `w:del` elements under three ids, and listing `Deleted "Le"`, `Deleted "gor"`, `Deleted
+ * "a"` reads one edit as three. Adjacent same-kind, same-author items merge into one card
+ * before the halves pair, so the pair is whole-word against whole-word.
+ *
+ * Every address rides along, so accept and reject resolve the pair in one transaction.
  * Resolving half a replacement is never what the reviewer meant.
  */
 function pairReplacements(
-  items: readonly ReviewRevisionItem[],
+  allItems: readonly ReviewRevisionItem[],
   order: ReadonlyMap<string, number>
 ): ReviewRevisionItem[] {
+  const items = mergeAdjacentSameKindEdits(allItems);
   // Not `ranges.length === 1`. One tracked edit becomes SEVERAL `w:del` elements whenever the
   // struck text crosses something that is not text — an endnote or footnote reference, a
   // field, a break — because those cannot go inside the same wrapper. Requiring a single range
@@ -425,25 +437,27 @@ function pairReplacements(
     const candidates = insertionsByStart.get(`${end.paragraphId} ${end.offset}`) ?? [];
     for (const insertion of candidates) {
       if (taken.has(insertion.id)) continue;
+      // Same AUTHOR is the whole predicate, deliberately. A time window used to sit here
+      // too, but Word itself pairs on adjacency alone: a reviewer who strikes text one day
+      // and types its replacement the next still sees one `Replaced` card in Word, and the
+      // halves of a foreign file routinely carry timestamps hours or days apart. Splitting
+      // those into a Deleted and an Inserted card misread one edit as two.
       if (insertion.author !== deletion.author) continue;
-      // Same MOMENT, not just the same author. Adjacency alone folded two edits an hour
-      // apart into one card, and accepting it then resolved a revision the reviewer was not
-      // looking at. The window matches the write side's.
-      if (!sameMoment(deletion.date, insertion.date)) continue;
       taken.add(deletion.id);
       taken.add(insertion.id);
       // Anchored at whichever half comes FIRST, so the card sits where the edit starts.
       const first = before(deletion.ranges[0]!, insertion.ranges[0]!, order) ? deletion : insertion;
+      // The card is dated when the replacement was COMPLETED: the later half's stamp.
+      const date = replacementDate(deletion.date, insertion.date);
       replacements.set(deletion.id, {
         ...first,
         id: `replace-${deletion.id}-${insertion.id}`,
         revisionKind: 'replace',
+        ...(date === undefined ? {} : { date }),
         // DEDUPED: when this engine wrote the replacement both halves share one identity,
         // and applying the same `acceptRevision` twice in one transaction refuses the second
         // — which refused the whole thing and left the replacement unresolved.
-        addresses: sameAddress(deletion.address, insertion.address)
-          ? [deletion.address]
-          : [deletion.address, insertion.address],
+        addresses: dedupeAddresses([...deletion.addresses, ...insertion.addresses]),
         text: insertion.text,
         replacedText: deletion.text,
         ranges: [...deletion.ranges, ...insertion.ranges],
@@ -467,21 +481,128 @@ function pairReplacements(
   return out;
 }
 
+/**
+ * Fold chains of ADJACENT items of one kind by one author into single cards.
+ *
+ * A word struck in several gestures — or re-struck around something a `w:del` cannot
+ * contain — lands in the file as several sibling elements under distinct ids. They are one
+ * decision to the reviewer, and Word shows them as one. Adjacency is the same exact
+ * end-to-start test the replacement pairing uses, so an untracked character between two
+ * deletions keeps them apart.
+ */
+function mergeAdjacentSameKindEdits(
+  items: readonly ReviewRevisionItem[]
+): readonly ReviewRevisionItem[] {
+  const mergeable = items.filter(
+    (item) =>
+      (item.revisionKind === 'insert' || item.revisionKind === 'delete') &&
+      !item.readOnly &&
+      item.ranges.length > 0
+  );
+  if (mergeable.length < 2) return items;
+
+  const keyOf = (item: ReviewRevisionItem, position: ReviewPosition): string =>
+    `${item.revisionKind} ${item.author} ${position.paragraphId} ${position.offset}`;
+  const byStart = new Map<string, ReviewRevisionItem>();
+  const endKeys = new Set<string>();
+  for (const item of mergeable) {
+    byStart.set(keyOf(item, item.ranges[0]!.start), item);
+    endKeys.add(keyOf(item, item.ranges[item.ranges.length - 1]!.end));
+  }
+
+  const consumed = new Set<string>();
+  const merged = new Map<string, ReviewRevisionItem>();
+  for (const head of mergeable) {
+    if (consumed.has(head.id)) continue;
+    // A chain is walked from its HEAD only — an item whose start some sibling's end meets
+    // is a tail, and walking it early would split the chain in two.
+    if (endKeys.has(keyOf(head, head.ranges[0]!.start))) continue;
+    const chain = [head];
+    let current = head;
+    for (;;) {
+      const next = byStart.get(keyOf(current, current.ranges[current.ranges.length - 1]!.end));
+      if (!next || next === current || consumed.has(next.id)) break;
+      consumed.add(next.id);
+      chain.push(next);
+      current = next;
+    }
+    if (chain.length > 1) merged.set(head.id, foldChain(chain));
+  }
+  if (merged.size === 0) return items;
+
+  const out: ReviewRevisionItem[] = [];
+  for (const item of items) {
+    if (consumed.has(item.id)) continue;
+    out.push(merged.get(item.id) ?? item);
+  }
+  return out;
+}
+
+/** One card from a chain of adjacent same-kind halves, in document order. */
+function foldChain(chain: readonly ReviewRevisionItem[]): ReviewRevisionItem {
+  const first = chain[0]!;
+  const addresses = [...first.addresses];
+  const ranges = [...first.ranges];
+  let text = first.text;
+  let date = first.date;
+  for (const next of chain.slice(1)) {
+    for (const address of next.addresses) {
+      if (!addresses.some((known) => sameAddress(known, address))) addresses.push(address);
+    }
+    ranges.push(...next.ranges);
+    text += next.text;
+    date = laterStamp(date, next.date);
+  }
+  return {
+    ...first,
+    id: chain.map((item) => item.id).join('+'),
+    addresses,
+    ranges,
+    text,
+    ...(date === undefined ? {} : { date }),
+  };
+}
+
+/** The later of two stamps; the first one when they cannot be compared. */
+function laterStamp(a: string | undefined, b: string | undefined): string | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  const first = Date.parse(a);
+  const second = Date.parse(b);
+  if (Number.isNaN(first) || Number.isNaN(second)) return a;
+  return second > first ? b : a;
+}
+
+/** Every address once, keeping first-seen order. */
+function dedupeAddresses(addresses: readonly RevisionAddress[]): RevisionAddress[] {
+  const out: RevisionAddress[] = [];
+  for (const address of addresses) {
+    if (!out.some((known) => sameAddress(known, address))) out.push(address);
+  }
+  return out;
+}
+
 /** Two addresses naming one revision. */
 function sameAddress(a: RevisionAddress, b: RevisionAddress): boolean {
   return a.id === b.id && a.author === b.author && (a.date ?? '') === (b.date ?? '');
 }
 
-/** The same editing moment, by the same rule the writer coalesces on. */
-function sameMoment(a: string | undefined, b: string | undefined): boolean {
-  if (a === undefined || b === undefined) return a === b;
-  const from = Date.parse(a);
-  const to = Date.parse(b);
-  if (Number.isNaN(from) || Number.isNaN(to)) return a === b;
-  return Math.abs(to - from) <= PAIR_WINDOW_MS;
+/**
+ * When the replacement was completed: the later of the two halves' stamps. Preference goes
+ * to the insertion whenever the stamps cannot be compared — the inserted text is the half
+ * the reviewer reads as "the edit", and typing it is the gesture that finished the change.
+ */
+function replacementDate(
+  deletion: string | undefined,
+  insertion: string | undefined
+): string | undefined {
+  if (insertion === undefined) return deletion;
+  if (deletion === undefined) return insertion;
+  const struck = Date.parse(deletion);
+  const typed = Date.parse(insertion);
+  if (Number.isNaN(struck) || Number.isNaN(typed)) return insertion;
+  return struck > typed ? deletion : insertion;
 }
-
-const PAIR_WINDOW_MS = 60_000;
 
 /** Document order of two ranges' starts. */
 function before(a: ReviewRange, b: ReviewRange, order: ReadonlyMap<string, number>): boolean {
@@ -653,8 +774,10 @@ export function collectReviewItems(input: ReviewModelInput): ReviewItem[] {
   const order: ReadonlyMap<string, number> =
     parts.length === 1 ? paragraphOrderOfPart(parts[0]!) : new Map<string, number>();
   for (const part of parts) {
-    revisions.push(...revisionItemsOf(part));
-    anchors.push(...commentAnchorsOfStory(part));
+    // Loops, not `push(...spread)`: a heavily tracked part yields tens of thousands of
+    // items, and spreading them as call arguments overflows the engine's argument limit.
+    for (const item of revisionItemsOf(part)) revisions.push(item);
+    for (const anchor of commentAnchorsOfStory(part)) anchors.push(anchor);
     if (parts.length === 1) continue;
     const merged = order as Map<string, number>;
     const base = merged.size;

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -434,7 +434,17 @@ function pairReplacements(
     // The deletion's LAST range end: the end that actually meets the insertion's first
     // start when the halves span more than one range each.
     const end = deletion.ranges[deletion.ranges.length - 1]!.end;
-    const candidates = insertionsByStart.get(`${end.paragraphId} ${end.offset}`) ?? [];
+    const bucket = insertionsByStart.get(`${end.paragraphId} ${end.offset}`) ?? [];
+    // A ZERO-WIDTH insertion is not the replacement, even when it starts exactly here.
+    // Several legal shapes cover no characters: an empty run carrying only run properties,
+    // a comment reference, a bookmark pair. Taking the first candidate in the bucket paired
+    // the deletion with one of those, so the card read Replaced-old-with-nothing while the
+    // real insertion beside it was orphaned into an Inserted card of its own. Text-bearing
+    // candidates go first; order within each group is preserved.
+    const candidates =
+      bucket.length > 1
+        ? [...bucket].sort((a, b) => (a.text.length > 0 ? 0 : 1) - (b.text.length > 0 ? 0 : 1))
+        : bucket;
     for (const insertion of candidates) {
       if (taken.has(insertion.id)) continue;
       // Same AUTHOR is the whole predicate, deliberately. A time window used to sit here
@@ -549,7 +559,7 @@ function foldChain(chain: readonly ReviewRevisionItem[]): ReviewRevisionItem {
     for (const address of next.addresses) {
       if (!addresses.some((known) => sameAddress(known, address))) addresses.push(address);
     }
-    ranges.push(...next.ranges);
+    for (const range of next.ranges) ranges.push(range);
     text += next.text;
     date = laterStamp(date, next.date);
   }

--- a/packages/pro/src/__tests__/review-model.test.ts
+++ b/packages/pro/src/__tests__/review-model.test.ts
@@ -76,6 +76,10 @@ const ins = (id: string, inner: string, author = 'QA') =>
   `<w:ins w:id="${id}" w:author="${author}" w:date="D">${inner}</w:ins>`;
 const del = (id: string, inner: string, author = 'Dev') =>
   `<w:del w:id="${id}" w:author="${author}" w:date="D">${inner}</w:del>`;
+const insAt = (id: string, inner: string, date: string, author = 'QA') =>
+  `<w:ins w:id="${id}" w:author="${author}" w:date="${date}">${inner}</w:ins>`;
+const delAt = (id: string, inner: string, date: string, author = 'QA') =>
+  `<w:del w:id="${id}" w:author="${author}" w:date="${date}">${inner}</w:del>`;
 const cStart = (id: string) => `<w:commentRangeStart w:id="${id}"/>`;
 const cEnd = (id: string) =>
   `<w:commentRangeEnd w:id="${id}"/><w:r><w:commentReference w:id="${id}"/></w:r>`;
@@ -225,6 +229,93 @@ describe('a replacement says where its halves divide', () => {
     const part = story(`<w:p>${ins('1', run('new'))}</w:p>`);
     const item = revisionsOf(collectReviewItems({ storyPart: part }))[0]!;
     expect(item.replacedRangeCount).toBeUndefined();
+  });
+
+  test('halves stamped a day apart still pair — Word pairs on adjacency, not time', () => {
+    // Foreign files routinely hold a deletion struck one day and its replacement typed the
+    // next. One author, end to start: one Replaced card.
+    const part = story(
+      `<w:p>${run('keep ')}${delAt('2', delRun('old'), '2024-01-01T10:00:00Z')}` +
+        `${insAt('1', run('new'), '2024-01-02T09:00:00Z')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.revisionKind).toBe('replace');
+    expect(items[0]!.addresses).toHaveLength(2);
+    expect(items[0]!.replacedRangeCount).toBe(1);
+  });
+
+  test('the paired card is dated when the replacement was completed', () => {
+    const part = story(
+      `<w:p>${delAt('2', delRun('old'), '2024-01-01T10:00:00Z')}` +
+        `${insAt('1', run('new'), '2024-01-02T09:00:00Z')}</w:p>`
+    );
+    const item = revisionsOf(collectReviewItems({ storyPart: part }))[0]!;
+    expect(item.date).toBe('2024-01-02T09:00:00Z');
+  });
+
+  test('adjacent halves by different authors stay two cards', () => {
+    const part = story(
+      `<w:p>${delAt('2', delRun('old'), '2024-01-01T10:00:00Z', 'Ada')}` +
+        `${insAt('1', run('new'), '2024-01-01T10:00:00Z', 'Grace')}</w:p>`
+    );
+    const kinds = revisionsOf(collectReviewItems({ storyPart: part }))
+      .map((item) => item.revisionKind)
+      .sort();
+    expect(kinds).toEqual(['delete', 'insert']);
+  });
+
+  test('a word struck in three gestures pairs whole against its replacement', () => {
+    // Three sibling `w:del` elements under three ids, then the insertion typed a day later:
+    // one decision, one card — never `Deleted "mor"`, `Deleted "ni"`, `Deleted "ng"`,
+    // `Added "evening"`.
+    const part = story(
+      `<w:p>${run('at ')}${delAt('3', delRun('mor'), '2024-01-01T10:00:00Z')}` +
+        `${delAt('4', delRun('ni'), '2024-01-01T10:00:00Z')}` +
+        `${delAt('5', delRun('ng'), '2024-01-01T10:00:01Z')}` +
+        `${insAt('6', run('evening'), '2024-01-02T09:00:00Z')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.revisionKind).toBe('replace');
+    expect(items[0]!.replacedText).toBe('morning');
+    expect(items[0]!.text).toBe('evening');
+    expect(items[0]!.addresses).toHaveLength(4);
+    expect(items[0]!.replacedRangeCount).toBe(3);
+  });
+
+  test('adjacent same-author deletions with no insertion are one Deleted card', () => {
+    const part = story(
+      `<w:p>${run('keep ')}${delAt('3', delRun('mor'), '2024-01-01T10:00:00Z')}` +
+        `${delAt('4', delRun('ning'), '2024-01-01T10:00:05Z')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.revisionKind).toBe('delete');
+    expect(items[0]!.text).toBe('morning');
+    expect(items[0]!.addresses).toHaveLength(2);
+    expect(items[0]!.date).toBe('2024-01-01T10:00:05Z');
+  });
+
+  test('an untracked character between two deletions keeps them apart', () => {
+    const part = story(
+      `<w:p>${delAt('3', delRun('one'), '2024-01-01T10:00:00Z')}${run('x')}` +
+        `${delAt('4', delRun('two'), '2024-01-01T10:00:00Z')}</w:p>`
+    );
+    expect(revisionsOf(collectReviewItems({ storyPart: part }))).toHaveLength(2);
+  });
+
+  test('an insertion followed by a deletion stays two cards', () => {
+    // This engine only ever writes delete-then-insert; the reverse order in a foreign file
+    // is two edits, and folding them would be an invention.
+    const part = story(
+      `<w:p>${insAt('1', run('new'), '2024-01-01T10:00:00Z')}` +
+        `${delAt('2', delRun('old'), '2024-01-01T10:00:00Z')}</w:p>`
+    );
+    const kinds = revisionsOf(collectReviewItems({ storyPart: part }))
+      .map((item) => item.revisionKind)
+      .sort();
+    expect(kinds).toEqual(['delete', 'insert']);
   });
 });
 

--- a/packages/pro/src/__tests__/review-model.test.ts
+++ b/packages/pro/src/__tests__/review-model.test.ts
@@ -305,6 +305,24 @@ describe('a replacement says where its halves divide', () => {
     expect(revisionsOf(collectReviewItems({ storyPart: part }))).toHaveLength(2);
   });
 
+  test('a zero-width insertion does not steal the pairing from the real one', () => {
+    // An inserted run carrying only run properties covers no characters, and it starts at
+    // exactly the offset the deletion ends at. Pairing with it produced a card that read
+    // Replaced "old" with nothing, and orphaned the words that actually replaced it.
+    const part = story(
+      `<w:p>${run('keep ')}${delAt('2', delRun('old'), '2024-01-01T10:00:00Z')}` +
+        `<w:ins w:id="3" w:author="QA" w:date="2024-01-01T10:00:00Z">` +
+        `<w:r><w:rPr><w:b/></w:rPr></w:r></w:ins>` +
+        `${insAt('4', run('new'), '2024-01-02T09:00:00Z')}</w:p>`
+    );
+    const replaced = revisionsOf(collectReviewItems({ storyPart: part })).find(
+      (item) => item.revisionKind === 'replace'
+    );
+    expect(replaced).toBeDefined();
+    expect(replaced!.replacedText).toBe('old');
+    expect(replaced!.text).toBe('new');
+  });
+
   test('an insertion followed by a deletion stays two cards', () => {
     // This engine only ever writes delete-then-insert; the reverse order in a foreign file
     // is two edits, and folding them would be an invention.


### PR DESCRIPTION
Tracked changes from other editors were listed one card per XML element rather than one card per decision.

`pairReplacements` required both halves of a replacement to fall inside a 60s window. Word stamps them whenever they were made — a deletion struck one day and its replacement typed the next is ordinary — so a replacement arrived as a separate Deleted card and Added card. Word pairs on adjacency and author alone, and so does this now; the paired card carries the later half's date.

A word struck in several gestures is also several sibling `w:del` elements under distinct ids. Those now merge into one card before pairing, so the pair is whole-word against whole-word rather than fragment against word.

A zero-width insertion (an empty run carrying only run properties, a comment reference) can start exactly where a deletion ends; it no longer wins the pairing and orphans the real replacement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629242&installation_model_id=422592&pr_number=202&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F202&signature=16db14d62a1ff97ca05a697eb8bcbf8b960fc81dfa09aab20d3fb6edb6bd3e0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->