### PR TITLE
fix: interleave benchmark runs so machine drift cannot masquerade as a delta

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,13 +6,20 @@ name: Performance benchmark
 #     UX number: keystroke handler and frame latency through the real editor;
 #   - the deterministic edit benchmark (scripts/bench/edit-bench.ts) — the
 #     engine layout pipeline with exact work counters.
+#
+# The two sides run INTERLEAVED (head, base, base, head): a whole benchmark
+# run inherits the machine's momentary state, so back-to-back one-shot runs
+# systematically favor one side. A/B/B/A cancels that drift to first order,
+# and the comment renders any delta smaller than the observed same-side
+# spread as neutral.
+#
 # Wall-clock numbers from a shared runner are informational only — this job
 # never fails on a head-vs-base timing delta, and single-sample timing tails
 # are warn-only here (EDIT_BROWSER_BENCH_TIMING_TAILS=warn). Deterministic
 # gates still apply: the pinned work-counter test
 # (scripts/bench/edit-bench-gates.test.ts) inside `bun run test` in ci.yml,
 # and the browser spec's structural and median-based gates, which fail the
-# HEAD browser run (this is the only CI execution of that spec). A failing
+# HEAD browser runs (this is the only CI execution of that spec). A failing
 # BASELINE run only degrades the comment.
 
 on:
@@ -56,68 +63,108 @@ jobs:
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
 
-      - name: Benchmark PR head
+      - name: Prepare baseline worktree
+        id: baseline
         run: |
           mkdir -p bench-out
-          bun scripts/bench/edit-bench.ts --runs 10 --json > bench-out/head.json
-
-      - name: Browser-benchmark PR head
-        # The UX measurement: trusted Chromium input through the real adapter,
-        # review rail, and paginated DOM. Only the latency test — clipboard and
-        # burst stay local tools. SUSTAINED_EDITS is trimmed for the spec's 180s
-        # per-test timeout on shared runners; the SAME value must be set on the
-        # baseline run below, or the two reports' medians come from different
-        # sample counts.
-        # TIMING_TAILS=warn: single-sample tail gates (p95 spikes, sustained max)
-        # log instead of failing — one scheduler stall on a shared runner trips
-        # them. Structural and median-based gates stay hard and fail this step.
-        run: |
-          EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
-            EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
-            EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/head-ux.json" \
-            bunx playwright test --config e2e/edit-browser-bench.config.ts \
-            --grep "browser editing latency"
-
-      - name: Benchmark baseline
-        run: |
           # HEAD is the PR merge ref, so this resolves to the main tip the merge
           # ref was built against — the delta isolates exactly what merging this
           # PR changes. Do not "fix" this to the branch fork point.
           BASE=$(git merge-base HEAD "origin/${{ github.base_ref }}")
           echo "baseline commit: $BASE"
           git worktree add "$RUNNER_TEMP/base" "$BASE"
-          # Run the baseline's OWN benchmark script against baseline code, so it
-          # measures what main actually did. Comparability is checked later via
-          # fixtureSha256 in the comment script; a baseline without the benchmark
-          # (or without the fixture) simply yields a head-only report.
           if [ -f "$RUNNER_TEMP/base/scripts/bench/edit-bench.ts" ] && \
              [ -f "$RUNNER_TEMP/base/e2e/fixtures/synthetic-long-edit.docx" ]; then
             cd "$RUNNER_TEMP/base"
             bun install --frozen-lockfile
-            bun scripts/bench/edit-bench.ts --runs 10 --json > "$GITHUB_WORKSPACE/bench-out/base.json"
-            # Same for the browser bench, using the baseline's own spec. Browser
-            # binaries live in the shared Playwright cache; install still runs in
-            # case the baseline pins a different Playwright build. Failure here
-            # degrades the comment to a head-only UX table rather than failing
-            # the job.
-            if [ -f "$RUNNER_TEMP/base/e2e/edit-browser-bench.config.ts" ]; then
+            # Browser binaries live in the shared Playwright cache; install still
+            # runs in case the baseline pins a different Playwright build.
+            # ux only when the baseline spec understands the RUNS env var, or its
+            # default sample count would silently differ from the head rounds'.
+            if [ -f "$RUNNER_TEMP/base/e2e/edit-browser-bench.config.ts" ] && \
+               grep -q EDIT_BROWSER_BENCH_RUNS "$RUNNER_TEMP/base/e2e/edit-browser.bench.spec.ts"; then
               bunx playwright install --with-deps chromium || true
