### PR TITLE
fix(core): keep a tracked row's card when its first cell is typed in

### DIFF
--- a/.changeset/tracked-row-card-survives-typing.md
+++ b/.changeset/tracked-row-card-survives-typing.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typing in a tracked table row no longer drops that row's tracked-change card, so the row insertion stays acceptable and rejectable.

--- a/packages/core/src/binding/review-patch.ts
+++ b/packages/core/src/binding/review-patch.ts
@@ -1,0 +1,190 @@
+// The CONSERVATIVE local review patch: how a one-paragraph text-local edit updates the
+// review queue without re-deriving it from the whole story.
+//
+// Split out of `tree-session.ts`, which owns the cache and calls these; the rules
+// themselves are pure over the queue and read no session state. The bar is deliberately
+// high — every predicate here answers "is the fast path still TRUE", and the fallback is
+// the full derivation, which is always correct. A patch that keeps a stale card, or drops
+// a live one, is worse than a slower keystroke.
+
+import {
+  linkRevisionReplies,
+  reviewItemKey,
+  reviewItemPositionRank,
+  type ReviewCommentItem,
+  type ReviewItem,
+  type ReviewRevisionItem,
+} from '../layout/review-support.ts';
+import { findNode, type OoxmlPart, type TreeModelChange } from '@docx-editor.dev/core/store';
+
+/** What the queue cache carries that the fast-path decision has to compare against. */
+export interface LocalReviewPatchCache {
+  readonly bodyRevision: number;
+  readonly packageRevision: number;
+  readonly commentsPart: OoxmlPart | undefined;
+  readonly commentsExtendedPart: OoxmlPart | undefined;
+}
+
+function itemStartParagraphRank(
+  item: ReviewItem,
+  order: ReadonlyMap<string, number>
+): number | null {
+  const range = item.kind === 'revision' ? (item.ranges[0] ?? null) : item.range;
+  if (!range) return null;
+  const rank = order.get(range.start.paragraphId);
+  return rank === undefined ? null : rank;
+}
+
+export function canApplyLocalReviewPatch(
+  cached: readonly ReviewItem[],
+  localRevisions: readonly ReviewRevisionItem[],
+  dirtyParagraphId: string
+): boolean {
+  for (const local of localRevisions) {
+    if (local.ranges.length === 0) return false;
+  }
+  const keptRangelessKeys = new Set<string>();
+  for (const item of cached) {
+    if (item.kind !== 'revision' || item.ranges.length > 0) continue;
+    if (isRevisionWhollyInParagraph(item, dirtyParagraphId)) continue;
+    keptRangelessKeys.add(reviewItemKey(item));
+  }
+  for (const local of localRevisions) {
+    if (keptRangelessKeys.has(reviewItemKey(local))) return false;
+  }
+  return true;
+}
+
+export function patchLocalReviewItems(
+  cached: readonly ReviewItem[],
+  paragraphOrder: ReadonlyMap<string, number>,
+  dirtyParagraphId: string,
+  localRevisions: readonly ReviewRevisionItem[]
+): ReviewItem[] {
+  const dirtyRank = paragraphOrder.get(dirtyParagraphId);
+  if (dirtyRank === undefined) return [...cached];
+
+  const patched: ReviewItem[] = [];
+  let insertAt: number | null = null;
+
+  for (const item of cached) {
+    if (item.kind === 'revision' && isRevisionWhollyInParagraph(item, dirtyParagraphId)) {
+      if (insertAt === null) insertAt = patched.length;
+      continue;
+    }
+    if (insertAt === null) {
+      const rank = itemStartParagraphRank(item, paragraphOrder);
+      if (rank !== null && rank > dirtyRank) insertAt = patched.length;
+    }
+    patched.push(item);
+  }
+
+  if (insertAt === null) insertAt = patched.length;
+  if (localRevisions.length > 0) {
+    const orderedLocalRevisions =
+      localRevisions.length < 2
+        ? [...localRevisions]
+        : [...localRevisions].sort(
+            (a, b) =>
+              reviewItemPositionRank(a, paragraphOrder) - reviewItemPositionRank(b, paragraphOrder)
+          );
+    patched.splice(insertAt, 0, ...orderedLocalRevisions);
+  }
+  // RE-LINKED, because the local revisions were derived from one paragraph and carry no
+  // replies. Splicing them in as-is dropped the link between a tracked change and the comment
+  // answering it, so a keystroke in that paragraph tore the reply out into a card of its own —
+  // and the next full re-derive put it back. The pass is over the patched list and costs
+  // nothing when no comment answers a change.
+  return linkRevisionReplies(patched);
+}
+
+function isRevisionWhollyInParagraph(item: ReviewRevisionItem, paragraphId: string): boolean {
+  return (
+    item.ranges.length > 0 &&
+    item.ranges.every(
+      (range) => range.start.paragraphId === paragraphId && range.end.paragraphId === paragraphId
+    )
+  );
+}
+
+function commentTouchesParagraph(item: ReviewCommentItem, paragraphId: string): boolean {
+  if (!item.range) return false;
+  return item.range.start.paragraphId === paragraphId || item.range.end.paragraphId === paragraphId;
+}
+
+/**
+ * True for a revision ANCHORED to this paragraph whose markup lives outside it.
+ *
+ * A tracked ROW is the case: `w:trPr/w:ins` and the `w:cellIns` beside it sit on the row and
+ * its cells, and the site index anchors all of them to the row's FIRST paragraph so the card
+ * has somewhere to point. The patch replaces every cached revision "wholly inside" the dirty
+ * paragraph with what a walk of that paragraph's SUBTREE finds — which holds none of those
+ * markers. So typing in that first cell dropped the row's card while the row stayed painted
+ * as a proposal: a change on screen with nothing left to accept it by.
+ */
+function revisionAnchoredOutsideParagraph(item: ReviewRevisionItem, paragraphId: string): boolean {
+  return (
+    item.revisionKind === 'structural' &&
+    item.ranges.some(
+      (range) => range.start.paragraphId === paragraphId || range.end.paragraphId === paragraphId
+    )
+  );
+}
+
+function revisionCrossesParagraphBoundary(item: ReviewRevisionItem, paragraphId: string): boolean {
+  if (item.ranges.length === 0) return false;
+  const touches = item.ranges.some(
+    (range) => range.start.paragraphId === paragraphId || range.end.paragraphId === paragraphId
+  );
+  if (!touches) return false;
+  return !item.ranges.every(
+    (range) => range.start.paragraphId === paragraphId && range.end.paragraphId === paragraphId
+  );
+}
+
+/** The one paragraph a patch may rebuild, or null to fall back to the full derivation. */
+export function localReviewPatchParagraphId(
+  change: TreeModelChange,
+  cache: LocalReviewPatchCache,
+  items: readonly ReviewItem[],
+  part: OoxmlPart,
+  commentsPart: OoxmlPart | undefined,
+  commentsExtendedPart: OoxmlPart | undefined,
+  currentPackageRevision: number
+): string | null {
+  if (change.fromRevision !== cache.bodyRevision) return null;
+  // Body text-local edits bump package revision by exactly one. A header/footer or package
+  // write can move package revision without moving the body revision — patching against a
+  // queue derived before that would keep stale furniture cards by reference.
+  if (currentPackageRevision !== cache.packageRevision + 1) return null;
+  if (change.story !== undefined && change.story.kind !== 'body') return null;
+  if (change.impact !== 'text-local') return null;
+  if (change.dirty.length !== 1) return null;
+  if (change.created.length > 0 || change.deleted.length > 0 || change.splitJoin.length > 0) {
+    return null;
+  }
+  if (cache.commentsPart !== commentsPart || cache.commentsExtendedPart !== commentsExtendedPart) {
+    return null;
+  }
+  const paragraphId = change.dirty[0]!;
+  const paragraph = findNode(part, paragraphId);
+  if (!paragraph || paragraph.kind !== 'paragraph') return null;
+
+  for (const item of items) {
+    if (item.kind === 'comment') {
+      if (commentTouchesParagraph(item, paragraphId)) return null;
+      continue;
+    }
+    // A custom node's item is refreshed by the FULL derivation only; a local revision
+    // patch on its paragraph could go stale, so refuse the fast path when one touches it.
+    if (item.kind === 'custom') {
+      if (item.range?.start.paragraphId === paragraphId) return null;
+      continue;
+    }
+    // Full derivation, not the fast path: the paragraph walk cannot see this item's markup,
+    // so patching would delete a decision the document still holds.
+    if (revisionAnchoredOutsideParagraph(item, paragraphId)) return null;
+    if (revisionCrossesParagraphBoundary(item, paragraphId)) return null;
+  }
+  return paragraphId;
+}

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -12,15 +12,12 @@
 // collapse to a single honest statement of what the part contains.
 
 import type { Node as PMNode } from 'prosemirror-model';
