### PR TITLE
refactor: finish the .docx-editor CSS namespace rename

### DIFF
--- a/.changeset/docx-editor-class-prefix.md
+++ b/.changeset/docx-editor-class-prefix.md
@@ -1,0 +1,7 @@
+---
+'@docx-editor.dev/core': minor
+'@docx-editor.dev/react': minor
+'@docx-editor.dev/pro': minor
+---
+
+Every remaining `ep-` prefixed CSS class and keyframe is renamed to `docx-editor-`, so the whole stylesheet shares one namespace with the `.docx-editor` root class. If your own CSS targets an `.ep-*` class or the `ep-caret-blink` keyframe, switch it to the same name under `docx-editor-` (`.ep-one-surface__caret` becomes `.docx-editor-one-surface__caret`).

--- a/examples/vite/src/test-harness/TreeSurfaceHarness.tsx
+++ b/examples/vite/src/test-harness/TreeSurfaceHarness.tsx
@@ -118,10 +118,10 @@ export function TreeSurfaceHarness({ fixtureUrl }: { fixtureUrl: string }) {
 
       <div style={{ padding: 24, display: 'flex', justifyContent: 'center' }}>
         <div
-          className="ep-browser-first__page"
+          className="docx-editor-browser-first__page"
           style={{ background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.2)' }}
         >
-          <div ref={mountRef} className="ep-browser-first__mount" data-testid="tree-mount" />
+          <div ref={mountRef} className="docx-editor-browser-first__mount" data-testid="tree-mount" />
         </div>
       </div>
 

--- a/packages/core/src/editor/__tests__/editor-css-tokens.test.ts
+++ b/packages/core/src/editor/__tests__/editor-css-tokens.test.ts
@@ -1,6 +1,6 @@
 // Every `--doc-*` token a stylesheet CONSUMES must also be DEFINED (interactive-paginated-editing).
 //
-// `.ep-one-surface__caret { background: var(--doc-caret) }` shipped with `--doc-caret`
+// `.docx-editor-one-surface__caret { background: var(--doc-caret) }` shipped with `--doc-caret`
 // declared only inside the dark-mode block, so in the default theme it resolved to nothing
 // and the caret painted as a 1px transparent div: correctly positioned, visible, blinking,
 // and completely invisible. A missing custom property fails silently — `var()` with no
@@ -129,7 +129,7 @@ describe('editor stylesheet custom properties', () => {
   });
 
   test('the caret rule paints a colour rather than relying on a default', () => {
-    const rule = /\.ep-one-surface__caret\s*\{([^}]*)\}/.exec(withoutComments);
+    const rule = /\.docx-editor-one-surface__caret\s*\{([^}]*)\}/.exec(withoutComments);
     expect(rule).not.toBeNull();
     expect(rule![1]).toMatch(/background:\s*var\(--doc-caret/);
     // 2px, not 1: a hairline caret is a single device pixel on a high-DPI screen and

--- a/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
+++ b/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
@@ -309,7 +309,7 @@ describe('scoped HF interaction regressions', () => {
     expect(surface.state().selection.head).toEqual({ paragraphId, offset: afterLeft });
 
     // Engine caret is parented into the active band (story-relative), not the body content box.
-    const caret = container.querySelector('.ep-one-surface__caret') as HTMLElement | null;
+    const caret = container.querySelector('.docx-editor-one-surface__caret') as HTMLElement | null;
     expect(caret).not.toBeNull();
     expect(caret!.closest('[data-docx-hf-active]')?.getAttribute('data-docx-hf')).toBe('header');
     expect(
@@ -341,7 +341,7 @@ describe('scoped HF interaction regressions', () => {
       head: { paragraphId, offset: beforeC },
     });
 
-    const caret = container.querySelector('.ep-one-surface__caret') as HTMLElement;
+    const caret = container.querySelector('.docx-editor-one-surface__caret') as HTMLElement;
     expect(caret).not.toBeNull();
     const caretX = Number.parseFloat(caret.style.left);
     // Story-relative: must sit at CONFIDENTIAL, not at the pre-tab edge after "v2".
@@ -384,7 +384,7 @@ describe('scoped HF interaction regressions', () => {
       head: hit!.position,
     });
 
-    const caret = container.querySelector('.ep-one-surface__caret') as HTMLElement | null;
+    const caret = container.querySelector('.docx-editor-one-surface__caret') as HTMLElement | null;
     expect(caret).not.toBeNull();
     expect(caret!.closest('[data-docx-hf-active]')?.getAttribute('data-docx-hf')).toBe('footer');
     expect(Number.parseFloat(caret!.style.left)).toBeGreaterThanOrEqual(0);
@@ -475,7 +475,7 @@ describe('scoped HF interaction regressions', () => {
       anchor: { paragraphId, offset: 0 },
       head: { paragraphId, offset: 0 },
     });
-    let caret = container.querySelector('.ep-one-surface__caret') as HTMLElement | null;
+    let caret = container.querySelector('.docx-editor-one-surface__caret') as HTMLElement | null;
     expect(caret?.closest('[data-page-index]')?.getAttribute('data-page-index')).toBe(
       String(first.index)
     );
@@ -497,7 +497,7 @@ describe('scoped HF interaction regressions', () => {
     expect(surface.activeScope()).toEqual({ kind: 'headerFooter', rId: 'rId10' });
     expect(activeOn(second.index)).not.toBeNull();
     expect(activeOn(first.index)).toBeNull();
-    caret = container.querySelector('.ep-one-surface__caret') as HTMLElement | null;
+    caret = container.querySelector('.docx-editor-one-surface__caret') as HTMLElement | null;
     expect(caret).not.toBeNull();
     expect(caret!.closest('[data-page-index]')?.getAttribute('data-page-index')).toBe(
       String(second.index)
@@ -519,7 +519,7 @@ describe('scoped HF interaction regressions', () => {
     expect(surface.enterHeaderFooter({ rId: 'rId10', pageIndex: first.index })).toBe(true);
     expect(activeOn(first.index)).not.toBeNull();
     expect(activeOn(second.index)).toBeNull();
-    caret = container.querySelector('.ep-one-surface__caret') as HTMLElement | null;
+    caret = container.querySelector('.docx-editor-one-surface__caret') as HTMLElement | null;
     expect(caret?.closest('[data-page-index]')?.getAttribute('data-page-index')).toBe(
       String(first.index)
     );

--- a/packages/core/src/editor/__tests__/surface-caret.test.ts
+++ b/packages/core/src/editor/__tests__/surface-caret.test.ts
@@ -103,7 +103,7 @@ function putCaret(surface: PaginatedSurface, offset: number, paragraphIndex = 0)
 }
 
 const caretElement = (container: HTMLElement) =>
-  container.querySelector<HTMLElement>('.ep-one-surface__caret');
+  container.querySelector<HTMLElement>('.docx-editor-one-surface__caret');
 
 /** The caret's inline geometry, which is the only geometry it has. */
 const geometryOf = (element: HTMLElement) => ({
@@ -232,14 +232,14 @@ describe('the painted caret', () => {
     putCaret(surface, 2);
     const painted = caretElement(container)!;
     // The stylesheet owns width, colour and the blink; the element only has to claim them.
-    expect(painted.classList.contains('ep-one-surface__caret')).toBe(true);
+    expect(painted.classList.contains('docx-editor-one-surface__caret')).toBe(true);
     // A caret that keeps blinking under an arrow key or a drag disappears mid-gesture.
-    expect(painted.classList.contains('ep-one-surface__caret--steady')).toBe(true);
+    expect(painted.classList.contains('docx-editor-one-surface__caret--steady')).toBe(true);
 
     await Bun.sleep(700);
-    expect(painted.classList.contains('ep-one-surface__caret--steady')).toBe(false);
+    expect(painted.classList.contains('docx-editor-one-surface__caret--steady')).toBe(false);
     putCaret(surface, 7);
-    expect(painted.classList.contains('ep-one-surface__caret--steady')).toBe(true);
+    expect(painted.classList.contains('docx-editor-one-surface__caret--steady')).toBe(true);
   });
 
   test('an unfocused surface keeps the native caret and paints nothing', () => {

--- a/packages/core/src/editor/surface-caret.ts
+++ b/packages/core/src/editor/surface-caret.ts
@@ -66,8 +66,8 @@ export interface SurfaceCaret {
 }
 
 /** Appearance — width, colour, blink — lives in the stylesheet under these names. */
-const CARET_CLASS = 'ep-one-surface__caret';
-const STEADY_CLASS = 'ep-one-surface__caret--steady';
+const CARET_CLASS = 'docx-editor-one-surface__caret';
+const STEADY_CLASS = 'docx-editor-one-surface__caret--steady';
 
 /**
  * How long a moved caret stays solid before it resumes blinking.

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -196,7 +196,7 @@
    *
    * Declared here for the DEFAULT theme, which it was not: `--doc-page-bg` existed only
    * inside the dark block (and a dark print override), so
-   * `.ep-one-surface__page { background: var(--doc-page-bg) }` resolved to nothing in light
+   * `.docx-editor-one-surface__page { background: var(--doc-page-bg) }` resolved to nothing in light
    * mode and the sheet painted TRANSPARENT — a box-shadow around a see-through interior,
    * because neither the viewport nor the surface sets a background either. The same silent
    * `var()` failure as the caret, in the same file, found by the scope-aware token check
@@ -222,12 +222,12 @@
    * for the inverted canvas.
    *
    * This was missing entirely and only ever declared in the dark block, so
-   * `.ep-one-surface__caret { background: var(--doc-caret) }` resolved to nothing in the
+   * `.docx-editor-one-surface__caret { background: var(--doc-caret) }` resolved to nothing in the
    * default theme and painted a 1px transparent div — the caret was correctly positioned,
    * visible and non-blinking-off, and simply had no colour.
    *
    * `--doc-caret-contrast` is its complement, drawn as a 1px ring so the insertion point
-   * survives a backdrop the core colour disappears into (see `.ep-one-surface__caret`).
+   * survives a backdrop the core colour disappears into (see `.docx-editor-one-surface__caret`).
    * The two are transformed together by the dark page's inversion, so their contrast with
    * each other holds in both themes. */
   --doc-caret: #202124;
@@ -1515,12 +1515,12 @@ a.docx-hyperlink:focus-visible {
   * hover:bg utilities don't dedupe and the active slab could lose its color on
   * hover (white icon on a light bg). The `.docx-editor` prefix outranks the
   * single-class Tailwind hover utilities. */
-.docx-editor .ep-toolbar-toggle:hover {
+.docx-editor .docx-editor-toolbar-toggle:hover {
   background-color: var(--doc-bg-hover);
   color: var(--doc-text);
 }
-.docx-editor .ep-toolbar-toggle[data-active='true'],
-.docx-editor .ep-toolbar-toggle[data-active='true']:hover {
+.docx-editor .docx-editor-toolbar-toggle[data-active='true'],
+.docx-editor .docx-editor-toolbar-toggle[data-active='true']:hover {
   background-color: var(--doc-toggle-active-bg);
   color: var(--doc-toggle-active-fg);
 }
@@ -1708,10 +1708,10 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Body caret blink for the Vue adapter's painted caret (useSelectionSync sets
-    `animation: ep-caret-blink ...` inline). React drives its caret's blink from a
+    `animation: docx-editor-caret-blink ...` inline). React drives its caret's blink from a
     JS timer instead; both land on the same 530ms half-period, which is the
     platform default. Defined here so the keyframes aren't duplicated per adapter. */
-@keyframes ep-caret-blink {
+@keyframes docx-editor-caret-blink {
   0%,
   49% {
     opacity: 1;
@@ -1753,7 +1753,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Hyperlink popup icon button hover */
-.ep-hyperlink-popup__icon-btn:hover {
+.docx-editor-hyperlink-popup__icon-btn:hover {
   background: var(--doc-bg-hover);
 }
 
@@ -2022,19 +2022,19 @@ a.docx-hyperlink:focus-visible {
   text-decoration: line-through;
 }
 
-.ep-revision-cell.ep-revision-ins {
+.docx-editor-revision-cell.docx-editor-revision-ins {
   box-shadow: inset 0 3px 0 var(--doc-revision-insertion);
   background-color: var(--doc-revision-insertion-tint);
 }
 
-.ep-revision-cell.ep-revision-del {
+.docx-editor-revision-cell.docx-editor-revision-del {
   box-shadow: inset 0 3px 0 var(--doc-revision-deletion);
   background-color: var(--doc-revision-deletion-tint);
   text-decoration: line-through;
   text-decoration-color: color-mix(in srgb, var(--doc-revision-deletion) 60%, transparent);
 }
 
-.ep-revision-cell.ep-revision-merge {
+.docx-editor-revision-cell.docx-editor-revision-merge {
   box-shadow: inset 0 3px 0 var(--doc-text-muted);
   background-color: color-mix(in srgb, var(--doc-text-muted) 8%, transparent);
 }
@@ -2078,11 +2078,11 @@ a.docx-hyperlink:focus-visible {
  *
  * Layer model, bottom to top, inside one scroll container:
  *
- *   .ep-one-surface                 positioning context
- *   └ .ep-one-surface__pages        stacked page boxes
- *     └ .ep-one-surface__page       one engine-sized page box
- *       ├ .ep-one-surface__content  painted DisplayItem[] (engine geometry)
- *       └ .ep-one-surface__overlay  caret + selection, pointer-transparent
+ *   .docx-editor-one-surface                 positioning context
+ *   └ .docx-editor-one-surface__pages        stacked page boxes
+ *     └ .docx-editor-one-surface__page       one engine-sized page box
+ *       ├ .docx-editor-one-surface__content  painted DisplayItem[] (engine geometry)
+ *       └ .docx-editor-one-surface__overlay  caret + selection, pointer-transparent
  *
  * Every box that carries document geometry is positioned by the engine in
  * content pixels through inline styles. Nothing here invents or overrides a
@@ -2093,7 +2093,7 @@ a.docx-hyperlink:focus-visible {
  * and geometry and paint agree by construction.
  * ======================================================================== */
 
-.ep-one-surface {
+.docx-editor-one-surface {
   position: relative;
   /* Page separation is a paint concern; the engine reports the same gap in
    * scrollGeometry so hit testing and paint stay in agreement. */
@@ -2102,7 +2102,7 @@ a.docx-hyperlink:focus-visible {
 
 /* Scroll container. The host reports scrollTop/scrollLeft to the engine as
  * InteractionHostMetrics.scrollOffset — the engine never reads the DOM. */
-.ep-one-surface__viewport {
+.docx-editor-one-surface__viewport {
   position: relative;
   overflow: auto;
   overscroll-behavior: contain;
@@ -2119,7 +2119,7 @@ a.docx-hyperlink:focus-visible {
  * (`align-items: center` on a stretched box) instead offsets every page from the
  * stack origin, which shifts every hit test by that offset and makes clicks land
  * on "page background". */
-.ep-one-surface__pages {
+.docx-editor-one-surface__pages {
   display: flex;
   flex-direction: column;
   width: max-content;
@@ -2132,7 +2132,7 @@ a.docx-hyperlink:focus-visible {
   transform-origin: 0 0;
 }
 
-.ep-one-surface__page {
+.docx-editor-one-surface__page {
   position: relative;
   flex: none;
   background: var(--doc-page-bg);
@@ -2145,32 +2145,32 @@ a.docx-hyperlink:focus-visible {
 /* Painted display items. Text is selected through the engine's semantic
  * selection, never the browser's, so native selection is suppressed here to
  * stop a second, contradictory selection appearing on the same glyphs. */
-.ep-one-surface__content {
+.docx-editor-one-surface__content {
   position: absolute;
   inset: 0;
   user-select: none;
   -webkit-user-select: none;
 }
 
-.ep-one-surface__content > * {
+.docx-editor-one-surface__content > * {
   position: absolute;
 }
 
 /* Overlay layer: caret and selection rectangles, both derived from
  * interaction-frame geometry. Pointer-transparent so a click always reaches
  * the page and resolves through the engine hit test. */
-.ep-one-surface__overlay {
+.docx-editor-one-surface__overlay {
   position: absolute;
   inset: 0;
   pointer-events: none;
 }
 
-.ep-one-surface__selection-rect {
+.docx-editor-one-surface__selection-rect {
   position: absolute;
   background: var(--doc-selection);
 }
 
-.ep-one-surface__caret {
+.docx-editor-one-surface__caret {
   position: absolute;
   /* 2px, not 1: a hairline caret disappears against body text at 100% zoom on a
    * high-DPI screen, and reads as a rendering artefact rather than a cursor.
@@ -2194,23 +2194,23 @@ a.docx-hyperlink:focus-visible {
    * the caret would blend to white and the dark page's inversion would then paint it black
    * on black: the very bug this ring exists to fix. The pair needs no backdrop at all. */
   box-shadow: 0 0 0 1px var(--doc-caret-contrast);
-  animation: ep-caret-blink 1.06s steps(1) infinite;
+  animation: docx-editor-caret-blink 1.06s steps(1) infinite;
 }
 
 /* A caret that is being moved or dragged should not blink. */
-.ep-one-surface__caret--steady {
+.docx-editor-one-surface__caret--steady {
   animation: none;
 }
 
 /* Right-to-left runs paint their caret on the trailing edge; the engine
  * supplies the rect, this only marks direction for the host. */
-.ep-one-surface__caret--rtl {
+.docx-editor-one-surface__caret--rtl {
   direction: rtl;
 }
 
 /* Active IME composition. The composed range stays visible under the engine
  * selection so the user can see what the input method is holding. */
-.ep-one-surface__composition {
+.docx-editor-one-surface__composition {
   position: absolute;
   border-bottom: 1px solid var(--doc-text);
   pointer-events: none;
@@ -2220,7 +2220,7 @@ a.docx-hyperlink:focus-visible {
  * object controls that must receive their own pointer events. Anything using
  * this class opts out deliberately — it is not the default for overlay content.
  */
-.ep-one-surface__overlay-control {
+.docx-editor-one-surface__overlay-control {
   pointer-events: auto;
 }
 
@@ -2247,13 +2247,13 @@ a.docx-hyperlink:focus-visible {
 
 /* The host must never expose a second visible or assistive copy of the
  * document, so its projected content is not painted. */
-.ep-one-surface__input-host * {
+.docx-editor-one-surface__input-host * {
   color: transparent;
 }
 
 /* Private browser-feedback checkpoint: one page-like sheet with the real
  * ProseMirror contenteditable. It is deliberately not a pagination claim. */
-.ep-browser-first__page {
+.docx-editor-browser-first__page {
   box-sizing: border-box;
   width: 816px;
   min-height: 1056px;
@@ -2262,12 +2262,12 @@ a.docx-hyperlink:focus-visible {
   cursor: text;
 }
 
-.ep-browser-first__mount,
-.ep-browser-first__mount * {
+.docx-editor-browser-first__mount,
+.docx-editor-browser-first__mount * {
   color: var(--doc-caret);
 }
 
-.ep-browser-first__mount .ProseMirror {
+.docx-editor-browser-first__mount .ProseMirror {
   min-height: 864px;
   outline: none;
   font-size: 11pt;
@@ -2276,12 +2276,12 @@ a.docx-hyperlink:focus-visible {
   overflow-wrap: break-word;
 }
 
-.ep-browser-first__mount .ProseMirror p {
+.docx-editor-browser-first__mount .ProseMirror p {
   margin: 0 0 0.75em;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ep-one-surface__caret {
+  .docx-editor-one-surface__caret {
     animation: none;
   }
 }
@@ -2294,12 +2294,12 @@ a.docx-hyperlink:focus-visible {
  * toolbar, rulers, and the page indicator.
  *
  * The shell owns CHROME ONLY. It sets no document geometry — the page stack
- * inside `.ep-shell__canvas` is positioned by the engine, and the shell must
+ * inside `.docx-editor-shell__canvas` is positioned by the engine, and the shell must
  * not introduce any horizontal offset the engine does not know about, or hit
  * testing drifts (the lesson from M3's centering bug).
  * ======================================================================== */
 
-.ep-shell {
+.docx-editor-shell {
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -2308,15 +2308,15 @@ a.docx-hyperlink:focus-visible {
   color: var(--doc-text);
 }
 
-.ep-shell__title,
-.ep-shell__toolbar {
+.docx-editor-shell__title,
+.docx-editor-shell__toolbar {
   flex: none;
   border-bottom: 1px solid var(--doc-border);
   background: var(--doc-surface);
 }
 
 /* The scrolling document region — the backdrop the page sits on. */
-.ep-shell__document {
+.docx-editor-shell__document {
   position: relative;
   flex: 1;
   min-height: 0;
@@ -2328,7 +2328,7 @@ a.docx-hyperlink:focus-visible {
 
 /* Sticky horizontal ruler: scrolls horizontally with the document, stays put
  * vertically, and never covers the page content. */
-.ep-shell__ruler-h {
+.docx-editor-shell__ruler-h {
   position: sticky;
   top: 0;
   z-index: 2;
@@ -2339,7 +2339,7 @@ a.docx-hyperlink:focus-visible {
   background: var(--doc-bg);
 }
 
-.ep-shell__canvas {
+.docx-editor-shell__canvas {
   position: relative;
   flex: 1;
   min-height: 0;
@@ -2348,7 +2348,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Vertical ruler pinned to the canvas's left edge so it scrolls with the page. */
-.ep-shell__ruler-v {
+.docx-editor-shell__ruler-v {
   position: absolute;
   left: 0;
   top: 0;
@@ -2357,16 +2357,16 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* The one-surface viewport fills the canvas. Page centering stays the page
- * stack's own job (`margin-inline: auto` on `.ep-one-surface__pages`), so the
+ * stack's own job (`margin-inline: auto` on `.docx-editor-one-surface__pages`), so the
  * shell adds no offset the engine would have to be told about. */
-.ep-shell__canvas > .ep-one-surface {
+.docx-editor-shell__canvas > .docx-editor-one-surface {
   flex: 1;
   min-width: 0;
 }
 
 /* Floating page indicator, out of the document flow and pointer-transparent so
  * it can never swallow a click meant for the page. */
-.ep-shell__page-indicator {
+.docx-editor-shell__page-indicator {
   position: absolute;
   bottom: 16px;
   left: 50%;
@@ -2378,8 +2378,8 @@ a.docx-hyperlink:focus-visible {
 /* Document scroll region padding: breathing room around the sheet, matching the
  * legacy backdrop. Applied to the viewport rather than the page stack so it
  * cannot shift the stack origin away from the engine's page origin. */
-.ep-shell .ep-one-surface__viewport,
-.docx-editor__content .ep-one-surface__viewport {
+.docx-editor-shell .docx-editor-one-surface__viewport,
+.docx-editor__content .docx-editor-one-surface__viewport {
   padding: 24px 0;
   scrollbar-gutter: stable both-edges;
 }
@@ -2388,7 +2388,7 @@ a.docx-hyperlink:focus-visible {
  * stays inline in `DocxEditorShell.tsx`; only what it expressed in CSS is here.
  *
  * A DEVIATION RECORDED HERE EARLIER IS NOW REVERTED: this file used to keep
- * `.ep-one-surface__viewport` as the scroller inside the shell as well. With the shell's
+ * `.docx-editor-one-surface__viewport` as the scroller inside the shell as well. With the shell's
  * container also declaring `overflow: auto`, neither box ended up bounded — the whole
  * chain grew to document height and the window scrolled, so the page indicator never
  * left page 1. Legacy's structure is restored: inside the shell,
@@ -2396,7 +2396,7 @@ a.docx-hyperlink:focus-visible {
  * Bare (no chrome), the viewport still scrolls and nothing about it changes. */
 
 /* Hosted in the shell: the shell's container scrolls, not this box. */
-.ep-one-surface__viewport--hosted {
+.docx-editor-one-surface__viewport--hosted {
   overflow: visible;
 }
 /* The title + menu column, INSIDE the header row (legacy layout). It used to render as
@@ -2426,14 +2426,14 @@ a.docx-hyperlink:focus-visible {
 
 /* Title chrome and page indicator (interactive-paginated-editing M4.3). */
 
-.ep-shell__title-bar {
+.docx-editor-shell__title-bar {
   display: flex;
   align-items: center;
   gap: 12px;
   padding: 8px 16px;
 }
 
-.ep-shell__title-input {
+.docx-editor-shell__title-input {
   flex: 1;
   min-width: 0;
   border: 1px solid transparent;
@@ -2449,17 +2449,17 @@ a.docx-hyperlink:focus-visible {
   background: transparent;
 }
 
-.ep-shell__title-input:hover:not([readonly]) {
+.docx-editor-shell__title-input:hover:not([readonly]) {
   border-color: var(--doc-border);
 }
 
-.ep-shell__title-input:focus {
+.docx-editor-shell__title-input:focus {
   outline: none;
   border-color: var(--doc-primary);
   box-shadow: 0 0 0 2px var(--doc-focus-ring);
 }
 
-.ep-shell__title-actions {
+.docx-editor-shell__title-actions {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2467,7 +2467,7 @@ a.docx-hyperlink:focus-visible {
 
 /* The indicator is a dark scrim in BOTH themes, so its text stays light —
  * --doc-on-primary flips dark in dark mode and would vanish here. */
-.ep-shell__page-indicator-chip {
+.docx-editor-shell__page-indicator-chip {
   background: var(--doc-overlay);
   color: #fff;
   padding: 6px 12px;
@@ -2509,7 +2509,7 @@ a.docx-hyperlink:focus-visible {
  * markers and no drag handles: this change owns no section-geometry contract,
  * so a draggable handle would be a control that silently does nothing. */
 
-.ep-ruler {
+.docx-editor-ruler {
   position: relative;
   background: var(--doc-surface);
   border: 1px solid var(--doc-border-light);
@@ -2518,7 +2518,7 @@ a.docx-hyperlink:focus-visible {
   pointer-events: none;
 }
 
-.ep-ruler--horizontal {
+.docx-editor-ruler--horizontal {
   height: 22px;
 }
 
@@ -2536,26 +2536,26 @@ a.docx-hyperlink:focus-visible {
   }
 }
 
-.ep-ruler--vertical {
+.docx-editor-ruler--vertical {
   height: 100%;
 }
 
-.ep-ruler__tick {
+.docx-editor-ruler__tick {
   position: absolute;
   background: var(--doc-text-subtle);
 }
 
-.ep-ruler--horizontal .ep-ruler__tick {
+.docx-editor-ruler--horizontal .docx-editor-ruler__tick {
   bottom: 0;
   width: 1px;
 }
 
-.ep-ruler--vertical .ep-ruler__tick {
+.docx-editor-ruler--vertical .docx-editor-ruler__tick {
   right: 0;
   height: 1px;
 }
 
-.ep-ruler__label {
+.docx-editor-ruler__label {
   position: absolute;
   font:
     400 9px/1 -apple-system,
@@ -2566,12 +2566,12 @@ a.docx-hyperlink:focus-visible {
   color: var(--doc-text-muted);
 }
 
-.ep-ruler--horizontal .ep-ruler__label {
+.docx-editor-ruler--horizontal .docx-editor-ruler__label {
   left: 2px;
   bottom: 11px;
 }
 
-.ep-ruler--vertical .ep-ruler__label {
+.docx-editor-ruler--vertical .docx-editor-ruler__label {
   right: 11px;
   top: -4px;
 }
@@ -2591,7 +2591,7 @@ a.docx-hyperlink:focus-visible {
  * (Toolbar.tsx:679: `flex items-center px-2 py-1 bg-muted rounded-full min-h-[36px]
  * overflow-x-auto mx-2 mb-1`). Only the scroll behaviour stays here: the pill scrolls
  * horizontally and must never become a second VERTICAL scroller. */
-.ep-toolbar {
+.docx-editor-toolbar {
   flex-wrap: nowrap;
   flex-shrink: 0;
   overflow-y: hidden;
@@ -2600,12 +2600,12 @@ a.docx-hyperlink:focus-visible {
 
 /* One group plus the separator that precedes it, so the pair wraps together and a
  * separator never becomes the first thing on a wrapped row. */
-.ep-toolbar__group-wrap {
+.docx-editor-toolbar__group-wrap {
   display: inline-flex;
   align-items: center;
 }
 
-.ep-toolbar__group {
+.docx-editor-toolbar__group {
   display: flex;
   align-items: center;
   gap: 2px;
@@ -2613,7 +2613,7 @@ a.docx-hyperlink:focus-visible {
 
 /* Visually hidden but present for assistive technology: a parity-only picker has no
  * tooltip of its own, so its unavailable reason is exposed here instead. */
-.ep-sr-only {
+.docx-editor-sr-only {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -2625,7 +2625,7 @@ a.docx-hyperlink:focus-visible {
   border: 0;
 }
 
-.ep-toolbar__separator {
+.docx-editor-toolbar__separator {
   width: 1px;
   align-self: stretch;
   margin: 4px 6px;
@@ -2634,7 +2634,7 @@ a.docx-hyperlink:focus-visible {
 
 /* Sidebar frame (interactive-paginated-editing M4.6). */
 
-.ep-sidebar {
+.docx-editor-sidebar {
   display: flex;
   flex-direction: column;
   width: 300px;
@@ -2643,7 +2643,7 @@ a.docx-hyperlink:focus-visible {
   background: var(--doc-surface);
 }
 
-.ep-sidebar__header {
+.docx-editor-sidebar__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2652,7 +2652,7 @@ a.docx-hyperlink:focus-visible {
   border-bottom: 1px solid var(--doc-border);
 }
 
-.ep-sidebar__title {
+.docx-editor-sidebar__title {
   font:
     500 13px/1.2 -apple-system,
     BlinkMacSystemFont,
@@ -2662,7 +2662,7 @@ a.docx-hyperlink:focus-visible {
   color: var(--doc-text);
 }
 
-.ep-sidebar__close {
+.docx-editor-sidebar__close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2675,11 +2675,11 @@ a.docx-hyperlink:focus-visible {
   cursor: pointer;
 }
 
-.ep-sidebar__close:hover {
+.docx-editor-sidebar__close:hover {
   background: var(--doc-bg-hover);
 }
 
-.ep-sidebar__body {
+.docx-editor-sidebar__body {
   flex: 1;
   min-height: 0;
   overflow: auto;
@@ -2812,7 +2812,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* The page floats on the workspace backdrop with a drop shadow, as in the reference. */
-.docx-editor__content .ep-one-surface__page {
+.docx-editor__content .docx-editor-one-surface__page {
   box-shadow:
     0 1px 3px rgb(60 64 67 / 30%),
     0 4px 8px 3px rgb(60 64 67 / 15%);
@@ -2916,14 +2916,14 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* The pill needs enough fill to read AS a pill against the workspace. */
-.ep-toolbar {
+.docx-editor-toolbar {
   background: var(--doc-bg-subtle);
   border: 1px solid var(--doc-border);
 }
 
 /* Ruler margin zones (M6V.6), from the legacy `ui/HorizontalRuler.tsx`:
  * `MARGIN_ZONE_COLOR = var(--doc-shadow-subtle)` with a 1px border on the inner edge. */
-.ep-ruler__margin {
+.docx-editor-ruler__margin {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -2931,26 +2931,26 @@ a.docx-hyperlink:focus-visible {
   pointer-events: none;
 }
 
-.ep-ruler__margin--start {
+.docx-editor-ruler__margin--start {
   left: 0;
   border-right: 1px solid var(--doc-shadow-subtle);
 }
 
-.ep-ruler__margin--end {
+.docx-editor-ruler__margin--end {
   right: 0;
   border-left: 1px solid var(--doc-shadow-subtle);
 }
 
-/* The vertical ruler's zones run the other axis; the shared `.ep-ruler__margin` rule
+/* The vertical ruler's zones run the other axis; the shared `.docx-editor-ruler__margin` rule
  * pins top/bottom, so these override the horizontal defaults. */
-.ep-ruler__margin--top {
+.docx-editor-ruler__margin--top {
   left: 0;
   right: 0;
   bottom: auto;
   border-bottom: 1px solid var(--doc-shadow-subtle);
 }
 
-.ep-ruler__margin--bottom {
+.docx-editor-ruler__margin--bottom {
   left: 0;
   right: 0;
   top: auto;
@@ -3213,7 +3213,7 @@ a.docx-hyperlink:focus-visible {
  * - bar: `flex items-center px-2 py-1 bg-muted rounded-full min-h-[36px]`
  *   — the neutral #f1f3f4-family pill.
  * - buttons: 28px ghost squares (h-7 w-7), muted
- *   glyphs, subtle hover, the dark active slab (`.ep-toolbar-toggle`
+ *   glyphs, subtle hover, the dark active slab (`.docx-editor-toolbar-toggle`
  *   [data-active] → --doc-toggle-active tokens), disabled at opacity .3.
  * - pickers (style, font family, editing mode): TRANSPARENT triggers with a
  *   chevron (h-8 rounded px-2 bg-transparent hover:bg-muted/80),
@@ -4373,20 +4373,20 @@ a.docx-hyperlink:focus-visible {
   }
 }
 
-/* ── Vue registry-toolbar (`ep-toolbar` family) additions for the same shapes:
+/* ── Vue registry-toolbar (`docx-editor-toolbar` family) additions for the same shapes:
  * the parity stepper lookalike and the merged alignment dropdown. */
-.ep-toolbar__stepper {
+.docx-editor-toolbar__stepper {
   display: inline-flex;
   align-items: center;
   height: 28px;
   flex: none;
 }
 
-.ep-toolbar__stepper[aria-disabled='true'] {
+.docx-editor-toolbar__stepper[aria-disabled='true'] {
   opacity: 0.5;
 }
 
-.ep-toolbar__stepper-button {
+.docx-editor-toolbar__stepper-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -4397,19 +4397,19 @@ a.docx-hyperlink:focus-visible {
   user-select: none;
 }
 
-.ep-toolbar__stepper-value {
+.docx-editor-toolbar__stepper-value {
   min-width: 34px;
   text-align: center;
   font-variant-numeric: tabular-nums;
   user-select: none;
 }
 
-.ep-toolbar__alignment {
+.docx-editor-toolbar__alignment {
   position: relative;
   display: inline-flex;
 }
 
-.ep-toolbar__alignment-popup {
+.docx-editor-toolbar__alignment-popup {
   position: absolute;
   top: 100%;
   left: 0;

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -1053,7 +1053,7 @@ function ReviewDraft({ top, className, hidden }: ReviewPartProps & { top: number
             submit();
           }}
         >
-          <label className="ep-sr-only" htmlFor={fieldId}>
+          <label className="docx-editor-sr-only" htmlFor={fieldId}>
             {t('comments.addComment')}
           </label>
           <input
@@ -1924,7 +1924,7 @@ function ReviewReply({ className, hidden, children }: ReviewPartProps) {
         submit();
       }}
     >
-      <label className="ep-sr-only" htmlFor={fieldId}>
+      <label className="docx-editor-sr-only" htmlFor={fieldId}>
         {t('comments.replyPlaceholder')}
       </label>
       <input

--- a/packages/react/src/components/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar.tsx
@@ -312,9 +312,9 @@ export function ToolbarButton({
       variant="ghost"
       size="icon-sm"
       className={cn(
-        // Hover + active states live in editor.css (.ep-toolbar-toggle); see
+        // Hover + active states live in editor.css (.docx-editor-toolbar-toggle); see
         // that rule for why they're not Tailwind utilities here.
-        'ep-toolbar-toggle text-muted-foreground',
+        'docx-editor-toolbar-toggle text-muted-foreground',
         disabled && 'opacity-30 cursor-not-allowed',
         className
       )}

--- a/packages/react/src/editor/DocxEditorContentControl.tsx
+++ b/packages/react/src/editor/DocxEditorContentControl.tsx
@@ -241,7 +241,7 @@ function ContentControlRoot({
 
   const titled = (
     <>
-      <span id={titleId} className="ep-sr-only">
+      <span id={titleId} className="docx-editor-sr-only">
         {t('contentControl.inspectorPanel.title')}
       </span>
       {body}

--- a/packages/react/src/editor/DocxEditorHyperLink.tsx
+++ b/packages/react/src/editor/DocxEditorHyperLink.tsx
@@ -316,7 +316,7 @@ function HyperLinkUrl({ className, asChild, hidden, children }: HyperLinkPartPro
     return (
       <span {...shared}>
         {children ?? text}
-        <span className="ep-sr-only">{hint}</span>
+        <span className="docx-editor-sr-only">{hint}</span>
       </span>
     );
   }
@@ -448,7 +448,7 @@ function HyperLinkFields({ className, hidden }: HyperLinkPartProps) {
   if (hidden) return null;
   return (
     <div className={`docx-hyperlink-popup__fields${className ? ` ${className}` : ''}`}>
-      <label className="ep-sr-only" htmlFor={textId}>
+      <label className="docx-editor-sr-only" htmlFor={textId}>
         {t('hyperlinkPopup.displayTextPlaceholder')}
       </label>
       <input
@@ -460,7 +460,7 @@ function HyperLinkFields({ className, hidden }: HyperLinkPartProps) {
         onChange={(event) => setText(event.target.value)}
         onKeyDown={onKeyDown}
       />
-      <label className="ep-sr-only" htmlFor={urlId}>
+      <label className="docx-editor-sr-only" htmlFor={urlId}>
         {t('hyperlinkPopup.urlPlaceholder')}
       </label>
       <input

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -102,7 +102,7 @@ function DocxEditorLoadingImpl({
           <DocxEditorLoadingSpinner />
           {/* The spinner is decorative, so the live region would otherwise announce an
               empty string — worse than having no region at all. */}
-          <span className="ep-sr-only">{t('loading.label')}</span>
+          <span className="docx-editor-sr-only">{t('loading.label')}</span>
         </>
       )}
     </div>

--- a/packages/react/src/editor/DocxEditorPageNumber.tsx
+++ b/packages/react/src/editor/DocxEditorPageNumber.tsx
@@ -63,7 +63,7 @@ export function DocxEditorPageNumber({ className, style }: DocxEditorPageNumberP
     : t('viewer.pageIndicator', { current, total });
   return (
     <div
-      className={`docx-editor ep-shell__page-indicator-chip docx-editor__page-number${
+      className={`docx-editor docx-editor-shell__page-indicator-chip docx-editor__page-number${
         className ? ` ${className}` : ''
       }`}
       style={style}

--- a/packages/react/src/editor/DocxEditorViewport.tsx
+++ b/packages/react/src/editor/DocxEditorViewport.tsx
@@ -2,7 +2,7 @@
 //
 // The class list is LOAD-BEARING, not styling sugar:
 // - `docx-editor` scopes every --doc-* token and the library's Tailwind layer;
-// - `ep-one-surface ep-one-surface__viewport` carry the one-surface chrome geometry;
+// - `docx-editor-one-surface docx-editor-one-surface__viewport` carry the one-surface chrome geometry;
 // - `docx-editor__scroll-container` is how the engine finds its scroller — the
 //   paginated pages locate the nearest ancestor with that class for scroll
 //   rematerialization and page-visibility work. Without it the engine falls back to
@@ -81,7 +81,7 @@ export function DocxEditorViewport({ className, style, children }: DocxEditorVie
       data-testid="docx-editor-scroll"
       onKeyDownCapture={onKeyDownCapture}
       {...(reserve ? { 'data-review-pane': paneOpen ? 'open' : 'closed' } : {})}
-      className={`docx-editor ep-one-surface ep-one-surface__viewport docx-editor__scroll-container${
+      className={`docx-editor docx-editor-one-surface docx-editor-one-surface__viewport docx-editor__scroll-container${
         className ? ` ${className}` : ''
       }`}
       style={{ ...style, ['--docx-nav-shift' as string]: `${shift}px` } as CSSProperties}

--- a/packages/react/src/editor/images/ImageSelectionOverlay.tsx
+++ b/packages/react/src/editor/images/ImageSelectionOverlay.tsx
@@ -494,7 +494,7 @@ export function ImageSelectionOverlay({
     return (
       <div
         ref={overlayRef}
-        className="docx-image-selection-overlay ep-one-surface__overlay-control"
+        className="docx-image-selection-overlay docx-editor-one-surface__overlay-control"
         data-drawing-node-id={active.id}
         tabIndex={0}
         onKeyDown={onOverlayKeyDown}

--- a/packages/react/src/editor/menu/parts.tsx
+++ b/packages/react/src/editor/menu/parts.tsx
@@ -121,7 +121,7 @@ export function MenuRow(props: MenuRowProps) {
       <span className="docx-menubar__item-label">{children}</span>
       {shortcut ? <span className="docx-menubar__item-shortcut">{shortcut}</span> : null}
       {describe ? (
-        <span id={reasonId} className="ep-sr-only">
+        <span id={reasonId} className="docx-editor-sr-only">
           {title}
         </span>
       ) : null}

--- a/packages/react/src/editor/navigation/navigation-geometry.ts
+++ b/packages/react/src/editor/navigation/navigation-geometry.ts
@@ -5,7 +5,7 @@
 // feel like the editor jumped sideways for no reason — on a 1600px window with a Letter
 // page there is already 500px of empty gutter, and the pane fits in it untouched.
 //
-// The page stack centres itself in the viewport (`.ep-one-surface__pages` is
+// The page stack centres itself in the viewport (`.docx-editor-one-surface__pages` is
 // `width: max-content` + `margin-inline: auto`), so a left padding P on the viewport does
 // NOT move the page by P: it shrinks the centring box, and the page moves by P/2 — until
 // the box gets narrower than the page, at which point the auto margins collapse to zero

--- a/packages/react/src/editor/toolbar/table-chrome-shared.tsx
+++ b/packages/react/src/editor/toolbar/table-chrome-shared.tsx
@@ -61,7 +61,7 @@ export function useTableChromeTriggerA11y({
     },
     reasonNode:
       describe && disabledReason ? (
-        <span id={reasonId} className="ep-sr-only">
+        <span id={reasonId} className="docx-editor-sr-only">
           {disabledReason}
         </span>
       ) : null,

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -242,7 +242,7 @@ describe('DocxEditor.Loading', () => {
     const el = view.container.querySelector(LOADING)!;
 
     expect(el.textContent!.trim().length).toBeGreaterThan(0);
-    expect(el.querySelector('.ep-sr-only')).not.toBeNull();
+    expect(el.querySelector('.docx-editor-sr-only')).not.toBeNull();
   });
 
   test('carries its own token scope, so it is styled wherever it is composed', () => {

--- a/packages/vue/src/DocxEditor.ts
+++ b/packages/vue/src/DocxEditor.ts
@@ -163,7 +163,7 @@ export default defineComponent({
         'div',
         {
           'data-testid': 'docx-editor-scroll',
-          class: 'docx-editor ep-one-surface ep-one-surface__viewport',
+          class: 'docx-editor docx-editor-one-surface docx-editor-one-surface__viewport',
         },
         [
           h('div', {

--- a/packages/vue/src/DocxEditorShell.ts
+++ b/packages/vue/src/DocxEditorShell.ts
@@ -20,21 +20,21 @@ export default defineComponent({
   name: 'DocxEditorShell',
   setup(_props, { slots }) {
     return () =>
-      h('div', { class: 'docx-editor ep-shell', 'data-testid': 'docx-editor-shell' }, [
-        slots.titleBar ? h('div', { class: 'ep-shell__title' }, slots.titleBar()) : null,
-        slots.toolbar ? h('div', { class: 'ep-shell__toolbar' }, slots.toolbar()) : null,
-        h('div', { class: 'ep-shell__document' }, [
+      h('div', { class: 'docx-editor docx-editor-shell', 'data-testid': 'docx-editor-shell' }, [
+        slots.titleBar ? h('div', { class: 'docx-editor-shell__title' }, slots.titleBar()) : null,
+        slots.toolbar ? h('div', { class: 'docx-editor-shell__toolbar' }, slots.toolbar()) : null,
+        h('div', { class: 'docx-editor-shell__document' }, [
           slots.horizontalRuler
-            ? h('div', { class: 'ep-shell__ruler-h' }, slots.horizontalRuler())
+            ? h('div', { class: 'docx-editor-shell__ruler-h' }, slots.horizontalRuler())
             : null,
-          h('div', { class: 'ep-shell__canvas' }, [
+          h('div', { class: 'docx-editor-shell__canvas' }, [
             slots.verticalRuler
-              ? h('div', { class: 'ep-shell__ruler-v' }, slots.verticalRuler())
+              ? h('div', { class: 'docx-editor-shell__ruler-v' }, slots.verticalRuler())
               : null,
             slots.default ? slots.default() : null,
           ]),
           slots.pageIndicator
-            ? h('div', { class: 'ep-shell__page-indicator' }, slots.pageIndicator())
+            ? h('div', { class: 'docx-editor-shell__page-indicator' }, slots.pageIndicator())
             : null,
         ]),
       ]);

--- a/packages/vue/src/DocxEditorSidebar.ts
+++ b/packages/vue/src/DocxEditorSidebar.ts
@@ -55,18 +55,18 @@ export default defineComponent({
       return h(
         'aside',
         {
-          class: 'ep-sidebar',
+          class: 'docx-editor-sidebar',
           'data-testid': 'docx-editor-sidebar',
           'aria-label': 'Document panels',
         },
         [
-          h('div', { class: 'ep-sidebar__header' }, [
-            h('span', { class: 'ep-sidebar__title' }, items[0]!.title),
+          h('div', { class: 'docx-editor-sidebar__header' }, [
+            h('span', { class: 'docx-editor-sidebar__title' }, items[0]!.title),
             h(
               'button',
               {
                 type: 'button',
-                class: 'ep-sidebar__close',
+                class: 'docx-editor-sidebar__close',
                 onClick: () => emit('close'),
                 'aria-label': 'Close panel',
               },
@@ -90,7 +90,7 @@ export default defineComponent({
               ]
             ),
           ]),
-          h('div', { class: 'ep-sidebar__body' }, items[0]!.content),
+          h('div', { class: 'docx-editor-sidebar__body' }, items[0]!.content),
         ]
       );
     };

--- a/packages/vue/src/DocxEditorTitleBar.ts
+++ b/packages/vue/src/DocxEditorTitleBar.ts
@@ -21,16 +21,18 @@ export default defineComponent({
   emits: { 'update:title': (_value: string) => true },
   setup(props, { emit, slots }) {
     return () =>
-      h('div', { class: 'ep-shell__title-bar', 'data-testid': 'document-title-bar' }, [
+      h('div', { class: 'docx-editor-shell__title-bar', 'data-testid': 'document-title-bar' }, [
         h('input', {
-          class: 'ep-shell__title-input',
+          class: 'docx-editor-shell__title-input',
           'data-testid': 'document-title',
           value: props.title,
           readonly: props.readOnly,
           'aria-label': 'Document title',
           onInput: (event: Event) => emit('update:title', (event.target as HTMLInputElement).value),
         }),
-        slots.actions ? h('div', { class: 'ep-shell__title-actions' }, slots.actions()) : null,
+        slots.actions
+          ? h('div', { class: 'docx-editor-shell__title-actions' }, slots.actions())
+          : null,
       ]);
   },
 });

--- a/packages/vue/src/DocxEditorToolbar.ts
+++ b/packages/vue/src/DocxEditorToolbar.ts
@@ -92,7 +92,7 @@ function control(
       {
         key: c.id,
         type: 'button',
-        class: 'ep-toolbar__button',
+        class: 'docx-editor-toolbar__button',
         'data-testid': `toolbar-${slotId}`,
         disabled: !editor || !onSave,
         title: label,
@@ -113,16 +113,16 @@ function control(
       'span',
       {
         key: c.id,
-        class: 'ep-toolbar__stepper',
+        class: 'docx-editor-toolbar__stepper',
         'data-testid': `toolbar-${slotId}`,
         'aria-disabled': 'true',
         onMousedown: (event: MouseEvent) => event.preventDefault(),
       },
       [
-        h('span', { class: 'ep-toolbar__stepper-button', 'aria-hidden': 'true' }, '−'),
-        h('span', { class: 'ep-toolbar__stepper-value' }, c.valueText ?? ''),
-        h('span', { class: 'ep-toolbar__stepper-button', 'aria-hidden': 'true' }, '+'),
-        h('span', { class: 'ep-sr-only' }, `${label} — ${t(CHROME_UNAVAILABLE_KEY)}`),
+        h('span', { class: 'docx-editor-toolbar__stepper-button', 'aria-hidden': 'true' }, '−'),
+        h('span', { class: 'docx-editor-toolbar__stepper-value' }, c.valueText ?? ''),
+        h('span', { class: 'docx-editor-toolbar__stepper-button', 'aria-hidden': 'true' }, '+'),
+        h('span', { class: 'docx-editor-sr-only' }, `${label} — ${t(CHROME_UNAVAILABLE_KEY)}`),
       ]
     );
   }
@@ -138,7 +138,7 @@ function control(
       'span',
       {
         key: c.id,
-        class: 'ep-toolbar__picker',
+        class: 'docx-editor-toolbar__picker',
         'data-testid': `toolbar-${slotId}`,
         'aria-disabled': 'true',
         // A picker is a <span>, so it does not take focus itself, but a mousedown
@@ -147,9 +147,9 @@ function control(
       },
       [
         ...(c.paths ? [icon(c.paths)] : []),
-        ...(value ? [h('span', { class: 'ep-toolbar__picker-value' }, value)] : []),
-        h('span', { class: 'ep-toolbar__picker-caret', 'aria-hidden': 'true' }, '▾'),
-        h('span', { class: 'ep-sr-only' }, `${label} — ${t(CHROME_UNAVAILABLE_KEY)}`),
+        ...(value ? [h('span', { class: 'docx-editor-toolbar__picker-value' }, value)] : []),
+        h('span', { class: 'docx-editor-toolbar__picker-caret', 'aria-hidden': 'true' }, '▾'),
+        h('span', { class: 'docx-editor-sr-only' }, `${label} — ${t(CHROME_UNAVAILABLE_KEY)}`),
       ]
     );
   }
@@ -166,7 +166,7 @@ function control(
       {
         key: c.id,
         type: 'button',
-        class: 'ep-toolbar__button',
+        class: 'docx-editor-toolbar__button',
         'data-testid': `toolbar-${slotId}`,
         // Kept under its original name: hosts style off it, and it still marks exactly
         // what it always marked — present for parity, not driven by this toolbar.
@@ -195,7 +195,7 @@ function control(
     {
       key: c.id,
       type: 'button',
-      class: 'ep-toolbar__button',
+      class: 'docx-editor-toolbar__button',
       'data-testid': `toolbar-${slotId}`,
       disabled: !state.enabled,
       'aria-pressed': state.active ? 'true' : 'false',
@@ -240,55 +240,59 @@ const AlignmentDropdown = defineComponent({
       const current = options.find((option) => option.state.active) ?? options[0]!;
       const enabled = options.some((option) => option.state.enabled);
       const currentLabel = props.t(current.control.labelKey);
-      return h('span', { class: 'ep-toolbar__alignment', 'data-testid': 'toolbar-alignment' }, [
-        h(
-          'button',
-          {
-            type: 'button',
-            class: 'ep-toolbar__button ep-toolbar__alignment-trigger',
-            disabled: !enabled,
-            'aria-haspopup': 'true',
-            'aria-expanded': open.value ? 'true' : 'false',
-            'aria-label': currentLabel,
-            title: enabled ? currentLabel : (current.state.disabledReason ?? currentLabel),
-            onMousedown: (event: MouseEvent) => event.preventDefault(),
-            onClick: () => {
-              open.value = !open.value;
+      return h(
+        'span',
+        { class: 'docx-editor-toolbar__alignment', 'data-testid': 'toolbar-alignment' },
+        [
+          h(
+            'button',
+            {
+              type: 'button',
+              class: 'docx-editor-toolbar__button docx-editor-toolbar__alignment-trigger',
+              disabled: !enabled,
+              'aria-haspopup': 'true',
+              'aria-expanded': open.value ? 'true' : 'false',
+              'aria-label': currentLabel,
+              title: enabled ? currentLabel : (current.state.disabledReason ?? currentLabel),
+              onMousedown: (event: MouseEvent) => event.preventDefault(),
+              onClick: () => {
+                open.value = !open.value;
+              },
             },
-          },
-          [
-            icon(current.control.paths ?? []),
-            h('span', { class: 'ep-toolbar__picker-caret', 'aria-hidden': 'true' }, '▾'),
-          ]
-        ),
-        open.value
-          ? h(
-              'div',
-              { class: 'ep-toolbar__alignment-popup' },
-              options.map((option) =>
-                h(
-                  'button',
-                  {
-                    key: option.slot,
-                    type: 'button',
-                    class: 'ep-toolbar__button',
-                    'data-testid': `toolbar-${option.slot}`,
-                    disabled: !option.state.enabled,
-                    'aria-pressed': option.state.active ? 'true' : 'false',
-                    title: option.state.disabledReason ?? props.t(option.control.labelKey),
-                    'aria-label': props.t(option.control.labelKey),
-                    onMousedown: (event: MouseEvent) => event.preventDefault(),
-                    onClick: () => {
-                      runToolbarCommand(props.editor, option.slot);
-                      open.value = false;
+            [
+              icon(current.control.paths ?? []),
+              h('span', { class: 'docx-editor-toolbar__picker-caret', 'aria-hidden': 'true' }, '▾'),
+            ]
+          ),
+          open.value
+            ? h(
+                'div',
+                { class: 'docx-editor-toolbar__alignment-popup' },
+                options.map((option) =>
+                  h(
+                    'button',
+                    {
+                      key: option.slot,
+                      type: 'button',
+                      class: 'docx-editor-toolbar__button',
+                      'data-testid': `toolbar-${option.slot}`,
+                      disabled: !option.state.enabled,
+                      'aria-pressed': option.state.active ? 'true' : 'false',
+                      title: option.state.disabledReason ?? props.t(option.control.labelKey),
+                      'aria-label': props.t(option.control.labelKey),
+                      onMousedown: (event: MouseEvent) => event.preventDefault(),
+                      onClick: () => {
+                        runToolbarCommand(props.editor, option.slot);
+                        open.value = false;
+                      },
                     },
-                  },
-                  [icon(option.control.paths ?? [])]
+                    [icon(option.control.paths ?? [])]
+                  )
                 )
               )
-            )
-          : null,
-      ]);
+            : null,
+        ]
+      );
     };
   },
 });
@@ -317,7 +321,7 @@ export default defineComponent({
       return h(
         'div',
         {
-          class: 'ep-toolbar',
+          class: 'docx-editor-toolbar',
           role: 'toolbar',
           'aria-label': props.t('toolbar.ariaLabel'),
           'data-testid': 'docx-editor-toolbar',
@@ -330,12 +334,14 @@ export default defineComponent({
         // (image / table / save) are composition-only, and the alignment group
         // renders as ONE merged dropdown — same rules as the React toolbar.
         defaultChromeGroups().map((group, index) =>
-          h('div', { key: group.id, class: 'ep-toolbar__group-wrap' }, [
-            ...(index > 0 ? [h('div', { class: 'ep-toolbar__separator', role: 'separator' })] : []),
+          h('div', { key: group.id, class: 'docx-editor-toolbar__group-wrap' }, [
+            ...(index > 0
+              ? [h('div', { class: 'docx-editor-toolbar__separator', role: 'separator' })]
+              : []),
             h(
               'div',
               {
-                class: 'ep-toolbar__group',
+                class: 'docx-editor-toolbar__group',
                 role: 'group',
                 'aria-label': props.t(group.labelKey),
                 'data-group': group.id,

--- a/packages/vue/src/HorizontalRuler.ts
+++ b/packages/vue/src/HorizontalRuler.ts
@@ -37,7 +37,7 @@ export default defineComponent({
         ? h(
             'div',
             {
-              class: 'ep-ruler ep-ruler--horizontal',
+              class: 'docx-editor-ruler docx-editor-ruler--horizontal',
               'data-testid': 'horizontal-ruler',
               role: 'presentation',
               'aria-hidden': 'true',
@@ -48,10 +48,10 @@ export default defineComponent({
                 'div',
                 {
                   key: tick.position,
-                  class: 'ep-ruler__tick',
+                  class: 'docx-editor-ruler__tick',
                   style: { left: `${tick.position * props.zoom}px`, height: `${tick.height}px` },
                 },
-                tick.label ? [h('span', { class: 'ep-ruler__label' }, tick.label)] : []
+                tick.label ? [h('span', { class: 'docx-editor-ruler__label' }, tick.label)] : []
               )
             )
           )

--- a/packages/vue/src/PageIndicator.ts
+++ b/packages/vue/src/PageIndicator.ts
@@ -36,7 +36,7 @@ export default defineComponent({
         ? h(
             'div',
             {
-              class: 'ep-shell__page-indicator-chip',
+              class: 'docx-editor-shell__page-indicator-chip',
               'data-testid': 'page-indicator',
               style: { opacity: props.visible ? 1 : 0 },
               'aria-live': 'polite',

--- a/packages/vue/src/VerticalRuler.ts
+++ b/packages/vue/src/VerticalRuler.ts
@@ -40,7 +40,7 @@ export default defineComponent({
         ? h(
             'div',
             {
-              class: 'ep-ruler ep-ruler--vertical',
+              class: 'docx-editor-ruler docx-editor-ruler--vertical',
               'data-testid': 'vertical-ruler',
               role: 'presentation',
               'aria-hidden': 'true',
@@ -51,10 +51,10 @@ export default defineComponent({
                 'div',
                 {
                   key: tick.position,
-                  class: 'ep-ruler__tick',
+                  class: 'docx-editor-ruler__tick',
                   style: { top: `${tick.position * props.zoom}px`, width: `${tick.height}px` },
                 },
-                tick.label ? [h('span', { class: 'ep-ruler__label' }, tick.label)] : []
+                tick.label ? [h('span', { class: 'docx-editor-ruler__label' }, tick.label)] : []
               )
             )
           )

--- a/packages/vue/test/toolbar-engine-state.test.ts
+++ b/packages/vue/test/toolbar-engine-state.test.ts
@@ -161,7 +161,7 @@ describe('the Vue toolbar reads enabled state from the engine', () => {
     await nextTick();
 
     const trigger = toolbar.querySelector(
-      '.ep-toolbar__alignment-trigger'
+      '.docx-editor-toolbar__alignment-trigger'
     ) as HTMLButtonElement | null;
     expect(trigger).not.toBeNull();
     expect(trigger!.disabled).toBe(false);

--- a/scripts/build-core-styles.mjs
+++ b/scripts/build-core-styles.mjs
@@ -60,7 +60,7 @@ const prefixKeyframes = {
     const renamed = new Map();
     cssRoot.walkAtRules(/^(-\w+-)?keyframes$/, (rule) => {
       const name = rule.params.trim();
-      if (name.startsWith('docx-') || name.startsWith('ep-') || name.startsWith('hf-')) return;
+      if (name.startsWith('docx-') || name.startsWith('hf-')) return;
       const next = `docx-editor-${name}`;
       renamed.set(name, next);
       rule.params = next;

--- a/scripts/core-css-assertions.mjs
+++ b/scripts/core-css-assertions.mjs
@@ -24,7 +24,7 @@ const SCOPE = '.docx-editor';
  * matched on painted document elements rather than on chrome descendants, so
  * requiring the scope class on them would be wrong.
  */
-const OWNED_PREFIXES = ['.docx-', '.ep-', '.layout-', '.paged-editor', '.ProseMirror-'];
+const OWNED_PREFIXES = ['.docx-', '.layout-', '.paged-editor', '.ProseMirror-'];
 
 /** A keyframe step (`from`, `to`, `47%`) is not a selector. */
 const KEYFRAME_STEP = /^(from|to|-?[\d.]+%)$/;
@@ -77,7 +77,7 @@ export function coreCssProblems(rawCss) {
   // so they carry the editor's prefix instead (see build-core-styles.mjs).
   root.walkAtRules(/^(-\w+-)?keyframes$/, (rule) => {
     const name = rule.params.trim();
-    if (!/^(docx-|ep-|hf-)/.test(name)) {
+    if (!/^(docx-|hf-)/.test(name)) {
       problems.push(`@keyframes name is in the global namespace: ${name}`);
     }
   });


### PR DESCRIPTION
The root class rename left every other class on the old prefix, so the stylesheet carried two namespaces. Blocks are unchanged, only the prefix moves: `.ep-one-surface__caret` becomes `.docx-editor-one-surface__caret`, and the `ep-caret-blink` keyframe follows.

The CSS guards in `scripts/` no longer allowlist the retired prefix, so a reintroduced `.ep-*` selector now fails the build rather than passing silently.

Untouched on purpose: the separate `docx-toolbar__*` / `docx-menubar__*` / `docx-dialog__*` family, and the old names inside CHANGELOGs and archived specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788636498&installation_model_id=422592&pr_number=210&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F210&signature=306a007cf0ddb797e9614442aa5139fe0be3657cd49a6221d31973ea785b69d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->