### PR TITLE
docs: say Office.js compatible rather than naming the object model

### DIFF
--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -8,7 +8,7 @@ seoTitle: 'Office.js-compatible DOCX editing API'
 
 <PackageStats name="@docx-editor.dev/editor-api" />
 
-`@docx-editor.dev/editor-api` is an **Office.js-compatible editing API** for DOCX. It implements the Word JavaScript object model (`context.document.body.paragraphs`, `load()` then `sync()`, `search()`, `getFirstOrNullObject()`) so code written for a Word add-in compiles and runs here.
+`@docx-editor.dev/editor-api` is an **Office.js-compatible editing API** for DOCX. It implements the same object model (`context.document.body.paragraphs`, `load()` then `sync()`, `search()`, `getFirstOrNullObject()`) so code written for a Word add-in compiles and runs here.
 
 You describe work against objects (paragraphs, ranges, comments, revisions, content controls) and one `sync()` sends it as a single ordered batch that either applies whole or not at all. The same code runs in two places: on a server over DOCX bytes, or in a page against a document a reader already has open.
 

--- a/docs/site/content/editor-api/word-js-api.mdx
+++ b/docs/site/content/editor-api/word-js-api.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Office.js compatibility'
-description: 'The Office.js-compatible subset: which parts of the Word JavaScript object model are implemented, how compatibility is verified in CI, and what it omits.'
+description: 'The Office.js-compatible subset: which parts of the object model are implemented, how compatibility is verified in CI, and what it omits.'
 category: 'Editing API'
 order: 53
 ---
 
-`@docx-editor.dev/editor-api` is Office.js-compatible: it implements the Word JavaScript object model, so `context.document.body.paragraphs`, `load()` then `sync()`, `search(text, options)`, `getFirstOrNullObject()` and `isNullObject` all mean here what they mean in an add-in. Word add-in code ports by changing how the batch is opened.
+`@docx-editor.dev/editor-api` is Office.js-compatible: it implements the same object model, so `context.document.body.paragraphs`, `load()` then `sync()`, `search(text, options)`, `getFirstOrNullObject()` and `isNullObject` all mean here what they mean in an add-in. Word add-in code ports by changing how the batch is opened.
 
 The exact scope of that claim:
 


### PR DESCRIPTION
## Why

Three spots described `@docx-editor.dev/editor-api` as implementing "the Word JavaScript object model". Office.js is the name developers search for and recognize; the longer phrasing is Microsoft's spec language and reads as unfamiliar jargon to the audience actually porting an add-in.

The page these live on is already titled **Office.js compatibility**, so the phrasing was also inconsistent with its own heading.

## What

Each of the three sentences already said "Office.js-compatible" in the same breath, so this drops the restatement rather than losing information:

- `editor-api/index.mdx` — "It implements the Word JavaScript object model (...)" → "It implements the same object model (...)"
- `editor-api/word-js-api.mdx` — same change in the body, plus the frontmatter `description`

The concrete API surface each sentence lists (`context.document.body.paragraphs`, `load()` then `sync()`, `search()`, `getFirstOrNullObject()`) is untouched, so nothing gets vaguer.

The file slug stays `word-js-api`: it is a real route with redirects pointing at it, and only the visible prose changes here.

## Verification

- `bun run check:docs-mdx` (the gate from #218): `docs mdx: OK — 32 pages, no bare expressions`
- `prettier --check` on both files: clean
- No `Word JavaScript` or `Word JS API` left anywhere under `docs/site/content/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788645181&installation_model_id=422592&pr_number=221&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F221&signature=bb0e99ef0bf6740c83ecc3311303c334c384dc4e0de4058eec20a018126dd3de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->