### PR TITLE
feat(editor-api): add structured document discovery

### DIFF
--- a/.changeset/enumerate-story-bookmarks.md
+++ b/.changeset/enumerate-story-bookmarks.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': minor
+---
+
+Add `Body.bookmarks` to enumerate bookmarks in a body story without first searching for text.

--- a/.changeset/preflight-bound-content-controls.md
+++ b/.changeset/preflight-bound-content-controls.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': minor
+---
+
+Add `ContentControl.isBound` for safely preflighting custom-XML-bound controls before writes.

--- a/.changeset/read-note-text-directly.md
+++ b/.changeset/read-note-text-directly.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': minor
+---
+
+Add read-only `NoteItem.text` so footnote and endnote text can be loaded directly in one post-listing sync while preserving `NoteItem.body` for structured access.

--- a/.changeset/reveal-selected-automation-ranges.md
+++ b/.changeset/reveal-selected-automation-ranges.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': patch
+---
+
+Fix browser `Range.select()` calls so offscreen ranges are revealed as well as logically selected.

--- a/.changeset/select-browser-bookmarks.md
+++ b/.changeset/select-browser-bookmarks.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': patch
+---
+
+Fix browser `Bookmark.select()` calls so they resolve and reveal the bookmark without requiring a prior `bookmark.range` sync.

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -8,7 +8,7 @@
 export const AUTOMATION_COMMAND_OPERATIONS: readonly ["insertText", "replaceSpan", "insertParagraph", "splitParagraph", "deleteParagraph", "selectSpan", "selectBookmark", "setFont", "setParagraphFormat", "setStyle", "setPageSetup", "deleteNote", "setListLevel", "insertListParagraph", "setHyperlink", "setCommentResolved", "replyToComment", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "setContentControlValue", "setContentControlProperties", "deleteContentControl", "insertContentControlText", "insertContentControl", "insertCustomNode"];
 
 // @public
-export const AUTOMATION_QUERY_OPERATIONS: readonly ["getDocument", "getBody", "getParagraphs", "getSpanParagraphs", "getText", "getSpanText", "getParagraphId", "search", "getFont", "getParagraphFormat", "getStyle", "getSections", "getPageSetup", "getFurniture", "getNotes", "getNoteBody", "getNoteKind", "getLists", "getListId", "getListById", "getListParagraphs", "getParagraphList", "getListLevel", "getHyperlink", "getBookmarks", "getBookmarkName", "getBookmarkRange", "getComments", "getCommentReplies", "getCommentId", "getCommentAuthor", "getCommentDate", "getCommentText", "getCommentRange", "getCommentResolved", "getRevisions", "getRevisionType", "getRevisionAuthor", "getRevisionDate", "getRevisionRange", "getContentControls", "getContentControlById", "getContentControlsByTag", "getContentControlsByTitle", "getContentControlTag", "getContentControlTitle", "getContentControlFileId", "getContentControlSubtype", "getContentControlLock", "getContentControlPlaceholderShown", "getContentControlTemporary", "getContentControlText", "getContentControlParagraphs", "getContentControlRange"];
+export const AUTOMATION_QUERY_OPERATIONS: readonly ["getDocument", "getBody", "getParagraphs", "getSpanParagraphs", "getText", "getSpanText", "getParagraphId", "search", "getFont", "getParagraphFormat", "getStyle", "getSections", "getPageSetup", "getFurniture", "getNotes", "getNoteBody", "getNoteKind", "getLists", "getListId", "getListById", "getListParagraphs", "getParagraphList", "getListLevel", "getHyperlink", "getBookmarks", "getBookmarkName", "getBookmarkRange", "getComments", "getCommentReplies", "getCommentId", "getCommentAuthor", "getCommentDate", "getCommentText", "getCommentRange", "getCommentResolved", "getRevisions", "getRevisionType", "getRevisionAuthor", "getRevisionDate", "getRevisionRange", "getContentControls", "getContentControlById", "getContentControlsByTag", "getContentControlsByTitle", "getContentControlTag", "getContentControlTitle", "getContentControlFileId", "getContentControlSubtype", "getContentControlLock", "getContentControlIsBound", "getContentControlPlaceholderShown", "getContentControlTemporary", "getContentControlText", "getContentControlParagraphs", "getContentControlRange"];
 
 // @public
 export const AUTOMATION_SOLITARY_OPERATIONS: readonly ["deleteNote", "setCommentResolved", "replyToComment", "insertCustomNode"];
@@ -764,6 +764,16 @@ export type AutomationOperation =
 /** The `ST_Lock` in force, INCLUDING what an enclosing control imposes. */
 | {
     readonly op: 'getContentControlLock';
+    readonly contentControl: AutomationHandle;
+}
+/**
+* Whether the control declares `w:dataBinding`.
+*
+* Presence only: no XPath, namespace mapping, store id, or custom XML content crosses this
+* protocol boundary, and the binding target is never resolved or fetched.
+*/
+| {
+    readonly op: 'getContentControlIsBound';
     readonly contentControl: AutomationHandle;
 }
 /** Whether the control is showing its placeholder rather than a value (`w:showingPlcHdr`). */

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -8,7 +8,7 @@
 export const AUTOMATION_COMMAND_OPERATIONS: readonly ["insertText", "replaceSpan", "insertParagraph", "splitParagraph", "deleteParagraph", "selectSpan", "selectBookmark", "setFont", "setParagraphFormat", "setStyle", "setPageSetup", "deleteNote", "setListLevel", "insertListParagraph", "setHyperlink", "setCommentResolved", "replyToComment", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "setContentControlValue", "setContentControlProperties", "deleteContentControl", "insertContentControlText", "insertContentControl", "insertCustomNode"];
 
 // @public
-export const AUTOMATION_QUERY_OPERATIONS: readonly ["getDocument", "getBody", "getParagraphs", "getSpanParagraphs", "getText", "getSpanText", "getParagraphId", "search", "getFont", "getParagraphFormat", "getStyle", "getSections", "getPageSetup", "getFurniture", "getNotes", "getNoteBody", "getNoteKind", "getLists", "getListId", "getListById", "getListParagraphs", "getParagraphList", "getListLevel", "getHyperlink", "getBookmarks", "getBookmarkName", "getBookmarkRange", "getComments", "getCommentReplies", "getCommentId", "getCommentAuthor", "getCommentDate", "getCommentText", "getCommentRange", "getCommentResolved", "getRevisions", "getRevisionType", "getRevisionAuthor", "getRevisionDate", "getRevisionRange", "getContentControls", "getContentControlById", "getContentControlsByTag", "getContentControlsByTitle", "getContentControlTag", "getContentControlTitle", "getContentControlFileId", "getContentControlSubtype", "getContentControlLock", "getContentControlIsBound", "getContentControlPlaceholderShown", "getContentControlTemporary", "getContentControlText", "getContentControlParagraphs", "getContentControlRange"];
+export const AUTOMATION_QUERY_OPERATIONS: readonly ["getDocument", "getBody", "getParagraphs", "getSpanParagraphs", "getText", "getSpanText", "getParagraphId", "search", "getFont", "getParagraphFormat", "getStyle", "getSections", "getPageSetup", "getFurniture", "getNotes", "getNoteBody", "getNoteText", "getNoteKind", "getLists", "getListId", "getListById", "getListParagraphs", "getParagraphList", "getListLevel", "getHyperlink", "getBookmarks", "getBookmarkName", "getBookmarkRange", "getComments", "getCommentReplies", "getCommentId", "getCommentAuthor", "getCommentDate", "getCommentText", "getCommentRange", "getCommentResolved", "getRevisions", "getRevisionType", "getRevisionAuthor", "getRevisionDate", "getRevisionRange", "getContentControls", "getContentControlById", "getContentControlsByTag", "getContentControlsByTitle", "getContentControlTag", "getContentControlTitle", "getContentControlFileId", "getContentControlSubtype", "getContentControlLock", "getContentControlIsBound", "getContentControlPlaceholderShown", "getContentControlTemporary", "getContentControlText", "getContentControlParagraphs", "getContentControlRange"];
 
 // @public
 export const AUTOMATION_SOLITARY_OPERATIONS: readonly ["deleteNote", "setCommentResolved", "replyToComment", "insertCustomNode"];
@@ -407,6 +407,16 @@ export type AutomationOperation =
 /** One note's story, as a BODY. Two notes in one part are two stories. */
 | {
     readonly op: 'getNoteBody';
+    readonly note: AutomationHandle;
+}
+/**
+* One note's story as plain text.
+*
+* Exactly the same projection as reading `getText` from the body returned by `getNoteBody`,
+* without requiring that intermediate handle: paragraphs joined by one `\r` paragraph mark.
+*/
+| {
+    readonly op: 'getNoteText';
     readonly note: AutomationHandle;
 }
 /** Whether a note is a footnote or an endnote. */

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export const AUTOMATION_COMMAND_OPERATIONS: readonly ["insertText", "replaceSpan", "insertParagraph", "splitParagraph", "deleteParagraph", "selectSpan", "setFont", "setParagraphFormat", "setStyle", "setPageSetup", "deleteNote", "setListLevel", "insertListParagraph", "setHyperlink", "setCommentResolved", "replyToComment", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "setContentControlValue", "setContentControlProperties", "deleteContentControl", "insertContentControlText", "insertContentControl", "insertCustomNode"];
+export const AUTOMATION_COMMAND_OPERATIONS: readonly ["insertText", "replaceSpan", "insertParagraph", "splitParagraph", "deleteParagraph", "selectSpan", "selectBookmark", "setFont", "setParagraphFormat", "setStyle", "setPageSetup", "deleteNote", "setListLevel", "insertListParagraph", "setHyperlink", "setCommentResolved", "replyToComment", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "setContentControlValue", "setContentControlProperties", "deleteContentControl", "insertContentControlText", "insertContentControl", "insertCustomNode"];
 
 // @public
 export const AUTOMATION_QUERY_OPERATIONS: readonly ["getDocument", "getBody", "getParagraphs", "getSpanParagraphs", "getText", "getSpanText", "getParagraphId", "search", "getFont", "getParagraphFormat", "getStyle", "getSections", "getPageSetup", "getFurniture", "getNotes", "getNoteBody", "getNoteKind", "getLists", "getListId", "getListById", "getListParagraphs", "getParagraphList", "getListLevel", "getHyperlink", "getBookmarks", "getBookmarkName", "getBookmarkRange", "getComments", "getCommentReplies", "getCommentId", "getCommentAuthor", "getCommentDate", "getCommentText", "getCommentRange", "getCommentResolved", "getRevisions", "getRevisionType", "getRevisionAuthor", "getRevisionDate", "getRevisionRange", "getContentControls", "getContentControlById", "getContentControlsByTag", "getContentControlsByTitle", "getContentControlTag", "getContentControlTitle", "getContentControlFileId", "getContentControlSubtype", "getContentControlLock", "getContentControlPlaceholderShown", "getContentControlTemporary", "getContentControlText", "getContentControlParagraphs", "getContentControlRange"];
