### PR TITLE
fix: keep the editor's CSS inside the editor

### DIFF
--- a/.changeset/one-scope-class-per-tree.md
+++ b/.changeset/one-scope-class-per-tree.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Under the packaged `<DocxEditor>`, `.docx-editor` is now on the editor root and nowhere else. The toolbar, menu bar, navigation pane, context menu, viewport and page-number chip each added the class as their own Tailwind scope, which they only need when there is no scoped ancestor. A host rule like `.my-shell .docx-editor { height: 100% }` therefore also matched the toolbar. Composing from `DocxEditor.Root`, which renders no element, is unchanged: the parts still scope themselves.

--- a/.changeset/scope-layout-rules.md
+++ b/.changeset/scope-layout-rules.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+The painted-document rules are now scoped to the editor. Around a hundred `.layout-*` and `.paged-editor*` selectors shipped unscoped, so a host with its own `.layout-page-header` or `.layout-page-content` had those elements restyled by the editor's stylesheet. The class names are unchanged; only the rules moved under `.docx-editor`. The stylesheet guard now exempts `.docx-` alone, so nothing else can ship unanchored.

--- a/.changeset/scope-yjs-cursor-styles.md
+++ b/.changeset/scope-yjs-cursor-styles.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+The y-prosemirror remote-cursor styles are now scoped to the editor. `.ProseMirror-yjs-cursor` is y-prosemirror's class name rather than one the engine mints, and it shipped unscoped, so a host running its own ProseMirror editor with Yjs on the same page had its remote cursors restyled. The stylesheet guard no longer treats `.ProseMirror-` as an engine-owned namespace.

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -717,7 +717,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Transient paragraph flash used by scrollToParaId({ highlight }). */
-.layout-paragraph.docx-paragraph-flash {
+.docx-editor .layout-paragraph.docx-paragraph-flash {
   animation: docx-paragraph-flash-fade var(--docx-paragraph-flash-duration, 1200ms) ease-out both;
 }
 
@@ -1200,7 +1200,7 @@ a.docx-hyperlink:focus-visible {
   cursor: pointer;
 }
 
-.paged-editor--readonly .docx-table-furniture {
+.docx-editor .paged-editor--readonly .docx-table-furniture {
   display: none !important;
 }
 
@@ -1390,13 +1390,13 @@ a.docx-hyperlink:focus-visible {
   * TABLE CELL SELECTION (visible layout table cells)
   * ============================================================================ */
 
-.layout-table-cell-selected {
+.docx-editor .layout-table-cell-selected {
   position: relative;
   outline: 2px solid var(--doc-selection);
   outline-offset: -2px;
 }
 
-.layout-table-cell-selected::after {
+.docx-editor .layout-table-cell-selected::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -1404,17 +1404,17 @@ a.docx-hyperlink:focus-visible {
   pointer-events: none;
 }
 
-.layout-table-resize-handle {
+.docx-editor .layout-table-resize-handle {
   background-color: transparent;
   transition: background-color 0.15s;
 }
 
-.layout-table-resize-handle[data-active='true'] {
+.docx-editor .layout-table-resize-handle[data-active='true'] {
   background-color: transparent;
 }
 
-.layout-table-resize-handle[data-active='true']::after,
-.layout-table-edge-handle-right[data-active='true']::after {
+.docx-editor .layout-table-resize-handle[data-active='true']::after,
+.docx-editor .layout-table-edge-handle-right[data-active='true']::after {
   content: '';
   position: absolute;
   top: 0;
@@ -1427,24 +1427,24 @@ a.docx-hyperlink:focus-visible {
   transform: translateX(-50%);
 }
 
-.layout-table-resize-handle:hover,
-.layout-table-resize-handle.dragging {
+.docx-editor .layout-table-resize-handle:hover,
+.docx-editor .layout-table-resize-handle.dragging {
   background-color: transparent;
 }
 
-.layout-table-resize-handle:hover::after,
-.layout-table-resize-handle.dragging::after {
+.docx-editor .layout-table-resize-handle:hover::after,
+.docx-editor .layout-table-resize-handle.dragging::after {
   opacity: 1;
 }
 
 /* Row resize handles */
-.layout-table-row-resize-handle,
-.layout-table-edge-handle-bottom {
+.docx-editor .layout-table-row-resize-handle,
+.docx-editor .layout-table-edge-handle-bottom {
   background-color: transparent;
   transition: background-color 0.15s;
 }
 
-.layout-table-row-resize-handle[data-active='true']::after {
+.docx-editor .layout-table-row-resize-handle[data-active='true']::after {
   content: '';
   position: absolute;
   top: 50%;
@@ -1457,35 +1457,35 @@ a.docx-hyperlink:focus-visible {
   transform: translateY(-50%);
 }
 
-.layout-table-row-resize-handle:hover,
-.layout-table-row-resize-handle.dragging,
-.layout-table-edge-handle-bottom:hover,
-.layout-table-edge-handle-bottom.dragging {
+.docx-editor .layout-table-row-resize-handle:hover,
+.docx-editor .layout-table-row-resize-handle.dragging,
+.docx-editor .layout-table-edge-handle-bottom:hover,
+.docx-editor .layout-table-edge-handle-bottom.dragging {
   background-color: transparent;
 }
 
-.layout-table-row-resize-handle:hover::after,
-.layout-table-row-resize-handle.dragging::after {
+.docx-editor .layout-table-row-resize-handle:hover::after,
+.docx-editor .layout-table-row-resize-handle.dragging::after {
   opacity: 1;
 }
 
 /* Right edge handle */
-.layout-table-edge-handle-right {
+.docx-editor .layout-table-edge-handle-right {
   background-color: transparent;
   transition: background-color 0.15s;
 }
 
-.layout-table-edge-handle-right[data-active='true'] {
+.docx-editor .layout-table-edge-handle-right[data-active='true'] {
   background-color: transparent;
 }
 
-.layout-table-edge-handle-right:hover,
-.layout-table-edge-handle-right.dragging {
+.docx-editor .layout-table-edge-handle-right:hover,
+.docx-editor .layout-table-edge-handle-right.dragging {
   background-color: transparent;
 }
 
-.layout-table-edge-handle-right:hover::after,
-.layout-table-edge-handle-right.dragging::after {
+.docx-editor .layout-table-edge-handle-right:hover::after,
+.docx-editor .layout-table-edge-handle-right.dragging::after {
   opacity: 1;
 }
 
@@ -1494,22 +1494,22 @@ a.docx-hyperlink:focus-visible {
   * ============================================================================ */
 
 /* Hide table resize handles */
-.paged-editor--readonly .layout-table-resize-handle,
-.paged-editor--readonly .layout-table-row-resize-handle,
-.paged-editor--readonly .layout-table-edge-handle-bottom,
-.paged-editor--readonly .layout-table-edge-handle-right {
+.docx-editor .paged-editor--readonly .layout-table-resize-handle,
+.docx-editor .paged-editor--readonly .layout-table-row-resize-handle,
+.docx-editor .paged-editor--readonly .layout-table-edge-handle-bottom,
+.docx-editor .paged-editor--readonly .layout-table-edge-handle-right {
   display: none !important;
 }
 
 /* Remove header/footer hover effects and edit hints */
-.paged-editor--readonly .layout-page-header,
-.paged-editor--readonly .layout-page-footer {
+.docx-editor .paged-editor--readonly .layout-page-header,
+.docx-editor .paged-editor--readonly .layout-page-footer {
   cursor: default;
   pointer-events: none;
 }
 
 /* Remove text cursor from page content */
-.paged-editor--readonly .layout-page-content {
+.docx-editor .paged-editor--readonly .layout-page-content {
   cursor: default;
 }
 
@@ -1572,7 +1572,7 @@ a.docx-hyperlink:focus-visible {
   * ============================================================================ */
 
 /* Page content area — show text cursor when hovering over editable content */
-.layout-page-content {
+.docx-editor .layout-page-content {
   cursor: text;
 }
 
@@ -1583,7 +1583,7 @@ a.docx-hyperlink:focus-visible {
     like Word, with a corner label chip revealed on hover/focus. The box is
     non-interactive so it never steals clicks from the editable content under it.
     Nested controls each draw their own (slightly inset) box. */
-.layout-block-sdt-box {
+.docx-editor .layout-block-sdt-box {
   pointer-events: none;
   border: 1px solid transparent;
   border-radius: 4px;
@@ -1591,12 +1591,12 @@ a.docx-hyperlink:focus-visible {
   transition: border-color 0.1s ease;
   z-index: 1;
 }
-.layout-block-sdt-box.is-active,
-.layout-block-sdt-box.is-focused {
+.docx-editor .layout-block-sdt-box.is-active,
+.docx-editor .layout-block-sdt-box.is-focused {
   border-color: rgba(25, 103, 210, 0.5);
 }
 /* Corner label chip — hidden until its control is hovered/active. */
-.layout-block-sdt-label {
+.docx-editor .layout-block-sdt-label {
   position: absolute;
   left: -1px;
   bottom: 100%;
@@ -1613,8 +1613,8 @@ a.docx-hyperlink:focus-visible {
   border-radius: 4px 4px 0 0;
   display: none;
 }
-.layout-block-sdt-box.is-active .layout-block-sdt-label,
-.layout-block-sdt-box.is-focused .layout-block-sdt-label {
+.docx-editor .layout-block-sdt-box.is-active .layout-block-sdt-label,
+.docx-editor .layout-block-sdt-box.is-focused .layout-block-sdt-label {
   display: inline-flex;
   align-items: center;
   gap: 2px;
@@ -1628,30 +1628,30 @@ a.docx-hyperlink:focus-visible {
     stays the double-click-to-edit target; only its content is passed through.
     Kept here (not only in prosemirror/editor.css) so the React adapter's
     styles.css build — which compiles this file — ships the rule. */
-.layout-page-header > *,
-.layout-page-footer > * {
+.docx-editor .layout-page-header > *,
+.docx-editor .layout-page-footer > * {
   pointer-events: none;
 }
 
 /* While editing a region, its content must be hittable again so clicks map to
     header/footer caret positions. */
-.paged-editor--editing-header .layout-page-header > *,
-.paged-editor--editing-footer .layout-page-footer > * {
+.docx-editor .paged-editor--editing-header .layout-page-header > *,
+.docx-editor .paged-editor--editing-footer .layout-page-footer > * {
   pointer-events: auto;
 }
 
 /* Header/footer areas — double-click hint */
-.layout-page-header,
-.layout-page-footer {
+.docx-editor .layout-page-header,
+.docx-editor .layout-page-footer {
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
-.layout-page-header:hover,
-.layout-page-footer:hover {
+.docx-editor .layout-page-header:hover,
+.docx-editor .layout-page-footer:hover {
   background-color: rgba(37, 99, 235, 0.06);
 }
 /* Show "Double-click to edit" hint on hover when area is empty */
-.layout-page-header:empty:hover::after {
+.docx-editor .layout-page-header:empty:hover::after {
   content: 'Double-click to add header';
   display: block;
   text-align: center;
@@ -1659,7 +1659,7 @@ a.docx-hyperlink:focus-visible {
   font-size: 11px;
   padding: 4px 0;
 }
-.layout-page-footer:empty:hover::after {
+.docx-editor .layout-page-footer:empty:hover::after {
   content: 'Double-click to add footer';
   display: block;
   text-align: center;
@@ -1677,7 +1677,7 @@ a.docx-hyperlink:focus-visible {
   */
 
 /* Dim body content when editing header/footer */
-.paged-editor--hf-editing .layout-page-content {
+.docx-editor .paged-editor--hf-editing .layout-page-content {
   opacity: 0.4;
   pointer-events: none;
   transition: opacity 0.15s ease;
@@ -1686,19 +1686,19 @@ a.docx-hyperlink:focus-visible {
 /* While editing one HF region, the sibling region (and the non-edited area)
     shows a normal arrow, not the double-click "pointer" hint. The active
     region's `cursor: text` below wins via later source order. */
-.paged-editor--hf-editing .layout-page-header,
-.paged-editor--hf-editing .layout-page-footer {
+.docx-editor .paged-editor--hf-editing .layout-page-header,
+.docx-editor .paged-editor--hf-editing .layout-page-footer {
   cursor: default;
 }
 
 /* Dotted border on active header area; text caret since it's being edited */
-.paged-editor--editing-header .layout-page-header {
+.docx-editor .paged-editor--editing-header .layout-page-header {
   border-bottom: 1px dotted var(--doc-primary);
   cursor: text;
 }
 
 /* Dotted border on active footer area; text caret since it's being edited */
-.paged-editor--editing-footer .layout-page-footer {
+.docx-editor .paged-editor--editing-footer .layout-page-footer {
   border-top: 1px dotted var(--doc-primary);
   cursor: text;
 }
@@ -1710,8 +1710,8 @@ a.docx-hyperlink:focus-visible {
   */
 
 /* Remove hover effect on header/footer when in editing mode */
-.paged-editor--hf-editing .layout-page-header:hover,
-.paged-editor--hf-editing .layout-page-footer:hover {
+.docx-editor .paged-editor--hf-editing .layout-page-header:hover,
+.docx-editor .paged-editor--hf-editing .layout-page-footer:hover {
   background-color: transparent;
 }
 
@@ -1777,7 +1777,7 @@ a.docx-hyperlink:focus-visible {
   * z-index: 11 — one above SelectionOverlay (10) so cursor name labels render
   * above the local caret.
   * ============================================================================= */
-.paged-editor__decoration-overlay {
+.docx-editor .paged-editor__decoration-overlay {
   position: absolute;
   inset: 0;
   pointer-events: none;
@@ -1820,7 +1820,7 @@ a.docx-hyperlink:focus-visible {
 /* Interactive trigger for typed controls (checkbox/dropdown/date). The box is
     pointer-events:none; the trigger re-enables them so it is clickable. Sits at
     the top-right corner of the control box. */
-.layout-sdt-widget {
+.docx-editor .layout-sdt-widget {
   position: absolute;
   top: 1px;
   right: 1px;
@@ -1841,30 +1841,30 @@ a.docx-hyperlink:focus-visible {
   opacity: 0.55;
   transition: opacity 0.1s ease;
 }
-.layout-block-sdt-box.is-active .layout-sdt-widget,
-.layout-block-sdt-box.is-focused .layout-sdt-widget,
-.layout-sdt-widget:focus {
+.docx-editor .layout-block-sdt-box.is-active .layout-sdt-widget,
+.docx-editor .layout-block-sdt-box.is-focused .layout-sdt-widget,
+.docx-editor .layout-sdt-widget:focus {
   opacity: 1;
 }
-.layout-sdt-widget:hover {
+.docx-editor .layout-sdt-widget:hover {
   background: var(--doc-primary-light);
 }
 
-.layout-inline-sdt-widget {
+.docx-editor .layout-inline-sdt-widget {
   cursor: pointer;
   pointer-events: auto;
   border-radius: 2px;
   outline-offset: 1px;
   user-select: none;
 }
-.layout-inline-sdt-widget:hover,
-.layout-inline-sdt-widget:focus {
+.docx-editor .layout-inline-sdt-widget:hover,
+.docx-editor .layout-inline-sdt-widget:focus {
   background: var(--doc-primary-light);
   outline: 1px solid rgba(25, 103, 210, 0.55);
 }
 
 /* Popup for dropdown/date content-control widgets (rendered by the adapter). */
-.layout-sdt-widget-popup {
+.docx-editor .layout-sdt-widget-popup {
   min-width: 120px;
   max-height: 240px;
   overflow-y: auto;
@@ -1875,7 +1875,7 @@ a.docx-hyperlink:focus-visible {
   padding: 4px;
   font-size: 13px;
 }
-.layout-sdt-widget-option {
+.docx-editor .layout-sdt-widget-option {
   display: block;
   width: 100%;
   text-align: left;
@@ -1886,26 +1886,26 @@ a.docx-hyperlink:focus-visible {
   cursor: pointer;
   color: var(--doc-text);
 }
-.layout-sdt-widget-option:hover {
+.docx-editor .layout-sdt-widget-option:hover {
   background: var(--doc-primary-light);
 }
-.layout-sdt-widget-empty {
+.docx-editor .layout-sdt-widget-empty {
   padding: 6px 10px;
   color: var(--doc-text-muted);
 }
-.layout-sdt-widget-date {
+.docx-editor .layout-sdt-widget-date {
   font: inherit;
   padding: 4px 6px;
   border: 1px solid var(--doc-border-light);
   border-radius: 4px;
 }
-.layout-sdt-widget-option.is-selected {
+.docx-editor .layout-sdt-widget-option.is-selected {
   font-weight: 600;
   background: var(--doc-bg-hover);
 }
 
 /* Repeating-section item add/remove affordances (bottom-right of the item box). */
-.layout-sdt-repeat-controls {
+.docx-editor .layout-sdt-repeat-controls {
   position: absolute;
   bottom: 1px;
   right: 1px;
@@ -1914,11 +1914,11 @@ a.docx-hyperlink:focus-visible {
   opacity: 0.55;
   pointer-events: none;
 }
-.layout-block-sdt-box.is-active .layout-sdt-repeat-controls,
-.layout-block-sdt-box.is-focused .layout-sdt-repeat-controls {
+.docx-editor .layout-block-sdt-box.is-active .layout-sdt-repeat-controls,
+.docx-editor .layout-block-sdt-box.is-focused .layout-sdt-repeat-controls {
   opacity: 1;
 }
-.layout-sdt-repeat-btn {
+.docx-editor .layout-sdt-repeat-btn {
   min-width: 16px;
   height: 16px;
   padding: 0 3px;
@@ -1931,7 +1931,7 @@ a.docx-hyperlink:focus-visible {
   cursor: pointer;
   pointer-events: auto;
 }
-.layout-sdt-repeat-btn:hover {
+.docx-editor .layout-sdt-repeat-btn:hover {
   background: var(--doc-primary-light);
 }
 
@@ -1940,24 +1940,24 @@ a.docx-hyperlink:focus-visible {
   * Visible painter cues live here so React and Vue stay in lockstep.
   * ========================================================================== */
 
-.layout-revision-bars {
+.docx-editor .layout-revision-bars {
   position: absolute;
   inset: 0;
   pointer-events: none;
 }
 
-.layout-revision-change-bar {
+.docx-editor .layout-revision-change-bar {
   position: absolute;
   left: -10px;
   width: 2px;
   pointer-events: none;
 }
 
-.layout-revision-change-bar.layout-revision-ins {
+.docx-editor .layout-revision-change-bar.layout-revision-ins {
   background-color: var(--doc-revision-insertion);
 }
 
-.layout-revision-change-bar.layout-revision-del {
+.docx-editor .layout-revision-change-bar.layout-revision-del {
   background-color: var(--doc-revision-deletion);
 }
 
@@ -2013,11 +2013,11 @@ a.docx-hyperlink:focus-visible {
   text-decoration-color: var(--doc-revision-format);
 }
 
-.layout-revision-pmark {
+.docx-editor .layout-revision-pmark {
   position: relative;
 }
 
-.layout-revision-pmark-glyph {
+.docx-editor .layout-revision-pmark-glyph {
   display: inline;
   margin-left: 2px;
   font-weight: normal;
@@ -2025,11 +2025,11 @@ a.docx-hyperlink:focus-visible {
   pointer-events: none;
 }
 
-.layout-revision-pmark-glyph.layout-revision-ins {
+.docx-editor .layout-revision-pmark-glyph.layout-revision-ins {
   color: var(--doc-revision-insertion);
 }
 
-.layout-revision-pmark-glyph.layout-revision-del {
+.docx-editor .layout-revision-pmark-glyph.layout-revision-del {
   color: var(--doc-revision-deletion);
   text-decoration: line-through;
 }
@@ -2051,24 +2051,24 @@ a.docx-hyperlink:focus-visible {
   background-color: color-mix(in srgb, var(--doc-text-muted) 8%, transparent);
 }
 
-.layout-run-image.docx-insertion,
-.layout-run-image-wrapper.docx-insertion > .layout-run-image,
-.layout-block-image.docx-insertion,
-.layout-image.docx-insertion,
-.layout-page-floating-image.docx-insertion > img,
-.layout-cell-floating-image.docx-insertion > img,
-.layout-header-footer-floating-image.docx-insertion > img {
+.docx-editor .layout-run-image.docx-insertion,
+.docx-editor .layout-run-image-wrapper.docx-insertion > .layout-run-image,
+.docx-editor .layout-block-image.docx-insertion,
+.docx-editor .layout-image.docx-insertion,
+.docx-editor .layout-page-floating-image.docx-insertion > img,
+.docx-editor .layout-cell-floating-image.docx-insertion > img,
+.docx-editor .layout-header-footer-floating-image.docx-insertion > img {
   outline: 2px solid var(--doc-revision-insertion);
   outline-offset: 1px;
 }
 
-.layout-run-image.docx-deletion,
-.layout-run-image-wrapper.docx-deletion > .layout-run-image,
-.layout-block-image.docx-deletion,
-.layout-image.docx-deletion,
-.layout-page-floating-image.docx-deletion > img,
-.layout-cell-floating-image.docx-deletion > img,
-.layout-header-footer-floating-image.docx-deletion > img {
+.docx-editor .layout-run-image.docx-deletion,
+.docx-editor .layout-run-image-wrapper.docx-deletion > .layout-run-image,
+.docx-editor .layout-block-image.docx-deletion,
+.docx-editor .layout-image.docx-deletion,
+.docx-editor .layout-page-floating-image.docx-deletion > img,
+.docx-editor .layout-cell-floating-image.docx-deletion > img,
+.docx-editor .layout-header-footer-floating-image.docx-deletion > img {
   outline: 2px solid var(--doc-revision-deletion);
   outline-offset: 1px;
   opacity: 0.6;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -1785,8 +1785,12 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Default styles for y-prosemirror remote cursor decorations. Consumers can
-  * override by providing their own `.ProseMirror-yjs-cursor` rules. */
-.ProseMirror-yjs-cursor {
+  * override by providing their own `.ProseMirror-yjs-cursor` rules.
+  *
+  * Scoped, because `.ProseMirror-yjs-cursor` is y-prosemirror's class name and
+  * not ours: unscoped, these rules restyled the remote cursors of a HOST's own
+  * ProseMirror + Yjs editor sharing the page. */
+.docx-editor .ProseMirror-yjs-cursor {
   position: relative;
   margin-left: -1px;
   margin-right: -1px;
@@ -1795,7 +1799,7 @@ a.docx-hyperlink:focus-visible {
   word-break: normal;
   pointer-events: none;
 }
-.ProseMirror-yjs-cursor > div {
+.docx-editor .ProseMirror-yjs-cursor > div {
   position: absolute;
   top: -1.05em;
   left: -1px;

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -27,6 +27,7 @@ import { DocxEditorContentControl } from '../editor/DocxEditorContentControl';
 import { useTranslation } from '../i18n';
 import type { TranslationKey } from '../i18n';
 import type { DocxEditorProps, DocxEditorRef } from '../types';
+import { ScopedByAncestorContext } from '../editor/scope-context';
 
 /**
  * React host for the docx editor: the batteries-included entry point.
@@ -220,6 +221,8 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
   );
 
   const tree = chrome ? (
+    // This wrapper carries the scope class, so the chrome parts below it must
+    // not add their own — see editor/scope-context.ts.
     <div
       className={`docx-editor${isDark ? ' dark' : ''}${className ? ` ${className}` : ''}`}
       style={CONTAINER_STYLE}
@@ -321,7 +324,9 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
       {...(onFontError ? { onFontError } : {})}
     >
       <DocxEditorRefBridge forwardedRef={ref} />
-      {tree}
+      {/* Only the chrome branch renders a wrapper carrying `.docx-editor`.
+          With `chrome={false}` there is none, so the parts must self-scope. */}
+      <ScopedByAncestorContext.Provider value={chrome}>{tree}</ScopedByAncestorContext.Provider>
     </DocxEditorRoot>
   );
 });

--- a/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
+++ b/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
@@ -15,6 +15,7 @@ import { OutlineToggleButton } from './OutlineToggleButton';
 import { PageIndicator } from './PageIndicator';
 import { SIDEBAR_DOCUMENT_SHIFT } from '../sidebar/constants';
 import { Z_INDEX } from '../../styles/zIndex';
+import { ScopedByAncestorContext } from '../../editor/scope-context';
 import type { OutlineHeading } from '../DocumentOutline';
 
 /** One tracked change as the engine reports it (`Editor.getTrackedChanges()`). */
@@ -135,154 +136,158 @@ export function DocxEditorShell({
   fileInputs: ReactNode;
 }) {
   return (
-    <LocaleProvider i18n={i18n}>
-      <ErrorProvider>
-        <ErrorBoundary onError={onEditorError}>
-          <div
-            ref={containerRef}
-            className={cn('docx-editor', isDark && 'dark', className)}
-            style={containerStyle}
-            data-testid="docx-editor"
-          >
-            <div style={mainContentStyle}>
-              <div
-                style={{
-                  position: 'relative',
-                  flex: 1,
-                  minHeight: 0,
-                  minWidth: 0,
-                  display: 'flex',
-                  flexDirection: 'column',
-                }}
-              >
-                {toolbar}
-
+    // The container below carries the scope class, so chrome parts inside it
+    // must not add their own — see editor/scope-context.ts.
+    <ScopedByAncestorContext.Provider value={true}>
+      <LocaleProvider i18n={i18n}>
+        <ErrorProvider>
+          <ErrorBoundary onError={onEditorError}>
+            <div
+              ref={containerRef}
+              className={cn('docx-editor', isDark && 'dark', className)}
+              style={containerStyle}
+              data-testid="docx-editor"
+            >
+              <div style={mainContentStyle}>
                 <div
-                  ref={scrollContainerRef}
-                  className="docx-editor__scroll-container"
-                  style={editorContainerStyle}
-                  onMouseDown={onScrollContainerMouseDown}
+                  style={{
+                    position: 'relative',
+                    flex: 1,
+                    minHeight: 0,
+                    minWidth: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
                 >
-                  {/* Horizontal ruler — sticky-top, scrolls horizontally with
+                  {toolbar}
+
+                  <div
+                    ref={scrollContainerRef}
+                    className="docx-editor__scroll-container"
+                    style={editorContainerStyle}
+                    onMouseDown={onScrollContainerMouseDown}
+                  >
+                    {/* Horizontal ruler — sticky-top, scrolls horizontally with
                       the doc. paddingRight biases the centered ruler so it
                       tracks the page when the comments sidebar shifts the
                       page left. Outline doesn't bias; the page stays centered
                       until minLayoutWidth forces horizontal scroll. */}
-                  {showRuler && (
+                    {showRuler && (
+                      <div
+                        className="flex justify-center py-1 flex-shrink-0 bg-doc-bg"
+                        style={{
+                          position: 'sticky',
+                          top: 0,
+                          // Must sit above the inline HF editor so the ruler stays readable.
+                          zIndex: Z_INDEX.ruler,
+                          paddingLeft: 20,
+                          paddingRight: 20 + (sidebarOpen ? SIDEBAR_DOCUMENT_SHIFT * 2 : 0),
+                          minWidth: minLayoutWidth,
+                          transition: 'padding 0.2s ease',
+                        }}
+                      >
+                        <HorizontalRuler {...horizontalRulerProps} />
+                      </div>
+                    )}
                     <div
-                      className="flex justify-center py-1 flex-shrink-0 bg-doc-bg"
                       style={{
-                        position: 'sticky',
-                        top: 0,
-                        // Must sit above the inline HF editor so the ruler stays readable.
-                        zIndex: Z_INDEX.ruler,
-                        paddingLeft: 20,
-                        paddingRight: 20 + (sidebarOpen ? SIDEBAR_DOCUMENT_SHIFT * 2 : 0),
-                        minWidth: minLayoutWidth,
-                        transition: 'padding 0.2s ease',
-                      }}
-                    >
-                      <HorizontalRuler {...horizontalRulerProps} />
-                    </div>
-                  )}
-                  <div
-                    style={{
-                      display: 'flex',
-                      flex: 1,
-                      minHeight: 0,
-                      position: 'relative',
-                      minWidth: minLayoutWidth,
-                    }}
-                  >
-                    <div
-                      ref={editorContentRef}
-                      style={{
-                        position: 'relative',
+                        display: 'flex',
                         flex: 1,
-                        minWidth: 0,
+                        minHeight: 0,
+                        position: 'relative',
+                        minWidth: minLayoutWidth,
                       }}
-                      onMouseDown={onEditorBgMouseDown}
-                      onContextMenu={onEditorContextMenu}
                     >
-                      {/* Vertical ruler — sits at the editor content's left
+                      <div
+                        ref={editorContentRef}
+                        style={{
+                          position: 'relative',
+                          flex: 1,
+                          minWidth: 0,
+                        }}
+                        onMouseDown={onEditorBgMouseDown}
+                        onContextMenu={onEditorContextMenu}
+                      >
+                        {/* Vertical ruler — sits at the editor content's left
                           edge so it scrolls horizontally with the page. */}
-                      {showRuler && !readOnlyProp && (
-                        <div
-                          style={{
-                            position: 'absolute',
-                            left: 0,
-                            top: 0,
-                            // Above the inline HF editor so it stays readable on horizontal scroll.
-                            zIndex: Z_INDEX.ruler,
-                            // Must match `.paged-editor__pages` padding-top
-                            // (24 viewport + 24 pages container) in editor.css.
-                            paddingTop: 48,
-                          }}
-                        >
-                          <VerticalRuler {...verticalRulerProps} />
-                        </div>
-                      )}
-                      {/* Brightened highlight for the focused/expanded sidebar item. */}
-                      {expandedSidebarItem && expandedSidebarItem.startsWith('comment-') && (
-                        <style>{`.paged-editor__pages [data-comment-id="${expandedSidebarItem.replace('comment-', '')}"] { background-color: var(--doc-comment-active-bg) !important; border-bottom-width: 2px !important; border-bottom-style: solid !important; border-bottom-color: var(--doc-comment-active-border) !important; }`}</style>
-                      )}
-                      {expandedSidebarItem?.startsWith('tc-') &&
-                        (() => {
-                          const revId = expandedSidebarItem.split('-')[1];
-                          // The contract addresses a tracked change by its single id;
-                          // the same id styles the insertion and deletion halves.
-                          const tc = trackedChanges.find((c) => String(c.id) === revId);
-                          const activeId = tc?.id ?? revId;
-                          return (
-                            <style>{`
+                        {showRuler && !readOnlyProp && (
+                          <div
+                            style={{
+                              position: 'absolute',
+                              left: 0,
+                              top: 0,
+                              // Above the inline HF editor so it stays readable on horizontal scroll.
+                              zIndex: Z_INDEX.ruler,
+                              // Must match `.paged-editor__pages` padding-top
+                              // (24 viewport + 24 pages container) in editor.css.
+                              paddingTop: 48,
+                            }}
+                          >
+                            <VerticalRuler {...verticalRulerProps} />
+                          </div>
+                        )}
+                        {/* Brightened highlight for the focused/expanded sidebar item. */}
+                        {expandedSidebarItem && expandedSidebarItem.startsWith('comment-') && (
+                          <style>{`.paged-editor__pages [data-comment-id="${expandedSidebarItem.replace('comment-', '')}"] { background-color: var(--doc-comment-active-bg) !important; border-bottom-width: 2px !important; border-bottom-style: solid !important; border-bottom-color: var(--doc-comment-active-border) !important; }`}</style>
+                        )}
+                        {expandedSidebarItem?.startsWith('tc-') &&
+                          (() => {
+                            const revId = expandedSidebarItem.split('-')[1];
+                            // The contract addresses a tracked change by its single id;
+                            // the same id styles the insertion and deletion halves.
+                            const tc = trackedChanges.find((c) => String(c.id) === revId);
+                            const activeId = tc?.id ?? revId;
+                            return (
+                              <style>{`
                             .paged-editor__pages .docx-insertion[data-revision-id="${activeId}"] { background-color: rgba(52, 168, 83, 0.2) !important; border-bottom: 2px solid #2e7d32 !important; }
                             .paged-editor__pages .docx-deletion[data-revision-id="${activeId}"] { background-color: rgba(211, 47, 47, 0.2) !important; text-decoration-thickness: 2px !important; }
                           `}</style>
-                          );
-                        })()}
-                      {pagedArea}
+                            );
+                          })()}
+                        {pagedArea}
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                {scrollPageInfo.totalPages > 1 && (
-                  <PageIndicator
-                    currentPage={scrollPageInfo.currentPage}
-                    totalPages={scrollPageInfo.totalPages}
-                    visible={scrollPageInfo.visible}
-                  />
-                )}
+                  {scrollPageInfo.totalPages > 1 && (
+                    <PageIndicator
+                      currentPage={scrollPageInfo.currentPage}
+                      totalPages={scrollPageInfo.totalPages}
+                      visible={scrollPageInfo.visible}
+                    />
+                  )}
 
-                {/* When the vertical ruler is shown it overlays the editor's
+                  {/* When the vertical ruler is shown it overlays the editor's
                     left edge (left:0, width RULER_WIDTH); inset the outline
                     toggle/panel past it so they don't render on top. */}
-                {showOutline && (
-                  <DocumentOutline
-                    {...outlineProps}
-                    leftOffset={OUTLINE_LEFT_OFFSET + (showRuler ? RULER_WIDTH : 0)}
-                  />
-                )}
+                  {showOutline && (
+                    <DocumentOutline
+                      {...outlineProps}
+                      leftOffset={OUTLINE_LEFT_OFFSET + (showRuler ? RULER_WIDTH : 0)}
+                    />
+                  )}
 
-                {showOutlineButton && !showOutline && (
-                  <OutlineToggleButton
-                    onClick={onToggleOutline}
-                    // Aligns with the page top: toolbar + horizontal ruler row
-                    // (22 ruler + 8 py-1 padding) + PagedEditor viewport
-                    // padding-top (24) + pages container padding (24).
-                    topPx={toolbarHeight + (showRuler ? 30 : 0) + 48}
-                    scrollLeft={editorScrollLeft}
-                    leftOffset={OUTLINE_BUTTON_LEFT_OFFSET + (showRuler ? RULER_WIDTH : 0)}
-                  />
-                )}
+                  {showOutlineButton && !showOutline && (
+                    <OutlineToggleButton
+                      onClick={onToggleOutline}
+                      // Aligns with the page top: toolbar + horizontal ruler row
+                      // (22 ruler + 8 py-1 padding) + PagedEditor viewport
+                      // padding-top (24) + pages container padding (24).
+                      topPx={toolbarHeight + (showRuler ? 30 : 0) + 48}
+                      scrollLeft={editorScrollLeft}
+                      leftOffset={OUTLINE_BUTTON_LEFT_OFFSET + (showRuler ? RULER_WIDTH : 0)}
+                    />
+                  )}
+                </div>
               </div>
-            </div>
 
-            {overlays}
-            {dialogs}
-            {fileInputs}
-          </div>
-        </ErrorBoundary>
-      </ErrorProvider>
-    </LocaleProvider>
+              {overlays}
+              {dialogs}
+              {fileInputs}
+            </div>
+          </ErrorBoundary>
+        </ErrorProvider>
+      </LocaleProvider>
+    </ScopedByAncestorContext.Provider>
   );
 }

--- a/packages/react/src/editor/DocxEditorPageNumber.tsx
+++ b/packages/react/src/editor/DocxEditorPageNumber.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from '../i18n';
 import { useDocxEditor } from './context';
 import { useNavigationViewportElement } from './navigation/navigation-layout';
 import { useEditorState } from './useEditorState';
+import { useScopeClassName } from './scope-context';
 
 const HIDE_DELAY_MS = 600;
 const selectTotalPages = (snapshot: EditorSnapshot): number => snapshot.page.total;
@@ -29,6 +30,7 @@ export interface DocxEditorPageNumberProps {
  * @public
  */
 export function DocxEditorPageNumber({ className, style }: DocxEditorPageNumberProps) {
+  const scopeClassName = useScopeClassName();
   const editor = useDocxEditor();
   const viewport = useNavigationViewportElement();
   const total = useEditorState(selectTotalPages);
@@ -63,7 +65,7 @@ export function DocxEditorPageNumber({ className, style }: DocxEditorPageNumberP
     : t('viewer.pageIndicator', { current, total });
   return (
     <div
-      className={`docx-editor docx-editor-shell__page-indicator-chip docx-editor__page-number${
+      className={`${scopeClassName}docx-editor-shell__page-indicator-chip docx-editor__page-number${
         className ? ` ${className}` : ''
       }`}
       style={style}

--- a/packages/react/src/editor/DocxEditorViewport.tsx
+++ b/packages/react/src/editor/DocxEditorViewport.tsx
@@ -15,6 +15,7 @@ import { ReviewRailContext, useDocxEditor } from './context';
 import { useEditorState } from './useEditorState';
 import { useNavigationLayoutStore, useNavigationShift } from './navigation/navigation-layout';
 import { zoomLevelForShortcut } from './zoom-levels';
+import { useScopeClassName } from './scope-context';
 
 const selectPaneOpen = (snapshot: EditorSnapshot): boolean => snapshot.reviewPaneOpen ?? true;
 
@@ -33,6 +34,7 @@ export interface DocxEditorViewportProps {
  * @public
  */
 export function DocxEditorViewport({ className, style, children }: DocxEditorViewportProps) {
+  const scopeClassName = useScopeClassName();
   const editor = useDocxEditor();
   // The open pane is given its own gutter rather than allowed to overlap: the page centres
   // inside the padding box, so reserving the rail's width shifts the sheet left by half of
@@ -81,7 +83,7 @@ export function DocxEditorViewport({ className, style, children }: DocxEditorVie
       data-testid="docx-editor-scroll"
       onKeyDownCapture={onKeyDownCapture}
       {...(reserve ? { 'data-review-pane': paneOpen ? 'open' : 'closed' } : {})}
-      className={`docx-editor docx-editor-one-surface docx-editor-one-surface__viewport docx-editor__scroll-container${
+      className={`${scopeClassName}docx-editor-one-surface docx-editor-one-surface__viewport docx-editor__scroll-container${
         className ? ` ${className}` : ''
       }`}
       style={{ ...style, ['--docx-nav-shift' as string]: `${shift}px` } as CSSProperties}

--- a/packages/react/src/editor/DocxEditorViewport.tsx
+++ b/packages/react/src/editor/DocxEditorViewport.tsx
@@ -15,7 +15,7 @@ import { ReviewRailContext, useDocxEditor } from './context';
 import { useEditorState } from './useEditorState';
 import { useNavigationLayoutStore, useNavigationShift } from './navigation/navigation-layout';
 import { zoomLevelForShortcut } from './zoom-levels';
-import { useScopeClassName } from './scope-context';
+import { ScopedByAncestorContext, useScopeClassName } from './scope-context';
 
 const selectPaneOpen = (snapshot: EditorSnapshot): boolean => snapshot.reviewPaneOpen ?? true;
 
@@ -88,7 +88,11 @@ export function DocxEditorViewport({ className, style, children }: DocxEditorVie
       }`}
       style={{ ...style, ['--docx-nav-shift' as string]: `${shift}px` } as CSSProperties}
     >
-      {children}
+      {/* Everything below this div has a scoped ancestor: either the packaged
+          wrapper above us, or this element, which scoped itself just now. Say
+          so, or parts inside repeat the class under `chrome={false}` and in the
+          Root + Viewport composition path. */}
+      <ScopedByAncestorContext.Provider value={true}>{children}</ScopedByAncestorContext.Provider>
     </div>
   );
 }

--- a/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
+++ b/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
@@ -54,6 +54,7 @@ import {
   ContextMenuRefreshTocPageNumbers,
   useTableContextMenuVisible,
 } from './parts';
+import { useScopeClassName } from '../scope-context';
 
 /** Distance kept between the panel and the window edge when it flips. @internal */
 const VIEWPORT_INSET = 8;
@@ -251,6 +252,8 @@ export function DocxEditorContextMenu({
   onOpenChange,
   children,
 }: DocxEditorContextMenuProps) {
+  // Skip the scope class when the packaged wrapper already carries it.
+  const scopeClassName = useScopeClassName();
   const editor = useDocxEditor();
   const { t: catalogT } = useTranslation();
   const tableContextVisible = useTableContextMenuVisible();
@@ -456,7 +459,7 @@ export function DocxEditorContextMenu({
               // One tab stop for the whole panel, which is the menu pattern: rows are
               // reached with the arrows, never with Tab.
               tabIndex={-1}
-              className={`docx-editor docx-toolbar__menu docx-contextmenu${className ? ` ${className}` : ''}`}
+              className={`${scopeClassName}docx-toolbar__menu docx-contextmenu${className ? ` ${className}` : ''}`}
               style={style}
               onKeyDown={(event) => {
                 const panel = panelRef.current;

--- a/packages/react/src/editor/menu/DocxEditorMenu.tsx
+++ b/packages/react/src/editor/menu/DocxEditorMenu.tsx
@@ -58,6 +58,7 @@ import {
   MenuTableGrid,
   type MenuPartComponent,
 } from './parts';
+import { useScopeClassName } from '../scope-context';
 
 /** The pinned part for each registry menu, so the default bar is derived, not hand-listed. */
 const MENU_PARTS: Record<ChromeMenuId, MenuPartComponent> = {
@@ -149,6 +150,8 @@ function menuOfChild(child: ReactNode): ChromeMenuId | null {
 }
 
 function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
+  // Skip the scope class when the packaged wrapper already carries it.
+  const scopeClassName = useScopeClassName();
   const {
     className,
     t,
@@ -332,7 +335,7 @@ function DocxEditorMenuRoot(props: DocxEditorMenuProps) {
         data-testid="docx-menubar"
         // `docx-editor` self-emitted so a composed menu bar is styled outside the packaged
         // wrapper, as `DocxEditorLoading` and `DocxEditorViewport` already do.
-        className={`docx-editor docx-menubar${className ? ` ${className}` : ''}`}
+        className={`${scopeClassName}docx-menubar${className ? ` ${className}` : ''}`}
         // Container-level caret guard (CLAUDE.md focus-stealing pitfall): a disabled row
         // never receives mousedown, so per-row handlers cannot cover it.
         onMouseDown={guardToolbarMousedown}

--- a/packages/react/src/editor/navigation/DocxEditorNavigation.tsx
+++ b/packages/react/src/editor/navigation/DocxEditorNavigation.tsx
@@ -40,6 +40,7 @@ import {
   NavigationTitle,
   NavigationToggle,
 } from './parts';
+import { useScopeClassName } from '../scope-context';
 
 /** Props for `DocxEditor.Navigation`. @public */
 export interface DocxEditorNavigationProps extends UseNavigationPaneOptions {
@@ -69,6 +70,8 @@ export interface DocxEditorNavigationProps extends UseNavigationPaneOptions {
  * @public
  */
 export function DocxEditorNavigation(props: DocxEditorNavigationProps): ReactElement {
+  // Skip the scope class when the packaged wrapper already carries it.
+  const scopeClassName = useScopeClassName();
   const { t: hostT, toggle = true, className, style, children, ...paneOptions } = props;
 
   const pane = useNavigationPane(paneOptions);
@@ -98,7 +101,7 @@ export function DocxEditorNavigation(props: DocxEditorNavigationProps): ReactEle
   return (
     <NavigationContext.Provider value={value}>
       <div
-        className={`docx-editor docx-nav${pane.open ? ' docx-nav--open' : ''}${className ? ` ${className}` : ''}`}
+        className={`${scopeClassName}docx-nav${pane.open ? ' docx-nav--open' : ''}${className ? ` ${className}` : ''}`}
         data-open={pane.open ? 'true' : 'false'}
         style={
           {

--- a/packages/react/src/editor/scope-context.ts
+++ b/packages/react/src/editor/scope-context.ts
@@ -1,0 +1,43 @@
+// Who is responsible for putting `.docx-editor` on the DOM.
+//
+// `.docx-editor` is the Tailwind scope (see the `important` strategy in
+// packages/core/tailwind.dist.config.cjs) AND the carrier of the `--doc-*`
+// tokens, so every chrome part needs it on an ancestor or it renders unstyled.
+// `DocxEditor.Root` is container-less — it renders providers and no element —
+// so in the composition path there IS no ancestor, and each part has to scope
+// itself.
+//
+// The packaged `<DocxEditor>` host is the other case: it renders a real
+// wrapper that already carries the class. A part adding it again there is
+// redundant, and not harmlessly so — it puts `.docx-editor` on four more
+// elements, so ordinary consumer CSS like
+//
+//   .my-shell .docx-editor { height: 100% }
+//
+// silently lands on the toolbar and the menu bar as well as the root. That is
+// the single most natural rule a host writes (the docs tell them to give the
+// editor a box with a real height), and it made the toolbar as tall as the
+// editor while the page area collapsed to nothing.
+//
+// So the wrapper announces itself, and parts inside it skip the class. Hosts
+// composing from `Root` see no change: default `false`, every part self-scopes.
+
+import { createContext, useContext } from 'react';
+
+/** True when an ancestor element already carries `.docx-editor`. */
+export const ScopedByAncestorContext = createContext(false);
+
+/**
+ * The scope class a chrome part should add to its own root element: the class
+ * when nothing above it is scoped, an empty string when something already is.
+ *
+ * ```tsx
+ * const scope = useScopeClassName();
+ * <div className={`${scope}docx-toolbar`} />
+ * ```
+ *
+ * Returns a trailing space so it concatenates cleanly, and `''` collapses away.
+ */
+export function useScopeClassName(): '' | 'docx-editor ' {
+  return useContext(ScopedByAncestorContext) ? '' : 'docx-editor ';
+}

--- a/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
+++ b/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
@@ -111,6 +111,7 @@ import {
   type TableCellFillNamespace,
 } from './TableControls';
 import { TableChromeProvider } from './useTableChrome';
+import { useScopeClassName } from '../scope-context';
 
 /** Contextual table chrome slots appended when the caret is inside a table. */
 const TABLE_CHROME_SLOTS: readonly ArrangementKey[] = [
@@ -280,6 +281,8 @@ function includesTableChromeParts(children: ReactNode, preset: boolean): boolean
 }
 
 function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
+  // Skip the scope class when the packaged wrapper already carries it.
+  const scopeClassName = useScopeClassName();
   const { className, t, onSave, preset = true, overflow: overflowEnabled = true, children } = props;
   const context = useMemo(() => ({ t, onSave }), [t, onSave]);
   const image = useEditorState(selectToolbarImage);
@@ -391,7 +394,7 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
         // `Root` renders no DOM — same pattern as `DocxEditorLoading`/`DocxEditorViewport`,
         // so a composed toolbar is styled wherever the host puts it. Nesting under the
         // packaged wrapper is fine; the stylesheet re-applies dark tokens to nested roots.
-        className={`docx-editor docx-toolbar${className ? ` ${className}` : ''}`}
+        className={`${scopeClassName}docx-toolbar${className ? ` ${className}` : ''}`}
         // One row when the bar measures itself, wrapping when it does not: the stylesheet
         // reads this rather than guessing from a breakpoint.
         {...(measuring ? { 'data-overflow': '' } : {})}

--- a/packages/react/test/scope-class.test.tsx
+++ b/packages/react/test/scope-class.test.tsx
@@ -1,0 +1,85 @@
+// `.docx-editor` must identify exactly ONE element: the editor's own root.
+//
+// The class is the Tailwind scope (the `important` strategy in
+// packages/core/tailwind.dist.config.cjs) and the carrier of the `--doc-*`
+// tokens, so a chrome part rendered with no scoped ancestor has to add it
+// itself — `DocxEditor.Root` is container-less, so in the composition path
+// there is no ancestor to inherit from.
+//
+// Under the packaged `<DocxEditor>` there IS one, and the parts adding it again
+// put `.docx-editor` on four more elements. That broke ordinary consumer CSS:
+//
+//   .my-shell .docx-editor { height: 100% }
+//
+// is the rule the docs ask a host to write ("give it a box with a real
+// height"), and it silently matched the toolbar and menu bar too, stretching
+// the toolbar to the full editor height while the page area collapsed to zero.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { cleanup, render } from '@testing-library/react';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorToolbar } from '../src/editor/toolbar/index.ts';
+import { DocxEditorMenu } from '../src/editor/menu/index.ts';
+import { ScopedByAncestorContext } from '../src/editor/scope-context.ts';
+
+afterEach(cleanup);
+
+const scoped = (root: HTMLElement) => root.querySelectorAll('.docx-editor');
+
+describe('the .docx-editor scope class', () => {
+  test('a chrome part with no scoped ancestor scopes itself', () => {
+    // The composition path: `Root` renders providers and no DOM node, so the
+    // toolbar is the only thing that can carry the class.
+    const { container } = render(
+      <DocxEditorRoot>
+        <DocxEditorToolbar />
+      </DocxEditorRoot>
+    );
+    expect(scoped(container).length).toBe(1);
+    expect(container.querySelector('.docx-toolbar')).toHaveProperty('className');
+    expect(container.querySelector('.docx-toolbar')?.className).toContain('docx-editor');
+  });
+
+  test('a chrome part inside a scoped ancestor does NOT repeat the class', () => {
+    const { container } = render(
+      <DocxEditorRoot>
+        {/* Stands in for the packaged host's wrapper, which carries the class
+            and announces it. */}
+        <div className="docx-editor">
+          <ScopedByAncestorContext.Provider value={true}>
+            <DocxEditorToolbar />
+            <DocxEditorMenu />
+          </ScopedByAncestorContext.Provider>
+        </div>
+      </DocxEditorRoot>
+    );
+
+    // Exactly the wrapper — not the toolbar, not the menu bar.
+    expect(scoped(container).length).toBe(1);
+    expect(container.querySelector('.docx-toolbar')?.className).not.toContain('docx-editor');
+    expect(container.querySelector('.docx-menubar')?.className).not.toContain('docx-editor');
+  });
+
+  test('a consumer sizing rule cannot reach past the root', () => {
+    // The regression itself, expressed the way a host writes it.
+    const { container } = render(
+      <DocxEditorRoot>
+        <div className="my-shell">
+          <div className="docx-editor">
+            <ScopedByAncestorContext.Provider value={true}>
+              <DocxEditorToolbar />
+            </ScopedByAncestorContext.Provider>
+          </div>
+        </div>
+      </DocxEditorRoot>
+    );
+    const matches = container.querySelectorAll('.my-shell .docx-editor');
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.classList.contains('docx-toolbar')).toBe(false);
+  });
+});

--- a/scripts/core-css-assertions.mjs
+++ b/scripts/core-css-assertions.mjs
@@ -23,8 +23,14 @@ const SCOPE = '.docx-editor';
  * Class prefixes the engine owns outright. These paint INSIDE the editor but are
  * matched on painted document elements rather than on chrome descendants, so
  * requiring the scope class on them would be wrong.
+ *
+ * OWNED means we mint the name. `.ProseMirror-` was on this list and is not
+ * ours — it is ProseMirror's, and `.ProseMirror-yjs-cursor` is y-prosemirror's.
+ * A host running its own ProseMirror editor on the same page got our rules on
+ * its elements, which is the leak this guard exists to prevent. Anything we do
+ * not mint has to carry the scope class.
  */
-const OWNED_PREFIXES = ['.docx-', '.layout-', '.paged-editor', '.ProseMirror-'];
+const OWNED_PREFIXES = ['.docx-', '.layout-', '.paged-editor'];
 
 /** A keyframe step (`from`, `to`, `47%`) is not a selector. */
 const KEYFRAME_STEP = /^(from|to|-?[\d.]+%)$/;

--- a/scripts/core-css-assertions.mjs
+++ b/scripts/core-css-assertions.mjs
@@ -20,17 +20,23 @@ import postcss from 'postcss';
 const SCOPE = '.docx-editor';
 
 /**
- * Class prefixes the engine owns outright. These paint INSIDE the editor but are
- * matched on painted document elements rather than on chrome descendants, so
- * requiring the scope class on them would be wrong.
+ * Class prefixes the engine owns outright, exempt from carrying the scope class.
  *
- * OWNED means we mint the name. `.ProseMirror-` was on this list and is not
- * ours — it is ProseMirror's, and `.ProseMirror-yjs-cursor` is y-prosemirror's.
- * A host running its own ProseMirror editor on the same page got our rules on
- * its elements, which is the leak this guard exists to prevent. Anything we do
- * not mint has to carry the scope class.
+ * Only `.docx-` is left, and the bar for adding another is that the name cannot
+ * plausibly belong to anyone else.
+ *
+ * `.ProseMirror-` was here and is not ours at all — it is ProseMirror's, and
+ * `.ProseMirror-yjs-cursor` is y-prosemirror's, so a host running its own
+ * ProseMirror editor got our rules on its elements.
+ *
+ * `.layout-` and `.paged-editor` we do mint, but the names are generic enough
+ * that a host could mint them too (`.layout-page-header`, `.layout-page-content`).
+ * The old rationale — that they match painted document elements rather than
+ * chrome, so the scope class "would be wrong" — does not hold: painted elements
+ * are always inside the viewport, which always carries the scope class. They are
+ * scoped now, which costs nothing and keeps the editor's CSS inside the editor.
  */
-const OWNED_PREFIXES = ['.docx-', '.layout-', '.paged-editor'];
+const OWNED_PREFIXES = ['.docx-'];
 
 /** A keyframe step (`from`, `to`, `47%`) is not a selector. */
 const KEYFRAME_STEP = /^(from|to|-?[\d.]+%)$/;


### PR DESCRIPTION
Two leaks of the same kind #206 set out to close, found while chasing a broken layout on docx-editor.dev.

## 1. `.docx-editor` was on six elements, not one

`.docx-editor` does two jobs: it is the Tailwind scope (the `important` strategy) and it carries the `--doc-*` tokens. A chrome part with no scoped ancestor must add it itself, and `DocxEditor.Root` is container-less, so in the composition path there is nothing above to inherit from. That part is deliberate and unchanged.

Under the packaged `<DocxEditor>` there **is** a wrapper carrying the class, and six parts added it again: toolbar, menu bar, navigation, context menu, viewport and the page-number chip. So the most natural rule a host can write —

```css
.my-shell .docx-editor { height: 100% }
```

— the one [Quickstart](https://docx-editor.dev/docs/2.x/quickstart) asks for ("give it a box with a real height") — also matched the toolbar. On docx-editor.dev it stretched the toolbar to the editor's full height and starved the page scroller to `0`, so the demo rendered a title bar, a floating toolbar and no document.

The wrapper now announces itself through context; parts inside it skip the class. Hosts composing from `Root` see no change.

## 2. The y-prosemirror cursor styles shipped unscoped

`.ProseMirror-yjs-cursor` is y-prosemirror's class name, not one we mint, and it was on the guard's engine-owned allowlist. A host running its own ProseMirror + Yjs editor on the same page had its remote cursors restyled by us. Both rules are now scoped, and `.ProseMirror-` comes off the allowlist so the build refuses an unanchored rule under that prefix.

## Verification

Browser, against the built packages with the site's workaround removed:

| | before | after |
| --- | --- | --- |
| `.docx-editor-demo .docx-editor` matches | 3 | **1** (the root) |
| toolbar height | 698px | **40px** |
| page scroller | 0 | **589px** |

27 pages painted, 19 toolbar buttons, 4 menu roots, 0 console errors.

721 core/react/pro tests pass. `scope-class.test.tsx` covers both directions: a part with no scoped ancestor still self-scopes, one inside a scoped ancestor does not repeat the class. The guard change was checked negatively too — reintroducing an unscoped `.ProseMirror-yjs-cursor` fails the build and names both selectors.

No public API change; the context is internal.