### PR TITLE
feat: measure typing latency in the benchmark comment

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,11 +7,13 @@ name: Performance benchmark
 #   - the deterministic edit benchmark (scripts/bench/edit-bench.ts) — the
 #     engine layout pipeline with exact work counters.
 # Wall-clock numbers from a shared runner are informational only — this job
-# never fails on a head-vs-base timing delta. Deterministic gates still apply:
-# the pinned work-counter test (scripts/bench/edit-bench-gates.test.ts) inside
-# `bun run test` in ci.yml, and the browser spec's own structural and
-# self-calibrated gates, which fail the HEAD browser run (this is the only CI
-# execution of that spec). A failing BASELINE run only degrades the comment.
+# never fails on a head-vs-base timing delta, and single-sample timing tails
+# are warn-only here (EDIT_BROWSER_BENCH_TIMING_TAILS=warn). Deterministic
+# gates still apply: the pinned work-counter test
+# (scripts/bench/edit-bench-gates.test.ts) inside `bun run test` in ci.yml,
+# and the browser spec's structural and median-based gates, which fail the
+# HEAD browser run (this is the only CI execution of that spec). A failing
+# BASELINE run only degrades the comment.
 
 on:
   pull_request:
@@ -66,8 +68,12 @@ jobs:
         # per-test timeout on shared runners; the SAME value must be set on the
         # baseline run below, or the two reports' medians come from different
         # sample counts.
+        # TIMING_TAILS=warn: single-sample tail gates (p95 spikes, sustained max)
+        # log instead of failing — one scheduler stall on a shared runner trips
+        # them. Structural and median-based gates stay hard and fail this step.
         run: |
           EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+            EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
             EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/head-ux.json" \
             bunx playwright test --config e2e/edit-browser-bench.config.ts \
             --grep "browser editing latency"
@@ -97,6 +103,7 @@ jobs:
             if [ -f "$RUNNER_TEMP/base/e2e/edit-browser-bench.config.ts" ]; then
               bunx playwright install --with-deps chromium || true
               EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+                EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
                 EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/base-ux.json" \
                 bunx playwright test --config e2e/edit-browser-bench.config.ts \
                 --grep "browser editing latency" || echo "baseline browser bench failed; continuing"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,11 +1,17 @@
 name: Performance benchmark
 
-# Runs the deterministic edit benchmark (scripts/bench/edit-bench.ts) on the PR
-# head and on its merge-base with main, then upserts one sticky PR comment with
-# the before/after table. Wall-clock numbers from a shared runner are
-# informational only — this job never fails on a timing regression. The hard
-# regression gate is the pinned work-counter test
-# (scripts/bench/edit-bench-gates.test.ts) inside `bun run test` in ci.yml.
+# Runs two benchmarks on the PR head and on its baseline, then upserts one
+# sticky PR comment with the before/after tables:
+#   - the browser typing-latency bench (e2e/edit-browser.bench.spec.ts) — the
+#     UX number: keystroke handler and frame latency through the real editor;
+#   - the deterministic edit benchmark (scripts/bench/edit-bench.ts) — the
+#     engine layout pipeline with exact work counters.
+# Wall-clock numbers from a shared runner are informational only — this job
+# never fails on a head-vs-base timing delta. Deterministic gates still apply:
+# the pinned work-counter test (scripts/bench/edit-bench-gates.test.ts) inside
+# `bun run test` in ci.yml, and the browser spec's own structural and
+# self-calibrated gates, which fail the HEAD browser run (this is the only CI
+# execution of that spec). A failing BASELINE run only degrades the comment.
 
 on:
   pull_request:
@@ -45,10 +51,26 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
       - name: Benchmark PR head
         run: |
           mkdir -p bench-out
           bun scripts/bench/edit-bench.ts --runs 10 --json > bench-out/head.json
+
+      - name: Browser-benchmark PR head
+        # The UX measurement: trusted Chromium input through the real adapter,
+        # review rail, and paginated DOM. Only the latency test — clipboard and
+        # burst stay local tools. SUSTAINED_EDITS is trimmed for the spec's 180s
+        # per-test timeout on shared runners; the SAME value must be set on the
+        # baseline run below, or the two reports' medians come from different
+        # sample counts.
+        run: |
+          EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+            EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/head-ux.json" \
+            bunx playwright test --config e2e/edit-browser-bench.config.ts \
+            --grep "browser editing latency"
 
       - name: Benchmark baseline
         run: |