@@ -687,6 +687,17 @@ export type AutomationOperation =
 | {
     readonly op: 'selectSpan';
     readonly span: AutomationSpanRef;
+    readonly mode: AutomationSelectionMode;
+}
+/**
+* Put the reader's selection on the range a bookmark currently encloses.
+*
+* The bookmark is resolved inside the batch so callers do not need a separate round trip to
+* obtain an addressable range. Requires the `selection` capability, like `selectSpan`.
+*/
+| {
+    readonly op: 'selectBookmark';
+    readonly bookmark: AutomationHandle;
     readonly mode: AutomationSelectionMode;
 }
 /**

--- a/docs/api/docx-editor-editor-api/browser.api.md
+++ b/docs/api/docx-editor-editor-api/browser.api.md
@@ -17,6 +17,7 @@ export type BesideLocation = Extract<InsertLocation, 'Before' | 'After'>;
 
 // @public
 class Body_2 extends ModelObject {
+    get bookmarks(): BookmarkCollection;
     clear(): void;
     get contentControls(): ContentControlCollection;
     get font(): Font;
@@ -187,6 +188,7 @@ export class ContentControl extends ModelObject implements PromisedItem {
     hydrateNull(): void;
     get id(): string;
     insertText(text: string, insertLocation: 'Replace' | 'Start' | 'End'): Range_2;
+    get isBound(): boolean;
     // @internal
     protected onLoad(request: ResolvedLoadOptions): void;
     get paragraphs(): ParagraphCollection;
@@ -480,6 +482,7 @@ export class NoteItem extends ModelObject implements PromisedItem {
     protected onLoad(request: ResolvedLoadOptions): void;
     // @internal
     static promised(context: RequestContext, label: string, nullable: boolean): NoteItem;
+    get text(): string;
     get type(): NoteItemType;
 }
 

--- a/docs/api/docx-editor-editor-api/index.api.md
+++ b/docs/api/docx-editor-editor-api/index.api.md
@@ -16,6 +16,7 @@ export type BesideLocation = Extract<InsertLocation, 'Before' | 'After'>;
 
 // @public
 class Body_2 extends ModelObject {
+    get bookmarks(): BookmarkCollection;
     clear(): void;
     get contentControls(): ContentControlCollection;
     get font(): Font;
@@ -186,6 +187,7 @@ export class ContentControl extends ModelObject implements PromisedItem {
     hydrateNull(): void;
     get id(): string;
     insertText(text: string, insertLocation: 'Replace' | 'Start' | 'End'): Range_2;
+    get isBound(): boolean;
     // @internal
     protected onLoad(request: ResolvedLoadOptions): void;
     get paragraphs(): ParagraphCollection;
@@ -478,6 +480,7 @@ export class NoteItem extends ModelObject implements PromisedItem {
     protected onLoad(request: ResolvedLoadOptions): void;
     // @internal
     static promised(context: RequestContext, label: string, nullable: boolean): NoteItem;
+    get text(): string;
     get type(): NoteItemType;
 }
 

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -42,6 +42,24 @@ try {
 }
 ```
 
+To discover bookmarks without first knowing their text, enumerate the story that owns them:
+
+```ts
+await runtime.run(async (context) => {
+  const bookmarks = context.document.body.bookmarks;
+  bookmarks.load('items');
+  await context.sync();
+
+  for (const bookmark of bookmarks.items) bookmark.load('name');
+  await context.sync();
+
+  console.log(bookmarks.items.map(({ name }) => name));
+});
+```
+
+`document.body.bookmarks` covers only the main body story. A header or footer `Body` has its own
+collection; this accessor never combines separate stories into a document-wide answer.
+
 ## In the browser
 
 The browser entry takes an editor the host already created (from `@docx-editor.dev/react` or a plain page) and drives it in place. Edits land in the open document with the reader's undo stack intact, so there is no `save()`: the host saves the way it already did.

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -92,6 +92,10 @@ to keep that browser code out of the bundle.
   `runtime.run(object, callback)` for adoption. No proxy survives `dispose()`.
 - `getFirstOrNullObject` and `getLastOrNullObject` answer an object whose `isNullObject` is `true` after the sync, which is the difference between "no such heading" and a crash.
 
+For content-control writes, load `isBound` with the other properties and skip controls where it is
+true. That boolean is safe preflight metadata, not a write guarantee: `sync()` always checks the
+current document again and atomically refuses the batch if a control is bound by then.
+
 ## Capabilities
 
 `runtime.capabilities` reports host differences. `save` is false in the browser; `selection`,

--- a/docs/site/content/editor-api/office-js-api.mdx
+++ b/docs/site/content/editor-api/office-js-api.mdx
@@ -127,6 +127,13 @@ The following APIs are absent from the public types, so code that uses them fail
   await context.sync();
   ```
 
+DocxEditor also adds the read-only `ContentControl.isBound` boolean. Load it before choosing a
+control for `setValue()` to skip controls whose value is mapped through OOXML `w:dataBinding`.
+The flag exposes presence only: it never returns the XPath, namespace mappings, custom XML store
+identifier, or custom XML content, and it never resolves or fetches the target. It is advisory
+preflight rather than a race-free guarantee. The atomic write at `sync()` rechecks the current
+document and still refuses a bound control if the file changed after `isBound` was loaded.
+
 ## Migrating an add-in
 
 1. Replace `Word.run(async (context) => { … })` with a runtime you construct: `DocxEditor.createServer(bytes)` on a server, `DocxEditor.createBrowser(editor)` in a page. The callback body is the part that stays the same.

--- a/docs/site/content/editor-api/office-js-api.mdx
+++ b/docs/site/content/editor-api/office-js-api.mdx
@@ -50,6 +50,18 @@ expansion is not supported yet. A non-empty `expand` is rejected immediately wit
 `InvalidArgument` targeting the object's `.expand` option; omit it or pass `expand: []`. Load a
 navigation object or collection explicitly and sync it in the usual way.
 
+DocxEditor also adds `Body.bookmarks` for bookmark discovery. It returns the bookmarks declared in
+that `Body` object's one story: `document.body.bookmarks` is the main body story, not a
+document-wide union of headers, footers, and notes. Office.js exposes `Range.bookmarks` but has no
+equivalent body-level discovery member, so this additive accessor is recorded as a DocxEditor
+extension rather than an Office.js conformance claim.
+
+In a browser runtime, `Range.select()` and `Bookmark.select()` also navigate the editor viewport to
+the selected content, matching Word's contract. Selection capability is the only preflight required:
+each operation owns its reveal and verifies selection again at `sync()`. The reveal uses paginated
+layout coordinates, so it works when the target page is virtualized and has no painted element yet.
+A server runtime refuses either `select()` with `NotSupported` because it has no reader or viewport.
+
 Review dates are file-authored rather than synthesized. `Comment.creationDate`,
 `CommentReply.creationDate`, and `Revision.date` return `Date | null`: a missing or invalid OOXML
 date becomes `null`, so strict TypeScript consumers must narrow it before calling `Date` methods.

--- a/docs/site/content/editor-api/office-js-api.mdx
+++ b/docs/site/content/editor-api/office-js-api.mdx
@@ -56,6 +56,11 @@ document-wide union of headers, footers, and notes. Office.js exposes `Range.boo
 equivalent body-level discovery member, so this additive accessor is recorded as a DocxEditor
 extension rather than an Office.js conformance claim.
 
+`NoteItem.text` is another read-only DocxEditor extension. After loading a footnote or endnote
+collection, load `text` on every item and one more `sync()` returns all note text. Its value is
+exactly `note.body.text`, including carriage returns between paragraphs; `note.body` remains the
+structured story for traversal and edits.
+
 In a browser runtime, `Range.select()` and `Bookmark.select()` also navigate the editor viewport to
 the selected content, matching Word's contract. Selection capability is the only preflight required:
 each operation owns its reveal and verifies selection again at `sync()`. The reveal uses paginated

--- a/examples/automation/README.md
+++ b/examples/automation/README.md
@@ -39,6 +39,23 @@ try {
 The first sync retrieves the collection's items. Only then are the individual paragraphs
 available to ask for their text, so the second sync retrieves those property values.
 
+Bookmarks are discoverable from the story that owns them, without searching for target text first:
+
+```ts
+await runtime.run(async (context) => {
+  const bookmarks = context.document.body.bookmarks;
+  bookmarks.load();
+  await context.sync();
+
+  for (const bookmark of bookmarks.items) bookmark.load('name');
+  await context.sync();
+  console.log(bookmarks.items.map(({ name }) => name));
+});
+```
+
+That collection covers the main body story only. Header and footer bodies have separate bookmark
+collections; there is no document-wide aggregation.
+
 Four rules carry most of the API:
 
 - **Read what you asked for.** A property you did not `load()` throws instead of answering

--- a/packages/core/src/automation/__tests__/automation-capabilities.test.ts
+++ b/packages/core/src/automation/__tests__/automation-capabilities.test.ts
@@ -201,6 +201,7 @@ describe('the operation vocabulary declares which operations write', () => {
       'splitParagraph',
       'deleteParagraph',
       'selectSpan',
+      'selectBookmark',
       'setFont',
       'setParagraphFormat',
       'setStyle',

--- a/packages/core/src/automation/__tests__/automation-content-controls.test.ts
+++ b/packages/core/src/automation/__tests__/automation-content-controls.test.ts
@@ -74,6 +74,16 @@ function metadata(host: AutomationHost, control: AutomationHandle, op: string): 
   );
 }
 
+function bindingState(host: AutomationHost, control: AutomationHandle): boolean {
+  const result = host.execute({
+    operations: [{ op: 'getContentControlIsBound', contentControl: control }],
+  }).results[0];
+  if (result?.status !== 'ok' || result.value.kind !== 'flag') {
+    throw new Error('the binding-state read did not answer a flag');
+  }
+  return result.value.value;
+}
+
 describe('a control answers what the document says about it', () => {
   test('a story lists its controls in document order', () => {
     const host = withControls();
@@ -104,6 +114,34 @@ describe('a control answers what the document says about it', () => {
     });
     expect(textAt(locks, 0)).toBe('sdtLocked');
     expect(textAt(locks, 1)).toBe('unlocked');
+  });
+
+  test('binding state reports presence only across mixed and custom control kinds', () => {
+    const secretXpath = '/attacker/private[1]';
+    const secretMappings = "xmlns:evil='urn:attacker-secret'";
+    const host = open(
+      docx(
+        `<w:sdt><w:sdtPr><w:tag w:val="plain"/><w:text/></w:sdtPr><w:sdtContent>` +
+          `<w:p><w:r><w:t>open</w:t></w:r></w:p></w:sdtContent></w:sdt>` +
+          `<w:sdt><w:sdtPr><w:tag w:val="custom"/>` +
+          `<w:dataBinding w:prefixMappings="${secretMappings}" w:xpath="${secretXpath}" ` +
+          `w:storeItemID="{ATTACKER-ID}"/><w:group/></w:sdtPr><w:sdtContent>` +
+          `<w:p><w:r><w:t>bound</w:t></w:r></w:p></w:sdtContent></w:sdt>`
+      )
+    );
+    const controls = controlsOf(host, roots(host).body);
+    const response = host.execute({
+      operations: controls.map((contentControl) => ({
+        op: 'getContentControlIsBound' as const,
+        contentControl,
+      })),
+    });
+    expect(bindingState(host, controls[0]!)).toBe(false);
+    expect(bindingState(host, controls[1]!)).toBe(true);
+    expect(response.results.map((result) => result.status)).toEqual(['ok', 'ok']);
+    expect(JSON.stringify(response)).not.toContain(secretXpath);
+    expect(JSON.stringify(response)).not.toContain(secretMappings);
+    expect(JSON.stringify(response)).not.toContain('ATTACKER-ID');
   });
 
   test('a control names the paragraphs it holds and the range they cover', () => {

--- a/packages/core/src/automation/__tests__/automation-links.test.ts
+++ b/packages/core/src/automation/__tests__/automation-links.test.ts
@@ -314,4 +314,22 @@ describe('a bookmark is a name over a range', () => {
     expect(response.ok).toBe(false);
     expect(refusal(response)).toBe('invalid-handle');
   });
+
+  test('selecting a missing bookmark refuses the object before asking for a reader', () => {
+    const host = withLinks();
+    const { body } = roots(host);
+    const [bookmark] = bookmarksOf(host, body) as [AutomationHandle];
+    const paragraphs = handlesAt(host.execute({ operations: [{ op: 'getParagraphs', body }] }), 0);
+    expect(
+      host.execute({
+        operations: [{ op: 'deleteParagraph', paragraph: paragraphs[1] as AutomationHandle }],
+      }).ok
+    ).toBe(true);
+
+    const response = host.execute({
+      operations: [{ op: 'selectBookmark', bookmark, mode: 'select' }],
+    });
+    expect(response.ok).toBe(false);
+    expect(refusal(response)).toBe('invalid-handle');
+  });
 });

--- a/packages/core/src/automation/__tests__/automation-sections.test.ts
+++ b/packages/core/src/automation/__tests__/automation-sections.test.ts
@@ -371,6 +371,24 @@ describe('a footnote is a story too', () => {
     ]);
   });
 
+  test('a note text read is exactly its body text without an intermediate body handle', () => {
+    const host = withFootnotes();
+    const notes = handlesAt(
+      host.execute({
+        operations: [{ op: 'getNotes', document: documentOf(host), noteKind: 'footnote' }],
+      }),
+      0
+    );
+    const direct = notes.map((note) =>
+      textAt(host.execute({ operations: [{ op: 'getNoteText', note }] }), 0)
+    );
+    const throughBody = notes.map((note) => {
+      const body = handleAt(host.execute({ operations: [{ op: 'getNoteBody', note }] }), 0);
+      return textAt(host.execute({ operations: [{ op: 'getText', target: body }] }), 0);
+    });
+    expect(direct).toEqual(throughBody);
+  });
+
   test('the reserved separators are not notes a caller can reach', () => {
     // `w:id="-1"` and `w:id="0"` are the separator and continuation-separator Word writes into
     // every notes part. Listing them would report a document with two more footnotes than it has.
@@ -534,6 +552,9 @@ describe('a footnote is a story too', () => {
     );
     host.execute({ operations: [{ op: 'deleteNote', note: notes[0]! }] });
     expect(errorAt(host.execute({ operations: [{ op: 'getNoteBody', note: notes[0]! }] }), 0)).toBe(
+      'invalid-handle'
+    );
+    expect(errorAt(host.execute({ operations: [{ op: 'getNoteText', note: notes[0]! }] }), 0)).toBe(
       'invalid-handle'
     );
   });

--- a/packages/core/src/automation/operations.ts
+++ b/packages/core/src/automation/operations.ts
@@ -504,6 +504,17 @@ export type AutomationOperation =
       readonly mode: AutomationSelectionMode;
     }
   /**
+   * Put the reader's selection on the range a bookmark currently encloses.
+   *
+   * The bookmark is resolved inside the batch so callers do not need a separate round trip to
+   * obtain an addressable range. Requires the `selection` capability, like `selectSpan`.
+   */
+  | {
+      readonly op: 'selectBookmark';
+      readonly bookmark: AutomationHandle;
+      readonly mode: AutomationSelectionMode;
+    }
+  /**
    * The content controls a scope holds, outermost first and in document order.
    *
    * A control INSIDE another is reached through the one that holds it, never listed beside it:
@@ -742,6 +753,7 @@ export const AUTOMATION_COMMAND_OPERATIONS = [
   'splitParagraph',
   'deleteParagraph',
   'selectSpan',
+  'selectBookmark',
   'setFont',
   'setParagraphFormat',
   'setStyle',

--- a/packages/core/src/automation/operations.ts
+++ b/packages/core/src/automation/operations.ts
@@ -316,6 +316,13 @@ export type AutomationOperation =
   | { readonly op: 'getNotes'; readonly document: AutomationHandle; readonly noteKind: NoteKind }
   /** One note's story, as a BODY. Two notes in one part are two stories. */
   | { readonly op: 'getNoteBody'; readonly note: AutomationHandle }
