### PR TITLE
feat(pro): give each review marker the glyph for what it is

### DIFF
--- a/.changeset/review-marker-icons.md
+++ b/.changeset/review-marker-icons.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+The collapsed review rail now draws a glyph for what each marker actually is — an insertion, a deletion, a formatting change, a comment or a custom node — instead of one comment bubble for every kind. A custom node names its own through `reviewCard`'s new `icon`, and the `Markers` part takes an `icon` of its own for a host that wants to draw all of them itself.

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -1437,6 +1437,7 @@ export interface ReviewCustomItem {
     readonly carded: boolean;
     readonly data?: unknown;
     readonly detail?: string;
+    readonly icon?: string;
     readonly id: string;
     // (undocumented)
     readonly kind: 'custom';

--- a/docs/api/docx-editor-core/contracts-modules.api.md
+++ b/docs/api/docx-editor-core/contracts-modules.api.md
@@ -79,6 +79,7 @@ export interface ReviewCustomItem {
     readonly carded: boolean;
     readonly data?: unknown;
     readonly detail?: string;
+    readonly icon?: string;
     readonly id: string;
     // (undocumented)
     readonly kind: 'custom';

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -2168,6 +2168,7 @@ export interface ReviewCustomItem {
     readonly carded: boolean;
     readonly data?: unknown;
     readonly detail?: string;
+    readonly icon?: string;
     readonly id: string;
     // (undocumented)
     readonly kind: 'custom';

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2183,6 +2183,7 @@ export interface ReviewCustomItem {
     readonly carded: boolean;
     readonly data?: unknown;
     readonly detail?: string;
+    readonly icon?: string;
     readonly id: string;
     // (undocumented)
     readonly kind: 'custom';

--- a/docs/api/docx-editor-pro/index.api.md
+++ b/docs/api/docx-editor-pro/index.api.md
@@ -69,6 +69,7 @@ export interface CustomNodeDefinition<Schema extends StandardSchemaV1 | undefine
     }) => {
         readonly title: string;
         readonly detail?: string;
+        readonly icon?: string;
     } | null;
     readonly schema?: Schema;
     readonly tagAttrs?: (data: InferSchemaOutput<Schema>) => Readonly<Record<string, string>>;

--- a/docs/api/docx-editor-pro/react.api.md
+++ b/docs/api/docx-editor-pro/react.api.md
@@ -100,6 +100,23 @@ export interface ReviewActionProps extends ReviewPartProps {
 export type ReviewItemView = ReviewItemPlacement;
 
 // @public
+export interface ReviewMarkersProps {
+    // (undocumented)
+    className?: string;
+    // (undocumented)
+    hidden?: boolean;
+    icon?: ReactNode | ((item: ReviewItemView) => ReactNode);
+    // (undocumented)
+    offset?: number;
+    // (undocumented)
+    scale?: number;
+    window?: {
+        top: number;
+        bottom: number;
+    } | null;
+}
+
+// @public
 export function reviewModule(options?: ReviewModuleOptions): EditorModule;
 
 // @public

--- a/examples/igloo/src/IglooReview.tsx
+++ b/examples/igloo/src/IglooReview.tsx
@@ -3,7 +3,8 @@
 // Every card is still the packaged `DocxEditorReview` card — anchoring, stacking,
 // virtualization, accept/reject and the reply box are the library's. This file changes only
 // what a reader sees, through five customization rungs at once: `furniture`, part `children`,
-// part `className`/`icon`, an unrecognized child appended to every card, and `--doc-*` tokens.
+// part `className`/`icon`, a per-item `icon` on the collapsed rail's markers, an
+// unrecognized child appended to every card, and `--doc-*` tokens.
 
 import { DocxEditorReview, useReview, useReviewItem } from '@docx-editor.dev/pro/react';
 import type { ReviewRevisionKind } from '@docx-editor.dev/core/contracts/editor';
@@ -11,7 +12,7 @@ import { BergGlyph, DomeGlyph } from './art/Specimen';
 import { Stats } from './SpecimenPopover';
 import { useChromeTranslate } from '@docx-editor.dev/react';
 import { ICE_LABELS } from './labels';
-import { IceMelt, IceRefreeze } from './icons/review';
+import { iceMarker, IceMelt, IceRefreeze } from './icons/review';
 import { blocksOf, insideTemperature, OUTSIDE, surveyOf, tipHeight } from './specimens';
 
 /**
@@ -47,6 +48,11 @@ export function IglooReview() {
       <DocxEditorReview.Avatar className="igloo-rail__avatar" />
       <DocxEditorReview.Accept className="igloo-rail__action" icon={IceMelt} />
       <DocxEditorReview.Reject className="igloo-rail__action" icon={IceRefreeze} />
+
+      {/* The COLLAPSED rail's gutter markers. `icon` takes a function of the item, so a
+          comment, a shift and a specimen are three shapes rather than three bubbles. The
+          anchoring and virtualization the part was handed stay the library's. */}
+      <DocxEditorReview.Markers icon={iceMarker} />
 
       {/* The card body, replaced inside the packaged wrapper. */}
       <DocxEditorReview.Summary className="igloo-rail__summary">

--- a/examples/igloo/src/icons/review.tsx
+++ b/examples/igloo/src/icons/review.tsx
@@ -18,3 +18,36 @@ export const IceRefreeze = (
     <path d="M9 5.5 12 3l3 2.5M9 18.5 12 21l3-2.5" />
   </Frost>
 );
+
+/**
+ * The collapsed rail's gutter markers, in the theme's line.
+ *
+ * A FUNCTION of the item, because one `Markers` draws every marker: a single node would put
+ * one shape on all of them, which is the thing the packaged part was fixed to stop doing.
+ */
+export const iceMarker = (item: { kind: string }) => {
+  if (item.kind === 'comment') {
+    // A breath cloud: someone said something.
+    return (
+      <Frost>
+        <path d="M7 15a3 3 0 0 1 .4-6 4 4 0 0 1 7.5-1.2A3.4 3.4 0 1 1 16 15Z" />
+        <path d="M9 19h7" />
+      </Frost>
+    );
+  }
+  if (item.kind === 'custom') {
+    // A specimen flag. The definition's own glyph is the packaged fallback; the ice theme
+    // draws its own so the gutter stays one drawing language.
+    return (
+      <Frost>
+        <path d="M7 21V4l10 3.5L7 11" />
+      </Frost>
+    );
+  }
+  // A tracked change: the crystal, the same mark the reject button carries.
+  return (
+    <Frost>
+      <path d="M12 4v16M6 8l12 8M18 8 6 16" />
+    </Frost>
+  );
+};

--- a/examples/igloo/src/specimens.ts
+++ b/examples/igloo/src/specimens.ts
@@ -95,6 +95,10 @@ export const ICEBERG = defineCustomNode({
       detail: survey.notes
         ? `${survey.notes}${survey.surveyedBy ? ` — ${survey.surveyedBy}` : ''}`
         : `“${text}” is all of it that surfaced. The other nine tenths are below the line.`,
+      // The glyph in the COLLAPSED rail, so a specimen is not a comment bubble like
+      // everything else. A Material Symbols path (the `0 -960 960 960` viewBox), and
+      // host-authored — it lands in an SVG `d`, so never anything the file supplied.
+      icon: 'M120-160v-80h150l106-320H240v-80h480v80H582l106 320h152v80H560v-80h44l-30-90H386l-30 90h44v80H120Zm292-250h136l-68-204-68 204Z',
     };
   },
 });
