### PR TITLE
fix(core): land a reveal on its target instead of one margin short

### DIFF
--- a/.changeset/reveal-frames-its-target.md
+++ b/.changeset/reveal-frames-its-target.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Jumping to a tracked change or a selection now lands on it: the reveal was measuring caret geometry against the top of the sheet rather than the page's content box, so every jump stopped one page margin short and left the target just under the fold. Reveals that have to travel now centre their target instead of stopping the moment it clears the bottom edge, and one that is already on screen still does not move.

--- a/packages/core/src/editor/__tests__/reveal-scrolling.test.ts
+++ b/packages/core/src/editor/__tests__/reveal-scrolling.test.ts
@@ -12,6 +12,7 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { caretAt } from '../../layout/semantic-interaction.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -190,6 +191,69 @@ describe('revealPosition and the setSelection command scroll without focus', () 
     // A RANGE selection: the internal caret-follow explicitly sits those out, so a moved
     // viewport proves the command scrolled on its own.
     expect(scroller.scrollTop).toBeGreaterThan(0);
+    editor.destroy();
+  });
+});
+
+describe('a reveal frames its target rather than merely moving the viewport', () => {
+  /**
+   * Where the target actually IS, in the scroller's own coordinates.
+   *
+   * Derived from the layout records rather than from the reveal, so it cannot agree with
+   * the bug it exists to catch: caret geometry is CONTENT-BOX relative (the painter parents
+   * the caret into `.docx-page-content`, one top margin down the sheet), and the reveal used
+   * to add it to `page.box.y` — the top of the SHEET — which undershot every jump by exactly
+   * that margin and left the target just under the fold.
+   */
+  function targetTop(editor: DocxEditorInstance, paragraphId: string): number {
+    const layout = editor.surface!.layout();
+    const caret = caretAt(layout, { paragraphId, offset: 0 })!;
+    const page = layout.pages.find((entry) => entry.index === caret.pageIndex)!;
+    // Records are POINTS; `scrollTop` is CSS PIXELS. The surface's default scale, and the
+    // container sits at the top of the scroller in this harness.
+    return (page.contentBox.y + caret.y) * (96 / 72);
+  }
+
+  test('the revealed line lands inside the viewport, not one page margin below it', () => {
+    const { editor, scroller } = mount();
+    const ids = editor.surface!.session.paragraphIds();
+    const last = ids[ids.length - 1]!;
+    expect(editor.surface!.revealPosition({ paragraphId: last, offset: 0 })).toBe(true);
+
+    const top = targetTop(editor, last);
+    // The whole point of a reveal: the caller can now SEE the thing.
+    expect(top).toBeGreaterThanOrEqual(scroller.scrollTop);
+    expect(top).toBeLessThanOrEqual(scroller.scrollTop + scroller.clientHeight);
+    editor.destroy();
+  });
+
+  test('centerIfNeeded centres a target it has to travel to', () => {
+    const { editor, scroller } = mount();
+    const ids = editor.surface!.session.paragraphIds();
+    const last = ids[ids.length - 1]!;
+    expect(
+      editor.surface!.revealPosition({ paragraphId: last, offset: 0 }, { block: 'centerIfNeeded' })
+    ).toBe(true);
+
+    const middle = scroller.scrollTop + scroller.clientHeight / 2;
+    // Within a line of centre. `'nearest'` parks the target flush against the bottom edge,
+    // which is a legal reveal and a poor one: the reader arrives looking at the last line of
+    // the window rather than at what they asked to see.
+    expect(Math.abs(targetTop(editor, last) - middle)).toBeLessThan(24);
+    editor.destroy();
+  });
+
+  test('centerIfNeeded leaves a target that is already on screen alone', () => {
+    const { editor, scroller } = mount();
+    const ids = editor.surface!.session.paragraphIds();
+    const last = ids[ids.length - 1]!;
+    editor.surface!.revealPosition({ paragraphId: last, offset: 0 }, { block: 'centerIfNeeded' });
+    const settled = scroller.scrollTop;
+
+    // Re-revealing the same position must not move anything — a rail whose cards re-activate
+    // on every selection change would otherwise jerk the page on each click.
+    editor.surface!.revealPosition({ paragraphId: last, offset: 0 }, { block: 'centerIfNeeded' });
+    expect(scroller.scrollTop).toBe(settled);
     editor.destroy();
   });
 });

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -356,11 +356,12 @@ export function execEditorCommand(
       // — "select this paragraph" means "show it to me" — and the caret-follow scroll
       // inside `setSelection` cannot serve it: it sits out for range selections and for
       // callers whose focus is outside the pages layer, which is the normal state for a
-      // host driving the editor from its own chrome. `'nearest'` keeps an already-visible
-      // target still.
+      // host driving the editor from its own chrome. `'centerIfNeeded'` keeps an
+      // already-visible target still and centres one it has to travel to, rather than
+      // stopping the moment it clears the bottom edge.
       if ('range' in command && isSurfaceSelection(command.range)) {
         mounted.setSelection(command.range);
-        mounted.revealPosition(command.range.head, { block: 'nearest' });
+        mounted.revealPosition(command.range.head, { block: 'centerIfNeeded' });
         // Selection is not document state: nothing to save changed.
         return { ok: true, changed: false };
       }
@@ -383,7 +384,7 @@ export function execEditorCommand(
       );
       if (!resolved.ok) return resolved;
       mounted.setSelection(resolved.selection);
-      mounted.revealPosition(resolved.selection.head, { block: 'nearest' });
+      mounted.revealPosition(resolved.selection.head, { block: 'centerIfNeeded' });
       return { ok: true, changed: false };
     }
     default:

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -2228,7 +2228,11 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         lastReviewSelection = { key, from: span.start, to: span.end };
         // Focus-independent by design: the rail card focused itself on mousedown, which is
         // exactly what keeps the caret-follow scroll from ever firing here.