+  /**
+   * One note's story as plain text.
+   *
+   * Exactly the same projection as reading `getText` from the body returned by `getNoteBody`,
+   * without requiring that intermediate handle: paragraphs joined by one `\r` paragraph mark.
+   */
+  | { readonly op: 'getNoteText'; readonly note: AutomationHandle }
   /** Whether a note is a footnote or an endnote. */
   | { readonly op: 'getNoteKind'; readonly note: AutomationHandle }
   /**
@@ -712,6 +719,7 @@ export const AUTOMATION_QUERY_OPERATIONS = [
   'getFurniture',
   'getNotes',
   'getNoteBody',
+  'getNoteText',
   'getNoteKind',
   'getLists',
   'getListId',

--- a/packages/core/src/automation/operations.ts
+++ b/packages/core/src/automation/operations.ts
@@ -562,6 +562,13 @@ export type AutomationOperation =
   | { readonly op: 'getContentControlSubtype'; readonly contentControl: AutomationHandle }
   /** The `ST_Lock` in force, INCLUDING what an enclosing control imposes. */
   | { readonly op: 'getContentControlLock'; readonly contentControl: AutomationHandle }
+  /**
+   * Whether the control declares `w:dataBinding`.
+   *
+   * Presence only: no XPath, namespace mapping, store id, or custom XML content crosses this
+   * protocol boundary, and the binding target is never resolved or fetched.
+   */
+  | { readonly op: 'getContentControlIsBound'; readonly contentControl: AutomationHandle }
   /** Whether the control is showing its placeholder rather than a value (`w:showingPlcHdr`). */
   | { readonly op: 'getContentControlPlaceholderShown'; readonly contentControl: AutomationHandle }
   /** Whether the control removes itself on the first edit (`w:temporary`). */
@@ -738,6 +745,7 @@ export const AUTOMATION_QUERY_OPERATIONS = [
   'getContentControlFileId',
   'getContentControlSubtype',
   'getContentControlLock',
+  'getContentControlIsBound',
   'getContentControlPlaceholderShown',
   'getContentControlTemporary',
   'getContentControlText',

--- a/packages/core/src/automation/plan.ts
+++ b/packages/core/src/automation/plan.ts
@@ -1649,6 +1649,28 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
     return { ok: true, kind: 'command', ops: [], story: reads.story, answer: () => APPLIED };
   };
 
