### PR TITLE
docs: align lossless round-trip claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.docx-editor.dev/docs"><img src="https://img.shields.io/badge/Docs-3B5BDB?style=flat-square&logo=readthedocs&logoColor=white" alt="Documentation" /></a>
 </p>
 
-Open-source WYSIWYG `.docx` editor for React. Word-faithful pagination, tracked changes, comments — and **lossless**: everything you do not edit comes back byte for byte, including the parts the editor does not understand. **[Live demo](https://docx-editor.dev/editor)** | **[Documentation](https://www.docx-editor.dev/docs)**
+Open-source WYSIWYG `.docx` editor for React. Word-faithful pagination, tracked changes, comments — and **lossless round-trip**: untouched content and unsupported OOXML survive editing and save. **[Live demo](https://docx-editor.dev/editor)** | **[Documentation](https://www.docx-editor.dev/docs)**
 
 ## Quick Start
 
@@ -30,9 +30,9 @@ See the [React quick start](#react) below.
 
 ## Nothing is lost
 
-Open a document, edit one word, save it. Everything you did not touch comes back byte for byte: custom XML, embedded fonts, macros, media, Smart Tags, and markup from add-ins the editor has never heard of.
+Open a document, edit one word, save it. Everything you did not touch survives: custom XML, embedded fonts, macros, media, Smart Tags, and markup from add-ins the editor has never heard of.
 
-The mechanism is the canonical tree. Parsing types a node only where layout needs it and keeps everything else generic, holding the original element verbatim. On save, typed parts re-serialize and the rest is repacked from the source file. An element the parser cannot type — unknown, or known but in an invalid position — becomes a generic node instead of being dropped, so unrecognized markup never blocks editing.
+The mechanism is the canonical tree. Parsing types a node only where layout needs it and keeps everything else generic. On save, the tree serializes with structural fidelity and package payloads such as media, fonts, and VBA binaries pass through untouched. An element the parser cannot type — unknown, or known but in an invalid position — becomes a generic node instead of being dropped, so unrecognized markup never blocks editing.
 
 CI checks this on a corpus of real documents with two oracles: a canonical fingerprint over the tree, and a semantic digest compared across save and reopen. A change that drops content fails the build.
 

--- a/docs/site/content/core/architecture.mdx
+++ b/docs/site/content/core/architecture.mdx
@@ -45,9 +45,9 @@ Selection maps through paragraph identity and offsets, never through DOM travers
 
 ## Saving
 
-Modeled parts are re-emitted normalized from the tree. Everything else (custom XML, embedded fonts, media, extensions the engine has never seen) is repacked from the original file untouched.
+Every parsed XML part is re-emitted from the canonical tree with structural fidelity, including custom XML and unknown extensions. Package payloads such as embedded fonts, media, and VBA binaries pass through untouched.
 
-That is what "structural fidelity" means here: the editor rewrites what it understands and preserves the rest byte-for-byte. Two oracles gate it in CI: a canonical fingerprint over the tree, and a save-and-reopen semantic digest.
+That is what "structural fidelity" means here: unsupported XML and package payloads survive editing and save without loss. Two oracles gate it in CI: a canonical fingerprint over the tree, and a save-and-reopen semantic digest.
 
 ## Adapters
 

--- a/docs/site/content/core/index.mdx
+++ b/docs/site/content/core/index.mdx
@@ -70,7 +70,7 @@ bytes → bounded OPC/XML read → canonical document tree → layout → painte
 
 The painted pages _are_ the editable surface. There is no shadow document model to keep in sync with what you see.
 
-Fidelity is structural. Parts the engine models are re-emitted normalized; parts it does not model are carried through byte-for-byte. Content it cannot type (an unknown element, or a known one in an invalid position) becomes a generic node rather than being dropped, so unknown content never blocks editing and never disappears on save.
+Fidelity is structural. The canonical tree preserves XML content and package payloads pass through untouched. Content the engine cannot type (an unknown element, or a known one in an invalid position) becomes a generic node rather than being dropped, so unknown content never blocks editing and never disappears on save.
 
 ## Untrusted input
 

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -7,7 +7,7 @@ seoTitle: 'Content controls (SDTs)'
 
 Word content controls (`w:sdt`, Structured Document Tags) are labeled, bounded regions of a document. A control carries a stable `tag`, `title`, and `id`. That stability makes them the natural anchor for templates and programmatic filling: design the template in Word, tag the fillable regions, then fill them by tag from code.
 
-The editor parses controls into the canonical tree, keeps them editable, renders their boundary, and round-trips them losslessly on save, including properties it does not model, such as `w:dataBinding` and `w15:repeatingSection`.
+The editor parses controls into the canonical tree, keeps them editable, renders their boundary, and round-trips them with structural fidelity. Properties it does not model, such as `w:dataBinding` and `w15:repeatingSection`, remain as generic nodes and survive editing and save.
 
 <Callout>
   Content controls are addressed by `tag`, `title`, or `id`. They are not `{{ mustache }}` template

--- a/docs/site/content/guides/dark-mode.mdx
+++ b/docs/site/content/guides/dark-mode.mdx
@@ -45,7 +45,7 @@ Dark mode has two layers:
 
 It is a display transform only. Dark mode never changes the document itself:
 
-- The saved DOCX is byte-for-byte unaffected; authored colors are preserved as written.
+- Authored document colors are preserved; the display transform is never written into the DOCX.
 - Printing always uses a white page with black text, regardless of `colorMode`.
 - Embedded images, logos, and screenshots are not inverted; they render as authored.
 

--- a/docs/site/content/guides/headers-footers.mdx
+++ b/docs/site/content/guides/headers-footers.mdx
@@ -38,12 +38,11 @@ Documents using any of these render and round-trip correctly; editing a header e
 
 ## Watermarks
 
-Word stores watermarks as VML or drawings in header parts. The editor does not currently render or
-edit them as watermarks. `Editor.getWatermark()` is a stub, and no public interactive or headless
-API authors them.
+Watermarks live in header parts (that is how Word models them). Their VML or
+DrawingML markup and image payloads are preserved through editing and save.
 
-The save pipeline can preserve existing structural markup in a header part, but watermark support
-remains planned. Do not rely on the editor to display, modify or create text or picture watermarks.
+Dedicated watermark rendering, insertion, editing, and headless authoring are not
+supported yet. Existing watermarks remain inert rather than being dropped.
 
 ## Next steps
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -11,9 +11,9 @@ DrawingML pictures (`w:drawing` with `pic:pic`) lay out, paint, and round-trip t
 
 | Format                                      | Insert (React)                       | Layout & paint                                                     | Round-trip                                |
 | ------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------ | ----------------------------------------- |
-| PNG, JPEG, GIF                              | Yes, `normalizeImageBytes` preflight | Full decode at authored `wp:extent`                                | Byte-identical media unless replaced      |
-| BMP, WebP                                   | No insert                            | Full decode at authored `wp:extent`                                | Byte-identical media                      |
-| SVG                                         | No insert                            | Painted at authored `wp:extent`                                    | Byte-identical media                      |
+| PNG, JPEG, GIF                              | Yes, `normalizeImageBytes` preflight | Full decode at authored `wp:extent`                                | Original media preserved unless replaced  |
+| BMP, WebP                                   | No insert                            | Full decode at authored `wp:extent`                                | Original media preserved                  |
+| SVG                                         | No insert                            | Painted at authored `wp:extent`                                    | Original media preserved                  |
 | TIFF, EMF, WMF                              | No insert                            | Rasterized when conversion succeeds; labeled placeholder otherwise | Preserved; no zero-click fetch            |
 | External `r:link` / `TargetMode="External"` | No auto-load                         | Placeholder + preserved rel                                        | Preserved; explicit user gesture to embed |
 
@@ -23,9 +23,9 @@ BMP and WebP decode in the browser and paint like PNG or JPEG. BMP support inclu
 bitmaps and the 12-byte `BITMAPCOREHEADER`. WebP support includes lossy, lossless, and extended
 containers.
 
-TIFF, EMF, and WMF paint only when conversion to a validated raster succeeds. The original bytes
-stay in the package untouched, so saving round-trips them unchanged. When conversion is
-unavailable, declined, or fails, the image keeps its extent and shows a labeled placeholder.
+TIFF, EMF, and WMF paint when conversion to a validated raster succeeds. The original media stays
+unchanged in the package through save. When conversion is unavailable, declined, or fails, the
+image keeps its extent and shows a labeled placeholder.
 
 SVG is painted through an `<img>`, which puts the browser in secure static mode: scripts in the
 file never run and external references in it are never fetched. Its intrinsic size is read from

--- a/docs/site/content/index.mdx
+++ b/docs/site/content/index.mdx
@@ -8,7 +8,7 @@ seoTitle: 'DOCX Editor for React'
 
 `docx-editor` is an open-source WYSIWYG DOCX editor for React. It parses OOXML in the browser, paints real paginated pages, and serializes the current document back to `.docx`. You do not need an upload service or a conversion backend for normal browser editing.
 
-Saving is lossless. Everything you do not edit comes back byte for byte, including the parts the editor does not understand. Opening a document here cannot quietly destroy it.
+Saving has a lossless semantic round-trip: untouched content, unsupported OOXML, and package payloads survive editing and save. Opening a document here cannot quietly destroy it.
 
 <Cards>
   <Card title="Get it running" href="/docs/2.x/quickstart">
@@ -72,15 +72,15 @@ Feature-by-feature coverage and known limits: [Word fidelity](/docs/2.x/word-fid
 
 ## Lossless round-trip
 
-Open a document, edit one word, save it. Everything you did not touch comes back byte for
-byte: custom XML, embedded fonts, macros, media, VBA, Smart Tags, and markup from add-ins the
-editor has never heard of.
+Open a document, edit one word, save it. Everything you did not touch survives: custom XML,
+embedded fonts, macros, media, VBA, Smart Tags, and markup from add-ins the editor has never
+heard of.
 
 The mechanism is the canonical tree. Parsing types a node only where layout needs it and keeps
-everything else generic, holding the original element verbatim. On save, typed parts
-re-serialize and the rest is repacked from the source file. An element the parser cannot type
-(unknown, or known but in an invalid position) becomes a generic node instead of being dropped,
-so unrecognized markup never blocks editing.
+everything else generic. On save, the tree serializes with structural fidelity and package
+payloads such as media, fonts, and VBA binaries pass through untouched. An element the parser
+cannot type (unknown, or known but in an invalid position) becomes a generic node instead of
+being dropped, so unrecognized markup never blocks editing.
 
 CI checks this on a corpus of real documents with two oracles: a canonical fingerprint over the
 tree, and a semantic digest compared across save and reopen. A change that drops content fails

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Word fidelity'
-description: 'Word feature support matrix for the DOCX editor: what renders, what edits, what round-trips unchanged, plus the security model and API stability policy.'
+description: 'Word feature support matrix for the DOCX editor: what renders, what edits, what round-trips with structural fidelity, plus the security model and API stability policy.'
 category: 'Getting Started'
 seoTitle: 'Word feature support and fidelity'
 ---
@@ -10,7 +10,7 @@ seoTitle: 'Word feature support and fidelity'
 ## Overview
 
 - **Browser editor use is client-side.** Parsing, rendering, editing, and serialization run in the browser for normal `<DocxEditor>` usage. The server-side editing API runs wherever you host it.
-- **`.docx` in, `.docx` out.** The editor reads OOXML and writes OOXML. Parts of the file it does not edit are carried over from the original archive unchanged.
+- **`.docx` in, `.docx` out.** The editor reads OOXML and writes OOXML. Untouched content, unsupported markup, and package payloads survive editing and save.
 - **Apache 2.0**, every published package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`, which are under the EigenPal Pro Evaluation License 1.0 (evaluate freely; production use needs a commercial agreement). **SemVer**, with the public API tracked by generated snapshots in CI.
 - **Commercial support**: [docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com).
 
@@ -20,16 +20,16 @@ Every feature is tracked on three axes:
 
 - **Editing**: can a user (or code driving the editor) change it in the editor?
 - **Rendering**: does it display the way Microsoft Word renders it?
-- **Round-trip**: does it survive open, then save, unchanged?
+- **Round-trip**: does it survive open, edit, save, and reopen without loss?
 
-A construct the editor doesn't model is preserved byte-for-byte and
-written back on save; that's the "Preserved" status below.
+A construct the editor doesn't model is retained as inert content and written
+back with structural fidelity; that's the "Preserved" status below.
 
 <FeatureSummary />
 
 **Legend**: Full = works like Word · Partial = works with noted limits ·
-Render only = displays correctly, not editable · Preserved = round-trips
-losslessly without rendering · Planned = on the roadmap · No = not supported.
+Render only = displays correctly, not editable · Preserved = carried inertly
+through editing and save · Planned = on the roadmap · No = not supported.
 
 ### Text & formatting
 
@@ -87,14 +87,15 @@ next to Word.
 
 ## Drawings, shapes and legacy images
 
-These rows in the "Images & drawings" matrix are not Full yet. Original bytes
-round-trip on save, so editing the document does not lose them.
+These rows in the "Images & drawings" matrix are not Full yet, but their
+authored markup and payloads survive editing and save.
 
-- **Text boxes**: render and round-trip; inner text is editable. Move and
-  resize handles for the box are not built yet.
-- **Drawing shapes**: round-trip but are not painted yet. Custom geometry is
-  reduced to its bounding rectangle on save.
-- **WMF / EMF**: round-trip without loss; not rendered yet.
+- **Text boxes**: story content renders read-only inside the authored extent;
+  editing, linked chains, autofit, and rotation are not built yet.
+- **Drawing shapes**: unsupported geometry reserves its extent with a
+  placeholder; the original markup is preserved.
+- **WMF / EMF**: rasterized where supported, otherwise shown as a placeholder;
+  the original media bytes are preserved.
 
 ## Round-trip behavior
 
@@ -102,14 +103,14 @@ A `.docx` file is a ZIP of XML parts, and Word writes a lot of XML the
 editor has no reason to model: bookmarks, custom XML parts, mail-merge fields,
 compatibility settings, VBA projects.
 
-This editor's pipeline is parse → document model → edit → serialize. On
-save it rewrites only the parts it changed (the body, plus headers, footers,
-comments and notes when touched) and repacks every other part of the
-original archive as-is: `styles.xml`, themes, the font table, settings,
-media, relationships, custom XML. Concretely:
+This editor's pipeline is parse → document model → edit → serialize. On save,
+the canonical tree preserves the structure and semantics of every parsed XML
+part, while package payloads pass through untouched. Concretely:
 
-- Unmodeled XML elements and attributes are kept and re-emitted in place. (One exception: legacy run-level VML drawn shapes other than watermarks, namely `v:rect`, `v:line`, and non-text `v:shape`, are not yet modeled or preserved.)
-- Whole parts the editor never touches (custom XML, VBA projects, embedded fonts, OLE objects) are copied through the ZIP untouched.
+- Unmodeled XML elements and attributes are kept as generic nodes and
+  re-emitted in place, including legacy VML, custom XML, and add-in markup.
+- Non-XML payloads such as media, VBA projects, embedded fonts, and OLE
+  binaries are copied through the ZIP untouched.
 - References stay intact: relationship IDs, bookmark names, field codes, style IDs and numbering definitions are not renamed or renumbered.
 - Output is canonical OOXML, not merely valid: tracked changes are real `w:ins`/`w:del` revisions Word's review pane understands, theme colors stay theme references, numbering keeps its definitions.
 
@@ -119,10 +120,9 @@ digest; serializer tests assert specific constructs (revisions, fields,
 hyperlinks, content controls) survive; and browser end-to-end tests drive the
 painted editor.
 
-What this does not mean: bit-identical files. The ZIP container is
-rebuilt and XML is re-serialized, so whitespace and part ordering can differ.
-The goal is semantic preservation: content you did not edit should not be lost or reinterpreted. A document that
-breaks this behavior is a bug; attach it to a
+The preservation contract is semantic and structural: content you did not edit
+must not be lost or reinterpreted. A document that breaks this behavior is a
+bug; attach it to a
 [GitHub issue](https://github.com/eigenpal/docx-editor/issues/new/choose).
 
 ## Security

--- a/docs/site/data/word-features.test.ts
+++ b/docs/site/data/word-features.test.ts
@@ -40,7 +40,12 @@ describe('word-features — images lane honesty', () => {
   });
 
   test('unsupported non-picture payloads are preserved inertly, not claimed as supported', () => {
-    for (const id of ['images.charts', 'images.smartart', 'images.shapes', 'images.textboxes'] as const) {
+    for (const id of [
+      'images.charts',
+      'images.smartart',
+      'images.shapes',
+      'images.textboxes',
+    ] as const) {
       const row = feature(id);
       expect(row.editing).toBe('none');
       expect(row.rendering).toBe('partial');
@@ -61,5 +66,28 @@ describe('word-features — images lane honesty', () => {
     expect(row.rendering).toBe('full');
     expect(row.editing).toBe('partial');
     expect(row.roundTrip).toBe('full');
+  });
+});
+
+describe('word-features — lossless round-trip contract', () => {
+  test('every tracked construct is full or preserved on round-trip', () => {
+    for (const row of wordFeatures) {
+      expect(['full', 'preserved']).toContain(row.roundTrip);
+    }
+  });
+
+  test('inert constructs proven by the focused preservation fixture stay marked preserved', () => {
+    for (const id of [
+      'lists.picture-bullets',
+      'images.effects',
+      'images.ink',
+      'layout.background',
+      'fields.citations',
+      'fields.legacy-forms',
+      'structure.ole',
+    ]) {
+      expect(feature(id).roundTrip).toBe('preserved');
+    }
+    expect(feature('images.adjustments').roundTrip).toBe('full');
   });
 });

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -10,7 +10,7 @@
  * Status axes:
  * - editing:   can the user (or code driving the editor) change it in the editor?
  * - rendering: does it display like Microsoft Word renders it?
- * - roundTrip: does it survive open -> save unchanged?
+ * - roundTrip: does it survive open -> edit -> save -> reopen without loss?
  *
  * Honesty rule: when in doubt, downgrade. A "partial" that turns out to be
  * full delights; a "full" that turns out to be partial burns trust.
@@ -20,7 +20,7 @@ export type FeatureStatus =
   | 'full'
   | 'partial'
   | 'render-only'
-  | 'preserved' // round-trips losslessly, not editable or rendered
+  | 'preserved' // round-trips losslessly as inert content; editing/rendering may be absent
   | 'planned'
   | 'none';
 
@@ -315,9 +315,10 @@ export const wordFeatures: WordFeature[] = [
     category: 'lists',
     editing: 'none',
     rendering: 'none',
-    roundTrip: 'none',
+    roundTrip: 'preserved',
     tier: 'community',
-    notes: 'Not parsed; an image bullet is dropped on save and falls back to no bullet.',
+    notes:
+      'Not rendered or editable; the numPicBullet definition and its authored markup are preserved on save.',
   },
 
   // --- Tables -------------------------------------------------------------
@@ -545,10 +546,10 @@ export const wordFeatures: WordFeature[] = [
     category: 'images',
     editing: 'none',
     rendering: 'partial',
-    roundTrip: 'partial',
+    roundTrip: 'full',
     tier: 'community',
     notes:
-      'Transparency (opacity) renders and round-trips; brightness, contrast, recolor and artistic effects are dropped.',
+      'Transparency, brightness, contrast and grayscale project where supported; authored adjustment markup is preserved on save.',
   },
   {
     id: 'images.effects',
@@ -556,9 +557,10 @@ export const wordFeatures: WordFeature[] = [
     category: 'images',
     editing: 'none',
     rendering: 'none',
-    roundTrip: 'partial',
+    roundTrip: 'preserved',
     tier: 'community',
-    notes: 'Not painted; effectExtent spacing round-trips, the effect itself may not.',
+    notes:
+      'Not painted or editable; authored effect markup and effectExtent spacing are preserved.',
   },
   {
     id: 'images.charts',
@@ -589,9 +591,9 @@ export const wordFeatures: WordFeature[] = [
     category: 'images',
     editing: 'none',
     rendering: 'none',
-    roundTrip: 'none',
+    roundTrip: 'preserved',
     tier: 'community',
-    notes: 'Not modeled; dropped on save.',
+    notes: 'Not rendered or editable; ink markup is preserved generically on save.',
   },
 
   // --- Page layout, headers & footers --------------------------------------
@@ -710,9 +712,9 @@ export const wordFeatures: WordFeature[] = [
     category: 'layout',
     editing: 'none',
     rendering: 'none',
-    roundTrip: 'none',
+    roundTrip: 'preserved',
     tier: 'community',
-    notes: 'Parsed but not serialized; dropped on save and not rendered.',
+    notes: 'Not rendered or editable; authored background markup and relationships are preserved.',
   },
   {
     id: 'layout.page-num-format',
@@ -848,10 +850,10 @@ export const wordFeatures: WordFeature[] = [
     category: 'fields',
     editing: 'none',
     rendering: 'none',
-    roundTrip: 'none',
+    roundTrip: 'preserved',
     tier: 'community',
     notes:
-      'CITATION/BIBLIOGRAPHY fields and the b:Sources store are not parsed; bibliography data is dropped (any cached result text survives as plain runs).',
+      'CITATION/BIBLIOGRAPHY fields remain inert and the b:Sources store is preserved; citation evaluation and editing are not supported.',
   },
   {
     id: 'fields.legacy-forms',
@@ -859,10 +861,10 @@ export const wordFeatures: WordFeature[] = [
     category: 'fields',
     editing: 'none',
     rendering: 'partial',
-    roundTrip: 'partial',
+    roundTrip: 'preserved',
     tier: 'community',
     notes:
-      'The field result shows as static text; w:ffData (checkbox state, constraints) is dropped and the control is not interactive.',
+      'The field result shows as static text; w:ffData, including checkbox state and constraints, is preserved but the control is not interactive.',
   },
 
   // --- Document structure & content controls ---------------------------------
@@ -910,7 +912,8 @@ export const wordFeatures: WordFeature[] = [
     rendering: 'none',
     roundTrip: 'preserved',
     tier: 'community',
-    notes: 'customXml parts and w:dataBinding round-trip byte-stable; no binding evaluation.',
+    notes:
+      'customXml parts and w:dataBinding round-trip with structural fidelity; no binding evaluation.',
   },
   {
     id: 'structure.macros',
@@ -929,9 +932,10 @@ export const wordFeatures: WordFeature[] = [
     category: 'structure',
     editing: 'none',
     rendering: 'none',
-    roundTrip: 'none',
+    roundTrip: 'preserved',
     tier: 'community',
-    notes: 'Embedded objects are dropped; only a fallback preview image, when present, survives.',
+    notes:
+      'Never executed or rendered; OLE markup and embedded binary payloads are preserved through editing and save.',
   },
   {
     id: 'structure.protection',

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -67,11 +67,10 @@ of unknown extensions still opens, edits, and saves.
 
 ## Fidelity
 
-Everything you do not edit comes back byte for byte, including parts the engine does not model:
-custom XML, embedded fonts, macros, media, unknown extensions. On save, modeled parts are
-re-emitted normalized; everything else is repacked from the original file untouched. Two
-oracles gate this in CI: a canonical fingerprint over the tree, and a save-and-reopen semantic
-digest.
+Untouched content, unsupported OOXML, and package payloads survive editing and save. The
+canonical tree preserves document structure while embedded fonts, macros, media, and other
+payloads pass through untouched. Two oracles gate this in CI: a canonical fingerprint over the
+tree, and a save-and-reopen semantic digest.
 
 ## Untrusted input
 

--- a/packages/core/src/store/__tests__/roundtrip-feature-preservation.test.ts
+++ b/packages/core/src/store/__tests__/roundtrip-feature-preservation.test.ts
@@ -1,0 +1,222 @@
+// Public "lossless round-trip" claims need feature-specific teeth.
+//
+// The broad real-document census catches a dropped element class, but it does not identify
+// constructs that older support-matrix rows used to call partial or unsupported. This fixture
+// keeps those constructs beside an ordinary editable paragraph and proves that an unrelated edit
+// survives save/reopen without changing their normalized structure or binary payloads.
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import {
+  readOoxmlPackage,
+  withPart,
+  writeOoxmlPackage,
+  type OoxmlPackage,
+} from '../package/ooxml-package.ts';
+import {
+  canonicalOoxmlFingerprint,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../package/ooxml-tree.ts';
+import { TreeDocumentStore } from '../store/tree-store.ts';
+import { paragraphTextOf } from '../store/tree-ops.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const O = 'urn:schemas-microsoft-com:office:office';
+const V = 'urn:schemas-microsoft-com:vml';
+const B = 'http://schemas.openxmlformats.org/officeDocument/2006/bibliography';
+
+const OFFICE_DOCUMENT = `${R}/officeDocument`;
+const NUMBERING = `${R}/numbering`;
+const IMAGE = `${R}/image`;
+const OLE_OBJECT = `${R}/oleObject`;
+
+const OLE_BYTES = new Uint8Array([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1, 1, 2, 3, 4]);
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function documentXml(): string {
+  return (
+    `<w:document xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" xmlns:a="${A}"` +
+    ` xmlns:pic="${PIC}" xmlns:o="${O}" xmlns:v="${V}">` +
+    '<w:background w:color="DDEEFF"><w:backgroundImage r:id="rIdImage"/></w:background>' +
+    '<w:body>' +
+    '<w:p><w:r><w:t>editable</w:t></w:r></w:p>' +
+    '<w:p><w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    '<wp:extent cx="152400" cy="152400"/><wp:docPr id="1" name="adjusted"/>' +
+    '<wp:cNvGraphicFramePr/><a:graphic>' +
+    `<a:graphicData uri="${PIC}"><pic:pic>` +
+    '<pic:nvPicPr><pic:cNvPr id="1" name="adjusted"/><pic:cNvPicPr/></pic:nvPicPr>' +
+    '<pic:blipFill><a:blip r:embed="rIdImage">' +
+    '<a:lum bright="70000" contrast="20000"/><a:grayscl/>' +
+    '</a:blip><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+    '<pic:spPr><a:xfrm><a:ext cx="152400" cy="152400"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>' +
+    '<a:effectLst><a:outerShdw blurRad="40000" dist="20000" dir="5400000">' +
+    '<a:srgbClr val="000000"><a:alpha val="50000"/></a:srgbClr>' +
+    '</a:outerShdw><a:glow rad="30000"><a:srgbClr val="FF0000"/></a:glow></a:effectLst>' +
+    '</pic:spPr></pic:pic></a:graphicData></a:graphic>' +
+    '</wp:inline></w:drawing></w:r></w:p>' +
+    '<w:p><w:r><w:ink w:id="ink-1"/></w:r></w:p>' +
+    '<w:p><w:r><w:pict><v:rect id="rect-1"/><v:line id="line-1"/>' +
+    '<v:shape id="shape-1" type="#custom"/></w:pict></w:r></w:p>' +
+    '<w:p><w:r><w:object o:progId="Word.Document.8" r:id="rIdOle">' +
+    '<o:OLEObject Type="Embed" ProgID="Word.Document.8" r:id="rIdOle"/>' +
+    '</w:object></w:r></w:p>' +
+    '<w:p><w:r><w:fldChar w:fldCharType="begin"><w:ffData>' +
+    '<w:name w:val="LegacyField"/><w:checkBox><w:checked w:val="1"/></w:checkBox>' +
+    '</w:ffData></w:fldChar><w:instrText> FORMCHECKBOX </w:instrText>' +
+    '<w:fldChar w:fldCharType="separate"/><w:t>☒</w:t>' +
+    '<w:fldChar w:fldCharType="end"/></w:r></w:p>' +
+    '<w:p><w:fldSimple w:instr=" CITATION source-1 "><w:r><w:t>[1]</w:t></w:r></w:fldSimple></w:p>' +
+    '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="7"/></w:numPr></w:pPr>' +
+    '<w:r><w:t>picture bullet</w:t></w:r></w:p>' +
+    '</w:body></w:document>'
+  );
+}
+
+function buildFixture(): Uint8Array {
+  const contentTypes =
+    `<Types xmlns="${CT}">` +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Default Extension="png" ContentType="image/png"/>' +
+    '<Default Extension="bin" ContentType="application/vnd.openxmlformats-officedocument.oleObject"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>' +
+    '</Types>';
+  const rootRels =
+    `<Relationships xmlns="${REL}">` +
+    `<Relationship Id="rId1" Type="${OFFICE_DOCUMENT}" Target="word/document.xml"/>` +
+    '</Relationships>';
+  const documentRels =
+    `<Relationships xmlns="${REL}">` +
+    `<Relationship Id="rIdNumbering" Type="${NUMBERING}" Target="numbering.xml"/>` +
+    `<Relationship Id="rIdImage" Type="${IMAGE}" Target="media/image1.png"/>` +
+    `<Relationship Id="rIdOle" Type="${OLE_OBJECT}" Target="embeddings/oleObject1.bin"/>` +
+    '</Relationships>';
+  const numbering =
+    `<w:numbering xmlns:w="${W}">` +
+    '<w:numPicBullet w:numPicBulletId="1"><w:pict><w:shape w:id="bullet-shape"/></w:pict></w:numPicBullet>' +
+    '<w:abstractNum w:abstractNumId="4"><w:lvl w:ilvl="0"><w:start w:val="1"/>' +
+    '<w:numFmt w:val="bullet"/><w:lvlText w:val="•"/><w:lvlPicBulletId w:val="1"/>' +
+    '</w:lvl></w:abstractNum><w:num w:numId="7"><w:abstractNumId w:val="4"/></w:num>' +
+    '</w:numbering>';
+  const bibliography =
+    `<b:Sources xmlns:b="${B}" SelectedStyle="APA.XSL" StyleName="APA">` +
+    '<b:Source><b:Tag>source-1</b:Tag><b:SourceType>Book</b:SourceType>' +
+    '<b:Title>Preserved title</b:Title></b:Source></b:Sources>';
+
+  return zipSync({
+    '[Content_Types].xml': strToU8(contentTypes),
+    '_rels/.rels': strToU8(rootRels),
+    'word/document.xml': strToU8(documentXml()),
+    'word/_rels/document.xml.rels': strToU8(documentRels),
+    'word/numbering.xml': strToU8(numbering),
+    'word/media/image1.png': PNG_BYTES,
+    'word/embeddings/oleObject1.bin': OLE_BYTES,
+    'customXml/item1.xml': strToU8(bibliography),
+  });
+}
+
+function* walk(node: OoxmlNode): Generator<OoxmlNode> {
+  yield node;
+  if (node.kind === 'textValue') return;
+  for (const child of node.children) yield* walk(child);
+}
+
+function nodesNamed(pkg: OoxmlPackage, localName: string): OoxmlNode[] {
+  const nodes: OoxmlNode[] = [];
+  for (const part of pkg.parts.values()) {
+    for (const node of walk(part.root)) {
+      if (node.kind !== 'textValue' && node.localName === localName) nodes.push(node);
+    }
+  }
+  return nodes;
+}
+
+function featureFingerprints(pkg: OoxmlPackage, localName: string): string[] {
+  return nodesNamed(pkg, localName).map(canonicalOoxmlFingerprint).sort();
+}
+
+function mainPart(pkg: OoxmlPackage): OoxmlPart {
+  const part = pkg.parts.get(pkg.mainDocumentPart);
+  if (!part) throw new Error('missing main document part');
+  return part;
+}
+
+function editedRoundTrip(): {
+  before: OoxmlPackage;
+  after: OoxmlPackage;
+  editedText: string | null;
+} {
+  const opened = readOoxmlPackage(buildFixture());
+  if (!opened.ok) throw new Error(`open failed: ${opened.reason}`);
+  const before = opened.package;
+  const store = new TreeDocumentStore(mainPart(before));
+  const paragraph = [...walk(store.part.root)].find(
+    (node) => node.kind === 'paragraph' && paragraphTextOf(store.part, node.id) === 'editable'
+  );
+  if (!paragraph || paragraph.kind !== 'paragraph') throw new Error('missing editable paragraph');
+  const edited = store.transact((tx) =>
+    tx.apply({ op: 'insertText', paragraphId: paragraph.id, offset: 0, text: 'X' })
+  );
+  if (!edited.ok) throw new Error(`edit failed: ${edited.reason}`);
+  const saved = writeOoxmlPackage(withPart(before, store.part));
+  const reopened = readOoxmlPackage(saved);
+  if (!reopened.ok) throw new Error(`reopen failed: ${reopened.reason}`);
+  return {
+    before,
+    after: reopened.package,
+    editedText: paragraphTextOf(mainPart(reopened.package), paragraph.id),
+  };
+}
+
+describe('disputed feature rows preserve untouched content through an adjacent edit', () => {
+  const XML_FEATURES = [
+    'background',
+    'backgroundImage',
+    'lum',
+    'grayscl',
+    'effectLst',
+    'outerShdw',
+    'glow',
+    'ink',
+    'rect',
+    'line',
+    'shape',
+    'object',
+    'OLEObject',
+    'ffData',
+    'checkBox',
+    'fldSimple',
+    'Sources',
+    'Source',
+    'numPicBullet',
+    'lvlPicBulletId',
+  ] as const;
+
+  test('the adjacent edit commits and survives reopen', () => {
+    expect(editedRoundTrip().editedText).toBe('Xeditable');
+  });
+
+  for (const localName of XML_FEATURES) {
+    test(`${localName} keeps its normalized structure`, () => {
+      const { before, after } = editedRoundTrip();
+      expect(featureFingerprints(before, localName)).not.toEqual([]);
+      expect(featureFingerprints(after, localName)).toEqual(featureFingerprints(before, localName));
+    });
+  }
+
+  test('the OLE binary and image bytes remain byte-identical', () => {
+    const { before, after } = editedRoundTrip();
+    for (const partName of ['/word/embeddings/oleObject1.bin', '/word/media/image1.png']) {
+      expect(after.partBytes.get(partName)).toEqual(before.partBytes.get(partName));
+    }
+  });
+});

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -18,9 +18,9 @@ WYSIWYG `.docx` editor for React. Opens a Word file in the browser, paints the r
 layout, edits it in place, and writes a `.docx` back out. No upload service, no conversion
 backend: parsing and serialization both happen client-side.
 
-Saving is lossless. Everything you do not edit comes back byte for byte, including the parts
-the editor does not understand: custom XML, embedded fonts, macros, unknown extensions. Two
-oracles gate that in CI, so opening a document here cannot quietly destroy it.
+Saving has a lossless semantic round-trip. Untouched content, unsupported OOXML, and package
+payloads survive editing and save. Two oracles gate that in CI, so opening a document here
+cannot quietly destroy it.
 
 ```bash
 npm install @docx-editor.dev/react


### PR DESCRIPTION
## Summary
- present lossless round-trip consistently across public documentation and the feature matrix
- add focused save/reopen coverage for previously understated preserved features
- remove stale watermark and drawing claims

## Test plan
- [x] `bun test ./packages/core/src/store/__tests__/roundtrip-feature-preservation.test.ts ./docs/site/data/word-features.test.ts`
- [x] `bun run check:docs-mdx`
- [x] pre-commit checks (typecheck, API snapshots, format, lint)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788693718&installation_model_id=422592&pr_number=243&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F243&signature=0910e9d8143e6a53e9f89f4c2e6fb81f78a1c78aa4f614229b5046e2d8b90ad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->