### PR TITLE
fix(core): paint header/footer ink past the band instead of clipping it

### DIFF
--- a/.changeset/hf-band-ink-overflow.md
+++ b/.changeset/hf-band-ink-overflow.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Header and footer ink now overflows its band like Word instead of being clipped: anchored shapes offset past the content width or below the header text stay visible, and negative indents hang into the margin. Overflowing shapes stay inert until the band is edited, so they never swallow clicks meant for the body.

--- a/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
@@ -150,6 +150,9 @@ describe('headers and footers, read-only', () => {
     // Two default lines (14pt each with the fixed measurer) — nowhere near a 9144000-EMU extent.
     expect(height).toBeGreaterThan(0);
     expect(height).toBeLessThan(60);
+    // The band's GEOMETRY stops at flow height, but its INK must not: Word paints header
+    // overflow (negative indents, anchored shapes past the box) into the margins.
+    expect(header.style.overflow).toBe('visible');
   });
 
   test('a header taller than the margin pushes the content area down', () => {

--- a/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
@@ -275,4 +275,42 @@ describe('header band ink overflows instead of clipping', () => {
     // box sits exactly at the section's top margin.
     expect(parseFloat(content.style.top)).toBeCloseTo(72, 0);
   });
+
+  test('ink escaping the band is still clipped at the SHEET', () => {
+    // Overflow is the fix; unbounded overflow is a new bug. A story-relative record can
+    // resolve past the paper — a footer shape anchored far above its paragraph, a header
+    // one reaching far below — and without a clip it paints across the inter-page gutter
+    // onto the neighbouring sheet. The clip is the sheet in the band's own coordinates.
+    const painted = paint(layout);
+    const page = layout.pages[0]!;
+    const story = page.header!;
+    const band = painted.querySelector<HTMLElement>('[data-docx-hf="header"]')!;
+
+    const clip = band.style.clipPath;
+    expect(clip).toContain('polygon');
+    const numbers = [...clip.matchAll(/(-?[\d.]+)px/g)].map((match) => Number(match[1]));
+    expect(numbers).toHaveLength(8);
+    const xs = numbers.filter((_, index) => index % 2 === 0);
+    const ys = numbers.filter((_, index) => index % 2 === 1);
+    // Exactly the sheet, expressed relative to the band's own origin.
+    expect(Math.min(...xs)).toBeCloseTo(page.box.x - story.box.x, 3);
+    expect(Math.max(...xs)).toBeCloseTo(page.box.x - story.box.x + page.box.width, 3);
+    expect(Math.min(...ys)).toBeCloseTo(page.box.y - story.box.y, 3);
+    expect(Math.max(...ys)).toBeCloseTo(page.box.y - story.box.y + page.box.height, 3);
+    // And the clip is genuinely OUTSIDE the band, or it would be the old bug again.
+    expect(Math.max(...ys)).toBeGreaterThan(parseFloat(band.style.height));
+  });
+
+  test('a nested drawing inside inert furniture is inert too', () => {
+    // `pointer-events: none` on an ancestor is undone by an explicit `auto` on a child,
+    // and every nested drawing carries one — a letterhead authored as a text box with a
+    // picture inside would still have taken clicks meant for the body underneath.
+    const painted = paint(layout);
+    const nested = painted.querySelectorAll<HTMLElement>(
+      '[data-docx-hf="header"] .docx-drawing-layer .docx-drawing'
+    );
+    for (const element of nested) {
+      expect(element.style.pointerEvents).toBe('none');
+    }
+  });
 });