-              EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
-                EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
-                EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/base-ux.json" \
-                bunx playwright test --config e2e/edit-browser-bench.config.ts \
-                --grep "browser editing latency" || echo "baseline browser bench failed; continuing"
+              echo "ux=true" >> "$GITHUB_OUTPUT"
             fi
+            echo "engine=true" >> "$GITHUB_OUTPUT"
           else
-            echo "merge-base has no edit benchmark; skipping baseline"
+            echo "merge-base has no edit benchmark; head-only comment"
           fi
+
+      # ---- Interleaved rounds: head, base, base, head. Sample counts are
+      # halved per round (two rounds per side aggregate back to full size) and
+      # MUST stay identical across all four, or the medians stop being
+      # comparable. Head browser rounds fail the job on the spec's structural
+      # gates; baseline rounds only degrade the comment.
+
+      - name: Round 1 — PR head
+        run: |
+          bun scripts/bench/edit-bench.ts --runs 5 --json > bench-out/head-1.json
+          EDIT_BROWSER_BENCH_RUNS=5 \
+            EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+            EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
+            EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/head-ux-1.json" \
+            bunx playwright test --config e2e/edit-browser-bench.config.ts \
+            --grep "browser editing latency"
+
+      - name: Round 1 — baseline
+        if: steps.baseline.outputs.engine == 'true'
+        run: |
+          cd "$RUNNER_TEMP/base"
+          bun scripts/bench/edit-bench.ts --runs 5 --json > "$GITHUB_WORKSPACE/bench-out/base-1.json" \
+            || { rm -f "$GITHUB_WORKSPACE/bench-out/base-1.json"; echo "baseline engine round 1 failed; continuing"; }
+          if [ "${{ steps.baseline.outputs.ux }}" = "true" ]; then
+            EDIT_BROWSER_BENCH_RUNS=5 \
+              EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+              EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
+              EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/base-ux-1.json" \
+              bunx playwright test --config e2e/edit-browser-bench.config.ts \
+              --grep "browser editing latency" || echo "baseline browser round 1 failed; continuing"
+          fi
+
+      - name: Round 2 — baseline
+        if: steps.baseline.outputs.engine == 'true'
+        run: |
+          cd "$RUNNER_TEMP/base"
+          bun scripts/bench/edit-bench.ts --runs 5 --json > "$GITHUB_WORKSPACE/bench-out/base-2.json" \
+            || { rm -f "$GITHUB_WORKSPACE/bench-out/base-2.json"; echo "baseline engine round 2 failed; continuing"; }
+          if [ "${{ steps.baseline.outputs.ux }}" = "true" ]; then
+            EDIT_BROWSER_BENCH_RUNS=5 \
+              EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+              EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
+              EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/base-ux-2.json" \
+              bunx playwright test --config e2e/edit-browser-bench.config.ts \
+              --grep "browser editing latency" || echo "baseline browser round 2 failed; continuing"
+          fi
+
+      - name: Round 2 — PR head
+        run: |
+          # A tolerated baseline crash can orphan its dev server; head must not
+          # inherit a red job from an infrastructure leftover on the port.
+          (lsof -ti tcp:5275 | xargs -r kill -9) 2>/dev/null || true
+          bun scripts/bench/edit-bench.ts --runs 5 --json > bench-out/head-2.json
+          EDIT_BROWSER_BENCH_RUNS=5 \
+            EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
+            EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
+            EDIT_BROWSER_BENCH_OUTPUT="$GITHUB_WORKSPACE/bench-out/head-ux-2.json" \
+            bunx playwright test --config e2e/edit-browser-bench.config.ts \
+            --grep "browser editing latency"
 
       - name: Render comment
         run: |
