### PR TITLE
chore: collapse dependabot into two grouped PR streams

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,120 +2,50 @@
 # Compromised packages (stolen maintainer tokens) are almost always yanked
 # within hours, well before this window elapses.
 #
-# Dependabot v2 has no global default and rejects YAML aliases
-# (dependabot-core#1582), so the cooldown block + groups block are
-# duplicated per entry. The `dev-dependencies` group bundles every
-# patch+minor devDep bump into one PR per directory, so dependabot-lockfile.yml
-# only has to refresh `bun.lock` once per week per directory. Major bumps
-# still get their own PR (real upgrade work).
+# Two npm streams, one grouped PR each per week:
+#
+#   library  — the root workspace minus examples/. `/` covers every workspace
+#              member, so `exclude-paths` is what keeps examples out; a
+#              per-package entry would double-cover and open a second PR for
+#              the same bump (that is where the three harfbuzzjs PRs came from).
+#   examples — the demo apps, grouped across all ten directories at once.
+#
+# Majors stay ungrouped on purpose: they are real upgrade work and need to be
+# revertable on their own. Fold them in by adding 'major' to `update-types`.
+#
+# Dependabot v2 rejects YAML aliases (dependabot-core#1582), so the cooldown
+# and group blocks are spelled out per entry.
 version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    exclude-paths:
+      - 'examples/**'
     schedule:
       interval: 'weekly'
       day: 'monday'
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: 'chore(deps)'
     groups:
-      dev-dependencies:
-        dependency-type: 'development'
+      library:
+        patterns: ['*']
         update-types: ['minor', 'patch']
 
   - package-ecosystem: 'npm'
-    directory: '/packages/editor-api'
+    directories:
+      - '/examples/*'
     schedule:
       interval: 'weekly'
       day: 'monday'
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: 'chore(deps-examples)'
     groups:
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/i18n'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    cooldown:
-      default-days: 7
-    groups:
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/react'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    cooldown:
-      default-days: 7
-    groups:
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/vue'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    cooldown:
-      default-days: 7
-    groups:
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/examples/astro'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    cooldown:
-      default-days: 7
-    groups:
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/examples/remix'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    cooldown:
-      default-days: 7
-    groups:
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/examples/vite'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    cooldown:
-      default-days: 7
-    groups:
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/examples/vue'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    cooldown:
-      default-days: 7
-    groups:
-      dev-dependencies:
-        dependency-type: 'development'
+      examples:
+        patterns: ['*']
         update-types: ['minor', 'patch']
 
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
The nine npm entries double-covered each other: `/` already sweeps every workspace member, so the per-package entries opened a second PR for the same bump (three separate harfbuzzjs PRs last week). Now one entry for the library (root, `examples/**` excluded) and one for the examples, each with a single group, so a normal week is two PRs instead of nine.

`exclude-paths` is what keeps examples out of the root stream — worth confirming it validates on the Dependabot tab after merge, since a rejected key would put examples back to double-covered. Majors stay ungrouped on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789548231&installation_model_id=422592&pr_number=285&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F285&signature=b1db4117566c7d623a87cd41189dfeaaea60d2bda9b21a3dbe9c964fa34e2699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->