### PR TITLE
docs: escape the literal brace in the custom nodes onEdit row

### DIFF
--- a/docs/site/content/pro/custom-nodes.mdx
+++ b/docs/site/content/pro/custom-nodes.mdx
@@ -69,7 +69,7 @@ Presentation and interaction:
 | `chrome.color`        | `string`                                               | Chip tint and border.                        |
 | `reviewCard`          | `({ attrs, text, data }) => { title, detail } \| null` | Contributes a sidebar card per node.         |
 | `onClick` / `onHover` | `(node: ActivatedCustomNode) => void`                  | Pointer events on the painted chip.          |
-| `onEdit`              | `(node: ActivatedCustomNode) => void`                  | The context menu's "Edit {label}" row.       |
+| `onEdit`              | `(node: ActivatedCustomNode) => void`                  | The context menu's "Edit \{label}" row.      |
 
 Advanced — skip these until you need them:
 


### PR DESCRIPTION
MDX reads the unescaped `{label}` as an expression, so `pro/custom-nodes` fails to compile and the docs build stops there. Introduced by #178.

Swept every `.mdx` under `docs/site/content` for bare braces outside code spans; this was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788642092&installation_model_id=422592&pr_number=216&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F216&signature=89dd40ca11f11ac880991d935b85b0fdf8955a1f72c7944c695a6b2af13a0541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->