### PR TITLE
fix(editor-api): say which InvalidObjectPath a caller hit

### DIFF
--- a/.changeset/promised-object-refusal.md
+++ b/.changeset/promised-object-refusal.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': patch
+---
+
+`InvalidObjectPath` now says which of the two states it means: an object an item accessor answered becomes usable after the next `await context.sync()`, while a released object needs `context.trackedObjects.add(...)`. The message previously described only the released case.

--- a/docs/api/docx-editor-editor-api/browser.api.md
+++ b/docs/api/docx-editor-editor-api/browser.api.md
@@ -315,7 +315,14 @@ export type DocxEditorErrorCode =
 'PropertyNotLoaded'
 /** A `ClientResult` value was read before the sync that fills it. */
 | 'ValueNotLoaded'
-/** The object is no longer addressable: its run ended and it was not tracked. */
+/**
+* The object cannot be addressed, in either of the two ways that happens.
+*
+* NOT YET: an item accessor answers a proxy the read that names it has not answered for, and it
+* becomes usable at the next `sync()`. NOT ANY MORE: its run ended and nothing tracked it, which
+* is terminal. One code because from a consumer's side both are "this object cannot be used
+* here"; the message says which one, because the fix for one is not the fix for the other.
+*/
 | 'InvalidObjectPath'
 /** The object still belongs to a run that has not finished, so it cannot be handed over. */
 | 'ObjectInUse'

--- a/docs/api/docx-editor-editor-api/index.api.md
+++ b/docs/api/docx-editor-editor-api/index.api.md
@@ -314,7 +314,14 @@ export type DocxEditorErrorCode =
 'PropertyNotLoaded'
 /** A `ClientResult` value was read before the sync that fills it. */
 | 'ValueNotLoaded'
-/** The object is no longer addressable: its run ended and it was not tracked. */
+/**
+* The object cannot be addressed, in either of the two ways that happens.
+*
+* NOT YET: an item accessor answers a proxy the read that names it has not answered for, and it
+* becomes usable at the next `sync()`. NOT ANY MORE: its run ended and nothing tracked it, which
+* is terminal. One code because from a consumer's side both are "this object cannot be used
+* here"; the message says which one, because the fix for one is not the fix for the other.
+*/
 | 'InvalidObjectPath'
 /** The object still belongs to a run that has not finished, so it cannot be handed over. */
 | 'ObjectInUse'

--- a/docs/site/content/editor-api/office-js-api.mdx
+++ b/docs/site/content/editor-api/office-js-api.mdx
@@ -7,8 +7,9 @@ order: 53
 
 `@docx-editor.dev/editor-api` implements an Office.js-compatible object model.
 `context.document.body.paragraphs`, `load()` then `sync()`, `search(text, options)`,
-`getFirstOrNullObject()` and `isNullObject` work as they do in an add-in. To port Word add-in code,
-change how the batch opens.
+`getFirstOrNullObject()` and `isNullObject` are the same members you already write. To port Word
+add-in code, change how the batch opens, then read the divergences below: a few of them cost your
+batch an extra `sync()`.
 
 ## Compatibility boundaries
 
@@ -63,12 +64,43 @@ The following APIs are absent from the public types, so code that uses them fail
 
 - `ContentControl.id` is a string because DOCX files can repeat or omit the value.
 - `ContentControl.subtype` reports the file format's terms.
+- An item accessor answers an object that is not usable yet. `getFirst()`, `getLast()` and their
+  `OrNullObject` forms need one `await context.sync()` before you can load or write through the
+  object they return. Which object it is comes back from a read, and a batch has to name its targets
+  before it is sent, so resolving it in place would mean several round trips per `sync()`. Using it
+  too early throws `InvalidObjectPath`, and the message names the sync.
+
+  ```ts
+  const results = context.document.body.search('Total');
+  await context.sync();
+
+  const first = results.getFirst();
+  await context.sync(); // the extra one
+
+  first.insertText('TOTAL', 'Replace');
+  await context.sync();
+  ```
+
+- A collection loads its items, not their properties. `paragraphs.load('text')` and
+  `paragraphs.load('items/text')` are refused with `InvalidArgument`. Load the collection, sync, then
+  load what you want from the items, for the same reason: the items are not addressable until the
+  first read has answered.
+
+  ```ts
+  const paragraphs = context.document.body.paragraphs;
+  paragraphs.load();
+  await context.sync();
+
+  for (const paragraph of paragraphs.items) paragraph.load('text');
+  await context.sync();
+  ```
 
 ## Migrating an add-in
 
 1. Replace `Word.run(async (context) => { … })` with a runtime you construct: `DocxEditor.createServer(bytes)` on a server, `DocxEditor.createBrowser(editor)` in a page. The callback body is the part that stays the same.
 2. Expect the same load/sync discipline you already write. Reads still have to be declared, and a property you did not load still fails.
