### PR TITLE
fix: render pictures inside footnote and text-box stories

### DIFF
--- a/.changeset/story-drawing-pictures.md
+++ b/.changeset/story-drawing-pictures.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Pictures inside footnotes, endnotes and text boxes now render. They previously painted nothing at all, not even a placeholder.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1486,6 +1486,13 @@ export interface NotesLayoutInput {
 export function noteStoryBlocks(note: OoxmlNode, displayMode?: RevisionDisplayMode): OoxmlElement[];
 
 // @public
+export interface NoteStoryDrawings {
+    readonly drawingTokenForParagraph?: (paragraph: OoxmlNode) => string;
+    // (undocumented)
+    readonly inlineDrawingLayout: InlineDrawingLayoutContext;
+}
+
+// @public
 export interface NoteStoryLayout {
     readonly fallbackReason?: NoteLayoutFallbackReason;
     readonly flowHeight: number;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1467,6 +1467,7 @@ export interface NotesLayoutInput {
     // (undocumented)
     readonly documentEndnoteProps: ResolvedEndnoteProperties;
     readonly documentFootnoteProps: ResolvedFootnoteProperties;
+    readonly drawingsForPart?: (ownerPartName: string) => NoteStoryDrawings | undefined;
     readonly endnotePropsBySection: readonly ResolvedEndnoteProperties[];
     // (undocumented)
     readonly endnotesPart: OoxmlPart | null;

--- a/openspec/changes/textbox-story-layout/specs/textbox-story-rendering/spec.md
+++ b/openspec/changes/textbox-story-layout/specs/textbox-story-rendering/spec.md
@@ -114,3 +114,31 @@ file-derived strings.
 - **THEN** the story paints inside the drawing's bounds on the anchor page
 - **AND** wrap behaviour for surrounding text derives from the drawing's extent
   exactly as before this change
+
+### Requirement: Pictures inside a textbox story render
+
+A `w:drawing` inside `w:txbxContent` SHALL stay a typed drawing and project like any other
+run-level drawing atom of the host part: demoting the shape's own DrawingML vocabulary (a
+`wps` graphic data is not a picture graphic data) SHALL NOT cascade into the WML story the
+shape hosts. The story SHALL lay out with the host part's inline drawing context, so its
+pictures resolve against the same relationships as the surrounding body. The host
+paragraph's break cache key SHALL carry the resource identity of the pictures inside the
+story: the box's own resource is unrenderable and never moves, so nothing else would
+invalidate the break when an inner picture decodes. Story descent SHALL be bounded by a
+text-box nesting cap. Anchored drawings inside a textbox story stay out of scope.
+
+#### Scenario: Picture inside a text box paints
+
+- **WHEN** an anchored text box's story holds one inline picture
+- **THEN** the story's fragments carry a drawing record for it and the picture paints inside
+  the box
+
+#### Scenario: Inner picture survives its decode
+
+- **WHEN** that picture's decode settles after the first layout pass
+- **THEN** the host paragraph re-breaks and the ready image paints
+
+#### Scenario: Nested boxes stop at the cap
+
+- **WHEN** a file nests text boxes beyond the projection nesting cap
+- **THEN** the scan stops descending and the pass still terminates

--- a/openspec/changes/typed-notes-footnotes-endnotes/specs/notes-semantic-layout/spec.md
+++ b/openspec/changes/typed-notes-footnotes-endnotes/specs/notes-semantic-layout/spec.md
@@ -140,3 +140,24 @@ The reference mark and the note's own mark SHALL be styled by the document's res
 
 - **WHEN** a document redefines `FootnoteReference` without superscript
 - **THEN** the mark renders as that style specifies, not forced superscript
+
+### Requirement: A picture inside a note is an ordinary inline drawing
+
+A note story SHALL lay out inline drawings the way a body paragraph does, resolving them
+against the relationships of the part the note lives in (`/word/footnotes.xml` or
+`/word/endnotes.xml`) rather than the body part's. A note paragraph's break cache key SHALL
+carry the resource identity of the pictures it paints, so a picture whose decode settles
+after the first pass reaches the page instead of staying a placeholder. Anchored drawings
+inside a note stay out of scope: they would need frame and exclusion semantics against a
+story that has no page until pagination places it.
+
+#### Scenario: Footnote picture renders
+
+- **WHEN** a footnote body contains an inline picture embedded through `footnotes.xml.rels`
+- **THEN** the note's fragments carry a drawing record for it and the picture paints in the
+  note area
+
+#### Scenario: Decoded picture reaches the note
+
+- **WHEN** the picture's decode settles after the first layout pass
+- **THEN** a later pass paints the ready image rather than the loading placeholder

--- a/openspec/changes/typed-notes-footnotes-endnotes/tasks.md
+++ b/openspec/changes/typed-notes-footnotes-endnotes/tasks.md
@@ -81,7 +81,7 @@
 - [x] 8.1 `w:continuationNotice` authoring UI — round-tripped and drawn, not authored
 - [x] 8.2 Note references inside headers, footers, or other notes — round-tripped and deletable, not laid out
 - [x] 8.3 Tracked note insertions — owned by `typed-revisions-and-comments`
-- [x] 8.4 Images inside notes — blocked on `typed-drawings-and-images`
+- [x] 8.4 Anchored drawings inside notes — inline pictures now lay out (see `notes-semantic-layout`); an anchored drawing in a note still needs frame/exclusion semantics and stays out of scope
 
 ## 9. Review findings
 

--- a/packages/core/src/editor/__tests__/story-drawing-resource.test.ts
+++ b/packages/core/src/editor/__tests__/story-drawing-resource.test.ts
@@ -23,6 +23,7 @@ const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
 const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
 const IMG = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
 const FOOTNOTES = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes';
+const ENDNOTES = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes';
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
@@ -78,7 +79,30 @@ function textboxWithPicture(): string {
   );
 }
 
-function docx(options: { readonly bodyRuns: string; readonly footnoteRuns: string }): Uint8Array {
+/** A drawing that never types, carrying the story element's NAME in a position it cannot open one. */
+function strayStoryNameDrawing(): string {
+  return (
+    '<w:r><w:drawing>' +
+    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" ' +
+    'layoutInCell="1" allowOverlap="1" relativeHeight="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="2743200" cy="1828800"/><wp:wrapNone/><wp:docPr id="20" name="stray"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}">` +
+    '<wps:wsp><wps:cNvSpPr txBox="1"/>' +
+    // `w:txbxContent` under the shape properties rather than under `wps:txbx`.
+    `<wps:spPr><w:txbxContent><w:p>${inlinePicture(21)}</w:p></w:txbxContent></wps:spPr>` +
+    '<wps:bodyPr/></wps:wsp>' +
+    '</a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
+  );
+}
+
+function docx(options: {
+  readonly bodyRuns: string;
+  readonly footnoteRuns: string;
+  readonly endnoteRuns?: string;
+}): Uint8Array {
   const imageRels = strToU8(
     `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/></Relationships>`
   );
@@ -89,6 +113,7 @@ function docx(options: { readonly bodyRuns: string; readonly footnoteRuns: strin
         '<Default Extension="png" ContentType="image/png"/>' +
         '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
         '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '<Override PartName="/word/endnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml"/>' +
         '</Types>'
     ),
     '_rels/.rels': strToU8(
@@ -105,6 +130,7 @@ function docx(options: { readonly bodyRuns: string; readonly footnoteRuns: strin
     'word/_rels/document.xml.rels': strToU8(
       `<Relationships xmlns="${REL}">` +
         `<Relationship Id="rIdFn" Type="${FOOTNOTES}" Target="footnotes.xml"/>` +
+        `<Relationship Id="rIdEn" Type="${ENDNOTES}" Target="endnotes.xml"/>` +
         `<Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/>` +
         '</Relationships>'
     ),
@@ -115,24 +141,61 @@ function docx(options: { readonly bodyRuns: string; readonly footnoteRuns: strin
         `<w:footnote w:id="1"><w:p><w:r><w:footnoteRef/></w:r><w:r><w:t>note </w:t></w:r>${options.footnoteRuns}</w:p></w:footnote>` +
         '</w:footnotes>'
     ),
+    'word/endnotes.xml': strToU8(
+      `<w:endnotes ${NS}>` +
+        '<w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>' +
+        '<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>' +
+        `<w:endnote w:id="1"><w:p><w:r><w:endnoteRef/></w:r><w:r><w:t>note </w:t></w:r>${options.endnoteRuns ?? '<w:r><w:t>plain</w:t></w:r>'}</w:p></w:endnote>` +
+        '</w:endnotes>'
+    ),
     'word/_rels/footnotes.xml.rels': imageRels,
+    'word/_rels/endnotes.xml.rels': imageRels,
     'word/media/image1.png': PNG_1X1,
   });
 }
 
 const FOOTNOTE_REFERENCE = '<w:r><w:footnoteReference w:id="1"/></w:r>';
+const ENDNOTE_REFERENCE = '<w:r><w:endnoteReference w:id="1"/></w:r>';
+
+function decodeBytes(bytes: Uint8Array, mime: string): { pixelWidth: number; pixelHeight: number } {
+  const header = validateRasterHeader(bytes, mime);
+  if (!header) throw new Error('invalid raster');
+  const limits = resolveImageResourceLimits();
+  if (header.pixelWidth * header.pixelHeight > limits.maxPixels) throw new Error('too large');
+  return header;
+}
 
 /** Validates the real bytes, like the browser port does, but without a browser. */
 function decodePort(): ImageDecodePort {
   return Object.freeze({
     async decode(bytes, mime) {
-      const header = validateRasterHeader(bytes, mime);
-      if (!header) throw new Error('invalid raster');
-      const limits = resolveImageResourceLimits();
-      if (header.pixelWidth * header.pixelHeight > limits.maxPixels) throw new Error('too large');
-      return Object.freeze({ ...header, dpiX: 96, dpiY: 96 });
+      return Object.freeze({ ...decodeBytes(bytes, mime), dpiX: 96, dpiY: 96 });
     },
   });
+}
+
+/**
+ * A decode port that does not settle until told to.
+ *
+ * The whole asynchronous half of this fix — the resource identity in the break key — is only
+ * observable if a layout is READ while the picture is still pending. A port that resolves on
+ * its own microtask makes every assertion a post-decode one, and a test written that way
+ * passes with the invalidation removed entirely.
+ */
+function deferredDecodePort(): { port: ImageDecodePort; release: () => void } {
+  let release = (): void => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    port: Object.freeze({
+      async decode(bytes, mime) {
+        await gate;
+        return Object.freeze({ ...decodeBytes(bytes, mime), dpiX: 96, dpiY: 96 });
+      },
+    }),
+    release: () => release(),
+  };
 }
 
 /** Resource resolution and the relayout it triggers are both asynchronous. */
@@ -165,6 +228,14 @@ function footnoteDrawingKinds(page: PageRecord): string[] {
   return kinds;
 }
 
+function endnoteDrawingKinds(page: PageRecord): string[] {
+  const kinds: string[] = [];
+  for (const note of page.endnotes?.notes ?? []) {
+    kinds.push(...blockDrawingKinds(note.fragments));
+  }
+  return kinds;
+}
+
 function textboxDrawingKinds(page: PageRecord): string[] {
   const kinds: string[] = [];
   for (const drawing of page.anchoredDrawings ?? []) {
@@ -175,7 +246,10 @@ function textboxDrawingKinds(page: PageRecord): string[] {
   return kinds;
 }
 
-async function mount(bytes: Uint8Array): Promise<{
+async function mount(
+  bytes: Uint8Array,
+  port: ImageDecodePort = decodePort()
+): Promise<{
   surface: PaginatedSurface;
   container: HTMLElement;
 }> {
@@ -183,21 +257,74 @@ async function mount(bytes: Uint8Array): Promise<{
   document.body.append(container);
   const opened = mountPaginatedSurface(container, bytes, {
     scale: 1,
-    imageDecodePort: decodePort(),
+    imageDecodePort: port,
   });
   if (!opened.ok) throw new Error(opened.reason);
   await settle();
   return { surface: opened.surface, container };
 }
 
+/** `<img>` elements painted inside a page's note areas. */
+function paintedNoteImages(container: HTMLElement): HTMLImageElement[] {
+  return [...container.querySelectorAll('.docx-notes img')];
+}
+
 describe('pictures in stories outside the body flow', () => {
-  test('a footnote picture lays out and resolves', async () => {
+  test('a footnote picture lays out, resolves, and paints', async () => {
     const { surface, container } = await mount(
       docx({ bodyRuns: FOOTNOTE_REFERENCE, footnoteRuns: inlinePicture(2) })
     );
     const page = surface.layout().pages[0]!;
     expect(footnoteDrawingKinds(page)).toEqual(['ready']);
     expect(container.querySelectorAll('.docx-drawing-placeholder')).toHaveLength(0);
+    expect(paintedNoteImages(container)).toHaveLength(1);
+    surface.destroy();
+    container.remove();
+  });
+
+  test('an endnote picture does too', async () => {
+    const { surface, container } = await mount(
+      docx({
+        bodyRuns: ENDNOTE_REFERENCE,
+        footnoteRuns: '<w:r><w:t>plain</w:t></w:r>',
+        endnoteRuns: inlinePicture(3),
+      })
+    );
+    const page = surface.layout().pages[0]!;
+    expect(endnoteDrawingKinds(page)).toEqual(['ready']);
+    expect(paintedNoteImages(container)).toHaveLength(1);
+    surface.destroy();
+    container.remove();
+  });
+
+  // The invalidation half: the first pass MUST publish `pending`, and a later pass MUST
+  // replace it. Reading only after the decode settles would pass with the resource identity
+  // stripped out of the break key entirely.
+  test('a footnote picture pending at first paint reaches the page when it decodes', async () => {
+    const { port, release } = deferredDecodePort();
+    const { surface, container } = await mount(
+      docx({ bodyRuns: FOOTNOTE_REFERENCE, footnoteRuns: inlinePicture(2) }),
+      port
+    );
+    expect(footnoteDrawingKinds(surface.layout().pages[0]!)).toEqual(['pending']);
+    release();
+    await settle();
+    expect(footnoteDrawingKinds(surface.layout().pages[0]!)).toEqual(['ready']);
+    expect(paintedNoteImages(container)).toHaveLength(1);
+    surface.destroy();
+    container.remove();
+  });
+
+  test('a text-box picture pending at first paint reaches the page when it decodes', async () => {
+    const { port, release } = deferredDecodePort();
+    const { surface, container } = await mount(
+      docx({ bodyRuns: textboxWithPicture(), footnoteRuns: '<w:r><w:t>plain</w:t></w:r>' }),
+      port
+    );
+    expect(textboxDrawingKinds(surface.layout().pages[0]!)).toEqual(['pending']);
+    release();
+    await settle();
+    expect(textboxDrawingKinds(surface.layout().pages[0]!)).toEqual(['ready']);
     surface.destroy();
     container.remove();
   });
@@ -208,6 +335,19 @@ describe('pictures in stories outside the body flow', () => {
     );
     const page = surface.layout().pages[0]!;
     expect(textboxDrawingKinds(page)).toEqual(['ready']);
+    surface.destroy();
+    container.remove();
+  });
+
+  // The story carve-out in the drawing-kind demotion is positional: only a `w:txbxContent`
+  // directly under a `wps:txbx` opens one. A file that plants the name elsewhere inside a
+  // failed drawing subtree must not get typed drawings preserved there.
+  test('a stray txbxContent outside a text box opens no story', async () => {
+    const { surface, container } = await mount(
+      docx({ bodyRuns: strayStoryNameDrawing(), footnoteRuns: '<w:r><w:t>plain</w:t></w:r>' })
+    );
+    const page = surface.layout().pages[0]!;
+    expect(textboxDrawingKinds(page)).toEqual([]);
     surface.destroy();
     container.remove();
   });

--- a/packages/core/src/editor/__tests__/story-drawing-resource.test.ts
+++ b/packages/core/src/editor/__tests__/story-drawing-resource.test.ts
@@ -1,0 +1,214 @@
+// A picture in a footnote or a text box has to reach the page like a body picture does.
+//
+// Both are stories laid out OUTSIDE the body flow, and both were dropping their drawings
+// entirely: a note story was flowed with no drawing context at all, so a footnote picture
+// contributed no record and painted nothing; a text-box story's inner picture was never even
+// projected, so there was nothing to resolve. On top of that, resource resolution is
+// asynchronous — the first pass publishes `pending` and a later pass must pick the ready one
+// up, which only happens if the key that governs reuse carries the resource identity.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { validateRasterHeader, type ImageDecodePort } from '../../store/package/image-resources.ts';
+import { resolveImageResourceLimits } from '../../store/runtime/limits.ts';
+import type { BlockFragmentRecord, PageRecord } from '../../layout/semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const IMG = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
+const FOOTNOTES = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+const PNG_1X1 = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  ),
+  (c) => c.charCodeAt(0)
+);
+
+const NS = `xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}" xmlns:wps="${WPS}"`;
+
+function picture(id: number): string {
+  return (
+    `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
+    `<pic:nvPicPr><pic:cNvPr id="${id}" name="pic"/><pic:cNvPicPr/></pic:nvPicPr>` +
+    '<pic:blipFill><a:blip r:embed="rIdImg"/><a:srcRect/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+    '<pic:spPr><a:xfrm><a:ext cx="457200" cy="457200"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
+    '</pic:pic></a:graphicData></a:graphic>'
+  );
+}
+
+function inlinePicture(id: number): string {
+  return (
+    '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    `<wp:extent cx="457200" cy="457200"/><wp:docPr id="${id}" name="pic"/>` +
+    `${picture(id)}</wp:inline></w:drawing></w:r>`
+  );
+}
+
+/** An anchored text box whose story holds one inline picture. */
+function textboxWithPicture(): string {
+  return (
+    '<w:r><w:drawing>' +
+    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" ' +
+    'layoutInCell="1" allowOverlap="1" relativeHeight="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="2743200" cy="1828800"/><wp:wrapNone/><wp:docPr id="10" name="box"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}">` +
+    '<wps:wsp><wps:cNvSpPr txBox="1"/>' +
+    '<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2743200" cy="1828800"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"/></wps:spPr>' +
+    '<wps:txbx><w:txbxContent>' +
+    `<w:p><w:r><w:t>in the box</w:t></w:r>${inlinePicture(11)}</w:p>` +
+    '</w:txbxContent></wps:txbx>' +
+    '<wps:bodyPr/></wps:wsp>' +
+    '</a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
+  );
+}
+
+function docx(options: { readonly bodyRuns: string; readonly footnoteRuns: string }): Uint8Array {
+  const imageRels = strToU8(
+    `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/></Relationships>`
+  );
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="png" ContentType="image/png"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document ${NS}><w:body>` +
+        `<w:p><w:r><w:t>body</w:t></w:r>${options.bodyRuns}</w:p>` +
+        '<w:sectPr>' +
+        '<w:pgSz w:w="11906" w:h="16838"/>' +
+        '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720"/>' +
+        '</w:sectPr></w:body></w:document>'
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        `<Relationship Id="rIdFn" Type="${FOOTNOTES}" Target="footnotes.xml"/>` +
+        `<Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/>` +
+        '</Relationships>'
+    ),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes ${NS}>` +
+        '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
+        '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>' +
+        `<w:footnote w:id="1"><w:p><w:r><w:footnoteRef/></w:r><w:r><w:t>note </w:t></w:r>${options.footnoteRuns}</w:p></w:footnote>` +
+        '</w:footnotes>'
+    ),
+    'word/_rels/footnotes.xml.rels': imageRels,
+    'word/media/image1.png': PNG_1X1,
+  });
+}
+
+const FOOTNOTE_REFERENCE = '<w:r><w:footnoteReference w:id="1"/></w:r>';
+
+/** Validates the real bytes, like the browser port does, but without a browser. */
+function decodePort(): ImageDecodePort {
+  return Object.freeze({
+    async decode(bytes, mime) {
+      const header = validateRasterHeader(bytes, mime);
+      if (!header) throw new Error('invalid raster');
+      const limits = resolveImageResourceLimits();
+      if (header.pixelWidth * header.pixelHeight > limits.maxPixels) throw new Error('too large');
+      return Object.freeze({ ...header, dpiX: 96, dpiY: 96 });
+    },
+  });
+}
+
+/** Resource resolution and the relayout it triggers are both asynchronous. */
+async function settle(): Promise<void> {
+  for (let turn = 0; turn < 10; turn += 1) await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+function blockDrawingKinds(blocks: readonly BlockFragmentRecord[]): string[] {
+  const kinds: string[] = [];
+  const visit = (block: BlockFragmentRecord): void => {
+    if (block.kind === 'table') {
+      for (const row of block.rows) {
+        for (const cell of row.cells) for (const inner of cell.blocks) visit(inner);
+      }
+      return;
+    }
+    for (const line of block.lines) {
+      for (const drawing of line.drawings ?? []) kinds.push(drawing.resource.kind);
+    }
+  };
+  for (const block of blocks) visit(block);
+  return kinds;
+}
+
+function footnoteDrawingKinds(page: PageRecord): string[] {
+  const kinds: string[] = [];
+  for (const note of page.footnotes?.notes ?? []) {
+    kinds.push(...blockDrawingKinds(note.fragments));
+  }
+  return kinds;
+}
+
+function textboxDrawingKinds(page: PageRecord): string[] {
+  const kinds: string[] = [];
+  for (const drawing of page.anchoredDrawings ?? []) {
+    const story = drawing.textboxStory;
+    if (!story) continue;
+    kinds.push(...blockDrawingKinds(story.fragments));
+  }
+  return kinds;
+}
+
+async function mount(bytes: Uint8Array): Promise<{
+  surface: PaginatedSurface;
+  container: HTMLElement;
+}> {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, bytes, {
+    scale: 1,
+    imageDecodePort: decodePort(),
+  });
+  if (!opened.ok) throw new Error(opened.reason);
+  await settle();
+  return { surface: opened.surface, container };
+}
+
+describe('pictures in stories outside the body flow', () => {
+  test('a footnote picture lays out and resolves', async () => {
+    const { surface, container } = await mount(
+      docx({ bodyRuns: FOOTNOTE_REFERENCE, footnoteRuns: inlinePicture(2) })
+    );
+    const page = surface.layout().pages[0]!;
+    expect(footnoteDrawingKinds(page)).toEqual(['ready']);
+    expect(container.querySelectorAll('.docx-drawing-placeholder')).toHaveLength(0);
+    surface.destroy();
+    container.remove();
+  });
+
+  test('a picture inside a text box lays out and resolves', async () => {
+    const { surface, container } = await mount(
+      docx({ bodyRuns: textboxWithPicture(), footnoteRuns: '<w:r><w:t>plain</w:t></w:r>' })
+    );
+    const page = surface.layout().pages[0]!;
+    expect(textboxDrawingKinds(page)).toEqual(['ready']);
+    surface.destroy();
+    container.remove();
+  });
+});

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -694,6 +694,9 @@ export function mountPaginatedSurface(
       cache: layoutCache,
       styleCascade,
       defaultTabStopPt,
+      inlineDrawingLayoutForPart: (partName) => drawingBundle.contextForPart(partName),
+      drawingTokenForParagraphForPart: (partName, paragraph) =>
+        drawingBundle.drawingTokenForParagraph(paragraph, partName),
     });
     return layoutSemanticDocument(session.part(), revision, {
       measurer,

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -7,7 +7,7 @@
 // story memo.
 
 import type { TreeDocxSession } from '@docx-editor.dev/core/binding';
-import type { OoxmlElement, OoxmlPart } from '@docx-editor.dev/core/store';
+import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
 import { resolveRelationship } from '@docx-editor.dev/core/store';
 import {
   buildNumberingIndex,
@@ -460,6 +460,13 @@ export function createNotesLayoutInput(env: {
   readonly cache: Parameters<typeof layoutHeaderFooterStory>[4];
   readonly styleCascade?: StyleCascadeTable;
   readonly defaultTabStopPt?: number;
+  readonly inlineDrawingLayoutForPart?: (
+    partName: string
+  ) => import('../layout/drawing-layout.ts').InlineDrawingLayoutContext | undefined;
+  readonly drawingTokenForParagraphForPart?: (
+    partName: string,
+    paragraph: import('@docx-editor.dev/core/store').OoxmlNode
+  ) => string;
 }): NotesLayoutInput | undefined {
   const pkg = env.session.currentPackage();
   const footnotesPart = resolveNotesPart(pkg, 'footnote');
@@ -488,6 +495,26 @@ export function createNotesLayoutInput(env: {
     )
   );
 
+  const inlineDrawingLayoutForPart = env.inlineDrawingLayoutForPart;
+  const drawingTokenForParagraphForPart = env.drawingTokenForParagraphForPart;
+  // A notes part carries its own relationships, so its pictures resolve against a context
+  // built for THAT part — the body context would look their `r:embed` up in document.xml.rels.
+  const drawingsForPart = inlineDrawingLayoutForPart
+    ? (partName: string) => {
+        const inlineDrawingLayout = inlineDrawingLayoutForPart(partName);
+        if (!inlineDrawingLayout) return undefined;
+        return {
+          inlineDrawingLayout,
+          ...(drawingTokenForParagraphForPart
+            ? {
+                drawingTokenForParagraph: (paragraph: OoxmlNode) =>
+                  drawingTokenForParagraphForPart(partName, paragraph),
+              }
+            : {}),
+        };
+      }
+    : undefined;
+
   return {
     footnotesPart,
     endnotesPart,
@@ -502,6 +529,7 @@ export function createNotesLayoutInput(env: {
     cache: env.cache,
     styleCascade: env.styleCascade,
     defaultTabStopPt: env.defaultTabStopPt,
+    ...(drawingsForPart ? { drawingsForPart } : {}),
   };
 }
 

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -258,6 +258,8 @@ export function layoutHeaderFooterStory(
               ...(effectiveCtx ? { pageContext: effectiveCtx } : {}),
               ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
               ...(displayMode ? { displayMode } : {}),
+              inlineDrawingLayout,
+              ...(drawingTokenForParagraph ? { drawingTokenForParagraph } : {}),
             }),
           collectAnchoredDrawings: (drawings) => {
             pendingAnchoredDrawings.push(...drawings);

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -309,6 +309,7 @@ export {
   MAX_NOTES_LAID_OUT,
   MAX_NOTE_FRAGMENTS,
   type NoteStoryLayout,
+  type NoteStoryDrawings,
   type NoteSeparatorLayout,
   type NoteSeparatorRuleStyle,
   type NoteLayoutFallbackReason,

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -192,23 +192,23 @@ function drawingResourceLayoutToken(resource: ImageResourceState): string {
   }
 }
 
+/** Bound on text-box-in-text-box descent while building a paragraph's drawing token. */
+const MAX_HOSTED_STORY_TOKEN_DEPTH = 4;
+
+function collectDrawingAtoms(node: OoxmlNode, ids: string[]): void {
+  if (node.kind === 'drawing' || isRunLevelMcAlternateContent(node)) {
+    ids.push(node.id);
+    return;
+  }
+  if ('children' in node) {
+    for (const child of node.children) collectDrawingAtoms(child, ids);
+  }
+}
+
 function drawingAtomsInParagraph(paragraph: OoxmlNode): readonly string[] {
   if (paragraph.kind !== 'paragraph') return [];
   const ids: string[] = [];
-  const visit = (node: OoxmlNode): void => {
-    if (node.kind === 'drawing') {
-      ids.push(node.id);
-      return;
-    }
-    if (isRunLevelMcAlternateContent(node)) {
-      ids.push(node.id);
-      return;
-    }
-    if ('children' in node) {
-      for (const child of node.children) visit(child);
-    }
-  };
-  for (const child of paragraph.children) visit(child);
+  for (const child of paragraph.children) collectDrawingAtoms(child, ids);
   return Object.freeze(ids);
 }
 
@@ -318,10 +318,38 @@ function createPartDrawingContextSlot(options: {
     resourceOf,
   });
 
+  /**
+   * Atom ids in the paragraph, plus the atoms of any text-box story they host.
+   *
+   * A text box's OWN resource is `unrenderable` — it is a shape, not a picture — and never
+   * changes, so a picture inside it settling would move no token in the host paragraph's key
+   * and repaint nothing. The story's atoms have to ride the host paragraph's key, because
+   * that is what governs the break the story is laid out from.
+   */
+  const atomsWithHostedStories = (paragraph: OoxmlNode): readonly string[] => {
+    const direct = drawingAtomsInParagraph(paragraph);
+    let expanded: string[] | null = null;
+    const visit = (atomIds: readonly string[], depth: number): void => {
+      if (depth > MAX_HOSTED_STORY_TOKEN_DEPTH) return;
+      for (const atomId of atomIds) {
+        const story = atomProjections.get(atomId)?.textboxStory;
+        if (!story) continue;
+        const inner: string[] = [];
+        collectDrawingAtoms(story.content, inner);
+        if (inner.length === 0) continue;
+        expanded ??= [...direct];
+        expanded.push(...inner);
+        visit(inner, depth + 1);
+      }
+    };
+    visit(direct, 0);
+    return expanded ?? direct;
+  };
+
   const drawingTokenForParagraph = (paragraph: OoxmlNode): string => {
     const cached = drawingTokensByParagraph.get(paragraph);
     if (cached?.resourceEpoch === resourceEpoch) return cached.token;
-    const atoms = drawingAtomsInParagraph(paragraph);
+    const atoms = atomsWithHostedStories(paragraph);
     if (atoms.length === 0) {
       drawingTokensByParagraph.set(paragraph, { resourceEpoch, token: '' });
       return '';

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -192,8 +192,16 @@ function drawingResourceLayoutToken(resource: ImageResourceState): string {
   }
 }
 
-/** Bound on text-box-in-text-box descent while building a paragraph's drawing token. */
-const MAX_HOSTED_STORY_TOKEN_DEPTH = 4;
+/**
+ * Story levels folded into a paragraph's drawing token.
+ *
+ * ONE, because one is what paints: `layoutTextboxStory` does not hand its own flow a
+ * textbox-story layout function, so a box inside a box renders nothing. Walking deeper would
+ * not just be wasted work — the token calls `resourceOf` on every atom it names, which
+ * schedules a decode and retains validated bytes for a picture nothing will ever draw. Raise
+ * this only together with nested story layout.
+ */
+const MAX_HOSTED_STORY_TOKEN_DEPTH = 1;
 
 function collectDrawingAtoms(node: OoxmlNode, ids: string[]): void {
   if (node.kind === 'drawing' || isRunLevelMcAlternateContent(node)) {
@@ -239,6 +247,7 @@ function createPartDrawingContextSlot(options: {
     OoxmlNode,
     { readonly resourceEpoch: number; readonly token: string }
   >();
+  const atomsByParagraph = new WeakMap<OoxmlNode, readonly string[]>();
   let resourceEpoch = 0;
 
   const resolveRelationshipTarget = createDrawingRelationshipResolver(pkg, ownerPartName);
@@ -325,25 +334,36 @@ function createPartDrawingContextSlot(options: {
    * changes, so a picture inside it settling would move no token in the host paragraph's key
    * and repaint nothing. The story's atoms have to ride the host paragraph's key, because
    * that is what governs the break the story is laid out from.
+   *
+   * Memoized on the paragraph NODE, not on the resource epoch: which atoms a paragraph owns
+   * is a fact about the tree, and the tree does not move when a picture decodes. Keying this
+   * with the token would re-walk every hosted story of every paragraph in the part each time
+   * any one image settles.
    */
   const atomsWithHostedStories = (paragraph: OoxmlNode): readonly string[] => {
+    const memo = atomsByParagraph.get(paragraph);
+    if (memo) return memo;
     const direct = drawingAtomsInParagraph(paragraph);
     let expanded: string[] | null = null;
     const visit = (atomIds: readonly string[], depth: number): void => {
-      if (depth > MAX_HOSTED_STORY_TOKEN_DEPTH) return;
+      if (depth >= MAX_HOSTED_STORY_TOKEN_DEPTH) return;
       for (const atomId of atomIds) {
         const story = atomProjections.get(atomId)?.textboxStory;
         if (!story) continue;
         const inner: string[] = [];
         collectDrawingAtoms(story.content, inner);
         if (inner.length === 0) continue;
-        expanded ??= [...direct];
-        expanded.push(...inner);
+        if (!expanded) expanded = [...direct];
+        // A LOOP, not `push(...inner)`: the count comes from the file, and spreading a few
+        // hundred thousand arguments is a stack overflow on V8, not a slow call.
+        for (const id of inner) expanded.push(id);
         visit(inner, depth + 1);
       }
     };
     visit(direct, 0);
-    return expanded ?? direct;
+    const atoms = expanded ?? direct;
+    atomsByParagraph.set(paragraph, atoms);
+    return atoms;
   };
 
   const drawingTokenForParagraph = (paragraph: OoxmlNode): string => {

--- a/packages/core/src/layout/note-layout.ts
+++ b/packages/core/src/layout/note-layout.ts
@@ -24,6 +24,7 @@ import {
   type NoteKind,
   MAX_NOTES_PER_PART,
 } from '../store/package/note-nodes.ts';
+import type { InlineDrawingLayoutContext } from './drawing-layout.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
 import type { NoteMarkContext } from './note-projection.ts';
 import type { PendingLine } from './paragraph-flow.ts';
@@ -107,6 +108,26 @@ export interface NoteSeparatorLayout {
   readonly fallbackReason?: NoteLayoutFallbackReason;
 }
 
+/**
+ * Inline drawing support for ONE notes part.
+ *
+ * A note lives in `/word/footnotes.xml` or `/word/endnotes.xml`, not in the body part, so its
+ * pictures resolve against that part's relationships — the same per-part shape header/footer
+ * furniture uses. Without it a note paragraph flows with no drawing context at all and a
+ * picture inside it contributes no record: no image, and no placeholder either.
+ */
+export interface NoteStoryDrawings {
+  readonly inlineDrawingLayout: InlineDrawingLayoutContext;
+  /**
+   * Per-paragraph projection + RESOURCE token for the break cache key.
+   *
+   * Image resources settle asynchronously, and the authored extent does not move when one
+   * does — so without the resource in the key the cached `pending` lines are served forever
+   * and a decoded picture never reaches the page.
+   */
+  readonly drawingTokenForParagraph?: (paragraph: OoxmlNode) => string;
+}
+
 export interface LayoutNoteStoryOptions {
   readonly measurer: TextMeasurer;
   readonly producer: string;
@@ -120,6 +141,13 @@ export interface LayoutNoteStoryOptions {
    * unbounded page fragments; overflow is split by the pagination layer, not here.
    */
   readonly maxFlowHeightPt?: number;
+  /** Resolves inline drawing support for the notes part a story lives in. */
+  readonly drawingsForPart?: (ownerPartName: string) => NoteStoryDrawings | undefined;
+  /**
+   * Notes part the story being laid out came from. Set by {@link layoutNoteById} /
+   * {@link layoutNoteSeparator}, which are the callers that hold the part.
+   */
+  readonly ownerPartName?: string;
 }
 
 /**
@@ -181,6 +209,12 @@ export function layoutNoteStory(
     ? { ...options.noteMarks, activeNoteKey: scopeId }
     : { marks: new Map(), activeNoteKey: scopeId };
 
+  // INLINE pictures only. An anchored drawing in a note would need frame and exclusion
+  // semantics against a story that has no page of its own until pagination places it.
+  const drawings = options.ownerPartName
+    ? options.drawingsForPart?.(options.ownerPartName)
+    : undefined;
+
   const flow = flowBlocksInBox(blocks, 0, width, 0, 0, {
     measurer: options.measurer,
     cache: options.cache,
@@ -190,6 +224,14 @@ export function layoutNoteStory(
     noteMarks,
     ...(options.defaultTabStopPt !== undefined
       ? { defaultTabStopPt: options.defaultTabStopPt }
+      : {}),
+    ...(drawings
+      ? {
+          inlineDrawingLayout: drawings.inlineDrawingLayout,
+          ...(drawings.drawingTokenForParagraph
+            ? { drawingTokenForParagraph: drawings.drawingTokenForParagraph }
+            : {}),
+        }
       : {}),
   });
 
@@ -240,7 +282,7 @@ export function layoutNoteById(
   if (!part) return null;
   const note = findNoteById(part.root, noteId);
   if (!note) return null;
-  return layoutNoteStory(note, contentWidth, options);
+  return layoutNoteStory(note, contentWidth, { ...options, ownerPartName: part.name });
 }
 
 /**
@@ -337,7 +379,10 @@ export function layoutNoteSeparator(
         ruleStyle,
       };
     }
-    const laid = layoutNoteStory(authored, contentWidth, options);
+    const laid = layoutNoteStory(authored, contentWidth, {
+      ...options,
+      ...(part ? { ownerPartName: part.name } : {}),
+    });
     if (laid && laid.flowHeight > 0) {
       const cap = maxFlowHeightPt ?? Number.POSITIVE_INFINITY;
       if (laid.flowHeight > cap + 0.001) {

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -39,6 +39,7 @@ import {
   MAX_NOTE_FRAGMENTS,
   type NoteLayoutFallbackReason,
   type NoteSeparatorLayout,
+  type NoteStoryDrawings,
   type NoteStoryLayout,
   type LayoutNoteStoryOptions,
 } from './note-layout.ts';
@@ -139,6 +140,11 @@ export interface NotesLayoutInput {
   readonly cache?: ParagraphLayoutCache<readonly PendingLine[]>;
   readonly styleCascade?: StyleCascadeTable;
   readonly defaultTabStopPt?: number;
+  /**
+   * Inline drawing support per notes part. Absent means note paragraphs flow without
+   * drawing records, which is what a headless caller with no image port wants.
+   */
+  readonly drawingsForPart?: (ownerPartName: string) => NoteStoryDrawings | undefined;
 }
 
 /**
@@ -337,6 +343,7 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
     styleCascade: input.styleCascade,
     defaultTabStopPt: input.defaultTabStopPt,
     noteMarks,
+    drawingsForPart: input.drawingsForPart,
   };
 }
 

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1294,6 +1294,8 @@ function layoutBlocksPass(
       styleCascade,
       ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
       ...(displayMode ? { displayMode } : {}),
+      inlineDrawingLayout: options.inlineDrawingLayout,
+      drawingTokenForParagraph: options.drawingTokenForParagraph,
     });
 
   // Table layout shares the flow's line counter, paragraph cache, and precomputed list

--- a/packages/core/src/layout/textbox-story-layout.ts
+++ b/packages/core/src/layout/textbox-story-layout.ts
@@ -84,6 +84,19 @@ export interface TextboxStoryLayoutOptions {
   readonly displayMode?: RevisionDisplayMode;
   /** Story nesting depth; a textbox laid out from inside another textbox passes depth + 1. */
   readonly depth?: number;
+  /**
+   * Inline drawing context for the part the text box lives in.
+   *
+   * A picture inside `w:txbxContent` is an ordinary inline drawing of the HOST part — same
+   * relationships, same resources — so the host's context is the right one. Scoped to inline
+   * drawings: an anchored drawing inside a text box would need frame and exclusion semantics
+   * against the box, which is a separate question.
+   */
+  readonly inlineDrawingLayout?: import('./drawing-layout.ts').InlineDrawingLayoutContext;
+  /** Per-paragraph projection + resource token for the break cache key. */
+  readonly drawingTokenForParagraph?: (
+    paragraph: import('@docx-editor.dev/core/store').OoxmlNode
+  ) => string;
 }
 
 /** Stable line-id namespace for one textbox story. */
@@ -148,6 +161,10 @@ export function layoutTextboxStory(
       ? { defaultTabStopPt: options.defaultTabStopPt }
       : {}),
     ...(options.displayMode ? { displayMode: options.displayMode } : {}),
+    ...(options.inlineDrawingLayout ? { inlineDrawingLayout: options.inlineDrawingLayout } : {}),
+    ...(options.drawingTokenForParagraph
+      ? { drawingTokenForParagraph: options.drawingTokenForParagraph }
+      : {}),
   });
 
   let fragments = flow.blocks;

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -1555,10 +1555,23 @@ export function projectRunLevelMcDrawing(
   return projection;
 }
 
+/**
+ * How many text boxes deep the part scan will follow a story.
+ *
+ * A text box inside a text box is legal OOXML, and a hostile file can chain them: each
+ * level is a fresh story root the scan would otherwise descend into unconditionally. The
+ * element budget already bounds total work; this bounds the shape of it, so a deep chain
+ * costs a few levels rather than the whole budget. Word itself stops rendering nested
+ * boxes well before this.
+ */
+const MAX_TEXTBOX_STORY_NESTING = 4;
+
 interface PartCollectFrame {
   readonly node: OoxmlNode;
   readonly namespaceScope: ReadonlyMap<string, string>;
   readonly depth: number;
+  /** Text-box stories entered on the path to this node. */
+  readonly storyDepth: number;
 }
 
 function collectDrawingsInPartBounded(
@@ -1569,9 +1582,35 @@ function collectDrawingsInPartBounded(
   atomIndex?: Map<string, DrawingProjection>
 ): void {
   const stack: PartCollectFrame[] = [
-    { node: root, namespaceScope: emptyNamespaceScope(), depth: 0 },
+    { node: root, namespaceScope: emptyNamespaceScope(), depth: 0, storyDepth: 0 },
   ];
   let visited = 0;
+  // A drawing that hosts a text box is not a leaf: its story is ordinary WML that can hold
+  // pictures of its own, and those need projections (and atom ids) like any other run-level
+  // drawing, or the story lays out with nothing to draw. Descend through the drawing's own
+  // subtree rather than jumping to the story root, so the picture inside is read under the
+  // xmlns bindings its ancestors declare — `a:graphicData` and `wps:wsp` routinely carry them.
+  const descendIntoTextboxStory = (
+    projected: DrawingProjection | null,
+    frame: PartCollectFrame,
+    scope: ReadonlyMap<string, string>
+  ): boolean => {
+    if (!projected?.textboxStory) return false;
+    if (frame.storyDepth >= MAX_TEXTBOX_STORY_NESTING) return false;
+    if (frame.depth >= MAX_XML_DEPTH) return false;
+    if (!isElement(frame.node)) return false;
+    for (let index = frame.node.children.length - 1; index >= 0; index -= 1) {
+      const child = frame.node.children[index];
+      if (!isElement(child)) continue;
+      stack.push({
+        node: child,
+        namespaceScope: scope,
+        depth: frame.depth + 1,
+        storyDepth: frame.storyDepth + 1,
+      });
+    }
+    return true;
+  };
   while (stack.length > 0) {
     const frame = stack.pop()!;
     if (!isElement(frame.node)) continue;
@@ -1591,6 +1630,7 @@ function collectDrawingsInPartBounded(
         out.push(projected);
         atomIndex?.set(frame.node.id, projected);
       }
+      descendIntoTextboxStory(projected, frame, scope);
       continue;
     }
 
@@ -1606,6 +1646,7 @@ function collectDrawingsInPartBounded(
         out.push(projected);
         atomIndex?.set(frame.node.id, projected);
       }
+      descendIntoTextboxStory(projected, frame, scope);
       continue;
     }
 
@@ -1613,7 +1654,12 @@ function collectDrawingsInPartBounded(
     for (let index = frame.node.children.length - 1; index >= 0; index -= 1) {
       const child = frame.node.children[index];
       if (isElement(child)) {
-        stack.push({ node: child, namespaceScope: scope, depth: frame.depth + 1 });
+        stack.push({
+          node: child,
+          namespaceScope: scope,
+          depth: frame.depth + 1,
+          storyDepth: frame.storyDepth,
+        });
       }
     }
   }

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -1590,17 +1590,21 @@ function collectDrawingsInPartBounded(
   // drawing, or the story lays out with nothing to draw. Descend through the drawing's own
   // subtree rather than jumping to the story root, so the picture inside is read under the
   // xmlns bindings its ancestors declare — `a:graphicData` and `wps:wsp` routinely carry them.
+  //
+  // `from` is the node whose subtree actually holds the story. For a plain `w:drawing` that
+  // is the drawing itself; for an `mc:AlternateContent` it is the CHOSEN branch, never the
+  // wrapper — Word emits every anchored text box with a VML fallback carrying a duplicate
+  // `w:txbxContent`, and descending the wrapper would project that dead copy too.
   const descendIntoTextboxStory = (
-    projected: DrawingProjection | null,
+    from: OoxmlNode,
     frame: PartCollectFrame,
     scope: ReadonlyMap<string, string>
-  ): boolean => {
-    if (!projected?.textboxStory) return false;
-    if (frame.storyDepth >= MAX_TEXTBOX_STORY_NESTING) return false;
-    if (frame.depth >= MAX_XML_DEPTH) return false;
-    if (!isElement(frame.node)) return false;
-    for (let index = frame.node.children.length - 1; index >= 0; index -= 1) {
-      const child = frame.node.children[index];
+  ): void => {
+    if (frame.storyDepth >= MAX_TEXTBOX_STORY_NESTING) return;
+    if (frame.depth >= MAX_XML_DEPTH) return;
+    if (!isElement(from)) return;
+    for (let index = from.children.length - 1; index >= 0; index -= 1) {
+      const child = from.children[index];
       if (!isElement(child)) continue;
       stack.push({
         node: child,
@@ -1609,7 +1613,6 @@ function collectDrawingsInPartBounded(
         storyDepth: frame.storyDepth + 1,
       });
     }
-    return true;
   };
   while (stack.length > 0) {
     const frame = stack.pop()!;
@@ -1630,7 +1633,7 @@ function collectDrawingsInPartBounded(
         out.push(projected);
         atomIndex?.set(frame.node.id, projected);
       }
-      descendIntoTextboxStory(projected, frame, scope);
+      if (projected?.textboxStory) descendIntoTextboxStory(frame.node, frame, scope);
       continue;
     }
 
@@ -1646,7 +1649,15 @@ function collectDrawingsInPartBounded(
         out.push(projected);
         atomIndex?.set(frame.node.id, projected);
       }
-      descendIntoTextboxStory(projected, frame, scope);
+      if (projected?.textboxStory) {
+        const chosen = resolveRunLevelMcAtom(
+          frame.node,
+          scope,
+          ctx.supportedMcRequires,
+          ctx.limits
+        ).drawing;
+        if (chosen) descendIntoTextboxStory(chosen, frame, scope);
+      }
       continue;
     }
 
@@ -1718,12 +1729,13 @@ export function projectDrawingsInPackage(
   const projections: DrawingProjection[] = [];
   for (const [partName, part] of pkg.parts) {
     if (!STORY_PART_RE.test(partName)) continue;
-    projections.push(
-      ...projectDrawingsInPart(part, {
-        ...context,
-        resolveRelationship: createDrawingRelationshipResolver(pkg, partName),
-      })
-    );
+    // Appended in a loop rather than spread: the count is file-controlled, and a spread of
+    // several hundred thousand arguments overflows the stack instead of being merely slow.
+    const inPart = projectDrawingsInPart(part, {
+      ...context,
+      resolveRelationship: createDrawingRelationshipResolver(pkg, partName),
+    });
+    for (const projection of inPart) projections.push(projection);
   }
   return Object.freeze(projections.map(freezeDrawingProjection));
 }

--- a/packages/core/src/store/package/ooxml-drawing-rules.ts
+++ b/packages/core/src/store/package/ooxml-drawing-rules.ts
@@ -1069,10 +1069,30 @@ export function resolveDrawingElementKind(
   return null;
 }
 
-/** Demote every typed drawing kind under a generic parent subtree. */
+/**
+ * Whether a node opens a WML story that a drawing merely HOSTS.
+ *
+ * `w:txbxContent` is not part of the DrawingML grammar around it: it is ordinary body
+ * content — paragraphs, runs, and drawings of their own — that happens to live inside a
+ * shape.
+ */
+function opensHostedWmlStory(node: OoxmlElement): boolean {
+  return node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'txbxContent';
+}
+
+/**
+ * Demote every typed drawing kind under a generic parent subtree.
+ *
+ * Stops at a hosted WML story. A text box is a `wps:wsp` under an `a:graphicData` whose uri
+ * is not the picture one, so that graphicData is correctly not a typed `drawingGraphicData`
+ * and demotes — but its story is a separate grammar, and cascading into it stripped the
+ * typed `w:drawing` off a picture INSIDE the box. Nothing then recognized that picture as a
+ * drawing atom: no projection, no resource, nothing painted.
+ */
 export function demoteDrawingKindsInSubtree(children: readonly OoxmlNode[]): readonly OoxmlNode[] {
   return children.map((child) => {
     if (child.kind === 'textValue') return child;
+    if (opensHostedWmlStory(child)) return child;
     const nextKind = isDrawingKnownKind(child.kind) ? 'generic' : child.kind;
     return {
       ...child,

--- a/packages/core/src/store/package/ooxml-drawing-rules.ts
+++ b/packages/core/src/store/package/ooxml-drawing-rules.ts
@@ -6,6 +6,7 @@
 import type { OoxmlAttribute, OoxmlElement, OoxmlNode } from './ooxml-tree.ts';
 
 const WML_NAMESPACE_URI = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const WPS_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
 const DRAWINGML_MAIN_NAMESPACE_URI = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 const WP_NAMESPACE_URI = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const PIC_NAMESPACE_URI = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
@@ -1076,8 +1077,16 @@ export function resolveDrawingElementKind(
  * content — paragraphs, runs, and drawings of their own — that happens to live inside a
  * shape.
  */
-function opensHostedWmlStory(node: OoxmlElement): boolean {
-  return node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'txbxContent';
+/** Just enough of the parent to place a node; the tree node itself may not exist yet. */
+type DemotionParent = { readonly namespaceUri: string; readonly localName: string };
+
+function opensHostedWmlStory(node: OoxmlElement, parent: DemotionParent | undefined): boolean {
+  return (
+    node.namespaceUri === WML_NAMESPACE_URI &&
+    node.localName === 'txbxContent' &&
+    parent?.namespaceUri === WPS_NAMESPACE_URI &&
+    parent.localName === 'txbx'
+  );
 }
 
 /**
@@ -1088,16 +1097,23 @@ function opensHostedWmlStory(node: OoxmlElement): boolean {
  * and demotes — but its story is a separate grammar, and cascading into it stripped the
  * typed `w:drawing` off a picture INSIDE the box. Nothing then recognized that picture as a
  * drawing atom: no projection, no resource, nothing painted.
+ *
+ * The carve-out is positional, not name-only: only a `w:txbxContent` directly under a
+ * `wps:txbx` opens a story. A stray element of that name planted anywhere else in a failed
+ * drawing subtree demotes like everything around it.
  */
-export function demoteDrawingKindsInSubtree(children: readonly OoxmlNode[]): readonly OoxmlNode[] {
+export function demoteDrawingKindsInSubtree(
+  children: readonly OoxmlNode[],
+  parent?: DemotionParent
+): readonly OoxmlNode[] {
   return children.map((child) => {
     if (child.kind === 'textValue') return child;
-    if (opensHostedWmlStory(child)) return child;
+    if (opensHostedWmlStory(child, parent)) return child;
     const nextKind = isDrawingKnownKind(child.kind) ? 'generic' : child.kind;
     return {
       ...child,
       kind: nextKind,
-      children: demoteDrawingKindsInSubtree(child.children),
+      children: demoteDrawingKindsInSubtree(child.children, child),
     } as OoxmlElement;
   });
 }

--- a/packages/core/src/store/package/ooxml-tree.ts
+++ b/packages/core/src/store/package/ooxml-tree.ts
@@ -1862,7 +1862,7 @@ function convertElement(
     candidateKind !== 'generic' && attributesOk && kindChecksPass ? candidateKind : 'generic';
   const finalChildren =
     kind === 'generic' && isDrawingKnownKind(candidateKind)
-      ? demoteDrawingKindsInSubtree(children)
+      ? demoteDrawingKindsInSubtree(children, name)
       : children;
   return {
     id: `${partName}#${path}`,


### PR DESCRIPTION
Pictures in a footnote, an endnote or a text box painted nothing at all — no image, and no placeholder either.

Two different bugs behind one symptom. A note story was flowed with no drawing context, so a picture in it contributed no record; notes live in their own part, so the context comes from that part the way header/footer furniture already resolves one.

A text box was a store-lane bug one layer below projection. A `wps` shape hangs off an `a:graphicData` whose uri is not the picture one, so that element correctly fails to type — but the demotion cascaded through the whole subtree and stripped the typed `w:drawing` off a picture inside `w:txbxContent`, which is not DrawingML at all but ordinary body content the shape hosts. Demotion stops at that boundary (positionally, under a `wps:txbx`), the part scan descends into the story under a nesting cap, and the story flows with the host part's drawing context.

Both stories key their break on the picture's resource identity, so a decode that settles after the first pass still reaches the page.

Anchored drawings inside either story stay out of scope: they need frame and exclusion semantics against a box, or against a page the story has not been placed on yet.

Incidentally this also stops a text box's picture being invisible to the live-reference count, which could GC a media part the box still used.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788641116&installation_model_id=422592&pr_number=215&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F215&signature=aeca4ce02355dba95146448e9b59d2cfaf50397314726d6aae5d05fab37ab250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->