### PR TITLE
fix(pro): compose review card and add-comment overrides

### DIFF
--- a/.changeset/clean-review-composition.md
+++ b/.changeset/clean-review-composition.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Allow custom Add Comment controls, review lists, card templates, and empty states to compose without replacing one another.

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -444,7 +444,7 @@ Root parts remain ordinary siblings, so a custom Add Comment control and custom 
 The older root callback form remains supported as shorthand for an implicit `List`, but it
 cannot express root siblings and is not recommended for new code.
 
-When the whole review surface shares nothing with the packaged layout, `preset={false}` mounts the rail and its context without the packaged arrangement, so you can arrange every part yourself. `useStackedReviewPositions(items, heights, { gap, scale: editor.getRenderScale() })` provides the packaged stacking math. See [Tracked changes](/docs/2.x/pro/tracked-changes) for the scale and placement details. Below that, `useReview()` gives you the queue with no chrome at all.
+When the whole review surface shares nothing with the packaged layout, `preset={false}` mounts the rail and its context without the packaged arrangement, so you can arrange every part yourself. Explicit parts still receive their root-owned positioning; omitted defaults stay omitted. `useStackedReviewPositions(items, heights, { gap, scale: editor.getRenderScale() })` provides the packaged stacking math. See [Tracked changes](/docs/2.x/pro/tracked-changes) for the scale and placement details. Below that, `useReview()` gives you the queue with no chrome at all.
 
 To add host content to some cards and not others, `useReviewItem()` reads the card a child is rendered inside:
 

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -411,23 +411,40 @@ Each card is a compound. Reorder, hide, and re-icon its parts in place:
 
 ```tsx
 <DocxEditorReview className="my-review">
-  <DocxEditorReview.Card className="my-card">
-    <DocxEditorReview.Avatar className="my-avatar" />
-    <DocxEditorReview.Author />
-    <DocxEditorReview.Time hidden />
-    <DocxEditorReview.Summary />
-    <DocxEditorReview.Accept icon={MyCheck} />
-    <DocxEditorReview.Reject icon={MyCross} />
-    <DocxEditorReview.Replies />
-    <DocxEditorReview.Reply />
-  </DocxEditorReview.Card>
-  <DocxEditorReview.Empty>Nothing to review</DocxEditorReview.Empty>
+  <DocxEditorReview.List>
+    <DocxEditorReview.Card className="my-card">
+      <DocxEditorReview.Avatar className="my-avatar" />
+      <DocxEditorReview.Author />
+      <DocxEditorReview.Time hidden />
+      <DocxEditorReview.Summary />
+      <DocxEditorReview.Accept icon={MyCheck} />
+      <DocxEditorReview.Reject icon={MyCross} />
+      <DocxEditorReview.Replies />
+      <DocxEditorReview.Reply />
+    </DocxEditorReview.Card>
+    <DocxEditorReview.Empty>Nothing to review</DocxEditorReview.Empty>
+  </DocxEditorReview.List>
 </DocxEditorReview>
 ```
 
 Every part takes `className`, `asChild`, and `hidden`; the action parts also take `icon`.
 
-For cards that share nothing with the packaged layout, `preset={false}` mounts the rail and its context without the packaged arrangement, so you keep the subscription and the anchoring and render the cards yourself. `useStackedReviewPositions(items, heights, { gap, scale: editor.getRenderScale() })` provides the packaged stacking math. See [Tracked changes](/docs/2.x/pro/tracked-changes) for the scale and placement details. Below that, `useReview()` gives you the queue with no chrome at all.
+When the card shares no markup with the packaged one, put the render callback on `List`.
+Root parts remain ordinary siblings, so a custom Add Comment control and custom cards compose:
+
+```tsx
+<DocxEditorReview>
+  <DocxEditorReview.AddComment asChild>
+    <MyAddCommentButton />
+  </DocxEditorReview.AddComment>
+  <DocxEditorReview.List>{(item) => <MyReviewCard item={item} />}</DocxEditorReview.List>
+</DocxEditorReview>
+```
+
+The older root callback form remains supported as shorthand for an implicit `List`, but it
+cannot express root siblings and is not recommended for new code.
+
+When the whole review surface shares nothing with the packaged layout, `preset={false}` mounts the rail and its context without the packaged arrangement, so you can arrange every part yourself. `useStackedReviewPositions(items, heights, { gap, scale: editor.getRenderScale() })` provides the packaged stacking math. See [Tracked changes](/docs/2.x/pro/tracked-changes) for the scale and placement details. Below that, `useReview()` gives you the queue with no chrome at all.
 
 To add host content to some cards and not others, `useReviewItem()` reads the card a child is rendered inside:
 

