### PR TITLE
docs: split custom nodes into a guide and a reference

### DIFF
--- a/docs/site/content/meta.json
+++ b/docs/site/content/meta.json
@@ -29,6 +29,7 @@
     "pro/tracked-changes",
     "pro/comments",
     "pro/custom-nodes",
+    "pro/custom-nodes-reference",
     "---Editing API---",
     "editor-api/index",
     "editor-api/office-js-api",

--- a/docs/site/content/pro/custom-nodes-reference.mdx
+++ b/docs/site/content/pro/custom-nodes-reference.mdx
@@ -1,0 +1,355 @@
+---
+title: 'Custom nodes reference'
+description: 'Custom node API: every option, every error code, the on-disk format.'
+category: 'Pro'
+order: 64
+---
+
+The API surface of [custom nodes](/docs/2.x/pro/custom-nodes). Start with the guide if you have not
+built one yet.
+
+A node stores what it knows in two places:
+
+| Location    | Holds               | Limit                                        |
+| ----------- | ------------------- | -------------------------------------------- |
+| `w:tag`     | The node's identity | 64 characters, including the prefix and name |
+| The payload | Everything else     | 256 KB                                       |
+
+The payload is a customXml data part that the control binds to through `w:dataBinding`. Word
+preserves both.
+
+## defineCustomNode
+
+Required:
+
+| Parameter   | Type     | Description                                                |
+| ----------- | -------- | ---------------------------------------------------------- |
+| `name`      | `string` | Node type name. The second segment of the tag.             |
+| `tagPrefix` | `string` | The prefix this definition claims. `docx` claims `docx:*`. |
+
+What the node carries and shows:
+
+| Parameter | Type                                                       | Description                                                                                                  |
+| --------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `schema`  | zod (or any [Standard Schema](https://standardschema.dev)) | Shape of the payload. Nothing is bundled; bring your own. A schema that validates asynchronously is refused. |
+| `text`    | `(data) => string`                                         | What the document shows, from the payload. Reads the schema's output type.                                   |
+
+Presentation and interaction:
+
+| Parameter             | Type                                                   | Description                                  |
+| --------------------- | ------------------------------------------------------ | -------------------------------------------- |
+| `label`               | `string`                                               | Display name for chrome. Defaults to `name`. |
+| `chrome.color`        | `string`                                               | Chip tint and border.                        |
+| `reviewCard`          | `({ attrs, text, data }) => { title, detail } \| null` | Contributes a sidebar card per node.         |
+| `onClick` / `onHover` | `(node: ActivatedCustomNode) => void`                  | Pointer events on the painted chip.          |
+| `onEdit`              | `(node: ActivatedCustomNode) => void`                  | The context menu's "Edit \{label}" row.      |
+
+Advanced:
+
+| Parameter          | Type                                       | When                                                                                                                                                                        |
+| ------------------ | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `preserveOnExport` | `boolean \| 'text'`                        | The node should not travel intact. See [preserveOnExport](#preserveonexport).                                                                                               |
+| `tagAttrs`         | `(data) => Record<string, string>`         | A reader without the payload store should still identify the node.                                                                                                          |
+| `payloadNamespace` | `string`                                   | You need a specific customXml namespace. Defaults to one from `tagPrefix`. It goes into an XPath prefix declaration, so quotes, angle brackets and ampersands are rejected. |
+| `fromDocx`         | `({ attrs, text, data }) => attrs \| null` | The node has **no** schema and keeps its data in the tag, or you need to disown a control by returning `null`.                                                              |
+
+The returned `CustomNode` carries [`dataOf`](#dataof) alongside the definition.
+
+## customNodesModule
+
+```ts
+customNodesModule({ nodes: [Citation], onDiagnostic });
+```
+
+| Option         | Type                                       | Description                                                   |
+| -------------- | ------------------------------------------ | ------------------------------------------------------------- |
+| `nodes`        | `readonly AnyCustomNodeDefinition[]`       | The definitions this editor recognizes.                       |
+| `onDiagnostic` | `({ code, name, nodeId, issues }) => void` | `'payload-invalid'` or `'payload-missing'` on a node it read. |
+| `licenseKey`   | `string`                                   | Never validated at construction, never touches the network.   |
+
+The listener belongs to the editor the module is registered on. Two editors on one page hear only
+their own documents, and a listener goes when its editor does.
+
+## Writes
+
+| Function                                        | Behavior                                |
+| ----------------------------------------------- | --------------------------------------- |
+| `insertCustomNode(editor, def, input)`          | Inserts at the caret, or at `input.at`. |
+| `updateCustomNode(editor, def, nodeId, update)` | Rewrites in place.                      |
+| `removeCustomNode(editor, nodeId)`              | Deletes the node and its payload.       |
+
+Each is one transaction and one undo step, payload included.
+
+### Input
+
+| Field   | Type                                                            | Description                                                                          |
+| ------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `data`  | The schema's input type                                         | The payload. Validated before anything is written.                                   |
+| `attrs` | `Record<string, string>`                                        | Tag attrs. Derived by `tagAttrs` when declared. Passing it overrides the derivation. |
+| `text`  | `string`                                                        | Document text. Derived by `text` when declared. Passing it overrides the derivation. |
+| `at`    | `{ paragraphId, offset }`                                       | Insert position. Defaults to the caret. `insertCustomNode` only.                     |
+| `lock`  | `false \| 'sdtLocked' \| 'sdtContentLocked' \| 'contentLocked'` | Defaults to `contentLocked`.                                                         |
+| `alias` | `string`                                                        | `w:alias`, the title Word shows on the control.                                      |
+
+`updateCustomNode` keeps the payload you do not mention. Pass `data: null` to remove one.
+
+`contentLocked` prevents inline text editing while leaving the node deletable as a unit, in the
+editor and in Word. A node carrying a payload is uneditable regardless of `lock`: the engine refuses
+content edits inside a bound control, and so does Word.
+
+### Returns
+
+`{ ok: true, changed: true, nodeId }`, or a refusal.
+
+`nodeId` names the control the write authored. A rewrite replaces the control rather than editing
+it, so the id passed to `updateCustomNode` names nothing afterwards. `removeCustomNode` authors no
+control, so it returns no `nodeId`.
+
+A refusal carries a `code`:
+
+| `code`        | Meaning                                                                                                               |
+| ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `invalidArgs` | Fixable by passing something else: a payload past the cap, a tag over 64 characters, an offset outside the paragraph. |
+| `unsupported` | A fact about the document: a lock, a protected form, viewing mode.                                                    |
+| `notFound`    | No document is mounted, or `updateCustomNode` was given an id no node has.                                            |
+
+A payload the schema rejected also carries `issues`:
+
+| Field     | Type                            | Description                           |
+| --------- | ------------------------------- | ------------------------------------- |
+| `message` | `string`                        | What the schema said.                 |
+| `path`    | `readonly (string \| number)[]` | Route to the field: `['authors', 0]`. |
+| `pointer` | `string`                        | The same path joined: `authors.0`.    |
+
+## Reads
+
+### customNodesOf
+
+`customNodesOf(editor, options?)` reads the body and recognizes every definition registered on the
+editor, in document order. Pass `{ nodes }` to narrow it. It derives from the document each time it
+is called. There is no change event, so re-read after an edit rather than holding the array.
+
+A payload with no `schema` comes back as parsed JSON on a null-prototype object, so
+`hasOwnProperty` and `instanceof Object` do not hold on it.
+
+### dataOf
+
+`Citation.dataOf(node)` returns the schema's output type, or `undefined` for a different
+definition's node, one with no payload, or one whose payload the schema rejects. A `name` is checked
+when the object has one and never required, so it also works on your own state:
+
+```ts
+const survey = Citation.dataOf(popoverState); // { data } is enough
+```
+
+Inside `text`, `reviewCard` and `fromDocx`, `data` is already the schema's output type. Everywhere
+else it is `unknown`, because those surfaces carry every definition's nodes under one type.
+
+A definition does not need `reviewCard` to be read. A node without one is still recognized and still
+carries its payload; it contributes nothing to the sidebar.
+
+### Review items
+
+Nodes with ranges, for anchoring UI. Requires the review module:
+
+```ts
+const cards = editor.getReviewItems().filter((entry) => entry.item.kind === 'custom');
+```
+
+## Export
+
+| The file is going to | Call                    | Custom nodes                                  |
+| -------------------- | ----------------------- | --------------------------------------------- |
+| Your own storage     | `editor.save()`         | Kept, always.                                 |
+| Anyone else          | `saveForExport(editor)` | Each definition's `preserveOnExport` decides. |
+
+```mermaid
+flowchart TD
+    doc["one document"]
+    doc -- "editor.save()" --> keep["your storage<br/>reopens here with the chips working"]
+    doc -- "saveForExport(editor)" --> send["the user's download<br/>an ordinary .docx"]
+```
+
+`saveForExport` calls `editor.save()`, then applies every definition registered in `modules`. There
+is no list to pass and no list to get wrong. Pass `nodes` to narrow it.
+
+`unwrapped` and `removed` count the controls each policy touched. A refusal returns no bytes, only a
+`reason`.
+
+Pass `destination` when the choice is made at runtime. `'internal'` returns the saved bytes
+unchanged, so one code path covers both:
+
+```ts
+const copy = await saveForExport(editor, {
+  destination: keepOurMarkup ? 'internal' : 'external',
+});
+```
+
+Store the saved bytes, not the exported ones. What the export stripped is gone: unwrapped text does
+not become a node again.
+
+### preserveOnExport
+
+Declared on the definition, applied only when you export. `editor.save()` ignores it.
+
+| Value            | The recipient gets                                              | Use for                                                         |
+| ---------------- | --------------------------------------------------------------- | --------------------------------------------------------------- |
+| `true` (default) | The node, whole. Tag, binding and payload all travel.           | Nodes the recipient is meant to keep working with.              |
+| `'text'`         | The words only. The control, binding and payload are unwrapped. | A citation, where the reader needs the text but not the markup. |
+| `false`          | Nothing. The node is removed with its content.                  | Internal annotations that must not leave.                       |
+
+The default is `true`, and for most node types it is the right answer: the recipient gets a valid
+`.docx` that opens anywhere, and the node still works if the file comes back to you. Stripping is
+the opt-in, per definition:
+
+```ts
+const Citation = defineCustomNode({ name: 'citation', /* … */ preserveOnExport: 'text' });
+const InternalNote = defineCustomNode({ name: 'note', /* … */ preserveOnExport: false });
+const MergeField = defineCustomNode({ name: 'merge' /* … */ }); // true, the default
+```
+
+One document can hold nodes with all three settings and each is decided independently. A tag no
+definition claims is never touched: this applies your own policy to your own markup, it is not a
+scrub of the document.
+
+A node that leaves takes its payload with it, even when other nodes in the same store remain. When
+the last node for a namespace is gone, both `customXml` parts, both relationships and the
+content-type override are removed.
+
+Every story is covered, so a chip in a header is treated like a chip in the body.
+
+This removes markup written by this library. It does not touch `docProps/app.xml`,
+`docProps/core.xml`, comment and revision authors, rsids, or custom document properties. It does not
+anonymize a document.
+
+### prepareForExport
+
+`saveForExport` needs an editor. Where there is none, `prepareForExport` is the same pipeline over
+bytes, with the definitions spelled out. It touches no DOM:
+
+```ts
+import { prepareForExport } from '@docx-editor.dev/pro';
+
+// A document your backend generated with customNodeXml, stripped before it is sent.
+const generated = await renderContract(order);
+const outgoing = prepareForExport(generated, [Clause, InternalNote]);
+if (!outgoing.ok) throw new Error(outgoing.reason);
+await email.attach(outgoing.bytes);
+```
+
+List every definition whose nodes might be in the document. **A definition you do not pass is not
+touched**, and an untouched node travels whole.
+
+`packages/pro/src/__tests__/custom-node-server.test.ts` runs the whole path, author then store then
+strip, with the DOM globals deleted.
+
+## Server-side authoring
+
+`customNodeXml(definition, attrs, text, options)` builds the same content control as XML, with no
+editor and no DOM. A node written on a server is recognized identically when the document opens in
+the editor.
+
+```ts
+import { customNodeXml } from '@docx-editor.dev/pro';
+
+const built = customNodeXml(Citation, { sourceId: 'smith-2024' }, '(Smith 2024)', {
+  data: { sourceId: 'smith-2024', locator: 'p.14', authors: ['Smith, J.'], year: 2024 },
+});
+if (built.ok) {
+  template.replace('{{citation}}', built.xml);
+}
+```
+
+`built.store` returns the parts you have to add: both `customXml` parts, both relationships, and the
+content-type override. All five are required. A control whose binding names a store that is not
+there is a document Word offers to repair.
+
+`encodeCustomNodeTag` and `decodeCustomNodeTag` are the tag codec if you need to read or write the
+identity yourself. Tags are capped at `MAX_TAG_LENGTH`.
+
+## Nodes without a payload
+
+A node can skip `schema` and keep everything in the `w:tag`, which Word caps at 64 characters. Then
+`attrs` is all it has, and `fromDocx` is where you clamp those untrusted strings or return `null` to
+leave the control literal:
+
+```ts
+const Mention = defineCustomNode({
+  name: 'mention',
+  tagPrefix: 'docx',
+  fromDocx: ({ attrs }) => (attrs['userId'] ? attrs : null),
+});
+```
+
+Writes then pass `attrs` and `text` themselves, since there is no payload to derive from.
+
+`attrs` and `text` reaching `fromDocx` come from the `.docx`, which the sender controls end to end.
+They are rendered as text, never as markup; do not build URLs or DOM from them without sanitizing.
+`data` has been validated against `schema`.
+
+## Word round-trip
+
+A recognized node is an ordinary inline content control. Word renders its text, honors the lock, and
+preserves the tag, the binding and the payload. A document edited in Word and reopened here is
+recognized from the same tag. If a Word user edited the text of an unbound node despite the lock,
+`fromDocx` sees the drift.
+
+A document opened without your definition registered renders the control's content literally, as
+Word does. Nothing is lost.
+
+A bound control is read-only in Word: Word renders its text from the payload and does not accept
+typing into it.
+
+## Payload lifecycle
+
+| Event                             | Result                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------- |
+| `removeCustomNode`                | The payload is removed in the same transaction.                                     |
+| A control deleted in Word         | Collected on the next open, by reconciling against what the document binds.         |
+| `updateCustomNode` with `data`    | Label and payload are written together.                                             |
+| `updateCustomNode` without `data` | The payload is carried forward under the new label.                                 |
+| A chip cut or copied              | The clipboard carries the chip's text, not the control. Pasting inserts plain text. |
+
+The open-time sweep is not undoable: it collects payloads whose control was already gone when the
+document arrived.
+
+## On-disk format
+
+`customXml/item1.xml`:
+
+```xml
+<docxEditor xmlns="urn:docx-editor.dev:custom-node:docx">
+  <node id="cx1">
+    <label>(Smith 2024)</label>
+    <data>{"sourceId":"smith-2024","locator":"p.14","authors":["Smith, J."],"year":2024}</data>
+  </node>
+</docxEditor>
+```
+
+The control in `word/document.xml` that binds it:
+
+```xml
+<w:dataBinding w:prefixMappings="xmlns:ns0='urn:docx-editor.dev:custom-node:docx'"
+               w:xpath="/ns0:docxEditor/ns0:node[@id='cx1']/ns0:label"
+               w:storeItemID="{...}"/>
+```
+
+`w:storeItemID` matches `ds:itemID` in `customXml/itemProps1.xml`. The store is reached through the
+`customXml` relationship on the story part; that pair is what picks one store out of several.
+
+Node ids are `cx1`, `cx2`, … derived from the store's current contents, so writing the same document
+twice produces the same bytes. One store per `payloadNamespace`: two definitions sharing a
+`tagPrefix` share a store.
+
+Payloads are capped at 262,144 UTF-16 code units (`MAX_CUSTOM_NODE_DATA_LENGTH`) on write and on
+read; labels at 4096 on write. Keys named `__proto__`, `constructor` and `prototype` are stripped
+from a parsed payload at every depth. A legitimate field with one of those names therefore arrives
+missing, and a schema requiring it fails with "expected string, received undefined".
+
+## Limits
+
+- No in-place edit dialog. Re-authoring is `updateCustomNode` with a form you supply. The activation
+  carries `nodeId`, `text` and `data` to prefill it.
+- A bound node cannot be edited in Word. Making one editable requires a two-way binding, which is
+  not implemented.
+- The clipboard carries text only. Cutting a chip and pasting it produces plain text, not a node.

--- a/docs/site/content/pro/custom-nodes.mdx
+++ b/docs/site/content/pro/custom-nodes.mdx
@@ -1,180 +1,172 @@
 ---
 title: 'Custom nodes'
-description: 'Define your own inline node types, such as citations, mentions, and merge fields, stored as Word content controls that survive a round trip through Word.'
+description: 'Your own inline node types (citations, mentions, merge fields) as Word content controls.'
 category: 'Pro'
 order: 63
 ---
 
-A custom node is an inline node type you define: a citation, a mention, a merge field, a clause reference. It is stored as an inline Word content control (`w:sdt`), so Word opens the document, renders the node's text, and returns it unchanged.
-
-A node stores what it knows in two places:
-
-| Location    | Holds               | Limit                                        |
-| ----------- | ------------------- | -------------------------------------------- |
-| `w:tag`     | The node's identity | 64 characters, including the prefix and name |
-| The payload | Everything else     | 256 KB                                       |
-
-The payload is a customXml data part that the control binds to through `w:dataBinding`. Word preserves both.
+Use a custom node for an element DOCX has no type for: a citation, an @mention, a merge field, a
+signature placeholder. Each is stored as an inline Word content control (`w:sdt`), so Word renders
+its text and hands it back unchanged.
 
 Requires the custom-nodes module from [`@docx-editor.dev/pro`](/docs/2.x/pro).
 
-<Callout>
-  Custom nodes render fine in Word and Word Online, so `editor.save()` is usually the whole answer.
-  Reach for [`saveForExport`](#save-vs-export) only when a recipient should not have the nodes at
-  all.
-</Callout>
-
-## Define a node
+## A citation, end to end
 
 ```tsx
 import { z } from 'zod';
-import { defineCustomNode, customNodesModule } from '@docx-editor.dev/pro';
-
-const CitationData = z.object({
-  sourceId: z.string().min(1),
-  locator: z.string(),
-  authors: z.array(z.string()).max(64),
-  year: z.number().int(),
-});
+import { customNodesModule, defineCustomNode, insertCustomNode } from '@docx-editor.dev/pro';
+import { CustomNodeChrome } from '@docx-editor.dev/pro/react';
+import { DocxEditor, useDocxEditor } from '@docx-editor.dev/react';
 
 const Citation = defineCustomNode({
   name: 'citation',
-  tagPrefix: 'docx',
-  schema: CitationData,
-  text: (data) => `(${data.authors[0]} ${String(data.year)})`,
+  tagPrefix: 'acme',
+  schema: z.object({
+    sourceId: z.string().min(1),
+    author: z.string(),
+    year: z.number().int(),
+  }),
+  text: (data) => `(${data.author} ${String(data.year)})`,
 });
 
+// Built once, outside render: modules are read when the editor is constructed.
 const MODULES = [customNodesModule({ nodes: [Citation] })];
-```
 
-`schema` is the shape of the payload: a zod schema, or any [Standard Schema](https://standardschema.dev). Nothing is bundled, bring your own. It does two jobs. A write is rejected before anything reaches the document when the data does not fit, and a read comes back as that type instead of `unknown`. Payloads also arrive from `.docx` files someone else wrote, so it is what stands between that JSON and your code. A schema that validates asynchronously is refused.
-
-`text` turns the payload into the words the document shows. It reads the schema's OUTPUT, so a `.default()` or a `.transform()` has already been applied.
-
-A node can skip `schema` and keep everything in its tag. See [Nodes without a payload](#nodes-without-a-payload).
-
-Modules are read once, when the editor is constructed. Changing the array afterwards has no effect; remount the Root to change them.
-
-### Parameters
-
-Required:
-
-| Parameter   | Type     | Description                                                |
-| ----------- | -------- | ---------------------------------------------------------- |
-| `name`      | `string` | Node type name. The second segment of the tag.             |
-| `tagPrefix` | `string` | The prefix this definition claims. `docx` claims `docx:*`. |
-
-What the node carries and shows:
-
-| Parameter | Type                                                       | Description                                                                                                  |
-| --------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `schema`  | zod (or any [Standard Schema](https://standardschema.dev)) | Shape of the payload. Nothing is bundled; bring your own. A schema that validates asynchronously is refused. |
-| `text`    | `(data) => string`                                         | What the document shows, from the payload.                                                                   |
-
-Presentation and interaction:
-
-| Parameter             | Type                                                   | Description                                  |
-| --------------------- | ------------------------------------------------------ | -------------------------------------------- |
-| `label`               | `string`                                               | Display name for chrome. Defaults to `name`. |
-| `chrome.color`        | `string`                                               | Chip tint and border.                        |
-| `reviewCard`          | `({ attrs, text, data }) => { title, detail } \| null` | Contributes a sidebar card per node.         |
-| `onClick` / `onHover` | `(node: ActivatedCustomNode) => void`                  | Pointer events on the painted chip.          |
-| `onEdit`              | `(node: ActivatedCustomNode) => void`                  | The context menu's "Edit \{label}" row.      |
-
-Advanced, skip these until you need them:
-
-| Parameter          | Type                                       | When                                                                                                                                                                        |
-| ------------------ | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `preserveOnExport` | `boolean \| 'text'`                        | The node should not travel intact. See [preserveOnExport](#preserveonexport).                                                                                               |
-| `tagAttrs`         | `(data) => Record<string, string>`         | A reader without the payload store should still identify the node.                                                                                                          |
-| `payloadNamespace` | `string`                                   | You need a specific customXml namespace. Defaults to one from `tagPrefix`. It goes into an XPath prefix declaration, so quotes, angle brackets and ampersands are rejected. |
-| `fromDocx`         | `({ attrs, text, data }) => attrs \| null` | The node has **no** schema and keeps its data in the tag, or you need to disown a control by returning `null`.                                                              |
-
-## Render the chips
-
-`CustomNodeChrome` paints the recognized nodes and dispatches interaction. `CustomNodeContextMenu` adds a section on top of the packaged context menu, which is the editing entry point since chips are content-locked by default:
-
-```tsx
-import { DocxEditor } from '@docx-editor.dev/react';
-import { CustomNodeChrome, CustomNodeContextMenu } from '@docx-editor.dev/pro/react';
+function CiteButton() {
+  const editor = useDocxEditor(); // null until the content is mounted
+  return (
+    <button
+      disabled={!editor}
+      onClick={() => {
+        const result = insertCustomNode(editor!, Citation, {
+          data: { sourceId: 'smith-2024', author: 'Smith', year: 2024 },
+        });
+        if (!result.ok) console.warn(result.reason);
+      }}
+    >
+      Cite
+    </button>
+  );
+}
 
 export function Editor({ bytes }: { bytes: Uint8Array }) {
   return (
     <DocxEditor.Root document={bytes} modules={MODULES}>
+      <CiteButton />
       <DocxEditor.Viewport>
         <DocxEditor.Content />
-        <CustomNodeChrome onNodeClick={(node) => openPopover(node)} />
-        <DocxEditor.ContextMenu>
-          <CustomNodeContextMenu onEditNode={(node) => openEditForm(node)} />
-        </DocxEditor.ContextMenu>
+        <CustomNodeChrome onNodeClick={(node) => console.log(Citation.dataOf(node))} />
       </DocxEditor.Viewport>
     </DocxEditor.Root>
   );
 }
 ```
 
-An activated node gives you `name`, `attrs`, `tag`, `data`, and `rect` (viewport-relative, for anchoring your own popover), plus `nodeId` and `text` when they resolve.
+Cite drops `(Smith 2024)` at the caret as a chip. Save, open in Word, bring it back: the chip is
+recognized again, payload included.
 
-`CustomNodeContextMenu` also takes `onRemoveRefused(node, reason)`. Remove can be refused, by a locked wrapper or a document open for viewing, and without a handler the menu simply closes and leaves the node where it was. Pass one if you have somewhere to show the engine's reason.
+## I want to
+
+<Cards>
+  <Card title="Store data on a node" href="#define-a-node">
+    A payload validated by your schema, up to 256 KB, kept in a customXml part.
+  </Card>
+  <Card title="Show a chip and react to clicks" href="#render-the-chips">
+    `CustomNodeChrome` paints recognized nodes and gives you the click, hover and rect.
+  </Card>
+  <Card title="Insert, edit or delete a node" href="#insert-update-remove">
+    Three functions, one transaction and one undo step each.
+  </Card>
+  <Card title="Find every node in the document" href="#read-the-nodes">
+    `customNodesOf(editor)` in document order, `dataOf` to get your type back.
+  </Card>
+  <Card title="Strip my markup before sending a file out" href="#save-vs-export">
+    `saveForExport` applies each definition's `preserveOnExport`.
+  </Card>
+  <Card title="Write nodes on a server" href="#patterns">
+    `customNodeXml` builds the same control with no editor and no DOM.
+  </Card>
+  <Card title="Look up a parameter or an error code" href="/docs/2.x/pro/custom-nodes-reference">
+    Every option on `defineCustomNode`, every refusal code, the on-disk format.
+  </Card>
+</Cards>
+
+## Define a node
+
+```ts
+const Citation = defineCustomNode({
+  name: 'citation', // second segment of the tag
+  tagPrefix: 'acme', // this definition claims acme:*
+  schema: CitationData, // shape of the payload
+  text: (data) => `(${data.author} ${String(data.year)})`, // what the document shows
+});
+```
+
+`schema` is any [Standard Schema](https://standardschema.dev): zod, valibot, arktype. The pro
+package bundles none of them, so bring the one you already use.
+
+- Invalid data is rejected before anything is written to the document.
+- Data read back out is returned as your type instead of `unknown`.
+
+Payloads also arrive from `.docx` files someone else wrote, so the schema is what stands between
+that JSON and your code. Async validation is refused.
+
+`text` reads the schema's _output_, so a `.default()` or a `.transform()` has already run.
+
+A node can skip `schema` and keep everything in its tag, which Word caps at 64 characters. See
+[nodes without a payload](/docs/2.x/pro/custom-nodes-reference#nodes-without-a-payload).
+
+Modules are read once, at construction. Changing the array afterwards does nothing; remount the Root.
+
+Everything else is optional: `label` and `chrome.color` for the chip, `onClick` / `onHover` /
+`onEdit`, `reviewCard` for a sidebar card, `preserveOnExport` for what leaves. See the
+[reference](/docs/2.x/pro/custom-nodes-reference#definecustomnode).
+
+## Render the chips
+
+Chips are content-locked by default, so editing runs through the context menu:
+
+```tsx
+import { CustomNodeChrome, CustomNodeContextMenu } from '@docx-editor.dev/pro/react';
+
+<DocxEditor.Viewport>
+  <DocxEditor.Content />
+  <CustomNodeChrome onNodeClick={(node) => openPopover(node)} />
+  <DocxEditor.ContextMenu>
+    <CustomNodeContextMenu onEditNode={(node) => openEditForm(node)} />
+  </DocxEditor.ContextMenu>
+</DocxEditor.Viewport>;
+```
+
+An activated node carries `name`, `attrs`, `tag`, `data` and `rect` (viewport-relative, for
+anchoring your own popover), plus `nodeId` and `text` when they resolve.
+
+Remove can be refused, by a locked wrapper or a document open for viewing. Pass
+`onRemoveRefused(node, reason)` to show the engine's reason; without it the menu just closes.
 
 ## Insert, update, remove
 
-```tsx
-import { insertCustomNode, updateCustomNode, removeCustomNode } from '@docx-editor.dev/pro';
+```ts
+import { insertCustomNode, removeCustomNode, updateCustomNode } from '@docx-editor.dev/pro';
 
-const result = insertCustomNode(editor, Citation, {
-  data: { sourceId: 'smith-2024', locator: 'p.14', authors: ['Smith, J.'], year: 2024 },
-});
-if (!result.ok) console.warn(result.reason);
+insertCustomNode(editor, Citation, { data }); // at the caret, or at input.at
+updateCustomNode(editor, Citation, nodeId, { data }); // rewrites in place
+removeCustomNode(editor, nodeId); // node and payload
 ```
 
-| Function                                        | Behavior                                |
-| ----------------------------------------------- | --------------------------------------- |
-| `insertCustomNode(editor, def, input)`          | Inserts at the caret, or at `input.at`. |
-| `updateCustomNode(editor, def, nodeId, update)` | Rewrites in place.                      |
-| `removeCustomNode(editor, nodeId)`              | Deletes the node and its payload.       |
+Each is one transaction and one undo step, payload included. Each returns
+`{ ok: true, changed: true, nodeId }` or a refusal with a `reason` and a `code`.
 
-Each is one transaction and one undo step, payload included.
-
-### Input
-
-| Field   | Type                                                            | Description                                                                          |
-| ------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `data`  | The schema's input type                                         | The payload. Validated before anything is written.                                   |
-| `attrs` | `Record<string, string>`                                        | Tag attrs. Derived by `tagAttrs` when declared. Passing it overrides the derivation. |
-| `text`  | `string`                                                        | Document text. Derived by `text` when declared. Passing it overrides the derivation. |
-| `at`    | `{ paragraphId, offset }`                                       | Insert position. Defaults to the caret. `insertCustomNode` only.                     |
-| `lock`  | `false \| 'sdtLocked' \| 'sdtContentLocked' \| 'contentLocked'` | Defaults to `contentLocked`.                                                         |
-| `alias` | `string`                                                        | `w:alias`, the title Word shows on the control.                                      |
-
-`updateCustomNode` keeps the payload you do not mention. Pass `data: null` to remove one.
-
-`contentLocked` prevents inline text editing while leaving the node deletable as a unit, in the editor and in Word. A node carrying a payload is uneditable regardless of `lock`: the engine refuses content edits inside a bound control, and so does Word.
-
-### Returns
-
-`{ ok: true, changed: true, nodeId }`, or a refusal.
-
-`nodeId` names the control the write authored. A rewrite replaces the control rather than editing
-it, so the id passed to `updateCustomNode` names nothing afterwards. Re-point anything attached to
-that node, a card, a selection, your own index, at the returned one:
+A rewrite replaces the control, so the id you passed names nothing afterwards. Re-point whatever was
+attached to it at the returned one:
 
 ```tsx
 const result = updateCustomNode(editor, Citation, card.nodeId, { data: next });
 if (result.ok && result.nodeId) setCard({ ...card, nodeId: result.nodeId });
 ```
 
-`removeCustomNode` authors no control, so it returns no `nodeId`.
-
-A refusal carries a `code`:
-
-| `code`        | Meaning                                                                                                               |
-| ------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `invalidArgs` | Fixable by passing something else: a payload past the cap, a tag over 64 characters, an offset outside the paragraph. |
-| `unsupported` | A fact about the document: a lock, a protected form, viewing mode.                                                    |
-| `notFound`    | No document is mounted, or `updateCustomNode` was given an id no node has.                                            |
-
-A payload the schema rejected also carries `issues`:
+A payload the schema rejected comes back with `issues`, each pointing at a field:
 
 ```tsx
 const result = insertCustomNode(editor, Citation, { data: form });
@@ -185,45 +177,37 @@ if (!result.ok) {
 }
 ```
 
-| Field     | Type                            | Description                           |
-| --------- | ------------------------------- | ------------------------------------- |
-| `message` | `string`                        | What the schema said.                 |
-| `path`    | `readonly (string \| number)[]` | Route to the field: `['authors', 0]`. |
-| `pointer` | `string`                        | The same path joined: `authors.0`.    |
+`attrs`, `lock`, `alias`, `at` and the three refusal codes are in the
+[reference](/docs/2.x/pro/custom-nodes-reference#writes).
 
-## Read
-
-Inside `text`, `reviewCard` and `fromDocx`, `data` is the schema's output type. Elsewhere it is `unknown`, because those surfaces carry every definition's nodes under one type.
-
-Use `dataOf` to cross that boundary. It narrows a node to this definition and validates its payload against this schema, so you never write a parse at the call site:
-
-```tsx
-// Every node in the document, in order, with its payload.
-for (const node of customNodesOf(editor)) {
-  const citation = Citation.dataOf(node);
-  if (citation) index.add(citation.sourceId);
-}
-
-// On the chip: click, hover, and the context menu's Edit row.
-<CustomNodeChrome onNodeClick={(node) => open(Citation.dataOf(node))} />;
-
-// With ranges, for anchoring UI. Requires the review module.
-const cards = editor.getReviewItems().filter((entry) => entry.item.kind === 'custom');
-```
-
-`customNodesOf` reads the body and recognizes every definition registered on the editor; pass `{ nodes }` to narrow it. It derives from the document each time it is called. There is no change event, so re-read after an edit rather than holding the array.
-
-A payload with no `schema` comes back as parsed JSON on a null-prototype object, so `hasOwnProperty` and `instanceof Object` do not hold on it.
-
-`Citation.dataOf(node)` returns the schema's output type or `undefined`, for a different definition's node, one with no payload, or one whose payload the schema rejects. A `name` is checked when the object has one and never required, so it also works on your own state:
+## Read the nodes
 
 ```ts
-const survey = Citation.dataOf(popoverState); // { data } is enough
+import { customNodesOf } from '@docx-editor.dev/pro';
+
+for (const node of customNodesOf(editor)) {
+  const citation = Citation.dataOf(node);
+  if (citation) index.add(citation.sourceId); // typed
+}
 ```
 
-A definition does not need `reviewCard` for this. A node without one is still recognized and still carries its payload; it contributes nothing to the sidebar.
+`customNodesOf` reads the body in document order and recognizes every definition registered on the
+editor. It derives from the document on every call and there is no change event, so re-read after an
+edit rather than holding the array.
 
-`data` is `undefined` in three cases: the node carries no payload, its binding names a store node the document does not hold, or the payload failed the schema. The last two report through `onDiagnostic`:
+Chrome and read surfaces carry every definition's nodes under one type, so their `data` is
+`unknown`. `dataOf` narrows a node to this definition and validates its payload, so you never write
+a parse at the call site:
+
+```tsx
+<CustomNodeChrome onNodeClick={(node) => open(Citation.dataOf(node))} />
+```
+
+Inside `text`, `reviewCard` and `fromDocx`, `data` is already the schema's output type.
+
+`data` is `undefined` when the node carries no payload, when its binding names a store node the
+document does not hold, or when the payload fails the schema. The last two report through
+`onDiagnostic`:
 
 ```ts
 customNodesModule({
@@ -235,18 +219,14 @@ customNodesModule({
 });
 ```
 
-The listener belongs to the editor the module is registered on. Two editors on one page hear only their own documents, and a listener goes when its editor does.
-
 ## Save vs export
 
-Most of the time there is nothing to do here. A custom node is an ordinary inline content control: Word and Word Online both render its text, honor the lock, and hand the tag, binding and payload back unchanged. `editor.save()` produces a file that opens correctly for everyone and reopens here with the chips working. Ship that.
+Usually there is nothing to do here. Word and Word Online render a custom node's text, honor the
+lock, and hand the tag, binding and payload back unchanged, so `editor.save()` is the whole answer.
 
-Export is for the other case, where the recipient should not have the nodes at all. Internal annotations that must not leave. Markup that means nothing outside your system. Then the file you store and the file they download are different, and that is two calls:
-
-| The file is going to | Call                    | Custom nodes                                  |
-| -------------------- | ----------------------- | --------------------------------------------- |
-| Your own storage     | `editor.save()`         | Kept, always.                                 |
-| Anyone else          | `saveForExport(editor)` | Each definition's `preserveOnExport` decides. |
+Export is for the case where the recipient should not have the nodes at all: internal annotations,
+markup that means nothing outside your system. Then the file you store and the file they download
+are two different files.
 
 ```ts
 import { saveForExport } from '@docx-editor.dev/pro';
@@ -260,93 +240,63 @@ if (!outgoing.ok) throw new Error(outgoing.reason);
 download(outgoing.bytes);
 ```
 
-```mermaid
-flowchart TD
-    doc["one document"]
-    doc -- "editor.save()" --> keep["your storage<br/>reopens here with the chips working"]
-    doc -- "saveForExport(editor)" --> send["the user's download<br/>an ordinary .docx"]
-```
+`preserveOnExport` decides per definition: `true` (default) travels whole, `'text'` keeps the words
+and drops the control, `false` removes the node and its content. A tag no definition claims is never
+touched.
 
-`saveForExport` calls `editor.save()`, then applies every definition registered in `modules`. There is no list to pass and no list to get wrong. Pass `nodes` to narrow it.
+Store the saved bytes, not the exported ones. What the export stripped is gone: unwrapped text does
+not become a node again.
 
-Store the saved bytes, not the exported ones. What the export stripped is gone: unwrapped text does not become a node again.
+<Callout>
+  `saveForExport` needs an editor. On a server, `prepareForExport(bytes, definitions)` is the same
+  pipeline over bytes with no DOM. A definition you do not pass is not touched. See
+  [export](/docs/2.x/pro/custom-nodes-reference#export).
+</Callout>
 
-`unwrapped` and `removed` count the controls each policy touched. A refusal returns no bytes, only a `reason`.
+## Patterns
 
-### preserveOnExport
-
-`preserveOnExport` is declared on the definition and applied only when you export. `editor.save()` ignores it.
-
-| Value            | The recipient gets                                              | Use for                                                         |
-| ---------------- | --------------------------------------------------------------- | --------------------------------------------------------------- |
-| `true` (default) | The node, whole. Tag, binding and payload all travel.           | Nodes the recipient is meant to keep working with.              |
-| `'text'`         | The words only. The control, binding and payload are unwrapped. | A citation, where the reader needs the text but not the markup. |
-| `false`          | Nothing. The node is removed with its content.                  | Internal annotations that must not leave.                       |
-
-The default is `true`, and for most node types it is the right answer: the recipient gets a valid `.docx` that opens anywhere, and the node still works if the file comes back to you. Stripping is the opt-in, per definition:
+**A mention, no payload.** Everything fits in the tag, so there is no schema and no customXml part.
+`fromDocx` clamps the untrusted strings a `.docx` hands you, or returns `null` to leave the control
+literal:
 
 ```ts
-const Citation = defineCustomNode({ name: 'citation', /* … */ preserveOnExport: 'text' });
-const InternalNote = defineCustomNode({ name: 'note', /* … */ preserveOnExport: false });
-const MergeField = defineCustomNode({ name: 'merge' /* … */ }); // true, the default
-```
-
-One document can hold nodes with all three settings and each is decided independently. A tag no definition claims is never touched: this applies your own policy to your own markup, it is not a scrub of the document.
-
-Pass `destination` when the choice is made at runtime. `'internal'` returns the saved bytes unchanged, so one code path covers both:
-
-```ts
-const copy = await saveForExport(editor, {
-  destination: keepOurMarkup ? 'internal' : 'external',
+const Mention = defineCustomNode({
+  name: 'mention',
+  tagPrefix: 'acme',
+  fromDocx: ({ attrs }) => (attrs['userId'] ? attrs : null),
 });
 ```
 
-A node that leaves takes its payload with it, even when other nodes in the same store remain. When the last node for a namespace is gone, both `customXml` parts, both relationships and the content-type override are removed.
-
-Every story is covered, so a chip in a header is treated like a chip in the body.
-
-This removes markup written by this library. It does not touch `docProps/app.xml`, `docProps/core.xml`, comment and revision authors, rsids, or custom document properties. It does not anonymize a document.
-
-### On a server
-
-`saveForExport` needs an editor. Where there is none, `prepareForExport` is the same pipeline over bytes, with the definitions spelled out. It touches no DOM:
+**An internal note that must not leave.** Kept on save, removed on export:
 
 ```ts
-import { prepareForExport } from '@docx-editor.dev/pro';
-
-// A document your backend generated with customNodeXml, stripped before it is sent.
-const generated = await renderContract(order);
-const outgoing = prepareForExport(generated, [Clause, InternalNote]);
-if (!outgoing.ok) throw new Error(outgoing.reason);
-await email.attach(outgoing.bytes);
+const InternalNote = defineCustomNode({
+  name: 'note',
+  tagPrefix: 'acme',
+  schema: NoteData,
+  text: (data) => data.body,
+  preserveOnExport: false,
+});
 ```
 
-List every definition whose nodes might be in the document. **A definition you do not pass is not touched**, and an untouched node travels whole.
-
-`packages/pro/src/__tests__/custom-node-server.test.ts` runs the whole path, author then store then strip, with the DOM globals deleted.
-
-## Server-side authoring
-
-`customNodeXml` builds the same content control as XML, with no editor and no DOM. A node written on a server is recognized identically when the document opens in the editor.
+**A node written on a server.** `customNodeXml` builds the same control as XML, no editor and no
+DOM. The document opens here with the node recognized:
 
 ```ts
 import { customNodeXml } from '@docx-editor.dev/pro';
 
 const built = customNodeXml(Citation, { sourceId: 'smith-2024' }, '(Smith 2024)', {
-  data: { sourceId: 'smith-2024', locator: 'p.14', authors: ['Smith, J.'], year: 2024 },
+  data: { sourceId: 'smith-2024', author: 'Smith', year: 2024 },
 });
-if (built.ok) {
-  template.replace('{{citation}}', built.xml);
-}
+if (built.ok) template.replace('{{citation}}', built.xml);
 ```
 
-`built.store` returns the parts you have to add: both `customXml` parts, both relationships, and the content-type override. All five are required. A control whose binding names a store that is not there is a document Word offers to repair.
+`built.store` returns the five parts you must add alongside it. All five are required, or Word offers
+to repair the file. See
+[server-side authoring](/docs/2.x/pro/custom-nodes-reference#server-side-authoring).
 
-`encodeCustomNodeTag` and `decodeCustomNodeTag` are the tag codec if you need to read or write the identity yourself. Tags are capped at `MAX_TAG_LENGTH`.
-
-## Cards in the review sidebar
-
-A definition with `reviewCard` puts one card per node into the review sidebar, anchored at the node's range. `useReviewItem()` scopes host content to the card it is rendered inside, so you can add your own actions to citation cards only:
+**A card in the review sidebar.** `reviewCard` contributes one card per node, anchored at its range.
+`useReviewItem()` scopes your content to the card it renders inside:
 
 ```tsx
 import { DocxEditorReview, useReviewItem } from '@docx-editor.dev/pro/react';
@@ -354,7 +304,6 @@ import { DocxEditorReview, useReviewItem } from '@docx-editor.dev/pro/react';
 function CitationActions() {
   const item = useReviewItem();
   if (item?.kind !== 'custom') return null;
-
   return <button onClick={() => openSource(item)}>Open source</button>;
 }
 
@@ -365,80 +314,10 @@ function CitationActions() {
 
 This needs the review module registered alongside the custom-nodes module.
 
-## Word round-trip
-
-A recognized node is an ordinary inline content control. Word renders its text, honors the lock, and preserves the tag, the binding and the payload. A document edited in Word and reopened here is recognized from the same tag. If a Word user edited the text of an unbound node despite the lock, `fromDocx` sees the drift.
-
-A document opened without your definition registered renders the control's content literally, as Word does. Nothing is lost.
-
-A bound control is read-only in Word: Word renders its text from the payload and does not accept typing into it.
-
-## Reference
-
-### Nodes without a payload
-
-A node can skip `schema` and keep everything in the `w:tag`, which Word caps at 64 characters. Then `attrs` is all it has, and `fromDocx` is where you clamp those untrusted strings or return `null` to leave the control literal:
-
-```ts
-const Mention = defineCustomNode({
-  name: 'mention',
-  tagPrefix: 'docx',
-  fromDocx: ({ attrs }) => (attrs['userId'] ? attrs : null),
-});
-```
-
-Writes then pass `attrs` and `text` themselves, since there is no payload to derive from.
-
-`attrs` and `text` reaching `fromDocx` come from the `.docx`, which the sender controls end to end. They are rendered as text, never as markup; do not build URLs or DOM from them without sanitizing. `data` has been validated against `schema`.
-
-### Payload lifecycle
-
-| Event                             | Result                                                                              |
-| --------------------------------- | ----------------------------------------------------------------------------------- |
-| `removeCustomNode`                | The payload is removed in the same transaction.                                     |
-| A control deleted in Word         | Collected on the next open, by reconciling against what the document binds.         |
-| `updateCustomNode` with `data`    | Label and payload are written together.                                             |
-| `updateCustomNode` without `data` | The payload is carried forward under the new label.                                 |
-| A chip cut or copied              | The clipboard carries the chip's text, not the control. Pasting inserts plain text. |
-
-The open-time sweep is not undoable: it collects payloads whose control was already gone when the document arrived.
-
-### On-disk format
-
-`customXml/item1.xml`:
-
-```xml
-<docxEditor xmlns="urn:docx-editor.dev:custom-node:docx">
-  <node id="cx1">
-    <label>(Smith 2024)</label>
-    <data>{"sourceId":"smith-2024","locator":"p.14","authors":["Smith, J."],"year":2024}</data>
-  </node>
-</docxEditor>
-```
-
-The control in `word/document.xml` that binds it:
-
-```xml
-<w:dataBinding w:prefixMappings="xmlns:ns0='urn:docx-editor.dev:custom-node:docx'"
-               w:xpath="/ns0:docxEditor/ns0:node[@id='cx1']/ns0:label"
-               w:storeItemID="{...}"/>
-```
-
-`w:storeItemID` matches `ds:itemID` in `customXml/itemProps1.xml`. The store is reached through the `customXml` relationship on the story part; that pair is what picks one store out of several.
-
-Node ids are `cx1`, `cx2`, … derived from the store's current contents, so writing the same document twice produces the same bytes. One store per `payloadNamespace`: two definitions sharing a `tagPrefix` share a store.
-
-Payloads are capped at 262,144 UTF-16 code units (`MAX_CUSTOM_NODE_DATA_LENGTH`) on write and on read; labels at 4096 on write. Keys named `__proto__`, `constructor` and `prototype` are stripped from a parsed payload at every depth. A legitimate field with one of those names therefore arrives missing, and a schema requiring it fails with "expected string, received undefined".
-
-## Limits
-
-- No in-place edit dialog. Re-authoring is `updateCustomNode` with a form you supply. The activation carries `nodeId`, `text` and `data` to prefill it.
-- A bound node cannot be edited in Word. Making one editable requires a two-way binding, which is not implemented.
-- The clipboard carries text only. Cutting a chip and pasting it produces plain text, not a node.
-
 ## Next steps
 
-- [Tracked changes](/docs/2.x/pro/tracked-changes)
-- [Comments](/docs/2.x/pro/comments)
+- [Custom nodes reference](/docs/2.x/pro/custom-nodes-reference): every parameter, every error code,
+  the on-disk format
+- [Runnable example](https://github.com/eigenpal/docx-editor/tree/main/examples/custom-nodes):
+  define, insert, edit, and round-trip a citation with a payload
 - [Content controls](/docs/2.x/guides/content-controls): the built-in control surface these build on
-- [Runnable example](https://github.com/eigenpal/docx-editor/tree/main/examples/custom-nodes): define, insert, edit, and round-trip a citation with a payload

--- a/docs/site/content/pro/meta.json
+++ b/docs/site/content/pro/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Pro",
-  "pages": ["index", "tracked-changes", "comments", "custom-nodes"]
+  "pages": ["index", "tracked-changes", "comments", "custom-nodes", "custom-nodes-reference"]
 }


### PR DESCRIPTION
The guide opens with a complete working example, then one example per task. Tables, refusal codes, export policy, server authoring and the on-disk format move to `pro/custom-nodes-reference`, registered in both `meta.json` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676005&installation_model_id=422592&pr_number=226&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F226&signature=22313f713684726483ded2a5cba3aa8a0012e4fc318401f2ca8cd8ca47dacd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->