-          ARGS="--head bench-out/head.json --out bench-out/comment.md"
-          [ -f bench-out/base.json ] && ARGS="$ARGS --base bench-out/base.json"
-          [ -f bench-out/head-ux.json ] && ARGS="$ARGS --head-ux bench-out/head-ux.json"
-          [ -f bench-out/base-ux.json ] && ARGS="$ARGS --base-ux bench-out/base-ux.json"
+          ARGS="--out bench-out/comment.md"
+          for f in bench-out/head-1.json bench-out/head-2.json; do
+            [ -f "$f" ] && ARGS="$ARGS --head $f"
+          done
+          for f in bench-out/base-1.json bench-out/base-2.json; do
+            [ -f "$f" ] && ARGS="$ARGS --base $f"
+          done
+          for f in bench-out/head-ux-1.json bench-out/head-ux-2.json; do
+            [ -f "$f" ] && ARGS="$ARGS --head-ux $f"
+          done
+          for f in bench-out/base-ux-1.json bench-out/base-ux-2.json; do
+            [ -f "$f" ] && ARGS="$ARGS --base-ux $f"
+          done
           node scripts/bench/edit-bench-comment.mjs $ARGS
 
       - name: Upload benchmark artifacts

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -56,10 +56,14 @@ delta isolates exactly what merging the PR changes:
   typing user feels;
 - `bench:edit --runs 10` — the headless engine pipeline with deterministic work counters.
 
-`scripts/bench/edit-bench-comment.mjs` renders all reports into a single sticky PR comment —
-the typing-latency table first, the engine table below it, plus any work-counter changes.
-Comparability is guarded per report by the fixture SHA-256: if the fixture changed on the PR,
-or the baseline predates a benchmark, that section degrades to head-only numbers.
+The two sides run INTERLEAVED (head, base, base, head): a whole benchmark run inherits the
+machine's momentary state, so back-to-back one-shot runs systematically favor one side.
+`scripts/bench/edit-bench-comment.mjs` aggregates each side's runs (mean of medians), renders
+all reports into a single sticky PR comment — the typing-latency table first, the engine table
+below it, plus any work-counter changes — and refuses to color a delta smaller than the
+observed same-side spread, so the comment measures its own noise instead of reporting it as a
+result. Comparability is guarded per report by the fixture SHA-256: if the fixture changed on
+the PR, or the baseline predates a benchmark, that section degrades to head-only numbers.
 
 Timings in that comment are informational: shared runners are noisy, so the job never fails on
 a head-vs-base wall-clock delta, and the single-sample timing tails run warn-only there

--- a/scripts/bench/edit-bench-comment.mjs
+++ b/scripts/bench/edit-bench-comment.mjs
@@ -2,13 +2,19 @@
 // baselines) as the markdown body of the sticky PR comment posted by
 // .github/workflows/bench.yml.
 //
+// Each side may supply SEVERAL runs (the workflow interleaves head/base/base/head
+// to cancel machine drift); runs aggregate to mean medians, and a delta smaller
+// than the observed same-side spread renders neutral — the comment measures its
+// own noise instead of coloring it.
+//
 // Wall-clock numbers come from a shared CI runner, so the comment is advisory:
 // it flags regressions but never fails the job on a head-vs-base delta. The
 // deterministic gates live elsewhere: edit-bench-gates.test.ts pins the engine
-// work counters, and the browser spec's own structural gates fail its head run.
+// work counters, and the browser spec's own structural gates fail its head runs.
 //
-// Usage: node scripts/bench/edit-bench-comment.mjs --head head.json [--base base.json]
-//          [--head-ux browser.json] [--base-ux browser-base.json] --out comment.md
+// Usage: node scripts/bench/edit-bench-comment.mjs --head head-1.json [--head head-2.json]
+//          [--base base-1.json ...] [--head-ux browser-1.json ...] [--base-ux ...]
+//          --out comment.md
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
@@ -17,26 +23,30 @@ export const COMMENT_MARKER = '<!-- edit-bench-report -->';
 
 const REGRESSION_WARN_PCT = 20;
 