--- a/packages/pro/src/__tests__/review-composition.test.tsx
+++ b/packages/pro/src/__tests__/review-composition.test.tsx
@@ -1,0 +1,163 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Review compound ownership: root affordances, list templates and card parts must compose
+// without one scope consuming or nesting another.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { Fragment } from 'react';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, render } from '@testing-library/react';
+import { strToU8, zipSync } from 'fflate';
+import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
+import { DocxEditorContent, DocxEditorRoot, DocxEditorViewport } from '@docx-editor.dev/react';
+import { reviewModule } from '../index.ts';
+import { DocxEditorReview } from '../react/index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const PLAIN = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
+const TRACKED = docx(
+  '<w:p><w:r><w:t xml:space="preserve">base </w:t></w:r>' +
+    '<w:ins w:id="1" w:author="Ada Lovelace" w:date="2026-01-01T00:00:00Z">' +
+    '<w:r><w:t>added</w:t></w:r></w:ins></w:p>'
+);
+
+afterEach(cleanup);
+
+describe('review compound composition', () => {
+  test('combines an AddComment override with a List render callback', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={TRACKED}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview>
+            <Fragment>
+              <DocxEditorReview.List>
+                {(item) => <div data-testid="custom-review-card">{item.text}</div>}
+              </DocxEditorReview.List>
+              <DocxEditorReview.AddComment>
+                <button type="button" data-testid="custom-add-comment">
+                  Add
+                </button>
+              </DocxEditorReview.AddComment>
+            </Fragment>
+          </DocxEditorReview>
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+
+    expect(view.getAllByTestId('custom-review-card')).toHaveLength(1);
+    await act(async () => {
+      instance!.surface!.selectAll();
+    });
+    expect(view.getByTestId('custom-add-comment')).toBeDefined();
+  });
+
+  test('renders a List Card template directly and applies both card classes', () => {
+    const view = render(
+      <DocxEditorRoot document={TRACKED} modules={[reviewModule()]}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview card={{ className: 'root-card-class' }}>
+            <DocxEditorReview.List>
+              <Fragment>
+                <DocxEditorReview.Card className="template-card-class">
+                  <DocxEditorReview.Author />
+                  <span data-testid="card-extra">Host action</span>
+                </DocxEditorReview.Card>
+              </Fragment>
+            </DocxEditorReview.List>
+          </DocxEditorReview>
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+
+    const cards = view.getAllByTestId('review-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]!.classList.contains('root-card-class')).toBe(true);
+    expect(cards[0]!.classList.contains('template-card-class')).toBe(true);
+    expect(cards[0]!.querySelector('[data-testid="review-card"]')).toBeNull();
+    expect(view.getByTestId('card-extra').textContent).toBe('Host action');
+  });
+
+  test('keeps direct root Card children as a compatibility shorthand', () => {
+    const view = render(
+      <DocxEditorRoot document={TRACKED} modules={[reviewModule()]}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview>
+            <DocxEditorReview.Card>
+              <span data-testid="root-card-extra">Root shorthand</span>
+            </DocxEditorReview.Card>
+          </DocxEditorReview>
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+
+    expect(view.getAllByTestId('review-card')).toHaveLength(1);
+    expect(view.getByTestId('root-card-extra').textContent).toBe('Root shorthand');
+  });
+
+  test('uses a List Empty override and preserves legacy root render children', () => {
+    const empty = render(
+      <DocxEditorRoot document={PLAIN} modules={[reviewModule()]}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview>
+            <DocxEditorReview.List>
+              <DocxEditorReview.Empty>All clear</DocxEditorReview.Empty>
+            </DocxEditorReview.List>
+          </DocxEditorReview>
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    expect(empty.getByTestId('review-empty').textContent).toBe('All clear');
+    empty.unmount();
+
+    const legacy = render(
+      <DocxEditorRoot document={TRACKED} modules={[reviewModule()]}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview>
+            {(item) => <div data-testid="legacy-review-card">{item.text}</div>}
+          </DocxEditorReview>
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    expect(legacy.getAllByTestId('legacy-review-card')).toHaveLength(1);
+  });
+});

--- a/packages/pro/src/__tests__/review-composition.test.tsx
+++ b/packages/pro/src/__tests__/review-composition.test.tsx
@@ -132,6 +132,47 @@ describe('review compound composition', () => {
     expect(view.getByTestId('root-card-extra').textContent).toBe('Root shorthand');
   });
 
+  test('wires explicitly supplied parts without adding preset defaults', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={TRACKED}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview preset={false}>
+            <DocxEditorReview.AddComment>
+              <button type="button" data-testid="explicit-add-comment">
+                Add
+              </button>
+            </DocxEditorReview.AddComment>
+            <DocxEditorReview.Draft />
+            <DocxEditorReview.List>
+              {(item) => <div data-testid="explicit-review-card">{item.text}</div>}
+            </DocxEditorReview.List>
+          </DocxEditorReview>
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+
+    expect(view.getAllByTestId('explicit-review-card')).toHaveLength(1);
+    expect(view.queryByTestId('review-balloon')).toBeNull();
+    await act(async () => {
+      instance!.surface!.selectAll();
+    });
+    const add = view.getByTestId('explicit-add-comment');
+    expect(add.style.position).toBe('absolute');
+    expect(add.style.top).not.toBe('');
+    await act(async () => {
+      add.click();
+    });
+    expect(view.getByTestId('review-draft')).toBeDefined();
+  });
+
   test('uses a List Empty override and preserves legacy root render children', () => {
     const empty = render(
       <DocxEditorRoot document={PLAIN} modules={[reviewModule()]}>

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -59,6 +59,7 @@ import {
   useTranslation,
   type ToolbarTranslate,
 } from '@docx-editor.dev/react';
+import { cloneReviewCard, partitionReviewChildren } from './review-composition';
 import { useReview, type ReviewItemView } from './useReview';
 
 /**
@@ -261,12 +262,14 @@ export interface ReviewProps extends Omit<ReviewPartProps, 'children'> {
   /** Class for each card. The rail's own `className` styles the column; this the boxes in it. */
   card?: { className?: string };
   /**
-   * The cards, or a render prop that replaces the packaged card entirely while keeping the
-   * rail's subscription, anchoring, stacking and virtualization. Nodes are treated as part
-   * overrides for the packaged card instead.
+   * Compound parts for the rail and its implicit List. A function remains supported as the
+   * legacy shorthand for a List render callback, but cannot be combined with root siblings;
+   * prefer an explicit `<Review.List>{item => ...}</Review.List>` in new code.
    *
    * ```tsx
-   * <DocxEditor.Review>{(item) => <MyCard item={item} />}</DocxEditor.Review>
+   * <DocxEditor.Review>
+   *   <DocxEditor.Review.List>{(item) => <MyCard item={item} />}</DocxEditor.Review.List>
+   * </DocxEditor.Review>
    * ```
    */
   children?: ReactNode | ((item: ReviewItemView) => ReactNode);
@@ -713,9 +716,18 @@ function ReviewRoot({
     style: metrics.left === null ? undefined : { left: metrics.left, right: 'auto' },
   };
 
-  // Root-level slots a child can replace in place. A render prop is not an override — it is
-  // the card itself, and travels down to `ReviewList` untouched.
-  const rootParts = typeof children === 'function' ? {} : partOverrides(children);
+  // Root parts and card parts are separate scopes. A root render prop remains the legacy
+  // shorthand for the implicit List's render prop; node children that are not root parts become
+  // that List's card template. Without this partition an AddComment sibling was also forwarded
+  // into every Card, while a root render prop made it impossible to supply AddComment at all.
+  const rootChildren: {
+    parts: Record<string, ReactNode>;
+    rest: ReactNode | ((item: ReviewItemView) => ReactNode);
+  } =
+    typeof children === 'function'
+      ? { parts: {}, rest: children }
+      : partitionReviewChildren(children, 'root');
+  const rootParts = rootChildren.parts;
   // An override REPLACES the packaged element but inherits its wiring: these parts are handed
   // geometry the rail alone can compute — the markers' `scale`/`offset`/`window`, the compose
   // box's `top` — and a host writing `<Review.Markers icon={…}/>` cannot supply any of it.
@@ -763,7 +775,7 @@ function ReviewRoot({
             offset={metrics.top}
             window={window_}
           >
-            {children}
+            {rootChildren.rest}
           </ReviewList>
         )
       : // Closed, the rail keeps its anchors and drops everything else: a small marker per item
@@ -854,11 +866,14 @@ function ReviewList({
   const { review, measure, cardClassName } = useRail();
   if (hidden) return null;
 
+  const listChildren =
+    typeof children === 'function' ? null : partitionReviewChildren(children, 'list');
   const present = idsOf(review.items);
   const roots = review.items.filter((entry) => !isThreadedReply(entry, present));
 
   if (roots.length === 0) {
-    return typeof children === 'function' ? null : <ReviewEmpty />;
+    if (typeof children === 'function') return null;
+    return listChildren?.parts.Empty ?? <ReviewEmpty />;
   }
 
   return (
@@ -885,9 +900,12 @@ function ReviewList({
             >
               {typeof children === 'function' ? (
                 children(entry)
+              ) : listChildren?.parts.Card &&
+                isValidElement<{ className?: string }>(listChildren.parts.Card) ? (
+                cloneReviewCard(listChildren.parts.Card, cardClassName)
               ) : (
                 <ReviewCard {...(cardClassName ? { className: cardClassName } : {})}>
-                  {children}
+                  {listChildren?.rest}
                 </ReviewCard>
               )}
             </div>
@@ -986,12 +1004,12 @@ ReviewMarkers.docxReviewPart = 'Markers' as const;
  * @public
  */
 function ReviewAddComment({
-  top,
+  top = null,
   drafting = false,
   className,
   hidden,
   children,
-}: ReviewPartProps & { top: number | null; drafting?: boolean }) {
+}: ReviewPartProps & { top?: number | null; drafting?: boolean }) {
   const { beginDraft } = useRail();
   const t = useReviewLabel();
   // Offered for ANY range, including one inside an existing comment: overlapping comments

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -284,7 +284,8 @@ export interface ReviewProps extends Omit<ReviewPartProps, 'children'> {
   furniture?: ReactNode;
   /**
    * Render the packaged arrangement. `false` mounts the rail and its context only, so a host
-   * can lay the cards out itself while keeping the subscription and the anchoring.
+   * can lay the cards out itself while keeping the subscription and the anchoring. Explicit
+   * compound parts still inherit root-owned geometry; no omitted part is added back.
    */
   preset?: boolean;
   /**
@@ -744,47 +745,52 @@ function ReviewRoot({
     });
   };
 
-  const affordances = preset ? (
+  const affordances = (
     <>
-      {takeRoot(
-        'AddComment',
-        <ReviewAddComment top={composeTop} drafting={draftAnchorY !== null} />
-      )}
-      {!open || draftAnchorY === null || composeTop === null
+      {preset || 'AddComment' in rootParts
+        ? takeRoot(
+            'AddComment',
+            <ReviewAddComment top={composeTop} drafting={draftAnchorY !== null} />
+          )
+        : null}
+      {!open || draftAnchorY === null || composeTop === null || (!preset && !('Draft' in rootParts))
         ? null
         : takeRoot('Draft', <ReviewDraft top={composeTop} />)}
       {/* Mounted open OR closed: the balloon is how a reader inspects a change whose rail
           card is filtered away, and a closed pane filters ALL of them away. */}
-      {takeRoot('Balloon', <ReviewBalloon />)}
+      {preset || 'Balloon' in rootParts ? takeRoot('Balloon', <ReviewBalloon />) : null}
     </>
-  ) : null;
+  );
 
-  // `preset={false}` hands the panel over verbatim, but a render prop needs the list to run it.
-  const body = !preset
-    ? typeof children === 'function'
-      ? null
-      : children
-    : open
-      ? takeRoot(
-          'List',
-          <ReviewList
-            stack={stack}
-            positions={stacked}
-            collapsed={collapsedKeys}
-            scale={metrics.scale}
-            offset={metrics.top}
-            window={window_}
-          >
-            {rootChildren.rest}
-          </ReviewList>
-        )
-      : // Closed, the rail keeps its anchors and drops everything else: a small marker per item
+  const list = (
+    <ReviewList
+      stack={stack}
+      positions={stacked}
+      collapsed={collapsedKeys}
+      scale={metrics.scale}
+      offset={metrics.top}
+      window={window_}
+    >
+      {rootChildren.rest}
+    </ReviewList>
+  );
+  const markers = <ReviewMarkers scale={metrics.scale} offset={metrics.top} window={window_} />;
+  // `preset={false}` supplies no defaults, but an explicit compound part still inherits the
+  // geometry only the root can calculate. Unrecognized host nodes remain verbatim.
+  const body = open
+    ? preset || 'List' in rootParts
+      ? takeRoot('List', list)
+      : typeof rootChildren.rest === 'function'
+        ? null
+        : rootChildren.rest
+    : preset || 'Markers' in rootParts
+      ? // Closed, the rail keeps its anchors and drops everything else: a small marker per item
         // in the margin, which is how a reader sees there is something to read without giving up
         // the width. Clicking one opens the pane on that item.
-        takeRoot(
-          'Markers',
-          <ReviewMarkers scale={metrics.scale} offset={metrics.top} window={window_} />
-        );
+        takeRoot('Markers', markers)
+      : typeof rootChildren.rest === 'function'
+        ? null
+        : rootChildren.rest;
 
   return (
     <ReviewContext.Provider value={value}>
@@ -1043,7 +1049,7 @@ ReviewAddComment.docxReviewPart = 'AddComment' as const;
  *
  * @public
  */
-function ReviewDraft({ top, className, hidden }: ReviewPartProps & { top: number }) {
+function ReviewDraft({ top = 0, className, hidden }: ReviewPartProps & { top?: number }) {
   const { review, endDraft, measure } = useRail();
   const t = useReviewLabel();
   const [text, setText] = useState('');

--- a/packages/pro/src/react/review-composition.tsx
+++ b/packages/pro/src/react/review-composition.tsx
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Scope-aware composition helpers for the review compound.
+
+import { Fragment, cloneElement, isValidElement, type ReactElement, type ReactNode } from 'react';
+
+const ROOT_PARTS = new Set(['List', 'Markers', 'AddComment', 'Draft', 'Balloon']);
+const LIST_PARTS = new Set(['Card', 'Empty']);
+
+/**
+ * Split one compound scope from the children that belong to its nested scope.
+ *
+ * Fragments are transparent, matching Toolbar/Menu override behavior. A recognized part is
+ * consumed at this level; everything else keeps its order and travels to the next level.
+ */
+export function partitionReviewChildren(
+  children: ReactNode,
+  scope: 'root' | 'list'
+): { parts: Record<string, ReactNode>; rest: ReactNode[] } {
+  const accepted = scope === 'root' ? ROOT_PARTS : LIST_PARTS;
+  const parts: Record<string, ReactNode> = {};
+  const rest: ReactNode[] = [];
+  const visit = (node: ReactNode): void => {
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child);
+      return;
+    }
+    if (!isValidElement(node)) {
+      if (node !== null && node !== undefined && node !== false) rest.push(node);
+      return;
+    }
+    if (node.type === Fragment) {
+      visit((node.props as { children?: ReactNode }).children);
+      return;
+    }
+    const marker = (node.type as { docxReviewPart?: string }).docxReviewPart;
+    if (marker && accepted.has(marker)) parts[marker] = node;
+    else rest.push(node);
+  };
+  visit(children);
+  return { parts, rest };
+}
+
+/** Apply the root card class to an explicit Card template without nesting another Card. */
+export function cloneReviewCard(
+  card: ReactElement<{ className?: string }>,
+  rootClassName: string | undefined
+): ReactNode {
+  if (!rootClassName) return card;
+  const ownClassName = card.props.className;
+  return cloneElement(card, {
+    className: `${rootClassName}${ownClassName ? ` ${ownClassName}` : ''}`,
+  });
+}


### PR DESCRIPTION
## Summary
- separate root, list, and card child scopes in the review compound
- support custom Add Comment controls alongside List render callbacks
- preserve legacy root render callbacks and direct root Card shorthand

## Test plan
- `bun test packages/pro/src/__tests__/review-composition.test.tsx packages/pro/src/__tests__/custom-review-cards.test.tsx packages/pro/src/__tests__/review-sidebar.test.tsx`
- `bun run typecheck`
- `bun run lint`
- `bun run build:packages && bun run api:check`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788941327&installation_model_id=422592&pr_number=265&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F265&signature=13bd261ee85b2b58f93f02ead4082093495505ab2fc80e5753a2b4da900eee00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->