### PR TITLE
fix(core): make review activation report whether it landed

### DIFF
--- a/.changeset/review-activation-reports.md
+++ b/.changeset/review-activation-reports.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Activating a review card now reports whether it landed. `setActiveReviewItem` returns an `ExecResult` and `useReview().setActive` a boolean, so a host walking the queue with next/previous controls can tell a step that did nothing from one that worked — activation is refused for an unknown key, an item with no range, a story that will not open, and a revision kind the rail excluded. Review items carry a matching `activatable` flag, so a card that cannot be clicked can be drawn that way instead of discovering it on click.

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -594,7 +594,7 @@ export interface Editor {
     scrollToBlock(blockId: string): boolean;
     scrollToPage(pageNumber: number): boolean;
     selectMatch(match: TextMatch): ExecResult;
-    setActiveReviewItem(key: string | null): void;
+    setActiveReviewItem(key: string | null): ExecResult;
     // (undocumented)
     setActiveScope(scope: ViewScope): void;
     // (undocumented)
@@ -1464,6 +1464,7 @@ export type ReviewItemPlacement = ReviewCommentPlacement | ReviewRevisionPlaceme
 
 // @public
 export interface ReviewItemPlacementBase {
+    readonly activatable: boolean;
     readonly anchorY: number | null;
     // (undocumented)
     readonly author: string;

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1207,7 +1207,7 @@ export interface Editor {
     scrollToBlock(blockId: string): boolean;
     scrollToPage(pageNumber: number): boolean;
     selectMatch(match: TextMatch): ExecResult;
-    setActiveReviewItem(key: string | null): void;
+    setActiveReviewItem(key: string | null): ExecResult;
     // (undocumented)
     setActiveScope(scope: ViewScope): void;
     // (undocumented)
@@ -2195,6 +2195,7 @@ export type ReviewItemPlacement = ReviewCommentPlacement | ReviewRevisionPlaceme
 
 // @public
 export interface ReviewItemPlacementBase {
+    readonly activatable: boolean;
     readonly anchorY: number | null;
     // (undocumented)
     readonly author: string;

--- a/docs/api/docx-editor-pro/react.api.md
+++ b/docs/api/docx-editor-pro/react.api.md
@@ -156,7 +156,7 @@ export interface UseReviewReturn {
     readonly remove: (item: ReviewItemView) => boolean;
     readonly reply: (item: ReviewItemView, text: string, author?: string) => boolean;
     readonly selectionAnchorY: number | null;
-    readonly setActive: (key: string | null) => void;
+    readonly setActive: (key: string | null) => boolean;
     readonly setPaneOpen: (open: boolean) => void;
 }
 

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -561,8 +561,16 @@ export interface Editor {
    */
   getSelectionPlacement(): { readonly anchorY: number; readonly pageIndex: number } | null;
 
-  /** Card to document: select the item's range and scroll to it. `null` clears the active item. */
-  setActiveReviewItem(key: string | null): void;
+  /**
+   * Card to document: select the item's range and scroll to it. `null` clears the active item.
+   *
+   * REPORTS, like {@link acceptReviewItem} and for the same reason. Activation is refused for
+   * an item with no resolvable range, for a kind the host's rail excluded (see
+   * {@link setReviewActivationExclusions}), and when the story it lives in will not open —
+   * and a host walking a queue with next/previous controls has no other way to learn that a
+   * step did nothing. Consult {@link ReviewItemPlacement.activatable} to avoid asking.
+   */
+  setActiveReviewItem(key: string | null): ExecResult;
 
   /**
    * Revision kinds the caret must never activate, or null for none.
@@ -766,6 +774,16 @@ export interface ReviewItemPlacementBase {
    * explains why it cannot.
    */
   readonly readOnly: boolean;
+  /**
+   * Whether {@link Editor.setActiveReviewItem} would take this key.
+   *
+   * False for an item with no resolvable range, and for a revision kind the host's rail
+   * excluded through {@link Editor.setReviewActivationExclusions} — the queue still LISTS
+   * those, because `getReviewItems` answers "what does this document hold" rather than "what
+   * may be clicked", and a host filtering the two apart needs to be told which is which. A
+   * card drawn for an item that cannot be activated is a card that does nothing when clicked.
+   */
+  readonly activatable: boolean;
   /** Document-space Y of the anchor, or null when the item has no resolvable range. */
   readonly anchorY: number | null;
   readonly pageIndex: number | null;

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -1151,6 +1151,24 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   }
 
   /**
+   * Whether `setActiveReviewItem` would take this item.
+   *
+   * The one definition both the flag on a placement and the verb itself read, so a rail can
+   * never be told an item is clickable by one and refused by the other. Two grounds, and
+   * they are the ones activation checks first: an item with no range has nothing to select,
+   * and a kind the host's rail hides must not be reachable — the band would light a card
+   * nothing on screen renders.
+   */
+  function reviewItemActivatable(item: ReviewItem): boolean {
+    if (firstReviewRange(item) === null) return false;
+    return !(
+      item.kind === 'revision' &&
+      reviewActivationExclusions !== null &&
+      reviewActivationExclusions.includes(item.revisionKind)
+    );
+  }
+
+  /**
    * Paragraph anchors, built once per layout.
    *
    * Keyed on the layout OBJECT: a published layout is immutable, so the index is valid for
@@ -1567,6 +1585,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         key,
         id: item.id,
         ...(dateOfItem(item) !== undefined ? { date: dateOfItem(item)! } : {}),
+        // Derived from the two facts activation itself checks, so the flag and the verb
+        // cannot disagree. Not from `geometry`, which is null for a whole page that has not
+        // been laid out yet — an item is addressable long before it has a Y.
+        activatable: reviewItemActivatable(item),
         anchorY: geometry?.y ?? null,
         pageIndex: geometry?.pageIndex ?? null,
         isActive: key === activeReviewKey,
@@ -2169,19 +2191,42 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
 
     getReviewRevision: () => reviewRevision(),
 
-    setActiveReviewItem(key: string | null) {
+    setActiveReviewItem(key: string | null): ExecResult {
       // Dismissing is the only thing a key of `null` can mean here: the caret decides which
       // card is open, and a card the reader closed stays closed until the caret next moves.
       if (key === null) {
         surface?.dismissActiveReview();
         bump();
         emitSelectionChange();
-        return;
+        return { ok: true, changed: false };
+      }
+      if (!surface) {
+        return { ok: false, code: 'notFound', reason: 'no document is open' };
       }
       const placement = reviewPlacements().find((entry) => entry.key === key);
       const item = placement?.item;
-      const range = item ? firstReviewRange(item) : null;
-      if (!range || !surface) return;
+      if (!item) {
+        return { ok: false, code: 'notFound', reason: 'no review item with that key' };
+      }
+      const range = firstReviewRange(item);
+      if (!range) {
+        return {
+          ok: false,
+          code: 'unsupported',
+          reason: 'this review item has no range to select',
+        };
+      }
+      // The rail's own exclusion filter. Refused OUT LOUD rather than by falling through to
+      // a selection nothing lights up: the caret would land on the text, no card would open,
+      // and a host stepping through its queue would see the viewport move and the active key
+      // stay put with nothing to explain it.
+      if (!reviewItemActivatable(item)) {
+        return {
+          ok: false,
+          code: 'unsupported',
+          reason: `review items of kind '${(item as { revisionKind?: string }).revisionKind}' are excluded from activation`,
+        };
+      }
       // A card whose range lives in a header/footer opens that scope, exactly as Word does:
       // the body selection cannot address a furniture paragraph, so setting it would only
       // clamp the caret to some unrelated body position. The mounted `enterHeaderFooter`
@@ -2198,13 +2243,25 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
           kind: home.kind,
           position: { paragraphId: range.start.paragraphId, offset: range.start.offset },
         });
-        if (!entered) return;
+        if (!entered) {
+          return {
+            ok: false,
+            code: 'unsupported',
+            reason: 'the header or footer this change lives in could not be opened',
+          };
+        }
       } else if (note !== null) {
         const entered = surface.enterNote?.(note, {
           paragraphId: range.start.paragraphId,
           offset: range.start.offset,
         });
-        if (!entered) return;
+        if (!entered) {
+          return {
+            ok: false,
+            code: 'unsupported',
+            reason: 'the note this change lives in could not be opened',
+          };
+        }
       } else {
         // Card to document. The caret may be parked in a furniture or note scope from the
         // PREVIOUS card — leave it first, exactly as the pointer path does, or the body
@@ -2239,6 +2296,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // not respond to any number of further clicks.
       bump();
       emitSelectionChange();
+      // `changed: false` — activation moves the caret and the open card, and neither is
+      // document state. A host must not mark its document dirty for opening a card.
+      return { ok: true, changed: false };
     },
 
     setReviewActivationExclusions(kinds: readonly ReviewRevisionKind[] | null) {

--- a/packages/pro/src/__tests__/review-activation-reporting.test.ts
+++ b/packages/pro/src/__tests__/review-activation-reporting.test.ts
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Whether activation ANSWERS, and whether the queue says so before it is asked.
+//
+// `setActiveReviewItem` used to return nothing, and a refusal was indistinguishable from a
+// success: asking for a kind the host's rail excluded moved the caret, opened no card, and
+// reported nothing at all. A host stepping through its own queue with next/previous controls
+// saw the viewport jump and the active key stay put, with no way to learn it should skip on.
+// The same shape as the accept/reject `ExecResult` hole — an API that names an outcome and
+// delivers part of it.
+//
+// Separate from `review-facade.test.ts` because that file is at its line cap.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '@docx-editor.dev/core/editor';
+import { reviewModule as testReviewModule } from '../review/review-module.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W15 = 'http://schemas.microsoft.com/office/word/2012/wordml';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:w15="${W15}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function mount(body: string): DocxEditorInstance {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({
+    container,
+    document: docx(body),
+    author: 'Grace Hopper',
+    modules: [testReviewModule()],
+  });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+const INSERTION =
+  `<w:p><w:r><w:t xml:space="preserve">Kept </w:t></w:r>` +
+  `<w:ins w:id="1" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z">` +
+  `<w:r><w:t>added text</w:t></w:r></w:ins></w:p>`;
+
+/** A format change the rail hides by default, plus an insertion it shows. */
+const FORMAT_AND_INSERT =
+  `<w:p><w:r><w:rPr>` +
+  `<w:rPrChange w:id="3" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z"><w:b/></w:rPrChange>` +
+  `<w:b/></w:rPr><w:t>bold</w:t></w:r></w:p>` +
+  INSERTION;
+
+describe('activation reports what it did', () => {
+  test('a key the queue does not hold is refused rather than ignored', () => {
+    const editor = mount(INSERTION);
+    const refused = editor.setActiveReviewItem('no-such-key');
+    expect(refused.ok).toBe(false);
+    expect(refused.ok === false && refused.code).toBe('notFound');
+
+    // A real one lands. `changed: false` — opening a card moves the caret and nothing else,
+    // so a host must not mark its document dirty for it.
+    const card = editor.getReviewItems()[0]!;
+    expect(editor.setActiveReviewItem(card.key)).toEqual({ ok: true, changed: false });
+    expect(editor.setActiveReviewItem(null)).toEqual({ ok: true, changed: false });
+    editor.destroy();
+  });
+
+  test('an excluded kind is refused OUT LOUD, and the queue says so before it is asked', () => {
+    const editor = mount(FORMAT_AND_INSERT);
+    const format = editor
+      .getReviewItems()
+      .find((card) => card.kind === 'revision' && card.revisionKind === 'format')!;
+    expect(format).toBeDefined();
+    expect(format.activatable).toBe(true);
+
+    editor.setReviewActivationExclusions(['format', 'structural']);
+
+    // The queue still LISTS the card — `getReviewItems` answers what the document holds —
+    // and now says it is not clickable, so a host can render it disabled rather than
+    // discovering the refusal on click.
+    const excluded = editor.getReviewItems().find((card) => card.key === format.key)!;
+    expect(excluded).toBeDefined();
+    expect(excluded.activatable).toBe(false);
+
+    const refused = editor.setActiveReviewItem(format.key);
+    expect(refused.ok).toBe(false);
+    expect(refused.ok === false && refused.reason).toContain('format');
+
+    // A kind the rail DOES show is untouched by the filter.
+    const insert = editor
+      .getReviewItems()
+      .find((card) => card.kind === 'revision' && card.revisionKind === 'insert')!;
+    expect(insert.activatable).toBe(true);
+    expect(editor.setActiveReviewItem(insert.key).ok).toBe(true);
+    editor.destroy();
+  });
+
+  test('the flag and the verb cannot disagree', () => {
+    // One predicate behind both, so a rail is never told an item is clickable by the queue
+    // and then refused by the call — which is the only way a host can trust the flag.
+    const editor = mount(FORMAT_AND_INSERT);
+    editor.setReviewActivationExclusions(['format']);
+    const cards = editor.getReviewItems();
+    expect(cards.length).toBeGreaterThan(1);
+    for (const card of cards) {
+      expect(editor.setActiveReviewItem(card.key).ok).toBe(card.activatable);
+    }
+    editor.destroy();
+  });
+
+  test('clearing the filter makes an excluded card clickable again', () => {
+    const editor = mount(FORMAT_AND_INSERT);
+    const format = editor
+      .getReviewItems()
+      .find((card) => card.kind === 'revision' && card.revisionKind === 'format')!;
+
+    editor.setReviewActivationExclusions(['format']);
+    expect(editor.getReviewItems().find((c) => c.key === format.key)!.activatable).toBe(false);
+
+    editor.setReviewActivationExclusions(null);
+    expect(editor.getReviewItems().find((c) => c.key === format.key)!.activatable).toBe(true);
+    expect(editor.setActiveReviewItem(format.key).ok).toBe(true);
+    editor.destroy();
+  });
+});

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -216,7 +216,7 @@ const INERT_RAIL: ReviewRailValue = {
   review: {
     items: [],
     activeKey: null,
-    setActive: () => {},
+    setActive: () => false,
     accept: () => false,
     reject: () => false,
     remove: () => false,

--- a/packages/pro/src/react/useReview.ts
+++ b/packages/pro/src/react/useReview.ts
@@ -45,8 +45,16 @@ export interface UseReviewReturn {
   readonly items: readonly ReviewItemView[];
   /** The item the caret is in, or null. */
   readonly activeKey: string | null;
-  /** Card to document: selects the item's range and scrolls to it. */
-  readonly setActive: (key: string | null) => void;
+  /**
+   * Card to document: selects the item's range and scrolls to it.
+   *
+   * Reports whether it landed, on the same terms as {@link accept}. False for an item whose
+   * `activatable` is false — no range to select, or a revision kind this rail excluded — and
+   * for a story that will not open. A queue walked with next/previous controls has no other
+   * way to tell a step that did nothing from one that worked, and skipping to the next item
+   * is only possible if you can find out.
+   */
+  readonly setActive: (key: string | null) => boolean;
   /**
    * Accept a revision. Reports whether it landed.
    *
@@ -148,8 +156,9 @@ export function useReviewOf(editor: Editor | null, query?: ReviewItemQuery): Use
   const activeKey = useMemo(() => items.find((entry) => entry.isActive)?.key ?? null, [items]);
 
   const setActive = useCallback(
-    (key: string | null) => {
-      editor?.setActiveReviewItem(key);
+    (key: string | null): boolean => {
+      if (!editor) return false;
+      return editor.setActiveReviewItem(key).ok;
     },
     [editor]
   );


### PR DESCRIPTION
`setActiveReviewItem` returned `void`, so a refusal was indistinguishable from a success. Asking for a revision kind the host's rail excluded moved the caret, opened no card, and reported nothing — a host stepping through its own queue with next/previous controls saw the viewport jump and the active key stay put, with no way to learn it should skip on. Same shape as the accept/reject `ExecResult` hole closed in #203.

It reports now (`ExecResult` on the engine, `boolean` from `useReview().setActive`), with distinct refusals for an unknown key, an item with no range, an excluded kind, and a story that will not open.

And the queue says so before it is asked: `ReviewItemPlacement` carries `activatable`. `getReviewItems()` still lists excluded kinds — it answers what the document holds, not what may be clicked — so a host filtering the two apart needs to be told which is which. Both the flag and the verb read one predicate, which a test pins down directly.

Additive for consumers, hence `minor`. Independent of #227; either can land first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788677195&installation_model_id=422592&pr_number=229&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F229&signature=402933204e4f14b10779cd8f5c40e8dbd514769fccc20ab3ce2f9fd68bbfb1db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->