### PR TITLE
fix(react): put the packaged title bar and toolbar on one chrome band

### DIFF
--- a/.changeset/sugar-chrome-band.md
+++ b/.changeset/sugar-chrome-band.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+`<DocxEditor>`'s title bar and toolbar now sit on one `--doc-surface` band, closed by a hairline and a soft shadow directly under the toolbar, with the ruler row and the workspace below it on `--doc-bg`. The seam used to be a border under the title bar, which split the band in two and left the toolbar edge to edge on no ground of its own: the toolbar paints a rounded pill, so flush against the frame its radius never showed and the row read as a second flat bar. Hosts were adding their own wrapper to get the packaged chrome to look like the composed demo it is modelled on. Nothing about the API changes, and both surfaces follow the dark palette as before.

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -116,13 +116,49 @@ const VERTICAL_RULER_STYLE: CSSProperties = {
   pointerEvents: 'none',
 };
 
+/**
+ * The chrome band: title bar and toolbar on ONE `--doc-surface` surface, closed by a
+ * seam (hairline + soft shadow) directly under the toolbar. The ruler row and the
+ * workspace below sit on the gray `--doc-bg`, which is what makes the band read as a
+ * single piece of chrome rather than a white title bar with a toolbar loose on the
+ * workspace.
+ *
+ * The seam belongs HERE and not on the title bar: a border under the title bar cuts
+ * the band in two and leaves the toolbar with no ground of its own.
+ *
+ * `z-index` lifts the seam's shadow over the workspace, and the menus that open from
+ * this row stack inside its context, above everything below.
+ */
+const CHROME_BAND_STYLE: CSSProperties = {
+  flex: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative',
+  zIndex: 30,
+  backgroundColor: 'var(--doc-surface)',
+  // Longhand on purpose: the `border-bottom` shorthand does not survive a var()
+  // in every DOM implementation the suite runs against.
+  borderBottomWidth: 1,
+  borderBottomStyle: 'solid',
+  borderBottomColor: 'var(--doc-border)',
+  boxShadow: '0 1px 3px var(--doc-shadow-subtle)',
+};
+
+/**
+ * Insets the toolbar inside the band. The toolbar paints its own pill
+ * (`.docx-toolbar` is a rounded `--doc-bg-subtle` slab); flush against the band's
+ * edges that pill has nothing to sit on and its radius never shows, so the row reads
+ * as a second flat bar under the title.
+ */
+const TOOLBAR_ROW_STYLE: CSSProperties = {
+  padding: '8px 12px',
+};
+
 const TITLE_BAR_STYLE: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   gap: 8,
-  padding: '6px 12px',
-  borderBottom: '1px solid var(--doc-border)',
-  backgroundColor: 'var(--doc-surface)',
+  padding: '8px 12px 0',
   color: 'var(--doc-text)',
 };
 
@@ -264,44 +300,50 @@ const DocxEditorImpl = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxE
       className={`docx-editor${isDark ? ' dark' : ''}${className ? ` ${className}` : ''}`}
       style={CONTAINER_STYLE}
     >