@@ -113,6 +117,7 @@ export const IGLOO = defineCustomNode({
     return {
       title: `Igloo: ${blocks} blocks`,
       detail: `${insideTemperature(blocks)} °C in here, ${OUTSIDE} °C out there. Click it to lay another.`,
+      icon: 'M240-200h120v-200h240v200h120v-360L480-740 240-560v360Zm-80 80v-480l320-240 320 240v480H520v-200h-80v200H160Zm320-350Z',
     };
   },
 });

--- a/examples/vite/src/DemoCitation.tsx
+++ b/examples/vite/src/DemoCitation.tsx
@@ -60,6 +60,11 @@ export const DEMO_CITATION = defineCustomNode({
     detail: data
       ? `${data.authors.join(', ') || 'no authors'} (${String(data.year)})${data.locator ? `, ${data.locator}` : ''}`
       : text,
+    // The glyph this node gets in the COLLAPSED rail — a book, so a citation is
+    // distinguishable from a comment or a tracked change without opening the pane. An SVG
+    // path in Material Symbols' `0 -960 960 960` viewBox, host-authored: it lands in a `d`
+    // attribute, so it must never be built from anything the document supplied.
+    icon: 'M300-80q-58 0-99-41t-41-99v-520q0-58 41-99t99-41h500v600q-25 0-42.5 17.5T740-220q0 25 17.5 42.5T800-160v80H300Zm-60-267q14-7 29-10t31-3h20v-440h-20q-25 0-42.5 17.5T240-740v393Zm160-13h320v-440H400v440Zm-160 13v-453 453Zm60 187h373q-6-14-9.5-28.5T660-220q0-16 3-31t10-29H300q-26 0-43 17.5T240-220q0 26 17 43t43 17Z',
   }),
 });
 

