### PR TITLE
fix: four interleaved engine rounds per side in the benchmark job

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -93,13 +93,13 @@ jobs:
 
       # ---- Interleaved rounds: head, base, base, head. Sample counts are
       # halved per round (two rounds per side aggregate back to full size) and
-      # MUST stay identical across all four, or the medians stop being
+      # MUST stay identical across all rounds, or the medians stop being
       # comparable. Head browser rounds fail the job on the spec's structural
       # gates; baseline rounds only degrade the comment.
 
       - name: Round 1 — PR head
         run: |
-          bun scripts/bench/edit-bench.ts --runs 5 --json > bench-out/head-1.json
+          bun scripts/bench/edit-bench.ts --runs 3 --json > bench-out/head-1.json
           EDIT_BROWSER_BENCH_RUNS=5 \
             EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
             EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
@@ -111,7 +111,7 @@ jobs:
         if: steps.baseline.outputs.engine == 'true'
         run: |
           cd "$RUNNER_TEMP/base"
-          bun scripts/bench/edit-bench.ts --runs 5 --json > "$GITHUB_WORKSPACE/bench-out/base-1.json" \
+          bun scripts/bench/edit-bench.ts --runs 3 --json > "$GITHUB_WORKSPACE/bench-out/base-1.json" \
             || { rm -f "$GITHUB_WORKSPACE/bench-out/base-1.json"; echo "baseline engine round 1 failed; continuing"; }
           if [ "${{ steps.baseline.outputs.ux }}" = "true" ]; then
             EDIT_BROWSER_BENCH_RUNS=5 \
@@ -126,7 +126,7 @@ jobs:
         if: steps.baseline.outputs.engine == 'true'
         run: |
           cd "$RUNNER_TEMP/base"
-          bun scripts/bench/edit-bench.ts --runs 5 --json > "$GITHUB_WORKSPACE/bench-out/base-2.json" \
+          bun scripts/bench/edit-bench.ts --runs 3 --json > "$GITHUB_WORKSPACE/bench-out/base-2.json" \
             || { rm -f "$GITHUB_WORKSPACE/bench-out/base-2.json"; echo "baseline engine round 2 failed; continuing"; }
           if [ "${{ steps.baseline.outputs.ux }}" = "true" ]; then
             EDIT_BROWSER_BENCH_RUNS=5 \
@@ -142,7 +142,7 @@ jobs:
           # A tolerated baseline crash can orphan its dev server; head must not
           # inherit a red job from an infrastructure leftover on the port.
           (lsof -ti tcp:5275 | xargs -r kill -9) 2>/dev/null || true
-          bun scripts/bench/edit-bench.ts --runs 5 --json > bench-out/head-2.json
+          bun scripts/bench/edit-bench.ts --runs 3 --json > bench-out/head-2.json
           EDIT_BROWSER_BENCH_RUNS=5 \
             EDIT_BROWSER_BENCH_SUSTAINED_EDITS=120 \
             EDIT_BROWSER_BENCH_TIMING_TAILS=warn \
@@ -150,13 +150,38 @@ jobs:
             bunx playwright test --config e2e/edit-browser-bench.config.ts \
             --grep "browser editing latency"
 
+      # Engine-only rounds 3-4: headless runs are ~20s, so the engine table gets
+      # four interleaved rounds per side (H B B H · H B B H — balanced under
+      # linear drift) where the browser, which pays a full dev-server boot per
+      # round, stays at two.
+
+      - name: Engine round 3 — PR head
+        run: bun scripts/bench/edit-bench.ts --runs 3 --json > bench-out/head-3.json
+
+      - name: Engine round 3 — baseline
+        if: steps.baseline.outputs.engine == 'true'
+        run: |
+          cd "$RUNNER_TEMP/base"
+          bun scripts/bench/edit-bench.ts --runs 3 --json > "$GITHUB_WORKSPACE/bench-out/base-3.json" \
+            || { rm -f "$GITHUB_WORKSPACE/bench-out/base-3.json"; echo "baseline engine round 3 failed; continuing"; }
+
+      - name: Engine round 4 — baseline
+        if: steps.baseline.outputs.engine == 'true'
+        run: |
+          cd "$RUNNER_TEMP/base"
+          bun scripts/bench/edit-bench.ts --runs 3 --json > "$GITHUB_WORKSPACE/bench-out/base-4.json" \
+            || { rm -f "$GITHUB_WORKSPACE/bench-out/base-4.json"; echo "baseline engine round 4 failed; continuing"; }
+
+      - name: Engine round 4 — PR head
+        run: bun scripts/bench/edit-bench.ts --runs 3 --json > bench-out/head-4.json
+
       - name: Render comment
         run: |
           ARGS="--out bench-out/comment.md"
-          for f in bench-out/head-1.json bench-out/head-2.json; do
+          for f in bench-out/head-1.json bench-out/head-2.json bench-out/head-3.json bench-out/head-4.json; do
             [ -f "$f" ] && ARGS="$ARGS --head $f"
           done
-          for f in bench-out/base-1.json bench-out/base-2.json; do
+          for f in bench-out/base-1.json bench-out/base-2.json bench-out/base-3.json bench-out/base-4.json; do
             [ -f "$f" ] && ARGS="$ARGS --base $f"
           done
           for f in bench-out/head-ux-1.json bench-out/head-ux-2.json; do


### PR DESCRIPTION
Two rounds per side estimate the same-side spread from only two points and cancel drift weakly. Headless engine runs are cheap, so the engine table now gets four interleaved rounds per side (12 samples each, H B B H · H B B H); the browser rounds, which each pay a dev-server boot, stay at two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789559622&installation_model_id=422592&pr_number=302&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F302&signature=362eba9176394ff32f492192a7891ceb6ffdb382bcb495a2092058e89709f414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->