@@ -67,19 +89,29 @@ jobs:
             cd "$RUNNER_TEMP/base"
             bun install --frozen-lockfile
             bun scripts/bench/edit-bench.ts --runs 10 --json > "$GITHUB_WORKSPACE/bench-out/base.json"
+            # Same for the browser bench, using the baseline's own spec. Browser
+            # binaries live in the shared Playwright cache; install still runs in
+            # case the baseline pins a different Playwright build. Failure here
+            # degrades the comment to a head-only UX table rather than failing
+            # the job.
+            if [ -f "$RUNNER_TEMP/base/e2e/edit-browser-bench.config.ts" ]; then
+              bunx playwright install --with-deps chromium || true
+              EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+                EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/base-ux.json" \
+                bunx playwright test --config e2e/edit-browser-bench.config.ts \
+                --grep "browser editing latency" || echo "baseline browser bench failed; continuing"
+            fi
           else
             echo "merge-base has no edit benchmark; skipping baseline"
           fi
 
       - name: Render comment
         run: |
-          if [ -f bench-out/base.json ]; then
-            node scripts/bench/edit-bench-comment.mjs \
-              --head bench-out/head.json --base bench-out/base.json --out bench-out/comment.md
-          else
-            node scripts/bench/edit-bench-comment.mjs \
-              --head bench-out/head.json --out bench-out/comment.md
-          fi
+          ARGS="--head bench-out/head.json --out bench-out/comment.md"
+          [ -f bench-out/base.json ] && ARGS="$ARGS --base bench-out/base.json"
+          [ -f bench-out/head-ux.json ] && ARGS="$ARGS --head-ux bench-out/head-ux.json"
+          [ -f bench-out/base-ux.json ] && ARGS="$ARGS --base-ux bench-out/base-ux.json"
+          node scripts/bench/edit-bench-comment.mjs $ARGS
 
       - name: Upload benchmark artifacts
         if: always()