--- a/packages/core/src/layout/review-support.ts
+++ b/packages/core/src/layout/review-support.ts
@@ -236,6 +236,18 @@ export interface ReviewCustomItem {
   readonly title: string;
   /** Card body, from the definition's `reviewCard` hook. */
   readonly detail?: string;
+  /**
+   * Glyph for this node in the collapsed rail, as an SVG path in a `0 -960 960 960` viewBox.
+   *
+   * A PATH rather than a rendered node because this item crosses core, which is DOM-free and
+   * React-free — the same reason `title` and `detail` are strings. A host that wants arbitrary
+   * markup overrides the `Markers` part's `icon` instead, which lives in the adapter where JSX
+   * belongs. Absent falls back to the generic custom-node glyph.
+   *
+   * HOST-AUTHORED, never file data: it is interpolated into an SVG `d` attribute, and a path
+   * taken from a document would be attacker-controlled markup.
+   */
+  readonly icon?: string;
   readonly range: ReviewRange | null;
 }
 

--- a/packages/pro/src/__tests__/review-sidebar.test.tsx
+++ b/packages/pro/src/__tests__/review-sidebar.test.tsx
@@ -533,3 +533,92 @@ describe('DocxEditor.Review while the document is loading', () => {
     expect(view.queryByTestId('review-rail')).toBeNull();
   });
 });
