### PR TITLE
fix(core): make the generated binding type declaration deterministic

### DIFF
--- a/.changeset/deterministic-tree-schema-types.md
+++ b/.changeset/deterministic-tree-schema-types.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Pin the node and mark name unions on `treeSchema` so the generated type declaration is identical between builds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,8 +282,13 @@ Never push the `chore: release` commit by hand, delete `.changeset/*.md` outside
 
 **Third-party notices.** Every publishable package ships a
 `THIRD_PARTY_NOTICES.md` reproducing the license of each package esbuild inlines
-into its bundles — core pulls in fast-xml-parser, fflate and prosemirror-\*, and
-MIT/Apache-2.0 both require the notice to travel with the copy. The Release
+into its bundles, because MIT/Apache-2.0 both require the notice to travel with
+the copy. Only genuinely inlined code counts: core declares fast-xml-parser,
+fflate and prosemirror-\* as real `dependencies` with no `noExternal`, so esbuild
+leaves them external, npm installs them with their own licenses, and every
+package currently generates an empty notice. An empty run is the correct result
+here, not a broken generator — what would be wrong is a bundled dependency
+missing its text, which fails the run outright. The Release
 workflow generates it from `dist/metafile-*.json` just before publishing; the
 file is gitignored, so regenerate with `bun run build:packages && bun run
 notices:generate`. `notices:check` compares against the CURRENT `dist/`, so it

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -183,7 +183,7 @@ export interface TreeDocxSession {
 }
 
 // @public
-export const treeSchema: Schema<"paragraph" | "text" | "tab" | "hardBreak" | "pageBreak" | "doc" | "unknownInline", "runProps">;
+export const treeSchema: Schema<'doc' | 'paragraph' | 'text' | 'tab' | 'hardBreak' | 'pageBreak' | 'unknownInline', 'runProps'>;
 
 // @public
 export type TreeSessionRejection = OoxmlPackageRejection | 'no-main-document-tree';

--- a/packages/core/src/binding/tree-schema.ts
+++ b/packages/core/src/binding/tree-schema.ts
@@ -31,8 +31,17 @@ export interface ParagraphAttrs {
  * paragraphs, text, tabs, breaks, and run properties as marks — because everything it does NOT
  * model stays on the tree and is preserved losslessly there. Widening this schema moves content
  * out of the tree's custody, which is the opposite of what it is for.
+ *
+ * The node and mark unions are written out rather than inferred from the spec below. Inferred,
+ * tsup's dts worker emits their members in an order that varies run to run, so the generated
+ * `binding.api.md` differed between builds of identical source and `api:check` failed at random.
+ * An explicit annotation pins the emitted order. Adding a node or mark to the spec means adding
+ * it here too — the compiler rejects the assignment otherwise.
  */
-export const treeSchema = new Schema({
+export const treeSchema: Schema<
+  'doc' | 'paragraph' | 'text' | 'tab' | 'hardBreak' | 'pageBreak' | 'unknownInline',
+  'runProps'
+> = new Schema({
   nodes: {
     doc: { content: 'paragraph+' },
 


### PR DESCRIPTION
`treeSchema` let TypeScript infer its node and mark name unions, and tsup's dts worker emitted their members in an order that varied between builds of identical source. Four consecutive builds of unchanged source produced two different orderings, so `api:check` failed at random rather than on real API drift. Annotating the constant pins the emitted order; the compiler rejects the assignment if a node or mark is added to the spec without adding it here.

Also corrects the third-party notices note in CLAUDE.md, which described core as inlining fast-xml-parser, fflate and prosemirror-*. They are declared as real dependencies with no `noExternal`, so nothing is bundled and an empty notice is the expected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788644333&installation_model_id=422592&pr_number=220&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F220&signature=1a5891786034f3b70083f768e55d4c9145919ab7748f7b3a1ea2b7d634959001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->