-      <div style={TITLE_BAR_STYLE}>
-        {renderTitleBarLeft?.()}
-        <div style={TITLE_BLOCK_STYLE}>
-          {onTitleChange ? (
-            <input
-              aria-label={translate('titleBar.documentNameAriaLabel')}
-              value={title ?? ''}
-              placeholder={translate('titleBar.untitled')}
-              onChange={(event) => onTitleChange(event.target.value)}
-              style={TITLE_INPUT_STYLE}
-            />
-          ) : (
-            <span style={{ minWidth: 0, padding: '2px 6px' }}>
-              {title ?? translate('titleBar.untitled')}
-            </span>
-          )}
-          {/* File · Format · Insert · Help. Every row is a chrome slot, so it shares its
-              label, icon and enabled state with the toolbar control for the same
-              capability. Open and Save work with no configuration; `onOpen`/`onSave`
-              replace them. */}
-          {menu !== false ? (
-            <DocxEditorMenu
-              t={translate}
-              {...(title !== undefined ? { fileName: title } : {})}
-              {...(onOpen ? { onOpen } : {})}
-              {...(onSave ? { onSave } : {})}
-              // An object `menu` is menu props, spread LAST so a host's own handler wins
-              // over the ones derived from the top-level props above.
-              {...(typeof menu === 'object' ? menu : {})}
-            />
-          ) : null}
+      {/* Title bar and toolbar share one surface, closed by the seam under the
+          toolbar — see CHROME_BAND_STYLE. */}
+      <div style={CHROME_BAND_STYLE}>
+        <div style={TITLE_BAR_STYLE}>
+          {renderTitleBarLeft?.()}
+          <div style={TITLE_BLOCK_STYLE}>
+            {onTitleChange ? (
+              <input
+                aria-label={translate('titleBar.documentNameAriaLabel')}
+                value={title ?? ''}
+                placeholder={translate('titleBar.untitled')}
+                onChange={(event) => onTitleChange(event.target.value)}
+                style={TITLE_INPUT_STYLE}
+              />
+            ) : (
+              <span style={{ minWidth: 0, padding: '2px 6px' }}>
+                {title ?? translate('titleBar.untitled')}
+              </span>
+            )}
+            {/* File · Format · Insert · Help. Every row is a chrome slot, so it shares its
+                label, icon and enabled state with the toolbar control for the same
+                capability. Open and Save work with no configuration; `onOpen`/`onSave`
+                replace them. */}
+            {menu !== false ? (
+              <DocxEditorMenu
+                t={translate}
+                {...(title !== undefined ? { fileName: title } : {})}
+                {...(onOpen ? { onOpen } : {})}
+                {...(onSave ? { onSave } : {})}
+                // An object `menu` is menu props, spread LAST so a host's own handler wins
+                // over the ones derived from the top-level props above.
+                {...(typeof menu === 'object' ? menu : {})}
+              />
+            ) : null}
+          </div>
+          {renderTitleBarRight?.()}
         </div>
-        {renderTitleBarRight?.()}
+        {/* Save is deliberately absent here: the registry marks the `file` group contextual,
+            so `defaultChromeGroups()` filters it out and only explicit composition mounts it.
+            File -> Save in the menu bar carries it. */}
+        <div style={TOOLBAR_ROW_STYLE}>
+          <DocxEditorToolbar t={translate} />
+        </div>
       </div>
