### PR TITLE
ci: gate advisories in the published dependency closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
   shipped-advisories:
     if: github.actor != 'dependabot[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -100,7 +103,20 @@ jobs:
           bun-version: latest
 
       - name: Shipped dependency advisories
-        run: bun run check:shipped-advisories
+        run: bun run check:shipped-advisories --sarif=shipped-advisories.sarif
+
+      # `always()` so a failing gate still publishes what it found: the run log
+      # is where a finding goes to be forgotten. `continue-on-error` because a
+      # fork PR gets a read-only token and cannot upload — the gate above has
+      # already passed or failed on its own, so a refused upload must not
+      # change the job result.
+      - name: Upload SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: shipped-advisories.sarif
+          category: shipped-advisories
 
   build:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,29 @@ jobs:
       - name: CLA logic tests
         run: bash .github/cla/cla.test.sh
 
+  # Advisories in the dependency closure we publish. Deliberately NOT `bun audit`:
+  # that reads the whole workspace lock, so devDependencies and the demo apps in
+  # examples/ would fail the build for CVEs no consumer can reach. See the header
+  # of scripts/check-shipped-advisories.mjs.
+  #
+  # No `bun install` step on purpose. The script reads bun.lock and the package
+  # manifests, so a checkout is the whole setup and the job finishes in seconds.
+  # It is independent of lint/test, so `build` does not wait on it.
+  shipped-advisories:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Shipped dependency advisories
+        run: bun run check:shipped-advisories
+
   build:
     if: github.actor != 'dependabot[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -22,6 +22,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Lets the advisory gate below publish its SARIF to the Security tab.
+  security-events: write
 
 jobs:
   refresh-and-verify:
@@ -65,7 +67,15 @@ jobs:
       # advisories in what we publish. A bump that pulls a vulnerable transitive
       # package fails here rather than at the next release.
       - name: Shipped dependency advisories
-        run: bun run check:shipped-advisories
+        run: bun run check:shipped-advisories --sarif=shipped-advisories.sarif
+
+      - name: Upload SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: shipped-advisories.sarif
+          category: shipped-advisories
 
       - name: Lint
         run: bun run lint

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -60,6 +60,13 @@ jobs:
             echo "bun.lock already in sync — nothing to commit"
           fi
 
+      # Runs first, and against the refreshed lockfile above. ci.yml skips
+      # Dependabot, so this is the only place a dependency bump is checked for
+      # advisories in what we publish. A bump that pulls a vulnerable transitive
+      # package fails here rather than at the next release.
+      - name: Shipped dependency advisories
+        run: bun run check:shipped-advisories
+
       - name: Lint
         run: bun run lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ examples/vite/public/sample-20x.docx
 examples/vite/public/sample-review.docx
 examples/vite/public/sample-review-20x.docx
 e2e/fixtures/synthetic-huge-tracked.docx
+
+# SARIF from `bun run check:shipped-advisories --sarif=...`
+*.sarif

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "check:license-headers": "bun run check:pro-license-headers && bun run check:editor-api-license-headers",
     "check:parity-contract": "node scripts/check-parity-contract.mjs",
     "check:public-docs-surface": "node scripts/check-public-docs-surface.mjs",
+    "check:shipped-advisories": "node scripts/check-shipped-advisories.mjs",
     "demo-doc:build": "bun scripts/demo-doc/build.ts",
     "dev": "bun run --filter './examples/vite' --filter './examples/vue' dev",
     "dev:agent": "cd examples/agent && npm run dev",

--- a/scripts/check-shipped-advisories.mjs
+++ b/scripts/check-shipped-advisories.mjs
@@ -21,7 +21,7 @@
 // bun.lock, so the dependency graph sees direct manifest entries only (185 of
 // 2485). Transitive CVEs raise no alert. That gap is why this script exists.
 
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -35,6 +35,8 @@ const DEFAULT_AUDIT_LEVEL = 'moderate';
 
 const args = process.argv.slice(2);
 const asJson = args.includes('--json');
