### PR TITLE
feat(core): let a mounted editor insert a content control

### DIFF
--- a/.changeset/insert-content-control-docedits.md
+++ b/.changeset/insert-content-control-docedits.md
@@ -1,0 +1,9 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Add `insertContentControl` to `DocEdits`, so a mounted editor can create a content control as well as set and remove one.
+
+The tree op already existed and was reachable only through the automation protocol, which meant a host with an editor mounted had to `save()`, insert through a headless automation host, and `load()` the result back — discarding the undo stack. The insertion is now a single undoable step like every other edit.
+
+Wraps the current selection; refuses a collapsed caret and a selection that crosses paragraphs, since a control spanning paragraphs is a block wrapper rather than the inline one this authors.

--- a/docs/api/docx-editor-core/contracts-document.api.md
+++ b/docs/api/docx-editor-core/contracts-document.api.md
@@ -171,6 +171,12 @@ export interface DocEdits {
         target: DocTarget;
         kind: 'page' | 'column' | 'line' | 'section';
     };
+    insertContentControl: {
+        target: DocTarget;
+        subtype: InsertableContentControlType;
+        tag?: string;
+        title?: string;
+    };
     // (undocumented)
     insertHyperlink: {
         target: DocTarget;
@@ -413,6 +419,9 @@ export interface IndentFormatting {
     };
     readonly right: number;
 }
