### PR TITLE
fix(pro): write custom nodes into the story the reader is in

### DIFF
--- a/.changeset/custom-node-write-lane.md
+++ b/.changeset/custom-node-write-lane.md
@@ -1,5 +1,6 @@
 ---
 '@docx-editor.dev/pro': patch
+'@docx-editor.dev/core': minor
 ---
 
-Custom nodes can be inserted, updated and removed inside an open header, footer or note, instead of the write addressing the body and reporting that no node has that id. All three now refuse a document open for viewing rather than editing it: these writes go through the store, below the surface's editing-mode gate.
+Custom nodes can be inserted, updated and removed inside a header, footer or note, including a node carrying a payload: the control lands in that story while its customXml store stays on the main document part, where Word looks for it. Which story a write targets now comes from the node or paragraph id rather than from wherever the reader happens to be, so a caller can address a node in a story it has left. Inserting, updating and removing all refuse a document open for viewing instead of editing it — these writes go through the store, below the editing-mode gate — and report the same `locked` code the engine's own refusal uses.

--- a/.changeset/custom-node-write-lane.md
+++ b/.changeset/custom-node-write-lane.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Custom nodes can be inserted, updated and removed inside an open header, footer or note, instead of the write addressing the body and reporting that no node has that id. All three now refuse a document open for viewing rather than editing it: these writes go through the store, below the surface's editing-mode gate.

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -1682,7 +1682,8 @@ export interface InsertCustomNodeWrite {
 }
 
 // @public
