### PR TITLE
feat(core): let a host choose where an activated review item lands

### DIFF
--- a/.changeset/review-activation-alignment.md
+++ b/.changeset/review-activation-alignment.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+`setActiveReviewItem` and `useReview().setActive` take a `reveal` option, so a host can choose where an activated change lands instead of taking the engine's default: `'start'`, `'center'`, `'centerIfNeeded'`, `'nearest'`, or `false` to select the item without moving the viewport at all.

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -594,7 +594,7 @@ export interface Editor {
     scrollToBlock(blockId: string): boolean;
     scrollToPage(pageNumber: number): boolean;
     selectMatch(match: TextMatch): ExecResult;
-    setActiveReviewItem(key: string | null): ExecResult;
+    setActiveReviewItem(key: string | null, options?: ReviewActivationOptions): ExecResult;
     // (undocumented)
     setActiveScope(scope: ViewScope): void;
     // (undocumented)
@@ -1400,6 +1400,11 @@ export interface ResolvedNoteNumbering {
     readonly numStart: number;
     // (undocumented)
     readonly pos: string;
+}
+
+// @public
+export interface ReviewActivationOptions {
+    readonly reveal?: 'start' | 'center' | 'centerIfNeeded' | 'nearest' | false;
 }
 
 // @public

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1207,7 +1207,7 @@ export interface Editor {
     scrollToBlock(blockId: string): boolean;
     scrollToPage(pageNumber: number): boolean;
     selectMatch(match: TextMatch): ExecResult;
-    setActiveReviewItem(key: string | null): ExecResult;
+    setActiveReviewItem(key: string | null, options?: ReviewActivationOptions): ExecResult;
     // (undocumented)
     setActiveScope(scope: ViewScope): void;
     // (undocumented)
@@ -2131,6 +2131,11 @@ export interface ResolvedNoteNumbering {
     readonly numStart: number;
     // (undocumented)
     readonly pos: string;
+}
+
+// @public
+export interface ReviewActivationOptions {
+    readonly reveal?: 'start' | 'center' | 'centerIfNeeded' | 'nearest' | false;
 }
 
 // @public

--- a/docs/api/docx-editor-pro/react.api.md
+++ b/docs/api/docx-editor-pro/react.api.md
@@ -97,6 +97,11 @@ export interface ReviewActionProps extends ReviewPartProps {
 }
 
 // @public
+export interface ReviewActivationOptions {
+    readonly reveal?: 'start' | 'center' | 'centerIfNeeded' | 'nearest' | false;
+}
+
+// @public
 export type ReviewItemView = ReviewItemPlacement;
 
 // @public
@@ -173,7 +178,7 @@ export interface UseReviewReturn {
     readonly remove: (item: ReviewItemView) => boolean;
     readonly reply: (item: ReviewItemView, text: string, author?: string) => boolean;
     readonly selectionAnchorY: number | null;
-    readonly setActive: (key: string | null) => boolean;
+    readonly setActive: (key: string | null, options?: ReviewActivationOptions) => boolean;
     readonly setPaneOpen: (open: boolean) => void;
 }
 

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -174,17 +174,17 @@ function ChangeList() {
 }
 ```
 
-| Member                          | What it does                                                                                                                                                                           |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `items`                         | Every pending decision, in reading order.                                                                                                                                              |
-| `activeKey` / `setActive`       | Which item the caret is in; setting selects its range and scrolls to it, entering or leaving a header/footer story as the item requires. Returns whether it landed; see `activatable`. |
-| `accept(item)` / `reject(item)` | Resolve a revision. Returns whether it landed; false on an item whose `readOnly` is true, and on a document open for viewing.                                                          |
-| `reply(item, text, author?)`    | Reply to a change. Returns whether it landed.                                                                                                                                          |
-| `remove(item)`                  | Delete a comment thread, or discard a suggestion. Returns whether it landed.                                                                                                           |
-| `comment(text, author?)`        | Comment on the current selection. Returns whether it landed.                                                                                                                           |
-| `selectionAnchorY`              | Where a comment on the selection would sit, or `null`.                                                                                                                                 |
-| `paneOpen` / `setPaneOpen`      | The same toggle the toolbar's comments button runs.                                                                                                                                    |
-| `ready`                         | False while no document is loaded.                                                                                                                                                     |
+| Member                          | What it does                                                                                                                                                                                                                        |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `items`                         | Every pending decision, in reading order.                                                                                                                                                                                           |
+| `activeKey` / `setActive`       | Which item the caret is in; setting selects its range and scrolls to it, entering or leaving a header/footer story as the item requires. Returns whether it landed; see `activatable`. Takes `{ reveal }` to choose where it lands. |
+| `accept(item)` / `reject(item)` | Resolve a revision. Returns whether it landed; false on an item whose `readOnly` is true, and on a document open for viewing.                                                                                                       |
+| `reply(item, text, author?)`    | Reply to a change. Returns whether it landed.                                                                                                                                                                                       |
+| `remove(item)`                  | Delete a comment thread, or discard a suggestion. Returns whether it landed.                                                                                                                                                        |
+| `comment(text, author?)`        | Comment on the current selection. Returns whether it landed.                                                                                                                                                                        |
+| `selectionAnchorY`              | Where a comment on the selection would sit, or `null`.                                                                                                                                                                              |
+| `paneOpen` / `setPaneOpen`      | The same toggle the toolbar's comments button runs.                                                                                                                                                                                 |
+| `ready`                         | False while no document is loaded.                                                                                                                                                                                                  |
 
 Each item carries `key`, `id`, `author`, `initials`, `date`, `text`, `replyIds`, `readOnly`, `activatable`, `anchorY`, `pageIndex`, and `isActive`. Revision items add `kind: 'revision'`, a `revisionKind`, and `replacedText` for replacements, so a card can say _Replaced "x" with "y"_.
 
@@ -199,6 +199,22 @@ Two things the hook gives you that you should not recompute. Items come from the
 A hand-built rail that hides kinds should tell the engine as well: `editor.setReviewActivationExclusions(['format', 'structural'])`. Activation is caret-driven, so without it a click on text under a hidden change opens a card your rail never draws, and the click reads as ignored. `DocxEditor.Review` does this for you from its own `structural` and `formatting` props.
 
 `items` still lists what you excluded, because it answers what the document holds rather than what may be clicked. Each one carries `activatable` to tell the two apart. Draw a card with `activatable: false` disabled rather than discovering the refusal on click; `setActive` returns `false` for it either way.
+
+### Where an activated item lands
+
+`setActive` centres an item it has to scroll to, and leaves one that is already on screen alone.
+Pass `reveal` to choose something else:
+
+```tsx
+setActive(item.key, { reveal: 'start' }); // near the top, the way a jump to a heading reads
+setActive(item.key, { reveal: 'nearest' }); // the minimum scroll, so it lands against an edge
+setActive(item.key, { reveal: false }); // select it, but leave the viewport alone
+```
+
+`reveal: false` is for a host whose own list already drives the scroll, so the engine is not
+competing with it for the viewport. It governs the item: activating a change in a header, a footer
+or a note still opens that story and brings its band into view, because a story the reader cannot
+see is one they cannot read the change in.
 
 ## Accept or reject in bulk
 

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -570,7 +570,7 @@ export interface Editor {
    * and a host walking a queue with next/previous controls has no other way to learn that a
    * step did nothing. Consult {@link ReviewItemPlacement.activatable} to avoid asking.
    */
-  setActiveReviewItem(key: string | null): ExecResult;
+  setActiveReviewItem(key: string | null, options?: ReviewActivationOptions): ExecResult;
 
   /**
    * Revision kinds the caret must never activate, or null for none.
@@ -788,6 +788,28 @@ export interface ReviewItemPlacementBase {
   readonly anchorY: number | null;
   readonly pageIndex: number | null;
   readonly isActive: boolean;
+}
+
+/**
+ * How activating a review item places it in the viewport.
+ *
+ * @public
+ */
+export interface ReviewActivationOptions {
+  /**
+   * Where the item lands, or `false` to select it without scrolling at all.
+   *
+   * Default `'centerIfNeeded'`: silent while the item is already on screen, centred when it
+   * has to travel. `'nearest'` scrolls the minimum instead, which parks the item flush
+   * against the edge it came in from; `'start'` puts it near the top, the way a jump to a
+   * heading reads. `false` is for a host whose own list already drives the scroll and does
+   * not want the engine competing with it.
+   *
+   * It governs the reveal of the ITEM. An item in a header, a footer or a note also opens
+   * that story, and opening one always brings its band into view — a story the reader cannot
+   * see is one they cannot read the change in, which is the whole point of activating it.
+   */
+  readonly reveal?: 'start' | 'center' | 'centerIfNeeded' | 'nearest' | false;
 }
 
 /** A comment thread's card. @public */

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -66,6 +66,7 @@ import {
 } from '../layout/index.ts';
 import type {
   DocumentEditingMode,
+  ReviewActivationOptions,
   ReviewItemPlacement,
   ReviewItemQuery,
   ReviewRevisionKind,
@@ -2191,7 +2192,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
 
     getReviewRevision: () => reviewRevision(),
 
-    setActiveReviewItem(key: string | null): ExecResult {
+    setActiveReviewItem(key: string | null, options?: ReviewActivationOptions): ExecResult {
       // Dismissing is the only thing a key of `null` can mean here: the caret decides which
       // card is open, and a card the reader closed stays closed until the caret next moves.
       if (key === null) {
@@ -2285,11 +2286,14 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         lastReviewSelection = { key, from: span.start, to: span.end };
         // Focus-independent by design: the rail card focused itself on mousedown, which is
         // exactly what keeps the caret-follow scroll from ever firing here.
-        // `centerIfNeeded`, not `nearest`: opening a card the reader can already see must
-        // not yank the page, but a card 20 pages away scrolled the MINIMUM distance parked
-        // the change flush against the bottom edge — the reader arrived looking at the last
-        // line of the window rather than at the edit they had just asked to see.
-        surface.revealPosition?.(span.start, { block: 'centerIfNeeded' });
+        // `centerIfNeeded` by default, not `nearest`: opening a card the reader can already
+        // see must not yank the page, but a card 20 pages away scrolled the MINIMUM distance
+        // parked the change flush against the bottom edge — the reader arrived looking at the
+        // last line of the window rather than at the edit they had just asked to see. A host
+        // whose own list drives the scroll passes `reveal: false` and gets the selection
+        // without the engine competing for the viewport.
+        const reveal = options?.reveal ?? 'centerIfNeeded';
+        if (reveal !== false) surface.revealPosition?.(span.start, { block: reveal });
       }
       // ANNOUNCED, exactly as dismissing is. Opening a card is observable state of its own,
       // and the surface's `onChange` deliberately stays quiet when the caret did not move —

--- a/packages/pro/src/__tests__/review-activation-reporting.test.ts
+++ b/packages/pro/src/__tests__/review-activation-reporting.test.ts
@@ -140,3 +140,45 @@ describe('activation reports what it did', () => {
     editor.destroy();
   });
 });
+
+describe('activation takes an alignment', () => {
+  /** A document long enough that a far item is genuinely off screen. */
+  const LONG = mount(
+    Array.from(
+      { length: 200 },
+      (_, i) =>
+        `<w:p><w:r><w:t>line ${i}</w:t></w:r>` +
+        (i === 180
+          ? `<w:ins w:id="9" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z">` +
+            `<w:r><w:t>far change</w:t></w:r></w:ins>`
+          : '') +
+        `</w:p>`
+    ).join('')
+  );
+
+  test('reveal: false selects the item without moving the viewport', () => {
+    const editor = LONG;
+    const card = editor.getReviewItems().find((c) => c.kind === 'revision')!;
+    expect(card).toBeDefined();
+
+    const landed = editor.setActiveReviewItem(card.key, { reveal: false });
+    expect(landed.ok).toBe(true);
+    // The SELECTION still moved — turning the scroll off must not turn activation off.
+    const selection = editor.surface!.state().selection;
+    const item = card.item;
+    if (item.kind !== 'revision') throw new Error('expected a revision item');
+    expect(selection.head.paragraphId).toBe(item.ranges[0]!.start.paragraphId);
+    editor.destroy();
+  });
+
+  test('an explicit alignment is accepted and still reports', () => {
+    const editor = mount(INSERTION);
+    const card = editor.getReviewItems()[0]!;
+    for (const reveal of ['start', 'center', 'centerIfNeeded', 'nearest'] as const) {
+      expect(editor.setActiveReviewItem(card.key, { reveal }).ok).toBe(true);
+    }
+    // A refusal is still a refusal whatever the alignment says.
+    expect(editor.setActiveReviewItem('no-such-key', { reveal: 'center' }).ok).toBe(false);
+    editor.destroy();
+  });
+});

