### PR TITLE
fix: apply Word's automatic paragraph spacing

### DIFF
--- a/.changeset/paragraph-auto-spacing.md
+++ b/.changeset/paragraph-auto-spacing.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Apply Word's automatic paragraph spacing when `w:beforeAutospacing` or `w:afterAutospacing` is set, instead of the measurement the flag replaces. Documents written by Word's HTML filter carry it on every paragraph and were laid out 9pt tight per boundary, which moved page breaks.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -33,6 +33,9 @@ export function attachNotesToLayout(layout: SemanticLayout, allRefs: readonly Pa
 }): NotesAttachResult;
 
 // @public
+export const AUTO_PARAGRAPH_SPACING_PT = 14;
+
+// @public
 export const AUTO_PREFERRED_WIDTH: PreferredWidth;
 
 // @public
@@ -1648,6 +1651,12 @@ export function pagesToMaterialize(input: MaterializationInput): Set<number>;
 export const PARAGRAPH_BORDER_SIDES: readonly ["top", "left", "bottom", "right", "between", "bar"];
 
 // @public
+export interface ParagraphAutoSpacingContext {
+    readonly inList?: boolean;
+    readonly inTableCell?: boolean;
+}
+
+// @public
 export interface ParagraphBorderEdge {
     readonly color: string | null;
     readonly shadow?: true;
@@ -1861,7 +1870,7 @@ export interface ParagraphSpacing {
 }
 
 // @public
-export function paragraphSpacing(props: readonly OoxmlProperty[]): ParagraphSpacing;
+export function paragraphSpacing(props: readonly OoxmlProperty[], context?: ParagraphAutoSpacingContext): ParagraphSpacing;
 
 // @public
 export function paragraphTabStops(pPr: OoxmlNode | undefined): ResolvedTabStops;
@@ -2097,7 +2106,7 @@ export function resolveNumberingLevel(index: NumberingIndex, numId: string, ilvl
 export function resolveOoxmlShadingFill(attributes: Readonly<Record<string, string>> | undefined): string | undefined;
 
 // @public
-export function resolveParagraphLayoutInputs(paragraph: OoxmlElement, contentWidth: number, styleCascade: StyleCascadeTable | undefined, listItem?: ResolvedListItem, tableCellStyle?: TableCellStyleFormatting): ParagraphLayoutInputs;
+export function resolveParagraphLayoutInputs(paragraph: OoxmlElement, contentWidth: number, styleCascade: StyleCascadeTable | undefined, listItem?: ResolvedListItem, tableCellStyle?: TableCellStyleFormatting, inTableCell?: boolean): ParagraphLayoutInputs;
 
 // @public
 export function resolveRunStyle(props: readonly OoxmlProperty[], themeFonts?: ThemeFonts): ResolvedRunStyle;

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -201,7 +201,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. Font external leading is excluded from line boxes, and trailing auto-spacing may cross the bottom text margin when the glyphs fit, matching Word’s vertical pagination. The paragraph mark’s w:sz participates in the last line’s metrics, matching Word when a cover-page mark is taller than the visible runs. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends.',
+      'Space before/after and line spacing (single, multiple, exactly, at least) all reach pagination, so a 1.5- or double-spaced document breaks pages where Word breaks them. Font external leading is excluded from line boxes, and trailing auto-spacing may cross the bottom text margin when the glyphs fit, matching Word’s vertical pagination. The paragraph mark’s w:sz participates in the last line’s metrics, matching Word when a cover-page mark is taller than the visible runs. Contextual spacing drops the gap between same-style neighbours, the way Word’s List Paragraph style intends. Automatic spacing (w:beforeAutospacing / w:afterAutospacing, which Word writes on documents from its HTML filter) resolves to Word’s 14pt, or to nothing inside a list item or table cell, rather than to the measurement the flag replaces.',
   },
   {
     id: 'paragraphs.indentation',

--- a/packages/core/src/layout/__tests__/paragraph-spacing-borders.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-spacing-borders.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
 import {
+  AUTO_PARAGRAPH_SPACING_PT,
   MAX_PARAGRAPH_SPACING_PT,
   appliedSpaceBefore,
   collapsedSpaceBefore,
@@ -72,6 +73,105 @@ describe('paragraphSpacing resolves w:spacing before/after', () => {
     expect(appliedSpaceBefore(18, 0, true, false)).toBe(0);
     expect(appliedSpaceBefore(18, 0, true, true)).toBe(18);
     expect(appliedSpaceBefore(18, 10, false, false)).toBe(8);
+  });
+});
+
+// `w:beforeAutospacing` / `w:afterAutospacing` (§17.3.1.2, §17.3.1.13). Word writes the pair
+// `w:before="100" w:beforeAutospacing="1"` on every paragraph of a document that has been
+// through its HTML filter, and the 100 twips beside the flag is NOT the value: the flag means
+// the consumer picks, and Word picks HTML's `<p>` margin. Reading the literal laid such a
+// document out 9pt tight per paragraph boundary, which is enough to lose a page.
+describe('paragraphSpacing resolves w:beforeAutospacing / w:afterAutospacing', () => {
+  const AUTO = {
+    localName: 'spacing',
+    attributes: {
+      before: '100',
+      after: '100',
+      beforeAutospacing: '1',
+      afterAutospacing: '1',
+    },
+  };
+
+  test('auto replaces the measurement beside it rather than adding to it', () => {
+    expect(paragraphSpacing([AUTO])).toEqual({
+      before: AUTO_PARAGRAPH_SPACING_PT,
+      after: AUTO_PARAGRAPH_SPACING_PT,
+    });
+  });
+
+  test('each side is independent', () => {
+    expect(
+      paragraphSpacing([
+        {
+          localName: 'spacing',
+          attributes: { before: '100', after: '240', afterAutospacing: '1' },
+        },
+      ])
+    ).toEqual({ before: 5, after: AUTO_PARAGRAPH_SPACING_PT });
+  });
+
+  test('an explicit off keeps the authored measurement', () => {
+    for (const off of ['0', 'false', 'off']) {
+      expect(
+        paragraphSpacing([
+          { localName: 'spacing', attributes: { before: '240', beforeAutospacing: off } },
+        ])
+      ).toEqual({ before: 12, after: 0 });
+    }
+  });
+
+  test('list items and table cells resolve auto to 0, the way HTML collapses li/td margins', () => {
+    expect(paragraphSpacing([AUTO], { inList: true })).toEqual({ before: 0, after: 0 });
+    expect(paragraphSpacing([AUTO], { inTableCell: true })).toEqual({ before: 0, after: 0 });
+    // Suppression is about the auto value only — an authored measurement still applies.
+    expect(
+      paragraphSpacing([{ localName: 'spacing', attributes: { before: '240' } }], { inList: true })
+    ).toEqual({ before: 12, after: 0 });
+  });
+
+  test('the flags merge per attribute, like the measurements they sit beside', () => {
+    // A style turns auto spacing on; the paragraph overrides only `@before`. The flag must
+    // survive, or direct formatting silently reverts the paragraph to the style's 100 twips.
+    expect(
+      paragraphSpacing([AUTO, { localName: 'spacing', attributes: { before: '400' } }])
+    ).toEqual({ before: AUTO_PARAGRAPH_SPACING_PT, after: AUTO_PARAGRAPH_SPACING_PT });
+    // ...and a style that turns it off is not undone by a later element that says nothing.
+    expect(
+      paragraphSpacing([
+        AUTO,
+        { localName: 'spacing', attributes: { beforeAutospacing: '0', afterAutospacing: '0' } },
+        { localName: 'spacing', attributes: { before: '400' } },
+      ])
+    ).toEqual({ before: 20, after: 5 });
+  });
+});
+
+describe('layout applies Word’s auto spacing, not the twips beside the flag', () => {
+  const AUTO_PPR =
+    '<w:spacing w:after="100" w:afterAutospacing="1" w:before="100" w:beforeAutospacing="1"/>';
+
+  test('two body paragraphs sit 14pt apart, not 5pt', () => {
+    const layout = lay(load(paragraph('one', AUTO_PPR) + paragraph('two', AUTO_PPR)));
+    const [first, second] = layout.pages[0]!.fragments;
+    if (first!.kind !== 'paragraph' || second!.kind !== 'paragraph') throw new Error('paragraphs');
+    expect(first!.spacing.after).toBe(AUTO_PARAGRAPH_SPACING_PT);
+    // Collapsed against the previous after, so the gap is one 14pt band and not two.
+    expect(second!.lines[0]!.box.y - first!.lines[0]!.box.y).toBe(14 + AUTO_PARAGRAPH_SPACING_PT);
+  });
+
+  test('the same paragraphs in a table cell get no auto spacing at all', () => {
+    const cell = `<w:tc>${paragraph('one', AUTO_PPR)}${paragraph('two', AUTO_PPR)}</w:tc>`;
+    const layout = lay(load(`<w:tbl><w:tr>${cell}</w:tr></w:tbl>`));
+    const table = layout.pages[0]!.fragments.find((fragment) => fragment.kind === 'table');
+    if (table?.kind !== 'table') throw new Error('table fragment');
+    const paragraphs = table.rows[0]!.cells[0]!.blocks.filter(
+      (block) => block.kind === 'paragraph'
+    );
+    expect(paragraphs).toHaveLength(2);
+    for (const fragment of paragraphs) {
+      if (fragment.kind !== 'paragraph') continue;
+      expect(fragment.spacing).toEqual({ before: 0, after: 0 });
+    }
   });
 });
 

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -174,6 +174,7 @@ export {
   type TextMeasurer,
 } from './semantic-records.ts';
 export {
+  AUTO_PARAGRAPH_SPACING_PT,
   MAX_BORDER_SPACE_PT,
   MAX_BORDER_WIDTH_PT,
   MAX_PARAGRAPH_SPACING_PT,
@@ -193,6 +194,7 @@ export {
   paragraphLineSpacing,
   paragraphSpacing,
   type LineSpacingRule,
+  type ParagraphAutoSpacingContext,
   type ParagraphBorders,
   type ParagraphLineSpacing,
 } from './paragraph-style.ts';

--- a/packages/core/src/layout/paragraph-style.ts
+++ b/packages/core/src/layout/paragraph-style.ts
@@ -43,6 +43,32 @@ export interface ParagraphSpacing {
 }
 
 /**
+ * The gap Word substitutes when `w:beforeAutospacing` / `w:afterAutospacing` is on
+ * (ECMA-376 §17.3.1.2, §17.3.1.13).
+ *
+ * The attribute means "the consumer decides", and the authored `@before` / `@after` beside it
+ * is IGNORED rather than used as the value. Word's answer is HTML's default `<p>` margin,
+ * 14pt, which is what a document round-tripped through Word's HTML filter carries — and this
+ * one is everywhere, because Word writes `w:before="100" w:beforeAutospacing="1"` for it. Reading
+ * only the literal 100 twips lays every such paragraph out 9pt tight, which moves page breaks.
+ */
+export const AUTO_PARAGRAPH_SPACING_PT = 14;
+
+/**
+ * Where a paragraph sits, for the two contexts in which Word's auto spacing resolves to 0
+ * instead of {@link AUTO_PARAGRAPH_SPACING_PT}.
+ *
+ * Both come from the HTML model the attribute emulates: a `<li>` and a `<td>` collapse the
+ * paragraph margin, a bare `<p>` does not. A caller that says nothing gets the body answer.
+ */
+export interface ParagraphAutoSpacingContext {
+  /** The paragraph participates in numbering (`w:numPr`), i.e. it is a list item. */
+  readonly inList?: boolean;
+  /** The paragraph lives in a table cell. */
+  readonly inTableCell?: boolean;
+}
+
+/**
  * Resolved line spacing (`w:spacing/@line` + `@lineRule`, ECMA-376 17.3.1.33).
  *
  * `auto` is the interesting one: `@line` is 240ths of a line, so 240 is single, 360 is
@@ -161,6 +187,11 @@ function twipsToPoints(raw: string | undefined): number {
   return clampNonNegative(twips / 20, MAX_PARAGRAPH_SPACING_PT);
 }
 
+/** `ST_OnOff` carried as an attribute value: anything but an explicit off is on (§17.17.4). */
+function isOn(raw: string): boolean {
+  return raw !== '0' && raw !== 'false' && raw !== 'off';
+}
+
 function hexColor(raw: string | undefined): string | null {
   if (raw === undefined || raw === 'auto') return null;
   return HEX_COLOR.test(raw) ? raw.toUpperCase() : null;
@@ -182,10 +213,18 @@ function childNamed(node: OoxmlElement, localName: string): OoxmlElement | undef
  *
  * Line spacing (`w:line` / `w:lineRule`) is a separate concern — it changes measured line
  * height, not the gap between paragraphs — and is not resolved here.
+ *
+ * `w:beforeAutospacing` / `w:afterAutospacing` REPLACE the authored measurement on their own
+ * side rather than adding to it; see {@link AUTO_PARAGRAPH_SPACING_PT}.
  */
-export function paragraphSpacing(props: readonly OoxmlProperty[]): ParagraphSpacing {
+export function paragraphSpacing(
+  props: readonly OoxmlProperty[],
+  context?: ParagraphAutoSpacingContext
+): ParagraphSpacing {
   let before = 0;
   let after = 0;
+  let beforeAuto = false;
+  let afterAuto = false;
   for (const property of props) {
     if (property.localName !== 'spacing') continue;
     // Merged PER ATTRIBUTE, not per element. `w:spacing` is one element carrying
@@ -196,6 +235,18 @@ export function paragraphSpacing(props: readonly OoxmlProperty[]): ParagraphSpac
     const authoredAfter = property.attributes?.after;
     if (authoredBefore !== undefined) before = twipsToPoints(authoredBefore);
     if (authoredAfter !== undefined) after = twipsToPoints(authoredAfter);
+    // The autospacing flags merge per attribute too, and independently of the measurement
+    // beside them: a style may turn auto spacing OFF while leaving the `@before` it inherited
+    // in place, and that paragraph must then use the measurement, not 0.
+    const authoredBeforeAuto = property.attributes?.beforeAutospacing;
+    const authoredAfterAuto = property.attributes?.afterAutospacing;
+    if (authoredBeforeAuto !== undefined) beforeAuto = isOn(authoredBeforeAuto);
+    if (authoredAfterAuto !== undefined) afterAuto = isOn(authoredAfterAuto);
+  }
+  if (beforeAuto || afterAuto) {
+    const auto = context?.inList || context?.inTableCell ? 0 : AUTO_PARAGRAPH_SPACING_PT;
+    if (beforeAuto) before = auto;
+    if (afterAuto) after = auto;
   }
   return { before, after };
 }
@@ -279,7 +330,7 @@ export function paragraphContextualSpacing(props: readonly OoxmlProperty[]): boo
   for (const property of props) {
     if (property.localName !== 'contextualSpacing') continue;
     const raw = property.attributes?.val;
-    value = raw !== '0' && raw !== 'false' && raw !== 'off';
+    value = raw === undefined || isOn(raw);
   }
   return value;
 }

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -559,7 +559,8 @@ function placeCellParagraph(
     cellContentWidth,
     deps.styleCascade,
     listItem,
-    options?.tableCellStyle
+    options?.tableCellStyle,
+    true
   );
   // `w:defaultTabStop` lives in settings.xml, which the paragraph cascade never reads.
   const tabStops = withDefaultTabInterval(cascadedTabStops, deps.defaultTabStopPt);

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -687,13 +687,17 @@ export interface ParagraphLayoutInputs {
  *
  * `tableCellStyle` carries what the enclosing table's style says about this cell's
  * paragraphs; body paragraphs pass nothing.
+ *
+ * `inTableCell` is asked for separately because a cell paragraph may have no table style to
+ * inherit at all, and `w:beforeAutospacing` still needs to know it is in a cell.
  */
 export function resolveParagraphLayoutInputs(
   paragraph: OoxmlElement,
   contentWidth: number,
   styleCascade: StyleCascadeTable | undefined,
   listItem?: import('./list-resolve.ts').ResolvedListItem,
-  tableCellStyle?: TableCellStyleFormatting
+  tableCellStyle?: TableCellStyleFormatting,
+  inTableCell = false
 ): ParagraphLayoutInputs {
   const pPr = findParagraphProperties(paragraph);
   const cascaded = styleCascade
@@ -758,7 +762,7 @@ export function resolveParagraphLayoutInputs(
     indent,
     available: Math.max(1, contentWidth - indent.left - indent.right),
     alignment: paragraphAlignment(props),
-    spacing: paragraphSpacing(props),
+    spacing: paragraphSpacing(props, { inList: listItem !== undefined, inTableCell }),
     lineSpacing: paragraphLineSpacing(props),
     contextualSpacing: paragraphContextualSpacing(props),
     styleId: cascaded ? cascaded.styleId : (styleIdFromProps(props, 'pStyle') ?? null),


### PR DESCRIPTION
`w:beforeAutospacing` / `w:afterAutospacing` say the consumer decides the gap, and the `w:before` / `w:after` beside them is ignored rather than used. Layout read only the measurement, so a document that has been through Word's HTML filter (which writes `w:before="100" w:beforeAutospacing="1"` on every paragraph) came out 5pt where Word puts 14pt. Enough boundaries of that and a page goes missing.

Word's auto value is HTML's `<p>` margin, 14pt, collapsed to 0 inside a list item or a table cell. The existing before/after collapse and `w:contextualSpacing` handling are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788640266&installation_model_id=422592&pr_number=214&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F214&signature=a9f44f5f0230af27a9d153ad6573a3590175ad4f4a6088b6a478ea5afe27b0f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->