+
+/**
+ * A document with an insertion, a deletion and a comment — three kinds that must not all
+ * draw the same glyph in the closed rail's gutter.
+ */
+const THREE_KINDS = docx(
+  '<w:p><w:r><w:t xml:space="preserve">Kept </w:t></w:r>' +
+    '<w:ins w:id="1" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z">' +
+    '<w:r><w:t>added</w:t></w:r></w:ins></w:p>' +
+    '<w:p><w:del w:id="2" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z">' +
+    '<w:r><w:delText>struck</w:delText></w:r></w:del></w:p>'
+);
+
+/** The glyph each marker drew, keyed by the kind it is for. */
+function markerGlyphs(view: ReturnType<typeof render>): Map<string, string> {
+  const glyphs = new Map<string, string>();
+  for (const marker of view.queryAllByTestId('review-marker')) {
+    const kind = marker.getAttribute('data-kind') ?? '';
+    glyphs.set(kind, marker.querySelector('path')?.getAttribute('d') ?? '');
+  }
+  return glyphs;
+}
+
+describe('the collapsed rail says what each marker IS', () => {
+  test('a marker draws the glyph for its kind, not one comment bubble for all of them', () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={THREE_KINDS}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    act(() => undefined);
+    // Markers replace the cards only while the pane is CLOSED — that is the whole surface
+    // under test, and it is the one a reader spends most of their time looking at.
+    act(() => {
+      instance!.exec({ type: 'toggleReviewPane' });
+    });
+
+    const glyphs = markerGlyphs(view);
+    expect(glyphs.get('insert')).toBeTruthy();
+    expect(glyphs.get('delete')).toBeTruthy();
+    // The regression: every one of these used to be byte-identical.
+    expect(glyphs.get('insert')).not.toBe(glyphs.get('delete'));
+  });
+
+  test('the Markers part takes a per-item icon and keeps the wiring it was handed', () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={THREE_KINDS}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview>
+            <DocxEditorReview.Markers
+              icon={(item) => <span data-testid="host-glyph">{item.kind}</span>}
+            />
+          </DocxEditorReview>
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    act(() => undefined);
+    act(() => {
+      instance!.exec({ type: 'toggleReviewPane' });
+    });
+
+    // The host's glyph reached every marker...
+    expect(view.queryAllByTestId('host-glyph').length).toBeGreaterThan(0);
+    // ...and the override did NOT lose the anchoring the rail computed for it. Taken
+    // verbatim, an override mounts with the default scale and no positioning, which stacks
+    // every marker on top of the first.
+    for (const marker of view.queryAllByTestId('review-marker')) {
+      expect((marker as HTMLElement).style.position).toBe('absolute');
+    }
+  });
+});

--- a/packages/pro/src/custom-nodes/define-custom-node.ts
+++ b/packages/pro/src/custom-nodes/define-custom-node.ts
@@ -194,7 +194,21 @@ export interface CustomNodeDefinition<
     readonly text: string;
     /** The bound payload, already through `schema` — see {@link CustomNodeDefinition.fromDocx}. */
     readonly data?: InferSchemaOutput<Schema>;