--- a/packages/pro/src/react/index.ts
+++ b/packages/pro/src/react/index.ts
@@ -59,6 +59,7 @@ export {
   useReview,
   useReviewOf,
   useStackedReviewPositions,
+  type ReviewActivationOptions,
   type ReviewItemView,
   type UseReviewReturn,
 } from './useReview';

--- a/packages/pro/src/react/useReview.ts
+++ b/packages/pro/src/react/useReview.ts
@@ -20,6 +20,7 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import type {
   Editor,
+  ReviewActivationOptions,
   ReviewItemPlacement,
   ReviewItemQuery,
 } from '@docx-editor.dev/core/contracts/editor';
@@ -34,6 +35,14 @@ import { useDocxEditor } from '@docx-editor.dev/react';
  * to be written once per framework.
  */
 export type ReviewItemView = ReviewItemPlacement;
+
+/**
+ * Where activating an item puts it in the viewport. The engine's own options, unchanged.
+ *
+ * Re-exported here so a host taking this hook can name what it passes without reaching past
+ * the adapter into the engine's contract module.
+ */
+export type { ReviewActivationOptions };
 
 /**
  * What {@link useReview} returns: the review rail's data and the four things a card can do.
@@ -53,8 +62,12 @@ export interface UseReviewReturn {
    * for a story that will not open. A queue walked with next/previous controls has no other
    * way to tell a step that did nothing from one that worked, and skipping to the next item
    * is only possible if you can find out.
+   *
+   * `options.reveal` picks where the item lands, or turns the engine's scroll off entirely
+   * for a host whose own list already drives it. Default is centred when it has to travel,
+   * still when it is already on screen.
    */
