### PR TITLE
feat: benchmark every PR and report the edit numbers as a sticky comment

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-name: Edit benchmark
+name: Performance benchmark
 
 # Runs the deterministic edit benchmark (scripts/bench/edit-bench.ts) on the PR
 # head and on its merge-base with main, then upserts one sticky PR comment with

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,117 @@
+name: Edit benchmark
+
+# Runs the deterministic edit benchmark (scripts/bench/edit-bench.ts) on the PR
+# head and on its merge-base with main, then upserts one sticky PR comment with
+# the before/after table. Wall-clock numbers from a shared runner are
+# informational only — this job never fails on a timing regression. The hard
+# regression gate is the pinned work-counter test
+# (scripts/bench/edit-bench-gates.test.ts) inside `bun run test` in ci.yml.
+
+on:
+  pull_request:
+    branches: [main]
+
+# Least-privilege default; the bench job escalates pull-requests itself.
+permissions:
+  contents: read
+
+# A new push supersedes the previous run's numbers and its pending comment.
+concurrency:
+  group: bench-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read # checkout + merge-base worktree
+      pull-requests: write # upsert the single sticky benchmark comment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          # Full history so the baseline commit is reachable for the worktree.
+          fetch-depth: 0
+          # The bench steps run PR-branch code; keep the token out of .git/config.
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Benchmark PR head
+        run: |
+          mkdir -p bench-out
+          bun scripts/bench/edit-bench.ts --runs 10 --json > bench-out/head.json
+
+      - name: Benchmark baseline
+        run: |
+          # HEAD is the PR merge ref, so this resolves to the main tip the merge
+          # ref was built against — the delta isolates exactly what merging this
+          # PR changes. Do not "fix" this to the branch fork point.
+          BASE=$(git merge-base HEAD "origin/${{ github.base_ref }}")
+          echo "baseline commit: $BASE"
+          git worktree add "$RUNNER_TEMP/base" "$BASE"
+          # Run the baseline's OWN benchmark script against baseline code, so it
+          # measures what main actually did. Comparability is checked later via
+          # fixtureSha256 in the comment script; a baseline without the benchmark
+          # (or without the fixture) simply yields a head-only report.
+          if [ -f "$RUNNER_TEMP/base/scripts/bench/edit-bench.ts" ] && \
+             [ -f "$RUNNER_TEMP/base/e2e/fixtures/synthetic-long-edit.docx" ]; then
+            cd "$RUNNER_TEMP/base"
+            bun install --frozen-lockfile
+            bun scripts/bench/edit-bench.ts --runs 10 --json > "$GITHUB_WORKSPACE/bench-out/base.json"
+          else
+            echo "merge-base has no edit benchmark; skipping baseline"
+          fi
+
+      - name: Render comment
+        run: |
+          if [ -f bench-out/base.json ]; then
+            node scripts/bench/edit-bench-comment.mjs \
+              --head bench-out/head.json --base bench-out/base.json --out bench-out/comment.md
+          else
+            node scripts/bench/edit-bench-comment.mjs \
+              --head bench-out/head.json --out bench-out/comment.md
+          fi
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: edit-bench-report
+          path: bench-out/
+          if-no-files-found: ignore
+
+      - name: Upsert PR comment
+        # Fork PRs get a read-only token; their numbers live in the artifact.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('bench-out/comment.md', 'utf8');
+            // Must equal COMMENT_MARKER in scripts/bench/edit-bench-comment.mjs,
+            // which puts it on the first line of every rendered comment. If they
+            // drift, every push appends a new comment instead of updating one.
+            const marker = '<!-- edit-bench-report -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -44,6 +44,22 @@ when validating those layers.
 Run timing comparisons sequentially. Concurrent benchmark processes compete for CPU and can hide
 or exaggerate timing changes; the structural work counters remain deterministic either way.
 
