### PR TITLE
fix: clear the open code scanning alerts

### DIFF
--- a/.changeset/bounded-clipboard-and-mime-readers.md
+++ b/.changeset/bounded-clipboard-and-mime-readers.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Pasting from an application that offers only an HTML flavour now recovers its text more faithfully: an attribute value holding a `>` no longer truncates the paste, unterminated markup is no longer pasted as literal text, and a very large table no longer blocks the page. Reading a document's content types no longer uses a pattern a crafted file could make backtrack.

--- a/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
@@ -176,4 +176,82 @@ describe('the visible text of an HTML fragment', () => {
     const html = '<p onclick="evil()">text<img src=x onerror=alert(1)></p>';
     expect(plainTextFromHtml(html)).toBe('text');
   });
+
+  test('a bracket a browser shows as text is kept, even beside a removed element', () => {
+    // A `<` that opens no tag is text, so removing the element after it can leave that `<`
+    // next to a word — `<script>` here, where the tag-stripping reader gave `script>`. The
+    // output is only ever inserted as run text, so a bracket in it is a character, not
+    // markup; what matters is that the reader never RE-READS what it wrote.
+    expect(plainTextFromHtml('<<div>script>')).toBe('<script>');
+    expect(plainTextFromHtml('<<!---->script>')).toBe('<script>');
+    expect(plainTextFromHtml('<scr<div>ipt>alert(1)')).toBe('ipt>alert(1)');
+  });
+
+  test('a quoted attribute may hold a bracket without ending the tag', () => {
+    expect(plainTextFromHtml('<p title="a > b">text</p>')).toBe('text');
+    expect(plainTextFromHtml("<p data-x='a > b'>text</p>")).toBe('text');
+  });
+
+  test('an apostrophe in an unquoted attribute is a character, not a quote', () => {
+    // Only the quote directly after `=` opens a value. Reading this one as an opening quote
+    // sent the scan hunting for a partner to the end of the payload and pasted nothing.
+    expect(plainTextFromHtml("<p class=note title=it's>Para one</p><p>Second</p>")).toBe(
+      'Para one\nSecond'
+    );
+    expect(plainTextFromHtml("<div><img src=a.jpg alt=John's photo><p>Caption</p></div>")).toBe(
+      'Caption'
+    );
+  });
+
+  test('an unpaired bracket in prose stays prose', () => {
+    expect(plainTextFromHtml('<p>1 < 2 and 3 > 2</p>')).toBe('1 < 2 and 3 > 2');
+  });
+
+  test('a doctype is furniture, not text', () => {
+    expect(plainTextFromHtml('<!DOCTYPE html><p>alpha</p>')).toBe('alpha');
+  });
+
+  test('a comment that closes at once does not swallow the payload behind it', () => {
+    // `<!-->` and `<!--->` are complete comments. Demanding a full `-->` after them found no
+    // terminator and dropped everything that followed — the whole paste, for five characters.
+    expect(plainTextFromHtml('<!-->text')).toBe('text');
+    expect(plainTextFromHtml('<!--->text')).toBe('text');
+    expect(plainTextFromHtml('a<!--<!-- -->b')).toBe('ab');
+  });
+
+  test('raw text stays out of the document even when the elements overlap', () => {
+    expect(plainTextFromHtml('<style><script></style>alert(1)</script>')).toBe('alert(1)');
+    expect(plainTextFromHtml('<script>a<script>b</script>c</script>')).toBe('c');
+    expect(plainTextFromHtml('<SCRIPT>alert(1)</SCRIPT>keep')).toBe('keep');
+  });
+
+  test('an attribute does not stop a break or a cell from reading as one', () => {
+    expect(plainTextFromHtml('a<br class="x">b')).toBe('a\nb');
+    expect(plainTextFromHtml('<tr><td>a</td class=x><td>b</td></tr>')).toBe('a\tb');
+  });
+
+  test('truncation landing inside a tag does not paste the tag as text', () => {
+    const text = plainTextFromHtml(`${'x'.repeat(1_999_990)}<p class="y`);
+    expect(text.endsWith('x')).toBe(true);
+    expect(text).not.toContain('<p');
+  });
+
+  test('a payload built to make a reader backtrack still finishes at once', () => {
+    // Raw-text elements and bare brackets, repeated: each branch of the walk consumes what
+    // it reads, so the cost stays proportional to the length rather than squaring it.
+    const hostile = `${'<style>x</style>'.repeat(50_000)}${'< '.repeat(100_000)} text`;
+    const started = performance.now();
+    expect(plainTextFromHtml(hostile)).toContain('text');
+    expect(performance.now() - started).toBeLessThan(2_000);
+  });
+
+  test('a solid run of cell tabs is answered at once too', () => {
+    // `</td>` emits exactly one tab, so a payload of nothing else is a tab run a sender
+    // controls. Trimming those with `/\t+\n/g` backtracked over every position of the run:
+    // 80,000 cells cost 2.7 seconds, and the input cap allows five times that many.
+    const hostile = `${'</td>'.repeat(80_000)}z`;
+    const started = performance.now();
+    expect(plainTextFromHtml(hostile)).toContain('z');
+    expect(performance.now() - started).toBeLessThan(2_000);
+  });
 });