+/** `--sarif=<path>` also writes SARIF 2.1.0 for GitHub code scanning. */
+const sarifPath = args.find((a) => a.startsWith('--sarif='))?.split('=')[1];
 const levelArg = args.find((a) => a.startsWith('--audit-level='))?.split('=')[1];
 const auditLevel = levelArg ?? DEFAULT_AUDIT_LEVEL;
 if (!SEVERITY_ORDER.includes(auditLevel)) {
@@ -94,14 +96,17 @@ function readJson(path) {
 // --- The published surface -------------------------------------------------
 
 const packagesDir = join(ROOT, 'packages');
-const manifests = readdirSync(packagesDir)
-  .map((dir) => join(packagesDir, dir, 'package.json'))
-  .filter((path) => existsSync(path))
-  .map((path) => readJson(path));
+const sources = readdirSync(packagesDir)
+  .map((dir) => ({ dir, absPath: join(packagesDir, dir, 'package.json') }))
+  .filter((s) => existsSync(s.absPath))
+  .map((s) => ({ ...s, uri: `packages/${s.dir}/package.json`, manifest: readJson(s.absPath) }));
 
+const manifests = sources.map((s) => s.manifest);
 const published = manifests.filter((m) => m.private !== true);
 const publishedNames = new Set(published.map((m) => m.name));
 const byName = new Map(manifests.map((m) => [m.name, m]));
+/** Published package name -> its manifest, for SARIF result locations. */
+const sourceByName = new Map(sources.map((s) => [s.manifest.name, s]));
 
 const lock = parseBunLock(readFileSync(join(ROOT, 'bun.lock'), 'utf8'));
 const packages = lock.packages ?? {};
@@ -223,10 +228,26 @@ for (const [marker, trails] of shipped) {
   trailsByName.set(name, merged);
 }
 
+/**
+ * Anchor a finding to the line that declares the direct dependency it came in
+ * through. A trail reads `@docx-editor.dev/core > fast-xml-parser > strnum`, so
+ * the first hop names the published package and the second names the line to
+ * point at. GitHub code scanning drops any result without a location.
+ */
+function locate(trail) {
+  const [rootName, directDep] = (trail ?? '').split(' > ');
+  const source = sourceByName.get(rootName);
+  if (!source || !directDep) return null;
+  const lines = readFileSync(source.absPath, 'utf8').split('\n');
+  const index = lines.findIndex((line) => line.includes(`"${directDep}"`));
+  return { uri: source.uri, line: index >= 0 ? index + 1 : 1 };
+}
+
 const findings = [];
 for (const [name, list] of Object.entries(advisories)) {
   for (const advisory of list) {
     const id = advisory.github_advisory_id ?? advisory.url?.split('/').pop() ?? String(advisory.id);
+    const paths = [...(trailsByName.get(name) ?? [])].slice(0, 3);
     findings.push({
       name,
       id,
@@ -235,7 +256,8 @@ for (const [name, list] of Object.entries(advisories)) {
       url: advisory.url,
       vulnerableVersions: advisory.vulnerable_versions,
       ignored: ignoreById.has(id),
-      paths: [...(trailsByName.get(name) ?? [])].slice(0, 3),
+      paths,
+      location: locate(paths[0]),
     });
   }
 }
@@ -245,6 +267,74 @@ const threshold = SEVERITY_ORDER.indexOf(auditLevel);
 const blocking = findings.filter(
   (f) => !f.ignored && SEVERITY_ORDER.indexOf(f.severity) >= threshold,
 );
+
+// --- SARIF for the GitHub Security tab --------------------------------------
+
+/** GitHub renders its severity band from this number, not from `level`. */
+const SECURITY_SEVERITY = { critical: '9.0', high: '7.0', moderate: '5.0', low: '3.0', info: '1.0' };
+
+function buildSarif() {
+  const rules = new Map();
+  const results = [];
+  for (const finding of findings) {
+    const blocks = !finding.ignored && SEVERITY_ORDER.indexOf(finding.severity) >= threshold;
+    if (!rules.has(finding.id)) {
+      rules.set(finding.id, {
+        id: finding.id,
+        name: `Advisory/${finding.name}`,
+        shortDescription: { text: `${finding.severity}: ${finding.name}` },
+        fullDescription: { text: finding.title ?? finding.id },
+        helpUri: finding.url,
+        help: { text: `${finding.title}\nAffects ${finding.vulnerableVersions}\n${finding.url}` },
+        defaultConfiguration: { level: blocks ? 'error' : 'note' },
+        properties: { tags: ['security'], 'security-severity': SECURITY_SEVERITY[finding.severity] ?? '1.0' },
+      });
+    }
+    const why = finding.ignored
+      ? ' (accepted in scripts/shipped-advisories-ignore.json)'
+      : blocks
+        ? ''
+        : ` (below the ${auditLevel} threshold)`;
+    // Without a trail the package came straight off the lock, so anchor there
+    // rather than dropping the result on the floor.
+    const at = finding.location ?? { uri: 'bun.lock', line: 1 };
+    results.push({
+      ruleId: finding.id,
+      level: blocks ? 'error' : 'note',
+      message: {
+        text: `${finding.name} ${finding.vulnerableVersions}: ${finding.title}${why}. Reached via ${finding.paths[0] ?? 'bun.lock'}.`,
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: { uri: at.uri },
+            region: { startLine: at.line },
+          },
+        },
+      ],
+    });
+  }
+  return {
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    version: '2.1.0',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'shipped-advisories',
+            informationUri: 'https://github.com/eigenpal/docx-editor/blob/main/scripts/check-shipped-advisories.mjs',
+            rules: [...rules.values()],
+          },
+        },
+        results,
+      },
+    ],
+  };
+}
+
+if (sarifPath) {
+  writeFileSync(sarifPath, `${JSON.stringify(buildSarif(), null, 2)}\n`);
+}
 
 if (asJson) {
   console.log(JSON.stringify({ auditLevel, packages: shipped.size, findings, expired }, null, 2));

--- a/scripts/check-shipped-advisories.mjs
+++ b/scripts/check-shipped-advisories.mjs
@@ -1,0 +1,275 @@
+// Advisory gate for the dependency closure we actually ship.
+//
+// `bun audit` reads the whole workspace lock: ~2485 packages, most of them build
+// tooling and demo apps. When this landed it reported 96 advisories, and every
+// one traced to a devDependency or to examples/. Gating on that number fails the
+// build on day one for CVEs no consumer can reach. A gate that is red on day one
+// gets ignored, and then deleted.
+//
+// A consumer installs a published package and gets its `dependencies`,
+// transitively. That closure is what this script resolves and checks, at the
+// versions pinned in bun.lock.
+//
+// Deliberately out of scope:
+//   - devDependencies. They never leave CI.
+//   - examples/*. Demos, never published.
+//   - private packages (vue, nuxt today). Not published, so not shipped.
+//   - peerDependencies (react, react-dom, vue, pdf-lib, yjs). The consumer
+//     installs and upgrades those; we only declare a range. Listed, never gated.
+//
+// GitHub's own Dependabot alerts do NOT cover this closure. GitHub cannot parse
+// bun.lock, so the dependency graph sees direct manifest entries only (185 of
+// 2485). Transitive CVEs raise no alert. That gap is why this script exists.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const IGNORE_FILE = join(ROOT, 'scripts', 'shipped-advisories-ignore.json');
+const BULK_ENDPOINT = 'https://registry.npmjs.org/-/npm/v1/security/advisories/bulk';
+
+/** Lowest severity that fails the run. Everything found is printed regardless. */
+const SEVERITY_ORDER = ['info', 'low', 'moderate', 'high', 'critical'];
+const DEFAULT_AUDIT_LEVEL = 'moderate';
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const levelArg = args.find((a) => a.startsWith('--audit-level='))?.split('=')[1];
+const auditLevel = levelArg ?? DEFAULT_AUDIT_LEVEL;
+if (!SEVERITY_ORDER.includes(auditLevel)) {
+  console.error(`Unknown --audit-level=${auditLevel}. Use one of: ${SEVERITY_ORDER.join(', ')}`);
+  process.exit(2);
+}
+
+/**
+ * bun.lock is JSONC: it carries trailing commas. It has no comments, and every
+ * string value is a package name, a version, or a base64 hash, so no string can
+ * contain the `,}` / `,]` pair this strips.
+ */
+function parseBunLock(text) {
+  return JSON.parse(text.replace(/,(\s*[}\]])/g, '$1'));
+}
+
+/** Split a lock key into node_modules segments, keeping `@scope/name` whole. */
+function splitKey(key) {
+  const parts = key.split('/');
+  const segments = [];
+  for (let i = 0; i < parts.length; i += 1) {
+    if (parts[i].startsWith('@') && i + 1 < parts.length) {
+      segments.push(`${parts[i]}/${parts[i + 1]}`);
+      i += 1;
+    } else {
+      segments.push(parts[i]);
+    }
+  }
+  return segments;
+}
+
+/**
+ * Node resolution over the hoisted lock: try the nested copy first, then walk up
+ * one directory at a time, then the hoisted root.
+ */
+function resolveDependency(packages, fromKey, name) {
+  const segments = fromKey ? splitKey(fromKey) : [];
+  for (let depth = segments.length; depth >= 0; depth -= 1) {
+    const candidate = [...segments.slice(0, depth), name].join('/');
+    if (packages[candidate]) return candidate;
+  }
+  return null;
+}
+
+/** `@scope/name@1.2.3` -> `1.2.3`; workspace entries have no resolvable version. */
+function versionOf(descriptor) {
+  const at = descriptor.lastIndexOf('@');
+  if (at <= 0) return null;
+  const version = descriptor.slice(at + 1);
+  return version.startsWith('workspace:') ? null : version;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+// --- The published surface -------------------------------------------------
+
+const packagesDir = join(ROOT, 'packages');
+const manifests = readdirSync(packagesDir)
+  .map((dir) => join(packagesDir, dir, 'package.json'))
+  .filter((path) => existsSync(path))
+  .map((path) => readJson(path));
+
+const published = manifests.filter((m) => m.private !== true);
+const publishedNames = new Set(published.map((m) => m.name));
+const byName = new Map(manifests.map((m) => [m.name, m]));
+
+const lock = parseBunLock(readFileSync(join(ROOT, 'bun.lock'), 'utf8'));
+const packages = lock.packages ?? {};
+
+// --- Resolve the shipped closure -------------------------------------------
+
+/** name@version -> Set of human-readable paths that reach it. */
+const shipped = new Map();
+const declaredPeers = new Map();
+const unresolved = [];
+
+/** Walk `dependencies` only. Peers are the consumer's; dev never ships. */
+function walk(lockKey, trail) {
+  const entry = packages[lockKey];
+  if (!entry) return;
+  const descriptor = entry[0];
+  const version = versionOf(descriptor);
+  if (!version) return;
+  const meta = entry[2] ?? {};
+  // The descriptor is the authority on the name; the lock key is a hoist path.
+  const marker = `${descriptor.slice(0, descriptor.lastIndexOf('@'))}@${version}`;
+  const seen = shipped.get(marker);
+  if (seen) {
+    seen.add(trail);
+    return;
+  }
+  shipped.set(marker, new Set([trail]));
+  for (const dep of Object.keys({ ...meta.dependencies, ...meta.optionalDependencies })) {
+    const next = resolveDependency(packages, lockKey, dep);
+    if (!next) {
+      unresolved.push(`${trail} > ${dep}`);
+      continue;
+    }
+    walk(next, `${trail} > ${dep}`);
+  }
+}
+
+for (const manifest of published) {
+  for (const [dep] of Object.entries(manifest.peerDependencies ?? {})) {
+    if (publishedNames.has(dep)) continue;
+    if (!declaredPeers.has(dep)) declaredPeers.set(dep, new Set());
+    declaredPeers.get(dep).add(manifest.name);
+  }
+}
+
+/** Internal packages are seeded from their own manifest, never from the lock. */
+const seededWorkspaces = new Set();
+function seedWorkspace(manifest, trail) {
+  if (seededWorkspaces.has(manifest.name)) return;
+  seededWorkspaces.add(manifest.name);
+  for (const dep of Object.keys(manifest.dependencies ?? {})) {
+    const internal = byName.get(dep);
+    if (internal) {
+      seedWorkspace(internal, `${trail} > ${dep}`);
+      continue;
+    }
+    const key = resolveDependency(packages, manifest.name, dep);
+    if (!key) {
+      unresolved.push(`${trail} > ${dep}`);
+      continue;
+    }
+    walk(key, `${trail} > ${dep}`);
+  }
+}
+
+for (const manifest of published) seedWorkspace(manifest, manifest.name);
+
+if (unresolved.length > 0) {
+  console.error('Could not resolve these shipped dependencies against bun.lock:');
+  for (const path of unresolved) console.error(`  ${path}`);
+  console.error('\nRun `bun install` to refresh the lockfile, then retry.');
+  process.exit(2);
+}
+
+// --- Query the advisory database -------------------------------------------
+
+const query = {};
+for (const marker of shipped.keys()) {
+  const at = marker.lastIndexOf('@');
+  const name = marker.slice(0, at);
+  (query[name] ??= []).push(marker.slice(at + 1));
+}
+
+let advisories;
+try {
+  const response = await fetch(BULK_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(query),
+  });
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+  advisories = await response.json();
+} catch (error) {
+  // A security gate that passes when it cannot reach the database is worthless.
+  console.error(`Could not reach the npm advisory database: ${error.message}`);
+  process.exit(2);
+}
+
+// --- Apply the ignore list --------------------------------------------------
+
+const ignoreFile = existsSync(IGNORE_FILE) ? readJson(IGNORE_FILE) : { ignore: [] };
+const today = new Date().toISOString().slice(0, 10);
+const ignoreById = new Map();
+const expired = [];
+for (const rule of ignoreFile.ignore ?? []) {
+  if (rule.expires && rule.expires < today) {
+    expired.push(rule);
+    continue;
+  }
+  ignoreById.set(rule.id, rule);
+}
+
+/** All trails that reach any version of a package, for the "via" lines. */
+const trailsByName = new Map();
+for (const [marker, trails] of shipped) {
+  const name = marker.slice(0, marker.lastIndexOf('@'));
+  const merged = trailsByName.get(name) ?? new Set();
+  for (const trail of trails) merged.add(trail);
+  trailsByName.set(name, merged);
+}
+
+const findings = [];
+for (const [name, list] of Object.entries(advisories)) {
+  for (const advisory of list) {
+    const id = advisory.github_advisory_id ?? advisory.url?.split('/').pop() ?? String(advisory.id);
+    findings.push({
+      name,
+      id,
+      severity: advisory.severity ?? 'info',
+      title: advisory.title,
+      url: advisory.url,
+      vulnerableVersions: advisory.vulnerable_versions,
+      ignored: ignoreById.has(id),
+      paths: [...(trailsByName.get(name) ?? [])].slice(0, 3),
+    });
+  }
+}
+findings.sort((a, b) => SEVERITY_ORDER.indexOf(b.severity) - SEVERITY_ORDER.indexOf(a.severity));
+
+const threshold = SEVERITY_ORDER.indexOf(auditLevel);
+const blocking = findings.filter(
+  (f) => !f.ignored && SEVERITY_ORDER.indexOf(f.severity) >= threshold,
+);
+
+if (asJson) {
+  console.log(JSON.stringify({ auditLevel, packages: shipped.size, findings, expired }, null, 2));
+} else {
+  console.log(`Shipped closure: ${shipped.size} packages from ${published.length} published packages.`);
+  console.log(`Peers left to the consumer: ${[...declaredPeers.keys()].join(', ') || 'none'}`);
+  console.log(`Audit level: ${auditLevel} and above fails.\n`);
+
+  for (const finding of findings) {
+    const tag = finding.ignored ? 'IGNORED' : SEVERITY_ORDER.indexOf(finding.severity) >= threshold ? 'FAIL' : 'below';
+    console.log(`${tag.padEnd(8)} ${finding.severity.padEnd(9)} ${finding.name}  ${finding.id}`);
+    console.log(`         ${finding.title}`);
+    console.log(`         affects ${finding.vulnerableVersions} — ${finding.url}`);
+    for (const path of finding.paths) console.log(`         via ${path}`);
+  }
+
+  if (findings.length === 0) console.log('No advisories against any shipped dependency.');
+
+  for (const rule of expired) {
+    console.error(`\nExpired ignore for ${rule.id} (expired ${rule.expires}). Re-review it or extend the date.`);
+  }
+}
+
+if (expired.length > 0) process.exit(1);
+if (blocking.length > 0) {
+  console.error(`\n${blocking.length} advisory/advisories at or above ${auditLevel} in shipped dependencies.`);
+  process.exit(1);
+}

