### PR TITLE
feat(react): rulers in the packaged frame, and onSave stops drawing a button

### DIFF
--- a/.changeset/sugar-rulers-and-save.md
+++ b/.changeset/sugar-rulers-and-save.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/react': minor
+'@docx-editor.dev/react': patch
 ---
 
 `<DocxEditor>` now shows rulers, and `onSave` no longer draws a button. The horizontal ruler compensates for the navigation shift and the review gutter itself, so it only measures correctly in the row above the scroll container — a slot the packaged host is the only thing that can offer, which meant a host mounting it by hand got ticks that drifted off the page. Pass `rulers={false}` for a bare page. Separately, setting `onSave` also rendered an inline-styled Save button into the title bar that a host could not remove; `onSave` is now just the action, and File -> Save still invokes it.

--- a/.changeset/sugar-rulers-and-save.md
+++ b/.changeset/sugar-rulers-and-save.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': minor
+---
+
+`<DocxEditor>` now shows rulers, and `onSave` no longer draws a button. The horizontal ruler compensates for the navigation shift and the review gutter itself, so it only measures correctly in the row above the scroll container — a slot the packaged host is the only thing that can offer, which meant a host mounting it by hand got ticks that drifted off the page. Pass `rulers={false}` for a bare page. Separately, setting `onSave` also rendered an inline-styled Save button into the title bar that a host could not remove; `onSave` is now just the action, and File -> Save still invokes it.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -636,6 +636,7 @@ export interface DocxEditorProps {
     readonly renderTitleBarLeft?: () => ReactNode;
     // (undocumented)
     readonly renderTitleBarRight?: () => ReactNode;
+    rulers?: boolean;
     t?: (key: string, params?: Record<string, string | number>) => string;
     title?: string;
     // (undocumented)

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -88,6 +88,34 @@ const WORKSPACE_STYLE: CSSProperties = {
   minWidth: 0,
 };
 
+/**
+ * The ruler's row. It sits between the toolbar and the scroll container, which
+ * is the only place the part measures correctly: it applies the navigation
+ * shift and the review gutter itself, so it has to be OUTSIDE the viewport that
+ * already reserves them.
+ *
+ * `min-height` holds the row open before a document is loaded — the ruler draws
+ * nothing without a page, and letting the row collapse made the page stack jump
+ * when the ticks appeared.
+ */
+const RULER_ROW_STYLE: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'center',
+  flex: 'none',
+  minHeight: 34,
+  padding: '6px 0 2px',
+  overflow: 'hidden',
+  backgroundColor: 'var(--doc-bg)',
+};
+
+const VERTICAL_RULER_STYLE: CSSProperties = {
+  position: 'absolute',
+  top: 40,
+  left: 0,
+  zIndex: 10,
+  pointerEvents: 'none',
+};
+
 const TITLE_BAR_STYLE: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
@@ -161,6 +189,7 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
     contextMenu = true,
     menu = true,
     navigation = true,
+    rulers = true,
   } = props;
 
   // Chrome colour mode: 'system' subscribes to the OS setting. Only the chrome
@@ -216,6 +245,14 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
         />
       )}
       <DocxEditorContentControl />
+      {/* The vertical ruler scrolls WITH the document, so unlike its horizontal
+          twin it belongs inside the scroller. aria-hidden: it carries no
+          operable handles, unlike the horizontal one's indent sliders. */}
+      {rulers && chrome ? (
+        <div style={VERTICAL_RULER_STYLE} aria-hidden="true">
+          <DocxEditorVerticalRuler />
+        </div>
+      ) : null}
       {props.children}
     </DocxEditorViewport>
   );
@@ -259,29 +296,23 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
             />
           ) : null}
         </div>
-        {onSave ? (
-          <button
-            type="button"
-            onClick={() => onSave()}
-            style={{
-              font: 'inherit',
-              color: 'inherit',
-              backgroundColor: 'var(--doc-bg-input)',
-              border: '1px solid var(--doc-border-input)',
-              borderRadius: 4,
-              padding: '2px 10px',
-              cursor: 'pointer',
-            }}
-          >
-            {translate('common.save')}
-          </button>
-        ) : null}
         {renderTitleBarRight?.()}
       </div>
       {/* Save is deliberately absent here: the registry marks the `file` group contextual,
           so `defaultChromeGroups()` filters it out and only explicit composition mounts it.
-          The title bar above carries the save control instead. */}
+          File -> Save in the menu bar carries it. */}
       <DocxEditorToolbar t={translate} />
