### PR TITLE
fix(core): keep trailing tabs on their line and paint behindDoc furniture under the body

### DIFF
--- a/.changeset/trailing-tabs-and-hf-stacking.md
+++ b/.changeset/trailing-tabs-and-hf-stacking.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Trailing tabs no longer start a new line, so a header authored as tabbed columns keeps its own height and stops pushing the body down the page. Header and footer shapes marked `behindDoc` now paint beneath the body text instead of over it.

--- a/packages/core/src/layout/__tests__/paragraph-tabs.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-tabs.test.ts
@@ -285,3 +285,43 @@ describe('page layout regression with tabs present', () => {
     expect(plain!.spans[0]!.box.x).toBe(0);
   });
 });
+
+describe('a trailing tab ends its line rather than starting one', () => {
+  // Word treats a tab with nothing after it like a trailing space: it does not wrap. The
+  // shape this protects is the ordinary header line — `LEFT<tab><tab>RIGHT<tab><tab>` —
+  // where wrapping on each trailing tab added a line per tab. In a header that also moves
+  // the BODY, because a header's flow height sets the effective top margin.
+  // 80pt of content width against the default 36pt tab grid: the third tab is already past
+  // the right edge, so the wrap rule is genuinely reached rather than merely stated.
+  const narrow = {
+    width: 100,
+    height: 400,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+  };
+
+  test('tabs past the right edge with no text after them add no lines', () => {
+    const part = load(`<w:p><w:r><w:t>LEFT</w:t><w:tab/><w:tab/><w:tab/><w:tab/></w:r></w:p>`);
+    const layout = layoutSemanticDocument(part, 1, { measurer, geometry: narrow });
+    expect(linesOf(layout)).toHaveLength(1);
+  });
+
+  test('a tab that still has text after it wraps as before', () => {
+    // The same shape with content after the tabs keeps Word's wrap rule, so the
+    // trailing-tab exception cannot be mistaken for "tabs never wrap".
+    const part = load(
+      `<w:p><w:r><w:t>LEFT</w:t><w:tab/><w:tab/><w:tab/><w:t>AFTER</w:t></w:r></w:p>`
+    );
+    const layout = layoutSemanticDocument(part, 1, { measurer, geometry: narrow });
+    expect(linesOf(layout).length).toBeGreaterThan(1);
+  });
+
+  test('trailing tabs after the last word add no lines of their own', () => {
+    const part = load(
+      `<w:p><w:r><w:t>LEFT</w:t><w:tab/><w:t>RIGHT</w:t><w:tab/><w:tab/><w:tab/></w:r></w:p>`
+    );
+    const layout = layoutSemanticDocument(part, 1, { measurer, geometry: narrow });
+    const lines = linesOf(layout);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.spans.some((span) => span.text === 'RIGHT')).toBe(true);
+  });
+});

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -234,6 +234,34 @@ function wordBoundaries(text: string): number[] {
  * Measure text following a tab until the next tab or hard break, across mixed-style pieces.
  * Also reports the advance to the first decimal point for decimal-aligned stops.
  */
+/**
+ * Whether anything that occupies space still follows this tab on its own line.
+ *
+ * A TRAILING tab does not wrap in Word — same rule as a trailing space. Header lines are
+ * routinely authored as `LEFT<tab><tab><tab>RIGHT<tab><tab>`, and treating the last tabs
+ * as wrappable opened a new line per tab: the header grew by several lines, and because a
+ * header's flow height sets the body's effective top margin, the body was pushed down the
+ * page. Stops at a hard break, which ends the line anyway, and skips further tabs and
+ * spaces, which are themselves trimmed at the line end.
+ */
+function placeableContentFollows(
+  pieces: readonly Piece[],
+  pieceIndex: number,
+  offsetInPiece: number
+): boolean {
+  for (let index = pieceIndex; index < pieces.length; index += 1) {
+    const piece = pieces[index]!;
+    if (piece.inlineDrawing) return true;
+    const from = index === pieceIndex ? offsetInPiece : 0;
+    for (let cursor = from; cursor < piece.text.length; cursor += 1) {
+      const ch = piece.text[cursor]!;
+      if (ch === '\n' || ch === PAGE_BREAK_CHAR) return false;
+      if (ch !== '\t' && ch !== ' ') return true;
+    }
+  }
+  return false;
+}
+
 function measureFollowingTabSegment(
   pieces: readonly Piece[],
   pieceIndex: number,
@@ -1313,8 +1341,14 @@ export function breakParagraph(
 
       if (candidate === '\t') {
         // A tab that cannot advance on this line wraps first, then reapplies — matching
-        // Word's "tab past the right margin starts a new line" behaviour.
-        if ((line.spans.length > 0 || line.drawings.length > 0) && line.width >= lineAvailable())
+        // Word's "tab past the right margin starts a new line" behaviour. Unless it is
+        // TRAILING: a tab with nothing placeable after it ends the line rather than
+        // starting one, exactly as a trailing space does.
+        if (
+          (line.spans.length > 0 || line.drawings.length > 0) &&
+          line.width >= lineAvailable() &&
+          placeableContentFollows(pieces, pieceIndex, boundary)
+        )
           closeLine();
         const currentX = lineOrigin() + line.width;
         const segment = measureFollowingTabSegment(pieces, pieceIndex, boundary, measurer);

--- a/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
@@ -55,10 +55,10 @@ const STRIP_Y_EMU = 63_500; // 5pt
 const STRIP_CX_EMU = 208_280; // ~16.4pt
 const STRIP_CY_EMU = 976_630; // ~76.9pt
 
-function headerStripDrawing(): string {
+function headerStripDrawing(behindDoc: '0' | '1' = '0'): string {
   return (
     '<w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"' +
-    ' relativeHeight="1" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">' +
+    ` relativeHeight="1" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">` +
     '<wp:simplePos x="0" y="0"/>' +
     `<wp:positionH relativeFrom="column"><wp:posOffset>${STRIP_X_EMU}</wp:posOffset></wp:positionH>` +
     `<wp:positionV relativeFrom="paragraph"><wp:posOffset>${STRIP_Y_EMU}</wp:posOffset></wp:positionV>` +
@@ -73,14 +73,14 @@ function headerStripDrawing(): string {
   );
 }
 
-function headerDoc(): Uint8Array {
+function headerDoc(behindDoc: '0' | '1' = '0'): Uint8Array {
   const ns = `xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"`;
   // The header paragraph hangs 35.4pt into the left margin (w:ind left="-708" twips) and
   // carries the anchored strip.
   const headerParagraph =
     '<w:p><w:pPr><w:ind w:left="-708"/></w:pPr>' +
     '<w:r><w:t>Sample header line</w:t></w:r>' +
-    `<w:r>${headerStripDrawing()}</w:r></w:p>`;
+    `<w:r>${headerStripDrawing(behindDoc)}</w:r></w:p>`;
   return zipSync({
     '[Content_Types].xml': strToU8(
       `<Types xmlns="${CT}">` +
@@ -193,8 +193,8 @@ function furnitureWithDrawings(
   });
 }
 
-function layoutHeaderDoc(): SemanticLayout {
-  const pkg = openPackage(headerDoc());
+function layoutHeaderDoc(behindDoc: '0' | '1' = '0'): SemanticLayout {
+  const pkg = openPackage(headerDoc(behindDoc));
   const part = pkg.parts.get(pkg.mainDocumentPart)!;
   return layoutSemanticDocument(part, 1, {
     measurer,
@@ -299,6 +299,34 @@ describe('header band ink overflows instead of clipping', () => {
     expect(Math.max(...ys)).toBeCloseTo(page.box.y - story.box.y + page.box.height, 3);
     // And the clip is genuinely OUTSIDE the band, or it would be the old bug again.
     expect(Math.max(...ys)).toBeGreaterThan(parseFloat(band.style.height));
+  });
+
+  test('a behindDoc header shape paints UNDER the body, not over it', () => {
+    // `behindDoc` means behind the DOCUMENT. Painted from inside the band — which the page
+    // appends after its content box — a letterhead reaching down over the body covered the
+    // first body lines, the one thing the flag exists to prevent.
+    const painted = paint(layoutHeaderDoc('1'));
+    const page = painted.querySelector<HTMLElement>('.docx-page')!;
+    const children = [...page.children];
+    const behind = page.querySelector<HTMLElement>('[data-docx-hf-behind="header"]');
+    const content = page.querySelector<HTMLElement>('.docx-page-content');
+    expect(behind).toBeTruthy();
+    expect(content).toBeTruthy();
+    expect(children.indexOf(behind!)).toBeLessThan(children.indexOf(content!));
+    // It carries real ink, and it is clipped to the sheet so it cannot reach the next page.
+    expect(behind!.querySelector('.docx-drawing-layer > *')).toBeTruthy();
+    expect(behind!.style.overflow).toBe('hidden');
+    // Never interactive: furniture behind the body must not take a click meant for text.
+    for (const element of behind!.querySelectorAll<HTMLElement>('.docx-drawing-layer > *')) {
+      expect(element.style.pointerEvents).toBe('none');
+    }
+  });
+
+  test('an inFront header shape still paints in the band, above the body', () => {
+    const painted = paint(layout);
+    const band = painted.querySelector<HTMLElement>('[data-docx-hf="header"]')!;
+    expect(band.querySelector('.docx-drawing-layer > *')).toBeTruthy();
+    expect(painted.querySelector('[data-docx-hf-behind="header"]')).toBeNull();
   });
 
   test('a nested drawing inside inert furniture is inert too', () => {

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -376,6 +376,42 @@ function hfAnchorOnPageSheet(
   });
 }
 
+/**
+ * Every header/footer BEHIND drawing, lifted onto the sheet and clipped to it.
+ *
+ * Both frames go through `hfAnchorOnPageSheet`: it resolves a page-frame axis against the
+ * page box and a story-relative one against the story box, which is what makes one layer
+ * able to carry both. Inert always — furniture behind the body must never take a click
+ * meant for the text over it, and the band, not this layer, is what editing activates.
+ */
+function appendHfBehindDrawingLayer(
+  document: Document,
+  pageElement: HTMLElement,
+  story: HeaderFooterStoryRecord,
+  drawings: readonly AnchoredDrawingRecord[],
+  ctx: ResolvedPaintContext,
+  pageOrigin: {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  }
+): void {
+  const lifted = drawings.map((drawing) => hfAnchorOnPageSheet(story, drawing, pageOrigin));
+  // The wrapper spans the sheet exactly, so `overflow: hidden` on it is the paper edge:
+  // furniture ink can reach anywhere on this page and nowhere on the next.
+  const clip = document.createElement('div');
+  clip.className = 'docx-hf-behind-layer';
+  clip.dataset.docxHfBehind = story.kind;
+  clip.setAttribute('contenteditable', 'false');
+  clip.style.position = 'absolute';
+  clip.style.inset = '0';
+  clip.style.overflow = 'hidden';
+  clip.style.pointerEvents = 'none';
+  appendAnchoredDrawingsForRecords(document, clip, lifted, ctx, pageOrigin, 'behind', false);
+  if (clip.childElementCount > 0) pageElement.append(clip);
+}
+
 function appendHfPageRelativeDrawingLayer(
   document: Document,
   pageElement: HTMLElement,
@@ -1846,6 +1882,23 @@ function paintPage(
   });
   appendAnchoredDrawingLayer(document, element, page, options, bodyAnchorOrigin, 'behind');
 
+  // FURNITURE INK THAT GOES BEHIND THE TEXT IS PAINTED BEFORE THE TEXT.
+  //
+  // `behindDoc` means behind the DOCUMENT, and a letterhead or watermark anchored in a
+  // header routinely reaches down over the body. Painted from inside the band — which the
+  // page appends after its content box — it covered the first body lines instead, the one
+  // thing `behindDoc` exists to prevent. Every header/footer behind-drawing is lifted onto
+  // the sheet here, ahead of the content, exactly as the body's own behind layer is.
+  for (const story of [page.header, page.footer]) {
+    if (!story?.anchoredDrawings?.length) continue;
+    appendHfBehindDrawingLayer(document, element, story, story.anchoredDrawings, options, {
+      x: page.box.x,
+      y: page.box.y,
+      width: page.box.width,
+      height: page.box.height,
+    });
+  }
+
   const content = document.createElement('div');
   content.className = 'docx-page-content';
   content.style.position = 'absolute';
@@ -1930,16 +1983,8 @@ function paintPage(
       options.activeHeaderFooterRId === story.rId &&
       (options.activeHeaderFooterPageIndex === undefined ||
         options.activeHeaderFooterPageIndex === page.index);
-    appendHfPageRelativeDrawingLayer(
-      document,
-      element,
-      story,
-      anchored,
-      options,
-      pageOrigin,
-      'behind',
-      active
-    );
+    // The BEHIND half was already painted, on the sheet and ahead of the body content —
+    // see `appendHfBehindDrawingLayer`. Only the in-front ink belongs to the band.
     const container = document.createElement('div');
     container.className = 'docx-hf';
     container.dataset.docxHf = story.kind;
@@ -1991,15 +2036,6 @@ function paintPage(
       height: story.box.height,
     });
     const storyRelative = anchored.filter((drawing) => !isPageRelativeHfAnchor(drawing));
-    appendAnchoredDrawingsForRecords(
-      document,
-      container,
-      storyRelative,
-      asResolvedPaintContext(options),
-      storyOrigin,
-      'behind',
-      active
-    );
     // Furniture links paint styled but inert — see `paintHyperlinkAnchor`.
     const furnitureCtx: ResolvedPaintContext = {
       ...options,


### PR DESCRIPTION
Stacked on #204. Two header-fidelity defects that surfaced alongside it.

A tab with nothing placeable after it now ends its line rather than starting one, as a trailing space does. Headers are routinely authored as `LEFT<tab><tab>RIGHT<tab><tab>`, and each trailing tab was opening a line — which also moved the body, because a header's flow height sets the effective top margin.

Header and footer drawings marked `behindDoc` are lifted onto the sheet ahead of the page content, so a letterhead reaching over the body paints beneath the text the way the flag says. The body's own behind layer already worked this way; the furniture one was painted from inside the band, which the page appends after its content. The lifted layer is clipped to the sheet and never interactive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629284&installation_model_id=422592&pr_number=205&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F205&signature=7e65090e0a05181325622b02d6c31d1ca2218fc161a055644ed0b02ef2825588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->