### PR TITLE
fix(core): layer menus above the editor's own chrome

### DIFF
--- a/.changeset/chrome-layering-bands.md
+++ b/.changeset/chrome-layering-bands.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Menus and popovers now paint above the editor's own furniture. Toolbar dropdowns, the menu bar, colour pickers and the hyperlink popover sat at a lower z-index than the navigation gutter and table chrome, so opening File put the menu underneath the navigation toggle. Layering is now three `--doc-z-*` tokens (`chrome`, `overlay`, `context`) rather than a dozen hand-picked numbers.

--- a/packages/core/src/styles/__tests__/chrome-layering.test.ts
+++ b/packages/core/src/styles/__tests__/chrome-layering.test.ts
@@ -1,0 +1,99 @@
+// Chrome layering contract.
+//
+// A surface the user just opened has to paint over furniture that was already
+// on screen. That ordering used to live in a dozen hand-picked z-index values,
+// which drifted: the menus sat at 30 while the navigation gutter sat at 40, so
+// opening File put the menu UNDERNEATH the navigation toggle.
+//
+// The values are now three tokens. These tests fail if a floating surface goes
+// back to a literal, or if the bands invert.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import postcss from 'postcss';
+
+const repositoryRoot = resolve(import.meta.dir, '../../../../..');
+const cssPath = resolve(repositoryRoot, 'packages/core/src/styles/editor.css');
+
+/** Every floating surface, and the band it belongs to. */
+const OVERLAY_SELECTORS = [
+  '.docx-menubar__menu',
+  '.docx-hyperlink-popup',
+  '.docx-toolbar__swatch-popup',
+  '.docx-toolbar__alignment-popup',
+  '.docx-toolbar__zoom-menu',
+  '.docx-toolbar__line-spacing-menu',
+  '.docx-toolbar__font-size-menu',
+  '.docx-toolbar__more-panel',
+  '.docx-toolbar__mode-menu',
+  '.docx-toolbar__image-wrap-menu',
+  '.docx-toolbar__alt-text-panel',
+];
+const CHROME_SELECTORS = ['.docx-nav', '.docx-table-chrome__panel', '.docx-editor__outline-toggle'];
+const CONTEXT_SELECTORS = ['.docx-contextmenu'];
+
+function tokenValues(css: string): Record<string, number> {
+  const root = postcss.parse(css, { from: cssPath });
+  const out: Record<string, number> = {};
+  root.walkRules((rule) => {
+    if (rule.selector !== '.docx-editor') return;
+    rule.walkDecls((decl) => {
+      if (decl.prop.startsWith('--doc-z-')) out[decl.prop] = Number(decl.value.trim());
+    });
+  });
+  return out;
+}
+
+/** z-index declarations keyed by the selector they were found on. */
+function zIndexDecls(css: string): Array<{ selector: string; value: string }> {
+  const root = postcss.parse(css, { from: cssPath });
+  const found: Array<{ selector: string; value: string }> = [];
+  root.walkDecls('z-index', (decl) => {
+    const rule = decl.parent;
+    if (!rule || rule.type !== 'rule') return;
+    found.push({ selector: (rule as postcss.Rule).selector, value: decl.value.trim() });
+  });
+  return found;
+}
+
+describe('chrome layering', () => {
+  const css = readFileSync(cssPath, 'utf8');
+
+  test('the three bands are defined, and ordered chrome < overlay < context', () => {
+    const t = tokenValues(css);
+    expect(t['--doc-z-chrome']).toBeGreaterThan(0);
+    expect(t['--doc-z-overlay']).toBeGreaterThan(t['--doc-z-chrome']);
+    expect(t['--doc-z-context']).toBeGreaterThan(t['--doc-z-overlay']);
+  });
+
+  test('every transient overlay sits in the overlay or context band', () => {
+    const decls = zIndexDecls(css);
+    for (const selector of [...OVERLAY_SELECTORS, ...CONTEXT_SELECTORS]) {
+      const matches = decls.filter((d) => d.selector.includes(selector));
+      expect(matches.length).toBeGreaterThan(0);
+      for (const match of matches) {
+        expect(match.value).toMatch(/^var\(--doc-z-(overlay|context)\)$/);
+      }
+    }
+  });
+
+  test('ambient chrome sits in the chrome band', () => {
+    const decls = zIndexDecls(css);
+    for (const selector of CHROME_SELECTORS) {
+      const matches = decls.filter((d) => d.selector.includes(selector));
+      expect(matches.length).toBeGreaterThan(0);
+      for (const match of matches) {
+        expect(match.value).toBe('var(--doc-z-chrome)');
+      }
+    }
+  });
+
+  test('no floating surface reintroduces a literal z-index', () => {
+    const named = [...OVERLAY_SELECTORS, ...CHROME_SELECTORS, ...CONTEXT_SELECTORS];
+    const offenders = zIndexDecls(css)
+      .filter((d) => named.some((s) => d.selector.includes(s)))
+      .filter((d) => !/^var\(--doc-z-[a-z]+\)$/.test(d.value));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/core/src/styles/__tests__/table-chrome-styles.test.ts
+++ b/packages/core/src/styles/__tests__/table-chrome-styles.test.ts
@@ -92,6 +92,8 @@ describe('table chrome stylesheet contract (Task 9 fix round 2)', () => {
     expect(declarations.get('position')).toBe('absolute');
     expect(declarations.get('top')).toBe('calc(100% + 6px)');
     expect(declarations.get('right')).toBe('0');
-    expect(Number(declarations.get('z-index'))).toBeGreaterThan(0);
+    // The panel is ambient chrome, so it takes the chrome band rather than a
+    // literal. The band ordering itself is covered by chrome-layering.test.ts.
+    expect(declarations.get('z-index')).toBe('var(--doc-z-chrome)');
   });
 });

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -192,6 +192,29 @@
   --doc-focus-ring: rgba(26, 115, 232, 0.4);
   --doc-selection: rgba(26, 115, 232, 0.3);
 
+  /* ----------------------------------------------------------------------
+    * Chrome layering.
+    *
+    * Two bands, and the order between them is the whole point: something the
+    * user just OPENED must paint over furniture that was already there. Before
+    * these tokens the popups sat at 30 and the gutter at 40, so the File menu
+    * opened underneath the navigation toggle.
+    *
+    *   --doc-z-chrome    ambient furniture that is always on screen: the
+    *                     navigation gutter, table chrome, the outline toggle.
+    *   --doc-z-overlay   anything transient the user summoned: menus, popovers,
+    *                     colour pickers, the toolbar overflow panel.
+    *   --doc-z-context   the context menu, which is raised over a selection
+    *                     that may already have an overlay open, so it outranks
+    *                     every other overlay.
+    *
+    * Add a new floating surface by picking the band, never a fresh number.
+    * `chrome-layering.test.ts` fails the build if a band inverts.
+    * -------------------------------------------------------------------- */
+  --doc-z-chrome: 40;
+  --doc-z-overlay: 50;
+  --doc-z-context: 55;
+
   /* The page sheet itself — the paper.
    *
    * Declared here for the DEFAULT theme, which it was not: `--doc-page-bg` existed only
@@ -1214,7 +1237,7 @@ a.docx-hyperlink:focus-visible {
 
 .docx-table-chrome__panel {
   position: absolute;
-  z-index: 40;
+  z-index: var(--doc-z-chrome);
   top: calc(100% + 6px);
   right: 0;
   min-width: 150px;
@@ -2908,7 +2931,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   left: 26px;
   top: 44px;
-  z-index: 31;
+  z-index: var(--doc-z-chrome);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3339,7 +3362,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: calc(100% + 6px);
   inset-inline-end: 0;
-  z-index: 60;
+  z-index: var(--doc-z-overlay);
   box-sizing: border-box;
   inline-size: min(340px, calc(100vw - 16px));
   min-inline-size: min(260px, calc(100vw - 16px));
@@ -3740,7 +3763,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
   min-width: 72px;
   max-height: 280px;
@@ -3771,7 +3794,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
   min-width: 232px;
 }
@@ -3808,7 +3831,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
   min-width: 96px;
 }
@@ -3831,7 +3854,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
   display: flex;
   gap: 2px;
@@ -3906,7 +3929,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
   padding: 10px;
   display: flex;
@@ -4421,7 +4444,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
   display: flex;
   gap: 2px;
@@ -4491,7 +4514,7 @@ a.docx-hyperlink:focus-visible {
  */
 .docx-hyperlink-popup {
   position: absolute;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -4772,7 +4795,7 @@ a.docx-hyperlink:focus-visible {
   inset-block: 0;
   inset-inline-start: 0;
   width: var(--docx-nav-reservation, 328px);
-  z-index: 40;
+  z-index: var(--doc-z-chrome);
   pointer-events: none;
   font-size: 13px;
   color: var(--doc-text);
@@ -5485,7 +5508,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  z-index: 40;
+  z-index: var(--doc-z-overlay);
   display: flex;
   min-width: 260px;
   flex-direction: column;
@@ -5698,7 +5721,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 30;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
   min-width: 220px;
 }
@@ -5846,7 +5869,7 @@ a.docx-hyperlink:focus-visible {
  * and dropdowns (z-index 40) because it is opened ON them as often as on the page. */
 .docx-editor .docx-contextmenu,
 .docx-contextmenu {
-  z-index: 45;
+  z-index: var(--doc-z-context);
   min-width: 240px;
   /* A menu longer than the window scrolls rather than overflowing it. The flip in
    * `DocxEditorContextMenu` clamps the panel to the top inset when it cannot fit; without
@@ -5970,7 +5993,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
-  z-index: 40;
+  z-index: var(--doc-z-overlay);
   min-width: 220px;
   padding: 4px 0;
   background: var(--doc-surface);
@@ -6008,7 +6031,7 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  z-index: 40;
+  z-index: var(--doc-z-overlay);
   width: 280px;
   padding: 12px;
   background: var(--doc-surface);


### PR DESCRIPTION
Opening File put the menu underneath the navigation toggle.

Toolbar dropdowns, the menu bar, colour pickers and the hyperlink popover were at `z-index: 30`, while the navigation gutter, table chrome and the outline toggle were at `40`. Anything the user had just opened painted below furniture that was already on screen. Seven surfaces were affected, not just the menu bar.

The values are now three bands (`--doc-z-chrome` 40, `--doc-z-overlay` 50, `--doc-z-context` 55), so a new floating surface picks a band instead of inventing a number. `chrome-layering.test.ts` fails if a band inverts or a literal comes back.

Verified in a browser against the built stylesheet: at the point where the navigation toggle overlaps the open File menu, `elementFromPoint` returned the toggle icon before and returns `.docx-menubar__item` after.

`.docx-editor__page-number` (1000) is left alone; it paints inside the page's own stacking context and never competes with chrome.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788679818&installation_model_id=422592&pr_number=232&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F232&signature=5ebdf15869cb24ebbc9121c0d791a03b57d29ba2f48926dd5c8f11bcb4963b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->