### PR TITLE
docs: mermaid for diagrams, not ASCII

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,12 @@ updates both.
 has its own. Register a new page in BOTH, or it is URL-reachable but missing from
 the sidebar.
 
+**Diagrams are mermaid**, in a ` ```mermaid ` fence — not ASCII box drawing.
+ASCII renders at whatever the code block's font does, wraps on a phone, and is
+unreadable to a screen reader; mermaid scales and picks up the site theme. Keep
+it to the shape being explained (a flow, a sequence, a state machine); a diagram
+that just restates the prose earns nothing.
+
 OOXML reference: `reference/quick-ref/wordprocessingml.md`, `themes-colors.md`;
 schemas in `reference/ecma-376/part1/schemas/`. PDFs are gitignored — run `bun
 run reference:fetch` once when needed.

--- a/docs/site/content/pro/custom-nodes.mdx
+++ b/docs/site/content/pro/custom-nodes.mdx
@@ -260,18 +260,11 @@ if (!outgoing.ok) throw new Error(outgoing.reason);
 download(outgoing.bytes);
 ```
 
-```
-                     one document
-                          │
-          ┌───────────────┴────────────────┐
-          │                                │
-   editor.save()                 saveForExport(editor)
-          │                                │
-          ▼                                ▼
-    your storage                 the user's download
-                                 an ordinary .docx
-  reopens in this editor
-  with the chips working
+```mermaid
+flowchart TD
+    doc["one document"]
+    doc -- "editor.save()" --> keep["your storage<br/>reopens here with the chips working"]
+    doc -- "saveForExport(editor)" --> send["the user's download<br/>an ordinary .docx"]
 ```
 
 `saveForExport` calls `editor.save()`, then applies every definition registered in `modules`. There is no list to pass and no list to get wrong. Pass `nodes` to narrow it.


### PR DESCRIPTION
ASCII box drawing renders at whatever the code block's font does, wraps on a phone, and is opaque to a screen reader. Converts the one diagram in the custom-nodes page and records the convention.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788646264&installation_model_id=422592&pr_number=224&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F224&signature=43fb682ddcc162361273bc562fc1149c12e6c2e35870c37d2852ea579f5ad45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->