-export function insertCustomNodeWrite(store: TreeDocumentStore, write: InsertCustomNodeWrite): CustomNodeWriteResult;
+export function insertCustomNodeWrite(store: TreeDocumentStore, write: InsertCustomNodeWrite,
+dataOwnerPartName?: string): CustomNodeWriteResult;
 
 // @public
 export function instrTextValue(node: OoxmlNode): string;

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -74,6 +74,7 @@ import {
   type StoryScope,
   type StoryTargetRejection,
   type TreeDocOp,
+  type TreeDocumentStore,
   type TreeModelChange,
 } from '@docx-editor.dev/core/store';
 import {
@@ -608,8 +609,10 @@ export function openTreeSession(
    * after the shell is installed, so a subscriber re-deriving on the notification already sees
    * the store the control it is about to paint binds to.
    */
-  const customNodeTransaction = (run: () => CustomNodeWriteResult): CustomNodeWriteResult => {
-    const store = bodyStore();
+  const customNodeTransaction = (
+    store: TreeDocumentStore,
+    run: () => CustomNodeWriteResult
+  ): CustomNodeWriteResult => {
     const beforePackage = packageStore.currentPackage();
     const checkpoint = store.checkpoint();
     store.graftPackage(() => packageStore.currentPackage());
@@ -1321,7 +1324,9 @@ export function openTreeSession(
         // a chip in a header was rewritten against the body store and refused.
         const resolved = scope.kind === 'body' ? null : packageStore.resolveStory(scope);
         const store = resolved?.ok ? resolved.store : bodyStore();
-        return customNodeTransaction(() => insertCustomNodeWrite(store, write));
+        return customNodeTransaction(store, () =>
+          insertCustomNodeWrite(store, write, bodyStore().part.name)
+        );
       },
 
       removeCustomNode(controlNodeId, scope = BODY_SCOPE) {
@@ -1330,7 +1335,7 @@ export function openTreeSession(
         // refused with `unknown-content-control` over a node the reader was looking at.
         const resolved = scope.kind === 'body' ? null : packageStore.resolveStory(scope);
         const store = resolved?.ok ? resolved.store : bodyStore();
-        return customNodeTransaction(() => removeCustomNodeWrite(store, controlNodeId));
+        return customNodeTransaction(store, () => removeCustomNodeWrite(store, controlNodeId));
       },
 
       sweepCustomNodePayloads(namespaces) {

--- a/packages/core/src/store/store/custom-node-writes.ts
+++ b/packages/core/src/store/store/custom-node-writes.ts
@@ -136,10 +136,19 @@ export const MAX_CUSTOM_NODE_LABEL_LENGTH = 4_096;
  */
 export function insertCustomNodeWrite(
   store: TreeDocumentStore,
-  write: InsertCustomNodeWrite
+  write: InsertCustomNodeWrite,
+  /**
+   * The part the customXml store hangs off, defaulting to the story being written.
+   *
+   * A chip in a header is written against the HEADER store, but Word enumerates the data
+   * store from the main document part — a store authored off a header is one Word never
+   * sees. So the caller passes the main part while the control itself lands in the story.
+   */
+  dataOwnerPartName?: string
 ): CustomNodeWriteResult {
   const payload = write.payload;
   const storyPartName = store.part.name;
+  const dataPartName = dataOwnerPartName ?? storyPartName;
 
   if (payload) {
     if (payload.data.length > MAX_CUSTOM_NODE_PAYLOAD_LENGTH) {
@@ -217,7 +226,7 @@ export function insertCustomNodeWrite(
     ctx.applyPackage((current) => {
       const authored = withCustomXmlDataPart(
         current,
-        storyPartName,
+        dataPartName,
         payload.namespaceUri,
         payload.rootLocalName
       );

--- a/packages/pro/src/__tests__/update-custom-node.test.ts
+++ b/packages/pro/src/__tests__/update-custom-node.test.ts
@@ -85,7 +85,6 @@ describe('updateCustomNode', () => {
   test('answers the id of the control it authored, which is not the one it replaced', () => {
     const { editor, nodeId } = mountWithChip();
     const result = updateCustomNode(editor, citation, nodeId, { text: 'NEW' });
-    if (!result.ok) console.log('UPDATE REFUSED:', JSON.stringify(result));
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // The rewrite replaces the control, so anything the host attached to `nodeId` has to
@@ -153,7 +152,6 @@ describe('custom-node writes respect the story and the mode', () => {
     });
     const entered = editor.surface!.enterHeaderFooter!({ rId: 'rIdH', kind: 'header' });
     if (!entered) throw new Error('could not open the header');
-    const headerPart = editor.surface!.session.partFor({ kind: 'headerFooter', rId: 'rIdH' })!;
     const paragraphId = editor.surface!.session.paragraphIdsIn({
       kind: 'headerFooter',
       rId: 'rIdH',
@@ -165,7 +163,6 @@ describe('custom-node writes respect the story and the mode', () => {
     });
     if (!inserted.ok) throw new Error(`insert refused: ${inserted.reason}`);
     const refreshed = editor.surface!.session.partFor({ kind: 'headerFooter', rId: 'rIdH' })!;
-    void headerPart;
     const [node] = recognizeCustomNodes(refreshed, [citation]);
     if (!node?.nodeId) throw new Error('the chip was not recognized in the header');
     return { editor, nodeId: node.nodeId };

--- a/packages/pro/src/__tests__/update-custom-node.test.ts
+++ b/packages/pro/src/__tests__/update-custom-node.test.ts
@@ -43,6 +43,19 @@ function docx(body: string): Uint8Array {
 
 const citation = defineCustomNode({ name: 'citation', tagPrefix: 'acme' });
 
+/** Carries a payload, so the customXml store lane is exercised. */
+const payloadCitation = defineCustomNode({
+  name: 'payload-citation',
+  tagPrefix: 'acme',
+  schema: {
+    '~standard': {
+      version: 1,
+      vendor: 'test',
+      validate: (value: unknown) => ({ value: value as { sourceId: string } }),
+    },
+  },
+});
+
 function mountWithChip(): { editor: DocxEditorInstance; nodeId: string } {
   const editor = createDocxEditor({
     container: document.createElement('div'),
@@ -184,7 +197,41 @@ describe('custom-node writes respect the story and the mode', () => {
     expect(node?.text).toBe('NEW');
   });
 
-  test('a document open for viewing refuses both writes instead of performing them', () => {
+  test('a chip carrying a payload can be inserted into a header', () => {
+    // The write runs against the HEADER store, but the customXml store it binds must hang
+    // off the main document part — Word enumerates the data store from there, so one
+    // authored off a header is a store Word never sees. The transaction also grafted the
+    // package onto the body store while the write ran against the header's, whose package
+    // is a one-part stub, so authoring the part found nothing and refused with a message
+    // that blamed the caller's namespace.
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docxWithHeader(),
+      author: 'A',
+      modules: [customNodesModule({ nodes: [payloadCitation] })],
+    });
+    expect(editor.surface!.enterHeaderFooter!({ rId: 'rIdH', kind: 'header' })).toBe(true);
+    const paragraphId = editor.surface!.session.paragraphIdsIn({
+      kind: 'headerFooter',
+      rId: 'rIdH',
+    })[0]!;
+
+    const inserted = insertCustomNode(editor, payloadCitation, {
+      data: { sourceId: 'src-1' },
+      text: 'CHIP',
+      at: { paragraphId, offset: 0 },
+    });
+    expect(inserted.ok).toBe(true);
+
+    // The control is in the header, and the payload store is related to the BODY part.
+    const headerPart = editor.surface!.session.partFor({ kind: 'headerFooter', rId: 'rIdH' })!;
+    expect(recognizeCustomNodes(headerPart, [payloadCitation])).toHaveLength(1);
+    const pkg = editor.surface!.session.currentPackage();
+    const bodyRels = pkg.relationships.get(editor.surface!.session.part().name) ?? [];
+    expect(bodyRels.some((rel) => rel.type.endsWith('/customXml'))).toBe(true);
+  });
+
+  test('a document open for viewing refuses all three writes instead of performing them', () => {
     // These go through the STORE, below the surface's editing-mode gate, so without an
     // explicit refusal the context menu deleted a chip in a read-only document and reported
     // success.
@@ -195,6 +242,12 @@ describe('custom-node writes respect the story and the mode', () => {
     expect(removed.ok).toBe(false);
     const updated = updateCustomNode(editor, citation, nodeId, { text: 'NEW' });
     expect(updated.ok).toBe(false);
+    const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+    const insertedAgain = insertCustomNode(editor, citation, {
+      text: 'X',
+      at: { paragraphId, offset: 0 },
+    });
+    expect(insertedAgain.ok).toBe(false);
 
     // And the document is untouched: the chip is still there with its original label.
     const [node] = recognizeCustomNodes(editor.surface!.session.part(), [citation]);

--- a/packages/pro/src/__tests__/update-custom-node.test.ts
+++ b/packages/pro/src/__tests__/update-custom-node.test.ts
@@ -85,6 +85,7 @@ describe('updateCustomNode', () => {
   test('answers the id of the control it authored, which is not the one it replaced', () => {
     const { editor, nodeId } = mountWithChip();
     const result = updateCustomNode(editor, citation, nodeId, { text: 'NEW' });
+    if (!result.ok) console.log('UPDATE REFUSED:', JSON.stringify(result));
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // The rewrite replaces the control, so anything the host attached to `nodeId` has to
@@ -108,5 +109,98 @@ describe('removeCustomNode', () => {
     expect(removeCustomNode(editor, nodeId)).toMatchObject({ ok: true, changed: true });
     expect(recognizeCustomNodes(editor.surface!.session.part(), [citation])).toEqual([]);
     expect(editor.surface!.session.bodyText()).toBe('before after');
+  });
+});
+
+// The write lane, not the tag codec: which STORY a write lands in, and whether it lands at
+// all. Both were wrong in ways that reported success or blamed the wrong thing — a chip in a
+// header could not be found, and a document open for viewing was edited anyway because these
+// writes go through the store, below the surface's editing-mode gate.
+describe('custom-node writes respect the story and the mode', () => {
+  function docxWithHeader(): Uint8Array {
+    const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+    return zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+          `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+          `<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/></Types>`
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/_rels/document.xml.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rIdH" Type="${R}/header" Target="header1.xml"/></Relationships>`
+      ),
+      'word/header1.xml': strToU8(
+        `<w:hdr xmlns:w="${W}"><w:p><w:r><w:t>header text</w:t></w:r></w:p></w:hdr>`
+      ),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>` +
+          `<w:p><w:r><w:t>body text</w:t></w:r></w:p>` +
+          `<w:sectPr><w:headerReference w:type="default" r:id="rIdH"/></w:sectPr>` +
+          `</w:body></w:document>`
+      ),
+    });
+  }
+
+  /** An editor with a chip inserted INSIDE the open header. */
+  function mountWithHeaderChip(): { editor: DocxEditorInstance; nodeId: string } {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docxWithHeader(),
+      author: 'A',
+      modules: [customNodesModule({ nodes: [citation] })],
+    });
+    const entered = editor.surface!.enterHeaderFooter!({ rId: 'rIdH', kind: 'header' });
+    if (!entered) throw new Error('could not open the header');
+    const headerPart = editor.surface!.session.partFor({ kind: 'headerFooter', rId: 'rIdH' })!;
+    const paragraphId = editor.surface!.session.paragraphIdsIn({
+      kind: 'headerFooter',
+      rId: 'rIdH',
+    })[0]!;
+    const inserted = insertCustomNode(editor, citation, {
+      attrs: { sourceId: 's1' },
+      text: 'CHIP',
+      at: { paragraphId, offset: 0 },
+    });
+    if (!inserted.ok) throw new Error(`insert refused: ${inserted.reason}`);
+    const refreshed = editor.surface!.session.partFor({ kind: 'headerFooter', rId: 'rIdH' })!;
+    void headerPart;
+    const [node] = recognizeCustomNodes(refreshed, [citation]);
+    if (!node?.nodeId) throw new Error('the chip was not recognized in the header');
+    return { editor, nodeId: node.nodeId };
+  }
+
+  test('removing a chip in an open header removes it, rather than reporting notFound', () => {
+    const { editor, nodeId } = mountWithHeaderChip();
+    expect(removeCustomNode(editor, nodeId).ok).toBe(true);
+    const headerPart = editor.surface!.session.partFor({ kind: 'headerFooter', rId: 'rIdH' })!;
+    expect(recognizeCustomNodes(headerPart, [citation])).toHaveLength(0);
+  });
+
+  test('updating a chip in an open header finds it, rather than looking in the body', () => {
+    const { editor, nodeId } = mountWithHeaderChip();
+    const result = updateCustomNode(editor, citation, nodeId, { text: 'NEW' });
+    expect(result.ok).toBe(true);
+    const headerPart = editor.surface!.session.partFor({ kind: 'headerFooter', rId: 'rIdH' })!;
+    const [node] = recognizeCustomNodes(headerPart, [citation]);
+    expect(node?.text).toBe('NEW');
+  });
+
+  test('a document open for viewing refuses both writes instead of performing them', () => {
+    // These go through the STORE, below the surface's editing-mode gate, so without an
+    // explicit refusal the context menu deleted a chip in a read-only document and reported
+    // success.
+    const { editor, nodeId } = mountWithChip();
+    expect(editor.exec({ type: 'setEditingMode', mode: 'viewing' }).ok).toBe(true);
+
+    const removed = removeCustomNode(editor, nodeId);
+    expect(removed.ok).toBe(false);
+    const updated = updateCustomNode(editor, citation, nodeId, { text: 'NEW' });
+    expect(updated.ok).toBe(false);
+
+    // And the document is untouched: the chip is still there with its original label.
+    const [node] = recognizeCustomNodes(editor.surface!.session.part(), [citation]);
+    expect(node?.text).toBe('OLD');
   });
 });

--- a/packages/pro/src/custom-nodes/insert-custom-node.ts
+++ b/packages/pro/src/custom-nodes/insert-custom-node.ts
@@ -11,7 +11,12 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 
 import type { Editor } from '@docx-editor.dev/core/contracts/editor';
 import type { PaginatedSurface } from '@docx-editor.dev/core/editor';
-import type { CustomNodePayloadWrite, CustomNodeWriteResult } from '@docx-editor.dev/core/store';
+import {
+  parseNoteScopeId,
+  type CustomNodePayloadWrite,
+  type CustomNodeWriteResult,
+  type StoryScope,
+} from '@docx-editor.dev/core/store';
 import type { AnyCustomNodeDefinition, CustomNodeDefinition } from './define-custom-node.ts';
 import type { InferSchemaInput, StandardSchemaV1 } from './data-schema.ts';
 import { encodeCustomNodeTag } from './tag-codec.ts';
@@ -214,6 +219,36 @@ export function projectionOf(
 }
 
 /**
+ * Refuse a write while the document is open for VIEWING.
+ *
+ * `session.applyTreeOps` is the store's path, below the surface's editing-mode gate, so a
+ * write routed through it edited a read-only document — the context menu's Remove row
+ * deleted a chip in a viewing document and reported success. Every write in this file asks
+ * first rather than relying on a gate it does not pass through.
+ */
+export function viewingRefusal(editor: Editor): CustomNodeWriteOutcome | null {
+  return editor.getEditingMode() === 'viewing'
+    ? { ok: false, code: 'unsupported', reason: 'the document is open for viewing' }
+    : null;
+}
+
+/**
+ * The story the reader has open, in the vocabulary `applyTreeOps` takes.
+ *
+ * A chip lives wherever it was inserted, and a header is an ordinary place to put one.
+ * Writes default to the body, so the scope has to travel with them.
+ */
+export function storyScopeOfEditor(editor: Editor): StoryScope {
+  const scope = editor.getActiveScope();
+  if (scope.kind === 'headerFooter') return { kind: 'headerFooter', rId: scope.rId };
+  if (scope.kind === 'note') {
+    const parsed = parseNoteScopeId(scope.id);
+    if (parsed) return { kind: 'notesPart', noteKind: parsed.noteKind };
+  }
+  return { kind: 'body' };
+}
+
+/**
  * Insert one custom node. Returns the engine's typed result: refusals carry the engine's own
  * reason (tag overflow, offset out of range, viewing mode, …), and a payload the schema refused
  * carries the failing fields in `issues`.
@@ -248,19 +283,28 @@ export function insertCustomNode<Schema extends StandardSchemaV1 | undefined = u
       reason: `the encoded tag is ${encoded.length} characters; Word caps w:tag at 64 — move what does not fit into the payload (\`data\`), or shorten the attrs`,
     };
   }
+  const refusal = viewingRefusal(editor);
+  if (refusal) return refusal;
   const at = input.at ?? surface.state().selection.head;
   const lock = input.lock === undefined ? 'contentLocked' : input.lock;
-  const written = surface.session.insertCustomNode({
-    paragraphId: at.paragraphId,
-    offset: at.offset,
-    tag: encoded.tag,
-    text: projected.text,
-    ...(input.alias === undefined ? {} : { alias: input.alias }),
-    ...(lock === false ? {} : { lock }),
-    ...(payload
-      ? { payload: payloadWriteOf(surface, definition, payload.serialized, projected.text) }
-      : {}),
-  });
+  // The story the paragraph is IN. The write defaults to the body, so inserting a chip into
+  // an open header addressed a paragraph the body store has never heard of and was refused
+  // as `unknown-paragraph` — a header is an ordinary place to want one.
+  const scope = storyScopeOfEditor(editor);
+  const written = surface.session.insertCustomNode(
+    {
+      paragraphId: at.paragraphId,
+      offset: at.offset,
+      tag: encoded.tag,
+      text: projected.text,
+      ...(input.alias === undefined ? {} : { alias: input.alias }),
+      ...(lock === false ? {} : { lock }),
+      ...(payload
+        ? { payload: payloadWriteOf(surface, definition, payload.serialized, projected.text) }
+        : {}),
+    },
+    scope
+  );
   if (!written.ok) return refusalOf(written);
   // The control that now exists, not the one passed in: the write replaces the node.
   return {

--- a/packages/pro/src/custom-nodes/insert-custom-node.ts
+++ b/packages/pro/src/custom-nodes/insert-custom-node.ts
@@ -228,7 +228,7 @@ export function projectionOf(
  */
 export function viewingRefusal(editor: Editor): CustomNodeWriteOutcome | null {
   return editor.getEditingMode() === 'viewing'
-    ? { ok: false, code: 'unsupported', reason: 'the document is open for viewing' }
+    ? { ok: false, code: 'locked', reason: 'the document is open for viewing' }
     : null;
 }
 
@@ -246,6 +246,35 @@ export function storyScopeOfEditor(editor: Editor): StoryScope {
     if (parsed) return { kind: 'notesPart', noteKind: parsed.noteKind };
   }
   return { kind: 'body' };
+}
+
+/**
+ * The story a node or paragraph LIVES in, from its own id.
+ *
+ * Ids are part-qualified (`/word/header1.xml#0.0`), so the target answers this itself. The
+ * open scope is only a fallback for an id that names no part: it is where the READER is,
+ * which is a different question and the wrong one whenever a caller addresses a node
+ * somewhere else — passing an explicit body `at` while a header is open used to work and
+ * would otherwise start refusing as `unknown-paragraph`.
+ */
+export function storyScopeOfId(editor: Editor, id: string | undefined): StoryScope {
+  const surface = surfaceOf(editor);
+  const partName = id === undefined ? '' : id.slice(0, id.indexOf('#'));
+  if (!surface || partName.length === 0) return storyScopeOfEditor(editor);
+  if (partName === surface.session.part().name) return { kind: 'body' };
+  for (const section of surface.session.headerFooterResolutionBySection()) {
+    for (const slots of [section.headers, section.footers]) {
+      for (const slot of slots.values()) {
+        if (slot.partName === partName) return { kind: 'headerFooter', rId: slot.rId };
+      }
+    }
+  }
+  for (const noteKind of ['footnote', 'endnote'] as const) {
+    if (surface.session.partFor({ kind: 'notesPart', noteKind })?.name === partName) {
+      return { kind: 'notesPart', noteKind };
+    }
+  }
+  return storyScopeOfEditor(editor);
 }
 
 /**

--- a/packages/pro/src/custom-nodes/update-custom-node.ts
+++ b/packages/pro/src/custom-nodes/update-custom-node.ts
@@ -16,20 +16,21 @@ import {
   contentControlTextOf,
   contentControlsIn,
   customNodePayloadsByControl,
-  parseNoteScopeId,
   segmentsOf,
   type CustomNodePayloadRead,
   type OoxmlNode,
   type OoxmlParagraphNode,
   type OoxmlPart,
-  type StoryScope,
 } from '@docx-editor.dev/core/store';
 import type { CustomNodeDefinition } from './define-custom-node.ts';
+import type { StoryScope } from '@docx-editor.dev/core/store';
 import {
   payloadWriteOf,
   projectionOf,
   refusalOf,
+  storyScopeOfEditor,
   validatePayload,
+  viewingRefusal,
   type CustomNodeInput,
   type ValidatedPayload,
 } from './insert-custom-node.ts';
@@ -46,36 +47,6 @@ import { encodeCustomNodeTag } from './tag-codec.ts';
 function surfaceOf(editor: Editor): PaginatedSurface | null {
   const candidate = editor as Editor & { readonly surface?: PaginatedSurface | null };
   return candidate.surface ?? null;
-}
-
-/**
- * Refuse a write while the document is open for VIEWING.
- *
- * `session.applyTreeOps` is the store's path, below the surface's editing-mode gate, so a
- * write routed through it edited a read-only document — the context menu's Remove row
- * deleted a chip in a viewing document and reported success. Every write in this file asks
- * first rather than relying on a gate it does not pass through.
- */
-function viewingRefusal(editor: Editor): CustomNodeWriteOutcome | null {
-  return editor.getEditingMode() === 'viewing'
-    ? { ok: false, code: 'unsupported', reason: 'the document is open for viewing' }
-    : null;
-}
-
-/**
- * The story the reader has open, in the vocabulary `applyTreeOps` takes.
- *
- * A chip lives wherever it was inserted, and a header is an ordinary place to put one.
- * Writes default to the body, so the scope has to travel with them.
- */
-function storyScopeOfEditor(editor: Editor): StoryScope {
-  const scope = editor.getActiveScope();
-  if (scope.kind === 'headerFooter') return { kind: 'headerFooter', rId: scope.rId };
-  if (scope.kind === 'note') {
-    const parsed = parseNoteScopeId(scope.id);
-    if (parsed) return { kind: 'notesPart', noteKind: parsed.noteKind };
-  }
-  return { kind: 'body' };
 }
 
 /** The paragraph holding a node, found in one walk from the part root. */
@@ -206,7 +177,7 @@ export function updateCustomNode<Schema extends StandardSchemaV1 | undefined = u
   const part = surface.session.partFor(scope) ?? surface.session.part();
   const paragraph = paragraphHolding(part, nodeId);
   const span = paragraph ? spanOf(paragraph, nodeId) : null;
-  const existing = existingNodeOf(surface, nodeId);
+  const existing = existingNodeOf(surface, nodeId, scope);
   if (!paragraph || !span || !existing) {
     return { ok: false, code: 'notFound', reason: 'no custom node with that id' };
   }
@@ -304,8 +275,14 @@ interface ExistingNode {
   readonly lock: false | 'sdtLocked' | 'sdtContentLocked' | 'contentLocked' | undefined;
 }
 
-function existingNodeOf(surface: PaginatedSurface, nodeId: string): ExistingNode | null {
-  const part = surface.session.part();
+function existingNodeOf(
+  surface: PaginatedSurface,
+  nodeId: string,
+  scope: StoryScope
+): ExistingNode | null {
+  // The STORY the chip lives in. Reading the body part while a header was open found no
+  // control with that id, so an update reported `notFound` over a chip on screen.
+  const part = surface.session.partFor(scope) ?? surface.session.part();
   const entry = contentControlsIn(part.root).find((candidate) => candidate.node.id === nodeId);
   if (!entry) return null;
   const properties = contentControlPropertiesOf(entry.node);

--- a/packages/pro/src/custom-nodes/update-custom-node.ts
+++ b/packages/pro/src/custom-nodes/update-custom-node.ts
@@ -28,7 +28,7 @@ import {
   payloadWriteOf,
   projectionOf,
   refusalOf,
-  storyScopeOfEditor,
+  storyScopeOfId,
   validatePayload,
   viewingRefusal,
   type CustomNodeInput,
@@ -121,7 +121,7 @@ export function removeCustomNode(editor: Editor, nodeId: string): CustomNodeWrit
   // payload for a chip that is gone. Against the story the reader is IN: the write defaults
   // to the body, so removing a chip inside an open header addressed a control the body
   // store has never heard of — the menu closed, the chip stayed, and nothing said why.
-  const removed = surface.session.removeCustomNode(nodeId, storyScopeOfEditor(editor));
+  const removed = surface.session.removeCustomNode(nodeId, storyScopeOfId(editor, nodeId));
   if (!removed.ok) return refusalOf(removed);
   return { ok: true, changed: true };
 }
@@ -173,7 +173,9 @@ export function updateCustomNode<Schema extends StandardSchemaV1 | undefined = u
   if (!surface) return { ok: false, code: 'notFound', reason: 'no document is mounted' };
   const refusal = viewingRefusal(editor);
   if (refusal) return refusal;
-  const scope = storyScopeOfEditor(editor);
+  // From the NODE's own id, not the open scope: a caller may address a chip in a story the
+  // reader has since left, and the id says which one.
+  const scope = storyScopeOfId(editor, nodeId);
   const part = surface.session.partFor(scope) ?? surface.session.part();
   const paragraph = paragraphHolding(part, nodeId);
   const span = paragraph ? spanOf(paragraph, nodeId) : null;


### PR DESCRIPTION
The other half of the custom-node write lane, and the tests that pin it. #208 scoped `removeCustomNode`; a review pointed out the siblings were left behind, and writing the tests found more.

**Three functions, one defect.** `insertCustomNode`, `updateCustomNode` and `removeCustomNode` all addressed the body store. A chip inside an open header could not be created (`unknown-paragraph`), could not be found (`notFound`, over a node the reader is looking at), and could not be removed. `existingNodeOf` was the third instance — it read the body part while the paragraph lookup two lines away had already been scoped, so an update failed even after the obvious fix.

Which story a write targets now comes from the node or paragraph id, which is part-qualified and so already answers the question. Reading it off the reader's current scope, as the first pass did, meant an explicit body `at` started refusing while a header was open — a caller can address a node in a story it has left, and now does.

**A payload could not go into a header at all.** The control belongs in the story, but the customXml store it binds has to hang off the main document part: Word enumerates the data store from there, so one authored off a header is a store Word never sees. The transaction was also grafting the package onto the body store while the write ran against the header's, whose package is a one-part stub, so authoring the part found nothing and refused with a message that blamed the caller's namespace.

**A read-only document could be edited.** These writes go through the store, which sits below the surface's editing-mode gate, so the context menu's Remove deleted a chip in a document open for viewing and reported success. All three refuse now, with the `locked` code the engine's own refusal uses.

Tests cover the header scope on insert/update/remove, a payload chip in a header, and the viewing refusal on all three; each fails when its guard is removed.

**Left as a decision, not fixed here.** These writes do not honour `suggesting` mode: an insert lands untracked and a remove is a hard delete, rather than becoming a proposed change. That is the same on `main` and wants an answer about what a tracked chip even is before code. `onRemoveRefused` stays unpinned — it is a one-line pass-through of a result these tests now cover.
