### PR TITLE
fix(editor-api): make the Office.js auto-adopt gate total, and the workflow runnable

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -69,7 +69,9 @@ jobs:
           # Always-allowlisted: bots, plus named maintainer handles as a
           # safety net (in case the org-membership lookup fails for any
           # reason — private membership, transient API error, etc.).
-          ALLOWLIST: 'dependabot[bot] github-actions[bot] renovate[bot] jedrazb'
+          # eigenpal-release-pal[bot] is this workflow's own App: it authors the
+          # PRs office-compat-drift.yml opens, and a bot cannot sign a CLA.
+          ALLOWLIST: 'dependabot[bot] github-actions[bot] renovate[bot] eigenpal-release-pal[bot] jedrazb'
           # Auto-allowlist members of this org. Public members are recognized
           # via the workflow's GITHUB_TOKEN; private members will be prompted
           # to sign once (then they're recorded like anyone else). To turn the

--- a/.github/workflows/office-compat-drift.yml
+++ b/.github/workflows/office-compat-drift.yml
@@ -33,18 +33,24 @@ permissions:
   contents: read
   issues: write
 
+# One run at a time: a workflow_dispatch racing the schedule would push the
+# same branch twice, and the "is a PR already open" guard below is not atomic.
+concurrency:
+  group: office-compat-drift
+  cancel-in-progress: false
+
 jobs:
   check-drift:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # No pull-requests: write — every `gh pr` call and the push below use the
+    # release-pal App token, which carries its own installation permissions.
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     defaults:
       run:
         working-directory: packages/editor-api
-    env:
-      DRIFT_RESULT: ${{ runner.temp }}/office-compat-drift.json
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -54,16 +60,28 @@ jobs:
         with:
           bun-version: latest
 
+      # HUSKY=0 for the same reason dependabot-lockfile.yml sets it: the root
+      # `prepare` script points core.hooksPath at .husky, and the adopt step
+      # below commits. That pre-commit hook runs api:check, which needs a
+      # built dist this job never produces.
       - name: Install dependencies
         working-directory: .
+        env:
+          HUSKY: 0
         run: bun install --frozen-lockfile
 
       - name: Check for upstream @types/office-js drift
         id: drift
+        env:
+          # Step-level, not job-level: the `runner` context is not available
+          # in a job `env:` block, where it silently expands to nothing.
+          DRIFT_RESULT: ${{ runner.temp }}/office-compat-drift.json
         run: |
+          # set +e: the check exits 1 on drift by design, and drift is the
+          # case this workflow exists to handle, not a step failure.
           set +e
           node scripts/fetch-office-reference.mjs --check --json "$DRIFT_RESULT" > drift-output.txt 2>&1
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          echo "drift check exited $?"
           cat drift-output.txt
 
       # The check prints for people; this file is the same answer for the
@@ -73,6 +91,8 @@ jobs:
       # "no drift".
       - name: Read the drift decision
         id: decision
+        env:
+          DRIFT_RESULT: ${{ runner.temp }}/office-compat-drift.json
         run: |
           if [ ! -f "$DRIFT_RESULT" ]; then
             echo "Drift check produced no result file — it failed before deciding anything."
@@ -108,30 +128,46 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: docx-editor
 
+      # --version pins this to the release the decision above measured. Without
+      # it both steps resolve the `latest` dist-tag independently, so a publish
+      # between them would either be adopted under the previous version's
+      # branch name and PR title, or refuse and fail the run with no issue
+      # filed. This step failing for any other reason (a shape change that
+      # landed mid-run, an unprovable source commit) fails the whole run, which
+      # is the intended fallback: loud, and nothing written.
       - name: Adopt the provenance-only bump
+        id: adopt
         if: steps.decision.outputs.drift == 'true' && steps.decision.outputs.shape_changed == 'false'
         env:
           # Spent on the DefinitelyTyped commit walk that proves the source
           # commit; the anonymous 60/hour limit is shared per runner IP.
           GITHUB_TOKEN: ${{ steps.pal-token.outputs.token }}
+          VERSION: ${{ steps.decision.outputs.upstream_version }}
         run: |
-          bun run compat:adopt
+          node scripts/fetch-office-reference.mjs --adopt --version "$VERSION"
           bun run compat:generate
 
       - name: Verify the adopted reference offline
+        id: verify
         if: steps.decision.outputs.drift == 'true' && steps.decision.outputs.shape_changed == 'false'
         run: bun test src/office-compat
 
       - name: Open a PR for the adopted bump
+        id: pr
         if: steps.decision.outputs.drift == 'true' && steps.decision.outputs.shape_changed == 'false'
         env:
           GH_TOKEN: ${{ steps.pal-token.outputs.token }}
           VERSION: ${{ steps.decision.outputs.upstream_version }}
+          HUSKY: 0
         working-directory: .
         run: |
           branch="chore/office-compat-$VERSION"
-          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')" ]; then
-            echo "A PR for $branch is already open — nothing to do."
+          # --state all, not open: a PR a maintainer closed unmerged is a
+          # decision, and reopening it every Monday would ignore that. It also
+          # keeps the force-push below off any branch a human has touched,
+          # because touching it means there was a PR.
+          if [ -n "$(gh pr list --head "$branch" --state all --json number --jq '.[0].number')" ]; then
+            echo "A PR for $branch already exists (open, merged or closed) — nothing to do."
             exit 0
           fi
           if [ -z "$(git status --porcelain packages/editor-api/compat)" ]; then
@@ -148,6 +184,10 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" \
             "HEAD:refs/heads/$branch"
 
+          # Only now may the tracking issue be closed: every early exit above
+          # leaves this unset, so a re-run that opens nothing closes nothing.
+          echo "opened=true" >> "$GITHUB_OUTPUT"
+
           gh pr create \
             --head "$branch" \
             --base main \
@@ -158,9 +198,12 @@ jobs:
               "The pinned commit was accepted only because its \`types/office-js/index.d.ts\` is byte-identical to the integrity-verified npm tarball.")"
 
       - name: Close the tracking issue the PR resolves
-        if: steps.decision.outputs.drift == 'true' && steps.decision.outputs.shape_changed == 'false'
+        if: steps.pr.outputs.opened == 'true'
         env:
-          GH_TOKEN: ${{ steps.pal-token.outputs.token }}
+          # The job's own GITHUB_TOKEN, not the App: this job is granted
+          # `issues: write` above, while the App's installation permissions are
+          # contents/pull-requests/statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.decision.outputs.upstream_version }}
         working-directory: .
         run: |
@@ -172,21 +215,53 @@ jobs:
           gh issue close "$number" \
             --comment "Adopted @types/office-js $VERSION automatically: no symbol or member changed, so the bump is provenance-only. Reopening happens on the next shape change, not on a republish."
 
-      # --- Shape drift: a person has to read this -------------------------
+      # --- Everything a person has to read --------------------------------
 
+      # Fires on a shape change, and also when the adopt path itself failed —
+      # an unprovable source commit, a shape change that landed between the two
+      # fetches, a failing offline verify. Without the second half those end as
+      # a red scheduled run and nothing else, and a red weekly cron is seen by
+      # almost nobody. `!cancelled()` rather than the implicit success(), since
+      # by construction this needs to run after a failed step.
       - name: Open or update a tracking issue
-        if: steps.decision.outputs.drift == 'true' && steps.decision.outputs.shape_changed == 'true'
+        if: >-
+          !cancelled() && steps.decision.outputs.drift == 'true' &&
+          (steps.decision.outputs.shape_changed == 'true' ||
+          steps.adopt.outcome == 'failure' ||
+          steps.verify.outcome == 'failure' ||
+          steps.pr.outcome == 'failure')
         uses: actions/github-script@v9
+        env:
+          ADOPT_FAILED: ${{ steps.decision.outputs.shape_changed != 'true' }}
         with:
           script: |
             const fs = require('fs');
             const output = fs.readFileSync('packages/editor-api/drift-output.txt', 'utf8');
             const title = 'Office.js compatibility reference drift detected';
