### PR TITLE
fix(core): hash every published field of a fragment

### DIFF
--- a/.changeset/fragment-signature-every-published-field.md
+++ b/.changeset/fragment-signature-every-published-field.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
-Accepting, rejecting or reassigning a tracked change on a paragraph mark now reaches the page instead of leaving the old attribution drawn, and every field a fragment publishes takes part in incremental layout reuse. A mark inside a table cell is unchanged, because layout does not publish its revision yet.
+Tracked changes on a paragraph mark now reach the page: both halves of an insert-then-delete pair are read instead of the first, a mark inside a table cell is drawn at all, the margin gets its change bar, and a resolved view draws no attribution. Renumbering a footnote and any field a fragment publishes now take part in incremental layout reuse, so a page that was reused no longer shows a value the document has moved past.

--- a/.changeset/fragment-signature-every-published-field.md
+++ b/.changeset/fragment-signature-every-published-field.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-Tracked changes on a paragraph mark now reach the page: both decisions on a mark are read instead of the first, a mark inside a table cell is drawn, the margin gets its change bar, and a resolved view draws no attribution. Renumbering a list or a footnote, and every field a fragment publishes, now take part in incremental layout reuse, so a reused page no longer shows a value the document has moved past.
+Tracked changes on a paragraph mark now reach the page and the review pane: every decision on a mark is read rather than the first, a paragraph moved whole raises a card and resolves, a format change on the mark is published, a mark inside a table cell is drawn, the margin gets its change bar, and a resolved view draws no attribution. Renumbering a list or a footnote, and every field a fragment publishes, now take part in incremental layout reuse, so a reused page no longer shows a value the document has moved past.

--- a/.changeset/fragment-signature-every-published-field.md
+++ b/.changeset/fragment-signature-every-published-field.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Accepting, rejecting or reassigning a tracked change on a paragraph mark now reaches the page instead of leaving the old attribution drawn, and every field a fragment publishes takes part in incremental layout reuse. A mark inside a table cell is unchanged, because layout does not publish its revision yet.