+  const resolveBookmarkRange = (handle: AutomationHandle) => {
+    const target = handles.resolve(handle, 'bookmark');
+    if (!target || target.kind !== 'bookmark')
+      return refuse('invalid-handle', 'that handle does not name a bookmark', 'bookmark');
+    const reads = packageReads.story(target.story);
+    if (!reads) return refuse('invalid-handle', 'that story is not in this document');
+    const bookmark = bookmarkIn(reads, target.name);
+    if (!bookmark)
+      return refuse(
+        'invalid-handle',
+        'this document no longer declares that bookmark',
+        target.name
+      );
+    const point = (marker: { readonly paragraphId: string; readonly offset: number }) => ({
+      story: reads.story,
+      paragraphId: marker.paragraphId,
+      index: reads.indexOf(marker.paragraphId),
+      offset: marker.offset,
+    });
+    return { reads, range: { start: point(bookmark.start), end: point(bookmark.end) } };
+  };
+
   const plan = (operation: AutomationOperation): PlannedOperation => {
     switch (operation.op) {
       case 'getDocument':
@@ -2149,33 +2171,9 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
       }
 
       case 'getBookmarkRange': {
-        const target = handles.resolve(operation.bookmark, 'bookmark');
-        if (!target || target.kind !== 'bookmark')
-          return refuse('invalid-handle', 'that handle does not name a bookmark', 'bookmark');
-        const reads = packageReads.story(target.story);
-        if (!reads) return refuse('invalid-handle', 'that story is not in this document');
-        const bookmark = bookmarkIn(reads, target.name);
-        // GONE MEANS GONE. The markers left with the text that held them, and a range derived from
-        // where they used to be would point at whatever moved in.
-        if (!bookmark)
-          return refuse(
-            'invalid-handle',
-            'this document no longer declares that bookmark',
-            target.name
-          );
-        const start: ResolvedPoint = {
-          story: reads.story,
-          paragraphId: bookmark.start.paragraphId,
-          index: reads.indexOf(bookmark.start.paragraphId),
-          offset: bookmark.start.offset,
-        };
-        const end: ResolvedPoint = {
-          story: reads.story,
-          paragraphId: bookmark.end.paragraphId,
-          index: reads.indexOf(bookmark.end.paragraphId),
-          offset: bookmark.end.offset,
-        };
-        return query({ kind: 'span', span: spanOf({ start, end }) });
+        const found = resolveBookmarkRange(operation.bookmark);
+        if (!('reads' in found)) return found;
+        return query({ kind: 'span', span: spanOf(found.range) });
       }
 
       case 'getComments': {
@@ -2423,6 +2421,12 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
         const story = storyReadsOf(resolved.value);
         if (!story) return refuse('invalid-handle', 'that story is not in this document');
         return planSelect(planFor(story), resolved.value, operation.mode);
+      }
+
+      case 'selectBookmark': {
+        const found = resolveBookmarkRange(operation.bookmark);
+        if (!('reads' in found)) return found;
+        return planSelect(planFor(found.reads), found.range, operation.mode);
       }
 
       case 'getContentControls': {

--- a/packages/core/src/automation/plan.ts
+++ b/packages/core/src/automation/plan.ts
@@ -2518,17 +2518,18 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
         return query({ kind: 'text', text: text ?? '' });
       }
 
+      case 'getContentControlIsBound':
       case 'getContentControlPlaceholderShown':
       case 'getContentControlTemporary': {
         const found = controlOf(operation.contentControl);
         if (!('control' in found)) return found;
-        return query({
-          kind: 'flag',
-          value:
-            operation.op === 'getContentControlPlaceholderShown'
+        const value =
+          operation.op === 'getContentControlIsBound'
+            ? found.control.properties.dataBinding !== undefined
+            : operation.op === 'getContentControlPlaceholderShown'
               ? found.control.properties.showingPlaceholder
-              : found.control.properties.temporary,
-        });
+              : found.control.properties.temporary;
+        return query({ kind: 'flag', value });
       }
 
       case 'getContentControlText': {

--- a/packages/core/src/automation/plan.ts
+++ b/packages/core/src/automation/plan.ts
@@ -1972,20 +1972,20 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
         });
       }
 
