### PR TITLE
chore: release the stylesheet change as a minor

### DIFF
--- a/.changeset/scoped-compiled-stylesheet.md
+++ b/.changeset/scoped-compiled-stylesheet.md
@@ -1,6 +1,6 @@
 ---
-'@docx-editor.dev/core': major
+'@docx-editor.dev/core': minor
 '@docx-editor.dev/react': minor
 ---
 
-The shipped stylesheet is now precompiled and fully namespaced: every Tailwind utility, editable-surface rule and keyframe is scoped under the renamed `.docx-editor` root class (previously `.ep-root`), so the CSS no longer collides with a host app's Tailwind setup and styles the chrome correctly in hosts without Tailwind. Breaking: consumer CSS targeting `.ep-root` must switch to `.docx-editor`.
+The shipped stylesheet is now precompiled and fully namespaced: every Tailwind utility, editable-surface rule and keyframe is scoped under the renamed `.docx-editor` root class (previously `.ep-root`), so the CSS no longer collides with a host app's Tailwind setup and styles the chrome correctly in hosts without Tailwind. If your own CSS targets `.ep-root`, switch it to `.docx-editor`.


### PR DESCRIPTION
The stylesheet changeset from #206 declared `@docx-editor.dev/core: major`. Published packages are one fixed group, so that took every one of them — react included — to 3.0.0.

Both entries are now `minor`, which lands the group on 2.1.0. The summary still names the change consumers have to make (`.ep-root` → `.docx-editor`); only the bump moves.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788632246&installation_model_id=422592&pr_number=207&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F207&signature=c9d2fa0ec14531809570aba9eb1c1b18d842b916011b9c8f6be93c02eea056fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->