+### CI benchmark comment
+
+`.github/workflows/bench.yml` runs `bench:edit --runs 10` on every PR, twice: once on the PR
+merge ref (the PR merged into current `main`) and once on the `main` tip that merge ref was
+built against (using that commit's own copy of the script, in a separate worktree), so the
+delta isolates exactly what merging the PR changes. `scripts/bench/edit-bench-comment.mjs`
+renders both reports into a single sticky PR comment — a per-scenario median table with
+deltas, plus any work-counter changes. Comparability is guarded by the fixture SHA-256: if
+the fixture changed on the PR, or the baseline predates the benchmark, the comment degrades
+to head-only numbers.
+
+Timings in that comment are informational: shared runners are noisy, so the job never fails on
+a wall-clock regression. The hard gate stays in `edit-bench-gates.test.ts`, which pins the
+deterministic work counters inside `bun run test`. Fork PRs cannot receive comments (read-only
+token); their reports are in the `edit-bench-report` workflow artifact.
+
 ### Browser editing benchmark
 
 `bench:edit` deliberately stops after the store and layout pipeline. The browser benchmark drives

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -44,16 +44,16 @@ when validating those layers.
 Run timing comparisons sequentially. Concurrent benchmark processes compete for CPU and can hide
 or exaggerate timing changes; the structural work counters remain deterministic either way.
 
-### CI benchmark comment
+### CI performance-benchmark comment
 
 `.github/workflows/bench.yml` runs `bench:edit --runs 10` on every PR, twice: once on the PR
 merge ref (the PR merged into current `main`) and once on the `main` tip that merge ref was
 built against (using that commit's own copy of the script, in a separate worktree), so the
 delta isolates exactly what merging the PR changes. `scripts/bench/edit-bench-comment.mjs`
 renders both reports into a single sticky PR comment — a per-scenario median table with
-deltas, plus any work-counter changes. Comparability is guarded by the fixture SHA-256: if
-the fixture changed on the PR, or the baseline predates the benchmark, the comment degrades
-to head-only numbers.
+deltas, plus any work-counter changes, plus a mermaid chart of the medians (bars = the PR,
+line = the baseline). Comparability is guarded by the fixture SHA-256: if the fixture changed
+on the PR, or the baseline predates the benchmark, the comment degrades to head-only numbers.
 
 Timings in that comment are informational: shared runners are noisy, so the job never fails on
 a wall-clock regression. The hard gate stays in `edit-bench-gates.test.ts`, which pins the

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -51,9 +51,9 @@ merge ref (the PR merged into current `main`) and once on the `main` tip that me
 built against (using that commit's own copy of the script, in a separate worktree), so the
 delta isolates exactly what merging the PR changes. `scripts/bench/edit-bench-comment.mjs`
 renders both reports into a single sticky PR comment — a per-scenario median table with
-deltas, plus any work-counter changes, plus a mermaid chart of the medians (bars = the PR,
-line = the baseline). Comparability is guarded by the fixture SHA-256: if the fixture changed
-on the PR, or the baseline predates the benchmark, the comment degrades to head-only numbers.
+deltas, plus any work-counter changes. Comparability is guarded by the fixture SHA-256: if
+the fixture changed on the PR, or the baseline predates the benchmark, the comment degrades
+to head-only numbers.
 
 Timings in that comment are informational: shared runners are noisy, so the job never fails on
 a wall-clock regression. The hard gate stays in `edit-bench-gates.test.ts`, which pins the

--- a/scripts/bench/edit-bench-comment.mjs
+++ b/scripts/bench/edit-bench-comment.mjs
@@ -62,73 +62,6 @@ function formatDelta(baseMs, headMs) {
   return `⚪ ${text}`;
 }
 
-/** Compact x-axis labels for the chart; the table above carries the full names. */
-const SCENARIO_SHORT_LABELS = new Map([
-  ['steady-middle-text', 'steady'],
-  ['wrap-middle-text', 'wrap'],
-  ['forced-middle-reflow', 'reflow-mid'],
-  ['forced-early-reflow', 'reflow-early'],
-]);
-
-function shortLabel(name) {
-  return SCENARIO_SHORT_LABELS.get(name) ?? name.slice(0, 14);
-}
-
-/**
- * Grouped comparison as a mermaid chart (GitHub renders these natively in comments).
- * Mermaid overlays multiple bar series at full width — it has no native grouped bars —
- * so the pairing is built from categories instead: each scenario contributes two
- * adjacent x slots, baseline then PR, and each series holds zeros in the other's slots
- * (a zero-height bar draws nothing). The result is a literal gray-next-to-blue pair per
- * scenario. The gray (#6e7781) is a deliberate neutral for the reference series, and
- * both colors clear 3:1 contrast on GitHub's light and dark comment surfaces.
- */
-function medianChart(head, base) {
-  if (head.scenarios.length === 0) return null;
-  const headValues = head.scenarios.map((scenario) => scenario.total.medianMs);
-  const baseByName = base
-    ? new Map(base.scenarios.map((scenario) => [scenario.name, scenario]))
-    : null;
-  const baseValues = baseByName
-    ? head.scenarios.map((scenario) => baseByName.get(scenario.name)?.total.medianMs ?? 0)
-    : null;
-  const values = [...headValues, ...(baseValues ?? [])];
-  if (values.length === 0 || values.some((value) => !Number.isFinite(value))) return null;
-  const top = Math.max(1, Math.ceil(Math.max(...values) * 1.15));
-  const series = (list) => `[${list.map((value) => value.toFixed(2)).join(', ')}]`;
-
-  let categories;
-  let seriesLines;
-  let palette;
-  if (baseValues) {
-    categories = head.scenarios.flatMap((scenario) => [
-      `${shortLabel(scenario.name)} (main)`,
-      `${shortLabel(scenario.name)} (PR)`,
-    ]);
-    const baseSlots = baseValues.flatMap((value) => [value, 0]);
-    const headSlots = headValues.flatMap((value) => [0, value]);
-    palette = '#6e7781, #0969da';
-    seriesLines = [`  bar ${series(baseSlots)}`, `  bar ${series(headSlots)}`];
-  } else {
-    categories = head.scenarios.map((scenario) => shortLabel(scenario.name));
-    palette = '#0969da';
-    seriesLines = [`  bar ${series(headValues)}`];
-  }
-
-  const lines = [
-    '```mermaid',
-    `%%{init: {"themeVariables": {"xyChart": {"plotColorPalette": "${palette}"}}}}%%`,
-    'xychart-beta',
-    `  title "Median edit latency (ms)"`,
-    `  x-axis [${categories.map((name) => `"${name}"`).join(', ')}]`,
-    `  y-axis "ms" 0 --> ${top}`,
-    ...seriesLines,
-    '```',
-    baseValues ? '⬛ `main` baseline · 🟦 this PR' : '🟦 this PR (no comparable baseline)',
-  ];
-  return lines.join('\n');
-}
-
 /** Flatten a work summary into dotted numeric leaves so any schema drift still diffs. */
 function numericLeaves(value, prefix = '') {
   const leaves = new Map();
@@ -187,7 +120,6 @@ export function renderComment(head, base) {
   const lines = [COMMENT_MARKER, '## Performance benchmark', ''];
   const note = comparisonNote(head, base);
   const comparable = note === null;
-  const chart = medianChart(head, comparable ? base : undefined);
 
   if (comparable) {
     lines.push(
@@ -237,7 +169,6 @@ export function renderComment(head, base) {
     lines.push('');
   }
 
-  if (chart) lines.push(chart, '');
   lines.push(detailsBlock('Head report (full JSON)', head));
   if (base) lines.push('', detailsBlock('Base report (full JSON)', base));
   return `${lines.join('\n')}\n`;

--- a/scripts/bench/edit-bench-comment.mjs
+++ b/scripts/bench/edit-bench-comment.mjs
@@ -48,12 +48,69 @@ function formatMs(value) {
   return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(2)} ms` : 'n/a';
 }
 
+// Within this band a delta is runner noise, not a signal — shown neutral.
+const NOISE_BAND_PCT = 5;
+
 function formatDelta(baseMs, headMs) {
   if (!Number.isFinite(baseMs) || !Number.isFinite(headMs)) return 'n/a';
-  if (baseMs === 0) return headMs === 0 ? '±0%' : 'n/a';
+  if (baseMs === 0) return headMs === 0 ? '⚪ ±0%' : 'n/a';
   const pct = Number((((headMs - baseMs) / baseMs) * 100).toFixed(1));
   const text = `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`;
-  return pct > REGRESSION_WARN_PCT ? `${text} ⚠️` : text;
+  if (pct > REGRESSION_WARN_PCT) return `🔴 ${text} ⚠️`;
+  if (pct > NOISE_BAND_PCT) return `🔴 ${text}`;
+  if (pct < -NOISE_BAND_PCT) return `🟢 ${text}`;
+  return `⚪ ${text}`;
+}
+
+/** Compact x-axis labels for the chart; the table above carries the full names. */
+const SCENARIO_SHORT_LABELS = new Map([
+  ['steady-middle-text', 'steady'],
+  ['wrap-middle-text', 'wrap'],
+  ['forced-middle-reflow', 'reflow-mid'],
+  ['forced-early-reflow', 'reflow-early'],
+]);
+
+function shortLabel(name) {
+  return SCENARIO_SHORT_LABELS.get(name) ?? name.slice(0, 14);
+}
+
+/**
+ * Grouped comparison as a mermaid chart (GitHub renders these natively in comments).
+ * Head medians are bars; the baseline is a LINE, not a second bar series — mermaid
+ * overlays bar series at full width, so a second bar would occlude the first. The gray
+ * (#6e7781) is a deliberate neutral for the reference series — identity is carried by
+ * mark shape and the caption, and both colors clear 3:1 contrast on GitHub's light and
+ * dark comment surfaces.
+ */
+function medianChart(head, base) {
+  const names = head.scenarios.map((scenario) => shortLabel(scenario.name));
+  if (names.length === 0) return null;
+  const headValues = head.scenarios.map((scenario) => scenario.total.medianMs);
+  const baseByName = base
+    ? new Map(base.scenarios.map((scenario) => [scenario.name, scenario]))
+    : null;
+  const baseValues = baseByName
+    ? head.scenarios.map((scenario) => baseByName.get(scenario.name)?.total.medianMs ?? 0)
+    : null;
+  const values = [...headValues, ...(baseValues ?? [])].filter((value) => Number.isFinite(value));
+  if (values.length === 0 || values.some((value) => !Number.isFinite(value))) return null;
+  const top = Math.max(1, Math.ceil(Math.max(...values) * 1.15));
+  const series = (list) => `[${list.map((value) => value.toFixed(2)).join(', ')}]`;
+  const lines = [
+    '```mermaid',
+    `%%{init: {"themeVariables": {"xyChart": {"plotColorPalette": "#0969da${baseValues ? ', #6e7781' : ''}"}}}}%%`,
+    'xychart-beta',
+    `  title "Median edit latency (ms)"`,
+    `  x-axis [${names.map((name) => `"${name}"`).join(', ')}]`,
+    `  y-axis "ms" 0 --> ${top}`,
+    `  bar ${series(headValues)}`,
+    ...(baseValues ? [`  line ${series(baseValues)}`] : []),
+    '```',
+    baseValues
+      ? '🟦 bars: this PR · ⬛ line: `main` baseline'
+      : '🟦 bars: this PR (no comparable baseline)',
+  ];
+  return lines.join('\n');
 }
 
 /** Flatten a work summary into dotted numeric leaves so any schema drift still diffs. */
@@ -111,9 +168,10 @@ function detailsBlock(summary, report) {
 }
 
 export function renderComment(head, base) {
-  const lines = [COMMENT_MARKER, '## Edit benchmark', ''];
+  const lines = [COMMENT_MARKER, '## Performance benchmark', ''];
   const note = comparisonNote(head, base);
   const comparable = note === null;
+  const chart = medianChart(head, comparable ? base : undefined);
 
   if (comparable) {
     lines.push(
@@ -163,12 +221,8 @@ export function renderComment(head, base) {
     lines.push('');
   }
 
-  lines.push(
-    `Timings are medians of ${head.config.runs} runs on a shared GitHub runner — informational only. ` +
-      'The deterministic regression gate is `scripts/bench/edit-bench-gates.test.ts` inside `bun run test`.',
-    '',
-    detailsBlock('Head report (full JSON)', head)
-  );
+  if (chart) lines.push(chart, '');
+  lines.push(detailsBlock('Head report (full JSON)', head));
   if (base) lines.push('', detailsBlock('Base report (full JSON)', base));
   return `${lines.join('\n')}\n`;
 }

--- a/scripts/bench/edit-bench-comment.mjs
+++ b/scripts/bench/edit-bench-comment.mjs
@@ -76,15 +76,15 @@ function shortLabel(name) {
 
 /**
  * Grouped comparison as a mermaid chart (GitHub renders these natively in comments).
- * Head medians are bars; the baseline is a LINE, not a second bar series — mermaid
- * overlays bar series at full width, so a second bar would occlude the first. The gray
- * (#6e7781) is a deliberate neutral for the reference series — identity is carried by
- * mark shape and the caption, and both colors clear 3:1 contrast on GitHub's light and
- * dark comment surfaces.
+ * Mermaid overlays multiple bar series at full width — it has no native grouped bars —
+ * so the pairing is built from categories instead: each scenario contributes two
+ * adjacent x slots, baseline then PR, and each series holds zeros in the other's slots
+ * (a zero-height bar draws nothing). The result is a literal gray-next-to-blue pair per
+ * scenario. The gray (#6e7781) is a deliberate neutral for the reference series, and
+ * both colors clear 3:1 contrast on GitHub's light and dark comment surfaces.
  */
 function medianChart(head, base) {
-  const names = head.scenarios.map((scenario) => shortLabel(scenario.name));
-  if (names.length === 0) return null;
+  if (head.scenarios.length === 0) return null;
   const headValues = head.scenarios.map((scenario) => scenario.total.medianMs);
   const baseByName = base
     ? new Map(base.scenarios.map((scenario) => [scenario.name, scenario]))
@@ -92,23 +92,39 @@ function medianChart(head, base) {
   const baseValues = baseByName
     ? head.scenarios.map((scenario) => baseByName.get(scenario.name)?.total.medianMs ?? 0)
     : null;
-  const values = [...headValues, ...(baseValues ?? [])].filter((value) => Number.isFinite(value));
+  const values = [...headValues, ...(baseValues ?? [])];
   if (values.length === 0 || values.some((value) => !Number.isFinite(value))) return null;
   const top = Math.max(1, Math.ceil(Math.max(...values) * 1.15));
   const series = (list) => `[${list.map((value) => value.toFixed(2)).join(', ')}]`;
+
+  let categories;
+  let seriesLines;
+  let palette;
+  if (baseValues) {
+    categories = head.scenarios.flatMap((scenario) => [
+      `${shortLabel(scenario.name)} (main)`,
+      `${shortLabel(scenario.name)} (PR)`,
+    ]);
+    const baseSlots = baseValues.flatMap((value) => [value, 0]);
+    const headSlots = headValues.flatMap((value) => [0, value]);
+    palette = '#6e7781, #0969da';
+    seriesLines = [`  bar ${series(baseSlots)}`, `  bar ${series(headSlots)}`];
+  } else {
+    categories = head.scenarios.map((scenario) => shortLabel(scenario.name));
+    palette = '#0969da';
+    seriesLines = [`  bar ${series(headValues)}`];
+  }
+
   const lines = [
     '```mermaid',
-    `%%{init: {"themeVariables": {"xyChart": {"plotColorPalette": "#0969da${baseValues ? ', #6e7781' : ''}"}}}}%%`,
+    `%%{init: {"themeVariables": {"xyChart": {"plotColorPalette": "${palette}"}}}}%%`,
     'xychart-beta',
     `  title "Median edit latency (ms)"`,
-    `  x-axis [${names.map((name) => `"${name}"`).join(', ')}]`,
+    `  x-axis [${categories.map((name) => `"${name}"`).join(', ')}]`,
     `  y-axis "ms" 0 --> ${top}`,
-    `  bar ${series(headValues)}`,
-    ...(baseValues ? [`  line ${series(baseValues)}`] : []),
+    ...seriesLines,
     '```',
-    baseValues
-      ? '🟦 bars: this PR · ⬛ line: `main` baseline'
-      : '🟦 bars: this PR (no comparable baseline)',
+    baseValues ? '⬛ `main` baseline · 🟦 this PR' : '🟦 this PR (no comparable baseline)',
   ];
   return lines.join('\n');
 }

--- a/scripts/bench/edit-bench-comment.mjs
+++ b/scripts/bench/edit-bench-comment.mjs
@@ -1,0 +1,195 @@
+// Render an edit-bench JSON report (plus an optional baseline report) as the
+// markdown body of the sticky PR comment posted by .github/workflows/bench.yml.
+//
+// Wall-clock numbers come from a shared CI runner, so the comment is advisory:
+// it flags regressions but never fails the job. The deterministic gate stays in
+// scripts/bench/edit-bench-gates.test.ts, which pins the work counters exactly.
+//
+// Usage: node scripts/bench/edit-bench-comment.mjs --head head.json [--base base.json] --out comment.md
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const COMMENT_MARKER = '<!-- edit-bench-report -->';
+
+const REGRESSION_WARN_PCT = 20;
+
+// GitHub caps issue comment bodies at 65536 characters; leave room for the
+// wrapper text around the <details> payloads.
+const MAX_COMMENT_CHARS = 60_000;
+
+function parseArgs(argv) {
+  let head;
+  let base;
+  let out;
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--head') head = argv[++index];
+    else if (value === '--base') base = argv[++index];
+    else if (value === '--out') out = argv[++index];
+    else throw new Error(`unknown argument: ${value}`);
+  }
+  if (!head) throw new Error('--head <report.json> is required');
+  if (!out) throw new Error('--out <comment.md> is required');
+  return { head, base, out };
+}
+
+function readReport(path) {
+  const report = JSON.parse(readFileSync(path, 'utf8'));
+  const shapeOk =
+    report.schema === 1 &&
+    Array.isArray(report.scenarios) &&
+    report.scenarios.every((scenario) => Number.isFinite(scenario?.total?.medianMs));
+  if (!shapeOk) throw new Error(`${path}: not an edit-bench schema-1 report`);
+  return report;
+}
+
+function formatMs(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(2)} ms` : 'n/a';
+}
+
+function formatDelta(baseMs, headMs) {
+  if (!Number.isFinite(baseMs) || !Number.isFinite(headMs)) return 'n/a';
+  if (baseMs === 0) return headMs === 0 ? '±0%' : 'n/a';
+  const pct = Number((((headMs - baseMs) / baseMs) * 100).toFixed(1));
+  const text = `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`;
+  return pct > REGRESSION_WARN_PCT ? `${text} ⚠️` : text;
+}
+
+/** Flatten a work summary into dotted numeric leaves so any schema drift still diffs. */
+function numericLeaves(value, prefix = '') {
+  const leaves = new Map();
+  if (value === null || typeof value !== 'object') return leaves;
+  for (const [key, child] of Object.entries(value)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof child === 'number') leaves.set(path, child);
+    else if (child && typeof child === 'object') {
+      for (const [leafPath, leafValue] of numericLeaves(child, path))
+        leaves.set(leafPath, leafValue);
+    }
+  }
+  return leaves;
+}
+
+function workCounterDeltas(baseScenario, headScenario) {
+  const baseLeaves = numericLeaves(baseScenario.work);
+  const headLeaves = numericLeaves(headScenario.work);
+  const rows = [];
+  for (const [path, headValue] of headLeaves) {
+    const baseValue = baseLeaves.get(path);
+    if (baseValue !== undefined && baseValue !== headValue) {
+      rows.push(`  - \`${path}\`: ${baseValue} → ${headValue}`);
+    }
+  }
+  return rows;
+}
+
+function comparisonNote(head, base) {
+  if (!base) return 'Baseline unavailable (no comparable merge-base run) — head-only numbers.';
+  if (base.fixtureSha256 !== head.fixtureSha256) {
+    return 'Baseline not comparable: the benchmark fixture differs from the merge-base — head-only numbers.';
+  }
+  return null;
+}
+
+function detailsBlock(summary, report) {
+  const json = JSON.stringify(report, null, 2);
+  const body =
+    json.length > MAX_COMMENT_CHARS / 2
+      ? `${json.slice(0, MAX_COMMENT_CHARS / 2)}\n… truncated …`
+      : json;
+  return [
+    '<details>',
+    `<summary>${summary}</summary>`,
+    '',
+    '```json',
+    body,
+    '```',
+    '',
+    '</details>',
+  ].join('\n');
+}
+
+export function renderComment(head, base) {
+  const lines = [COMMENT_MARKER, '## Edit benchmark', ''];
+  const note = comparisonNote(head, base);
+  const comparable = note === null;
+
+  if (comparable) {
+    lines.push(
+      '| Scenario | Base median | Head median | Δ | Head p95 |',
+      '| --- | --- | --- | --- | --- |'
+    );
+    const baseByName = new Map(base.scenarios.map((scenario) => [scenario.name, scenario]));
+    const counterRows = [];
+    for (const scenario of head.scenarios) {
+      const baseScenario = baseByName.get(scenario.name);
+      if (!baseScenario) {
+        lines.push(
+          `| ${scenario.name} | — | ${formatMs(scenario.total.medianMs)} | n/a | ${formatMs(scenario.total.p95Ms)} |`
+        );
+        continue;
+      }
+      lines.push(
+        `| ${scenario.name} | ${formatMs(baseScenario.total.medianMs)} | ${formatMs(scenario.total.medianMs)} | ${formatDelta(baseScenario.total.medianMs, scenario.total.medianMs)} | ${formatMs(scenario.total.p95Ms)} |`
+      );
+      const deltas = workCounterDeltas(baseScenario, scenario);
+      if (deltas.length > 0) counterRows.push(`- **${scenario.name}**`, ...deltas);
+    }
+    const headNames = new Set(head.scenarios.map((scenario) => scenario.name));
+    for (const scenario of base.scenarios) {
+      if (headNames.has(scenario.name)) continue;
+      lines.push(`| ${scenario.name} | ${formatMs(scenario.total.medianMs)} | — | n/a | — |`);
+    }
+    lines.push('');
+    if (counterRows.length > 0) {
+      lines.push(
+        '**Work counters changed** (deterministic — investigate before merging):',
+        '',
+        ...counterRows,
+        ''
+      );
+    } else {
+      lines.push('Work counters: unchanged.', '');
+    }
+  } else {
+    lines.push(`> ${note}`, '');
+    lines.push('| Scenario | Median | p95 | Min | Max |', '| --- | --- | --- | --- | --- |');
+    for (const scenario of head.scenarios) {
+      lines.push(
+        `| ${scenario.name} | ${formatMs(scenario.total.medianMs)} | ${formatMs(scenario.total.p95Ms)} | ${formatMs(scenario.total.minMs)} | ${formatMs(scenario.total.maxMs)} |`
+      );
+    }
+    lines.push('');
+  }
+
+  lines.push(
+    `Timings are medians of ${head.config.runs} runs on a shared GitHub runner — informational only. ` +
+      'The deterministic regression gate is `scripts/bench/edit-bench-gates.test.ts` inside `bun run test`.',
+    '',
+    detailsBlock('Head report (full JSON)', head)
+  );
+  if (base) lines.push('', detailsBlock('Base report (full JSON)', base));
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const head = readReport(args.head);
+  let base;
+  if (args.base) {
+    try {
+      base = readReport(args.base);
+    } catch (error) {
+      // Degrade to head-only, but say why: a truncated or shape-drifted base.json
+      // must be distinguishable in CI logs from a merge-base without the bench.
+      console.error(`ignoring base report: ${error instanceof Error ? error.message : error}`);
+      base = undefined;
+    }
+  }
+  writeFileSync(args.out, renderComment(head, base));
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main();

--- a/scripts/bench/edit-bench-comment.test.ts
+++ b/scripts/bench/edit-bench-comment.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+
+import { COMMENT_MARKER, renderComment } from './edit-bench-comment.mjs';
+
+function timing(medianMs: number): Record<string, number> {
+  return { medianMs, p95Ms: medianMs * 1.2, minMs: medianMs * 0.8, maxMs: medianMs * 1.5 };
+}
+
+function report(overrides: {
+  fixtureSha256?: string;
+  medianMs?: number;
+  cacheMisses?: number;
+}): Record<string, unknown> {
+  const medianMs = overrides.medianMs ?? 10;
+  return {
+    schema: 1,
+    fixture: 'e2e/fixtures/synthetic-long-edit.docx',
+    fixtureBytes: 27000,
+    fixtureSha256: overrides.fixtureSha256 ?? 'abc123',
+    environment: { runtime: 'bun', arch: 'arm64' },
+    config: { runs: 10, warmup: 2, measurer: 'deterministic' },
+    scenarios: [
+      {
+        name: 'steady-middle-text',
+        target: { paragraphIndex: 1600, paragraphId: 'p-1600' },
+        transaction: timing(medianMs / 10),
+        layout: timing(medianMs),
+        total: timing(medianMs),
+        work: {
+          placed: 13,
+          total: 3200,
+          reusedPages: 154,
+          fullPasses: 1,
+          pagesBefore: 204,
+          pagesAfter: 204,
+          cache: { hits: 0, misses: overrides.cacheMisses ?? 3213, evictions: 3213, size: 0 },
+        },
+      },
+    ],
+  };
+}
+
+describe('edit-bench comment rendering', () => {
+  test('comparable base renders a delta table with the sticky marker first', () => {
+    const body = renderComment(report({ medianMs: 8 }), report({ medianMs: 10 }));
+    expect(body.startsWith(COMMENT_MARKER)).toBe(true);
+    expect(body).toContain('| steady-middle-text | 10.00 ms | 8.00 ms | -20.0% |');
+    expect(body).toContain('Work counters: unchanged.');
+    expect(body).not.toContain('⚠️');
+  });
+
+  test('a regression past the threshold gets the warning marker', () => {
+    const body = renderComment(report({ medianMs: 15 }), report({ medianMs: 10 }));
+    expect(body).toContain('+50.0% ⚠️');
+  });
+
+  test('changed work counters are listed as deterministic deltas', () => {
+    const body = renderComment(report({ cacheMisses: 4000 }), report({ cacheMisses: 3213 }));
+    expect(body).toContain('Work counters changed');
+    expect(body).toContain('`cache.misses`: 3213 → 4000');
+  });
+
+  test('a fixture hash mismatch degrades to a head-only table', () => {
+    const body = renderComment(report({ fixtureSha256: 'new' }), report({ fixtureSha256: 'old' }));
+    expect(body).toContain('Baseline not comparable');
+    expect(body).toContain('| Scenario | Median | p95 | Min | Max |');
+    expect(body).not.toContain('| Base median |');
+  });
+
+  test('a missing base degrades to a head-only table', () => {
+    const body = renderComment(report({}), undefined);
+    expect(body).toContain('Baseline unavailable');
+    expect(body.startsWith(COMMENT_MARKER)).toBe(true);
+  });
+
+  test('a scenario present only in the base still gets a row', () => {
+    const base = report({});
+    const head = report({});
+    (head.scenarios as Array<{ name: string }>)[0]!.name = 'renamed-scenario';
+    const body = renderComment(head, base);
+    expect(body).toContain('| renamed-scenario | — |');
+    expect(body).toContain('| steady-middle-text | 10.00 ms | — | n/a | — |');
+  });
+});

--- a/scripts/bench/edit-bench-comment.test.ts
+++ b/scripts/bench/edit-bench-comment.test.ts
@@ -44,14 +44,36 @@ describe('edit-bench comment rendering', () => {
   test('comparable base renders a delta table with the sticky marker first', () => {
     const body = renderComment(report({ medianMs: 8 }), report({ medianMs: 10 }));
     expect(body.startsWith(COMMENT_MARKER)).toBe(true);
-    expect(body).toContain('| steady-middle-text | 10.00 ms | 8.00 ms | -20.0% |');
+    expect(body).toContain('## Performance benchmark');
+    expect(body).toContain('| steady-middle-text | 10.00 ms | 8.00 ms | 🟢 -20.0% |');
     expect(body).toContain('Work counters: unchanged.');
     expect(body).not.toContain('⚠️');
   });
 
   test('a regression past the threshold gets the warning marker', () => {
     const body = renderComment(report({ medianMs: 15 }), report({ medianMs: 10 }));
-    expect(body).toContain('+50.0% ⚠️');
+    expect(body).toContain('🔴 +50.0% ⚠️');
+  });
+
+  test('a delta inside the noise band renders neutral', () => {
+    const body = renderComment(report({ medianMs: 10.3 }), report({ medianMs: 10 }));
+    expect(body).toContain('⚪ +3.0%');
+  });
+
+  test('comparable mode charts head bars against a baseline line', () => {
+    const body = renderComment(report({ medianMs: 8 }), report({ medianMs: 10 }));
+    expect(body).toContain('```mermaid');
+    expect(body).toContain('xychart-beta');
+    expect(body).toContain('bar [8.00]');
+    expect(body).toContain('line [10.00]');
+    expect(body).toContain('line: `main` baseline');
+  });
+
+  test('head-only mode charts a single bar series', () => {
+    const body = renderComment(report({}), undefined);
+    expect(body).toContain('xychart-beta');
+    expect(body).toContain('bar [10.00]');
+    expect(body).not.toContain('line [');
   });
 
   test('changed work counters are listed as deterministic deltas', () => {

--- a/scripts/bench/edit-bench-comment.test.ts
+++ b/scripts/bench/edit-bench-comment.test.ts
@@ -60,22 +60,9 @@ describe('edit-bench comment rendering', () => {
     expect(body).toContain('⚪ +3.0%');
   });
 
-  test('comparable mode charts paired baseline and PR bars per scenario', () => {
+  test('the comment is the table alone — no chart block', () => {
     const body = renderComment(report({ medianMs: 8 }), report({ medianMs: 10 }));
-    expect(body).toContain('```mermaid');
-    expect(body).toContain('xychart-beta');
-    expect(body).toContain('"steady (main)", "steady (PR)"');
-    // Zero-height slots keep each series invisible in the other's column.
-    expect(body).toContain('bar [10.00, 0.00]');
-    expect(body).toContain('bar [0.00, 8.00]');
-    expect(body).toContain('⬛ `main` baseline · 🟦 this PR');
-  });
-
-  test('head-only mode charts a single bar series', () => {
-    const body = renderComment(report({}), undefined);
-    expect(body).toContain('xychart-beta');
-    expect(body).toContain('bar [10.00]');
-    expect(body).not.toContain('(main)');
+    expect(body).not.toContain('```mermaid');
   });
 
   test('changed work counters are listed as deterministic deltas', () => {

--- a/scripts/bench/edit-bench-comment.test.ts
+++ b/scripts/bench/edit-bench-comment.test.ts
@@ -60,20 +60,22 @@ describe('edit-bench comment rendering', () => {
     expect(body).toContain('⚪ +3.0%');
   });
 
-  test('comparable mode charts head bars against a baseline line', () => {
+  test('comparable mode charts paired baseline and PR bars per scenario', () => {
     const body = renderComment(report({ medianMs: 8 }), report({ medianMs: 10 }));
     expect(body).toContain('```mermaid');
     expect(body).toContain('xychart-beta');
-    expect(body).toContain('bar [8.00]');
-    expect(body).toContain('line [10.00]');
-    expect(body).toContain('line: `main` baseline');
+    expect(body).toContain('"steady (main)", "steady (PR)"');
+    // Zero-height slots keep each series invisible in the other's column.
+    expect(body).toContain('bar [10.00, 0.00]');
+    expect(body).toContain('bar [0.00, 8.00]');
+    expect(body).toContain('⬛ `main` baseline · 🟦 this PR');
   });
 
   test('head-only mode charts a single bar series', () => {
     const body = renderComment(report({}), undefined);
     expect(body).toContain('xychart-beta');
     expect(body).toContain('bar [10.00]');
-    expect(body).not.toContain('line [');
+    expect(body).not.toContain('(main)');
   });
 
   test('changed work counters are listed as deterministic deltas', () => {


### PR DESCRIPTION
Runs the deterministic edit benchmark on the PR merge ref and on the main tip it was built against, then upserts one sticky comment with the per-scenario median table, deltas, and any work-counter changes. Timings are informational; the hard gate stays in the pinned work-counter test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789551539&installation_model_id=422592&pr_number=294&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F294&signature=758100b66c3218e76b08efef69340f4d1630a547068f1c493d03fa6d2094882b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->