### PR TITLE
fix(core): preserve comment reply threads in Word

### DIFF
--- a/.changeset/bright-threads-export.md
+++ b/.changeset/bright-threads-export.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix exported comment replies opening as separate comments instead of a thread in Microsoft Word.

--- a/packages/core/src/store/__tests__/comment-offset-authority.test.ts
+++ b/packages/core/src/store/__tests__/comment-offset-authority.test.ts
@@ -217,3 +217,69 @@ describe('a marker never lands inside an indivisible group', () => {
     expect(fieldChars).toBe(5);
   });
 });
+
+describe('coincident markers keep Word classic order', () => {
+  test('a second range on the same span nests starts/ends and trails references', () => {
+    // Same insertion biases `addComment` uses for a reply. Interleaved end→ref pairs here
+    // are exactly what made Word drop thread parent links on export.
+    const store = storeOf(`<w:p>${run('abcdef')}</w:p>`);
+    const paragraph = firstParagraph(store);
+    const place = (commentId: string) => {
+      const applied = store.transact((ctx) => {
+        ctx.apply({
+          op: 'insertCommentMarker',
+          paragraphId: paragraph.id,
+          offset: 6,
+          commentId,
+          marker: 'reference',
+        });
+        ctx.apply({
+          op: 'insertCommentMarker',
+          paragraphId: paragraph.id,
+          offset: 6,
+          commentId,
+          marker: 'end',
+        });
+        ctx.apply({
+          op: 'insertCommentMarker',
+          paragraphId: paragraph.id,
+          offset: 0,
+          commentId,
+          marker: 'start',
+        });
+      });
+      expect(applied.ok).toBe(true);
+    };
+    place('1');
+    place('2');
+
+    const after = firstParagraph(store);
+    const shape: string[] = [];
+    for (const child of after.children) {
+      if (child.kind === 'commentRangeStart' || child.kind === 'commentRangeEnd') {
+        const id = child.attributes.find((entry) => entry.localName === 'id')?.value;
+        shape.push(`${child.kind}#${id ?? '?'}`);
+        continue;
+      }
+      if (
+        child.kind === 'run' &&
+        child.children.some((inner) => inner.kind === 'commentReference')
+      ) {
+        const ref = child.children.find((inner) => inner.kind === 'commentReference');
+        const id =
+          ref && ref.kind !== 'textValue'
+            ? ref.attributes.find((entry) => entry.localName === 'id')?.value
+            : undefined;
+        shape.push(`commentReference#${id ?? '?'}`);
+      }
+    }
+    expect(shape).toEqual([
+      'commentRangeStart#1',
+      'commentRangeStart#2',
+      'commentRangeEnd#2',
+      'commentRangeEnd#1',
+      'commentReference#1',
+      'commentReference#2',
+    ]);
+  });
+});