-        surface.revealPosition?.(span.start, { block: 'nearest' });
+        // `centerIfNeeded`, not `nearest`: opening a card the reader can already see must
+        // not yank the page, but a card 20 pages away scrolled the MINIMUM distance parked
+        // the change flush against the bottom edge — the reader arrived looking at the last
+        // line of the window rather than at the edit they had just asked to see.
+        surface.revealPosition?.(span.start, { block: 'centerIfNeeded' });
       }
       // ANNOUNCED, exactly as dismissing is. Opening a card is observable state of its own,
       // and the surface's `onChange` deliberately stays quiet when the caret did not move —

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -243,9 +243,13 @@ export interface PaginatedSurfacePerf {
 export interface RevealOptions {
   /**
    * `'start'` puts the target near the top (a heading the user jumped to), `'center'`
-   * centres it, `'nearest'` scrolls only when it is out of view. Default `'start'`.
+   * centres it, `'nearest'` scrolls only when it is out of view — and only far enough to
+   * clear the edge, which parks the target flush against it. `'centerIfNeeded'` is the one
+   * a jump-to-next-thing control wants: silent while the target is already on screen, and
+   * centred when it has to move, so the reader lands looking AT the thing rather than at
+   * the bottom line of the window. Default `'start'`.
    */
-  readonly block?: 'start' | 'center' | 'nearest';
+  readonly block?: 'start' | 'center' | 'centerIfNeeded' | 'nearest';
   /** Padding above the target, in CSS pixels. Default 24. */
   readonly offsetPx?: number;
   readonly behavior?: ScrollBehavior;

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -3300,7 +3300,12 @@ export function mountPaginatedSurface(
       if (!caret) return false;
       const page = currentLayout.pages.find((entry) => entry.index === caret.pageIndex);
       if (!page) return false;
-      return scrollToContentY(page.box.y + caret.y, caret.height, options);
+      // `contentBox`, not `box`: caret geometry is CONTENT-BOX relative — the painter parents
+      // the caret into `.docx-page-content`, which starts one top margin down the sheet.
+      // Against `box.y` every reveal undershot by exactly that margin (72pt on a 1" page), so
+      // the target landed just under the fold and the reader had to scroll to see what they
+      // had just jumped to.
+      return scrollToContentY(page.contentBox.y + caret.y, caret.height, options);
     },
 
     revealPosition(position, options) {
@@ -3311,7 +3316,7 @@ export function mountPaginatedSurface(
       if (!page) return false;
       // 'nearest' by default: callers reveal on every activation, and a target already in
       // view must not yank the viewport.
-      return scrollToContentY(page.box.y + caret.y, caret.height, {
+      return scrollToContentY(page.contentBox.y + caret.y, caret.height, {
         block: 'nearest',
         ...options,
       });
@@ -3750,7 +3755,7 @@ export function mountPaginatedSurface(
     contentY: number,
     contentHeight: number,
     options?: {
-      block?: 'start' | 'center' | 'nearest';
+      block?: 'start' | 'center' | 'centerIfNeeded' | 'nearest';
       offsetPx?: number;
       behavior?: ScrollBehavior;
     }
@@ -3762,13 +3767,13 @@ export function mountPaginatedSurface(
     const padding = options?.offsetPx ?? 24;
     const block = options?.block ?? 'start';
     const viewport = scroller.clientHeight;
-    if (block === 'nearest') {
+    if (block === 'nearest' || block === 'centerIfNeeded') {
       const above = top < scroller.scrollTop;
       const below = top + height > scroller.scrollTop + viewport;
       if (!above && !below) return true;
     }
     const target =
-      block === 'center'
+      block === 'center' || block === 'centerIfNeeded'
         ? top - Math.max(0, (viewport - height) / 2)
         : block === 'nearest' && top > scroller.scrollTop
           ? top + height + padding - viewport


### PR DESCRIPTION
Caret geometry is content-box relative — the painter parents the caret into `.docx-page-content`, one top margin down the sheet — but `revealParagraph`/`revealPosition` added it to `page.box.y`, the top of the sheet. Every jump undershot by exactly that margin, so activating a review card scrolled to the right page and left the change just under the fold.

Reveals that have to travel now centre their target (`centerIfNeeded`) rather than stopping the moment it clears the bottom edge; a target already on screen still does not move, which is why `nearest` was chosen in the first place. Caret-follow while typing keeps `nearest`.

The existing tests only asserted `scrollTop > 0`, which is why a one-margin offset survived. The new ones derive the target's position from the layout records and assert it is framed; both fail on the old math.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676607&installation_model_id=422592&pr_number=227&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F227&signature=0ea27538af2a4a774a74866efeec3e50a8b342ad0a9ba2eb56c3d5c6eda6e058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->