### PR TITLE
docs: require Simplified Technical English in replies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,22 @@
 WYSIWYG editor and rendering engine for DOCX. Output must match MS Word: fonts,
 theme colors, styles, tables, headers/footers, section layout.
 
+## Communication
+
+Write all replies in ASD-STE100 Simplified Technical English.
+
+- Use the active voice.
+- Keep sentences to 20 words or fewer.
+- Give one idea in each sentence.
+- Use simple tenses: present, past, and future.
+- Use the same word for the same idea each time.
+- Do not use idioms, slang, or jargon.
+- Keep paragraphs to 6 sentences or fewer.
+
+Keep technical items exact. File paths, function names, flags, and numbers do not
+change. For example, write `packages/core/src/layout/semantic-layout.ts` and
+`w:contextualSpacing` in full.
+
 ## Packages
 
 One engine. Thin chrome on top.


### PR DESCRIPTION
Adds a Communication section to CLAUDE.md: replies use ASD-STE100 Simplified Technical English, with technical identifiers left exact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789548357&installation_model_id=422592&pr_number=287&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F287&signature=322f37332d98875bdf9267d47c63202371ada853354cd729e2a49096d3782a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->