--- a/packages/core/src/store/__tests__/review-reads.test.ts
+++ b/packages/core/src/store/__tests__/review-reads.test.ts
@@ -16,6 +16,7 @@ import {
   collectReviewItems,
   commentBodyText,
   commentPartNameOf,
+  commentsOfPart,
   commentsExtendedPartNameOf,
   deepParagraphOrderOfPart,
   locateSites,
@@ -90,6 +91,28 @@ describe('the store lane answers the review queue', () => {
     expect(comment.orphaned).toBe(false);
     expect(comment.range?.start).toEqual({ paragraphId, offset: 0 });
     expect(comment.range?.end).toEqual({ paragraphId, offset: 5 });
+  });
+});
+
+describe('comment thread identity', () => {
+  test('uses the last comment paragraph paraId, as commentsExtended requires', () => {
+    const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+    const W14_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
+    const result = readOoxmlPart(
+      `<w:comments xmlns:w="${W_NS}" xmlns:w14="${W14_NS}">` +
+        `<w:comment w:id="0" w:author="QA">` +
+        `<w:p w14:paraId="11111111"><w:r><w:t>first</w:t></w:r></w:p>` +
+        `<w:p w14:paraId="22222222"><w:r><w:t>last</w:t></w:r></w:p>` +
+        `</w:comment></w:comments>`,
+      {
+        name: '/word/comments.xml',
+        contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml',
+      }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+
+    expect(commentsOfPart(result.part)[0]?.paraId).toBe('22222222');
   });
 });
 

--- a/packages/core/src/store/package/comment-lifecycle.ts
+++ b/packages/core/src/store/package/comment-lifecycle.ts
@@ -142,9 +142,10 @@ function commentRecords(
   return byId;
 }
 
-/** The `w14:paraId` of a comment's first paragraph, upper-cased, when it has one. */
+/** The `w14:paraId` of a comment's last paragraph, upper-cased, when it has one. */
 function paraIdOf(comment: OoxmlElement): string | null {
-  for (const child of comment.children) {
+  for (let index = comment.children.length - 1; index >= 0; index -= 1) {
+    const child = comment.children[index]!;
     if (child.kind !== 'paragraph') continue;
     const value = attribute(child, W14_NAMESPACE_URI, 'paraId');
     return value === undefined ? null : value.toUpperCase();

--- a/packages/core/src/store/store/comment-reads.ts
+++ b/packages/core/src/store/store/comment-reads.ts
@@ -82,7 +82,7 @@ export interface CommentRecord {
   readonly date?: string;
   /** Body paragraphs, as tree nodes, so the surface renders measured text rather than a string. */
   readonly blocks: readonly OoxmlElement[];
-  /** `w14:paraId` of the first body paragraph — the key thread state is stored under. */
+  /** `w14:paraId` of the last body paragraph — the key thread state is stored under. */
   readonly paraId?: string;
   /** `@w16cid:parentId` — the `w:id` of the comment this replies to, when the file names it. */
   readonly parentCommentId?: string;
@@ -283,8 +283,13 @@ export function commentsOfPart(part: OoxmlPart): CommentRecord[] {
         }
         const initials = wml(node, 'initials');
         const date = wml(node, 'date');
-        const first = blocks.find((block) => block.kind === 'paragraph');
-        const paraId = first ? attribute(first, W14_NAMESPACE_URI, 'paraId') : undefined;
+        let last: OoxmlElement | undefined;
+        for (let index = blocks.length - 1; index >= 0; index -= 1) {
+          if (blocks[index]?.kind !== 'paragraph') continue;
+          last = blocks[index];
+          break;
+        }
+        const paraId = last ? attribute(last, W14_NAMESPACE_URI, 'paraId') : undefined;
         // A comment naming ITSELF as parent is a file defect, not a cycle to propagate.
         const rawParent = attribute(node, W16CID_NAMESPACE_URI, 'parentId');
         const parentCommentId = rawParent === id ? undefined : rawParent;

--- a/packages/core/src/store/store/comment-writes.ts
+++ b/packages/core/src/store/store/comment-writes.ts
@@ -210,14 +210,15 @@ function paraIdsInPackage(pkg: OoxmlPackage): Set<string> {
   return used;
 }
 
-/** The `w14:paraId` of a comment's first paragraph, when it has one. */
+/** The `w14:paraId` of a comment's last paragraph, which keys its `w15:commentEx`. */
 function paraIdOfComment(part: OoxmlPart | undefined, commentId: string): string | null {
   if (!part) return null;
   let found: string | null = null;
   const visit = (node: OoxmlNode): void => {
     if (found !== null || node.kind === 'textValue') return;
     if (node.kind === 'comment' && attribute(node, WML_NAMESPACE_URI, 'id') === commentId) {
-      for (const child of node.children) {
+      for (let index = node.children.length - 1; index >= 0; index -= 1) {
+        const child = node.children[index]!;
         if (child.kind !== 'paragraph') continue;
         const value = attribute(child, W14_NAMESPACE_URI, 'paraId');
         if (value !== undefined && isValidParaId(value)) found = value.toUpperCase();
@@ -231,8 +232,8 @@ function paraIdOfComment(part: OoxmlPart | undefined, commentId: string): string
   return found;
 }
 
-/** The paragraph a comment's `w14:paraId` belongs on: its first, which is where Word puts it. */
-function firstParagraphOfComment(
+/** The last paragraph of a comment, where Word keys its `w15:commentEx` state. */
+function lastParagraphOfComment(
   part: OoxmlPart | undefined,
   commentId: string
 ): OoxmlElement | null {
@@ -241,7 +242,8 @@ function firstParagraphOfComment(
   const visit = (node: OoxmlNode): void => {
     if (found !== null || node.kind === 'textValue') return;
     if (node.kind === 'comment' && attribute(node, WML_NAMESPACE_URI, 'id') === commentId) {
-      for (const child of node.children) {
+      for (let index = node.children.length - 1; index >= 0; index -= 1) {
+        const child = node.children[index]!;
         if (child.kind === 'paragraph') {
           found = child;
           return;
@@ -471,7 +473,7 @@ export function addComment(store: TreeDocumentStore, request: AddCommentRequest)
       : paraIdOfComment(commentsPart, request.replyToCommentId);
   const parentTarget =
     request.replyToCommentId !== undefined && existingParentParaId === null
-      ? firstParagraphOfComment(commentsPart, request.replyToCommentId)
+      ? lastParagraphOfComment(commentsPart, request.replyToCommentId)
       : null;
   // A reply to a comment the part does not hold cannot be linked to anything.
   if (request.replyToCommentId !== undefined && existingParentParaId === null && !parentTarget) {
@@ -536,38 +538,21 @@ export function addComment(store: TreeDocumentStore, request: AddCommentRequest)
       ctx.applyPackage((current) => {
         const part = current.parts.get(extendedName);
         if (!part) return current;
-        const entry = element(
-          `${extendedName}#ex-${paraId}`,
-          'generic',
-          W15_NAMESPACE_URI,
-          'w15',
-          'commentEx',
-          [
-            {
-              kind: 'genericExtension' as const,
-              namespaceUri: W15_NAMESPACE_URI,
-              localName: 'paraId',
-              prefix: 'w15',
-              value: paraId,
-            },
-            {
-              kind: 'genericExtension' as const,
-              namespaceUri: W15_NAMESPACE_URI,
-              localName: 'paraIdParent',
-              prefix: 'w15',
-              value: parentParaId,
-            },
-            {
-              kind: 'genericExtension' as const,
-              namespaceUri: W15_NAMESPACE_URI,
-              localName: 'done',
-              prefix: 'w15',
-              value: '0',
-            },
-          ],
-          []
-        );
-        const appended = insertChildren(part, part.root.id, part.root.children.length, [entry], {
+        const entries = extendedEntries(part);
+        // Word expects commentsExtended.xml to describe BOTH ends of a thread. Our reader can
+        // follow a child-only parent pointer, but Word discards that incomplete thread and draws
+        // two independent comments on the coincident range. Preserve an existing parent record
+        // verbatim (including resolved state or its own parent link); otherwise add the top-level
+        // record before the reply.
+        const additions = [
+          ...(entries.has(parentParaId.toUpperCase())
+            ? []
+            : [
+                resolvedEntry(`${extendedName}#ex-${parentParaId}`, parentParaId, undefined, false),
+              ]),
+          resolvedEntry(`${extendedName}#ex-${paraId}`, paraId, parentParaId, false),
+        ];
+        const appended = insertChildren(part, part.root.id, part.root.children.length, additions, {
           deferValidation: true,
         });
         return appended.ok ? withPart(current, appended.part) : current;
@@ -695,7 +680,7 @@ export function setCommentResolved(
   const extendedName = extendedPartNameFor(pkg, storyPartName);
   const commentsPart = pkg.parts.get(commentsName);
   if (!commentsPart) return { ok: false, reason: 'unknown-comment' };
-  const target = firstParagraphOfComment(commentsPart, commentId);
+  const target = lastParagraphOfComment(commentsPart, commentId);
   if (!target) return { ok: false, reason: 'unknown-comment' };
 
   // The thread: this comment, plus every comment whose recorded parent is it.

--- a/packages/core/src/store/store/comment-writes.ts
+++ b/packages/core/src/store/store/comment-writes.ts
@@ -559,22 +559,23 @@ export function addComment(store: TreeDocumentStore, request: AddCommentRequest)
       });
     }
 
-    // The story markers last. The END goes in before the START when both are in one paragraph,
-    // because inserting at the start would otherwise shift nothing — the markers occupy no
-    // offsets — but the run split at the start reshapes the children the end index counts.
-    ctx.applyTo(storyPartName, {
-      op: 'insertCommentMarker',
-      paragraphId: endParagraphId,
-      offset: request.anchor.end,
-      commentId,
-      marker: 'end',
-    });
+    // The story markers last. Equal-offset insertions land before the marker already there, so
+    // REFERENCE is applied before END to serialize in Word's required END → REFERENCE order.
+    // Both go in before START when the range is in one paragraph: markers occupy no offsets,
+    // but splitting the run at the start reshapes the children the end index counts.
     ctx.applyTo(storyPartName, {
       op: 'insertCommentMarker',
       paragraphId: endParagraphId,
       offset: request.anchor.end,
       commentId,
       marker: 'reference',
+    });
+    ctx.applyTo(storyPartName, {
+      op: 'insertCommentMarker',
+      paragraphId: endParagraphId,
+      offset: request.anchor.end,
+      commentId,
+      marker: 'end',
     });
     ctx.applyTo(storyPartName, {
       op: 'insertCommentMarker',

--- a/packages/core/src/store/store/comment-writes.ts
+++ b/packages/core/src/store/store/comment-writes.ts
@@ -559,10 +559,11 @@ export function addComment(store: TreeDocumentStore, request: AddCommentRequest)
       });
     }
 
-    // The story markers last. Equal-offset insertions land before the marker already there, so
-    // REFERENCE is applied before END to serialize in Word's required END → REFERENCE order.
-    // Both go in before START when the range is in one paragraph: markers occupy no offsets,
-    // but splitting the run at the start reshapes the children the end index counts.
+    // The story markers last. `insertCommentMarker` orders coincident markup for Word
+    // (starts outer→inner, ends inner→outer, refs outer→inner). REFERENCE is applied before
+    // END so a brand-new range still serializes end→ref; both go in before START when the
+    // range is in one paragraph, because splitting the run at the start reshapes the children
+    // the end index counts even though markers occupy no offsets.
     ctx.applyTo(storyPartName, {
       op: 'insertCommentMarker',
       paragraphId: endParagraphId,

--- a/packages/core/src/store/store/tree-op-comments.ts
+++ b/packages/core/src/store/store/tree-op-comments.ts
@@ -181,6 +181,65 @@ function referenceRun(id: string, commentId: string): OoxmlElement {
   } as OoxmlElement;
 }
 
+/** A run that carries a `w:commentReference` and nothing measured (no text, drawing, …). */
+function isCommentReferenceRun(node: OoxmlNode): boolean {
+  if (node.kind !== 'run') return false;
+  let sawReference = false;
+  for (const child of node.children) {
+    if (child.kind === 'commentReference') {
+      sawReference = true;
+      continue;
+    }
+    if (child.kind === 'runProperties') continue;
+    return false;
+  }
+  return sawReference;
+}
+
+/** Zero-width comment markup already parked at an equal offset. */
+function isCoincidentCommentMarkup(node: OoxmlNode): boolean {
+  return (
+    node.kind === 'commentRangeStart' ||
+    node.kind === 'commentRangeEnd' ||
+    isCommentReferenceRun(node)
+  );
+}
+
+/**
+ * Where a new marker sits among zero-width comment markup already at this offset.
+ *
+ * Word's accepted coincident-range shape is
+ * `start_outer…start_inner…end_inner…end_outer…ref_outer…ref_inner`. Equal-offset
+ * insertion otherwise always lands *before* the marker already there and produces
+ * interleaved end→ref pairs that make Word drop `@w15:paraIdParent`.
+ */
+function coincidentInsertIndex(
+  container: OoxmlElement,
+  index: number,
+  marker: CommentMarkerKind
+): number {
+  let insertIndex = index;
+  if (marker === 'start' || marker === 'end') {
+    // Starts nest inside existing starts; ends stay after those starts (empty ranges)
+    // but before any end/ref already at the offset.
+    while (
+      insertIndex < container.children.length &&
+      container.children[insertIndex]!.kind === 'commentRangeStart'
+    ) {
+      insertIndex += 1;
+    }
+    return insertIndex;
+  }
+  // References trail the whole end/ref cluster so parent refs precede reply refs.
+  while (
+    insertIndex < container.children.length &&
+    isCoincidentCommentMarkup(container.children[insertIndex]!)
+  ) {
+    insertIndex += 1;
+  }
+  return insertIndex;
+}
+
 export interface InsertCommentMarkerOp {
   readonly op: 'insertCommentMarker';
   readonly paragraphId: string;
@@ -196,10 +255,8 @@ export interface InsertCommentMarkerOp {
  * cannot be placed inside one. Splitting changes no characters, so every other offset in the
  * paragraph — and every anchor addressed by one — is unmoved.
  *
- * A reply reuses its parent's offsets. Equal-offset insertion otherwise lands *before* the
- * marker already there, so the reply's `commentRangeStart` would open outside the parent and
- * Word would discard `@w15:paraIdParent` on open. Skip past existing starts at this offset so
- * the new start nests inside — the shape Word keeps for a threaded reply.
+ * Coincident markers (a reply on its parent's range, or a second remark on the same span) are
+ * ordered for Word: starts outer→inner, ends inner→outer, references outer→inner.
  */
 export function applyInsertCommentMarker(
   part: OoxmlPart,
@@ -217,16 +274,9 @@ export function applyInsertCommentMarker(
   if (!at) return { ok: false, reason: 'offset-out-of-range' };
 
   let insertIndex = at.index;
-  if (op.marker === 'start') {
-    const container = findNode(split.part, at.containerId);
-    if (container && container.kind !== 'textValue') {
-      while (
-        insertIndex < container.children.length &&
-        container.children[insertIndex]!.kind === 'commentRangeStart'
-      ) {
-        insertIndex += 1;
-      }
-    }
+  const container = findNode(split.part, at.containerId);
+  if (container && container.kind !== 'textValue') {
+    insertIndex = coincidentInsertIndex(container, at.index, op.marker);
   }
 
   const nodeId = `${part.name}#comment-${op.marker}-${op.commentId}-${op.offset}`;

--- a/packages/core/src/store/store/tree-op-comments.ts
+++ b/packages/core/src/store/store/tree-op-comments.ts
@@ -195,6 +195,11 @@ export interface InsertCommentMarkerOp {
  * The run straddling the offset is split first, because a range marker is a sibling of runs and
  * cannot be placed inside one. Splitting changes no characters, so every other offset in the
  * paragraph — and every anchor addressed by one — is unmoved.
+ *
+ * A reply reuses its parent's offsets. Equal-offset insertion otherwise lands *before* the
+ * marker already there, so the reply's `commentRangeStart` would open outside the parent and
+ * Word would discard `@w15:paraIdParent` on open. Skip past existing starts at this offset so
+ * the new start nests inside — the shape Word keeps for a threaded reply.
  */
 export function applyInsertCommentMarker(
   part: OoxmlPart,
@@ -211,6 +216,19 @@ export function applyInsertCommentMarker(
   const at = locateOffset(reloaded, reloaded, op.offset, 0);
   if (!at) return { ok: false, reason: 'offset-out-of-range' };
 
+  let insertIndex = at.index;
+  if (op.marker === 'start') {
+    const container = findNode(split.part, at.containerId);
+    if (container && container.kind !== 'textValue') {
+      while (
+        insertIndex < container.children.length &&
+        container.children[insertIndex]!.kind === 'commentRangeStart'
+      ) {
+        insertIndex += 1;
+      }
+    }
+  }
+
   const nodeId = `${part.name}#comment-${op.marker}-${op.commentId}-${op.offset}`;
   const node =
     op.marker === 'reference'
@@ -222,7 +240,7 @@ export function applyInsertCommentMarker(
           op.commentId
         );
 
-  const inserted = insertChildren(split.part, at.containerId, at.index, [node], options);
+  const inserted = insertChildren(split.part, at.containerId, insertIndex, [node], options);
   if (!inserted.ok) {
     return { ok: false, reason: 'tree-invariant', detail: JSON.stringify(inserted.issues) };
   }

--- a/packages/pro/src/__tests__/comment-writes.test.ts
+++ b/packages/pro/src/__tests__/comment-writes.test.ts
@@ -199,38 +199,11 @@ describe('adding a comment', () => {
 });
 
 describe('replying', () => {
-  test('serializes each range end before its comment reference, as Word requires', () => {
-    const store = open();
-    const target = paragraphWithText(store.part, 20);
-    const parent = addComment(store, {
-      anchor: { paragraphId: target.id, start: 0, end: 6 },
-      author: 'QA',
-      text: 'parent',
-    });
-    expect(parent.ok).toBe(true);
-    if (!parent.ok) return;
-    const reply = addComment(store, {
-      anchor: { paragraphId: target.id, start: 0, end: 6 },
-      author: 'Dev',
-      text: 'reply',
-      replyToCommentId: parent.commentId,
-    });
-    expect(reply.ok).toBe(true);
-    if (!reply.ok) return;
-
-    const story = serializeOoxmlPart(store.part);
-    for (const commentId of [parent.commentId, reply.commentId]) {
-      const end = story.indexOf(`<w:commentRangeEnd w:id="${commentId}"/>`);
-      const reference = story.indexOf(`<w:commentReference w:id="${commentId}"/>`);
-      expect(end).toBeGreaterThanOrEqual(0);
-      expect(reference).toBeGreaterThan(end);
-    }
-  });
-
-  test('a reply nests its range markers inside the parent range, as Word requires', () => {
-    // Equal-offset insertion used to open the reply *before* the parent start. Word then
-    // dropped `@w15:paraIdParent` on open even though commentsExtended named the thread, so
-    // the reply rendered as a sibling and later Word-authored replies could not restore it.
+  test('serializes coincident parent/reply markers in Word classic order', () => {
+    // Word accepts a thread only when the shared range serializes as
+    // start_parent, start_reply, end_reply, end_parent, ref_parent, ref_reply.
+    // Interleaved per-comment end→ref pairs (end_r, ref_r, end_p, ref_p) keep
+    // commentsExtended intact in our reader but make Word drop paraIdParent.
     const store = open();
     const target = paragraphWithText(store.part, 20);
     const parent = addComment(store, {
@@ -254,10 +227,14 @@ describe('replying', () => {
     const replyStart = story.indexOf(`<w:commentRangeStart w:id="${reply.commentId}"/>`);
     const replyEnd = story.indexOf(`<w:commentRangeEnd w:id="${reply.commentId}"/>`);
     const parentEnd = story.indexOf(`<w:commentRangeEnd w:id="${parent.commentId}"/>`);
+    const parentReference = story.indexOf(`<w:commentReference w:id="${parent.commentId}"/>`);
+    const replyReference = story.indexOf(`<w:commentReference w:id="${reply.commentId}"/>`);
     expect(parentStart).toBeGreaterThanOrEqual(0);
     expect(replyStart).toBeGreaterThan(parentStart);
     expect(replyEnd).toBeGreaterThan(replyStart);
     expect(parentEnd).toBeGreaterThan(replyEnd);
+    expect(parentReference).toBeGreaterThan(parentEnd);
+    expect(replyReference).toBeGreaterThan(parentReference);
   });
 
   test('a reply links to its parent through commentsExtended', () => {

--- a/packages/pro/src/__tests__/comment-writes.test.ts
+++ b/packages/pro/src/__tests__/comment-writes.test.ts
@@ -227,6 +227,39 @@ describe('replying', () => {
     }
   });
 
+  test('a reply nests its range markers inside the parent range, as Word requires', () => {
+    // Equal-offset insertion used to open the reply *before* the parent start. Word then
+    // dropped `@w15:paraIdParent` on open even though commentsExtended named the thread, so
+    // the reply rendered as a sibling and later Word-authored replies could not restore it.
+    const store = open();
+    const target = paragraphWithText(store.part, 20);
+    const parent = addComment(store, {
+      anchor: { paragraphId: target.id, start: 0, end: 6 },
+      author: 'QA',
+      text: 'parent',
+    });
+    expect(parent.ok).toBe(true);
+    if (!parent.ok) return;
+    const reply = addComment(store, {
+      anchor: { paragraphId: target.id, start: 0, end: 6 },
+      author: 'Dev',
+      text: 'reply',
+      replyToCommentId: parent.commentId,
+    });
+    expect(reply.ok).toBe(true);
+    if (!reply.ok) return;
+
+    const story = serializeOoxmlPart(store.part);
+    const parentStart = story.indexOf(`<w:commentRangeStart w:id="${parent.commentId}"/>`);
+    const replyStart = story.indexOf(`<w:commentRangeStart w:id="${reply.commentId}"/>`);
+    const replyEnd = story.indexOf(`<w:commentRangeEnd w:id="${reply.commentId}"/>`);
+    const parentEnd = story.indexOf(`<w:commentRangeEnd w:id="${parent.commentId}"/>`);
+    expect(parentStart).toBeGreaterThanOrEqual(0);
+    expect(replyStart).toBeGreaterThan(parentStart);
+    expect(replyEnd).toBeGreaterThan(replyStart);
+    expect(parentEnd).toBeGreaterThan(replyEnd);
+  });
+
   test('a reply links to its parent through commentsExtended', () => {
     const store = open();
     const target = paragraphWithText(store.part, 20);

--- a/packages/pro/src/__tests__/comment-writes.test.ts
+++ b/packages/pro/src/__tests__/comment-writes.test.ts
@@ -199,6 +199,34 @@ describe('adding a comment', () => {
 });
 
 describe('replying', () => {
+  test('serializes each range end before its comment reference, as Word requires', () => {
+    const store = open();
+    const target = paragraphWithText(store.part, 20);
+    const parent = addComment(store, {
+      anchor: { paragraphId: target.id, start: 0, end: 6 },
+      author: 'QA',
+      text: 'parent',
+    });
+    expect(parent.ok).toBe(true);
+    if (!parent.ok) return;
+    const reply = addComment(store, {
+      anchor: { paragraphId: target.id, start: 0, end: 6 },
+      author: 'Dev',
+      text: 'reply',
+      replyToCommentId: parent.commentId,
+    });
+    expect(reply.ok).toBe(true);
+    if (!reply.ok) return;
+
+    const story = serializeOoxmlPart(store.part);
+    for (const commentId of [parent.commentId, reply.commentId]) {
+      const end = story.indexOf(`<w:commentRangeEnd w:id="${commentId}"/>`);
+      const reference = story.indexOf(`<w:commentReference w:id="${commentId}"/>`);
+      expect(end).toBeGreaterThanOrEqual(0);
+      expect(reference).toBeGreaterThan(end);
+    }
+  });
+
   test('a reply links to its parent through commentsExtended', () => {
     const store = open();
     const target = paragraphWithText(store.part, 20);

--- a/packages/pro/src/__tests__/comment-writes.test.ts
+++ b/packages/pro/src/__tests__/comment-writes.test.ts
@@ -234,7 +234,9 @@ describe('replying', () => {
     expect(replyParaId).toBeDefined();
 
     const state = threadStateOfPart(extended);
+    expect(state.get(parentParaId!.toUpperCase())).toEqual({ done: false });
     expect(state.get(replyParaId!.toUpperCase())?.parentParaId).toBe(parentParaId!.toUpperCase());
+    expect(state.size).toBe(2);
   });
 
   test('creating the thread part is part of the same transaction', () => {
@@ -315,7 +317,9 @@ describe('replying', () => {
     // reply under the comment instead of beside it.
     const extended = store.package.parts.get('/word/commentsExtended.xml');
     expect(extended).toBeDefined();
-    expect(serializeOoxmlPart(extended!)).toContain(`w15:paraIdParent="${parentParaId}"`);
+    const state = threadStateOfPart(extended!);
+    expect(state.get(parentParaId!)).toEqual({ done: false });
+    expect([...state.values()].some((entry) => entry.parentParaId === parentParaId)).toBe(true);
   });
 
   test('a reply to a comment the part does not hold is refused', () => {
@@ -357,6 +361,7 @@ describe('replying', () => {
     const state = threadStateOfPart(reopened.package.parts.get('/word/commentsExtended.xml')!);
     const replyParaId = comments.find((entry) => entry.id === reply.commentId)?.paraId;
     const parentParaId = comments.find((entry) => entry.id === parent.commentId)?.paraId;
+    expect(state.get(parentParaId!.toUpperCase())).toEqual({ done: false });
     expect(state.get(replyParaId!.toUpperCase())?.parentParaId).toBe(parentParaId!.toUpperCase());
   });
 });


### PR DESCRIPTION
## Summary
- write both parent and reply records to `commentsExtended.xml`
- use the required final comment paragraph ID for thread state

## Test plan
- `bun test packages/pro/src/__tests__/comment-writes.test.ts packages/core/src/store/__tests__/review-reads.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788938440&installation_model_id=422592&pr_number=262&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F262&signature=ee8d4d253e354175c25cc15ecb8e43b0864a1eee18e8d2530f379c0fb223beb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->