--- a/e2e/edit-browser-bench-gates.ts
+++ b/e2e/edit-browser-bench-gates.ts
@@ -15,6 +15,25 @@ const EXPECTED_LAYOUT_WORK = {
 const TIMING_P95_FACTOR = 3;
 const TIMING_P95_FLOOR_MS = 50;
 
+/**
+ * `EDIT_BROWSER_BENCH_TIMING_TAILS=warn` downgrades the single-sample tail gates —
+ * p95-vs-median and the sustained max-sample ceilings — to console warnings. On a
+ * shared CI runner one scheduler stall is enough to trip them, and the CI benchmark
+ * job treats wall clock as advisory. Everything median-based or structural (work
+ * counters, growth percentages, heap, DOM size) stays a hard assertion in every mode.
+ */
+const TIMING_TAILS_WARN = process.env.EDIT_BROWSER_BENCH_TIMING_TAILS === 'warn';
+
+function expectTailCeiling(actual: number, ceiling: number, label: string): void {
+  if (TIMING_TAILS_WARN) {
+    if (actual > ceiling) {
+      console.warn(`[timing-tail warn-only] ${label}: ${actual} ms exceeds ${ceiling} ms`);
+    }
+    return;
+  }
+  expect(actual, label).toBeLessThanOrEqual(ceiling);
+}
+
 /** Engine layout/paint/selection combined should stay within 5× input-task median (generous for React/review rail). */
 const ENGINE_TO_INPUT_FACTOR = 5;
 const ENGINE_TO_INPUT_FLOOR_MS = 500;
@@ -36,11 +55,10 @@ const BURST_HANDLER_P95_FACTOR = 4;
 const BURST_HANDLER_P95_FLOOR_MS = 40;
 
 function assertTimingTail(summary: TimingSummary, label: string): void {
-  expect(
+  expectTailCeiling(
     summary.p95Ms,
+    Math.max(summary.medianMs * TIMING_P95_FACTOR, summary.medianMs + TIMING_P95_FLOOR_MS),
     `${label} p95 (${summary.p95Ms} ms) vs median (${summary.medianMs} ms)`
-  ).toBeLessThanOrEqual(
-    Math.max(summary.medianMs * TIMING_P95_FACTOR, summary.medianMs + TIMING_P95_FLOOR_MS)
   );
 }
 
@@ -87,14 +105,18 @@ export function assertSustainedLatencyGates(sustained: SustainedReport): void {
     sustained.frameMedianChangePct,
     `${sustained.mode} sustained frame median change`
   ).toBeLessThan(SUSTAINED_MEDIAN_GROWTH_PCT);
-  expect(sustained.maxInputTaskMs).toBeLessThanOrEqual(
+  expectTailCeiling(
+    sustained.maxInputTaskMs,
     Math.max(
       sustained.lastInputTask.p95Ms * TIMING_P95_FACTOR,
       sustained.lastInputTask.medianMs + 200
-    )
+    ),
+    `${sustained.mode} sustained max input task`
   );
-  expect(sustained.maxFrameMs).toBeLessThanOrEqual(
-    Math.max(sustained.lastFrame.p95Ms * TIMING_P95_FACTOR, sustained.lastFrame.medianMs + 400)
+  expectTailCeiling(
+    sustained.maxFrameMs,
+    Math.max(sustained.lastFrame.p95Ms * TIMING_P95_FACTOR, sustained.lastFrame.medianMs + 400),
+    `${sustained.mode} sustained max frame`
   );
   if (sustained.heapChangeBytes !== null) {
     expect(sustained.heapChangeBytes).toBeLessThan(SUSTAINED_HEAP_CEILING_BYTES);

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -46,18 +46,27 @@ or exaggerate timing changes; the structural work counters remain deterministic 
 
 ### CI performance-benchmark comment
 
-`.github/workflows/bench.yml` runs `bench:edit --runs 10` on every PR, twice: once on the PR
+`.github/workflows/bench.yml` runs two benchmarks on every PR, each twice: once on the PR
 merge ref (the PR merged into current `main`) and once on the `main` tip that merge ref was
-built against (using that commit's own copy of the script, in a separate worktree), so the
-delta isolates exactly what merging the PR changes. `scripts/bench/edit-bench-comment.mjs`
-renders both reports into a single sticky PR comment — a per-scenario median table with
-deltas, plus any work-counter changes. Comparability is guarded by the fixture SHA-256: if
-the fixture changed on the PR, or the baseline predates the benchmark, the comment degrades
-to head-only numbers.
+built against (using that commit's own copy of the scripts, in a separate worktree), so the
+delta isolates exactly what merging the PR changes:
+
+- the browser typing-latency test from `e2e/edit-browser.bench.spec.ts` — keystroke handler
+  and frame latency through the real adapter, review rail, and paginated DOM: the number a
+  typing user feels;
+- `bench:edit --runs 10` — the headless engine pipeline with deterministic work counters.
+
+`scripts/bench/edit-bench-comment.mjs` renders all reports into a single sticky PR comment —
+the typing-latency table first, the engine table below it, plus any work-counter changes.
+Comparability is guarded per report by the fixture SHA-256: if the fixture changed on the PR,
+or the baseline predates a benchmark, that section degrades to head-only numbers.
 
 Timings in that comment are informational: shared runners are noisy, so the job never fails on
-a wall-clock regression. The hard gate stays in `edit-bench-gates.test.ts`, which pins the
-deterministic work counters inside `bun run test`. Fork PRs cannot receive comments (read-only
+a head-vs-base wall-clock delta. Deterministic gates still apply — `edit-bench-gates.test.ts`
+pins the engine work counters inside `bun run test`, and the browser spec's own gates (pinned
+work counters plus the self-calibrated tails described under "CI gates and threshold
+rationale") fail the job when the HEAD browser run trips them; a failing BASELINE browser run
+only degrades the comment to head-only numbers. Fork PRs cannot receive comments (read-only
 token); their reports are in the `edit-bench-report` workflow artifact.
 
 ### Browser editing benchmark

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -62,11 +62,12 @@ Comparability is guarded per report by the fixture SHA-256: if the fixture chang
 or the baseline predates a benchmark, that section degrades to head-only numbers.
 
 Timings in that comment are informational: shared runners are noisy, so the job never fails on
-a head-vs-base wall-clock delta. Deterministic gates still apply — `edit-bench-gates.test.ts`
-pins the engine work counters inside `bun run test`, and the browser spec's own gates (pinned
-work counters plus the self-calibrated tails described under "CI gates and threshold
-rationale") fail the job when the HEAD browser run trips them; a failing BASELINE browser run
-only degrades the comment to head-only numbers. Fork PRs cannot receive comments (read-only
+a head-vs-base wall-clock delta, and the single-sample timing tails run warn-only there
+(`EDIT_BROWSER_BENCH_TIMING_TAILS=warn` — one scheduler stall on a shared runner trips a
+max-sample gate). Deterministic gates still apply — `edit-bench-gates.test.ts` pins the engine
+work counters inside `bun run test`, and the browser spec's structural and median-based gates
+fail the job when the HEAD browser run trips them; a failing BASELINE browser run only
+degrades the comment to head-only numbers. Fork PRs cannot receive comments (read-only
 token); their reports are in the `edit-bench-report` workflow artifact.
 
 ### Browser editing benchmark

--- a/scripts/bench/edit-bench-comment.mjs
+++ b/scripts/bench/edit-bench-comment.mjs
@@ -1,11 +1,14 @@
-// Render an edit-bench JSON report (plus an optional baseline report) as the
-// markdown body of the sticky PR comment posted by .github/workflows/bench.yml.
+// Render the edit-bench and browser typing-latency JSON reports (plus optional
+// baselines) as the markdown body of the sticky PR comment posted by
+// .github/workflows/bench.yml.
 //
 // Wall-clock numbers come from a shared CI runner, so the comment is advisory:
-// it flags regressions but never fails the job. The deterministic gate stays in
-// scripts/bench/edit-bench-gates.test.ts, which pins the work counters exactly.
+// it flags regressions but never fails the job on a head-vs-base delta. The
+// deterministic gates live elsewhere: edit-bench-gates.test.ts pins the engine
+// work counters, and the browser spec's own structural gates fail its head run.
 //
-// Usage: node scripts/bench/edit-bench-comment.mjs --head head.json [--base base.json] --out comment.md
+// Usage: node scripts/bench/edit-bench-comment.mjs --head head.json [--base base.json]
+//          [--head-ux browser.json] [--base-ux browser-base.json] --out comment.md
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
@@ -21,26 +24,47 @@ const MAX_COMMENT_CHARS = 60_000;
 function parseArgs(argv) {
   let head;
   let base;
+  let headUx;
+  let baseUx;
   let out;
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === '--head') head = argv[++index];
     else if (value === '--base') base = argv[++index];
+    else if (value === '--head-ux') headUx = argv[++index];
+    else if (value === '--base-ux') baseUx = argv[++index];
     else if (value === '--out') out = argv[++index];
     else throw new Error(`unknown argument: ${value}`);
   }
   if (!head) throw new Error('--head <report.json> is required');
   if (!out) throw new Error('--out <comment.md> is required');
-  return { head, base, out };
+  return { head, base, headUx, baseUx, out };
 }
 
 function readReport(path) {
   const report = JSON.parse(readFileSync(path, 'utf8'));
   const shapeOk =
     report.schema === 1 &&
+    typeof report.fixtureSha256 === 'string' &&
     Array.isArray(report.scenarios) &&
     report.scenarios.every((scenario) => Number.isFinite(scenario?.total?.medianMs));
   if (!shapeOk) throw new Error(`${path}: not an edit-bench schema-1 report`);
+  return report;
+}
+
+/**
+ * A browser (UX) report from e2e/edit-browser.bench.spec.ts: per-scenario `inputTask`
+ * is the keystroke-handler latency and `frame` the time until the frame presents —
+ * the numbers a typing user actually feels.
+ */
+function readUxReport(path) {
+  const report = JSON.parse(readFileSync(path, 'utf8'));
+  const shapeOk =
+    report.schema === 1 &&
+    typeof report.fixtureSha256 === 'string' &&
+    Array.isArray(report.scenarios) &&
+    report.scenarios.every((scenario) => Number.isFinite(scenario?.inputTask?.medianMs));
+  if (!shapeOk) throw new Error(`${path}: not a browser-bench schema-1 report`);
   return report;
 }
 
@@ -98,12 +122,9 @@ function comparisonNote(head, base) {
   return null;
 }
 
-function detailsBlock(summary, report) {
+function detailsBlock(summary, report, budget) {
   const json = JSON.stringify(report, null, 2);
-  const body =
-    json.length > MAX_COMMENT_CHARS / 2
-      ? `${json.slice(0, MAX_COMMENT_CHARS / 2)}\n… truncated …`
-      : json;
+  const body = json.length > budget ? `${json.slice(0, budget)}\n… truncated …` : json;
   return [
     '<details>',
     `<summary>${summary}</summary>`,
@@ -116,10 +137,53 @@ function detailsBlock(summary, report) {
   ].join('\n');
 }
 
-export function renderComment(head, base) {
+/**
+ * The typing-feel section: keystroke latency measured in a real Chromium through the
+ * full adapter/DOM path. Rendered FIRST — it is the user-facing number; the engine
+ * table below it is the algorithmic detail.
+ */
+function renderUxSection(headUx, baseUx) {
+  if (!headUx) return [];
+  const lines = ['### Typing latency (browser)', ''];
+  const comparable = baseUx && baseUx.fixtureSha256 === headUx.fixtureSha256;
+  if (comparable) {
+    lines.push(
+      '| Scenario | Base median | Head median | Δ | Head p95 | Frame p95 |',
+      '| --- | --- | --- | --- | --- | --- |'
+    );
+    const baseByName = new Map(baseUx.scenarios.map((scenario) => [scenario.name, scenario]));
+    for (const scenario of headUx.scenarios) {
+      const baseScenario = baseByName.get(scenario.name);
+      lines.push(
+        `| ${scenario.name} | ${formatMs(baseScenario?.inputTask.medianMs)} | ${formatMs(scenario.inputTask.medianMs)} | ${baseScenario ? formatDelta(baseScenario.inputTask.medianMs, scenario.inputTask.medianMs) : 'n/a'} | ${formatMs(scenario.inputTask.p95Ms)} | ${formatMs(scenario.frame?.p95Ms)} |`
+      );
+    }
+    const headNames = new Set(headUx.scenarios.map((scenario) => scenario.name));
+    for (const scenario of baseUx.scenarios) {
+      if (headNames.has(scenario.name)) continue;
+      lines.push(
+        `| ${scenario.name} | ${formatMs(scenario.inputTask.medianMs)} | — | n/a | — | — |`
+      );
+    }
+  } else {
+    if (baseUx) lines.push('> Browser baseline not comparable (fixture differs).', '');
+    lines.push('| Scenario | Median | p95 | Frame p95 |', '| --- | --- | --- | --- |');
+    for (const scenario of headUx.scenarios) {
+      lines.push(
+        `| ${scenario.name} | ${formatMs(scenario.inputTask.medianMs)} | ${formatMs(scenario.inputTask.p95Ms)} | ${formatMs(scenario.frame?.p95Ms)} |`
+      );
+    }
+  }
+  lines.push('');
+  return lines;
+}
+
+export function renderComment(head, base, ux = {}) {
   const lines = [COMMENT_MARKER, '## Performance benchmark', ''];
   const note = comparisonNote(head, base);
   const comparable = note === null;
+  lines.push(...renderUxSection(ux.headUx, ux.baseUx));
+  if (ux.headUx) lines.push('### Engine layout (headless)', '');
 
   if (comparable) {
     lines.push(
@@ -169,26 +233,40 @@ export function renderComment(head, base) {
     lines.push('');
   }
 
-  lines.push(detailsBlock('Head report (full JSON)', head));
-  if (base) lines.push('', detailsBlock('Base report (full JSON)', base));
+  // The per-block truncation budget shares MAX_COMMENT_CHARS across however many
+  // blocks render, so the assembled body stays under GitHub's 65,536-char cap
+  // whatever the reports grow to.
+  const blocks = [
+    ['Head report (full JSON)', head],
+    ...(base ? [['Base report (full JSON)', base]] : []),
+    ...(ux.headUx ? [['Browser report (full JSON)', ux.headUx]] : []),
+    ...(ux.headUx && ux.baseUx ? [['Browser baseline (full JSON)', ux.baseUx]] : []),
+  ];
+  const budget = Math.floor(MAX_COMMENT_CHARS / blocks.length);
+  lines.push(blocks.map(([summary, report]) => detailsBlock(summary, report, budget)).join('\n\n'));
   return `${lines.join('\n')}\n`;
+}
+
+/** Optional inputs degrade to absence, loudly: see the base-report rationale below. */
+function readOptional(path, reader, label) {
+  if (!path) return undefined;
+  try {
+    return reader(path);
+  } catch (error) {
+    console.error(`ignoring ${label}: ${error instanceof Error ? error.message : error}`);
+    return undefined;
+  }
 }
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const head = readReport(args.head);
-  let base;
-  if (args.base) {
-    try {
-      base = readReport(args.base);
-    } catch (error) {
-      // Degrade to head-only, but say why: a truncated or shape-drifted base.json
-      // must be distinguishable in CI logs from a merge-base without the bench.
-      console.error(`ignoring base report: ${error instanceof Error ? error.message : error}`);
-      base = undefined;
-    }
-  }
-  writeFileSync(args.out, renderComment(head, base));
+  // Degrade to head-only, but say why: a truncated or shape-drifted base.json
+  // must be distinguishable in CI logs from a merge-base without the bench.
+  const base = readOptional(args.base, readReport, 'base report');
+  const headUx = readOptional(args.headUx, readUxReport, 'browser report');
+  const baseUx = readOptional(args.baseUx, readUxReport, 'browser baseline');
+  writeFileSync(args.out, renderComment(head, base, { headUx, baseUx }));
 }
 
 const invokedDirectly =

--- a/scripts/bench/edit-bench-comment.test.ts
+++ b/scripts/bench/edit-bench-comment.test.ts
@@ -93,3 +93,81 @@ describe('edit-bench comment rendering', () => {
     expect(body).toContain('| steady-middle-text | 10.00 ms | — | n/a | — |');
   });
 });
+
+function uxReport(overrides: { fixtureSha256?: string; inputMedianMs?: number }) {
+  const median = overrides.inputMedianMs ?? 40;
+  return {
+    schema: 1,
+    fixture: 'synthetic-long-edit.docx',
+    fixtureSha256: overrides.fixtureSha256 ?? 'abc123',
+    environment: { browser: 'chromium', platform: 'linux' },
+    config: { runs: 7, warmup: 2 },
+    scenarios: [
+      {
+        name: 'editing-character',
+        inputTask: {
+          medianMs: median,
+          p95Ms: median * 1.4,
+          minMs: median * 0.8,
+          maxMs: median * 2,
+        },
+        frame: { medianMs: median + 8, p95Ms: median + 20, minMs: median, maxMs: median * 2 },
+      },
+    ],
+  };
+}
+
+describe('browser typing-latency section', () => {
+  test('renders first, with deltas, and subtitles the engine table', () => {
+    const body = renderComment(report({}), report({}), {
+      headUx: uxReport({ inputMedianMs: 30 }),
+      baseUx: uxReport({ inputMedianMs: 40 }),
+    });
+    expect(body).toContain('### Typing latency (browser)');
+    expect(body).toContain('### Engine layout (headless)');
+    expect(body.indexOf('Typing latency')).toBeLessThan(body.indexOf('Engine layout'));
+    expect(body).toContain('| editing-character | 40.00 ms | 30.00 ms | 🟢 -25.0% |');
+  });
+
+  test('head-only browser report renders without deltas', () => {
+    const body = renderComment(report({}), undefined, { headUx: uxReport({}) });
+    expect(body).toContain('### Typing latency (browser)');
+    expect(body).toContain('| editing-character | 40.00 ms |');
+    expect(body).not.toContain('| Base median | Head median | Δ | Head p95 | Frame p95 |');
+  });
+
+  test('a browser fixture mismatch degrades that section to head-only', () => {
+    const body = renderComment(report({}), report({}), {
+      headUx: uxReport({ fixtureSha256: 'new' }),
+      baseUx: uxReport({ fixtureSha256: 'old' }),
+    });
+    expect(body).toContain('Browser baseline not comparable');
+  });
+
+  test('no browser report keeps the original single-table layout', () => {
+    const body = renderComment(report({}), report({}));
+    expect(body).not.toContain('Typing latency');
+    expect(body).not.toContain('Engine layout');
+  });
+
+  test('a scenario removed on head still shows its baseline row', () => {
+    const base = uxReport({});
+    const head = uxReport({});
+    (head.scenarios as Array<{ name: string }>)[0]!.name = 'renamed-ux-scenario';
+    const body = renderComment(report({}), report({}), { headUx: head, baseUx: base });
+    expect(body).toContain('| editing-character | 40.00 ms | — | n/a | — | — |');
+  });
+
+  test('four oversized reports stay under the GitHub comment cap', () => {
+    const oversize = (target: Record<string, unknown>) => ({
+      ...target,
+      padding: 'x'.repeat(40_000),
+    });
+    const body = renderComment(oversize(report({})), oversize(report({})), {
+      headUx: oversize(uxReport({})),
+      baseUx: oversize(uxReport({})),
+    });
+    expect(body.length).toBeLessThan(65_536);
+    expect(body).toContain('… truncated …');
+  });
+});


### PR DESCRIPTION
The benchmark comment now leads with what typing feels like: the browser latency test from the existing Playwright bench runs in CI on the PR head and its baseline, and the sticky comment shows keystroke-handler and frame latency per scenario with deltas, above the headless engine table. Timings stay advisory; the browser spec's structural gates fail only the head run, and a failing baseline degrades the comment to head-only numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789557073&installation_model_id=422592&pr_number=298&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F298&signature=a2054675106c8d22ee415426aec62eef6e6b05312196a1820c64d3686955d0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->