+// Within this band a delta is runner noise, not a signal — shown neutral. The
+// observed same-side spread widens this floor per scenario.
+const NOISE_BAND_PCT = 5;
+
 // GitHub caps issue comment bodies at 65536 characters; leave room for the
 // wrapper text around the <details> payloads.
 const MAX_COMMENT_CHARS = 60_000;
 
 function parseArgs(argv) {
-  let head;
-  let base;
-  let headUx;
-  let baseUx;
+  const head = [];
+  const base = [];
+  const headUx = [];
+  const baseUx = [];
   let out;
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
-    if (value === '--head') head = argv[++index];
-    else if (value === '--base') base = argv[++index];
-    else if (value === '--head-ux') headUx = argv[++index];
-    else if (value === '--base-ux') baseUx = argv[++index];
+    if (value === '--head') head.push(argv[++index]);
+    else if (value === '--base') base.push(argv[++index]);
+    else if (value === '--head-ux') headUx.push(argv[++index]);
+    else if (value === '--base-ux') baseUx.push(argv[++index]);
     else if (value === '--out') out = argv[++index];
     else throw new Error(`unknown argument: ${value}`);
   }
-  if (!head) throw new Error('--head <report.json> is required');
+  if (head.length === 0) throw new Error('--head <report.json> is required');
   if (!out) throw new Error('--out <comment.md> is required');
   return { head, base, headUx, baseUx, out };
 }
@@ -68,22 +78,96 @@ function readUxReport(path) {
   return report;
 }
 