+
+// @public
+export type InsertableContentControlType = 'richText' | 'plainText' | 'dropDownList' | 'comboBox' | 'date';
 
 // @public
 export interface Paragraph {

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -193,6 +193,12 @@ export interface DocEdits {
         target: DocTarget;
         kind: 'page' | 'column' | 'line' | 'section';
     };
+    insertContentControl: {
+        target: DocTarget;
+        subtype: InsertableContentControlType;
+        tag?: string;
+        title?: string;
+    };
     // (undocumented)
     insertHyperlink: {
         target: DocTarget;
@@ -1267,6 +1273,9 @@ export interface IndentFormatting {
     };
     readonly right: number;
 }
+
+// @public
+export type InsertableContentControlType = 'richText' | 'plainText' | 'dropDownList' | 'comboBox' | 'date';
 
 // @public
 export type InteractionAffinity = 'upstream' | 'downstream';

--- a/docs/api/docx-editor-core/contracts-types.api.md
+++ b/docs/api/docx-editor-core/contracts-types.api.md
@@ -200,6 +200,9 @@ export interface IndentFormatting {
 }
 
 // @public
+export type InsertableContentControlType = 'richText' | 'plainText' | 'dropDownList' | 'comboBox' | 'date';
+
+// @public
 export interface NumberingRef {
     readonly level: number;
     // (undocumented)

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -768,6 +768,12 @@ export interface DocEdits {
         target: DocTarget;
         kind: 'page' | 'column' | 'line' | 'section';
     };
+    insertContentControl: {
+        target: DocTarget;
+        subtype: InsertableContentControlType;
+        tag?: string;
+        title?: string;
+    };
     // (undocumented)
     insertHyperlink: {
         target: DocTarget;
@@ -1978,6 +1984,9 @@ export interface IndentFormatting {
     };
     readonly right: number;
 }
+
+// @public
+export type InsertableContentControlType = 'richText' | 'plainText' | 'dropDownList' | 'comboBox' | 'date';
 
 // @public
 export type InteractionAffinity = 'upstream' | 'downstream';

--- a/packages/core/src/contracts/document.ts
+++ b/packages/core/src/contracts/document.ts
@@ -20,6 +20,7 @@ import type {
   ContentControlType,
   DocComment,
   DocRange,
+  InsertableContentControlType,
   Revision,
   StyleDefinitions,
   DocTarget,
@@ -53,6 +54,7 @@ export type {
   Extent,
   HeaderFooterSet,
   IndentFormatting,
+  InsertableContentControlType,
   Paragraph,
   Revision,
   RevisionType,
@@ -122,6 +124,23 @@ export interface DocEdits {
   acceptAllRevisions: Record<never, never>;
   rejectAllRevisions: Record<never, never>;
 
+  /**
+   * Wrap the addressed span in a NEW control.
+   *
+   * `title` is Word's `w:alias` — the label a user sees — and `tag` is `w:tag`, the
+   * machine-readable identity a host looks the control back up by. Named as the automation
+   * protocol names them so a caller who reaches for both surfaces writes one vocabulary.
+   *
+   * One paragraph only. A control that starts in one paragraph and ends in another is a
+   * BLOCK control over both, which is a different wrapper than the inline one this authors —
+   * refused rather than guessed, so a caller learns which they asked for.
+   */
+  insertContentControl: {
+    target: DocTarget;
+    subtype: InsertableContentControlType;
+    tag?: string;
+    title?: string;
+  };
   setContentControlValue: { target: DocTarget; value: string };
   removeContentControl: { target: DocTarget };
   addRepeatingSectionItem: { target: DocTarget; index?: number };

--- a/packages/core/src/contracts/types.ts
+++ b/packages/core/src/contracts/types.ts
@@ -289,6 +289,26 @@ export type ContentControlType =
   | 'repeatingSection';
 
 /**
+ * The control types an insertion may author. Picture and repeating section are deferred.
+ *
+ * A NARROWING of {@link ContentControlType} rather than a reuse of it: `checkbox` and
+ * `picture` carry content an insertion would have to invent, and `repeatingSection` is a
+ * container whose items have their own verbs. Reading a control still answers the wider
+ * type — a document may hold kinds this cannot create.
+ *
+ * `dropDownList` is spelt as OOXML spells the element, which is NOT how `ContentControlType`
+ * spells the same kind (`dropdown`). The read vocabulary and the write vocabulary disagree
+ * here already; this type sides with the one the tree op and the automation protocol use, so
+ * a caller who moves between the two surfaces writes the same string in both.
+ */
+export type InsertableContentControlType =
+  | 'richText'
+  | 'plainText'
+  | 'dropDownList'
+  | 'comboBox'
+  | 'date';
+
+/**
  * Narrows a content-control query. Fields combine with AND; an empty filter matches every
  * control.
  */

--- a/packages/core/src/editor/__tests__/content-controls-command.test.ts
+++ b/packages/core/src/editor/__tests__/content-controls-command.test.ts
@@ -248,3 +248,108 @@ describe('removeContentControl command', () => {
     expect(editor.exec({ type: 'removeContentControl' })).toEqual(can);
   });
 });
+
+describe('insertContentControl command', () => {
+  function selectRange(
+    surface: NonNullable<ReturnType<typeof createDocxEditor>['surface']>,
+    from: number,
+    to: number,
+    paragraphIndex = 0
+  ) {
+    const paragraphId = surface.session.paragraphIds()[paragraphIndex]!;
+    surface.setSelection({
+      anchor: { paragraphId, offset: from },
+      head: { paragraphId, offset: to },
+    });
+  }
+
+  test('wraps the selection in a new control carrying its tag and title', () => {
+    const editor = mount(p('Between ACME CORP and BUYER LTD'));
+    selectRange(editor.surface!, 8, 18);
+
+    const result = editor.exec({
+      type: 'insertContentControl',
+      subtype: 'plainText',
+      tag: 'party_name',
+      title: 'Party Name',
+    });
+
+    expect(result).toEqual({ ok: true, changed: true });
+    // Reading it back is the round trip: the query walks the tree from scratch, so a
+    // wrapper that only existed in the op would not be here.
+    expect(editor.query({ type: 'contentControls' })).toMatchObject([
+      { tag: 'party_name', alias: 'Party Name' },
+    ]);
+    // The characters are the ones that were there — wrapping moves run boundaries, it does
+    // not rewrite text.
+    expect(editor.query({ type: 'paragraphs' })[0]?.text).toBe('Between ACME CORP and BUYER LTD');
+  });
+
+  // The reason this command exists. The `save()` → headless insert → `load()` workaround
+  // reaches the same document and throws the undo stack away with it, so an insertion that
+  // cannot be undone is the bug being fixed, not a missing nicety.
+  test('is one undo step, and undo puts the document back', () => {
+    const editor = mount(p('Between ACME CORP and BUYER LTD'));
+    selectRange(editor.surface!, 8, 18);
+
+    editor.exec({ type: 'insertContentControl', subtype: 'plainText', tag: 'party_name' });
+    expect(editor.query({ type: 'contentControls' })).toHaveLength(1);
+
+    expect(editor.exec({ type: 'undo' })).toEqual({ ok: true, changed: true });
+    expect(editor.query({ type: 'contentControls' })).toHaveLength(0);
+    expect(editor.query({ type: 'paragraphs' })[0]?.text).toBe('Between ACME CORP and BUYER LTD');
+  });
+
+  test('refuses a collapsed caret rather than wrapping nothing', () => {
+    const editor = mount(p('Between ACME CORP'));
+    caretAt(editor.surface!, 8);
+
+    const command = { type: 'insertContentControl' as const, subtype: 'plainText' as const };
+    const can = editor.can(command);
+    expect(can).toEqual({
+      ok: false,
+      code: 'invalidArgs',
+      reason: 'there is nothing selected to wrap in a content control',
+    });
+    expect(editor.exec(command)).toEqual(can);
+    expect(editor.query({ type: 'contentControls' })).toHaveLength(0);
+  });
+
+  test('refuses a selection that crosses paragraphs', () => {
+    const editor = mount(p('first') + p('second'));
+    const ids = editor.surface!.session.paragraphIds();
+    editor.surface!.setSelection({
+      anchor: { paragraphId: ids[0]!, offset: 1 },
+      head: { paragraphId: ids[1]!, offset: 3 },
+    });
+
+    const command = { type: 'insertContentControl' as const, subtype: 'richText' as const };
+    const can = editor.can(command);
+    expect(can).toEqual({
+      ok: false,
+      code: 'unsupported',
+      reason: 'wrapping several paragraphs in one content control is not supported',
+    });
+    expect(editor.exec(command)).toEqual(can);
+    expect(editor.query({ type: 'contentControls' })).toHaveLength(0);
+  });
+
+  // `picture` and `repeatingSection` are real `ContentControlType` values a reader can
+  // return, so an untyped caller can hand one straight back to this command.
+  test('refuses a control type an insertion cannot author, and can() agrees', () => {
+    const editor = mount(p('Between ACME CORP'));
+    selectRange(editor.surface!, 8, 17);
+
+    const command = { type: 'insertContentControl', subtype: 'picture' } as unknown as Parameters<
+      typeof editor.exec
+    >[0];
+    const can = editor.can(command);
+    expect(can).toEqual({
+      ok: false,
+      code: 'invalidArgs',
+      reason: 'that control type cannot be inserted (picture)',
+    });
+    expect(editor.exec(command)).toEqual(can);
+    expect(editor.query({ type: 'contentControls' })).toHaveLength(0);
+  });
+});

--- a/packages/core/src/editor/content-controls.ts
+++ b/packages/core/src/editor/content-controls.ts
@@ -13,7 +13,11 @@ import type {
   ExecErrorCode,
   ExecResult,
 } from '@docx-editor.dev/core/contracts/editor';
-import type { ContentControlFilter, ContentControlType } from '../contracts/types.ts';
+import type {
+  ContentControlFilter,
+  ContentControlType,
+  InsertableContentControlType,
+} from '../contracts/types.ts';
 import type { ContentControlSummary } from '../contracts/document.ts';
 import type { DocAnchor, DocLocation, DocRange } from '../contracts/types.ts';
 import {
@@ -334,13 +338,84 @@ export function inlineContentControlsAt(
 // ─── Command dispatch ────────────────────────────────────────────────────────
 
 export type ContentControlEditorCommand =
+  | {
+      type: 'insertContentControl';
+      target?: DocTarget;
+      subtype: InsertableContentControlType;
+      tag?: string;
+      title?: string;
+    }
   | { type: 'setContentControlValue'; target?: DocTarget; value: string }
   | { type: 'removeContentControl'; target?: DocTarget };
 
 export function isContentControlEditorCommand(command: {
   type: string;
 }): command is ContentControlEditorCommand {
-  return command.type === 'setContentControlValue' || command.type === 'removeContentControl';
+  return (
+    command.type === 'insertContentControl' ||
+    command.type === 'setContentControlValue' ||
+    command.type === 'removeContentControl'
+  );
+}
+
+/**
+ * The control types an insertion may author, as a runtime set.
+ *
+ * The contract type already narrows this at compile time; the set is what answers an
+ * untyped caller, which is the same reason the gate below re-checks `value` for
+ * `setContentControlValue` rather than trusting its declared type.
+ */
+const INSERTABLE_SUBTYPES: ReadonlySet<string> = new Set<InsertableContentControlType>([
+  'richText',
+  'plainText',
+  'dropDownList',
+  'comboBox',
+  'date',
+]);
+
+/**
+ * The tree op for an insertion, or the refusal explaining why there is none.
+ *
+ * Reads the SELECTION rather than `command.target`, unlike its two neighbours. They address
+ * a control that already exists and can look one up by id; an insertion addresses the span
+ * that is about to become one, and the surface's own selection is the only range the user
+ * ever pointed at. `selectionMarkOf` already answers null when that range crosses
+ * paragraphs, which is exactly the shape a single inline `w:sdt` cannot wrap.
+ */
+function insertContentControlOp(
+  surface: PaginatedSurface,
+  command: Extract<ContentControlEditorCommand, { type: 'insertContentControl' }>
+): { ok: true; op: TreeDocOp } | { ok: false; code: ExecErrorCode; reason: string } {
+  const mark = selectionMarkOf(surface.state().selection);
+  if (!mark) {
+    return {
+      ok: false,
+      code: 'unsupported',
+      reason: 'wrapping several paragraphs in one content control is not supported',
+    };
+  }
+  // A collapsed caret has no characters to wrap. Word inserts a placeholder control here;
+  // this refuses instead, because a control holding text the caller never asked for is a
+  // document edit they did not request and would have to detect to undo.
+  if (mark.start === mark.end) {
+    return {
+      ok: false,
+      code: 'invalidArgs',
+      reason: 'there is nothing selected to wrap in a content control',
+    };
+  }
+  return {
+    ok: true,
+    op: {
+      op: 'insertContentControl',
+      paragraphId: mark.paragraphId,
+      start: mark.start,
+      end: mark.end,
+      type: command.subtype,
+      ...(command.tag === undefined ? {} : { tag: command.tag }),
+      ...(command.title === undefined ? {} : { alias: command.title }),
+    },
+  };
 }
 
 type CommandGate = { ok: true } | { ok: false; refusal: Extract<ExecResult, { ok: false }> };
@@ -605,6 +680,16 @@ function gateContentControlCommand(
       },
     };
   }
+  if (command.type === 'insertContentControl' && !INSERTABLE_SUBTYPES.has(command.subtype)) {
+    return {
+      ok: false,
+      refusal: {
+        ok: false,
+        code: 'invalidArgs',
+        reason: `that control type cannot be inserted (${String(command.subtype)})`,
+      },
+    };
+  }
   return { ok: true };
 }
 
@@ -623,14 +708,20 @@ export function canContentControlCommand(
 ): CanResult {
   const gated = gateContentControlCommand(command, surface, mode, options);
   if (!gated.ok) return gated.refusal;
-  const resolved = resolveContentControlTarget(surface!, command.target);
-  if (!resolved.ok) {
+  // An insertion has no control to resolve — it is about to create the one it addresses —
+  // so it skips the lookup its neighbours depend on and builds its op from the selection.
+  const built =
+    command.type === 'insertContentControl' ? insertContentControlOp(surface!, command) : null;
+  if (built && !built.ok) return { ok: false, code: built.code, reason: built.reason };
+  const resolved = built ? null : resolveContentControlTarget(surface!, command.target);
+  if (resolved && !resolved.ok) {
     return { ok: false, code: resolved.code, reason: resolved.reason };
   }
-  const op: TreeDocOp =
-    command.type === 'setContentControlValue'
-      ? { op: 'setContentControlValue', controlId: resolved.controlId, value: command.value }
-      : { op: 'removeContentControl', controlId: resolved.controlId };
+  const op: TreeDocOp = built
+    ? built.op
+    : command.type === 'setContentControlValue'
+      ? { op: 'setContentControlValue', controlId: resolved!.controlId, value: command.value }
+      : { op: 'removeContentControl', controlId: resolved!.controlId };
   const rejection = validateTreeOp(surface!.session.part(), op);
   if (rejection) {
     return {
@@ -647,8 +738,20 @@ export function execContentControlCommand(
   surface: PaginatedSurface,
   command: ContentControlEditorCommand
 ): ExecResult {
-  const resolved = resolveContentControlTarget(surface, command.target);
-  if (!resolved.ok) {
+  // See `canContentControlCommand`: an insertion builds its op from the selection rather
+  // than resolving a control that does not exist yet.
+  const built =
+    command.type === 'insertContentControl' ? insertContentControlOp(surface, command) : null;
+  if (built && !built.ok) {
+    return {
+      ok: false,
+      code: built.code,
+      reason: built.reason,
+      ...(command.target !== undefined ? { target: command.target } : {}),
+    };
+  }
+  const resolved = built ? null : resolveContentControlTarget(surface, command.target);
+  if (resolved && !resolved.ok) {
     const target = resolved.target ?? command.target;
     return {
       ok: false,
@@ -660,10 +763,11 @@ export function execContentControlCommand(
 
   const before = surface.session.revision();
   const mark = selectionMarkOf(surface.state().selection);
-  const op: TreeDocOp =
-    command.type === 'setContentControlValue'
-      ? { op: 'setContentControlValue', controlId: resolved.controlId, value: command.value }
-      : { op: 'removeContentControl', controlId: resolved.controlId };
+  const op: TreeDocOp = built
+    ? built.op
+    : command.type === 'setContentControlValue'
+      ? { op: 'setContentControlValue', controlId: resolved!.controlId, value: command.value }
+      : { op: 'removeContentControl', controlId: resolved!.controlId };
 
   const result = surface.session.applyTreeOps([op], mark, mark);
   if (result.rejected) {


### PR DESCRIPTION
Closes #263 — happy to close this instead if the omission there turns out to be deliberate.

## What this does

Adds `insertContentControl` to `DocEdits`, so a mounted editor can create a content control as well as set and remove one.

The tree op already existed and was wired end to end through `tree-op-validate` and `tree-op-apply`; it was only reachable from the automation protocol. This adds the entry to the editor's own vocabulary pointing at it. No engine work — the diff is the contract entry plus its wiring.

## Why it matters

Without it, a host with an editor mounted has to `editor.save()` → `createServerAutomationHost(bytes)` → `insertContentControl` → `editor.load(bytes)`. That reload discards the undo stack: insert a field, press Ctrl+Z, nothing happens — and everything the user did before the insert is gone from history too.

## Design notes

- **Resolves a range, not a control.** Unlike its two neighbours the command has no existing control to look up, so it reads the selection rather than `command.target`. `selectionMarkOf` already answers `null` when the selection crosses paragraphs, which is exactly the shape a single inline `w:sdt` cannot wrap — the same refusal `plan.ts` makes for the automation op.
- **A collapsed caret is refused.** Word inserts a placeholder control there; this doesn't, because a control holding text the caller never asked for is an edit they would have to detect to undo.
- **`InsertableContentControlType` narrows `ContentControlType`** rather than reusing it: `checkbox` and `picture` carry content an insertion would have to invent, and `repeatingSection` is a container with its own verbs. It sides with the `dropDownList` spelling the tree op and automation protocol use, rather than `ContentControlType`'s `dropdown`, so a caller moving between the two surfaces writes one vocabulary. The runtime set in `content-controls.ts` is what answers an untyped caller, for the same reason the gate re-checks `value` for `setContentControlValue`.
- **`title` → `w:alias`, `tag` → `w:tag`**, named as the automation operation names them.

## Test plan

Five tests added to `content-controls-command.test.ts`:

- [x] wraps the selection in a new control carrying its tag and title, verified by re-querying the tree rather than trusting the op
- [x] is one undo step and undo restores the document — the behaviour the issue is about
- [x] refuses a collapsed caret
- [x] refuses a selection crossing paragraphs
- [x] refuses an uninsertable subtype, with `can()` agreeing with `exec()`

Verified locally:

- [x] `bun run typecheck` — 8/8 packages exit 0
- [x] `bun test src/editor src/automation src/store` in `packages/core` — 3520 pass, 0 fail
- [x] `bun run lint` — 0 errors (60 pre-existing warnings, all in `packages/react`)
- [x] `bun run check:editor-contract` — passes
- [x] `bun run api:check` — passes after `api:extract`; the four regenerated reports are purely additive, 30 insertions and 0 deletions

Changeset included as a `minor` on `@docx-editor.dev/core`.

Happy to split this (contract + wiring, then docs) if that reviews better, and I'll sign the CLA when the bot prompts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788940755&installation_model_id=422592&pr_number=264&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F264&signature=35af5207dec7078f2c04adedb17bf9e15209d9ca5bae92f1979c233c4d3d9c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->