-3. Check the omissions above. If your add-in walks tables or inserts pictures, that work has no equivalent here yet.
+3. Add the syncs the divergences above describe. The statements stay the same; a batch that reaches an item accessor or a collection's item properties needs one more round trip than it does in an add-in.
+4. Check the omissions above. If your add-in walks tables or inserts pictures, that work has no equivalent here yet.
 
 ## Next steps
 

--- a/packages/editor-api/compat/manifest.json
+++ b/packages/editor-api/compat/manifest.json
@@ -439,6 +439,10 @@
     {
       "uid": "Word.Section#getHeader / #getFooter",
       "note": "A section that declares no header of its own INHERITS the previous section's, which is what Word paints, and this is what these members answer. Upstream's own behaviour additionally MINTS an empty header part when none exists anywhere; this subset refuses instead (ItemNotFound), because a read that adds a part to the package is a write, and a getter that writes cannot be batched with reads under one transaction. Shape conformance is unaffected; the divergence is behavioural and recorded here."
+    },
+    {
+      "uid": "Word.ParagraphCollection#getFirst / #getLast, Word.RangeCollection#getFirst, Word.CommentCollection#getFirst, Word.ListCollection#getFirst and every other item accessor",
+      "note": "The object an item accessor answers needs ONE await context.sync() before it can be loaded, written to or passed anywhere — upstream's needs none. Which object the accessor names is the answer to a read, a host handle is DATA in the batch request, and so an operation targeting that object cannot be in the same batch that resolves it. Resolving it in place would mean sending several batches per sync() and giving up 'one sync is one atomic batch', which is the property this runtime exists to guarantee. Source compatibility is unaffected and is held in place by src/runtime/__tests__/runtime-examples.test.ts, which runs a Word sample's own statements and names the extra sync as the only added line; what differs is the number of round trips at runtime. Using the object early is refused (InvalidObjectPath) rather than guessed, and the message names the sync."
     }
   ],
   "$divergencesComment": "Members that ARE selected and DO conform in shape, but whose behaviour differs from upstream in a way a caller can observe. Kept apart from \"omissions\" on purpose: an omission is a member this subset does not publish, and one of these is a member it publishes and answers differently. Nothing in the tooling reads this list; it is the record that each difference was decided."

--- a/packages/editor-api/src/runtime/__tests__/runtime-lifetime.test.ts
+++ b/packages/editor-api/src/runtime/__tests__/runtime-lifetime.test.ts
@@ -173,6 +173,49 @@ describe('a proxy dies with its run unless something kept it', () => {
   });
 });
 