-  }) => { readonly title: string; readonly detail?: string } | null;
+  }) => {
+    readonly title: string;
+    readonly detail?: string;
+    /**
+     * Glyph for this node in the COLLAPSED rail, as an SVG path in a `0 -960 960 960`
+     * viewBox (a Material Symbol path is exactly this). Without one every marker in the
+     * gutter is the generic comment bubble, so a citation, a tracked deletion and a
+     * comment are indistinguishable until the pane is opened.
+     *
+     * HOST-AUTHORED. Unlike `title` and `detail`, this is not derived from `attrs` or
+     * `text`: it lands in an SVG `d` attribute, and a path out of a document would be
+     * attacker-controlled markup.
+     */
+    readonly icon?: string;
+  } | null;
   /**
    * The "Edit {label}" row the context menu shows at the top when the
    * right-click lands on the node's chip. The HOST owns the dialog.

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -310,29 +310,14 @@ export interface ReviewProps extends Omit<ReviewPartProps, 'children'> {
 }
 
 // Inline SVG, like the toolbar's icons: this package ships no icon font.
-const icon = (path: string): ReactNode => (
-  <svg viewBox="0 -960 960 960" width={16} height={16} aria-hidden="true" focusable="false">
-    <path d={path} fill="currentColor" />
-  </svg>
-);
-
-const ADD_COMMENT_ICON =
-  'M440-400h80v-120h120v-80H520v-120h-80v120H320v80h120v120ZM80-80v-720q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H240L80-80Zm126-240h594v-480H160v525l46-45Zm-46 0v-480 480Z';
-const COMMENT_ICON =
-  'M240-400h480v-80H240v80Zm0-120h480v-80H240v80Zm0-120h480v-80H240v80ZM880-80 720-240H160q-33 0-56.5-23.5T80-320v-480q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v720ZM160-320h594l46 45v-525H160v480Zm0 0v-480 480Z';
-const ACCEPT_ICON = 'M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z';
-const REJECT_ICON =
-  'm256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z';
-/**
- * A TRASH can, not the reject X.
- *
- * Deliberately a different glyph from {@link REJECT_ICON} even though both sit in the same
- * actions row and both discard something. On a revision card the two would otherwise read as
- * the same button drawn twice, and the destructive one — deleting a reviewer's remark outright
- * — is the one that must not be reached for by mistake.
- */
-const DELETE_ICON =
-  'M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z';
+import {
+  ACCEPT_ICON,
+  ADD_COMMENT_ICON,
+  DELETE_ICON,
+  REJECT_ICON,
+  icon,
+  markerIconPath,
+} from './review-icons.tsx';
 
 /**
  * The review rail.
@@ -731,8 +716,21 @@ function ReviewRoot({
   // Root-level slots a child can replace in place. A render prop is not an override — it is
   // the card itself, and travels down to `ReviewList` untouched.
   const rootParts = typeof children === 'function' ? {} : partOverrides(children);
-  const takeRoot = (key: string, fallback: ReactNode): ReactNode =>
-    key in rootParts ? rootParts[key] : fallback;
+  // An override REPLACES the packaged element but inherits its wiring: these parts are handed
+  // geometry the rail alone can compute — the markers' `scale`/`offset`/`window`, the compose
+  // box's `top` — and a host writing `<Review.Markers icon={…}/>` cannot supply any of it.
+  // Taken verbatim, such a child mounted a markers layer with `scale: 1` and no window, which
+  // stacked every marker at the top of the gutter. Host props still win, so an override that
+  // DOES pass one of them keeps it.
+  const takeRoot = (key: string, fallback: ReactNode): ReactNode => {
+    if (!(key in rootParts)) return fallback;
+    const override = rootParts[key];
+    if (!isValidElement(override) || !isValidElement(fallback)) return override;
+    return cloneElement(override, {
+      ...(fallback.props as Record<string, unknown>),
+      ...(override.props as Record<string, unknown>),
+    });
+  };
 
   const affordances = preset ? (
     <>
@@ -902,6 +900,28 @@ function ReviewList({
 ReviewList.docxReviewPart = 'List' as const;
 
 /**
+ * Props for the collapsed rail's gutter markers. @public
+ *
+ * `scale`, `offset` and `window` are the rail's own geometry and are supplied for you — an
+ * override inherits them, so a host passes only what it wants to change.
+ */
+export interface ReviewMarkersProps {
+  scale?: number;
+  offset?: number;
+  /** Visible band of the scroller; markers outside it are not mounted. */
+  window?: { top: number; bottom: number } | null;
+  className?: string;
+  hidden?: boolean;
+  /**
+   * Replace the glyph. A FUNCTION of the item, unlike the action parts' plain node, because
+   * one `Markers` draws every marker in the gutter — a single node would put one shape on all
+   * of them, which is the thing this part was fixed to stop doing. Return null or undefined
+   * for an item to keep its packaged glyph.
+   */
+  icon?: ReactNode | ((item: ReviewItemView) => ReactNode);
+}
+
+/**
  * The collapsed rail: one marker per item, at its anchor.
  *
  * @public
@@ -912,14 +932,8 @@ function ReviewMarkers({
   window: visible = null,
   className,
   hidden,
-}: {
-  scale?: number;
-  offset?: number;
-  /** Visible band of the scroller; markers outside it are not mounted. */
-  window?: { top: number; bottom: number } | null;
-  className?: string;
-  hidden?: boolean;
-}) {
+  icon: iconOverride,
+}: ReviewMarkersProps) {
   const { review } = useRail();
   const t = useReviewLabel();
   if (hidden) return null;
@@ -953,7 +967,8 @@ function ReviewMarkers({
               review.setActive(entry.key);
             }}
           >
-            {icon(COMMENT_ICON)}
+            {(typeof iconOverride === 'function' ? iconOverride(entry) : iconOverride) ??
+              icon(markerIconPath(entry))}
           </button>
         );
       })}

--- a/packages/pro/src/react/index.ts
+++ b/packages/pro/src/react/index.ts
@@ -40,6 +40,7 @@ export {
   useReviewItem,
   type DocxEditorReviewNamespace,
   type ReviewActionProps,
+  type ReviewMarkersProps,
   type ReviewPartProps,
   type ReviewProps,
 } from './DocxEditorReview';