+const mean = (values) => values.reduce((sum, value) => sum + value, 0) / values.length;
+
+function aggregateSummary(summaries) {
+  const finite = (key) => summaries.map((summary) => summary?.[key]).filter(Number.isFinite);
+  const medians = finite('medianMs');
+  if (medians.length === 0) return summaries[0];
+  return {
+    medianMs: mean(medians),
+    p95Ms: finite('p95Ms').length > 0 ? mean(finite('p95Ms')) : undefined,
+    minMs: finite('minMs').length > 0 ? Math.min(...finite('minMs')) : undefined,
+    maxMs: finite('maxMs').length > 0 ? Math.max(...finite('maxMs')) : undefined,
+  };
+}
+
+const SUMMARY_KEYS = ['transaction', 'layout', 'total', 'inputTask', 'frame', 'paint', 'selection'];
+
+/**
+ * Fold same-side runs into one report-shaped aggregate: mean medians/p95 per
+ * scenario, plus a per-scenario spread (max−min of the primary-metric medians as
+ * a percent of their mean) so the tables can refuse to color deltas inside it.
+ * Runs whose fixture hash differs from the first run's are dropped loudly.
+ */
+export function aggregateReports(reports, primaryOf) {
+  const [first, ...rest] = reports;
+  const matching = [
+    first,
+    ...rest.filter((report) => {
+      if (report.fixtureSha256 === first.fixtureSha256) return true;
+      console.error('dropping run with mismatched fixture hash from aggregation');
+      return false;
+    }),
+  ];
+  const spreadPct = new Map();
+  const scenarios = first.scenarios.map((scenario) => {
+    const runs = matching
+      .map((report) => report.scenarios.find((candidate) => candidate.name === scenario.name))
+      .filter(Boolean);
+    const primaries = runs.map((run) => primaryOf(run).medianMs).filter(Number.isFinite);
+    if (primaries.length > 1) {
+      const primaryMean = mean(primaries);
+      // All-zero medians mean zero observed variation: record no spread rather
+      // than 0/0 = NaN, which would neutralize every delta for the scenario.
+      if (primaryMean > 0) {
+        spreadPct.set(
+          scenario.name,
+          ((Math.max(...primaries) - Math.min(...primaries)) / primaryMean) * 100
+        );
+      }
+    }
+    const aggregated = { ...scenario };
+    for (const key of SUMMARY_KEYS) {
+      if (scenario[key]) aggregated[key] = aggregateSummary(runs.map((run) => run[key]));
+    }
+    return aggregated;
+  });
+  return { ...first, scenarios, spreadPct, runCount: matching.length, raw: matching };
+}
+
 function formatMs(value) {
   return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(2)} ms` : 'n/a';
 }
 
-// Within this band a delta is runner noise, not a signal — shown neutral.
-const NOISE_BAND_PCT = 5;
-
-function formatDelta(baseMs, headMs) {
+function formatDelta(baseMs, headMs, spreadFloorPct = 0) {
   if (!Number.isFinite(baseMs) || !Number.isFinite(headMs)) return 'n/a';
   if (baseMs === 0) return headMs === 0 ? '⚪ ±0%' : 'n/a';
   const pct = Number((((headMs - baseMs) / baseMs) * 100).toFixed(1));
   const text = `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`;
-  if (pct > REGRESSION_WARN_PCT) return `🔴 ${text} ⚠️`;
-  if (pct > NOISE_BAND_PCT) return `🔴 ${text}`;
-  if (pct < -NOISE_BAND_PCT) return `🟢 ${text}`;
+  const floor = Math.max(NOISE_BAND_PCT, spreadFloorPct);
+  if (pct > floor && pct > REGRESSION_WARN_PCT) return `🔴 ${text} ⚠️`;
+  if (pct > floor) return `🔴 ${text}`;
+  if (pct < -floor) return `🟢 ${text}`;
   return `⚪ ${text}`;
+}
+
+function spreadFloor(headReport, baseReport, name) {
+  return Math.max(headReport.spreadPct?.get(name) ?? 0, baseReport?.spreadPct?.get(name) ?? 0);
+}
+
+function spreadNote(headReport, baseReport) {
+  if ((headReport.runCount ?? 1) < 2 && (baseReport?.runCount ?? 1) < 2) return [];
+  const all = [
+    ...(headReport.spreadPct?.values() ?? []),
+    ...(baseReport?.spreadPct?.values() ?? []),
+  ];
+  const worst = all.length > 0 ? Math.max(...all) : 0;
+  return [
+    `Interleaved runs per side: head ${headReport.runCount ?? 1}, base ${baseReport?.runCount ?? 1}. ` +
+      `Deltas inside the same-side spread (worst ${worst.toFixed(1)}%) render neutral.`,
+    '',
+  ];
 }
 
 /** Flatten a work summary into dotted numeric leaves so any schema drift still diffs. */
@@ -155,7 +239,7 @@ function renderUxSection(headUx, baseUx) {
     for (const scenario of headUx.scenarios) {
       const baseScenario = baseByName.get(scenario.name);
       lines.push(
-        `| ${scenario.name} | ${formatMs(baseScenario?.inputTask.medianMs)} | ${formatMs(scenario.inputTask.medianMs)} | ${baseScenario ? formatDelta(baseScenario.inputTask.medianMs, scenario.inputTask.medianMs) : 'n/a'} | ${formatMs(scenario.inputTask.p95Ms)} | ${formatMs(scenario.frame?.p95Ms)} |`
+        `| ${scenario.name} | ${formatMs(baseScenario?.inputTask.medianMs)} | ${formatMs(scenario.inputTask.medianMs)} | ${baseScenario ? formatDelta(baseScenario.inputTask.medianMs, scenario.inputTask.medianMs, spreadFloor(headUx, baseUx, scenario.name)) : 'n/a'} | ${formatMs(scenario.inputTask.p95Ms)} | ${formatMs(scenario.frame?.p95Ms)} |`
       );
     }
     const headNames = new Set(headUx.scenarios.map((scenario) => scenario.name));
@@ -165,6 +249,8 @@ function renderUxSection(headUx, baseUx) {
         `| ${scenario.name} | ${formatMs(scenario.inputTask.medianMs)} | — | n/a | — | — |`
       );
     }
+    lines.push('');
+    lines.push(...spreadNote(headUx, baseUx));
   } else {
     if (baseUx) lines.push('> Browser baseline not comparable (fixture differs).', '');
     lines.push('| Scenario | Median | p95 | Frame p95 |', '| --- | --- | --- | --- |');
@@ -173,8 +259,8 @@ function renderUxSection(headUx, baseUx) {
         `| ${scenario.name} | ${formatMs(scenario.inputTask.medianMs)} | ${formatMs(scenario.inputTask.p95Ms)} | ${formatMs(scenario.frame?.p95Ms)} |`
       );
     }
+    lines.push('');
   }
-  lines.push('');
   return lines;
 }
 
@@ -201,7 +287,7 @@ export function renderComment(head, base, ux = {}) {
         continue;
       }
       lines.push(
-        `| ${scenario.name} | ${formatMs(baseScenario.total.medianMs)} | ${formatMs(scenario.total.medianMs)} | ${formatDelta(baseScenario.total.medianMs, scenario.total.medianMs)} | ${formatMs(scenario.total.p95Ms)} |`
+        `| ${scenario.name} | ${formatMs(baseScenario.total.medianMs)} | ${formatMs(scenario.total.medianMs)} | ${formatDelta(baseScenario.total.medianMs, scenario.total.medianMs, spreadFloor(head, base, scenario.name))} | ${formatMs(scenario.total.p95Ms)} |`
       );
       const deltas = workCounterDeltas(baseScenario, scenario);
       if (deltas.length > 0) counterRows.push(`- **${scenario.name}**`, ...deltas);
@@ -212,6 +298,7 @@ export function renderComment(head, base, ux = {}) {
       lines.push(`| ${scenario.name} | ${formatMs(scenario.total.medianMs)} | — | n/a | — |`);
     }
     lines.push('');
+    lines.push(...spreadNote(head, base));
     if (counterRows.length > 0) {
       lines.push(
         '**Work counters changed** (deterministic — investigate before merging):',
@@ -235,37 +322,47 @@ export function renderComment(head, base, ux = {}) {
 
   // The per-block truncation budget shares MAX_COMMENT_CHARS across however many
   // blocks render, so the assembled body stays under GitHub's 65,536-char cap
-  // whatever the reports grow to.
+  // whatever the reports grow to. Only the first run per side is embedded; every
+  // raw run lives in the workflow artifact.
+  const firstRun = (report) => report.raw?.[0] ?? report;
   const blocks = [
-    ['Head report (full JSON)', head],
-    ...(base ? [['Base report (full JSON)', base]] : []),
-    ...(ux.headUx ? [['Browser report (full JSON)', ux.headUx]] : []),
-    ...(ux.headUx && ux.baseUx ? [['Browser baseline (full JSON)', ux.baseUx]] : []),
+    ['Head report (full JSON)', firstRun(head)],
+    ...(base ? [['Base report (full JSON)', firstRun(base)]] : []),
+    ...(ux.headUx ? [['Browser report (full JSON)', firstRun(ux.headUx)]] : []),
+    ...(ux.headUx && ux.baseUx ? [['Browser baseline (full JSON)', firstRun(ux.baseUx)]] : []),
   ];
   const budget = Math.floor(MAX_COMMENT_CHARS / blocks.length);
   lines.push(blocks.map(([summary, report]) => detailsBlock(summary, report, budget)).join('\n\n'));
   return `${lines.join('\n')}\n`;
 }
 
-/** Optional inputs degrade to absence, loudly: see the base-report rationale below. */
-function readOptional(path, reader, label) {
-  if (!path) return undefined;
-  try {
-    return reader(path);
-  } catch (error) {
-    console.error(`ignoring ${label}: ${error instanceof Error ? error.message : error}`);
-    return undefined;
+/** Optional inputs degrade to absence, loudly: a truncated or shape-drifted run
+ * must be distinguishable in CI logs from a side without the bench. */
+function readAll(paths, reader, label) {
+  const reports = [];
+  for (const path of paths) {
+    try {
+      reports.push(reader(path));
+    } catch (error) {
+      console.error(`ignoring ${label}: ${error instanceof Error ? error.message : error}`);
+    }
   }
+  return reports;
 }
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const head = readReport(args.head);
-  // Degrade to head-only, but say why: a truncated or shape-drifted base.json
-  // must be distinguishable in CI logs from a merge-base without the bench.
-  const base = readOptional(args.base, readReport, 'base report');
-  const headUx = readOptional(args.headUx, readUxReport, 'browser report');
-  const baseUx = readOptional(args.baseUx, readUxReport, 'browser baseline');
+  const engine = (scenario) => scenario.total;
+  const input = (scenario) => scenario.inputTask;
+  const headRuns = readAll(args.head, readReport, 'head report');
+  if (headRuns.length === 0) throw new Error('no readable --head report');
+  const head = aggregateReports(headRuns, engine);
+  const baseRuns = readAll(args.base, readReport, 'base report');
+  const base = baseRuns.length > 0 ? aggregateReports(baseRuns, engine) : undefined;
+  const headUxRuns = readAll(args.headUx, readUxReport, 'browser report');
+  const headUx = headUxRuns.length > 0 ? aggregateReports(headUxRuns, input) : undefined;
+  const baseUxRuns = readAll(args.baseUx, readUxReport, 'browser baseline');
+  const baseUx = baseUxRuns.length > 0 ? aggregateReports(baseUxRuns, input) : undefined;
   writeFileSync(args.out, renderComment(head, base, { headUx, baseUx }));
 }
 

--- a/scripts/bench/edit-bench-comment.test.ts
+++ b/scripts/bench/edit-bench-comment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { COMMENT_MARKER, renderComment } from './edit-bench-comment.mjs';
+import { aggregateReports, COMMENT_MARKER, renderComment } from './edit-bench-comment.mjs';
 
 function timing(medianMs: number): Record<string, number> {
   return { medianMs, p95Ms: medianMs * 1.2, minMs: medianMs * 0.8, maxMs: medianMs * 1.5 };
@@ -91,6 +91,48 @@ describe('edit-bench comment rendering', () => {
     const body = renderComment(head, base);
     expect(body).toContain('| renamed-scenario | — |');
     expect(body).toContain('| steady-middle-text | 10.00 ms | — | n/a | — |');
+  });
+});
+
+describe('interleaved-run aggregation', () => {
+  const engine = (scenario: { total: { medianMs: number } }) => scenario.total;
+
+  test('two runs aggregate to the mean of their medians', () => {
+    const head = aggregateReports([report({ medianMs: 10 }), report({ medianMs: 12 })], engine);
+    const body = renderComment(head, aggregateReports([report({ medianMs: 10 })], engine));
+    expect(body).toContain('| steady-middle-text | 10.00 ms | 11.00 ms |');
+    expect(body).toContain('Interleaved runs per side: head 2, base 1.');
+  });
+
+  test('a delta inside the same-side spread renders neutral, outside it colors', () => {
+    // Head runs 10 and 14: mean 12, spread (14-10)/12 = 33%. The +20% delta vs a
+    // base of 10 stays neutral because the head disagrees with itself by more.
+    const noisy = aggregateReports([report({ medianMs: 10 }), report({ medianMs: 14 })], engine);
+    const base = aggregateReports([report({ medianMs: 10 })], engine);
+    const noisyBody = renderComment(noisy, base);
+    expect(noisyBody).toContain('| ⚪ +20.0% |');
+    expect(noisyBody).toContain('(worst 33.3%) render neutral');
+    // Steady runs 12 and 12: zero spread, same +20% delta now colors red.
+    const steady = aggregateReports([report({ medianMs: 12 }), report({ medianMs: 12 })], engine);
+    expect(renderComment(steady, base)).toContain('| 🔴 +20.0% |');
+  });
+
+  test('all-zero medians record no spread instead of a NaN that neutralizes everything', () => {
+    const zeroHead = aggregateReports([report({ medianMs: 0 }), report({ medianMs: 0 })], engine);
+    const base = aggregateReports([report({ medianMs: 10 })], engine);
+    const body = renderComment(zeroHead, base);
+    expect(body).toContain('🟢 -100.0%');
+    expect(body).not.toContain('NaN');
+  });
+
+  test('a run with a different fixture hash is dropped from the aggregate', () => {
+    const head = aggregateReports(
+      [report({ medianMs: 10 }), report({ medianMs: 20, fixtureSha256: 'other' })],
+      engine
+    );
+    expect(head.runCount).toBe(1);
+    const body = renderComment(head, aggregateReports([report({ medianMs: 10 })], engine));
+    expect(body).toContain('| steady-middle-text | 10.00 ms | 10.00 ms |');
   });
 });
 


### PR DESCRIPTION
The benchmark's two sides ran back-to-back on one machine, so a whole run inherited the machine's momentary state and one side systematically won by 20-40% — the comment on a recent perf PR reported +43% on a change that measures -14% on quiet hardware. Runs now interleave (head, base, base, head) so drift cancels, each side's runs aggregate to mean medians, and the comment computes its own per-scenario run-to-run spread and renders any delta inside it as neutral instead of coloring noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789558935&installation_model_id=422592&pr_number=301&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F301&signature=98aea179b67566a7785ef7da885d7f3733df81238aa97b9c2375693400aff3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->