+describe('the other half of InvalidObjectPath: an object that is not addressable YET', () => {
+  // One code covers two states, and only one of them is fixed by tracking. A consumer who reached
+  // a paragraph through a search hit's `getFirst()` was told "the object is no longer usable …
+  // unless context.trackedObjects.add(...) kept them", which describes the state they were not in
+  // — so they tracked an object that had never been released and it did not help. The state they
+  // were in is fixed by one more `sync()`, and the sentence has to say so.
+  test('a promised object refuses, and the refusal names the sync that fixes it', async () => {
+    const runtime = createRuntime({ host: openHost(docx(p('find me'))), save: true });
+    await runtime.run(async (context) => {
+      const found = context.document.body.search('me');
+      found.load();
+      await context.sync();
+
+      const promised = found.items[0]!.paragraphs.getFirst();
+      // Not released: nothing has ended. Not addressable either, until the read answers.
+      let refusal: { code?: unknown; message?: string } = {};
+      try {
+        promised.load('text');
+      } catch (error) {
+        refusal = error as { code?: unknown; message?: string };
+      }
+      expect(refusal.code).toBe('InvalidObjectPath');
+      expect(refusal.message).toContain('context.sync()');
+
+      // And the fix the message names is the fix: one sync, then the object works.
+      await context.sync();
+      promised.load('text');
+      await context.sync();
+      expect(promised.text).toBe('find me');
+    });
+    runtime.dispose();
+  });
+
+  test('the released half still says what keeps an object alive', async () => {
+    const runtime = createRuntime({ host: openHost(), save: true });
+    const escaped = await firstParagraph(runtime, { track: false });
+    expect(() => escaped.load('text')).toThrowError(
+      expect.objectContaining({ message: expect.stringContaining('trackedObjects.add') })
+    );
+    runtime.dispose();
+  });
+});
+
 describe('a callback that throws', () => {
   test('rejects with what was thrown, applies nothing, and releases the objects', async () => {
     const spy = spyHost(openHost(docx(p('untouched'))));

--- a/packages/editor-api/src/runtime/errors.ts
+++ b/packages/editor-api/src/runtime/errors.ts
@@ -30,7 +30,14 @@ export type DocxEditorErrorCode =
   | 'PropertyNotLoaded'
   /** A `ClientResult` value was read before the sync that fills it. */
   | 'ValueNotLoaded'
-  /** The object is no longer addressable: its run ended and it was not tracked. */
+  /**
+   * The object cannot be addressed, in either of the two ways that happens.
+   *
+   * NOT YET: an item accessor answers a proxy the read that names it has not answered for, and it
+   * becomes usable at the next `sync()`. NOT ANY MORE: its run ended and nothing tracked it, which
+   * is terminal. One code because from a consumer's side both are "this object cannot be used
+   * here"; the message says which one, because the fix for one is not the fix for the other.
+   */
   | 'InvalidObjectPath'
   /** The object still belongs to a run that has not finished, so it cannot be handed over. */
   | 'ObjectInUse'
@@ -79,8 +86,9 @@ const MESSAGES: Readonly<Record<DocxEditorErrorCode, string>> = Object.freeze({
     'the property has not been loaded. Call load(...) and await context.sync() before reading it.',
   ValueNotLoaded: 'the result has not been filled in yet. Await context.sync() before reading it.',
   InvalidObjectPath:
-    'the object is no longer usable. Objects are released when their run ends unless ' +
-    'context.trackedObjects.add(...) kept them.',
+    'the object cannot be addressed. An object an item accessor answered is usable after the ' +
+    'next await context.sync(); an object whose run has ended is released for good, unless ' +
+    'context.trackedObjects.add(...) kept it.',
   ObjectInUse:
     'the object still belongs to a run that has not finished. Await that run before passing the ' +
     'object to another one.',

--- a/packages/editor-api/src/runtime/object-path.ts
+++ b/packages/editor-api/src/runtime/object-path.ts
@@ -114,6 +114,11 @@ export class ObjectPath {
    * Both refusals are `InvalidObjectPath` on purpose: from a consumer's side "this object was
    * released" and "this object is still a promise" are the same mistake — using an object the
    * runtime cannot address yet or any more — and the `target` says which object it was.
+   *
+   * THE CODE IS ONE THING AND THE MESSAGE IS ANOTHER. The two states have different fixes — a
+   * promise needs a `sync()`, a released object needs to have been tracked — so the sentence in
+   * `errors.ts` names both. It described only the released half for a while, which sent a
+   * consumer holding a perfectly good promised object off to `trackedObjects.add(...)`.
    */
   address(): ObjectAddress {
     const state = this.state;


### PR DESCRIPTION
One code covers two states and the message described only one of them. An object an item accessor answers is pending, not released, so `range.paragraphs.getFirst()` followed by `load()` was told to reach for `trackedObjects.add(...)`, which cannot help. Reported from a first integration against 2.1.x; the behaviour is unchanged and correct, only the sentence was wrong.

The extra sync those accessors need was documented in the runtime's own comments but absent from both the compat manifest's divergences and the Office.js compatibility page, along with the two-phase collection load. Both are recorded now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788691056&installation_model_id=422592&pr_number=240&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F240&signature=9639d3c74c54ccaf9c1b26d89effe5a4116dd3aa4ca3d5b4042b06021896e5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->