### PR TITLE
chore: run all CI jobs on Blacksmith runners

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   bench:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     permissions:
       contents: read # checkout + merge-base worktree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   lint:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -42,7 +42,7 @@ jobs:
 
   test:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -81,7 +81,7 @@ jobs:
 
   build:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [lint, test]
     steps:
       - name: Checkout

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   cla:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # NOTE: the bot login below is hardcoded in three places (this if:,
     # GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL). They must stay in sync; missing
     # this if: when renaming the App would let the bot self-sign again.

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   refresh-and-verify:
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/office-compat-drift.yml
+++ b/.github/workflows/office-compat-drift.yml
@@ -41,7 +41,7 @@ concurrency:
 
 jobs:
   check-drift:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     # No pull-requests: write — every `gh pr` call and the push below use the
     # release-pal App token, which carries its own installation permissions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # Default job timeout is 6h; a hung step (e.g. an apt prompt) otherwise burns
     # a runner for hours. A healthy run finishes in well under 10 min.
     timeout-minutes: 30


### PR DESCRIPTION
Every job in every workflow moves from ubuntu-latest to blacksmith-4vcpu-ubuntu-2404, the drop-in equivalent (Ubuntu 24.04, 4 vCPU). Steadier hardware also reduces noise in the benchmark comment's timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789557645&installation_model_id=422592&pr_number=299&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F299&signature=7fb445ae01fb313276c7e8f7d251d0326786ff0735008aeacf721cbc754c2749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->