+import { paragraphOrderOfPart, type ReviewItem } from '../layout/review-support.ts';
 import {
-  linkRevisionReplies,
-  paragraphOrderOfPart,
-  reviewItemKey,
-  reviewItemPositionRank,
-  type ReviewCommentItem,
-  type ReviewItem,
-  type ReviewRevisionItem,
-} from '../layout/review-support.ts';
+  canApplyLocalReviewPatch,
+  localReviewPatchParagraphId,
+  patchLocalReviewItems,
+} from './review-patch.ts';
 import type { ReviewModuleContribution } from '../contracts/modules.ts';
 import {
   addComment,
@@ -53,7 +50,6 @@ import {
   ensureNumberingLevel,
   ensureHyperlinkRelationship,
   buildBookmarkIndex,
-  findNode,
   relationshipTargetIn,
   isHeaderFooterLifecycleOp,
   isNoteLifecycleOp,
@@ -1419,152 +1415,6 @@ function projectedText(part: OoxmlPart): string {
   return bodyParagraphs(part)
     .map((paragraph) => paragraphTextOf(part, paragraph.id) ?? '')
     .join('\n');
-}
-
-function itemStartParagraphRank(
-  item: ReviewItem,
-  order: ReadonlyMap<string, number>
-): number | null {
-  const range = item.kind === 'revision' ? (item.ranges[0] ?? null) : item.range;
-  if (!range) return null;
-  const rank = order.get(range.start.paragraphId);
-  return rank === undefined ? null : rank;
-}
-
-function canApplyLocalReviewPatch(
-  cached: readonly ReviewItem[],
-  localRevisions: readonly ReviewRevisionItem[],
-  dirtyParagraphId: string
-): boolean {
-  for (const local of localRevisions) {
-    if (local.ranges.length === 0) return false;
-  }
-  const keptRangelessKeys = new Set<string>();
-  for (const item of cached) {
-    if (item.kind !== 'revision' || item.ranges.length > 0) continue;
-    if (isRevisionWhollyInParagraph(item, dirtyParagraphId)) continue;
-    keptRangelessKeys.add(reviewItemKey(item));
-  }
-  for (const local of localRevisions) {
-    if (keptRangelessKeys.has(reviewItemKey(local))) return false;
-  }
-  return true;
-}
-
-function patchLocalReviewItems(
-  cached: readonly ReviewItem[],
-  paragraphOrder: ReadonlyMap<string, number>,
-  dirtyParagraphId: string,
-  localRevisions: readonly ReviewRevisionItem[]
-): ReviewItem[] {
-  const dirtyRank = paragraphOrder.get(dirtyParagraphId);
-  if (dirtyRank === undefined) return [...cached];
-
-  const patched: ReviewItem[] = [];
-  let insertAt: number | null = null;
-
-  for (const item of cached) {
-    if (item.kind === 'revision' && isRevisionWhollyInParagraph(item, dirtyParagraphId)) {
-      if (insertAt === null) insertAt = patched.length;
-      continue;
-    }
-    if (insertAt === null) {
-      const rank = itemStartParagraphRank(item, paragraphOrder);
-      if (rank !== null && rank > dirtyRank) insertAt = patched.length;
-    }
-    patched.push(item);
-  }
-
-  if (insertAt === null) insertAt = patched.length;
-  if (localRevisions.length > 0) {
-    const orderedLocalRevisions =
-      localRevisions.length < 2
-        ? [...localRevisions]
-        : [...localRevisions].sort(
-            (a, b) =>
-              reviewItemPositionRank(a, paragraphOrder) - reviewItemPositionRank(b, paragraphOrder)
-          );
-    patched.splice(insertAt, 0, ...orderedLocalRevisions);
-  }
-  // RE-LINKED, because the local revisions were derived from one paragraph and carry no
-  // replies. Splicing them in as-is dropped the link between a tracked change and the comment
-  // answering it, so a keystroke in that paragraph tore the reply out into a card of its own —
-  // and the next full re-derive put it back. The pass is over the patched list and costs
-  // nothing when no comment answers a change.
-  return linkRevisionReplies(patched);
-}
-
-function isRevisionWhollyInParagraph(item: ReviewRevisionItem, paragraphId: string): boolean {
-  return (
-    item.ranges.length > 0 &&
-    item.ranges.every(
-      (range) => range.start.paragraphId === paragraphId && range.end.paragraphId === paragraphId
-    )
-  );
-}
-
-function commentTouchesParagraph(item: ReviewCommentItem, paragraphId: string): boolean {
-  if (!item.range) return false;
-  return item.range.start.paragraphId === paragraphId || item.range.end.paragraphId === paragraphId;
-}
-
-function revisionCrossesParagraphBoundary(item: ReviewRevisionItem, paragraphId: string): boolean {
-  if (item.ranges.length === 0) return false;
-  const touches = item.ranges.some(
-    (range) => range.start.paragraphId === paragraphId || range.end.paragraphId === paragraphId
-  );
-  if (!touches) return false;
-  return !item.ranges.every(
-    (range) => range.start.paragraphId === paragraphId && range.end.paragraphId === paragraphId
-  );
-}
-
-function localReviewPatchParagraphId(
-  change: TreeModelChange,
-  cache: {
-    bodyRevision: number;
-    packageRevision: number;
-    commentsPart: OoxmlPart | undefined;
-    commentsExtendedPart: OoxmlPart | undefined;
-  },
-  items: readonly ReviewItem[],
-  part: OoxmlPart,
-  commentsPart: OoxmlPart | undefined,
-  commentsExtendedPart: OoxmlPart | undefined,
-  currentPackageRevision: number
-): string | null {
-  if (change.fromRevision !== cache.bodyRevision) return null;
-  // Body text-local edits bump package revision by exactly one. A header/footer or package
-  // write can move package revision without moving the body revision — patching against a
-  // queue derived before that would keep stale furniture cards by reference.
-  if (currentPackageRevision !== cache.packageRevision + 1) return null;
-  if (change.story !== undefined && change.story.kind !== 'body') return null;
-  if (change.impact !== 'text-local') return null;
-  if (change.dirty.length !== 1) return null;
-  if (change.created.length > 0 || change.deleted.length > 0 || change.splitJoin.length > 0) {
-    return null;
-  }
-  if (cache.commentsPart !== commentsPart || cache.commentsExtendedPart !== commentsExtendedPart) {
-    return null;
-  }
-  const paragraphId = change.dirty[0]!;
-  const paragraph = findNode(part, paragraphId);
-  if (!paragraph || paragraph.kind !== 'paragraph') return null;
-
-  for (const item of items) {
-    if (item.kind === 'comment') {
-      if (commentTouchesParagraph(item, paragraphId)) return null;
-      continue;
-    }
-    // A custom node's item is refreshed by the FULL derivation only; a local revision
-    // patch on its paragraph could go stale, so refuse the fast path when one touches it.
-    if (item.kind === 'custom') {
-      if (item.range?.start.paragraphId === paragraphId) return null;
-      continue;
-    }
-    if (revisionCrossesParagraphBoundary(item, paragraphId)) return null;
-  }
-  return paragraphId;
 }
 
 /**

--- a/packages/pro/src/__tests__/tree-session-review-patch.test.ts
+++ b/packages/pro/src/__tests__/tree-session-review-patch.test.ts
@@ -169,6 +169,21 @@ const NESTED_TBLPR_COLLISION =
   `<w:p>${run('second ')}${ins('2', run('kept'))}</w:p>` +
   BODY_TABLE_STRUCTURAL;
 
+/**
+ * A tracked ROW: `w:trPr/w:ins` plus a `w:cellIns` per cell, all under one address.
+ *
+ * None of those markers lives inside a paragraph — they anchor to the row's first one — which
+ * is the case the local patch has to leave alone.
+ */
+const TRACKED_ROW_TABLE =
+  `<w:tbl><w:tblPr/>` +
+  `<w:tr><w:tc><w:tcPr/><w:p>${run('kept cell')}</w:p></w:tc></w:tr>` +
+  `<w:tr><w:trPr>${tblPrIns('50', 'Ada', '2026-01-03T00:00:00Z')}</w:trPr>` +
+  `<w:tc><w:tcPr><w:cellIns w:id="50" w:author="Ada" w:date="2026-01-03T00:00:00Z"/></w:tcPr>` +
+  `<w:p>${run('typed here')}</w:p></w:tc>` +
+  `<w:tc><w:tcPr><w:cellIns w:id="50" w:author="Ada" w:date="2026-01-03T00:00:00Z"/></w:tcPr>` +
+  `<w:p>${run('other cell')}</w:p></w:tc></w:tr></w:tbl>`;
+
 const MIXED_LOCAL_REVISION_ORDER =
   `<w:p>` +
   `<w:pPr><w:rPr><w:ins w:id="6" w:author="QA" w:date="2026-01-01T00:00:00Z"/></w:rPr></w:pPr>` +
@@ -260,6 +275,36 @@ describe('local review patch after one-paragraph text-local edits', () => {
     expect(after).toEqual(oracle(session));
     expect(after.find((item) => item === structural)).toBe(structural);
     expect(after.find((item) => item === neighbor)).toBe(neighbor);
+  });
+
+  test('typing in a tracked row keeps the row card', () => {
+    const session = open(docx(TRACKED_ROW_TABLE));
+    const rowCardOf = (items: readonly ReviewItem[]) =>
+      items.find(
+        (item): item is ReviewRevisionItem => isRevision(item) && item.revisionKind === 'structural'
+      );
+    const before = rowCardOf(session.reviewItems())!;
+    expect(before.readOnly).toBe(false);
+    // The row's markers anchor to the FIRST cell's paragraph — the one being typed in.
+    const paragraphId = session.paragraphIds()[1]!;
+    expect(before.ranges[0]!.start.paragraphId).toBe(paragraphId);
+
+    const result = session.applyTreeOps([
+      {
+        op: 'insertText',
+        paragraphId,
+        offset: 0,
+        text: 'X',
+        revision: { author: 'Ada', date: '2026-01-03T00:00:00Z' },
+      },
+    ]);
+    expect(result.committed).toBe(true);
+
+    const after = session.reviewItems();
+    expect(after).toEqual(oracle(session));
+    // The row is still painted as a proposal, so its decision has to still be in the queue.
+    expect(rowCardOf(after)).toBeDefined();
+    expect(rowCardOf(after)!.readOnly).toBe(false);
   });
 
   test('range-less local ambiguity falls back instead of patching', () => {


### PR DESCRIPTION
Inserting a row in suggesting mode painted the row as a proposal, but typing into its first cell removed the row's card from the review queue — leaving a tracked change on screen with no way to accept or reject it.

The row's `w:trPr/w:ins` and `w:cellIns` markers live outside any paragraph and anchor to the row's first one. The local review patch read that anchor as "paragraph-local", dropped the card, and the paragraph re-walk that replaces it cannot see markers outside the paragraph subtree. The patch now falls back to the full derivation when the dirty paragraph anchors a structural revision.

The patch rules move to `binding/review-patch.ts`; `tree-session.ts` was already over its line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788643195&installation_model_id=422592&pr_number=219&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F219&signature=1731c515f97ac1306181c7c4426753dbd8c00cfef1d11135cabac849b50356fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->