### PR TITLE
feat: render BMP and WebP images

### DIFF
--- a/.changeset/bmp-webp-images.md
+++ b/.changeset/bmp-webp-images.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+BMP and WebP images now render instead of showing an unsupported-format placeholder.

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -1760,7 +1760,7 @@ export interface StyleDefinitions {
 }
 
 // @public
-export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif';
+export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/bmp' | 'image/webp';
 
 // @public
 export interface Table {

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -1728,7 +1728,7 @@ export function sniffImageMime(bytes: Uint8Array): RenderableImageMime | Preserv
 export function sourceCropFromCropPercent(crop: ImageCropPercent): SourceCrop;
 
 // @public
-export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif';
+export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/bmp' | 'image/webp';
 
 // @public
 export interface SurfaceExtent {

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -2521,7 +2521,7 @@ export interface StyleDefinitions {
 }
 
 // @public
-export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif';
+export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/bmp' | 'image/webp';
 
 // @public
 export interface SurfaceHyperlink {

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3610,7 +3610,7 @@ export interface StyleIndexEntry {
 export function stylesPartOf(pkg: OoxmlPackage): OoxmlPart | undefined;
 
 // @public
-export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif';
+export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/bmp' | 'image/webp';
 
 // @public
 export function sweepCustomNodePayloads(pkg: OoxmlPackage, storyPartName: string, namespaces: readonly string[]): CustomNodeSweepResult;

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -12,11 +12,15 @@ DrawingML pictures (`w:drawing` with `pic:pic`) lay out, paint, and round-trip t
 | Format                                      | Insert (React)                       | Layout & paint                      | Round-trip                                |
 | ------------------------------------------- | ------------------------------------ | ----------------------------------- | ----------------------------------------- |
 | PNG, JPEG, GIF                              | Yes, `normalizeImageBytes` preflight | Full decode at authored `wp:extent` | Byte-identical media unless replaced      |
+| BMP, WebP                                   | No insert                            | Full decode at authored `wp:extent` | Byte-identical media                      |
 | SVG                                         | No insert                            | Painted at authored `wp:extent`     | Byte-identical media                      |
 | TIFF, EMF, WMF                              | No insert                            | Converted to a raster and painted   | Preserved; no zero-click fetch            |
 | External `r:link` / `TargetMode="External"` | No auto-load                         | Placeholder + preserved rel         | Preserved; explicit user gesture to embed |
 
 Insert accepts PNG/JPEG/GIF only. Other payloads stay in the package and participate in pagination through their authored extent.
+
+BMP and WebP decode natively in the browser and paint like PNG or JPEG. BMP is what older
+documents tend to carry; WebP is what current Word writes.
 
 TIFF, EMF and WMF are rasterized in the browser and painted like any other image. The original
 bytes stay in the package untouched, so saving round-trips them unchanged. A file that cannot be

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -445,6 +445,18 @@ export const wordFeatures: WordFeature[] = [
       'Nine wrap choices, exclusion reflow, z-order, and anchored drag/resize in React. Vue wrap/alt/properties chrome deferred; engine setImageWrapType and toolbarCommandState are shared.',
   },
   {
+    id: 'images.bmp-webp',
+    name: 'BMP and WebP images',
+    category: 'images',
+    editing: 'none',
+    rendering: 'full',
+    roundTrip: 'full',
+    tier: 'community',
+    docsLink: '/docs/2.x/guides/images',
+    notes:
+      'Decoded natively by the browser and painted at the authored size, like PNG or JPEG. BMP covers what older documents carry (including top-down bitmaps and the 12-byte BITMAPCOREHEADER); WebP covers lossy, lossless and extended containers. Inserting a new one is not supported yet.',
+  },
+  {
     id: 'images.svg',
     name: 'SVG images',
     category: 'images',

--- a/examples/vite/src/test-harness/TreeSurfaceHarness.tsx
+++ b/examples/vite/src/test-harness/TreeSurfaceHarness.tsx
@@ -123,7 +123,11 @@ export function TreeSurfaceHarness({ fixtureUrl }: { fixtureUrl: string }) {
           className="docx-editor-browser-first__page"
           style={{ background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.2)' }}
         >
-          <div ref={mountRef} className="docx-editor-browser-first__mount" data-testid="tree-mount" />
+          <div
+            ref={mountRef}
+            className="docx-editor-browser-first__mount"
+            data-testid="tree-mount"
+          />
         </div>
       </div>
 

--- a/packages/core/src/store/__tests__/image-resources.test.ts
+++ b/packages/core/src/store/__tests__/image-resources.test.ts
@@ -10,14 +10,28 @@ import {
   MAX_SVG_SNIFF_BYTES,
   resolveSvgIntrinsicSize,
   sniffImageMime,
+  validateBmpHeader,
   validateGifHeader,
   validateJpegHeader,
   validatePngHeader,
   validateRasterHeader,
   validateTiffHeader,
+  validateWebpHeader,
   type ImageDecodePort,
   type ImageResourceState,
 } from '../package/image-resources.ts';
+import {
+  bmp24,
+  bmpCore,
+  bmpWithBitCount,
+  bmpWithDibSize,
+  bmpWithPlanes,
+  webpExtended,
+  webpLossless,
+  webpLossy,
+  webpLossyWithoutStartCode,
+  webpUnknownChunk,
+} from './raster-format-bytes.ts';
 import {
   baselineRgbTiff,
   buildTiff,
@@ -115,6 +129,8 @@ function contentTypes(extra = ''): string {
     '<Default Extension="jpg" ContentType="image/jpeg"/>' +
     '<Default Extension="jpeg" ContentType="image/jpeg"/>' +
     '<Default Extension="gif" ContentType="image/gif"/>' +
+    '<Default Extension="bmp" ContentType="image/bmp"/>' +
+    '<Default Extension="webp" ContentType="image/webp"/>' +
     '<Default Extension="svg" ContentType="image/svg+xml"/>' +
     '<Default Extension="tif" ContentType="image/tiff"/>' +
     '<Default Extension="emf" ContentType="image/x-emf"/>' +
@@ -388,9 +404,96 @@ describe('image resource validation and cache (task 4)', () => {
     ] as const)('TIFF header rejects %s', (_label, bytes) => {
       expect(validateTiffHeader(bytes)).toBeNull();
     });
+
+    test('BMP reads its extent from either DIB header', () => {
+      expect(validateBmpHeader(bmp24(4, 3))).toEqual({ pixelWidth: 4, pixelHeight: 3 });
+      expect(validateBmpHeader(bmpCore(3, 5))).toEqual({ pixelWidth: 3, pixelHeight: 5 });
+    });
+
+    test('a top-down BMP has a negative height, not a malformed one', () => {
+      // Word-era encoders write these routinely; read as unsigned it is ~4 billion tall.
+      expect(validateBmpHeader(bmp24(4, -3))).toEqual({ pixelWidth: 4, pixelHeight: 3 });
+    });
+
+    test.each([
+      ['not a bitmap', Uint8Array.from([0x42, 0x4e, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])],
+      ['truncated before the DIB header', bmp24(4, 3).slice(0, 20)],
+      ['a zero extent', bmp24(0, 3)],
+      ['an unknown DIB header size', bmpWithDibSize(24)],
+      ['a bit count no BMP defines', bmpWithBitCount(7)],
+      ['a plane count other than one', bmpWithPlanes(2)],
+    ] as const)('BMP header rejects %s', (_label, bytes) => {
+      expect(validateBmpHeader(bytes)).toBeNull();
+    });
+
+    test.each([
+      ['lossy VP8', webpLossy(32, 16), { pixelWidth: 32, pixelHeight: 16 }],
+      ['lossless VP8L', webpLossless(16, 8), { pixelWidth: 16, pixelHeight: 8 }],
+      ['extended VP8X', webpExtended(100, 50), { pixelWidth: 100, pixelHeight: 50 }],
+    ] as const)('WebP reads its extent from %s', (_label, bytes, expected) => {
+      expect(validateWebpHeader(bytes)).toEqual(expected);
+    });
+
+    test.each([
+      ['a truncated container', webpLossy().slice(0, 20)],
+      ['an unknown body chunk', webpUnknownChunk()],
+      ['a lossy frame with no start code', webpLossyWithoutStartCode()],
+    ] as const)('WebP header rejects %s', (_label, bytes) => {
+      expect(validateWebpHeader(bytes)).toBeNull();
+    });
+
+    test('sniffing recognizes both without help from the content type', () => {
+      expect(sniffImageMime(bmp24())).toBe('image/bmp');
+      expect(sniffImageMime(webpLossy())).toBe('image/webp');
+      expect(sniffImageMime(webpLossless())).toBe('image/webp');
+      // `RIFF` alone is not WebP — it is also WAV and AVI.
+      const riffOnly = Uint8Array.from(webpLossy());
+      riffOnly[8] = 0x57;
+      riffOnly[9] = 0x41;
+      riffOnly[10] = 0x56;
+      riffOnly[11] = 0x45;
+      expect(sniffImageMime(riffOnly)).toBe('unknown');
+    });
+
+    test('validateRasterHeader dispatches the new formats', () => {
+      expect(validateRasterHeader(bmp24(4, 3), 'image/bmp')).toEqual({
+        pixelWidth: 4,
+        pixelHeight: 3,
+      });
+      expect(validateRasterHeader(webpLossless(16, 8), 'image/webp')).toEqual({
+        pixelWidth: 16,
+        pixelHeight: 8,
+      });
+    });
   });
 
   describe('embedded resolve', () => {
+    test.each([
+      ['bmp', bmp24(4, 3), 'image/bmp', { width: 4, height: 3 }],
+      ['webp', webpLossless(16, 8), 'image/webp', { width: 16, height: 8 }],
+    ] as const)(
+      'an embedded %s resolves ready through the ordinary raster path',
+      async (extension, bytes, mime, extent) => {
+        const part = `word/media/image1.${extension}`;
+        const loaded = buildPackage({
+          includeDefaultMedia: false,
+          media: { [part]: bytes },
+          docRels:
+            `<Relationships xmlns="${REL_NS}">` +
+            `<Relationship Id="rId2" Type="${IMAGE_REL}" Target="media/image1.${extension}"/>` +
+            '</Relationships>',
+        });
+        if (!loaded.ok) throw new Error(loaded.reason);
+        const cache = createImageResourceCache(loaded.package, { decodePort: mockDecodePort() });
+        const state = await cache.resolveEmbedded('/word/document.xml', 'rId2');
+        expect(state.kind).toBe('ready');
+        if (state.kind !== 'ready') return;
+        expect(state.mime).toBe(mime);
+        expect(state.pixelWidth).toBe(extent.width);
+        expect(state.pixelHeight).toBe(extent.height);
+      }
+    );
+
     test('content-type spoofing yields signature-mismatch', async () => {
       const loaded = buildPackage({ media: { 'word/media/image1.png': JPEG_1X1 } });
       if (!loaded.ok) throw new Error(loaded.reason);

--- a/packages/core/src/store/__tests__/raster-format-bytes.ts
+++ b/packages/core/src/store/__tests__/raster-format-bytes.ts
@@ -1,0 +1,145 @@
+// Deterministic BMP and WebP bytes for tests.
+//
+// `bmp24` is a real, decodable 1x1 bitmap. The WebP builders are HEADER fixtures: each of
+// the three body chunks stores its extent differently, and the extent is all the structural
+// validator reads — a real VP8 bitstream would add nothing to what is under test.
+
+function ascii(text: string): number[] {
+  return [...text].map((character) => character.charCodeAt(0));
+}
+
+function u16(value: number): number[] {
+  return [value & 0xff, (value >>> 8) & 0xff];
+}
+
+function u32(value: number): number[] {
+  return [value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff];
+}
+
+/** A real 24-bit BMP: 14-byte file header, 40-byte BITMAPINFOHEADER, one padded pixel row. */
+export function bmp24(width = 1, height = 1): Uint8Array {
+  const rowStride = Math.ceil((width * 3) / 4) * 4;
+  const pixels = new Array<number>(rowStride * Math.abs(height)).fill(0x40);
+  return Uint8Array.from([
+    ...ascii('BM'),
+    ...u32(54 + pixels.length),
+    ...u32(0),
+    ...u32(54),
+    ...u32(40), // BITMAPINFOHEADER
+    ...u32(width),
+    ...u32(height), // signed: negative is a top-down bitmap
+    ...u16(1), // planes
+    ...u16(24), // bit count
+    ...u32(0), // BI_RGB
+    ...u32(pixels.length),
+    ...u32(2835),
+    ...u32(2835),
+    ...u32(0),
+    ...u32(0),
+    ...pixels,
+  ]);
+}
+
+/** BMP with the 12-byte `BITMAPCOREHEADER`, whose extent is 16-bit rather than 32-bit. */
+export function bmpCore(width = 3, height = 5): Uint8Array {
+  const pixels = new Array<number>(12).fill(0);
+  return Uint8Array.from([
+    ...ascii('BM'),
+    ...u32(26 + pixels.length),
+    ...u32(0),
+    ...u32(26),
+    ...u32(12),
+    ...u16(width),
+    ...u16(height),
+    ...u16(1),
+    ...u16(24),
+    ...pixels,
+  ]);
+}
+
+/** A 24-bit BMP whose DIB header claims a size no BMP revision defines. */
+export function bmpWithDibSize(dibSize: number): Uint8Array {
+  const bytes = bmp24(4, 3);
+  new DataView(bytes.buffer).setUint32(14, dibSize, true);
+  return bytes;
+}
+
+/** A BMP declaring a bit depth outside the set BITMAPINFOHEADER allows. */
+export function bmpWithBitCount(bitCount: number): Uint8Array {
+  const bytes = bmp24(4, 3);
+  new DataView(bytes.buffer).setUint16(28, bitCount, true);
+  return bytes;
+}
+
+/** A BMP declaring a plane count other than the mandatory 1. */
+export function bmpWithPlanes(planes: number): Uint8Array {
+  const bytes = bmp24(4, 3);
+  new DataView(bytes.buffer).setUint16(26, planes, true);
+  return bytes;
+}
+
+function webpContainer(chunk: string, body: readonly number[]): Uint8Array {
+  const bytes = [
+    ...ascii('RIFF'),
+    ...u32(4 + 8 + body.length),
+    ...ascii('WEBP'),
+    ...ascii(chunk),
+    ...u32(body.length),
+    ...body,
+  ];
+  // The structural validator refuses anything under 30 bytes, which every real file clears.
+  while (bytes.length < 30) bytes.push(0);
+  return Uint8Array.from(bytes);
+}
+
+/** Lossy `VP8 `: key-frame start code, then 14-bit width and height. */
+export function webpLossy(width = 32, height = 16): Uint8Array {
+  return webpContainer('VP8 ', [
+    0x00,
+    0x00,
+    0x00, // frame tag
+    0x9d,
+    0x01,
+    0x2a, // start code
+    ...u16(width),
+    ...u16(height),
+  ]);
+}
+
+/** Lossless `VP8L`: signature byte, then two 14-bit "minus one" extents packed together. */
+export function webpLossless(width = 16, height = 8): Uint8Array {
+  const packed = ((width - 1) & 0x3fff) | (((height - 1) & 0x3fff) << 14);
+  return webpContainer('VP8L', [0x2f, ...u32(packed >>> 0)]);
+}
+
+/** A WebP container whose body chunk is none of the three that carry an extent. */
+export function webpUnknownChunk(): Uint8Array {
+  return webpContainer('ANIM', new Array<number>(16).fill(0));
+}
+
+/** Lossy WebP whose key-frame start code is missing — a truncated or forged frame. */
+export function webpLossyWithoutStartCode(): Uint8Array {
+  const bytes = webpLossy();
+  bytes[23] = 0;
+  bytes[24] = 0;
+  bytes[25] = 0;
+  return bytes;
+}
+
+/** Extended `VP8X`: canvas extent as two 24-bit "minus one" values. */
+export function webpExtended(width = 100, height = 50): Uint8Array {
+  const w = width - 1;
+  const h = height - 1;
+  return webpContainer('VP8X', [
+    0x10, // flags
+    0x00,
+    0x00,
+    0x00, // reserved
+    w & 0xff,
+    (w >>> 8) & 0xff,
+    (w >>> 16) & 0xff,
+    h & 0xff,
+    (h >>> 8) & 0xff,
+    (h >>> 16) & 0xff,
+  ]);
+}

--- a/packages/core/src/store/package/drawing-package-edit.ts
+++ b/packages/core/src/store/package/drawing-package-edit.ts
@@ -32,12 +32,16 @@ const MIME_TO_CONTENT_TYPE: Readonly<Record<SupportedImageMime, string>> = Objec
   'image/png': 'image/png',
   'image/jpeg': 'image/jpeg',
   'image/gif': 'image/gif',
+  'image/bmp': 'image/bmp',
+  'image/webp': 'image/webp',
 });
 
 const MIME_TO_EXTENSION: Readonly<Record<SupportedImageMime, string>> = Object.freeze({
   'image/png': 'png',
   'image/jpeg': 'jpeg',
   'image/gif': 'gif',
+  'image/bmp': 'bmp',
+  'image/webp': 'webp',
 });
 
 const IMAGE_CONTENT_TYPES: ReadonlySet<string> = new Set([
@@ -45,6 +49,10 @@ const IMAGE_CONTENT_TYPES: ReadonlySet<string> = new Set([
   'image/jpeg',
   'image/jpg',
   'image/gif',
+  'image/bmp',
+  'image/x-ms-bmp',
+  'image/x-bmp',
+  'image/webp',
   'image/svg+xml',
   'image/tiff',
   'image/x-emf',

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -23,8 +23,19 @@ import {
   type ImageResourceLimits,
 } from '../runtime/limits.ts';
 
-/** Raster media the decode port measures and any authoring path may write. */
-export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif';
+/**
+ * Raster media the decode port measures and any authoring path may write.
+ *
+ * BMP and WebP are here for the same reason the other three are: an `<img>` decodes them
+ * natively, so they need a signature and a structural header and nothing else. BMP is what
+ * older documents carry; WebP is what current Word writes.
+ */
+export type SupportedImageMime =
+  | 'image/png'
+  | 'image/jpeg'
+  | 'image/gif'
+  | 'image/bmp'
+  | 'image/webp';
 /**
  * Vector media painted straight from validated bytes. An `<img>` renders SVG in the
  * browser's secure static mode — no script, no external subresource loads — so there is
@@ -140,6 +151,11 @@ const CONTENT_TYPE_TO_MIME: Readonly<Record<string, RenderableImageMime | Preser
     'image/jpeg': 'image/jpeg',
     'image/jpg': 'image/jpeg',
     'image/gif': 'image/gif',
+    // `image/bmp` is the registered type; Word and older producers also write these two.
+    'image/bmp': 'image/bmp',
+    'image/x-ms-bmp': 'image/bmp',
+    'image/x-bmp': 'image/bmp',
+    'image/webp': 'image/webp',
     'image/svg+xml': 'image/svg+xml',
     'image/tiff': 'image/tiff',
     'image/x-emf': 'image/x-emf',
@@ -197,7 +213,13 @@ export function hasBoundedSvgRoot(bytes: Uint8Array): boolean {
 }
 
 function isRasterSupportedMime(mime: string): mime is SupportedImageMime {
-  return mime === 'image/png' || mime === 'image/jpeg' || mime === 'image/gif';
+  return (
+    mime === 'image/png' ||
+    mime === 'image/jpeg' ||
+    mime === 'image/gif' ||
+    mime === 'image/bmp' ||
+    mime === 'image/webp'
+  );
 }
 
 function isPreservedMime(mime: string): mime is PreservedImageMime {
@@ -211,6 +233,24 @@ export function sniffImageMime(
   if (bytesStartWith(bytes, PNG_SIGNATURE)) return 'image/png';
   if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
     return 'image/jpeg';
+  }
+  // `BM` — the only file type BITMAPFILEHEADER declares. The DIB header behind it is what
+  // `validateBmpHeader` reads; two bytes alone are a weak signature, which is exactly why
+  // nothing downstream trusts the sniff on its own.
+  if (bytes.length >= 2 && bytes[0] === 0x42 && bytes[1] === 0x4d) return 'image/bmp';
+  // RIFF container with a `WEBP` form type: `RIFF....WEBP`.
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return 'image/webp';
   }
   if (
     bytes.length >= 6 &&
@@ -364,6 +404,76 @@ export function validateJpegHeader(bytes: Uint8Array): ValidatedRasterHeader | n
       return { pixelWidth, pixelHeight };
     }
     offset = segmentEnd;
+  }
+  return null;
+}
+
+/** `BITMAPCOREHEADER` is 12 bytes and 16-bit; every later DIB header is 40 or more and 32-bit. */
+const BMP_CORE_HEADER_SIZE = 12;
+const BMP_INFO_HEADER_SIZE = 40;
+/** Bit depths BITMAPINFOHEADER defines. Anything else is not a bitmap this file claims to be. */
+const BMP_BIT_COUNTS: ReadonlySet<number> = new Set([0, 1, 4, 8, 16, 24, 32]);
+
+/**
+ * Structural BMP validation: file header, DIB header size, and the extent it declares.
+ *
+ * Height is SIGNED — a negative one is a top-down bitmap, which is ordinary and must not be
+ * read as a malformed file or as a huge unsigned number.
+ */
+export function validateBmpHeader(bytes: Uint8Array): ValidatedRasterHeader | null {
+  if (bytes.length < 26) return null;
+  if (bytes[0] !== 0x42 || bytes[1] !== 0x4d) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const dibSize = view.getUint32(14, true);
+  if (dibSize === BMP_CORE_HEADER_SIZE) {
+    const pixelWidth = view.getUint16(18, true);
+    const pixelHeight = view.getUint16(20, true);
+    if (pixelWidth === 0 || pixelHeight === 0) return null;
+    return { pixelWidth, pixelHeight };
+  }
+  // 40 (INFO), 52/56 (V2/V3), 108 (V4), 124 (V5) all share the first 16 bytes.
+  if (dibSize < BMP_INFO_HEADER_SIZE || dibSize > 1024) return null;
+  if (bytes.length < 14 + BMP_INFO_HEADER_SIZE) return null;
+  const pixelWidth = view.getInt32(18, true);
+  const signedHeight = view.getInt32(22, true);
+  const pixelHeight = Math.abs(signedHeight);
+  if (pixelWidth <= 0 || pixelHeight === 0) return null;
+  if (view.getUint16(26, true) !== 1) return null; // planes: always 1
+  if (!BMP_BIT_COUNTS.has(view.getUint16(28, true))) return null;
+  return { pixelWidth, pixelHeight };
+}
+
+/**
+ * Structural WebP validation across the three body chunks: `VP8 ` lossy, `VP8L` lossless,
+ * and `VP8X` extended (animated or with alpha/ICC, where the canvas size is authoritative).
+ *
+ * Each stores its extent differently and none of them stores it in the RIFF header, so all
+ * three are read rather than assuming the common case.
+ */
+export function validateWebpHeader(bytes: Uint8Array): ValidatedRasterHeader | null {
+  if (bytes.length < 30) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const chunk = String.fromCharCode(bytes[12]!, bytes[13]!, bytes[14]!, bytes[15]!);
+  if (chunk === 'VP8 ') {
+    // Key-frame start code, then 14-bit width and height.
+    if (bytes[23] !== 0x9d || bytes[24] !== 0x01 || bytes[25] !== 0x2a) return null;
+    const pixelWidth = view.getUint16(26, true) & 0x3fff;
+    const pixelHeight = view.getUint16(28, true) & 0x3fff;
+    if (pixelWidth === 0 || pixelHeight === 0) return null;
+    return { pixelWidth, pixelHeight };
+  }
+  if (chunk === 'VP8L') {
+    if (bytes[20] !== 0x2f) return null; // lossless signature byte
+    const packed = view.getUint32(21, true);
+    const pixelWidth = (packed & 0x3fff) + 1;
+    const pixelHeight = ((packed >>> 14) & 0x3fff) + 1;
+    return { pixelWidth, pixelHeight };
+  }
+  if (chunk === 'VP8X') {
+    // Canvas extent as two 24-bit little-endian "minus one" values.
+    const pixelWidth = (bytes[24]! | (bytes[25]! << 8) | (bytes[26]! << 16)) + 1;
+    const pixelHeight = (bytes[27]! | (bytes[28]! << 8) | (bytes[29]! << 16)) + 1;
+    return { pixelWidth, pixelHeight };
   }
   return null;
 }
@@ -595,6 +705,10 @@ export function validateRasterHeader(
       return validateGifHeader(bytes);
     case 'image/jpeg':
       return validateJpegHeader(bytes);
+    case 'image/bmp':
+      return validateBmpHeader(bytes);
+    case 'image/webp':
+      return validateWebpHeader(bytes);
     default:
       return null;
   }


### PR DESCRIPTION
Both decode natively in an `<img>`, so they need a signature, a structural header and a content-type entry, then they ride the raster path PNG and JPEG already take. BMP is what older documents carry (Paint-era clipart, scanned inserts); WebP is what current Word writes. Until now both landed on the unsupported-format placeholder.

The structural headers are where the care goes, since these bytes are attacker-controlled:

- **BMP** reads either DIB layout — the 12-byte `BITMAPCOREHEADER` as well as `BITMAPINFOHEADER` and its successors — and treats a negative height as the top-down bitmap it is rather than a ~4-billion-pixel one. Plane count and bit depth are checked against what the format actually defines.
- **WebP** reads all three body chunks. Lossy `VP8 `, lossless `VP8L` and extended `VP8X` each store the extent differently and none of them stores it in the RIFF header, so assuming the common case would have silently mis-sized the other two. `RIFF` alone is not enough to claim WebP — it is also WAV and AVI — so the form type is checked too.

Widening `SupportedImageMime` made the compiler point at the two exhaustive maps that needed the new entries, which is why this is a minor rather than a patch.

Inserting a new BMP or WebP is still unsupported, same as SVG and TIFF; the docs say so.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788637897&installation_model_id=422592&pr_number=211&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F211&signature=12e72cbddd5547ee4d3b578dba9951bd44df4845aa6a8eaf12276ca8f0d5a0a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->