--- a/packages/core/src/editor/clipboard-plain-text.ts
+++ b/packages/core/src/editor/clipboard-plain-text.ts
@@ -58,8 +58,129 @@ function decodeEntities(text: string): string {
   });
 }
 
+/** Tags whose CONTENT is source, not visible text: the whole element is dropped. */
+const RAW_TEXT_TAGS = new Set(['script', 'style']);
+/** Close tags that end a block, so what follows starts a new line. */
+const BLOCK_TAGS = new Set([
+  'p',
+  'div',
+  'li',
+  'tr',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'blockquote',
+  'section',
+  'article',
+  'pre',
+  'table',
+]);
+/** Close tags that end a table cell, which reads as a tab like a copied cell range. */
+const CELL_TAGS = new Set(['td', 'th']);
+
+const isNameStart = (char: string | undefined): boolean =>
+  char !== undefined && ((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z'));
+const isNameChar = (char: string | undefined): boolean =>
+  isNameStart(char) || (char !== undefined && char >= '0' && char <= '9');
+const isSpace = (char: string | undefined): boolean =>
+  char === ' ' || char === '\t' || char === '\n' || char === '\r' || char === '\f';
+
+interface ScannedTag {
+  readonly name: string;
+  readonly closing: boolean;
+  /** Index just past the `>`, or the end of input for an unterminated tag. */
+  readonly end: number;
+}
+
+/**
+ * Read the tag that starts at `start`, or null when that `<` is only literal text.
+ *
+ * Quoted attribute values may hold a `>`; a browser does not end the tag there, so neither
+ * does this. But ONLY a quote that opens a value counts — the one directly after an `=`.
+ * An apostrophe anywhere else is an ordinary character inside an unquoted value, exactly as
+ * a browser reads it, and treating `title=it's` as an opening quote sent the scan looking
+ * for a partner that never came and swallowed the rest of the paste.
+ *
+ * Each call consumes what it scans, which keeps the whole walk linear.
+ */
+function scanTag(html: string, start: number): ScannedTag | null {
+  let at = start + 1;
+  const closing = html[at] === '/';
+  if (closing) at += 1;
+  if (!isNameStart(html[at])) return null;
+  const nameStart = at;
+  while (at < html.length && isNameChar(html[at])) at += 1;
+  const name = html.slice(nameStart, at).toLowerCase();
+  let quote = '';
+  let afterEquals = false;
+  while (at < html.length) {
+    const char = html[at]!;
+    if (quote !== '') {
+      if (char === quote) quote = '';
+    } else if (char === '=') {
+      afterEquals = true;
+    } else if (afterEquals && (char === '"' || char === "'")) {
+      quote = char;
+      afterEquals = false;
+    } else if (char === '>') {
+      return { name, closing, end: at + 1 };
+    } else if (!isSpace(char)) {
+      afterEquals = false;
+    }
+    at += 1;
+  }
+  return { name, closing, end: html.length };
+}
+
+/**
+ * A line without the tabs a final cell in each row leaves behind.
+ *
+ * Written as a backward walk rather than `/\t+\n/g`, which backtracks over every position of
+ * a tab run: `</td>` emits exactly one tab, so a payload of nothing but close-cell tags is a
+ * solid run of them under a sender's control, and at the input cap that regex cost about a
+ * minute of blocked main thread.
+ */
+function withoutTrailingTabs(line: string): string {
+  let end = line.length;
+  while (end > 0 && line.charCodeAt(end - 1) === 0x09) end -= 1;
+  return end === line.length ? line : line.slice(0, end);
+}
+
+/**
+ * The index just past `</name>`, or the end of input when it never closes.
+ *
+ * An unclosed `<script>` drops everything after it rather than pasting its body.
+ */
+function rawTextEnd(html: string, name: string, from: number): number {
+  for (let at = from; at < html.length; ) {
+    const close = html.indexOf('</', at);
+    if (close === -1) return html.length;
+    let after = close + 2;
+    if (html.slice(after, after + name.length).toLowerCase() === name) {
+      after += name.length;
+      while (after < html.length && isSpace(html[after])) after += 1;
+      if (html[after] === '>') return after + 1;
+    }
+    at = close + 2;
+  }
+  return html.length;
+}
+
 /**
  * The visible text of an HTML fragment.
+ *
+ * A single forward walk, not a sequence of `replace` passes. The walk never re-reads what it
+ * has already written, so no later stage can turn emitted text back into a tag, and every
+ * branch moves the cursor forward over a range the next branch will not revisit — a hostile
+ * payload costs one pass over its own length.
+ *
+ * It does NOT promise the output holds no angle brackets. A payload may write a literal `<`
+ * that a browser also shows as text, and removing the element after it can leave that `<`
+ * beside a word. That is fine here and only here: the result is inserted as run text through
+ * the same path typed characters take, and is escaped again on save. Nothing re-parses it.
  *
  * Block boundaries become newlines and table cells become tabs, matching how this engine
  * already flattens a copied cell range — so an HTML table pasted here lands in the same
@@ -67,26 +188,64 @@ function decodeEntities(text: string): string {
  */
 export function plainTextFromHtml(html: string): string {
   const bounded = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
+  let text = '';
+  let at = 0;
+  while (at < bounded.length) {
+    const open = bounded.indexOf('<', at);
+    if (open === -1) {
+      text += bounded.slice(at);
+      break;
+    }
+    text += bounded.slice(at, open);
+    // Comments first: they can contain anything, including tag-shaped text.
+    if (bounded.startsWith('<!--', open)) {
+      // `<!-->` and `<!--->` close AT ONCE. Demanding a full `-->` after them found no
+      // terminator and swallowed the rest of the payload — five characters at the head of
+      // a paste were enough to drop all of it.
+      if (bounded[open + 4] === '>') {
+        at = open + 5;
+        continue;
+      }
+      if (bounded[open + 4] === '-' && bounded[open + 5] === '>') {
+        at = open + 6;
+        continue;
+      }
+      const close = bounded.indexOf('-->', open + 4);
+      at = close === -1 ? bounded.length : close + 3;
+      continue;
+    }
+    // Doctypes, processing instructions and bogus comments run to the next `>`.
+    if (bounded[open + 1] === '!' || bounded[open + 1] === '?') {
+      const close = bounded.indexOf('>', open + 1);
+      at = close === -1 ? bounded.length : close + 1;
+      continue;
+    }
+    const tag = scanTag(bounded, open);
+    if (tag === null) {
+      // A `<` that starts no tag is text, exactly as a browser reads it.
+      text += '<';
+      at = open + 1;
+      continue;
+    }
+    at = tag.end;
+    if (!tag.closing && RAW_TEXT_TAGS.has(tag.name)) {
+      at = rawTextEnd(bounded, tag.name, tag.end);
+    } else if (!tag.closing && tag.name === 'br') {
+      text += '\n';
+    } else if (tag.closing && CELL_TAGS.has(tag.name)) {
+      text += '\t';
+    } else if (tag.closing && BLOCK_TAGS.has(tag.name)) {
+      text += '\n';
+    }
+  }
   return (
-    decodeEntities(
-      bounded
-        // Comments first: they can contain anything, including tag-shaped text.
-        .replace(/<!--[\s\S]*?-->/g, '')
-        // Script and style CONTENT is not visible text — dropping the tags alone would
-        // paste the source of both.
-        .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '')
-        .replace(/<(script|style)\b[^>]*>[\s\S]*$/gi, '')
-        .replace(/<br\s*\/?>/gi, '\n')
-        .replace(/<\/(td|th)\s*>/gi, '\t')
-        .replace(/<\/(p|div|li|tr|h[1-6]|blockquote|section|article|pre|table)\s*>/gi, '\n')
-        // Every remaining tag, open or close. `[^>]*` is linear — no nested quantifier for
-        // a hostile payload to walk into.
-        .replace(/<[^>]*>/g, '')
-    )
+    decodeEntities(text)
       // Collapse the runs of blank lines that block-level markup leaves behind, and drop
       // the trailing tab a final cell contributes.
       .replace(/\r\n?/g, '\n')
-      .replace(/\t+\n/g, '\n')
+      .split('\n')
+      .map(withoutTrailingTabs)
+      .join('\n')
       .replace(/\n{3,}/g, '\n\n')
       .trim()
   );

--- a/packages/core/src/store/__tests__/content-types.test.ts
+++ b/packages/core/src/store/__tests__/content-types.test.ts
@@ -125,6 +125,33 @@ describe('content-type index', () => {
     expect(buildContentTypeIndex(records([['xml', 'bogus']])).ok).toBe(false);
   });
 
+  test('parameters are accepted, and an empty parameter is not', () => {
+    expect(isValidMime('text/plain; charset=UTF-8')).toBe(true);
+    expect(isValidMime('text/plain;charset=UTF-8;boundary=x')).toBe(true);
+    expect(isValidMime('text/plain;')).toBe(false);
+    expect(isValidMime('text/plain;;charset=UTF-8')).toBe(false);
+    expect(isValidMime('text/plain ')).toBe(false);
+    expect(isValidMime(';charset=UTF-8')).toBe(false);
+    // The boundaries the hand-written parameter walk has to reproduce exactly, because the
+    // single pattern it replaced got them for free.
+    expect(isValidMime('text/plain; ')).toBe(true); // a whitespace-only parameter counts
+    expect(isValidMime('text/plain \t;charset=UTF-8')).toBe(true); // whitespace before the `;`
+    expect(isValidMime('text/plain;charset=UTF-8;')).toBe(false); // trailing empty segment
+    expect(isValidMime('text/plain\n')).toBe(false); // `$` does not forgive a final newline
+  });
+
+  test('a content type built to make the reader backtrack is answered at once', () => {
+    // The shape a crafted `[Content_Types].xml` used. The old group was exponential in the
+    // NUMBER of `;`-plus-whitespace segments (and polynomial in each one's length), so the
+    // cost is bought with segments, not with size: these 88 characters cost it 1.2 seconds,
+    // and 406 characters of the same shape cost it 10.9. The trailing `;` is what forces the
+    // walk — it refuses every split the group can try.
+    const hostile = `a/b${`;${' '.repeat(20)}`.repeat(4)};`;
+    const started = performance.now();
+    expect(isValidMime(hostile)).toBe(false);
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
   test('record count enforces N (ok) and N+1 (fail)', () => {
     const many = (n: number): ContentTypeRecords =>
       records(

--- a/packages/core/src/store/__tests__/tracked-edits.test.ts
+++ b/packages/core/src/store/__tests__/tracked-edits.test.ts
@@ -587,9 +587,8 @@ describe('the offset model is the shared one', () => {
       text: 'X',
       revision: ADA,
     });
-    const text = xml(after)
-      .match(/<w:t[^>]*>([^<]*)<\/w:t>/g)!
-      .map((node) => node.replace(/<[^>]+>/g, ''))
+    const text = [...xml(after).matchAll(/<w:t[^>]*>([^<]*)<\/w:t>/g)]
+      .map(([, body]) => body!)
       .join('');
     expect(text).toBe('abcXd');
   });

--- a/packages/core/src/store/__tests__/tree-drawing-ops.test.ts
+++ b/packages/core/src/store/__tests__/tree-drawing-ops.test.ts
@@ -475,12 +475,6 @@ describe('refuses invalid or locked drawing operations', () => {
   });
 
   test('refuses non-picture graphic', () => {
-    const part = parse(
-      inlinePictureDrawing()
-        .replace(PIC_URI, CHART_URI)
-        .replace('<pic:pic>', '<pic:pic>')
-        .replace('pic:pic', 'pic:pic')
-    );
     const xml = inlinePictureDrawing().replace(`uri="${PIC_URI}"`, `uri="${CHART_URI}"`);
     const chartPart = parse(xml);
     const drawing = drawingOf(chartPart);

--- a/packages/core/src/store/package/content-types.ts
+++ b/packages/core/src/store/package/content-types.ts
@@ -46,13 +46,25 @@ export type ContentTypeError =
   | { readonly code: 'invalid-override-name'; readonly partName: string }
   | { readonly code: 'too-many-records'; readonly limit: number };
 
-// Media type per RFC 2045-ish: type "/" subtype, optional ";" parameters.
-const MIME_RE =
-  /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*(\s*;\s*[^;]+)*$/;
+// Media type per RFC 2045-ish: type "/" subtype. Parameters are checked by hand below,
+// NOT by a trailing `(\s*;\s*[^;]+)*` group: `\s*` and `[^;]+` both match whitespace, so a
+// crafted `[Content_Types].xml` value like "a/b;" plus a long run of spaces made the engine
+// backtrack exponentially. The essence pattern alone is unambiguous and linear.
+const MIME_ESSENCE_RE = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$/;
+// The same essence, allowing the trailing whitespace a `;` may sit behind.
+const MIME_ESSENCE_BEFORE_PARAMS_RE =
+  /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\s*$/;
 
 /** Whether a string is syntactically a MIME type. Syntax only — no registry lookup. */
 export function isValidMime(value: string): boolean {
-  return MIME_RE.test(value);
+  const firstSemicolon = value.indexOf(';');
+  if (firstSemicolon === -1) return MIME_ESSENCE_RE.test(value);
+  if (!MIME_ESSENCE_BEFORE_PARAMS_RE.test(value.slice(0, firstSemicolon))) return false;
+  // Every parameter segment must carry something; a bare or doubled `;` is not a parameter.
+  return value
+    .slice(firstSemicolon + 1)
+    .split(';')
+    .every((parameter) => parameter.length > 0);
 }
 
 /** ASCII-case-insensitive extension key (leading dot removed; ASCII-only fold). */

--- a/packages/editor-api/src/office-compat/__tests__/fetch-office-reference.test.ts
+++ b/packages/editor-api/src/office-compat/__tests__/fetch-office-reference.test.ts
@@ -53,6 +53,23 @@ function sha512Integrity(buffer: Buffer): string {
   return `sha512-${createHash('sha512').update(buffer).digest('base64')}`;
 }
 
+/** A literal string as a regular expression: every character the engine treats as syntax
+ * is escaped, the backslash first so it cannot consume the escape added after it. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|/-]/g, '\\$&');
+}
+
+/** Whether a URL addresses the npm registry itself. The HOST has to match: a substring
+ * test would also answer for `https://registry.npmjs.org.example.invalid/`, which is a
+ * different host entirely. */
+function isRegistryUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname === 'registry.npmjs.org';
+  } catch {
+    return false;
+  }
+}
+
 /** Builds a fake `fetch` that answers the npm registry metadata request and
  * the tarball download for a single synthetic, unpinned `@types/office-js`
  * version — never touching the real network. */
@@ -63,7 +80,7 @@ function fakeNpmFetch({ version, declarationText }: { version: string; declarati
   const integrity = sha512Integrity(tarballGzip);
 
   return async (url: string) => {
-    if (url.includes('registry.npmjs.org')) {
+    if (isRegistryUrl(url)) {
       return {
         ok: true,
         status: 200,
@@ -157,7 +174,7 @@ describe('checkForDrift against a new @types/office-js version with no reviewed 
 
     // Explicitly flagged as unreviewed, not silently treated as adoptable.
     expect(result.reviewRequired).toBe(true);
-    expect(result.reviewReason).toMatch(new RegExp(UNPINNED_VERSION.replace(/[.-]/g, '\\$&')));
+    expect(result.reviewReason).toMatch(new RegExp(escapeRegExp(UNPINNED_VERSION)));
     expect(result.provenance).toBeNull();
     expect(result.provenanceJson).toBeNull();
   });
@@ -169,7 +186,7 @@ describe('checkForDrift against a new @types/office-js version with no reviewed 
     });
     const brokenFetchImpl = async (url: string, ...rest: unknown[]) => {
       const response = await fetchImpl(url, ...(rest as []));
-      if (url.includes('registry.npmjs.org')) {
+      if (isRegistryUrl(url)) {
         const body = await response.json();
         // Corrupt the integrity hash so verification must fail loudly.
         return {

--- a/packages/fonts/scripts/generate-google-catalog.mjs
+++ b/packages/fonts/scripts/generate-google-catalog.mjs
@@ -207,6 +207,23 @@ async function buildCatalog() {
   return { entries, skipped };
 }
 
+/**
+ * An upstream string as a single-quoted TypeScript string literal.
+ *
+ * The backslash goes FIRST: escaping only the quote leaves `\` able to consume the escape
+ * this adds, so an upstream family name ending in one would close the literal early and the
+ * generated file would carry whatever followed as code. The line terminators are escaped
+ * too — `familyName()` reads the name with `[^"]+`, which spans a newline, and a raw one
+ * inside a single-quoted literal is a syntax error rather than an injection.
+ */
+function singleQuoted(value) {
+  return `'${value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')}'`;
+}
+
 function render(entries) {
   const families = new Set(entries.map((entry) => entry.family));
   return (
@@ -249,9 +266,12 @@ function render(entries) {
     entries
       .map(
         (entry) =>
-          `  { family: '${entry.family.replace(/'/g, "\\'")}', weight: ${entry.weight}, ` +
-          `style: '${entry.style}', url: '${entry.url}', byteLength: ${entry.byteLength}, ` +
-          `hash: '${entry.hash}' },`
+          // `url` is built from upstream repository paths, so it is escaped like the family
+          // name. `style` comes from the fixed FACES list, and `hash`/`byteLength`/`weight`
+          // are validated hex and numbers.
+          `  { family: ${singleQuoted(entry.family)}, weight: ${entry.weight}, ` +
+          `style: '${entry.style}', url: ${singleQuoted(entry.url)}, ` +
+          `byteLength: ${entry.byteLength}, hash: '${entry.hash}' },`
       )
       .join('\n') +
     '\n];\n'
@@ -274,7 +294,7 @@ function check() {
     process.exit(1);
   }
   const pattern =
-    /family: '((?:[^'\\]|\\')+)',\s*weight: (400|700),\s*style: '(normal|italic)',\s*url: '([^']+)',\s*byteLength: (\d+),\s*hash: '(sha256:[0-9a-f]{64})'/g;
+    /family: '((?:[^'\\]|\\.)+)',\s*weight: (400|700),\s*style: '(normal|italic)',\s*url: '([^']+)',\s*byteLength: (\d+),\s*hash: '(sha256:[0-9a-f]{64})'/g;
   const byFamily = new Map();
   let count = 0;
   for (const match of current.matchAll(pattern)) {

--- a/scripts/lib/nested-object.mjs
+++ b/scripts/lib/nested-object.mjs
@@ -1,8 +1,17 @@
-// Keys that would mutate the prototype chain rather than the target object.
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+// Keys that would mutate the prototype chain rather than the target object. Compared one
+// literal at a time, in the loop that does the writing, so the guard sits on the same path
+// a reader (or a static analyzer) walks to reach the assignment.
+//
+// The three names are spelled out again inside `setNestedValue`, at the descent step and at
+// the leaf write. That repetition is deliberate — a guard behind a helper call is a guard
+// the analysis cannot see — so ADDING A NAME HERE MEANS ADDING IT AT BOTH SITES TOO.
+// `scripts/lib/nested-object.test.mjs` asserts the three lists agree.
+function isUnsafeKey(key) {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype';
+}
 
 function assertSafePath(path, parts, action) {
-  if (parts.some((p) => UNSAFE_KEYS.has(p))) {
+  if (parts.some(isUnsafeKey)) {
     throw new Error(`Refusing to ${action} unsafe key path: ${path}`);
   }
 }
@@ -14,6 +23,9 @@ export function setNestedValue(obj, path, value) {
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const key = parts[i];
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new Error(`Refusing to set unsafe key path: ${path}`);
+    }
     if (
       !Object.hasOwn(current, key) ||
       typeof current[key] !== 'object' ||
@@ -28,7 +40,11 @@ export function setNestedValue(obj, path, value) {
     }
     current = current[key];
   }
-  Object.defineProperty(current, parts[parts.length - 1], {
+  const leafKey = parts[parts.length - 1];
+  if (leafKey === '__proto__' || leafKey === 'constructor' || leafKey === 'prototype') {
+    throw new Error(`Refusing to set unsafe key path: ${path}`);
+  }
+  Object.defineProperty(current, leafKey, {
     value,
     writable: true,
     enumerable: true,

--- a/scripts/lib/nested-object.test.mjs
+++ b/scripts/lib/nested-object.test.mjs
@@ -24,4 +24,18 @@ describe('nested object mutation', () => {
     expect(() => deleteNestedValue(target, 'constructor.prototype.polluted')).toThrow();
     expect(Object.prototype.polluted).toBeUndefined();
   });
+
+  test('every unsafe key is refused at the head, in the middle and at the leaf', () => {
+    // `setNestedValue` spells the three names out three times: once in the shared guard, once
+    // at the descent step and once at the leaf write. A name added to only one of them would
+    // still pass the test above, so each position is checked for each name.
+    for (const key of ['__proto__', 'constructor', 'prototype']) {
+      expect(() => setNestedValue({}, key, 1)).toThrow();
+      expect(() => setNestedValue({}, `${key}.leaf`, 1)).toThrow();
+      expect(() => setNestedValue({}, `a.${key}.leaf`, 1)).toThrow();
+      expect(() => setNestedValue({}, `a.b.${key}`, 1)).toThrow();
+      expect(() => deleteNestedValue({}, `a.${key}.leaf`)).toThrow();
+    }
+    expect(Object.prototype.polluted).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Clears all 12 open CodeQL alerts. Verified by running the same query suite locally against `origin/main` and this branch: 12 results before, 0 after, no new findings.

Two rewrites changed behaviour beyond the alert itself. `plainTextFromHtml` now reads a payload once instead of stripping it repeatedly, which also stops an attribute value holding a `>` from truncating a paste, stops unterminated markup from being pasted as literal text, and removes a quadratic trim that cost about a minute of blocked main thread at the input cap. `isValidMime` was differential-tested against the pattern it replaces over roughly 113M inputs and against the content types of all 102 `.docx` fixtures here, with no disagreement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789581585&installation_model_id=422592&pr_number=305&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F305&signature=fa89fc1a93c3367c8f3f1f9a0bd95c5f37b07301175f062201ab54d311b55ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->