-      case 'getNoteBody': {
+      case 'getNoteBody':
+      case 'getNoteText': {
         const target = handles.resolve(operation.note, 'note');
         if (!target || target.kind !== 'note')
           return refuse('invalid-handle', 'that handle does not name a note', 'note');
-        const story: AutomationStoryId = {
-          kind: 'note',
-          noteKind: target.noteKind,
-          noteId: target.noteId,
-        };
+        const story: AutomationStoryId = target;
         // A note DELETED since the handle was minted has no story, and saying so is the point:
-        // answering an empty body would let a script write into a note the document lost.
-        if (!packageReads.story(story))
+        // answering empty text or a body would hide that the document lost it.
+        const reads = packageReads.story(story);
+        if (!reads)
           return refuse('invalid-handle', 'that note is not in this document', storyKey(story));
-        return query({ kind: 'handle', handle: handles.body(story) });
+        return operation.op === 'getNoteText'
+          ? query({ kind: 'text', text: reads.text() })
+          : query({ kind: 'handle', handle: handles.body(story) });
       }
 
       case 'getNoteKind': {

--- a/packages/core/src/editor/automation-host.ts
+++ b/packages/core/src/editor/automation-host.ts
@@ -195,14 +195,23 @@ function sessionPort(editor: DocxEditorInstance): AutomationDocumentPort {
     // offsets — the same vocabulary `SemanticSelection` already uses — so nothing is translated
     // and there is no second coordinate space that could drift. Collapsing to one end is done
     // by pointing both ends at it, which is what a caret IS to the surface.
+    //
+    // THROUGH THE EDITOR COMMAND, not `surface.setSelection` directly. The public Office-shaped
+    // contract says selecting also navigates the reader to the range, and `setSelection` is the
+    // canonical focus-independent path that installs the logical selection and reveals its head
+    // from layout geometry. That keeps virtualized pages viable: the target usually has no DOM
+    // node to measure yet, and the reveal materializes it on the way.
     select(range, mode) {
       const surface = editor.surface;
       if (!surface) return;
       const anchor = mode === 'end' ? range.end : range.start;
       const head = mode === 'start' ? range.start : range.end;
-      surface.setSelection({
-        anchor: { paragraphId: anchor.paragraphId, offset: anchor.offset },
-        head: { paragraphId: head.paragraphId, offset: head.offset },
+      editor.exec({
+        type: 'setSelection',
+        range: {
+          anchor: { paragraphId: anchor.paragraphId, offset: anchor.offset },
+          head: { paragraphId: head.paragraphId, offset: head.offset },
+        },
       });
     },
     // The EDITOR's change event, not the session's: the facade re-subscribes to each new

--- a/packages/editor-api/compat/manifest.json
+++ b/packages/editor-api/compat/manifest.json
@@ -391,6 +391,10 @@
       "reason": "See Word.Comment#text."
     },
     {
+      "uid": "Word.NoteItem#text",
+      "reason": "Implemented by DocxEditor's object model as a read-only shortcut to the exact plain text returned by NoteItem#body.text. Upstream has no such member to select for exact conformance, so it is recorded as a DocxEditor extension rather than added to the reference shape. The body remains available for structured traversal and edits."
+    },
+    {
       "uid": "Word.Body#revisions",
       "reason": "See Word.Document#revisions."
     },

--- a/packages/editor-api/compat/manifest.json
+++ b/packages/editor-api/compat/manifest.json
@@ -413,6 +413,10 @@
     {
       "uid": "Word.Body#revisions",
       "reason": "Implemented by DocxEditor's object model \u2014 a header or a footnote can carry tracked changes of its own, and a review pass over one story is the natural way to reach them \u2014 but not selected for exact conformance: upstream declares revisions on Document (selected here), not on Body, so there is no reference shape for the story-scoped accessor. Recorded so the extra member is a decision rather than drift."
+    },
+    {
+      "uid": "Word.Body#bookmarks",
+      "reason": "Implemented by DocxEditor's object model as a story-scoped discovery accessor over the same BookmarkCollection that Word exposes on Range. Upstream has no Body#bookmarks member to select for exact conformance, while putting this collection on Document would falsely imply aggregation across the main body, headers, footers and notes. Each Body answers only the bookmarks declared in that body's own story."
     }
   ],
   "divergences": [

--- a/packages/editor-api/compat/manifest.json
+++ b/packages/editor-api/compat/manifest.json
@@ -296,7 +296,7 @@
     },
     {
       "uid": "Word.ContentControl#xmlMapping",
-      "reason": "Custom-XML-bound content control writes are refused until XML mapping is a separate supported lane (per the redesign plan); the mapping object itself is out of scope here."
+      "reason": "Custom-XML-bound content control writes are refused until XML mapping is a separate supported lane (per the redesign plan); the mapping object itself is out of scope here. DocxEditor's own read-only isBound boolean exposes binding presence for advisory preflight without exposing XPath, namespace mappings, store ids, or custom XML content."
     },
     {
       "uid": "Word.Range#start",
@@ -450,7 +450,7 @@
     },
     {
       "uid": "Word.ContentControlCollection",
-      "note": "getByTag, getByTitle, getFirst, getFirstOrNullObject and ContentControl#setValue are implemented and are NOT in this list's frozen reference fixture, so they are published as DocxEditor's own additions rather than as conformance-checked members. setValue exists because a control's value is not its characters: a dropdown takes a declared item, a date an ISO instant, a checkbox a state, and upstream spreads those over five sibling objects this subset does not ship."
+      "note": "getByTag, getByTitle, getFirst, getFirstOrNullObject, ContentControl#setValue and ContentControl#isBound are implemented and are NOT in this list's frozen reference fixture, so they are published as DocxEditor's own additions rather than as conformance-checked members. setValue exists because a control's value is not its characters: a dropdown takes a declared item, a date an ISO instant, a checkbox a state, and upstream spreads those over five sibling objects this subset does not ship. isBound is a presence-only advisory preflight; sync-time refusal remains authoritative."
     },
     {
       "uid": "Word.Section#getHeader / #getFooter",

--- a/packages/editor-api/src/__tests__/bookmark-types.test.ts
+++ b/packages/editor-api/src/__tests__/bookmark-types.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+import { expectTypeOf, test } from 'bun:test';
+import type {
+  Body as BrowserBody,
+  BookmarkCollection as BrowserBookmarkCollection,
+} from '../browser.ts';
+import type {
+  Body as ServerBody,
+  BookmarkCollection as ServerBookmarkCollection,
+  Document,
+} from '../index.ts';
+
+test('both public entries expose bookmarks on one story body, not on the document', () => {
+  expectTypeOf<BrowserBody>().toEqualTypeOf<ServerBody>();
+  expectTypeOf<BrowserBookmarkCollection>().toEqualTypeOf<ServerBookmarkCollection>();
+  expectTypeOf<ServerBody['bookmarks']>().toEqualTypeOf<ServerBookmarkCollection>();
+  expectTypeOf<'bookmarks' extends keyof Document ? true : false>().toEqualTypeOf<false>();
+});

--- a/packages/editor-api/src/__tests__/content-control-types.test.ts
+++ b/packages/editor-api/src/__tests__/content-control-types.test.ts
@@ -1,0 +1,16 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+import { expectTypeOf, test } from 'bun:test';
+import type { ContentControl as BrowserContentControl } from '../browser.ts';
+import type { ContentControl as ServerContentControl } from '../index.ts';
+
+test('both public entries expose binding presence as a read-only boolean', () => {
+  expectTypeOf<BrowserContentControl>().toEqualTypeOf<ServerContentControl>();
+  expectTypeOf<ServerContentControl['isBound']>().toEqualTypeOf<boolean>();
+  expectTypeOf<Pick<ServerContentControl, 'isBound'>>().toEqualTypeOf<{
+    readonly isBound: boolean;
+  }>();
+});

--- a/packages/editor-api/src/__tests__/note-types.test.ts
+++ b/packages/editor-api/src/__tests__/note-types.test.ts
@@ -1,0 +1,14 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+import { expectTypeOf, test } from 'bun:test';
+import type { NoteItem as BrowserNoteItem } from '../browser.ts';
+import type { NoteItem as ServerNoteItem } from '../index.ts';
+
+test('both public entries expose read-only note text', () => {
+  expectTypeOf<BrowserNoteItem>().toEqualTypeOf<ServerNoteItem>();
+  expectTypeOf<ServerNoteItem['text']>().toEqualTypeOf<string>();
+  expectTypeOf<ServerNoteItem['body']['text']>().toEqualTypeOf<string>();
+});

--- a/packages/editor-api/src/model/__tests__/model-content-controls.test.ts
+++ b/packages/editor-api/src/model/__tests__/model-content-controls.test.ts
@@ -59,6 +59,15 @@ const AMBIGUOUS = docx(
     `<w:p><w:r><w:t>c</w:t></w:r></w:p></w:sdtContent></w:sdt>`
 );
 
+const BOUND_MIXED = docx(
+  `<w:sdt><w:sdtPr><w:tag w:val="open"/><w:text/></w:sdtPr><w:sdtContent>` +
+    `<w:p><w:r><w:t>open</w:t></w:r></w:p></w:sdtContent></w:sdt>` +
+    `<w:sdt><w:sdtPr><w:tag w:val="bound"/>` +
+    `<w:dataBinding w:prefixMappings="xmlns:x='urn:secret'" w:xpath="/x:root/private" ` +
+    `w:storeItemID="{SECRET-ID}"/><w:group/></w:sdtPr><w:sdtContent>` +
+    `<w:p><w:r><w:t>bound</w:t></w:r></w:p></w:sdtContent></w:sdt>`
+);
+
 async function codeOf(call: () => Promise<unknown>): Promise<string> {
   try {
     await call();
@@ -163,6 +172,63 @@ describe('a control says what the document says about it', () => {
       temporary: true,
       text: 'Click here to enter text.',
     });
+  });
+
+  test('isBound is a loadable boolean across a mixed collection and every subtype', async () => {
+    const runtime = await serverRuntime(BOUND_MIXED);
+    const state = await runtime.run(async (context) => {
+      const controls = context.document.contentControls;
+      controls.load();
+      await context.sync();
+      for (const control of controls.items) control.load(['tag', 'subtype', 'isBound']);
+      await context.sync();
+      return controls.items.map((control) => ({
+        tag: control.tag,
+        subtype: control.subtype,
+        isBound: control.isBound,
+      }));
+    });
+    expect(state).toEqual([
+      { tag: 'open', subtype: 'plainText', isBound: false },
+      { tag: 'bound', subtype: 'group', isBound: true },
+    ]);
+    expect(JSON.stringify(state)).not.toContain('private');
+    expect(JSON.stringify(state)).not.toContain('SECRET-ID');
+    expect(JSON.stringify(state)).not.toContain('urn:secret');
+  });
+
+  test('isBound follows unloaded and detached proxy rules', async () => {
+    const runtime = await serverRuntime(BOUND_MIXED);
+    const escaped = await runtime.run(async (context) => {
+      const controls = context.document.contentControls;
+      controls.load();
+      await context.sync();
+      expect(() => controls.items[0]!.isBound).toThrowError(
+        expect.objectContaining({ code: 'PropertyNotLoaded' })
+      );
+      controls.items[1]!.load('isBound');
+      await context.sync();
+      return { loaded: controls.items[1]!, unloaded: controls.items[0]! };
+    });
+    expect(escaped.loaded.isBound).toBe(true);
+    expect(() => escaped.unloaded.isBound).toThrowError(
+      expect.objectContaining({ code: 'InvalidObjectPath' })
+    );
+  });
+
+  test('a stale control cannot refresh binding state after deletion', async () => {
+    const runtime = await serverRuntime(BOUND_MIXED);
+    const code = await codeOf(() =>
+      runtime.run(async (context) => {
+        const control = context.document.contentControls.getFirst();
+        await context.sync();
+        control.delete(false);
+        await context.sync();
+        control.load('isBound');
+        await context.sync();
+      })
+    );
+    expect(code).toBe('InvalidObjectPath');
   });
 
   test('a control’s range reads the characters it holds', async () => {
@@ -366,6 +432,23 @@ describe('a control is written through the document’s own write path', () => {
     expect(await mainXmlOf(runtime)).toBe(before);
   });
 
+  test('a bound value still refuses the whole mixed batch at sync', async () => {
+    const runtime = await serverRuntime(BOUND_MIXED);
+    const before = await mainXmlOf(runtime);
+    const code = await codeOf(() =>
+      runtime.run(async (context) => {
+        const controls = context.document.contentControls;
+        controls.load();
+        await context.sync();
+        controls.items[0]!.setValue({ kind: 'text', text: 'would apply' });
+        controls.items[1]!.setValue({ kind: 'text', text: 'must refuse' });
+        await context.sync();
+      })
+    );
+    expect(code).not.toBe('');
+    expect(await mainXmlOf(runtime)).toBe(before);
+  });
+
   // The three locations source-compatible code writes. `Replace` takes the control's value path;
   // the edges are insertions at the ends of what it holds. The range that comes back names the
   // TEXT THAT WAS WRITTEN in every case, not the control's whole content.
@@ -509,10 +592,10 @@ describe('a control is written through the document’s own write path', () => {
 describe('both hosts answer the same document', () => {
   test('the browser host reads the controls the server host reads', async () => {
     const container = globalThis.document.createElement('div');
-    const editor = createDocxEditor({ container, document: CONTROLS });
+    const editor = createDocxEditor({ container, document: BOUND_MIXED });
     if (!editor.surface) throw new Error('surface failed to mount');
     const browser: DocxEditorRuntime = createBrowser(editor);
-    const server = await serverRuntime(CONTROLS);
+    const server = await serverRuntime(BOUND_MIXED);
 
     const script = async (runtime: DocxEditorRuntime): Promise<unknown> =>
       runtime.run(async (context) => {
@@ -520,7 +603,7 @@ describe('both hosts answer the same document', () => {
         controls.load();
         await context.sync();
         for (const control of controls.items) {
-          control.load(['id', 'tag', 'title', 'subtype', 'text']);
+          control.load(['id', 'tag', 'title', 'subtype', 'isBound', 'text']);
         }
         await context.sync();
         return controls.items.map((control) => ({
@@ -528,6 +611,7 @@ describe('both hosts answer the same document', () => {
           tag: control.tag,
           title: control.title,
           subtype: control.subtype,
+          isBound: control.isBound,
           text: control.text,
         }));
       });

--- a/packages/editor-api/src/model/__tests__/model-office-groups.test.ts
+++ b/packages/editor-api/src/model/__tests__/model-office-groups.test.ts
@@ -16,8 +16,10 @@ import { createServer } from '../../runtime/server.ts';
 import { isDocxEditorError } from '../../runtime/errors.ts';
 import {
   docx,
+  p,
   reopen,
   serverRuntime,
+  WITH_BOOKMARKED_STORIES,
   WITH_FURNITURE,
   WITH_REVIEW_DATE_CASES,
 } from './support/documents.ts';
@@ -195,6 +197,94 @@ describe('links and bookmarks are the names a document gives to its own text', (
       return { name: bookmark.name, text: range.text };
     });
     expect(found).toEqual({ name: 'Target', text: 'marked' });
+  });
+
+  test('a body enumerates an empty bookmark collection without searchable text', async () => {
+    const runtime = await serverRuntime(docx(p('plain')));
+    const found = await runtime.run(async (context) => {
+      const bookmarks = context.document.body.bookmarks;
+      bookmarks.load('items');
+      await context.sync();
+      return bookmarks.items;
+    });
+    expect(found).toEqual([]);
+  });
+
+  test('a body enumerates multiple bookmarks, keeps the first duplicate, and applies load queries', async () => {
+    const runtime = await serverRuntime(WITH_BOOKMARKED_STORIES);
+    const found = await runtime.run(async (context) => {
+      const body = context.document.body;
+      const bookmarks = body.bookmarks;
+      expect(body.bookmarks).toBe(bookmarks);
+      bookmarks.load('items');
+      await context.sync();
+
+      const all = [...bookmarks.items];
+      for (const bookmark of all) bookmark.load('name');
+      await context.sync();
+      const duplicate = all[1]!;
+      const range = duplicate.range;
+      await context.sync();
+      range.load('text');
+      await context.sync();
+
+      bookmarks.load({ select: 'items', skip: 1, top: 1 });
+      await context.sync();
+      const filtered = bookmarks.items[0]!;
+      filtered.load('name');
+      await context.sync();
+      return {
+        names: all.map((bookmark) => bookmark.name),
+        duplicateText: range.text,
+        filtered: filtered.name,
+      };
+    });
+    expect(found).toEqual({
+      names: ['First', 'Duplicate'],
+      duplicateText: 'kept',
+      filtered: 'Duplicate',
+    });
+  });
+
+  test('each body enumerates only the bookmarks in its own story', async () => {
+    const runtime = await serverRuntime(WITH_BOOKMARKED_STORIES);
+    const found = await runtime.run(async (context) => {
+      const main = context.document.body.bookmarks;
+      const sections = context.document.sections;
+      main.load('items');
+      sections.load('items');
+      await context.sync();
+
+      const header = sections.items[0]!.getHeader('Primary');
+      await context.sync();
+      const headerBookmarks = header.bookmarks;
+      headerBookmarks.load('items');
+      await context.sync();
+
+      for (const bookmark of [...main.items, ...headerBookmarks.items]) bookmark.load('name');
+      await context.sync();
+      return {
+        main: main.items.map((bookmark) => bookmark.name),
+        header: headerBookmarks.items.map((bookmark) => bookmark.name),
+      };
+    });
+    expect(found).toEqual({ main: ['First', 'Duplicate'], header: ['Duplicate'] });
+  });
+
+  test('selecting a bookmark without a reader is refused at the call', async () => {
+    const runtime = await serverRuntime(BOOKMARKED);
+    const code = await codeOf(async () =>
+      runtime.run(async (context) => {
+        const whole = context.document.body.search('marked');
+        whole.load('items');
+        await context.sync();
+        const bookmarks = whole.items[0]!.bookmarks;
+        bookmarks.load('items');
+        await context.sync();
+        bookmarks.items[0]!.select();
+      })
+    );
+    expect(code).toBe('NotSupported');
   });
 });
 

--- a/packages/editor-api/src/model/__tests__/model-office-groups.test.ts
+++ b/packages/editor-api/src/model/__tests__/model-office-groups.test.ts
@@ -21,6 +21,7 @@ import {
   serverRuntime,
   WITH_BOOKMARKED_STORIES,
   WITH_FURNITURE,
+  WITH_NOTE_TEXT_CASES,
   WITH_REVIEW_DATE_CASES,
 } from './support/documents.ts';
 
@@ -356,6 +357,74 @@ describe('a section is the page a story is laid out on', () => {
       return { type: note.type, text: body.text, count: notes.items.length };
     });
     expect(found).toEqual({ type: 'Footnote', text: 'in the footnote', count: 1 });
+  });
+
+  test('note text is unloaded until one post-listing load round fills every item', async () => {
+    const runtime = await createServer(WITH_NOTE_TEXT_CASES);
+    const found = await runtime.run(async (context) => {
+      const footnotes = context.document.footnotes;
+      const endnotes = context.document.endnotes;
+      footnotes.load();
+      endnotes.load();
+      await context.sync();
+
+      const notes = [...footnotes.items, ...endnotes.items];
+      for (const note of notes) {
+        expect(() => note.text).toThrowError(
+          expect.objectContaining({
+            code: 'PropertyNotLoaded',
+            target: expect.stringContaining('.text'),
+          })
+        );
+        note.load(['text', 'type']);
+      }
+      await context.sync();
+      return notes.map((note) => ({ type: note.type, text: note.text }));
+    });
+    expect(found).toEqual([
+      { type: 'Footnote', text: '' },
+      { type: 'Footnote', text: 'first\t<unsafe>\nline\rsecond' },
+      { type: 'Endnote', text: 'end note' },
+    ]);
+  });
+
+  test('direct note text is exactly the note body text', async () => {
+    const runtime = await createServer(WITH_NOTE_TEXT_CASES);
+    const found = await runtime.run(async (context) => {
+      const notes = context.document.footnotes;
+      notes.load();
+      await context.sync();
+
+      for (const note of notes.items) {
+        note.load('text');
+        void note.body;
+      }
+      await context.sync();
+      for (const note of notes.items) note.body.load('text');
+      await context.sync();
+      return notes.items.map((note) => [note.text, note.body.text]);
+    });
+    expect(found).toEqual([
+      ['', ''],
+      ['first\t<unsafe>\nline\rsecond', 'first\t<unsafe>\nline\rsecond'],
+    ]);
+  });
+
+  test('a deleted note refuses a later direct text load', async () => {
+    const runtime = await createServer(WITH_NOTE_TEXT_CASES);
+    const code = await codeOf(() =>
+      runtime.run(async (context) => {
+        const notes = context.document.footnotes;
+        notes.load();
+        await context.sync();
+        const note = notes.items[0]!;
+        note.delete();
+        await context.sync();
+        note.load('text');
+        await context.sync();
+      })
+    );
+    expect(code).toBe('InvalidObjectPath');
   });
 });
 

--- a/packages/editor-api/src/model/__tests__/support/documents.ts
+++ b/packages/editor-api/src/model/__tests__/support/documents.ts
@@ -66,6 +66,7 @@ const STYLES_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relati
 const HEADER_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
 const FOOTER_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
 const NOTES_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes';
+const ENDNOTES_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes';
 const COMMENTS_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments';
 const OFFICE_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 
@@ -115,6 +116,47 @@ export const WITH_FURNITURE: Uint8Array = zipSync({
     `<w:footnotes xmlns:w="${W}">` +
       '<w:footnote w:id="2"><w:p><w:r><w:t>in the footnote</w:t></w:r></w:p></w:footnote>' +
       '</w:footnotes>'
+  ),
+});
+
+/** Footnotes and endnotes covering empty, multi-paragraph, tab, break and untrusted text reads. */
+export const WITH_NOTE_TEXT_CASES: Uint8Array = zipSync({
+  '[Content_Types].xml': strToU8(
+    `<Types xmlns="${CT}">` +
+      '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+      '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+      '<Override PartName="/word/endnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml"/>' +
+      '</Types>'
+  ),
+  '_rels/.rels': strToU8(
+    `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+  ),
+  'word/_rels/document.xml.rels': strToU8(
+    `<Relationships xmlns="${REL}">` +
+      `<Relationship Id="rId9" Type="${NOTES_REL}" Target="footnotes.xml"/>` +
+      `<Relationship Id="rId10" Type="${ENDNOTES_REL}" Target="endnotes.xml"/>` +
+      '</Relationships>'
+  ),
+  'word/document.xml': strToU8(
+    `<w:document xmlns:w="${W}"><w:body><w:p>` +
+      '<w:r><w:footnoteReference w:id="2"/></w:r>' +
+      '<w:r><w:footnoteReference w:id="3"/></w:r>' +
+      '<w:r><w:endnoteReference w:id="4"/></w:r>' +
+      '</w:p></w:body></w:document>'
+  ),
+  'word/footnotes.xml': strToU8(
+    `<w:footnotes xmlns:w="${W}">` +
+      '<w:footnote w:id="2"><w:p/></w:footnote>' +
+      '<w:footnote w:id="3">' +
+      '<w:p><w:r><w:t>first</w:t><w:tab/><w:t>&lt;unsafe&gt;</w:t><w:br/><w:t>line</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>second</w:t></w:r></w:p>' +
+      '</w:footnote></w:footnotes>'
+  ),
+  'word/endnotes.xml': strToU8(
+    `<w:endnotes xmlns:w="${W}">` +
+      '<w:endnote w:id="4"><w:p><w:r><w:t>end note</w:t></w:r></w:p></w:endnote>' +
+      '</w:endnotes>'
   ),
 });
 

--- a/packages/editor-api/src/model/__tests__/support/documents.ts
+++ b/packages/editor-api/src/model/__tests__/support/documents.ts
@@ -180,6 +180,36 @@ export const WITH_REVIEW_DATE_CASES: Uint8Array = (() => {
 })();
 
 /**
+ * Bookmarks in two stories, including a repeated name in the main story.
+ *
+ * `w:id` and bookmark names are story-scoped. Reusing both in the header is intentional: a
+ * story-owned accessor must neither flatten that bookmark into the main body nor confuse the two
+ * ranges.
+ */
+export const WITH_BOOKMARKED_STORIES: Uint8Array = (() => {
+  const parts = unzipSync(WITH_FURNITURE);
+  const main = strFromU8(parts['word/document.xml'] as Uint8Array).replace(
+    '<w:r><w:t>in the body</w:t></w:r>',
+    '<w:bookmarkStart w:id="1" w:name="First"/><w:r><w:t>first</w:t></w:r>' +
+      '<w:bookmarkEnd w:id="1"/>' +
+      '<w:bookmarkStart w:id="2" w:name="Duplicate"/><w:r><w:t>kept</w:t></w:r>' +
+      '<w:bookmarkEnd w:id="2"/>' +
+      '<w:bookmarkStart w:id="3" w:name="Duplicate"/><w:r><w:t>ignored</w:t></w:r>' +
+      '<w:bookmarkEnd w:id="3"/>'
+  );
+  const header = strFromU8(parts['word/header1.xml'] as Uint8Array).replace(
+    '<w:r><w:t>in the header</w:t></w:r>',
+    '<w:bookmarkStart w:id="1" w:name="Duplicate"/><w:r><w:t>header</w:t></w:r>' +
+      '<w:bookmarkEnd w:id="1"/>'
+  );
+  return zipSync({
+    ...parts,
+    'word/document.xml': strToU8(main),
+    'word/header1.xml': strToU8(header),
+  });
+})();
+
+/**
  * A document awkward enough to compare two hosts over: a style cascade, a table with cell
  * paragraphs, inline furniture (a tab and a break), and section properties.
  *

--- a/packages/editor-api/src/model/body.ts
+++ b/packages/editor-api/src/model/body.ts
@@ -27,6 +27,7 @@ import {
   type RequestContext,
   type ResolvedLoadOptions,
 } from '../runtime/model-support.ts';
+import { BookmarkCollection } from './bookmarks.ts';
 import { ParagraphCollection, RangeCollection } from './collections.ts';
 import { ContentControlCollection } from './content-controls.ts';
 import { ListCollection } from './lists.ts';
@@ -57,6 +58,7 @@ import { searchOptions, type SearchOptions } from './search-options.ts';
  */
 export class Body extends ModelObject {
   #paragraphs: ParagraphCollection | undefined;
+  #bookmarks: BookmarkCollection | undefined;
   #font: Font | undefined;
   #lists: ListCollection | undefined;
   #contentControls: ContentControlCollection | undefined;
@@ -102,6 +104,24 @@ export class Body extends ModelObject {
   get paragraphs(): ParagraphCollection {
     this.#paragraphs ??= this.paragraphsUnder(`${this.path.label}.paragraphs`);
     return this.#paragraphs;
+  }
+
+  /**
+   * Every bookmark declared in this story, in document order.
+   *
+   * This is story-scoped: `document.body.bookmarks` covers only the main body story. A header,
+   * footer or note body answers its own bookmarks through that body's accessor; this collection
+   * does not aggregate bookmarks from other stories.
+   */
+  get bookmarks(): BookmarkCollection {
+    const handle = this.#handle();
+    this.#bookmarks ??= BookmarkCollection.of(
+      this.context,
+      `${this.path.label}.bookmarks`,
+      this.path,
+      () => ({ op: 'getBookmarks', scope: { body: handle } })
+    );
+    return this.#bookmarks;
   }
 
   /** The character formatting of the whole story: what all of it agrees on, and what a write sets. */

--- a/packages/editor-api/src/model/bookmarks.ts
+++ b/packages/editor-api/src/model/bookmarks.ts
@@ -93,24 +93,26 @@ export class Bookmark extends ModelObject implements PromisedItem {
     return this.#range;
   }
 
-  /** Put the reader's selection on the bookmark. `NotSupported` where there is no reader. */
+  /**
+   * Put the reader's selection on the bookmark and navigate the editor viewport to it.
+   *
+   * The bookmark's current range is resolved as part of the selection, so callers do not need to
+   * read {@link Bookmark.range} first. `Start` and `End` collapse to that endpoint. Refused with
+   * `NotSupported` where there is no reader.
+   */
   select(selectionMode_?: SelectionMode): void {
     const target = `${this.path.label}.select`;
     const mode = selectionMode(selectionMode_, target);
     this.requireAddressable();
     if (!this.internals.capabilities.selection) fail({ code: 'NotSupported', target });
     const bookmark = this.#handle();
-    // TWO operations in one batch and in this order: the range first, then the selection over it.
-    // A bookmark is a name, and the caret goes on characters.
-    const found = Range.promised(this.context, target, false);
-    this.read(
-      `${target}.range`,
-      () => ({ op: 'getBookmarkRange', bookmark }),
-      (value) => {
-        found.hydrateAddress({ kind: 'span', span: hydratedSpan(value, target) });
-      }
-    );
-    found.select(mode);
+    // One canonical operation: resolving the bookmark and moving the reader belong to the same
+    // batch. A pending Range cannot be targeted until a previous sync makes it addressable.
+    this.command('select', () => ({
+      op: 'selectBookmark',
+      bookmark,
+      mode: mode === 'Select' ? 'select' : mode === 'Start' ? 'start' : 'end',
+    }));
   }
 
   /** @internal Plan the read this object's `load(...)` asked for. */

--- a/packages/editor-api/src/model/content-controls.ts
+++ b/packages/editor-api/src/model/content-controls.ts
@@ -170,6 +170,18 @@ export class ContentControl extends ModelObject implements PromisedItem {
   }
 
   /**
+   * Whether the control currently declares an OOXML data binding.
+   *
+   * This is advisory preflight for callers choosing controls to write. A document can change
+   * after this property is loaded, so the atomic sync-time refusal remains the final authority.
+   * Only binding presence is exposed: XPath, namespace mappings, store ids, and custom XML
+   * content remain inside the untrusted-document boundary.
+   */
+  get isBound(): boolean {
+    return this.loadedProperty<boolean>('isBound');
+  }
+
+  /**
    * Whether the control refuses to be deleted.
    *
    * Reads the lock IN FORCE, so a control an enclosing one protects reports true even when its
@@ -259,7 +271,9 @@ export class ContentControl extends ModelObject implements PromisedItem {
    *
    * The refusals belong to the document, not to this method: a locked control, a control the file
    * bound to custom XML, and a value the control's type does not accept are all refused by the
-   * engine's single write path, which is the same path a keystroke takes.
+   * engine's single write path, which is the same path a keystroke takes. {@link isBound} is an
+   * advisory preflight only; this sync-time check remains authoritative if the document changed
+   * after the flag was loaded.
    */
   setValue(value: ContentControlValue): void {
     const target = `${this.path.label}.setValue`;
@@ -323,6 +337,7 @@ export class ContentControl extends ModelObject implements PromisedItem {
       'tag',
       'title',
       'subtype',
+      'isBound',
       'text',
       'cannotDelete',
       'cannotEdit',
@@ -341,6 +356,16 @@ export class ContentControl extends ModelObject implements PromisedItem {
     }
     if (selected.includes('subtype')) {
       this.loadTextInto('subtype', () => ({ op: 'getContentControlSubtype', contentControl }));
+    }
+    if (selected.includes('isBound')) {
+      const label = `${this.path.label}.isBound`;
+      this.read(
+        label,
+        () => ({ op: 'getContentControlIsBound', contentControl }),
+        (value) => {
+          this.setLoadedProperty('isBound', hydratedFlag(value, label));
+        }
+      );
     }
     if (selected.includes('text')) {
       this.loadTextInto('text', () => ({ op: 'getContentControlText', contentControl }));

--- a/packages/editor-api/src/model/notes.ts
+++ b/packages/editor-api/src/model/notes.ts
@@ -87,6 +87,17 @@ export class NoteItem extends ModelObject implements PromisedItem {
     return this.loadedProperty<NoteItemType>('type');
   }
 
+  /**
+   * The note's plain text.
+   *
+   * This is the same value as loading `text` from {@link NoteItem.body}: every paragraph in the
+   * note story, in reading order, joined by one carriage return per paragraph mark. Load it
+   * directly when structured traversal or editing through {@link NoteItem.body} is not needed.
+   */
+  get text(): string {
+    return this.loadedProperty<string>('text');
+  }
+
   /** The note's own story. */
   get body(): Body {
     if (this.#body) return this.#body;
@@ -148,18 +159,24 @@ export class NoteItem extends ModelObject implements PromisedItem {
 
   /** @internal Plan the read this object's `load(...)` asked for. */
   protected override onLoad(request: ResolvedLoadOptions): void {
-    if (!this.selection(request, ['type']).includes('type')) return;
-    const label = `${this.path.label}.type`;
-    const note = this.#handle();
-    this.read(
-      label,
-      () => ({ op: 'getNoteKind', note }),
-      (value) => {
-        // Word's spelling on this side, OOXML's on the engine's — the mapping lives here and in
-        // `getNext`, and nowhere else.
-        this.setLoadedProperty('type', kindOf(hydratedText(value, label)));
-      }
-    );
+    const selected = this.selection(request, ['text', 'type']);
+    if (selected.includes('text')) {
+      const note = this.#handle();
+      this.loadTextInto('text', () => ({ op: 'getNoteText', note }));
+    }
+    if (selected.includes('type')) {
+      const label = `${this.path.label}.type`;
+      const note = this.#handle();
+      this.read(
+        label,
+        () => ({ op: 'getNoteKind', note }),
+        (value) => {
+          // Word's spelling on this side, OOXML's on the engine's — the mapping lives here and in
+          // `getNext`, and nowhere else.
+          this.setLoadedProperty('type', kindOf(hydratedText(value, label)));
+        }
+      );
+    }
   }
 
   #handle(): AutomationHandle {

--- a/packages/editor-api/src/model/range.ts
+++ b/packages/editor-api/src/model/range.ts
@@ -246,11 +246,16 @@ export class Range extends ModelObject implements PromisedItem {
   }
 
   /**
-   * Put the reader's selection on this range.
+   * Put the reader's selection on this range and navigate the editor viewport to it.
+   *
+   * The whole range is selected by default. `Start` and `End` instead collapse the caret to that
+   * endpoint and reveal it. An already-visible endpoint stays still; an offscreen one is brought
+   * into view from the editor's layout, including when its page has not been materialized yet.
    *
    * Refused with `NotSupported` where there is no reader — a document opened from bytes on a
-   * server has no caret, and moving one would be a claim about a screen nobody is looking at. The
-   * check is at the CALL rather than at the sync, so the mistake is reported where it was made.
+   * server has no caret or viewport, and moving one would be a claim about a screen nobody is
+   * looking at. The check is at the CALL rather than at the sync, so the mistake is reported where
+   * it was made.
    */
   select(selectionMode_?: SelectionMode): void {
     const target = `${this.path.label}.select`;

--- a/packages/editor-api/src/runtime/__conformance__/declared-lifecycle.ts
+++ b/packages/editor-api/src/runtime/__conformance__/declared-lifecycle.ts
@@ -152,6 +152,7 @@ const bodyAnswersItsOwnObjects: Satisfies<
   [Range, Paragraph, RangeCollection]
 > = true;
 const bodyHasParagraphs: Satisfies<Body['paragraphs'], ParagraphCollection> = true;
+const bodyHasBookmarks: Satisfies<Body['bookmarks'], BookmarkCollection> = true;
 
 // ---------------------------------------------------------------------------
 // Ranges and paragraphs
@@ -444,6 +445,7 @@ void bodyInsertsAParagraph;
 void bodySearches;
 void bodyAnswersItsOwnObjects;
 void bodyHasParagraphs;
+void bodyHasBookmarks;
 void rangeTextIsAString;
 void rangeSelects;
 void rangeInsertsText;

--- a/packages/editor-api/src/runtime/__tests__/runtime-hosts.test.ts
+++ b/packages/editor-api/src/runtime/__tests__/runtime-hosts.test.ts
@@ -21,6 +21,7 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import { createDocxEditor } from '@docx-editor.dev/core/editor';
+import { caretAt } from '@docx-editor.dev/core/layout';
 import { DocxEditor } from '../../index.ts';
 import { DocxEditor as DocxEditorBrowser } from '../../browser.ts';
 import type { DocxEditorRuntime } from '../runtime.ts';
@@ -75,6 +76,29 @@ describe('DocxEditor.createServer', () => {
     runtime.dispose();
   });
 
+  test('enumerates body bookmarks headlessly and releases the collection with its run', async () => {
+    const runtime = await DocxEditor.createServer(
+      docx(
+        '<w:p><w:bookmarkStart w:id="1" w:name="Headless"/>' +
+          '<w:r><w:t>server bookmark</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p>'
+      )
+    );
+    const escaped = await runtime.run(async (context) => {
+      const bookmarks = context.document.body.bookmarks;
+      bookmarks.load('items');
+      await context.sync();
+      const bookmark = bookmarks.items[0]!;
+      bookmark.load('name');
+      await context.sync();
+      expect(bookmark.name).toBe('Headless');
+      return bookmarks;
+    });
+    expect(() => escaped.load()).toThrowError(
+      expect.objectContaining({ code: 'InvalidObjectPath' })
+    );
+    runtime.dispose();
+  });
+
   test('refuses bytes that are not a document, without throwing anything untyped', async () => {
     await expect(DocxEditor.createServer(new Uint8Array([1, 2, 3, 4]))).rejects.toMatchObject({
       code: 'InvalidArgument',
@@ -96,6 +120,41 @@ describe('DocxEditor.createBrowser', () => {
     const editor = createDocxEditor({ container, document: TWO_PARAGRAPHS });
     if (!editor.surface) throw new Error('surface failed to mount');
     return { editor, container };
+  }
+
+  function mountScrollable(bookmarked = false): {
+    editor: ReturnType<typeof createDocxEditor>;
+    scroller: HTMLElement;
+  } {
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    const container = document.createElement('div');
+    scroller.append(container);
+    document.body.append(scroller);
+    Object.defineProperty(scroller, 'clientHeight', { value: 600, configurable: true });
+    Object.defineProperty(scroller, 'scrollHeight', { value: 100_000, configurable: true });
+    let scrollTop = 0;
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => scrollTop,
+      set: (next: number) => {
+        scrollTop = next;
+      },
+      configurable: true,
+    });
+    scroller.scrollTo = ((options: ScrollToOptions) => {
+      scrollTop = options.top ?? 0;
+    }) as HTMLElement['scrollTo'];
+    const body = Array.from({ length: 120 }, (_, index) => {
+      if (index !== 119) return p(`paragraph ${index}`);
+      if (!bookmarked) return p('automation target');
+      return (
+        '<w:p><w:bookmarkStart w:id="1" w:name="AutomationTarget"/>' +
+        '<w:r><w:t>automation target</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p>'
+      );
+    }).join('');
+    const editor = createDocxEditor({ container, document: docx(body) });
+    if (!editor.surface) throw new Error('surface failed to mount');
+    return { editor, scroller };
   }
 
   test('reads the document that is already open', async () => {
@@ -138,6 +197,75 @@ describe('DocxEditor.createBrowser', () => {
     });
     expect('save' in runtime).toBe(false);
     runtime.dispose();
+  });
+
+  test('Range.select reveals an offscreen result and preserves its logical range', async () => {
+    const { editor, scroller } = mountScrollable();
+    const runtime = DocxEditorBrowser.createBrowser(editor);
+    expect(scroller.scrollTop).toBe(0);
+
+    await runtime.run(async (context) => {
+      const matches = context.document.body.search('automation target', { matchCase: true });
+      matches.load();
+      await context.sync();
+      matches.items[0]!.select();
+      await context.sync();
+    });
+
+    const selection = editor.surface!.state().selection;
+    expect(selection.anchor.paragraphId).toBe(selection.head.paragraphId);
+    expect(selection.anchor.offset).toBe(0);
+    expect(selection.head.offset).toBe('automation target'.length);
+    expect(scroller.scrollTop).toBeGreaterThan(0);
+
+    const caret = caretAt(editor.surface!.layout(), selection.head);
+    expect(caret).not.toBeNull();
+    const page = editor.surface!.layout().pages.find((entry) => entry.index === caret!.pageIndex);
+    expect(page).toBeDefined();
+    const targetTop = (page!.contentBox.y + caret!.y) * (96 / 72);
+    expect(targetTop).toBeGreaterThanOrEqual(scroller.scrollTop);
+    expect(targetTop).toBeLessThanOrEqual(scroller.scrollTop + scroller.clientHeight);
+
+    runtime.dispose();
+    editor.destroy();
+    scroller.remove();
+  });
+
+  test('Bookmark.select resolves and reveals an offscreen bookmark in one selection sync', async () => {
+    const { editor, scroller } = mountScrollable(true);
+    const runtime = DocxEditorBrowser.createBrowser(editor);
+    expect(scroller.scrollTop).toBe(0);
+
+    await runtime.run(async (context) => {
+      const matches = context.document.body.search('automation target', { matchCase: true });
+      matches.load();
+      await context.sync();
+      const bookmarks = matches.items[0]!.bookmarks;
+      bookmarks.load();
+      await context.sync();
+      // No `bookmark.range` read or intermediate sync: selection resolves the current marker pair
+      // inside this batch.
+      bookmarks.items[0]!.select();
+      await context.sync();
+    });
+
+    const selection = editor.surface!.state().selection;
+    expect(selection.anchor.paragraphId).toBe(selection.head.paragraphId);
+    expect(selection.anchor.offset).toBe(0);
+    expect(selection.head.offset).toBe('automation target'.length);
+    expect(scroller.scrollTop).toBeGreaterThan(0);
+
+    const caret = caretAt(editor.surface!.layout(), selection.head);
+    expect(caret).not.toBeNull();
+    const page = editor.surface!.layout().pages.find((entry) => entry.index === caret!.pageIndex);
+    expect(page).toBeDefined();
+    const targetTop = (page!.contentBox.y + caret!.y) * (96 / 72);
+    expect(targetTop).toBeGreaterThanOrEqual(scroller.scrollTop);
+    expect(targetTop).toBeLessThanOrEqual(scroller.scrollTop + scroller.clientHeight);
+
+    runtime.dispose();
+    editor.destroy();
+    scroller.remove();
   });
 
   test('disposing the runtime leaves the editor mounted and editable', async () => {

--- a/packages/editor-api/src/runtime/__tests__/runtime-load.test.ts
+++ b/packages/editor-api/src/runtime/__tests__/runtime-load.test.ts
@@ -16,6 +16,7 @@ import { createRuntime } from '../runtime.ts';
 import { resolveLoadOption, type LoadOption } from '../load-options.ts';
 import { openHost, spyHost } from './support/hosts.ts';
 import { docx, p } from './support/docx.ts';
+import { WITH_NOTE_TEXT_CASES } from '../../model/__tests__/support/documents.ts';
 
 const FOUR = docx(`${p('one')}${p('two')}${p('three')}${p('four')}`);
 
@@ -57,6 +58,36 @@ describe('a property is only readable once a sync has filled it', () => {
       first.load('text');
       await context.sync();
       expect(first.text).toBe('alpha');
+    });
+    runtime.dispose();
+  });
+
+  test('all listed note texts load in one following host round', async () => {
+    const spy = spyHost(openHost(WITH_NOTE_TEXT_CASES));
+    const runtime = createRuntime({ host: spy.host, save: true });
+    await runtime.run(async (context) => {
+      const footnotes = context.document.footnotes;
+      const endnotes = context.document.endnotes;
+      footnotes.load();
+      endnotes.load();
+      await context.sync();
+      spy.reset();
+
+      const notes = [...footnotes.items, ...endnotes.items];
+      for (const note of notes) note.load('text');
+      await context.sync();
+
+      expect(spy.requests).toHaveLength(1);
+      expect(spy.requests[0]!.operations.map((operation) => operation.op)).toEqual([
+        'getNoteText',
+        'getNoteText',
+        'getNoteText',
+      ]);
+      expect(notes.map((note) => note.text)).toEqual([
+        '',
+        'first\t<unsafe>\nline\rsecond',
+        'end note',
+      ]);
     });
     runtime.dispose();
   });


### PR DESCRIPTION
## Summary
- Enumerate bookmarks within their owning story and reveal selected bookmark ranges in browser hosts.
- Expose content-control binding presence through `isBound` so callers can preflight writes.
- Read note content directly through `NoteItem.text` while preserving story boundaries.

## Test plan
- [x] 212 focused core/editor-api discovery tests across bookmarks, content controls, notes, hosts, and loading
- [x] Commit hooks: typecheck, API snapshots, lint, formatting, license headers
- [x] `bun run check:parity`
- [x] `bun run i18n:validate`

Stacked on #254

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788868836&installation_model_id=422592&pr_number=255&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F255&signature=bbcb5b03b529a7d3fe8dbb6447fcef8ebfd9ec224ed5425728c5793f52f032e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->