--- a/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
@@ -79,7 +79,7 @@ function headerDoc(): Uint8Array {
   // carries the anchored strip.
   const headerParagraph =
     '<w:p><w:pPr><w:ind w:left="-708"/></w:pPr>' +
-    '<w:r><w:t>ACME header line</w:t></w:r>' +
+    '<w:r><w:t>Sample header line</w:t></w:r>' +
     `<w:r>${headerStripDrawing()}</w:r></w:p>`;
   return zipSync({
     '[Content_Types].xml': strToU8(

--- a/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
@@ -1,0 +1,278 @@
+// Header/footer band ink OVERFLOWS instead of clipping.
+//
+// The band's GEOMETRY is the flow height of its text (#856) — anchored objects never grow
+// it, and the body's effective top margin never moves for them. But Word paints header ink
+// wherever it lands: a letterhead strip anchored past the content width sits in the right
+// margin and reaches below the header's last line, and a negative indent hangs into the
+// left margin. An `overflow: hidden` band silently deleted both, which read as "the engine
+// dropped my header". Overflowing ink stays INERT while the band is not being edited, so a
+// shape hanging over the body cannot swallow clicks meant for the document text.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  createFixedMeasurer,
+  enumerateDocumentSections,
+  geometryOfSection,
+  layoutSemanticDocument,
+  type PageFurniture,
+  type SemanticLayout,
+} from '../../layout/index.ts';
+import { layoutHeaderFooterStory, type HeaderFooterStoryLayout } from '../../layout/hf-layout.ts';
+import type { InlineDrawingLayoutContext } from '../../layout/drawing-layout.ts';
+import {
+  readOoxmlPackage,
+  resolveHeaderFooterPartsBySection,
+  type OoxmlPackage,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import { mockReadyImageResource } from '../../store/__tests__/drawing-ready-fixture.ts';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+const measurer = createFixedMeasurer(6, 14);
+
+// A narrow, TALL strip anchored 477pt from the column start — past an A4 content width of
+// ~451pt — and reaching ~82pt below the header paragraph it is anchored to. The shape a
+// letterhead rule takes.
+const STRIP_X_EMU = 6_057_900; // 477pt
+const STRIP_Y_EMU = 63_500; // 5pt
+const STRIP_CX_EMU = 208_280; // ~16.4pt
+const STRIP_CY_EMU = 976_630; // ~76.9pt
+
+function headerStripDrawing(): string {
+  return (
+    '<w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"' +
+    ' relativeHeight="1" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    `<wp:positionH relativeFrom="column"><wp:posOffset>${STRIP_X_EMU}</wp:posOffset></wp:positionH>` +
+    `<wp:positionV relativeFrom="paragraph"><wp:posOffset>${STRIP_Y_EMU}</wp:posOffset></wp:positionV>` +
+    `<wp:extent cx="${STRIP_CX_EMU}" cy="${STRIP_CY_EMU}"/>` +
+    '<wp:effectExtent l="0" t="0" r="0" b="0"/><wp:wrapNone/>' +
+    '<wp:docPr id="1" name="strip"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    `<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${STRIP_CX_EMU}" cy="${STRIP_CY_EMU}"/></a:xfrm>` +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>' +
+    '<a:solidFill><a:srgbClr val="4472C4"/></a:solidFill></wps:spPr>' +
+    '<wps:bodyPr/></wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing>'
+  );
+}
+
+function headerDoc(): Uint8Array {
+  const ns = `xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"`;
+  // The header paragraph hangs 35.4pt into the left margin (w:ind left="-708" twips) and
+  // carries the anchored strip.
+  const headerParagraph =
+    '<w:p><w:pPr><w:ind w:left="-708"/></w:pPr>' +
+    '<w:r><w:t>ACME header line</w:t></w:r>' +
+    `<w:r>${headerStripDrawing()}</w:r></w:p>`;
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/header" Target="header1.xml"/></Relationships>`
+    ),
+    'word/header1.xml': strToU8(`<w:hdr ${ns}>${headerParagraph}</w:hdr>`),
+    'word/document.xml': strToU8(
+      `<w:document ${ns}><w:body><w:p><w:r><w:t>body text</w:t></w:r></w:p>` +
+        '<w:sectPr><w:headerReference w:type="default" r:id="rId1"/>' +
+        '<w:pgSz w:w="11906" w:h="16838"/>' +
+        '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720"/>' +
+        '</w:sectPr></w:body></w:document>'
+    ),
+  });
+}
+
+function openPackage(bytes: Uint8Array): OoxmlPackage {
+  const result = readOoxmlPackage(bytes);
+  if (!result.ok) throw new Error(result.reason);
+  return result.package;
+}
+
+function drawingLayoutFor(part: OoxmlPart): InlineDrawingLayoutContext {
+  const atomProjections = indexInlineDrawingProjectionsInPart(part);
+  const ready = mockReadyImageResource({
+    bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
+  });
+  return {
+    ownerPartName: part.name,
+    projectionForAtom: (atomId) => atomProjections.get(atomId) ?? null,
+    project: (node) =>
+      atomProjections.get(node.id) ??
+      projectDrawing(node, {
+        ownerPartName: part.name,
+        limits: DEFAULT_DRAWING_PROJECTION_LIMITS,
+      }),
+    resourceOf: () => ready,
+  };
+}
+
+function furnitureWithDrawings(
+  pkg: OoxmlPackage,
+  part: OoxmlPart
+): readonly (PageFurniture | undefined)[] {
+  const sections = enumerateDocumentSections(part);
+  const bySection = resolveHeaderFooterPartsBySection(pkg);
+  return sections.map((section, index) => {
+    const parts = bySection[index];
+    if (!parts || (parts.headers.size === 0 && parts.footers.size === 0)) return undefined;
+    const geometry = geometryOfSection(section.properties);
+    const width = geometry.width - geometry.margin.left - geometry.margin.right;
+    const pageContext = {
+      pageNumber: 1,
+      pageWidth: geometry.width,
+      pageHeight: geometry.height,
+      marginLeft: geometry.margin.left,
+      marginRight: geometry.margin.right,
+      marginTop: geometry.margin.top,
+      marginBottom: geometry.margin.bottom,
+    };
+    // The real pipeline stamps the slot's relationship id on the laid story; the
+    // active-band paint keys on it. Recursive so a per-page relayout keeps the stamp.
+    const stampRId = (story: HeaderFooterStoryLayout, rId: string): HeaderFooterStoryLayout => ({
+      ...story,
+      rId,
+      withPageContext: (ctx) => stampRId(story.withPageContext(ctx), rId),
+    });
+    const mapStories = (source: typeof parts.headers) => {
+      const laid = new Map();
+      for (const [variant, hfPart] of source)
+        laid.set(
+          variant,
+          stampRId(
+            layoutHeaderFooterStory(
+              hfPart,
+              width,
+              measurer,
+              'test',
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              drawingLayoutFor(hfPart),
+              undefined,
+              undefined,
+              pageContext
+            ),
+            'rId1'
+          )
+        );
+      return laid;
+    };
+    return {
+      titlePage: parts.titlePage,
+      evenAndOddHeaders: parts.evenAndOddHeaders,
+      headers: mapStories(parts.headers),
+      footers: mapStories(parts.footers),
+    };
+  });
+}
+
+function layoutHeaderDoc(): SemanticLayout {
+  const pkg = openPackage(headerDoc());
+  const part = pkg.parts.get(pkg.mainDocumentPart)!;
+  return layoutSemanticDocument(part, 1, {
+    measurer,
+    producer: 'test',
+    sectionFurniture: furnitureWithDrawings(pkg, part),
+  });
+}
+
+function paint(layout: SemanticLayout, activeHeaderFooterRId?: string): HTMLElement {
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, {
+    scale: 1,
+    ...(activeHeaderFooterRId ? { activeHeaderFooterRId, activeHeaderFooterPageIndex: 0 } : {}),
+  });
+  return container;
+}
+
+describe('header band ink overflows instead of clipping', () => {
+  const layout = layoutHeaderDoc();
+
+  test('the band keeps flow-height geometry and visible overflow', () => {
+    const story = layout.pages[0]!.header;
+    expect(story).toBeDefined();
+    // #856: anchored extents never size the band. One 14pt line, not 80+pt of strip.
+    expect(story!.box.height).toBeLessThan(60);
+
+    const painted = paint(layout);
+    const band = painted.querySelector<HTMLElement>('[data-docx-hf="header"]')!;
+    expect(band).toBeTruthy();
+    expect(band.style.overflow).toBe('visible');
+    expect(parseFloat(band.style.height)).toBeCloseTo(story!.box.height, 0);
+  });
+
+  test('a column-frame strip anchored past the content width still paints', () => {
+    const painted = paint(layout);
+    const band = painted.querySelector<HTMLElement>('[data-docx-hf="header"]')!;
+    const drawing = band.querySelector<HTMLElement>('.docx-drawing-layer > *');
+    expect(drawing).toBeTruthy();
+    // Entirely outside the band box: right of the content width, deeper than the flow
+    // height. Under the old clip this element existed and no pixel of it survived.
+    const left = parseFloat(drawing!.style.left);
+    const top = parseFloat(drawing!.style.top);
+    const height = parseFloat(drawing!.style.height);
+    const bandWidth = parseFloat(band.style.width);
+    const bandHeight = parseFloat(band.style.height);
+    expect(left).toBeGreaterThan(bandWidth);
+    expect(top + height).toBeGreaterThan(bandHeight);
+  });
+
+  test('overflowing ink is inert in normal mode and interactive while editing the band', () => {
+    const inactive = paint(layout);
+    const inactiveDrawing = inactive.querySelector<HTMLElement>(
+      '[data-docx-hf="header"] .docx-drawing-layer > *'
+    )!;
+    expect(inactiveDrawing.style.pointerEvents).toBe('none');
+
+    const active = paint(layout, 'rId1');
+    const activeDrawing = active.querySelector<HTMLElement>(
+      '[data-docx-hf="header"] .docx-drawing-layer > *'
+    )!;
+    expect(activeDrawing.style.pointerEvents).toBe('auto');
+  });
+
+  test('a negative indent hangs into the left margin instead of being cut', () => {
+    const painted = paint(layout);
+    const band = painted.querySelector<HTMLElement>('[data-docx-hf="header"]')!;
+    const lefts = [...band.querySelectorAll<HTMLElement>('*')]
+      .map((element) => parseFloat(element.style.left))
+      .filter((left) => Number.isFinite(left));
+    // -708 twips = -35.4pt of hanging ink.
+    expect(Math.min(...lefts)).toBeLessThan(0);
+  });
+
+  test('the body is not displaced by the overflowing strip', () => {
+    const painted = paint(layout);
+    const content = painted.querySelector<HTMLElement>('.docx-page-content')!;
+    // headerDistance 36pt + one 14pt line stays under the 72pt margin, so the content
+    // box sits exactly at the section's top margin.
+    expect(parseFloat(content.style.top)).toBeCloseTo(72, 0);
+  });
+});

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -313,6 +313,15 @@ function appendAnchoredDrawingsForRecords(
   )) {
     // Inline, not a stylesheet rule: this `auto` would beat any CSS guard.
     element.style.pointerEvents = interactive ? 'auto' : 'none';
+    if (!interactive) {
+      // DESCENDANTS TOO. `pointer-events: none` on an ancestor is undone by an explicit
+      // `auto` on a child, and every nested drawing gets one — inline, from
+      // `positionedBox`, and from the `.docx-drawing` rule. A letterhead authored as a
+      // text box with a picture inside would still have swallowed the click underneath it.
+      for (const nested of element.querySelectorAll<HTMLElement>('.docx-drawing')) {
+        nested.style.pointerEvents = 'none';
+      }
+    }
     layerElement.append(element);
   }
   if (layerElement.childElementCount > 0) parent.append(layerElement);
