### PR TITLE
fix(core): keep line.drawings in the fragment signature

### DIFF
--- a/packages/core/src/layout/__tests__/incremental-semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/incremental-semantic-layout.test.ts
@@ -18,7 +18,8 @@ import {
   type PageGeometry,
   type SemanticLayout,
 } from '../index.ts';
-import { fragmentSignature } from '../semantic-fragment-signature.ts';
+import { fragmentSignature, sameFragments } from '../semantic-fragment-signature.ts';
+import type { BlockFragmentRecord } from '../semantic-records.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -255,5 +256,41 @@ describe('the cache and the session compose (tasks 9.2, 9.3)', () => {
 
     const same = { ...base, rows: [...base.rows] };
     expect(fragmentSignature(same)).toBe(fragmentSignature(base));
+  });
+
+  test('an inline drawing resource transition changes the open-page fragment signature', () => {
+    const base = lay(load(paragraph('open page')), 1).pages[0]!.fragments[0]!;
+    expect(base.kind).toBe('paragraph');
+    if (base.kind !== 'paragraph') return;
+
+    const withResource = (resource: object): BlockFragmentRecord =>
+      ({
+        ...base,
+        lines: base.lines.map((line, index) =>
+          index === 0
+            ? {
+                ...line,
+                drawings: [
+                  {
+                    kind: 'inlineDrawing',
+                    drawingNodeId: 'drawing-1',
+                    resource,
+                  },
+                ],
+              }
+            : line
+        ),
+      }) as BlockFragmentRecord;
+
+    const pending = withResource({ kind: 'pending', resourceKey: 'drawing-1' });
+    const samePending = withResource({ kind: 'pending', resourceKey: 'drawing-1' });
+    const ready = withResource({
+      kind: 'ready',
+      resourceKey: 'drawing-1-ready',
+      contentId: 'content-1',
+    });
+
+    expect(sameFragments([pending], [samePending])).toBe(true);
+    expect(sameFragments([pending], [ready])).toBe(false);
   });
 });

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -58,6 +58,10 @@ export function fragmentSignature(fragment: BlockFragmentRecord): string {
             line.contentX,
             line.baseline,
             line.spans,
+            // Resource resolution changes paint state without moving the line. If drawings
+            // are omitted, pending→ready can falsely converge on an open page and replace
+            // the freshly rebuilt fragment with the previous page's pending record.
+            line.drawings,
           ]),
         ]);
   signatures.set(fragment, signature);


### PR DESCRIPTION
Hit this while evaluating the library for a reader I'm building.

## Summary

- An inline image whose paragraph sits on the page still open when incremental
  layout converges stays on the `Loading image` placeholder forever. The
  resource does reach `ready` — the page fragment carrying that state is the
  thing that gets dropped.
- `fragmentSignature()` hashes `line.spans` but not `line.drawings`, so a
  `pending → ready` transition moves nothing in the signature. `sameFragments()`
  then reports the rebuilt open page as unchanged, convergence fires, and
  `previous.pages.slice(mark.pageCount)` restores the older fragment with the
  `pending` record still in it.
- Same class as the `indent` and `borders` omissions already documented in that
  function's comments: published state that no other hashed field moves.

## Repro

`repro.docx` (2.7 KB, attached) — two inline PNGs, one early and one pushed past
a page boundary by filler paragraphs. On `@docx-editor.dev/core@2.1.3` the first
paints and the second does not; `document.querySelectorAll('img')` returns 1.

_Before/after screenshots of that page are in the comment below._

Before:
<img width="1200" height="1300" alt="before-2 1 3" src="https://github.com/user-attachments/assets/b6f01908-5b1a-4821-9346-5489b6835ba8" />
After:
<img width="1200" height="1300" alt="after-fix" src="https://github.com/user-attachments/assets/0f959bcf-3abf-40fc-8915-f5d7c7b57476" />

## Test plan

- [x] `bun test packages/core/src/layout/__tests__/incremental-semantic-layout.test.ts`
      — added `an inline drawing resource transition changes the open-page
      fragment signature`; fails on `main` (15 pass / 1 fail), passes with the
      change (16 pass / 0 fail).
- [x] `bun test packages/core/src/editor/__tests__/story-drawing-resource.test.ts`
      — 6 pass / 0 fail.
- [x] Built `packages/core` + `packages/react` from source and rendered
      `repro.docx` through `DocxEditor`: 1 image / 1 placeholder before, 2 images
      / 0 placeholders after.
- [x] Checked the other `line.spans` mappings — this is the only signature path
      with the same omission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788715917&installation_model_id=422592&pr_number=251&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F251&signature=d8edcc552721c6dace5e524675254869fed2e1a637d67b9097865174f2dacb6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->