--- a/packages/pro/src/react/review-icons.tsx
+++ b/packages/pro/src/react/review-icons.tsx
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// The rail's glyphs, and which one a collapsed marker draws.
+//
+// Split out of `DocxEditorReview.tsx` when that file reached its line cap. Everything here is
+// presentation: Material Symbols paths in a `0 -960 960 960` viewBox, and the one function
+// that maps a review item to the path standing for it.
+
+import type { ReactNode } from 'react';
+import type { ReviewItemView } from './useReview.ts';
+
+export const icon = (path: string): ReactNode => (
+  <svg viewBox="0 -960 960 960" width={16} height={16} aria-hidden="true" focusable="false">
+    <path d={path} fill="currentColor" />
+  </svg>
+);
+
+export const ADD_COMMENT_ICON =
+  'M440-400h80v-120h120v-80H520v-120h-80v120H320v80h120v120ZM80-80v-720q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H240L80-80Zm126-240h594v-480H160v525l46-45Zm-46 0v-480 480Z';
+export const COMMENT_ICON =
+  'M240-400h480v-80H240v80Zm0-120h480v-80H240v80Zm0-120h480v-80H240v80ZM880-80 720-240H160q-33 0-56.5-23.5T80-320v-480q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v720ZM160-320h594l46 45v-525H160v480Zm0 0v-480 480Z';
+export const ACCEPT_ICON = 'M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z';
+export const REJECT_ICON =
+  'm256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z';
+/**
+ * A TRASH can, not the reject X.
+ *
+ * Deliberately a different glyph from {@link REJECT_ICON} even though both sit in the same
+ * actions row and both discard something. On a revision card the two would otherwise read as
+ * the same button drawn twice, and the destructive one — deleting a reviewer's remark outright
+ * — is the one that must not be reached for by mistake.
+ */
+export const DELETE_ICON =
+  'M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z';
+
+/** A pencil: text was typed. Also `moveTo`, which is an insertion that came from elsewhere. */
+export const INSERT_ICON =
+  'M200-200h57l391-391-57-57-391 391v57Zm-80 80v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T817-647L290-120H120Zm640-584-56-56 56 56Zm-141 85-28-29 57 57-29-28Z';
+/** A strikethrough: text was struck out. Also `moveFrom`. */
+export const DELETE_REVISION_ICON =
+  'M486-160q-76 0-135-45t-85-123l88-38q14 48 48.5 78t85.5 30q42 0 76-20t34-64q0-18-7-33t-19-27h112q5 14 7.5 28.5T694-341q0 86-61.5 133.5T486-160ZM80-520v-80h800v80H80Zm402-360q66 0 116 30t74 84l-88 38q-11-28-38.5-47T480-794q-42 0-72 19t-30 51q0 15 6 27t18 22H272q-6-13-9-27t-3-30q0-70 55-114t167-44Z';
+/** A paintbrush: only the FORMATTING changed, the words did not. */
+export const FORMAT_ICON =
+  'M360-160q-83 0-141.5-58.5T160-360v-360q0-83 58.5-141.5T360-920q83 0 141.5 58.5T560-720v360q0 83-58.5 141.5T360-160Zm0-80q50 0 85-35t35-85v-360q0-50-35-85t-85-35q-50 0-85 35t-35 85v360q0 50 35 85t85 35Zm300 80q29 0 49.5-20.5T730-230q0-22-12.5-40T684-296l-64-32v-232l100 100q23 23 51.5 35.5T832-412v-80q-17 0-32-6.5T773-517L633-657q-12-12-27.5-17.5T573-680h-13v520h100ZM360-720Z';
+/** A quote mark: the generic custom-node card, for a definition that names no icon of its own. */
+export const CUSTOM_ICON =
+  'M580-360q-25 0-42.5-17.5T520-420v-160q0-25 17.5-42.5T580-640h160q25 0 42.5 17.5T800-580v260q0 66-47 113t-113 47v-80q33 0 56.5-23.5T720-320v-40H580Zm-360 0q-25 0-42.5-17.5T160-420v-160q0-25 17.5-42.5T220-640h160q25 0 42.5 17.5T440-580v260q0 66-47 113t-113 47v-80q33 0 56.5-23.5T360-320v-40H220Z';
+
+/**
+ * The glyph a collapsed marker draws, by what the item IS.
+ *
+ * Every marker used to be the comment bubble, so a citation, a struck sentence and a remark
+ * were one shape in the gutter and the pane had to be opened to tell them apart — which is
+ * the one thing the collapsed rail exists to avoid.
+ */
+export function markerIconPath(entry: ReviewItemView): string {
+  if (entry.kind === 'comment') return COMMENT_ICON;
+  if (entry.kind === 'custom') {
+    // The definition's own glyph, host-authored, or the generic custom-node one.
+    return (entry.item as { icon?: string }).icon ?? CUSTOM_ICON;
+  }
+  switch (entry.revisionKind) {
+    case 'insert':
+    case 'moveTo':
+      return INSERT_ICON;
+    case 'delete':
+    case 'moveFrom':
+      return DELETE_REVISION_ICON;
+    case 'format':
+      return FORMAT_ICON;
+    default:
+      // `replace`, `paragraphMark`, `structural` and anything added later: a replacement is
+      // both halves of an edit, so neither the pencil nor the strike is honest about it.
+      return COMMENT_ICON;
+  }
+}