+      {/* The ruler belongs to the packaged frame: every editor this component is
+          modelled on shows one, and a host that had to mount it by hand got the
+          placement wrong — the part compensates for the review gutter itself, so
+          inside the scroll container that reservation is counted twice and the
+          ticks drift off the page they measure. It has to sit ABOVE the
+          scroller, which is a slot only this component can offer. */}
+      {rulers ? (
+        <div style={RULER_ROW_STYLE}>
+          <DocxEditorHorizontalRuler />
+        </div>
+      ) : null}
       {/* Word's font compatibility bar: shown when the document's declared faces render
           in substitutes, dismissible per set of missing families. */}
       <DocxEditorFontNotice t={translate} />

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -139,6 +139,18 @@ export interface DocxEditorProps {
    * `useNavigationPane` / `useDocumentOutline` / `useDocumentSearch`, for a different one.
    */
   navigation?: boolean;
+  /**
+   * Horizontal and vertical rulers, on by default with the packaged chrome.
+   *
+   * They are part of the frame rather than an extra: every editor this
+   * component is modelled on shows them, and the placement is not something a
+   * host can get right from outside. The horizontal ruler applies the
+   * navigation shift and the review gutter itself, so it has to sit ABOVE the
+   * scroll container — mounted inside it, the gutter is counted twice and the
+   * ticks drift off the page. Set `false` for a bare page, or compose
+   * `DocxEditor.HorizontalRuler` / `DocxEditor.VerticalRuler` yourself.
+   */
+  rulers?: boolean;
   /** A document to load: DOCX bytes or an existing handle. */
   document?: DocumentSource;
   /** 'edit' (default) or 'view' (read-only). Applied at mount only — not reactive; remount to change. */

--- a/packages/react/test/sugar-rulers-and-save.test.tsx
+++ b/packages/react/test/sugar-rulers-and-save.test.tsx
@@ -1,0 +1,71 @@
+// Two claims about the packaged `<DocxEditor>` frame.
+//
+// 1. It shows rulers. Every editor this component is modelled on does, and the
+//    placement is not something a host can get right from outside: the
+//    horizontal ruler applies the navigation shift and the review gutter
+//    itself, so mounted inside the scroll container that gutter is counted
+//    twice and the ticks drift off the page they measure. Only this component
+//    can put it in the row above the scroller.
+//
+// 2. `onSave` is an ACTION, not a button. It used to also render an
+//    inline-styled button into the title bar that a host had no way to remove,
+//    so intercepting Cmd+S meant accepting a button you never asked for.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { cleanup, render } from '@testing-library/react';
+import { DocxEditor } from '../src/components/DocxEditor.tsx';
+
+afterEach(cleanup);
+
+const rulerRow = (root: HTMLElement) =>
+  root.querySelector('[class*="ruler"], [data-testid*="ruler"]');
+
+describe('the packaged frame', () => {
+  test('mounts the ruler row by default', () => {
+    const { container } = render(<DocxEditor />);
+    // The ruler paints nothing without a page, so assert the ROW is reserved
+    // rather than the ticks: that is the part a host cannot place itself.
+    const rows = [...container.querySelectorAll('div')].filter(
+      (el) => el.style.minHeight === '34px' && el.style.justifyContent === 'center'
+    );
+    expect(rows.length).toBe(1);
+  });
+
+  test('rulers={false} removes it', () => {
+    const { container } = render(<DocxEditor rulers={false} />);
+    const rows = [...container.querySelectorAll('div')].filter(
+      (el) => el.style.minHeight === '34px' && el.style.justifyContent === 'center'
+    );
+    expect(rows.length).toBe(0);
+  });
+
+  test('chrome={false} has no ruler row either', () => {
+    const { container } = render(<DocxEditor chrome={false} />);
+    expect(rulerRow(container)).toBeNull();
+  });
+
+  test('onSave does not put a button in the title bar', () => {
+    const { container } = render(<DocxEditor onSave={() => {}} />);
+    const buttons = [...container.querySelectorAll('button')];
+    const save = buttons.filter((b) => (b.textContent ?? '').trim().toLowerCase() === 'save');
+    expect(save).toEqual([]);
+  });
+
+  test('onSave still reaches the menu, so File -> Save works', () => {
+    // The handler is threaded into DocxEditorMenu; the menu bar renders whether
+    // or not a save handler exists, so assert the menu is there and the button
+    // is not — the regression was the button, not the wiring.
+    const { container } = render(<DocxEditor onSave={() => {}} />);
+    expect(container.querySelector('.docx-menubar')).not.toBeNull();
+    expect(
+      [...container.querySelectorAll('button')].some(
+        (b) => (b.textContent ?? '').trim().toLowerCase() === 'save'
+      )
+    ).toBe(false);
+  });
+});

--- a/scripts/check-editor-contract.mjs
+++ b/scripts/check-editor-contract.mjs
@@ -29,7 +29,7 @@ const REACT_PROPS_NOT_YET_IN_VUE = new Set([
   // M6V.1 chrome props, React-only until 10V.1 ports the chrome to Vue.
   //
   // These are NOT idiomatic-framework divergences like the three above — they are a
-  // deliberate, time-boxed gap with a named closing task. 10V.1 MUST remove all five
+  // deliberate, time-boxed gap with a named closing task. 10V.1 MUST remove all six
   // entries; a divergence with no closing task is how a gate quietly stops meaning
   // anything.
   't',
@@ -37,6 +37,11 @@ const REACT_PROPS_NOT_YET_IN_VUE = new Set([
   'title',
   'onTitleChange',
   'onSave',
+  // Same gap, same closing task: the ruler chrome is part of the React frame,
+  // and Vue has no ruler slot yet, so there is no toggle for it to expose. The
+  // ENGINE half is shared — page setup, zoom and the margin/indent commands all
+  // come from core — so this is the chrome, not the capability.
+  'rulers',
   // The link popover is part of the provider/hooks layer, which landed React-first: it is
   // a context-backed hook plus a compound over it, and its Vue twin is the composable form
   // that lands with the rest of that layer. The ENGINE half is already shared — typed

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -26,7 +26,8 @@
       "menu": "The packaged menu bar \u2014 File \u00b7 Format \u00b7 Insert \u00b7 Help \u2014 part of the React-first provider/hooks layer. The ENGINE half is already shared: `CHROME_MENUS` is the core registry both adapters read, every actionable row is a `ChromeSlotId` whose enabled state comes from the same `toolbarCommandState`, and the styles live in the core stylesheet \u2014 so this defers the markup, not the capability.",
       "onOpen": "Open handler for the menu bar's File \u203a Open row. Deferred to the Vue menu bar with `menu`; the engine half (`Editor.load`) is already shared.",
       "contextMenu": "The packaged right-click menu, part of the React-first provider/hooks layer: a compound whose rows ARE the menu bar's rows, so its Vue twin lands with that layer. The ENGINE half is already shared \u2014 `selectAll`, `copy`, `cut` and `paste` are core commands, every row's enabled state comes from the same `Editor.can`, and the surface's pointer controller already ignores non-primary buttons so a right-click reaches a menu with the selection intact \u2014 so this defers the panel, not the capability.",
-      "children": "React renders viewport-extras children inside the sugar viewport (the pro review pane mounts through it). Vue reaches the same via a default slot when its viewport slot lands with the Vue chrome lane."
+      "children": "React renders viewport-extras children inside the sugar viewport (the pro review pane mounts through it). Vue reaches the same via a default slot when its viewport slot lands with the Vue chrome lane.",
+      "rulers": "React's packaged frame mounts the rulers and takes a boolean to drop them. The Vue host has no ruler slot yet, so there is nothing to toggle; the prop lands there with the ruler chrome."
     },
     "vueExclusive": {}
   },


### PR DESCRIPTION
Two things a host cannot fix from outside.

## Rulers are part of the frame

`<DocxEditor>` rendered no rulers, so a host had to mount `DocxEditor.HorizontalRuler` itself — and the placement is not reachable from there. The part applies the navigation shift and the review gutter **itself**, so it only measures correctly in the row **above** the scroll container. Children of the packaged host land *inside* the viewport, which already reserves that gutter in its `padding-right`, so it gets counted twice: the row overflows by the gutter width and the ticks sit ~49px left of the page they measure. Measured on docx-editor.dev before the fix:

```
ruler inner  l:76   r:892   w:816
page         l:234  r:1050  w:816
```

After, with the site's workaround deleted, on both the landing demo and /editor:

```
ruler  l:234 r:1050 w:816
page   l:234 r:1050 w:816     one ruler, exactly on the page
```

`rulers={false}` opts out; `chrome={false}` has none either way.

## `onSave` drew a button

Setting `onSave` also rendered an inline-styled Save button into the title bar. A host that only wanted to intercept Cmd+S or File → Save got a button it never asked for and had no way to remove — the site worked around it by routing save through `menu={{ onSave }}` instead, which reaches the same row without the button. `onSave` is now the action alone.

## Notes

Released as a **patch** by owner's call. `rulers` is an additive prop, and the Save button disappearing is visible to anyone who was relying on it, so flagging that the version does not signal either — the changeset summary does.

`rulers` is declared in both parity gates (`parity.contract.json` and `check-editor-contract.mjs`) as a staged React-only divergence with the same closing task as the other chrome props; Vue has no ruler slot yet, so there is nothing there to toggle.

719 react + pro tests pass. `sugar-rulers-and-save.test.tsx` covers the row being present by default, absent under `rulers={false}` and `chrome={false}`, and no Save button when `onSave` is set.