+            const adoptFailed = process.env.ADOPT_FAILED === 'true';
+            const lead = adoptFailed
+              ? [
+                  'The scheduled drift check found a **provenance-only** `@types/office-js` release',
+                  '(no symbol or member moved), but adopting it automatically FAILED. Nothing in this',
+                  'repository was changed. See the run log for which step failed — commonly an',
+                  'unprovable DefinitelyTyped source commit, or a release published between the',
+                  'check and the adopt.',
+                ]
+              : [
+                  'The scheduled drift check found that the current stable `@types/office-js` release',
+                  'no longer matches `packages/editor-api/compat/reference/word.reference.json`, and the',
+                  'delta is a **shape change**: the reference moved beyond the version string.',
+                  'Provenance-only republishes are adopted automatically by PR; this one is not,',
+                  'because it is a fact about the Word API.',
+                ];
+            // A fence long enough to survive whatever the delta contains:
+            // upstream type strings are attacker-controlled, and a ``` inside
+            // one would otherwise close the block early and render the rest of
+            // upstream's text as markdown in this issue.
+            const longestRun = Math.max(0, ...[...output.matchAll(/`+/g)].map((m) => m[0].length));
+            const fence = '`'.repeat(Math.max(3, longestRun + 1));
             const body = [
-              'The scheduled drift check found that the current stable `@types/office-js` release',
-              'no longer matches `packages/editor-api/compat/reference/word.reference.json`, and the',
-              'delta is a **shape change**: a symbol or member moved. Provenance-only republishes are',
-              'adopted automatically by PR; this one is not, because it is a fact about the Word API.',
+              ...lead,
               '',
               'This issue is informational — nothing in this repository was changed automatically.',
               'To review and adopt the new reference:',
@@ -204,9 +279,9 @@ jobs:
               '',
               '<details><summary>Drift check output</summary>',
               '',
-              '```',
+              fence,
               output,
-              '```',
+              fence,
               '</details>',
               '',
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
@@ -235,9 +310,3 @@ jobs:
                 labels: ['office-compat-drift'],
               });
             }
-
-      - name: Fail the run when the drift check itself failed
-        if: steps.drift.outputs.exit_code != '0' && steps.decision.outputs.drift != 'true'
-        run: |
-          echo "compat:check-drift exited ${{ steps.drift.outputs.exit_code }} without reporting drift."
-          exit 1

--- a/packages/editor-api/compat/README.md
+++ b/packages/editor-api/compat/README.md
@@ -54,9 +54,10 @@ bun run compat:generate
 # reference fixture, without overwriting anything (exit code 1 on drift).
 bun run compat:check-drift
 
-# Network: adopt an upstream release that changed no symbol and no member —
-# version string, provenance, and the newly proved source-commit pin only.
-# Refuses (exit code 1) as soon as any shape differs.
+# Network: adopt an upstream release whose reference differs in nothing but the
+# version string. Rewrites reference/word.reference.json (its generatedFrom
+# carries the release), provenance.json, and definitely-typed-commits.json.
+# Refuses (exit code 1) as soon as anything else differs.
 bun run compat:adopt
 ```
 
@@ -82,24 +83,33 @@ upstream data is never written to
 ## Which drift a machine may adopt
 
 Most upstream releases move nothing this directory measures: Microsoft
-republishes, the version string changes, and the manifest-selected shape is
+republishes, the version string changes, and the manifest-selected reference is
 identical. That delta says nothing about the Word API, so
 `.github/workflows/office-compat-drift.yml` adopts it itself with
-`compat:adopt` and opens an ordinary PR. When a symbol or member does move,
-the same workflow opens a tracking issue instead and changes nothing.
+`compat:adopt` and opens an ordinary PR. When anything else moves, the same
+workflow opens a tracking issue instead and changes nothing.
 
 `compat:adopt` is the only path that may record a source-commit pin without a
 maintainer, and it earns that two ways:
 
-- **It refuses shape changes.** One added, removed, or changed symbol or
-  member and it exits 1 with the delta. The version string is the only thing
-  it can carry forward.
+- **It refuses every change but the version string.** The gate compares the two
+  fixtures whole, in a key-sorted canonical form, with only
+  `generatedFrom.version` excluded — deliberately _not_ by asking
+  `reference-diff.mjs`. That diff exists to explain a change to a person, so it
+  compares the fields worth naming in a report; anything it does not compare
+  (overload order, a parameter name, a uid) would read as "no differences" and
+  adopt a Word API change unattended. Comparing the whole fixture makes the
+  gate total by construction: a field added to `reference-normalize.mjs` is
+  covered the day it is added, with no second place to remember.
 - **It proves the commit rather than trusting it.** npm publishes no `gitHead`
   for `@types/*`, so `scripts/lib/definitely-typed-commit.mjs` walks the
   commits touching `types/office-js` and accepts one only when git's blob hash
   of its `index.d.ts` equals the blob hash of the `index.d.ts` inside the
   integrity-verified tarball. A wrong, renamed, or force-pushed-away commit
   cannot pass that comparison, and an unexplained release aborts the adopt.
+  What this establishes is that the declarations at that commit are the
+  published ones — not that the whole tree there was what got published, which
+  a blob comparison cannot show.
 
 What lands is still a PR: full CI, human approval.
 

--- a/packages/editor-api/scripts/fetch-office-reference.mjs
+++ b/packages/editor-api/scripts/fetch-office-reference.mjs
@@ -21,7 +21,8 @@
  * pulls out of it, plus provenance for exactly what was fetched.
  *
  * Usage:
- *   node scripts/fetch-office-reference.mjs [--version <semver>] [--check|--adopt]
+ *   node scripts/fetch-office-reference.mjs [--version <semver>]
+ *                                           [--check [--json <path>] | --adopt]
  *
  *   --version <semver>  Pin a specific @types/office-js version instead of
  *                        the current "latest" dist-tag.
@@ -36,12 +37,13 @@
  *   --json <path>       With `--check`, also write that result as JSON, so
  *                        the workflow can branch on it instead of parsing
  *                        prose out of stdout.
- *   --adopt             Adopt a *shape-identical* upstream release: only the
- *                        version string and provenance move, so there is
- *                        nothing about the API for a human to review. Writes
- *                        the fixture, the provenance record, and the newly
- *                        resolved source-commit pin. Refuses (exit 1) the
- *                        moment any symbol or member differs.
+ *   --adopt             Adopt a *shape-identical* upstream release: no symbol
+ *                        and no member moved, so there is nothing about the
+ *                        API for a human to review. Rewrites the fixture (its
+ *                        `generatedFrom.version` carries the release), the
+ *                        provenance record, and the source-commit pin.
+ *                        Refuses (exit 1) the moment any symbol or member
+ *                        differs.
  *
  * ## Which drift a machine may adopt
  *
@@ -146,15 +148,43 @@ export class MissingDefinitelyTypedCommitError extends Error {
  * than in this file: `--adopt` writes an entry, and data a script edits
  * belongs in data, not in the script's own source.
  */
+/**
+ * An unreadable or malformed pin file reads as "nothing is pinned" rather than
+ * throwing. On `main` these pins were an in-source constant that could not
+ * fail to load, and a hand-edit leaving a trailing comma must not turn the
+ * weekly drift check into a hard failure that reports no delta at all: no pin
+ * means review-required drift, which is exactly the right answer here. The
+ * write path stays strict — `writePinnedCommit` re-reads and re-parses, so a
+ * corrupt file cannot be silently overwritten.
+ */
 async function loadPinnedCommits() {
-  const raw = await readFile(PINNED_COMMITS_PATH, 'utf8');
-  return JSON.parse(raw).commits ?? {};
+  try {
+    const raw = await readFile(PINNED_COMMITS_PATH, 'utf8');
+    return JSON.parse(raw).commits ?? {};
+  } catch (error) {
+    console.warn(`Could not read ${PINNED_COMMITS_PATH}: ${error.message}`);
+    console.warn('Treating every version as unpinned.');
+    return {};
+  }
+}
+
+/**
+ * Adds one entry, preserving every other key in the file. `schemaVersion`,
+ * `package` and `note` carry the whole contract of what a pin means, so a
+ * write that rebuilt the object from scratch would silently delete the
+ * documentation of the thing it just wrote. Pure, so that invariant is
+ * testable without touching disk.
+ */
+export function withPinnedCommit(pins, version, commit) {
+  return { ...pins, commits: { ...pins.commits, [version]: commit } };
 }
 
 async function writePinnedCommit(version, commit) {
   const pins = JSON.parse(await readFile(PINNED_COMMITS_PATH, 'utf8'));
-  pins.commits = { ...pins.commits, [version]: commit };
-  await writeFile(PINNED_COMMITS_PATH, `${JSON.stringify(pins, null, 2)}\n`);
+  await writeFile(
+    PINNED_COMMITS_PATH,
+    `${JSON.stringify(withPinnedCommit(pins, version, commit), null, 2)}\n`
+  );
 }
 
 async function resolvePinnedCommit(version) {
@@ -164,13 +194,33 @@ async function resolvePinnedCommit(version) {
 
 /**
  * Fetch -> verify -> extract -> normalize, stopping short of anything that
- * requires a reviewed source-commit pin. This is the
- * part of the pipeline that must succeed for *any* published version,
- * reviewed or not — it's what lets `checkForDrift` compute a real delta for
- * a brand-new version before a maintainer has pinned its source commit.
+ * requires a reviewed source-commit pin. This is the part of the pipeline
+ * that must succeed for *any* published version, reviewed or not — it's what
+ * lets `checkForDrift` compute a real delta for a brand-new version before a
+ * maintainer has pinned its source commit.
  */
+/**
+ * The version string npm hands back travels a long way from here: into the
+ * fixture, into provenance, into a `$GITHUB_OUTPUT` line, a branch name, a
+ * commit message and a PR title. Registry metadata is attacker-controlled by
+ * this package's own threat model, so it is constrained to what a semver
+ * string can hold before any of that. A newline here would inject an extra
+ * `key=value` line into the workflow's own decision output.
+ */
+const SAFE_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9.+-]{0,63}$/;
+
+function assertSafeVersion(version) {
+  if (typeof version !== 'string' || !SAFE_VERSION_PATTERN.test(version)) {
+    throw new Error(
+      `npm registry returned an unusable ${PACKAGE_NAME} version string: ${JSON.stringify(version)}`
+    );
+  }
+  return version;
+}
+
 async function fetchAndBuildFixture({ version, fetchImpl }) {
   const registryMetadata = await fetchRegistryMetadata(version, fetchImpl);
+  assertSafeVersion(registryMetadata.version);
   const upstreamPackageBase = {
     name: PACKAGE_NAME,
     version: registryMetadata.version,
@@ -237,12 +287,20 @@ async function buildProvenanceForFixture({
     throw new MissingDefinitelyTypedCommitError(upstreamPackageBase.version);
   }
 
+  // Named fields only, never a spread of the registry's `repository` object:
+  // that object is attacker-controlled, and spreading it would let a hostile
+  // publish decorate a committed provenance record with keys of its choosing,
+  // or claim a repository that has nothing to do with the commit recorded
+  // beside it. `validateProvenance` holds the url and directory to
+  // DefinitelyTyped; this decides what is even eligible to be validated.
   const { sourceRepositoryRaw, ...upstreamPackageRest } = upstreamPackageBase;
   const upstreamPackage = {
     ...upstreamPackageRest,
     sourceRepository: sourceRepositoryRaw
       ? {
-          ...sourceRepositoryRaw,
+          url: sourceRepositoryRaw.url ?? null,
+          type: sourceRepositoryRaw.type ?? null,
+          directory: sourceRepositoryRaw.directory ?? null,
           commit: definitelyTypedCommit,
           sourceUrl: `https://github.com/DefinitelyTyped/DefinitelyTyped/tree/${definitelyTypedCommit}/types/office-js`,
         }
@@ -292,12 +350,73 @@ export async function regenerate({
   return { fixture, provenance };
 }
 
-/** True when any symbol or member moved — the delta a human has to read. */
-function hasShapeChanges(diff) {
+/**
+ * True when the symbol/member delta has something to report. This drives the
+ * *wording* of the report, never the decision to adopt —
+ * `isProvenanceOnlyFixtureChange` below is the gate, because it is total and
+ * this is not.
+ */
+export function hasShapeChanges(diff) {
   return (
     diff.addedSymbols.length > 0 ||
     diff.removedSymbols.length > 0 ||
     diff.changedSymbols.length > 0
+  );
+}
+
+/** Key-sorted serialization, so equality means "says the same thing". */
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+/** Every fact the fixture records, minus the upstream version string. */
+function fixtureFactsSignature(fixture) {
+  const { generatedFrom, ...rest } = fixture ?? {};
+  const { version: upstreamVersion, ...generatedFromRest } = generatedFrom ?? {};
+  void upstreamVersion; // the one field a republish is allowed to move
+  return canonicalJson({ ...rest, generatedFrom: generatedFromRest });
+}
+
+/**
+ * The gate on automatic adoption: true only when the two fixtures differ in
+ * nothing but `generatedFrom.version`.
+ *
+ * This deliberately does NOT ask `diffReferenceFixtures`. That diff exists to
+ * explain a change to a person, and it compares the fields worth naming in a
+ * report — not every field the fixture records. Anything it does not compare
+ * (overload order and multiplicity, parameter names, a uid) would read as "no
+ * differences" and auto-adopt. Comparing the canonical bytes instead makes
+ * the gate total by construction: a new field in `reference-normalize.mjs`
+ * is covered the day it is added, with no second place to remember.
+ *
+ * Fails closed. A missing or unreadable previous fixture is a difference, so
+ * it refuses rather than adopting into the unknown.
+ */
+export function isProvenanceOnlyFixtureChange(previousFixture, nextFixture) {
+  return fixtureFactsSignature(previousFixture) === fixtureFactsSignature(nextFixture);
+}
+
+/**
+ * The delta as prose, with an honest footnote when the gate and the diff
+ * disagree — the gate sees a difference the diff has no vocabulary for, and
+ * silently printing "no differences" in that case is how a reviewer would be
+ * misled about why a run refused.
+ */
+function describeChange(diff, provenanceOnly) {
+  const summary = formatReferenceDiff(diff);
+  if (provenanceOnly || hasShapeChanges(diff)) return summary;
+  return (
+    `${summary}\n\n` +
+    'The fixture nevertheless differs beyond the upstream version string, in a field this ' +
+    'delta does not compare (overload order, a parameter name, a uid). Diff the regenerated ' +
+    'fixture against the checked-in one directly.'
   );
 }
 
@@ -343,7 +462,8 @@ export async function checkForDrift({
   const previousFixture =
     existingFixtureJson != null ? JSON.parse(existingFixtureJson) : { symbols: {} };
   const diff = diffReferenceFixtures(previousFixture, fixture);
-  const diffSummary = formatReferenceDiff(diff);
+  const provenanceOnly = isProvenanceOnlyFixtureChange(previousFixture, fixture);
+  const diffSummary = describeChange(diff, provenanceOnly);
 
   let provenance = null;
   let reviewRequired = false;
@@ -365,7 +485,7 @@ export async function checkForDrift({
 
   return {
     driftDetected: true,
-    shapeChanged: hasShapeChanges(diff),
+    shapeChanged: !provenanceOnly,
     upstreamVersion: upstreamPackageBase.version,
     fixture,
     fixtureJson,
@@ -392,7 +512,15 @@ export async function checkForDrift({
  * is proved against the published bytes (see `definitely-typed-commit.mjs`),
  * never inferred from a branch ref or a publish date.
  *
+ * An already-pinned version keeps its pin: a maintainer's reviewed entry is
+ * the more trustworthy of the two answers, and re-resolving would let a
+ * machine overwrite it.
+ *
  * Writes nothing itself; returns what `main` (or a test) should write.
+ *
+ * @param existingPins Optional pin map (`{ [version]: commit }`), injected by
+ *   tests so both the pinned and unpinned branch are reachable without
+ *   depending on what the checked-in pin file happens to contain today.
  */
 export async function adoptShapeIdenticalDrift({
   version,
@@ -400,6 +528,7 @@ export async function adoptShapeIdenticalDrift({
   fetchImpl = fetch,
   githubToken = null,
   existingFixtureJson,
+  existingPins = null,
 } = {}) {
   const { upstreamPackageBase, fixture, declarationBuffer } = await fetchAndBuildFixture({
     version,
@@ -411,13 +540,17 @@ export async function adoptShapeIdenticalDrift({
   const previousFixture =
     existingFixtureJson != null ? JSON.parse(existingFixtureJson) : { symbols: {} };
   const diff = diffReferenceFixtures(previousFixture, fixture);
-  const diffSummary = formatReferenceDiff(diff);
+  const provenanceOnly = isProvenanceOnlyFixtureChange(previousFixture, fixture);
+  const diffSummary = describeChange(diff, provenanceOnly);
 
-  if (hasShapeChanges(diff)) {
+  if (!provenanceOnly) {
     return { adopted: false, reason: 'shape-changed', upstreamVersion, diff, diffSummary };
   }
 
-  const pinnedCommit = await resolvePinnedCommit(upstreamVersion);
+  const pinnedCommit =
+    existingPins != null
+      ? (existingPins[upstreamVersion] ?? null)
+      : await resolvePinnedCommit(upstreamVersion);
   const resolved = pinnedCommit
     ? { commit: pinnedCommit, blobSha: null }
     : await resolveDefinitelyTypedCommitFromSource({
@@ -457,15 +590,26 @@ async function readCheckedInFixture() {
  * branches on `shapeChanged` (auto-adopt vs open a review issue), and
  * reading that decision out of a JSON file beats grepping prose out of a
  * stdout stream whose wording is meant for people.
+ *
+ * These four keys ARE the workflow contract: `.github/workflows/
+ * office-compat-drift.yml` reads each one through `jq`, and a renamed key
+ * makes both of its branches silently false. Exported so a test holds that
+ * contract still, rather than the workflow discovering it next Monday.
  */
-async function writeCheckResultJson(path, result) {
-  const summary = {
+export function buildCheckResultSummary(result) {
+  return {
     driftDetected: Boolean(result.driftDetected),
-    shapeChanged: Boolean(result.shapeChanged),
+    // `!== false`, not `Boolean(...)`: this field grants a machine the right to
+    // write. An absent or undefined value must read as "a human should look",
+    // so the only value that unlocks adoption is an explicit false.
+    shapeChanged: result.shapeChanged !== false,
     upstreamVersion: result.upstreamVersion,
     reviewRequired: Boolean(result.reviewRequired),
   };
-  await writeFile(path, `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+async function writeCheckResultJson(path, result) {
+  await writeFile(path, `${JSON.stringify(buildCheckResultSummary(result), null, 2)}\n`);
 }
 
 async function adopt({ version }) {
@@ -478,7 +622,8 @@ async function adopt({ version }) {
   if (!result.adopted) {
     console.error(
       `Refusing to adopt ${PACKAGE_NAME}@${result.upstreamVersion} automatically: the ` +
-        'manifest-selected shape changed, which needs a maintainer to review it.'
+        'manifest-selected reference changed beyond the version string, which needs a ' +
+        'maintainer to review it.'
     );
     console.error('');
     console.error(result.diffSummary);
@@ -486,13 +631,22 @@ async function adopt({ version }) {
     return;
   }
 
-  await writeFile(REFERENCE_PATH, result.fixtureJson);
-  await writeFile(PROVENANCE_PATH, result.provenanceJson);
+  // Pin first, deliberately. Every later write can fail (a full disk, a
+  // read-only tree), and the orders differ in what they leave behind: pin last
+  // leaves a provenance record naming a version with no pin — the one state
+  // definitely-typed-commits.json says cannot exist, and one the next drift
+  // check reports as "no drift" while compat:fetch-reference refuses. Pin
+  // first leaves a spare verified entry, which is inert.
   if (!result.commitWasPinned) {
     await writePinnedCommit(result.upstreamVersion, result.definitelyTypedCommit);
   }
+  await writeFile(REFERENCE_PATH, result.fixtureJson);
+  await writeFile(PROVENANCE_PATH, result.provenanceJson);
 
-  console.log(`Adopted ${PACKAGE_NAME}@${result.upstreamVersion} (no symbol/member changes).`);
+  console.log(
+    `Adopted ${PACKAGE_NAME}@${result.upstreamVersion} (provenance only: the fixture differs in ` +
+      'nothing but the version string).'
+  );
   console.log(
     `DefinitelyTyped commit: ${result.definitelyTypedCommit}` +
       (result.commitWasPinned

--- a/packages/editor-api/scripts/lib/definitely-typed-commit.mjs
+++ b/packages/editor-api/scripts/lib/definitely-typed-commit.mjs
@@ -87,11 +87,20 @@ async function githubJson(url, { fetchImpl, githubToken }) {
  * Walks the commits that touched `types/office-js`, newest first, and
  * returns the first one whose `index.d.ts` blob matches `declaration`.
  *
- * Newest-first is deliberate. Two commits can share an identical
- * `index.d.ts` (a commit that only edits tests or `package.json` still
- * triggers a republish), so "the newest commit carrying these exact bytes"
- * is the one the release was cut from — this resolver only ever runs for
- * the release currently on the `latest` dist-tag.
+ * What this proves, exactly: at the returned commit, the declaration file is
+ * byte-identical to the one in the verified tarball. That is the fact
+ * `provenance.json` records, and it is strictly less than "this release was
+ * cut from this commit" — the two can differ. A commit that edits only
+ * `package.json` or the tests leaves `index.d.ts` untouched, so consecutive
+ * commits can carry identical declaration bytes, and a blob comparison cannot
+ * tell them apart. Newest-first resolves that to the most recent commit
+ * carrying the published declarations, which is the closest answer the
+ * evidence supports; distinguishing further would need a publish timestamp
+ * npm does not expose per version for `@types` packages.
+ *
+ * The guarantee that matters is the negative one: a commit whose declarations
+ * differ from the published release — a renamed, rewritten, hostile or simply
+ * wrong commit — cannot pass this comparison at all.
  *
  * @param {Buffer} params.declaration `index.d.ts` bytes from the verified tarball.
  * @returns `{ commit, blobSha, commitDate, htmlUrl }`

--- a/packages/editor-api/scripts/lib/provenance.mjs
+++ b/packages/editor-api/scripts/lib/provenance.mjs
@@ -10,6 +10,17 @@ import { isWellFormedCommitSha, validateDocsReferenceMetadata } from './docs-ref
 
 const SCHEMA_VERSION = 1;
 
+/**
+ * The only repository and directory this reference may claim to come from.
+ * `sourceRepository.url`/`directory` arrive from npm registry metadata, which
+ * the publisher controls, while `commit`/`sourceUrl` are generated here
+ * against DefinitelyTyped. Without this check a hostile or simply renamed
+ * publish could commit a provenance record whose two halves disagree about
+ * which repository was read.
+ */
+const EXPECTED_SOURCE_REPOSITORY_URL = 'https://github.com/DefinitelyTyped/DefinitelyTyped.git';
+const EXPECTED_SOURCE_DIRECTORY = 'types/office-js';
+
 function collectRequirementSets(fixture) {
   const set = new Set();
   for (const symbol of Object.values(fixture.symbols ?? {})) {
@@ -56,6 +67,16 @@ export function validateProvenance(provenance) {
   if (!up.sourceRepository || !up.sourceRepository.url) {
     errors.push('upstreamPackage.sourceRepository: required (with a url)');
   } else {
+    if (up.sourceRepository.url !== EXPECTED_SOURCE_REPOSITORY_URL) {
+      errors.push(
+        `upstreamPackage.sourceRepository.url: expected ${JSON.stringify(EXPECTED_SOURCE_REPOSITORY_URL)}, got ${JSON.stringify(up.sourceRepository.url)}`
+      );
+    }
+    if (up.sourceRepository.directory !== EXPECTED_SOURCE_DIRECTORY) {
+      errors.push(
+        `upstreamPackage.sourceRepository.directory: expected ${JSON.stringify(EXPECTED_SOURCE_DIRECTORY)}, got ${JSON.stringify(up.sourceRepository.directory)}`
+      );
+    }
     if (!isWellFormedCommitSha(up.sourceRepository.commit)) {
       errors.push(
         `upstreamPackage.sourceRepository.commit: expected a 40-character hex commit sha, got ${JSON.stringify(up.sourceRepository.commit)}`

--- a/packages/editor-api/scripts/lib/reference-diff.mjs
+++ b/packages/editor-api/scripts/lib/reference-diff.mjs
@@ -36,29 +36,40 @@ function diffOverloads(previousOverloads, nextOverloads) {
  * two fixtures. Returns `null` when there is no observable difference —
  * callers filter nulls out rather than pushing empty change records.
  */
+/** `{ from, to }` when the two differ, `undefined` when they don't. */
+function changedField(previous, next) {
+  return (previous ?? null) !== (next ?? null) ? { from: previous ?? null, to: next ?? null } : undefined;
+}
+
 function diffMemberLike(previous, next) {
   const { added: addedOverloads, removed: removedOverloads } = diffOverloads(
     previous.overloads ?? [],
     next.overloads ?? []
   );
-  const readonlyChanged =
-    Boolean(previous.readonly) !== Boolean(next.readonly)
-      ? { from: Boolean(previous.readonly), to: Boolean(next.readonly) }
-      : undefined;
-  const requirementSetChanged =
-    (previous.requirementSet ?? null) !== (next.requirementSet ?? null)
-      ? { from: previous.requirementSet ?? null, to: next.requirementSet ?? null }
-      : undefined;
+  const readonlyChanged = changedField(Boolean(previous.readonly), Boolean(next.readonly));
+  const requirementSetChanged = changedField(previous.requirementSet, next.requirementSet);
+  // A property turning into a method (or the reverse) keeps the same name and
+  // can keep the same call shape — `style: string` and `style(): string` both
+  // normalize to one zero-parameter overload returning `string`. Without this,
+  // that reads as no difference at all.
+  const kindChanged = changedField(previous.kind, next.kind);
 
   if (
     addedOverloads.length === 0 &&
     removedOverloads.length === 0 &&
     readonlyChanged === undefined &&
-    requirementSetChanged === undefined
+    requirementSetChanged === undefined &&
+    kindChanged === undefined
   ) {
     return null;
   }
-  return { addedOverloads, removedOverloads, readonlyChanged, requirementSetChanged };
+  return {
+    addedOverloads,
+    removedOverloads,
+    readonlyChanged,
+    requirementSetChanged,
+    kindChanged,
+  };
 }
 
 function diffClassOrInterfaceSymbol(previous, next) {
@@ -80,10 +91,30 @@ function diffClassOrInterfaceSymbol(previous, next) {
     if (memberDiff) changedMembers.push({ uid: nextMember.uid, ...memberDiff });
   }
 
-  if (addedMembers.length === 0 && removedMembers.length === 0 && changedMembers.length === 0) {
+  // The symbol's own facts, not just its members'. `requirementSet` is diffed
+  // per member already; a class whose whole requirement set moves (Word API
+  // 1.1 -> 1.9) is the same kind of fact and feeds
+  // `provenance.targetRequirementSets`.
+  const requirementSetChanged = changedField(previous.requirementSet, next.requirementSet);
+  const kindChanged = changedField(previous.kind, next.kind);
+
+  if (
+    addedMembers.length === 0 &&
+    removedMembers.length === 0 &&
+    changedMembers.length === 0 &&
+    requirementSetChanged === undefined &&
+    kindChanged === undefined
+  ) {
     return null;
   }
-  return { uid: next.uid, addedMembers, removedMembers, changedMembers };
+  return {
+    uid: next.uid,
+    addedMembers,
+    removedMembers,
+    changedMembers,
+    requirementSetChanged,
+    kindChanged,
+  };
 }
 
 /**
@@ -186,6 +217,11 @@ export function formatReferenceDiff(diff) {
             `        requirementSet: ${memberChange.requirementSetChanged.from} -> ${memberChange.requirementSetChanged.to}`
           );
         }
+        if (memberChange.kindChanged) {
+          lines.push(
+            `        kind: ${memberChange.kindChanged.from} -> ${memberChange.kindChanged.to}`
+          );
+        }
       }
       // Function-kind symbols (e.g. Word.run) carry addedOverloads/removedOverloads directly.
       formatOverloadChanges(change.uid, change.addedOverloads, change.removedOverloads, lines);
@@ -198,6 +234,9 @@ export function formatReferenceDiff(diff) {
         lines.push(
           `      requirementSet: ${change.requirementSetChanged.from} -> ${change.requirementSetChanged.to}`
         );
+      }
+      if (change.kindChanged) {
+        lines.push(`      kind: ${change.kindChanged.from} -> ${change.kindChanged.to}`);
       }
     }
   }

--- a/packages/editor-api/src/office-compat/__tests__/definitely-typed-commit.test.ts
+++ b/packages/editor-api/src/office-compat/__tests__/definitely-typed-commit.test.ts
@@ -61,7 +61,7 @@ describe('gitBlobSha', () => {
 describe('resolveDefinitelyTypedCommitFromSource', () => {
   test('returns the newest commit whose index.d.ts is byte-identical to the published tarball', async () => {
     const declaration = Buffer.from('declare namespace Word { class Body {} }');
-    const { fetchImpl } = fakeGitHub([
+    const { fetchImpl, seenUrls } = fakeGitHub([
       { sha: 'a'.repeat(40), declarationBlobSha: 'differentblobsha' },
       { sha: 'b'.repeat(40), declarationBlobSha: gitBlobSha(declaration) },
       { sha: 'c'.repeat(40), declarationBlobSha: gitBlobSha(declaration) },
@@ -75,6 +75,15 @@ describe('resolveDefinitelyTypedCommitFromSource', () => {
 
     expect(resolved.commit).toBe('b'.repeat(40));
     expect(resolved.blobSha).toBe(gitBlobSha(declaration));
+
+    // Scoped to the package directory, and bounded. Without the path filter
+    // the walk covers all of DefinitelyTyped, where nearly no commit touches
+    // types/office-js, so nothing would ever resolve.
+    expect(seenUrls[0]).toContain('/repos/DefinitelyTyped/DefinitelyTyped/commits');
+    expect(seenUrls[0]).toContain('path=types%2Foffice-js');
+    expect(seenUrls[0]).toMatch(/per_page=\d+/);
+    // Stops at the first match rather than walking the rest.
+    expect(seenUrls.some((url) => url.includes('ref=' + 'c'.repeat(40)))).toBe(false);
   });
 
   test('sends the token when one is supplied, so the workflow is not on the shared anonymous rate limit', async () => {
@@ -105,8 +114,28 @@ describe('resolveDefinitelyTypedCommitFromSource', () => {
       { sha: 'f'.repeat(40), declarationBlobSha: 'anotherblob' },
     ]);
 
+    const error = await resolveDefinitelyTypedCommitFromSource({
+      version: '1.0.605',
+      declaration,
+      fetchImpl,
+    }).catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(UnresolvedDefinitelyTypedCommitError);
+    // Both fields a maintainer needs to finish the job by hand: which release
+    // could not be explained, and the blob hash to search for.
+    expect(error.version).toBe('1.0.605');
+    expect(error.blobSha).toBe(gitBlobSha(declaration));
+    expect(error.message).toContain('definitely-typed-commits.json');
+  });
+
+  test('aborts rather than guessing when the commit list comes back empty', async () => {
+    const { fetchImpl } = fakeGitHub([]);
     await expect(
-      resolveDefinitelyTypedCommitFromSource({ version: '1.0.605', declaration, fetchImpl })
-    ).rejects.toBeInstanceOf(UnresolvedDefinitelyTypedCommitError);
+      resolveDefinitelyTypedCommitFromSource({
+        version: '1.0.605',
+        declaration: Buffer.from('declare namespace Word {}'),
+        fetchImpl,
+      })
+    ).rejects.toThrow(/no commits touching/);
   });
 });

--- a/packages/editor-api/src/office-compat/__tests__/fetch-office-reference.test.ts
+++ b/packages/editor-api/src/office-compat/__tests__/fetch-office-reference.test.ts
@@ -6,19 +6,26 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 /**
  * Orchestration tests for `fetch-office-reference.mjs`'s network-fetch ->
  * verify -> extract -> diff pipeline, with `fetch` injected so no real
- * network call happens. This is deliberately narrow: it covers the one
- * behavior that matters for CI/drift-check correctness (does `--check`
- * still produce a symbol/member delta when the fetched version has no
- * reviewed `PINNED_DEFINITELY_TYPED_COMMITS` entry?), not full coverage of
- * every branch in the script (see `task-1-report.md`'s Concern 3).
+ * network call happens. Three behaviors carry weight here:
+ *
+ * - `--check` still produces a full symbol/member delta for a version with no
+ *   reviewed source-commit pin, because a version bump is how drift arrives;
+ * - `--adopt` writes only when the reference differs in nothing but the
+ *   version string, and refuses every other difference, including the ones the
+ *   symbol/member delta has no vocabulary for;
+ * - `shapeChanged` and the `--json` summary keys, which are the contract the
+ *   scheduled workflow branches on.
  */
 import { describe, test, expect } from 'bun:test';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import {
   adoptShapeIdenticalDrift,
+  buildCheckResultSummary,
   checkForDrift,
+  isProvenanceOnlyFixtureChange,
   regenerate,
+  withPinnedCommit,
 } from '../../../scripts/fetch-office-reference.mjs';
 import { gitBlobSha } from '../../../scripts/lib/definitely-typed-commit.mjs';
 import { PINNED_DOCS_REFERENCE_COMMIT } from '../../../scripts/lib/docs-reference.mjs';
@@ -134,6 +141,9 @@ describe('checkForDrift against a new @types/office-js version with no reviewed 
 
     expect(result.driftDetected).toBe(true);
     expect(result.upstreamVersion).toBe(UNPINNED_VERSION);
+    // The field the scheduled workflow branches on: an added member routes to
+    // a maintainer, never to the auto-adopt step.
+    expect(result.shapeChanged).toBe(true);
 
     // The complete delta must be present, not skipped — this is the whole
     // point: a version bump is how real drift arrives, so the scheduled
@@ -242,6 +252,98 @@ const SHAPE_IDENTICAL_DECLARATION = `declare namespace Word {
   }
 }`;
 
+const SOURCE_COMMIT = 'e8ab93aca9dcb062ad042380341762b019c4a488';
+
+/**
+ * The fixture a given declaration produces, taken from the pipeline itself
+ * rather than hand-written. Lets a gate test say "upstream used to declare
+ * THIS and now declares THAT" and compare what the real extractor makes of
+ * each, instead of asserting against a fixture literal that could drift from
+ * what `reference-normalize.mjs` actually emits.
+ */
+async function fixtureJsonFor(declarationText: string): Promise<string> {
+  const result = await checkForDrift({
+    version: UNPINNED_VERSION,
+    fetchImpl: fakeNpmFetch({ version: UNPINNED_VERSION, declarationText }),
+    existingFixtureJson: null,
+    existingProvenance: null,
+  });
+  return result.fixtureJson;
+}
+
+async function adoptAfterUpstreamChange(previousDeclaration: string, nextDeclaration: string) {
+  return adoptShapeIdenticalDrift({
+    version: UNPINNED_VERSION,
+    fetchImpl: fakeAdoptFetch({
+      version: UNPINNED_VERSION,
+      declarationText: nextDeclaration,
+      sourceCommit: SOURCE_COMMIT,
+    }),
+    existingFixtureJson: await fixtureJsonFor(previousDeclaration),
+  });
+}
+
+/**
+ * Each pair changes one fact about the API and nothing else. Every one of them
+ * must refuse. The last three are the reason the gate compares canonical
+ * fixture bytes instead of asking `diffReferenceFixtures`: that diff has no
+ * vocabulary for them, so a gate built on it would call them "no differences"
+ * and adopt a Word API change with no maintainer in the loop.
+ */
+const REFUSABLE_UPSTREAM_CHANGES: {
+  what: string;
+  previous: string;
+  next: string;
+}[] = [
+  {
+    what: 'a member added',
+    previous: 'declare namespace Word { class Body { readonly text: string; } }',
+    next: 'declare namespace Word { class Body { readonly text: string; clear(): void; } }',
+  },
+  {
+    what: 'a member removed',
+    previous: 'declare namespace Word { class Body { readonly text: string; clear(): void; } }',
+    next: 'declare namespace Word { class Body { readonly text: string; } }',
+  },
+  {
+    what: 'a whole symbol added',
+    previous: 'declare namespace Word { class Body { readonly text: string; } }',
+    next: `declare namespace Word {
+      class Body { readonly text: string; }
+      class Paragraph { readonly text: string; }
+    }`,
+  },
+  {
+    what: 'a whole symbol removed',
+    previous: `declare namespace Word {
+      class Body { readonly text: string; }
+      class Paragraph { readonly text: string; }
+    }`,
+    next: 'declare namespace Word { class Body { readonly text: string; } }',
+  },
+  {
+    what: "a symbol's own requirement set moved",
+    previous: `declare namespace Word {
+      /** [Api set: WordApi 1.1] */
+      class Body { readonly text: string; }
+    }`,
+    next: `declare namespace Word {
+      /** [Api set: WordApi 1.9] */
+      class Body { readonly text: string; }
+    }`,
+  },
+  {
+    what: 'a property became a method of the same call shape',
+    previous: 'declare namespace Word { class Body { style: string; } }',
+    next: 'declare namespace Word { class Body { style(): string; } }',
+  },
+  {
+    what: 'a parameter was renamed',
+    previous: 'declare namespace Word { class Body { insertText(text: string): void; } }',
+    next: 'declare namespace Word { class Body { insertText(value: string): void; } }',
+  },
+];
+
 describe('adoptShapeIdenticalDrift() (the write path used by compat:adopt)', () => {
   test('adopts a provenance-only bump and proves the source commit against the published bytes', async () => {
     const sourceCommit = 'e8ab93aca9dcb062ad042380341762b019c4a488';
@@ -266,31 +368,83 @@ describe('adoptShapeIdenticalDrift() (the write path used by compat:adopt)', () 
     expect(provenance.upstreamPackage.version).toBe(UNPINNED_VERSION);
     expect(provenance.upstreamPackage.sourceRepository.commit).toBe(sourceCommit);
     expect(provenance.upstreamPackage.sourceRepository.sourceUrl).toContain(sourceCommit);
+
+    // The fixture it hands back is the regenerated one, carrying the new
+    // version — returning the old bytes would ship a PR whose two files
+    // disagree about which release is checked in.
+    const fixture = JSON.parse(result.fixtureJson);
+    expect(fixture.generatedFrom.version).toBe(UNPINNED_VERSION);
+    expect(Object.keys(fixture.symbols)).toEqual(['Body']);
   });
 
-  test('refuses a release whose shape moved, leaving it for a maintainer to review', async () => {
+  test('keeps a maintainer-reviewed pin instead of re-resolving it', async () => {
+    const reviewedCommit = '929735ef7d8bafb29c17e39b26042ada8529e670';
     const result = await adoptShapeIdenticalDrift({
       version: UNPINNED_VERSION,
       fetchImpl: fakeAdoptFetch({
         version: UNPINNED_VERSION,
-        // One member more than the checked-in fixture: a fact about the API.
-        declarationText: `declare namespace Word {
-          class Body {
-            readonly text: string;
-            clear(): void;
-          }
-        }`,
-        sourceCommit: 'e8ab93aca9dcb062ad042380341762b019c4a488',
+        declarationText: SHAPE_IDENTICAL_DECLARATION,
+        // A different commit is on offer from the resolver; it must not win.
+        sourceCommit: SOURCE_COMMIT,
       }),
       existingFixtureJson: `${JSON.stringify(PREVIOUS_FIXTURE, null, 2)}\n`,
+      existingPins: { [UNPINNED_VERSION]: reviewedCommit },
     });
 
-    expect(result.adopted).toBe(false);
-    expect(result.reason).toBe('shape-changed');
+    expect(result.adopted).toBe(true);
+    expect(result.commitWasPinned).toBe(true);
+    expect(result.definitelyTypedCommit).toBe(reviewedCommit);
+    expect(JSON.parse(result.provenanceJson).upstreamPackage.sourceRepository.commit).toBe(
+      reviewedCommit
+    );
+  });
+
+  for (const { what, previous, next } of REFUSABLE_UPSTREAM_CHANGES) {
+    test(`refuses to adopt when ${what}`, async () => {
+      const result = await adoptAfterUpstreamChange(previous, next);
+
+      expect(result.adopted).toBe(false);
+      expect(result.reason).toBe('shape-changed');
+      // Nothing adoptable is produced, so nothing can be written by mistake.
+      expect(result.provenanceJson).toBeUndefined();
+      expect(result.fixtureJson).toBeUndefined();
+    });
+  }
+
+  test('names the change in the report when the symbol/member delta can express it', async () => {
+    const result = await adoptAfterUpstreamChange(
+      'declare namespace Word { class Body { readonly text: string; } }',
+      'declare namespace Word { class Body { readonly text: string; clear(): void; } }'
+    );
     expect(result.diffSummary).toContain('Word.Body#clear');
-    // Nothing adoptable is produced, so nothing can be written by mistake.
-    expect(result.provenanceJson).toBeUndefined();
-    expect(result.fixtureJson).toBeUndefined();
+    expect(result.diffSummary).toMatch(/added/i);
+    // The delta explained it, so the "differs beyond" footnote must stay off.
+    expect(result.diffSummary).not.toContain('differs beyond the upstream version string');
+  });
+
+  test('names a whole symbol appearing or disappearing, without the cannot-express footnote', async () => {
+    const twoSymbols = `declare namespace Word {
+      class Body { readonly text: string; }
+      class Paragraph { readonly text: string; }
+    }`;
+    const oneSymbol = 'declare namespace Word { class Body { readonly text: string; } }';
+
+    const added = await adoptAfterUpstreamChange(oneSymbol, twoSymbols);
+    expect(added.diffSummary).toContain('Word.Paragraph');
+    expect(added.diffSummary).not.toContain('differs beyond the upstream version string');
+
+    const removed = await adoptAfterUpstreamChange(twoSymbols, oneSymbol);
+    expect(removed.diffSummary).toContain('Word.Paragraph');
+    expect(removed.diffSummary).not.toContain('differs beyond the upstream version string');
+  });
+
+  test('says so plainly when the delta cannot express the change, instead of printing "no differences"', async () => {
+    const result = await adoptAfterUpstreamChange(
+      'declare namespace Word { class Body { insertText(text: string): void; } }',
+      'declare namespace Word { class Body { insertText(value: string): void; } }'
+    );
+    expect(result.adopted).toBe(false);
+    expect(result.diffSummary).toContain('differs beyond the upstream version string');
   });
 
   test('fails loudly when no DefinitelyTyped commit explains the published bytes', async () => {
@@ -306,6 +460,158 @@ describe('adoptShapeIdenticalDrift() (the write path used by compat:adopt)', () 
         existingFixtureJson: `${JSON.stringify(PREVIOUS_FIXTURE, null, 2)}\n`,
       })
     ).rejects.toThrow(/has an index\.d\.ts matching the published/);
+  });
+});
+
+describe('the version string npm hands back', () => {
+  // It reaches a $GITHUB_OUTPUT line, a branch name, a commit message and a
+  // PR title. A newline in it would inject a second key=value pair into the
+  // workflow's own decision output — including the one that unlocks writing.
+  test('is refused when it could not be a version', async () => {
+    const hostileVersion = '1.0.605\nshape_changed=false';
+    await expect(
+      checkForDrift({
+        version: hostileVersion,
+        fetchImpl: fakeNpmFetch({
+          version: hostileVersion,
+          declarationText: SHAPE_IDENTICAL_DECLARATION,
+        }),
+        existingFixtureJson: null,
+        existingProvenance: null,
+      })
+    ).rejects.toThrow(/unusable @types\/office-js version string/);
+  });
+
+  test('accepts an ordinary release, prerelease and build-metadata version', async () => {
+    // Deliberately versions with no reviewed pin, so this exercises the
+    // version check without also reaching for the docs-reference commit.
+    for (const version of ['9.9.9', '9.9.9-beta.1', '9.9.9+build.7']) {
+      const result = await checkForDrift({
+        version,
+        fetchImpl: fakeNpmFetch({ version, declarationText: SHAPE_IDENTICAL_DECLARATION }),
+        existingFixtureJson: null,
+        existingProvenance: null,
+      });
+      expect(result.upstreamVersion).toBe(version);
+    }
+  });
+});
+
+describe('the adoption gate itself', () => {
+  const fixture = {
+    schemaVersion: 1,
+    generatedFrom: { package: '@types/office-js', version: '1.0.604' },
+    symbols: {
+      Body: {
+        uid: 'Word.Body',
+        kind: 'class',
+        requirementSet: 'WordApi 1.1',
+        members: {
+          insertText: {
+            uid: 'Word.Body#insertText',
+            kind: 'method',
+            requirementSet: 'WordApi 1.1',
+            overloads: [
+              { params: [{ name: 'text', type: 'string' }], returns: 'void' },
+              { params: [], returns: 'void' },
+            ],
+          },
+        },
+      },
+    },
+  };
+  const clone = () => JSON.parse(JSON.stringify(fixture));
+
+  test('a moved version string alone is provenance-only', () => {
+    const next = clone();
+    next.generatedFrom.version = '1.0.605';
+    expect(isProvenanceOnlyFixtureChange(fixture, next)).toBe(true);
+  });
+
+  test('key order is not a difference', () => {
+    const next = {
+      symbols: clone().symbols,
+      generatedFrom: { version: '1.0.605', package: '@types/office-js' },
+      schemaVersion: 1,
+    };
+    expect(isProvenanceOnlyFixtureChange(fixture, next)).toBe(true);
+  });
+
+  test('reordered overloads are a difference, even though the set is the same', () => {
+    const next = clone();
+    next.symbols.Body.members.insertText.overloads.reverse();
+    expect(isProvenanceOnlyFixtureChange(fixture, next)).toBe(false);
+  });
+
+  test('a changed uid is a difference', () => {
+    const next = clone();
+    next.symbols.Body.uid = 'Word.Body2';
+    expect(isProvenanceOnlyFixtureChange(fixture, next)).toBe(false);
+  });
+
+  test('a missing previous fixture is a difference, so nothing adopts into the unknown', () => {
+    expect(isProvenanceOnlyFixtureChange(null, fixture)).toBe(false);
+    expect(isProvenanceOnlyFixtureChange({ symbols: {} }, fixture)).toBe(false);
+  });
+});
+
+describe('buildCheckResultSummary() (the JSON contract the workflow branches on)', () => {
+  test('emits exactly the four keys the workflow reads', () => {
+    const summary = buildCheckResultSummary({
+      driftDetected: true,
+      shapeChanged: false,
+      upstreamVersion: '1.0.605',
+      reviewRequired: true,
+    });
+    expect(Object.keys(summary).sort()).toEqual([
+      'driftDetected',
+      'reviewRequired',
+      'shapeChanged',
+      'upstreamVersion',
+    ]);
+    expect(summary).toEqual({
+      driftDetected: true,
+      shapeChanged: false,
+      upstreamVersion: '1.0.605',
+      reviewRequired: true,
+    });
+  });
+
+  test('fails closed: only an explicit false unlocks automatic adoption', () => {
+    // A future return path that forgets the field must route to a maintainer,
+    // never to the step that writes.
+    expect(buildCheckResultSummary({ driftDetected: true }).shapeChanged).toBe(true);
+    expect(buildCheckResultSummary({ driftDetected: true, shapeChanged: null }).shapeChanged).toBe(
+      true
+    );
+    expect(buildCheckResultSummary({ driftDetected: true, shapeChanged: false }).shapeChanged).toBe(
+      false
+    );
+  });
+});
+
+describe('withPinnedCommit()', () => {
+  test('adds the entry and keeps every field that documents what a pin means', () => {
+    const before = {
+      schemaVersion: 1,
+      package: '@types/office-js',
+      note: 'what an entry here means',
+      commits: { '1.0.604': '929735ef7d8bafb29c17e39b26042ada8529e670' },
+    };
+
+    const after = withPinnedCommit(before, '1.0.605', 'e8ab93aca9dcb062ad042380341762b019c4a488');
+
+    expect(after).toEqual({
+      schemaVersion: 1,
+      package: '@types/office-js',
+      note: 'what an entry here means',
+      commits: {
+        '1.0.604': '929735ef7d8bafb29c17e39b26042ada8529e670',
+        '1.0.605': 'e8ab93aca9dcb062ad042380341762b019c4a488',
+      },
+    });
+    // Pure: the caller's object is untouched.
+    expect(Object.keys(before.commits)).toEqual(['1.0.604']);
   });
 });
 

--- a/packages/editor-api/src/office-compat/__tests__/manifest-and-reference-live.test.ts
+++ b/packages/editor-api/src/office-compat/__tests__/manifest-and-reference-live.test.ts
@@ -16,6 +16,7 @@ import path from 'node:path';
 import manifest from '../../../compat/manifest.json';
 import referenceFixture from '../../../compat/reference/word.reference.json';
 import provenance from '../../../compat/provenance.json';
+import definitelyTypedCommits from '../../../compat/definitely-typed-commits.json';
 import {
   validateManifestAgainstReference,
   validateManifestSchemaVersion,
@@ -42,6 +43,34 @@ describe('the checked-in compat/ fixtures', () => {
 
   test('provenance.json is well-formed', () => {
     expect(validateProvenance(provenance)).toEqual([]);
+  });
+
+  // The three files are written by one command but in three separate writes,
+  // and `compat:adopt` runs unattended. Each file alone is valid in every
+  // partial state, so only a cross-file check catches "provenance says 1.0.605
+  // while the fixture still says 1.0.604", or a provenance record naming a
+  // commit that no reviewed pin backs. The scheduled workflow runs these tests
+  // before it opens its PR, which is the point at which this has to fail.
+  test('the reference fixture, provenance, and the reviewed pin all name the same release', () => {
+    const version = provenance.upstreamPackage.version;
+    expect(referenceFixture.generatedFrom.version).toBe(version);
+    expect(referenceFixture.generatedFrom.package).toBe(provenance.upstreamPackage.name);
+    expect(provenance.upstreamPackage.tarballUrl).toContain(version);
+
+    const pins: Record<string, string> = definitelyTypedCommits.commits;
+    expect(Object.keys(pins)).toContain(version);
+    expect(provenance.upstreamPackage.sourceRepository.commit).toBe(pins[version]);
+    expect(provenance.upstreamPackage.sourceRepository.sourceUrl).toContain(pins[version]);
+  });
+
+  test('every reviewed pin is a well-formed commit sha, and the pin file keeps its own contract fields', () => {
+    expect(definitelyTypedCommits.schemaVersion).toBe(1);
+    expect(definitelyTypedCommits.package).toBe('@types/office-js');
+    expect(definitelyTypedCommits.note.length).toBeGreaterThan(0);
+    for (const [version, commit] of Object.entries(definitelyTypedCommits.commits)) {
+      expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(commit).toMatch(/^[0-9a-f]{40}$/);
+    }
   });
 
   test('every symbol compat/docxeditor/declarations.ts exports is either a selected manifest symbol or an allowlisted support type (no Table/Image stub can sneak in)', () => {

--- a/packages/editor-api/src/office-compat/__tests__/provenance.test.ts
+++ b/packages/editor-api/src/office-compat/__tests__/provenance.test.ts
@@ -91,6 +91,44 @@ describe('validateProvenance', () => {
     expect(validateProvenance(provenance)).toEqual([]);
   });
 
+  // `sourceRepository.url`/`directory` come from npm registry metadata, which
+  // the publisher controls, while `commit`/`sourceUrl` are generated against
+  // DefinitelyTyped. A record whose two halves name different repositories is
+  // not provenance, and `compat:adopt` can commit one unattended.
+  test('flags a source repository that is not DefinitelyTyped', () => {
+    const provenance = buildProvenance({
+      upstreamPackage: {
+        ...validUpstreamPackage,
+        sourceRepository: {
+          ...validUpstreamPackage.sourceRepository,
+          url: 'https://github.com/attacker/DefinitelyTyped.git',
+        },
+      },
+      fixture: { symbols: {} },
+      fetchedAt: '2026-08-01T00:00:00.000Z',
+      docsReference: validDocsReference,
+    });
+    const errors = validateProvenance(provenance);
+    expect(errors.some((e) => /sourceRepository\.url/.test(e))).toBe(true);
+  });
+
+  test('flags a source directory other than types/office-js', () => {
+    const provenance = buildProvenance({
+      upstreamPackage: {
+        ...validUpstreamPackage,
+        sourceRepository: {
+          ...validUpstreamPackage.sourceRepository,
+          directory: 'types/office-js-preview',
+        },
+      },
+      fixture: { symbols: {} },
+      fetchedAt: '2026-08-01T00:00:00.000Z',
+      docsReference: validDocsReference,
+    });
+    const errors = validateProvenance(provenance);
+    expect(errors.some((e) => /sourceRepository\.directory/.test(e))).toBe(true);
+  });
+
   test('flags a missing integrity hash', () => {
     const provenance = buildProvenance({
       upstreamPackage: { ...validUpstreamPackage, integrity: '' },

--- a/packages/editor-api/src/office-compat/__tests__/reference-diff.test.ts
+++ b/packages/editor-api/src/office-compat/__tests__/reference-diff.test.ts
@@ -4,7 +4,10 @@ Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-a
 Production use requires a commercial agreement: licensing@eigenpal.com
 */
 import { describe, test, expect } from 'bun:test';
-import { diffReferenceFixtures } from '../../../scripts/lib/reference-diff.mjs';
+import {
+  diffReferenceFixtures,
+  formatReferenceDiff,
+} from '../../../scripts/lib/reference-diff.mjs';
 
 function fixture(symbols) {
   return {
@@ -292,5 +295,72 @@ describe('diffReferenceFixtures', () => {
     expect(diff.changedSymbols[0].uid).toBe('Word.run');
     expect(diff.changedSymbols[0].addedOverloads).toHaveLength(1);
     expect(diff.changedSymbols[0].removedOverloads).toEqual([]);
+  });
+});
+
+/**
+ * Facts a symbol or member carries beside its call shape. Both of these read as
+ * "no differences" until they are compared explicitly: a symbol's own
+ * requirement set has no member to attach to, and a property that becomes a
+ * zero-parameter method of the same return type normalizes to the very same
+ * overload.
+ */
+describe('diffReferenceFixtures on facts beside the call shape', () => {
+  function bodyWith(overrides) {
+    return fixture({
+      Body: {
+        uid: 'Word.Body',
+        kind: 'class',
+        requirementSet: 'WordApi 1.1',
+        members: {
+          style: {
+            uid: 'Word.Body#style',
+            kind: 'property',
+            readonly: false,
+            requirementSet: 'WordApi 1.1',
+            overloads: [{ params: [], returns: 'string' }],
+          },
+        },
+        ...overrides,
+      },
+    });
+  }
+
+  test("reports a symbol's own requirement set moving", () => {
+    const diff = diffReferenceFixtures(bodyWith({}), bodyWith({ requirementSet: 'WordApi 1.9' }));
+
+    expect(diff.changedSymbols).toHaveLength(1);
+    expect(diff.changedSymbols[0].requirementSetChanged).toEqual({
+      from: 'WordApi 1.1',
+      to: 'WordApi 1.9',
+    });
+    expect(formatReferenceDiff(diff)).toContain('requirementSet: WordApi 1.1 -> WordApi 1.9');
+  });
+
+  test('reports a symbol changing kind', () => {
+    const diff = diffReferenceFixtures(bodyWith({}), bodyWith({ kind: 'interface' }));
+
+    expect(diff.changedSymbols[0].kindChanged).toEqual({ from: 'class', to: 'interface' });
+    expect(formatReferenceDiff(diff)).toContain('kind: class -> interface');
+  });
+
+  test('reports a property becoming a method of the same call shape', () => {
+    const previous = bodyWith({});
+    const next = bodyWith({});
+    next.symbols.Body.members.style.kind = 'method';
+    delete next.symbols.Body.members.style.readonly;
+
+    const diff = diffReferenceFixtures(previous, next);
+
+    const memberChange = diff.changedSymbols[0].changedMembers[0];
+    expect(memberChange.uid).toBe('Word.Body#style');
+    expect(memberChange.kindChanged).toEqual({ from: 'property', to: 'method' });
+    expect(formatReferenceDiff(diff)).toContain('kind: property -> method');
+  });
+
+  test('still reports nothing when neither moved', () => {
+    const diff = diffReferenceFixtures(bodyWith({}), bodyWith({}));
+    expect(diff.changedSymbols).toEqual([]);
+    expect(formatReferenceDiff(diff)).toContain('No symbol-level differences');
   });
 });


### PR DESCRIPTION
Review of #296 found two things worth landing before the next Monday run.

**The gate could adopt real API changes.** It asked `reference-diff.mjs`, which compares the fields worth naming in a report rather than every field the fixture records. A symbol's own `requirementSet`, a `property` becoming a `method` of the same call shape, a renamed parameter and a reordered overload all read as "no differences". The gate now compares the two fixtures whole, key-sorted, with only `generatedFrom.version` excluded, so a field added to `reference-normalize.mjs` is covered the day it is added. `reference-diff.mjs` learns to report symbol-level `requirementSet` and `kind` so its prose matches what the gate sees, and the report says so plainly when the delta cannot express what the gate found.

**The workflow could not complete a run.** `runner.temp` is not a legal context in a job-level `env:`, so the result path expanded to nothing and every week failed at the decision step. `bun install` points `core.hooksPath` at a pre-commit hook that runs `api:check` against a build this job never makes, so the commit would have failed. The adopt step now takes `--version` from the check rather than re-resolving `latest`, the issue-close step waits on an output the PR step sets only when it really opened one, and any adopt failure files the tracking issue instead of only reddening the run.

Also: the pin is written before the files that depend on it, an unreadable pin file degrades to review-required rather than killing the check, npm's version string is constrained before it reaches a `$GITHUB_OUTPUT` line, provenance keeps only named fields and must name DefinitelyTyped, and `eigenpal-release-pal[bot]` joins the CLA allowlist so its PRs are mergeable.

Each new guard was checked by mutation: breaking it fails a test.

No changeset: `files` ships `dist` only, so nothing here reaches a consumer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789556775&installation_model_id=422592&pr_number=297&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F297&signature=f0bff578c4959838b8c65b633c80c554680ca2b6cbbde5a450f2acd3683f514d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->