### PR TITLE
fix(core): place comment markers by the paragraph offset authority

### DIFF
--- a/.changeset/comment-offset-authority.md
+++ b/.changeset/comment-offset-authority.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Comment markers now land on the character they were asked for in paragraphs holding a drawing, a field or an inline content control. The comment writer measured those paragraphs with a walk of its own that counted such elements as nothing, so commenting near one was either refused outright or, worse, placed the marker silently on the wrong character.
+Comment markers now land on the character they were asked for in paragraphs holding a drawing, a field or an inline content control, and a comment can be anchored inside a content control at all. The comment writer measured those paragraphs with a walk of its own that counted such elements as nothing, so commenting near one was either refused outright or, worse, placed the marker silently on the wrong character. A marker at the far edge of a complex field is also placed after the whole field rather than among its parts, where Word would drop it on the next field rebuild.

--- a/.changeset/comment-offset-authority.md
+++ b/.changeset/comment-offset-authority.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Comment markers now land on the character they were asked for in paragraphs holding a drawing, a field or an inline content control. The comment writer measured those paragraphs with a walk of its own that counted such elements as nothing, so commenting near one was either refused outright or, worse, placed the marker silently on the wrong character.

--- a/packages/core/src/store/__tests__/comment-offset-authority.test.ts
+++ b/packages/core/src/store/__tests__/comment-offset-authority.test.ts
@@ -141,6 +141,20 @@ describe('a marker lands at the offset it was asked for', () => {
       name: 'a footnote mark leading the paragraph',
       body: `<w:p><w:r><w:footnoteRef/></w:r>${run('note text')}</w:p>`,
     },
+    { name: 'an inline content control', body: `<w:p>${INLINE_SDT}${run('cd')}</w:p>` },
+    {
+      name: 'a control holding two runs',
+      body:
+        `<w:p><w:sdt><w:sdtPr><w:tag w:val="t"/></w:sdtPr><w:sdtContent>` +
+        `${run('AB')}${run('CD')}</w:sdtContent></w:sdt>${run('ef')}</w:p>`,
+    },
+    {
+      name: 'a link inside a tracked insertion inside a control',
+      body:
+        `<w:p><w:sdt><w:sdtPr><w:tag w:val="t"/></w:sdtPr><w:sdtContent>` +
+        `<w:ins w:id="9" w:author="A" w:date="D"><w:hyperlink>${run('link')}</w:hyperlink></w:ins>` +
+        `</w:sdtContent></w:sdt>${run('after')}</w:p>`,
+    },
   ];
 
   for (const { name, body } of cases) {
@@ -148,11 +162,9 @@ describe('a marker lands at the offset it was asked for', () => {
       const length = lengthOfBody(body);
       expect(length).toBeGreaterThan(0);
       for (let offset = 0; offset <= length; offset += 1) {
-        // A refusal is a legitimate answer for an offset inside something indivisible (the
-        // middle of a drawing is not a place). Landing SOMEWHERE ELSE never is.
-        const landed = markerOffset(body, offset);
-        if (landed === null) continue;
-        expect({ offset, landed }).toEqual({ offset, landed: offset });
+        // LANDS, at the offset asked for. Not "does not land wrong": a skipped refusal is
+        // how the first version of this test managed to assert nothing at all.
+        expect({ offset, landed: markerOffset(body, offset) }).toEqual({ offset, landed: offset });
       }
     });
   }