--- a/.changeset/fragment-signature-every-published-field.md
+++ b/.changeset/fragment-signature-every-published-field.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-Tracked changes on a paragraph mark now reach the page: both halves of an insert-then-delete pair are read instead of the first, a mark inside a table cell is drawn at all, the margin gets its change bar, and a resolved view draws no attribution. Renumbering a footnote and any field a fragment publishes now take part in incremental layout reuse, so a page that was reused no longer shows a value the document has moved past.
+Tracked changes on a paragraph mark now reach the page: both decisions on a mark are read instead of the first, a mark inside a table cell is drawn, the margin gets its change bar, and a resolved view draws no attribution. Renumbering a list or a footnote, and every field a fragment publishes, now take part in incremental layout reuse, so a reused page no longer shows a value the document has moved past.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1284,6 +1284,9 @@ export interface ListMarkerRecord {
 export type ListSuffix = 'tab' | 'space' | 'nothing';
 
 // @public
+export function markRevisionRemovesMark(revision: RevisionAttribution): boolean;
+
+// @public
 export interface MaterializationInput {
     // (undocumented)
     readonly layout: SemanticLayout;
@@ -1749,6 +1752,7 @@ export interface ParagraphFragmentRecord {
     // (undocumented)
     readonly lines: readonly LineRecord[];
     readonly marker?: ListMarkerRecord;
+    readonly markFormatRevision?: RevisionAttribution;
     // @deprecated
     readonly markRevision?: RevisionAttribution;
     readonly markRevisions?: readonly RevisionAttribution[];
@@ -1858,6 +1862,9 @@ export function paragraphLineSpacing(props: readonly OoxmlProperty[]): Paragraph
 
 // @public
 export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean;
+
+// @public
+export function paragraphMarkFormatRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null;
 
 // @public @deprecated
 export function paragraphMarkRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1859,7 +1859,7 @@ export function paragraphLineSpacing(props: readonly OoxmlProperty[]): Paragraph
 // @public
 export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean;
 
-// @public @deprecated (undocumented)
+// @public @deprecated
 export function paragraphMarkRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null;
 
 // @public

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1749,7 +1749,9 @@ export interface ParagraphFragmentRecord {
     // (undocumented)
     readonly lines: readonly LineRecord[];
     readonly marker?: ListMarkerRecord;
+    // @deprecated
     readonly markRevision?: RevisionAttribution;
+    readonly markRevisions?: readonly RevisionAttribution[];
     // (undocumented)
     readonly paragraphId: string;
     // (undocumented)
@@ -1857,8 +1859,11 @@ export function paragraphLineSpacing(props: readonly OoxmlProperty[]): Paragraph
 // @public
 export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean;
 
-// @public
+// @public @deprecated (undocumented)
 export function paragraphMarkRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null;
+
+// @public
+export function paragraphMarkRevisionsOf(paragraph: OoxmlNode): readonly RevisionAttribution[];
 
 // @public
 export function paragraphOrderOfPart(part: OoxmlPart): ReadonlyMap<string, number>;
@@ -2800,6 +2805,9 @@ export interface ShapingEnvironmentInput {
     // (undocumented)
     readonly variationAxes: Readonly<Record<string, number>>;
 }
+
+// @public
+export function shownMarkRevision(revisions: readonly RevisionAttribution[]): RevisionAttribution | undefined;
 
 // @public
 export const SINGLE_LINE_SPACING: ParagraphLineSpacing;

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -52,11 +52,19 @@ export function Reviewer({ bytes }: { bytes: Uint8Array }) {
 The revision model covers more than inline text:
 
 - **Text** insertions and deletions, including replacements: one card, the way Word presents it.
-- **Paragraph structure**: inserted and deleted paragraph marks, paragraph property changes.
+- **Paragraph structure**: inserted and deleted paragraph marks, paragraph property changes. A
+  changed mark shows as a coloured pilcrow with a change bar in the margin, wherever the
+  paragraph is, table cells included. One mark can hold two decisions at once — one author
+  inserted the break, the next proposed removing it — and both are offered.
 - **Tables**: row and cell insert and delete, plus row, cell, and table property changes.
 - **Formatting**: run and paragraph property changes, as their own cards.
 
 All of these round-trip as real OOXML revisions, not editor-private state.
+
+Attribution is drawn in **All Markup** only, as Word draws it. The resolved views answer what
+the document would be once every decision is taken, so they show no colours, no pilcrows and no
+change bars — but they still show the paragraph break itself, rather than merging the two
+paragraphs the way accepting the change would.
 
 ## The review sidebar
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -745,7 +745,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'A full revision model, including structural changes to paragraph breaks, paragraph properties, and table rows and cells. A tracked insert or delete around a field result paints as tracked, not as ordinary text. The output opens cleanly in Word’s review pane.',
+      'A full revision model, including structural changes to paragraph breaks, paragraph properties, and table rows and cells. A change to a paragraph mark draws a pilcrow and a change bar wherever the paragraph is, table cells included, and a mark that one author inserted and another proposed removing carries both decisions. A tracked insert or delete around a field result paints as tracked, not as ordinary text. Attribution is drawn in All Markup only, as in Word; the resolved views drop the attribution but still show the paragraph break itself. The output opens cleanly in Word’s review pane.',
     docsLink: '/docs/2.x/pro/tracked-changes',
   },
   {

--- a/packages/core/src/layout/__tests__/anchor-defer-reuse.test.ts
+++ b/packages/core/src/layout/__tests__/anchor-defer-reuse.test.ts
@@ -1,0 +1,134 @@
+// Overlap resolution can push an anchored drawing onto the NEXT page. Until that debt is paid
+// it is flow state, exactly like the cursor and the open page's fragments — and it was the one
+// piece of flow state a checkpoint did not carry. A resume started with an empty list, and a
+// convergence called a flow that still owed the next page two drawings equal to one that owed
+// it nothing, so the drawings left the document.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  WML_NAMESPACE_URI,
+  readOoxmlPart,
+  type OoxmlPart,
+} from '../../store/package/ooxml-tree.ts';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import type { ImageResourceState } from '../../store/package/image-resources.ts';
+import type { InlineDrawingLayoutContext } from '../drawing-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import type { PageGeometry, SemanticLayout } from '../semantic-records.ts';
+
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const OWNER = '/word/document.xml';
+const measurer = createFixedMeasurer(6, 14);
+
+const GEOMETRY: PageGeometry = {
+  width: 300,
+  height: 300,
+  margin: { top: 20, right: 20, bottom: 20, left: 20 },
+};
+
+const READY: ImageResourceState = Object.freeze({
+  kind: 'ready',
+  partName: '/word/media/image1.png',
+  contentId: 'image1',
+  resourceKey: 'k1',
+  mime: 'image/png',
+  pixelWidth: 100,
+  pixelHeight: 100,
+  dpiX: 96,
+  dpiY: 96,
+});
+
+/**
+ * Anchors that MUST NOT overlap, all pinned to the same offset down the page.
+ *
+ * `allowOverlap="0"` (§20.4.2.3) is what makes displacement run: each one is pushed below the
+ * last, and the ones that no longer fit are deferred to the next page.
+ */
+function anchor(index: number): string {
+  return (
+    '<w:p><w:r><w:drawing>' +
+    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0"' +
+    ` allowOverlap="0" layoutInCell="1" relativeHeight="${index + 1}">` +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="page"><wp:posOffset>457200</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="1828800" cy="914400"/>' +
+    '<wp:wrapNone/>' +
+    `<wp:docPr id="${index + 1}" name="pic${index + 1}"/>` +
+    `<a:graphic><a:graphicData uri="${PIC}"><pic:pic><pic:nvPicPr>` +
+    `<pic:cNvPr id="${index + 1}" name=""/><pic:cNvPicPr/></pic:nvPicPr>` +
+    '<pic:blipFill><a:blip r:embed="rId1"/><a:srcRect/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+    '<pic:spPr><a:xfrm><a:ext cx="1828800" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
+    '</pic:pic></a:graphicData></a:graphic></wp:anchor></w:drawing></w:r></w:p>'
+  );
+}
+
+const document = (bodyText: string): string =>
+  `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"><w:body>` +
+  Array.from({ length: 6 }, (_, index) => anchor(index)).join('') +
+  Array.from(
+    { length: 30 },
+    (_, index) =>
+      `<w:p><w:r><w:t>${index === 12 ? bodyText : 'body'} ${index} ${'word '.repeat(8)}</w:t></w:r></w:p>`
+  ).join('') +
+  '</w:body></w:document>';
+
+function load(xml: string): OoxmlPart {
+  const result = readOoxmlPart(xml, {
+    name: OWNER,
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function context(part: OoxmlPart): InlineDrawingLayoutContext {
+  const projections = indexInlineDrawingProjectionsInPart(part);
+  return {
+    ownerPartName: OWNER,
+    projectionForAtom: (atomId) => projections.get(atomId) ?? null,
+    project: (node) =>
+      projections.get(node.id) ??
+      projectDrawing(node, { ownerPartName: OWNER, limits: DEFAULT_DRAWING_PROJECTION_LIMITS }),
+    resourceOf: () => READY,
+  };
+}
+
+function lay(part: OoxmlPart, session?: ReturnType<typeof createLayoutSession>): SemanticLayout {
+  return layoutSemanticDocument(part, 1, {
+    measurer,
+    geometry: GEOMETRY,
+    inlineDrawingLayout: context(part),
+    ...(session ? { session } : {}),
+  });
+}
+
+/** Where the drawings ended up, page by page — the thing a deferral moves. */
+const anchoredPerPage = (layout: SemanticLayout): number[] =>
+  layout.pages.map((page) => page.anchoredDrawings?.length ?? 0);
+
+describe('a deferred anchored drawing survives an incremental pass', () => {
+  test('an edit above the deferral gives the same drawings as a full pass', () => {
+    const session = createLayoutSession();
+    const first = lay(load(document('body')), session);
+    // Deferral has to be real, or the test proves nothing: some drawings must have been
+    // pushed off the page they were anchored to.
+    expect(first.pages.length).toBeGreaterThan(1);
+    expect(
+      anchoredPerPage(first)
+        .slice(1)
+        .reduce((sum, count) => sum + count, 0)
+    ).toBeGreaterThan(0);
+
+    const edited = load(document('edited'));
+    expect(anchoredPerPage(lay(edited, session))).toEqual(anchoredPerPage(lay(edited)));
+  });
+});

--- a/packages/core/src/layout/__tests__/incremental-semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/incremental-semantic-layout.test.ts
@@ -19,7 +19,11 @@ import {
   type SemanticLayout,
 } from '../index.ts';
 import { fragmentSignature, sameFragments } from '../semantic-fragment-signature.ts';
-import type { BlockFragmentRecord } from '../semantic-records.ts';
+import type {
+  BlockFragmentRecord,
+  LineRecord,
+  ParagraphFragmentRecord,
+} from '../semantic-records.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -315,4 +319,124 @@ describe('the cache and the session compose (tasks 9.2, 9.3)', () => {
     expect(sameFragments([pending], [samePending])).toBe(true);
     expect(sameFragments([pending], [ready])).toBe(false);
   });
+});
+
+// Convergence restores the previous pass's open page verbatim, so a published field the
+// signature does not carry comes back at its pre-edit value. Each case below is a state
+// transition that moves ONE field and no geometry, which is exactly what makes it invisible
+// to a hand-written field list.
+describe('every published field of a fragment participates in its signature', () => {
+  const openPageFragment = (): ParagraphFragmentRecord => {
+    const fragment = lay(load(paragraph('open page')), 1).pages[0]!.fragments[0]!;
+    if (fragment.kind !== 'paragraph') throw new Error('expected a paragraph fragment');
+    return fragment;
+  };
+
+  const withFirstLine = (
+    fragment: ParagraphFragmentRecord,
+    patch: Partial<LineRecord>
+  ): ParagraphFragmentRecord => ({
+    ...fragment,
+    lines: fragment.lines.map((line, index) => (index === 0 ? { ...line, ...patch } : line)),
+  });
+
+  // `lines.drawings` belongs to this set too; the pending → ready transition has its own
+  // test above, which arrived with the document that reproduced it.
+  const TRANSITIONS: readonly [
+    string,
+    (base: ParagraphFragmentRecord) => ParagraphFragmentRecord,
+  ][] = [
+    [
+      'accepting the tracked revision on the paragraph mark',
+      (base) => ({
+        ...base,
+        markRevision: { kind: 'insert', id: '7', author: 'A', nodeId: 'revision-7' },
+      }),
+    ],
+    [
+      'a line-spacing rule moving the space above the glyph band',
+      (base) => withFirstLine(base, { leading: base.lines[0]!.leading + 1 }),
+    ],
+    [
+      'a line-spacing rule moving the space below the glyph band',
+      (base) => withFirstLine(base, { trailingSpacing: (base.lines[0]!.trailingSpacing ?? 0) + 1 }),
+    ],
+    [
+      'a deletion the caret must step over appearing on the line',
+      (base) =>
+        withFirstLine(base, {
+          deletedRanges: [{ start: 0, end: 1 }],
+        }),
+    ],
+    [
+      'the model range a line covers moving under equal geometry',
+      (base) =>
+        withFirstLine(base, {
+          range: { ...base.lines[0]!.range, end: base.lines[0]!.range.end + 1 },
+        }),
+    ],
+  ];
+
+  for (const [name, vary] of TRANSITIONS) {
+    test(`${name} changes the signature`, () => {
+      const base = openPageFragment();
+      const moved = vary(base);
+      expect(fragmentSignature(moved)).not.toBe(fragmentSignature(base));
+      expect(sameFragments([base], [moved])).toBe(false);
+    });
+  }
+
+  test('a rebuilt fragment with no change keeps its signature', () => {
+    const base = openPageFragment();
+    const rebuilt: ParagraphFragmentRecord = {
+      ...base,
+      lines: base.lines.map((line) => ({ ...line })),
+    };
+    expect(fragmentSignature(rebuilt)).toBe(fragmentSignature(base));
+    expect(sameFragments([base], [rebuilt])).toBe(true);
+  });
+});
+
+// The review decisions that reach layout as a paragraph-MARK edit. Each rewrites
+// `w:pPr/w:rPr/w:ins|w:del` and moves nothing else a page publishes: the pilcrow keeps its
+// place, the text keeps its metrics, and `props` still reads the one `rPr` it read before.
+// So the fragment signature was the only thing standing between the decision and a page that
+// kept drawing the old attribution.
+describe('a tracked paragraph mark reaches the incremental layout', () => {
+  const TARGET = paragraph('paragraph 12 word word word word word word ');
+  const marked = (rPr: string) =>
+    paragraph('paragraph 12 word word word word word word ', `<w:rPr>${rPr}</w:rPr>`);
+
+  /** Every published field of every page, so a stale one anywhere fails the comparison. */
+  const publishedShapeOf = (layout: SemanticLayout): string => JSON.stringify(layout.pages);
+
+  // `CT_ParaRPr` is a SEQUENCE with `EG_ParaRPrTrackChanges` (`ins? del? moveFrom? moveTo?`)
+  // ahead of `EG_RPrBase`, which is why the mark's revision precedes its `w:b` here and in
+  // `CT_RPR_SEQUENCE` (store/store/tree-op-properties.ts). A fixture in the other order is a
+  // document Word calls damaged, and this reader would accept it and hide that.
+  const DECISIONS: readonly [string, string, string][] = [
+    [
+      'accepting an insertion whose mark keeps its other run properties',
+      '<w:ins w:id="7" w:author="A"/><w:b/>',
+      '<w:b/>',
+    ],
+    ['rejecting a deletion the mark carried', '<w:del w:id="7" w:author="A"/><w:b/>', '<w:b/>'],
+    // Word does not rewrite an author while editing, but two of its own operations produce
+    // exactly this: the Document Inspector under `w:removePersonalInformation`, which
+    // rewrites every `w:author` and leaves `w:id` alone, and Compare or Combine Documents.
+    [
+      'the mark changing hands to another author',
+      '<w:ins w:id="7" w:author="A"/>',
+      '<w:ins w:id="7" w:author="B"/>',
+    ],
+  ];
+
+  for (const [name, before, after] of DECISIONS) {
+    test(`${name} matches a full pass`, () => {
+      const session = createLayoutSession();
+      lay(load(DOCUMENT.replace(TARGET, marked(before))), 1, session);
+      const decided = load(DOCUMENT.replace(TARGET, marked(after)));
+      expect(publishedShapeOf(lay(decided, 2, session))).toBe(publishedShapeOf(lay(decided, 2)));
+    });
+  }
 });

--- a/packages/core/src/layout/__tests__/incremental-semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/incremental-semantic-layout.test.ts
@@ -350,7 +350,7 @@ describe('every published field of a fragment participates in its signature', ()
       'accepting the tracked revision on the paragraph mark',
       (base) => ({
         ...base,
-        markRevision: { kind: 'insert', id: '7', author: 'A', nodeId: 'revision-7' },
+        markRevisions: [{ kind: 'insert', id: '7', author: 'A', nodeId: 'revision-7' }],
       }),
     ],
     [
@@ -421,6 +421,13 @@ describe('a tracked paragraph mark reaches the incremental layout', () => {
       '<w:b/>',
     ],
     ['rejecting a deletion the mark carried', '<w:del w:id="7" w:author="A"/><w:b/>', '<w:b/>'],
+    // The pair `EG_ParaRPrTrackChanges` allows and this engine's own writer emits: B proposes
+    // removing a mark A proposed adding. Both decisions have to reach the page.
+    [
+      'a second author proposing the removal of an inserted mark',
+      '<w:ins w:id="7" w:author="A"/>',
+      '<w:ins w:id="7" w:author="A"/><w:del w:id="8" w:author="B"/>',
+    ],
     // Word does not rewrite an author while editing, but two of its own operations produce
     // exactly this: the Document Inspector under `w:removePersonalInformation`, which
     // rewrites every `w:author` and leaves `w:id` alone, and Compare or Combine Documents.

--- a/packages/core/src/layout/__tests__/list-renumber-reuse.test.ts
+++ b/packages/core/src/layout/__tests__/list-renumber-reuse.test.ts
@@ -1,0 +1,87 @@
+// A list marker is DERIVED — from `numbering.xml` and the counter state, never from the
+// paragraph — so a renumber leaves every paragraph subtree byte-identical. The break-cache key
+// holds the marker's LENGTH on purpose, because only the length can move a line break, which
+// left `1.` becoming `2.` moving no key at all: the unchanged-document exit returned the
+// previous pages whole and the reader kept the old numbering.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession, type LayoutSession } from '../layout-session.ts';
+import { resolveStoryListItems } from '../list-resolve.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+function load(xml: string, name: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const item = (text: string) =>
+  '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+  `<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+const document = () =>
+  load(
+    `<w:document xmlns:w="${W}"><w:body>${item('first')}${item('second')}</w:body></w:document>`,
+    '/word/document.xml'
+  );
+
+/** `w:start` is the one Word writes when a list is told to begin elsewhere (§17.9.25). */
+const numbering = (start: string) =>
+  load(
+    `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">` +
+      `<w:start w:val="${start}"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>` +
+      '</w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>',
+    '/word/numbering.xml'
+  );
+
+function markersOf(
+  part: OoxmlPart,
+  start: string,
+  session?: LayoutSession
+): (string | undefined)[] {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  const paragraphs = body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph'
+  );
+  const listItems = resolveStoryListItems(
+    paragraphs,
+    buildNumberingIndex(numbering(start).root as OoxmlElement),
+    undefined
+  );
+  const layout = layoutSemanticDocument(part, 1, {
+    measurer,
+    listItems,
+    ...(session ? { session } : {}),
+  });
+  return layout.pages
+    .flatMap((page) => page.fragments)
+    .map((fragment) => (fragment.kind === 'paragraph' ? fragment.marker?.text : undefined));
+}
+
+describe('a renumbered list is re-placed, not reused', () => {
+  test('a w:start change reaches an incremental pass', () => {
+    const part = document();
+    const session = createLayoutSession();
+    expect(markersOf(part, '1', session)).toEqual(['1.', '2.']);
+    expect(markersOf(part, '2', session)).toEqual(markersOf(part, '2'));
+    expect(markersOf(part, '2')).toEqual(['2.', '3.']);
+  });
+
+  test('an unchanged list still reuses its pages', () => {
+    // The flow key carries the marker text; it must not carry anything that varies per pass,
+    // or every keystroke in a list document becomes a full pass.
+    const part = document();
+    const session = createLayoutSession();
+    markersOf(part, '1', session);
+    markersOf(part, '1', session);
+    expect(session.stats.placed).toBe(0);
+    expect(session.stats.reusedPages).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/layout/__tests__/note-mark-reuse.test.ts
+++ b/packages/core/src/layout/__tests__/note-mark-reuse.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../store/package/note-properties.ts';
 import { createFixedMeasurer } from '../fixed-measurer.ts';
 import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
 import { layoutSemanticDocument } from '../semantic-layout.ts';
 import { enumerateDocumentSections } from '../section-properties.ts';
 import { layoutSemanticDocumentWithNotes, type NotesLayoutInput } from '../note-pagination.ts';
@@ -63,7 +64,11 @@ function doc(): Uint8Array {
 
 const measurer = createFixedMeasurer();
 
-function layWith(numFmt: string, session?: ReturnType<typeof createLayoutSession>): SemanticLayout {
+function layWith(
+  numFmt: string,
+  session?: ReturnType<typeof createLayoutSession>,
+  cache?: ReturnType<typeof createParagraphLayoutCache>
+): SemanticLayout {
   const loaded = readOoxmlPackage(doc());
   if (!loaded.ok) throw new Error(loaded.reason);
   const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
@@ -84,6 +89,7 @@ function layWith(numFmt: string, session?: ReturnType<typeof createLayoutSession
     measurer,
     geometry: { width: 612, height: 300, margin: { top: 36, right: 36, bottom: 36, left: 36 } },
     ...(session ? { session } : {}),
+    ...(cache ? { cache } : {}),
   };
   return layoutSemanticDocumentWithNotes(part, sections, options as never, notes, (opts) =>
     layoutSemanticDocument(part, 1, opts as never)
@@ -120,6 +126,17 @@ describe('a renumbered note is measured, not just relettered', () => {
     const incremental = layWith('lowerRoman', session);
     expect(citations(incremental)).toEqual(citations(layWith('lowerRoman')));
     expect(citations(incremental)[1]).toEqual({ text: 'ii', w: 10.91, x: 201.82 });
+  });
+
+  test('a numFmt change reaches a warm break cache', () => {
+    // The session is one of TWO caches keyed on this. The paragraph break cache holds the
+    // measured line — citation width included — under a key built from `producer`, and a mark
+    // is derived, so the paragraph's own subtree cannot move when its citation does.
+    const cache = createParagraphLayoutCache();
+    layWith('decimal', undefined, cache);
+    expect(citations(layWith('lowerRoman', undefined, cache))).toEqual(
+      citations(layWith('lowerRoman'))
+    );
   });
 
   test('an unchanged document still resumes', () => {

--- a/packages/core/src/layout/__tests__/note-mark-reuse.test.ts
+++ b/packages/core/src/layout/__tests__/note-mark-reuse.test.ts
@@ -1,0 +1,137 @@
+// A note's displayed mark is DERIVED, so it moves without moving any paragraph subtree.
+// Nothing in a block key or a fragment signature sees it, which leaves the session context
+// as the only thing that can refuse a resume onto pages measured for the old marks.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import { resolveNotesPart } from '../../store/package/note-references.ts';
+import {
+  resolveEndnoteProperties,
+  resolveFootnoteProperties,
+} from '../../store/package/note-properties.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import { enumerateDocumentSections } from '../section-properties.ts';
+import { layoutSemanticDocumentWithNotes, type NotesLayoutInput } from '../note-pagination.ts';
+import type { SemanticLayout } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function doc(): Uint8Array {
+  const paras = Array.from({ length: 8 }, (_, i) =>
+    i === 1
+      ? `<w:p><w:r><w:t>Body ${i} ${'word '.repeat(6)}</w:t><w:footnoteReference w:id="1"/><w:t> tail text</w:t></w:r></w:p>`
+      : i === 3
+        ? `<w:p><w:r><w:t>Body ${i} ${'word '.repeat(6)}</w:t><w:footnoteReference w:id="2"/><w:t> tail text</w:t></w:r></w:p>`
+        : `<w:p><w:r><w:t>Body ${i} ${'word '.repeat(6)}</w:t></w:r></w:p>`
+  ).join('');
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${paras}` +
+        '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/></w:sectPr>' +
+        '</w:body></w:document>'
+    ),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}">` +
+        '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
+        '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>' +
+        '<w:footnote w:id="1"><w:p><w:r><w:t>First note</w:t></w:r></w:p></w:footnote>' +
+        '<w:footnote w:id="2"><w:p><w:r><w:t>Second note</w:t></w:r></w:p></w:footnote>' +
+        '</w:footnotes>'
+    ),
+  });
+}
+
+const measurer = createFixedMeasurer();
+
+function layWith(numFmt: string, session?: ReturnType<typeof createLayoutSession>): SemanticLayout {
+  const loaded = readOoxmlPackage(doc());
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+  const sections = enumerateDocumentSections(part);
+  const fp = resolveFootnoteProperties({ numFmt } as never, undefined);
+  const ep = resolveEndnoteProperties(undefined, undefined);
+  const notes: NotesLayoutInput = {
+    footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+    endnotesPart: null,
+    footnotePropsBySection: sections.map(() => fp),
+    endnotePropsBySection: sections.map(() => ep),
+    documentFootnoteProps: fp,
+    documentEndnoteProps: ep,
+    measurer,
+    producer: 'probe',
+  };
+  const options = {
+    measurer,
+    geometry: { width: 612, height: 300, margin: { top: 36, right: 36, bottom: 36, left: 36 } },
+    ...(session ? { session } : {}),
+  };
+  return layoutSemanticDocumentWithNotes(part, sections, options as never, notes, (opts) =>
+    layoutSemanticDocument(part, 1, opts as never)
+  );
+}
+
+const citations = (l: SemanticLayout) =>
+  l.pages.flatMap((p) =>
+    p.fragments.flatMap((f) =>
+      f.kind === 'paragraph'
+        ? f.lines.flatMap((line) =>
+            line.spans
+              .filter((s) => s.noteNav?.direction === 'to-note')
+              .map((s) => ({
+                text: s.text,
+                w: Number(s.box.width.toFixed(2)),
+                x: Number(s.box.x.toFixed(2)),
+              }))
+          )
+        : []
+    )
+  );
+
+describe('a renumbered note is measured, not just relettered', () => {
+  test('a numFmt change reaches an incremental pass', () => {
+    // `1` and `2` are one glyph each; `i` is one and `ii` is two. Reprojection rewrites the
+    // display text on any pass, so the digits alone prove nothing — the width is what tells
+    // a resumed page from a fresh one, and every span after the citation rides on it.
+    const session = createLayoutSession();
+    expect(citations(layWith('decimal', session))).toEqual([
+      { text: '1', w: 5.45, x: 201.82 },
+      { text: '2', w: 5.45, x: 201.82 },
+    ]);
+    const incremental = layWith('lowerRoman', session);
+    expect(citations(incremental)).toEqual(citations(layWith('lowerRoman')));
+    expect(citations(incremental)[1]).toEqual({ text: 'ii', w: 10.91, x: 201.82 });
+  });
+
+  test('an unchanged document still resumes', () => {
+    // The token has to be STABLE, not merely complete: it is rebuilt from a new map every
+    // pass, so a token that varied with allocation would turn every keystroke into a full
+    // pass and pay for this fix with the whole of incremental layout.
+    const session = createLayoutSession();
+    layWith('decimal', session);
+    const before = session.stats.fullPasses;
+    layWith('decimal', session);
+    expect(session.stats.placed).toBe(0);
+    expect(session.stats.reusedPages).toBeGreaterThan(0);
+    expect(session.stats.fullPasses).toBe(before);
+  });
+});

--- a/packages/core/src/layout/__tests__/page-record-reuse-guard.test.ts
+++ b/packages/core/src/layout/__tests__/page-record-reuse-guard.test.ts
@@ -40,8 +40,10 @@ describe('every field of a reused page has a named guard', () => {
       '<w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>' +
       '<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
     const body =
-      Array.from({ length: 24 }, (_, index) => `<w:p><w:r><w:t>page ${index}</w:t></w:r></w:p>`)
-        .join('') +
+      Array.from(
+        { length: 24 },
+        (_, index) => `<w:p><w:r><w:t>page ${index}</w:t></w:r></w:p>`
+      ).join('') +
       table +
       columns;
     const layout = layoutSemanticDocument(load(body), 1, {

--- a/packages/core/src/layout/__tests__/page-record-reuse-guard.test.ts
+++ b/packages/core/src/layout/__tests__/page-record-reuse-guard.test.ts
@@ -30,11 +30,26 @@ function load(body: string): OoxmlPart {
 
 describe('every field of a reused page has a named guard', () => {
   test('a real page publishes nothing the table does not classify', () => {
-    const layout = layoutSemanticDocument(load('<w:p><w:r><w:t>page one</w:t></w:r></w:p>'), 1, {
+    // A plain paragraph publishes barely half the record. This document carries a table, a
+    // column separator and enough content to open a second page, so the optional fields are
+    // present to be checked rather than absent and trivially passing.
+    const columns = '<w:sectPr><w:cols w:num="2" w:sep="1" w:space="360"/></w:sectPr>';
+    const table =
+      '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid><w:tr><w:tc>' +
+      '<w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>' +
+      '<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+    const body =
+      Array.from({ length: 24 }, (_, index) => `<w:p><w:r><w:t>page ${index}</w:t></w:r></w:p>`)
+        .join('') +
+      table +
+      columns;
+    const layout = layoutSemanticDocument(load(body), 1, {
       measurer: createFixedMeasurer(6, 14),
       geometry: GEOMETRY,
     });
-    expect(unguardedPageFields(layout.pages[0]!)).toEqual([]);
+    expect(layout.pages.length).toBeGreaterThan(1);
+    for (const page of layout.pages) expect(unguardedPageFields(page)).toEqual([]);
   });
 
   test('the flow fields are the ones a stopping pass actually compares', () => {

--- a/packages/core/src/layout/__tests__/page-record-reuse-guard.test.ts
+++ b/packages/core/src/layout/__tests__/page-record-reuse-guard.test.ts
@@ -1,0 +1,48 @@
+// A page is reused WHOLE. Convergence appends `previous.pages.slice(...)` and the unchanged
+// exit returns the previous pages by identity, so nothing compares a page field by field the
+// way `fragmentSignature` compares a fragment. Every field is guarded somewhere else instead,
+// and each of those guards is hand-written.
+//
+// This file is that hand-written set, written down. A new field on `PageRecord` is a type
+// error here until somebody says which mechanism keeps it current, because the failure it
+// would otherwise ship is silent: a reused page showing a value the document no longer has.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument, type PageGeometry } from '../index.ts';
+import { PAGE_REUSE_GUARDS, unguardedPageFields } from '../page-reuse-guards.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const GEOMETRY: PageGeometry = {
+  width: 300,
+  height: 120,
+  margin: { top: 10, right: 10, bottom: 10, left: 10 },
+};
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+describe('every field of a reused page has a named guard', () => {
+  test('a real page publishes nothing the table does not classify', () => {
+    const layout = layoutSemanticDocument(load('<w:p><w:r><w:t>page one</w:t></w:r></w:p>'), 1, {
+      measurer: createFixedMeasurer(6, 14),
+      geometry: GEOMETRY,
+    });
+    expect(unguardedPageFields(layout.pages[0]!)).toEqual([]);
+  });
+
+  test('the flow fields are the ones a stopping pass actually compares', () => {
+    // Stated as an assertion rather than a comment, so a field quietly reclassified as
+    // `flow` has to face the comparisons that word implies.
+    const flowFields = Object.entries(PAGE_REUSE_GUARDS)
+      .filter(([, guard]) => guard === 'flow')
+      .map(([field]) => field);
+    expect(flowFields).toEqual(['fragments', 'anchoredDrawings']);
+  });
+});

--- a/packages/core/src/layout/__tests__/paragraph-mark-revisions.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-mark-revisions.test.ts
@@ -1,0 +1,115 @@
+// What a tracked PARAGRAPH MARK publishes, and where.
+//
+// The mark is `w:pPr/w:rPr/w:ins|w:del` (ECMA-376 §17.13.5.20, §17.13.5.15). It decorates no
+// character, so a fragment carries it rather than a span, and nothing else in the layout moves
+// when it changes. Every gap below shipped as silence: a decision a reader could not see.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { paragraphMarkRevisionsOf, type RevisionDisplayMode } from '../revision-projection.ts';
+import type { ParagraphFragmentRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/** Every paragraph fragment on every page, cells included. */
+function paragraphFragments(
+  part: OoxmlPart,
+  mode?: RevisionDisplayMode
+): ParagraphFragmentRecord[] {
+  const layout = layoutSemanticDocument(part, 1, {
+    measurer,
+    ...(mode ? { displayMode: mode } : {}),
+  });
+  const found: ParagraphFragmentRecord[] = [];
+  const walk = (fragments: readonly { kind: string }[]): void => {
+    for (const fragment of fragments) {
+      if (fragment.kind === 'paragraph') found.push(fragment as ParagraphFragmentRecord);
+      if (fragment.kind === 'table') {
+        for (const row of (
+          fragment as {
+            rows: readonly { cells: readonly { blocks: readonly { kind: string }[] }[] }[];
+          }
+        ).rows) {
+          for (const cell of row.cells) walk(cell.blocks);
+        }
+      }
+    }
+  };
+  for (const page of layout.pages) walk(page.fragments);
+  return found;
+}
+
+const MARKED = (rPr: string, text = 'paragraph text') =>
+  `<w:p><w:pPr><w:rPr>${rPr}</w:rPr></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+describe('a paragraph mark can carry more than one decision', () => {
+  test('both halves of an insert-then-delete pair are projected, in file order', () => {
+    // `EG_ParaRPrTrackChanges` is `ins? del? moveFrom? moveTo?`, and this engine's own writer
+    // emits the first two together: B proposing removal of a break A proposed adding. Reading
+    // only the first hid B's decision from the page and from the review pane, and no later
+    // edit could move a field that was never published.
+    const part = load(MARKED('<w:ins w:id="7" w:author="A"/><w:del w:id="8" w:author="B"/>'));
+    const body = part.root.children.find(
+      (child) => child.kind !== 'textValue' && child.localName === 'body'
+    )!;
+    const paragraph = (body as { children: readonly { kind: string }[] }).children.find(
+      (child) => child.kind === 'paragraph'
+    )!;
+    expect(paragraphMarkRevisionsOf(paragraph as never)).toEqual([
+      { kind: 'insert', id: '7', author: 'A', nodeId: expect.any(String) },
+      { kind: 'delete', id: '8', author: 'B', nodeId: expect.any(String) },
+    ]);
+    expect(paragraphFragments(part)[0]?.markRevisions).toHaveLength(2);
+  });
+
+  test('an unmarked paragraph publishes nothing at all', () => {
+    expect(
+      paragraphFragments(load('<w:p><w:r><w:t>plain</w:t></w:r></w:p>'))[0]?.markRevisions
+    ).toBeUndefined();
+  });
+});
+
+describe('a mark inside a table cell is a mark', () => {
+  const CELL_DOC =
+    '<w:tbl><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+    MARKED('<w:del w:id="3" w:author="A"/>', 'cell paragraph') +
+    '</w:tc></w:tr></w:tbl>';
+
+  test('the cell lane publishes it, as the body lane does', () => {
+    // The cell lane builds its own paragraph fragment. It did not write this field, so a
+    // tracked split or merge inside a `w:tc` drew no pilcrow, no margin rule, and raised no
+    // review card — in a document type where tables hold most of the negotiated text.
+    const marks = paragraphFragments(load(CELL_DOC)).flatMap(
+      (fragment) => fragment.markRevisions ?? []
+    );
+    expect(marks).toEqual([{ kind: 'delete', id: '3', author: 'A', nodeId: expect.any(String) }]);
+  });
+});
+
+describe('a resolved view shows no attribution', () => {
+  // Word draws the mark in All Markup only. `proposed` and `original` answer what the document
+  // WOULD be once every decision is taken, and a document that has taken them has nothing left
+  // to attribute.
+  for (const mode of ['proposed', 'original'] as const) {
+    test(`${mode} publishes no mark revision`, () => {
+      const part = load(MARKED('<w:ins w:id="7" w:author="A"/>'));
+      expect(paragraphFragments(part, mode)[0]?.markRevisions).toBeUndefined();
+    });
+  }
+
+  test('all-markup publishes it', () => {
+    const part = load(MARKED('<w:ins w:id="7" w:author="A"/>'));
+    expect(paragraphFragments(part, 'all-markup')[0]?.markRevisions).toHaveLength(1);
+  });
+});

--- a/packages/core/src/layout/__tests__/paragraph-mark-revisions.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-mark-revisions.test.ts
@@ -57,8 +57,8 @@ describe('a paragraph mark can carry more than one decision', () => {
   test('both halves of an insert-then-delete pair are projected, in file order', () => {
     // `EG_ParaRPrTrackChanges` is `ins? del? moveFrom? moveTo?`, and this engine's own writer
     // emits the first two together: B proposing removal of a break A proposed adding. Reading
-    // only the first hid B's decision from the page and from the review pane, and no later
-    // edit could move a field that was never published.
+    // only the first hid B's decision from the PAGE. The review pane reads the tree directly
+    // and always listed both, which is the worse shape: a card for a change nothing showed.
     const part = load(MARKED('<w:ins w:id="7" w:author="A"/><w:del w:id="8" w:author="B"/>'));
     const body = part.root.children.find(
       (child) => child.kind !== 'textValue' && child.localName === 'body'
@@ -81,8 +81,13 @@ describe('a paragraph mark can carry more than one decision', () => {
 });
 
 describe('a mark inside a table cell is a mark', () => {
+  // `CT_Tbl` declares `w:tblPr` without `minOccurs`, so it is required, and Word writes
+  // `w:tcW` on every cell. A fixture the reader happens to accept is still a document Word
+  // would call damaged.
   const CELL_DOC =
-    '<w:tbl><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+    '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+    '<w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>' +
     MARKED('<w:del w:id="3" w:author="A"/>', 'cell paragraph') +
     '</w:tc></w:tr></w:tbl>';
 

--- a/packages/core/src/layout/__tests__/paragraph-mark-revisions.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-mark-revisions.test.ts
@@ -118,3 +118,53 @@ describe('a resolved view shows no attribution', () => {
     expect(paragraphFragments(part, 'all-markup')[0]?.markRevisions).toHaveLength(1);
   });
 });
+
+describe('a moved paragraph carries its mark like any other', () => {
+  // `EG_ParaRPrTrackChanges` is `ins? del? moveFrom? moveTo?`. Word writes `w:moveFrom` on the
+  // mark of the copy the paragraph left and `w:moveTo` on the copy it arrived at, so a move of
+  // whole paragraphs is recorded on the mark and nowhere else.
+  test('both move halves are projected', () => {
+    const from = paragraphFragments(load(MARKED('<w:moveFrom w:id="4" w:author="A"/>')));
+    const to = paragraphFragments(load(MARKED('<w:moveTo w:id="5" w:author="A"/>')));
+    expect(from[0]?.markRevisions).toEqual([
+      { kind: 'moveFrom', id: '4', author: 'A', nodeId: expect.any(String) },
+    ]);
+    expect(to[0]?.markRevisions).toEqual([
+      { kind: 'moveTo', id: '5', author: 'A', nodeId: expect.any(String) },
+    ]);
+  });
+
+  test('the half that REMOVES the mark is the one a single-value reader sees', () => {
+    // `moveFrom` is a removal — accepting the move takes this copy of the break away — so it
+    // must win the same way a deletion does, or the glyph and the margin rule disagree.
+    const both = load(MARKED('<w:ins w:id="6" w:author="A"/><w:moveFrom w:id="4" w:author="B"/>'));
+    expect(paragraphFragments(both)[0]?.markRevision).toMatchObject({
+      kind: 'moveFrom',
+      author: 'B',
+    });
+  });
+});
+
+describe('a format change on the mark reaches the page', () => {
+  // `w:rPrChange` on `w:pPr/w:rPr` (§17.13.5.32) is the mark's own formatting changing under
+  // tracking. It draws no pilcrow — Word draws none either — but it needs geometry, or a
+  // review card has no place on the page to point at.
+  const CHANGED =
+    '<w:p><w:pPr><w:rPr><w:b/>' +
+    '<w:rPrChange w:id="11" w:author="A" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange>' +
+    '</w:rPr></w:pPr><w:r><w:t>paragraph text</w:t></w:r></w:p>';
+
+  test('it is published, with its own provenance', () => {
+    expect(paragraphFragments(load(CHANGED))[0]?.markFormatRevision).toEqual({
+      kind: 'format',
+      id: '11',
+      author: 'A',
+      date: '2026-01-01T00:00:00Z',
+      nodeId: expect.any(String),
+    });
+  });
+
+  test('a resolved view publishes none of it', () => {
+    expect(paragraphFragments(load(CHANGED), 'proposed')[0]?.markFormatRevision).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -392,6 +392,8 @@ export {
   DEFAULT_REVISION_DISPLAY_MODE,
   formatRevisionOf,
   paragraphMarkRevisionOf,
+  paragraphMarkRevisionsOf,
+  shownMarkRevision,
   revisionsAreDeletion,
   revisionsVisible,
   type RevisionAttribution,

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -391,6 +391,8 @@ export {
 export {
   DEFAULT_REVISION_DISPLAY_MODE,
   formatRevisionOf,
+  markRevisionRemovesMark,
+  paragraphMarkFormatRevisionOf,
   paragraphMarkRevisionOf,
   paragraphMarkRevisionsOf,
   shownMarkRevision,

--- a/packages/core/src/layout/layout-session.ts
+++ b/packages/core/src/layout/layout-session.ts
@@ -14,6 +14,17 @@ export interface FlowCheckpoint {
   readonly pageFragments: readonly import('./semantic-records.ts').BlockFragmentRecord[];
   /** Anchored drawings already collected for the open page. */
   readonly pendingAnchoredDrawings: readonly AnchoredDrawingRecord[];
+  /**
+   * Anchored drawings overlap resolution pushed onto the NEXT page, and how many times each
+   * drawing has been pushed.
+   *
+   * Flow state like the rest of this record, and carried for the same reason: a resume that
+   * started with an empty list dropped a drawing that the previous pass had deferred but not
+   * yet placed, and a convergence that did not compare them accepted a flow that still owed
+   * the next page a drawing as equal to one that owed it nothing.
+   */
+  readonly deferredAnchoredDrawings: readonly AnchoredDrawingRecord[];
+  readonly anchorPageDeferCounts: ReadonlyMap<string, number>;
   readonly cursorY: number;
   readonly lineCounter: number;
   /** Trailing paragraph spacing participating in adjacent-spacing collapse. */

--- a/packages/core/src/layout/note-projection.ts
+++ b/packages/core/src/layout/note-projection.ts
@@ -163,23 +163,37 @@ export function noteAtomModelText(): typeof NOTE_ATOM_CHAR {
   return NOTE_ATOM_CHAR;
 }
 
-/** Compact cache token for note-mark identity (bounded; not a full serialization). */
+/**
+ * Cache token for note-mark identity — EVERY mark, not a sample of them.
+ *
+ * The session context this feeds decides whether an incremental pass may resume. A note's
+ * displayed mark is DERIVED (`w:footnotePr/w:numFmt`, `w:numStart`, `w:numRestart`, and the
+ * section overrides of each), so it moves without any paragraph subtree moving with it: no
+ * block key changes, and the pass resumes onto pages measured for the old marks. Body
+ * reprojection then rewrites the display text and deliberately keeps the reserved width, so
+ * the digits update and the geometry stays where the old digits put it — `1` becoming `ii`
+ * kept a one-glyph slot, and every span after it on that line kept its old x.
+ *
+ * Bounding this by count was the same mistake one level down: two documents whose marks
+ * agree for the first N notes and differ after are not the same document. It is memoized on
+ * the context object, so a multi-section pass pays for the walk once rather than per section.
+ */
+const markTokens = new WeakMap<object, string>();
+
 export function noteMarksCacheToken(context: NoteMarkContext | undefined): string {
-  if (!context || context.marks.size === 0) {
-    return context?.reservedMarkText ? `r:${context.reservedMarkText}` : '';
-  }
-  const parts: string[] = [];
-  let n = 0;
-  for (const [key, mark] of context.marks) {
-    if (n >= 64) {
-      parts.push('…');
-      break;
-    }
-    parts.push(`${key}=${mark ?? ''}`);
-    n += 1;
-  }
-  if (context.reservedMarkText) parts.push(`r:${context.reservedMarkText}`);
-  return parts.join(',');
+  if (!context) return '';
+  const cached = markTokens.get(context);
+  if (cached !== undefined) return cached;
+  // Serialized rather than joined with separators: a custom mark (`w:footnoteRef` text) is
+  // author-supplied and may hold any character, and `null` — `customMarkFollows` — is not the
+  // empty mark. Two contexts that differ must not be able to spell the same token.
+  const token = JSON.stringify([
+    [...context.marks],
+    context.reservedMarkText ?? null,
+    context.activeNoteKey ?? null,
+  ]);
+  markTokens.set(context, token);
+  return token;
 }
 
 /** Re-export for callers that already have a note node. */

--- a/packages/core/src/layout/note-projection.ts
+++ b/packages/core/src/layout/note-projection.ts
@@ -29,7 +29,13 @@ import type { OoxmlNode } from '../store/package/ooxml-tree.ts';
  * — fail-open with an empty display (model atom preserved).
  */
 export interface NoteMarkContext {
-  /** scopeId → formatted mark (or null when suppressed). */
+  /**
+   * scopeId → formatted mark (or null when suppressed).
+   *
+   * IMMUTABLE once the context is built. `noteMarksCacheToken` memoizes on the context object
+   * and that token reaches every paragraph's cache key, so a later `marks.set` would pin the
+   * whole document to a token for marks it no longer has.
+   */
   readonly marks: ReadonlyMap<string, string | null>;
   /**
    * When set, every automatic mark measures at least this string's width (eachPage
@@ -163,6 +169,16 @@ export function noteAtomModelText(): typeof NOTE_ATOM_CHAR {
   return NOTE_ATOM_CHAR;
 }
 
+/** FNV-1a over 32 bits, in `Math.imul` arithmetic: no BigInt on a per-pass path. */
+function fnv1a32(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
 /**
  * Cache token for note-mark identity — EVERY mark, not a sample of them.
  *
@@ -186,12 +202,17 @@ export function noteMarksCacheToken(context: NoteMarkContext | undefined): strin
   if (cached !== undefined) return cached;
   // Serialized rather than joined with separators: a custom mark (`w:footnoteRef` text) is
   // author-supplied and may hold any character, and `null` — `customMarkFollows` — is not the
-  // empty mark. Two contexts that differ must not be able to spell the same token.
-  const token = JSON.stringify([
+  // empty mark. Two contexts that differ must not be able to spell the same serialization.
+  const serialized = JSON.stringify([
     [...context.marks],
     context.reservedMarkText ?? null,
     context.activeNoteKey ?? null,
   ]);
+  // HASHED to a constant width, because this reaches the key of every paragraph in the
+  // document, not just the section context. A thousand-note document would otherwise carry
+  // tens of kilobytes into every one of those keys and compare it there. The count rides
+  // along, so two documents would have to collide on both to be mistaken for each other.
+  const token = `${context.marks.size}:${fnv1a32(serialized)}`;
   markTokens.set(context, token);
   return token;
 }

--- a/packages/core/src/layout/page-reuse-guards.ts
+++ b/packages/core/src/layout/page-reuse-guards.ts
@@ -1,0 +1,71 @@
+// What keeps each field of a REUSED page current.
+//
+// A page is reused whole. Convergence appends `previous.pages.slice(...)` and the unchanged
+// exit returns the previous pages by identity, so nothing compares a page field by field the
+// way `fragmentSignature` compares a fragment. Every field is guarded somewhere else instead,
+// and each of those guards is hand-written and lives in a different file.
+//
+// This is that set, written down and type-checked. A new field on `PageRecord` is a type
+// error here until somebody says which mechanism keeps it current, because the failure it
+// would otherwise ship is silent: a reused page showing a value the document no longer has.
+
+import type { PageRecord } from './semantic-records.ts';
+
+/** How a page field stays current across a pass that reuses the page it sits on. */
+export type PageReuseGuard =
+  /** The page's own name in the previous layout; reuse is the point, not a hazard. */
+  | 'identity'
+  /**
+   * Folded into the session `context` string (`semantic-layout.ts`, `const context =`). A
+   * change there makes the session incomparable, so the pass cannot resume at all.
+   */
+  | 'context'
+  /**
+   * Carried by the flow and compared where a pass may stop early: fragments through
+   * `fragmentSignature`, anchored drawings through `sameAnchoredDrawings`, and the blocks
+   * that produce both through their per-block keys.
+   */
+  | 'flow'
+  /** Re-derived over the assembled page list every pass, so a reused page is re-annotated. */
+  | 'rebuilt';
+
+export const PAGE_REUSE_GUARDS = {
+  id: 'identity',
+  index: 'identity',
+  // Page geometry opens the context string, so a margin or sheet change is a full pass by
+  // construction.
+  box: 'context',
+  contentBox: 'context',
+  fragments: 'flow',
+  // `columnsContext` carries `w:cols`, and `resumable` additionally requires a single column,
+  // so a multi-column section never reaches the reuse paths at all.
+  columnSeparators: 'context',
+  // Produced by the blocks on the page: the per-block key carries the drawing token, and the
+  // open page's pending and deferred lists are compared where a pass may stop early.
+  anchoredDrawings: 'flow',
+  // `furnitureContext` folds each variant's flow height, content key and drawing-resource
+  // token, which is what a header or footer edit moves.
+  header: 'context',
+  footer: 'context',
+  // `attachNotesToLayout` rebuilds the note areas over the assembled pages every pass, and
+  // the reserves and every derived mark are in the context besides.
+  footnotes: 'rebuilt',
+  endnotes: 'rebuilt',
+  noteStream: 'rebuilt',
+  // `withPageFieldSources` re-annotates every page every pass, which is what keeps PAGE and
+  // SECTIONPAGES right when only the numbering moved.
+  pageFieldSource: 'rebuilt',
+  // `withContentControlMetadata` re-attaches boundaries, and returns the same array only
+  // when the control-context token matches.
+  contentControls: 'rebuilt',
+} as const satisfies Record<keyof PageRecord, PageReuseGuard>;
+
+/**
+ * Fields a page actually carries that the table above does not classify.
+ *
+ * The `satisfies` clause catches a field added to the INTERFACE. This catches the other
+ * direction — a record built with a key the interface never declared.
+ */
+export function unguardedPageFields(page: PageRecord): readonly string[] {
+  return Object.keys(page).filter((key) => !(key in PAGE_REUSE_GUARDS));
+}

--- a/packages/core/src/layout/page-reuse-guards.ts
+++ b/packages/core/src/layout/page-reuse-guards.ts
@@ -37,8 +37,9 @@ export const PAGE_REUSE_GUARDS = {
   box: 'context',
   contentBox: 'context',
   fragments: 'flow',
-  // `columnsContext` carries `w:cols`, and `resumable` additionally requires a single column,
-  // so a multi-column section never reaches the reuse paths at all.
+  // `columnsContext` carries `w:cols`. Note that a multi-column section DOES reach reuse: the
+  // resume and convergence paths require `resumable`, which is single-column, but the
+  // unchanged-document exit gates on `comparable` and returns the previous pages by identity.
   columnSeparators: 'context',
   // Produced by the blocks on the page: the per-block key carries the drawing token, and the
   // open page's pending and deferred lists are compared where a pass may stop early.
@@ -55,8 +56,8 @@ export const PAGE_REUSE_GUARDS = {
   // `withPageFieldSources` re-annotates every page every pass, which is what keeps PAGE and
   // SECTIONPAGES right when only the numbering moved.
   pageFieldSource: 'rebuilt',
-  // `withContentControlMetadata` re-attaches boundaries, and returns the same array only
-  // when the control-context token matches.
+  // `attachContentControlBoundaries`, from `finish()`, rebuilds the per-page boundaries every
+  // pass and early-returns only on a matching control-context token.
   contentControls: 'rebuilt',
 } as const satisfies Record<keyof PageRecord, PageReuseGuard>;
 

--- a/packages/core/src/layout/pagination-keeps.ts
+++ b/packages/core/src/layout/pagination-keeps.ts
@@ -221,6 +221,32 @@ export function keepNextGroupHeight(
  * paragraph cannot grow a key linear in its own length. Returns the input array unchanged
  * when nothing keeps, which is the overwhelming majority of passes.
  */
+/**
+ * Flow keys that also carry each block's LIST MARKER text.
+ *
+ * The marker is derived from `numbering.xml` and the counter state, not from the paragraph, so
+ * a `w:start`, `w:startOverride` or restart change renumbers a list while every paragraph
+ * subtree stays byte-identical. The break-cache key holds the marker's LENGTH on purpose —
+ * only the length can move a line break — so on its own it let `1.` become `2.` with no key
+ * moving anywhere, and the unchanged-document exit then returned the previous pages whole.
+ *
+ * Separate from the break key for that same reason: renumbering must re-place the blocks
+ * without discarding measurements that are still correct.
+ */
+export function listMarkerFlowKeys(
+  keys: string[],
+  markerAt: (index: number) => string | undefined
+): string[] {
+  let flow = keys;
+  for (let index = 0; index < keys.length; index += 1) {
+    const marker = markerAt(index);
+    if (marker === undefined) continue;
+    if (flow === keys) flow = [...keys];
+    flow[index] = `${flow[index]}~mk~${marker}`;
+  }
+  return flow;
+}
+
 export function keepNextFlowKeys(keys: string[], keepsNext: (index: number) => boolean): string[] {
   let flow = keys;
   let chain = 0;

--- a/packages/core/src/layout/revision-projection.ts
+++ b/packages/core/src/layout/revision-projection.ts
@@ -155,37 +155,87 @@ export function revisionsVisible(
 }
 
 /**
- * The revision on a paragraph's own MARK, from `w:pPr/w:rPr/w:ins|w:del`.
+ * Every revision on a paragraph's own MARK, from `w:pPr/w:rPr/w:ins|w:del`.
  *
  * `EG_ParaRPrTrackChanges` records that the pilcrow itself was inserted or deleted, which is how
  * Word writes a paragraph split or merge. It is not content — there is no text to decorate — so
  * a surface shows it as a mark of its own beside the paragraph, the way Word draws a struck-
  * through ¶.
  *
+ * A LIST, because the group is `ins? del? moveFrom? moveTo?` and the first two can both be
+ * there: that pair is what Word writes when a second author proposes removing a mark the first
+ * proposed adding, and it is what this engine's own writer emits (`tree-op-tracked.ts`).
+ * Answering with the first one hid the second author's decision from every reader and from the
+ * review pane, and no later edit could move a field that was never published.
+ *
+ * Ordered as the file orders them, which is the order the group declares.
+ *
  * Property-position `w:ins`/`w:del` stay `generic` in the tree deliberately, so this reads them
  * by name rather than by kind.
  */
-export function paragraphMarkRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null {
-  if (paragraph.kind === 'textValue') return null;
+export function paragraphMarkRevisionsOf(paragraph: OoxmlNode): readonly RevisionAttribution[] {
+  if (paragraph.kind === 'textValue') return EMPTY_MARK_REVISIONS;
   const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
-  if (!pPr || pPr.kind === 'textValue') return null;
+  if (!pPr || pPr.kind === 'textValue') return EMPTY_MARK_REVISIONS;
   const rPr = pPr.children.find((child) => child.kind === 'runProperties');
-  if (!rPr || rPr.kind === 'textValue') return null;
+  if (!rPr || rPr.kind === 'textValue') return EMPTY_MARK_REVISIONS;
+  const revisions: RevisionAttribution[] = [];
   for (const child of rPr.children) {
     if (child.kind === 'textValue') continue;
     if (child.namespaceUri !== WML_NAMESPACE_URI) continue;
     const kind = child.localName === 'ins' ? 'insert' : child.localName === 'del' ? 'delete' : null;
     if (kind === null) continue;
     const date = attributeValue(child, 'date');
-    return {
+    revisions.push({
       kind,
       id: attributeValue(child, 'id') ?? '',
       author: attributeValue(child, 'author') ?? '',
       ...(date === undefined ? {} : { date }),
       nodeId: child.id,
-    };
+    });
   }
-  return null;
+  return revisions.length > 0 ? revisions : EMPTY_MARK_REVISIONS;
+}
+
+/** One shared empty, so an unmarked paragraph publishes no array of its own. */
+const EMPTY_MARK_REVISIONS: readonly RevisionAttribution[] = Object.freeze([]);
+
+/**
+ * The single decision a one-field reader sees.
+ *
+ * A DELETION wins when a mark carries both, for the reason paint draws it that way: a break
+ * proposed and then unproposed ends up removed, so that is the decision a reader who can only
+ * see one must see. One function decides it, so the deprecated field, the deprecated function
+ * and the painted glyph cannot answer differently.
+ */
+export function shownMarkRevision(
+  revisions: readonly RevisionAttribution[]
+): RevisionAttribution | undefined {
+  return revisions.find((revision) => revision.kind === 'delete') ?? revisions[0];
+}
+
+/**
+ * What a fragment publishes for one mark: the list, and the single decision derived from it.
+ *
+ * Both lanes that build a paragraph fragment call this, so the body and the cell cannot come
+ * to publish different shapes for the same markup.
+ */
+export function markRevisionFields(revisions: readonly RevisionAttribution[]): {
+  markRevisions?: readonly RevisionAttribution[];
+  markRevision?: RevisionAttribution;
+} {
+  const shown = shownMarkRevision(revisions);
+  return shown ? { markRevisions: revisions, markRevision: shown } : {};
+}
+
+/**
+ * The one decision on a paragraph's mark that a single-field reader sees.
+ *
+ * @deprecated Reads one of the revisions a mark can carry. Use {@link paragraphMarkRevisionsOf},
+ * which answers with all of them.
+ */
+export function paragraphMarkRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null {
+  return shownMarkRevision(paragraphMarkRevisionsOf(paragraph)) ?? null;
 }
 
 /**

--- a/packages/core/src/layout/revision-projection.ts
+++ b/packages/core/src/layout/revision-projection.ts
@@ -155,12 +155,11 @@ export function revisionsVisible(
 }
 
 /**
- * The insert and delete revisions on a paragraph's own MARK, from `w:pPr/w:rPr/w:ins|w:del`.
+ * Every revision on a paragraph's own MARK, from `w:pPr/w:rPr/w:ins|w:del|w:moveFrom|w:moveTo`.
  *
- * `w:moveFrom` and `w:moveTo` sit in the same group and are NOT read here, which matches the
- * store lane: `revisionItemsOf` ignores them under `pPr/rPr` too, so a moved paragraph's mark
- * raises no card either. Reading them needs the same change to widen `paragraphMarkDeleted`
- * and the removal face, or the margin rule and the glyph would disagree about a `moveFrom`.
+ * All four members of `EG_ParaRPrTrackChanges`. A moved paragraph carries `w:moveFrom` on the
+ * mark of the copy it left and `w:moveTo` on the mark of the copy it arrived at, so a move
+ * that spans whole paragraphs is recorded here and nowhere else.
  *
  * `EG_ParaRPrTrackChanges` records that the pilcrow itself was inserted or deleted, which is how
  * Word writes a paragraph split or merge. It is not content — there is no text to decorate — so
@@ -189,8 +188,8 @@ export function paragraphMarkRevisionsOf(paragraph: OoxmlNode): readonly Revisio
   for (const child of rPr.children) {
     if (child.kind === 'textValue') continue;
     if (child.namespaceUri !== WML_NAMESPACE_URI) continue;
-    const kind = child.localName === 'ins' ? 'insert' : child.localName === 'del' ? 'delete' : null;
-    if (kind === null) continue;
+    const kind = MARK_REVISION_KINDS[child.localName];
+    if (kind === undefined) continue;
     const date = attributeValue(child, 'date');
     revisions.push({
       kind,
@@ -201,6 +200,47 @@ export function paragraphMarkRevisionsOf(paragraph: OoxmlNode): readonly Revisio
     });
   }
   return revisions.length > 0 ? revisions : EMPTY_MARK_REVISIONS;
+}
+
+/** `EG_ParaRPrTrackChanges` in full: `ins? del? moveFrom? moveTo?` (§17.13.5.20-25). */
+const MARK_REVISION_KINDS: Readonly<Record<string, RevisionKind | undefined>> = {
+  ins: 'insert',
+  del: 'delete',
+  moveFrom: 'moveFrom',
+  moveTo: 'moveTo',
+};
+
+/**
+ * The tracked FORMAT change on a paragraph's own mark, from `w:pPr/w:rPr/w:rPrChange`.
+ *
+ * `CT_ParaRPr` ends with it (§17.13.5.32), and Word writes it when a user changes the mark's
+ * own run properties with tracking on. It reaches the fragment rather than a span because it
+ * decorates no characters, and it is not in `props`: a fragment's `props` carry the mark's
+ * `w:rPr` by NAME only, with none of its children.
+ *
+ * Note that `w:rPrChange/w:rPr` is `CT_ParaRPrOriginal`, which may carry its own revision
+ * marks. Those describe the mark as it WAS and must not be read as live ones, which is why
+ * this reads the change element's own attributes and never descends into it.
+ */
+export function paragraphMarkFormatRevisionOf(paragraph: OoxmlNode): RevisionAttribution | null {
+  if (paragraph.kind === 'textValue') return null;
+  const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
+  if (!pPr || pPr.kind === 'textValue') return null;
+  const rPr = pPr.children.find((child) => child.kind === 'runProperties');
+  if (!rPr || rPr.kind === 'textValue') return null;
+  for (const child of rPr.children) {
+    if (child.kind === 'textValue') continue;
+    if (child.namespaceUri !== WML_NAMESPACE_URI || child.localName !== 'rPrChange') continue;
+    const date = attributeValue(child, 'date');
+    return {
+      kind: 'format',
+      id: attributeValue(child, 'id') ?? '',
+      author: attributeValue(child, 'author') ?? '',
+      ...(date === undefined ? {} : { date }),
+      nodeId: child.id,
+    };
+  }
+  return null;
 }
 
 /** One shared empty, so an unmarked paragraph publishes no array of its own. */
@@ -217,7 +257,19 @@ const EMPTY_MARK_REVISIONS: readonly RevisionAttribution[] = Object.freeze([]);
 export function shownMarkRevision(
   revisions: readonly RevisionAttribution[]
 ): RevisionAttribution | undefined {
-  return revisions.find((revision) => revision.kind === 'delete') ?? revisions[0];
+  return revisions.find((revision) => markRevisionRemovesMark(revision)) ?? revisions[0];
+}
+
+/**
+ * Does this decision, taken, remove the paragraph mark?
+ *
+ * A deletion does, and so does a `moveFrom`: the copy the paragraph moved OUT of goes away
+ * when the move is accepted. `insert` and `moveTo` are the other half of each pair, and they
+ * keep the break. Paint, the change bar and the resolved views all ask this one question, so
+ * a `moveFrom` cannot end up struck through in the margin and blue on the glyph.
+ */
+export function markRevisionRemovesMark(revision: RevisionAttribution): boolean {
+  return revision.kind === 'delete' || revision.kind === 'moveFrom';
 }
 
 /**
@@ -226,12 +278,19 @@ export function shownMarkRevision(
  * Both lanes that build a paragraph fragment call this, so the body and the cell cannot come
  * to publish different shapes for the same markup.
  */
-export function markRevisionFields(revisions: readonly RevisionAttribution[]): {
+export function markRevisionFields(
+  revisions: readonly RevisionAttribution[],
+  formatRevision?: RevisionAttribution | null
+): {
   markRevisions?: readonly RevisionAttribution[];
   markRevision?: RevisionAttribution;
+  markFormatRevision?: RevisionAttribution;
 } {
   const shown = shownMarkRevision(revisions);
-  return shown ? { markRevisions: revisions, markRevision: shown } : {};
+  return {
+    ...(shown ? { markRevisions: revisions, markRevision: shown } : {}),
+    ...(formatRevision ? { markFormatRevision: formatRevision } : {}),
+  };
 }
 
 /**

--- a/packages/core/src/layout/revision-projection.ts
+++ b/packages/core/src/layout/revision-projection.ts
@@ -155,7 +155,12 @@ export function revisionsVisible(
 }
 
 /**
- * Every revision on a paragraph's own MARK, from `w:pPr/w:rPr/w:ins|w:del`.
+ * The insert and delete revisions on a paragraph's own MARK, from `w:pPr/w:rPr/w:ins|w:del`.
+ *
+ * `w:moveFrom` and `w:moveTo` sit in the same group and are NOT read here, which matches the
+ * store lane: `revisionItemsOf` ignores them under `pPr/rPr` too, so a moved paragraph's mark
+ * raises no card either. Reading them needs the same change to widen `paragraphMarkDeleted`
+ * and the removal face, or the margin rule and the glyph would disagree about a `moveFrom`.
  *
  * `EG_ParaRPrTrackChanges` records that the pilcrow itself was inserted or deleted, which is how
  * Word writes a paragraph split or merge. It is not content — there is no text to decorate — so
@@ -165,8 +170,9 @@ export function revisionsVisible(
  * A LIST, because the group is `ins? del? moveFrom? moveTo?` and the first two can both be
  * there: that pair is what Word writes when a second author proposes removing a mark the first
  * proposed adding, and it is what this engine's own writer emits (`tree-op-tracked.ts`).
- * Answering with the first one hid the second author's decision from every reader and from the
- * review pane, and no later edit could move a field that was never published.
+ * Answering with the first one hid the second author's decision from the PAGE. The review pane
+ * walks the tree itself and always listed both, which is the worse shape of the two: a card
+ * offering a decision the reader could see no sign of.
  *
  * Ordered as the file orders them, which is the order the group declares.
  *

--- a/packages/core/src/layout/revision-visibility.ts
+++ b/packages/core/src/layout/revision-visibility.ts
@@ -42,10 +42,12 @@ function childNamed(node: OoxmlNode, localName: string): OoxmlNode | undefined {
 }
 
 /**
- * `w:pPr/w:rPr/w:del` — the paragraph mark was deleted by a tracked revision.
+ * `w:pPr/w:rPr/w:del` or `w:moveFrom` — a tracked revision REMOVES the paragraph mark.
  *
- * Read from the paragraph-mark run properties only. A `w:del` anywhere else in the paragraph
- * deletes run content, which is a different statement entirely.
+ * Both say the break goes away once the decision is taken: a deletion outright, a `moveFrom`
+ * because the paragraph left this place for another. Read from the paragraph-mark run
+ * properties only. A `w:del` anywhere else in the paragraph deletes run content, which is a
+ * different statement entirely.
  */
 export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean {
   if (paragraph.kind === 'textValue') return false;
@@ -53,7 +55,11 @@ export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean {
   if (!properties) return false;
   const markRunProperties =
     childNamed(properties, 'runProperties') ?? childNamed(properties, 'rPr');
-  return markRunProperties !== undefined && childNamed(markRunProperties, 'del') !== undefined;
+  if (markRunProperties === undefined) return false;
+  return (
+    childNamed(markRunProperties, 'del') !== undefined ||
+    childNamed(markRunProperties, 'moveFrom') !== undefined
+  );
 }
 
 /**

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -55,14 +55,13 @@ const PARAGRAPH_FIELDS = {
   borders: 'hashed',
   shading: 'hashed',
   shadingBox: 'hashed',
-  // The revision on the paragraph MARK. Accepting or rejecting a tracked pilcrow rewrites
+  // The revisions on the paragraph MARK. Accepting or rejecting a tracked pilcrow rewrites
   // `w:pPr/w:rPr/w:ins|w:del` and moves no geometry at all, so nothing else here moves with
-  // it: paint kept drawing the attribution of a decision the document no longer records.
-  //
-  // A mark inside a `w:tc` never reaches this: semantic-table-layout builds its own paragraph
-  // fragment and does not publish the field at all. That is a gap in what a cell publishes,
-  // not one in what this compares.
-  markRevision: 'hashed',
+  // them: paint kept drawing the attribution of a decision the document no longer records.
+  markRevisions: 'hashed',
+  // Derived from `markRevisions` at publish time by one shared function, so it cannot move
+  // without the list moving first.
+  markRevision: 'covered',
   marker: 'hashed',
   // WHOLESALE, not a projection of the fields a line happens to publish today. A line owns
   // `contentX` (the only alignment carrier on a span-less line), `leading`, `trailingSpacing`,
@@ -158,6 +157,24 @@ export function sameAnchoredDrawings(
   for (let index = 0; index < left.length; index += 1) {
     if (left[index] === right[index]) continue;
     return false;
+  }
+  return true;
+}
+
+/** Shared empties, so a checkpoint per block costs one reference in a document with none. */
+export const NO_DEFERRED_DRAWINGS: readonly import('./drawing-layout.ts').AnchoredDrawingRecord[] =
+  Object.freeze([]);
+export const NO_DEFER_COUNTS: ReadonlyMap<string, number> = new Map();
+
+/** Are two anchor-deferral tallies the same? Order is irrelevant; the counts are not. */
+export function sameDeferCounts(
+  left: ReadonlyMap<string, number>,
+  right: ReadonlyMap<string, number>
+): boolean {
+  if (left === right) return true;
+  if (left.size !== right.size) return false;
+  for (const [nodeId, count] of left) {
+    if (right.get(nodeId) !== count) return false;
   }
   return true;
 }

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -62,6 +62,8 @@ const PARAGRAPH_FIELDS = {
   // Derived from `markRevisions` at publish time by one shared function, so it cannot move
   // without the list moving first.
   markRevision: 'covered',
+  // Its own field, not covered by the list: a mark can carry a format change and no decision.
+  markFormatRevision: 'hashed',
   marker: 'hashed',
   // WHOLESALE, not a projection of the fields a line happens to publish today. A line owns
   // `contentX` (the only alignment carrier on a span-less line), `leading`, `trailingSpacing`,

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -3,7 +3,109 @@
 // Extracted from semantic-layout so the flow module stays under the line budget while every
 // published field still participates in equality.
 
-import type { BlockFragmentRecord } from './semantic-records.ts';
+import type {
+  BlockFragmentRecord,
+  ParagraphFragmentRecord,
+  TableFragmentRecord,
+} from './semantic-records.ts';
+
+/**
+ * What one field of a fragment record does in the signature.
+ *
+ * - `hashed` — the field is serialized. Every PUBLISHED field belongs here. A published
+ *   field left out converges a freshly built fragment against a stale one and discards the
+ *   new value, so the consumer keeps reading the pre-edit state.
+ * - `covered` — another hashed field ALREADY moves whenever this one moves, so hashing it
+ *   again buys nothing. Only a field with that proof gets this role.
+ *
+ * The maps below are `satisfies Record<keyof …>`, so a new field on a record is a TYPE ERROR
+ * here until somebody classifies it. That guard is the point: `props`, `indent`, `borders`
+ * and `lines.drawings` were each added to a record, missed here, and shipped as a stale-read
+ * bug that only a hand-written test could catch.
+ */
+type SignatureRole = 'hashed' | 'covered';
+
+/**
+ * Every field of a paragraph fragment, classified.
+ *
+ * Order is the record's own declaration order, and it is also the order the values are
+ * serialized in, so a diff of this map is a diff of the signature.
+ */
+const PARAGRAPH_FIELDS = {
+  // The branch this record takes below already separates it from a table fragment.
+  kind: 'covered',
+  id: 'hashed',
+  // `id` is `${paragraphId}#f${fragmentIndex}`, so both are already in it.
+  paragraphId: 'covered',
+  fragmentIndex: 'covered',
+  range: 'hashed',
+  // A paragraph-property change that layout does not read moves no geometry. Without this
+  // the freshly built fragment converged against the old one and was discarded, leaving a
+  // painter or style consumer reading the pre-edit value.
+  props: 'hashed',
+  spacing: 'hashed',
+  // The EFFECTIVE indent, for the same reason `props` is here. A list paragraph's indent
+  // comes from `numbering.xml`, so a renumber that moves the text but no other hashed field
+  // would converge against the stale fragment and leave the ruler reading the pre-edit value.
+  indent: 'hashed',
+  bottomBorder: 'hashed',
+  // Every `w:pBdr` stroke, not just the bottom one. A left rule's colour or width moves
+  // nothing else that is hashed here — `props` carries `pBdr` without its children — so
+  // leaving it out kept the old frame drawn.
+  borders: 'hashed',
+  shading: 'hashed',
+  shadingBox: 'hashed',
+  // The revision on the paragraph MARK. Accepting or rejecting a tracked pilcrow rewrites
+  // `w:pPr/w:rPr/w:ins|w:del` and moves no geometry at all, so nothing else here moves with
+  // it: paint kept drawing the attribution of a decision the document no longer records.
+  //
+  // A mark inside a `w:tc` never reaches this: semantic-table-layout builds its own paragraph
+  // fragment and does not publish the field at all. That is a gap in what a cell publishes,
+  // not one in what this compares.
+  markRevision: 'hashed',
+  marker: 'hashed',
+  // WHOLESALE, not a projection of the fields a line happens to publish today. A line owns
+  // `contentX` (the only alignment carrier on a span-less line), `leading`, `trailingSpacing`,
+  // `deletedRanges` and `drawings`, and each of those was reachable only by adding it here by
+  // hand. Serializing the record itself is what makes the next line field participate on the
+  // day it is published rather than on the day someone notices.
+  //
+  // The price is that a line's own KEY ORDER reaches the string, and the two sites that build
+  // one order their optional keys differently (semantic-layout.ts and semantic-table-layout.ts
+  // disagree about where `drawings` sits). That costs nothing: comparison is positional, and a
+  // body line is only ever compared against the body line at the same index, a cell line
+  // against a cell line inside `rows`. A line cannot change its construction site without
+  // changing the node id in `fragment.id`. Order can only cost a reuse, never restore a stale
+  // value, which is the direction this whole comparison is allowed to fail in.
+  lines: 'hashed',
+  box: 'hashed',
+} as const satisfies Record<keyof ParagraphFragmentRecord, SignatureRole>;
+
+/**
+ * Every field of a table fragment, classified.
+ *
+ * `rows` carries the cells, and a cell carries the paragraph fragments inside it, all
+ * wholesale. That is why a table cell never had the omissions the paragraph branch did.
+ */
+const TABLE_FIELDS = {
+  kind: 'covered',
+  id: 'hashed',
+  tableId: 'hashed',
+  fragmentIndex: 'hashed',
+  nestingDepth: 'hashed',
+  columnEdges: 'hashed',
+  rows: 'hashed',
+  box: 'hashed',
+} as const satisfies Record<keyof TableFragmentRecord, SignatureRole>;
+
+function hashedKeys<Fragment extends object>(
+  fields: Record<keyof Fragment, SignatureRole>
+): readonly (keyof Fragment)[] {
+  return (Object.keys(fields) as (keyof Fragment)[]).filter((key) => fields[key] === 'hashed');
+}
+
+const PARAGRAPH_KEYS = hashedKeys<ParagraphFragmentRecord>(PARAGRAPH_FIELDS);
+const TABLE_KEYS = hashedKeys<TableFragmentRecord>(TABLE_FIELDS);
 
 /** Cached per record, so a fragment is serialized once however often convergence is tested. */
 const signatures = new WeakMap<object, string>();
@@ -11,59 +113,12 @@ const signatures = new WeakMap<object, string>();
 export function fragmentSignature(fragment: BlockFragmentRecord): string {
   const cached = signatures.get(fragment);
   if (cached !== undefined) return cached;
-  // Every PUBLISHED field participates. A field left out converges a freshly built
-  // fragment against a stale one and discards the new value — the exact bug the `props`
-  // note below records for paragraph properties.
+  // An absent optional field serializes as `null` in place rather than vanishing, so the
+  // values stay positionally aligned with the key list that produced them.
   const signature =
     fragment.kind === 'table'
-      ? JSON.stringify([
-          fragment.id,
-          fragment.tableId,
-          fragment.fragmentIndex,
-          fragment.nestingDepth,
-          fragment.columnEdges,
-          fragment.box,
-          fragment.rows,
-        ])
-      : JSON.stringify([
-          fragment.id,
-          fragment.box,
-          fragment.range,
-          // `props` is a PUBLISHED field. A paragraph-property change layout does not read
-          // moves no geometry, so without this the freshly built fragment converged against
-          // the old one and was discarded — leaving a painter or style consumer reading the
-          // pre-edit value.
-          fragment.props,
-          fragment.spacing,
-          // The EFFECTIVE indent, for the same reason `props` is here. A list paragraph's
-          // indent comes from `numbering.xml`, so a renumber that moves the text but no
-          // other hashed field would converge against the stale fragment and leave the
-          // ruler reading the pre-edit value.
-          fragment.indent,
-          fragment.bottomBorder,
-          // Every `w:pBdr` stroke, not just the bottom one. A left rule's colour or width
-          // moves nothing else that is hashed here — `props` carries `pBdr` without its
-          // children — so leaving it out converges the repainted fragment against the stale
-          // one and keeps drawing the old frame.
-          fragment.borders,
-          fragment.shading,
-          fragment.shadingBox,
-          fragment.marker,
-          // `contentX` as well as `box`, because it is published geometry and everything
-          // published participates. It is the ONLY field carrying alignment on a span-less
-          // line, and nothing here guarantees a mover of it also moves `box` or `spans`.
-          fragment.lines.map((line) => [
-            line.id,
-            line.box,
-            line.contentX,
-            line.baseline,
-            line.spans,
-            // Resource resolution changes paint state without moving the line. If drawings
-            // are omitted, pending→ready can falsely converge on an open page and replace
-            // the freshly rebuilt fragment with the previous page's pending record.
-            line.drawings,
-          ]),
-        ]);
+      ? JSON.stringify(TABLE_KEYS.map((key) => fragment[key]))
+      : JSON.stringify(PARAGRAPH_KEYS.map((key) => fragment[key]));
   signatures.set(fragment, signature);
   return signature;
 }
@@ -88,7 +143,13 @@ export function sameFragments(
   return true;
 }
 
-/** Pending anchored drawings on the open page — reference identity for incremental reuse. */
+/**
+ * Pending anchored drawings on the open page — reference identity for incremental reuse.
+ *
+ * Identity is the STRICT side of the trade the fragments make: a rebuilt record compares
+ * unequal even when its content matches, so this can cost a convergence but can never
+ * restore a stale one.
+ */
 export function sameAnchoredDrawings(
   left: readonly import('./drawing-layout.ts').AnchoredDrawingRecord[],
   right: readonly import('./drawing-layout.ts').AnchoredDrawingRecord[]

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -161,7 +161,12 @@ export function sameAnchoredDrawings(
   return true;
 }
 
-/** Shared empties, so a checkpoint per block costs one reference in a document with none. */
+/**
+ * Shared empties, so a checkpoint per block costs one reference in a document with none.
+ *
+ * Module-internal on purpose. A `Map` cannot be frozen the way the array is, so the only thing
+ * keeping this one empty is that nothing outside this file can reach it to write to it.
+ */
 export const NO_DEFERRED_DRAWINGS: readonly import('./drawing-layout.ts').AnchoredDrawingRecord[] =
   Object.freeze([]);
 export const NO_DEFER_COUNTS: ReadonlyMap<string, number> = new Map();

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -33,7 +33,8 @@ import {
 } from './paragraph-flow.ts';
 import {
   DEFAULT_REVISION_DISPLAY_MODE,
-  paragraphMarkRevisionOf,
+  markRevisionFields,
+  paragraphMarkRevisionsOf,
   type RevisionDisplayMode,
 } from './revision-projection.ts';
 import {
@@ -136,6 +137,7 @@ import {
 } from './section-properties.ts';
 import { resolveSectionColumns, type ResolvedSectionColumns } from './section-columns.ts';
 import { layoutSemanticDocumentWithNotes } from './note-pagination.ts';
+import { noteMarksCacheToken } from './note-projection.ts';
 import {
   DEFAULT_PAGE_GEOMETRY,
   effectiveContentControlLock,
@@ -165,7 +167,13 @@ import {
 import type { NumberingIndex } from './numbering-index.ts';
 import { firstLineShift, withResolvedListItems, type ResolvedListItem } from './list-resolve.ts';
 import { publishListMarker } from './list-marker.ts';
-import { sameFragments, sameAnchoredDrawings } from './semantic-fragment-signature.ts';
+import {
+  NO_DEFERRED_DRAWINGS,
+  NO_DEFER_COUNTS,
+  sameAnchoredDrawings,
+  sameDeferCounts,
+  sameFragments,
+} from './semantic-fragment-signature.ts';
 import { type FlowCheckpoint, type LayoutSession } from './layout-session.ts';
 import { furnitureForSection, layoutMultiSectionDocument } from './multi-section-layout.ts';
 import { layoutTextboxStory } from './textbox-story-layout.ts';
@@ -726,6 +734,7 @@ function layoutBlocksPass(
   // it into `producer` is what makes a mode switch invalidate the break cache AND the session
   // checkpoints without a `ModelChange`: the document did not change, the projection of it did.
   const displayMode = options.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE;
+  const showsMarkup = displayMode === 'all-markup';
   const tocChromeParagraphIds = options.tocFieldChromeParagraphIds;
   const emptyTocPlaceholderIds = options.emptyTocPlaceholderParagraphIds;
   const emptyTocSuppressedResultIds = options.emptyTocSuppressedResultParagraphIds;
@@ -793,9 +802,13 @@ function layoutBlocksPass(
   const notesReserveKey = pageBottomReserves
     ? `|nr:${[...pageBottomReserves].map(([i, h]) => `${i}=${h}`).join(',')}`
     : '';
-  const noteMarksKey = options.noteMarks
-    ? `|nm:${options.noteMarks.reservedMarkText ?? ''}:${options.noteMarks.marks.size}`
-    : '';
+  // Every mark, not the COUNT of them. A renumber leaves the count alone — `w:numFmt`
+  // decimal to lowerRoman, a `w:numStart` shift, `eachSect` restart, a section override, a
+  // note deleted and another inserted in one transaction — and the mark a body citation
+  // paints is derived, so no paragraph subtree and no block key moves with it. Keying on the
+  // count let the pass resume onto pages measured for the old marks; reprojection then wrote
+  // the new digits into a slot sized for the old ones.
+  const noteMarksKey = options.noteMarks ? `|nm:${noteMarksCacheToken(options.noteMarks)}` : '';
   const columnRegionBottom = options.columnRegionBottom;
   const columnsContext = `|cols:${columns.widths.join(',')};${columns.gaps.join(',')};${columns.separator ? 1 : 0}${columnRegionBottom !== undefined ? `;bal:${columnRegionBottom}` : ''}`;
   // Body line ids are paragraph-local, so a changed line count in an earlier section does
@@ -1040,6 +1053,24 @@ function layoutBlocksPass(
   let lineCounter = lineCounterStart;
   let previousSpaceAfter = spaceBeforeCarry;
   const checkpoints: FlowCheckpoint[] = [];
+  /**
+   * The flow exactly as it stands: what a later pass resumes from and converges against. The
+   * deferred anchor state is copied only when there is some, because this is taken once per
+   * block and a document that defers nothing should pay one reference for saying so.
+   */
+  const checkpointNow = (): FlowCheckpoint => ({
+    pageCount: pages.length,
+    pageFragments: [...pageFragments],
+    pendingAnchoredDrawings: [...pendingAnchoredDrawings],
+    deferredAnchoredDrawings:
+      deferredAnchoredDrawings.length > 0 ? [...deferredAnchoredDrawings] : NO_DEFERRED_DRAWINGS,
+    anchorPageDeferCounts:
+      anchorPageDeferCounts.size > 0 ? new Map(anchorPageDeferCounts) : NO_DEFER_COUNTS,
+    cursorY,
+    lineCounter,
+    previousSpaceAfter,
+    flowColumnIndex,
+  });
   let startIndex = 0;
   let placed = 0;
   let reusedPages = 0;
@@ -1054,6 +1085,9 @@ function layoutBlocksPass(
     pages.push(...previous!.pages.slice(0, checkpoint.pageCount));
     pageFragments = [...checkpoint.pageFragments];
     pendingAnchoredDrawings = [...checkpoint.pendingAnchoredDrawings];
+    deferredAnchoredDrawings = [...checkpoint.deferredAnchoredDrawings];
+    anchorPageDeferCounts.clear();
+    for (const [id, n] of checkpoint.anchorPageDeferCounts) anchorPageDeferCounts.set(id, n);
     cursorY = checkpoint.cursorY;
     flowColumnIndex = checkpoint.flowColumnIndex;
     columnIndex = checkpoint.flowColumnIndex;
@@ -1882,15 +1916,7 @@ function layoutBlocksPass(
     const entry = prepareBlock(bodies[index]!, columnWidth());
 
     // The flow as it stands BEFORE this block: what a later pass resumes from.
-    checkpoints[index] = {
-      pageCount: pages.length,
-      pageFragments: [...pageFragments],
-      pendingAnchoredDrawings: [...pendingAnchoredDrawings],
-      cursorY,
-      lineCounter,
-      previousSpaceAfter,
-      flowColumnIndex,
-    };
+    checkpoints[index] = checkpointNow();
 
     // CONVERGENCE. Once inside the unchanged tail, if the flow returns to exactly the state
     // the previous pass was in at this same paragraph, everything after lays out identically
@@ -1915,7 +1941,10 @@ function layoutBlocksPass(
         mark.flowColumnIndex === flowColumnIndex &&
         mark.pageCount === pages.length &&
         sameFragments(mark.pageFragments, pageFragments) &&
-        sameAnchoredDrawings(mark.pendingAnchoredDrawings, pendingAnchoredDrawings)
+        sameAnchoredDrawings(mark.pendingAnchoredDrawings, pendingAnchoredDrawings) &&
+        // A flow that still owes the next page a drawing is not one that owes it nothing.
+        sameAnchoredDrawings(mark.deferredAnchoredDrawings, deferredAnchoredDrawings) &&
+        sameDeferCounts(mark.anchorPageDeferCounts, anchorPageDeferCounts)
       ) {
         const tail = previous!.pages.slice(mark.pageCount);
         pages.push(...tail);
@@ -2105,7 +2134,7 @@ function layoutBlocksPass(
       startY: number;
     }> | null = null;
 
-    const markRevision = paragraphMarkRevisionOf(entry.paragraph);
+    const markRevisions = paragraphMarkRevisionsOf(entry.paragraph);
 
     /**
      * How much of the first placed line's topAndBottom skip this paragraph's own anchor caused.
@@ -2279,8 +2308,11 @@ function layoutBlocksPass(
             }),
         ...(marker ? { marker } : {}),
         // The paragraph MARK lives at the end of the paragraph, so only the final fragment
-        // carries its revision — a paragraph split across pages must not draw two pilcrows.
-        ...(isLast && markRevision ? { markRevision } : {}),
+        // carries its revisions — a paragraph split across pages must not draw two pilcrows.
+        // `all-markup` only: the other two modes answer what the document WOULD be once every
+        // decision is taken, and a resolved view draws no attribution, as Word draws none in
+        // No Markup or Original.
+        ...(isLast && showsMarkup ? markRevisionFields(markRevisions) : {}),
         lines: pending,
         box: { x: columnX + indent.left, y: top, width: available, height },
       });
@@ -2583,15 +2615,7 @@ function layoutBlocksPass(
   // for which nothing was stored, so the most ordinary edit there is, typing at the bottom of
   // a document and pressing Enter, re-placed everything.
   if (!converged) {
-    checkpoints[prepared.length] = {
-      pageCount: pages.length,
-      pageFragments: [...pageFragments],
-      pendingAnchoredDrawings: [...pendingAnchoredDrawings],
-      cursorY,
-      lineCounter,
-      previousSpaceAfter,
-      flowColumnIndex,
-    };
+    checkpoints[prepared.length] = checkpointNow();
   }
 
   // Captured BEFORE the terminal flush, which zeroes the cursor. A converged pass stopped

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -52,6 +52,7 @@ import { resolveParagraphBorders } from './paragraph-border-resolve.ts';
 import {
   adjustedBreakIndex,
   keepNextFlowKeys,
+  listMarkerFlowKeys,
   keepNextGroupHeight,
   paragraphKeeps,
   MAX_KEEP_NEXT_CHAIN,
@@ -741,6 +742,10 @@ function layoutBlocksPass(
   const producer =
     (options.producer ?? 'unversioned-measurer') +
     (styleCascade ? `|sc:${styleCascade.cacheToken}` : '') +
+    // In `producer`, not beside it in the section context: a note mark is measured INTO the
+    // broken lines, so the break cache holds the citation's width under a key built from
+    // this. Keying only the section left a warm cache serving `1`-wide slots to roman marks.
+    (options.noteMarks ? `|nm:${noteMarksCacheToken(options.noteMarks)}` : '') +
     (listItems && listItems.size > 0 ? `|num:${listItems.size}` : '') +
     (defaultTabStopPt !== undefined ? `|dts:${defaultTabStopPt}` : '') +
     (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`);
@@ -802,18 +807,11 @@ function layoutBlocksPass(
   const notesReserveKey = pageBottomReserves
     ? `|nr:${[...pageBottomReserves].map(([i, h]) => `${i}=${h}`).join(',')}`
     : '';
-  // Every mark, not the COUNT of them. A renumber leaves the count alone — `w:numFmt`
-  // decimal to lowerRoman, a `w:numStart` shift, `eachSect` restart, a section override, a
-  // note deleted and another inserted in one transaction — and the mark a body citation
-  // paints is derived, so no paragraph subtree and no block key moves with it. Keying on the
-  // count let the pass resume onto pages measured for the old marks; reprojection then wrote
-  // the new digits into a slot sized for the old ones.
-  const noteMarksKey = options.noteMarks ? `|nm:${noteMarksCacheToken(options.noteMarks)}` : '';
   const columnRegionBottom = options.columnRegionBottom;
   const columnsContext = `|cols:${columns.widths.join(',')};${columns.gaps.join(',')};${columns.separator ? 1 : 0}${columnRegionBottom !== undefined ? `;bal:${columnRegionBottom}` : ''}`;
   // Body line ids are paragraph-local, so a changed line count in an earlier section does
   // not invalidate this section. Geometry, flow start, and document page index still do.
-  const context = `${producer}|${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}|fs:${flowStartY},${spaceBeforeCarry}|pi:${pageIndexStart}${furnitureContext}${notesReserveKey}${noteMarksKey}${columnsContext}`;
+  const context = `${producer}|${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}|fs:${flowStartY},${spaceBeforeCarry}|pi:${pageIndexStart}${furnitureContext}${notesReserveKey}${columnsContext}`;
 
   const pages: PageRecord[] = [];
   /**
@@ -955,9 +953,15 @@ function layoutBlocksPass(
     displayMode
   );
   const keepsNext = prepared.map((entry) => entry.kind === 'paragraph' && entry.keeps.keepNext);
+  const markerTexts = prepared.map((entry) =>
+    entry.kind === 'paragraph' ? listItems?.get(entry.paragraph.id)?.markerText : undefined
+  );
   // FLOW keys — what incremental resume compares. `keys` stays what the break cache is
   // stored under; only `w:keepNext` makes the two differ (§17.3.1.15).
-  const flowKeys = keepNextFlowKeys(keys, (index) => keepsNext[index]!);
+  const flowKeys = listMarkerFlowKeys(
+    keepNextFlowKeys(keys, (index) => keepsNext[index]!),
+    (index) => markerTexts[index]
+  );
   const previous = session?.previous ?? null;
   // A geometry or producer change invalidates every checkpoint, because it moves every
   // break; resuming from one would place new content against a stale flow.
@@ -1053,11 +1057,8 @@ function layoutBlocksPass(
   let lineCounter = lineCounterStart;
   let previousSpaceAfter = spaceBeforeCarry;
   const checkpoints: FlowCheckpoint[] = [];
-  /**
-   * The flow exactly as it stands: what a later pass resumes from and converges against. The
-   * deferred anchor state is copied only when there is some, because this is taken once per
-   * block and a document that defers nothing should pay one reference for saying so.
-   */
+  /** The flow as it stands: what a later pass resumes from and converges against. The
+   * deferred anchor state is copied only when there is some — this runs once per block. */
   const checkpointNow = (): FlowCheckpoint => ({
     pageCount: pages.length,
     pageFragments: [...pageFragments],

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -34,6 +34,7 @@ import {
 import {
   DEFAULT_REVISION_DISPLAY_MODE,
   markRevisionFields,
+  paragraphMarkFormatRevisionOf,
   paragraphMarkRevisionsOf,
   type RevisionDisplayMode,
 } from './revision-projection.ts';
@@ -2308,12 +2309,12 @@ function layoutBlocksPass(
                   : paragraphShadingBox(pending, regionX + indent.left, available)!,
             }),
         ...(marker ? { marker } : {}),
-        // The paragraph MARK lives at the end of the paragraph, so only the final fragment
-        // carries its revisions — a paragraph split across pages must not draw two pilcrows.
-        // `all-markup` only: the other two modes answer what the document WOULD be once every
-        // decision is taken, and a resolved view draws no attribution, as Word draws none in
-        // No Markup or Original.
-        ...(isLast && showsMarkup ? markRevisionFields(markRevisions) : {}),
+        // Final fragment only — a paragraph split across pages must not draw two pilcrows —
+        // and `all-markup` only, as Word draws attribution in All Markup alone. The record's
+        // own declaration carries the rest of the reasoning.
+        ...(isLast && showsMarkup
+          ? markRevisionFields(markRevisions, paragraphMarkFormatRevisionOf(entry.paragraph))
+          : {}),
         lines: pending,
         box: { x: columnX + indent.left, y: top, width: available, height },
       });

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -400,6 +400,16 @@ export interface ParagraphFragmentRecord {
    */
   readonly markRevision?: RevisionAttribution;
   /**
+   * The tracked FORMAT change on this paragraph's mark (`w:pPr/w:rPr/w:rPrChange`), absent
+   * when there is none. Final fragment only, and `all-markup` only, like the decisions above.
+   *
+   * Published without a glyph of its own on purpose. Word draws no pilcrow for a mark whose
+   * only change is its own formatting — the decision belongs to the review pane, which lists
+   * it either way. What was missing was GEOMETRY: with nothing on the fragment, a card had
+   * no place on the page to point at.
+   */
+  readonly markFormatRevision?: RevisionAttribution;
+  /**
    * List marker painted in the hanging-indent slot of the FIRST fragment only.
    *
    * Not part of model text: no UTF-16 range, never contributes to caret/selection offsets,

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -380,6 +380,13 @@ export interface ParagraphFragmentRecord {
    * a deletion of that insertion by the next. Published only in `all-markup`: the other two
    * display modes answer what the document WOULD be, and a resolved view draws no
    * attribution.
+   *
+   * Those two modes are ATTRIBUTION-resolved, not STRUCTURE-resolved. Taking a deleted mark
+   * in `proposed` merges the paragraph into the next one, and taking an inserted mark in
+   * `original` un-splits it, but `revision-visibility.ts` does that only for a paragraph that
+   * renders no text. So a resolved view still shows the break — it just no longer draws a
+   * coloured pilcrow beside it. The merge is the fix for that; suppressing the glyph is not,
+   * and must not be read as it.
    */
   readonly markRevisions?: readonly RevisionAttribution[];
   /**

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -368,13 +368,28 @@ export interface ParagraphFragmentRecord {
    */
   readonly shadingBox?: LayoutBox;
   /**
-   * The revision on this paragraph's own MARK (`w:pPr/w:rPr/w:ins|w:del`), absent when there
-   * is none.
+   * The revisions on this paragraph's own MARK (`w:pPr/w:rPr/w:ins|w:del`), absent when there
+   * are none.
    *
-   * Carried on the fragment rather than on a span because it decorates no characters: the
+   * Carried on the fragment rather than on a span because they decorate no characters: the
    * pilcrow was inserted or deleted, which is how a split or a merge is recorded. Only the
-   * FINAL fragment carries it — the mark lives at the end of the paragraph, so a paragraph
+   * FINAL fragment carries them — the mark lives at the end of the paragraph, so a paragraph
    * split across pages must not draw two of them.
+   *
+   * A LIST because one mark can hold two decisions at once — an insertion by one author and
+   * a deletion of that insertion by the next. Published only in `all-markup`: the other two
+   * display modes answer what the document WOULD be, and a resolved view draws no
+   * attribution.
+   */
+  readonly markRevisions?: readonly RevisionAttribution[];
+  /**
+   * The one decision a single-field reader sees, absent when there are none.
+   *
+   * Derived from {@link markRevisions} at publish time, never authored beside it, so the two
+   * cannot disagree: a deletion when the mark carries one, because that is where the pair
+   * lands once every decision is taken, and it is the face paint draws for the same reason.
+   *
+   * @deprecated Shows one of the decisions a mark can carry. Read {@link markRevisions}.
    */
   readonly markRevision?: RevisionAttribution;
   /**

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -894,10 +894,11 @@ function placeCellParagraph(
   // The paragraph MARK, on the fragment that finishes the paragraph — the cell lane publishes
   // it for the same reason the body lane does, and until it did, a tracked split or merge
   // inside a `w:tc` drew nothing at all: no pilcrow, no margin rule, no review card.
+  //
+  // Read only when this fragment will carry it. Placement runs for trial rows and for every
+  // continuation, and the projection walks `w:pPr/w:rPr` each time it is asked.
   const markRevisions =
-    deps.displayMode === undefined || deps.displayMode === 'all-markup'
-      ? paragraphMarkRevisionsOf(paragraph)
-      : [];
+    complete && deps.displayMode === 'all-markup' ? paragraphMarkRevisionsOf(paragraph) : [];
   const marker =
     lineStart === 0
       ? publishListMarker(
@@ -926,7 +927,7 @@ function placeCellParagraph(
     ...(shading === undefined ? {} : { shading }),
     ...(shadingBox === undefined ? {} : { shadingBox }),
     ...(marker ? { marker } : {}),
-    ...(complete ? markRevisionFields(markRevisions) : {}),
+    ...markRevisionFields(markRevisions),
     lines: records,
     box: {
       x: fragmentX,

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -36,7 +36,11 @@ import {
 import type { FieldPageContext, HyperlinkProjector } from './field-projection.ts';
 import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
 import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
-import type { RevisionDisplayMode } from './revision-projection.ts';
+import {
+  markRevisionFields,
+  paragraphMarkRevisionsOf,
+  type RevisionDisplayMode,
+} from './revision-projection.ts';
 import {
   collapsedSpaceBefore,
   paragraphBorderExtentPt,
@@ -887,6 +891,13 @@ function placeCellParagraph(
             height: Math.max(contentBottom - contentTop, 0),
           }
         : paragraphShadingBox(records, fragmentX, available);
+  // The paragraph MARK, on the fragment that finishes the paragraph — the cell lane publishes
+  // it for the same reason the body lane does, and until it did, a tracked split or merge
+  // inside a `w:tc` drew nothing at all: no pilcrow, no margin rule, no review card.
+  const markRevisions =
+    deps.displayMode === undefined || deps.displayMode === 'all-markup'
+      ? paragraphMarkRevisionsOf(paragraph)
+      : [];
   const marker =
     lineStart === 0
       ? publishListMarker(
@@ -915,6 +926,7 @@ function placeCellParagraph(
     ...(shading === undefined ? {} : { shading }),
     ...(shadingBox === undefined ? {} : { shadingBox }),
     ...(marker ? { marker } : {}),
+    ...(complete ? markRevisionFields(markRevisions) : {}),
     lines: records,
     box: {
       x: fragmentX,

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -38,6 +38,7 @@ import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts
 import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
 import {
   markRevisionFields,
+  paragraphMarkFormatRevisionOf,
   paragraphMarkRevisionsOf,
   type RevisionDisplayMode,
 } from './revision-projection.ts';
@@ -897,8 +898,9 @@ function placeCellParagraph(
   //
   // Read only when this fragment will carry it. Placement runs for trial rows and for every
   // continuation, and the projection walks `w:pPr/w:rPr` each time it is asked.
-  const markRevisions =
-    complete && deps.displayMode === 'all-markup' ? paragraphMarkRevisionsOf(paragraph) : [];
+  const showsMarkup = complete && deps.displayMode === 'all-markup';
+  const markRevisions = showsMarkup ? paragraphMarkRevisionsOf(paragraph) : [];
+  const markFormatRevision = showsMarkup ? paragraphMarkFormatRevisionOf(paragraph) : null;
   const marker =
     lineStart === 0
       ? publishListMarker(
@@ -927,7 +929,7 @@ function placeCellParagraph(
     ...(shading === undefined ? {} : { shading }),
     ...(shadingBox === undefined ? {} : { shadingBox }),
     ...(marker ? { marker } : {}),
-    ...markRevisionFields(markRevisions),
+    ...markRevisionFields(markRevisions, markFormatRevision),
     lines: records,
     box: {
       x: fragmentX,

--- a/packages/core/src/output/__tests__/revision-paint.test.ts
+++ b/packages/core/src/output/__tests__/revision-paint.test.ts
@@ -229,6 +229,22 @@ describe('changes that decorate no characters', () => {
     expect(glyphs[0]!.dataset.revisionIds).toBe('7 8');
   });
 
+  test('a moved-away mark reads as a removal, like the deletion it becomes', () => {
+    // `w:moveFrom` on the mark says this copy of the break goes away when the move is
+    // accepted. The change bar already counts `moveFrom` as a removal, so a glyph that drew
+    // it in the insertion colour put a blue pilcrow beside a red rule.
+    const root = paint(
+      '<w:p><w:pPr><w:rPr><w:moveFrom w:id="4" w:author="A"/></w:rPr></w:pPr>' +
+        `${run('moved away')}</w:p>`
+    );
+    const glyph = root.querySelector<HTMLElement>('.docx-revision-pmark')!;
+    expect(glyph.style.color).toBe('var(--doc-revision-deletion)');
+    expect(glyph.style.textDecorationLine).toBe('line-through');
+    expect(root.querySelector<HTMLElement>('.docx-change-bar')!.className).toContain(
+      'docx-change-bar-deletion'
+    );
+  });
+
   test('a mark-only change still rules the margin beside its line', () => {
     // The bar is the only signal a reader scanning the margin has. Built from spans alone, a
     // paragraph whose sole change is its own break — a split or a merge, the most ordinary

--- a/packages/core/src/output/__tests__/revision-paint.test.ts
+++ b/packages/core/src/output/__tests__/revision-paint.test.ts
@@ -212,6 +212,33 @@ describe('changes that decorate no characters', () => {
     ).toHaveLength(0);
   });
 
+  test('a mark carrying both decisions draws ONE pilcrow, and it reads as deleted', () => {
+    // `EG_ParaRPrTrackChanges` is `ins? del? …`, and both halves are what Word writes when a
+    // second author proposes removing a break the first proposed adding. There is still one
+    // pilcrow — a second glyph beside it would read as a second paragraph break — and the
+    // deletion takes the face, because that is where the pair lands if every decision is
+    // accepted. Both ids stay on the element so review chrome can offer both.
+    const root = paint(
+      '<w:p><w:pPr><w:rPr><w:ins w:id="7" w:author="A"/><w:del w:id="8" w:author="B"/></w:rPr>' +
+        `</w:pPr>${run('proposed, then unproposed')}</w:p>`
+    );
+    const glyphs = root.querySelectorAll<HTMLElement>('.docx-revision-pmark');
+    expect(glyphs).toHaveLength(1);
+    expect(glyphs[0]!.dataset.revisionKind).toBe('delete');
+    expect(glyphs[0]!.dataset.revisionAuthor).toBe('B');
+    expect(glyphs[0]!.dataset.revisionIds).toBe('7 8');
+  });
+
+  test('a mark-only change still rules the margin beside its line', () => {
+    // The bar is the only signal a reader scanning the margin has. Built from spans alone, a
+    // paragraph whose sole change is its own break — a split or a merge, the most ordinary
+    // tracked edit there is — announced itself with a coloured ¶ and nothing else.
+    const root = paint(mark('del', 'merges forward'));
+    const bars = root.querySelectorAll<HTMLElement>('.docx-change-bar');
+    expect(bars).toHaveLength(1);
+    expect(bars[0]!.className).toContain('docx-change-bar-deletion');
+  });
+
   test('the pilcrow is furniture, not text', () => {
     const glyph = paint(mark('del', 'x')).querySelector<HTMLElement>('.docx-revision-pmark')!;
     expect(glyph.getAttribute('aria-hidden')).toBe('true');

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -868,9 +868,11 @@ function paintParagraphMark(
   glyph.dataset.revisionKind = shown.kind;
   glyph.dataset.revisionId = shown.id;
   glyph.dataset.revisionAuthor = shown.author;
-  if (revisions.length > 1) {
-    glyph.dataset.revisionIds = revisions.map((revision) => revision.id).join(' ');
-  }
+  // Always, not only for a pair: a consumer reading `data-revision-ids` should not have to
+  // fall back to `data-revision-id` for the ordinary case. Kinds ride alongside, because the
+  // ids alone cannot say which decision each one is.
+  glyph.dataset.revisionIds = revisions.map((revision) => revision.id).join(' ');
+  glyph.dataset.revisionKinds = revisions.map((revision) => revision.kind).join(' ');
   glyph.textContent = '\u00b6';
   glyph.style.position = 'absolute';
   glyph.style.pointerEvents = 'none';

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -15,7 +15,11 @@
 import { baselineShiftPtOf, TAB_LEADER_GLYPH } from '@docx-editor.dev/core/layout';
 import { DEFAULT_CANVAS_FONT_STACK } from '../layout/canvas-measurer.ts';
 import { revisionPresentationOf } from './revision-presentation.ts';
-import { formatRevisionOf, type RevisionAttribution } from '@docx-editor.dev/core/layout';
+import {
+  formatRevisionOf,
+  shownMarkRevision,
+  type RevisionAttribution,
+} from '@docx-editor.dev/core/layout';
 import type {
   ContentControlBoundaryRecord,
   ContentControlMappedType,
@@ -848,23 +852,32 @@ function applyRevisionPresentation(element: HTMLElement, span: StyleSpanRecord):
  */
 function paintParagraphMark(
   document: Document,
-  revision: RevisionAttribution,
+  revisions: readonly RevisionAttribution[],
   scale: number
 ): HTMLElement {
+  // ONE glyph however many decisions stand on it: there is one pilcrow, and drawing a second
+  // beside it would read as a second paragraph break. The DELETION wins the face when a mark
+  // carries both — a break proposed and then unproposed ends up removed, and the same rule
+  // already decides the colour of a change bar over mixed lines. Both attributions are
+  // published on the element, so review chrome can still offer both decisions.
+  const shown = shownMarkRevision(revisions)!;
   const glyph = document.createElement('span');
-  glyph.className = `docx-revision-pmark docx-revision-pmark-${revision.kind}`;
+  glyph.className = `docx-revision-pmark docx-revision-pmark-${shown.kind}`;
   glyph.setAttribute('aria-hidden', 'true');
   glyph.contentEditable = 'false';
-  glyph.dataset.revisionKind = revision.kind;
-  glyph.dataset.revisionId = revision.id;
-  glyph.dataset.revisionAuthor = revision.author;
+  glyph.dataset.revisionKind = shown.kind;
+  glyph.dataset.revisionId = shown.id;
+  glyph.dataset.revisionAuthor = shown.author;
+  if (revisions.length > 1) {
+    glyph.dataset.revisionIds = revisions.map((revision) => revision.id).join(' ');
+  }
   glyph.textContent = '\u00b6';
   glyph.style.position = 'absolute';
   glyph.style.pointerEvents = 'none';
   glyph.style.marginLeft = `${2 * scale}px`;
   glyph.style.color =
-    revision.kind === 'delete' ? 'var(--doc-revision-deletion)' : 'var(--doc-revision-insertion)';
-  if (revision.kind === 'delete') glyph.style.textDecorationLine = 'line-through';
+    shown.kind === 'delete' ? 'var(--doc-revision-deletion)' : 'var(--doc-revision-insertion)';
+  if (shown.kind === 'delete') glyph.style.textDecorationLine = 'line-through';
   return glyph;
 }
 
@@ -893,8 +906,16 @@ function paintChangeBars(
     deleted: boolean;
   }
   const runs: BarRun[] = [];
+  // The mark belongs to the LAST line, and it is a revision like any other. Reading only the
+  // spans left a paragraph whose sole change was its own pilcrow — a split or a merge, the
+  // most ordinary tracked edit there is — with a coloured ¶ and no rule in the margin, so a
+  // reader scanning the margin never saw that the paragraph had been changed at all.
+  const markLine = fragment.lines[fragment.lines.length - 1];
   for (const line of fragment.lines) {
-    const revisions = line.spans.flatMap((span) => span.revisions ?? []);
+    const revisions = [
+      ...line.spans.flatMap((span) => span.revisions ?? []),
+      ...(line === markLine ? (fragment.markRevisions ?? []) : []),
+    ];
     if (revisions.length === 0) continue;
     const deleted = revisions.some(
       (revision) => revision.kind === 'delete' || revision.kind === 'moveFrom'
@@ -1370,8 +1391,8 @@ function paintFragment(
   // is the only signal that a change exists at all once the reader is in a resolved view.
   const bars = paintChangeBars(document, fragment, scale);
   if (bars) element.append(bars);
-  if (fragment.markRevision) {
-    const glyph = paintParagraphMark(document, fragment.markRevision, scale);
+  if (fragment.markRevisions && fragment.markRevisions.length > 0) {
+    const glyph = paintParagraphMark(document, fragment.markRevisions, scale);
     const last = fragment.lines[fragment.lines.length - 1];
     if (last) {
       // At the end of the last line's text, which is where the mark itself sits.

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -17,6 +17,7 @@ import { DEFAULT_CANVAS_FONT_STACK } from '../layout/canvas-measurer.ts';
 import { revisionPresentationOf } from './revision-presentation.ts';
 import {
   formatRevisionOf,
+  markRevisionRemovesMark,
   shownMarkRevision,
   type RevisionAttribution,
 } from '@docx-editor.dev/core/layout';
@@ -856,10 +857,11 @@ function paintParagraphMark(
   scale: number
 ): HTMLElement {
   // ONE glyph however many decisions stand on it: there is one pilcrow, and drawing a second
-  // beside it would read as a second paragraph break. The DELETION wins the face when a mark
+  // beside it would read as a second paragraph break. A REMOVAL wins the face when a mark
   // carries both — a break proposed and then unproposed ends up removed, and the same rule
-  // already decides the colour of a change bar over mixed lines. Both attributions are
-  // published on the element, so review chrome can still offer both decisions.
+  // already decides the colour of a change bar over mixed lines. `moveFrom` counts as a
+  // removal, which is what keeps this glyph agreeing with the rule in the margin beside it.
+  // Both attributions are published on the element, so review chrome can offer both.
   const shown = shownMarkRevision(revisions)!;
   const glyph = document.createElement('span');
   glyph.className = `docx-revision-pmark docx-revision-pmark-${shown.kind}`;
@@ -877,9 +879,9 @@ function paintParagraphMark(
   glyph.style.position = 'absolute';
   glyph.style.pointerEvents = 'none';
   glyph.style.marginLeft = `${2 * scale}px`;
-  glyph.style.color =
-    shown.kind === 'delete' ? 'var(--doc-revision-deletion)' : 'var(--doc-revision-insertion)';
-  if (shown.kind === 'delete') glyph.style.textDecorationLine = 'line-through';
+  const removes = markRevisionRemovesMark(shown);
+  glyph.style.color = removes ? 'var(--doc-revision-deletion)' : 'var(--doc-revision-insertion)';
+  if (removes) glyph.style.textDecorationLine = 'line-through';
   return glyph;
 }
 

--- a/packages/core/src/store/__tests__/revision-resolve.test.ts
+++ b/packages/core/src/store/__tests__/revision-resolve.test.ts
@@ -383,3 +383,35 @@ describe('accept-all and reject-all', () => {
     );
   });
 });
+
+describe('a move recorded on the paragraph mark', () => {
+  // `EG_ParaRPrTrackChanges` is `ins? del? moveFrom? moveTo?`. When a whole paragraph moves
+  // with tracking on, Word records it on the MARK: `w:moveFrom` on the copy the paragraph
+  // left, `w:moveTo` on the copy it arrived at. Reading only `ins`/`del` there left the move
+  // raising no card at all, so a reviewer had nothing to accept.
+  const moved = (name: 'moveFrom' | 'moveTo') =>
+    load(
+      `<w:p><w:pPr><w:rPr><w:${name} w:id="${QA.id}" w:author="${QA.author}" w:date="${QA.date}"/></w:rPr></w:pPr>` +
+        `${run('first')}</w:p><w:p>${run('second')}</w:p>`
+    );
+
+  test('accepting a moveFrom mark runs the paragraph into the next one', () => {
+    // Accepting the move removes THIS copy of the break, exactly as accepting a deletion does.
+    const out = xml(apply(moved('moveFrom'), accept(QA)));
+    expect(out).not.toContain('<w:moveFrom');
+    expect(out.match(/<w:p[ >]/g)).toHaveLength(1);
+    expect(out).toContain('first');
+    expect(out).toContain('second');
+  });
+
+  test('rejecting a moveFrom mark keeps the break and drops the record', () => {
+    const out = xml(apply(moved('moveFrom'), reject(QA)));
+    expect(out).not.toContain('<w:moveFrom');
+    expect(out.match(/<w:p[ >]/g)).toHaveLength(2);
+  });
+
+  test('a moveTo mark is the other half: rejecting removes the break it arrived at', () => {
+    expect(xml(apply(moved('moveTo'), reject(QA))).match(/<w:p[ >]/g)).toHaveLength(1);
+    expect(xml(apply(moved('moveTo'), accept(QA))).match(/<w:p[ >]/g)).toHaveLength(2);
+  });
+});

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -61,6 +61,9 @@ const REFUSED_REVISION_NAMES: ReadonlySet<string> = new Set([
 /** Property-change wrappers this pass does resolve: the run and paragraph property records. */
 const PROPERTY_CHANGE_NAMES: ReadonlySet<string> = new Set(['rPrChange', 'pPrChange']);
 
+/** The two members of `EG_ParaRPrTrackChanges` that record a MOVE of the paragraph mark. */
+const MARK_MOVE_NAMES: ReadonlySet<string> = new Set(['moveFrom', 'moveTo']);
+
 /**
  * Parents that make a `w:ins`/`w:del` a STRUCTURAL revision rather than a content one.
  *
@@ -218,8 +221,13 @@ function collectRevisionSitesIn(part: OoxmlPart, scopeRootId?: string): Revision
       grandparent?.namespaceUri === WML_NAMESPACE_URI ? grandparent.localName : undefined;
     if (node.namespaceUri === WML_NAMESPACE_URI) {
       const isContent = isContentRevisionKind(node.kind);
+      // A mark-position `w:moveFrom`/`w:moveTo` is generic in the tree, so `isContent` misses
+      // it; naming it here is what raises the card for a paragraph that was MOVED whole.
+      const markMove =
+        parentName === 'rPr' && grandparentName === 'pPr' && MARK_MOVE_NAMES.has(node.localName);
       const isNamedRevision =
         isContent ||
+        markMove ||
         REFUSED_REVISION_NAMES.has(node.localName) ||
         PROPERTY_CHANGE_NAMES.has(node.localName) ||
         node.localName === 'ins' ||
@@ -246,7 +254,10 @@ function collectRevisionSitesIn(part: OoxmlPart, scopeRootId?: string): Revision
         // not a paragraph mark, and treating it as one made accepting it merge two
         // paragraphs — a silent structural edit from markup no valid file contains.
         const paragraphMark =
-          !isContent && parentName === 'rPr' && grandparentName === 'pPr' && !structural;
+          (!isContent || markMove) &&
+          parentName === 'rPr' &&
+          grandparentName === 'pPr' &&
+          !structural;
         sites.push({
           node,
           parent,
@@ -742,9 +753,14 @@ export function resolveRevisions(
       // split or a merge. Accepting a deleted mark, or rejecting an inserted one, removes the
       // mark — and the paragraph then runs into the one after it. Removing only the element
       // would report the decision applied while leaving the split in place.
+      // `moveFrom` and `moveTo` are the same two decisions under another name: accepting a
+      // move removes the mark the paragraph left, rejecting one removes the mark it arrived
+      // at. Both then run the paragraph into the one after it, exactly as `del`/`ins` do.
       const removesMark =
-        (action === 'accept' && site.node.localName === 'del') ||
-        (action === 'reject' && site.node.localName === 'ins');
+        (action === 'accept' &&
+          (site.node.localName === 'del' || site.node.localName === 'moveFrom')) ||
+        (action === 'reject' &&
+          (site.node.localName === 'ins' || site.node.localName === 'moveTo'));
       dropMarks.add(site.node.id);
       if (removesMark) {
         const paragraph = paragraphOwning(part, site.node.id);


### PR DESCRIPTION
Incremental layout reuses the previous pass's pages, so anything published that no key covers survives an edit that should have changed it. The fragment signature picked its fields by hand, and derived state — note marks, list markers — sat outside both the session and break-cache keys.

Every field of a fragment and of a page is now classified by the compiler: a new field is a type error until somebody says what keeps it current.

Leaks found and fixed along the way: a tracked paragraph mark never reaching the page, only the first of a mark's revisions being read, a mark inside a table cell never drawn, no change bar for a mark-only change, attribution drawn in the resolved views, a renumbered list or footnote keeping its old measurement, and a resume dropping a displaced anchored drawing. Each has a test that fails on `main`.

Subsumes #251. `markRevision` and `paragraphMarkRevisionOf` stay as deprecated derived readers, so the API change is additive.

Not addressed: `proposed` and `original` still show the paragraph break where Word merges it. That needs a fragment to hold lines from more than one paragraph, and 13 modules assume the opposite.