-      {/* Save is deliberately absent here: the registry marks the `file` group contextual,
-          so `defaultChromeGroups()` filters it out and only explicit composition mounts it.
-          File -> Save in the menu bar carries it. */}
-      <DocxEditorToolbar t={translate} />
       {/* The ruler belongs to the packaged frame: every editor this component is
           modelled on shows one, and a host that had to mount it by hand got the
           placement wrong — the part compensates for the review gutter itself, so

--- a/packages/react/test/sugar-chrome-band.test.tsx
+++ b/packages/react/test/sugar-chrome-band.test.tsx
@@ -1,0 +1,73 @@
+// The packaged frame's chrome band: the title bar and the toolbar sit on ONE
+// `--doc-surface` surface, and the seam that closes it is under the TOOLBAR.
+//
+// The regression this pins: the seam used to be a border under the title bar,
+// which cut the band in two and left the toolbar with no ground of its own. The
+// toolbar paints a rounded pill, so flush against the band's edges the radius
+// never showed and the row read as a second flat bar. Hosts worked around it
+// with their own wrapper; the composed demo in `examples/vite` is where this
+// layout came from.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { cleanup, render } from '@testing-library/react';
+import { DocxEditor } from '../src/components/DocxEditor.tsx';
+
+afterEach(cleanup);
+
+const band = (container: HTMLElement) => {
+  const toolbar = container.querySelector('.docx-toolbar');
+  // toolbar -> inset row -> band
+  return toolbar?.parentElement?.parentElement ?? null;
+};
+
+describe('the packaged frame chrome band', () => {
+  test('title bar and toolbar share one surface', () => {
+    const { container } = render(<DocxEditor />);
+    const surface = band(container);
+    expect(surface).not.toBeNull();
+    expect(surface!.style.backgroundColor).toBe('var(--doc-surface)');
+    // The menu bar lives in the title bar, so finding it under the same box is
+    // what proves the two rows are one band and not siblings.
+    expect(surface!.querySelector('.docx-menubar')).not.toBeNull();
+  });
+
+  test('the seam closes the band under the toolbar, not under the title bar', () => {
+    const { container } = render(<DocxEditor />);
+    const surface = band(container);
+    expect(surface!.style.borderBottomWidth).toBe('1px');
+    expect(surface!.style.borderBottomColor).toBe('var(--doc-border)');
+    expect(surface!.style.boxShadow).toBe('0 1px 3px var(--doc-shadow-subtle)');
+
+    // The title bar is the band's first row and carries no seam of its own.
+    const titleBar = surface!.firstElementChild as HTMLElement;
+    expect(titleBar.querySelector('.docx-menubar')).not.toBeNull();
+    expect(titleBar.style.borderBottomWidth).toBe('');
+    expect(titleBar.style.backgroundColor).toBe('');
+  });
+
+  test('the toolbar is inset, so its pill sits on the band', () => {
+    const { container } = render(<DocxEditor />);
+    const row = container.querySelector('.docx-toolbar')!.parentElement as HTMLElement;
+    expect(row.style.padding).toBe('8px 12px');
+  });
+
+  test('the ruler row stays outside the band, on the workspace', () => {
+    const { container } = render(<DocxEditor />);
+    const rulerRow = [...container.querySelectorAll('div')].find(
+      (el) => el.style.minHeight === '34px' && el.style.justifyContent === 'center'
+    );
+    expect(rulerRow).toBeDefined();
+    expect(band(container)!.contains(rulerRow!)).toBe(false);
+    expect(rulerRow!.style.backgroundColor).toBe('var(--doc-bg)');
+  });
+
+  test('chrome={false} renders no band at all', () => {
+    const { container } = render(<DocxEditor chrome={false} />);
+    expect(container.querySelector('.docx-toolbar')).toBeNull();
+  });
+});


### PR DESCRIPTION
## The problem

The seam that closes `<DocxEditor>`'s chrome was a `border-bottom` on the **title bar**. That splits the band in two and leaves `<DocxEditorToolbar>` edge to edge on the gray workspace with no ground of its own — and the toolbar paints a rounded pill (`.docx-toolbar`, `border-radius: 9999px`), so flush against the frame its radius never shows and the row reads as a second flat bar under the title.

`examples/vite` already had the right layout, as demo-local CSS:

```css
.demo-chrome  { background: var(--doc-surface); border-bottom: 1px solid var(--doc-border);
                box-shadow: 0 1px 3px var(--doc-shadow-subtle); }
.demo-toolbar { margin: 8px 12px; }
```

A host wrapping the packaged chrome to make it look like the composed demo it is modelled on is the gap the sugar should close, not something every host re-derives.

## The change

Title bar and toolbar now share one `--doc-surface` box (`CHROME_BAND_STYLE`). The hairline and its soft shadow close it **directly under the toolbar**, and `TOOLBAR_ROW_STYLE` insets the toolbar `8px 12px` so the pill sits on the band. The ruler row and the workspace stay outside it on `--doc-bg`.

Border longhands rather than the `border-bottom` shorthand: the shorthand does not survive a `var()` in every DOM implementation the suite runs against.

No API change. Both surfaces follow the dark palette exactly as before.

## Verification

Mounted the sugar against a source build in `examples/vite` (nothing there mounts it, so this was a throwaway probe, since removed) and read back computed styles:

- light: band `rgb(255,255,255)` + `1px solid rgb(224,224,224)` + shadow, ruler row `rgb(248,249,250)` below it
- dark: band `#1f1f1f`, workspace `#262626`, seam visible
- 760px wide, where the toolbar overflows into its `…` menu — pill keeps the 12px inset

`packages/react/test/sugar-chrome-band.test.tsx` pins the four claims that regressed: one surface, seam under the toolbar and not the title bar, toolbar inset, ruler row outside the band.

Full react suite 387 pass / 0 fail. `check-editor-contract.mjs` clean, API snapshot clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788698777&installation_model_id=422592&pr_number=244&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F244&signature=4236421e1f413ce444167d53549ecd7ae1518b93c6659fed84d2a8a6e512415c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->