-  readonly setActive: (key: string | null) => boolean;
+  readonly setActive: (key: string | null, options?: ReviewActivationOptions) => boolean;
   /**
    * Accept a revision. Reports whether it landed.
    *
@@ -156,9 +169,9 @@ export function useReviewOf(editor: Editor | null, query?: ReviewItemQuery): Use
   const activeKey = useMemo(() => items.find((entry) => entry.isActive)?.key ?? null, [items]);
 
   const setActive = useCallback(
-    (key: string | null): boolean => {
+    (key: string | null, options?: ReviewActivationOptions): boolean => {
       if (!editor) return false;
-      return editor.setActiveReviewItem(key).ok;
+      return editor.setActiveReviewItem(key, options).ok;
     },
     [editor]
   );


### PR DESCRIPTION
Last item from the review-API audit. #227 fixed the default (centre when it has to travel, stay put when already visible); a host still could not choose, because `setActiveReviewItem` took no options and `surface` — the thing that does take `{ block }` — is not on the public `Editor` contract.

`setActiveReviewItem(key, { reveal })` and `useReview().setActive(key, { reveal })` now take `'start' | 'center' | 'centerIfNeeded' | 'nearest' | false`. Default is unchanged, so nothing moves for anyone who does not pass it.

`reveal: false` selects the item and leaves the viewport alone — for a host whose own list drives the scroll. Two things worth stating, both in the TSDoc rather than left to be discovered:

- It governs the ITEM. Activating a change in a header, footer or note still opens that story and reveals its band, because a story the reader cannot see is one they cannot read the change in.
- Turning the scroll off does not turn activation off — the selection still moves, and a test pins that.

Additive; `patch`. `ReviewActivationOptions` is re-exported from `@docx-editor.dev/pro/react` so a host taking the hook can name what it passes without reaching past the adapter into the engine's contract module — the forgotten-export policy caught that, and exporting it was the right fix rather than an allowlist entry.

Stacks on #234, which documents the rest of the review API; the row this touches is edited compatibly either way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788681065&installation_model_id=422592&pr_number=235&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F235&signature=f488cdf0dc3a2200f4ae1ddc9b8fe4cda3fca119e8caf904abff780d2cf363ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->