--- a/scripts/shipped-advisories-ignore.json
+++ b/scripts/shipped-advisories-ignore.json
@@ -1,0 +1,16 @@
+{
+  "$comment": [
+    "Accepted advisories for scripts/check-shipped-advisories.mjs.",
+    "",
+    "Add an entry only when the advisory is genuinely unreachable from how we use",
+    "the package, or when no patched version exists yet. Write the reason for a",
+    "reader who does not already know the code.",
+    "",
+    "`expires` is required and the gate fails once the date passes. That is the",
+    "point: an accepted risk gets re-reviewed, never silently inherited. Use a",
+    "short window (a release cycle or two), not a year.",
+    "",
+    "Shape: { id, package, reason, expires } with expires as YYYY-MM-DD."
+  ],
+  "ignore": []
+}


### PR DESCRIPTION
GitHub cannot parse `bun.lock`, so the dependency graph sees 185 of 2485 packages and transitive CVEs raise no Dependabot alert. `bun audit` has the opposite problem: it reads the whole workspace lock, so its 96 current advisories are all devDependencies or `examples/`, and gating on that number would be red on day one.

`scripts/check-shipped-advisories.mjs` resolves the closure a consumer actually installs, from the six published packages' `dependencies` through `bun.lock`, and checks only that. 64 packages today, zero advisories. Peers are listed, never gated.

Runs as its own job in `ci.yml` with no `bun install`, and as a step in `dependabot-lockfile.yml` after the lockfile refresh, since `ci.yml` skips Dependabot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789587851&installation_model_id=422592&pr_number=306&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F306&signature=7e7f2186591b276ddd81e9554be6fce7a983b24fa329f5d10f5bda96968e4eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->