@@ -170,5 +182,38 @@ describe('a marker lands at the offset it was asked for', () => {
     const body = `<w:p>${run('ab')}${DRAWING}${run('cd')}</w:p>`;
     expect(lengthOfBody(body)).toBe(5);
     expect(markerOffset(body, 5)).toBe(5);
+  });
+});
+
+describe('a marker never lands inside an indivisible group', () => {
+  test('an offset after a complex field clears the whole field, not just its begin', () => {
+    // A complex field is ONE offset unit spread over five nodes, four of which measure
+    // nothing. A boundary that matched the first zero-length sibling put the marker between
+    // the field's begin and its instruction — a place Word discards the next time it
+    // rebuilds the field, so the comment silently disappeared on a round trip.
+    const body = `<w:p>${COMPLEX_FIELD}${run('cd')}</w:p>`;
+    const store = storeOf(body);
+    const paragraph = firstParagraph(store);
+    const applied = store.transact((ctx) => {
+      ctx.apply({
+        op: 'insertCommentMarker',
+        paragraphId: paragraph.id,
+        offset: 1,
+        commentId: '1',
+        marker: 'start',
+      });
+    });
+    expect(applied.ok).toBe(true);
+
+    const after = firstParagraph(store);
+    const kinds = after.children.map((child) => child.kind);
+    const marker = kinds.indexOf('commentRangeStart');
+    expect(marker).toBeGreaterThan(-1);
+    // Everything before the marker that belongs to the field is present: the marker sits
+    // after the field's `end`, not among its parts.
+    const fieldChars = after.children
+      .slice(0, marker)
+      .filter((child) => child.kind === 'run').length;
+    expect(fieldChars).toBe(5);
   });
 });