--- a/packages/pro/src/review/review-model.ts
+++ b/packages/pro/src/review/review-model.ts
@@ -134,6 +134,7 @@ export function customItemsOf(
       carded: definition.reviewCard !== undefined && card !== null,
       title: card?.title ?? '',
       ...(card?.detail !== undefined ? { detail: card.detail } : {}),
+      ...(card?.icon !== undefined ? { icon: card.icon } : {}),
       range: where
         ? {
             partName: part.name,


### PR DESCRIPTION
Every marker in the collapsed rail drew `COMMENT_ICON`, so a citation, a struck sentence and a remark were one shape in the gutter — the pane had to be opened to tell them apart, which is the one thing the collapsed rail exists to avoid. The button already emitted `data-kind`; only the glyph was hardcoded.

Now: insertion/`moveTo` a pencil, deletion/`moveFrom` a strikethrough, format a brush, comment the bubble, custom node a quote mark. `replace` and `paragraphMark` keep the neutral bubble — a replacement is both halves of an edit, so neither the pencil nor the strike is honest about it.

**A custom node names its own** through `reviewCard`'s new `icon`. An SVG path rather than a node, because the item crosses `core`, which is React-free — the same reason `title` and `detail` are strings. Host-authored only: it lands in an SVG `d` attribute, so a path out of a document would be attacker-controlled markup, and the TSDoc says so.

**The `Markers` part takes an `icon`** for a host that wants to draw all of them — a function of the item, unlike the action parts' plain node, since one `Markers` renders every marker.

**Root part overrides now inherit their wiring.** `partOverrides` used the child verbatim, so `<Review.Markers icon={…}/>` mounted with no scale and no window and stacked every marker at the top of the gutter. `AddComment` and `Draft` had the same hole — both are handed a computed `top`.

Demos: the vite Citation gets a book, and igloo (the file that exists to show every customization rung) gets a per-item `icon` on `Markers` plus a glyph on each specimen.

Both tests fail on the old code. Verified in the browser too: the Citation draws a book in the gutter, and insert/delete/replace resolve to three distinct paths.

`DocxEditorReview.tsx` crossed its 2100-line cap, so the glyphs moved to `review-icons.tsx` rather than the cap going up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788679945&installation_model_id=422592&pr_number=233&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F233&signature=c680ef6591cf3644e03180f045d6f23dd27a0890c90f0791b42a4e2216d1e8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->