### PR TITLE
perf(core): stop rescanning the whole tree on every keystroke

### DIFF
--- a/.changeset/flush-scan-memos.md
+++ b/.changeset/flush-scan-memos.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Memoize package snapshots, section enumeration, and list resolution so a keystroke in a long document no longer rescans the whole tree; typing in large documents is significantly faster.

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -1093,8 +1093,8 @@ export function openTreeSession(
         // Package write, not a tree op: the story undo unit names the rId, while the
         // relationship itself is session-persistent across lifecycle package snapshots
         // (see `mergePersistentPackageShell`). Leftover rels are harmless; missing ones are not.
-        // `currentPackage()` mints a fresh object per call, so the identity check compares
-        // against the SAME instance the write was given.
+        // The identity check compares the write's output against the SAME `before` instance
+        // handed to the write; `currentPackage()` being memoized only strengthens that.
         const part = packageStore.partFor(scope);
         if (!part) return null;
         const before = currentPackage();
@@ -1406,8 +1406,8 @@ export function openTreeSession(
       ensureNumberingLevel(numId, level, kind) {
         // Same lane as `ensureListDefinition`: the numbering part lives on the PACKAGE,
         // and the memoized numbering root must forget what it read before this write.
-        // `currentPackage()` mints a fresh object per call, so the identity check must
-        // compare against the SAME instance the write was given.
+        // The identity check compares the write's output against the SAME `before`
+        // instance handed to the write; the `currentPackage()` memo preserves that.
         const before = currentPackage();
         const ensured = ensureNumberingLevel(before, numId, level, kind);
         if (!ensured) return false;

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'bun:test';
-import { readOoxmlPart } from '@docx-editor.dev/core/store';
-import { drawingAtomIdentities } from '../inline-drawing-source.ts';
+import {
+  readOoxmlPackage,
+  readOoxmlPart,
+  type ImageResourceLookup,
+} from '@docx-editor.dev/core/store';
+import { zipSync, strToU8 } from 'fflate';
+import { createInlineDrawingLayoutBundle, drawingAtomIdentities } from '../inline-drawing-source.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
@@ -18,4 +23,74 @@ test('part-wide drawing identity scan does not fail closed after 4k elements', (
   const atoms = drawingAtomIdentities(result.part);
 
   expect(atoms).not.toBeNull();
+});
+
+test('a slot hit resolves no package; a substrate change through sync still does', () => {
+  const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+  const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+  const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+  const bytes = zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>x</w:t></w:r></w:p></w:body></w:document>`
+    ),
+  });
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  let pkg = loaded.package;
+  let revision = 0;
+  let packageReads = 0;
+  const session = {
+    packageRevision: () => revision,
+    currentPackage: () => {
+      packageReads += 1;
+      return pkg;
+    },
+    part: () => pkg.parts.get(pkg.mainDocumentPart)!,
+  };
+  const resourceLookup: ImageResourceLookup = {
+    resolveEmbedded: async () => Object.freeze({ kind: 'missing' as const }),
+    resolveLinked: () => Object.freeze({ kind: 'missing' as const }),
+    resolveForProjection: async () => Object.freeze({ kind: 'missing' as const }),
+    liveReferenceCount: () => 0,
+    dispose: () => {},
+  };
+  const bundle = createInlineDrawingLayoutBundle({
+    session,
+    decodePort: Object.freeze({
+      decode: async () => {
+        throw new Error('unused');
+      },
+    }),
+    resourceLookup,
+    onResourcesChanged: () => {},
+  });
+  const paragraph = session
+    .part()
+    .root.children.find((node) => node.kind !== 'textValue' && node.localName === 'body')!;
+  const body = paragraph.kind === 'textValue' ? null : paragraph;
+  const firstParagraph = body!.children.find((node) => node.kind === 'paragraph')!;
+  if (firstParagraph.kind === 'textValue') throw new Error('unexpected text node');
+
+  bundle.drawingTokenForParagraph(firstParagraph, session.part().name);
+  const afterFirst = packageReads;
+  bundle.drawingTokenForParagraph(firstParagraph, session.part().name);
+  bundle.drawingTokenForParagraph(firstParagraph, session.part().name);
+  // The slot map answers repeat lookups; layout keys every paragraph through here, so a
+  // hit must not pay a package snapshot per call.
+  expect(packageReads).toBe(afterFirst);
+
+  pkg = Object.freeze({ ...pkg, parts: new Map(pkg.parts) });
+  revision += 1;
+  bundle.sync(session);
+  // Compatibility after a package move stays resetPackage's job — sync must still read.
+  expect(packageReads).toBeGreaterThan(afterFirst);
 });

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -5,7 +5,10 @@ import {
   type ImageResourceLookup,
 } from '@docx-editor.dev/core/store';
 import { zipSync, strToU8 } from 'fflate';
-import { createInlineDrawingLayoutBundle, drawingAtomIdentities } from '../inline-drawing-source.ts';
+import {
+  createInlineDrawingLayoutBundle,
+  drawingAtomIdentities,
+} from '../inline-drawing-source.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';

--- a/packages/core/src/layout/__tests__/list-resolve-memo.test.ts
+++ b/packages/core/src/layout/__tests__/list-resolve-memo.test.ts
@@ -1,0 +1,78 @@
+// The `withResolvedListItems` memo: identical raw inputs return the same item map and
+// linked index, so a no-change layout flush skips the sequential full-story counter walk;
+// any input moving by identity recomputes.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import { buildNumberingIndex } from '../numbering-index.ts';
+import { withResolvedListItems } from '../list-resolve.ts';
+import { storyBlocks } from '../story-roots.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function loadNumbering(body: string) {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${body}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildNumberingIndex(result.part.root);
+}
+
+const DECIMAL = `
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/>
+      <w:lvlJc w:val="left"/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+`;
+
+function loadBodyPart() {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>` +
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+      '<w:r><w:t>one</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+      '<w:r><w:t>two</w:t></w:r></w:p>' +
+      '</w:body></w:document>',
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+describe('withResolvedListItems memo', () => {
+  test('identical raw inputs return the same item map and linked index', () => {
+    const numberingIndex = loadNumbering(DECIMAL);
+    const blocks = storyBlocks(loadBodyPart());
+    const first = withResolvedListItems({ numberingIndex }, blocks);
+    const second = withResolvedListItems({ numberingIndex }, blocks);
+    expect(first.listItems).toBeDefined();
+    expect(second.listItems).toBe(first.listItems!);
+    expect(second.numberingIndex).toBe(first.numberingIndex);
+    expect(first.listItems!.size).toBe(2);
+  });
+
+  test('a different numbering index or block list recomputes', () => {
+    const numberingIndex = loadNumbering(DECIMAL);
+    const blocks = storyBlocks(loadBodyPart());
+    const first = withResolvedListItems({ numberingIndex }, blocks);
+
+    const freshIndex = loadNumbering(DECIMAL);
+    const byIndex = withResolvedListItems({ numberingIndex: freshIndex }, blocks);
+    expect(byIndex.listItems).not.toBe(first.listItems!);
+
+    const freshBlocks = storyBlocks(loadBodyPart());
+    const byBlocks = withResolvedListItems({ numberingIndex }, freshBlocks);
+    expect(byBlocks.listItems).not.toBe(first.listItems!);
+    expect(byBlocks.listItems!.size).toBe(first.listItems!.size);
+  });
+
+  test('a caller-supplied item map bypasses the memo untouched', () => {
+    const numberingIndex = loadNumbering(DECIMAL);
+    const blocks = storyBlocks(loadBodyPart());
+    const supplied = new Map();
+    const result = withResolvedListItems({ numberingIndex, listItems: supplied }, blocks);
+    expect(result.listItems).toBe(supplied);
+  });
+});

--- a/packages/core/src/layout/__tests__/list-resolve-memo.test.ts
+++ b/packages/core/src/layout/__tests__/list-resolve-memo.test.ts
@@ -7,6 +7,7 @@ import { readOoxmlPart } from '@docx-editor.dev/core/store';
 import { buildNumberingIndex } from '../numbering-index.ts';
 import { withResolvedListItems } from '../list-resolve.ts';
 import { storyBlocks } from '../story-roots.ts';
+import { buildStyleCascadeTable } from '../style-cascade.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -74,5 +75,54 @@ describe('withResolvedListItems memo', () => {
     const supplied = new Map();
     const result = withResolvedListItems({ numberingIndex, listItems: supplied }, blocks);
     expect(result.listItems).toBe(supplied);
+  });
+
+  test('with a style cascade: repeated resolves stay identity-stable, edits stay correct', () => {
+    const stylesXml =
+      `<w:styles xmlns:w="${W}">` +
+      '<w:style w:type="paragraph" w:styleId="ListNum">' +
+      '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+      '</w:style></w:styles>';
+    const stylesResult = readOoxmlPart(stylesXml, {
+      name: '/word/styles.xml',
+      contentType: 'app/xml',
+    });
+    if (!stylesResult.ok) throw new Error(stylesResult.reason);
+    const styleCascade = buildStyleCascadeTable(stylesResult.part.root);
+    const numberingIndex = loadNumbering(DECIMAL);
+
+    // Numbering arrives through the STYLE, so the per-paragraph prelude must run the
+    // cascade to find it — the exact path the prelude memo shortcuts.
+    const styledDoc = () => {
+      const result = readOoxmlPart(
+        `<w:document xmlns:w="${W}"><w:body>` +
+          '<w:p><w:pPr><w:pStyle w:val="ListNum"/></w:pPr><w:r><w:t>one</w:t></w:r></w:p>' +
+          '<w:p><w:pPr><w:pStyle w:val="ListNum"/></w:pPr><w:r><w:t>two</w:t></w:r></w:p>' +
+          '</w:body></w:document>',
+        { name: '/word/document.xml', contentType: 'app/xml' }
+      );
+      if (!result.ok) throw new Error(result.reason);
+      return result.part;
+    };
+
+    const blocks = storyBlocks(styledDoc());
+    const first = withResolvedListItems({ numberingIndex, styleCascade }, blocks);
+    expect(first.listItems).toBeDefined();
+    expect(first.listItems!.size).toBe(2);
+    const markers = [...first.listItems!.values()].map((item) => item.markerText);
+    expect(markers).toEqual(['1.', '2.']);
+
+    // Same inputs: the outer memo returns the same map and the same linked index.
+    const second = withResolvedListItems({ numberingIndex, styleCascade }, blocks);
+    expect(second.listItems).toBe(first.listItems!);
+    expect(second.numberingIndex).toBe(first.numberingIndex);
+
+    // A simulated edit (fresh part → fresh blocks) recomputes to EQUAL content; the
+    // per-paragraph preludes are keyed on node identity, so fresh nodes re-cascade.
+    const editedBlocks = storyBlocks(styledDoc());
+    const third = withResolvedListItems({ numberingIndex, styleCascade }, editedBlocks);
+    expect(third.listItems).not.toBe(first.listItems!);
+    expect([...third.listItems!.values()].map((item) => item.markerText)).toEqual(['1.', '2.']);
+    expect(third.numberingIndex).toBe(first.numberingIndex);
   });
 });

--- a/packages/core/src/layout/__tests__/section-properties.test.ts
+++ b/packages/core/src/layout/__tests__/section-properties.test.ts
@@ -17,6 +17,7 @@ import {
   enumerateDocumentSections,
   geometryOfSection,
   readSectionProperties,
+  storyBlocks,
 } from '../index.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -319,5 +320,36 @@ describe('w:pgNumType authored vs default', () => {
     const xml = strFromU8(reopened['word/document.xml']!);
     expect(xml).toMatch(/<w:pgNumType\s*\/>/);
     expect(xml).not.toMatch(/<w:pgNumType[^>]+\w+=/);
+  });
+});
+
+describe('section enumeration and story blocks are memoized per part identity', () => {
+  test('the same part returns the same references; a different part does not', () => {
+    const part = withSection('<w:pgSz w:w="11906" w:h="16838"/>');
+    expect(storyBlocks(part)).toBe(storyBlocks(part));
+    expect(enumerateDocumentSections(part)).toBe(enumerateDocumentSections(part));
+
+    // Parts are immutable — an edit publishes a NEW part object, so a re-parse of the
+    // same bytes stands in for one here.
+    const editedTwin = withSection('<w:pgSz w:w="11906" w:h="16838"/>');
+    expect(storyBlocks(editedTwin)).not.toBe(storyBlocks(part));
+    expect(enumerateDocumentSections(editedTwin)).not.toBe(enumerateDocumentSections(part));
+    expect(enumerateDocumentSections(editedTwin)).toEqual(enumerateDocumentSections(part));
+  });
+
+  test('display modes get distinct, individually stable entries', () => {
+    const part = load(
+      '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="a"/></w:rPr></w:pPr>' +
+        '<w:del w:id="2" w:author="a"><w:r><w:delText>gone</w:delText></w:r></w:del></w:p>' +
+        '<w:p><w:r><w:t>kept</w:t></w:r></w:p>'
+    );
+    const allMarkup = storyBlocks(part, 'all-markup');
+    const proposed = storyBlocks(part, 'proposed');
+    expect(allMarkup).not.toBe(proposed);
+    // The proposed view drops the revision-deleted paragraph; the memo must not
+    // leak one mode's filtering into the other.
+    expect(proposed.length).toBeLessThan(allMarkup.length);
+    expect(storyBlocks(part, 'all-markup')).toBe(allMarkup);
+    expect(storyBlocks(part, 'proposed')).toBe(proposed);
   });
 });

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -480,11 +480,15 @@ export function createInlineDrawingLayoutBundle(
     ownerPartName: string,
     reader: InlineDrawingPackageReader
   ): PartDrawingContextSlot => {
+    // Slot first: layout keys a drawing token per paragraph through here, and slot
+    // compatibility between flushes is `resetPackage`'s job (driven by `sync()`), not
+    // this lookup's. Resolving the part on every hit made each token pay a package
+    // snapshot for an answer the slot map already had.
+    const existing = slots.get(ownerPartName);
+    if (existing) return existing;
     const part = resolvePart(ownerPartName, reader);
     partByName.set(ownerPartName, part);
-    let slot = slots.get(ownerPartName);
-    if (slot) return slot;
-    slot = createPartDrawingContextSlot({
+    const slot = createPartDrawingContextSlot({
       ownerPartName,
       part,
       pkg: reader.currentPackage(),

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -125,12 +125,6 @@ function numIdForStyle(styleCascade: StyleCascadeTable, styleId: string): string
 }
 
 /**
- * Resolve `w:numStyleLink` delegation using the document's styles (§17.9.21).
- *
- * Without a style table there is nothing to follow, so the index is returned unchanged —
- * and so it is when nothing delegates, which keeps layout cache identity.
- */
-/**
  * Memo keyed on the index object, validated against the cascade. A WeakMap so a disposed
  * document's index releases its entry, and entered under the LINKED index too: layout
  * links the raw index once per flush, then hands the linked result back through this
@@ -144,6 +138,12 @@ const linkedIndexMemos = new WeakMap<
   { readonly styleCascade: StyleCascadeTable; readonly linked: NumberingIndex }
 >();
 
+/**
+ * Resolve `w:numStyleLink` delegation using the document's styles (§17.9.21).
+ *
+ * Without a style table there is nothing to follow, so the index is returned unchanged —
+ * and so it is when nothing delegates, which keeps layout cache identity.
+ */
 export function withNumberingStyleLinks(
   index: NumberingIndex,
   styleCascade: StyleCascadeTable | undefined
@@ -291,12 +291,6 @@ export function walkStoryParagraphs(
 }
 
 /**
- * Resolve every list paragraph in a story to a {@link ResolvedListItem}, keyed by node id.
- *
- * Non-list paragraphs are absent from the map. Hostile / missing numbering resolves inertly
- * (paragraph omitted — laid out as ordinary text).
- */
-/**
  * Per-paragraph prelude for the story walk below, memoized on the paragraph NODE: which
  * `numPr` a paragraph resolves to — and the cascaded property tiers feeding its indent and
  * marker face — are pure functions of the immutable paragraph and the cascade table. An
@@ -343,6 +337,12 @@ function paragraphListPrelude(
   return prelude;
 }
 
+/**
+ * Resolve every list paragraph in a story to a {@link ResolvedListItem}, keyed by node id.
+ *
+ * Non-list paragraphs are absent from the map. Hostile / missing numbering resolves inertly
+ * (paragraph omitted — laid out as ordinary text).
+ */
 export function resolveStoryListItems(
   blocks: readonly OoxmlElement[],
   index: NumberingIndex,

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -131,33 +131,32 @@ function numIdForStyle(styleCascade: StyleCascadeTable, styleId: string): string
  * and so it is when nothing delegates, which keeps layout cache identity.
  */
 /**
- * Single-entry memo keyed on raw input identity. Beyond skipping the re-resolve, this is
- * what keeps LEVEL OBJECTS identity-stable across edits: the per-paragraph caches below
- * key derived indent/marker work on the level object, and a fresh linked index per call
- * would orphan every entry on every keystroke.
+ * Memo keyed on the index object, validated against the cascade. A WeakMap so a disposed
+ * document's index releases its entry, and entered under the LINKED index too: layout
+ * links the raw index once per flush, then hands the linked result back through this
+ * function again, and without the self-entry that second call would clobber the memo
+ * every flush. Level-object identity across edits is NOT this memo's doing —
+ * `resolveNumberingStyleLinks` reuses the delegation target's `levels` maps by reference,
+ * so the per-paragraph `perLevel` caches stay warm even on a miss here.
  */
-let linkedIndexMemo: {
-  readonly index: NumberingIndex;
-  readonly styleCascade: StyleCascadeTable;
-  readonly linked: NumberingIndex;
-} | null = null;
+const linkedIndexMemos = new WeakMap<
+  NumberingIndex,
+  { readonly styleCascade: StyleCascadeTable; readonly linked: NumberingIndex }
+>();
 
 export function withNumberingStyleLinks(
   index: NumberingIndex,
   styleCascade: StyleCascadeTable | undefined
 ): NumberingIndex {
   if (!styleCascade) return index;
-  if (
-    linkedIndexMemo &&
-    linkedIndexMemo.index === index &&
-    linkedIndexMemo.styleCascade === styleCascade
-  ) {
-    return linkedIndexMemo.linked;
-  }
+  const memo = linkedIndexMemos.get(index);
+  if (memo && memo.styleCascade === styleCascade) return memo.linked;
   const linked = resolveNumberingStyleLinks(index, (styleId) =>
     numIdForStyle(styleCascade, styleId)
   );
-  linkedIndexMemo = { index, styleCascade, linked };
+  const entry = { styleCascade, linked };
+  linkedIndexMemos.set(index, entry);
+  linkedIndexMemos.set(linked, entry);
   return linked;
 }
 
@@ -305,7 +304,9 @@ export function walkStoryParagraphs(
  * keystroke; without this cache every unchanged paragraph re-ran the full style cascade
  * just to learn (usually) that it has no numbering. Only the counter advance is genuinely
  * sequential. `perLevel` holds level-derived indent/marker work, keyed on the level object
- * (identity-stable via the `withNumberingStyleLinks` memo).
+ * (identity-stable because `resolveNumberingStyleLinks` reuses the target's `levels` maps
+ * by reference) — a WeakMap, so level objects orphaned by a numbering edit take their
+ * entries with them.
  */
 interface ParagraphListPrelude {
   readonly styleCascade: StyleCascadeTable | undefined;
@@ -313,7 +314,10 @@ interface ParagraphListPrelude {
   readonly inheritedParagraphProperties: readonly OoxmlProperty[];
   readonly directProps: readonly OoxmlProperty[];
   readonly inheritedMarkProps: readonly OoxmlProperty[];
-  readonly perLevel: Map<object, { indent: NumberingLevelIndent; markerStyle: ResolvedRunStyle }>;
+  readonly perLevel: WeakMap<
+    object,
+    { indent: NumberingLevelIndent; markerStyle: ResolvedRunStyle }
+  >;
 }
 const paragraphListPreludes = new WeakMap<OoxmlElement, ParagraphListPrelude>();
 
@@ -333,7 +337,7 @@ function paragraphListPrelude(
     inheritedParagraphProperties: cascaded?.inheritedParagraphProperties ?? [],
     directProps: propertiesOf(pPr),
     inheritedMarkProps: cascaded ? cascaded.markRunProperties : propertiesOf(directMarkRun),
-    perLevel: new Map(),
+    perLevel: new WeakMap(),
   };
   paragraphListPreludes.set(paragraph, prelude);
   return prelude;
@@ -424,21 +428,23 @@ export function resolveStoryListItems(
 }
 
 /**
- * Memo for {@link withResolvedListItems}, keyed on the RAW inputs by identity — blocks
- * (stable per part via the `storyBlocks` memo), the unlinked numbering index, the style
- * cascade, and the font oracle. Keying on the linked index would never hit:
- * `withNumberingStyleLinks` mints a new object per call when a cascade is present. All
- * inputs are identity-stable across no-change flushes, so one entry suffices; a miss on
- * any input recomputes the sequential full-story counter walk exactly as before.
+ * Memo for {@link withResolvedListItems}, keyed on the blocks array (stable per part via
+ * the `storyBlocks` memo) and validated against the remaining RAW inputs by identity —
+ * the unlinked numbering index, the style cascade, and the font oracle. A WeakMap on the
+ * blocks array so a disposed document's entry dies with its part instead of pinning an
+ * O(document) item map at module scope. A miss on any input recomputes the sequential
+ * full-story counter walk exactly as before.
  */
-let resolvedListItemsMemo: {
-  readonly blocks: readonly OoxmlElement[];
-  readonly rawIndex: NumberingIndex | undefined;
-  readonly styleCascade: StyleCascadeTable | undefined;
-  readonly isFontAvailable: ((family: string) => boolean) | undefined;
-  readonly linkedIndex: NumberingIndex;
-  readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
-} | null = null;
+const resolvedListItemsMemos = new WeakMap<
+  readonly OoxmlElement[],
+  {
+    readonly rawIndex: NumberingIndex | undefined;
+    readonly styleCascade: StyleCascadeTable | undefined;
+    readonly isFontAvailable: ((family: string) => boolean) | undefined;
+    readonly linkedIndex: NumberingIndex;
+    readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
+  }
+>();
 
 /**
  * Attach a full-story list-item map to layout options.
@@ -455,6 +461,10 @@ export function withResolvedListItems<
      * Host oracle for "is this font family really loaded". Supplied, a Symbol/Wingdings
      * bullet keeps the file's own private-use codepoint so the authored typeface draws it;
      * absent, it falls back to the Unicode equivalent rather than a tofu box.
+     *
+     * The resolve is memoized on this function's IDENTITY: a host whose answers change
+     * over time (a font finished loading) must supply a new closure at that point, or the
+     * memo will keep serving marker glyphs computed from the old answers.
      */
     readonly isFontAvailable?: (family: string) => boolean;
   },
@@ -468,10 +478,9 @@ export function withResolvedListItems<
   // A caller-supplied item map bypasses the memo: the memo exists for the resolve below,
   // and a pre-supplied map carries its own provenance.
   if (options.listItems === undefined) {
-    const memo = resolvedListItemsMemo;
+    const memo = resolvedListItemsMemos.get(blocks);
     if (
       memo &&
-      memo.blocks === blocks &&
       memo.rawIndex === options.numberingIndex &&
       memo.styleCascade === options.styleCascade &&
       memo.isFontAvailable === options.isFontAvailable
@@ -495,14 +504,13 @@ export function withResolvedListItems<
       ? resolveStoryListItems(blocks, numberingIndex, options.styleCascade, options.isFontAvailable)
       : undefined);
   if (options.listItems === undefined) {
-    resolvedListItemsMemo = {
-      blocks,
+    resolvedListItemsMemos.set(blocks, {
       rawIndex: options.numberingIndex,
       styleCascade: options.styleCascade,
       isFontAvailable: options.isFontAvailable,
       linkedIndex: numberingIndex,
       listItems,
-    };
+    });
   }
   return {
     ...options,

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -130,12 +130,35 @@ function numIdForStyle(styleCascade: StyleCascadeTable, styleId: string): string
  * Without a style table there is nothing to follow, so the index is returned unchanged —
  * and so it is when nothing delegates, which keeps layout cache identity.
  */
+/**
+ * Single-entry memo keyed on raw input identity. Beyond skipping the re-resolve, this is
+ * what keeps LEVEL OBJECTS identity-stable across edits: the per-paragraph caches below
+ * key derived indent/marker work on the level object, and a fresh linked index per call
+ * would orphan every entry on every keystroke.
+ */
+let linkedIndexMemo: {
+  readonly index: NumberingIndex;
+  readonly styleCascade: StyleCascadeTable;
+  readonly linked: NumberingIndex;
+} | null = null;
+
 export function withNumberingStyleLinks(
   index: NumberingIndex,
   styleCascade: StyleCascadeTable | undefined
 ): NumberingIndex {
   if (!styleCascade) return index;
-  return resolveNumberingStyleLinks(index, (styleId) => numIdForStyle(styleCascade, styleId));
+  if (
+    linkedIndexMemo &&
+    linkedIndexMemo.index === index &&
+    linkedIndexMemo.styleCascade === styleCascade
+  ) {
+    return linkedIndexMemo.linked;
+  }
+  const linked = resolveNumberingStyleLinks(index, (styleId) =>
+    numIdForStyle(styleCascade, styleId)
+  );
+  linkedIndexMemo = { index, styleCascade, linked };
+  return linked;
 }
 
 /** Bound a file-derived indent both ways — negative is legal, unbounded is not. */
@@ -274,6 +297,48 @@ export function walkStoryParagraphs(
  * Non-list paragraphs are absent from the map. Hostile / missing numbering resolves inertly
  * (paragraph omitted — laid out as ordinary text).
  */
+/**
+ * Per-paragraph prelude for the story walk below, memoized on the paragraph NODE: which
+ * `numPr` a paragraph resolves to — and the cascaded property tiers feeding its indent and
+ * marker face — are pure functions of the immutable paragraph and the cascade table. An
+ * edit republishes only the touched paragraphs, yet the resolver walks the WHOLE story per
+ * keystroke; without this cache every unchanged paragraph re-ran the full style cascade
+ * just to learn (usually) that it has no numbering. Only the counter advance is genuinely
+ * sequential. `perLevel` holds level-derived indent/marker work, keyed on the level object
+ * (identity-stable via the `withNumberingStyleLinks` memo).
+ */
+interface ParagraphListPrelude {
+  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly numPr: { readonly numId: string; readonly ilvl: number } | null;
+  readonly inheritedParagraphProperties: readonly OoxmlProperty[];
+  readonly directProps: readonly OoxmlProperty[];
+  readonly inheritedMarkProps: readonly OoxmlProperty[];
+  readonly perLevel: Map<object, { indent: NumberingLevelIndent; markerStyle: ResolvedRunStyle }>;
+}
+const paragraphListPreludes = new WeakMap<OoxmlElement, ParagraphListPrelude>();
+
+function paragraphListPrelude(
+  paragraph: OoxmlElement,
+  styleCascade: StyleCascadeTable | undefined
+): ParagraphListPrelude {
+  const cached = paragraphListPreludes.get(paragraph);
+  if (cached && cached.styleCascade === styleCascade) return cached;
+  const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
+  const cascaded = styleCascade ? cascadeParagraphFormatting(styleCascade, pPr) : null;
+  const nodes: readonly OoxmlNode[] = cascaded ? cascaded.paragraphPropertyNodes : pPr ? [pPr] : [];
+  const directMarkRun = pPr && isElement(pPr) ? childNamed(pPr, 'rPr') : undefined;
+  const prelude: ParagraphListPrelude = {
+    styleCascade,
+    numPr: readNumPr(nodes),
+    inheritedParagraphProperties: cascaded?.inheritedParagraphProperties ?? [],
+    directProps: propertiesOf(pPr),
+    inheritedMarkProps: cascaded ? cascaded.markRunProperties : propertiesOf(directMarkRun),
+    perLevel: new Map(),
+  };
+  paragraphListPreludes.set(paragraph, prelude);
+  return prelude;
+}
+
 export function resolveStoryListItems(
   blocks: readonly OoxmlElement[],
   index: NumberingIndex,
@@ -288,36 +353,34 @@ export function resolveStoryListItems(
   const linked = withNumberingStyleLinks(index, styleCascade);
   const counters = createListCounterState(linked);
   for (const paragraph of walkStoryParagraphs(blocks)) {
-    const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
-    const cascaded = styleCascade ? cascadeParagraphFormatting(styleCascade, pPr) : null;
-    const nodes: readonly OoxmlNode[] = cascaded
-      ? cascaded.paragraphPropertyNodes
-      : pPr
-        ? [pPr]
-        : [];
-    const numPr = readNumPr(nodes);
+    const prelude = paragraphListPrelude(paragraph, styleCascade);
+    const numPr = prelude.numPr;
     if (!numPr) continue;
 
     const advanced = counters.advance(numPr.numId, numPr.ilvl);
     if (!advanced) continue;
 
-    // Split, not flattened: the level's indent outranks the STYLE's and is outranked by the
-    // paragraph's OWN `w:pPr`, so the merge needs the two tiers apart.
-    const directProps = propertiesOf(pPr);
-    const indent = mergeListIndent(
-      advanced.level.indent,
-      cascaded?.inheritedParagraphProperties ?? [],
-      directProps
-    );
-    const directMarkRun = pPr && isElement(pPr) ? childNamed(pPr, 'rPr') : undefined;
-    const markOnly = propertiesOf(directMarkRun);
-    const inheritedMarkProps = cascaded ? cascaded.markRunProperties : markOnly;
-    const markerProps = cascadeRunProperties(
-      inheritedMarkProps,
-      advanced.level.runProperties,
-      styleCascade
-    );
-    const markerStyle = resolveRunStyle(markerProps, styleCascade?.themeFonts);
+    let levelDerived = prelude.perLevel.get(advanced.level);
+    if (!levelDerived) {
+      // Split, not flattened: the level's indent outranks the STYLE's and is outranked by
+      // the paragraph's OWN `w:pPr`, so the merge needs the two tiers apart.
+      const indent = mergeListIndent(
+        advanced.level.indent,
+        prelude.inheritedParagraphProperties,
+        prelude.directProps
+      );
+      const markerProps = cascadeRunProperties(
+        prelude.inheritedMarkProps,
+        advanced.level.runProperties,
+        styleCascade
+      );
+      levelDerived = {
+        indent,
+        markerStyle: resolveRunStyle(markerProps, styleCascade?.themeFonts),
+      };
+      prelude.perLevel.set(advanced.level, levelDerived);
+    }
+    const { indent, markerStyle } = levelDerived;
     // Word writes a Symbol/Wingdings bullet as font-byte + 0xF000 (`` = U+F0B7 in
     // Symbol), which is a private-use codepoint no other font can draw. Mapping it here —
     // where the marker's FAMILY is finally known — keeps measurement and paint on the same

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -361,6 +361,23 @@ export function resolveStoryListItems(
 }
 
 /**
+ * Memo for {@link withResolvedListItems}, keyed on the RAW inputs by identity — blocks
+ * (stable per part via the `storyBlocks` memo), the unlinked numbering index, the style
+ * cascade, and the font oracle. Keying on the linked index would never hit:
+ * `withNumberingStyleLinks` mints a new object per call when a cascade is present. All
+ * inputs are identity-stable across no-change flushes, so one entry suffices; a miss on
+ * any input recomputes the sequential full-story counter walk exactly as before.
+ */
+let resolvedListItemsMemo: {
+  readonly blocks: readonly OoxmlElement[];
+  readonly rawIndex: NumberingIndex | undefined;
+  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly isFontAvailable: ((family: string) => boolean) | undefined;
+  readonly linkedIndex: NumberingIndex;
+  readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
+} | null = null;
+
+/**
  * Attach a full-story list-item map to layout options.
  *
  * Resolves once over `blocks` (body story including table cells) so counters continue across
@@ -385,6 +402,24 @@ export function withResolvedListItems<
   readonly numberingIndex: NumberingIndex;
   readonly listItems?: ReadonlyMap<string, ResolvedListItem>;
 } {
+  // A caller-supplied item map bypasses the memo: the memo exists for the resolve below,
+  // and a pre-supplied map carries its own provenance.
+  if (options.listItems === undefined) {
+    const memo = resolvedListItemsMemo;
+    if (
+      memo &&
+      memo.blocks === blocks &&
+      memo.rawIndex === options.numberingIndex &&
+      memo.styleCascade === options.styleCascade &&
+      memo.isFontAvailable === options.isFontAvailable
+    ) {
+      return {
+        ...options,
+        numberingIndex: memo.linkedIndex,
+        ...(memo.listItems ? { listItems: memo.listItems } : {}),
+      };
+    }
+  }
   // Published already linked (§17.9.21), so every reader of the index — not just the item
   // map built here — sees the levels a `w:numStyleLink` delegates to.
   const numberingIndex = withNumberingStyleLinks(
@@ -396,6 +431,16 @@ export function withResolvedListItems<
     (numberingIndex.nums.size > 0
       ? resolveStoryListItems(blocks, numberingIndex, options.styleCascade, options.isFontAvailable)
       : undefined);
+  if (options.listItems === undefined) {
+    resolvedListItemsMemo = {
+      blocks,
+      rawIndex: options.numberingIndex,
+      styleCascade: options.styleCascade,
+      isFontAvailable: options.isFontAvailable,
+      linkedIndex: numberingIndex,
+      listItems,
+    };
+  }
   return {
     ...options,
     numberingIndex,

--- a/packages/core/src/layout/section-properties.ts
+++ b/packages/core/src/layout/section-properties.ts
@@ -21,6 +21,7 @@ import {
   type OoxmlNode,
   type OoxmlPart,
 } from '@docx-editor.dev/core/store';
+import { createRecentRootCache } from '../store/store/recent-root-cache.ts';
 import { DEFAULT_PAGE_GEOMETRY, type PageGeometry } from './semantic-records.ts';
 import { storyBlocks } from './story-roots.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
@@ -455,8 +456,33 @@ export function enumerateDocumentSectionsBounded(
   return enumerateDocumentSectionsFromBlocks(part, storyBlocks(part, displayMode));
 }
 
+/**
+ * Memoized on the blocks array identity (stable per `(part, displayMode)` thanks to the
+ * `storyBlocks` memo), validated against the part: parts are immutable, so an identical
+ * `(part, blocks)` pair proves the enumeration cannot differ. One flush enumerates
+ * sections from several callers — layout geometry, furniture, note pagination, snapshot
+ * derivation — and each paid the full per-paragraph `w:sectPr` scan. Callers treat the
+ * result as read-only; a shared array is safe. Bounded WeakRef ring, not a WeakMap,
+ * because undo history retains snapshots by reference.
+ */
+const sectionsCache = createRecentRootCache<{
+  readonly part: OoxmlPart;
+  readonly result: DocumentSectionsEnumeration;
+}>(16);
+
 /** Internal shared-list variant for callers that already enumerated the story blocks. */
 export function enumerateDocumentSectionsFromBlocks(
+  part: OoxmlPart,
+  blocks: readonly OoxmlElement[]
+): DocumentSectionsEnumeration {
+  const cached = sectionsCache.get(blocks);
+  if (cached && cached.part === part) return cached.result;
+  const result = enumerateSectionsUncached(part, blocks);
+  sectionsCache.set(blocks, { part, result });
+  return result;
+}
+
+function enumerateSectionsUncached(
   part: OoxmlPart,
   blocks: readonly OoxmlElement[]
 ): DocumentSectionsEnumeration {

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -54,9 +54,8 @@ function acceptStoryBlock(block: OoxmlElement, displayMode: RevisionDisplayMode)
  * reference; 16 slots cover one flush's parts (body + header/footer variants + notes).
  * Callers treat the result as read-only, so a shared array is safe to hand out.
  */
-const storyBlocksCache = createRecentRootCache<
-  Partial<Record<RevisionDisplayMode, OoxmlElement[]>>
->(16);
+const storyBlocksCache =
+  createRecentRootCache<Partial<Record<RevisionDisplayMode, OoxmlElement[]>>>(16);
 
 /**
  * The story's blocks — paragraphs and tables — in document order, flattening through

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -15,6 +15,7 @@
 
 import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
 import { collectFlowBlocks } from '../store/package/content-control-walk.ts';
+import { createRecentRootCache } from '../store/store/recent-root-cache.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
 import { revisionRemovesParagraph } from './revision-visibility.ts';
 
@@ -45,16 +46,38 @@ function acceptStoryBlock(block: OoxmlElement, displayMode: RevisionDisplayMode)
 }
 
 /**
+ * Memoized per part identity: parts are immutable (edits publish a new part object), so
+ * the block list is a pure function of `(part, displayMode)`. Every keystroke flush asks
+ * for the body's blocks from several callers — layout, section enumeration, furniture,
+ * note pagination — and this walk ran fresh for each of them. A bounded WeakRef ring
+ * rather than a plain WeakMap because undo history retains package snapshots by
+ * reference; 16 slots cover one flush's parts (body + header/footer variants + notes).
+ * Callers treat the result as read-only, so a shared array is safe to hand out.
+ */
+const storyBlocksCache = createRecentRootCache<
+  Partial<Record<RevisionDisplayMode, OoxmlElement[]>>
+>(16);
+
+/**
  * The story's blocks — paragraphs and tables — in document order, flattening through
  * block-level content-control wrappers under the shared nesting budget.
+ *
+ * Repeated calls with the same part and display mode return the SAME array instance.
  */
 export function storyBlocks(
   part: OoxmlPart,
   displayMode: RevisionDisplayMode = 'all-markup'
 ): OoxmlElement[] {
+  const perMode = storyBlocksCache.get(part);
+  const cached = perMode?.[displayMode];
+  if (cached) return cached;
   const root = storyRootOf(part);
-  if (!root) return [];
-  return collectFlowBlocks(root.children, 0, (block) => acceptStoryBlock(block, displayMode));
+  const blocks = root
+    ? collectFlowBlocks(root.children, 0, (block) => acceptStoryBlock(block, displayMode))
+    : [];
+  if (perMode) perMode[displayMode] = blocks;
+  else storyBlocksCache.set(part, { [displayMode]: blocks });
+  return blocks;
 }
 
 /**

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -61,7 +61,8 @@ const storyBlocksCache =
  * The story's blocks — paragraphs and tables — in document order, flattening through
  * block-level content-control wrappers under the shared nesting budget.
  *
- * Repeated calls with the same part and display mode return the SAME array instance.
+ * Repeated calls with the same part and display mode return the SAME array instance,
+ * shared by every caller — treat it as read-only; mutating it corrupts later callers.
  */
 export function storyBlocks(
   part: OoxmlPart,

--- a/packages/core/src/store/__tests__/tree-package-store.test.ts
+++ b/packages/core/src/store/__tests__/tree-package-store.test.ts
@@ -494,3 +494,74 @@ describe('TreePackageStore — parked story history across delete/restore', () =
     expect(evicting.openedStoryCount()).toBe(2);
   });
 });
+
+describe('TreePackageStore — currentPackage identity memo', () => {
+  test('repeated calls with unchanged authority return the same frozen instance', () => {
+    const store = openPackage(build({}));
+    const first = store.currentPackage();
+    expect(store.currentPackage()).toBe(first);
+    expect(Object.isFrozen(first)).toBe(true);
+  });
+
+  test('a body transact yields a fresh, content-correct snapshot', () => {
+    const store = openPackage(build({}));
+    const before = store.currentPackage();
+    const bodyId = paragraphIds(store.bodyStore().part)[0]!;
+    store.transact({ kind: 'body' }, (ctx) => {
+      ctx.apply({ op: 'insertText', paragraphId: bodyId, offset: 0, text: 'X' });
+    });
+    const after = store.currentPackage();
+    expect(after).not.toBe(before);
+    const main = after.parts.get(after.mainDocumentPart)!;
+    expect(paragraphTextOf(main, paragraphIds(main)[0]!)).toContain('X');
+    expect(store.currentPackage()).toBe(after);
+  });
+
+  test('replacePackageShell invalidates without a revision bump', () => {
+    const store = openPackage(build({}));
+    const before = store.currentPackage();
+    const revBefore = store.packageRevision;
+    store.replacePackageShell(before);
+    expect(store.packageRevision).toBe(revBefore);
+    const after = store.currentPackage();
+    expect(after).not.toBe(before);
+    expect(store.currentPackage()).toBe(after);
+  });
+
+  test('opening a story store invalidates, and undo/redo track the snapshot', () => {
+    const store = openPackage(bodyAndHeaderDoc());
+    const closed = store.currentPackage();
+    const scope: StoryScope = { kind: 'headerFooter', rId: 'rId7' };
+    expect(store.resolveStory(scope).ok).toBe(true);
+    const opened = store.currentPackage();
+    expect(opened).not.toBe(closed);
+
+    const headerId = paragraphIds(store.partFor(scope)!)[0]!;
+    store.transact(scope, (ctx) => {
+      ctx.apply({ op: 'insertText', paragraphId: headerId, offset: 0, text: 'Z' });
+    });
+    const edited = store.currentPackage();
+    expect(edited).not.toBe(opened);
+    expect(paragraphTextOf(edited.parts.get('/word/header1.xml')!, headerId)).toContain('Z');
+
+    store.undo();
+    const undone = store.currentPackage();
+    expect(undone).not.toBe(edited);
+    expect(paragraphTextOf(undone.parts.get('/word/header1.xml')!, headerId)).not.toContain('Z');
+
+    store.redo();
+    const redone = store.currentPackage();
+    expect(paragraphTextOf(redone.parts.get('/word/header1.xml')!, headerId)).toContain('Z');
+  });
+
+  test('installPackageSnapshot invalidates', () => {
+    const store = openPackage(build({}));
+    const before = store.currentPackage();
+    store.installPackageSnapshot(
+      loadPackage(build({ body: '<w:p><w:r><w:t>other</w:t></w:r></w:p>' }))
+    );
+    const after = store.currentPackage();
+    expect(after).not.toBe(before);
+    expect(store.currentPackage()).toBe(after);
+  });
+});

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -210,6 +210,21 @@ export class TreePackageStore {
     packageWideEffects: boolean;
   } | null = null;
   private commitCounter = 0;
+  /**
+   * Memo for {@link currentPackage}, keyed on the COMPLETE read set of that method by
+   * object identity: the package shell, the body part, and each open story's part in
+   * map order. Identity is the only sound key — `packageRevision` deliberately is not
+   * part of it, because shell writes (`replacePackageShell`, story-store grafts, lazy
+   * store opens) move `this.pkg` or a `store.part` without bumping the revision.
+   * Packages and parts are frozen-immutable, so a matching tuple proves the merged
+   * snapshot cannot differ; no explicit invalidation exists anywhere.
+   */
+  private currentPackageMemo: {
+    readonly pkg: OoxmlPackage;
+    readonly bodyPart: OoxmlPart;
+    readonly storyParts: readonly OoxmlPart[];
+    readonly result: OoxmlPackage;
+  } | null = null;
 
   constructor(pkg: OoxmlPackage, main: OoxmlPart, options: TreePackageStoreOptions = {}) {
     this.pkg = withPart(pkg, main);
@@ -251,15 +266,41 @@ export class TreePackageStore {
    * The current package with every opened story store's part merged in.
    * Pure snapshot of authority; callers must not mutate.
    *
+   * Memoized on input identity: repeated calls with unchanged authority return the
+   * SAME frozen instance instead of minting a copy per call. Layout asks for this
+   * once per paragraph when keying drawing tokens, so the un-memoized `withPart`
+   * map copies dominated large-document keystroke flushes.
+   *
    * Stores whose parts are absent from the package shell (deleted furniture/notes)
    * stay parked for undo/redo identity but are not re-injected into the snapshot.
    */
   currentPackage(): OoxmlPackage {
+    const memo = this.currentPackageMemo;
+    if (memo && memo.pkg === this.pkg && memo.bodyPart === this.body.part) {
+      let index = 0;
+      let hit = true;
+      for (const store of this.stories.values()) {
+        if (memo.storyParts[index] !== store.part) {
+          hit = false;
+          break;
+        }
+        index += 1;
+      }
+      if (hit && index === memo.storyParts.length) return memo.result;
+    }
     let next = withPart(this.pkg, this.body.part);
+    const storyParts: OoxmlPart[] = [];
     for (const store of this.stories.values()) {
+      storyParts.push(store.part);
       if (!this.pkg.parts.has(store.part.name)) continue;
       next = withPart(next, store.part);
     }
+    this.currentPackageMemo = {
+      pkg: this.pkg,
+      bodyPart: this.body.part,
+      storyParts,
+      result: next,
+    };
     return next;
   }
 


### PR DESCRIPTION
Typing in a long document paid several full-document scans per keystroke flush: a package snapshot (with a parts-map copy) per paragraph via the drawing-token path, repeated storyBlocks/section walks from independent callers, and a full-story list cascade. Each is now memoized on input identity — the package snapshot on its complete read set (deliberately not packageRevision, which shell writes bypass), blocks/sections per part, and list resolution per paragraph node with a stable linked numbering index.

Typing latency measured with the browser benchmark on a quiet machine (main vs this branch, identical settings):

| Scenario | main | this PR | Δ |
| --- | --- | --- | --- |
| editing-character | 44.6 ms | 38.3 ms | -14.1% |
| editing-wrap | 46.9 ms | 45.1 ms | -3.8% |
| suggesting-character | 46.2 ms | 38.0 ms | -17.7% |
| suggesting-wrap | 44.4 ms | 36.4 ms | -18.0% |

Frame p95 drops in every scenario (e.g. 66.1 → 49.3 ms), and the sustained-typing worst keystroke drops 61.1 → 47.9 ms. The synthetic fixture has no numbering, so the list-resolution memo contributes nothing here; on a 200-page tracked-changes document with numbered clauses the same burst went ~3.5 s → ~2.2 s (production build). The CI comment's deltas on this PR are run-order noise — the two sides run sequentially on one machine — which is why its table disagrees with itself; work counters are byte-identical.

A side effect: adoptPackageUnit's before === after no-op guard can now fire, so a content-identical adopt no longer pushes a spurious undo pointer.

On the benchmark comment's red forced-reflow rows: reproduced locally at ~+0.6-1 ms per hard-break commit, concentrated in the transaction phase; a targeted revert attributes most of it to the package-snapshot memo's bookkeeping, which the headless bench pays without ever reaping a hit (it builds a fresh store per round). Real editing reaps the hit hundreds of times per flush — the same memo removes the per-paragraph snapshot cost that dominated long-document typing — and the browser table plus the local typing-latency numbers above show the net effect. Work counters are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