--- a/packages/core/src/store/__tests__/comment-offset-authority.test.ts
+++ b/packages/core/src/store/__tests__/comment-offset-authority.test.ts
@@ -1,0 +1,174 @@
+// A comment marker lands where the OFFSET AUTHORITY says, for every element it counts.
+//
+// `insertCommentMarker` used to measure the paragraph with a walk of its own, and anything the
+// authority counted and that walk did not put the two out of step. The visible half was a
+// refusal — `offset-out-of-range` for offsets past a drawing, a field, an inline content
+// control — and the invisible half was worse: an offset that still resolved placed the marker
+// on the wrong character, so the saved comment covered text nobody had selected.
+//
+// So the test is not "these offsets are accepted". It is: for EVERY offset in the paragraph,
+// the marker lands at the same offset the authority reports for it. That is the property a
+// second implementation cannot satisfy by accident.
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  paragraphOffsetIndex,
+  readOoxmlPackage,
+  TreeDocumentStore,
+  type OoxmlParagraphNode,
+} from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+/**
+ * A REAL package, zipped and read back. A hand-assembled one is refused by the package
+ * invariants (`missing-content-type`) on the first write, which would make every case below
+ * pass by being refused rather than by landing correctly.
+ */
+function storeOf(body: string): TreeDocumentStore {
+  const bytes = zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+  const pkg = readOoxmlPackage(bytes);
+  if (!pkg.ok) throw new Error(pkg.reason);
+  return new TreeDocumentStore(pkg.package, pkg.package.mainDocumentPart);
+}
+
+function firstParagraph(store: TreeDocumentStore): OoxmlParagraphNode {
+  let found: OoxmlParagraphNode | null = null;
+  const walk = (node: { kind: string; id: string; children?: readonly unknown[] }): void => {
+    if (found || node.kind === 'textValue') return;
+    if (node.kind === 'paragraph') {
+      found = node as unknown as OoxmlParagraphNode;
+      return;
+    }
+    for (const child of (node.children ?? []) as (typeof node)[]) walk(child);
+  };
+  walk(store.part.root as never);
+  if (!found) throw new Error('no paragraph');
+  return found;
+}
+
+const run = (text: string) => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
+const DRAWING =
+  `<w:r><w:drawing><wp:inline><wp:extent cx="914400" cy="914400"/>` +
+  `<wp:docPr id="1" name="p"/><a:graphic><a:graphicData uri="u"/></a:graphic>` +
+  `</wp:inline></w:drawing></w:r>`;
+const FLD_SIMPLE = `<w:fldSimple w:instr=" PAGE "><w:r><w:t>7</w:t></w:r></w:fldSimple>`;
+const COMPLEX_FIELD =
+  `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+  `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+  `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+  `<w:r><w:t>12</w:t></w:r>` +
+  `<w:r><w:fldChar w:fldCharType="end"/></w:r>`;
+const INLINE_SDT =
+  `<w:sdt><w:sdtPr><w:tag w:val="t"/></w:sdtPr>` +
+  `<w:sdtContent>${run('XY')}</w:sdtContent></w:sdt>`;
+
+/**
+ * Where the marker actually landed, in the authority's offsets, or null when refused.
+ *
+ * Read back from the SAVED tree rather than from the op: the whole failure being pinned is a
+ * marker that reports success and sits somewhere else.
+ */
+function markerOffset(body: string, offset: number): number | null {
+  const store = storeOf(body);
+  const paragraph = firstParagraph(store);
+  const result = store.transact((ctx) => {
+    ctx.apply({
+      op: 'insertCommentMarker',
+      paragraphId: paragraph.id,
+      offset,
+      commentId: '1',
+      marker: 'start',
+    });
+  });
+  if (!result.ok) return null;
+
+  const after = firstParagraph(store);
+  const index = paragraphOffsetIndex(after);
+  // The marker measures nothing, so its own span start IS the offset it was placed at.
+  let landed: number | null = null;
+  const walk = (node: { kind: string; id: string; children?: readonly unknown[] }): void => {
+    if (landed !== null || node.kind === 'textValue') return;
+    if (node.kind === 'commentRangeStart') {
+      landed = index.spanOf(node.id as string)?.start ?? null;
+      return;
+    }
+    for (const child of (node.children ?? []) as (typeof node)[]) walk(child);
+  };
+  walk(after as never);
+  return landed;
+}
+
+function lengthOfBody(body: string): number {
+  const store = storeOf(body);
+  return paragraphOffsetIndex(firstParagraph(store)).length;
+}
+
+describe('a marker lands at the offset it was asked for', () => {
+  const cases: readonly { readonly name: string; readonly body: string }[] = [
+    { name: 'text only', body: `<w:p>${run('abcd')}</w:p>` },
+    {
+      name: 'an inline drawing between words',
+      body: `<w:p>${run('ab')}${DRAWING}${run('cd')}</w:p>`,
+    },
+    { name: 'a simple field', body: `<w:p>${FLD_SIMPLE}${run('cd')}</w:p>` },
+    {
+      name: 'a complex field with a cached result',
+      body: `<w:p>${COMPLEX_FIELD}${run('cd')}</w:p>`,
+    },
+    { name: 'an inline content control', body: `<w:p>${INLINE_SDT}${run('cd')}</w:p>` },
+    { name: 'a drawing at the very end', body: `<w:p>${run('ab')}${DRAWING}</w:p>` },
+    {
+      name: 'a footnote mark leading the paragraph',
+      body: `<w:p><w:r><w:footnoteRef/></w:r>${run('note text')}</w:p>`,
+    },
+  ];
+
+  for (const { name, body } of cases) {
+    test(`${name}: every offset resolves to itself`, () => {
+      const length = lengthOfBody(body);
+      expect(length).toBeGreaterThan(0);
+      for (let offset = 0; offset <= length; offset += 1) {
+        // A refusal is a legitimate answer for an offset inside something indivisible (the
+        // middle of a drawing is not a place). Landing SOMEWHERE ELSE never is.
+        const landed = markerOffset(body, offset);
+        if (landed === null) continue;
+        expect({ offset, landed }).toEqual({ offset, landed: offset });
+      }
+    });
+  }
+
+  test('an offset past the end is refused rather than clamped', () => {
+    const body = `<w:p>${run('ab')}${DRAWING}${run('cd')}</w:p>`;
+    const length = lengthOfBody(body);
+    expect(markerOffset(body, length + 1)).toBeNull();
+  });
+
+  test('the end of a paragraph carrying a drawing is reachable', () => {
+    // The old walk counted the drawing as nothing, so the paragraph measured two short and
+    // the last two offsets — including the end, where a comment on the final word closes —
+    // were refused outright.
+    const body = `<w:p>${run('ab')}${DRAWING}${run('cd')}</w:p>`;
+    expect(lengthOfBody(body)).toBe(5);
+    expect(markerOffset(body, 5)).toBe(5);
+  });
+});

--- a/packages/core/src/store/package/ooxml-sdt.ts
+++ b/packages/core/src/store/package/ooxml-sdt.ts
@@ -264,6 +264,12 @@ export function validContentControlContentChildren(children: readonly OoxmlNode[
       child.kind === 'hyperlink' ||
       child.kind === 'bookmarkStart' ||
       child.kind === 'bookmarkEnd' ||
+      // Comment range markers belong to `EG_RangeMarkupElements` exactly as the bookmark
+      // markers above do, and `CT_SdtContentRun` is `EG_PContent`, which includes that
+      // group. Admitting the bookmarks and not these refused a comment anchored inside a
+      // content control — legal markup the schema has always allowed.
+      child.kind === 'commentRangeStart' ||
+      child.kind === 'commentRangeEnd' ||
       child.kind === 'generic'
   );
 }

--- a/packages/core/src/store/store/tree-op-comments.ts
+++ b/packages/core/src/store/store/tree-op-comments.ts
@@ -17,10 +17,10 @@ import {
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
 import { isContentRevisionKind } from '../package/ooxml-shared.ts';
-import {
-  contentControlContentNodeOf,
-  isContentControlNode,
-} from '../package/content-control-nodes.ts';
+// The SAME predicate and accessor the offset authority walks with. A second pair that
+// disagreed — `content-control-nodes.ts` matches only a TYPED control, while the authority
+// also measures a demoted generic `w:sdt` — would refuse offsets the authority hands out.
+import { contentControlContentOf, isContentControlNode } from './tree-op-nodes.ts';
 import { paragraphOffsetIndex } from './tree-op-segments.ts';
 import { DEPENDENCY_KEY_IDS } from '../registry/frozen-ids.ts';
 import { splitRunsAt } from './tree-op-apply.ts';
@@ -50,6 +50,38 @@ function locateOffset(
   const span =
     container.id === paragraph.id ? { start: 0, end: index.length } : index.spanOf(container);
   if (!span) return null;
+  // Nodes an atom swallowed: a complex field is one offset unit spread over its begin, its
+  // instruction, its separator, its cached result and its end. Each of those after the first
+  // measures zero, so a boundary would otherwise match INSIDE the group — between the field's
+  // begin and its instruction — where Word drops the marker the next time it rebuilds the
+  // field. The boundary belongs after the whole group.
+  // `removeNodeIds` names the field's INNER nodes (`w:fldChar`, `w:instrText`), so the set is
+  // mapped up to the container's own children — the runs holding them — before it is useful
+  // here. Built only when a multi-node atom is present, which is the only case it changes.
+  const swallowed = new Set<string>();
+  const atomInnerIds = new Set<string>();
+  for (const segment of index.segments) {
+    if ((segment.removeNodeIds?.length ?? 0) < 2) continue;
+    for (const id of segment.removeNodeIds ?? []) atomInnerIds.add(id);
+  }
+  if (atomInnerIds.size > 0) {
+    const holdsAtomInner = (node: OoxmlNode, depth: number): boolean => {
+      if (atomInnerIds.has(node.id)) return true;
+      if (node.kind === 'textValue' || depth > 8) return false;
+      return node.children.some((inner) => holdsAtomInner(inner, depth + 1));
+    };
+    // The FIRST child of the group still owns the atom's own offset, so it stays matchable;
+    // only the zero-length remainder is skipped past.
+    let seenGroupStart = false;
+    for (const child of container.children) {
+      if (child.kind === 'textValue' || !holdsAtomInner(child, 0)) {
+        seenGroupStart = false;
+        continue;
+      }
+      if (seenGroupStart) swallowed.add(child.id);
+      seenGroupStart = true;
+    }
+  }
   let cursor = span.start;
   for (let position = 0; position < container.children.length; position += 1) {
     const child = container.children[position]!;
@@ -57,7 +89,9 @@ function locateOffset(
     // AFTER the properties rather than before them. Inserting ahead of `w:pPr` produces a
     // paragraph the tree invariants reject, which is the invariant doing its job.
     const isProperties = child.kind === 'paragraphProperties' || child.kind === 'runProperties';
-    if (cursor === offset && !isProperties) return { containerId: container.id, index: position };
+    if (cursor === offset && !isProperties && !swallowed.has(child.id)) {
+      return { containerId: container.id, index: position };
+    }
     if (child.kind === 'textValue') continue;
     const length = index.lengthOf(child);
     // A container the offset falls STRICTLY inside is descended into, so the marker lands
@@ -96,7 +130,7 @@ function descendableContainer(child: OoxmlNode): OoxmlElement | null {
   }
   // An inline content control holds its content in `w:sdtContent`; the wrapper's other
   // children (`w:sdtPr`, `w:sdtEndPr`) are properties a marker must never land among.
-  if (isContentControlNode(child)) return contentControlContentNodeOf(child) ?? null;
+  if (isContentControlNode(child)) return contentControlContentOf(child) ?? null;
   return null;
 }
 

--- a/packages/core/src/store/store/tree-op-comments.ts
+++ b/packages/core/src/store/store/tree-op-comments.ts
@@ -17,7 +17,11 @@ import {
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
 import { isContentRevisionKind } from '../package/ooxml-shared.ts';
-import { isNoteAtomNode } from '../package/note-nodes.ts';
+import {
+  contentControlContentNodeOf,
+  isContentControlNode,
+} from '../package/content-control-nodes.ts';
+import { paragraphOffsetIndex } from './tree-op-segments.ts';
 import { DEPENDENCY_KEY_IDS } from '../registry/frozen-ids.ts';
 import { splitRunsAt } from './tree-op-apply.ts';
 import type { TreeOpResult } from './tree-op-validate.ts';
@@ -25,85 +29,75 @@ import type { TreeOpResult } from './tree-op-validate.ts';
 /** Which piece of comment markup an `insertCommentMarker` op places. */
 export type CommentMarkerKind = 'start' | 'end' | 'reference';
 
-/** Characters one run child contributes, matching `segmentsOf` exactly. */
-function textLengthOfRunChild(node: OoxmlNode): number {
-  if (node.kind === 'text' || node.kind === 'deletedText') {
-    let length = 0;
-    for (const value of node.children) if (value.kind === 'textValue') length += value.value.length;
-    return length;
-  }
-  // A tab and a hard break each occupy exactly one model offset, which is what `segmentsOf`
-  // counts. The two must not disagree, or a marker lands on a different character than the
-  // caret that asked for it.
-  if (node.kind === 'tab' || node.kind === 'hardBreak') return 1;
-  // So does a note atom — `w:footnoteRef`, `w:footnoteReference`, the separators — each of
-  // which `segmentsOf` gives one U+FFFC unit. Counting them as nothing measured the
-  // paragraph short by one per atom, so every offset at or after one was refused: Word
-  // writes `w:footnoteRef` as the first run of every footnote, which made commenting on a
-  // footnote impossible, and a body paragraph whose text follows a footnote reference
-  // failed the same way.
-  if (isNoteAtomNode(node)) return 1;
-  return 0;
-}
-
-function textLengthOfRun(run: OoxmlNode): number {
-  if (run.kind === 'textValue') return 0;
-  let length = 0;
-  for (const child of run.children) length += textLengthOfRunChild(child);
-  return length;
-}
-
-/** A child's length whether it is a run or another container holding runs. */
-function containerLength(node: OoxmlNode): number {
-  if (node.kind === 'textValue') return 0;
-  if (node.kind === 'run') return textLengthOfRun(node);
-  if (isContentRevisionKind(node.kind) || node.kind === 'hyperlink') {
-    let total = 0;
-    for (const child of node.children) total += containerLength(child);
-    return total;
-  }
-  return 0;
-}
-
 /**
- * Where in a container's child list an offset falls, descending into revision wrappers.
+ * Where in a container's child list an offset falls, descending into the containers a
+ * comment may legitimately be anchored inside.
  *
- * A comment anchored inside tracked text belongs inside the wrapper that tracks it, or the
- * markup would claim the comment covers text the revision does not.
+ * MEASURED BY THE PARAGRAPH OFFSET AUTHORITY, never by a second walk of its own. This
+ * function used to count characters itself, and every element the authority counts and it
+ * did not put the paragraph out of step by one: a drawing, a field, an inline content
+ * control. The visible half was a refusal (`offset-out-of-range`) for offsets past the
+ * element, and the invisible half was worse — an offset that still resolved landed the
+ * marker on the wrong character, so a comment silently covered text nobody selected.
  */
 function locateOffset(
+  paragraph: OoxmlParagraphNode,
   container: OoxmlElement,
   offset: number,
-  base: number,
   depth: number
 ): { readonly containerId: string; readonly index: number } | null {
-  let cursor = base;
-  for (let index = 0; index < container.children.length; index += 1) {
-    const child = container.children[index]!;
+  const index = paragraphOffsetIndex(paragraph);
+  const span =
+    container.id === paragraph.id ? { start: 0, end: index.length } : index.spanOf(container);
+  if (!span) return null;
+  let cursor = span.start;
+  for (let position = 0; position < container.children.length; position += 1) {
+    const child = container.children[position]!;
     // `w:pPr` and `w:rPr` must stay first among their siblings, so a marker at offset 0 goes
     // AFTER the properties rather than before them. Inserting ahead of `w:pPr` produces a
     // paragraph the tree invariants reject, which is the invariant doing its job.
     const isProperties = child.kind === 'paragraphProperties' || child.kind === 'runProperties';
-    if (cursor === offset && !isProperties) return { containerId: container.id, index };
+    if (cursor === offset && !isProperties) return { containerId: container.id, index: position };
     if (child.kind === 'textValue') continue;
-    if (child.kind === 'run') {
-      cursor += textLengthOfRun(child);
-      continue;
-    }
-    // A HYPERLINK is a run container exactly as a revision wrapper is, and `segmentsOf`
-    // descends into both. Skipping it here meant the paragraph measured shorter than the
-    // validator said it was, so commenting on link text — or on anything after a link, or at
-    // the end of that paragraph — was refused with `offset-out-of-range`.
-    if ((isContentRevisionKind(child.kind) || child.kind === 'hyperlink') && depth < 32) {
-      let inner = 0;
-      for (const grand of child.children) inner += containerLength(grand);
-      if (offset > cursor && offset < cursor + inner) {
-        return locateOffset(child, offset, cursor, depth + 1);
+    const length = index.lengthOf(child);
+    // A container the offset falls STRICTLY inside is descended into, so the marker lands
+    // where the text is rather than beside the wrapper. A hyperlink, a revision wrapper and
+    // an inline content control are all run containers, and any can hold another — a link
+    // inside a tracked insertion is ordinary. A comment anchored inside tracked text belongs
+    // inside the wrapper that tracks it, or the markup claims the comment covers text the
+    // revision does not.
+    if (offset > cursor && offset < cursor + length && depth < MAX_CONTAINER_DEPTH) {
+      const inner = descendableContainer(child);
+      if (inner) {
+        const found = locateOffset(paragraph, inner, offset, depth + 1);
+        if (found) return found;
       }
-      cursor += inner;
     }
+    cursor += length;
   }
   return cursor === offset ? { containerId: container.id, index: container.children.length } : null;
+}
+
+/** Matches the offset authority's own nesting bound. */
+const MAX_CONTAINER_DEPTH = 32;
+
+/**
+ * The element to descend into for an offset inside `child`, or null when the offset is
+ * inside something indivisible.
+ *
+ * A run is deliberately absent: `insertCommentMarker` splits the run straddling the offset
+ * before this runs, so an offset inside a run is already a boundary between runs by the time
+ * it is located. An atom — a drawing, a field, a note mark — has no inside to reach.
+ */
+function descendableContainer(child: OoxmlNode): OoxmlElement | null {
+  if (child.kind === 'textValue') return null;
+  if (isContentRevisionKind(child.kind) || child.kind === 'hyperlink') {
+    return child as OoxmlElement;
+  }
+  // An inline content control holds its content in `w:sdtContent`; the wrapper's other
+  // children (`w:sdtPr`, `w:sdtEndPr`) are properties a marker must never land among.
+  if (isContentControlNode(child)) return contentControlContentNodeOf(child) ?? null;
+  return null;
 }
 
 /**
@@ -180,7 +174,7 @@ export function applyInsertCommentMarker(
   const reloaded = findNode(split.part, paragraph.id);
   if (!reloaded || reloaded.kind !== 'paragraph') return { ok: false, reason: 'tree-invariant' };
 
-  const at = locateOffset(reloaded, op.offset, 0, 0);
+  const at = locateOffset(reloaded, reloaded, op.offset, 0);
   if (!at) return { ok: false, reason: 'offset-out-of-range' };
 
   const nodeId = `${part.name}#comment-${op.marker}-${op.commentId}-${op.offset}`;