@@ -379,12 +388,21 @@ function appendHfPageRelativeDrawingLayer(
     readonly width: number;
     readonly height: number;
   },
-  layer: 'behind' | 'inFront'
+  layer: 'behind' | 'inFront',
+  interactive = false
 ): void {
   const pageRelative = drawings
     .filter(isPageRelativeHfAnchor)
     .map((drawing) => hfAnchorOnPageSheet(story, drawing, pageOrigin));
-  appendAnchoredDrawingsForRecords(document, pageElement, pageRelative, ctx, pageOrigin, layer);
+  appendAnchoredDrawingsForRecords(
+    document,
+    pageElement,
+    pageRelative,
+    ctx,
+    pageOrigin,
+    layer,
+    interactive
+  );
 }
 
 const HEX = /^[0-9A-Fa-f]{6}$/;
@@ -1895,6 +1913,14 @@ function paintPage(
   for (const story of [page.header, page.footer]) {
     if (!story) continue;
     const anchored = story.anchoredDrawings ?? [];
+    // Ahead of the layers below, which BOTH need it: furniture ink is inert while the band
+    // is not being edited, wherever on the sheet it was lifted to.
+    const active =
+      !!options.activeHeaderFooterRId &&
+      !!story.rId &&
+      options.activeHeaderFooterRId === story.rId &&
+      (options.activeHeaderFooterPageIndex === undefined ||
+        options.activeHeaderFooterPageIndex === page.index);
     appendHfPageRelativeDrawingLayer(
       document,
       element,
@@ -1902,18 +1928,13 @@ function paintPage(
       anchored,
       options,
       pageOrigin,
-      'behind'
+      'behind',
+      active
     );
     const container = document.createElement('div');
     container.className = 'docx-hf';
     container.dataset.docxHf = story.kind;
     if (story.rId) container.dataset.docxRId = story.rId;
-    const active =
-      !!options.activeHeaderFooterRId &&
-      !!story.rId &&
-      options.activeHeaderFooterRId === story.rId &&
-      (options.activeHeaderFooterPageIndex === undefined ||
-        options.activeHeaderFooterPageIndex === page.index);
     if (active) {
       container.dataset.docxHfActive = '';
       container.setAttribute('contenteditable', 'true');
@@ -1941,6 +1962,19 @@ function paintPage(
     // GEOMETRY still stops at flow height, so hit-testing and the body's effective top
     // margin are untouched; overflowing drawings stay inert below via `interactive`.
     container.style.overflow = 'visible';
+    // BUT NEVER PAST THE PAPER. Word clips ink at the sheet edge, and the band's own
+    // records are story-relative: a footer shape anchored far above its paragraph, or a
+    // header one reaching far below, resolves to a paint box that runs off the sheet and
+    // would paint across the inter-page gutter onto the neighbouring page. The clip is the
+    // SHEET expressed in the band's own coordinates, so ink still escapes the band (the
+    // whole point) and still stops at the paper.
+    const sheetLeft = (page.box.x - story.box.x) * options.scale;
+    const sheetTop = (page.box.y - story.box.y) * options.scale;
+    const sheetRight = sheetLeft + page.box.width * options.scale;
+    const sheetBottom = sheetTop + page.box.height * options.scale;
+    container.style.clipPath =
+      `polygon(${sheetLeft}px ${sheetTop}px, ${sheetRight}px ${sheetTop}px, ` +
+      `${sheetRight}px ${sheetBottom}px, ${sheetLeft}px ${sheetBottom}px)`;
     const storyOrigin = Object.freeze({
       x: 0,
       y: 0,
@@ -2004,7 +2038,8 @@ function paintPage(
       anchored,
       options,
       pageOrigin,
-      'inFront'
+      'inFront',
+      active
     );
   }
 

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -285,7 +285,12 @@ function appendAnchoredDrawingsForRecords(
     readonly width: number;
     readonly height: number;
   },
-  layer: 'behind' | 'inFront'
+  layer: 'behind' | 'inFront',
+  // Inert drawings paint but never take a click. Header/footer bands pass `false` while
+  // the band is not being edited: their box overflows are VISIBLE (Word draws header ink
+  // into the margins and over the body), so a shape hanging past the band must not
+  // swallow clicks meant for the document text underneath (#856).
+  interactive = true
 ): void {
   if (drawings.length === 0) return;
   const drawing = drawingContextOf(ctx);
@@ -306,7 +311,8 @@ function appendAnchoredDrawingsForRecords(
     drawing.urlRegistry,
     origin
   )) {
-    element.style.pointerEvents = 'auto';
+    // Inline, not a stylesheet rule: this `auto` would beat any CSS guard.
+    element.style.pointerEvents = interactive ? 'auto' : 'none';
     layerElement.append(element);
   }
   if (layerElement.childElementCount > 0) parent.append(layerElement);
@@ -1928,7 +1934,13 @@ function paintPage(
         ? Math.max(story.box.height, page.box.y + page.box.height - story.box.y)
         : Math.max(story.box.height, page.contentBox.y - story.box.y);
     container.style.height = `${bandHeight * options.scale}px`;
-    container.style.overflow = 'hidden';
+    // VISIBLE, exactly because the box is sized by flow height alone (#856). Word paints
+    // header ink wherever it lands — a negative indent hangs into the left margin, an
+    // anchored shape offset past the content width sits in the right margin and reaches
+    // below the header text. Clipping to the band silently deleted both. The band's
+    // GEOMETRY still stops at flow height, so hit-testing and the body's effective top
+    // margin are untouched; overflowing drawings stay inert below via `interactive`.
+    container.style.overflow = 'visible';
     const storyOrigin = Object.freeze({
       x: 0,
       y: 0,
@@ -1942,7 +1954,8 @@ function paintPage(
       storyRelative,
       asResolvedPaintContext(options),
       storyOrigin,
-      'behind'
+      'behind',
+      active
     );
     // Furniture links paint styled but inert — see `paintHyperlinkAnchor`.
     const furnitureCtx: ResolvedPaintContext = {
@@ -1962,13 +1975,15 @@ function paintPage(
       storyRelative,
       asResolvedPaintContext(options),
       storyOrigin,
-      'inFront'
+      'inFront',
+      active
     );
     element.append(container);
     // Hover invitation for an EXISTING band: a pill just outside the story box, shown by
     // CSS only while the adjacent band is hovered (`.docx-hf:hover + .docx-hf-edit-hint`).
-    // Outside the band because the band clips (`overflow: hidden`) and its content would
-    // sit under the pill. Adjacency is load-bearing — keep this append right here.
+    // A SIBLING, not a child: the `+` selector needs the pill right after the band, and
+    // keeping it out of the band keeps band content from sitting under the pill.
+    // Adjacency is load-bearing — keep this append right here.
     const hint = document.createElement('div');
     hint.className = 'docx-hf-edit-hint';
     hint.dataset.docxHfHint = story.kind;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3044,7 +3044,7 @@ a.docx-hyperlink:focus-visible {
 
 /* Hovering an EXISTING inactive band tints it and floats an edit invitation beside it —
  * without this the enterable header answered a hover with nothing at all. The pill is a
- * sibling because the band clips its own overflow. */
+ * sibling because the `+` selector below needs it right after the band. */
 .docx-pages .docx-hf:not([data-docx-hf-active]):not(.docx-hf--placeholder):hover {
   background: var(--doc-primary-light);
   border-radius: 4px;


### PR DESCRIPTION
A header that rendered correctly before the v2 cutover came back missing its letterhead rule and with its first word cut off.

The band is sized by flow height alone, which is correct (#856), but it was also painted with `overflow: hidden`. Anything resolving outside that box was deleted: an anchored shape offset past the content width, and text hanging into the left margin from a negative indent. The parse and the layout were right in both cases — only the paint clipped. The pre-v2 model was overflow-visible plus inert content, and this restores it.

Unbounded overflow is its own bug, so the band carries the sheet as a clip path in its own coordinates: ink escapes the band and still stops at the paper rather than crossing the gutter onto the next page.

Overflowing furniture stays pointer-inert until its band is being edited, including nested drawings (an explicit `auto` on a child undoes an ancestor's `none`) and the page-relative lifted layer, which had been taking clicks over the body.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629273&installation_model_id=422592&pr_number=204&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F204&signature=072ffde100b944f6605070dac923bf823bd51438c36390de735912150e7fd532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->