--- a/packages/core/src/store/store/tree-op-segments.ts
+++ b/packages/core/src/store/store/tree-op-segments.ts
@@ -309,7 +309,13 @@ function walkParagraph(
     if (isContentControlNode(child) && depth < MAX_CONTENT_CONTROL_NESTING) {
       const content = contentControlContentOf(child);
       if (content) {
+        const contentStart = offset;
         for (const inner of content.children) visitInline(inner, depth + 1);
+        // The CONTENT node owns the span its children contributed, not only the wrapper.
+        // Without this a caller that descends into `w:sdtContent` — placing a comment
+        // marker inside a control, which the schema allows — asks for its span, gets null,
+        // and refuses every offset inside the control.
+        spans?.set(content.id, { start: contentStart, end: offset });
       }
     }
     record(child, start);


### PR DESCRIPTION
Found while reviewing #208, where it was out of scope.

The comment writer measured paragraphs with a character walk of its own. Anything the offset authority counts and that walk did not put the two out of step by one, and the engine has several such elements: an inline drawing, a `w:fldSimple`, a complex field, an inline content control.

The visible half was a refusal. Commenting on text after a drawing, or at the end of a paragraph that contains one, came back `offset-out-of-range` — and the end of the paragraph is exactly where a comment on the last word closes.

The invisible half is the reason this is worth its own PR: an offset that still resolved landed the marker somewhere else. In `ab` + drawing + `cd`, asking for offset 4 (between `c` and `d`) put the marker at the end of the paragraph. The write reported success and the saved comment covered text nobody selected.

There is already one authority on what an offset means — `paragraphOffsetIndex`, which exists precisely so a second implementation cannot disagree — so the walk now asks it instead of counting. It also descends into inline content controls alongside links and revision wrappers, so a marker inside one lands with the text rather than beside the wrapper. That descent needed the authority to record a span for `w:sdtContent`, and the tree to accept range markers as its children; without either it compiled and never fired.

The test asserts the property rather than the cases: for every offset in each paragraph shape, the marker must land at that same offset when read back from the saved tree. A refusal is allowed (the middle of a drawing is not a place); landing elsewhere never is. Ten of its thirteen tests fail against `main`.

**Two things this deliberately does not do.** A comment marker can now land inside a `contentLocked` content control, because the marker adds no characters and this path has never had a lock check — that wants an explicit answer about whether an annotation counts as editing locked content, rather than arriving as a side effect of the descent. And `w:smartTag` content stays invisible to the authority itself (`ab<smartTag>cd</smartTag>ef` measures 4, not 6), which is the same on `main` and belongs with the authority, not here.
