### PR TITLE
feat(core): render text-like field instructions

### DIFF
--- a/.changeset/body-page-fields.md
+++ b/.changeset/body-page-fields.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+PAGE, NUMPAGES, and SECTIONPAGES fields in the document body (and body tables) now render the page number, document page count, or section page count when the field has no cached result, instead of showing blank.

--- a/.changeset/document-property-fields.md
+++ b/.changeset/document-property-fields.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Document-property fields (TITLE, AUTHOR, SUBJECT, KEYWORDS, LASTSAVEDBY, COMMENTS, and DOCPROPERTY for those names) now render their value from the document properties when the field has no cached result, instead of showing blank.

--- a/.changeset/field-links-at-caret.md
+++ b/.changeset/field-links-at-caret.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+HYPERLINK field links now work with the link popover the same way typed links do: the popover opens read-only over one, Ctrl/Cmd+K reaches it, and it dismisses when the caret leaves the field. Two adjacent HYPERLINK fields that point at the same target now render as two separate links.

--- a/.changeset/text-field-instruction-rendering.md
+++ b/.changeset/text-field-instruction-rendering.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+SYMBOL, MACROBUTTON, and GOTOBUTTON fields and w:sym symbol runs now render, legacy FORMCHECKBOX and FORMDROPDOWN fields paint their w:ffData state, and PAGE-family fields nested inside other fields evaluate per page. HYPERLINK fields are clickable links with the same target sanitization as typed hyperlinks.

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -125,6 +125,7 @@ export interface TreeDocxSession {
     deleteImage(scope: StoryScope, drawingNodeId: string): ImageIntentResult;
     documentFonts(): readonly string[];
     documentOutline(): readonly DocumentOutlineEntry[];
+    documentProperties(): DocumentProperties;
     documentStyles(): readonly DocumentStyleEntry[];
     documentThemeColors(): readonly DocumentThemeColorEntry[];
     documentThemeFonts(): DocumentThemeFonts;

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -978,6 +978,7 @@ export interface HyperlinkOps {
         readonly text?: string;
         readonly tooltip?: string;
     }): boolean;
+    fieldLinkAtCaret(): SurfaceHyperlink | null;
     linkAtCaret(): SurfaceHyperlink | null;
     linkById(linkId: string): SurfaceHyperlink | null;
     linksInCaretParagraph(): SurfaceHyperlink[];

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1659,6 +1659,7 @@ export interface PageRecord {
     readonly footnotes?: NoteAreaRecord;
     // (undocumented)
     readonly fragments: readonly BlockFragmentRecord[];
+    readonly hasBodyPageFields?: boolean;
     readonly header?: HeaderFooterStoryRecord;
     // (undocumented)
     readonly id: string;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -599,6 +599,9 @@ export interface FieldAtomMarker {
 }
 
 // @public
+export type FieldLinkProjector = (spec: HyperlinkFieldSpec) => SpanLinkRecord | null;
+
+// @public
 export function filterRefsOnPage(page: PageRecord, allRefs: readonly PageRefHit[], refIndex?: PageRefIndex): readonly PageRefHit[];
 
 // @public
@@ -1008,6 +1011,13 @@ export function hitTestSemantic(layout: SemanticLayout, point: {
 
 // @public
 export function hitTestSheet(layout: SemanticLayout, point: HitPoint, options?: HitTestOptions): SemanticHit | null;
+
+// @public
+export interface HyperlinkFieldSpec {
+    readonly anchor: string | null;
+    readonly target: string | null;
+    readonly tooltip: string | null;
+}
 
 // @public
 export type HyperlinkProjector = (link: OoxmlNode) => SpanLinkRecord | null;
@@ -2520,6 +2530,7 @@ export interface SemanticLayoutOptions {
     readonly numberingIndex?: NumberingIndex;
     readonly pageBottomReserves?: ReadonlyMap<number, number>;
     readonly producer?: string;
+    readonly projectFieldLink?: FieldLinkProjector;
     readonly projectLink?: HyperlinkProjector;
     readonly sectionColumns?: SectionColumns;
     readonly sectionFurniture?: readonly (PageFurniture | undefined)[];

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1498,6 +1498,9 @@ export interface NotesLayoutInput {
     // (undocumented)
     readonly producer: string;
     // (undocumented)
+    readonly projectFieldLink?: FieldLinkProjector;
+    readonly projectLink?: HyperlinkProjector;
+    // (undocumented)
     readonly styleCascade?: StyleCascadeTable;
 }
 

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -596,6 +596,9 @@ export function expandLvlText(lvlText: string, counters: readonly number[], form
 // @public
 export interface FieldAtomMarker {
     readonly formField: boolean;
+    readonly pageField?: {
+        readonly kind: AllowlistedPageField;
+    };
 }
 
 // @public
@@ -1106,7 +1109,7 @@ export interface LayoutCacheStats {
 }
 
 // @public
-export function layoutHeaderFooterStory(part: OoxmlPart, contentWidth: number, measurer: TextMeasurer, producer: string, cache?: ParagraphLayoutCache<readonly PendingLine[]>, styleCascade?: StyleCascadeTable, pageContext?: FieldPageContext, maxPageContextEntries?: number, defaultTabStopPt?: number, displayMode?: RevisionDisplayMode, inlineDrawingLayout?: InlineDrawingLayoutContext, drawingTokenForParagraph?: (paragraph: OoxmlNode) => string, drawingLayoutToken?: string, hfPageContext?: HeaderFooterPageContext): HeaderFooterStoryLayout;
+export function layoutHeaderFooterStory(part: OoxmlPart, contentWidth: number, measurer: TextMeasurer, producer: string, cache?: ParagraphLayoutCache<readonly PendingLine[]>, styleCascade?: StyleCascadeTable, pageContext?: FieldPageContext, maxPageContextEntries?: number, defaultTabStopPt?: number, displayMode?: RevisionDisplayMode, inlineDrawingLayout?: InlineDrawingLayoutContext, drawingTokenForParagraph?: (paragraph: OoxmlNode) => string, drawingLayoutToken?: string, hfPageContext?: HeaderFooterPageContext, documentProperties?: DocumentProperties): HeaderFooterStoryLayout;
 
 // @public
 export function layoutNoteById(part: OoxmlPart | null | undefined, noteId: number, contentWidth: number, options: LayoutNoteStoryOptions): NoteStoryLayout | null;
@@ -1486,6 +1489,7 @@ export interface NotesLayoutInput {
     // (undocumented)
     readonly documentEndnoteProps: ResolvedEndnoteProperties;
     readonly documentFootnoteProps: ResolvedFootnoteProperties;
+    readonly documentProperties?: DocumentProperties;
     readonly drawingsForPart?: (ownerPartName: string) => NoteStoryDrawings | undefined;
     readonly endnotePropsBySection: readonly ResolvedEndnoteProperties[];
     // (undocumented)
@@ -2512,6 +2516,7 @@ export interface SemanticLayoutOptions {
     readonly cache?: ParagraphLayoutCache<readonly PendingLine[]>;
     readonly defaultTabStopPt?: number;
     readonly displayMode?: RevisionDisplayMode;
+    readonly documentProperties?: DocumentProperties;
     readonly drawingExclusionConverged?: boolean;
     readonly drawingExclusionPass?: number;
     readonly drawingExclusionZonesByPage?: ReadonlyMap<number, readonly ExclusionZone[]>;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -1093,6 +1093,18 @@ export function directParagraphMarkProperties(part: OoxmlPart, paragraphId: stri
 export function directParagraphProperties(part: OoxmlPart, paragraphId: string): readonly OoxmlProperty[];
 
 // @public
+export interface DocumentProperties {
+    readonly company?: string;
+    readonly creator?: string;
+    readonly description?: string;
+    readonly keywords?: string;
+    readonly lastModifiedBy?: string;
+    readonly manager?: string;
+    readonly subject?: string;
+    readonly title?: string;
+}
+
+// @public
 export interface DocumentTrackingSettings {
     readonly doNotTrackFormatting: boolean;
     readonly doNotTrackMoves: boolean;

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -803,7 +803,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Insert, edit, and remove a link with Ctrl+K, Cmd+K, or the toolbar. Targets are allowlisted: http, https, mailto, tel, and ftp. Any other target renders inert and still round-trips. Opening a document never requests a link target, because activation needs an explicit gesture.',
+      'Insert, edit, and remove a link with Ctrl+K, Cmd+K, or the toolbar. Targets are allowlisted: http, https, mailto, tel, and ftp. Any other target renders inert and still round-trips. A HYPERLINK field, complex or w:fldSimple, is a live link too: its target passes the same allowlist, and the link panel shows it read-only. Links in footnote and endnote text work the same way. Opening a document never requests a link target, because activation needs an explicit gesture.',
   },
   {
     id: 'fields.bookmarks',
@@ -825,7 +825,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'PAGE, NUMPAGES, and SECTIONPAGES project in headers and footers at layout time, as a complex field or w:fldSimple. PAGE respects the section pgNumType start and format. Fields inside an anchored header or footer text box also project, as does a page field nested inside another simple field such as STYLEREF. React header and footer chrome can insert them, including Page X of Y. Other field instructions stay inert, and body field evaluation is deferred.',
+      'PAGE, NUMPAGES, and SECTIONPAGES project in headers and footers at layout time, as a complex field or w:fldSimple. PAGE respects the section pgNumType start and format. Fields inside an anchored header or footer text box also project, as does a page field nested inside another field — simple or complex, such as STYLEREF — up to four levels deep, evaluated per page. React header and footer chrome can insert them, including Page X of Y. Body field evaluation is deferred.',
   },
   {
     id: 'fields.toc',
@@ -847,7 +847,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'preserved',
     tier: 'community',
     notes:
-      'The last computed result displays for a complex field and for w:fldSimple, and the field codes round-trip untouched. Painted results carry Word-like grey field shading. A legacy form field always shades unless w:doNotShadeFormData is set; other fields follow the fieldShading option (never, when-selected, always). The editor never executes a field instruction.',
+      'The last computed result displays for a complex field and for w:fldSimple, and the field codes round-trip untouched. SYMBOL renders its character from the instruction, with the \\f font and \\s size honored. MACROBUTTON and GOTOBUTTON render their display text; the macro never runs and the jump never fires. A field code under a tracked edit still renders: w:delInstrText is read when no live instruction remains. Painted results carry Word-like grey field shading. A legacy form field always shades unless w:doNotShadeFormData is set; other fields follow the fieldShading option (never, when-selected, always). The editor never executes a field instruction. DATE, REF, SEQ, and similar codes display only their cached result; AUTONUM, LISTNUM, and EQ are not evaluated.',
   },
   {
     id: 'fields.citations',
@@ -865,11 +865,11 @@ export const wordFeatures: WordFeature[] = [
     name: 'Legacy form fields (FORMTEXT, FORMCHECKBOX, FORMDROPDOWN)',
     category: 'fields',
     editing: 'partial',
-    rendering: 'partial',
+    rendering: 'full',
     roundTrip: 'preserved',
     tier: 'community',
     notes:
-      'FORMTEXT result text is editable inline, with an accurate caret and selection. Field markers, instructions, and w:ffData round-trip, and tracked edits survive. Form-field shading applies unless w:doNotShadeFormData is set. FORMCHECKBOX and FORMDROPDOWN render a static result. Checkbox and dropdown interaction, Tab navigation, ffData constraints, and forms-protection fill mode are not built.',
+      'FORMTEXT result text is editable inline, with an accurate caret and selection. FORMCHECKBOX renders its checked or default state from w:ffData, and an explicit w:size sets the glyph size. FORMDROPDOWN renders the cached result, or the selected list entry when the file caches none. Field markers, instructions, and w:ffData round-trip, and tracked edits survive. Form-field shading applies unless w:doNotShadeFormData is set. Checkbox and dropdown interaction, Tab navigation, ffData constraints, and forms-protection fill mode are not built.',
   },
 
   // --- Document structure & content controls ---------------------------------

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -825,7 +825,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'PAGE, NUMPAGES, and SECTIONPAGES project in headers and footers at layout time, as a complex field or w:fldSimple. PAGE respects the section pgNumType start and format. Fields inside an anchored header or footer text box also project, as does a page field nested inside another field — simple or complex, such as STYLEREF — up to four levels deep, evaluated per page. React header and footer chrome can insert them, including Page X of Y. Body field evaluation is deferred.',
+      'PAGE, NUMPAGES, and SECTIONPAGES project as a complex field or w:fldSimple. They evaluate in headers and footers and in the body flow, body tables included. PAGE respects the section pgNumType start and format. Fields inside an anchored header or footer text box also project, as does a page field nested inside another field — simple or complex, such as STYLEREF — up to four levels deep, evaluated per page. React header and footer chrome can insert them, including Page X of Y. A body field paints a placeholder that document layout substitutes per page. A multi-digit body value keeps the one-digit measured width, so mid-line following text does not reflow.',
   },
   {
     id: 'fields.toc',
@@ -847,7 +847,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'preserved',
     tier: 'community',
     notes:
-      'The last computed result displays for a complex field and for w:fldSimple, and the field codes round-trip untouched. SYMBOL renders its character from the instruction, with the \\f font and \\s size honored. MACROBUTTON and GOTOBUTTON render their display text; the macro never runs and the jump never fires. A field code under a tracked edit still renders: w:delInstrText is read when no live instruction remains. Painted results carry Word-like grey field shading. A legacy form field always shades unless w:doNotShadeFormData is set; other fields follow the fieldShading option (never, when-selected, always). The editor never executes a field instruction. DATE, REF, SEQ, and similar codes display only their cached result; AUTONUM, LISTNUM, and EQ are not evaluated.',
+      'The last computed result displays for a complex field and for w:fldSimple, and the field codes round-trip untouched. SYMBOL renders its character from the instruction, with the \\f font and \\s size honored. MACROBUTTON and GOTOBUTTON render their display text; the macro never runs and the jump never fires. A field code under a tracked edit still renders: w:delInstrText is read when no live instruction remains. Painted results carry Word-like grey field shading. A legacy form field always shades unless w:doNotShadeFormData is set; other fields follow the fieldShading option (never, when-selected, always). The editor never executes a field instruction. TITLE, AUTHOR, SUBJECT, KEYWORDS, LASTSAVEDBY, COMMENTS, and DOCPROPERTY for those names render from the document metadata in docProps, capped and sanitized. DATE-valued properties stay inert. DATE, TIME, and FILENAME are not evaluated. REF and SEQ display only their cached result; AUTONUM, LISTNUM, and EQ are not evaluated.',
   },
   {
     id: 'fields.citations',

--- a/openspec/changes/text-field-instruction-rendering/proposal.md
+++ b/openspec/changes/text-field-instruction-rendering/proposal.md
@@ -28,12 +28,17 @@ Each of these is display the file fully specifies. Painting nothing where Word p
 
 **Deleted instructions are recognized.** Live (`w:instrText`) and deleted (`w:delInstrText`) chunks buffer separately at every nesting level; the live buffer answers whenever any live element exists, and the deleted buffer answers only when none does. Synthesis is revision-aware — a result the display mode resolved away is free to be filled, a result the file hides stays hidden — demoted fields still shade, and nested field state survives drawing descents.
 
+**Document-property fields render from the file's metadata.** `TITLE`, `AUTHOR`, `SUBJECT`, `KEYWORDS`, `LASTSAVEDBY`, `COMMENTS`, and `DOCPROPERTY "Name"` over that same fixed set paint the matching value from `docProps/core.xml` and `docProps/app.xml` when the field caches no result. The reader matches only the known properties by exact (namespace, localName), trims and length-caps each value at the trust boundary, and the paint sink writes text, never markup. A DATE-valued property (`CREATEDATE`, `SAVEDATE`, `PRINTDATE`) is deliberately not evaluated. Every story resolves them: body, tables, notes, headers, footers, and text boxes.
+
+**Body `PAGE` / `NUMPAGES` / `SECTIONPAGES` evaluate in the flow.** The value is unknown while a paragraph is measured, so the paragraph walk reserves one model unit and paints a kind-marked placeholder digit; document finalize substitutes the per-page value once pagination converges. The field stays one model unit whatever the digit count, so offsets never move. It is measured at the one-digit placeholder width — a multi-digit value mid-line keeps that width rather than reflowing following text. `DATE`, `TIME`, and `FILENAME` stay out of scope.
+
 **One ratified scenario is amended.** `field-result-rendering` said an empty result paints nothing while holding its one model unit. That stays true for every cached-result field — but the synthesizing kinds above exist precisely because their files cache nothing, so for them an empty result is the trigger, not the answer.
 
 ## Impact
 
-- `core/layout`: new `symbol-run.ts`, `field-symbol.ts`, `field-button.ts`, `field-form.ts`, `field-link.ts`, `field-nested-page.ts`, `field-run-text.ts`; `field-instruction.ts` (dual live/deleted buffers, per-level state), `field-projection.ts`, `field-simple-result.ts`, `field-pieces.ts`, `paragraph-flow.ts`, `semantic-layout.ts`, `semantic-table-layout.ts`, `note-layout.ts`, `note-pagination.ts`.
-- `core/store`: `field-nodes.ts` (`legacyFormFieldDataOf` — bounded, state only).
+- `core/layout`: new `symbol-run.ts`, `field-symbol.ts`, `field-button.ts`, `field-form.ts`, `field-link.ts`, `field-nested-page.ts`, `field-run-text.ts`, `field-doc-property.ts`, `field-page-furniture.ts`, `field-synthesis.ts`; `field-instruction.ts` (dual live/deleted buffers, per-level state), `field-projection.ts`, `field-simple-result.ts`, `field-pieces.ts`, `paragraph-flow.ts`, `semantic-layout.ts`, `semantic-table-layout.ts`, `note-layout.ts`, `note-pagination.ts`, `textbox-story-layout.ts`, `hf-layout.ts`.
+- `core/store`: `field-nodes.ts` (`legacyFormFieldDataOf` — bounded, state only), new `package/document-properties.ts` (bounded metadata reader, fixed known properties only).
+- `core/binding`: `tree-session.ts` reads document properties for field resolution.
 - `core/editor`: new `surface-field-links.ts` (the one href trust boundary for field links), `paginated-surface.ts`.
 - `react`: the hyperlink popover stays open for field links, read-only.
 - No field instruction is ever executed, fetched, or resolved against a host origin. Every parser fails closed on hostile input.

--- a/openspec/changes/text-field-instruction-rendering/proposal.md
+++ b/openspec/changes/text-field-instruction-rendering/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`word-like-field-rendering` taught the page to paint a field's CACHED result. A whole class of text-like fields has no cached result to paint, because Word derives their display from somewhere else and re-renders it on every open:
+
+- **`SYMBOL`** (§17.16.5.60) displays a character code named in the instruction. Real files carry no result runs at all, so the field painted nothing.
+- **`MACROBUTTON` / `GOTOBUTTON`** (§17.16.5.36, §17.16.5.31) display the text after their first argument. Same shape: no cached result, blank page.
+- **`FORMCHECKBOX` / `FORMDROPDOWN`** (§17.16.5.22, §17.16.5.16) keep their state in `w:ffData` under the begin `w:fldChar`. A checkbox painted nothing; a dropdown painted only whatever the producer happened to cache.
+- **`w:sym`** runs (§17.3.3.30) are generic in the canonical tree and worth zero model offsets, so a symbol character vanished from the page even though the run around it painted.
+- **`HYPERLINK` fields** — the field spelling of a link, with no `w:hyperlink` element — painted their result as plain text. The typed-link lane resolves canonical node ids, so it could never make one clickable.
+- **A `PAGE`-family field nested inside another complex field** (a `STYLEREF` wrapping `PAGE`, say) stamped the producer's cached sheet number onto every page. The nested-field lane only evaluated the `w:fldSimple` shape.
+- **A field code under a tracked edit** leaves `w:delInstrText` beside `w:instrText`. The deleted chunks were invisible to the instruction buffer, so a field whose whole code was pending deletion lost its instruction — and with it, its rendering.
+
+Each of these is display the file fully specifies. Painting nothing where Word paints text is a fidelity defect, not a deferral.
+
+## What Changes
+
+**`w:sym` symbol runs render.** The glyph projects at its insertion point as a rendering-only piece over ZERO model width, so the store's offset authority does not move. Symbol-font bytes normalize through the same 0xF000-page PUA mapping as list bullets (`symbol-encoding.ts`); parsing of the attacker-controlled attributes fails closed to no glyph.
+
+**`SYMBOL` renders from its instruction.** `\f` overrides the font, `\s` the size in whole points, `\u` reads the code as a Unicode codepoint. Tokenization is one bounded pass over an already-capped string; every hostile or malformed instruction resolves to null and the field falls back to what it painted before.
+
+**`HYPERLINK` fields are live links**, complex and `w:fldSimple` alike. Layout parses the instruction into raw strings and NEVER builds an href; the surface's field-link registry applies the same `sanitizeHref` plus absolute-URI gate a relationship target must clear, mints span link records, and resolves clicks. A refused target falls back to the `\l` anchor or to no link at all. The registry fails closed at its cap: past it a new target paints plain text. The hyperlink popover shows a field link read-only. Footnote and endnote stories project links too — typed `w:hyperlink` and `HYPERLINK` fields both.
+
+**Legacy `FORMCHECKBOX` / `FORMDROPDOWN` render from `w:ffData`.** The checkbox paints ☒ or ☐ from its checked (or default) bit — state is the authority, so a stale cached glyph never wins; explicit `w:size` sets the glyph size and `w:sizeAuto` keeps the run's. The dropdown prefers its cached result and synthesizes the selected `w:listEntry` only when the file cached none. The `ffData` reader is bounded and reads state only — macro, name, and help fields are never read.
+
+**`MACROBUTTON` / `GOTOBUTTON` render their display text.** The macro name or jump target is consumed and discarded: nothing executes, nothing navigates, and no caller may wire a click to one. A non-empty cached display wins over synthesis.
+
+**Nested `PAGE` / `NUMPAGES` / `SECTIONPAGES` evaluate live inside complex outer fields**, at any nesting level 2..4, per sheet, matching the `w:fldSimple` lane. The tracker is level-aware: only the level whose `separate` armed it can append and disarm, so a begin/end pair inside a tracked result cannot clear tracking mid-field. Detection and projection share one allowlist so they cannot drift.
+
+**Deleted instructions are recognized.** Live (`w:instrText`) and deleted (`w:delInstrText`) chunks buffer separately at every nesting level; the live buffer answers whenever any live element exists, and the deleted buffer answers only when none does. Synthesis is revision-aware — a result the display mode resolved away is free to be filled, a result the file hides stays hidden — demoted fields still shade, and nested field state survives drawing descents.
+
+**One ratified scenario is amended.** `field-result-rendering` said an empty result paints nothing while holding its one model unit. That stays true for every cached-result field — but the synthesizing kinds above exist precisely because their files cache nothing, so for them an empty result is the trigger, not the answer.
+
+## Impact
+
+- `core/layout`: new `symbol-run.ts`, `field-symbol.ts`, `field-button.ts`, `field-form.ts`, `field-link.ts`, `field-nested-page.ts`, `field-run-text.ts`; `field-instruction.ts` (dual live/deleted buffers, per-level state), `field-projection.ts`, `field-simple-result.ts`, `field-pieces.ts`, `paragraph-flow.ts`, `semantic-layout.ts`, `semantic-table-layout.ts`, `note-layout.ts`, `note-pagination.ts`.
+- `core/store`: `field-nodes.ts` (`legacyFormFieldDataOf` — bounded, state only).
+- `core/editor`: new `surface-field-links.ts` (the one href trust boundary for field links), `paginated-surface.ts`.
+- `react`: the hyperlink popover stays open for field links, read-only.
+- No field instruction is ever executed, fetched, or resolved against a host origin. Every parser fails closed on hostile input.
+- No behaviour change for documents with none of these fields.

--- a/openspec/changes/text-field-instruction-rendering/specs/field-instruction-rendering/spec.md
+++ b/openspec/changes/text-field-instruction-rendering/specs/field-instruction-rendering/spec.md
@@ -85,6 +85,43 @@ The tracker SHALL be level-aware: it records the nesting level whose `separate` 
 - **WHEN** a tracked inner field's cached result itself contains a begin/end pair
 - **THEN** the deeper pair is ignored and the tracked field's own end still appends the live value
 
+### Requirement: A document-property field renders from the document metadata
+
+A `TITLE`, `AUTHOR`, `SUBJECT`, `KEYWORDS`, `LASTSAVEDBY`, or `COMMENTS` field, and a `DOCPROPERTY "Name"` field naming one of those same properties, SHALL render the matching value from `docProps/core.xml` and `docProps/app.xml`, complex and `w:fldSimple` alike, when the field carries no cached result — because Word derives their display from the stored metadata. Every story SHALL resolve them: body, tables, notes, headers, footers, and anchored text boxes. A property that is absent or empty SHALL paint nothing, exactly as an empty cached result would.
+
+The metadata is attacker-controlled. Each value SHALL be trimmed and length-capped at the read boundary, and the paint sink SHALL write it as text, never as markup. The reader SHALL match only the fixed, known properties by their exact namespace and local name, so a file-supplied element name is never turned into an object key. The instruction SHALL be recognized in one bounded, length-capped pass and SHALL NEVER be executed; an unrecognized `DOCPROPERTY` name resolves to null and stays inert. A DATE-valued document property (`CREATEDATE`, `SAVEDATE`, `PRINTDATE`) SHALL NOT be evaluated, because date formatting is out of scope, and SHALL stay inert rather than paint a nondeterministic value.
+
+#### Scenario: A TITLE field paints the stored title
+
+- **WHEN** a field carries the instruction `TITLE` and `docProps/core.xml` records a `dc:title`
+- **THEN** the stored title paints over the field's single model unit
+
+#### Scenario: DOCPROPERTY resolves a named property
+
+- **WHEN** a field carries `DOCPROPERTY "Author"` and `docProps/core.xml` records a `dc:creator`
+- **THEN** the stored author paints, and a `DOCPROPERTY` naming an unknown property paints nothing
+
+#### Scenario: A date-valued property stays inert
+
+- **WHEN** a field carries `SAVEDATE` or `CREATEDATE`
+- **THEN** nothing is synthesized and the field paints what it painted before
+
+### Requirement: A body page field evaluates after pagination
+
+A `PAGE`, `NUMPAGES`, or `SECTIONPAGES` field in the document body — body tables included — SHALL evaluate the page number, document page count, or section page count when the field carries no cached result, matching the header and footer lanes. The value cannot be known while a paragraph is measured, so the paragraph walk SHALL reserve one model unit and paint a placeholder digit marked with the field kind, and document layout SHALL substitute the per-page value once pagination is complete.
+
+The substituted field SHALL keep the reserved one model unit however many digits the value has, so `paragraphTextOf`, selection, and the caret keep agreeing the field is one thing. The field is measured at the one-digit placeholder width: a multi-digit value mid-line SHALL keep that width rather than re-measure and reflow the following text. `DATE`, `TIME`, and `FILENAME` fields in the body SHALL remain out of scope.
+
+#### Scenario: A body PAGE field counts per sheet
+
+- **WHEN** a body paragraph holds a `PAGE` field with no cached result across a multi-page document
+- **THEN** each sheet paints its own page number in place of the placeholder
+
+#### Scenario: A multi-digit value keeps its reserved width
+
+- **WHEN** a body `PAGE` field lands on a two-digit page with text after it on the same line
+- **THEN** the field paints the two-digit value and the following text keeps the offsets it had at the one-digit width
+
 ### Requirement: A deleted field instruction is recognized
 
 Live `w:instrText` and deleted `w:delInstrText` chunks SHALL buffer separately at every nesting level. The effective instruction SHALL be the live buffer whenever any live instruction element was seen — even an empty one — and the deleted buffer only when none was. The two SHALL never be merged into one string, because a merged instruction is neither field's code.

--- a/openspec/changes/text-field-instruction-rendering/specs/field-instruction-rendering/spec.md
+++ b/openspec/changes/text-field-instruction-rendering/specs/field-instruction-rendering/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: A symbol run renders its glyph without widening the model
+
+A `w:sym` run child (§17.3.3.30) SHALL render its character as a rendering-only projected glyph over ZERO model width, because the canonical tree keeps `w:sym` generic and the store's offset authority gives a generic run child no offsets. The caret, selection, and `paragraphTextOf` SHALL be unaffected by whether the glyph resolved.
+
+A symbol font's character SHALL normalize through the same 0xF000 PUA page mapping as list bullets, and the bare-byte spelling SHALL be accepted as well. Both attributes are attacker-controlled, so parsing SHALL fail closed to no glyph: strict bounded hex, no surrogates, no noncharacters, capped font-family length.
+
+#### Scenario: A Wingdings symbol paints
+
+- **WHEN** a run holds a `w:sym` with `@w:font="Wingdings"` and `@w:char="F0FC"`
+- **THEN** the mapped glyph paints at the symbol's insertion point in the symbol font
+- **AND** the paragraph's model text is no longer than it was when the glyph painted nothing
+
+#### Scenario: A hostile symbol fails closed
+
+- **WHEN** a `w:sym` carries a malformed code, a surrogate codepoint, or an oversized font name
+- **THEN** no glyph paints and the run's own text is unaffected
+
+### Requirement: A SYMBOL field renders from its instruction
+
+A `SYMBOL` field (§17.16.5.60) SHALL render the character its instruction names, complex and `w:fldSimple` alike, because real files carry no cached result for it — Word always re-renders it from the instruction. The `\f` switch SHALL override the font, `\s` SHALL set the size in whole points, and `\u` SHALL read the code as a Unicode codepoint with no symbol-page normalization; without `\u`, glyph resolution SHALL reuse the same PUA mapping and validation as `w:sym`.
+
+The instruction is attacker-controlled. Tokenization SHALL be one bounded pass over a length-capped string, numeric parses SHALL be length-capped before conversion, and every malformed or hostile instruction SHALL resolve to null so the field falls back to whatever it painted before. A synthesized glyph SHALL win over stale cached text, since the instruction is the authority Word itself re-renders from.
+
+#### Scenario: The named character paints
+
+- **WHEN** a complex field carries the instruction `SYMBOL 252 \f "Wingdings" \s 14`
+- **THEN** the mapped glyph paints in Wingdings at 14 points over the field's single model unit
+
+#### Scenario: A hostile instruction stays inert
+
+- **WHEN** a `SYMBOL` instruction carries an out-of-range code, a surrogate, or an overflowing token
+- **THEN** nothing is synthesized and the field paints what it painted before
+
+### Requirement: MACROBUTTON and GOTOBUTTON render display text and nothing else
+
+`MACROBUTTON` and `GOTOBUTTON` fields (§17.16.5.36, §17.16.5.31) SHALL render the display text after their first argument, complex and `w:fldSimple` alike, because real files carry no cached result for them. The macro name or jump target SHALL be consumed and discarded: the engine SHALL NOT execute a macro, resolve a target, navigate, or wire a click to the painted text. A non-empty cached display SHALL win over synthesis. A trailing formatting switch SHALL be stripped, and a backslash inside legitimate display text SHALL survive.
+
+#### Scenario: The button text paints
+
+- **WHEN** a field carries `MACROBUTTON AcceptAllChanges Double-click here`
+- **THEN** `Double-click here` paints over the field's single model unit
+- **AND** clicking it does nothing
+
+#### Scenario: The macro name never leaks
+
+- **WHEN** a `MACROBUTTON` or `GOTOBUTTON` field renders
+- **THEN** no part of the macro name or jump target is painted, stored on the span, or reachable from a DOM sink
+
+### Requirement: Legacy checkbox and dropdown fields render their w:ffData state
+
+A `FORMCHECKBOX` field SHALL paint ☒ (U+2612) when its `w:ffData` state is checked and ☐ (U+2610) when it is not, resolving `w:checked` first and `w:default` in its absence. The state SHALL be the authority — a stale cached glyph SHALL NOT win. An explicit `w:size` SHALL set the glyph size; `w:sizeAuto` SHALL keep the run's own.
+
+A `FORMDROPDOWN` field SHALL prefer its cached result and SHALL synthesize the selected `w:listEntry` (per `w:result`, defaulting to the first) only when the file cached no result at all — a cached result that exists but is hidden stays hidden.
+
+The `w:ffData` reader SHALL be bounded and SHALL read state only: macro names (`w:entryMacro`, `w:exitMacro`), `w:name`, and help/status text SHALL never be read. Every malformed shape SHALL fail closed to the previous behaviour (cached text or nothing).
+
+#### Scenario: A checked checkbox paints checked
+
+- **WHEN** a `FORMCHECKBOX` field's `w:ffData` carries `w:checked` on
+- **THEN** ☒ paints over the field's single model unit
+- **AND** with no `w:checked` and no `w:default`, ☐ paints
+
+#### Scenario: The dropdown shows its selection
+
+- **WHEN** a `FORMDROPDOWN` field caches no result and its `w:ffData` selects the second `w:listEntry`
+- **THEN** that entry's text paints
+- **AND** with an empty entry list, nothing is synthesized
+
+### Requirement: Nested page fields evaluate live inside complex fields
+
+A `PAGE`, `NUMPAGES`, or `SECTIONPAGES` field nested inside another complex field's cached result SHALL evaluate per sheet, at any nesting level from 2 up to the field-nesting cap, exactly as the `w:fldSimple` lane already does — so a `STYLEREF` wrapping `PAGE` never stamps the producer's saved sheet number onto every page. The inner field's cached digits SHALL be skipped and the live value appended when the inner field's own `end` closes.
+
+The tracker SHALL be level-aware: it records the nesting level whose `separate` armed it, and only that level's matching `end` appends and disarms. Everything at a deeper level while armed SHALL be treated as part of the replaced inner result. An inner cached result the file wholly suppresses SHALL stay suppressed — a live number never resurrects it. Detection and projection SHALL share one allowlist so they cannot drift, and nested field state SHALL survive a descent into an inline drawing.
+
+#### Scenario: A PAGE under STYLEREF counts per sheet
+
+- **WHEN** a footer holds a complex `STYLEREF` field whose cached result contains a complex `PAGE` field
+- **THEN** each page paints its own number in place of the cached digits
+- **AND** the rest of the `STYLEREF` cached result paints unchanged
+
+#### Scenario: A deeper begin cannot clear tracking
+
+- **WHEN** a tracked inner field's cached result itself contains a begin/end pair
+- **THEN** the deeper pair is ignored and the tracked field's own end still appends the live value
+
+### Requirement: A deleted field instruction is recognized
+
+Live `w:instrText` and deleted `w:delInstrText` chunks SHALL buffer separately at every nesting level. The effective instruction SHALL be the live buffer whenever any live instruction element was seen — even an empty one — and the deleted buffer only when none was. The two SHALL never be merged into one string, because a merged instruction is neither field's code.
+
+A field whose whole code is pending deletion therefore SHALL keep rendering from its deleted instruction, and its result SHALL carry the display-mode consequences its enclosing revision dictates. Synthesis SHALL be revision-aware: a result the display mode resolved away is free to be filled, and a result the file hides stays hidden. A field demoted from the typed lane SHALL still shade like any other field.
+
+#### Scenario: A field with only a deleted code still renders
+
+- **WHEN** a complex field's instruction is entirely `w:delInstrText`
+- **THEN** the instruction is recognized and the field renders as that kind
+
+#### Scenario: The live code wins beside a deleted one
+
+- **WHEN** a tracked edit leaves `w:delInstrText PAGE` beside a live `w:instrText NUMPAGES` in one field
+- **THEN** the field renders as `NUMPAGES` and the deleted chunks contribute nothing

--- a/openspec/changes/text-field-instruction-rendering/specs/field-link-rendering/spec.md
+++ b/openspec/changes/text-field-instruction-rendering/specs/field-link-rendering/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: A HYPERLINK field is a live link
+
+A `HYPERLINK` field (§17.16.5.25) SHALL render its cached result as a clickable link, complex and `w:fldSimple` alike. An admitted external target SHALL win over the `\l` anchor, mirroring the `r:id`-over-`w:anchor` rule of typed links; an anchor-only field SHALL be an internal link to that bookmark; the `\o` tooltip SHALL be carried as the hover text. The hyperlink popover SHALL show a field link read-only, because the field's code — not a `w:hyperlink` element — is its source of truth and the link editor cannot write one.
+
+Opening the target SHALL require the same explicit gesture as a typed link. Nothing SHALL be fetched or resolved on document open.
+
+#### Scenario: A field link opens like a typed one
+
+- **WHEN** a complex field carries `HYPERLINK "https://example.com" \o "Site"` around a cached result
+- **THEN** the result paints as a link with that tooltip and the same gesture that opens a typed link opens it
+
+#### Scenario: An anchor-only field jumps internally
+
+- **WHEN** a field carries `HYPERLINK \l "Section2"` and the document holds that bookmark
+- **THEN** activating the link moves to the bookmark, like a typed internal link
+
+#### Scenario: The popover is read-only for a field link
+
+- **WHEN** the link popover opens on a HYPERLINK field's result
+- **THEN** it shows the sanitized target without offering to edit it
+
+### Requirement: Every field-derived target crosses the one href trust boundary
+
+A field-derived link target SHALL pass through exactly the same sanitization as a typed `w:hyperlink` target: `sanitizeHref` plus the absolute-URI gate a relationship target must clear, applied at the surface trust boundary. Layout SHALL parse the instruction into raw strings and SHALL NEVER build an href — no DOM sink receives an attribute built from raw instruction text. A relative target SHALL be refused, because it would resolve against the host page's origin.
+
+A refused target SHALL fall back to the `\l` anchor when the field names one, and otherwise SHALL project no link at all: the cached result paints as plain text. Instruction, target, and switch values SHALL each be length-capped, and tokenization SHALL be one bounded pass. The per-surface link registry SHALL fail closed at its cap: past it, a NEW target projects no link while known targets keep resolving.
+
+#### Scenario: A hostile scheme paints plain
+
+- **WHEN** a field carries `HYPERLINK "javascript:alert(1)"`
+- **THEN** the target is refused, no href reaches the DOM, and the cached result paints as plain text
+
+#### Scenario: A refused target falls back to its anchor
+
+- **WHEN** a field carries a refused external target and a `\l` anchor
+- **THEN** the field projects an internal link to that anchor
+
+#### Scenario: The registry cap fails closed
+
+- **WHEN** a document projects more distinct field targets than the registry admits
+- **THEN** each target past the cap paints plain text and every admitted target keeps resolving
+
+### Requirement: Note stories project their links
+
+Footnote and endnote stories SHALL project links the same way the body does — typed `w:hyperlink` elements and `HYPERLINK` fields both — through the same trust boundary and click routing.
+
+#### Scenario: A link in a footnote is clickable
+
+- **WHEN** a footnote's text holds a typed link and a HYPERLINK field with admitted targets
+- **THEN** both paint as links on the note's page area and both resolve on the opening gesture

--- a/openspec/changes/text-field-instruction-rendering/specs/field-result-rendering/spec.md
+++ b/openspec/changes/text-field-instruction-rendering/specs/field-result-rendering/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: A simple field paints its cached result
+
+`w:fldSimple` (§17.16.19) SHALL paint its cached result — the child runs it carries — as one projected piece. It SHALL continue to occupy exactly one UTF-16 model unit however long that result is, so `paragraphTextOf`, selection and the caret keep agreeing that the field is one thing.
+
+This supersedes the exclusion of "body fields (including inert generic `w:fldSimple`)" in `semantic-paragraph-layout`, for rendering only. The instruction in `@w:instr` SHALL NOT be displayed and SHALL NOT be executed or resolved, and a nested field's markers and instruction inside the result SHALL contribute no text.
+
+An empty result SHALL paint nothing UNLESS the instruction names one of the synthesizing kinds — `SYMBOL`, `MACROBUTTON`, `GOTOBUTTON`, `FORMCHECKBOX`, `FORMDROPDOWN`, and the live page fields — whose display the engine derives from the instruction, `w:ffData` state, or the sheet, because those are exactly the fields real files cache no result for. Synthesis SHALL fill only a result that is genuinely absent or that the display mode resolved away, never one the file carries but hides.
+
+#### Scenario: The result is visible
+
+- **WHEN** a paragraph holds text, a `w:fldSimple` whose result is a cross-reference, and more text
+- **THEN** all three paint, in order
+- **AND** the text after the field keeps the offsets it had when the field painted nothing
+
+#### Scenario: An empty non-synthesizing result still holds its place
+
+- **WHEN** a `w:fldSimple` carrying a `REF` instruction has no result content
+- **THEN** nothing paints for it and it still occupies its single model unit
+
+#### Scenario: An empty synthesizing result renders
+
+- **WHEN** a `w:fldSimple` carrying a `SYMBOL` or `MACROBUTTON` instruction has no result content
+- **THEN** the instruction-derived display paints over that same single model unit
+
+#### Scenario: A hidden result is not resurrected
+
+- **WHEN** a synthesizing field's cached result exists but the file hides it
+- **THEN** nothing is synthesized over it
+
+#### Scenario: The instruction never reaches the page
+
+- **WHEN** a `w:fldSimple` carries an instruction in `@w:instr`
+- **THEN** no part of that instruction is painted

--- a/openspec/changes/text-field-instruction-rendering/tasks.md
+++ b/openspec/changes/text-field-instruction-rendering/tasks.md
@@ -1,0 +1,58 @@
+## 1. Symbol runs (`w:sym`)
+
+- [x] 1.1 `symbol-run.ts`: typed check for the generic `w:sym` child, strict bounded hex parse, 0xF000-page PUA normalization shared with `symbol-encoding.ts`, capped font length, fail-closed on surrogates and noncharacters
+- [x] 1.2 Project the resolved glyph as a rendering-only piece over zero model width, at the symbol's insertion point, with the font override carried on the piece
+- [x] 1.3 Tests: mapped and bare-byte codes, `\u`-style real Unicode families, hostile attributes, and offset neutrality
+
+## 2. SYMBOL field
+
+- [x] 2.1 `field-symbol.ts`: bounded tokenizer, `\f` / `\s` / `\u` switches, length-capped numeric parses, every failure resolving to null
+- [x] 2.2 Reuse `symbol-run.ts` glyph resolution so the two symbol paths cannot drift
+- [x] 2.3 Synthesize over the field's single atom unit on both the complex and `w:fldSimple` lanes; a resolved glyph wins over stale cached text
+- [x] 2.4 Tests: fonts, sizes, unicode mode, hostile instructions, both field shapes
+
+## 3. HYPERLINK fields
+
+- [x] 3.1 `field-link.ts`: bounded instruction parser producing raw strings — target, `\l` anchor, `\o` tooltip — and never an href
+- [x] 3.2 `surface-field-links.ts`: the one trust boundary — `sanitizeHref` plus the absolute-URI gate, target-over-anchor precedence, anchor fallback, no-link fallback, per-target id minting, click resolution, fail-closed registry cap
+- [x] 3.3 Route painted field-link clicks through the existing navigation gesture; nothing fetches or navigates on open
+- [x] 3.4 Keep the hyperlink popover open for field links, read-only (`react` popover + `useHyperlinkPopup`)
+- [x] 3.5 Project links in footnote and endnote stories — typed `w:hyperlink` and HYPERLINK fields both
+- [x] 3.6 Tests: sanitization refusals, anchor fallback, registry cap, popover behaviour, note-story links
+
+## 4. Legacy form fields
+
+- [x] 4.1 `store/package/field-nodes.ts`: `legacyFormFieldDataOf` — bounded `w:ffData` reader, state only, macro/name/help fields never read
+- [x] 4.2 `field-form.ts`: checkbox glyph from `w:checked` / `w:default`, `w:size` override, `w:sizeAuto` keep; dropdown selected `w:listEntry` synthesized only when no cached result exists
+- [x] 4.3 Fail closed on instruction/ffData mismatch, empty entry lists, and empty entries
+- [x] 4.4 Tests: reader bounds, both glyphs, size semantics, dropdown selection and cached-result precedence
+
+## 5. MACROBUTTON / GOTOBUTTON
+
+- [x] 5.1 `field-button.ts`: bounded display-text parser; macro name / jump target consumed and discarded; trailing formatting switch stripped without eating interior backslashes
+- [x] 5.2 Synthesize the display text on both lanes; a non-empty cached display wins
+- [x] 5.3 Tests: quoting, interior whitespace, trailing switches, never-executes contract
+
+## 6. Nested page fields in complex outer fields
+
+- [x] 6.1 Evaluate nested `PAGE` / `NUMPAGES` / `SECTIONPAGES` inside a complex field's cached result per sheet, skipping the cached digits and appending at the inner `end`
+- [x] 6.2 `field-nested-page.ts`: level-aware tracker — arms at the level whose `separate` offered it, ignores deeper begins/separates/ends, disarms defensively on a shallower end, never resurrects a wholly suppressed inner result
+- [x] 6.3 Align detection with projection on one allowlist, levels 2..4
+- [x] 6.4 Copy nested field state across drawing descents
+- [x] 6.5 Tests: depths 2..4, `STYLEREF` wrapping, malformed separators, suppression parity with `w:fldSimple`
+
+## 7. Correctness batch
+
+- [x] 7.1 Dual live/deleted instruction buffers per nesting level; live answers whenever any live `instrText` element was seen, deleted only when none was
+- [x] 7.2 Revision-aware synthesis suppression: fill a result the display mode resolved away, never one the file hides
+- [x] 7.3 Demoted fields still shade
+- [x] 7.4 Dropdown and checkbox `w:ffData` size semantics corrections from review
+- [x] 7.5 Tests: deleted-only codes, live-beside-deleted codes, mode-resolved vs file-hidden results
+
+## 8. Gates
+
+- [x] 8.1 `bun run typecheck`, `bun run lint`
+- [x] 8.2 `bun run test`
+- [x] 8.3 `bun run check:parity`, `bun run api:check`, `bun run i18n:validate`
+- [x] 8.4 Feature matrix rows in `docs/site/data/word-features.ts` updated to match
+- [x] 8.5 `bun run format`

--- a/openspec/changes/text-field-instruction-rendering/tasks.md
+++ b/openspec/changes/text-field-instruction-rendering/tasks.md
@@ -49,10 +49,25 @@
 - [x] 7.4 Dropdown and checkbox `w:ffData` size semantics corrections from review
 - [x] 7.5 Tests: deleted-only codes, live-beside-deleted codes, mode-resolved vs file-hidden results
 
-## 8. Gates
+## 8. Document-property fields
 
-- [x] 8.1 `bun run typecheck`, `bun run lint`
-- [x] 8.2 `bun run test`
-- [x] 8.3 `bun run check:parity`, `bun run api:check`, `bun run i18n:validate`
-- [x] 8.4 Feature matrix rows in `docs/site/data/word-features.ts` updated to match
-- [x] 8.5 `bun run format`
+- [x] 8.1 `store/package/document-properties.ts`: bounded reader over `docProps/core.xml` and `docProps/app.xml`, fixed known properties by exact (namespace, localName), per-value trim and length cap, no file-supplied element name as an object key
+- [x] 8.2 `field-doc-property.ts`: recognize `TITLE`, `AUTHOR`, `SUBJECT`, `KEYWORDS`, `LASTSAVEDBY`, `COMMENTS`, and `DOCPROPERTY "Name"` over the same fixed set; one bounded normalize pass; unknown names and DATE-valued properties resolve to null
+- [x] 8.3 Synthesize the property value over the field's single model unit when no cached result exists, on both lanes; resolve in body, tables, notes, headers/footers, and text boxes; paint through a text sink, never markup
+- [x] 8.4 Tests: each named field, DOCPROPERTY name matching, missing/empty property, date-valued fields inert, hostile element names
+
+## 9. Body page fields
+
+- [x] 9.1 `field-page-furniture.ts`: reserve one model unit and paint a kind-marked placeholder digit during the paragraph walk; substitute the per-page value at document finalize
+- [x] 9.2 Substitute PAGE, NUMPAGES, and SECTIONPAGES in body flow and body tables from the same per-page source the furniture lanes use
+- [x] 9.3 Keep the reserved one-unit width whatever the substituted length is; measure at the one-digit width and accept the mid-line multi-digit non-reflow caveat; keep DATE/TIME/FILENAME out of scope
+- [x] 9.4 Skip the substitution walk on a page with no body page field
+- [x] 9.5 Tests: per-sheet PAGE, NUMPAGES/SECTIONPAGES counts, body tables, multi-digit width neutrality
+
+## 10. Gates
+
+- [x] 10.1 `bun run typecheck`, `bun run lint`
+- [x] 10.2 `bun run test`
+- [x] 10.3 `bun run check:parity`, `bun run api:check`, `bun run i18n:validate`
+- [x] 10.4 Feature matrix rows in `docs/site/data/word-features.ts` updated to match
+- [x] 10.5 `bun run format`

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -115,6 +115,11 @@ import {
   readTrackingSettings,
   type DocumentTrackingSettings,
 } from '../store/package/tracking-settings.ts';
+import {
+  EMPTY_DOCUMENT_PROPERTIES,
+  readDocumentProperties,
+  type DocumentProperties,
+} from '../store/package/document-properties.ts';
 
 /**
  * What applying ops produced: whether it committed, and why not when it did not.
@@ -274,6 +279,12 @@ export interface TreeDocxSession {
    * Settings editing is a later slice, so this is immutable for the session.
    */
   settingsRoot(): OoxmlElement | null;
+  /**
+   * The document's own metadata from `docProps/core.xml` and `docProps/app.xml`, for
+   * document-property fields (TITLE, AUTHOR, SUBJECT, KEYWORDS, LASTSAVEDBY, COMMENTS). Read
+   * once per package revision; an empty object when the parts are absent.
+   */
+  documentProperties(): DocumentProperties;
   /**
    * What `settings.xml` says about tracking — `w:trackRevisions`, the tracked-changes
    * protection, and the two do-not-track switches.
@@ -730,6 +741,36 @@ export function openTreeSession(
     return settingsRoot;
   };
 
+  // The document-property parts, related off the PACKAGE root (`/`), not the main document part.
+  // Both are conventional docProps names, with a relationship lookup first so a renamed part
+  // still resolves. Read once per package revision — document properties editing is a later slice.
+  const CORE_PROPERTIES_REL_TYPE =
+    'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties';
+  const EXTENDED_PROPERTIES_REL_TYPE =
+    'http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties';
+  const resolvePropertiesPart = (relType: string, fallbackName: string): OoxmlPart | undefined => {
+    const live = currentPackage();
+    const record = (live.relationships.get('/') ?? []).find((rel) => rel.type === relType);
+    let part: OoxmlPart | undefined;
+    if (record) {
+      const resolved = resolveRelationship(record);
+      if (resolved.mode === 'Internal' && resolved.target.ok) {
+        part = live.parts.get(resolved.target.partName);
+      }
+    }
+    return part ?? live.parts.get(fallbackName);
+  };
+  let documentPropertiesRevision = -1;
+  let documentPropertiesValue: DocumentProperties = EMPTY_DOCUMENT_PROPERTIES;
+  const resolveDocumentProperties = (): DocumentProperties => {
+    if (documentPropertiesRevision === packageStore.packageRevision) return documentPropertiesValue;
+    documentPropertiesRevision = packageStore.packageRevision;
+    const core = resolvePropertiesPart(CORE_PROPERTIES_REL_TYPE, '/docProps/core.xml');
+    const app = resolvePropertiesPart(EXTENDED_PROPERTIES_REL_TYPE, '/docProps/app.xml');
+    documentPropertiesValue = readDocumentProperties(core?.root ?? null, app?.root ?? null);
+    return documentPropertiesValue;
+  };
+
   // The theme part, resolved like the styles part: through the main part's `theme`
   // relationship, with the conventional name as a fallback. Immutable in-session.
   const THEME_REL_TYPE =
@@ -1016,6 +1057,7 @@ export function openTreeSession(
       numberingRoot: () => resolveNumberingRoot(),
 
       settingsRoot: () => resolveSettingsRoot(),
+      documentProperties: () => resolveDocumentProperties(),
       trackingSettings: () => readTrackingSettings(resolveSettingsRoot()),
 
       documentThemeColors() {

--- a/packages/core/src/editor/__tests__/field-link-clicks.test.ts
+++ b/packages/core/src/editor/__tests__/field-link-clicks.test.ts
@@ -1,0 +1,156 @@
+// Clicking a HYPERLINK FIELD's painted result, end to end over a mounted editor.
+//
+// A field link has no `w:hyperlink` node, so the typed-link lane cannot resolve its id — the
+// surface registers every projected field link and routes `linkById` through that registry
+// first. These prove the registration is real: a plain click reaches the host popover with
+// the sanitized target, an `\l` field jumps to its bookmark, and a refused scheme paints no
+// anchor at all.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const PID = (index: number) => `/word/document.xml#0.0.${index}`;
+
+/** A complete complex field around one instruction, with a cached result. */
+function complexField(instr: string, result: string): string {
+  return (
+    '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+    `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+    '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+    result +
+    '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+  );
+}
+
+interface Mounted {
+  readonly editor: DocxEditorInstance;
+  readonly container: HTMLElement;
+}
+
+function mount(body: string): Mounted {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: docx(body) });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return { editor, container };
+}
+
+function caret(mounted: Mounted, index: number, offset: number): void {
+  mounted.editor.surface!.setSelection({
+    anchor: { paragraphId: PID(index), offset },
+    head: { paragraphId: PID(index), offset },
+  });
+}
+
+/** The painted anchor whose text is `text`, within THIS editor's container. */
+function anchorFor(mounted: Mounted, text: string): HTMLElement {
+  const anchors = [...mounted.container.querySelectorAll('a.docx-hyperlink')] as HTMLElement[];
+  const found = anchors.find((anchor) => anchor.textContent === text);
+  if (!found) {
+    const seen = anchors.map((anchor) => anchor.textContent);
+    throw new Error(
+      `no painted anchor with text ${JSON.stringify(text)}; saw ${JSON.stringify(seen)}`
+    );
+  }
+  return found;
+}
+
+/** Click an element the way a browser does, and report whether the default was prevented. */
+function click(element: HTMLElement): boolean {
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+  element.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+describe('clicking a painted HYPERLINK field', () => {
+  test('the result paints as an anchor with the sanitized href and a registered id', () => {
+    const mounted = mount(
+      '<w:p><w:r><w:t>See </w:t></w:r>' +
+        complexField(
+          ' HYPERLINK "https://example.com" \\o "Visit" ',
+          '<w:r><w:t>the site</w:t></w:r>'
+        ) +
+        '<w:r><w:t>.</w:t></w:r></w:p>'
+    );
+    const anchor = anchorFor(mounted, 'the site');
+    expect(anchor.getAttribute('href')).toBe('https://example.com');
+    expect(anchor.getAttribute('title')).toBe('Visit');
+    expect(anchor.dataset.docxLink).toStartWith('field-hyperlink:');
+  });
+
+  test('a plain click resolves through the registry to the host popover', () => {
+    const mounted = mount(
+      '<w:p><w:r><w:t>See </w:t></w:r>' +
+        complexField(' HYPERLINK "https://example.com" ', '<w:r><w:t>the site</w:t></w:r>') +
+        '<w:r><w:t>.</w:t></w:r></w:p>'
+    );
+    const seen: (string | null)[] = [];
+    mounted.editor.setHyperlinkChrome({
+      onPopover: (activation) => seen.push(activation.link.href),
+    });
+    caret(mounted, 0, 2);
+    expect(click(anchorFor(mounted, 'the site'))).toBe(true);
+    expect(seen).toEqual(['https://example.com']);
+  });
+
+  test('an \\l field jumps to its bookmark and moves the caret; no popover', () => {
+    const mounted = mount(
+      `<w:p>${complexField(' HYPERLINK \\l "target" ', '<w:r><w:t>Go</w:t></w:r>')}</w:p>` +
+        '<w:p><w:r><w:t>filler</w:t></w:r></w:p>' +
+        '<w:p><w:bookmarkStart w:id="1" w:name="target"/><w:r><w:t>Destination</w:t></w:r></w:p>'
+    );
+    const seen: string[] = [];
+    mounted.editor.setHyperlinkChrome({ onPopover: (activation) => seen.push(activation.link.id) });
+    caret(mounted, 0, 0);
+    click(anchorFor(mounted, 'Go'));
+    expect(seen).toEqual([]);
+    expect(mounted.editor.surface!.state().selection.head.paragraphId).toBe(PID(2));
+  });
+
+  test('a fldSimple HYPERLINK resolves the same way', () => {
+    const mounted = mount(
+      '<w:p><w:fldSimple w:instr=\' HYPERLINK "https://example.com" \'>' +
+        '<w:r><w:t>entry</w:t></w:r></w:fldSimple></w:p>'
+    );
+    const seen: (string | null)[] = [];
+    mounted.editor.setHyperlinkChrome({
+      onPopover: (activation) => seen.push(activation.link.href),
+    });
+    caret(mounted, 0, 0);
+    click(anchorFor(mounted, 'entry'));
+    expect(seen).toEqual(['https://example.com']);
+  });
+
+  test('a javascript: target paints its text with NO anchor at all', () => {
+    const mounted = mount(
+      `<w:p>${complexField(' HYPERLINK "javascript:alert(1)" ', '<w:r><w:t>Click me</w:t></w:r>')}</w:p>`
+    );
+    expect(mounted.container.textContent).toContain('Click me');
+    const anchors = [...mounted.container.querySelectorAll('a.docx-hyperlink')];
+    expect(anchors).toEqual([]);
+  });
+});

--- a/packages/core/src/editor/__tests__/hyperlink-editing.test.ts
+++ b/packages/core/src/editor/__tests__/hyperlink-editing.test.ts
@@ -537,3 +537,58 @@ describe('Ctrl/Cmd+K reports the request to the host', () => {
     expect(order).toEqual(['inner', 'outer']);
   });
 });
+
+/** A complete complex field around one instruction, with an optional cached result. */
+function complexField(instr: string, result = ''): string {
+  return (
+    '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+    `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+    '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+    result +
+    '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+  );
+}
+
+describe('a field link at the caret', () => {
+  // 'See ' is four characters; the HYPERLINK field's result projects as ONE atom over [4, 5).
+  const FIELD_DOC =
+    '<w:p><w:r><w:t>See </w:t></w:r>' +
+    complexField(' HYPERLINK "https://example.com" ', '<w:r><w:t>site</w:t></w:r>') +
+    '</w:p>';
+
+  test('resolves the field link when the caret sits on the atom start', () => {
+    const mounted = mount(FIELD_DOC);
+    caret(mounted, 0, 4);
+    const link = mounted.editor.surface!.hyperlinks.fieldLinkAtCaret();
+    expect(link).not.toBeNull();
+    expect(link!.href).toBe('https://example.com');
+    // A field link names no tree node, so it carries no addressable paragraph.
+    expect(link!.paragraphId).toBe('');
+  });
+
+  test('resolves the field link at the atom trailing edge too', () => {
+    const mounted = mount(FIELD_DOC);
+    caret(mounted, 0, 5);
+    expect(mounted.editor.surface!.hyperlinks.fieldLinkAtCaret()?.href).toBe('https://example.com');
+  });
+
+  test('returns null when the caret is off the atom', () => {
+    const mounted = mount(FIELD_DOC);
+    caret(mounted, 0, 1);
+    expect(mounted.editor.surface!.hyperlinks.fieldLinkAtCaret()).toBeNull();
+  });
+
+  test('the typed lane never returns the field link', () => {
+    const mounted = mount(FIELD_DOC);
+    caret(mounted, 0, 4);
+    // `linkAtCaret` walks `w:hyperlink` nodes; a field has none, so link-create cannot mistake
+    // the atom for an existing editable link.
+    expect(mounted.editor.surface!.hyperlinks.linkAtCaret()).toBeNull();
+  });
+
+  test('returns null in a document with no field link', () => {
+    const mounted = mount(p('plain text'));
+    caret(mounted, 0, 3);
+    expect(mounted.editor.surface!.hyperlinks.fieldLinkAtCaret()).toBeNull();
+  });
+});

--- a/packages/core/src/editor/__tests__/surface-field-links.test.ts
+++ b/packages/core/src/editor/__tests__/surface-field-links.test.ts
@@ -85,6 +85,15 @@ describe('identity and resolution', () => {
     expect(other.id).not.toBe(first.id);
   });
 
+  test('repeated projection of one spec never churns the id', () => {
+    const registry = createFieldLinkRegistry();
+    const spec = { target: 'https://example.com', anchor: null, tooltip: null };
+    const first = registry.project(spec)!;
+    for (let i = 0; i < 8; i += 1) {
+      expect(registry.project({ ...spec })!.id).toBe(first.id);
+    }
+  });
+
   test('a minted id resolves back to a record a click can act on', () => {
     const registry = createFieldLinkRegistry();
     const record = registry.project({
@@ -103,5 +112,45 @@ describe('identity and resolution', () => {
     // No `w:hyperlink` node backs it, so it addresses no range the editing lane could touch.
     expect(resolved!.paragraphId).toBe('');
     expect(registry.linkById('field-hyperlink:999')).toBeNull();
+  });
+});
+
+describe('the registration cap', () => {
+  test('past 4096 distinct links, a NEW target projects nothing — never an unresolvable id', () => {
+    const registry = createFieldLinkRegistry();
+    for (let i = 1; i <= 4096; i += 1) {
+      const record = registry.project({
+        target: `https://example.com/${i}`,
+        anchor: null,
+        tooltip: null,
+      });
+      expect(record).not.toBeNull();
+      expect(registry.linkById(record!.id)).not.toBeNull();
+    }
+    // The 4097th distinct target is refused, and CONSISTENTLY so: its text paints plain
+    // rather than as an anchor whose clicks resolve to nothing, and no per-call fresh id
+    // exists to churn an unchanged line's fragment signature on re-break.
+    const overflow = { target: 'https://overflow.example', anchor: null, tooltip: null };
+    expect(registry.project(overflow)).toBeNull();
+    expect(registry.project({ ...overflow })).toBeNull();
+  });
+
+  test('at the cap, a KNOWN key keeps returning its registered id and record', () => {
+    const registry = createFieldLinkRegistry();
+    const first = registry.project({
+      target: 'https://example.com/1',
+      anchor: null,
+      tooltip: null,
+    })!;
+    for (let i = 2; i <= 4096; i += 1) {
+      registry.project({ target: `https://example.com/${i}`, anchor: null, tooltip: null });
+    }
+    const again = registry.project({
+      target: 'https://example.com/1',
+      anchor: null,
+      tooltip: null,
+    })!;
+    expect(again.id).toBe(first.id);
+    expect(registry.linkById(first.id)).toMatchObject({ href: 'https://example.com/1' });
   });
 });

--- a/packages/core/src/editor/__tests__/surface-field-links.test.ts
+++ b/packages/core/src/editor/__tests__/surface-field-links.test.ts
@@ -1,0 +1,107 @@
+// The field-link registry: HYPERLINK instructions crossing the surface trust boundary.
+//
+// The raw target is attacker-controlled. Everything a DOM sink could see comes out of this
+// registry already sanitized, and every minted id resolves back to its record so a click on
+// the painted anchor means something.
+
+import { describe, expect, test } from 'bun:test';
+import { createFieldLinkRegistry } from '../surface-field-links.ts';
+
+describe('projecting a field link', () => {
+  test('an absolute allowlisted target becomes an external record', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({
+      target: 'https://example.com/Path%20A',
+      anchor: null,
+      tooltip: 'Visit',
+    });
+    expect(record).toEqual({
+      id: 'field-hyperlink:1',
+      kind: 'external',
+      href: 'https://example.com/Path%20A',
+      tooltip: 'Visit',
+    });
+  });
+
+  test('a javascript: target with an \\l anchor falls back to the anchor', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({
+      target: 'javascript:alert(1)',
+      anchor: 'section3',
+      tooltip: null,
+    });
+    expect(record).toMatchObject({ kind: 'internal', href: '#section3', anchor: 'section3' });
+  });
+
+  test('a javascript: target with no anchor projects nothing', () => {
+    const registry = createFieldLinkRegistry();
+    expect(registry.project({ target: 'javascript:alert(1)', anchor: null, tooltip: null })).toBe(
+      null
+    );
+  });
+
+  test('a smuggled scheme is refused after the control characters are stripped', () => {
+    const registry = createFieldLinkRegistry();
+    expect(
+      registry.project({ target: 'java\tscript:alert(1)', anchor: null, tooltip: null })
+    ).toBeNull();
+  });
+
+  test('a relative target is refused — it would resolve against the host origin', () => {
+    const registry = createFieldLinkRegistry();
+    expect(registry.project({ target: 'evil/page.html', anchor: null, tooltip: null })).toBeNull();
+    expect(registry.project({ target: '//evil.example', anchor: null, tooltip: null })).toBeNull();
+  });
+
+  test('an anchor-only spec is an internal record with a sanitized fragment', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({ target: null, anchor: 'top', tooltip: null });
+    expect(record).toMatchObject({ kind: 'internal', href: '#top', anchor: 'top' });
+  });
+
+  test('a hostile anchor keeps the link inert but present', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({
+      target: null,
+      anchor: 'javascript:alert(1)',
+      tooltip: null,
+    });
+    expect(record).toMatchObject({ kind: 'internal', href: null });
+  });
+});
+
+describe('identity and resolution', () => {
+  test('the same spec projects the same id; a different spec a different one', () => {
+    const registry = createFieldLinkRegistry();
+    const spec = { target: 'https://example.com', anchor: null, tooltip: null };
+    const first = registry.project(spec)!;
+    const again = registry.project({ ...spec })!;
+    const other = registry.project({
+      target: 'https://other.example',
+      anchor: null,
+      tooltip: null,
+    })!;
+    expect(again.id).toBe(first.id);
+    expect(other.id).not.toBe(first.id);
+  });
+
+  test('a minted id resolves back to a record a click can act on', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({
+      target: 'https://example.com',
+      anchor: null,
+      tooltip: 'Visit',
+    })!;
+    const resolved = registry.linkById(record.id);
+    expect(resolved).toMatchObject({
+      id: record.id,
+      kind: 'external',
+      href: 'https://example.com',
+      authored: 'https://example.com',
+      tooltip: 'Visit',
+    });
+    // No `w:hyperlink` node backs it, so it addresses no range the editing lane could touch.
+    expect(resolved!.paragraphId).toBe('');
+    expect(registry.linkById('field-hyperlink:999')).toBeNull();
+  });
+});

--- a/packages/core/src/editor/__tests__/surface-field-links.test.ts
+++ b/packages/core/src/editor/__tests__/surface-field-links.test.ts
@@ -33,6 +33,48 @@ describe('projecting a field link', () => {
     expect(record).toMatchObject({ kind: 'internal', href: '#section3', anchor: 'section3' });
   });
 
+  test('a target AND an \\l anchor carry the anchor as a #fragment on the external href', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({
+      target: 'https://example.com/p',
+      anchor: 'sec2',
+      tooltip: null,
+    });
+    expect(record).toMatchObject({ kind: 'external', href: 'https://example.com/p#sec2' });
+  });
+
+  test('a target that already carries a # keeps its own fragment (target-wins)', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({
+      target: 'https://example.com/p#top',
+      anchor: 'sec2',
+      tooltip: null,
+    });
+    expect(record).toMatchObject({ kind: 'external', href: 'https://example.com/p#top' });
+  });
+
+  test('a control char in the \\l anchor never reaches the #fragment', () => {
+    const registry = createFieldLinkRegistry();
+    const external = registry.project({
+      target: 'https://example.com/p',
+      anchor: 'se\x00c',
+      tooltip: null,
+    });
+    expect(external).toMatchObject({ kind: 'external', href: 'https://example.com/p#sec' });
+    const internal = registry.project({ target: null, anchor: 'se\x00c', tooltip: null });
+    expect(internal).toMatchObject({ kind: 'internal', href: '#sec', anchor: 'sec' });
+  });
+
+  test('a control char in the \\o tooltip never reaches the title', () => {
+    const registry = createFieldLinkRegistry();
+    const record = registry.project({
+      target: 'https://example.com',
+      anchor: null,
+      tooltip: 'a\x01b',
+    });
+    expect(record).toMatchObject({ tooltip: 'ab' });
+  });
+
   test('a javascript: target with no anchor projects nothing', () => {
     const registry = createFieldLinkRegistry();
     expect(registry.project({ target: 'javascript:alert(1)', anchor: null, tooltip: null })).toBe(

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -761,6 +761,7 @@ export function mountPaginatedSurface(
       furniture: furnitureSource.furniture(),
       projectLink,
       projectFieldLink: (spec) => fieldLinks.project(spec),
+      documentProperties: session.documentProperties(),
       inlineDrawingLayout: drawingBundle.bodyContext,
       drawingTokenForParagraph: (paragraph) =>
         drawingBundle.drawingTokenForParagraph(paragraph, session.part().name),

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -129,6 +129,7 @@ import { createSurfaceStructure } from './surface-structure.ts';
 // Deep import, not the store barrel: re-exporting a bound from there pulls the whole store
 // namespace into the published editor-api surface for one number.
 import { MIN_TABLE_COLUMN_WIDTH_TWIPS } from '../store/store/table-constraints.ts';
+import { createFieldLinkRegistry } from './surface-field-links.ts';
 import { createHyperlinkOps } from './surface-hyperlinks.ts';
 import { createSurfaceNavigation } from './surface-navigation.ts';
 import { drawingLinkByIdFromLayout } from './drawing-link-index.ts';
@@ -596,6 +597,13 @@ export function mountPaginatedSurface(
   };
 
   /**
+   * The SAME boundary for HYPERLINK fields: the raw instruction target crosses
+   * `sanitizeHref` inside the registry, which also remembers every minted record so a click
+   * on the painted anchor resolves through `linkById` like a typed link's does.
+   */
+  const fieldLinks = createFieldLinkRegistry();
+
+  /**
    * The session as every lane sees it: the mode rules applied to `applyTreeOps`.
    *
    * Gating one function inside this file was not enough. Breaks, lists, indent, section
@@ -707,7 +715,9 @@ export function mountPaginatedSurface(
     scale: () => scale,
     layout: () => currentLayout,
     bookmarks: () => session.bookmarks(),
-    linkById: (linkId) => hyperlinks.linkById(linkId),
+    // Field-derived ids first: they are a closed `field-hyperlink:` namespace, and the typed
+    // lane's tree walk could never answer for them.
+    linkById: (linkId) => fieldLinks.linkById(linkId) ?? hyperlinks.linkById(linkId),
     drawingLinkById: (drawingNodeId) => drawingLinkByIdFromLayout(currentLayout, drawingNodeId),
     setSelection: (position) => setSelection(collapsedAt(position)),
     isCollapsedSelection: () =>
@@ -746,6 +756,7 @@ export function mountPaginatedSurface(
       sectionFurniture: furnitureSource.sectionFurniture(),
       furniture: furnitureSource.furniture(),
       projectLink,
+      projectFieldLink: (spec) => fieldLinks.project(spec),
       inlineDrawingLayout: drawingBundle.bodyContext,
       drawingTokenForParagraph: (paragraph) =>
         drawingBundle.drawingTokenForParagraph(paragraph, session.part().name),

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -698,6 +698,10 @@ export function mountPaginatedSurface(
   });
   const hyperlinks = createHyperlinkOps({
     session: gatedSession,
+    // A HYPERLINK field is not a tree node, so its link resolves from the layout projection
+    // plus the field-link registry rather than the typed tree walk.
+    layout: () => currentLayout,
+    fieldLinkById: (linkId) => fieldLinks.linkById(linkId),
     // Asked BEFORE the relationship is minted. The gated session refuses the ops in viewing mode
     // either way, but the mint is a package write that the refusal does not roll back — Ctrl+K in a
     // document open for reading left its target declared in `.rels`.

--- a/packages/core/src/editor/surface-field-links.ts
+++ b/packages/core/src/editor/surface-field-links.ts
@@ -14,7 +14,7 @@
 // Nothing here fetches or navigates; opening stays with `surface-navigation.ts`.
 
 import { sanitizeHref } from '../store/package/sinks.ts';
-import { validateExternalTarget } from '../store/package/opc-names.ts';
+import { stripControlChars, validateExternalTarget } from '../store/package/opc-names.ts';
 import type { HyperlinkFieldSpec } from '../layout/field-link.ts';
 import type { SpanLinkRecord } from '../layout/semantic-records.ts';
 import type { SurfaceHyperlink } from './surface-hyperlinks.ts';
@@ -51,17 +51,32 @@ interface ResolvedFieldLink {
  * is no link at all — never an attribute built from raw input.
  */
 function resolveFieldLink(spec: HyperlinkFieldSpec): ResolvedFieldLink | null {
-  const tooltip = spec.tooltip !== null ? { tooltip: spec.tooltip } : {};
+  // The anchor becomes an inert `#fragment` and the tooltip a plain `title`, so neither can
+  // form a script href; still, the external path rejects control chars, so both scrub them for
+  // consistency (dropped, never smuggled through).
+  const tooltip = spec.tooltip !== null ? { tooltip: stripControlChars(spec.tooltip) } : {};
   if (spec.target !== null) {
     const projection = sanitizeHref(spec.target);
     const admitted =
       projection.ok && projection.href.length > 0 && validateExternalTarget(projection.href).ok;
     if (admitted) {
+      // Word navigates to `target#anchor` when a field carries BOTH an admitted external target
+      // and a `\l` anchor. Append the anchor as a fragment through the same sanitize path the
+      // anchor-only branch below uses. Skip it when the target already carries a `#` — Word's
+      // rule there is target-wins — so the separator is never doubled.
+      const anchorHref =
+        spec.anchor !== null && !projection.href.includes('#')
+          ? sanitizeHref(stripControlChars(spec.anchor))
+          : null;
+      const href =
+        anchorHref && anchorHref.ok && anchorHref.href.length > 0
+          ? `${projection.href}#${anchorHref.href}`
+          : projection.href;
       return {
         kind: 'external',
-        href: projection.href,
+        href,
         authored: spec.target,
-        ...(spec.anchor !== null ? { anchor: spec.anchor } : {}),
+        ...(spec.anchor !== null ? { anchor: stripControlChars(spec.anchor) } : {}),
         ...tooltip,
       };
     }
@@ -69,13 +84,15 @@ function resolveFieldLink(spec: HyperlinkFieldSpec): ResolvedFieldLink | null {
   }
   if (spec.anchor !== null) {
     // A fragment, not a URL — same rule as a typed `w:hyperlink w:anchor`: the name is
-    // file-derived, so it clears the same allowlist before a `#` is put in front of it.
-    const fragment = sanitizeHref(spec.anchor);
+    // file-derived, so it clears the same allowlist (and the control-char scrub the external
+    // path applies) before a `#` is put in front of it.
+    const anchor = stripControlChars(spec.anchor);
+    const fragment = sanitizeHref(anchor);
     return {
       kind: 'internal',
       href: fragment.ok && fragment.href.length > 0 ? `#${fragment.href}` : null,
       authored: spec.anchor,
-      anchor: spec.anchor,
+      anchor,
       ...tooltip,
     };
   }

--- a/packages/core/src/editor/surface-field-links.ts
+++ b/packages/core/src/editor/surface-field-links.ts
@@ -1,0 +1,139 @@
+// Field-derived hyperlinks at the surface trust boundary (paginated-surface seam).
+//
+// A `HYPERLINK "..."` complex field or `w:fldSimple` has no `w:hyperlink` element, so the
+// typed-link lane (`surface-hyperlinks.ts`) can never resolve one: its ids name canonical
+// nodes and its lookups walk the tree. This module is the field twin — it turns the parsed
+// instruction into the same sanitized {@link SpanLinkRecord} spans carry, minting an id per
+// distinct target and remembering the record so a click on the painted anchor resolves.
+//
+// THE ONE HREF TRUST BOUNDARY STAYS HERE. The raw target crosses `sanitizeHref` plus the
+// same absolute-URI gate a relationship target must clear (`validateExternalTarget`) —
+// a relative target would resolve against the HOST page's origin, which is not somewhere a
+// document gets to point. A refused target falls back to the `\l` anchor when the field
+// names one, and otherwise projects NO link at all: the cached result stays plain text.
+// Nothing here fetches or navigates; opening stays with `surface-navigation.ts`.
+
+import { sanitizeHref } from '../store/package/sinks.ts';
+import { validateExternalTarget } from '../store/package/opc-names.ts';
+import type { HyperlinkFieldSpec } from '../layout/field-link.ts';
+import type { SpanLinkRecord } from '../layout/semantic-records.ts';
+import type { SurfaceHyperlink } from './surface-hyperlinks.ts';
+
+/**
+ * Distinct field links remembered per surface. Documents hold links in proportion to their
+ * own size, so this only bites a hostile file; past it, later NEW targets still paint and
+ * carry their record — their clicks just resolve to nothing, which fails safe.
+ */
+const MAX_REGISTERED_FIELD_LINKS = 4096;
+
+export interface FieldLinkRegistry {
+  /** The projector layout calls for every parsed HYPERLINK field instruction. */
+  project(spec: HyperlinkFieldSpec): SpanLinkRecord | null;
+  /** Resolve a minted field-link id back to its record, for click routing. */
+  linkById(linkId: string): SurfaceHyperlink | null;
+}
+
+/** The sanitized halves of a field link, before identity is assigned. */
+interface ResolvedFieldLink {
+  readonly kind: SurfaceHyperlink['kind'];
+  readonly href: string | null;
+  readonly authored: string;
+  readonly anchor?: string;
+  readonly tooltip?: string;
+}
+
+/**
+ * Apply the trust boundary to one parsed spec, or null when nothing links.
+ *
+ * Mirrors `hyperlinkTargetOf` for the shapes a field can express: an admitted external
+ * target wins over the anchor (Word's `r:id`-over-`w:anchor` rule), an anchor-only field is
+ * an internal link whose fragment is itself sanitized, and a refused target with no anchor
+ * is no link at all — never an attribute built from raw input.
+ */
+function resolveFieldLink(spec: HyperlinkFieldSpec): ResolvedFieldLink | null {
+  const tooltip = spec.tooltip !== null ? { tooltip: spec.tooltip } : {};
+  if (spec.target !== null) {
+    const projection = sanitizeHref(spec.target);
+    const admitted =
+      projection.ok && projection.href.length > 0 && validateExternalTarget(projection.href).ok;
+    if (admitted) {
+      return {
+        kind: 'external',
+        href: projection.href,
+        authored: spec.target,
+        ...(spec.anchor !== null ? { anchor: spec.anchor } : {}),
+        ...tooltip,
+      };
+    }
+    if (spec.anchor === null) return null;
+  }
+  if (spec.anchor !== null) {
+    // A fragment, not a URL — same rule as a typed `w:hyperlink w:anchor`: the name is
+    // file-derived, so it clears the same allowlist before a `#` is put in front of it.
+    const fragment = sanitizeHref(spec.anchor);
+    return {
+      kind: 'internal',
+      href: fragment.ok && fragment.href.length > 0 ? `#${fragment.href}` : null,
+      authored: spec.anchor,
+      anchor: spec.anchor,
+      ...tooltip,
+    };
+  }
+  return null;
+}
+
+/**
+ * Create the per-surface registry.
+ *
+ * Content-keyed: two fields naming the same target share one id, so a repainted or re-laid
+ * paragraph resolves to the same registered record however many layout passes ran. Entries
+ * live as long as the surface — cached layout pages may carry any id ever minted.
+ */
+export function createFieldLinkRegistry(): FieldLinkRegistry {
+  const idByKey = new Map<string, string>();
+  const byId = new Map<string, SurfaceHyperlink>();
+  let minted = 0;
+
+  return {
+    project(spec) {
+      const resolved = resolveFieldLink(spec);
+      if (!resolved) return null;
+      const key = `${spec.target ?? ''}\u0000${spec.anchor ?? ''}\u0000${spec.tooltip ?? ''}`;
+      let id = idByKey.get(key);
+      if (id === undefined) {
+        minted += 1;
+        id = `field-hyperlink:${minted}`;
+        if (idByKey.size < MAX_REGISTERED_FIELD_LINKS) {
+          idByKey.set(key, id);
+          // A field link names no `w:hyperlink` node, so it has no addressable range: the
+          // position fields stay empty and the editing lane (retarget/unlink) never sees it.
+          byId.set(
+            id,
+            Object.freeze({
+              id,
+              paragraphId: '',
+              start: 0,
+              end: 0,
+              text: '',
+              kind: resolved.kind,
+              href: resolved.href,
+              authored: resolved.authored,
+              ...(resolved.anchor !== undefined ? { anchor: resolved.anchor } : {}),
+              ...(resolved.tooltip !== undefined ? { tooltip: resolved.tooltip } : {}),
+            })
+          );
+        }
+      }
+      return {
+        id,
+        kind: resolved.kind,
+        href: resolved.href,
+        ...(resolved.anchor !== undefined ? { anchor: resolved.anchor } : {}),
+        ...(resolved.tooltip !== undefined ? { tooltip: resolved.tooltip } : {}),
+      };
+    },
+    linkById(linkId) {
+      return byId.get(linkId) ?? null;
+    },
+  };
+}

--- a/packages/core/src/editor/surface-field-links.ts
+++ b/packages/core/src/editor/surface-field-links.ts
@@ -21,8 +21,8 @@ import type { SurfaceHyperlink } from './surface-hyperlinks.ts';
 
 /**
  * Distinct field links remembered per surface. Documents hold links in proportion to their
- * own size, so this only bites a hostile file; past it, later NEW targets still paint and
- * carry their record — their clicks just resolve to nothing, which fails safe.
+ * own size, so this only bites a hostile file; past it, a NEW target projects no link at
+ * all — its text paints plain, which fails closed. Known targets keep resolving.
  */
 const MAX_REGISTERED_FIELD_LINKS = 4096;
 
@@ -101,28 +101,30 @@ export function createFieldLinkRegistry(): FieldLinkRegistry {
       const key = `${spec.target ?? ''}\u0000${spec.anchor ?? ''}\u0000${spec.tooltip ?? ''}`;
       let id = idByKey.get(key);
       if (id === undefined) {
+        // Full and unknown: NO link, never an id minted without its record. An unregistered
+        // id would paint an anchor whose clicks resolve to nothing — and a FRESH id per call
+        // would churn the fragment signature of an unchanged line on every re-break.
+        if (idByKey.size >= MAX_REGISTERED_FIELD_LINKS) return null;
         minted += 1;
         id = `field-hyperlink:${minted}`;
-        if (idByKey.size < MAX_REGISTERED_FIELD_LINKS) {
-          idByKey.set(key, id);
-          // A field link names no `w:hyperlink` node, so it has no addressable range: the
-          // position fields stay empty and the editing lane (retarget/unlink) never sees it.
-          byId.set(
+        idByKey.set(key, id);
+        // A field link names no `w:hyperlink` node, so it has no addressable range: the
+        // position fields stay empty and the editing lane (retarget/unlink) never sees it.
+        byId.set(
+          id,
+          Object.freeze({
             id,
-            Object.freeze({
-              id,
-              paragraphId: '',
-              start: 0,
-              end: 0,
-              text: '',
-              kind: resolved.kind,
-              href: resolved.href,
-              authored: resolved.authored,
-              ...(resolved.anchor !== undefined ? { anchor: resolved.anchor } : {}),
-              ...(resolved.tooltip !== undefined ? { tooltip: resolved.tooltip } : {}),
-            })
-          );
-        }
+            paragraphId: '',
+            start: 0,
+            end: 0,
+            text: '',
+            kind: resolved.kind,
+            href: resolved.href,
+            authored: resolved.authored,
+            ...(resolved.anchor !== undefined ? { anchor: resolved.anchor } : {}),
+            ...(resolved.tooltip !== undefined ? { tooltip: resolved.tooltip } : {}),
+          })
+        );
       }
       return {
         id,

--- a/packages/core/src/editor/surface-hyperlinks.ts
+++ b/packages/core/src/editor/surface-hyperlinks.ts
@@ -18,7 +18,12 @@ import {
   type StoryScope,
   type TreeDocOp,
 } from '@docx-editor.dev/core/store';
-import type { SemanticPosition, SemanticSelection } from '@docx-editor.dev/core/layout';
+import {
+  fragmentsOfParagraph,
+  type SemanticLayout,
+  type SemanticPosition,
+  type SemanticSelection,
+} from '@docx-editor.dev/core/layout';
 
 /** Inline `w:sdt` nesting bound — matches `segmentsOf` and formatting walks. */
 const MAX_SDT_NESTING = 32;
@@ -189,8 +194,47 @@ export function hyperlinkAtPosition(
   return null;
 }
 
+/**
+ * The painted field link whose atom the position sits on, or null.
+ *
+ * A `HYPERLINK` field has no `w:hyperlink` node, so the typed lane above can never resolve it.
+ * It paints as ONE atom span over `[start, start + 1)` carrying `fieldAtom` and `link`. This
+ * walks the caret paragraph's laid-out fragments for that span and returns its link id.
+ *
+ * INCLUSIVE OF BOTH EDGES (`start <= offset <= end`), the same rule field shading uses: a field
+ * is one model unit, and the click that opens the reading panel lands the caret on a boundary.
+ * An exclusive test would report "the caret left the field" on the very tick after the opening
+ * click and self-close the panel.
+ *
+ * Two known edges, both narrow and left unhandled on purpose: at a boundary shared by two
+ * adjacent field atoms the first span in line order wins (left-biased), and the walk covers
+ * only body fragments — a field link inside a header/footer or note story does not resolve here
+ * (headers/footers never open the panel anyway; note-story links share the typed lane's own
+ * body-caret limitation).
+ */
+export function fieldLinkAtomIdAtPosition(
+  layout: SemanticLayout,
+  position: SemanticPosition
+): string | null {
+  for (const fragment of fragmentsOfParagraph(layout, position.paragraphId)) {
+    for (const line of fragment.lines) {
+      for (const span of line.spans) {
+        if (!span.fieldAtom || !span.link) continue;
+        if (position.offset >= span.range.start && position.offset <= span.range.end) {
+          return span.link.id;
+        }
+      }
+    }
+  }
+  return null;
+}
+
 export interface HyperlinkOpsDeps {
   readonly session: TreeDocxSession;
+  /** The current layout projection, for resolving a field link at the caret. */
+  readonly layout: () => SemanticLayout;
+  /** Resolve a field-link id minted by the field-link registry back to its record. */
+  readonly fieldLinkById: (linkId: string) => SurfaceHyperlink | null;
   /**
    * Whether a write would be refused right now — viewing, or suggesting with no author.
    *
@@ -223,6 +267,14 @@ export interface HyperlinkOps {
   linksInCaretParagraph(): SurfaceHyperlink[];
   /** The link the caret sits in, or null. */
   linkAtCaret(): SurfaceHyperlink | null;
+  /**
+   * The FIELD link whose painted atom the caret sits on, or null.
+   *
+   * Separate from {@link linkAtCaret} on purpose: a `HYPERLINK` field is not a tree node, so
+   * the typed lane never returns one, and link-create must not mistake a field atom for an
+   * editable link. Resolved from the layout projection, boundary-inclusive.
+   */
+  fieldLinkAtCaret(): SurfaceHyperlink | null;
   /** The link with this node id, or null. */
   linkById(linkId: string): SurfaceHyperlink | null;
   /**
@@ -261,6 +313,12 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
   const linkAtCaret = (): SurfaceHyperlink | null =>
     hyperlinkAtPosition(linksIn(deps.selection().head.paragraphId), deps.selection().head);
 
+  const fieldLinkAtCaret = (): SurfaceHyperlink | null => {
+    const head = deps.selection().head;
+    const id = fieldLinkAtomIdAtPosition(deps.layout(), head);
+    return id === null ? null : deps.fieldLinkById(id);
+  };
+
   const linkById = (linkId: string): SurfaceHyperlink | null => {
     // The link's own paragraph is the one holding it; walking the caret's paragraph first
     // covers every real caller in one lookup, and the full scan is the fallback.
@@ -277,6 +335,7 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
   return {
     linksInCaretParagraph: () => linksIn(deps.selection().head.paragraphId),
     linkAtCaret,
+    fieldLinkAtCaret,
     linkById,
 
     applyHyperlink(input) {

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -173,7 +173,8 @@ export function createFurnitureSource(env: {
             marginTop: sectionGeometry.margin.top,
             marginBottom: sectionGeometry.margin.bottom,
           }
-        : undefined
+        : undefined,
+      session.documentProperties()
     );
     const rId = rIdOfPart(part.name);
     const story = rId ? stampStoryRId(baseline, rId) : baseline;

--- a/packages/core/src/layout/__tests__/field-body-page-incremental.test.ts
+++ b/packages/core/src/layout/__tests__/field-body-page-incremental.test.ts
@@ -1,0 +1,146 @@
+// Body PAGE / NUMPAGES / SECTIONPAGES stay correct across an incremental re-layout and across
+// section boundaries.
+//
+// Two risks the piece-level tests cannot reach:
+//   1. A page reused (or re-laid) in the SAME layout session must never serve a STALE substituted
+//      number. When an edit changes the page count, a body NUMPAGES must update to the new total,
+//      and a body PAGE on a shifted page must update to the new page number. The `hasBodyPageFields`
+//      fast-out must not skip a page that carries a page field.
+//   2. In a genuine two-section document, section 2's body PAGE shows section 2's restarted number
+//      and its SECTIONPAGES shows section 2's own page count, distinct from the document NUMPAGES.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+  paragraphFragmentsOf,
+  type LayoutSession,
+  type PageRecord,
+  type SemanticLayout,
+  type StyleSpanRecord,
+} from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+/** Tight page geometry so a handful of one-line paragraphs already spills across pages. */
+const tightSectPr = (extra = '') =>
+  `<w:sectPr>${extra}<w:pgSz w:w="6000" w:h="2400"/>` +
+  `<w:pgMar w:top="200" w:right="200" w:bottom="200" w:left="200" w:header="100" w:footer="100"/>` +
+  `</w:sectPr>`;
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const simpleField = (instr: string) => `<w:p><w:fldSimple w:instr=" ${instr} "/></w:p>`;
+
+const filler = (count: number, tag = 'f') =>
+  Array.from({ length: count }, (_, i) => `<w:p><w:r><w:t>${tag} ${i}</w:t></w:r></w:p>`).join('');
+
+/** Every page-field span on any page, tagged with the page it landed on. */
+function pageFieldSpans(layout: SemanticLayout): { page: PageRecord; span: StyleSpanRecord }[] {
+  const found: { page: PageRecord; span: StyleSpanRecord }[] = [];
+  for (const page of layout.pages) {
+    for (const fragment of paragraphFragmentsOf(page)) {
+      for (const line of fragment.lines) {
+        for (const span of line.spans) {
+          if (span.fieldAtom?.pageField) found.push({ page, span });
+        }
+      }
+    }
+  }
+  return found;
+}
+
+const spanOfKind = (layout: SemanticLayout, kind: string) => {
+  const hit = pageFieldSpans(layout).find(
+    (entry) => entry.span.fieldAtom?.pageField?.kind === kind
+  );
+  if (!hit) throw new Error(`no ${kind} span`);
+  return hit;
+};
+
+const lay = (part: OoxmlPart, revision: number, session?: LayoutSession): SemanticLayout =>
+  layoutSemanticDocument(part, revision, {
+    measurer,
+    producer: 'test',
+    ...(session ? { session } : {}),
+  });
+
+describe('body page fields across an incremental re-layout in one session', () => {
+  test('a page-count change updates NUMPAGES and a shifted PAGE, no stale substituted number', () => {
+    // NUMPAGES rides page 1 (unchanged fragments across the edit, the reuse-risk case). A PAGE
+    // field sits after a block of filler that the edit grows, so it shifts to a later page.
+    const build = (before: number): string =>
+      simpleField('NUMPAGES') +
+      filler(before, 'a') +
+      simpleField('PAGE') +
+      filler(6, 'b') +
+      tightSectPr();
+
+    const session = createLayoutSession();
+    const first = lay(partOf(build(18)), 1, session);
+    const firstPages = first.pages.length;
+    expect(firstPages).toBeGreaterThan(2);
+    // Both fields resolved against the first pagination.
+    expect(spanOfKind(first, 'NUMPAGES').span.text).toBe(String(firstPages));
+    const firstPageField = spanOfKind(first, 'PAGE');
+    const firstPageValue =
+      firstPageField.page.pageFieldSource?.pageNumber ?? firstPageField.page.index + 1;
+    expect(firstPageField.span.text).toBe(String(firstPageValue));
+
+    // Grow the filler BEFORE the PAGE field, in the SAME session: more pages, PAGE lands later.
+    const second = lay(partOf(build(42)), 2, session);
+    const secondPages = second.pages.length;
+    expect(secondPages).toBeGreaterThan(firstPages);
+
+    // NUMPAGES on page 1 reflects the NEW total, not the stale first-pass count.
+    expect(spanOfKind(second, 'NUMPAGES').span.text).toBe(String(secondPages));
+
+    // The PAGE field shifted to a later page and shows that page's number.
+    const secondPageField = spanOfKind(second, 'PAGE');
+    const secondPageValue =
+      secondPageField.page.pageFieldSource?.pageNumber ?? secondPageField.page.index + 1;
+    expect(secondPageField.span.text).toBe(String(secondPageValue));
+    expect(secondPageValue).toBeGreaterThan(firstPageValue);
+  });
+});
+
+describe('body page fields in a genuine two-section document', () => {
+  test('section 2 PAGE restarts and SECTIONPAGES counts section 2, distinct from NUMPAGES', () => {
+    // Section 1: enough one-line paragraphs to fill more than one page, ended by a mid-body sectPr.
+    const section1 =
+      filler(16, 's1') + `<w:p><w:pPr>${tightSectPr()}</w:pPr><w:r><w:t>s1 end</w:t></w:r></w:p>`;
+    // Section 2: restarts page numbering at 1, spans multiple pages, and carries both fields.
+    const section2 =
+      simpleField('PAGE') +
+      filler(16, 's2') +
+      simpleField('SECTIONPAGES') +
+      tightSectPr('<w:pgNumType w:start="1"/>');
+
+    const layout = lay(partOf(section1 + section2), 1);
+    const total = layout.pages.length;
+    expect(total).toBeGreaterThan(3);
+
+    const pageField = spanOfKind(layout, 'PAGE');
+    const restartedNumber = pageField.page.pageFieldSource?.pageNumber ?? pageField.page.index + 1;
+    // Restarted: the section-2 PAGE value is BELOW its physical 1-based page index.
+    expect(restartedNumber).toBeLessThan(pageField.page.index + 1);
+    expect(pageField.span.text).toBe(String(restartedNumber));
+
+    const sectionPagesField = spanOfKind(layout, 'SECTIONPAGES');
+    const sectionCount = sectionPagesField.page.pageFieldSource?.sectionPageCount;
+    expect(sectionCount).toBeDefined();
+    // SECTIONPAGES counts section 2 only, so it is fewer than the document total.
+    expect(sectionCount!).toBeLessThan(total);
+    expect(sectionPagesField.span.text).toBe(String(sectionCount));
+  });
+});

--- a/packages/core/src/layout/__tests__/field-body-page-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-body-page-projection.test.ts
@@ -1,0 +1,284 @@
+// PAGE / NUMPAGES / SECTIONPAGES fields in the BODY flow evaluate to the page they land on.
+//
+// The value depends on a pagination that has not happened when the paragraph is measured, so the
+// walk reserves one model unit and paints a placeholder digit marked with the field kind. Document
+// finalize substitutes the real value per page. A cached result still wins, and a hidden field
+// paints nothing — exactly as it would in a header or footer.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  createFixedMeasurer,
+  layoutSemanticDocument,
+  paragraphFragmentsOf,
+  paragraphTextFromLayout,
+  type PageRecord,
+  type SemanticLayout,
+  type StyleSpanRecord,
+} from '../index.ts';
+import { piecesOfParagraph } from '../field-projection.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+function partOf(body: string, sectPr = '<w:sectPr/>'): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>${body}${sectPr}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+/** A body simple page field with no cached result. */
+const simpleField = (instr: string) => `<w:p><w:fldSimple w:instr=" ${instr} "/></w:p>`;
+
+/** A body complex page field: begin/instr/separate/end, no cached result. */
+const complexField = (instr: string) =>
+  `<w:p><w:r><w:fldChar w:fldCharType="begin"/><w:instrText> ${instr} </w:instrText>` +
+  `<w:fldChar w:fldCharType="separate"/><w:fldChar w:fldCharType="end"/></w:r></w:p>`;
+
+/** Filler body paragraphs, each one line, to push content across pages. */
+const filler = (count: number) =>
+  Array.from({ length: count }, (_, i) => `<w:p><w:r><w:t>filler ${i}</w:t></w:r></w:p>`).join('');
+
+/** Body-flow projection (bodyPageFields = true), the mode the layout uses for the document body. */
+function project(body: string, mode: RevisionDisplayMode = 'all-markup') {
+  return piecesOfParagraph(
+    paragraphOf(body),
+    [],
+    undefined, // pageContext: none in the body
+    undefined,
+    undefined,
+    undefined,
+    mode,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    true // bodyPageFields
+  );
+}
+
+function bodySpans(layout: SemanticLayout): { page: PageRecord; span: StyleSpanRecord }[] {
+  const found: { page: PageRecord; span: StyleSpanRecord }[] = [];
+  for (const page of layout.pages) {
+    for (const fragment of paragraphFragmentsOf(page)) {
+      for (const line of fragment.lines) {
+        for (const span of line.spans) found.push({ page, span });
+      }
+    }
+  }
+  return found;
+}
+
+/** The single span carrying a page-field marker, plus the page it landed on. */
+function pageFieldSpan(layout: SemanticLayout) {
+  const hits = bodySpans(layout).filter((entry) => entry.span.fieldAtom?.pageField);
+  expect(hits.length).toBe(1);
+  const { page, span } = hits[0]!;
+  const expectedPage = page.pageFieldSource?.pageNumber ?? page.index + 1;
+  const sectionPages = page.pageFieldSource?.sectionPageCount ?? layout.pages.length;
+  return { span, expectedPage, sectionPages, pageCount: layout.pages.length };
+}
+
+describe('a body page field at the piece level', () => {
+  test('a simple PAGE with no cached result paints a placeholder marked with its kind', () => {
+    const pieces = project(simpleField('PAGE'));
+    const field = pieces.find((piece) => piece.fieldAtom?.pageField);
+    expect(field).toBeDefined();
+    expect(field!.projected).toBe(true);
+    expect(field!.fieldAtom?.pageField?.kind).toBe('PAGE');
+    // One reserved model unit, whatever the substituted digits.
+    expect(field!.end - field!.start).toBe(1);
+  });
+
+  test('a complex PAGE with no cached result paints a placeholder marked with its kind', () => {
+    const pieces = project(complexField('PAGE'));
+    const field = pieces.find((piece) => piece.fieldAtom?.pageField);
+    expect(field).toBeDefined();
+    expect(field!.fieldAtom?.pageField?.kind).toBe('PAGE');
+    expect(field!.end - field!.start).toBe(1);
+  });
+
+  test('NUMPAGES and SECTIONPAGES are recognized too', () => {
+    for (const kind of ['NUMPAGES', 'SECTIONPAGES'] as const) {
+      const field = project(simpleField(kind)).find((piece) => piece.fieldAtom?.pageField);
+      expect(field!.fieldAtom?.pageField?.kind).toBe(kind);
+    }
+  });
+
+  test('a cached result wins: no placeholder marker, the cache paints', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" PAGE "><w:r><w:t>5</w:t></w:r></w:fldSimple></w:p>'
+    );
+    const marked = pieces.find((piece) => piece.fieldAtom?.pageField);
+    expect(marked).toBeUndefined();
+    const field = pieces.find((piece) => piece.projected);
+    expect(field?.text).toBe('5');
+  });
+
+  test('a vanished body PAGE paints nothing', () => {
+    const vanished =
+      '<w:p><w:r><w:rPr><w:vanish/></w:rPr><w:fldChar w:fldCharType="begin"/>' +
+      '<w:instrText> PAGE </w:instrText><w:fldChar w:fldCharType="separate"/>' +
+      '<w:fldChar w:fldCharType="end"/></w:r></w:p>';
+    const pieces = project(vanished);
+    expect(pieces.some((piece) => piece.fieldAtom?.pageField)).toBe(false);
+  });
+
+  test('a tracked-deleted body PAGE is gone from the proposed result', () => {
+    const deleted =
+      '<w:p><w:del w:id="1" w:author="a"><w:r><w:fldChar w:fldCharType="begin"/>' +
+      '<w:instrText> PAGE </w:instrText><w:fldChar w:fldCharType="separate"/>' +
+      '<w:fldChar w:fldCharType="end"/></w:r></w:del></w:p>';
+    const pieces = project(deleted, 'proposed');
+    expect(pieces.some((piece) => piece.fieldAtom?.pageField)).toBe(false);
+  });
+});
+
+describe('a body page field in a laid-out document', () => {
+  test('PAGE on the only page paints 1; NUMPAGES paints the page count', () => {
+    const layout = layoutSemanticDocument(partOf(simpleField('PAGE')), 1, {
+      measurer,
+      producer: 'test',
+    });
+    const { span, expectedPage } = pageFieldSpan(layout);
+    expect(expectedPage).toBe(1);
+    expect(span.text).toBe('1');
+
+    const numLayout = layoutSemanticDocument(partOf(simpleField('NUMPAGES')), 1, {
+      measurer,
+      producer: 'test',
+    });
+    const num = pageFieldSpan(numLayout);
+    expect(num.span.text).toBe(String(num.pageCount));
+  });
+
+  test('PAGE on a later page paints that page number; NUMPAGES paints the total', () => {
+    const body = filler(120) + simpleField('PAGE') + filler(120) + simpleField('NUMPAGES');
+    const part = partOf(body);
+    const layout = layoutSemanticDocument(part, 1, { measurer, producer: 'test' });
+    expect(layout.pages.length).toBeGreaterThan(2);
+
+    const marks = bodySpans(layout).filter((entry) => entry.span.fieldAtom?.pageField);
+    expect(marks.length).toBe(2);
+    for (const { page, span } of marks) {
+      const kind = span.fieldAtom!.pageField!.kind;
+      if (kind === 'PAGE') {
+        expect(span.text).toBe(String(page.pageFieldSource?.pageNumber ?? page.index + 1));
+        // Landed past page 1, proving substitution is page-aware.
+        expect(page.index).toBeGreaterThan(0);
+      } else {
+        expect(span.text).toBe(String(layout.pages.length));
+      }
+    }
+  });
+
+  test('SECTIONPAGES paints the section page count', () => {
+    const body = filler(60) + simpleField('SECTIONPAGES');
+    const layout = layoutSemanticDocument(partOf(body), 1, { measurer, producer: 'test' });
+    const { span, sectionPages, pageCount } = pageFieldSpan(layout);
+    // Single section, so SECTIONPAGES equals the document page count.
+    expect(sectionPages).toBe(pageCount);
+    expect(span.text).toBe(String(pageCount));
+  });
+
+  test('the complex-field equivalent paints the same value', () => {
+    const body = filler(120) + complexField('PAGE');
+    const layout = layoutSemanticDocument(partOf(body), 1, { measurer, producer: 'test' });
+    const { span, expectedPage } = pageFieldSpan(layout);
+    expect(span.text).toBe(String(expectedPage));
+    expect(expectedPage).toBeGreaterThan(1);
+  });
+
+  test('w:pgNumType/@w:start shifts the displayed body PAGE number', () => {
+    const layout = layoutSemanticDocument(
+      partOf(simpleField('PAGE'), '<w:sectPr><w:pgNumType w:start="5"/></w:sectPr>'),
+      1,
+      { measurer, producer: 'test' }
+    );
+    const { span, expectedPage } = pageFieldSpan(layout);
+    expect(expectedPage).toBe(5);
+    expect(span.text).toBe('5');
+  });
+
+  test('a cached result wins over substitution', () => {
+    const cached =
+      '<w:p><w:fldSimple w:instr=" PAGE "><w:r><w:t>cached</w:t></w:r></w:fldSimple></w:p>';
+    const layout = layoutSemanticDocument(partOf(cached), 1, { measurer, producer: 'test' });
+    const marked = bodySpans(layout).find((entry) => entry.span.fieldAtom?.pageField);
+    expect(marked).toBeUndefined();
+    const projected = bodySpans(layout).find((entry) => entry.span.projected);
+    expect(projected?.span.text).toBe('cached');
+  });
+
+  test('a body PAGE inside a table cell paints', () => {
+    const body =
+      filler(60) +
+      '<w:tbl><w:tr><w:tc>' +
+      '<w:p><w:fldSimple w:instr=" PAGE "/></w:p>' +
+      '</w:tc></w:tr></w:tbl>';
+    const layout = layoutSemanticDocument(partOf(body), 1, { measurer, producer: 'test' });
+    const { span, expectedPage } = pageFieldSpan(layout);
+    expect(span.text).toBe(String(expectedPage));
+    expect(expectedPage).toBeGreaterThan(1);
+  });
+
+  test('the field stays one model unit: paragraph text and offset coverage hold', () => {
+    // A three-digit page number would overflow a naive range; the model stays one unit.
+    const body = filler(120) + `<w:p><w:r><w:t>A</w:t></w:r><w:fldSimple w:instr=" PAGE "/></w:p>`;
+    const part = partOf(body);
+    const layout = layoutSemanticDocument(part, 1, { measurer, producer: 'test' });
+    const fieldEntry = bodySpans(layout).find((entry) => entry.span.fieldAtom?.pageField)!;
+    const paragraphId = fieldEntry.span.range.paragraphId;
+    // "A" + one field unit = two model units, whatever the substituted digits.
+    const text = paragraphTextFromLayout(layout, paragraphId);
+    expect(text.length).toBe(2);
+    expect(text[0]).toBe('A');
+    // The field's model range is exactly one unit.
+    expect(fieldEntry.span.range.end - fieldEntry.span.range.start).toBe(1);
+  });
+});
+
+describe('body page-field finalize identity discipline', () => {
+  test('finalize returns pages by identity where no page field changed', () => {
+    // Only the last page carries a PAGE field, so earlier pages must survive finalize by identity.
+    const body = filler(120) + simpleField('PAGE');
+    const part = partOf(body);
+    const first = layoutSemanticDocument(part, 1, { measurer, producer: 'test' });
+    const second = layoutSemanticDocument(part, 1, { measurer, producer: 'test' });
+    // A page with no page field is structurally identical across the two independent passes only
+    // if finalize did not clone it needlessly. Prove the substituted page differs from earlier
+    // pages that carry no marker.
+    const marked = bodySpans(first).filter((entry) => entry.span.fieldAtom?.pageField);
+    expect(marked.length).toBe(1);
+    // Earlier pages hold no page-field span at all.
+    const markedPageIndex = marked[0]!.page.index;
+    for (const page of first.pages) {
+      if (page.index === markedPageIndex) continue;
+      const hasMarker = paragraphFragmentsOf(page).some((f) =>
+        f.lines.some((l) => l.spans.some((s) => s.fieldAtom?.pageField))
+      );
+      expect(hasMarker).toBe(false);
+    }
+    expect(second.pages.length).toBe(first.pages.length);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-button-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-button-projection.test.ts
@@ -190,3 +190,46 @@ describe('a simple MACROBUTTON / GOTOBUTTON field', () => {
     expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
   });
 });
+
+describe('a button whose only cached result is wrapped in w:del', () => {
+  // The result exists on paper but the PROPOSED view resolves it away — after accepting,
+  // Word shows the display text there. Suppressing synthesis painted nothing at all.
+  const DEL = '<w:del w:id="1" w:author="A"><w:r><w:delText>Old</w:delText></w:r></w:del>';
+
+  test('complex: the proposed view synthesizes the display text', () => {
+    const pieces = project(`<w:p>${complexField(' MACROBUTTON M Click ', DEL)}</w:p>`, 'proposed');
+    expect(pieces.map((piece) => piece.text)).toEqual(['Click']);
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+  });
+
+  test('complex: all-markup keeps the cached content, struck', () => {
+    const pieces = project(`<w:p>${complexField(' MACROBUTTON M Click ', DEL)}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['Old']);
+    expect(pieces[0]!.revisions?.map((revision) => revision.kind)).toEqual(['delete']);
+  });
+
+  test('complex: the original view keeps the cached content', () => {
+    const pieces = project(`<w:p>${complexField(' MACROBUTTON M Click ', DEL)}</w:p>`, 'original');
+    expect(pieces.map((piece) => piece.text)).toEqual(['Old']);
+  });
+
+  test('simple: the proposed view synthesizes, other views keep the cache', () => {
+    const simple = `<w:p><w:fldSimple w:instr=" MACROBUTTON M Click ">${DEL}</w:fldSimple></w:p>`;
+    expect(project(simple, 'proposed').map((piece) => piece.text)).toEqual(['Click']);
+    expect(project(simple).map((piece) => piece.text)).toEqual(['Old']);
+    expect(project(simple, 'original').map((piece) => piece.text)).toEqual(['Old']);
+  });
+
+  test('a vanish-hidden result still suppresses synthesis in every mode', () => {
+    // Vanish is the case the flag exists for: the file hid the result on purpose, in
+    // every view, and painting the display text over it would resurrect it.
+    const hidden = '<w:r><w:rPr><w:vanish/></w:rPr><w:t>Hidden</w:t></w:r>';
+    for (const mode of ['all-markup', 'proposed', 'original'] as const) {
+      const pieces = project(
+        `<w:p>${complexField(' MACROBUTTON M Click ', hidden)}<w:r><w:t>B</w:t></w:r></w:p>`,
+        mode
+      );
+      expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+    }
+  });
+});

--- a/packages/core/src/layout/__tests__/field-button-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-button-projection.test.ts
@@ -95,6 +95,19 @@ describe('a complex MACROBUTTON field', () => {
     expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
   });
 
+  test('a cached result that exists but is hidden suppresses the display text', () => {
+    // The file cached a result and hid it with w:vanish. Painting the display text there
+    // would resurrect what the document hides; only a truly EMPTY cache synthesizes.
+    const pieces = project(
+      `<w:p>${complexField(
+        ' MACROBUTTON DoThing Click Here ',
+        '<w:r><w:rPr><w:vanish/></w:rPr><w:t>Hidden cache</w:t></w:r>'
+      )}<w:r><w:t>B</w:t></w:r></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+    expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
+  });
+
   test('hidden chrome paints nothing but keeps the unit', () => {
     const pieces = project(
       '<w:p><w:r><w:t>A</w:t></w:r>' +
@@ -164,5 +177,16 @@ describe('a simple MACROBUTTON / GOTOBUTTON field', () => {
       'proposed'
     );
     expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test('a hidden cached child run suppresses the display text too', () => {
+    // Mirrors the complex-field rule: a result that exists but is hidden stays hidden.
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" MACROBUTTON M Click ">' +
+        '<w:r><w:rPr><w:vanish/></w:rPr><w:t>Hidden</w:t></w:r></w:fldSimple>' +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+    expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
   });
 });

--- a/packages/core/src/layout/__tests__/field-button-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-button-projection.test.ts
@@ -1,0 +1,168 @@
+// MACROBUTTON / GOTOBUTTON fields display everything after their first argument.
+//
+// Word paints the display text and real files carry no cached result for these fields, so
+// without synthesis they paint nothing. The macro / jump target is never executed, resolved,
+// or navigated — display only. A cached result, when a file does carry one, wins: it is what
+// Word last painted.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { piecesOfParagraph, type HyperlinkProjector } from '../field-projection.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+import type { SpanLinkRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+function project(
+  body: string,
+  mode: RevisionDisplayMode = 'all-markup',
+  projectLink?: HyperlinkProjector
+) {
+  return piecesOfParagraph(
+    paragraphOf(body),
+    [],
+    undefined,
+    undefined,
+    projectLink,
+    undefined,
+    mode
+  );
+}
+
+/** A complex field around one instruction: begin/instr[/separate + result]/end. */
+function complexField(instr: string, result?: string, chromeRpr = ''): string {
+  const middle =
+    result === undefined
+      ? ''
+      : `<w:r>${chromeRpr}<w:fldChar w:fldCharType="separate"/></w:r>` + result;
+  return (
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="begin"/></w:r>` +
+    `<w:r>${chromeRpr}<w:instrText>${instr}</w:instrText></w:r>` +
+    middle +
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
+
+describe('a complex MACROBUTTON field', () => {
+  test('the no-separate shape paints the display text over one atom unit', () => {
+    const pieces = project(
+      `<w:p><w:r><w:t>A</w:t></w:r>${complexField(' MACROBUTTON DoThing Click Here ')}<w:r><w:t>B</w:t></w:r></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'Click Here', 'B']);
+    const button = pieces[1]!;
+    expect(button).toMatchObject({ start: 1, end: 2, projected: true });
+    expect(button.fieldAtom).toEqual({ formField: false });
+    expect(pieces[2]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('with a separate and a cached result, the cache wins', () => {
+    const pieces = project(
+      `<w:p>${complexField(' MACROBUTTON DoThing Click Here ', '<w:r><w:t>Cached</w:t></w:r>')}</w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Cached']);
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+  });
+
+  test('with a separate and an EMPTY result, the display text fills in', () => {
+    const pieces = project(
+      `<w:p>${complexField(' GOTOBUTTON bookmark3 Go to section 3 ', '')}</w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Go to section 3']);
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+  });
+
+  test('hidden chrome paints nothing but keeps the unit', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        complexField(' MACROBUTTON M Click ', undefined, '<w:rPr><w:vanish/></w:rPr>') +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+    expect(pieces[1]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('a tracked-deleted button is gone from the proposed result', () => {
+    const pieces = project(
+      `<w:p><w:del w:id="1" w:author="A">${complexField(' MACROBUTTON M Click ')}</w:del></w:p>`,
+      'proposed'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test('an enclosing w:hyperlink carries its link onto the display text', () => {
+    const link: SpanLinkRecord = Object.freeze({
+      id: 'enclosing',
+      kind: 'external' as const,
+      href: 'https://enclosing.example',
+    });
+    const pieces = project(
+      `<w:p><w:hyperlink w:anchor="a">${complexField(' MACROBUTTON M Click ')}</w:hyperlink></w:p>`,
+      'all-markup',
+      () => link
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Click']);
+    expect(pieces[0]!.link).toBe(link);
+  });
+});
+
+describe('a simple MACROBUTTON / GOTOBUTTON field', () => {
+  test('empty children paint the display text over one model unit', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        '<w:fldSimple w:instr=" MACROBUTTON DoThing Click Here "></w:fldSimple>' +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'Click Here', 'B']);
+    const button = pieces[1]!;
+    expect(button).toMatchObject({ start: 1, end: 2, projected: true });
+    expect(button.fieldAtom).toEqual({ formField: false });
+  });
+
+  test('GOTOBUTTON paints the same way and never navigates — no link record', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" GOTOBUTTON bookmark3 Go there "></w:fldSimple></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Go there']);
+    expect(pieces[0]!.link).toBeUndefined();
+  });
+
+  test('a cached child run wins over the synthesized display', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" MACROBUTTON M Click "><w:r><w:t>Cached</w:t></w:r></w:fldSimple></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Cached']);
+  });
+
+  test('a tracked-deleted simple button is gone from the proposed result', () => {
+    const pieces = project(
+      '<w:p><w:del w:id="1" w:author="A">' +
+        '<w:fldSimple w:instr=" MACROBUTTON M Click "></w:fldSimple></w:del></w:p>',
+      'proposed'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-button.test.ts
+++ b/packages/core/src/layout/__tests__/field-button.test.ts
@@ -1,0 +1,118 @@
+// MACROBUTTON / GOTOBUTTON instruction parsing (§17.16.5.36, §17.16.5.31).
+//
+// The instruction is attacker-controlled: every hostile shape must resolve to null (the
+// caller falls back to cached text or nothing) and must never throw. The first argument —
+// the macro name / jump target — is consumed and discarded; only display text comes out.
+
+import { describe, expect, test } from 'bun:test';
+import { parseButtonInstruction } from '../field-button.ts';
+import { MAX_FIELD_INSTRUCTION_CHARS } from '../field-instruction.ts';
+
+describe('parseButtonInstruction', () => {
+  test('a bare macro name: display is everything after it', () => {
+    expect(parseButtonInstruction(' MACROBUTTON MyMacro Click Here ')).toEqual({
+      display: 'Click Here',
+    });
+  });
+
+  test('GOTOBUTTON parses the same way', () => {
+    expect(parseButtonInstruction(' GOTOBUTTON bookmark3 Go to section 3 ')).toEqual({
+      display: 'Go to section 3',
+    });
+  });
+
+  test('recognition is case-insensitive; the display keeps its case', () => {
+    expect(parseButtonInstruction('macrobutton m Do It')).toEqual({ display: 'Do It' });
+    expect(parseButtonInstruction('GoToButton b There')).toEqual({ display: 'There' });
+  });
+
+  test('a quoted first argument is consumed whole, embedded spaces included', () => {
+    expect(parseButtonInstruction(' MACROBUTTON "My Long Macro" Press me ')).toEqual({
+      display: 'Press me',
+    });
+  });
+
+  test('internal quotes and backslashes in the display survive verbatim', () => {
+    expect(parseButtonInstruction('MACROBUTTON M Click "right here" now')).toEqual({
+      display: 'Click "right here" now',
+    });
+    expect(parseButtonInstruction('MACROBUTTON M Open C:\\docs\\file')).toEqual({
+      display: 'Open C:\\docs\\file',
+    });
+  });
+
+  test('internal whitespace is preserved, ends are trimmed', () => {
+    expect(parseButtonInstruction('MACROBUTTON M  Two  spaces  ')).toEqual({
+      display: 'Two  spaces',
+    });
+  });
+
+  test('a whole-remainder quoted display loses its surrounding quotes', () => {
+    expect(parseButtonInstruction(' MACROBUTTON M "Click Here" ')).toEqual({
+      display: 'Click Here',
+    });
+  });
+
+  test('quotes that close mid-remainder are part of the display', () => {
+    expect(parseButtonInstruction('MACROBUTTON M "a" b')).toEqual({ display: '"a" b' });
+  });
+
+  test('a trailing \\* MERGEFORMAT is stripped, case-insensitively', () => {
+    expect(parseButtonInstruction(' MACROBUTTON M Click Me \\* MERGEFORMAT ')).toEqual({
+      display: 'Click Me',
+    });
+    expect(parseButtonInstruction('MACROBUTTON M Click \\* mergeformat')).toEqual({
+      display: 'Click',
+    });
+  });
+
+  test('a generic trailing \\* switch and its argument are stripped, stacked ones too', () => {
+    expect(parseButtonInstruction('MACROBUTTON M Click \\* Upper')).toEqual({ display: 'Click' });
+    expect(parseButtonInstruction('MACROBUTTON M Click \\* Upper \\* MERGEFORMAT')).toEqual({
+      display: 'Click',
+    });
+  });
+
+  test('a mid-display \\* is NOT stripped — only a trailing switch tail is', () => {
+    expect(parseButtonInstruction('MACROBUTTON M a \\* b c')).toEqual({ display: 'a \\* b c' });
+  });
+
+  test('the keyword must be the exact token, not a prefix superstring', () => {
+    expect(parseButtonInstruction('MACROBUTTONX M text')).toBeNull();
+    expect(parseButtonInstruction('GOTOBUTTONS b text')).toBeNull();
+    expect(parseButtonInstruction('"MACROBUTTON" M text')).toBeNull();
+    expect(parseButtonInstruction(' PAGE ')).toBeNull();
+  });
+
+  test('no display text is null', () => {
+    expect(parseButtonInstruction('MACROBUTTON')).toBeNull();
+    expect(parseButtonInstruction('MACROBUTTON MyMacro')).toBeNull();
+    expect(parseButtonInstruction('MACROBUTTON MyMacro   ')).toBeNull();
+    expect(parseButtonInstruction('MACROBUTTON M \\* MERGEFORMAT')).toBeNull();
+    expect(parseButtonInstruction('MACROBUTTON M ""')).toBeNull();
+    expect(parseButtonInstruction('')).toBeNull();
+  });
+
+  test('an unclosed quoted argument swallows the rest and terminates', () => {
+    expect(parseButtonInstruction('MACROBUTTON "unclosed rest of line')).toBeNull();
+  });
+
+  test('an unclosed quoted display runs to the end, quote dropped', () => {
+    expect(parseButtonInstruction('MACROBUTTON M "unclosed')).toEqual({ display: 'unclosed' });
+  });
+
+  test('hostile over-cap input is rejected without a throw', () => {
+    const blob = `MACROBUTTON M ${'A'.repeat(100 * 1024)}`;
+    expect(parseButtonInstruction(blob)).toBeNull();
+    expect(parseButtonInstruction('"'.repeat(MAX_FIELD_INSTRUCTION_CHARS))).toBeNull();
+  });
+
+  test('display text stays within the instruction cap', () => {
+    const atCap = `MACROBUTTON M ${'A'.repeat(MAX_FIELD_INSTRUCTION_CHARS - 14)}`;
+    expect(atCap.length).toBe(MAX_FIELD_INSTRUCTION_CHARS);
+    const spec = parseButtonInstruction(atCap);
+    expect(spec).not.toBeNull();
+    expect(spec!.display.length).toBeLessThanOrEqual(MAX_FIELD_INSTRUCTION_CHARS);
+    expect(parseButtonInstruction(`${atCap}A`)).toBeNull();
+  });
+});

--- a/packages/core/src/layout/__tests__/field-button.test.ts
+++ b/packages/core/src/layout/__tests__/field-button.test.ts
@@ -5,8 +5,7 @@
 // the macro name / jump target — is consumed and discarded; only display text comes out.
 
 import { describe, expect, test } from 'bun:test';
-import { parseButtonInstruction } from '../field-button.ts';
-import { MAX_FIELD_INSTRUCTION_CHARS } from '../field-instruction.ts';
+import { MAX_BUTTON_INSTRUCTION_CHARS, parseButtonInstruction } from '../field-button.ts';
 
 describe('parseButtonInstruction', () => {
   test('a bare macro name: display is everything after it', () => {
@@ -117,15 +116,15 @@ describe('parseButtonInstruction', () => {
   test('hostile over-cap input is rejected without a throw', () => {
     const blob = `MACROBUTTON M ${'A'.repeat(100 * 1024)}`;
     expect(parseButtonInstruction(blob)).toBeNull();
-    expect(parseButtonInstruction('"'.repeat(MAX_FIELD_INSTRUCTION_CHARS))).toBeNull();
+    expect(parseButtonInstruction('"'.repeat(MAX_BUTTON_INSTRUCTION_CHARS))).toBeNull();
   });
 
   test('display text stays within the instruction cap', () => {
-    const atCap = `MACROBUTTON M ${'A'.repeat(MAX_FIELD_INSTRUCTION_CHARS - 14)}`;
-    expect(atCap.length).toBe(MAX_FIELD_INSTRUCTION_CHARS);
+    const atCap = `MACROBUTTON M ${'A'.repeat(MAX_BUTTON_INSTRUCTION_CHARS - 14)}`;
+    expect(atCap.length).toBe(MAX_BUTTON_INSTRUCTION_CHARS);
     const spec = parseButtonInstruction(atCap);
     expect(spec).not.toBeNull();
-    expect(spec!.display.length).toBeLessThanOrEqual(MAX_FIELD_INSTRUCTION_CHARS);
+    expect(spec!.display.length).toBeLessThanOrEqual(MAX_BUTTON_INSTRUCTION_CHARS);
     expect(parseButtonInstruction(`${atCap}A`)).toBeNull();
   });
 });

--- a/packages/core/src/layout/__tests__/field-button.test.ts
+++ b/packages/core/src/layout/__tests__/field-button.test.ts
@@ -77,6 +77,19 @@ describe('parseButtonInstruction', () => {
     expect(parseButtonInstruction('MACROBUTTON M a \\* b c')).toEqual({ display: 'a \\* b c' });
   });
 
+  test('a trailing lone backslash is display text, not a switch', () => {
+    expect(parseButtonInstruction('MACROBUTTON M \\')).toEqual({ display: '\\' });
+    expect(parseButtonInstruction('MACROBUTTON M x \\')).toEqual({ display: 'x \\' });
+  });
+
+  test('a quoted display shields a switch-looking tail from stripping', () => {
+    // The tail sits INSIDE one whole-remainder quoted token: the quotes come off, the
+    // "switch" stays — it is the authored display text.
+    expect(parseButtonInstruction('MACROBUTTON M "Click \\* MERGEFORMAT"')).toEqual({
+      display: 'Click \\* MERGEFORMAT',
+    });
+  });
+
   test('the keyword must be the exact token, not a prefix superstring', () => {
     expect(parseButtonInstruction('MACROBUTTONX M text')).toBeNull();
     expect(parseButtonInstruction('GOTOBUTTONS b text')).toBeNull();

--- a/packages/core/src/layout/__tests__/field-doc-property-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-doc-property-layout.test.ts
@@ -1,0 +1,227 @@
+// Document-property fields (TITLE, AUTHOR, ...) resolve inside a full layout, not only at the
+// piece level. Three surfaces are pinned here:
+//   1. Body: `paragraphTextFromLayout` clamps a projected atom to its ONE model unit, so a
+//      multi-character AUTHOR value never inflates Select All, the deletion range, or word motion.
+//   2. Footnote: the value threads from the body layout options into the note story
+//      (`inheritNotesLayoutInput`), so a note field is not painted blank.
+//   3. Body-anchored text box: the value threads into the anchored story, so a field in a body or
+//      table-cell text box is not painted blank.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  readOoxmlPackage,
+  readOoxmlPart,
+  type DocumentProperties,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import {
+  createFixedMeasurer,
+  layoutSemanticDocument,
+  paragraphTextFromLayout,
+  type SemanticLayout,
+} from '../index.ts';
+import type { NotesLayoutInput } from '../note-pagination.ts';
+import { resolveNotesPart } from '../../store/package/note-references.ts';
+import {
+  resolveEndnoteProperties,
+  resolveFootnoteProperties,
+} from '../../store/package/note-properties.ts';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import type { InlineDrawingLayoutContext } from '../drawing-layout.ts';
+import { mockReadyImageResource } from '../../store/__tests__/drawing-ready-fixture.ts';
+import { paintSemanticLayout } from '../../output/semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+const measurer = createFixedMeasurer(6, 14);
+
+// A multi-character value over a single model unit: 12 painted characters, one atom.
+const AUTHOR = 'Ada Lovelace';
+const PROPS: DocumentProperties = Object.freeze({ creator: AUTHOR });
+
+/** A complex AUTHOR field with no cached result: begin/instr/separate/end. */
+const authorField =
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  '<w:r><w:instrText> AUTHOR </w:instrText></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+function partOfBody(body: string, ns = `xmlns:w="${W}"`): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document ${ns}><w:body>${body}<w:sectPr/></w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function layoutText(layout: SemanticLayout, paragraphId: string): string {
+  return paragraphTextFromLayout(layout, paragraphId);
+}
+
+describe('body: paragraphTextFromLayout clamps a multi-character field atom to one model unit', () => {
+  test('an AUTHOR atom contributes one unit, not its painted length', () => {
+    // "A" then an AUTHOR field at the paragraph END = two model units, whatever the painted value.
+    // The field is last on purpose: a trailing character would slice the reconstruction back and
+    // mask an un-clamped overflow, so the atom must be the final piece to pin the clamp.
+    const part = partOfBody(`<w:p><w:r><w:t>A</w:t></w:r>${authorField}</w:p>`);
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      producer: 'doc-prop-layout',
+      documentProperties: PROPS,
+    });
+
+    // The atom paints the full value — it may split across spans (a space breaks the token), but
+    // every projected span carries the SAME one-unit model range. Concatenation proves the
+    // projection fired with the multi-character value.
+    const spans = layout.pages
+      .flatMap((page) => page.fragments)
+      .flatMap((fragment) => (fragment.kind === 'paragraph' ? fragment.lines : []))
+      .flatMap((line) => line.spans);
+    const projected = spans.filter((span) => span.projected);
+    expect(projected.length).toBeGreaterThan(0);
+    expect(projected.map((span) => span.text).join('')).toBe(AUTHOR);
+    for (const span of projected) expect(span.range.end - span.range.start).toBe(1);
+
+    const paragraphId = projected[0]!.range.paragraphId;
+    const text = layoutText(layout, paragraphId);
+    // Model length is 2: "A" + one field unit. Reverting the clamp lets the 12-character painted
+    // value through as the final piece, making this 5+ instead of 2.
+    expect(text.length).toBe(2);
+    expect(text[0]).toBe('A');
+  });
+});
+
+/** Package with a footnote whose body carries an AUTHOR field and no cached result. */
+function footnoteAuthorDoc(): Uint8Array {
+  const body = `<w:p><w:r><w:t>Body</w:t><w:footnoteReference w:id="1"/></w:r></w:p>`;
+  const footnotes =
+    `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:id="1"><w:p>${authorField}</w:p></w:footnote>`;
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(`<w:footnotes xmlns:w="${W}">${footnotes}</w:footnotes>`),
+  });
+}
+
+describe('footnote: an AUTHOR field resolves through inheritNotesLayoutInput', () => {
+  test('the note story paints the property value, not a blank', () => {
+    const loaded = readOoxmlPackage(footnoteAuthorDoc());
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) throw new Error(loaded.reason);
+    const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+    const documentFootnoteProps = resolveFootnoteProperties(undefined, undefined);
+    const documentEndnoteProps = resolveEndnoteProperties(undefined, undefined);
+    // The notes input pins NO document properties, so resolution proves body → notes threading.
+    const notes: NotesLayoutInput = {
+      footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+      endnotesPart: null,
+      footnotePropsBySection: [documentFootnoteProps],
+      endnotePropsBySection: [documentEndnoteProps],
+      documentFootnoteProps,
+      documentEndnoteProps,
+      measurer,
+      producer: 'doc-prop-note',
+    };
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      notes,
+      producer: 'doc-prop-note',
+      documentProperties: PROPS,
+    });
+    const noteText = layout.pages
+      .flatMap((page) => page.footnotes?.notes ?? [])
+      .flatMap((note) => note.fragments)
+      .flatMap((fragment) => (fragment.kind === 'paragraph' ? fragment.lines : []))
+      .flatMap((line) => line.spans.map((span) => span.text))
+      .join('');
+    expect(noteText).toContain(AUTHOR);
+  });
+});
+
+/** Anchored, page-positioned, wrap-none body text box carrying the given story content. */
+function bodyTextboxDrawing(content: string): string {
+  return (
+    '<w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"' +
+    ' relativeHeight="1" behindDoc="1" locked="0" layoutInCell="1" allowOverlap="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="page"><wp:posOffset>1000000</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="page"><wp:posOffset>1000000</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="2000000" cy="500000"/>' +
+    '<wp:effectExtent l="0" t="0" r="0" b="0"/><wp:wrapNone/>' +
+    '<wp:docPr id="1" name="TB"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    '<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="500000"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
+    `<wps:txbx><w:txbxContent>${content}</w:txbxContent></wps:txbx>` +
+    '<wps:bodyPr lIns="0" tIns="0" rIns="0" bIns="0"/>' +
+    '</wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing>'
+  );
+}
+
+function drawingLayoutFor(part: OoxmlPart): InlineDrawingLayoutContext {
+  const atomProjections = indexInlineDrawingProjectionsInPart(part);
+  const ready = mockReadyImageResource({
+    bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
+  });
+  return {
+    ownerPartName: part.name,
+    projectionForAtom: (atomId) => atomProjections.get(atomId) ?? null,
+    project: (node) =>
+      atomProjections.get(node.id) ??
+      projectDrawing(node, { ownerPartName: part.name, limits: DEFAULT_DRAWING_PROJECTION_LIMITS }),
+    resourceOf: () => ready,
+  };
+}
+
+describe('body text box: an AUTHOR field resolves through the anchored story (F2)', () => {
+  test('the painted text box carries the property value, not a blank', () => {
+    const ns = `xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"`;
+    const part = partOfBody(
+      `<w:p><w:r>${bodyTextboxDrawing(`<w:p>${authorField}</w:p>`)}</w:r></w:p>`,
+      ns
+    );
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      producer: 'doc-prop-textbox',
+      documentProperties: PROPS,
+      inlineDrawingLayout: drawingLayoutFor(part),
+    });
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const box = container.querySelector<HTMLElement>('.docx-drawing-textbox');
+    expect(box).not.toBeNull();
+    // Before the F2 fix the body text box omitted documentProperties, so this painted blank.
+    expect(box!.textContent).toContain(AUTHOR);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-doc-property-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-doc-property-projection.test.ts
@@ -1,0 +1,270 @@
+// Document-property fields (TITLE, AUTHOR, SUBJECT, KEYWORDS, LASTSAVEDBY, COMMENTS, and the
+// generic DOCPROPERTY "Name") paint their value from the parsed document properties when the
+// field carries no cached result of its own — exactly like Word.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  type DocumentProperties,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { piecesOfParagraph } from '../field-projection.ts';
+import { docPropertyValue, parseDocPropertyInstruction } from '../field-doc-property.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const PROPS: DocumentProperties = Object.freeze({
+  title: 'Sample Title',
+  creator: 'A. Author',
+  subject: 'Sample Subject',
+  keywords: 'alpha, beta',
+  lastModifiedBy: 'B. Editor',
+  description: 'Sample Comments',
+});
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+function project(
+  body: string,
+  props: DocumentProperties | undefined = PROPS,
+  mode: RevisionDisplayMode = 'all-markup'
+) {
+  return piecesOfParagraph(
+    paragraphOf(body),
+    [],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    mode,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    props
+  );
+}
+
+/** A complex field: begin/instr[/separate + result]/end. `chromeRpr` styles the chrome runs. */
+function complexField(instr: string, result?: string, chromeRpr = ''): string {
+  const middle =
+    result === undefined
+      ? ''
+      : `<w:r>${chromeRpr}<w:fldChar w:fldCharType="separate"/></w:r>` + result;
+  return (
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="begin"/></w:r>` +
+    `<w:r>${chromeRpr}<w:instrText>${instr}</w:instrText></w:r>` +
+    middle +
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
+
+const CASES: ReadonlyArray<readonly [string, string]> = [
+  ['TITLE', 'Sample Title'],
+  ['AUTHOR', 'A. Author'],
+  ['SUBJECT', 'Sample Subject'],
+  ['KEYWORDS', 'alpha, beta'],
+  ['LASTSAVEDBY', 'B. Editor'],
+  ['COMMENTS', 'Sample Comments'],
+];
+
+describe('a complex document-property field with no cached result', () => {
+  for (const [keyword, value] of CASES) {
+    test(`${keyword} paints its property value over one atom unit`, () => {
+      const pieces = project(
+        `<w:p><w:r><w:t>A</w:t></w:r>${complexField(` ${keyword} `)}<w:r><w:t>B</w:t></w:r></w:p>`
+      );
+      expect(pieces.map((piece) => piece.text)).toEqual(['A', value, 'B']);
+      expect(pieces[1]).toMatchObject({ start: 1, end: 2, projected: true });
+      expect(pieces[1]!.fieldAtom).toEqual({ formField: false });
+    });
+  }
+
+  test('the separate + EMPTY result shape synthesizes too', () => {
+    const pieces = project(`<w:p>${complexField(' TITLE ', '')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['Sample Title']);
+  });
+
+  test('a trailing \\* Upper format switch is stripped (value painted verbatim, not re-cased)', () => {
+    const pieces = project(`<w:p>${complexField(' AUTHOR \\* Upper ')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['A. Author']);
+  });
+});
+
+describe('a simple document-property field', () => {
+  for (const [keyword, value] of CASES) {
+    test(`fldSimple ${keyword} paints its property value`, () => {
+      const pieces = project(`<w:p><w:fldSimple w:instr=" ${keyword} "></w:fldSimple></w:p>`);
+      expect(pieces.map((piece) => piece.text)).toEqual([value]);
+      expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+    });
+  }
+});
+
+describe('DOCPROPERTY "Name"', () => {
+  test('a known name maps to its property (complex)', () => {
+    const pieces = project(`<w:p>${complexField(' DOCPROPERTY "Author" ')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['A. Author']);
+  });
+
+  test('a known name maps to its property (simple, case-insensitive)', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" DOCPROPERTY &quot;title&quot; "></w:fldSimple></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Sample Title']);
+  });
+
+  test('an unknown name stays inert (paints nothing)', () => {
+    const pieces = project(
+      `<w:p><w:r><w:t>A</w:t></w:r>${complexField(' DOCPROPERTY "CustomThing" ')}<w:r><w:t>B</w:t></w:r></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+  });
+});
+
+describe('when a cached result exists', () => {
+  test('the cached result wins over the property value (complex)', () => {
+    const pieces = project(`<w:p>${complexField(' TITLE ', '<w:r><w:t>Cached</w:t></w:r>')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['Cached']);
+  });
+
+  test('the cached result wins over the property value (simple)', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" TITLE "><w:r><w:t>Cached</w:t></w:r></w:fldSimple></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Cached']);
+  });
+
+  test('a cached result that exists but is hidden stays hidden — no synthesis', () => {
+    const pieces = project(
+      `<w:p>${complexField(
+        ' TITLE ',
+        '<w:r><w:rPr><w:vanish/></w:rPr><w:t>Hidden</w:t></w:r>'
+      )}<w:r><w:t>B</w:t></w:r></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+  });
+});
+
+describe('suppression', () => {
+  test('vanish chrome paints nothing but keeps the unit (complex)', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        complexField(' TITLE ', undefined, '<w:rPr><w:vanish/></w:rPr>') +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+    expect(pieces[1]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('a tracked-deleted field is gone from the proposed result', () => {
+    const pieces = project(
+      `<w:p><w:del w:id="1" w:author="A">${complexField(' TITLE ')}</w:del></w:p>`,
+      PROPS,
+      'proposed'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test('a missing property paints nothing (complex and simple)', () => {
+    const noTitle: DocumentProperties = { creator: 'A. Author' };
+    expect(
+      project(
+        `<w:p><w:r><w:t>A</w:t></w:r>${complexField(' TITLE ')}<w:r><w:t>B</w:t></w:r></w:p>`,
+        noTitle
+      ).map((piece) => piece.text)
+    ).toEqual(['A', 'B']);
+    expect(
+      project('<w:p><w:fldSimple w:instr=" TITLE "></w:fldSimple></w:p>', noTitle).map(
+        (piece) => piece.text
+      )
+    ).toEqual([]);
+  });
+
+  test('no documentProperties supplied paints nothing (the furniture-pass degradation)', () => {
+    // The 12th argument is omitted entirely, the degradation a furniture-only pass gets.
+    const pieces = piecesOfParagraph(
+      paragraphOf(`<w:p>${complexField(' TITLE ')}</w:p>`),
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'all-markup'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+});
+
+describe('a value with XML-special characters', () => {
+  // The painted piece carries the RAW value — escaping happens at paint time via textContent,
+  // never as markup — so the layout text must equal the property string exactly.
+  const raw = 'Jones & Co <Legal> "Draft"';
+  const hostile: DocumentProperties = { title: raw };
+
+  test('complex TITLE carries the raw value verbatim', () => {
+    const pieces = project(`<w:p>${complexField(' TITLE ')}</w:p>`, hostile);
+    expect(pieces).toHaveLength(1);
+    expect(pieces[0]!.text).toBe(raw);
+  });
+
+  test('simple TITLE carries the raw value verbatim', () => {
+    const pieces = project('<w:p><w:fldSimple w:instr=" TITLE "></w:fldSimple></w:p>', hostile);
+    expect(pieces[0]!.text).toBe(raw);
+  });
+});
+
+describe('parseDocPropertyInstruction / docPropertyValue', () => {
+  test('bare keywords map to their property key', () => {
+    expect(parseDocPropertyInstruction(' TITLE ')).toEqual({ property: 'title' });
+    expect(parseDocPropertyInstruction('AUTHOR')).toEqual({ property: 'creator' });
+    expect(parseDocPropertyInstruction('LastSavedBy')).toEqual({ property: 'lastModifiedBy' });
+    expect(parseDocPropertyInstruction('COMMENTS')).toEqual({ property: 'description' });
+  });
+
+  test('a trailing format switch is stripped for recognition', () => {
+    expect(parseDocPropertyInstruction(' TITLE \\* MERGEFORMAT ')).toEqual({ property: 'title' });
+    expect(parseDocPropertyInstruction(' AUTHOR \\* Upper ')).toEqual({ property: 'creator' });
+  });
+
+  test('DOCPROPERTY maps a known quoted name, rejects an unknown one', () => {
+    expect(parseDocPropertyInstruction(' DOCPROPERTY "Subject" ')).toEqual({ property: 'subject' });
+    expect(parseDocPropertyInstruction(' DOCPROPERTY "Nope" ')).toBeNull();
+  });
+
+  test('a non-property keyword and a glued keyword are not matched', () => {
+    expect(parseDocPropertyInstruction(' PAGE ')).toBeNull();
+    expect(parseDocPropertyInstruction('TITLEX')).toBeNull();
+    expect(parseDocPropertyInstruction('DOCPROPERTYX "Author"')).toBeNull();
+  });
+
+  test('docPropertyValue returns null for a missing or empty property', () => {
+    expect(docPropertyValue({ property: 'title' }, undefined)).toBeNull();
+    expect(docPropertyValue({ property: 'title' }, {})).toBeNull();
+    expect(docPropertyValue({ property: 'title' }, { title: 'X' })).toBe('X');
+  });
+});

--- a/packages/core/src/layout/__tests__/field-form-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-form-projection.test.ts
@@ -262,4 +262,20 @@ describe('a FORMDROPDOWN field', () => {
     expect(pieces.map((piece) => piece.text)).toEqual(['B']);
     expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
   });
+
+  test('a w:del-wrapped cached result synthesizes in the proposed view only', () => {
+    // The proposed view resolves the deletion away — after accepting, Word shows the
+    // selected entry there. The views that keep the deletion keep the cached pick.
+    const field = dropdownField(
+      `<w:result w:val="1"/>${ENTRIES}`,
+      '<w:del w:id="1" w:author="A"><w:r><w:delText>OldPick</w:delText></w:r></w:del>'
+    );
+    expect(project(`<w:p>${field}</w:p>`, 'proposed').map((piece) => piece.text)).toEqual([
+      'Green',
+    ]);
+    expect(project(`<w:p>${field}</w:p>`).map((piece) => piece.text)).toEqual(['OldPick']);
+    expect(project(`<w:p>${field}</w:p>`, 'original').map((piece) => piece.text)).toEqual([
+      'OldPick',
+    ]);
+  });
 });

--- a/packages/core/src/layout/__tests__/field-form-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-form-projection.test.ts
@@ -6,8 +6,13 @@
 // falls back to the previous behavior (cached text or nothing), never a throw.
 
 import { describe, expect, test } from 'bun:test';
-import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
-import { piecesOfParagraph } from '../field-projection.ts';
+import {
+  paragraphTextOf,
+  readOoxmlPart,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { piecesOfParagraph, type HyperlinkProjector } from '../field-projection.ts';
 import type { RevisionDisplayMode } from '../revision-projection.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -140,6 +145,70 @@ describe('a FORMCHECKBOX field', () => {
     expect(pieces.map((piece) => piece.text)).toEqual(['B']);
     expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
   });
+
+  test('checked=0 with default=1 paints the unchecked box — w:checked wins', () => {
+    const pieces = project(
+      `<w:p>${checkboxField('<w:checked w:val="0"/><w:default w:val="1"/>')}</w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['☐']);
+  });
+
+  test('a tracked-inserted checkbox glyph carries the insertion in all-markup', () => {
+    const pieces = project(
+      `<w:p><w:ins w:id="1" w:author="A">${checkboxField('<w:checked/>')}</w:ins></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['☒']);
+    expect(pieces[0]!.revisions?.map((revision) => revision.kind)).toEqual(['insert']);
+  });
+
+  test('a checkbox inside w:hyperlink carries the enclosing link', () => {
+    const link = Object.freeze({ id: 'stub', kind: 'external' as const, href: 'https://x.test' });
+    const projectLink: HyperlinkProjector = () => link;
+    const pieces = piecesOfParagraph(
+      paragraphOf(`<w:p><w:hyperlink>${checkboxField('<w:checked/>')}</w:hyperlink></w:p>`),
+      [],
+      undefined,
+      undefined,
+      projectLink
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['☒']);
+    expect(pieces[0]!.link).toBe(link);
+  });
+
+  test("FORMTEXT instruction-phase run text keeps the store's offsets and paints", () => {
+    // An editable-result field is NOT atomic, so the offset authority leaves ordinary `w:t`
+    // between begin and separate addressable. Layout must paint what the store addresses.
+    const body =
+      '<w:p><w:r><w:fldChar w:fldCharType="begin">' +
+      '<w:ffData><w:name w:val="T"/><w:textInput/></w:ffData></w:fldChar></w:r>' +
+      '<w:r><w:instrText> FORMTEXT </w:instrText></w:r>' +
+      '<w:r><w:t>SPILL</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>typed</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+    const part = partOf(body);
+    const findParagraph = (node: OoxmlNode): OoxmlNode | undefined => {
+      if (node.kind === 'paragraph') return node;
+      if (node.kind === 'textValue') return undefined;
+      for (const child of node.children ?? []) {
+        const hit = findParagraph(child);
+        if (hit) return hit;
+      }
+      return undefined;
+    };
+    const paragraph = findParagraph(part.root) as OoxmlNode & { id: string };
+    expect(paragraphTextOf(part, paragraph.id)).toBe('SPILLtyped');
+    const pieces = piecesOfParagraph(paragraph);
+    expect(
+      pieces.map((piece) => ({ text: piece.text, start: piece.start, end: piece.end }))
+    ).toEqual([
+      { text: 'SPILL', start: 0, end: 5 },
+      { text: 'typed', start: 5, end: 10 },
+    ]);
+    // The editable result shades as a form field; the instruction-phase spill does not.
+    expect(pieces[0]!.fieldAtom).toBeUndefined();
+    expect(pieces[1]!.fieldAtom).toEqual({ formField: true });
+  });
 });
 
 describe('a FORMDROPDOWN field', () => {
@@ -176,6 +245,19 @@ describe('a FORMDROPDOWN field', () => {
   test('an empty w:ddList paints nothing', () => {
     const pieces = project(
       `<w:p>${dropdownField('<w:result w:val="0"/>')}<w:r><w:t>B</w:t></w:r></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+    expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
+  });
+
+  test('a cached result that exists but is hidden suppresses entry synthesis', () => {
+    // The file cached a result and hid it. Synthesizing the selected entry would resurrect
+    // what the document hides; only a truly EMPTY cache may synthesize.
+    const pieces = project(
+      `<w:p>${dropdownField(
+        `<w:result w:val="1"/>${ENTRIES}`,
+        '<w:r><w:rPr><w:vanish/></w:rPr><w:t>OldPick</w:t></w:r>'
+      )}<w:r><w:t>B</w:t></w:r></w:p>`
     );
     expect(pieces.map((piece) => piece.text)).toEqual(['B']);
     expect(pieces[0]).toMatchObject({ start: 1, end: 2 });

--- a/packages/core/src/layout/__tests__/field-form-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-form-projection.test.ts
@@ -1,0 +1,183 @@
+// FORMCHECKBOX / FORMDROPDOWN legacy form fields render from their `w:ffData` state.
+//
+// The checkbox state is the authority — Word paints ☐/☒ from `w:checked`, never from a stale
+// cached glyph. The dropdown prefers its cached result (what Word last painted) and falls back
+// to the selected `w:listEntry` only when the cache is empty. Everything hostile or malformed
+// falls back to the previous behavior (cached text or nothing), never a throw.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { piecesOfParagraph } from '../field-projection.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+function project(body: string, mode: RevisionDisplayMode = 'all-markup') {
+  return piecesOfParagraph(paragraphOf(body), [], undefined, undefined, undefined, undefined, mode);
+}
+
+/** FORMCHECKBOX the way Word writes it: begin(ffData)/instr/end, NO separate. */
+function checkboxField(checkBoxInner: string, chromeRpr = ''): string {
+  return (
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="begin">` +
+    `<w:ffData><w:name w:val="Check1"/><w:enabled/><w:calcOnExit w:val="0"/>` +
+    `<w:checkBox>${checkBoxInner}</w:checkBox></w:ffData>` +
+    `</w:fldChar></w:r>` +
+    `<w:r>${chromeRpr}<w:instrText> FORMCHECKBOX </w:instrText></w:r>` +
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
+
+/** FORMDROPDOWN the way Word writes it: begin(ffData)/instr/separate/result/end. */
+function dropdownField(ddListInner: string, result = ''): string {
+  return (
+    `<w:r><w:fldChar w:fldCharType="begin">` +
+    `<w:ffData><w:name w:val="Dropdown1"/><w:ddList>${ddListInner}</w:ddList></w:ffData>` +
+    `</w:fldChar></w:r>` +
+    `<w:r><w:instrText> FORMDROPDOWN </w:instrText></w:r>` +
+    `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+    result +
+    `<w:r><w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
+
+const ENTRIES = '<w:listEntry w:val="Red"/><w:listEntry w:val="Green"/><w:listEntry w:val="Blue"/>';
+
+describe('a FORMCHECKBOX field', () => {
+  test('the no-separate shape paints an unchecked box over one atom unit', () => {
+    const pieces = project(
+      `<w:p><w:r><w:t>A</w:t></w:r>${checkboxField('<w:sizeAuto/>')}<w:r><w:t>B</w:t></w:r></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', '☐', 'B']);
+    const box = pieces[1]!;
+    expect(box).toMatchObject({ start: 1, end: 2, projected: true });
+    expect(box.fieldAtom).toEqual({ formField: true });
+    expect(pieces[2]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('w:checked paints the checked box', () => {
+    const pieces = project(`<w:p>${checkboxField('<w:checked/><w:sizeAuto/>')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['☒']);
+  });
+
+  test('w:default is the fallback when w:checked is absent', () => {
+    const pieces = project(`<w:p>${checkboxField('<w:default w:val="1"/><w:sizeAuto/>')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['☒']);
+  });
+
+  test('an explicit w:size of 24 half-points paints at 12pt', () => {
+    const pieces = project(`<w:p>${checkboxField('<w:size w:val="24"/>')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['☐']);
+    expect(pieces[0]!.style.fontSizePt).toBe(12);
+  });
+
+  test('the ffData state wins over a stale cached result', () => {
+    const pieces = project(
+      '<w:p>' +
+        `<w:r><w:fldChar w:fldCharType="begin">` +
+        `<w:ffData><w:checkBox><w:checked/></w:checkBox></w:ffData>` +
+        `</w:fldChar></w:r>` +
+        `<w:r><w:instrText> FORMCHECKBOX </w:instrText></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+        `<w:r><w:t>OLD</w:t></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        '</w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['☒']);
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+  });
+
+  test('hidden chrome paints nothing but keeps the unit', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        checkboxField('<w:checked/>', '<w:rPr><w:vanish/></w:rPr>') +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+    expect(pieces[1]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('a tracked-deleted checkbox is gone from the proposed result', () => {
+    const pieces = project(
+      `<w:p><w:del w:id="1" w:author="A">${checkboxField('<w:checked/>')}</w:del></w:p>`,
+      'proposed'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test('the instruction without ffData paints nothing (fail closed)', () => {
+    const pieces = project(
+      '<w:p>' +
+        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        `<w:r><w:instrText> FORMCHECKBOX </w:instrText></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+    expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
+  });
+});
+
+describe('a FORMDROPDOWN field', () => {
+  test('a non-empty cached result wins — it is what Word last painted', () => {
+    const pieces = project(
+      `<w:p>${dropdownField(`<w:result w:val="1"/>${ENTRIES}`, '<w:r><w:t>Cached</w:t></w:r>')}</w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Cached']);
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+    expect(pieces[0]!.fieldAtom).toEqual({ formField: true });
+  });
+
+  test('an empty cached result synthesizes the selected entry', () => {
+    const pieces = project(
+      `<w:p><w:r><w:t>A</w:t></w:r>${dropdownField(`<w:result w:val="1"/>${ENTRIES}`)}</w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'Green']);
+    const entry = pieces[1]!;
+    expect(entry).toMatchObject({ start: 1, end: 2, projected: true });
+    expect(entry.fieldAtom).toEqual({ formField: true });
+  });
+
+  test('an out-of-range result falls back to default, then to the first entry', () => {
+    const viaDefault = project(
+      `<w:p>${dropdownField(`<w:result w:val="9"/><w:default w:val="2"/>${ENTRIES}`)}</w:p>`
+    );
+    expect(viaDefault.map((piece) => piece.text)).toEqual(['Blue']);
+    const viaFirst = project(
+      `<w:p>${dropdownField(`<w:result w:val="9"/><w:default w:val="8"/>${ENTRIES}`)}</w:p>`
+    );
+    expect(viaFirst.map((piece) => piece.text)).toEqual(['Red']);
+  });
+
+  test('an empty w:ddList paints nothing', () => {
+    const pieces = project(
+      `<w:p>${dropdownField('<w:result w:val="0"/>')}<w:r><w:t>B</w:t></w:r></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+    expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
+  });
+});

--- a/packages/core/src/layout/__tests__/field-instruction-revisions.test.ts
+++ b/packages/core/src/layout/__tests__/field-instruction-revisions.test.ts
@@ -1,0 +1,110 @@
+// w:delInstrText NEXT TO live w:instrText — a tracked field-code edit.
+//
+// The machine buffers deleted and live instruction chunks separately: concatenating them
+// produces an instruction nobody authored (" PAGE  NUMPAGES "), which fails the allowlist
+// and sends a live field inert. The EFFECTIVE instruction is the live buffer when any live
+// element exists, else the deleted buffer, with overflow accounted per buffer.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  MAX_FIELD_INSTRUCTION_CHARS,
+  detectStoryPageFields,
+  piecesOfParagraph,
+} from '../field-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+/** One complex field whose instruction runs are supplied verbatim. */
+const fieldWith = (instructionRuns: string, cached = '9'): string =>
+  '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  instructionRuns +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  `<w:r><w:t>${cached}</w:t></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+
+describe('w:delInstrText NEXT TO live w:instrText', () => {
+  const mixed = fieldWith(
+    '<w:r><w:delInstrText> PAGE </w:delInstrText></w:r>' +
+      '<w:r><w:instrText> NUMPAGES </w:instrText></w:r>'
+  );
+
+  test('the live NUMPAGES stays live — deleted chunks never merge into it', () => {
+    const pieces = piecesOfParagraph(paragraphOf(mixed), [], {
+      pageNumber: 2,
+      pageCount: 7,
+    });
+    expect(pieces.map((piece) => piece.text)).toEqual(['7']);
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+  });
+
+  test('detection agrees: the story needs NUMPAGES, not PAGE', () => {
+    const needs = detectStoryPageFields(partOf(mixed).root);
+    expect(needs).toMatchObject({ hasPage: false, hasNumPages: true });
+  });
+
+  test('a huge deleted chunk does not overflow a small live instruction', () => {
+    const huge = 'X'.repeat(MAX_FIELD_INSTRUCTION_CHARS + 40);
+    const pieces = piecesOfParagraph(
+      paragraphOf(
+        fieldWith(
+          `<w:r><w:delInstrText>${huge}</w:delInstrText></w:r>` +
+            '<w:r><w:instrText> NUMPAGES </w:instrText></w:r>'
+        )
+      ),
+      [],
+      { pageNumber: 2, pageCount: 7 }
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['7']);
+  });
+
+  test('a huge LIVE instruction still overflows to inert (cached result paints)', () => {
+    const huge = ' NUMPAGES ' + 'X'.repeat(MAX_FIELD_INSTRUCTION_CHARS + 40);
+    const pieces = piecesOfParagraph(
+      paragraphOf(fieldWith(`<w:r><w:instrText>${huge}</w:instrText></w:r>`)),
+      [],
+      { pageNumber: 2, pageCount: 7 }
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['9']);
+  });
+
+  test('an EMPTY live element beside a deleted instruction goes inert, not deleted-driven', () => {
+    // Accepting the deletion leaves exactly the empty live instruction, so the deleted
+    // buffer must not answer for it.
+    const pieces = piecesOfParagraph(
+      paragraphOf(
+        fieldWith(
+          '<w:r><w:delInstrText> PAGE </w:delInstrText></w:r>' +
+            '<w:r><w:instrText></w:instrText></w:r>'
+        )
+      ),
+      [],
+      { pageNumber: 2, pageCount: 7 }
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['9']);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-link-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-link-projection.test.ts
@@ -182,6 +182,58 @@ describe('a complex HYPERLINK field', () => {
     expect(seen).toEqual([]);
   });
 
+  test('a ~1000-char URL parses and projects — the same URL behaves identically as fldSimple', () => {
+    // Real SharePoint / tracking URLs routinely exceed 256 chars. The complex-lane
+    // instruction buffer used to cap there while the `w:fldSimple` attribute lane parsed up
+    // to 4096, so the same field painted dead text in one shape and a link in the other.
+    const longUrl = `https://example.com/sites/team/${'a'.repeat(940)}?id=1`;
+    expect(longUrl.length).toBeGreaterThan(950);
+    const complexSeen: HyperlinkFieldSpec[] = [];
+    const complexPieces = project(
+      `<w:p>${complexField(` HYPERLINK "${longUrl}" `, '<w:r><w:t>doc</w:t></w:r>')}</w:p>`,
+      projectorStub(complexSeen)
+    );
+    expect(complexPieces.map((piece) => piece.text)).toEqual(['doc']);
+    expect(complexPieces[0]!.link).toEqual({
+      id: `stub:${longUrl}`,
+      kind: 'external',
+      href: longUrl,
+    });
+    // The projector seam is the sanitize boundary: the raw target crossed it exactly once.
+    expect(complexSeen).toEqual([{ target: longUrl, anchor: null, tooltip: null }]);
+
+    const simplePieces = project(
+      `<w:p><w:fldSimple w:instr=' HYPERLINK "${longUrl}" '>` +
+        '<w:r><w:t>doc</w:t></w:r></w:fldSimple></w:p>',
+      projectorStub()
+    );
+    expect(simplePieces.map((piece) => piece.text)).toEqual(['doc']);
+    // Parity pin: both lanes hand the projector the same spec and carry the same record.
+    expect(simplePieces[0]!.link).toEqual(complexPieces[0]!.link);
+  });
+
+  test('an instruction past the shared cap stays inert in both lanes, without a throw', () => {
+    const hugeUrl = `https://example.com/${'a'.repeat(4200)}`;
+    const seen: HyperlinkFieldSpec[] = [];
+    const complexPieces = project(
+      `<w:p>${complexField(` HYPERLINK "${hugeUrl}" `, '<w:r><w:t>dead</w:t></w:r>')}</w:p>`,
+      projectorStub(seen)
+    );
+    // Overflow fails closed: the cached result still paints, carries no link.
+    expect(complexPieces.map((piece) => piece.text)).toEqual(['dead']);
+    expect(complexPieces[0]!.link).toBeUndefined();
+
+    const simplePieces = project(
+      `<w:p><w:fldSimple w:instr=' HYPERLINK "${hugeUrl}" '>` +
+        '<w:r><w:t>dead</w:t></w:r></w:fldSimple></w:p>',
+      projectorStub(seen)
+    );
+    expect(simplePieces.map((piece) => piece.text)).toEqual(['dead']);
+    expect(simplePieces[0]!.link).toBeUndefined();
+    // Neither lane crossed the projector seam with the hostile blob.
+    expect(seen).toEqual([]);
+  });
+
   test('without a projector the result paints as plain text, exactly as before', () => {
     const pieces = project(
       `<w:p>${complexField(' HYPERLINK "https://example.com" ', '<w:r><w:t>plain</w:t></w:r>')}</w:p>`

--- a/packages/core/src/layout/__tests__/field-link-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-link-projection.test.ts
@@ -159,12 +159,16 @@ describe('a complex HYPERLINK field', () => {
     expect(pieces[0]!.link).toBeUndefined();
   });
 
-  test('an empty result paints nothing — never the URL', () => {
+  test('an empty result paints nothing — never the URL, and never mints a link', () => {
+    const seen: HyperlinkFieldSpec[] = [];
     const pieces = project(
       `<w:p><w:r><w:t>A</w:t></w:r>${complexField(' HYPERLINK "https://example.com" ')}<w:r><w:t>B</w:t></w:r></w:p>`,
-      projectorStub()
+      projectorStub(seen)
     );
     expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+    // Nothing paints the atom, so the projector seam is never crossed — no id is minted for a
+    // link no anchor would ever carry.
+    expect(seen).toEqual([]);
   });
 
   test('an enclosing w:hyperlink wins over the field instruction', () => {

--- a/packages/core/src/layout/__tests__/field-link-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-link-projection.test.ts
@@ -1,0 +1,230 @@
+// HYPERLINK fields project a live link onto their cached result.
+//
+// A complex `HYPERLINK "…"` field or `w:fldSimple` used to paint its cached result as plain
+// inert text while a typed `w:hyperlink` was clickable. Layout now parses the instruction and
+// asks the INJECTED projector for the sanitized record — the same seam `projectLink` uses —
+// so policy stays at the surface trust boundary. An enclosing `w:hyperlink` outranks the
+// field's own instruction, and an empty result paints nothing, URL included.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  piecesOfParagraph,
+  type FieldLinkProjector,
+  type HyperlinkProjector,
+} from '../field-projection.ts';
+import type { HyperlinkFieldSpec } from '../field-link.ts';
+import type { SpanLinkRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+/**
+ * A projector shaped like the surface's: external targets become records, `javascript:`
+ * emulates the sanitizer's refusal (anchor fallback, else no link). It also RECORDS the
+ * specs it was asked about, so a test can assert the seam was (or was not) crossed.
+ */
+function projectorStub(seen: HyperlinkFieldSpec[] = []): FieldLinkProjector {
+  return (spec) => {
+    seen.push(spec);
+    const refused = spec.target !== null && spec.target.startsWith('javascript:');
+    if (spec.target !== null && !refused) {
+      return {
+        id: `stub:${spec.target}`,
+        kind: 'external',
+        href: spec.target,
+        ...(spec.tooltip !== null ? { tooltip: spec.tooltip } : {}),
+      };
+    }
+    if (spec.anchor !== null) {
+      return {
+        id: `stub:#${spec.anchor}`,
+        kind: 'internal',
+        href: `#${spec.anchor}`,
+        anchor: spec.anchor,
+        ...(spec.tooltip !== null ? { tooltip: spec.tooltip } : {}),
+      };
+    }
+    return null;
+  };
+}
+
+/** The typed-`w:hyperlink` projector, for the precedence tests. */
+const ENCLOSING: SpanLinkRecord = Object.freeze({
+  id: 'enclosing',
+  kind: 'external',
+  href: 'https://enclosing.example',
+});
+const projectEnclosing: HyperlinkProjector = () => ENCLOSING;
+
+function project(
+  body: string,
+  projectFieldLink?: FieldLinkProjector,
+  projectLink?: HyperlinkProjector
+) {
+  return piecesOfParagraph(
+    paragraphOf(body),
+    [],
+    undefined,
+    undefined,
+    projectLink,
+    undefined,
+    'all-markup',
+    undefined,
+    undefined,
+    undefined,
+    projectFieldLink
+  );
+}
+
+/** A complete complex field around one instruction, with an optional cached result. */
+function complexField(instr: string, result = ''): string {
+  return (
+    '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+    `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+    '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+    result +
+    '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+  );
+}
+
+describe('a complex HYPERLINK field', () => {
+  test('its cached result carries the projected record over one atom unit', () => {
+    const seen: HyperlinkFieldSpec[] = [];
+    const pieces = project(
+      '<w:p><w:r><w:t>See </w:t></w:r>' +
+        complexField(
+          ' HYPERLINK "https://example.com" \\o "Visit" ',
+          '<w:r><w:t>the site</w:t></w:r>'
+        ) +
+        '<w:r><w:t>.</w:t></w:r></w:p>',
+      projectorStub(seen)
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['See ', 'the site', '.']);
+    const field = pieces[1]!;
+    expect(field.projected).toBe(true);
+    expect(field.start).toBe(4);
+    expect(field.end).toBe(5);
+    expect(field.link).toEqual({
+      id: 'stub:https://example.com',
+      kind: 'external',
+      href: 'https://example.com',
+      tooltip: 'Visit',
+    });
+    expect(seen).toEqual([{ target: 'https://example.com', anchor: null, tooltip: 'Visit' }]);
+  });
+
+  test('an anchor-only \\l field carries the internal record', () => {
+    const pieces = project(
+      `<w:p>${complexField(' HYPERLINK \\l "section3" ', '<w:r><w:t>Section 3</w:t></w:r>')}</w:p>`,
+      projectorStub()
+    );
+    expect(pieces[0]!.link).toEqual({
+      id: 'stub:#section3',
+      kind: 'internal',
+      href: '#section3',
+      anchor: 'section3',
+    });
+  });
+
+  test('a refused target projects NO link and the text still paints', () => {
+    const pieces = project(
+      `<w:p>${complexField(' HYPERLINK "javascript:alert(1)" ', '<w:r><w:t>Click</w:t></w:r>')}</w:p>`,
+      projectorStub()
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['Click']);
+    expect(pieces[0]!.link).toBeUndefined();
+  });
+
+  test('an empty result paints nothing — never the URL', () => {
+    const pieces = project(
+      `<w:p><w:r><w:t>A</w:t></w:r>${complexField(' HYPERLINK "https://example.com" ')}<w:r><w:t>B</w:t></w:r></w:p>`,
+      projectorStub()
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+  });
+
+  test('an enclosing w:hyperlink wins over the field instruction', () => {
+    const seen: HyperlinkFieldSpec[] = [];
+    const pieces = project(
+      `<w:p><w:hyperlink w:anchor="a">${complexField(
+        ' HYPERLINK "https://field.example" ',
+        '<w:r><w:t>linked</w:t></w:r>'
+      )}</w:hyperlink></w:p>`,
+      projectorStub(seen),
+      projectEnclosing
+    );
+    expect(pieces[0]!.link).toBe(ENCLOSING);
+    // The seam is never crossed: the enclosing link is captured before the flush asks.
+    expect(seen).toEqual([]);
+  });
+
+  test('without a projector the result paints as plain text, exactly as before', () => {
+    const pieces = project(
+      `<w:p>${complexField(' HYPERLINK "https://example.com" ', '<w:r><w:t>plain</w:t></w:r>')}</w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['plain']);
+    expect(pieces[0]!.link).toBeUndefined();
+  });
+});
+
+describe('a simple HYPERLINK field', () => {
+  test('its cached result carries the projected record', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=\' HYPERLINK "https://example.com" \'>' +
+        '<w:r><w:t>the site</w:t></w:r></w:fldSimple></w:p>',
+      projectorStub()
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['the site']);
+    expect(pieces[0]!.link).toEqual({
+      id: 'stub:https://example.com',
+      kind: 'external',
+      href: 'https://example.com',
+    });
+  });
+
+  test('inside a typed w:hyperlink the enclosing record wins', () => {
+    const seen: HyperlinkFieldSpec[] = [];
+    const pieces = project(
+      '<w:p><w:hyperlink w:anchor="a">' +
+        '<w:fldSimple w:instr=\' HYPERLINK "https://field.example" \'>' +
+        '<w:r><w:t>entry</w:t></w:r></w:fldSimple></w:hyperlink></w:p>',
+      projectorStub(seen),
+      projectEnclosing
+    );
+    expect(pieces[0]!.link).toBe(ENCLOSING);
+    expect(seen).toEqual([]);
+  });
+
+  test('a non-HYPERLINK simple field never crosses the seam', () => {
+    const seen: HyperlinkFieldSpec[] = [];
+    project(
+      '<w:p><w:fldSimple w:instr=" REF x "><w:r><w:t>Section 3</w:t></w:r></w:fldSimple></w:p>',
+      projectorStub(seen)
+    );
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-link-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-link-projection.test.ts
@@ -43,14 +43,16 @@ function paragraphOf(body: string): OoxmlNode {
 }
 
 /**
- * A projector shaped like the surface's: external targets become records, `javascript:`
- * emulates the sanitizer's refusal (anchor fallback, else no link). It also RECORDS the
- * specs it was asked about, so a test can assert the seam was (or was not) crossed.
+ * A projector shaped like the surface's: external targets become records, a dangerous scheme
+ * (`javascript:`/`data:`/`vbscript:`/`file:`) emulates the sanitizer's refusal (anchor fallback,
+ * else no link). It also RECORDS the specs it was asked about, so a test can assert the seam was
+ * (or was not) crossed.
  */
 function projectorStub(seen: HyperlinkFieldSpec[] = []): FieldLinkProjector {
   return (spec) => {
     seen.push(spec);
-    const refused = spec.target !== null && spec.target.startsWith('javascript:');
+    const refused =
+      spec.target !== null && /^\s*(javascript|data|vbscript|file):/i.test(spec.target);
     if (spec.target !== null && !refused) {
       return {
         id: `stub:${spec.target}`,

--- a/packages/core/src/layout/__tests__/field-link.test.ts
+++ b/packages/core/src/layout/__tests__/field-link.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   MAX_HYPERLINK_INSTRUCTION_CHARS,
+  MAX_HYPERLINK_SWITCH_ARG_CHARS,
   MAX_HYPERLINK_TARGET_CHARS,
   parseHyperlinkInstruction,
 } from '../field-link.ts';
@@ -159,5 +160,32 @@ describe('hostile input', () => {
     expect(
       parseHyperlinkInstruction(` HYPERLINK "https://example.com" \\o "${'t'.repeat(300)}" `)
     ).toEqual({ target: 'https://example.com', anchor: null, tooltip: null });
+  });
+
+  test('an over-cap first \\l consumes the switch; a later \\l never takes it', () => {
+    const blob = 'a'.repeat(MAX_HYPERLINK_SWITCH_ARG_CHARS + 1);
+    // First occurrence is invalid but still consumes anchor-hood, so "second" cannot win — and
+    // with no target and no anchor the instruction is no link at all.
+    expect(parseHyperlinkInstruction(` HYPERLINK \\l "${blob}" \\l "second" `)).toBeNull();
+    // With a target present, the invalid first \l still locks out the later one: no anchor.
+    expect(
+      parseHyperlinkInstruction(` HYPERLINK "https://example.com" \\l "${blob}" \\l "second" `)
+    ).toEqual({ target: 'https://example.com', anchor: null, tooltip: null });
+    // A VALID first \l still wins over a later duplicate.
+    expect(parseHyperlinkInstruction(' HYPERLINK \\l "first" \\l "second" ')).toEqual({
+      target: null,
+      anchor: 'first',
+      tooltip: null,
+    });
+  });
+
+  test('an over-cap first \\o consumes the switch; a later \\o never takes it', () => {
+    const blob = 't'.repeat(MAX_HYPERLINK_SWITCH_ARG_CHARS + 1);
+    expect(
+      parseHyperlinkInstruction(` HYPERLINK "https://example.com" \\o "${blob}" \\o "second" `)
+    ).toEqual({ target: 'https://example.com', anchor: null, tooltip: null });
+    expect(
+      parseHyperlinkInstruction(' HYPERLINK "https://example.com" \\o "first" \\o "second" ')
+    ).toEqual({ target: 'https://example.com', anchor: null, tooltip: 'first' });
   });
 });

--- a/packages/core/src/layout/__tests__/field-link.test.ts
+++ b/packages/core/src/layout/__tests__/field-link.test.ts
@@ -1,0 +1,140 @@
+// HYPERLINK field instruction parsing (§17.16.5.25).
+//
+// The instruction is attacker-controlled. The parser recognizes the grammar and hands the raw
+// pieces over VERBATIM — case and percent-encoding preserved, smuggled control characters
+// intact — because sanitization belongs to the surface's one href trust boundary, not here.
+// Every hostile shape resolves to null or a capped value, never a hang or a throw.
+
+import { describe, expect, test } from 'bun:test';
+import { MAX_HYPERLINK_INSTRUCTION_CHARS, parseHyperlinkInstruction } from '../field-link.ts';
+
+describe('grammar', () => {
+  test('a quoted target parses verbatim, case and percent-encoding preserved', () => {
+    expect(parseHyperlinkInstruction(' HYPERLINK "https://Example.com/Path%20A?q=B%2Fc" ')).toEqual(
+      {
+        target: 'https://Example.com/Path%20A?q=B%2Fc',
+        anchor: null,
+        tooltip: null,
+      }
+    );
+  });
+
+  test('a bare target parses too', () => {
+    expect(parseHyperlinkInstruction(' HYPERLINK https://example.com ')).toEqual({
+      target: 'https://example.com',
+      anchor: null,
+      tooltip: null,
+    });
+  });
+
+  test('the keyword is case-insensitive; the values are not', () => {
+    expect(parseHyperlinkInstruction(' hyperlink "https://EXAMPLE.com" ')).toEqual({
+      target: 'https://EXAMPLE.com',
+      anchor: null,
+      tooltip: null,
+    });
+  });
+
+  test('\\l alone is an anchor-only link', () => {
+    expect(parseHyperlinkInstruction(' HYPERLINK \\l "section3" ')).toEqual({
+      target: null,
+      anchor: 'section3',
+      tooltip: null,
+    });
+  });
+
+  test('target, \\l and \\o combine in any order', () => {
+    expect(
+      parseHyperlinkInstruction(' HYPERLINK \\o "Open the site" "https://example.com" \\l top ')
+    ).toEqual({
+      target: 'https://example.com',
+      anchor: 'top',
+      tooltip: 'Open the site',
+    });
+  });
+
+  test('duplicate targets and switches: first wins', () => {
+    expect(
+      parseHyperlinkInstruction(
+        ' HYPERLINK "https://first.example" "https://second.example" \\l one \\l two \\o "a" \\o "b" '
+      )
+    ).toEqual({ target: 'https://first.example', anchor: 'one', tooltip: 'a' });
+  });
+
+  test('\\t, \\m and \\n consume their argument without it becoming the target', () => {
+    expect(
+      parseHyperlinkInstruction(' HYPERLINK \\t "_blank" \\n x "https://example.com" ')
+    ).toEqual({
+      target: 'https://example.com',
+      anchor: null,
+      tooltip: null,
+    });
+  });
+
+  test('\\* MERGEFORMAT never becomes the target', () => {
+    expect(parseHyperlinkInstruction(' HYPERLINK \\l "x" \\* MERGEFORMAT ')).toEqual({
+      target: null,
+      anchor: 'x',
+      tooltip: null,
+    });
+  });
+
+  test('an unknown switch is inert and consumes nothing', () => {
+    expect(parseHyperlinkInstruction(' HYPERLINK \\z "https://example.com" ')).toEqual({
+      target: 'https://example.com',
+      anchor: null,
+      tooltip: null,
+    });
+  });
+
+  test('no target and no anchor is not a link', () => {
+    expect(parseHyperlinkInstruction(' HYPERLINK ')).toBeNull();
+    expect(parseHyperlinkInstruction(' HYPERLINK \\o "tip only" ')).toBeNull();
+    expect(parseHyperlinkInstruction(' HYPERLINK "" ')).toBeNull();
+  });
+
+  test('another instruction is not a HYPERLINK', () => {
+    expect(parseHyperlinkInstruction(' PAGE ')).toBeNull();
+    expect(parseHyperlinkInstruction(' SYMBOL 65 ')).toBeNull();
+    // A QUOTED first token is data, not a keyword.
+    expect(parseHyperlinkInstruction(' "HYPERLINK" "https://example.com" ')).toBeNull();
+  });
+});
+
+describe('hostile input', () => {
+  test('an unclosed quote runs to the end without hanging', () => {
+    expect(parseHyperlinkInstruction(' HYPERLINK "https://example.com/unterminated ')).toEqual({
+      target: 'https://example.com/unterminated ',
+      anchor: null,
+      tooltip: null,
+    });
+  });
+
+  test('a 100KB instruction is refused outright', () => {
+    const raw = ` HYPERLINK "https://example.com/${'a'.repeat(100_000)}" `;
+    expect(raw.length).toBeGreaterThan(MAX_HYPERLINK_INSTRUCTION_CHARS);
+    expect(parseHyperlinkInstruction(raw)).toBeNull();
+  });
+
+  test('embedded tab and newline in a quoted target pass through for the sanitizer', () => {
+    // Stripping `java\nscript:` smuggles is `sanitizeHref`'s job at the surface; the parser
+    // must hand the raw string over or the boundary would be checking a different value.
+    expect(parseHyperlinkInstruction(' HYPERLINK "java\nscri\tpt:alert(1)" ')).toEqual({
+      target: 'java\nscri\tpt:alert(1)',
+      anchor: null,
+      tooltip: null,
+    });
+  });
+
+  test('backslash-heavy garbage yields no link and no hang', () => {
+    expect(parseHyperlinkInstruction(` HYPERLINK ${'\\'.repeat(512)} `)).toBeNull();
+    expect(parseHyperlinkInstruction(' HYPERLINK \\l \\o \\t ')).toBeNull();
+  });
+
+  test('an over-cap anchor is ignored rather than truncated', () => {
+    expect(parseHyperlinkInstruction(` HYPERLINK \\l "${'a'.repeat(300)}" `)).toBeNull();
+    expect(
+      parseHyperlinkInstruction(` HYPERLINK "https://example.com" \\o "${'t'.repeat(300)}" `)
+    ).toEqual({ target: 'https://example.com', anchor: null, tooltip: null });
+  });
+});

--- a/packages/core/src/layout/__tests__/field-link.test.ts
+++ b/packages/core/src/layout/__tests__/field-link.test.ts
@@ -6,7 +6,11 @@
 // Every hostile shape resolves to null or a capped value, never a hang or a throw.
 
 import { describe, expect, test } from 'bun:test';
-import { MAX_HYPERLINK_INSTRUCTION_CHARS, parseHyperlinkInstruction } from '../field-link.ts';
+import {
+  MAX_HYPERLINK_INSTRUCTION_CHARS,
+  MAX_HYPERLINK_TARGET_CHARS,
+  parseHyperlinkInstruction,
+} from '../field-link.ts';
 
 describe('grammar', () => {
   test('a quoted target parses verbatim, case and percent-encoding preserved', () => {
@@ -129,6 +133,25 @@ describe('hostile input', () => {
   test('backslash-heavy garbage yields no link and no hang', () => {
     expect(parseHyperlinkInstruction(` HYPERLINK ${'\\'.repeat(512)} `)).toBeNull();
     expect(parseHyperlinkInstruction(' HYPERLINK \\l \\o \\t ')).toBeNull();
+  });
+
+  test('an empty-quoted first target forfeits the target; a later token never takes it', () => {
+    // Word takes the FIRST target-position token; a decoy `""` must not promote the second.
+    expect(parseHyperlinkInstruction(' HYPERLINK "" https://second.example ')).toBeNull();
+    // The `\l` anchor is its own lane: the forfeited target still leaves an internal link.
+    expect(parseHyperlinkInstruction(' HYPERLINK "" https://second.example \\l top ')).toEqual({
+      target: null,
+      anchor: 'top',
+      tooltip: null,
+    });
+  });
+
+  test('an over-cap first target forfeits the target; a later token never takes it', () => {
+    const blob = 'a'.repeat(MAX_HYPERLINK_TARGET_CHARS + 1);
+    expect(parseHyperlinkInstruction(` HYPERLINK "${blob}" https://second.example `)).toBeNull();
+    expect(
+      parseHyperlinkInstruction(` HYPERLINK "${blob}" https://second.example \\l top `)
+    ).toEqual({ target: null, anchor: 'top', tooltip: null });
   });
 
   test('an over-cap anchor is ignored rather than truncated', () => {

--- a/packages/core/src/layout/__tests__/field-nested-page.test.ts
+++ b/packages/core/src/layout/__tests__/field-nested-page.test.ts
@@ -1,0 +1,236 @@
+// A complex PAGE-family field nested inside a complex outer field evaluates per sheet.
+//
+// `STYLEREF` wrapping `PAGE` is ordinary in a running header. The outer field's cached result
+// used to concatenate the inner field's saved digits verbatim, so every sheet painted the
+// producer's last saved number — and detection missed the inner field too, so the story's
+// page-context key stayed empty and ONE layout served every sheet. Both halves are pinned
+// here, mirroring the `w:fldSimple` semantics in `field-simple-result.ts`.
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  readOoxmlPackage,
+  readOoxmlPart,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import {
+  detectStoryPageFields,
+  MAX_FIELD_INSTRUCTION_CHARS,
+  piecesOfParagraph,
+} from '../field-projection.ts';
+import { layoutHeaderFooterStory } from '../hf-layout.ts';
+import { createFixedMeasurer } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+/** One complex field: begin / instrText / separate / cached result / end, one run each. */
+function complexField(instr: string, cached: string): string {
+  return (
+    `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+    `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+    `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+    (cached.length > 0 ? `<w:r><w:t xml:space="preserve">${cached}</w:t></w:r>` : '') +
+    `<w:r><w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
+
+/** A complex STYLEREF whose cached result holds `content` (runs and nested fields). */
+function outerField(content: string): string {
+  return (
+    `<w:p>` +
+    `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+    `<w:r><w:instrText> STYLEREF "Heading 1" </w:instrText></w:r>` +
+    `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+    content +
+    `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+    `</w:p>`
+  );
+}
+
+const textRun = (text: string): string => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
+
+const NESTED_PAGE = outerField(textRun('Chapter p. ') + complexField(' PAGE ', '7') + textRun('!'));
+
+describe('a complex PAGE nested inside a complex outer field', () => {
+  test('evaluates per sheet inside the outer cached result', () => {
+    const paragraph = paragraphOf(NESTED_PAGE);
+    const pieces = piecesOfParagraph(paragraph, [], { pageNumber: 3, pageCount: 9 });
+    expect(pieces.map((piece) => piece.text)).toEqual(['Chapter p. 3!']);
+    // Still one atomic model unit; the inner field donates display text only.
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+    expect(
+      piecesOfParagraph(paragraph, [], { pageNumber: 8, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('Chapter p. 8!');
+  });
+
+  test('without a page context the cached digits stay verbatim', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(NESTED_PAGE))
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('Chapter p. 7!');
+  });
+
+  test('is detected so the story requests a per-sheet context at all', () => {
+    expect(detectStoryPageFields(partOf(NESTED_PAGE).root)).toEqual({
+      hasPage: true,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+  });
+
+  test('inner NUMPAGES and SECTIONPAGES evaluate and are detected', () => {
+    const numbers = outerField(
+      complexField(' NUMPAGES ', '99') + textRun('/') + complexField(' SECTIONPAGES ', '88')
+    );
+    expect(
+      piecesOfParagraph(paragraphOf(numbers), [], {
+        pageNumber: 3,
+        pageCount: 26,
+        sectionPageCount: 8,
+      })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('26/8');
+    expect(detectStoryPageFields(partOf(numbers).root)).toEqual({
+      hasPage: false,
+      hasNumPages: true,
+      hasSectionPages: true,
+    });
+  });
+
+  test('an inner non-page field keeps its cached text verbatim', () => {
+    const ref = outerField(textRun('see ') + complexField(' REF _Ref9 ', 'Section 4'));
+    expect(
+      piecesOfParagraph(paragraphOf(ref), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('see Section 4');
+  });
+
+  test('nesting past MAX_FIELD_NESTING stays inert and verbatim', () => {
+    // Levels 1..5: the fifth begin exceeds the cap, the whole outer field demotes, and no
+    // level evaluates. The deep PAGE's digits stay ordinary addressable text.
+    const depth5 = outerField(
+      textRun('A') +
+        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        `<w:r><w:instrText> REF b </w:instrText></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+        complexField(' PAGE ', '7') +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        textRun('Z')
+    );
+    const pieces = piecesOfParagraph(paragraphOf(depth5), [], { pageNumber: 3, pageCount: 9 });
+    expect(pieces.map((piece) => piece.text).join('')).toBe('A7Z');
+    expect(pieces.every((piece) => !piece.projected)).toBe(true);
+    expect(detectStoryPageFields(partOf(depth5).root)).toEqual({
+      hasPage: false,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+  });
+
+  test('an oversize inner instruction leaves that level inert and its sibling live', () => {
+    const oversize = ` PAGE ${'X'.repeat(MAX_FIELD_INSTRUCTION_CHARS + 1)} `;
+    const mixed = outerField(
+      textRun('p. ') + complexField(oversize, '7') + textRun('-') + complexField(' PAGE ', '9')
+    );
+    expect(
+      piecesOfParagraph(paragraphOf(mixed), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 7-3');
+    expect(detectStoryPageFields(partOf(mixed).root).hasPage).toBe(true);
+  });
+});
+
+describe('a header/footer story with a complex-nested PAGE', () => {
+  test('lays out per-sheet digits end-to-end', () => {
+    const measurer = createFixedMeasurer(6, 14);
+    const bytes = zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}">` +
+          '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>' +
+          '</Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/_rels/document.xml.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/footer" Target="footer1.xml"/></Relationships>`
+      ),
+      'word/footer1.xml': strToU8(`<w:ftr xmlns:w="${W}">${NESTED_PAGE}</w:ftr>`),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p>` +
+          `<w:sectPr><w:footerReference w:type="default" r:id="rId1"/></w:sectPr>` +
+          '</w:body></w:document>'
+      ),
+    });
+    const loaded = readOoxmlPackage(bytes);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const footer = [...loaded.package.parts.values()].find((part) =>
+      part.name.includes('footer1')
+    )!;
+    const baseline = layoutHeaderFooterStory(footer, 400, measurer, 'test');
+    // Detection must report the nested PAGE, or one layout serves every sheet.
+    expect(baseline.pageFieldNeeds).toEqual({
+      hasPage: true,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+    const textOf = (story: typeof baseline): string =>
+      story.fragments
+        .flatMap((fragment) =>
+          fragment.kind === 'paragraph'
+            ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+            : []
+        )
+        .join('');
+    expect(textOf(baseline)).toBe('Chapter p. 7!');
+    const page2 = baseline.withPageContext({ pageNumber: 2, pageCount: 26 });
+    const page9 = baseline.withPageContext({ pageNumber: 9, pageCount: 26 });
+    expect(textOf(page2)).toBe('Chapter p. 2!');
+    expect(textOf(page9)).toBe('Chapter p. 9!');
+    expect(page9).not.toBe(page2);
+    expect(baseline.withPageContext({ pageNumber: 2, pageCount: 26 })).toBe(page2);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-nested-page.test.ts
+++ b/packages/core/src/layout/__tests__/field-nested-page.test.ts
@@ -403,6 +403,39 @@ describe('nesting overflow keeps detection aligned with projection', () => {
     ).toBe('3');
   });
 
+  test('an early nested PAGE before an overflow in the SAME field stays undetected', () => {
+    // The level-2 PAGE separates cleanly BEFORE the hostile depth arrives, but the later
+    // overflow demotes the whole outer store span, so projection paints the cached digits
+    // verbatim. A note taken at separate-time that stood would buy a per-sheet relayout
+    // that paints identical text on every sheet; detection buffers notes per outer span
+    // and drops them when the span demotes.
+    const body = outerField(
+      textRun('A') +
+        complexField(' PAGE ', '7') +
+        BEGIN +
+        SEPARATE +
+        BEGIN +
+        SEPARATE +
+        BEGIN +
+        SEPARATE +
+        BEGIN +
+        SEPARATE +
+        END +
+        END +
+        END +
+        END +
+        textRun('Z')
+    );
+    const pieces = piecesOfParagraph(paragraphOf(body), [], { pageNumber: 3, pageCount: 9 });
+    expect(pieces.map((piece) => piece.text).join('')).toBe('A7Z');
+    expect(pieces.every((piece) => !piece.projected)).toBe(true);
+    expect(detectStoryPageFields(partOf(body).root)).toEqual({
+      hasPage: false,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+  });
+
   test('an in-cap PAGE after an overflow in the SAME field stays verbatim and undetected', () => {
     // The overflow demotes the whole outer field, so projection paints the cached digits
     // verbatim. Detection must agree, or every sheet pays a layout for identical text.
@@ -429,6 +462,64 @@ describe('nesting overflow keeps detection aligned with projection', () => {
     expect(detectStoryPageFields(partOf(body).root)).toEqual({
       hasPage: false,
       hasNumPages: false,
+      hasSectionPages: false,
+    });
+  });
+});
+
+describe('a nested field straddling a drawing descend', () => {
+  const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+  const partWithDrawing = (body: string): OoxmlPart => {
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
+        `<w:body>${body}</w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    return result.part;
+  };
+
+  /** Anchored textbox drawing whose story holds `content` (paragraphs). */
+  const textboxDrawing = (content: string): string =>
+    '<w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"' +
+    ' relativeHeight="1" behindDoc="1" locked="0" layoutInCell="1" allowOverlap="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="page"><wp:posOffset>3600450</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="page"><wp:posOffset>9000000</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="914400" cy="457200"/>' +
+    '<wp:effectExtent l="0" t="0" r="0" b="0"/><wp:wrapNone/>' +
+    '<wp:docPr id="1" name="TB"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    '<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
+    `<wps:txbx><w:txbxContent>${content}</w:txbxContent></wps:txbx>` +
+    '<wps:bodyPr/>' +
+    '</wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing>';
+
+  const NUMPAGES_PARA = `<w:p>${complexField(' NUMPAGES ', '99')}</w:p>`;
+
+  // A level-2 PAGE whose instruction is split around a run carrying the drawing: the descend
+  // saves the host field state, and the textbox story's paragraph resets must not reach the
+  // saved copy. A shallow copy aliased the per-level `inner` captures, so the reset emptied
+  // them in the saved state too, the second instruction chunk had no buffer to join, and the
+  // nested PAGE went undetected — stale digits on every sheet.
+  const STRADDLE = `<w:p>${outerMarkers(
+    BEGIN +
+      instrRun(' PA') +
+      `<w:r>${textboxDrawing(NUMPAGES_PARA)}</w:r>` +
+      instrRun('GE ') +
+      SEPARATE +
+      textRun('7') +
+      END
+  )}</w:p>`;
+
+  test('keeps the level-2 capture across the descend and detects the textbox field too', () => {
+    expect(detectStoryPageFields(partWithDrawing(STRADDLE).root)).toEqual({
+      hasPage: true,
+      hasNumPages: true,
       hasSectionPages: false,
     });
   });

--- a/packages/core/src/layout/__tests__/field-nested-page.test.ts
+++ b/packages/core/src/layout/__tests__/field-nested-page.test.ts
@@ -51,28 +51,31 @@ function paragraphOf(body: string): OoxmlNode {
   return paragraph;
 }
 
+const BEGIN = `<w:r><w:fldChar w:fldCharType="begin"/></w:r>`;
+const SEPARATE = `<w:r><w:fldChar w:fldCharType="separate"/></w:r>`;
+const END = `<w:r><w:fldChar w:fldCharType="end"/></w:r>`;
+const instrRun = (instr: string): string =>
+  `<w:r><w:instrText xml:space="preserve">${instr}</w:instrText></w:r>`;
+
 /** One complex field: begin / instrText / separate / cached result / end, one run each. */
 function complexField(instr: string, cached: string): string {
   return (
-    `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-    `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
-    `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+    BEGIN +
+    instrRun(instr) +
+    SEPARATE +
     (cached.length > 0 ? `<w:r><w:t xml:space="preserve">${cached}</w:t></w:r>` : '') +
-    `<w:r><w:fldChar w:fldCharType="end"/></w:r>`
+    END
   );
+}
+
+/** The complex-STYLEREF markers around `content`, without the paragraph wrapper. */
+function outerMarkers(content: string): string {
+  return BEGIN + instrRun(' STYLEREF "Heading 1" ') + SEPARATE + content + END;
 }
 
 /** A complex STYLEREF whose cached result holds `content` (runs and nested fields). */
 function outerField(content: string): string {
-  return (
-    `<w:p>` +
-    `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-    `<w:r><w:instrText> STYLEREF "Heading 1" </w:instrText></w:r>` +
-    `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-    content +
-    `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
-    `</w:p>`
-  );
+  return `<w:p>${outerMarkers(content)}</w:p>`;
 }
 
 const textRun = (text: string): string => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
@@ -180,10 +183,371 @@ describe('a complex PAGE nested inside a complex outer field', () => {
   });
 });
 
+describe('deeper nesting (levels 3 and 4) evaluates at the tracked level', () => {
+  // The tracker records the LEVEL whose separate armed it and appends only at that level's
+  // matching end. An append gate pinned to level 2 dropped these digits entirely: the inner
+  // end fired at level 3, appended nothing, and reset tracking.
+  const DEPTH3 = outerField(
+    textRun('Ch ') +
+      BEGIN +
+      instrRun(' REF _Ref9 ') +
+      SEPARATE +
+      textRun('p. ') +
+      complexField(' PAGE ', '7') +
+      textRun(' end') +
+      END +
+      textRun('!')
+  );
+  const DEPTH4 = outerField(
+    BEGIN +
+      instrRun(' REF a ') +
+      SEPARATE +
+      BEGIN +
+      instrRun(' REF b ') +
+      SEPARATE +
+      textRun('p. ') +
+      complexField(' PAGE ', '7') +
+      END +
+      END
+  );
+
+  test('a depth-3 PAGE under an inert level-2 REF paints live digits', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(DEPTH3), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('Ch p. 3 end!');
+  });
+
+  test('without a page context the depth-3 digits stay verbatim', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(DEPTH3))
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('Ch p. 7 end!');
+  });
+
+  test('a depth-3 PAGE is detected', () => {
+    expect(detectStoryPageFields(partOf(DEPTH3).root).hasPage).toBe(true);
+  });
+
+  test('a depth-4 PAGE paints live digits and is detected', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(DEPTH4), [], { pageNumber: 5, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 5');
+    expect(detectStoryPageFields(partOf(DEPTH4).root).hasPage).toBe(true);
+  });
+});
+
+describe('a tracked inner result containing its own begin/end pair', () => {
+  // Everything between the tracked PAGE's separate and ITS end — deeper begin/end pairs
+  // included — is the replaced result. An unconditional reset at every end cleared tracking
+  // at the deeper pair's end, dropped the digits before it and painted the rest verbatim.
+  const INNER_PAIR = outerField(
+    textRun('p. ') +
+      BEGIN +
+      instrRun(' PAGE ') +
+      SEPARATE +
+      textRun('«') +
+      BEGIN +
+      instrRun(' REF x ') +
+      SEPARATE +
+      textRun('4') +
+      END +
+      textRun('»') +
+      END +
+      textRun('!')
+  );
+
+  test('the live value replaces the whole tracked result', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(INNER_PAIR), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 3!');
+  });
+
+  test('without a page context the whole cached result stays verbatim', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(INNER_PAIR))
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. «4»!');
+  });
+});
+
+describe('a double separate at the tracked level', () => {
+  // Malformed but hostile-possible: the second separate answers null (level already
+  // separated) and must NOT clear tracking — the matched end still appends the live value.
+  const DOUBLE = outerField(
+    textRun('p. ') +
+      BEGIN +
+      instrRun(' PAGE ') +
+      SEPARATE +
+      textRun('7') +
+      SEPARATE +
+      textRun('8') +
+      END
+  );
+
+  test('tracking survives and the end appends the live value', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(DOUBLE), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 3');
+  });
+
+  test('without a page context both cached chunks stay verbatim', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(DOUBLE))
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 78');
+  });
+});
+
+describe('a nested PAGE inside the outer INSTRUCTION', () => {
+  // `IF « PAGE » = 1 "yes" "no"`: the nested PAGE lives in the outer field's instruction and
+  // is never painted, so projection must not evaluate it and detection must not request a
+  // per-sheet layout for it.
+  const IF_SHAPE =
+    `<w:p>` +
+    BEGIN +
+    instrRun(' IF ') +
+    complexField(' PAGE ', '1') +
+    instrRun(' = 1 "yes" "no" ') +
+    SEPARATE +
+    textRun('no') +
+    END +
+    `</w:p>`;
+
+  test('paints only the outer cached result, with and without a page context', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(IF_SHAPE), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('no');
+    expect(
+      piecesOfParagraph(paragraphOf(IF_SHAPE))
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('no');
+  });
+
+  test('is NOT detected — projection cannot replace it, so no per-sheet layouts', () => {
+    expect(detectStoryPageFields(partOf(IF_SHAPE).root)).toEqual({
+      hasPage: false,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+  });
+});
+
+describe('nesting overflow keeps detection aligned with projection', () => {
+  const HOSTILE_DEEP =
+    textRun('A') +
+    BEGIN +
+    instrRun(' REF b ') +
+    SEPARATE +
+    BEGIN +
+    SEPARATE +
+    BEGIN +
+    SEPARATE +
+    complexField(' PAGE ', '7') +
+    END +
+    END +
+    END +
+    textRun('Z');
+
+  test('a sibling field in the SAME paragraph stays verbatim and undetected (suffix)', () => {
+    // The atomic-span parser fails closed for the whole paragraph SUFFIX after hostile
+    // nesting, so the sibling demotes and paints its cached digits. Detection agrees, or the
+    // story would pay per-sheet layouts for text that never changes.
+    const body = `<w:p>${outerMarkers(HOSTILE_DEEP)}${textRun(' | ')}${complexField(' PAGE ', '9')}</w:p>`;
+    const pieces = piecesOfParagraph(paragraphOf(body), [], { pageNumber: 3, pageCount: 9 });
+    expect(pieces.map((piece) => piece.text).join('')).toBe('A7Z | 9');
+    expect(pieces.every((piece) => !piece.projected)).toBe(true);
+    expect(detectStoryPageFields(partOf(body).root)).toEqual({
+      hasPage: false,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+  });
+
+  test('a sibling field in the NEXT paragraph is detected and live', () => {
+    const body =
+      `<w:p>${outerMarkers(HOSTILE_DEEP)}</w:p>` + `<w:p>${complexField(' PAGE ', '9')}</w:p>`;
+    const part = partOf(body);
+    expect(detectStoryPageFields(part.root)).toEqual({
+      hasPage: true,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+    const paragraphs: OoxmlNode[] = [];
+    const gather = (node: OoxmlNode): void => {
+      if (node.kind === 'paragraph') {
+        paragraphs.push(node);
+        return;
+      }
+      if (node.kind === 'textValue') return;
+      for (const child of node.children ?? []) gather(child);
+    };
+    gather(part.root);
+    expect(
+      piecesOfParagraph(paragraphs[1]!, [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('3');
+  });
+
+  test('an in-cap PAGE after an overflow in the SAME field stays verbatim and undetected', () => {
+    // The overflow demotes the whole outer field, so projection paints the cached digits
+    // verbatim. Detection must agree, or every sheet pays a layout for identical text.
+    const body = outerField(
+      textRun('A') +
+        BEGIN +
+        SEPARATE +
+        BEGIN +
+        SEPARATE +
+        BEGIN +
+        SEPARATE +
+        BEGIN +
+        SEPARATE +
+        END +
+        END +
+        END +
+        END +
+        complexField(' PAGE ', '7') +
+        textRun('Z')
+    );
+    const pieces = piecesOfParagraph(paragraphOf(body), [], { pageNumber: 3, pageCount: 9 });
+    expect(pieces.map((piece) => piece.text).join('')).toBe('A7Z');
+    expect(pieces.every((piece) => !piece.projected)).toBe(true);
+    expect(detectStoryPageFields(partOf(body).root)).toEqual({
+      hasPage: false,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+  });
+});
+
+describe('two outer fields in one paragraph, the second nested', () => {
+  test('each evaluates independently', () => {
+    const body =
+      `<w:p>` +
+      complexField(' PAGE ', '5') +
+      textRun(' of ') +
+      outerMarkers(textRun('p. ') + complexField(' PAGE ', '7')) +
+      `</w:p>`;
+    expect(
+      piecesOfParagraph(paragraphOf(body), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('3 of p. 3');
+  });
+});
+
+describe('the skip path donates attribution and links (fldSimple parity with results)', () => {
+  const INS_WRAPPED = outerField(
+    BEGIN +
+      instrRun(' PAGE ') +
+      SEPARATE +
+      `<w:ins w:id="1" w:author="Reviewer" w:date="2026-08-05T08:12:15Z">` +
+      `<w:r><w:t>7</w:t></w:r></w:ins>` +
+      END
+  );
+
+  test('w:ins-wrapped inner digits attribute the live value as an insertion', () => {
+    const pieces = piecesOfParagraph(
+      paragraphOf(INS_WRAPPED),
+      [],
+      { pageNumber: 3, pageCount: 9 },
+      undefined,
+      undefined,
+      undefined,
+      'all-markup'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['3']);
+    expect(pieces[0]?.revisions?.map((rev) => `${rev.kind}:${rev.author}`)).toEqual([
+      'insert:Reviewer',
+    ]);
+  });
+
+  test('the ORIGINAL view suppresses the inserted live value entirely', () => {
+    const pieces = piecesOfParagraph(
+      paragraphOf(INS_WRAPPED),
+      [],
+      { pageNumber: 3, pageCount: 9 },
+      undefined,
+      undefined,
+      undefined,
+      'original'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test('w:hyperlink-wrapped inner digits carry the link onto the live value', () => {
+    const LINK = Object.freeze({ id: 'stub', kind: 'internal', href: '#top', anchor: 'top' });
+    const body = outerField(
+      BEGIN +
+        instrRun(' PAGE ') +
+        SEPARATE +
+        `<w:hyperlink w:anchor="top"><w:r><w:t>7</w:t></w:r></w:hyperlink>` +
+        END
+    );
+    const pieces = piecesOfParagraph(
+      paragraphOf(body),
+      [],
+      { pageNumber: 3, pageCount: 9 },
+      undefined,
+      () => LINK
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['3']);
+    expect(pieces[0]?.link).toBe(LINK);
+  });
+});
+
+describe('the fldSimple lane: a PAGE two machine levels down', () => {
+  // A complex REF directly in the `w:fldSimple` cache is machine level 1; the PAGE in ITS
+  // cache is level 2. The finish gate used to fire at level 1 only, so the level-2 digits
+  // were skipped at the separate and never appended — text loss on every sheet.
+  const SIMPLE_DEEP =
+    `<w:p><w:fldSimple w:instr=" QUOTE x ">` +
+    textRun('p. ') +
+    BEGIN +
+    instrRun(' REF a ') +
+    SEPARATE +
+    complexField(' PAGE ', '7') +
+    END +
+    `</w:fldSimple></w:p>`;
+
+  test('paints live digits with a page context', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(SIMPLE_DEEP), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 3');
+  });
+
+  test('stays verbatim without one', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(SIMPLE_DEEP))
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 7');
+  });
+
+  test('is detected', () => {
+    expect(detectStoryPageFields(partOf(SIMPLE_DEEP).root).hasPage).toBe(true);
+  });
+});
+
 describe('a header/footer story with a complex-nested PAGE', () => {
-  test('lays out per-sheet digits end-to-end', () => {
-    const measurer = createFixedMeasurer(6, 14);
-    const bytes = zipSync({
+  const footerPackage = (footerBody: string): Uint8Array =>
+    zipSync({
       '[Content_Types].xml': strToU8(
         `<Types xmlns="${CT}">` +
           '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
@@ -197,34 +561,42 @@ describe('a header/footer story with a complex-nested PAGE', () => {
       'word/_rels/document.xml.rels': strToU8(
         `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/footer" Target="footer1.xml"/></Relationships>`
       ),
-      'word/footer1.xml': strToU8(`<w:ftr xmlns:w="${W}">${NESTED_PAGE}</w:ftr>`),
+      'word/footer1.xml': strToU8(`<w:ftr xmlns:w="${W}">${footerBody}</w:ftr>`),
       'word/document.xml': strToU8(
         `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p>` +
           `<w:sectPr><w:footerReference w:type="default" r:id="rId1"/></w:sectPr>` +
           '</w:body></w:document>'
       ),
     });
-    const loaded = readOoxmlPackage(bytes);
+
+  const layoutFooter = (footerBody: string) => {
+    const measurer = createFixedMeasurer(6, 14);
+    const loaded = readOoxmlPackage(footerPackage(footerBody));
     expect(loaded.ok).toBe(true);
-    if (!loaded.ok) return;
+    if (!loaded.ok) throw new Error('package failed to load');
     const footer = [...loaded.package.parts.values()].find((part) =>
       part.name.includes('footer1')
     )!;
-    const baseline = layoutHeaderFooterStory(footer, 400, measurer, 'test');
+    return layoutHeaderFooterStory(footer, 400, measurer, 'test');
+  };
+
+  const textOf = (story: ReturnType<typeof layoutFooter>): string =>
+    story.fragments
+      .flatMap((fragment) =>
+        fragment.kind === 'paragraph'
+          ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+          : []
+      )
+      .join('');
+
+  test('lays out per-sheet digits end-to-end', () => {
+    const baseline = layoutFooter(NESTED_PAGE);
     // Detection must report the nested PAGE, or one layout serves every sheet.
     expect(baseline.pageFieldNeeds).toEqual({
       hasPage: true,
       hasNumPages: false,
       hasSectionPages: false,
     });
-    const textOf = (story: typeof baseline): string =>
-      story.fragments
-        .flatMap((fragment) =>
-          fragment.kind === 'paragraph'
-            ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
-            : []
-        )
-        .join('');
     expect(textOf(baseline)).toBe('Chapter p. 7!');
     const page2 = baseline.withPageContext({ pageNumber: 2, pageCount: 26 });
     const page9 = baseline.withPageContext({ pageNumber: 9, pageCount: 26 });
@@ -232,5 +604,27 @@ describe('a header/footer story with a complex-nested PAGE', () => {
     expect(textOf(page9)).toBe('Chapter p. 9!');
     expect(page9).not.toBe(page2);
     expect(baseline.withPageContext({ pageNumber: 2, pageCount: 26 })).toBe(page2);
+  });
+
+  test('a depth-3 PAGE under an inert REF lays out per-sheet digits too', () => {
+    const depth3 = outerField(
+      textRun('Ch ') +
+        BEGIN +
+        instrRun(' REF _Ref9 ') +
+        SEPARATE +
+        textRun('p. ') +
+        complexField(' PAGE ', '7') +
+        END +
+        textRun('!')
+    );
+    const baseline = layoutFooter(depth3);
+    expect(baseline.pageFieldNeeds).toEqual({
+      hasPage: true,
+      hasNumPages: false,
+      hasSectionPages: false,
+    });
+    expect(textOf(baseline)).toBe('Ch p. 7!');
+    expect(textOf(baseline.withPageContext({ pageNumber: 4, pageCount: 26 }))).toBe('Ch p. 4!');
+    expect(textOf(baseline.withPageContext({ pageNumber: 11, pageCount: 26 }))).toBe('Ch p. 11!');
   });
 });

--- a/packages/core/src/layout/__tests__/field-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-projection.test.ts
@@ -829,3 +829,95 @@ describe('document layout page index and page count', () => {
     }
   });
 });
+
+describe('w:delInstrText — a tracked-deleted field instruction', () => {
+  const paragraphOf = (part: OoxmlPart) => {
+    const find = (node: (typeof part)['root']): (typeof part)['root'] | undefined => {
+      if (node.kind === 'paragraph') return node;
+      if (node.kind === 'textValue') return undefined;
+      for (const child of node.children ?? []) {
+        const hit = find(child);
+        if (hit) return hit;
+      }
+      return undefined;
+    };
+    const paragraph = find(part.root);
+    if (!paragraph) throw new Error('no paragraph');
+    return paragraph;
+  };
+  // Word rewrites `w:instrText` as `w:delInstrText` inside a deletion; the machine must
+  // ingest it per phase exactly like the live form, and it must never paint.
+  const deletedField =
+    '<w:p><w:r><w:t>A</w:t></w:r>' +
+    '<w:del w:id="1" w:author="X">' +
+    '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+    '<w:r><w:delInstrText> PAGE </w:delInstrText></w:r>' +
+    '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+    '<w:r><w:delText>3</w:delText></w:r>' +
+    '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+    '</w:del><w:r><w:t>B</w:t></w:r></w:p>';
+
+  test('forms one atom and paints the struck result in all-markup', () => {
+    const pieces = piecesOfParagraph(paragraphOf(parsePart(deletedField)));
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', '3', 'B']);
+    const atom = pieces[1]!;
+    expect(atom).toMatchObject({ start: 1, end: 2, projected: true });
+    expect(atom.revisions?.map((revision) => revision.kind)).toEqual(['delete']);
+    expect(pieces[2]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('is gone from the proposed result, unit kept', () => {
+    const pieces = piecesOfParagraph(
+      paragraphOf(parsePart(deletedField)),
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'proposed'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+    expect(pieces[1]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('shows the pre-deletion document in the original view', () => {
+    const pieces = piecesOfParagraph(
+      paragraphOf(parsePart(deletedField)),
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'original'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', '3', 'B']);
+  });
+
+  test('the instruction text itself never paints in any mode', () => {
+    for (const mode of ['all-markup', 'proposed', 'original'] as const) {
+      const pieces = piecesOfParagraph(
+        paragraphOf(parsePart(deletedField)),
+        [],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        mode
+      );
+      expect(pieces.map((piece) => piece.text).join('')).not.toContain('PAGE');
+    }
+  });
+
+  test("a demoted field's buffered result pieces carry the field-atom shading", () => {
+    // No end marker: the field demotes, its cache flushes as ordinary addressable pieces —
+    // which are still a field's displayed result and shade like one.
+    const demoted =
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>cached</w:t></w:r></w:p>';
+    const pieces = piecesOfParagraph(paragraphOf(parsePart(demoted)));
+    expect(pieces.map((piece) => piece.text)).toEqual(['cached']);
+    expect(pieces[0]!.fieldAtom).toEqual({ formField: false });
+  });
+});

--- a/packages/core/src/layout/__tests__/field-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-projection.test.ts
@@ -920,4 +920,18 @@ describe('w:delInstrText — a tracked-deleted field instruction', () => {
     expect(pieces.map((piece) => piece.text)).toEqual(['cached']);
     expect(pieces[0]!.fieldAtom).toEqual({ formField: false });
   });
+
+  test('a fully-deleted PAGE still evaluates live, with delete attribution', () => {
+    // No live instrText at all: the deleted buffer answers, so the field keeps its meaning
+    // and the value paints struck in all-markup instead of going inert.
+    const pieces = piecesOfParagraph(paragraphOf(parsePart(deletedField)), [], {
+      pageNumber: 4,
+      pageCount: 9,
+    });
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', '4', 'B']);
+    expect(pieces[1]!.revisions?.map((revision) => revision.kind)).toEqual(['delete']);
+  });
 });
+
+// A LIVE `w:instrText` beside `w:delInstrText` (a tracked field-code edit) is covered in
+// `field-instruction-revisions.test.ts` — this file is at the max-lines cap.

--- a/packages/core/src/layout/__tests__/field-simple-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-simple-projection.test.ts
@@ -225,6 +225,66 @@ describe('a simple PAGE field', () => {
   });
 });
 
+describe('a nested simple field inside a tracked complex cache', () => {
+  // Everything between a tracked inner field's separate and its end is the REPLACED result.
+  // A nested `w:fldSimple PAGE` in that cache used to self-append its live value AND leave
+  // the tracked end appending another — the same number painted twice on every sheet. It is
+  // noted as replaced content instead: one live value, from the tracked end only.
+  const TRACKED_NESTED_SIMPLE =
+    '<w:p><w:fldSimple w:instr=" QUOTE x ">' +
+    '<w:r><w:t>p. </w:t></w:r>' +
+    '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+    '<w:r><w:instrText> PAGE </w:instrText></w:r>' +
+    '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+    '<w:fldSimple w:instr=" PAGE "><w:r><w:t>7</w:t></w:r></w:fldSimple>' +
+    '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+    '</w:fldSimple></w:p>';
+
+  test('paints exactly ONE live value', () => {
+    expect(
+      piecesOfParagraph(paragraphOf(TRACKED_NESTED_SIMPLE), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('p. 3');
+  });
+
+  test('a visible nested-fldSimple result keeps the tracked end appending', () => {
+    // The nested simple field's cached run still notes the tracker as VISIBLE replaced
+    // content — without that, `seen && !visible` reads as a hidden result and the tracked
+    // end appends nothing at all.
+    const visible =
+      '<w:p><w:fldSimple w:instr=" QUOTE x ">' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> PAGE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:fldSimple w:instr=" REF y "><w:r><w:t>7</w:t></w:r></w:fldSimple>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '</w:fldSimple></w:p>';
+    expect(
+      piecesOfParagraph(paragraphOf(visible), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('3');
+
+    // Contrast: a nested simple field whose whole cached result the file hides suppresses
+    // the live value too — a live number would resurrect a result the file says not to show.
+    const hidden =
+      '<w:p><w:fldSimple w:instr=" QUOTE x ">' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> PAGE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:fldSimple w:instr=" REF y ">' +
+      '<w:r><w:rPr><w:vanish/></w:rPr><w:t>7</w:t></w:r></w:fldSimple>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '</w:fldSimple></w:p>';
+    expect(
+      piecesOfParagraph(paragraphOf(hidden), [], { pageNumber: 3, pageCount: 9 })
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('');
+  });
+});
+
 describe('a tracked simple field', () => {
   const inserted =
     '<w:p><w:ins w:id="1" w:author="Author" w:date="2026-07-07T20:18:00Z">' +

--- a/packages/core/src/layout/__tests__/field-symbol-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-symbol-projection.test.ts
@@ -141,6 +141,121 @@ describe('a complex SYMBOL field', () => {
     const pieces = project(`<w:p>${complexField(' SYMBOL 65 \\zz \\h \\j "stray" ')}</w:p>`);
     expect(pieces.map((piece) => piece.text)).toEqual(['A']);
   });
+
+  test('instruction text split across several instrText runs still parses', () => {
+    const pieces = project(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> SYM</w:instrText></w:r>' +
+        '<w:r><w:instrText>BOL 0xF0</w:instrText></w:r>' +
+        '<w:r><w:instrText>FC \\f "Wingdings" </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['✔']);
+    expect(pieces[0]!.style.fontFamily).toBe('Wingdings');
+  });
+
+  test('a decimal code with an unquoted symbol font maps like the hex form', () => {
+    const pieces = project(`<w:p>${complexField(' SYMBOL 61692 \\f Wingdings ')}</w:p>`);
+    // 61692 = 0xF0FC, Wingdings check mark.
+    expect(pieces.map((piece) => piece.text)).toEqual(['✔']);
+  });
+
+  test("a nested inner field's instruction never leaks into the outer capture", () => {
+    // The inner PAGE must neither corrupt the outer SYMBOL nor paint its own text; the outer
+    // instruction is its OWN level-1 fragments, rejoined around the inner field.
+    const pieces = project(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> SYMBOL </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> PAGE </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+        '<w:r><w:instrText> 0xF0FC \\f "Wingdings" </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>cached</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['✔']);
+  });
+
+  test('\\f beats a theme-resolved run font when themeFonts are supplied', () => {
+    const pieces = piecesOfParagraph(
+      paragraphOf(
+        '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+          '<w:r><w:instrText> SYMBOL 65 \\u \\f "Courier New" </w:instrText></w:r>' +
+          '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+          '<w:r><w:rPr><w:rFonts w:asciiTheme="minorHAnsi"/></w:rPr><w:t>x</w:t></w:r>' +
+          '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+      ),
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'all-markup',
+      undefined,
+      undefined,
+      { major: 'Georgia', minor: 'Calibri' }
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A']);
+    expect(pieces[0]!.style.fontFamily).toBe('Courier New');
+  });
+
+  test('hostile >4-deep nesting refuses SYMBOL synthesis from outer fragments', () => {
+    const deep =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>'.repeat(5) +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>'.repeat(5);
+    const pieces = project(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> SYMBOL 0xF0FC \\f "Wingdings" </w:instrText></w:r>' +
+        deep +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test('a result made of one w:sym donates style and revision attribution', () => {
+    // The sym is the FIRST visible result content, so it captures like ordinary text: the
+    // atom carries the deletion in all-markup instead of painting as unchanged text.
+    const pieces = project(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:del w:id="1" w:author="A"><w:r><w:sym w:font="Wingdings" w:char="F0FC"/></w:r></w:del>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['✔']);
+    expect(pieces[0]!.revisions?.map((revision) => revision.kind)).toEqual(['delete']);
+    // And the deletion resolves away in the proposed result.
+    const proposed = project(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:del w:id="1" w:author="A"><w:r><w:sym w:font="Wingdings" w:char="F0FC"/></w:r></w:del>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>',
+      'proposed'
+    );
+    expect(proposed.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test("a demoted field's result w:sym paints as a projected zero-width glyph", () => {
+    // No end marker: the field demotes and its result is ordinary content — the sym must
+    // paint exactly as it does in an ordinary run instead of vanishing with the atomic skips.
+    const pieces = project(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>be</w:t><w:sym w:font="Wingdings" w:char="F0FC"/><w:t>fore</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['be', '✔', 'fore']);
+    const glyph = pieces[1]!;
+    expect(glyph).toMatchObject({ start: 2, end: 2, projected: true });
+    expect(glyph.style.fontFamily).toBe('Wingdings');
+    expect(glyph.fieldAtom).toEqual({ formField: false });
+    // Surrounding demoted result text keeps its literal offsets.
+    expect(pieces[2]).toMatchObject({ start: 2, end: 6 });
+  });
 });
 
 describe('a simple SYMBOL field', () => {
@@ -171,5 +286,28 @@ describe('a simple SYMBOL field', () => {
         '<w:r><w:t>cached</w:t></w:r></w:fldSimple></w:p>'
     );
     expect(pieces.map((piece) => piece.text)).toEqual(['cached']);
+  });
+
+  test('a tracked-deleted simple SYMBOL is gone from the proposed result', () => {
+    const pieces = project(
+      '<w:p><w:del w:id="1" w:author="A">' +
+        '<w:fldSimple w:instr=" SYMBOL 0xF0FC \\f &quot;Wingdings&quot; "/></w:del>' +
+        '<w:r><w:t>B</w:t></w:r></w:p>',
+      'proposed'
+    );
+    // The atom's unit is kept — B stays at offset 1 — but nothing paints for it.
+    expect(pieces.map((piece) => piece.text)).toEqual(['B']);
+    expect(pieces[0]).toMatchObject({ start: 1, end: 2 });
+  });
+
+  test('a hidden cached result does not hide the synthesized glyph', () => {
+    // SYMBOL is instruction-authoritative: the vanish belongs to the CACHED result run, and
+    // that run donates nothing. Only a hidden glyph style itself suppresses the paint.
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" SYMBOL 0xF0FC \\f &quot;Wingdings&quot; ">' +
+        '<w:r><w:rPr><w:vanish/></w:rPr><w:t>old</w:t></w:r></w:fldSimple>' +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['✔', 'B']);
   });
 });

--- a/packages/core/src/layout/__tests__/field-symbol-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-symbol-projection.test.ts
@@ -1,0 +1,175 @@
+// The SYMBOL field paints from its instruction (§17.16.5.60).
+//
+// Real files carry NO cached result for SYMBOL — Word always renders from the instruction —
+// so layout synthesizes the glyph over the field's single reserved model unit. Every hostile
+// instruction falls back to the previous behavior (cached text or nothing), never a throw.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { piecesOfParagraph } from '../field-projection.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(body: string): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(partOf(body).root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+function project(body: string, mode: RevisionDisplayMode = 'all-markup') {
+  return piecesOfParagraph(paragraphOf(body), [], undefined, undefined, undefined, undefined, mode);
+}
+
+/** A complete complex field around one instruction, with an optional cached result. */
+function complexField(instr: string, result = '', chromeRpr = ''): string {
+  return (
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="begin"/></w:r>` +
+    `<w:r>${chromeRpr}<w:instrText>${instr}</w:instrText></w:r>` +
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="separate"/></w:r>` +
+    result +
+    `<w:r>${chromeRpr}<w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
+
+describe('a complex SYMBOL field', () => {
+  test('paints the mapped glyph over one atom unit with the \\f family', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        complexField(' SYMBOL 0xF0FC \\f "Wingdings" ') +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', '✔', 'B']);
+    const glyph = pieces[1]!;
+    expect(glyph).toMatchObject({ start: 1, end: 2, projected: true });
+    expect(glyph.style.fontFamily).toBe('Wingdings');
+    expect(glyph.fieldAtom).toEqual({ formField: false });
+    expect(pieces[2]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('a decimal code on a symbol font normalizes onto the 0xF000 page', () => {
+    const pieces = project(`<w:p>${complexField(' SYMBOL 183 \\f "Symbol" ')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['•']);
+  });
+
+  test('\\u renders the codepoint directly and \\s sets whole points', () => {
+    const pieces = project(`<w:p>${complexField(' SYMBOL 8226 \\u \\s 24 ')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['•']);
+    expect(pieces[0]!.style.fontSizePt).toBe(24);
+  });
+
+  test('an unquoted \\f token works', () => {
+    const pieces = project(`<w:p>${complexField(' SYMBOL 0xF06C \\f Wingdings ')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['●']);
+    expect(pieces[0]!.style.fontFamily).toBe('Wingdings');
+  });
+
+  test('the instruction wins over a stale cached result', () => {
+    const pieces = project(
+      `<w:p>${complexField(' SYMBOL 0xF0FC \\f "Wingdings" ', '<w:r><w:t>OLD</w:t></w:r>')}</w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['✔']);
+    expect(pieces[0]).toMatchObject({ start: 0, end: 1, projected: true });
+  });
+
+  test('the begin/instr/end shape without separate still paints', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> SYMBOL 0xF0FC \\f "Wingdings" </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', '✔', 'B']);
+    expect(pieces[1]).toMatchObject({ start: 1, end: 2, projected: true });
+  });
+
+  test('hidden chrome runs paint nothing but keep the unit', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        complexField(' SYMBOL 0xF0FC \\f "Wingdings" ', '', '<w:rPr><w:vanish/></w:rPr>') +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', 'B']);
+    expect(pieces[1]).toMatchObject({ start: 2, end: 3 });
+  });
+
+  test('a tracked-deleted SYMBOL is gone from the proposed result', () => {
+    const pieces = project(
+      `<w:p><w:del w:id="1" w:author="A">${complexField(' SYMBOL 0xF0FC \\f "Wingdings" ')}</w:del></w:p>`,
+      'proposed'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual([]);
+  });
+
+  test('hostile instructions stay inert without throwing', () => {
+    for (const instr of [
+      ' SYMBOL 999999999999 ',
+      ' SYMBOL 0xD800 ',
+      ' SYMBOL 0xFFFC ',
+      ' SYMBOL ',
+    ]) {
+      // Previous behavior: the cached result paints; the instruction never does.
+      const pieces = project(`<w:p>${complexField(instr, '<w:r><w:t>cached</w:t></w:r>')}</w:p>`);
+      expect(pieces.map((piece) => piece.text)).toEqual(['cached']);
+      // And with an empty result the unit stays empty.
+      const empty = project(`<w:p>${complexField(instr)}<w:r><w:t>B</w:t></w:r></w:p>`);
+      expect(empty.map((piece) => piece.text)).toEqual(['B']);
+      expect(empty[0]).toMatchObject({ start: 1, end: 2 });
+    }
+  });
+
+  test('garbage switches never fail the parse', () => {
+    const pieces = project(`<w:p>${complexField(' SYMBOL 65 \\zz \\h \\j "stray" ')}</w:p>`);
+    expect(pieces.map((piece) => piece.text)).toEqual(['A']);
+  });
+});
+
+describe('a simple SYMBOL field', () => {
+  test('paints the glyph over its reserved unit', () => {
+    const pieces = project(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        '<w:fldSimple w:instr=" SYMBOL 0xF0FC \\f &quot;Wingdings&quot; "/>' +
+        '<w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['A', '✔', 'B']);
+    const glyph = pieces[1]!;
+    expect(glyph).toMatchObject({ start: 1, end: 2, projected: true });
+    expect(glyph.style.fontFamily).toBe('Wingdings');
+    expect(glyph.fieldAtom).toEqual({ formField: false });
+  });
+
+  test('the instruction wins over the cached result', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" SYMBOL 183 \\f Symbol ">' +
+        '<w:r><w:t>OLD</w:t></w:r></w:fldSimple></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['•']);
+  });
+
+  test('a hostile instruction falls back to the cached result', () => {
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" SYMBOL 0xD800 ">' +
+        '<w:r><w:t>cached</w:t></w:r></w:fldSimple></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['cached']);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-symbol.test.ts
+++ b/packages/core/src/layout/__tests__/field-symbol.test.ts
@@ -4,8 +4,11 @@
 // caller falls back to previous behavior) and must never throw.
 
 import { describe, expect, test } from 'bun:test';
-import { parseSymbolInstruction, symbolFieldGlyph } from '../field-symbol.ts';
-import { MAX_FIELD_INSTRUCTION_CHARS } from '../field-instruction.ts';
+import {
+  MAX_SYMBOL_INSTRUCTION_CHARS,
+  parseSymbolInstruction,
+  symbolFieldGlyph,
+} from '../field-symbol.ts';
 
 describe('parseSymbolInstruction', () => {
   test('parses a hex code with a quoted font', () => {
@@ -90,7 +93,7 @@ describe('parseSymbolInstruction', () => {
   });
 
   test('rejects an oversized instruction and an oversized font, without throwing', () => {
-    expect(parseSymbolInstruction(`SYMBOL 65 ${'x'.repeat(MAX_FIELD_INSTRUCTION_CHARS)}`)).toBe(
+    expect(parseSymbolInstruction(`SYMBOL 65 ${'x'.repeat(MAX_SYMBOL_INSTRUCTION_CHARS)}`)).toBe(
       null
     );
     // Oversized font: the switch is ignored, the code still parses.

--- a/packages/core/src/layout/__tests__/field-symbol.test.ts
+++ b/packages/core/src/layout/__tests__/field-symbol.test.ts
@@ -1,0 +1,166 @@
+// SYMBOL instruction parsing and glyph synthesis (§17.16.5.60).
+//
+// The instruction is attacker-controlled: every hostile shape must resolve to null (the
+// caller falls back to previous behavior) and must never throw.
+
+import { describe, expect, test } from 'bun:test';
+import { parseSymbolInstruction, symbolFieldGlyph } from '../field-symbol.ts';
+import { MAX_FIELD_INSTRUCTION_CHARS } from '../field-instruction.ts';
+
+describe('parseSymbolInstruction', () => {
+  test('parses a hex code with a quoted font', () => {
+    expect(parseSymbolInstruction(' SYMBOL 0xF0FC \\f "Wingdings" ')).toEqual({
+      code: 0xf0fc,
+      font: 'Wingdings',
+      sizePt: null,
+      unicode: false,
+    });
+  });
+
+  test('parses a decimal code', () => {
+    expect(parseSymbolInstruction('SYMBOL 183 \\f "Symbol"')).toMatchObject({
+      code: 183,
+      font: 'Symbol',
+    });
+  });
+
+  test('recognition is case-insensitive; the font keeps its case', () => {
+    expect(parseSymbolInstruction(' symbol 65 \\f "MS Gothic"')).toMatchObject({
+      code: 65,
+      font: 'MS Gothic',
+    });
+  });
+
+  test('accepts an unquoted single-token font', () => {
+    expect(parseSymbolInstruction('SYMBOL 0x41 \\f Wingdings')).toMatchObject({
+      font: 'Wingdings',
+    });
+  });
+
+  test('parses \\s whole points and \\u', () => {
+    expect(parseSymbolInstruction('SYMBOL 0x2022 \\u \\s 24')).toEqual({
+      code: 0x2022,
+      font: null,
+      sizePt: 24,
+      unicode: true,
+    });
+  });
+
+  test('an invalid \\s argument only drops the switch', () => {
+    expect(parseSymbolInstruction('SYMBOL 65 \\s 0')).toMatchObject({ code: 65, sizePt: null });
+    expect(parseSymbolInstruction('SYMBOL 65 \\s 1000')).toMatchObject({ sizePt: null });
+    expect(parseSymbolInstruction('SYMBOL 65 \\s huge')).toMatchObject({ sizePt: null });
+    expect(parseSymbolInstruction('SYMBOL 65 \\s')).toMatchObject({ sizePt: null });
+  });
+
+  test('inert and unknown switches never fail the parse', () => {
+    expect(parseSymbolInstruction('SYMBOL 65 \\h \\j \\a \\* MERGEFORMAT')).toMatchObject({
+      code: 65,
+    });
+    expect(parseSymbolInstruction('SYMBOL 65 \\zz garbage "stray"')).toMatchObject({ code: 65 });
+  });
+
+  test('a switch token never becomes a font name', () => {
+    expect(parseSymbolInstruction('SYMBOL 65 \\f \\s 24')).toEqual({
+      code: 65,
+      font: null,
+      sizePt: 24,
+      unicode: false,
+    });
+  });
+
+  test('rejects non-SYMBOL, missing code, and malformed codes', () => {
+    expect(parseSymbolInstruction(' PAGE ')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOLS 65')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL')).toBeNull();
+    expect(parseSymbolInstruction('"SYMBOL" 65')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL abc')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL 0x')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL 0xZZ')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL -5')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL "65"')).toBeNull();
+  });
+
+  test('rejects out-of-range and surrogate codes', () => {
+    expect(parseSymbolInstruction('SYMBOL 999999999999')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL 1114112')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL 0x110000')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL 0xD800')).toBeNull();
+    expect(parseSymbolInstruction('SYMBOL 0xDFFF')).toBeNull();
+  });
+
+  test('rejects an oversized instruction and an oversized font, without throwing', () => {
+    expect(parseSymbolInstruction(`SYMBOL 65 ${'x'.repeat(MAX_FIELD_INSTRUCTION_CHARS)}`)).toBe(
+      null
+    );
+    // Oversized font: the switch is ignored, the code still parses.
+    expect(parseSymbolInstruction(`SYMBOL 65 \\f "${'F'.repeat(200)}"`)).toMatchObject({
+      font: null,
+    });
+    expect(parseSymbolInstruction('SYMBOL 65 \\f ""')).toMatchObject({ font: null });
+    expect(parseSymbolInstruction('"'.repeat(64))).toBeNull();
+  });
+});
+
+describe('symbolFieldGlyph', () => {
+  test('maps a Wingdings PUA code to its Unicode glyph and keeps the family', () => {
+    const spec = parseSymbolInstruction('SYMBOL 0xF0FC \\f "Wingdings"')!;
+    const glyph = symbolFieldGlyph(spec, [])!;
+    expect(glyph.text).toBe('✔');
+    expect(glyph.style.fontFamily).toBe('Wingdings');
+  });
+
+  test('a bare byte on a symbol font normalizes onto the 0xF000 page', () => {
+    const spec = parseSymbolInstruction('SYMBOL 183 \\f "Symbol"')!;
+    expect(symbolFieldGlyph(spec, [])!.text).toBe('•');
+  });
+
+  test('an unmapped PUA code keeps the codepoint and the symbol font', () => {
+    const spec = parseSymbolInstruction('SYMBOL 0x21 \\f "Wingdings"')!;
+    const glyph = symbolFieldGlyph(spec, [])!;
+    expect(glyph.text).toBe('\uF021');
+    expect(glyph.style.fontFamily).toBe('Wingdings');
+  });
+
+  test('\\u renders the codepoint directly with no symbol-page mapping', () => {
+    const spec = parseSymbolInstruction('SYMBOL 183 \\f "Symbol" \\u')!;
+    const glyph = symbolFieldGlyph(spec, [])!;
+    expect(glyph.text).toBe('·');
+    expect(glyph.style.fontFamily).toBe('Symbol');
+  });
+
+  test('\\s overrides the size in whole points on top of the base props', () => {
+    const spec = parseSymbolInstruction('SYMBOL 65 \\s 24')!;
+    const glyph = symbolFieldGlyph(spec, [{ localName: 'b' }])!;
+    expect(glyph.style.fontSizePt).toBe(24);
+    expect(glyph.style.bold).toBe(true);
+  });
+
+  test('without \\f the base font decides the symbol-page logic', () => {
+    const baseProps = [{ localName: 'rFonts', attributes: { ascii: 'Wingdings' } }];
+    const spec = parseSymbolInstruction('SYMBOL 0x6C')!;
+    expect(symbolFieldGlyph(spec, baseProps)!.text).toBe('●');
+  });
+
+  test('rejects controls, noncharacters, and U+FFFC on a non-symbol font', () => {
+    for (const raw of [
+      'SYMBOL 7',
+      'SYMBOL 0x7F',
+      'SYMBOL 0xFFFE',
+      'SYMBOL 0xFDD0',
+      'SYMBOL 0x1FFFF',
+      'SYMBOL 0xFFFC',
+      'SYMBOL 0xFFFC \\u',
+    ]) {
+      const spec = parseSymbolInstruction(raw);
+      expect(spec).not.toBeNull();
+      expect(symbolFieldGlyph(spec!, [])).toBeNull();
+    }
+  });
+
+  test('a control BYTE on a symbol font still resolves via the PUA page', () => {
+    // 0x07 + 0xF000 is an unmapped Wingdings PUA glyph; the byte is not treated as a control.
+    const spec = parseSymbolInstruction('SYMBOL 7 \\f "Wingdings"')!;
+    expect(symbolFieldGlyph(spec, [])!.text).toBe('\uF007');
+  });
+});

--- a/packages/core/src/layout/__tests__/note-layout.test.ts
+++ b/packages/core/src/layout/__tests__/note-layout.test.ts
@@ -968,3 +968,6 @@ describe('note layout + pagination', () => {
     expect(reservedW).toBeGreaterThan(decimalW);
   });
 });
+
+// Note-story link projection lives in `note-link-projection.test.ts` — this file is at
+// the max-lines cap.

--- a/packages/core/src/layout/__tests__/note-link-projection.test.ts
+++ b/packages/core/src/layout/__tests__/note-link-projection.test.ts
@@ -1,0 +1,120 @@
+// Note-story link projection.
+//
+// Note stories run the same paragraph walk as the body, so they must receive the same
+// projector seams: a `w:hyperlink` or a HYPERLINK field in a footnote used to paint as
+// plain text with no link record — measured, but dead to paint and navigation. The seams
+// are inherited from the body's layout options at the semantic-layout notes seam.
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import { resolveNotesPart } from '../../store/package/note-references.ts';
+import {
+  authoredDocumentEndnoteProperties,
+  authoredDocumentFootnoteProperties,
+  resolveEndnoteProperties,
+  resolveFootnoteProperties,
+  settingsPartOf,
+} from '../../store/package/note-properties.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import type { NotesLayoutInput } from '../note-pagination.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function linkedNotesDoc(): Uint8Array {
+  const body =
+    `<w:p><w:r><w:t>A</w:t><w:footnoteReference w:id="1"/>` +
+    `<w:footnoteReference w:id="2"/></w:r></w:p>`;
+  const hyperlinkField =
+    '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+    '<w:r><w:instrText> HYPERLINK "https://example.com" </w:instrText></w:r>' +
+    '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+    '<w:r><w:t>example</w:t></w:r>' +
+    '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+  const footnotes =
+    `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:id="1"><w:p>` +
+    `<w:hyperlink w:anchor="top"><w:r><w:t>Jump</w:t></w:r></w:hyperlink>` +
+    `</w:p></w:footnote>` +
+    `<w:footnote w:id="2"><w:p>${hyperlinkField}</w:p></w:footnote>`;
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(`<w:footnotes xmlns:w="${W}">${footnotes}</w:footnotes>`),
+  });
+}
+
+describe('note-story link projection', () => {
+  test('w:hyperlink and HYPERLINK fields in footnotes carry span link records', () => {
+    const loaded = readOoxmlPackage(linkedNotesDoc());
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) throw new Error(loaded.reason);
+    const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+    const settings = settingsPartOf(loaded.package);
+    const documentFootnoteProps = resolveFootnoteProperties(
+      undefined,
+      authoredDocumentFootnoteProperties(settings)
+    );
+    const documentEndnoteProps = resolveEndnoteProperties(
+      undefined,
+      authoredDocumentEndnoteProperties(settings)
+    );
+    const notes: NotesLayoutInput = {
+      footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+      endnotesPart: null,
+      footnotePropsBySection: [documentFootnoteProps],
+      endnotePropsBySection: [documentEndnoteProps],
+      documentFootnoteProps,
+      documentEndnoteProps,
+      measurer: createFixedMeasurer(),
+      producer: 'note-link',
+    };
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      producer: 'note-link',
+      // The BODY's seams; the notes input above declares none, so these must be inherited.
+      projectLink: (node) =>
+        node.kind === 'textValue'
+          ? null
+          : { id: `typed:${node.id}`, kind: 'internal', href: '#top', anchor: 'top' },
+      projectFieldLink: (spec) =>
+        spec.target ? { id: `field:${spec.target}`, kind: 'external', href: spec.target } : null,
+    });
+
+    const noteSpans = layout.pages
+      .flatMap((page) => page.footnotes?.notes ?? [])
+      .flatMap((note) => note.fragments)
+      .flatMap((fragment) => (fragment.kind === 'paragraph' ? fragment.lines : []))
+      .flatMap((line) => line.spans);
+    expect(noteSpans.length).toBeGreaterThan(0);
+
+    const typedLinked = noteSpans.find((span) => span.text === 'Jump');
+    expect(typedLinked?.link).toMatchObject({ kind: 'internal', anchor: 'top' });
+
+    const fieldLinked = noteSpans.find((span) => span.text === 'example');
+    expect(fieldLinked?.link).toMatchObject({
+      id: 'field:https://example.com',
+      kind: 'external',
+      href: 'https://example.com',
+    });
+  });
+});

--- a/packages/core/src/layout/__tests__/symbol-run-projection.test.ts
+++ b/packages/core/src/layout/__tests__/symbol-run-projection.test.ts
@@ -1,0 +1,199 @@
+// `w:sym` (§17.3.3.30) paints one glyph without owning any model offset.
+//
+// The canonical tree keeps `w:sym` generic, and the store's offset authority gives a generic
+// run child ZERO model width — `paragraphTextOf` never counts it. So the glyph is a projected
+// piece at a zero-width range: it stands at an insertion point, paint emits it as furniture,
+// and every surrounding offset stays exactly where the store put it. Both attributes are
+// attacker-controlled; anything malformed fails closed to "no glyph".
+
+import { describe, expect, test } from 'bun:test';
+import {
+  paragraphTextOf,
+  readOoxmlPart,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { piecesOfParagraph } from '../field-projection.ts';
+import { symbolGlyphOf } from '../symbol-run.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphOf(part: OoxmlPart): OoxmlNode {
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind === 'paragraph') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const paragraph = find(part.root);
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph;
+}
+
+function project(body: string) {
+  return piecesOfParagraph(paragraphOf(partOf(body)), []);
+}
+
+const SYM = '<w:sym w:font="Wingdings" w:char="F0FC"/>';
+
+describe('a w:sym between two text nodes', () => {
+  const body = `<w:p><w:r><w:t>a</w:t>${SYM}<w:t>b</w:t></w:r></w:p>`;
+
+  test('paints three pieces in order, the glyph mapped from the symbol page', () => {
+    const pieces = project(body);
+    // Wingdings 0xFC (stored as U+F0FC) has an exact Unicode twin.
+    expect(pieces.map((piece) => piece.text)).toEqual(['a', '✔', 'b']);
+  });
+
+  test('the glyph is projected furniture over a zero-width range', () => {
+    const sym = project(body)[1]!;
+    expect(sym.projected).toBe(true);
+    expect(sym.start).toBe(1);
+    expect(sym.end).toBe(1);
+  });
+
+  test('the glyph carries the authored symbol family', () => {
+    expect(project(body)[1]!.style.fontFamily).toBe('Wingdings');
+  });
+
+  test('the model text is unchanged and unprojected pieces stay 1:1', () => {
+    const part = partOf(body);
+    const paragraph = paragraphOf(part);
+    expect(paragraphTextOf(part, paragraph.id)).toBe('ab');
+    const pieces = piecesOfParagraph(paragraph, []);
+    // No piece claims an offset the paragraph does not have, and ranges never overlap.
+    let cursor = 0;
+    for (const piece of pieces) {
+      expect(piece.start).toBeGreaterThanOrEqual(cursor);
+      cursor = piece.end;
+      if (!piece.projected) expect(piece.text.length).toBe(piece.end - piece.start);
+    }
+    expect(cursor).toBe(2);
+  });
+});
+
+describe('symbol-font encodings', () => {
+  test('a bare byte on a symbol font maps like its 0xF000-page twin', () => {
+    // Word accepts both `w:char="F046"` and `w:char="46"` for the same Wingdings glyph.
+    const bare = project('<w:p><w:r><w:sym w:font="Wingdings" w:char="6C"/></w:r></w:p>');
+    const paged = project('<w:p><w:r><w:sym w:font="Wingdings" w:char="F06C"/></w:r></w:p>');
+    expect(bare.map((piece) => piece.text)).toEqual(['●']);
+    expect(paged.map((piece) => piece.text)).toEqual(['●']);
+  });
+
+  test('an unmapped symbol-font code keeps the PUA character and the symbol font', () => {
+    // No Unicode twin in the Wingdings table — the shaper may still resolve the PUA glyph.
+    const pieces = project('<w:p><w:r><w:sym w:font="Wingdings" w:char="F046"/></w:r></w:p>');
+    expect(pieces.map((piece) => piece.text)).toEqual(['\uF046']);
+    expect(pieces[0]!.style.fontFamily).toBe('Wingdings');
+  });
+
+  test('a non-symbol font renders its code point directly', () => {
+    // The exact shape the content-control checkbox writer emits.
+    const pieces = project('<w:p><w:r><w:sym w:font="MS Gothic" w:char="2612"/></w:r></w:p>');
+    expect(pieces.map((piece) => piece.text)).toEqual(['☒']);
+    expect(pieces[0]!.style.fontFamily).toBe('MS Gothic');
+  });
+
+  test('a missing w:font keeps the run font', () => {
+    const pieces = project(
+      '<w:p><w:r><w:rPr><w:rFonts w:ascii="Georgia"/></w:rPr><w:sym w:char="2022"/></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['•']);
+    expect(pieces[0]!.style.fontFamily).toBe('Georgia');
+  });
+});
+
+describe('malformed w:sym', () => {
+  const cases = [
+    ['garbage', '<w:sym w:font="Wingdings" w:char="zzzz"/>'],
+    ['too long', '<w:sym w:font="Wingdings" w:char="F0FC1"/>'],
+    ['empty', '<w:sym w:font="Wingdings" w:char=""/>'],
+    ['missing char', '<w:sym w:font="Wingdings"/>'],
+    ['surrogate', '<w:sym w:char="D800"/>'],
+    ['noncharacter', '<w:sym w:char="FFFF"/>'],
+    ['control', '<w:sym w:char="0007"/>'],
+  ] as const;
+
+  for (const [label, sym] of cases) {
+    test(`${label} renders nothing and does not throw`, () => {
+      const pieces = project(`<w:p><w:r><w:t>a</w:t>${sym}<w:t>b</w:t></w:r></w:p>`);
+      expect(pieces.map((piece) => piece.text)).toEqual(['a', 'b']);
+      expect(pieces[1]).toMatchObject({ start: 1, end: 2 });
+    });
+  }
+});
+
+describe('a hidden w:sym', () => {
+  test('a vanish run paints no glyph', () => {
+    const pieces = project(`<w:p><w:r><w:rPr><w:vanish/></w:rPr>${SYM}</w:r></w:p>`);
+    expect(pieces).toEqual([]);
+  });
+});
+
+describe('w:sym inside field results', () => {
+  test('joins a fldSimple cached result when it maps to real Unicode', () => {
+    const pieces = project(
+      `<w:p><w:fldSimple w:instr=" REF x "><w:r><w:t>ok </w:t>${SYM}</w:r></w:fldSimple></w:p>`
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['ok ✔']);
+  });
+
+  test('an unmapped PUA glyph is skipped from a fldSimple result', () => {
+    // A collected display string cannot carry a font switch, so a glyph that only the symbol
+    // font can draw stays out rather than painting tofu in the result font.
+    const pieces = project(
+      '<w:p><w:fldSimple w:instr=" REF x "><w:r><w:t>ok</w:t>' +
+        '<w:sym w:font="Wingdings" w:char="F046"/></w:r></w:fldSimple></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['ok']);
+  });
+
+  test('joins a complex field cached result when it maps to real Unicode', () => {
+    const pieces = project(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText> REF x </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        `<w:r><w:t>ok </w:t>${SYM}</w:r>` +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    expect(pieces.map((piece) => piece.text)).toEqual(['ok ✔']);
+  });
+});
+
+describe('symbolGlyphOf', () => {
+  test('rejects an overlong font name', () => {
+    const part = partOf(`<w:p><w:r><w:sym w:font="${'A'.repeat(200)}" w:char="F0FC"/></w:r></w:p>`);
+    const find = (node: OoxmlNode): OoxmlNode | undefined => {
+      if (node.kind !== 'textValue' && node.localName === 'sym') return node;
+      if (node.kind === 'textValue') return undefined;
+      for (const child of node.children ?? []) {
+        const hit = find(child);
+        if (hit) return hit;
+      }
+      return undefined;
+    };
+    const sym = find(part.root);
+    expect(sym).toBeDefined();
+    const glyph = symbolGlyphOf(sym!);
+    // The code point still renders; the unusable family is dropped.
+    expect(glyph).toMatchObject({ text: '\uF0FC', font: null });
+  });
+
+  test('is null for anything that is not a w:sym', () => {
+    const part = partOf('<w:p><w:r><w:t>a</w:t></w:r></w:p>');
+    expect(symbolGlyphOf(part.root)).toBeNull();
+  });
+});

--- a/packages/core/src/layout/content-control-properties.ts
+++ b/packages/core/src/layout/content-control-properties.ts
@@ -1,0 +1,112 @@
+// Pure content-control (SDT) property helpers.
+//
+// These read chrome metadata off a content-control wrapper and its `sdtPr`
+// properties: value attributes, the properties element, typed markers, lock
+// state, mapped type, and structural level. They hold no layout state and close
+// over nothing in `semantic-layout.ts`; they operate only on their arguments.
+
+import type { OoxmlElement, OoxmlNode } from '@docx-editor.dev/core/store';
+import {
+  MAX_CONTENT_CONTROL_NESTING as MAX_SDT_NESTING,
+  contentControlContentChildren,
+  isContentControl,
+} from '../store/package/content-control-walk.ts';
+import type {
+  ContentControlLevel,
+  ContentControlLock,
+  ContentControlMappedType,
+} from './semantic-records.ts';
+
+const WML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const W15_NS = 'http://schemas.microsoft.com/office/word/2012/wordml';
+
+export function wmlValOf(node: OoxmlNode): string | undefined {
+  if (node.kind === 'textValue') return undefined;
+  for (const attribute of node.attributes) {
+    if (attribute.localName === 'val' && attribute.namespaceUri === WML_NS) return attribute.value;
+  }
+  return undefined;
+}
+
+export function contentControlPropertiesOf(control: OoxmlElement): OoxmlElement | undefined {
+  for (const child of control.children) {
+    if (child.kind === 'textValue') continue;
+    if (child.kind === 'contentControlProperties' || child.localName === 'sdtPr') return child;
+  }
+  return undefined;
+}
+
+export function propertyChild(
+  properties: OoxmlElement | undefined,
+  localName: string
+): OoxmlElement | undefined {
+  if (!properties) return undefined;
+  for (const child of properties.children) {
+    if (child.kind === 'textValue') continue;
+    if (child.localName === localName) return child;
+  }
+  return undefined;
+}
+
+export function propertyVal(
+  properties: OoxmlElement | undefined,
+  localName: string
+): string | undefined {
+  const child = propertyChild(properties, localName);
+  return child ? wmlValOf(child) : undefined;
+}
+
+export function parseContentControlLock(value: string | undefined): ContentControlLock {
+  if (value === 'sdtLocked' || value === 'contentLocked' || value === 'sdtContentLocked') {
+    return value;
+  }
+  return 'unlocked';
+}
+
+export function mapContentControlType(
+  properties: OoxmlElement | undefined
+): ContentControlMappedType {
+  if (!properties) return 'richText';
+  for (const child of properties.children) {
+    if (child.kind === 'textValue') continue;
+    const kind = child.kind;
+    const localName = child.localName;
+    const namespaceUri = child.namespaceUri;
+    // Typed markers after the SDT merge; `localName` covers demoted/generic fallbacks.
+    // Do not match `kind === 'text'` — that is `w:t`, not `CT_SdtText` (`contentControlText`).
+    if (kind === 'contentControlDropDownList' || localName === 'dropDownList') return 'dropdown';
+    if (kind === 'contentControlComboBox' || localName === 'comboBox') return 'comboBox';
+    if (kind === 'contentControlDate' || localName === 'date') return 'date';
+    if (localName === 'picture') return 'picture';
+    if (kind === 'contentControlText' || localName === 'text') return 'plainText';
+    if (localName === 'richText') return 'richText';
+    if (
+      kind === 'contentControlCheckbox' ||
+      (localName === 'checkbox' && namespaceUri === W14_NS)
+    ) {
+      return 'checkbox';
+    }
+    if (localName === 'repeatingSection' && namespaceUri === W15_NS) {
+      return 'repeatingSection';
+    }
+  }
+  return 'richText';
+}
+
+export function controlLevelOf(control: OoxmlElement): ContentControlLevel {
+  const classify = (nodes: readonly OoxmlNode[], depth: number): ContentControlLevel | null => {
+    for (const child of nodes) {
+      if (child.kind === 'textValue') continue;
+      if (child.kind === 'tableRow') return 'row';
+      if (child.kind === 'tableCell') return 'cell';
+      if (child.kind === 'paragraph' || child.kind === 'table') return 'block';
+      if (isContentControl(child) && depth < MAX_SDT_NESTING) {
+        const nested = classify(contentControlContentChildren(child), depth + 1);
+        if (nested) return nested;
+      }
+    }
+    return null;
+  };
+  return classify(contentControlContentChildren(control), 0) ?? 'inline';
+}

--- a/packages/core/src/layout/field-button.ts
+++ b/packages/core/src/layout/field-button.ts
@@ -10,7 +10,14 @@
 // length-capped string and every failure resolves to null (the caller falls back to cached
 // text or nothing, exactly as before this module existed).
 
-import { MAX_FIELD_INSTRUCTION_CHARS } from './field-instruction.ts';
+/**
+ * Local parser bound: a legitimate button field is a keyword, one argument, and short display
+ * text — anything near this length is garbage, and the display it caps must stay paintable.
+ * Deliberately NOT the shared machine cap (`MAX_FIELD_INSTRUCTION_CHARS`), which is sized for
+ * full-length HYPERLINK targets; this grammar's rejection threshold must not move when that
+ * bound does.
+ */
+export const MAX_BUTTON_INSTRUCTION_CHARS = 256;
 
 /** One parsed MACROBUTTON / GOTOBUTTON instruction: the text Word paints, nothing else. */
 export interface ButtonFieldSpec {
@@ -63,7 +70,7 @@ function skipToken(raw: string, index: number): number {
  * upstream bound), or a missing argument is null.
  */
 export function parseButtonInstruction(raw: string): ButtonFieldSpec | null {
-  if (raw.length === 0 || raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  if (raw.length === 0 || raw.length > MAX_BUTTON_INSTRUCTION_CHARS) return null;
   const keywordStart = skipWhitespace(raw, 0);
   if (raw[keywordStart] === '"') return null;
   const keywordEnd = skipToken(raw, keywordStart);

--- a/packages/core/src/layout/field-button.ts
+++ b/packages/core/src/layout/field-button.ts
@@ -1,0 +1,95 @@
+// MACROBUTTON / GOTOBUTTON (§17.16.5.36, §17.16.5.31) display-text parsing.
+//
+// `MACROBUTTON MacroName display text` and `GOTOBUTTON target display text` DISPLAY everything
+// after their first argument. Word paints that text, and real files carry no cached result for
+// these fields, so without synthesis they paint nothing. The macro name / jump target is
+// consumed and DISCARDED: this module produces display strings only — nothing here executes a
+// macro, resolves a target, or navigates, and no caller may wire a click to one.
+//
+// The instruction is attacker-controlled: tokenization is one bounded pass over a
+// length-capped string and every failure resolves to null (the caller falls back to cached
+// text or nothing, exactly as before this module existed).
+
+import { MAX_FIELD_INSTRUCTION_CHARS } from './field-instruction.ts';
+
+/** One parsed MACROBUTTON / GOTOBUTTON instruction: the text Word paints, nothing else. */
+export interface ButtonFieldSpec {
+  /**
+   * The display text: the raw remainder after the first argument, end-trimmed, surrounding
+   * quotes removed when the whole remainder is one quoted token. Internal whitespace and
+   * quotes survive verbatim — Word preserves them. Never empty.
+   */
+  readonly display: string;
+}
+
+const WHITESPACE = ' \t\n\r';
+
+/**
+ * A TRAILING formatting switch: `\*` plus its argument (`MERGEFORMAT`, `Upper`, …), quoted or
+ * bare. Anchored at the end so a backslash INSIDE legitimate display text is never eaten —
+ * only a tail that is nothing but the switch matches. Each piece is a distinct character
+ * class, so the match is linear.
+ */
+const TRAILING_FORMAT_SWITCH = /[ \t\n\r]*\\\*[ \t\n\r]*(?:"[^"]*"|[^ \t\n\r"\\]+)?[ \t\n\r]*$/;
+
+function skipWhitespace(raw: string, index: number): number {
+  let i = index;
+  while (i < raw.length && WHITESPACE.includes(raw[i]!)) i += 1;
+  return i;
+}
+
+/** End index just past one token; a quote opens a token that runs to the closing quote (or the end). */
+function skipToken(raw: string, index: number): number {
+  if (raw[index] === '"') {
+    let j = index + 1;
+    while (j < raw.length && raw[j] !== '"') j += 1;
+    return j < raw.length ? j + 1 : j;
+  }
+  let j = index;
+  while (j < raw.length && !' \t\n\r"'.includes(raw[j]!)) j += 1;
+  return j;
+}
+
+/**
+ * Parse a raw MACROBUTTON / GOTOBUTTON instruction, or null when it is not one (or is
+ * hostile).
+ *
+ * Recognition is the first token equalling either keyword case-insensitively — the exact
+ * token, so `MACROBUTTONX` is not one. The first argument (macro name / jump target, one
+ * quoted or bare token) is consumed and discarded, never stored. The display text is the raw
+ * remainder, end-trimmed, with any trailing `\*` formatting switch stripped and surrounding
+ * quotes removed when the whole remainder is one quoted token. An empty display, an
+ * over-cap instruction (which also caps the display — the `w:fldSimple` attribute path has no
+ * upstream bound), or a missing argument is null.
+ */
+export function parseButtonInstruction(raw: string): ButtonFieldSpec | null {
+  if (raw.length === 0 || raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  const keywordStart = skipWhitespace(raw, 0);
+  if (raw[keywordStart] === '"') return null;
+  const keywordEnd = skipToken(raw, keywordStart);
+  const keyword = raw.slice(keywordStart, keywordEnd).toUpperCase();
+  if (keyword !== 'MACROBUTTON' && keyword !== 'GOTOBUTTON') return null;
+
+  const argumentStart = skipWhitespace(raw, keywordEnd);
+  if (argumentStart >= raw.length) return null;
+  // The macro name / jump target: consumed and DISCARDED — display is all these fields do.
+  const argumentEnd = skipToken(raw, argumentStart);
+
+  let display = raw.slice(argumentEnd).trim();
+  // Strip trailing formatting switches one at a time (`… \* Upper \* MERGEFORMAT`); each pass
+  // shortens the string, so this terminates.
+  for (;;) {
+    const stripped = display.replace(TRAILING_FORMAT_SWITCH, '').trimEnd();
+    if (stripped === display) break;
+    display = stripped;
+  }
+  // Whole-remainder quote removal, on the tokenizer's own terms: the quote runs to the closing
+  // quote or the end. A close quote anywhere earlier means the quotes are PART of the display.
+  if (display[0] === '"') {
+    const close = display.indexOf('"', 1);
+    if (close === -1) display = display.slice(1);
+    else if (close === display.length - 1) display = display.slice(1, -1);
+  }
+  if (display.length === 0) return null;
+  return { display };
+}

--- a/packages/core/src/layout/field-doc-property.ts
+++ b/packages/core/src/layout/field-doc-property.ts
@@ -1,0 +1,117 @@
+// Document-property fields (§17.16): TITLE, AUTHOR, SUBJECT, KEYWORDS, LASTSAVEDBY, COMMENTS,
+// and the generic `DOCPROPERTY "Name"` over that same fixed set of names.
+//
+// These fields DISPLAY metadata the document already carries in `docProps/core.xml`. Nothing
+// here executes: the instruction is attacker-controlled and is only ever recognized, never
+// evaluated as code. Recognition is bounded (one length-capped normalize pass) and every
+// unrecognized instruction — including any custom-property name — resolves to null and stays
+// inert.
+//
+// DATE-valued document-property fields (CREATEDATE / SAVEDATE / PRINTDATE) are deliberately NOT
+// recognized here: date formatting is out of scope, so they stay inert rather than paint a
+// nondeterministic value.
+//
+// DEVIATION: a `\* Upper` / `\* Lower` / `\* FirstCap` / `\* Caps` casing switch is STRIPPED for
+// recognition but its transform is NOT applied — the raw property value paints. Word would
+// re-case it; this renders the stored string verbatim.
+
+import type { DocumentProperties } from '@docx-editor.dev/core/store';
+import { normalizeFieldInstruction } from './field-instruction.ts';
+
+/** The document-property keys a field may resolve to. A subset of {@link DocumentProperties}. */
+export type DocumentPropertyKey =
+  | 'title'
+  | 'creator'
+  | 'subject'
+  | 'keywords'
+  | 'lastModifiedBy'
+  | 'description';
+
+/** One recognized document-property field: which property it displays, nothing executable. */
+export interface DocPropertyField {
+  readonly property: DocumentPropertyKey;
+}
+
+/**
+ * The field keyword (and the equivalent `DOCPROPERTY` name) mapped to its property key.
+ *
+ * A fixed table read by exact uppercased key: a file-supplied name is only ever LOOKED UP here,
+ * never assigned, so a hostile `DOCPROPERTY "__proto__"` matches nothing and pollutes nothing.
+ */
+const KEYWORD_TO_PROPERTY: Readonly<Record<string, DocumentPropertyKey>> = Object.freeze({
+  TITLE: 'title',
+  AUTHOR: 'creator',
+  SUBJECT: 'subject',
+  KEYWORDS: 'keywords',
+  LASTSAVEDBY: 'lastModifiedBy',
+  COMMENTS: 'description',
+});
+
+/**
+ * One TRAILING field switch — `\*`, `\@`, `\#`, `\!` plus an optional argument — anchored at the
+ * end. The string is already normalized (uppercased, single-spaced), so the switch letter is
+ * upper case and each alternative is a distinct character class, keeping the match linear.
+ */
+const TRAILING_SWITCH = /\s*\\[A-Z*@#!]\s*(?:"[^"]*"|[^\s"\\]+)?\s*$/;
+
+/** Strip every trailing field switch, one bounded pass at a time (each pass shortens `s`). */
+function stripTrailingSwitches(s: string): string {
+  let out = s;
+  for (;;) {
+    const next = out.replace(TRAILING_SWITCH, '').trimEnd();
+    if (next === out) return out;
+    out = next;
+  }
+}
+
+/** The first whitespace- or quote-delimited token of `s`, unquoted, or null when empty. */
+function firstToken(s: string): string | null {
+  const trimmed = s.trimStart();
+  if (trimmed.length === 0) return null;
+  if (trimmed[0] === '"') {
+    const close = trimmed.indexOf('"', 1);
+    const inner = close === -1 ? trimmed.slice(1) : trimmed.slice(1, close);
+    return inner.length > 0 ? inner : null;
+  }
+  const space = trimmed.search(/\s/);
+  const token = space === -1 ? trimmed : trimmed.slice(0, space);
+  return token.length > 0 ? token : null;
+}
+
+/**
+ * Recognize a document-property instruction, or null when it is not one (or is hostile).
+ *
+ * Accepts a bare keyword (`TITLE`, `AUTHOR`, …) with no argument, and `DOCPROPERTY "Name"` for
+ * the same fixed set of names (matched case-insensitively). An unknown `DOCPROPERTY` name, a
+ * date-valued field, or anything over the shared length cap stays inert.
+ */
+export function parseDocPropertyInstruction(raw: string): DocPropertyField | null {
+  const normalized = normalizeFieldInstruction(raw);
+  if (normalized === null || normalized.length === 0) return null;
+  const stripped = stripTrailingSwitches(normalized);
+
+  const direct = KEYWORD_TO_PROPERTY[stripped];
+  if (direct) return { property: direct };
+
+  if (!stripped.startsWith('DOCPROPERTY')) return null;
+  const rest = stripped.slice('DOCPROPERTY'.length);
+  // The keyword must be followed by whitespace before the name: `DOCPROPERTYX` is not a match.
+  if (rest.length === 0 || !/^\s/.test(rest)) return null;
+  const name = firstToken(rest);
+  if (name === null) return null;
+  const property = KEYWORD_TO_PROPERTY[name];
+  return property ? { property } : null;
+}
+
+/**
+ * Resolve a recognized field to the text it paints, or null when the property is missing or
+ * empty (the field then paints nothing, exactly as an empty cached result would).
+ */
+export function docPropertyValue(
+  field: DocPropertyField,
+  props: DocumentProperties | undefined
+): string | null {
+  if (!props) return null;
+  const value = props[field.property];
+  return value !== undefined && value.length > 0 ? value : null;
+}

--- a/packages/core/src/layout/field-form.ts
+++ b/packages/core/src/layout/field-form.ts
@@ -1,0 +1,115 @@
+// FORMCHECKBOX / FORMDROPDOWN legacy form fields (§17.16.5.22, §17.16.5.16).
+//
+// Their state lives in `w:ffData` under the begin `w:fldChar`, read once at the trust boundary
+// by `store/package/field-nodes.ts` (`legacyFormFieldDataOf` — state only, macros never). This
+// module decides what that state paints over the field's single reserved atom unit:
+//
+// - FORMCHECKBOX always renders from ffData — the checked bit is the authority, so a stale
+//   cached glyph never wins. ☒ (U+2612) when checked, ☐ (U+2610) when not; an explicit
+//   `w:size` overrides the run's font size, `w:sizeAuto` keeps it.
+// - FORMDROPDOWN prefers its cached result (what Word last painted) and synthesizes the
+//   selected entry only when the cache is empty.
+//
+// Everything fails closed to the previous behavior (cached text or nothing): an instruction
+// without matching ffData state, an empty entry list, an empty selected entry.
+
+import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
+import { normalizeFieldInstruction } from './field-instruction.ts';
+import { parseHyperlinkInstruction, type HyperlinkFieldSpec } from './field-link.ts';
+import { parseSymbolInstruction, type SymbolFieldSpec } from './field-symbol.ts';
+import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
+
+/** Which legacy form field a complex-field instruction names. */
+export type FormFieldKind = 'checkbox' | 'dropdown';
+
+/** BALLOT BOX WITH X — what Word paints for a checked FORMCHECKBOX. */
+export const CHECKBOX_CHECKED_GLYPH = '☒';
+/** BALLOT BOX — the unchecked FORMCHECKBOX glyph. */
+export const CHECKBOX_UNCHECKED_GLYPH = '☐';
+
+/**
+ * Recognize a FORMCHECKBOX / FORMDROPDOWN instruction, bounded and normalized like every
+ * other allowlisted instruction. Anything else — including an overflowing instruction — is
+ * null and stays inert.
+ */
+export function parseFormFieldInstruction(raw: string): FormFieldKind | null {
+  const normalized = normalizeFieldInstruction(raw);
+  if (normalized === 'FORMCHECKBOX') return 'checkbox';
+  if (normalized === 'FORMDROPDOWN') return 'dropdown';
+  return null;
+}
+
+/**
+ * The instruction-derived specs a pending atomic field captures before the machine's buffer
+ * resets. Structural rather than `PendingFieldProjection` so this module needs nothing from
+ * the walk's vocabulary.
+ */
+export interface CapturedInstructionSpecs {
+  symbolSpec: SymbolFieldSpec | null;
+  linkSpec: HyperlinkFieldSpec | null;
+  formSpec: FormFieldKind | null;
+}
+
+/**
+ * Capture every instruction-derived spec at once — at the outermost `separate`, or at the
+ * no-separate `end`, while the machine still holds the raw instruction. The instructions are
+ * mutually exclusive, so the first recognizer that hits wins and the rest stay null.
+ */
+export function captureInstructionSpecs(pending: CapturedInstructionSpecs, raw: string): void {
+  pending.symbolSpec = parseSymbolInstruction(raw);
+  if (pending.symbolSpec) return;
+  pending.linkSpec = parseHyperlinkInstruction(raw);
+  if (pending.linkSpec) return;
+  pending.formSpec = parseFormFieldInstruction(raw);
+}
+
+/** The synthesized form-field result: text plus the props/style the piece should carry. */
+export interface FormFieldGlyph {
+  readonly text: string;
+  readonly props: readonly OoxmlProperty[];
+  readonly style: ResolvedRunStyle;
+}
+
+/**
+ * Resolve a pending form field to the text it paints, or null to fall through to the
+ * existing branches (cached text or nothing).
+ *
+ * A checkbox synthesizes unconditionally when its ffData state is present — ffData is the
+ * state authority and a stale cached glyph must not win. A dropdown defers to a non-empty
+ * cached result first. A form instruction whose ffData is missing or of the wrong shape
+ * fails closed.
+ */
+export function formFieldResult(
+  pending: {
+    readonly formSpec: FormFieldKind | null;
+    readonly formData: LegacyFormFieldData | null;
+    readonly cachedText: string;
+    readonly props: readonly OoxmlProperty[];
+    readonly style: ResolvedRunStyle;
+  },
+  themeFonts?: ThemeFonts
+): FormFieldGlyph | null {
+  if (pending.formSpec === 'checkbox') {
+    if (pending.formData?.kind !== 'checkbox') return null;
+    const text = pending.formData.checked ? CHECKBOX_CHECKED_GLYPH : CHECKBOX_UNCHECKED_GLYPH;
+    if (pending.formData.sizeHalfPoints === null) {
+      return { text, props: pending.props, style: pending.style };
+    }
+    // Explicit `w:size` is half-points, same unit as `w:sz` — landed as an override on the
+    // result-style chain and resolved through the ordinary cascade.
+    const props: readonly OoxmlProperty[] = [
+      ...pending.props,
+      { localName: 'sz', attributes: { val: String(pending.formData.sizeHalfPoints) } },
+    ];
+    return { text, props, style: resolveRunStyle(props, themeFonts) };
+  }
+  if (pending.formSpec === 'dropdown') {
+    if (pending.cachedText.length > 0) return null;
+    if (pending.formData?.kind !== 'dropdown') return null;
+    const text = pending.formData.entries[pending.formData.selectedIndex] ?? '';
+    if (text.length === 0) return null;
+    return { text, props: pending.props, style: pending.style };
+  }
+  return null;
+}

--- a/packages/core/src/layout/field-form.ts
+++ b/packages/core/src/layout/field-form.ts
@@ -8,7 +8,8 @@
 //   cached glyph never wins. ☒ (U+2612) when checked, ☐ (U+2610) when not; an explicit
 //   `w:size` overrides the run's font size, `w:sizeAuto` keeps it.
 // - FORMDROPDOWN prefers its cached result (what Word last painted) and synthesizes the
-//   selected entry only when the cache is empty.
+//   selected entry only when the file cached none at all — a cached result that exists but
+//   is hidden stays hidden.
 //
 // Everything fails closed to the previous behavior (cached text or nothing): an instruction
 // without matching ffData state, an empty entry list, an empty selected entry.
@@ -89,6 +90,8 @@ export function formFieldResult(
     readonly formSpec: FormFieldKind | null;
     readonly formData: LegacyFormFieldData | null;
     readonly cachedText: string;
+    /** Any result-phase content existed, hidden or not — see `PendingFieldProjection`. */
+    readonly sawResultContent: boolean;
     readonly props: readonly OoxmlProperty[];
     readonly style: ResolvedRunStyle;
   },
@@ -109,7 +112,9 @@ export function formFieldResult(
     return { text, props, style: resolveRunStyle(props, themeFonts) };
   }
   if (pending.formSpec === 'dropdown') {
-    if (pending.cachedText.length > 0) return null;
+    // A non-empty cache falls through to paint as-is; a cache that existed but was hidden
+    // suppresses synthesis too — the file said this result is not shown.
+    if (pending.cachedText.length > 0 || pending.sawResultContent) return null;
     if (pending.formData?.kind !== 'dropdown') return null;
     const text = pending.formData.entries[pending.formData.selectedIndex] ?? '';
     if (text.length === 0) return null;

--- a/packages/core/src/layout/field-form.ts
+++ b/packages/core/src/layout/field-form.ts
@@ -17,6 +17,7 @@
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
 import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
 import { parseButtonInstruction, type ButtonFieldSpec } from './field-button.ts';
+import { parseDocPropertyInstruction, type DocPropertyField } from './field-doc-property.ts';
 import { normalizeFieldInstruction } from './field-instruction.ts';
 import { parseHyperlinkInstruction, type HyperlinkFieldSpec } from './field-link.ts';
 import { parseSymbolInstruction, type SymbolFieldSpec } from './field-symbol.ts';
@@ -52,6 +53,7 @@ export interface CapturedInstructionSpecs {
   linkSpec: HyperlinkFieldSpec | null;
   formSpec: FormFieldKind | null;
   buttonSpec: ButtonFieldSpec | null;
+  docPropertySpec: DocPropertyField | null;
 }
 
 /**
@@ -67,6 +69,8 @@ export function captureInstructionSpecs(pending: CapturedInstructionSpecs, raw: 
   pending.formSpec = parseFormFieldInstruction(raw);
   if (pending.formSpec) return;
   pending.buttonSpec = parseButtonInstruction(raw);
+  if (pending.buttonSpec) return;
+  pending.docPropertySpec = parseDocPropertyInstruction(raw);
 }
 
 /** The synthesized form-field result: text plus the props/style the piece should carry. */

--- a/packages/core/src/layout/field-form.ts
+++ b/packages/core/src/layout/field-form.ts
@@ -15,6 +15,7 @@
 
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
 import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
+import { parseButtonInstruction, type ButtonFieldSpec } from './field-button.ts';
 import { normalizeFieldInstruction } from './field-instruction.ts';
 import { parseHyperlinkInstruction, type HyperlinkFieldSpec } from './field-link.ts';
 import { parseSymbolInstruction, type SymbolFieldSpec } from './field-symbol.ts';
@@ -49,6 +50,7 @@ export interface CapturedInstructionSpecs {
   symbolSpec: SymbolFieldSpec | null;
   linkSpec: HyperlinkFieldSpec | null;
   formSpec: FormFieldKind | null;
+  buttonSpec: ButtonFieldSpec | null;
 }
 
 /**
@@ -62,6 +64,8 @@ export function captureInstructionSpecs(pending: CapturedInstructionSpecs, raw: 
   pending.linkSpec = parseHyperlinkInstruction(raw);
   if (pending.linkSpec) return;
   pending.formSpec = parseFormFieldInstruction(raw);
+  if (pending.formSpec) return;
+  pending.buttonSpec = parseButtonInstruction(raw);
 }
 
 /** The synthesized form-field result: text plus the props/style the piece should carry. */

--- a/packages/core/src/layout/field-form.ts
+++ b/packages/core/src/layout/field-form.ts
@@ -90,7 +90,7 @@ export function formFieldResult(
     readonly formSpec: FormFieldKind | null;
     readonly formData: LegacyFormFieldData | null;
     readonly cachedText: string;
-    /** Any result-phase content existed, hidden or not — see `PendingFieldProjection`. */
+    /** Result content this display mode keeps existed — see `PendingFieldProjection`. */
     readonly sawResultContent: boolean;
     readonly props: readonly OoxmlProperty[];
     readonly style: ResolvedRunStyle;

--- a/packages/core/src/layout/field-instruction.ts
+++ b/packages/core/src/layout/field-instruction.ts
@@ -313,8 +313,9 @@ export function isInsideFieldResult(state: ComplexFieldParseState): boolean {
  * each paragraph — the same machine paragraph projection uses — and resets at paragraph
  * boundaries so malformed cross-paragraph fields never count. Allowlisted `w:fldSimple`
  * instructions count too, and a non-page simple field is still descended so a nested complex
- * PAGE inside it is not missed. A complex PAGE nested inside another complex field counts the
- * same way: `onFldCharSeparate` answers per level, so the separate branch below notes it.
+ * PAGE inside it is not missed. A complex PAGE nested inside another complex field's RESULT
+ * counts the same way: `onFldCharSeparate` answers per level, and the separate branch below
+ * notes it when projection can replace it (outer result phase, within the nesting cap).
  * Instruction text is extracted iteratively under the same node/depth/character budgets.
  */
 export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
@@ -332,11 +333,19 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
     else hasSectionPages = true;
   };
 
+  // Once a paragraph shows hostile nesting, the atomic-span parser fails closed for the
+  // REST of that paragraph (`parsedFieldSpansOf` refuses the suffix rather than rescanning
+  // it quadratically), so projection paints every later field there verbatim. Detection must
+  // agree for the same suffix, or a footer with one hostile field pays a per-sheet layout
+  // that paints identical text on every page. Cleared at paragraph boundaries.
+  let paragraphPoisoned = false;
+
   const processFieldChild = (grand: OoxmlNode, depth: number): void => {
     if (grand.kind === 'runProperties') return;
 
     if (isFldChar(grand, 'begin')) {
       onFldCharBegin(field);
+      if (field.nestingOverflow) paragraphPoisoned = true;
       return;
     }
 
@@ -346,8 +355,16 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
     }
 
     if (isFldChar(grand, 'separate')) {
+      const level = field.nesting;
+      const phase = field.phase;
       const kind = onFldCharSeparate(field);
-      if (kind) note(kind);
+      if (paragraphPoisoned) return;
+      // Note only what projection can actually replace. A top-level (level-1) field always
+      // projects. A NESTED field projects only out of the outer field's RESULT: a page field
+      // inside an outer INSTRUCTION (`IF { PAGE } = 1 "x"`) is never painted at all, and a
+      // field past the nesting cap demotes to verbatim text — noting either buys a per-sheet
+      // relayout that paints identical text on every page.
+      if (kind && (level <= 1 || phase === 'result')) note(kind);
       return;
     }
 
@@ -372,8 +389,10 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
         grand.children.length > 0
       ) {
         const saved = { ...field };
+        const savedPoison = paragraphPoisoned;
         walk(grand, depth + 1);
         Object.assign(field, saved);
+        paragraphPoisoned = savedPoison;
       }
       if (complete() || budget.exhausted) return;
     }
@@ -389,12 +408,14 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
     // begin in one paragraph cannot pair with separate/end in another.
     if (node.kind === 'paragraph') {
       resetFieldParseState(field);
+      paragraphPoisoned = false;
       for (const child of node.children) {
         walk(child, depth + 1);
         if (complete()) return;
         if (budget.exhausted) return;
       }
       resetFieldParseState(field);
+      paragraphPoisoned = false;
       return;
     }
 

--- a/packages/core/src/layout/field-instruction.ts
+++ b/packages/core/src/layout/field-instruction.ts
@@ -473,6 +473,14 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
   // that paints identical text on every page. Cleared at paragraph boundaries.
   let paragraphPoisoned = false;
 
+  // Notes are provisional until the OUTER span closes cleanly. A note fires at separate-time,
+  // but a LATER nesting overflow in the same span demotes the whole store span (the parser
+  // above breaks for the suffix), so projection paints the noted field's cached digits
+  // verbatim — a note that stood would buy a per-sheet relayout of identical text. Level-1
+  // notes buffer the same way: the overflow demotes the level-1 span too. Flushed at the
+  // outer end when the paragraph was not poisoned; dropped otherwise.
+  let pendingNotes: AllowlistedPageField[] = [];
+
   const processFieldChild = (grand: OoxmlNode, depth: number): void => {
     if (grand.kind === 'runProperties') return;
 
@@ -497,12 +505,16 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
       // inside an outer INSTRUCTION (`IF { PAGE } = 1 "x"`) is never painted at all, and a
       // field past the nesting cap demotes to verbatim text — noting either buys a per-sheet
       // relayout that paints identical text on every page.
-      if (kind && (level <= 1 || phase === 'result')) note(kind);
+      if (kind && (level <= 1 || phase === 'result')) pendingNotes.push(kind);
       return;
     }
 
     if (isFldChar(grand, 'end')) {
       onFldCharEnd(field);
+      if (field.nesting === 0) {
+        if (!paragraphPoisoned) for (const kind of pendingNotes) note(kind);
+        pendingNotes.length = 0;
+      }
     }
   };
 
@@ -521,11 +533,21 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
         'children' in grand &&
         grand.children.length > 0
       ) {
-        const saved = { ...field };
+        // Deep-copy the per-level captures: a shallow copy aliases the `inner` array and its
+        // level objects, so the nested story's paragraph resets would empty the saved capture
+        // too and a level-2 field straddling the drawing would lose its instruction. Level-1
+        // fields are strings/booleans — the spread copies those by value.
+        const saved: ComplexFieldParseState = {
+          ...field,
+          inner: field.inner.map((level) => ({ ...level })),
+        };
         const savedPoison = paragraphPoisoned;
+        const savedPending = pendingNotes;
+        pendingNotes = [];
         walk(grand, depth + 1);
         Object.assign(field, saved);
         paragraphPoisoned = savedPoison;
+        pendingNotes = savedPending;
       }
       if (complete() || budget.exhausted) return;
     }
@@ -542,6 +564,9 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
     if (node.kind === 'paragraph') {
       resetFieldParseState(field);
       paragraphPoisoned = false;
+      // A span still open at a paragraph boundary is malformed and never projects; its
+      // buffered notes drop with it.
+      pendingNotes.length = 0;
       for (const child of node.children) {
         walk(child, depth + 1);
         if (complete()) return;
@@ -549,6 +574,7 @@ export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
       }
       resetFieldParseState(field);
       paragraphPoisoned = false;
+      pendingNotes.length = 0;
       return;
     }
 

--- a/packages/core/src/layout/field-instruction.ts
+++ b/packages/core/src/layout/field-instruction.ts
@@ -121,12 +121,22 @@ export function consumeScanNode(budget: FieldScanBudget): boolean {
  */
 type FieldParsePhase = 'idle' | 'instruction' | 'result';
 
+/** Instruction capture for one NESTED field level (2..{@link MAX_FIELD_NESTING}). */
+interface NestedInstructionLevel {
+  instruction: string;
+  overflow: boolean;
+  separated: boolean;
+}
+
 export interface ComplexFieldParseState {
   nesting: number;
+  /** Level 1 (outermost) instruction buffer; levels 2+ live in {@link ComplexFieldParseState.inner}. */
   instruction: string;
   instructionOverflow: boolean;
   nestingOverflow: boolean;
   phase: FieldParsePhase;
+  /** Level N (2..{@link MAX_FIELD_NESTING}) at index N-2; deeper levels are never captured. */
+  inner: NestedInstructionLevel[];
 }
 
 export function createFieldParseState(): ComplexFieldParseState {
@@ -136,6 +146,7 @@ export function createFieldParseState(): ComplexFieldParseState {
     instructionOverflow: false,
     nestingOverflow: false,
     phase: 'idle',
+    inner: [],
   };
 }
 
@@ -145,6 +156,7 @@ export function resetFieldParseState(state: ComplexFieldParseState): void {
   state.instructionOverflow = false;
   state.nestingOverflow = false;
   state.phase = 'idle';
+  state.inner.length = 0;
 }
 
 export function onFldCharBegin(state: ComplexFieldParseState): void {
@@ -153,19 +165,55 @@ export function onFldCharBegin(state: ComplexFieldParseState): void {
     state.instructionOverflow = false;
     state.nestingOverflow = false;
     state.phase = 'instruction';
+    state.inner.length = 0;
   }
   state.nesting += 1;
-  if (state.nesting > MAX_FIELD_NESTING) state.nestingOverflow = true;
+  if (state.nesting > MAX_FIELD_NESTING) {
+    state.nestingOverflow = true;
+  } else if (state.nesting >= 2) {
+    // A sibling reopening this level replaces its capture, so one overflowed inner field
+    // never poisons the well-formed inner field after it.
+    state.inner[state.nesting - 2] = { instruction: '', overflow: false, separated: false };
+  }
 }
 
-export function onInstrText(state: ComplexFieldParseState, chunk: string): void {
-  if (state.phase !== 'instruction' || state.nesting !== 1 || state.instructionOverflow) return;
-  if (state.instruction.length + chunk.length > MAX_FIELD_INSTRUCTION_CHARS) {
+/** The capture for the innermost OPEN nested level, or null at level 1 / past the depth cap. */
+function innerLevelOf(state: ComplexFieldParseState): NestedInstructionLevel | null {
+  if (state.nesting < 2 || state.nesting > MAX_FIELD_NESTING) return null;
+  return state.inner[state.nesting - 2] ?? null;
+}
+
+/** True when the innermost open level still accepts instruction text. */
+function collectingLevelInstruction(state: ComplexFieldParseState): boolean {
+  if (state.nesting === 1) return state.phase === 'instruction' && !state.instructionOverflow;
+  const level = innerLevelOf(state);
+  return level !== null && !level.separated && !level.overflow;
+}
+
+/** Mark the innermost open level's instruction inert (char cap / budget / depth miss). */
+function overflowLevelInstruction(state: ComplexFieldParseState): void {
+  if (state.nesting === 1) {
     state.instructionOverflow = true;
     state.instruction = '';
     return;
   }
-  state.instruction += chunk;
+  const level = innerLevelOf(state);
+  if (level) {
+    level.overflow = true;
+    level.instruction = '';
+  }
+}
+
+export function onInstrText(state: ComplexFieldParseState, chunk: string): void {
+  if (!collectingLevelInstruction(state)) return;
+  const level = innerLevelOf(state);
+  const buffer = level ? level.instruction : state.instruction;
+  if (buffer.length + chunk.length > MAX_FIELD_INSTRUCTION_CHARS) {
+    overflowLevelInstruction(state);
+    return;
+  }
+  if (level) level.instruction = buffer + chunk;
+  else state.instruction = buffer + chunk;
 }
 
 /**
@@ -181,13 +229,12 @@ export function ingestInstrTextBounded(
   budget: FieldScanBudget,
   instrDepth: number
 ): void {
-  if (state.phase !== 'instruction' || state.nesting !== 1 || state.instructionOverflow) {
+  if (!collectingLevelInstruction(state)) {
     // Still charge the instrText node itself when the caller has not already.
     return;
   }
   if (instrDepth > MAX_STORY_FIELD_SCAN_DEPTH) {
-    state.instructionOverflow = true;
-    state.instruction = '';
+    overflowLevelInstruction(state);
     return;
   }
 
@@ -202,18 +249,16 @@ export function ingestInstrTextBounded(
   while (stack.length > 0) {
     const frame = stack.pop()!;
     if (!consumeScanNode(budget)) {
-      state.instructionOverflow = true;
-      state.instruction = '';
+      overflowLevelInstruction(state);
       return;
     }
     if (frame.depth > MAX_STORY_FIELD_SCAN_DEPTH) {
-      state.instructionOverflow = true;
-      state.instruction = '';
+      overflowLevelInstruction(state);
       return;
     }
     if (frame.node.kind === 'textValue') {
       onInstrText(state, frame.node.value);
-      if (state.instructionOverflow) return;
+      if (!collectingLevelInstruction(state)) return;
       continue;
     }
     const grandChildren = frame.node.children ?? [];
@@ -224,14 +269,26 @@ export function ingestInstrTextBounded(
 }
 
 /**
- * Advance past `fldChar separate`. Returns an allowlisted kind when the outermost field's
- * instruction is evaluable; otherwise null (inert / nested / overflow).
+ * Advance past `fldChar separate`. Returns an allowlisted kind when the separated field's
+ * instruction is evaluable; otherwise null (inert / overflow / nested too deep).
+ *
+ * At level 1 this also moves the machine into the result phase. At levels 2..
+ * {@link MAX_FIELD_NESTING} the outer phase is untouched: the level's own capture answers, so
+ * a PAGE nested inside another field's cached result is recognized instead of staying inert.
+ * Deeper levels and levels whose own instruction overflowed stay null (fail closed).
  */
 export function onFldCharSeparate(state: ComplexFieldParseState): AllowlistedPageField | null {
-  if (state.nesting !== 1 || state.phase !== 'instruction') return null;
-  state.phase = 'result';
-  if (state.instructionOverflow || state.nestingOverflow) return null;
-  return allowlistedPageField(state.instruction);
+  if (state.nesting === 1) {
+    if (state.phase !== 'instruction') return null;
+    state.phase = 'result';
+    if (state.instructionOverflow || state.nestingOverflow) return null;
+    return allowlistedPageField(state.instruction);
+  }
+  const level = innerLevelOf(state);
+  if (!level || level.separated) return null;
+  level.separated = true;
+  if (level.overflow) return null;
+  return allowlistedPageField(level.instruction);
 }
 
 export function onFldCharEnd(state: ComplexFieldParseState): void {
@@ -256,8 +313,9 @@ export function isInsideFieldResult(state: ComplexFieldParseState): boolean {
  * each paragraph — the same machine paragraph projection uses — and resets at paragraph
  * boundaries so malformed cross-paragraph fields never count. Allowlisted `w:fldSimple`
  * instructions count too, and a non-page simple field is still descended so a nested complex
- * PAGE inside it is not missed. Instruction text is extracted iteratively under the same
- * node/depth/character budgets.
+ * PAGE inside it is not missed. A complex PAGE nested inside another complex field counts the
+ * same way: `onFldCharSeparate` answers per level, so the separate branch below notes it.
+ * Instruction text is extracted iteratively under the same node/depth/character budgets.
  */
 export function detectStoryPageFields(root: OoxmlNode): StoryPageFieldNeeds {
   let hasPage = false;

--- a/packages/core/src/layout/field-instruction.ts
+++ b/packages/core/src/layout/field-instruction.ts
@@ -17,10 +17,17 @@ import {
   isInstrText as isInstrTextHelper,
   type OoxmlNode,
 } from '@docx-editor.dev/core/store';
-import { isDeletedInstrText } from '../store/package/field-nodes.ts';
+import { isDeletedInstrText, MAX_FIELD_INSTRUCTION_CHARS } from '../store/package/field-nodes.ts';
 
-/** Caps hostile instruction blobs and nesting depth (fail closed → inert). */
-export const MAX_FIELD_INSTRUCTION_CHARS = 256;
+/**
+ * Caps hostile instruction blobs and nesting depth (fail closed → inert).
+ *
+ * The character cap is the store's `MAX_FIELD_INSTRUCTION_CHARS` — one source of truth, so
+ * `parsedFieldSpansOf` addressing never diverges from what this machine buffers. It matches
+ * the `w:fldSimple` lane (`MAX_HYPERLINK_INSTRUCTION_CHARS`): a long `HYPERLINK` URL parses
+ * identically as a complex field and as a simple field.
+ */
+export { MAX_FIELD_INSTRUCTION_CHARS };
 export const MAX_FIELD_NESTING = 4;
 
 /**

--- a/packages/core/src/layout/field-instruction.ts
+++ b/packages/core/src/layout/field-instruction.ts
@@ -17,6 +17,7 @@ import {
   isInstrText as isInstrTextHelper,
   type OoxmlNode,
 } from '@docx-editor.dev/core/store';
+import { isDeletedInstrText } from '../store/package/field-nodes.ts';
 
 /** Caps hostile instruction blobs and nesting depth (fail closed → inert). */
 export const MAX_FIELD_INSTRUCTION_CHARS = 256;
@@ -121,18 +122,45 @@ export function consumeScanNode(budget: FieldScanBudget): boolean {
  */
 type FieldParsePhase = 'idle' | 'instruction' | 'result';
 
-/** Instruction capture for one NESTED field level (2..{@link MAX_FIELD_NESTING}). */
+/**
+ * Instruction capture for one NESTED field level (2..{@link MAX_FIELD_NESTING}).
+ *
+ * LIVE (`w:instrText`) and DELETED (`w:delInstrText`) chunks buffer separately — see
+ * {@link ComplexFieldParseState} for why concatenating them invents an instruction nobody
+ * authored.
+ */
 interface NestedInstructionLevel {
   instruction: string;
   overflow: boolean;
+  deletedInstruction: string;
+  deletedOverflow: boolean;
+  /** A live `instrText` element was seen — the live buffer answers, even when empty. */
+  sawLive: boolean;
   separated: boolean;
 }
 
 export interface ComplexFieldParseState {
   nesting: number;
-  /** Level 1 (outermost) instruction buffer; levels 2+ live in {@link ComplexFieldParseState.inner}. */
+  /**
+   * Level 1 (outermost) LIVE instruction buffer; levels 2+ live in
+   * {@link ComplexFieldParseState.inner}.
+   *
+   * A tracked edit of a field code leaves `w:delInstrText` (the deleted chunks) NEXT TO
+   * `w:instrText` (the live ones) in the same field. They buffer separately because
+   * concatenating them produces an instruction nobody authored — ` PAGE  NUMPAGES ` from a
+   * live NUMPAGES whose old PAGE code is still pending deletion — and that merged string
+   * fails the allowlist, flips FORMTEXT addressing, and lets a large deleted chunk overflow
+   * a small live instruction. The EFFECTIVE instruction is the live buffer whenever any live
+   * element exists, else the deleted buffer (a fully-deleted field keeps evaluating, with
+   * delete attribution). Overflow is accounted per buffer for the same reason.
+   */
   instruction: string;
   instructionOverflow: boolean;
+  /** Level 1 DELETED (`w:delInstrText`) buffer; answers only when no live element exists. */
+  deletedInstruction: string;
+  deletedInstructionOverflow: boolean;
+  /** A live level-1 `instrText` element was seen — the live buffer answers, even when empty. */
+  sawLiveInstruction: boolean;
   nestingOverflow: boolean;
   phase: FieldParsePhase;
   /** Level N (2..{@link MAX_FIELD_NESTING}) at index N-2; deeper levels are never captured. */
@@ -144,6 +172,9 @@ export function createFieldParseState(): ComplexFieldParseState {
     nesting: 0,
     instruction: '',
     instructionOverflow: false,
+    deletedInstruction: '',
+    deletedInstructionOverflow: false,
+    sawLiveInstruction: false,
     nestingOverflow: false,
     phase: 'idle',
     inner: [],
@@ -154,15 +185,46 @@ export function resetFieldParseState(state: ComplexFieldParseState): void {
   state.nesting = 0;
   state.instruction = '';
   state.instructionOverflow = false;
+  state.deletedInstruction = '';
+  state.deletedInstructionOverflow = false;
+  state.sawLiveInstruction = false;
   state.nestingOverflow = false;
   state.phase = 'idle';
   state.inner.length = 0;
+}
+
+/** The instruction that would take effect if the field's tracked edits were accepted. */
+export interface EffectiveFieldInstruction {
+  readonly instruction: string;
+  readonly overflow: boolean;
+}
+
+/**
+ * Resolve the level-1 EFFECTIVE instruction: the live buffer when any live `instrText`
+ * element exists (even an empty one — accepting the deletion leaves exactly that), else the
+ * deleted buffer, so a fully-deleted field keeps evaluating with delete attribution.
+ */
+export function effectiveFieldInstruction(
+  state: ComplexFieldParseState
+): EffectiveFieldInstruction {
+  return state.sawLiveInstruction
+    ? { instruction: state.instruction, overflow: state.instructionOverflow }
+    : { instruction: state.deletedInstruction, overflow: state.deletedInstructionOverflow };
+}
+
+function effectiveLevelInstruction(level: NestedInstructionLevel): EffectiveFieldInstruction {
+  return level.sawLive
+    ? { instruction: level.instruction, overflow: level.overflow }
+    : { instruction: level.deletedInstruction, overflow: level.deletedOverflow };
 }
 
 export function onFldCharBegin(state: ComplexFieldParseState): void {
   if (state.nesting === 0) {
     state.instruction = '';
     state.instructionOverflow = false;
+    state.deletedInstruction = '';
+    state.deletedInstructionOverflow = false;
+    state.sawLiveInstruction = false;
     state.nestingOverflow = false;
     state.phase = 'instruction';
     state.inner.length = 0;
@@ -173,7 +235,14 @@ export function onFldCharBegin(state: ComplexFieldParseState): void {
   } else if (state.nesting >= 2) {
     // A sibling reopening this level replaces its capture, so one overflowed inner field
     // never poisons the well-formed inner field after it.
-    state.inner[state.nesting - 2] = { instruction: '', overflow: false, separated: false };
+    state.inner[state.nesting - 2] = {
+      instruction: '',
+      overflow: false,
+      deletedInstruction: '',
+      deletedOverflow: false,
+      sawLive: false,
+      separated: false,
+    };
   }
 }
 
@@ -183,37 +252,92 @@ function innerLevelOf(state: ComplexFieldParseState): NestedInstructionLevel | n
   return state.inner[state.nesting - 2] ?? null;
 }
 
-/** True when the innermost open level still accepts instruction text. */
-function collectingLevelInstruction(state: ComplexFieldParseState): boolean {
-  if (state.nesting === 1) return state.phase === 'instruction' && !state.instructionOverflow;
+/** True when the innermost open level is still in its instruction phase at all. */
+function levelAcceptsInstruction(state: ComplexFieldParseState): boolean {
+  if (state.nesting === 1) return state.phase === 'instruction';
   const level = innerLevelOf(state);
-  return level !== null && !level.separated && !level.overflow;
+  return level !== null && !level.separated;
 }
 
-/** Mark the innermost open level's instruction inert (char cap / budget / depth miss). */
-function overflowLevelInstruction(state: ComplexFieldParseState): void {
+/** True when the innermost open level still accepts text into the given buffer. */
+function collectingLevelInstruction(state: ComplexFieldParseState, deleted: boolean): boolean {
+  if (!levelAcceptsInstruction(state)) return false;
   if (state.nesting === 1) {
-    state.instructionOverflow = true;
-    state.instruction = '';
+    return deleted ? !state.deletedInstructionOverflow : !state.instructionOverflow;
+  }
+  const level = innerLevelOf(state)!;
+  return deleted ? !level.deletedOverflow : !level.overflow;
+}
+
+/** Note a live `instrText` ELEMENT so the live buffer answers, even when it stays empty. */
+function markLiveInstructionSeen(state: ComplexFieldParseState): void {
+  if (state.nesting === 1) {
+    state.sawLiveInstruction = true;
     return;
   }
   const level = innerLevelOf(state);
-  if (level) {
+  if (level) level.sawLive = true;
+}
+
+/** Mark ONE buffer of the innermost open level inert (its own character cap). */
+function overflowLevelBuffer(state: ComplexFieldParseState, deleted: boolean): void {
+  if (state.nesting === 1) {
+    if (deleted) {
+      state.deletedInstructionOverflow = true;
+      state.deletedInstruction = '';
+    } else {
+      state.instructionOverflow = true;
+      state.instruction = '';
+    }
+    return;
+  }
+  const level = innerLevelOf(state);
+  if (!level) return;
+  if (deleted) {
+    level.deletedOverflow = true;
+    level.deletedInstruction = '';
+  } else {
     level.overflow = true;
     level.instruction = '';
   }
 }
 
-export function onInstrText(state: ComplexFieldParseState, chunk: string): void {
-  if (!collectingLevelInstruction(state)) return;
+/**
+ * Mark the innermost open level's instruction inert entirely (budget / depth miss).
+ *
+ * Both buffers fail closed together: a scan that ran out of budget cannot say which chunks
+ * it never saw, so neither buffer may claim to be complete.
+ */
+function overflowLevelInstruction(state: ComplexFieldParseState): void {
+  overflowLevelBuffer(state, false);
+  overflowLevelBuffer(state, true);
+}
+
+export function onInstrText(state: ComplexFieldParseState, chunk: string, deleted = false): void {
+  if (!collectingLevelInstruction(state, deleted)) return;
   const level = innerLevelOf(state);
-  const buffer = level ? level.instruction : state.instruction;
+  if (!deleted) markLiveInstructionSeen(state);
+  const buffer = level
+    ? deleted
+      ? level.deletedInstruction
+      : level.instruction
+    : deleted
+      ? state.deletedInstruction
+      : state.instruction;
   if (buffer.length + chunk.length > MAX_FIELD_INSTRUCTION_CHARS) {
-    overflowLevelInstruction(state);
+    // Per-buffer accounting: a huge deleted chunk must not overflow a small live
+    // instruction sitting next to it, and vice versa.
+    overflowLevelBuffer(state, deleted);
     return;
   }
-  if (level) level.instruction = buffer + chunk;
-  else state.instruction = buffer + chunk;
+  if (level) {
+    if (deleted) level.deletedInstruction = buffer + chunk;
+    else level.instruction = buffer + chunk;
+  } else if (deleted) {
+    state.deletedInstruction = buffer + chunk;
+  } else {
+    state.instruction = buffer + chunk;
+  }
 }
 
 /**
@@ -229,10 +353,16 @@ export function ingestInstrTextBounded(
   budget: FieldScanBudget,
   instrDepth: number
 ): void {
-  if (!collectingLevelInstruction(state)) {
+  if (!levelAcceptsInstruction(state)) {
     // Still charge the instrText node itself when the caller has not already.
     return;
   }
+  // One element is entirely live or entirely deleted — `w:delInstrText` is what a tracked
+  // deletion rewrites `w:instrText` into. A live element counts as a live instruction even
+  // when it holds no text: accepting the tracked deletion leaves exactly that.
+  const deleted = isDeletedInstrText(instrNode);
+  if (!deleted) markLiveInstructionSeen(state);
+  if (!collectingLevelInstruction(state, deleted)) return;
   if (instrDepth > MAX_STORY_FIELD_SCAN_DEPTH) {
     overflowLevelInstruction(state);
     return;
@@ -257,8 +387,8 @@ export function ingestInstrTextBounded(
       return;
     }
     if (frame.node.kind === 'textValue') {
-      onInstrText(state, frame.node.value);
-      if (!collectingLevelInstruction(state)) return;
+      onInstrText(state, frame.node.value, deleted);
+      if (!collectingLevelInstruction(state, deleted)) return;
       continue;
     }
     const grandChildren = frame.node.children ?? [];
@@ -281,14 +411,17 @@ export function onFldCharSeparate(state: ComplexFieldParseState): AllowlistedPag
   if (state.nesting === 1) {
     if (state.phase !== 'instruction') return null;
     state.phase = 'result';
-    if (state.instructionOverflow || state.nestingOverflow) return null;
-    return allowlistedPageField(state.instruction);
+    if (state.nestingOverflow) return null;
+    const effective = effectiveFieldInstruction(state);
+    if (effective.overflow) return null;
+    return allowlistedPageField(effective.instruction);
   }
   const level = innerLevelOf(state);
   if (!level || level.separated) return null;
   level.separated = true;
-  if (level.overflow) return null;
-  return allowlistedPageField(level.instruction);
+  const effective = effectiveLevelInstruction(level);
+  if (effective.overflow) return null;
+  return allowlistedPageField(effective.instruction);
 }
 
 export function onFldCharEnd(state: ComplexFieldParseState): void {

--- a/packages/core/src/layout/field-link.ts
+++ b/packages/core/src/layout/field-link.ts
@@ -12,9 +12,9 @@
 // grammar is recognized and the raw pieces are handed over verbatim, case and
 // percent-encoding preserved.
 
-/** Longest raw instruction even considered (matches the relationship-target bound). */
-export const MAX_HYPERLINK_INSTRUCTION_CHARS = 2048;
-/** Longest target captured — same bound the package puts on a relationship target. */
+/** Longest raw instruction even considered — room for a full-length target plus switches. */
+export const MAX_HYPERLINK_INSTRUCTION_CHARS = 4096;
+/** Longest target captured — the bound the package puts on a relationship target. */
 export const MAX_HYPERLINK_TARGET_CHARS = 2048;
 /** Longest `\l` anchor or `\o` tooltip captured. */
 export const MAX_HYPERLINK_SWITCH_ARG_CHARS = 256;
@@ -78,8 +78,10 @@ const ARGUMENT_SWITCHES = new Set(['\\l', '\\o', '\\t', '\\m', '\\n', '\\*', '\\
  * Recognition is the first token equalling `HYPERLINK` case-insensitively. The target is the
  * first quoted or bare token that is neither a switch nor a switch's argument; switches may
  * appear on either side of it. Duplicates: FIRST wins, for target and switches alike, which
- * is what Word does with a malformed double instruction. No target and no `\l` anchor is not
- * a link at all. Values are passed through verbatim — embedded whitespace inside a quoted
+ * is what Word does with a malformed double instruction — so an INVALID first target (empty
+ * quotes, or past the cap) forfeits the target rather than promoting a later token to it; an
+ * `\l` anchor may still make an internal link. No target and no `\l` anchor is not a link at
+ * all. Values are passed through verbatim — embedded whitespace inside a quoted
  * target survives; stripping smuggled control characters is the sanitizer's job, not the
  * parser's.
  */
@@ -91,6 +93,7 @@ export function parseHyperlinkInstruction(raw: string): HyperlinkFieldSpec | nul
   if (first.quoted || first.value.toUpperCase() !== 'HYPERLINK') return null;
 
   let target: string | null = null;
+  let targetTaken = false;
   let anchor: string | null = null;
   let tooltip: string | null = null;
   for (let i = 1; i < tokens.length; i += 1) {
@@ -109,12 +112,13 @@ export function parseHyperlinkInstruction(raw: string): HyperlinkFieldSpec | nul
       // `\t` / `\m` / `\n` / `\*` / `\#` / `\@`: argument consumed and ignored.
       continue;
     }
-    if (
-      target === null &&
-      token.value.length > 0 &&
-      token.value.length <= MAX_HYPERLINK_TARGET_CHARS
-    ) {
-      target = token.value;
+    if (!targetTaken) {
+      // The first target-position token CONSUMES target-hood even when it is invalid, so a
+      // hostile decoy (`""` or an over-cap blob) cannot promote a later token Word ignores.
+      targetTaken = true;
+      if (token.value.length > 0 && token.value.length <= MAX_HYPERLINK_TARGET_CHARS) {
+        target = token.value;
+      }
     }
     // A second bare/quoted token is a duplicate target: first wins.
   }

--- a/packages/core/src/layout/field-link.ts
+++ b/packages/core/src/layout/field-link.ts
@@ -101,7 +101,9 @@ export function parseHyperlinkInstruction(raw: string): HyperlinkFieldSpec | nul
   let target: string | null = null;
   let targetTaken = false;
   let anchor: string | null = null;
+  let anchorTaken = false;
   let tooltip: string | null = null;
+  let tooltipTaken = false;
   for (let i = 1; i < tokens.length; i += 1) {
     const token = tokens[i]!;
     if (!token.quoted && token.value.startsWith('\\')) {
@@ -113,8 +115,21 @@ export function parseHyperlinkInstruction(raw: string): HyperlinkFieldSpec | nul
       if (!arg || (!arg.quoted && arg.value.startsWith('\\'))) continue;
       i += 1;
       const withinCap = arg.value.length > 0 && arg.value.length <= MAX_HYPERLINK_SWITCH_ARG_CHARS;
-      if (name === '\\l' && anchor === null && withinCap) anchor = arg.value;
-      else if (name === '\\o' && tooltip === null && withinCap) tooltip = arg.value;
+      // First `\l` / `\o` CONSUMES the switch even when its argument is invalid (over-cap), so a
+      // later duplicate cannot win — the same first-wins rule the target token follows. An
+      // invalid first argument means the switch contributes nothing, not that it forfeits its
+      // slot to a later occurrence.
+      if (name === '\\l') {
+        if (!anchorTaken) {
+          anchorTaken = true;
+          if (withinCap) anchor = arg.value;
+        }
+      } else if (name === '\\o') {
+        if (!tooltipTaken) {
+          tooltipTaken = true;
+          if (withinCap) tooltip = arg.value;
+        }
+      }
       // `\t` / `\m` / `\n` / `\*` / `\#` / `\@`: argument consumed and ignored.
       continue;
     }

--- a/packages/core/src/layout/field-link.ts
+++ b/packages/core/src/layout/field-link.ts
@@ -1,0 +1,123 @@
+// HYPERLINK field (§17.16.5.25) instruction parsing.
+//
+// `HYPERLINK "target" [switches]` is how Word writes a link as a FIELD rather than as a typed
+// `w:hyperlink` element. The instruction is attacker-controlled: tokenization is one bounded
+// pass over a length-capped string, every captured value is length-capped again, and every
+// failure resolves to null (the caller paints the cached result as plain text, exactly as it
+// did before this module existed).
+//
+// THIS MODULE PRODUCES STRINGS, NEVER HREFS. Sanitization policy lives at the surface trust
+// boundary (`sanitizeHref` inside the projector the surface injects), so layout never decides
+// what a browser may follow. Nothing here fetches, resolves, or interprets a target — the
+// grammar is recognized and the raw pieces are handed over verbatim, case and
+// percent-encoding preserved.
+
+/** Longest raw instruction even considered (matches the relationship-target bound). */
+export const MAX_HYPERLINK_INSTRUCTION_CHARS = 2048;
+/** Longest target captured — same bound the package puts on a relationship target. */
+export const MAX_HYPERLINK_TARGET_CHARS = 2048;
+/** Longest `\l` anchor or `\o` tooltip captured. */
+export const MAX_HYPERLINK_SWITCH_ARG_CHARS = 256;
+
+/**
+ * One parsed `HYPERLINK` instruction: the raw, unsanitized pieces.
+ *
+ * `target` and `anchor` are verbatim from the instruction — the projector at the trust
+ * boundary decides what, if anything, they become in a DOM sink.
+ */
+export interface HyperlinkFieldSpec {
+  /** The target as authored (first quoted or bare non-switch token), or null. */
+  readonly target: string | null;
+  /** `\l` — a bookmark name in this document, or null. */
+  readonly anchor: string | null;
+  /** `\o` — the hover tooltip, or null. */
+  readonly tooltip: string | null;
+}
+
+interface InstructionToken {
+  readonly value: string;
+  readonly quoted: boolean;
+}
+
+/** One bounded pass; a quote opens a token that runs to the closing quote (or the end). */
+function tokenize(raw: string): InstructionToken[] {
+  const tokens: InstructionToken[] = [];
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw[i]!;
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      let j = i + 1;
+      while (j < raw.length && raw[j] !== '"') j += 1;
+      tokens.push({ value: raw.slice(i + 1, j), quoted: true });
+      i = j < raw.length ? j + 1 : j;
+      continue;
+    }
+    let j = i;
+    while (j < raw.length && !' \t\n\r"'.includes(raw[j]!)) j += 1;
+    tokens.push({ value: raw.slice(i, j), quoted: false });
+    i = j;
+  }
+  return tokens;
+}
+
+/**
+ * Switches that CONSUME the token after them. `\l` (anchor) and `\o` (tooltip) keep theirs;
+ * `\t` (target frame), `\m` (image-map coordinates) and `\n` (new window) are consumed and
+ * ignored; the generic formatting switches `\*` / `\#` / `\@` take a format argument that
+ * must not be mistaken for the target.
+ */
+const ARGUMENT_SWITCHES = new Set(['\\l', '\\o', '\\t', '\\m', '\\n', '\\*', '\\#', '\\@']);
+
+/**
+ * Parse a raw HYPERLINK instruction, or null when it is not one (or is hostile).
+ *
+ * Recognition is the first token equalling `HYPERLINK` case-insensitively. The target is the
+ * first quoted or bare token that is neither a switch nor a switch's argument; switches may
+ * appear on either side of it. Duplicates: FIRST wins, for target and switches alike, which
+ * is what Word does with a malformed double instruction. No target and no `\l` anchor is not
+ * a link at all. Values are passed through verbatim — embedded whitespace inside a quoted
+ * target survives; stripping smuggled control characters is the sanitizer's job, not the
+ * parser's.
+ */
+export function parseHyperlinkInstruction(raw: string): HyperlinkFieldSpec | null {
+  if (raw.length === 0 || raw.length > MAX_HYPERLINK_INSTRUCTION_CHARS) return null;
+  const tokens = tokenize(raw);
+  if (tokens.length < 2) return null;
+  const first = tokens[0]!;
+  if (first.quoted || first.value.toUpperCase() !== 'HYPERLINK') return null;
+
+  let target: string | null = null;
+  let anchor: string | null = null;
+  let tooltip: string | null = null;
+  for (let i = 1; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (!token.quoted && token.value.startsWith('\\')) {
+      const name = token.value.toLowerCase();
+      if (!ARGUMENT_SWITCHES.has(name)) continue; // unknown switch: inert, takes nothing
+      const arg = tokens[i + 1];
+      // A switch's argument is the next token unless that token is itself a switch — the
+      // same guard `field-symbol.ts` applies, so `\l \o "tip"` cannot eat the `\o`.
+      if (!arg || (!arg.quoted && arg.value.startsWith('\\'))) continue;
+      i += 1;
+      const withinCap = arg.value.length > 0 && arg.value.length <= MAX_HYPERLINK_SWITCH_ARG_CHARS;
+      if (name === '\\l' && anchor === null && withinCap) anchor = arg.value;
+      else if (name === '\\o' && tooltip === null && withinCap) tooltip = arg.value;
+      // `\t` / `\m` / `\n` / `\*` / `\#` / `\@`: argument consumed and ignored.
+      continue;
+    }
+    if (
+      target === null &&
+      token.value.length > 0 &&
+      token.value.length <= MAX_HYPERLINK_TARGET_CHARS
+    ) {
+      target = token.value;
+    }
+    // A second bare/quoted token is a duplicate target: first wins.
+  }
+  if (target === null && anchor === null) return null;
+  return { target, anchor, tooltip };
+}

--- a/packages/core/src/layout/field-link.ts
+++ b/packages/core/src/layout/field-link.ts
@@ -12,8 +12,14 @@
 // grammar is recognized and the raw pieces are handed over verbatim, case and
 // percent-encoding preserved.
 
-/** Longest raw instruction even considered — room for a full-length target plus switches. */
-export const MAX_HYPERLINK_INSTRUCTION_CHARS = 4096;
+import { MAX_FIELD_INSTRUCTION_CHARS } from './field-instruction.ts';
+
+/**
+ * Longest raw instruction even considered — room for a full-length target plus switches.
+ * The shared complex-field machine cap IS this bound, so a `HYPERLINK` instruction that fits
+ * a `w:fldSimple` attribute also fits the complex lane's instruction buffer.
+ */
+export const MAX_HYPERLINK_INSTRUCTION_CHARS: number = MAX_FIELD_INSTRUCTION_CHARS;
 /** Longest target captured — the bound the package puts on a relationship target. */
 export const MAX_HYPERLINK_TARGET_CHARS = 2048;
 /** Longest `\l` anchor or `\o` tooltip captured. */

--- a/packages/core/src/layout/field-nested-page.ts
+++ b/packages/core/src/layout/field-nested-page.ts
@@ -1,0 +1,60 @@
+// Live evaluation of an allowlisted PAGE-family field nested inside an open complex field's
+// atomic cached result.
+//
+// The paragraph walk in `field-projection.ts` skips such an inner field's cached digits and
+// appends the projected per-sheet value when the inner `end` closes — the same semantics
+// `collectSimpleFieldDisplay` gives a field nested in a `w:fldSimple` cache, so a `STYLEREF`
+// wrapping `PAGE` never stamps the producer's saved sheet number onto every page. This
+// tracker owns only that state: which inner field is armed, and whether its cached result was
+// seen and whether any of it was visible. Extracted so the walk stays a straight-line reading
+// of the field machine.
+
+import type { AllowlistedPageField } from './field-instruction.ts';
+import { projectPageFieldValue, type FieldPageContext } from './field-page-furniture.ts';
+
+export interface NestedPageTracker {
+  /** True while an armed inner live field is skipping its cached digits. */
+  readonly active: boolean;
+  /** Arm for one inner field; null disarms (non-allowlisted, or no page context). */
+  arm(kind: AllowlistedPageField | null): void;
+  /** Disarm and forget (outer begin, any inner end). */
+  reset(): void;
+  /** Record one piece of the inner field's cached result, visible or not. */
+  noteResult(visible: boolean): void;
+  /**
+   * The live value the closing inner `end` appends, or `''`. An inner cached result that
+   * existed but was entirely suppressed appends nothing — the file said this field's result
+   * is not shown, and a live number would resurrect it (fldSimple parity).
+   */
+  liveValue(pageContext: FieldPageContext | undefined): string;
+}
+
+export function createNestedPageTracker(): NestedPageTracker {
+  let kind: AllowlistedPageField | null = null;
+  let seen = false;
+  let visible = false;
+  return {
+    get active(): boolean {
+      return kind !== null;
+    },
+    arm(next: AllowlistedPageField | null): void {
+      kind = next;
+      seen = false;
+      visible = false;
+    },
+    reset(): void {
+      kind = null;
+      seen = false;
+      visible = false;
+    },
+    noteResult(wasVisible: boolean): void {
+      seen = true;
+      if (wasVisible) visible = true;
+    },
+    liveValue(pageContext: FieldPageContext | undefined): string {
+      if (kind === null || !pageContext) return '';
+      if (seen && !visible) return '';
+      return projectPageFieldValue(kind, pageContext);
+    },
+  };
+}

--- a/packages/core/src/layout/field-nested-page.ts
+++ b/packages/core/src/layout/field-nested-page.ts
@@ -1,13 +1,20 @@
 // Live evaluation of an allowlisted PAGE-family field nested inside an open complex field's
-// atomic cached result.
+// atomic cached result, or inside a `w:fldSimple` cache.
 //
-// The paragraph walk in `field-projection.ts` skips such an inner field's cached digits and
-// appends the projected per-sheet value when the inner `end` closes — the same semantics
-// `collectSimpleFieldDisplay` gives a field nested in a `w:fldSimple` cache, so a `STYLEREF`
-// wrapping `PAGE` never stamps the producer's saved sheet number onto every page. This
-// tracker owns only that state: which inner field is armed, and whether its cached result was
-// seen and whether any of it was visible. Extracted so the walk stays a straight-line reading
-// of the field machine.
+// Both walks skip such an inner field's cached digits and append the projected per-sheet
+// value when the inner field's own `end` closes, so a `STYLEREF` wrapping `PAGE` never stamps
+// the producer's saved sheet number onto every page. The tracker is LEVEL-AWARE: it records
+// the nesting level whose `separate` armed it, and only that level's matching `end` appends
+// and disarms. Everything at a DEEPER level while armed — begins, separates, ends, cached
+// text — is part of the replaced inner result and is ignored, so a begin/end pair inside a
+// tracked result cannot clear tracking mid-field and drop the digits around it. A second
+// `separate` at the tracked level (malformed) is ignored the same way: the matched end still
+// appends. Any level 2..MAX_FIELD_NESTING may arm when the walk offers it, so a PAGE three or
+// four levels down (under an inert REF, say) still evaluates instead of losing its digits.
+//
+// This tracker owns only that state: which inner field is armed, at which level, and whether
+// its cached result was seen and whether any of it was visible. Extracted so the walks stay a
+// straight-line reading of the field machine.
 
 import type { AllowlistedPageField } from './field-instruction.ts';
 import { projectPageFieldValue, type FieldPageContext } from './field-page-furniture.ts';
@@ -15,46 +22,65 @@ import { projectPageFieldValue, type FieldPageContext } from './field-page-furni
 export interface NestedPageTracker {
   /** True while an armed inner live field is skipping its cached digits. */
   readonly active: boolean;
-  /** Arm for one inner field; null disarms (non-allowlisted, or no page context). */
-  arm(kind: AllowlistedPageField | null): void;
-  /** Disarm and forget (outer begin, any inner end). */
+  /**
+   * Feed one nested `separate` (the machine's answer plus the nesting level it was seen at,
+   * BEFORE any machine advance). Arms when idle and the kind is allowlisted; ignored entirely
+   * while armed — a deeper separate belongs to the replaced inner result, and a duplicate
+   * separate at the tracked level (null kind) must not clear tracking (the matched end still
+   * appends). Callers pass null to decline arming (no page context, phase not projectable).
+   */
+  onSeparate(kind: AllowlistedPageField | null, level: number): void;
+  /**
+   * Feed one `end` at `level` (the nesting BEFORE the machine decrements). Returns the live
+   * text to append when this end closes the tracked field — possibly `''` when the inner
+   * cached result existed but was entirely suppressed (the file said this field's result is
+   * not shown, and a live number would resurrect it; fldSimple parity). Returns null when the
+   * end is not the tracked one: a deeper end inside the replaced result is ignored and the
+   * tracker stays armed; a shallower end (unbalanced input) disarms defensively.
+   */
+  onEnd(level: number, pageContext: FieldPageContext | undefined): string | null;
+  /** Disarm and forget (outer begin, budget abort). */
   reset(): void;
   /** Record one piece of the inner field's cached result, visible or not. */
   noteResult(visible: boolean): void;
-  /**
-   * The live value the closing inner `end` appends, or `''`. An inner cached result that
-   * existed but was entirely suppressed appends nothing — the file said this field's result
-   * is not shown, and a live number would resurrect it (fldSimple parity).
-   */
-  liveValue(pageContext: FieldPageContext | undefined): string;
 }
 
 export function createNestedPageTracker(): NestedPageTracker {
   let kind: AllowlistedPageField | null = null;
+  let level = 0;
   let seen = false;
   let visible = false;
+  const reset = (): void => {
+    kind = null;
+    level = 0;
+    seen = false;
+    visible = false;
+  };
   return {
     get active(): boolean {
       return kind !== null;
     },
-    arm(next: AllowlistedPageField | null): void {
+    onSeparate(next: AllowlistedPageField | null, atLevel: number): void {
+      if (kind !== null) return;
+      if (next === null) return;
       kind = next;
+      level = atLevel;
       seen = false;
       visible = false;
     },
-    reset(): void {
-      kind = null;
-      seen = false;
-      visible = false;
+    onEnd(atLevel: number, pageContext: FieldPageContext | undefined): string | null {
+      if (kind === null || atLevel > level) return null;
+      const closesTracked = atLevel === level;
+      const suppressed = seen && !visible;
+      const value =
+        closesTracked && pageContext && !suppressed ? projectPageFieldValue(kind, pageContext) : '';
+      reset();
+      return closesTracked ? value : null;
     },
+    reset,
     noteResult(wasVisible: boolean): void {
       seen = true;
       if (wasVisible) visible = true;
-    },
-    liveValue(pageContext: FieldPageContext | undefined): string {
-      if (kind === null || !pageContext) return '';
-      if (seen && !visible) return '';
-      return projectPageFieldValue(kind, pageContext);
     },
   };
 }

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -28,9 +28,11 @@ import type {
  *
  * Body content flows once, before the page count is known, so the real value cannot be measured
  * in place. The paragraph walk reserves one model unit and paints this single digit; document
- * finalize substitutes the value the atom lands on ({@link substituteBodyPageFields}). A digit is
- * chosen so a one-digit page number lays out exactly and a multi-digit one shifts only its own
- * trailing content on the line — the same non-reflow Word shows.
+ * finalize substitutes the value the atom lands on ({@link substituteBodyPageFields}). The field
+ * is measured at this one-digit width. A one-digit value lays out exactly. A multi-digit value
+ * that is NOT last on its line paints its extra digits over the following same-line content,
+ * because that content was placed at the one-digit x; Word instead re-measures and reflows.
+ * Last-on-line and label usage (the common cases) are unaffected.
  */
 export const PAGE_FIELD_PLACEHOLDER = '0';
 
@@ -159,6 +161,63 @@ export function withPageFieldSources(
   return changed ? next : (pages as PageRecord[]);
 }
 
+/** True when any span on this line carries a body page-field marker. */
+function lineHasBodyPageField(line: LineRecord): boolean {
+  for (const span of line.spans) {
+    if (span.fieldAtom?.pageField) return true;
+  }
+  return false;
+}
+
+/**
+ * True when a paragraph or a nested-table cell in this block carries a body page field.
+ *
+ * Recurses table rows and cells, matching {@link substituteBodyPageFields}'s reach, so a page's
+ * `hasBodyPageFields` flag agrees exactly with whether the substitution walk would change
+ * anything. The marker is a property of the paragraph content, not of the page, so the answer is
+ * the same across every sheet.
+ */
+function blockHasBodyPageField(block: BlockFragmentRecord): boolean {
+  if (block.kind === 'paragraph') {
+    for (const line of block.lines) {
+      if (lineHasBodyPageField(line)) return true;
+    }
+    return false;
+  }
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      for (const inner of cell.blocks) {
+        if (blockHasBodyPageField(inner)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Fold a flushed body page's fragments into the two facts pagination needs from them: the deepest
+ * used bottom (column-separator sizing) and whether ANY body page field is present. Both fall out
+ * of the one pass the page assembly already had to make, so the flag costs no extra traversal.
+ *
+ * The `hasBodyPageFields` result is stamped on the {@link PageRecord} and rides it through
+ * incremental reuse. So a page rebuilt this pass is walked once here; a page reused by identity
+ * keeps its fresh, content-derived answer without a second scan. When the flag is `false`,
+ * {@link finalizePageFieldProjection} skips the substitution walk for that page entirely — the
+ * common case, since page numbers usually live in footers, not the body flow.
+ */
+export function summarizeFlushedPage(
+  fragments: readonly BlockFragmentRecord[],
+  regionTop: number
+): { readonly usedBottom: number; readonly hasBodyPageFields: boolean } {
+  let usedBottom = regionTop;
+  let hasBodyPageFields = false;
+  for (const fragment of fragments) {
+    usedBottom = Math.max(usedBottom, fragment.box.y + fragment.box.height);
+    if (!hasBodyPageFields && blockHasBodyPageField(fragment)) hasBodyPageFields = true;
+  }
+  return { usedBottom, hasBodyPageFields };
+}
+
 /**
  * Substitute a body page-field placeholder line, or return it by identity.
  *
@@ -268,7 +327,13 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
     };
     const header = project(page.header);
     const footer = project(page.footer);
-    const fragments = substituteBodyPageFields(page.fragments, context);
+    // Fast-out: a page assembled with no body page field carries `hasBodyPageFields: false`, so
+    // its whole fragment/table walk is skipped. An `undefined` flag (a page built by a path that
+    // does not stamp it) still walks, which is safe — over-walking never drops a substitution.
+    const fragments =
+      page.hasBodyPageFields === false
+        ? page.fragments
+        : substituteBodyPageFields(page.fragments, context);
     if (header === page.header && footer === page.footer && fragments === page.fragments) {
       return page;
     }

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -14,7 +14,25 @@
 import type { AllowlistedPageField, StoryPageFieldNeeds } from './field-instruction.ts';
 import { NO_STORY_PAGE_FIELDS } from './field-instruction.ts';
 import { formatDecimal, formatNumFmt } from './numbering-format.ts';
-import type { HeaderFooterStoryRecord, PageRecord, SemanticLayout } from './semantic-records.ts';
+import type {
+  BlockFragmentRecord,
+  HeaderFooterStoryRecord,
+  LineRecord,
+  PageRecord,
+  SemanticLayout,
+  StyleSpanRecord,
+} from './semantic-records.ts';
+
+/**
+ * Placeholder a body PAGE/NUMPAGES/SECTIONPAGES atom paints during measurement.
+ *
+ * Body content flows once, before the page count is known, so the real value cannot be measured
+ * in place. The paragraph walk reserves one model unit and paints this single digit; document
+ * finalize substitutes the value the atom lands on ({@link substituteBodyPageFields}). A digit is
+ * chosen so a one-digit page number lays out exactly and a multi-digit one shifts only its own
+ * trailing content on the line — the same non-reflow Word shows.
+ */
+export const PAGE_FIELD_PLACEHOLDER = '0';
 
 /**
  * Page-field evaluation context for furniture projection.
@@ -142,12 +160,87 @@ export function withPageFieldSources(
 }
 
 /**
- * Project allowlisted PAGE/NUMPAGES/SECTIONPAGES onto every page's read-only furniture once
- * the document page count is known. Body stories are unchanged.
+ * Substitute a body page-field placeholder line, or return it by identity.
  *
- * Uses {@link PageFieldSource} when present (section restart + SECTIONPAGES + fmt). Absent
- * source keeps physical 1-based indices (`page.index + 1`) and treats the whole document as
- * one section — the empty-`pgNumType` comprehensive-fixture behaviour.
+ * Only a span carrying a {@link FieldAtomMarker.pageField} marker is touched, and only when the
+ * value the atom lands on differs from what the span already paints. The span's model `range`
+ * stays its reserved one-unit width whatever the substituted text length is — paint and the
+ * offset accounting clamp to that width, so a multi-digit page number never lengthens the model.
+ */
+function substituteBodyPageFieldLine(line: LineRecord, context: FieldPageContext): LineRecord {
+  let spans: StyleSpanRecord[] | null = null;
+  for (let index = 0; index < line.spans.length; index += 1) {
+    const span = line.spans[index]!;
+    const kind = span.fieldAtom?.pageField?.kind;
+    if (!kind) continue;
+    const text = projectPageFieldValue(kind, context);
+    if (text === span.text) continue;
+    if (!spans) spans = line.spans.slice();
+    spans[index] = { ...span, text };
+  }
+  return spans ? { ...line, spans } : line;
+}
+
+/**
+ * Substitute every body page-field placeholder in one block list against a page's context, or
+ * return the list by identity when nothing changed.
+ *
+ * Recurses through table rows and cells, so a PAGE field inside a body table cell resolves the
+ * same way a top-level one does. New records are minted only along the path to a changed span,
+ * mirroring {@link finalizePageFieldProjection}'s identity discipline so incremental layout keeps
+ * reusing untouched pages.
+ */
+export function substituteBodyPageFields(
+  blocks: readonly BlockFragmentRecord[],
+  context: FieldPageContext
+): readonly BlockFragmentRecord[] {
+  let next: BlockFragmentRecord[] | null = null;
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index]!;
+    let replacement: BlockFragmentRecord = block;
+    if (block.kind === 'paragraph') {
+      let mutatedLines: LineRecord[] | null = null;
+      for (let lineIndex = 0; lineIndex < block.lines.length; lineIndex += 1) {
+        const line = block.lines[lineIndex]!;
+        const nextLine = substituteBodyPageFieldLine(line, context);
+        if (nextLine === line) continue;
+        if (!mutatedLines) mutatedLines = block.lines.slice();
+        mutatedLines[lineIndex] = nextLine;
+      }
+      if (mutatedLines) replacement = { ...block, lines: mutatedLines };
+    } else {
+      let mutatedRows: (typeof block.rows)[number][] | null = null;
+      for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex += 1) {
+        const row = block.rows[rowIndex]!;
+        let mutatedCells: (typeof row.cells)[number][] | null = null;
+        for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex += 1) {
+          const cell = row.cells[cellIndex]!;
+          const cellBlocks = substituteBodyPageFields(cell.blocks, context);
+          if (cellBlocks === cell.blocks) continue;
+          if (!mutatedCells) mutatedCells = row.cells.slice();
+          mutatedCells[cellIndex] = { ...cell, blocks: cellBlocks };
+        }
+        if (!mutatedCells) continue;
+        if (!mutatedRows) mutatedRows = block.rows.slice();
+        mutatedRows[rowIndex] = { ...row, cells: mutatedCells };
+      }
+      if (mutatedRows) replacement = { ...block, rows: mutatedRows };
+    }
+    if (replacement === block) continue;
+    if (!next) next = blocks.slice();
+    next[index] = replacement;
+  }
+  return next ?? blocks;
+}
+
+/**
+ * Project allowlisted PAGE/NUMPAGES/SECTIONPAGES once the document page count is known.
+ *
+ * Header/footer furniture substitutes through each story's transient projector. Body flow (and
+ * body tables) substitutes the placeholders the paragraph walk reserved, using the SAME per-page
+ * context — {@link PageFieldSource} when present (section restart + SECTIONPAGES + fmt), else the
+ * physical 1-based index and the whole document as one section (empty-`pgNumType` behaviour).
+ * Pages and stories with no page field are returned by identity.
  */
 export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLayout {
   const pageCount = layout.pages.length;
@@ -175,11 +268,16 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
     };
     const header = project(page.header);
     const footer = project(page.footer);
-    if (header === page.header && footer === page.footer) return page;
+    const fragments = substituteBodyPageFields(page.fragments, context);
+    if (header === page.header && footer === page.footer && fragments === page.fragments) {
+      return page;
+    }
+    if (fragments !== page.fragments) changed = true;
     return {
       ...page,
       ...(header !== undefined ? { header } : {}),
       ...(footer !== undefined ? { footer } : {}),
+      ...(fragments !== page.fragments ? { fragments } : {}),
     };
   });
 

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -52,6 +52,15 @@ export interface FieldAtomMarker {
    * turns it off — because they mark the blanks somebody is meant to fill in.
    */
   readonly formField: boolean;
+  /**
+   * A BODY PAGE / NUMPAGES / SECTIONPAGES atom whose value depends on pagination.
+   *
+   * The paragraph walk cannot know which page the field lands on — layout runs before the page
+   * count — so it paints a placeholder and records the field's kind here. Document finalize
+   * (`substituteBodyPageFields`) reads this marker and substitutes the real value per page.
+   * Absent in headers/footers, which evaluate live through their own per-page projector.
+   */
+  readonly pageField?: { readonly kind: AllowlistedPageField };
 }
 
 /**

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -244,13 +244,18 @@ export interface PendingFieldProjection {
   /** Cached result text (for inert display or demotion flush). */
   cachedText: string;
   /**
-   * True once ANY result-phase content was seen — hidden, suppressed or visible.
+   * True once result-phase content the current display mode KEEPS was seen — visible or
+   * vanish-hidden. Only content with model text sets it (result text, tab / break, `w:sym`);
+   * drawings, `w:ptab` and note references never do.
    *
    * `cachedText` alone cannot tell "the file cached no result" from "the file cached one and
    * hid it": both leave it empty. Synthesis (MACROBUTTON / GOTOBUTTON display text, the
    * FORMDROPDOWN selected entry) fills only the first — painting over a vanished result would
-   * resurrect what the document hides. FORMCHECKBOX ignores this on purpose: its ffData state
-   * is the authority, and a hidden FIELD is already covered by the flush's style guard.
+   * resurrect what the document hides. A result the display mode resolves AWAY (a
+   * `w:del`-wrapped cache in the proposed view) does not set it: that view has no cached
+   * result left, and Word synthesizes there after the deletion is accepted. FORMCHECKBOX
+   * ignores this on purpose: its ffData state is the authority, and a hidden FIELD is
+   * already covered by the flush's style guard.
    */
   sawResultContent: boolean;
   /** Demotion-only: ordinary pieces when the field fails to close. */

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -12,6 +12,7 @@ import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlProperty } from '@docx-edi
 import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
+import type { ButtonFieldSpec } from './field-button.ts';
 import type { FormFieldKind } from './field-form.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
 import type { HyperlinkFieldSpec } from './field-link.ts';
@@ -217,6 +218,15 @@ export interface PendingFieldProjection {
    * non-empty cached result.
    */
   formSpec: FormFieldKind | null;
+  /**
+   * Parsed MACROBUTTON / GOTOBUTTON instruction, or null when the field is neither.
+   *
+   * Captured at the same points as {@link symbolSpec}. Display text only — the macro / target
+   * is discarded at parse and nothing ever executes or navigates. Unlike SYMBOL, a cached
+   * result WINS when present (it is what Word last painted); the flush synthesizes from this
+   * only when the cache is empty.
+   */
+  buttonSpec: ButtonFieldSpec | null;
   /**
    * Bounded `w:ffData` render state read at `begin` (`legacyFormFieldDataOf` — state only,
    * macros never), or null when absent or malformed. {@link formField} stays presence-based:

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -12,6 +12,7 @@ import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlProperty } from '@docx-edi
 import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
+import type { SymbolFieldSpec } from './field-symbol.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
@@ -169,6 +170,15 @@ export function positionalTabOf(node: OoxmlNode): PositionalTab | null {
 export interface PendingFieldProjection {
   /** Allowlisted kind when live-projecting; null paints inert cached text at the atom. */
   kind: AllowlistedPageField | null;
+  /**
+   * Parsed SYMBOL instruction, or null when the field is not one.
+   *
+   * Captured while the machine still holds the raw instruction — at `separate`, or at the
+   * outermost `end` for the begin/instr/end shape Word also writes — because `onFldCharEnd`
+   * resets the buffer before the flush reads anything. SYMBOL has no cached result in real
+   * files, so the flush renders from this and it wins over any stale cached text.
+   */
+  symbolSpec: SymbolFieldSpec | null;
   /** True when this pending field is a well-formed atomic unit (begin will close). */
   atomic: boolean;
   /** True when this closed FORMTEXT field exposes its authored result as ordinary text. */

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -13,6 +13,7 @@ import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
 import type { ButtonFieldSpec } from './field-button.ts';
+import type { DocPropertyField } from './field-doc-property.ts';
 import type { FormFieldKind } from './field-form.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
 import type { HyperlinkFieldSpec } from './field-link.ts';
@@ -227,6 +228,15 @@ export interface PendingFieldProjection {
    * only when the cache is empty.
    */
   buttonSpec: ButtonFieldSpec | null;
+  /**
+   * Recognized document-property field (TITLE / AUTHOR / … / `DOCPROPERTY "Name"`), or null.
+   *
+   * Captured at the same points as {@link symbolSpec}. Resolved against the document's parsed
+   * properties at flush time (not here — the properties are document-global, not on the field).
+   * A cached result WINS when present, exactly like {@link buttonSpec}; synthesis fills only an
+   * empty cache.
+   */
+  docPropertySpec: DocPropertyField | null;
   /**
    * Bounded `w:ffData` render state read at `begin` (`legacyFormFieldDataOf` — state only,
    * macros never), or null when absent or malformed. {@link formField} stays presence-based:

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -11,6 +11,7 @@
 import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlProperty } from '@docx-editor.dev/core/store';
 import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
+import type { AllowlistedPageField } from './field-instruction.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
@@ -153,4 +154,68 @@ export function positionalTabOf(node: OoxmlNode): PositionalTab | null {
       ? { leader: leader as NonNullable<PositionalTab['leader']> }
       : {}),
   };
+}
+
+/**
+ * Pending live or inert-cache projection for one atomic field unit.
+ *
+ * Well-formed computed fields contribute exactly one UTF-16 model unit. Cached result text
+ * is not independently addressable — it only donates display text and result-run style.
+ * Missing `end` demotes: buffered cache is flushed as ordinary pieces with real lengths.
+ *
+ * The state only; the machinery that fills and flushes it stays closure-bound inside
+ * `piecesOfParagraph`.
+ */
+export interface PendingFieldProjection {
+  /** Allowlisted kind when live-projecting; null paints inert cached text at the atom. */
+  kind: AllowlistedPageField | null;
+  /** True when this pending field is a well-formed atomic unit (begin will close). */
+  atomic: boolean;
+  /** True when this closed FORMTEXT field exposes its authored result as ordinary text. */
+  editableResult: boolean;
+  atomStart: number;
+  props: readonly OoxmlProperty[];
+  style: ResolvedRunStyle;
+  capturedResultStyle: boolean;
+  /** Cached result text (for inert display or demotion flush). */
+  cachedText: string;
+  /** Demotion-only: ordinary pieces when the field fails to close. */
+  buffered: FieldAwarePiece[];
+  /** Demotion-only running offset mirror while buffering ordinary pieces. */
+  bufferOffset: number;
+  /**
+   * The revision wrappers this field's displayed text sits inside, captured while the walk was
+   * still INSIDE them.
+   *
+   * An ATOMIC field's result is buffered at the run that carries it and flushed at `fldChar
+   * end`, by which point the depth-first walk has left the wrapper and restored the live stack
+   * to empty. Reading the live stack at flush time therefore attributed a tracked field result
+   * to nothing at all, and it painted as ordinary unchanged text — a deletion with no strike,
+   * an insertion with no underline.
+   *
+   * Both shapes reach here: a `w:del` around only the RESULT run with `begin`/`end` outside it
+   * (how Word records a form field whose value was replaced), and a wrapper around the whole
+   * `begin`…`end` sequence. The second used to demote instead — `atomicFieldSpansOf` did not
+   * descend into revision wrappers — until that walk was widened so the store and layout would
+   * stop disagreeing about what such a field is worth. Anything reasoning about "a wrapped field
+   * never forms an atom" is out of date; `commitAtomicField` now has to resolve visibility
+   * itself, because it can be reached with a stack that the display mode resolves away.
+   *
+   * A field whose result runs carry DIFFERENT stacks collapses to the first: the atom is one
+   * model unit and Word treats a field as one decision, so splitting it would invent a boundary
+   * the model does not have.
+   */
+  resultRevisions: readonly RevisionAttribution[];
+  /** Whether {@link resultRevisions} has been donated yet — an EMPTY stack is a real answer. */
+  capturedResultRevisions: boolean;
+  /** `w:ffData` on the begin marker — a legacy form field, which Word shades on its own rule. */
+  formField: boolean;
+  /**
+   * The link enclosing the displayed result, captured at `begin` for the same reason.
+   *
+   * Reachable where the revision capture is not: `atomicFieldSpansOf` DOES descend into
+   * `w:hyperlink`, so a field inside a link is still an atom, and without this its result was
+   * the one run in the link painting with no href.
+   */
+  resultLink?: SpanLinkRecord;
 }

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -12,6 +12,7 @@ import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlProperty } from '@docx-edi
 import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
+import type { HyperlinkFieldSpec } from './field-link.ts';
 import type { SymbolFieldSpec } from './field-symbol.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
@@ -179,6 +180,14 @@ export interface PendingFieldProjection {
    * files, so the flush renders from this and it wins over any stale cached text.
    */
   symbolSpec: SymbolFieldSpec | null;
+  /**
+   * Parsed HYPERLINK instruction, or null when the field is not one.
+   *
+   * Captured at the same points as {@link symbolSpec} and for the same reason. Only consulted
+   * when {@link resultLink} stays empty: an ENCLOSING `w:hyperlink` outranks the field's own
+   * instruction, exactly as Word resolves the nesting.
+   */
+  linkSpec: HyperlinkFieldSpec | null;
   /** True when this pending field is a well-formed atomic unit (begin will close). */
   atomic: boolean;
   /** True when this closed FORMTEXT field exposes its authored result as ordinary text. */

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -10,7 +10,9 @@
 
 import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlProperty } from '@docx-editor.dev/core/store';
 import type { HardBreakKind } from '@docx-editor.dev/core/store';
+import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
+import type { FormFieldKind } from './field-form.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
 import type { HyperlinkFieldSpec } from './field-link.ts';
 import type { SymbolFieldSpec } from './field-symbol.ts';
@@ -159,6 +161,25 @@ export function positionalTabOf(node: OoxmlNode): PositionalTab | null {
 }
 
 /**
+ * How layout turns a typed `w:hyperlink` node into the sanitized record spans carry.
+ *
+ * Injected rather than computed here because resolving `r:id` needs the PACKAGE's
+ * relationships and this module only ever sees one part's tree. `null` means the caller
+ * declined to project — the runs still measure and paint, they simply carry no link, which is
+ * the right degradation: text is never lost for want of a target.
+ */
+export type HyperlinkProjector = (link: OoxmlNode) => SpanLinkRecord | null;
+
+/**
+ * How layout turns a parsed HYPERLINK field instruction into the sanitized record spans carry.
+ *
+ * Injected for the same reason as {@link HyperlinkProjector}: the spec's raw target must cross
+ * the surface's ONE href trust boundary, and layout owns no sanitization policy. `null` means
+ * no link — the cached result still paints as plain text, which is the right degradation.
+ */
+export type FieldLinkProjector = (spec: HyperlinkFieldSpec) => SpanLinkRecord | null;
+
+/**
  * Pending live or inert-cache projection for one atomic field unit.
  *
  * Well-formed computed fields contribute exactly one UTF-16 model unit. Cached result text
@@ -188,6 +209,20 @@ export interface PendingFieldProjection {
    * instruction, exactly as Word resolves the nesting.
    */
   linkSpec: HyperlinkFieldSpec | null;
+  /**
+   * FORMCHECKBOX / FORMDROPDOWN instruction, or null when the field is neither.
+   *
+   * Captured at the same points as {@link symbolSpec}. Consulted with {@link formData}: the
+   * checkbox state is authoritative over any stale cached glyph, the dropdown defers to a
+   * non-empty cached result.
+   */
+  formSpec: FormFieldKind | null;
+  /**
+   * Bounded `w:ffData` render state read at `begin` (`legacyFormFieldDataOf` — state only,
+   * macros never), or null when absent or malformed. {@link formField} stays presence-based:
+   * ffData present with an unreadable payload still shades as a form field.
+   */
+  formData: LegacyFormFieldData | null;
   /** True when this pending field is a well-formed atomic unit (begin will close). */
   atomic: boolean;
   /** True when this closed FORMTEXT field exposes its authored result as ordinary text. */

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -243,6 +243,16 @@ export interface PendingFieldProjection {
   capturedResultStyle: boolean;
   /** Cached result text (for inert display or demotion flush). */
   cachedText: string;
+  /**
+   * True once ANY result-phase content was seen — hidden, suppressed or visible.
+   *
+   * `cachedText` alone cannot tell "the file cached no result" from "the file cached one and
+   * hid it": both leave it empty. Synthesis (MACROBUTTON / GOTOBUTTON display text, the
+   * FORMDROPDOWN selected entry) fills only the first — painting over a vanished result would
+   * resurrect what the document hides. FORMCHECKBOX ignores this on purpose: its ffData state
+   * is the authority, and a hidden FIELD is already covered by the flush's style guard.
+   */
+  sawResultContent: boolean;
   /** Demotion-only: ordinary pieces when the field fails to close. */
   buffered: FieldAwarePiece[];
   /** Demotion-only running offset mirror while buffering ordinary pieces. */

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -68,6 +68,7 @@ import {
   runPropertiesOf,
   type RunPropertyCascader,
 } from './field-run-text.ts';
+import { parseButtonInstruction } from './field-button.ts';
 import { captureInstructionSpecs, formFieldResult } from './field-form.ts';
 import { parseHyperlinkInstruction } from './field-link.ts';
 import { parseSymbolInstruction, symbolFieldGlyph } from './field-symbol.ts';
@@ -359,6 +360,10 @@ export function piecesOfParagraph(
       // Inert non-page field: paint cached result as layout-owned substitution for the
       // single model unit (same as live PAGE) so hit-test/span ranges stay one atom.
       push(pending.cachedText, pending.props, pending.style, true, start, end, carried);
+    } else if (pending.buttonSpec) {
+      // MACROBUTTON / GOTOBUTTON display their text; the macro / target never runs. A cached
+      // result (what Word last painted) wins above — this fills in only when it is empty.
+      push(pending.buttonSpec.display, pending.props, pending.style, true, start, end, carried);
     }
     pending = null;
     openAtomicBeginId = null;
@@ -566,6 +571,7 @@ export function piecesOfParagraph(
             symbolSpec: null,
             linkSpec: null,
             formSpec: null,
+            buttonSpec: null,
             // Bounded ffData STATE read (checkbox checked/size, dropdown entries/selection —
             // macros never); `formField` below stays presence-based so an unreadable payload
             // still shades.
@@ -867,6 +873,21 @@ export function piecesOfParagraph(
         }
         return;
       }
+    }
+
+    // A simple MACROBUTTON / GOTOBUTTON displays everything after its first argument; the
+    // macro / target never runs. A non-empty cached display wins — synthesis fills an empty one.
+    const buttonSpec =
+      display.text.length === 0 ? parseButtonInstruction(fldSimpleInstr(simple) ?? '') : null;
+    if (buttonSpec) {
+      const buttonStyle =
+        display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+      if (buttonStyle.hidden) return;
+      const buttonProps = display.resultProps ?? inheritedRunProperties;
+      push(buttonSpec.display, buttonProps, buttonStyle, true, start, start + 1, {
+        fieldAtom: { formField: false },
+      });
+      return;
     }
 
     if (display.text.length === 0) return;

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -68,6 +68,7 @@ import {
   runPropertiesOf,
   type RunPropertyCascader,
 } from './field-run-text.ts';
+import { parseHyperlinkInstruction, type HyperlinkFieldSpec } from './field-link.ts';
 import { parseSymbolInstruction, symbolFieldGlyph } from './field-symbol.ts';
 import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
 import {
@@ -166,6 +167,15 @@ export { propertiesOfRunContainer, type RunPropertyCascader } from './field-run-
 export type HyperlinkProjector = (link: OoxmlNode) => SpanLinkRecord | null;
 
 /**
+ * How layout turns a parsed HYPERLINK field instruction into the sanitized record spans carry.
+ *
+ * Injected for the same reason as {@link HyperlinkProjector}: the spec's raw target must cross
+ * the surface's ONE href trust boundary, and layout owns no sanitization policy. `null` means
+ * no link — the cached result still paints as plain text, which is the right degradation.
+ */
+export type FieldLinkProjector = (spec: HyperlinkFieldSpec) => SpanLinkRecord | null;
+
+/**
  * Flatten a paragraph into measurable pieces, projecting allowlisted page fields when a
  * page context is supplied (furniture finalize / `withPageContext`).
  *
@@ -190,7 +200,8 @@ export function piecesOfParagraph(
   displayMode: RevisionDisplayMode = DEFAULT_REVISION_DISPLAY_MODE,
   deletedRanges?: MutableModelRange[],
   inlineDrawingLayout?: InlineDrawingLayoutContext,
-  themeFonts?: ThemeFonts
+  themeFonts?: ThemeFonts,
+  projectFieldLink?: FieldLinkProjector
 ): FieldAwarePiece[] {
   if (paragraph.kind === 'textValue') return [];
   if (paragraph.kind !== 'paragraph') return [];
@@ -322,9 +333,16 @@ export function piecesOfParagraph(
       openAtomicBeginId = null;
       return;
     }
+    // A HYPERLINK field becomes a live link only when nothing already links it: an enclosing
+    // `w:hyperlink` captured into `resultLink` wins, exactly as it does for every other field.
+    const fieldLink =
+      !pending.resultLink && pending.linkSpec
+        ? (projectFieldLink?.(pending.linkSpec) ?? null)
+        : null;
+    const carriedLink = pending.resultLink ?? fieldLink;
     const carried = {
       ...(pending.resultRevisions.length > 0 ? { revisionsOverride: pending.resultRevisions } : {}),
-      ...(pending.resultLink ? { linkOverride: pending.resultLink } : {}),
+      ...(carriedLink ? { linkOverride: carriedLink } : {}),
       fieldAtom: { formField: pending.formField },
     };
     // SYMBOL renders from its instruction — Word never trusts a cached result for it, so a
@@ -353,13 +371,21 @@ export function piecesOfParagraph(
 
   const abandonPending = (): void => {
     if (!pending) return;
+    // A demoted HYPERLINK keeps its link too, when nothing already linked its pieces — the
+    // enclosing `w:hyperlink` a buffered piece carries wins, same precedence as the flush.
+    const fieldLink =
+      !pending.resultLink && pending.linkSpec
+        ? (projectFieldLink?.(pending.linkSpec) ?? null)
+        : null;
+    const linked = (piece: FieldAwarePiece): FieldAwarePiece =>
+      fieldLink && !piece.link ? { ...piece, link: fieldLink } : piece;
     if (pending.atomic) {
       // Missing end after an atomic begin should not happen (atoms require end). If the
       // scan budget aborts mid-field, roll the atom back and flush any buffered cache.
       offset = pending.atomStart;
       for (const piece of pending.buffered) {
         pieces.push({
-          ...piece,
+          ...linked(piece),
           start: offset,
           end: offset + (piece.end - piece.start),
         });
@@ -372,12 +398,13 @@ export function piecesOfParagraph(
           pending.style,
           false,
           offset,
-          offset + pending.cachedText.length
+          offset + pending.cachedText.length,
+          fieldLink ? { linkOverride: fieldLink } : undefined
         );
         offset += pending.cachedText.length;
       }
     } else {
-      for (const piece of pending.buffered) pieces.push(piece);
+      for (const piece of pending.buffered) pieces.push(linked(piece));
       offset = pending.bufferOffset;
     }
     pending = null;
@@ -542,6 +569,7 @@ export function piecesOfParagraph(
           pending = {
             kind: null,
             symbolSpec: null,
+            linkSpec: null,
             atomic,
             editableResult: editableResultBeginIds.has(grand.id),
             atomStart: offset,
@@ -581,9 +609,13 @@ export function piecesOfParagraph(
         const kind = onFldCharSeparate(field);
         if (outermostSeparate && pending) {
           pending.kind = kind && pageContext ? kind : null;
-          // Capture a SYMBOL spec while the machine still holds the raw instruction.
+          // Capture a SYMBOL or HYPERLINK spec while the machine still holds the raw
+          // instruction (`onFldCharEnd` resets the buffer before the flush reads anything).
           if (!pending.kind && !field.instructionOverflow) {
             pending.symbolSpec = parseSymbolInstruction(field.instruction);
+            if (!pending.symbolSpec) {
+              pending.linkSpec = parseHyperlinkInstruction(field.instruction);
+            }
           }
           // Prefer separate-run style until a measurable result run donates one.
           pending.props = props;
@@ -603,6 +635,9 @@ export function piecesOfParagraph(
           !field.instructionOverflow
         ) {
           pending.symbolSpec = parseSymbolInstruction(field.instruction);
+          if (!pending.symbolSpec) {
+            pending.linkSpec = parseHyperlinkInstruction(field.instruction);
+          }
         }
         onFldCharEnd(field);
         if (outermostEnd) {
@@ -845,6 +880,11 @@ export function piecesOfParagraph(
     // to inherited properties the same way a top-level simple PAGE does.
     const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
     if (style.hidden) return;
+    // A simple HYPERLINK links its cached result — but only outside a typed `w:hyperlink`,
+    // whose record `push` already applies and which outranks the field's own instruction.
+    // An empty result never reached here, so an empty result never paints the URL.
+    const linkSpec = currentLink ? null : parseHyperlinkInstruction(fldSimpleInstr(simple) ?? '');
+    const fieldLink = linkSpec ? (projectFieldLink?.(linkSpec) ?? null) : null;
     // `w:ffData` is a `w:fldChar` payload, so a simple field is never a legacy form field.
     push(
       display.text,
@@ -855,6 +895,7 @@ export function piecesOfParagraph(
       start + 1,
       {
         fieldAtom: { formField: false },
+        ...(fieldLink ? { linkOverride: fieldLink } : {}),
       }
     );
   };

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -14,7 +14,8 @@
 // supplied; a non-page `w:fldSimple` still contributes one model unit and paints its
 // cached result, except that allowlisted page fields nested inside that result (complex
 // or simple) are evaluated per sheet rather than concatenated from the saved cache.
-// Other nested field instructions stay inert. Body-side evaluation beyond that is deferred.
+// A complex outer field's atomic cached result gets the same nested evaluation. Other
+// nested field instructions stay inert. Body-side evaluation beyond that is deferred.
 //
 // Projection is a layout concern (span geometry + tab alignment), not paint-time substitution.
 
@@ -43,7 +44,6 @@ import {
   MAX_FIELD_NESTING,
   MAX_STORY_FIELD_SCAN_DEPTH,
   MAX_STORY_FIELD_SCAN_NODES,
-  NO_STORY_PAGE_FIELDS,
   normalizeFieldInstruction,
   onFldCharBegin,
   onFldCharEnd,
@@ -60,7 +60,6 @@ import {
   storyNeedsPageFields,
   withPageFieldSources,
   type FieldPageContext,
-  type PageFieldSource,
 } from './field-page-furniture.ts';
 import { collectSimpleFieldDisplay } from './field-simple-result.ts';
 import {
@@ -120,14 +119,11 @@ import {
 // Re-export instruction recognition + detection so existing layout-local imports stay stable.
 export {
   MAX_FIELD_INSTRUCTION_CHARS,
-  MAX_FIELD_NESTING,
   MAX_STORY_FIELD_SCAN_DEPTH,
   MAX_STORY_FIELD_SCAN_NODES,
-  NO_STORY_PAGE_FIELDS,
   allowlistedPageField,
   detectStoryPageFields,
   normalizeFieldInstruction,
-  type AllowlistedPageField,
   type StoryPageFieldNeeds,
 };
 
@@ -142,15 +138,11 @@ export {
   storyNeedsPageFields,
   withPageFieldSources,
   type FieldPageContext,
-  type PageFieldSource,
 };
 
 // The piece vocabulary now lives beside the walk rather than inside it. Same re-export reason:
 // every layout module already imports these from here.
 export {
-  appendModelRange,
-  positionalTabOf,
-  type FieldAtomMarker,
   type FieldAwarePiece,
   type FieldLinkProjector,
   type HyperlinkProjector,
@@ -221,6 +213,11 @@ export function piecesOfParagraph(
   let pending: PendingFieldProjection | null = null;
   /** Outermost begin id when the open field is atomic. */
   let openAtomicBeginId: string | null = null;
+  // Live-evaluated allowlisted field nested inside the open atomic result: its cached digits
+  // are skipped and the matching inner end appends the projected value (fldSimple parity).
+  let nestedKind: AllowlistedPageField | null = null;
+  let nestedSeen = false;
+  let nestedVisible = false;
   /**
    * The revision wrappers enclosing the run being processed, outermost first.
    *
@@ -565,6 +562,7 @@ export function piecesOfParagraph(
         onFldCharBegin(field);
         if (field.nesting === 1) {
           abandonPending();
+          nestedKind = null;
           openAtomicBeginId = atomic ? grand.id : null;
           pending = {
             kind: null,
@@ -623,6 +621,12 @@ export function piecesOfParagraph(
           // Prefer separate-run style until a measurable result run donates one.
           pending.props = props;
           pending.style = style;
+        } else if (pending?.atomic && field.phase === 'result') {
+          // Inner separate inside the outer atomic result: live-evaluate an allowlisted
+          // nested field instead of concatenating its cached digits (fldSimple parity).
+          nestedKind = pageContext ? kind : null;
+          nestedSeen = false;
+          nestedVisible = false;
         }
         continue;
       }
@@ -639,6 +643,13 @@ export function piecesOfParagraph(
         ) {
           captureInstructionSpecs(pending, field.instruction);
         }
+        // The end closing a skipped inner field appends its live value; an inner result that
+        // existed but was entirely suppressed appends nothing (fldSimple parity).
+        if (field.nesting === 2 && pending?.atomic && nestedKind && pageContext) {
+          if (!nestedSeen || nestedVisible)
+            pending.cachedText += projectPageFieldValue(nestedKind, pageContext);
+        }
+        nestedKind = null;
         onFldCharEnd(field);
         if (outermostEnd) {
           if (pending?.atomic) commitAtomicField();
@@ -657,7 +668,12 @@ export function piecesOfParagraph(
         // A cached result is one plain string and cannot carry a per-glyph font switch, so
         // only a `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
         if (isSymbolRunChild(grand)) {
-          if (pending.atomic && !style.hidden && revisionsVisible(revisions, displayMode)) {
+          if (
+            pending.atomic &&
+            !nestedKind &&
+            !style.hidden &&
+            revisionsVisible(revisions, displayMode)
+          ) {
             const glyph = symbolGlyphOf(grand);
             if (glyph?.unicode) pending.cachedText += glyph.text;
           }
@@ -696,6 +712,7 @@ export function piecesOfParagraph(
         }
 
         if (fieldSuppressed) {
+          if (pending.atomic && nestedKind) nestedSeen = true;
           if (!pending.atomic) {
             offset += text.length;
             pending.bufferOffset = offset;
@@ -705,6 +722,18 @@ export function piecesOfParagraph(
 
         if (pending.atomic) {
           // Atomic unit: cache donates display text/style only — offset already reserved.
+          if (nestedKind) {
+            // Skipped inner cached digits: the live value replaces them at the inner end.
+            nestedSeen = true;
+            if (style.hidden) continue;
+            nestedVisible = true;
+            if (!pending.capturedResultStyle) {
+              pending.props = props;
+              pending.style = style;
+              pending.capturedResultStyle = true;
+            }
+            continue;
+          }
           if (style.hidden) continue;
           if (!pending.capturedResultStyle) {
             pending.props = props;

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -555,6 +555,7 @@ export function piecesOfParagraph(
       if (!consumeScanNode(budget)) {
         abandonPending();
         resetFieldParseState(field);
+        nestedPage.reset();
         if (grand.kind === 'runProperties') continue;
         if (isFldChar(grand, 'begin') || isFldChar(grand, 'separate') || isFldChar(grand, 'end')) {
           continue;
@@ -621,6 +622,7 @@ export function piecesOfParagraph(
 
       if (isFldChar(grand, 'separate')) {
         const outermostSeparate = field.nesting === 1 && field.phase === 'instruction';
+        const separateLevel = field.nesting;
         const kind = onFldCharSeparate(field);
         if (outermostSeparate && pending) {
           pending.kind = kind && pageContext ? kind : null;
@@ -634,10 +636,14 @@ export function piecesOfParagraph(
           // Prefer separate-run style until a measurable result run donates one.
           pending.props = props;
           pending.style = style;
-        } else if (pending?.atomic && field.phase === 'result') {
+        } else if (pending?.atomic && field.phase === 'result' && !field.nestingOverflow) {
           // Inner separate inside the outer atomic result: live-evaluate an allowlisted
           // nested field instead of concatenating its cached digits (fldSimple parity).
-          nestedPage.arm(pageContext ? kind : null);
+          // Level-aware: the tracker arms at ANY nested level 2..MAX_FIELD_NESTING when idle,
+          // and while armed ignores deeper separates (part of the replaced result) and null
+          // duplicates at the tracked level. Overflowed nesting never arms — projection would
+          // be replacing content the atom parser already demoted.
+          nestedPage.onSeparate(pageContext ? kind : null, separateLevel);
         }
         continue;
       }
@@ -655,12 +661,14 @@ export function piecesOfParagraph(
         ) {
           captureInstructionSpecs(pending, field.instruction);
         }
-        // The end closing a skipped inner field appends its live value; an inner result that
-        // existed but was entirely suppressed appends nothing (fldSimple parity).
-        if (field.nesting === 2 && pending?.atomic) {
-          pending.cachedText += nestedPage.liveValue(pageContext);
+        // The end closing the TRACKED inner field appends its live value; an inner result that
+        // existed but was entirely suppressed appends nothing (fldSimple parity). Deeper ends
+        // inside the replaced result return null and leave the tracker armed, so a begin/end
+        // pair nested in a tracked result cannot clear tracking mid-field.
+        const appendedLive = nestedPage.onEnd(field.nesting, pageContext);
+        if (appendedLive !== null && pending?.atomic) {
+          pending.cachedText += appendedLive;
         }
-        nestedPage.reset();
         onFldCharEnd(field);
         if (outermostEnd) {
           if (pending?.atomic) commitAtomicField();
@@ -687,7 +695,13 @@ export function piecesOfParagraph(
         if (isSymbolRunChild(grand)) {
           if (pending.atomic) {
             pending.sawResultContent = true;
-            if (!nestedPage.active && !style.hidden && revisionsVisible(revisions, displayMode)) {
+            if (nestedPage.active) {
+              // A symbol inside the skipped inner cache is result content too: a visible one
+              // keeps the live replacement alive, a suppressed-only cache appends nothing.
+              nestedPage.noteResult(!style.hidden && revisionsVisible(revisions, displayMode));
+              continue;
+            }
+            if (!style.hidden && revisionsVisible(revisions, displayMode)) {
               const glyph = symbolGlyphOf(grand);
               if (glyph?.unicode) {
                 donateResultCapture();
@@ -763,13 +777,13 @@ export function piecesOfParagraph(
           // Atomic unit: cache donates display text/style only — offset already reserved.
           if (nestedPage.active) {
             // Skipped inner cached digits: the live value replaces them at the inner end.
+            // Donation is the FULL result capture — style, revision attribution and enclosing
+            // link — exactly like the ordinary result branch: when the atom's first visible
+            // result content is the nested digits wrapped in `w:ins` or `w:hyperlink`, the
+            // live value that replaces them must paint attributed and linked the same way.
             nestedPage.noteResult(!style.hidden);
             if (style.hidden) continue;
-            if (!pending.capturedResultStyle) {
-              pending.props = props;
-              pending.style = style;
-              pending.capturedResultStyle = true;
-            }
+            donateResultCapture();
             continue;
           }
           if (style.hidden) continue;

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -9,18 +9,15 @@
 // (aligned with `paragraphTextOf` / `segmentsOf`). FORMTEXT results instead keep their literal
 // character offsets because they are user input. Malformed fields demote so content remains.
 //
-// Shipped scope is furniture-only for live page-number evaluation. A simple PAGE /
-// NUMPAGES / SECTIONPAGES field evaluates like its complex twin when a page context is
-// supplied; a non-page `w:fldSimple` still contributes one model unit and paints its
-// cached result, except that allowlisted page fields nested inside that result (complex
-// or simple) are evaluated per sheet rather than concatenated from the saved cache.
-// A complex outer field's atomic cached result gets the same nested evaluation. Other
-// nested field instructions stay inert. Body-side evaluation beyond that is deferred.
+// Shipped scope is furniture-only for live page-number evaluation. Simple and complex
+// PAGE-family fields evaluate alike when a page context is supplied; a non-page field paints
+// its cached result, with allowlisted page fields nested inside that result (complex or
+// simple) evaluated per sheet rather than concatenated from the saved cache. Other nested
+// field instructions stay inert. Body-side evaluation beyond that is deferred.
 //
 // Projection is a layout concern (span geometry + tab alignment), not paint-time substitution.
 
 import {
-  fldSimpleInstr,
   hardBreakKind,
   hasLegacyFormFieldData,
   isFldSimple,
@@ -49,7 +46,6 @@ import {
   onFldCharEnd,
   onFldCharSeparate,
   resetFieldParseState,
-  type AllowlistedPageField,
   type StoryPageFieldNeeds,
 } from './field-instruction.ts';
 import {
@@ -61,16 +57,15 @@ import {
   withPageFieldSources,
   type FieldPageContext,
 } from './field-page-furniture.ts';
-import { collectSimpleFieldDisplay } from './field-simple-result.ts';
+import { projectSimpleFieldResult } from './field-simple-result.ts';
+import { createNestedPageTracker } from './field-nested-page.ts';
 import {
   modelTextOfRunChild,
   runPropertiesOf,
   type RunPropertyCascader,
 } from './field-run-text.ts';
-import { parseButtonInstruction } from './field-button.ts';
 import { captureInstructionSpecs, formFieldResult } from './field-form.ts';
-import { parseHyperlinkInstruction } from './field-link.ts';
-import { parseSymbolInstruction, symbolFieldGlyph } from './field-symbol.ts';
+import { symbolFieldGlyph } from './field-symbol.ts';
 import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
 import {
   appendModelRange,
@@ -116,7 +111,9 @@ import {
   MAX_CONTENT_CONTROL_NESTING,
 } from '../store/package/content-control-walk.ts';
 
-// Re-export instruction recognition + detection so existing layout-local imports stay stable.
+// Re-exports so existing layout-local imports stay stable: instruction recognition and
+// detection, whole-document page-field finalization (pagination-time values, own module),
+// the piece vocabulary, and the shared run-child text/property vocabulary.
 export {
   MAX_FIELD_INSTRUCTION_CHARS,
   MAX_STORY_FIELD_SCAN_DEPTH,
@@ -126,10 +123,6 @@ export {
   normalizeFieldInstruction,
   type StoryPageFieldNeeds,
 };
-
-// Same for the whole-document page-field finalization, which now lives in its own module: it
-// resolves values that only exist once pagination is done, and shares nothing with this walk
-// but the context type.
 export {
   fieldPageContextToken,
   finalizePageFieldProjection,
@@ -139,9 +132,6 @@ export {
   withPageFieldSources,
   type FieldPageContext,
 };
-
-// The piece vocabulary now lives beside the walk rather than inside it. Same re-export reason:
-// every layout module already imports these from here.
 export {
   type FieldAwarePiece,
   type FieldLinkProjector,
@@ -149,9 +139,6 @@ export {
   type ModelRange,
   type PositionalTab,
 };
-
-// Shared run-child text/property vocabulary — kept re-exported so paragraph-flow and
-// numbering-index keep their import site.
 export { propertiesOfRunContainer, type RunPropertyCascader } from './field-run-text.ts';
 
 /**
@@ -213,11 +200,8 @@ export function piecesOfParagraph(
   let pending: PendingFieldProjection | null = null;
   /** Outermost begin id when the open field is atomic. */
   let openAtomicBeginId: string | null = null;
-  // Live-evaluated allowlisted field nested inside the open atomic result: its cached digits
-  // are skipped and the matching inner end appends the projected value (fldSimple parity).
-  let nestedKind: AllowlistedPageField | null = null;
-  let nestedSeen = false;
-  let nestedVisible = false;
+  // Live-evaluated allowlisted field nested inside the open atomic result (fldSimple parity).
+  const nestedPage = createNestedPageTracker();
   /**
    * The revision wrappers enclosing the run being processed, outermost first.
    *
@@ -357,9 +341,10 @@ export function piecesOfParagraph(
       // Inert non-page field: paint cached result as layout-owned substitution for the
       // single model unit (same as live PAGE) so hit-test/span ranges stay one atom.
       push(pending.cachedText, pending.props, pending.style, true, start, end, carried);
-    } else if (pending.buttonSpec) {
+    } else if (pending.buttonSpec && !pending.sawResultContent) {
       // MACROBUTTON / GOTOBUTTON display their text; the macro / target never runs. A cached
-      // result (what Word last painted) wins above — this fills in only when it is empty.
+      // result (what Word last painted) wins above — this fills in only when the file cached
+      // NONE. A result that existed but was hidden stays hidden (`sawResultContent`).
       push(pending.buttonSpec.display, pending.props, pending.style, true, start, end, carried);
     }
     pending = null;
@@ -541,6 +526,31 @@ export function piecesOfParagraph(
     const props = runPropertiesOf(run, inheritedRunProperties, cascadeRuns);
     const style = resolveRunStyle(props, themeFonts);
 
+    /**
+     * Donate the run's style and attribution to the pending atom's flush, first-wins.
+     *
+     * The first result content that survives to be displayed donates both, because by flush
+     * time the walk has left any wrapper and the live stack is empty again. Locked by their
+     * own flags, not by the stack being non-empty: an UNTRACKED first run leaves the stack
+     * empty, and testing emptiness let a later tracked run donate its revision to the whole
+     * atom — `Section <w:del>3</w:del>` painted "Section 3" struck through entire. Shared by
+     * ordinary result text and a result `w:sym`, so a symbol-only result carries a style and
+     * an attribution too.
+     */
+    const donateResultCapture = (): void => {
+      if (!pending) return;
+      if (!pending.capturedResultStyle) {
+        pending.props = props;
+        pending.style = style;
+        pending.capturedResultStyle = true;
+      }
+      if (!pending.capturedResultRevisions) {
+        pending.resultRevisions = revisions;
+        pending.capturedResultRevisions = true;
+        if (!pending.resultLink && currentLink) pending.resultLink = currentLink;
+      }
+    };
+
     for (const grand of run.children) {
       if (!consumeScanNode(budget)) {
         abandonPending();
@@ -562,7 +572,7 @@ export function piecesOfParagraph(
         onFldCharBegin(field);
         if (field.nesting === 1) {
           abandonPending();
-          nestedKind = null;
+          nestedPage.reset();
           openAtomicBeginId = atomic ? grand.id : null;
           pending = {
             kind: null,
@@ -581,6 +591,7 @@ export function piecesOfParagraph(
             style,
             capturedResultStyle: false,
             cachedText: '',
+            sawResultContent: false,
             buffered: [],
             bufferOffset: offset,
             // A wrapper around the BEGIN marker wraps the whole field, and since
@@ -615,7 +626,9 @@ export function piecesOfParagraph(
           pending.kind = kind && pageContext ? kind : null;
           // Capture the SYMBOL / HYPERLINK / form-field spec while the machine still holds the
           // raw instruction (`onFldCharEnd` resets the buffer before the flush reads anything).
-          if (!pending.kind && !field.instructionOverflow) {
+          // Nesting overflow refuses exactly as PAGE projection does: a >4-deep hostile field
+          // must not synthesize output from whatever outer fragments the buffer kept.
+          if (!pending.kind && !field.instructionOverflow && !field.nestingOverflow) {
             captureInstructionSpecs(pending, field.instruction);
           }
           // Prefer separate-run style until a measurable result run donates one.
@@ -624,9 +637,7 @@ export function piecesOfParagraph(
         } else if (pending?.atomic && field.phase === 'result') {
           // Inner separate inside the outer atomic result: live-evaluate an allowlisted
           // nested field instead of concatenating its cached digits (fldSimple parity).
-          nestedKind = pageContext ? kind : null;
-          nestedSeen = false;
-          nestedVisible = false;
+          nestedPage.arm(pageContext ? kind : null);
         }
         continue;
       }
@@ -639,17 +650,17 @@ export function piecesOfParagraph(
           outermostEnd &&
           pending?.atomic &&
           field.phase === 'instruction' &&
-          !field.instructionOverflow
+          !field.instructionOverflow &&
+          !field.nestingOverflow
         ) {
           captureInstructionSpecs(pending, field.instruction);
         }
         // The end closing a skipped inner field appends its live value; an inner result that
         // existed but was entirely suppressed appends nothing (fldSimple parity).
-        if (field.nesting === 2 && pending?.atomic && nestedKind && pageContext) {
-          if (!nestedSeen || nestedVisible)
-            pending.cachedText += projectPageFieldValue(nestedKind, pageContext);
+        if (field.nesting === 2 && pending?.atomic) {
+          pending.cachedText += nestedPage.liveValue(pageContext);
         }
-        nestedKind = null;
+        nestedPage.reset();
         onFldCharEnd(field);
         if (outermostEnd) {
           if (pending?.atomic) commitAtomicField();
@@ -661,6 +672,12 @@ export function piecesOfParagraph(
       if (isCollectingInstruction(field)) {
         // Only well-formed atomic fields suppress instruction-phase run content.
         // Demoted / malformed opens must not make surrounding text disappear.
+        //
+        // An editable-result FORMTEXT field falls through ON PURPOSE: the offset authority
+        // (`walkParagraph` over `atomicFieldSpansOf`) only zeroes the nodes of ATOMIC spans,
+        // so ordinary `w:t` between its begin and separate keeps real model offsets — and
+        // layout must paint what the store addresses, or every offset after the field lies.
+        // Word would not save such content, but a file that carries it shows it.
         if (pending?.atomic) continue;
       }
 
@@ -668,19 +685,41 @@ export function piecesOfParagraph(
         // A cached result is one plain string and cannot carry a per-glyph font switch, so
         // only a `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
         if (isSymbolRunChild(grand)) {
-          if (
-            pending.atomic &&
-            !nestedKind &&
-            !style.hidden &&
-            revisionsVisible(revisions, displayMode)
-          ) {
-            const glyph = symbolGlyphOf(grand);
-            if (glyph?.unicode) pending.cachedText += glyph.text;
+          if (pending.atomic) {
+            pending.sawResultContent = true;
+            if (!nestedPage.active && !style.hidden && revisionsVisible(revisions, displayMode)) {
+              const glyph = symbolGlyphOf(grand);
+              if (glyph?.unicode) {
+                donateResultCapture();
+                pending.cachedText += glyph.text;
+              }
+            }
+            continue;
           }
+          // Demoted / editable-result field: the sym paints the way it does in an ordinary
+          // run — a projected zero-width glyph piece — instead of vanishing with the atomic
+          // skips. Buffered like the surrounding result text, so it flushes with it.
+          const glyph = symbolGlyphOf(grand);
+          if (!glyph || style.hidden || !revisionsVisible(revisions, displayMode)) continue;
+          const sym = symbolRunStyle(props, glyph, themeFonts);
+          pending.buffered.push({
+            text: glyph.text,
+            props: sym.props,
+            style: sym.style,
+            start: offset,
+            end: offset,
+            projected: true,
+            ...(revisions.length > 0 ? { revisions } : {}),
+            ...(currentLink ? { link: currentLink } : {}),
+            fieldAtom: { formField: pending.formField },
+          });
           continue;
         }
         const text = modelTextOfRunChild(grand);
         if (text.length === 0) continue;
+        // The result EXISTS, whatever suppresses it below — the flush needs the distinction
+        // to keep synthesis from painting over a result the file hid on purpose.
+        if (pending.atomic) pending.sawResultContent = true;
 
         // A field can be tracked as a whole — Word writes a deleted hyperlink as `w:del`
         // around the begin/instr/separate/result/end run — and its result text is BUFFERED
@@ -712,7 +751,7 @@ export function piecesOfParagraph(
         }
 
         if (fieldSuppressed) {
-          if (pending.atomic && nestedKind) nestedSeen = true;
+          if (pending.atomic && nestedPage.active) nestedPage.noteResult(false);
           if (!pending.atomic) {
             offset += text.length;
             pending.bufferOffset = offset;
@@ -722,11 +761,10 @@ export function piecesOfParagraph(
 
         if (pending.atomic) {
           // Atomic unit: cache donates display text/style only — offset already reserved.
-          if (nestedKind) {
+          if (nestedPage.active) {
             // Skipped inner cached digits: the live value replaces them at the inner end.
-            nestedSeen = true;
+            nestedPage.noteResult(!style.hidden);
             if (style.hidden) continue;
-            nestedVisible = true;
             if (!pending.capturedResultStyle) {
               pending.props = props;
               pending.style = style;
@@ -735,24 +773,7 @@ export function piecesOfParagraph(
             continue;
           }
           if (style.hidden) continue;
-          if (!pending.capturedResultStyle) {
-            pending.props = props;
-            pending.style = style;
-            pending.capturedResultStyle = true;
-          }
-          // The first result run that survives to be displayed donates the attribution the
-          // flush will replay, because by then the walk has left the wrapper. See
-          // `resultRevisions` for why first wins.
-          //
-          // Locked by its own flag, not by the stack being non-empty: an UNTRACKED first run
-          // leaves the stack empty, and testing emptiness let a later tracked run donate its
-          // revision to the whole atom. `Section <w:del>3</w:del>` then painted "Section 3"
-          // struck through entire — the engine claiming a deletion over words nobody deleted.
-          if (!pending.capturedResultRevisions) {
-            pending.resultRevisions = revisions;
-            pending.capturedResultRevisions = true;
-            if (!pending.resultLink && currentLink) pending.resultLink = currentLink;
-          }
+          donateResultCapture();
           pending.cachedText += text;
           continue;
         }
@@ -781,7 +802,9 @@ export function piecesOfParagraph(
           end: offset + text.length,
           ...(revisions.length > 0 ? { revisions } : {}),
           ...(currentLink ? { link: currentLink } : {}),
-          ...(pending.editableResult ? { fieldAtom: { formField: pending.formField } } : {}),
+          // EVERY buffered result piece is a field's displayed result — a demoted
+          // (unterminated) field's cache shades exactly like a FORMTEXT's editable one.
+          fieldAtom: { formField: pending.formField },
         });
         offset += text.length;
         pending.bufferOffset = offset;
@@ -828,11 +851,8 @@ export function piecesOfParagraph(
    * Paint a `w:fldSimple` (§17.16.19) as one projected model unit.
    *
    * The instruction lives in `@w:instr` and the last-computed result as child runs — there is
-   * no `separate` marker on the outer field itself. Allowlisted PAGE / NUMPAGES / SECTIONPAGES
-   * evaluate from the page context when one is supplied. Every other instruction paints its
-   * cached result, but nested allowlisted page fields inside that cache still evaluate live
-   * (see {@link collectSimpleFieldDisplay}) so a `STYLEREF` wrapping `PAGE` does not stamp the
-   * saved sheet's number onto every page.
+   * no `separate` marker on the outer field itself. What the unit paints is decided by
+   * {@link projectSimpleFieldResult}; this owns the model offset and OUTER visibility.
    *
    * Attribution comes from `push` reading the live stack — a `w:fldSimple` inside `w:ins` is
    * still inside it here, unlike a complex field's deferred flush.
@@ -843,9 +863,8 @@ export function piecesOfParagraph(
     if (simple.kind === 'textValue') return;
 
     // The atom is one model offset whatever it paints, so a revision enclosing the WHOLE field
-    // is answered here, once, before any of the branches below — including the live page-field
-    // one, which does not go through result collection and so would otherwise paint a deleted
-    // footer number straight into the accepted view.
+    // is answered here, once, before result collection — including the live page-field branch,
+    // which would otherwise paint a deleted footer number straight into the accepted view.
     //
     // The deleted range is recorded whether or not it was laid out, exactly as the complex path
     // and inline drawings do: the offset exists in every display mode and the caret has to step
@@ -855,7 +874,7 @@ export function piecesOfParagraph(
     }
     if (!revisionsVisible(revisions, displayMode)) return;
 
-    const display = collectSimpleFieldDisplay({
+    const projected = projectSimpleFieldResult({
       simple,
       depth,
       pageContext,
@@ -865,83 +884,15 @@ export function piecesOfParagraph(
       inheritedRunProperties,
       cascadeRuns,
       themeFonts,
+      currentLink,
+      projectFieldLink,
     });
-
-    // A simple PAGE/NUMPAGES/SECTIONPAGES field is evaluated like its complex twin when the
-    // caller supplies a page context. The CACHED result is whatever sheet the producer last
-    // saved from, so painting it verbatim would put that page's number on every page —
-    // `detectStoryPageFields` now reports these so furniture actually gets a per-sheet context
-    // to evaluate against.
-    const pageKind = allowlistedPageField(fldSimpleInstr(simple) ?? '');
-    if (pageKind && pageContext) {
-      const live = projectPageFieldValue(pageKind, pageContext);
-      const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
-      if (!style.hidden) {
-        push(live, display.resultProps ?? inheritedRunProperties, style, true, start, start + 1, {
-          fieldAtom: { formField: false },
-        });
-      }
-      return;
-    }
-
-    // A simple SYMBOL renders from its instruction like the complex shape does — there is no
-    // trustworthy cached result to prefer. An unresolvable spec falls through to the cached
-    // display (previous behavior).
-    const symbolSpec = parseSymbolInstruction(fldSimpleInstr(simple) ?? '');
-    if (symbolSpec) {
-      const glyph = symbolFieldGlyph(
-        symbolSpec,
-        display.resultProps ?? inheritedRunProperties,
-        themeFonts
-      );
-      if (glyph) {
-        if (!glyph.style.hidden) {
-          push(glyph.text, glyph.props, glyph.style, true, start, start + 1, {
-            fieldAtom: { formField: false },
-          });
-        }
-        return;
-      }
-    }
-
-    // A simple MACROBUTTON / GOTOBUTTON displays everything after its first argument; the
-    // macro / target never runs. A non-empty cached display wins — synthesis fills an empty one.
-    const buttonSpec =
-      display.text.length === 0 ? parseButtonInstruction(fldSimpleInstr(simple) ?? '') : null;
-    if (buttonSpec) {
-      const buttonStyle =
-        display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
-      if (buttonStyle.hidden) return;
-      const buttonProps = display.resultProps ?? inheritedRunProperties;
-      push(buttonSpec.display, buttonProps, buttonStyle, true, start, start + 1, {
-        fieldAtom: { formField: false },
-      });
-      return;
-    }
-
-    if (display.text.length === 0) return;
-    // Nested live PAGE may replace an empty cached result and leave no donor run; fall back
-    // to inherited properties the same way a top-level simple PAGE does.
-    const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
-    if (style.hidden) return;
-    // A simple HYPERLINK links its cached result — but only outside a typed `w:hyperlink`,
-    // whose record `push` already applies and which outranks the field's own instruction.
-    // An empty result never reached here, so an empty result never paints the URL.
-    const linkSpec = currentLink ? null : parseHyperlinkInstruction(fldSimpleInstr(simple) ?? '');
-    const fieldLink = linkSpec ? (projectFieldLink?.(linkSpec) ?? null) : null;
+    if (!projected) return;
     // `w:ffData` is a `w:fldChar` payload, so a simple field is never a legacy form field.
-    push(
-      display.text,
-      display.resultProps ?? inheritedRunProperties,
-      style,
-      true,
-      start,
-      start + 1,
-      {
-        fieldAtom: { formField: false },
-        ...(fieldLink ? { linkOverride: fieldLink } : {}),
-      }
-    );
+    push(projected.text, projected.props, projected.style, true, start, start + 1, {
+      fieldAtom: { formField: false },
+      ...(projected.link ? { linkOverride: projected.link } : {}),
+    });
   };
 
   const processInline = (

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -21,7 +21,6 @@
 import {
   fldSimpleInstr,
   hardBreakKind,
-  hardBreakText,
   hasLegacyFormFieldData,
   isFldSimple,
   type OoxmlNode,
@@ -65,12 +64,19 @@ import {
 } from './field-page-furniture.ts';
 import { collectSimpleFieldDisplay } from './field-simple-result.ts';
 import {
+  modelTextOfRunChild,
+  runPropertiesOf,
+  type RunPropertyCascader,
+} from './field-run-text.ts';
+import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
+import {
   appendModelRange,
   positionalTabOf,
   type FieldAtomMarker,
   type FieldAwarePiece,
   type ModelRange,
   type MutableModelRange,
+  type PendingFieldProjection,
   type PositionalTab,
 } from './field-pieces.ts';
 import type { InlineDrawingLayoutContext, InlineDrawingLayoutInput } from './drawing-layout.ts';
@@ -144,11 +150,9 @@ export {
   type PositionalTab,
 };
 
-/** Optional per-run merge of inherited + direct `rPr` (character styles, defaults). */
-export type RunPropertyCascader = (
-  inherited: readonly OoxmlProperty[],
-  direct: readonly OoxmlProperty[]
-) => readonly OoxmlProperty[];
+// Shared run-child text/property vocabulary — kept re-exported so paragraph-flow and
+// numbering-index keep their import site.
+export { propertiesOfRunContainer, type RunPropertyCascader } from './field-run-text.ts';
 
 /**
  * How layout turns a typed `w:hyperlink` node into the sanitized record spans carry.
@@ -159,110 +163,6 @@ export type RunPropertyCascader = (
  * the right degradation: text is never lost for want of a target.
  */
 export type HyperlinkProjector = (link: OoxmlNode) => SpanLinkRecord | null;
-
-function runPropertiesOf(
-  run: OoxmlNode,
-  inherited: readonly OoxmlProperty[],
-  cascadeRuns?: RunPropertyCascader
-): OoxmlProperty[] {
-  const direct = propertiesOfRunContainer(
-    run.kind === 'run' ? run.children.find((grand) => grand.kind === 'runProperties') : undefined
-  );
-  if (cascadeRuns) return [...cascadeRuns(inherited, direct)];
-  return inherited.length === 0 ? direct : [...inherited, ...direct];
-}
-
-export function propertiesOfRunContainer(container: OoxmlNode | undefined): OoxmlProperty[] {
-  if (!container || container.kind === 'textValue') return [];
-  const props: OoxmlProperty[] = [];
-  for (const child of container.children) {
-    if (child.kind === 'textValue') continue;
-    const attributes: Record<string, string> = {};
-    for (const entry of child.attributes) attributes[entry.localName] = entry.value;
-    props.push(
-      Object.keys(attributes).length > 0
-        ? { localName: child.localName, attributes }
-        : { localName: child.localName }
-    );
-  }
-  return props;
-}
-
-/** Model text contributed by one typed run child (same vocabulary as `paragraphTextOf`). */
-function modelTextOfRunChild(grand: OoxmlNode): string {
-  // `w:delText` holds real characters at a real position, so it counts in the model offset
-  // space exactly like `w:t`. Whether it is LAID OUT is a separate question, answered by the
-  // enclosing revision and the display mode.
-  if (grand.kind === 'text' || grand.kind === 'deletedText') {
-    let text = '';
-    for (const value of grand.children) if (value.kind === 'textValue') text += value.value;
-    return text;
-  }
-  if (grand.kind === 'tab') return '\t';
-  if (grand.kind === 'hardBreak') return hardBreakText(grand);
-  return '';
-}
-
-/**
- * Pending live or inert-cache projection for one atomic field unit.
- *
- * Well-formed computed fields contribute exactly one UTF-16 model unit. Cached result text
- * is not independently addressable — it only donates display text and result-run style.
- * Missing `end` demotes: buffered cache is flushed as ordinary pieces with real lengths.
- */
-interface PendingFieldProjection {
-  /** Allowlisted kind when live-projecting; null paints inert cached text at the atom. */
-  kind: AllowlistedPageField | null;
-  /** True when this pending field is a well-formed atomic unit (begin will close). */
-  atomic: boolean;
-  /** True when this closed FORMTEXT field exposes its authored result as ordinary text. */
-  editableResult: boolean;
-  atomStart: number;
-  props: readonly OoxmlProperty[];
-  style: ResolvedRunStyle;
-  capturedResultStyle: boolean;
-  /** Cached result text (for inert display or demotion flush). */
-  cachedText: string;
-  /** Demotion-only: ordinary pieces when the field fails to close. */
-  buffered: FieldAwarePiece[];
-  /** Demotion-only running offset mirror while buffering ordinary pieces. */
-  bufferOffset: number;
-  /**
-   * The revision wrappers this field's displayed text sits inside, captured while the walk was
-   * still INSIDE them.
-   *
-   * An ATOMIC field's result is buffered at the run that carries it and flushed at `fldChar
-   * end`, by which point the depth-first walk has left the wrapper and restored the live stack
-   * to empty. Reading the live stack at flush time therefore attributed a tracked field result
-   * to nothing at all, and it painted as ordinary unchanged text — a deletion with no strike,
-   * an insertion with no underline.
-   *
-   * Both shapes reach here: a `w:del` around only the RESULT run with `begin`/`end` outside it
-   * (how Word records a form field whose value was replaced), and a wrapper around the whole
-   * `begin`…`end` sequence. The second used to demote instead — `atomicFieldSpansOf` did not
-   * descend into revision wrappers — until that walk was widened so the store and layout would
-   * stop disagreeing about what such a field is worth. Anything reasoning about "a wrapped field
-   * never forms an atom" is out of date; `commitAtomicField` now has to resolve visibility
-   * itself, because it can be reached with a stack that the display mode resolves away.
-   *
-   * A field whose result runs carry DIFFERENT stacks collapses to the first: the atom is one
-   * model unit and Word treats a field as one decision, so splitting it would invent a boundary
-   * the model does not have.
-   */
-  resultRevisions: readonly RevisionAttribution[];
-  /** Whether {@link resultRevisions} has been donated yet — an EMPTY stack is a real answer. */
-  capturedResultRevisions: boolean;
-  /** `w:ffData` on the begin marker — a legacy form field, which Word shades on its own rule. */
-  formField: boolean;
-  /**
-   * The link enclosing the displayed result, captured at `begin` for the same reason.
-   *
-   * Reachable where the revision capture is not: `atomicFieldSpansOf` DOES descend into
-   * `w:hyperlink`, so a field inside a link is still an atom, and without this its result was
-   * the one run in the link painting with no href.
-   */
-  resultLink?: SpanLinkRecord;
-}
 
 /**
  * Flatten a paragraph into measurable pieces, projecting allowlisted page fields when a
@@ -564,6 +464,16 @@ export function piecesOfParagraph(
         push('\t', props, style, false, offset, offset, { positionalTab: positional });
       return;
     }
+    // A `w:sym` is generic in the canonical tree, so the store gives it NO model width. The
+    // glyph is therefore a projected piece at a zero-width range — paint emits it as
+    // furniture (no `data-start`) and every surrounding offset stays where the store put it.
+    if (isSymbolRunChild(grand)) {
+      const glyph = symbolGlyphOf(grand);
+      if (!glyph || style.hidden || !revisionsVisible(revisions, displayMode)) return;
+      const sym = symbolRunStyle(props, glyph, themeFonts);
+      push(glyph.text, sym.props, sym.style, true, offset, offset);
+      return;
+    }
     const text = modelTextOfRunChild(grand);
     if (text.length === 0) return;
     // A revision the display mode resolves away is suppressed the same way `w:vanish` is, and
@@ -681,6 +591,15 @@ export function piecesOfParagraph(
       }
 
       if (pending && isInsideFieldResult(field)) {
+        // A cached result is one plain string and cannot carry a per-glyph font switch, so
+        // only a `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
+        if (isSymbolRunChild(grand)) {
+          if (pending.atomic && !style.hidden && revisionsVisible(revisions, displayMode)) {
+            const glyph = symbolGlyphOf(grand);
+            if (glyph?.unicode) pending.cachedText += glyph.text;
+          }
+          continue;
+        }
         const text = modelTextOfRunChild(grand);
         if (text.length === 0) continue;
 

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -9,11 +9,14 @@
 // (aligned with `paragraphTextOf` / `segmentsOf`). FORMTEXT results instead keep their literal
 // character offsets because they are user input. Malformed fields demote so content remains.
 //
-// Shipped scope is furniture-only for live page-number evaluation. Simple and complex
-// PAGE-family fields evaluate alike when a page context is supplied; a non-page field paints
-// its cached result, with allowlisted page fields nested inside that result (complex or
-// simple) evaluated per sheet rather than concatenated from the saved cache. Other nested
-// field instructions stay inert. Body-side evaluation beyond that is deferred.
+// Simple and complex PAGE-family fields evaluate alike when a page context is supplied
+// (headers/footers): the live value paints from that context. In the BODY there is no page
+// context — the value depends on a pagination that has not happened yet — so a page field with
+// no cached result paints a placeholder digit and records its kind on the span's field-atom
+// marker; `substituteBodyPageFields` fills the real value once the page count is known. A
+// non-page field paints its cached result, with allowlisted page fields nested inside that
+// result (complex or simple) evaluated per sheet rather than concatenated from the saved cache.
+// Other nested field instructions stay inert.
 //
 // Projection is a layout concern (span geometry + tab alignment), not paint-time substitution.
 
@@ -170,7 +173,8 @@ export function piecesOfParagraph(
   inlineDrawingLayout?: InlineDrawingLayoutContext,
   themeFonts?: ThemeFonts,
   projectFieldLink?: FieldLinkProjector,
-  documentProperties?: DocumentProperties
+  documentProperties?: DocumentProperties,
+  bodyPageFields = false
 ): FieldAwarePiece[] {
   if (paragraph.kind === 'textValue') return [];
   if (paragraph.kind !== 'paragraph') return [];
@@ -329,9 +333,18 @@ export function piecesOfParagraph(
       pageContext,
       themeFonts,
       documentProperties,
+      bodyPageFields,
     });
     if (synthesis) {
-      push(synthesis.text, synthesis.props, synthesis.style, true, start, end, carried());
+      const extras = carried();
+      // A body page-field placeholder rides the same field-atom marker its finalize pass reads.
+      const withPageField = synthesis.pageField
+        ? {
+            ...extras,
+            fieldAtom: { formField: pending.formField, pageField: synthesis.pageField },
+          }
+        : extras;
+      push(synthesis.text, synthesis.props, synthesis.style, true, start, end, withPageField);
     }
     pending = null;
     openAtomicBeginId = null;
@@ -612,7 +625,10 @@ export function piecesOfParagraph(
         const separateLevel = field.nesting;
         const kind = onFldCharSeparate(field);
         if (outermostSeparate && pending) {
-          pending.kind = kind && pageContext ? kind : null;
+          // Capture the allowlisted kind whether or not a page context is present. With one
+          // (header/footer) the flush projects the live value; without one (body) it paints a
+          // placeholder the kind marks, and document finalize substitutes the page's value.
+          pending.kind = kind;
           // Capture the SYMBOL / HYPERLINK / form-field spec while the machine still holds the
           // raw instruction (`onFldCharEnd` resets the buffer before the flush reads anything).
           // Nesting overflow refuses exactly as PAGE projection does: a >4-deep hostile field
@@ -894,11 +910,16 @@ export function piecesOfParagraph(
       currentLink,
       projectFieldLink,
       documentProperties,
+      bodyPageFields,
     });
     if (!projected) return;
-    // `w:ffData` is a `w:fldChar` payload, so a simple field is never a legacy form field.
+    // `w:ffData` is a `w:fldChar` payload, so a simple field is never a legacy form field. A body
+    // page field carries its kind so document finalize substitutes the page's value.
     push(projected.text, projected.props, projected.style, true, start, start + 1, {
-      fieldAtom: { formField: false },
+      fieldAtom: {
+        formField: false,
+        ...(projected.pageField ? { pageField: projected.pageField } : {}),
+      },
       ...(projected.link ? { linkOverride: projected.link } : {}),
     });
   };

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -32,6 +32,7 @@ import {
   createFieldParseState,
   createScanBudget,
   detectStoryPageFields,
+  effectiveFieldInstruction,
   ingestInstrTextBounded,
   isCollectingInstruction,
   isFldChar,
@@ -630,8 +631,9 @@ export function piecesOfParagraph(
           // raw instruction (`onFldCharEnd` resets the buffer before the flush reads anything).
           // Nesting overflow refuses exactly as PAGE projection does: a >4-deep hostile field
           // must not synthesize output from whatever outer fragments the buffer kept.
-          if (!pending.kind && !field.instructionOverflow && !field.nestingOverflow) {
-            captureInstructionSpecs(pending, field.instruction);
+          const effective = effectiveFieldInstruction(field);
+          if (!pending.kind && !effective.overflow && !field.nestingOverflow) {
+            captureInstructionSpecs(pending, effective.instruction);
           }
           // Prefer separate-run style until a measurable result run donates one.
           pending.props = props;
@@ -652,14 +654,11 @@ export function piecesOfParagraph(
         const outermostEnd = field.nesting === 1;
         // A SYMBOL or FORMCHECKBOX with no `separate` at all (begin/instr/end) still renders
         // in Word. The machine's buffer is reset by `onFldCharEnd`, so capture BEFORE advancing.
-        if (
-          outermostEnd &&
-          pending?.atomic &&
-          field.phase === 'instruction' &&
-          !field.instructionOverflow &&
-          !field.nestingOverflow
-        ) {
-          captureInstructionSpecs(pending, field.instruction);
+        if (outermostEnd && pending?.atomic && field.phase === 'instruction') {
+          const effective = effectiveFieldInstruction(field);
+          if (!effective.overflow && !field.nestingOverflow) {
+            captureInstructionSpecs(pending, effective.instruction);
+          }
         }
         // The end closing the TRACKED inner field appends its live value; an inner result that
         // existed but was entirely suppressed appends nothing (fldSimple parity). Deeper ends
@@ -694,7 +693,12 @@ export function piecesOfParagraph(
         // only a `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
         if (isSymbolRunChild(grand)) {
           if (pending.atomic) {
-            pending.sawResultContent = true;
+            // The flag records only what THIS display mode keeps: a `w:del`-wrapped result
+            // hidden by the proposed view is gone from that view, and suppressing synthesis
+            // over it would paint nothing where Word (after accepting) shows the display
+            // text. Vanish-hidden content still sets it — that is the case the flag exists
+            // for.
+            if (revisionsVisible(revisions, displayMode)) pending.sawResultContent = true;
             if (nestedPage.active) {
               // A symbol inside the skipped inner cache is result content too: a visible one
               // keeps the live replacement alive, a suppressed-only cache appends nothing.
@@ -731,9 +735,6 @@ export function piecesOfParagraph(
         }
         const text = modelTextOfRunChild(grand);
         if (text.length === 0) continue;
-        // The result EXISTS, whatever suppresses it below — the flush needs the distinction
-        // to keep synthesis from painting over a result the file hid on purpose.
-        if (pending.atomic) pending.sawResultContent = true;
 
         // A field can be tracked as a whole — Word writes a deleted hyperlink as `w:del`
         // around the begin/instr/separate/result/end run — and its result text is BUFFERED
@@ -744,6 +745,12 @@ export function piecesOfParagraph(
         const fieldSuppressed =
           !revisionsVisible(revisions, displayMode) ||
           (grand.kind === 'deletedText' && !fieldDeleted);
+
+        // The result EXISTS in this display mode, whatever hides it below (vanish included) —
+        // the flush needs the distinction to keep synthesis from painting over a result the
+        // file hid on purpose. Revision-suppressed content does NOT count: the mode resolved
+        // it away, and Word (after accepting the deletion) synthesizes over the gap.
+        if (pending.atomic && !fieldSuppressed) pending.sawResultContent = true;
 
         // Deleted characters are recorded whether or not they were laid out, exactly as they
         // are for ordinary runs: they occupy model offsets in every display mode, and the caret

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -68,6 +68,7 @@ import {
   runPropertiesOf,
   type RunPropertyCascader,
 } from './field-run-text.ts';
+import { parseSymbolInstruction, symbolFieldGlyph } from './field-symbol.ts';
 import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
 import {
   appendModelRange,
@@ -326,6 +327,18 @@ export function piecesOfParagraph(
       ...(pending.resultLink ? { linkOverride: pending.resultLink } : {}),
       fieldAtom: { formField: pending.formField },
     };
+    // SYMBOL renders from its instruction — Word never trusts a cached result for it, so a
+    // synthesized glyph wins over stale cached text. An unresolvable spec falls through to
+    // the existing branches (cached text or nothing).
+    if (pending.symbolSpec) {
+      const glyph = symbolFieldGlyph(pending.symbolSpec, pending.props, themeFonts);
+      if (glyph) {
+        push(glyph.text, glyph.props, glyph.style, true, start, end, carried);
+        pending = null;
+        openAtomicBeginId = null;
+        return;
+      }
+    }
     if (pending.kind && pageContext) {
       const text = projectPageFieldValue(pending.kind, pageContext);
       push(text, pending.props, pending.style, true, start, end, carried);
@@ -528,6 +541,7 @@ export function piecesOfParagraph(
           openAtomicBeginId = atomic ? grand.id : null;
           pending = {
             kind: null,
+            symbolSpec: null,
             atomic,
             editableResult: editableResultBeginIds.has(grand.id),
             atomStart: offset,
@@ -567,6 +581,10 @@ export function piecesOfParagraph(
         const kind = onFldCharSeparate(field);
         if (outermostSeparate && pending) {
           pending.kind = kind && pageContext ? kind : null;
+          // Capture a SYMBOL spec while the machine still holds the raw instruction.
+          if (!pending.kind && !field.instructionOverflow) {
+            pending.symbolSpec = parseSymbolInstruction(field.instruction);
+          }
           // Prefer separate-run style until a measurable result run donates one.
           pending.props = props;
           pending.style = style;
@@ -576,6 +594,16 @@ export function piecesOfParagraph(
 
       if (isFldChar(grand, 'end')) {
         const outermostEnd = field.nesting === 1;
+        // A SYMBOL with no `separate` at all (begin/instr/end) still renders in Word. The
+        // machine's buffer is reset by `onFldCharEnd`, so capture the spec BEFORE advancing.
+        if (
+          outermostEnd &&
+          pending?.atomic &&
+          field.phase === 'instruction' &&
+          !field.instructionOverflow
+        ) {
+          pending.symbolSpec = parseSymbolInstruction(field.instruction);
+        }
         onFldCharEnd(field);
         if (outermostEnd) {
           if (pending?.atomic) commitAtomicField();
@@ -790,6 +818,26 @@ export function piecesOfParagraph(
         });
       }
       return;
+    }
+
+    // A simple SYMBOL renders from its instruction like the complex shape does — there is no
+    // trustworthy cached result to prefer. An unresolvable spec falls through to the cached
+    // display (previous behavior).
+    const symbolSpec = parseSymbolInstruction(fldSimpleInstr(simple) ?? '');
+    if (symbolSpec) {
+      const glyph = symbolFieldGlyph(
+        symbolSpec,
+        display.resultProps ?? inheritedRunProperties,
+        themeFonts
+      );
+      if (glyph) {
+        if (!glyph.style.hidden) {
+          push(glyph.text, glyph.props, glyph.style, true, start, start + 1, {
+            fieldAtom: { formField: false },
+          });
+        }
+        return;
+      }
     }
 
     if (display.text.length === 0) return;

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -21,6 +21,7 @@ import {
   hardBreakKind,
   hasLegacyFormFieldData,
   isFldSimple,
+  type DocumentProperties,
   type OoxmlNode,
   type OoxmlParagraphNode,
   type OoxmlProperty,
@@ -65,8 +66,8 @@ import {
   runPropertiesOf,
   type RunPropertyCascader,
 } from './field-run-text.ts';
-import { captureInstructionSpecs, formFieldResult } from './field-form.ts';
-import { symbolFieldGlyph } from './field-symbol.ts';
+import { captureInstructionSpecs } from './field-form.ts';
+import { synthesizeAtomicField } from './field-synthesis.ts';
 import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
 import {
   appendModelRange,
@@ -168,7 +169,8 @@ export function piecesOfParagraph(
   deletedRanges?: MutableModelRange[],
   inlineDrawingLayout?: InlineDrawingLayoutContext,
   themeFonts?: ThemeFonts,
-  projectFieldLink?: FieldLinkProjector
+  projectFieldLink?: FieldLinkProjector,
+  documentProperties?: DocumentProperties
 ): FieldAwarePiece[] {
   if (paragraph.kind === 'textValue') return [];
   if (paragraph.kind !== 'paragraph') return [];
@@ -319,39 +321,17 @@ export function piecesOfParagraph(
       };
       return carriedMemo;
     };
-    // SYMBOL renders from its instruction — Word never trusts a cached result for it, so a
-    // synthesized glyph wins over stale cached text. An unresolvable spec falls through to
-    // the existing branches (cached text or nothing).
-    if (pending.symbolSpec) {
-      const glyph = symbolFieldGlyph(pending.symbolSpec, pending.props, themeFonts);
-      if (glyph) {
-        push(glyph.text, glyph.props, glyph.style, true, start, end, carried());
-        pending = null;
-        openAtomicBeginId = null;
-        return;
-      }
-    }
-    // A legacy form field renders from its ffData state: a checkbox always (the state is the
-    // authority, a stale cached glyph must not win), a dropdown only when the cache is empty.
-    const form = formFieldResult(pending, themeFonts);
-    if (form) {
-      push(form.text, form.props, form.style, true, start, end, carried());
-      pending = null;
-      openAtomicBeginId = null;
-      return;
-    }
-    if (pending.kind && pageContext) {
-      const text = projectPageFieldValue(pending.kind, pageContext);
-      push(text, pending.props, pending.style, true, start, end, carried());
-    } else if (pending.cachedText.length > 0) {
-      // Inert non-page field: paint cached result as layout-owned substitution for the
-      // single model unit (same as live PAGE) so hit-test/span ranges stay one atom.
-      push(pending.cachedText, pending.props, pending.style, true, start, end, carried());
-    } else if (pending.buttonSpec && !pending.sawResultContent) {
-      // MACROBUTTON / GOTOBUTTON display their text; the macro / target never runs. A cached
-      // result (what Word last painted) wins above — this fills in only when the file cached
-      // NONE. A result that existed but was hidden stays hidden (`sawResultContent`).
-      push(pending.buttonSpec.display, pending.props, pending.style, true, start, end, carried());
+    // The whole synthesis dispatch — SYMBOL / form field / live PAGE / cached result / a
+    // document-property value / MACROBUTTON display — lives in `field-synthesis.ts`; it reads
+    // the pending state and the document-global context and returns the one glyph run to paint,
+    // or null for nothing (the reserved model unit stays either way).
+    const synthesis = synthesizeAtomicField(pending, {
+      pageContext,
+      themeFonts,
+      documentProperties,
+    });
+    if (synthesis) {
+      push(synthesis.text, synthesis.props, synthesis.style, true, start, end, carried());
     }
     pending = null;
     openAtomicBeginId = null;
@@ -587,6 +567,7 @@ export function piecesOfParagraph(
             linkSpec: null,
             formSpec: null,
             buttonSpec: null,
+            docPropertySpec: null,
             // Bounded ffData STATE read (checkbox checked/size, dropdown entries/selection —
             // macros never); `formField` below stays presence-based so an unreadable payload
             // still shades.
@@ -912,6 +893,7 @@ export function piecesOfParagraph(
       themeFonts,
       currentLink,
       projectFieldLink,
+      documentProperties,
     });
     if (!projected) return;
     // `w:ffData` is a `w:fldChar` payload, so a simple field is never a legacy form field.

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -304,15 +304,20 @@ export function piecesOfParagraph(
     }
     // A HYPERLINK field becomes a live link only when nothing already links it: an enclosing
     // `w:hyperlink` captured into `resultLink` wins, exactly as it does for every other field.
-    const fieldLink =
-      !pending.resultLink && pending.linkSpec
-        ? (projectFieldLink?.(pending.linkSpec) ?? null)
-        : null;
-    const carriedLink = pending.resultLink ?? fieldLink;
-    const carried = {
-      ...(pending.resultRevisions.length > 0 ? { revisionsOverride: pending.resultRevisions } : {}),
-      ...(carriedLink ? { linkOverride: carriedLink } : {}),
-      fieldAtom: { formField: pending.formField },
+    // Resolved LAZILY (and memoized): a field that paints nothing — empty result, no synthesized
+    // glyph — must never reach `projectFieldLink`, or it mints a registry id no piece ever uses.
+    const { resultLink, linkSpec, resultRevisions, formField } = pending;
+    let carriedMemo: NonNullable<Parameters<typeof push>[6]> | undefined;
+    const carried = (): NonNullable<Parameters<typeof push>[6]> => {
+      if (carriedMemo) return carriedMemo;
+      const fieldLink = !resultLink && linkSpec ? (projectFieldLink?.(linkSpec) ?? null) : null;
+      const carriedLink = resultLink ?? fieldLink;
+      carriedMemo = {
+        ...(resultRevisions.length > 0 ? { revisionsOverride: resultRevisions } : {}),
+        ...(carriedLink ? { linkOverride: carriedLink } : {}),
+        fieldAtom: { formField },
+      };
+      return carriedMemo;
     };
     // SYMBOL renders from its instruction — Word never trusts a cached result for it, so a
     // synthesized glyph wins over stale cached text. An unresolvable spec falls through to
@@ -320,7 +325,7 @@ export function piecesOfParagraph(
     if (pending.symbolSpec) {
       const glyph = symbolFieldGlyph(pending.symbolSpec, pending.props, themeFonts);
       if (glyph) {
-        push(glyph.text, glyph.props, glyph.style, true, start, end, carried);
+        push(glyph.text, glyph.props, glyph.style, true, start, end, carried());
         pending = null;
         openAtomicBeginId = null;
         return;
@@ -330,23 +335,23 @@ export function piecesOfParagraph(
     // authority, a stale cached glyph must not win), a dropdown only when the cache is empty.
     const form = formFieldResult(pending, themeFonts);
     if (form) {
-      push(form.text, form.props, form.style, true, start, end, carried);
+      push(form.text, form.props, form.style, true, start, end, carried());
       pending = null;
       openAtomicBeginId = null;
       return;
     }
     if (pending.kind && pageContext) {
       const text = projectPageFieldValue(pending.kind, pageContext);
-      push(text, pending.props, pending.style, true, start, end, carried);
+      push(text, pending.props, pending.style, true, start, end, carried());
     } else if (pending.cachedText.length > 0) {
       // Inert non-page field: paint cached result as layout-owned substitution for the
       // single model unit (same as live PAGE) so hit-test/span ranges stay one atom.
-      push(pending.cachedText, pending.props, pending.style, true, start, end, carried);
+      push(pending.cachedText, pending.props, pending.style, true, start, end, carried());
     } else if (pending.buttonSpec && !pending.sawResultContent) {
       // MACROBUTTON / GOTOBUTTON display their text; the macro / target never runs. A cached
       // result (what Word last painted) wins above — this fills in only when the file cached
       // NONE. A result that existed but was hidden stays hidden (`sawResultContent`).
-      push(pending.buttonSpec.display, pending.props, pending.style, true, start, end, carried);
+      push(pending.buttonSpec.display, pending.props, pending.style, true, start, end, carried());
     }
     pending = null;
     openAtomicBeginId = null;

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -68,7 +68,8 @@ import {
   runPropertiesOf,
   type RunPropertyCascader,
 } from './field-run-text.ts';
-import { parseHyperlinkInstruction, type HyperlinkFieldSpec } from './field-link.ts';
+import { captureInstructionSpecs, formFieldResult } from './field-form.ts';
+import { parseHyperlinkInstruction } from './field-link.ts';
 import { parseSymbolInstruction, symbolFieldGlyph } from './field-symbol.ts';
 import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
 import {
@@ -76,6 +77,8 @@ import {
   positionalTabOf,
   type FieldAtomMarker,
   type FieldAwarePiece,
+  type FieldLinkProjector,
+  type HyperlinkProjector,
   type ModelRange,
   type MutableModelRange,
   type PendingFieldProjection,
@@ -83,7 +86,7 @@ import {
 } from './field-pieces.ts';
 import type { InlineDrawingLayoutContext, InlineDrawingLayoutInput } from './drawing-layout.ts';
 import { isRunLevelMcAlternateContent } from '../store/package/drawing-projection.ts';
-import { parsedFieldSpansOf } from '../store/package/field-nodes.ts';
+import { legacyFormFieldDataOf, parsedFieldSpansOf } from '../store/package/field-nodes.ts';
 import {
   emptyNamespaceScope,
   namespaceScopeForNode,
@@ -148,6 +151,8 @@ export {
   positionalTabOf,
   type FieldAtomMarker,
   type FieldAwarePiece,
+  type FieldLinkProjector,
+  type HyperlinkProjector,
   type ModelRange,
   type PositionalTab,
 };
@@ -155,25 +160,6 @@ export {
 // Shared run-child text/property vocabulary — kept re-exported so paragraph-flow and
 // numbering-index keep their import site.
 export { propertiesOfRunContainer, type RunPropertyCascader } from './field-run-text.ts';
-
-/**
- * How layout turns a typed `w:hyperlink` node into the sanitized record spans carry.
- *
- * Injected rather than computed here because resolving `r:id` needs the PACKAGE's
- * relationships and this module only ever sees one part's tree. `null` means the caller
- * declined to project — the runs still measure and paint, they simply carry no link, which is
- * the right degradation: text is never lost for want of a target.
- */
-export type HyperlinkProjector = (link: OoxmlNode) => SpanLinkRecord | null;
-
-/**
- * How layout turns a parsed HYPERLINK field instruction into the sanitized record spans carry.
- *
- * Injected for the same reason as {@link HyperlinkProjector}: the spec's raw target must cross
- * the surface's ONE href trust boundary, and layout owns no sanitization policy. `null` means
- * no link — the cached result still paints as plain text, which is the right degradation.
- */
-export type FieldLinkProjector = (spec: HyperlinkFieldSpec) => SpanLinkRecord | null;
 
 /**
  * Flatten a paragraph into measurable pieces, projecting allowlisted page fields when a
@@ -356,6 +342,15 @@ export function piecesOfParagraph(
         openAtomicBeginId = null;
         return;
       }
+    }
+    // A legacy form field renders from its ffData state: a checkbox always (the state is the
+    // authority, a stale cached glyph must not win), a dropdown only when the cache is empty.
+    const form = formFieldResult(pending, themeFonts);
+    if (form) {
+      push(form.text, form.props, form.style, true, start, end, carried);
+      pending = null;
+      openAtomicBeginId = null;
+      return;
     }
     if (pending.kind && pageContext) {
       const text = projectPageFieldValue(pending.kind, pageContext);
@@ -570,6 +565,11 @@ export function piecesOfParagraph(
             kind: null,
             symbolSpec: null,
             linkSpec: null,
+            formSpec: null,
+            // Bounded ffData STATE read (checkbox checked/size, dropdown entries/selection —
+            // macros never); `formField` below stays presence-based so an unreadable payload
+            // still shades.
+            formData: legacyFormFieldDataOf(grand),
             atomic,
             editableResult: editableResultBeginIds.has(grand.id),
             atomStart: offset,
@@ -609,13 +609,10 @@ export function piecesOfParagraph(
         const kind = onFldCharSeparate(field);
         if (outermostSeparate && pending) {
           pending.kind = kind && pageContext ? kind : null;
-          // Capture a SYMBOL or HYPERLINK spec while the machine still holds the raw
-          // instruction (`onFldCharEnd` resets the buffer before the flush reads anything).
+          // Capture the SYMBOL / HYPERLINK / form-field spec while the machine still holds the
+          // raw instruction (`onFldCharEnd` resets the buffer before the flush reads anything).
           if (!pending.kind && !field.instructionOverflow) {
-            pending.symbolSpec = parseSymbolInstruction(field.instruction);
-            if (!pending.symbolSpec) {
-              pending.linkSpec = parseHyperlinkInstruction(field.instruction);
-            }
+            captureInstructionSpecs(pending, field.instruction);
           }
           // Prefer separate-run style until a measurable result run donates one.
           pending.props = props;
@@ -626,18 +623,15 @@ export function piecesOfParagraph(
 
       if (isFldChar(grand, 'end')) {
         const outermostEnd = field.nesting === 1;
-        // A SYMBOL with no `separate` at all (begin/instr/end) still renders in Word. The
-        // machine's buffer is reset by `onFldCharEnd`, so capture the spec BEFORE advancing.
+        // A SYMBOL or FORMCHECKBOX with no `separate` at all (begin/instr/end) still renders
+        // in Word. The machine's buffer is reset by `onFldCharEnd`, so capture BEFORE advancing.
         if (
           outermostEnd &&
           pending?.atomic &&
           field.phase === 'instruction' &&
           !field.instructionOverflow
         ) {
-          pending.symbolSpec = parseSymbolInstruction(field.instruction);
-          if (!pending.symbolSpec) {
-            pending.linkSpec = parseHyperlinkInstruction(field.instruction);
-          }
+          captureInstructionSpecs(pending, field.instruction);
         }
         onFldCharEnd(field);
         if (outermostEnd) {

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -59,6 +59,7 @@ import {
   formatPageNumber,
   projectPageFieldValue,
   storyNeedsPageFields,
+  summarizeFlushedPage,
   withPageFieldSources,
   type FieldPageContext,
 } from './field-page-furniture.ts';
@@ -134,6 +135,7 @@ export {
   formatPageNumber,
   projectPageFieldValue,
   storyNeedsPageFields,
+  summarizeFlushedPage,
   withPageFieldSources,
   type FieldPageContext,
 };

--- a/packages/core/src/layout/field-run-text.ts
+++ b/packages/core/src/layout/field-run-text.ts
@@ -1,0 +1,57 @@
+// Run-child model text and run-property collection, shared by the field walks.
+//
+// `piecesOfParagraph` and the `w:fldSimple` display collector both flatten runs and must
+// agree, character for character, with `paragraphTextOf` about what a run child is worth —
+// a disagreement is an offset bug. Keeping the vocabulary in one module keeps them agreeing
+// by construction.
+
+import { hardBreakText, type OoxmlNode, type OoxmlProperty } from '@docx-editor.dev/core/store';
+
+/** Optional per-run merge of inherited + direct `rPr` (character styles, defaults). */
+export type RunPropertyCascader = (
+  inherited: readonly OoxmlProperty[],
+  direct: readonly OoxmlProperty[]
+) => readonly OoxmlProperty[];
+
+/** Model text contributed by one typed run child (same vocabulary as `paragraphTextOf`). */
+export function modelTextOfRunChild(grand: OoxmlNode): string {
+  // `w:delText` holds real characters at a real position, so it counts in the model offset
+  // space exactly like `w:t`. Whether it is LAID OUT is a separate question, answered by the
+  // enclosing revision and the display mode.
+  if (grand.kind === 'text' || grand.kind === 'deletedText') {
+    let text = '';
+    for (const value of grand.children) if (value.kind === 'textValue') text += value.value;
+    return text;
+  }
+  if (grand.kind === 'tab') return '\t';
+  if (grand.kind === 'hardBreak') return hardBreakText(grand);
+  return '';
+}
+
+export function propertiesOfRunContainer(container: OoxmlNode | undefined): OoxmlProperty[] {
+  if (!container || container.kind === 'textValue') return [];
+  const props: OoxmlProperty[] = [];
+  for (const child of container.children) {
+    if (child.kind === 'textValue') continue;
+    const attributes: Record<string, string> = {};
+    for (const entry of child.attributes) attributes[entry.localName] = entry.value;
+    props.push(
+      Object.keys(attributes).length > 0
+        ? { localName: child.localName, attributes }
+        : { localName: child.localName }
+    );
+  }
+  return props;
+}
+
+export function runPropertiesOf(
+  run: OoxmlNode,
+  inherited: readonly OoxmlProperty[],
+  cascadeRuns?: RunPropertyCascader
+): OoxmlProperty[] {
+  const direct = propertiesOfRunContainer(
+    run.kind === 'run' ? run.children.find((grand) => grand.kind === 'runProperties') : undefined
+  );
+  if (cascadeRuns) return [...cascadeRuns(inherited, direct)];
+  return inherited.length === 0 ? direct : [...inherited, ...direct];
+}

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -60,9 +60,12 @@ export interface SimpleFieldDisplay {
   readonly resultProps: readonly OoxmlProperty[] | undefined;
   readonly resultStyle: ResolvedRunStyle | undefined;
   /**
-   * True once ANY cached-result content was seen — hidden, suppressed or visible. An empty
-   * `text` alone cannot tell "no cached result" from "a cached result the file hides", and
-   * synthesis (MACROBUTTON / GOTOBUTTON display) may only fill the first.
+   * True once cached-result content the current display mode KEEPS was seen — visible or
+   * vanish-hidden. Only content with model text sets it (result text, tab / break, `w:sym`);
+   * drawings, `w:ptab` and note references never do. An empty `text` alone cannot tell "no
+   * cached result" from "a cached result the file hides", and synthesis (MACROBUTTON /
+   * GOTOBUTTON display) may only fill the first. Revision-suppressed content does not
+   * count: the mode resolved it away, and synthesis must be free to fill that view.
    */
   readonly sawResultContent: boolean;
 }
@@ -162,7 +165,10 @@ export function collectSimpleFieldDisplay(args: {
           // A collected display string cannot carry a per-glyph font switch, so only a
           // `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
           if (isSymbolRunChild(grand)) {
-            sawResultContent = true;
+            // Only content this display mode keeps counts (vanish-hidden still does) —
+            // synthesis must fill the view a `w:del`-wrapped result is resolved out of,
+            // matching the complex-field walk.
+            if (revisionsVisible(local, displayMode)) sawResultContent = true;
             if (tracker.active) {
               tracker.noteResult(!style.hidden && revisionsVisible(local, displayMode));
               continue;
@@ -177,12 +183,13 @@ export function collectSimpleFieldDisplay(args: {
 
           const value = modelTextOfRunChild(grand);
           if (value.length === 0) continue;
-          sawResultContent = true;
           const deleted = revisionsAreDeletion(local);
-          const suppressed =
-            style.hidden ||
-            !revisionsVisible(local, displayMode) ||
-            (grand.kind === 'deletedText' && !deleted);
+          const revisionSuppressed =
+            !revisionsVisible(local, displayMode) || (grand.kind === 'deletedText' && !deleted);
+          // Revision-suppressed content does not count as a cached result: the mode resolved
+          // it away, and synthesis must be free to fill that view. Vanish-hidden still counts.
+          if (!revisionSuppressed) sawResultContent = true;
+          const suppressed = style.hidden || revisionSuppressed;
           if (tracker.active) {
             tracker.noteResult(!suppressed);
             if (!suppressed) captureStyle(props, style);

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -38,10 +38,15 @@ import {
   onFldCharBegin,
   onFldCharEnd,
   onFldCharSeparate,
+  type AllowlistedPageField,
   type FieldScanBudget,
 } from './field-instruction.ts';
 import { createNestedPageTracker } from './field-nested-page.ts';
-import { projectPageFieldValue, type FieldPageContext } from './field-page-furniture.ts';
+import {
+  PAGE_FIELD_PLACEHOLDER,
+  projectPageFieldValue,
+  type FieldPageContext,
+} from './field-page-furniture.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
 import {
   MAX_REVISION_DEPTH,
@@ -246,6 +251,11 @@ export interface SimpleFieldProjection {
   readonly style: ResolvedRunStyle;
   /** The HYPERLINK-instruction link the piece should carry, when one projects. */
   readonly link?: SpanLinkRecord;
+  /**
+   * Present when this is a BODY page-field placeholder (no page context): {@link text} is the
+   * measurement digit and document finalize substitutes the real value for this kind.
+   */
+  readonly pageField?: { readonly kind: AllowlistedPageField };
 }
 
 /**
@@ -282,6 +292,8 @@ export function projectSimpleFieldResult(args: {
   readonly projectFieldLink?: FieldLinkProjector;
   /** Parsed document properties, for a TITLE / AUTHOR / … / DOCPROPERTY simple field. */
   readonly documentProperties?: DocumentProperties;
+  /** True in BODY flow: an empty-cache page field paints a placeholder for finalize to fill. */
+  readonly bodyPageFields?: boolean;
 }): SimpleFieldProjection | null {
   const { simple, pageContext, inheritedRunProperties, themeFonts } = args;
   const display = collectSimpleFieldDisplay(args);
@@ -293,6 +305,20 @@ export function projectSimpleFieldResult(args: {
     const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
     if (style.hidden) return null;
     return { text: projectPageFieldValue(pageKind, pageContext), props, style };
+  }
+  // A BODY page field (no page context) with no cached result: paint a placeholder and mark the
+  // kind so document finalize substitutes the page's value. A cached result wins — it falls
+  // through to paint normally, exactly as it would in Word until the field is next updated.
+  if (
+    pageKind &&
+    args.bodyPageFields &&
+    !pageContext &&
+    display.text.length === 0 &&
+    !display.sawResultContent
+  ) {
+    const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+    if (style.hidden) return null;
+    return { text: PAGE_FIELD_PLACEHOLDER, props, style, pageField: { kind: pageKind } };
   }
 
   const symbolSpec = parseSymbolInstruction(instr);

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -11,10 +11,12 @@ import {
   fldSimpleInstr,
   isFieldChrome,
   isFldSimple,
+  type DocumentProperties,
   type OoxmlNode,
   type OoxmlProperty,
 } from '@docx-editor.dev/core/store';
 import { parseButtonInstruction } from './field-button.ts';
+import { docPropertyValue, parseDocPropertyInstruction } from './field-doc-property.ts';
 import { parseHyperlinkInstruction } from './field-link.ts';
 import type { FieldLinkProjector } from './field-pieces.ts';
 import {
@@ -278,6 +280,8 @@ export function projectSimpleFieldResult(args: {
   /** The enclosing typed `w:hyperlink` record, which outranks the field's instruction. */
   readonly currentLink?: SpanLinkRecord;
   readonly projectFieldLink?: FieldLinkProjector;
+  /** Parsed document properties, for a TITLE / AUTHOR / … / DOCPROPERTY simple field. */
+  readonly documentProperties?: DocumentProperties;
 }): SimpleFieldProjection | null {
   const { simple, pageContext, inheritedRunProperties, themeFonts } = args;
   const display = collectSimpleFieldDisplay(args);
@@ -301,9 +305,21 @@ export function projectSimpleFieldResult(args: {
   }
 
   // Synthesis fills only a result the file never cached: a cached result that exists but is
-  // hidden stays hidden (`sawResultContent`), matching the complex-field flush.
-  const buttonSpec =
-    display.text.length === 0 && !display.sawResultContent ? parseButtonInstruction(instr) : null;
+  // hidden stays hidden (`sawResultContent`), matching the complex-field flush. A
+  // document-property field (TITLE / AUTHOR / … / DOCPROPERTY) paints its property value here.
+  const emptyCache = display.text.length === 0 && !display.sawResultContent;
+  if (emptyCache) {
+    const docField = parseDocPropertyInstruction(instr);
+    if (docField) {
+      const value = docPropertyValue(docField, args.documentProperties);
+      if (value !== null) {
+        const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+        if (style.hidden) return null;
+        return { text: value, props, style };
+      }
+    }
+  }
+  const buttonSpec = emptyCache ? parseButtonInstruction(instr) : null;
   if (buttonSpec) {
     const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
     if (style.hidden) return null;

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -9,12 +9,17 @@
 
 import {
   fldSimpleInstr,
-  hardBreakText,
   isFieldChrome,
   isFldSimple,
   type OoxmlNode,
   type OoxmlProperty,
 } from '@docx-editor.dev/core/store';
+import {
+  modelTextOfRunChild,
+  runPropertiesOf,
+  type RunPropertyCascader,
+} from './field-run-text.ts';
+import { isSymbolRunChild, symbolGlyphOf } from './symbol-run.ts';
 import {
   allowlistedPageField,
   consumeScanNode,
@@ -44,54 +49,12 @@ import {
 } from './revision-projection.ts';
 
 /** Optional per-run merge of inherited + direct `rPr` (character styles, defaults). */
-export type SimpleFieldRunCascader = (
-  inherited: readonly OoxmlProperty[],
-  direct: readonly OoxmlProperty[]
-) => readonly OoxmlProperty[];
+export type SimpleFieldRunCascader = RunPropertyCascader;
 
 export interface SimpleFieldDisplay {
   readonly text: string;
   readonly resultProps: readonly OoxmlProperty[] | undefined;
   readonly resultStyle: ResolvedRunStyle | undefined;
-}
-
-function propertiesOfRunContainer(container: OoxmlNode | undefined): OoxmlProperty[] {
-  if (!container || container.kind === 'textValue') return [];
-  const props: OoxmlProperty[] = [];
-  for (const child of container.children) {
-    if (child.kind === 'textValue') continue;
-    const attributes: Record<string, string> = {};
-    for (const entry of child.attributes) attributes[entry.localName] = entry.value;
-    props.push(
-      Object.keys(attributes).length > 0
-        ? { localName: child.localName, attributes }
-        : { localName: child.localName }
-    );
-  }
-  return props;
-}
-
-function runPropertiesOf(
-  run: OoxmlNode,
-  inherited: readonly OoxmlProperty[],
-  cascadeRuns?: SimpleFieldRunCascader
-): OoxmlProperty[] {
-  const direct = propertiesOfRunContainer(
-    run.kind === 'run' ? run.children.find((grand) => grand.kind === 'runProperties') : undefined
-  );
-  if (cascadeRuns) return [...cascadeRuns(inherited, direct)];
-  return inherited.length === 0 ? direct : [...inherited, ...direct];
-}
-
-function modelTextOfRunChild(grand: OoxmlNode): string {
-  if (grand.kind === 'text' || grand.kind === 'deletedText') {
-    let text = '';
-    for (const value of grand.children) if (value.kind === 'textValue') text += value.value;
-    return text;
-  }
-  if (grand.kind === 'tab') return '\t';
-  if (grand.kind === 'hardBreak') return hardBreakText(grand);
-  return '';
 }
 
 /**
@@ -196,6 +159,17 @@ export function collectSimpleFieldDisplay(args: {
           }
 
           if (isFieldChrome(grand)) continue;
+
+          // A collected display string cannot carry a per-glyph font switch, so only a
+          // `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
+          if (isSymbolRunChild(grand)) {
+            if (skipCachedNestedResult) continue;
+            const glyph = symbolGlyphOf(grand);
+            if (!glyph?.unicode) continue;
+            if (style.hidden || !revisionsVisible(local, displayMode)) continue;
+            text += glyph.text;
+            continue;
+          }
 
           const value = modelTextOfRunChild(grand);
           if (value.length === 0) continue;

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -14,11 +14,16 @@ import {
   type OoxmlNode,
   type OoxmlProperty,
 } from '@docx-editor.dev/core/store';
+import { parseButtonInstruction } from './field-button.ts';
+import { parseHyperlinkInstruction } from './field-link.ts';
+import type { FieldLinkProjector } from './field-pieces.ts';
 import {
   modelTextOfRunChild,
   runPropertiesOf,
   type RunPropertyCascader,
 } from './field-run-text.ts';
+import { parseSymbolInstruction, symbolFieldGlyph } from './field-symbol.ts';
+import type { SpanLinkRecord } from './semantic-records.ts';
 import { isSymbolRunChild, symbolGlyphOf } from './symbol-run.ts';
 import {
   allowlistedPageField,
@@ -55,6 +60,12 @@ export interface SimpleFieldDisplay {
   readonly text: string;
   readonly resultProps: readonly OoxmlProperty[] | undefined;
   readonly resultStyle: ResolvedRunStyle | undefined;
+  /**
+   * True once ANY cached-result content was seen — hidden, suppressed or visible. An empty
+   * `text` alone cannot tell "no cached result" from "a cached result the file hides", and
+   * synthesis (MACROBUTTON / GOTOBUTTON display) may only fill the first.
+   */
+  readonly sawResultContent: boolean;
 }
 
 /**
@@ -89,6 +100,7 @@ export function collectSimpleFieldDisplay(args: {
   let text = '';
   let resultProps: readonly OoxmlProperty[] | undefined;
   let resultStyle: ResolvedRunStyle | undefined;
+  let sawResultContent = false;
 
   const nested = createFieldParseState();
   let liveNestedKind: AllowlistedPageField | null = null;
@@ -163,16 +175,19 @@ export function collectSimpleFieldDisplay(args: {
           // A collected display string cannot carry a per-glyph font switch, so only a
           // `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
           if (isSymbolRunChild(grand)) {
+            sawResultContent = true;
             if (skipCachedNestedResult) continue;
             const glyph = symbolGlyphOf(grand);
             if (!glyph?.unicode) continue;
             if (style.hidden || !revisionsVisible(local, displayMode)) continue;
+            captureStyle(props, style);
             text += glyph.text;
             continue;
           }
 
           const value = modelTextOfRunChild(grand);
           if (value.length === 0) continue;
+          sawResultContent = true;
           const deleted = revisionsAreDeletion(local);
           const suppressed =
             style.hidden ||
@@ -224,5 +239,88 @@ export function collectSimpleFieldDisplay(args: {
     skipCachedNestedResult = false;
   }
 
-  return { text, resultProps, resultStyle };
+  return { text, resultProps, resultStyle, sawResultContent };
+}
+
+/** The one projected piece a `w:fldSimple` paints over its reserved model unit. */
+export interface SimpleFieldProjection {
+  readonly text: string;
+  readonly props: readonly OoxmlProperty[];
+  readonly style: ResolvedRunStyle;
+  /** The HYPERLINK-instruction link the piece should carry, when one projects. */
+  readonly link?: SpanLinkRecord;
+}
+
+/**
+ * Decide what a `w:fldSimple` (§17.16.19) paints, or null for nothing.
+ *
+ * The caller owns the model offset (the field is one unit whatever it paints) and OUTER
+ * visibility — a revision enclosing the whole field is answered before this runs. This owns
+ * the branch order:
+ *
+ * - Allowlisted PAGE / NUMPAGES / SECTIONPAGES evaluate from the page context when one is
+ *   supplied — the cached result is whatever sheet the producer last saved from.
+ * - A simple SYMBOL renders from its instruction like the complex shape does; there is no
+ *   trustworthy cached result to prefer. An unresolvable spec falls through.
+ * - A simple MACROBUTTON / GOTOBUTTON displays everything after its first argument; the
+ *   macro / target never runs. A non-empty cached display wins — synthesis fills an empty one.
+ * - Otherwise the cached display paints, linked by a HYPERLINK instruction only outside a
+ *   typed `w:hyperlink` (`currentLink`), which outranks the field's own instruction. An empty
+ *   result never paints, URL included.
+ *
+ * A hidden result returns null in every branch: no piece, the unit stays.
+ */
+export function projectSimpleFieldResult(args: {
+  readonly simple: OoxmlNode;
+  readonly depth: number;
+  readonly pageContext?: FieldPageContext;
+  readonly budget: FieldScanBudget;
+  readonly revisions: readonly RevisionAttribution[];
+  readonly displayMode: RevisionDisplayMode;
+  readonly inheritedRunProperties: readonly OoxmlProperty[];
+  readonly cascadeRuns?: SimpleFieldRunCascader;
+  readonly themeFonts?: ThemeFonts;
+  /** The enclosing typed `w:hyperlink` record, which outranks the field's instruction. */
+  readonly currentLink?: SpanLinkRecord;
+  readonly projectFieldLink?: FieldLinkProjector;
+}): SimpleFieldProjection | null {
+  const { simple, pageContext, inheritedRunProperties, themeFonts } = args;
+  const display = collectSimpleFieldDisplay(args);
+  const instr = fldSimpleInstr(simple) ?? '';
+  const props = display.resultProps ?? inheritedRunProperties;
+
+  const pageKind = allowlistedPageField(instr);
+  if (pageKind && pageContext) {
+    const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+    if (style.hidden) return null;
+    return { text: projectPageFieldValue(pageKind, pageContext), props, style };
+  }
+
+  const symbolSpec = parseSymbolInstruction(instr);
+  if (symbolSpec) {
+    const glyph = symbolFieldGlyph(symbolSpec, props, themeFonts);
+    if (glyph) {
+      if (glyph.style.hidden) return null;
+      return { text: glyph.text, props: glyph.props, style: glyph.style };
+    }
+  }
+
+  // Synthesis fills only a result the file never cached: a cached result that exists but is
+  // hidden stays hidden (`sawResultContent`), matching the complex-field flush.
+  const buttonSpec =
+    display.text.length === 0 && !display.sawResultContent ? parseButtonInstruction(instr) : null;
+  if (buttonSpec) {
+    const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+    if (style.hidden) return null;
+    return { text: buttonSpec.display, props, style };
+  }
+
+  if (display.text.length === 0) return null;
+  // Nested live PAGE may replace an empty cached result and leave no donor run; fall back
+  // to inherited properties the same way a top-level simple PAGE does.
+  const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+  if (style.hidden) return null;
+  const linkSpec = args.currentLink ? null : parseHyperlinkInstruction(instr);
+  const fieldLink = linkSpec ? (args.projectFieldLink?.(linkSpec) ?? null) : null;
+  return { text: display.text, props, style, ...(fieldLink ? { link: fieldLink } : {}) };
 }

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -30,16 +30,15 @@ import {
   consumeScanNode,
   createFieldParseState,
   ingestInstrTextBounded,
-  isCollectingInstruction,
   isFldChar,
   isInstrText,
   MAX_STORY_FIELD_SCAN_DEPTH,
   onFldCharBegin,
   onFldCharEnd,
   onFldCharSeparate,
-  type AllowlistedPageField,
   type FieldScanBudget,
 } from './field-instruction.ts';
+import { createNestedPageTracker } from './field-nested-page.ts';
 import { projectPageFieldValue, type FieldPageContext } from './field-page-furniture.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
 import {
@@ -103,21 +102,16 @@ export function collectSimpleFieldDisplay(args: {
   let sawResultContent = false;
 
   const nested = createFieldParseState();
-  let liveNestedKind: AllowlistedPageField | null = null;
-  let skipCachedNestedResult = false;
-  let nestedResultSeen = false;
-  let nestedResultVisible = false;
+  // Level-aware live evaluation of an allowlisted page field nested in the cache (shared with
+  // the complex-field walk): the machine's level 1 is a complex field directly inside this
+  // `w:fldSimple`, deeper levels are fields nested in ITS cached result, and the tracker skips
+  // the tracked field's digits and appends the live value at that level's matching end only.
+  const tracker = createNestedPageTracker();
 
   const captureStyle = (props: readonly OoxmlProperty[], style: ResolvedRunStyle): void => {
     if (resultProps) return;
     resultProps = props;
     resultStyle = style;
-  };
-
-  const finishLiveNested = (): void => {
-    if (!liveNestedKind || !pageContext) return;
-    if (nestedResultSeen && !nestedResultVisible) return;
-    text += projectPageFieldValue(liveNestedKind, pageContext);
   };
 
   const collect = (node: OoxmlNode, nodeDepth: number, local: readonly RevisionAttribution[]) => {
@@ -133,40 +127,33 @@ export function collectSimpleFieldDisplay(args: {
 
           if (isFldChar(grand, 'begin')) {
             onFldCharBegin(nested);
-            if (nested.nesting === 1) {
-              liveNestedKind = null;
-              skipCachedNestedResult = false;
-              nestedResultSeen = false;
-              nestedResultVisible = false;
-            }
+            if (nested.nesting === 1) tracker.reset();
             continue;
           }
           if (isInstrText(grand)) {
-            if (isCollectingInstruction(nested)) {
-              ingestInstrTextBounded(nested, grand, budget, nodeDepth + 1);
-            }
+            // Bounded per-level ingestion: the machine itself knows whether the INNERMOST
+            // open level still collects. Gating on the level-1 phase here starved every
+            // deeper level's capture, so a PAGE two levels down could never be recognized.
+            ingestInstrTextBounded(nested, grand, budget, nodeDepth + 1);
             continue;
           }
           if (isFldChar(grand, 'separate')) {
+            const separateLevel = nested.nesting;
+            const separatePhase = nested.phase;
             const kind = onFldCharSeparate(nested);
-            if (kind && pageContext) {
-              liveNestedKind = kind;
-              skipCachedNestedResult = true;
-              nestedResultSeen = false;
-              nestedResultVisible = false;
-            } else {
-              liveNestedKind = null;
-              skipCachedNestedResult = false;
+            // A level-1 machine field sits directly in this cache and always projects. A
+            // DEEPER field projects only from a level-1 RESULT (never from an instruction —
+            // that content is not painted) and never past the nesting cap, matching what
+            // `detectStoryPageFields` notes so detection and projection stay one story.
+            if (separateLevel === 1 || (separatePhase === 'result' && !nested.nestingOverflow)) {
+              tracker.onSeparate(pageContext ? kind : null, separateLevel);
             }
             continue;
           }
           if (isFldChar(grand, 'end')) {
-            if (nested.nesting === 1 && skipCachedNestedResult) finishLiveNested();
+            const appendedLive = tracker.onEnd(nested.nesting, pageContext);
+            if (appendedLive !== null) text += appendedLive;
             onFldCharEnd(nested);
-            liveNestedKind = null;
-            skipCachedNestedResult = false;
-            nestedResultSeen = false;
-            nestedResultVisible = false;
             continue;
           }
 
@@ -176,7 +163,10 @@ export function collectSimpleFieldDisplay(args: {
           // `w:sym` with a real Unicode equivalent joins it; the rest are skipped.
           if (isSymbolRunChild(grand)) {
             sawResultContent = true;
-            if (skipCachedNestedResult) continue;
+            if (tracker.active) {
+              tracker.noteResult(!style.hidden && revisionsVisible(local, displayMode));
+              continue;
+            }
             const glyph = symbolGlyphOf(grand);
             if (!glyph?.unicode) continue;
             if (style.hidden || !revisionsVisible(local, displayMode)) continue;
@@ -193,12 +183,9 @@ export function collectSimpleFieldDisplay(args: {
             style.hidden ||
             !revisionsVisible(local, displayMode) ||
             (grand.kind === 'deletedText' && !deleted);
-          if (skipCachedNestedResult) {
-            nestedResultSeen = true;
-            if (!suppressed) {
-              nestedResultVisible = true;
-              captureStyle(props, style);
-            }
+          if (tracker.active) {
+            tracker.noteResult(!suppressed);
+            if (!suppressed) captureStyle(props, style);
             continue;
           }
           if (suppressed) continue;
@@ -208,7 +195,12 @@ export function collectSimpleFieldDisplay(args: {
         continue;
       }
       if (isFldSimple(child)) {
-        const nestedKind = allowlistedPageField(fldSimpleInstr(child) ?? '');
+        // Inside a tracked complex field's skipped cache the simple field is part of the
+        // replaced result: descend so its runs are NOTED (visible cached content keeps the
+        // live replacement alive), never appended on their own.
+        const nestedKind = tracker.active
+          ? null
+          : allowlistedPageField(fldSimpleInstr(child) ?? '');
         if (nestedKind && pageContext) {
           if (!revisionsVisible(local, displayMode)) continue;
           const beforeLen = text.length;
@@ -234,10 +226,6 @@ export function collectSimpleFieldDisplay(args: {
   };
 
   collect(simple, depth, revisions);
-  if (skipCachedNestedResult) {
-    liveNestedKind = null;
-    skipCachedNestedResult = false;
-  }
 
   return { text, resultProps, resultStyle, sawResultContent };
 }

--- a/packages/core/src/layout/field-symbol.ts
+++ b/packages/core/src/layout/field-symbol.ts
@@ -1,0 +1,193 @@
+// SYMBOL field (§17.16.5.60) rendering from its instruction.
+//
+// `SYMBOL n [switches]` displays character code n. Real files carry NO cached result for it —
+// Word always re-renders from the instruction — so the engine must synthesize the glyph or the
+// field paints nothing. The instruction is attacker-controlled: tokenization is one bounded
+// pass over an already-capped string, numeric parses are length-capped before conversion, and
+// every failure resolves to null (the caller falls back to whatever it painted before).
+//
+// Glyph resolution reuses `symbol-run.ts` — the same 0xF000-page normalization, PUA mapping
+// and codepoint validation as `w:sym` — so the two symbol paths cannot drift apart.
+
+import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+import { MAX_FIELD_INSTRUCTION_CHARS } from './field-instruction.ts';
+import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
+import { isSymbolEncodedFamily, mapSymbolPuaText } from './symbol-encoding.ts';
+import {
+  isRenderableCodePoint,
+  MAX_SYMBOL_FONT_LENGTH,
+  SYMBOL_PUA_BASE,
+  SYMBOL_PUA_END,
+} from './symbol-run.ts';
+
+/** Longest character-code token even considered: covers `0x10FFFF` and decimal 1114111. */
+const MAX_CODE_TOKEN_LENGTH = 9;
+
+/** One parsed `SYMBOL` instruction. */
+export interface SymbolFieldSpec {
+  /** The character code, already range-checked (≤ 0x10FFFF, not a surrogate). */
+  readonly code: number;
+  /** `\f` font override, case preserved, or null to keep the base font. */
+  readonly font: string | null;
+  /** `\s` size in WHOLE points (1..999), or null to keep the base size. */
+  readonly sizePt: number | null;
+  /** `\u`: the code is a Unicode codepoint — no symbol-page normalization. */
+  readonly unicode: boolean;
+}
+
+interface InstructionToken {
+  readonly value: string;
+  readonly quoted: boolean;
+}
+
+/** One bounded pass; a quote opens a token that runs to the closing quote (or the end). */
+function tokenize(raw: string): InstructionToken[] {
+  const tokens: InstructionToken[] = [];
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw[i]!;
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      let j = i + 1;
+      while (j < raw.length && raw[j] !== '"') j += 1;
+      tokens.push({ value: raw.slice(i + 1, j), quoted: true });
+      i = j < raw.length ? j + 1 : j;
+      continue;
+    }
+    let j = i;
+    while (j < raw.length && !' \t\n\r"'.includes(raw[j]!)) j += 1;
+    tokens.push({ value: raw.slice(i, j), quoted: false });
+    i = j;
+  }
+  return tokens;
+}
+
+/** `n`: decimal digits or `0x`-prefixed hex, strictly and with the length capped first. */
+function parseCharCode(token: InstructionToken): number | null {
+  if (token.quoted) return null;
+  const value = token.value;
+  if (value.length === 0 || value.length > MAX_CODE_TOKEN_LENGTH) return null;
+  let code: number;
+  if (value.startsWith('0x') || value.startsWith('0X')) {
+    const hex = value.slice(2);
+    if (!/^[0-9A-Fa-f]{1,6}$/.test(hex)) return null;
+    code = Number.parseInt(hex, 16);
+  } else {
+    if (!/^\d{1,7}$/.test(value)) return null;
+    code = Number.parseInt(value, 10);
+  }
+  // Structural range only; renderability (controls, noncharacters, U+FFFC) is answered at
+  // glyph time because a control BYTE on a symbol font still normalizes onto the PUA page.
+  if (code > 0x10ffff) return null;
+  if (code >= 0xd800 && code <= 0xdfff) return null;
+  return code;
+}
+
+/**
+ * Parse a raw SYMBOL instruction, or null when it is not one (or is hostile).
+ *
+ * Recognition is the first token equalling `SYMBOL` case-insensitively. `\f` takes a quoted
+ * or single-token font name (cap {@link MAX_SYMBOL_FONT_LENGTH}, case preserved); `\s` takes
+ * a whole-point size 1..999 (invalid → the switch is ignored); `\u` marks the code as a plain
+ * Unicode codepoint. `\h`, `\j`, `\a` and anything unrecognized are inert — only a bad
+ * character code fails the whole parse.
+ */
+export function parseSymbolInstruction(raw: string): SymbolFieldSpec | null {
+  if (raw.length === 0 || raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  const tokens = tokenize(raw);
+  if (tokens.length < 2) return null;
+  const first = tokens[0]!;
+  if (first.quoted || first.value.toUpperCase() !== 'SYMBOL') return null;
+  const code = parseCharCode(tokens[1]!);
+  if (code === null) return null;
+
+  let font: string | null = null;
+  let sizePt: number | null = null;
+  let unicode = false;
+  for (let i = 2; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (token.quoted || !token.value.startsWith('\\')) continue;
+    const name = token.value.toLowerCase();
+    if (name === '\\f') {
+      const arg = tokens[i + 1];
+      if (
+        arg &&
+        arg.value.length > 0 &&
+        arg.value.length <= MAX_SYMBOL_FONT_LENGTH &&
+        (arg.quoted || !arg.value.startsWith('\\'))
+      ) {
+        font = arg.value;
+        i += 1;
+      }
+      continue;
+    }
+    if (name === '\\s') {
+      const arg = tokens[i + 1];
+      if (arg && (arg.quoted || !arg.value.startsWith('\\'))) {
+        i += 1;
+        if (/^\d{1,3}$/.test(arg.value)) {
+          const points = Number(arg.value);
+          if (points >= 1 && points <= 999) sizePt = points;
+        }
+      }
+      continue;
+    }
+    if (name === '\\u') unicode = true;
+    // `\h`, `\j`, `\a`, `\*` and anything unknown: inert.
+  }
+  return { code, font, sizePt, unicode };
+}
+
+/** The synthesized glyph: text plus the props/style the piece should carry. */
+export interface SymbolFieldGlyph {
+  /** Exactly one code point (already PUA-mapped when applicable). */
+  readonly text: string;
+  readonly props: readonly OoxmlProperty[];
+  readonly style: ResolvedRunStyle;
+}
+
+/**
+ * Resolve a parsed SYMBOL to the glyph it paints, or null for no glyph (fall back).
+ *
+ * `baseProps` is the field's result-style property chain (result → separate → begin); `\f`
+ * and `\s` land as `rFonts` / `w:sz` overrides on top of it, resolved through the ordinary
+ * cascade. Without `\u`, the same symbol-font logic as `w:sym` applies: a byte on a
+ * symbol-encoded effective font normalizes onto the 0xF000 page, PUA codes map through
+ * `mapSymbolPuaText`, and an unmapped PUA code keeps the font for the shaper to try.
+ */
+export function symbolFieldGlyph(
+  spec: SymbolFieldSpec,
+  baseProps: readonly OoxmlProperty[],
+  themeFonts?: ThemeFonts
+): SymbolFieldGlyph | null {
+  const overrides: OoxmlProperty[] = [];
+  if (spec.font) {
+    overrides.push({ localName: 'rFonts', attributes: { ascii: spec.font, hAnsi: spec.font } });
+  }
+  if (spec.sizePt !== null) {
+    overrides.push({ localName: 'sz', attributes: { val: String(spec.sizePt * 2) } });
+  }
+  const props = overrides.length > 0 ? [...baseProps, ...overrides] : baseProps;
+  const style = resolveRunStyle(props, themeFonts);
+
+  if (spec.unicode) {
+    if (!isRenderableCodePoint(spec.code)) return null;
+    return { text: String.fromCodePoint(spec.code), props, style };
+  }
+
+  const family = spec.font ?? style.fontFamily;
+  if (isSymbolEncodedFamily(family)) {
+    const effective =
+      spec.code <= 0xff && spec.code + SYMBOL_PUA_BASE <= SYMBOL_PUA_END
+        ? spec.code + SYMBOL_PUA_BASE
+        : spec.code;
+    if (effective >= SYMBOL_PUA_BASE && effective <= SYMBOL_PUA_END) {
+      return { text: mapSymbolPuaText(String.fromCodePoint(effective), family), props, style };
+    }
+  }
+  if (!isRenderableCodePoint(spec.code)) return null;
+  return { text: String.fromCodePoint(spec.code), props, style };
+}

--- a/packages/core/src/layout/field-symbol.ts
+++ b/packages/core/src/layout/field-symbol.ts
@@ -10,7 +10,6 @@
 // and codepoint validation as `w:sym` — so the two symbol paths cannot drift apart.
 
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
-import { MAX_FIELD_INSTRUCTION_CHARS } from './field-instruction.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
 import { isSymbolEncodedFamily, mapSymbolPuaText } from './symbol-encoding.ts';
 import {
@@ -19,6 +18,14 @@ import {
   SYMBOL_PUA_BASE,
   SYMBOL_PUA_END,
 } from './symbol-run.ts';
+
+/**
+ * Local parser bound: a legitimate `SYMBOL` instruction is a keyword, a code, and a few short
+ * switches — anything near this length is garbage. Deliberately NOT the shared machine cap
+ * (`MAX_FIELD_INSTRUCTION_CHARS`), which is sized for full-length HYPERLINK targets; this
+ * grammar's rejection threshold must not move when that bound does.
+ */
+export const MAX_SYMBOL_INSTRUCTION_CHARS = 256;
 
 /** Longest character-code token even considered: covers `0x10FFFF` and decimal 1114111. */
 const MAX_CODE_TOKEN_LENGTH = 9;
@@ -96,7 +103,7 @@ function parseCharCode(token: InstructionToken): number | null {
  * character code fails the whole parse.
  */
 export function parseSymbolInstruction(raw: string): SymbolFieldSpec | null {
-  if (raw.length === 0 || raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  if (raw.length === 0 || raw.length > MAX_SYMBOL_INSTRUCTION_CHARS) return null;
   const tokens = tokenize(raw);
   if (tokens.length < 2) return null;
   const first = tokens[0]!;

--- a/packages/core/src/layout/field-synthesis.ts
+++ b/packages/core/src/layout/field-synthesis.ts
@@ -18,7 +18,12 @@ import type { OoxmlProperty } from '@docx-editor.dev/core/store';
 import type { DocumentProperties } from '@docx-editor.dev/core/store';
 import { docPropertyValue } from './field-doc-property.ts';
 import { formFieldResult } from './field-form.ts';
-import { projectPageFieldValue, type FieldPageContext } from './field-page-furniture.ts';
+import {
+  PAGE_FIELD_PLACEHOLDER,
+  projectPageFieldValue,
+  type FieldPageContext,
+} from './field-page-furniture.ts';
+import type { AllowlistedPageField } from './field-instruction.ts';
 import type { PendingFieldProjection } from './field-pieces.ts';
 import { symbolFieldGlyph } from './field-symbol.ts';
 import type { ResolvedRunStyle, ThemeFonts } from './run-style.ts';
@@ -28,6 +33,12 @@ export interface AtomicFieldSynthesis {
   readonly text: string;
   readonly props: readonly OoxmlProperty[];
   readonly style: ResolvedRunStyle;
+  /**
+   * Present when this is a BODY page-field placeholder: {@link text} is the measurement digit and
+   * document finalize substitutes the real value for this kind. The caller carries the marker onto
+   * the span. Absent for the live header/footer value and every other synthesis.
+   */
+  readonly pageField?: { readonly kind: AllowlistedPageField };
 }
 
 /** Document-global inputs the synthesis reads, none of them per-run. */
@@ -35,6 +46,12 @@ export interface AtomicSynthesisContext {
   readonly pageContext?: FieldPageContext;
   readonly themeFonts?: ThemeFonts;
   readonly documentProperties?: DocumentProperties;
+  /**
+   * True in BODY flow, where an empty-cache PAGE/NUMPAGES/SECTIONPAGES paints a placeholder for
+   * document finalize to substitute. Absent/false in headers, footers, notes and text boxes,
+   * which keep their live path or deferral — a placeholder there would never be substituted.
+   */
+  readonly bodyPageFields?: boolean;
 }
 
 /**
@@ -70,6 +87,17 @@ export function synthesizeAtomicField(
   }
   // Empty cache: synthesize. A result that existed but was hidden stays hidden.
   if (!pending.sawResultContent) {
+    // A BODY page field (no page context): paint a placeholder now and record the kind so
+    // document finalize substitutes the page's real value. Gated on `bodyPageFields` because
+    // headers/footers took the live branch above, and notes / text boxes have no substitute pass.
+    if (pending.kind && ctx.bodyPageFields) {
+      return {
+        text: PAGE_FIELD_PLACEHOLDER,
+        props: pending.props,
+        style: pending.style,
+        pageField: { kind: pending.kind },
+      };
+    }
     if (pending.docPropertySpec) {
       const value = docPropertyValue(pending.docPropertySpec, ctx.documentProperties);
       if (value !== null) return { text: value, props: pending.props, style: pending.style };

--- a/packages/core/src/layout/field-synthesis.ts
+++ b/packages/core/src/layout/field-synthesis.ts
@@ -1,0 +1,83 @@
+// The synthesis dispatch for one committed atomic complex field: given the pending state and the
+// document-global context, decide the single glyph run the field's reserved model unit paints.
+//
+// Split out of `field-projection.ts` (against the file-size cap) as a self-contained decision:
+// it reads the pending field and returns text/props/style, and owns none of the walk's closure
+// machinery. The caller keeps offset ownership, visibility guards, link/attribution carry and
+// the actual `push`.
+//
+// Branch order (mutually exclusive keywords, cached result winning where Word trusts it):
+//   1. SYMBOL — synthesized glyph wins over any stale cached text.
+//   2. legacy form field — checkbox from ffData state, dropdown from the selected entry.
+//   3. allowlisted PAGE-family — live value from the page context.
+//   4. cached result — a non-empty cache is what Word last painted; it wins over synthesis.
+//   5. empty cache only (and no hidden-but-present result): a document-property value, else a
+//      MACROBUTTON / GOTOBUTTON display.
+
+import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+import type { DocumentProperties } from '@docx-editor.dev/core/store';
+import { docPropertyValue } from './field-doc-property.ts';
+import { formFieldResult } from './field-form.ts';
+import { projectPageFieldValue, type FieldPageContext } from './field-page-furniture.ts';
+import type { PendingFieldProjection } from './field-pieces.ts';
+import { symbolFieldGlyph } from './field-symbol.ts';
+import type { ResolvedRunStyle, ThemeFonts } from './run-style.ts';
+
+/** The one glyph run a synthesized atomic field paints over its reserved model unit. */
+export interface AtomicFieldSynthesis {
+  readonly text: string;
+  readonly props: readonly OoxmlProperty[];
+  readonly style: ResolvedRunStyle;
+}
+
+/** Document-global inputs the synthesis reads, none of them per-run. */
+export interface AtomicSynthesisContext {
+  readonly pageContext?: FieldPageContext;
+  readonly themeFonts?: ThemeFonts;
+  readonly documentProperties?: DocumentProperties;
+}
+
+/**
+ * Resolve what a committed atomic field paints, or null for nothing (an empty result, an
+ * unresolvable spec, or a missing property — the model unit stays, painting no glyph).
+ *
+ * The caller has already answered outer visibility (`w:vanish`, a revision the mode hides), so
+ * this never re-checks it; it only chooses the glyph run.
+ */
+export function synthesizeAtomicField(
+  pending: PendingFieldProjection,
+  ctx: AtomicSynthesisContext
+): AtomicFieldSynthesis | null {
+  // SYMBOL renders from its instruction — Word never trusts a cached result for it.
+  if (pending.symbolSpec) {
+    const glyph = symbolFieldGlyph(pending.symbolSpec, pending.props, ctx.themeFonts);
+    if (glyph) return { text: glyph.text, props: glyph.props, style: glyph.style };
+  }
+  // A legacy form field renders from its ffData state (checkbox always; dropdown when empty).
+  const form = formFieldResult(pending, ctx.themeFonts);
+  if (form) return { text: form.text, props: form.props, style: form.style };
+
+  if (pending.kind && ctx.pageContext) {
+    return {
+      text: projectPageFieldValue(pending.kind, ctx.pageContext),
+      props: pending.props,
+      style: pending.style,
+    };
+  }
+  // A non-empty cached result is what Word last painted; it wins over synthesis.
+  if (pending.cachedText.length > 0) {
+    return { text: pending.cachedText, props: pending.props, style: pending.style };
+  }
+  // Empty cache: synthesize. A result that existed but was hidden stays hidden.
+  if (!pending.sawResultContent) {
+    if (pending.docPropertySpec) {
+      const value = docPropertyValue(pending.docPropertySpec, ctx.documentProperties);
+      if (value !== null) return { text: value, props: pending.props, style: pending.style };
+    }
+    // MACROBUTTON / GOTOBUTTON display their text; the macro / target never runs.
+    if (pending.buttonSpec) {
+      return { text: pending.buttonSpec.display, props: pending.props, style: pending.style };
+    }
+  }
+  return null;
+}

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -169,7 +169,8 @@ export function layoutHeaderFooterStory(
   inlineDrawingLayout?: import('./drawing-layout.ts').InlineDrawingLayoutContext,
   drawingTokenForParagraph?: (paragraph: import('@docx-editor.dev/core/store').OoxmlNode) => string,
   drawingLayoutToken?: string,
-  hfPageContext?: HeaderFooterPageContext
+  hfPageContext?: HeaderFooterPageContext,
+  documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties
 ): HeaderFooterStoryLayout {
   const needs = detectStoryPageFields(part.root);
   const contextCache = createBoundedContextCache(maxPageContextEntries);
@@ -243,6 +244,7 @@ export function layoutHeaderFooterStory(
           pageContext: effectiveCtx,
           ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
           ...(displayMode ? { displayMode } : {}),
+          ...(documentProperties ? { documentProperties } : {}),
           inlineDrawingLayout,
           anchorFrameBase,
           pageContentClip: () => pageClipRegion(anchorFrameBase()),
@@ -258,6 +260,7 @@ export function layoutHeaderFooterStory(
               ...(effectiveCtx ? { pageContext: effectiveCtx } : {}),
               ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
               ...(displayMode ? { displayMode } : {}),
+              ...(documentProperties ? { documentProperties } : {}),
               inlineDrawingLayout,
               ...(drawingTokenForParagraph ? { drawingTokenForParagraph } : {}),
             }),
@@ -311,6 +314,7 @@ export function layoutHeaderFooterStory(
         pageContext: effectiveCtx,
         ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
         ...(displayMode ? { displayMode } : {}),
+        ...(documentProperties ? { documentProperties } : {}),
       });
     }
 

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -236,7 +236,12 @@ export {
   type PageFurniture,
   type SemanticLayoutOptions,
 } from './semantic-layout.ts';
-export { formatPageNumber, type HyperlinkProjector } from './field-projection.ts';
+export {
+  formatPageNumber,
+  type FieldLinkProjector,
+  type HyperlinkProjector,
+} from './field-projection.ts';
+export type { HyperlinkFieldSpec } from './field-link.ts';
 export {
   EMPTY_NUMBERING_INDEX,
   MAX_LVL_OVERRIDES,

--- a/packages/core/src/layout/note-layout.ts
+++ b/packages/core/src/layout/note-layout.ts
@@ -142,6 +142,8 @@ export interface LayoutNoteStoryOptions {
    */
   readonly projectLink?: HyperlinkProjector;
   readonly projectFieldLink?: FieldLinkProjector;
+  /** Document properties for a document-property field inside a note story. */
+  readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
   /** Derived display marks for noteRef projection inside the note body. */
   readonly noteMarks?: NoteMarkContext;
   /**
@@ -232,6 +234,7 @@ export function layoutNoteStory(
     noteMarks,
     ...(options.projectLink ? { projectLink: options.projectLink } : {}),
     ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
+    ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
     ...(options.defaultTabStopPt !== undefined
       ? { defaultTabStopPt: options.defaultTabStopPt }
       : {}),

--- a/packages/core/src/layout/note-layout.ts
+++ b/packages/core/src/layout/note-layout.ts
@@ -25,6 +25,7 @@ import {
   MAX_NOTES_PER_PART,
 } from '../store/package/note-nodes.ts';
 import type { InlineDrawingLayoutContext } from './drawing-layout.ts';
+import type { FieldLinkProjector, HyperlinkProjector } from './field-pieces.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
 import type { NoteMarkContext } from './note-projection.ts';
 import type { PendingLine } from './paragraph-flow.ts';
@@ -134,6 +135,13 @@ export interface LayoutNoteStoryOptions {
   readonly cache?: ParagraphLayoutCache<readonly PendingLine[]>;
   readonly styleCascade?: StyleCascadeTable;
   readonly defaultTabStopPt?: number;
+  /**
+   * Same projector seams the BODY walk uses. Without them a `w:hyperlink` or a HYPERLINK
+   * field inside a note painted as plain text — measured, but carrying no link record for
+   * paint to anchor and navigation to activate.
+   */
+  readonly projectLink?: HyperlinkProjector;
+  readonly projectFieldLink?: FieldLinkProjector;
   /** Derived display marks for noteRef projection inside the note body. */
   readonly noteMarks?: NoteMarkContext;
   /**
@@ -222,6 +230,8 @@ export function layoutNoteStory(
     nextLineId: () => `${prefix}-line-${lineCounter++}`,
     styleCascade: options.styleCascade,
     noteMarks,
+    ...(options.projectLink ? { projectLink: options.projectLink } : {}),
+    ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
     ...(options.defaultTabStopPt !== undefined
       ? { defaultTabStopPt: options.defaultTabStopPt }
       : {}),

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -141,6 +141,13 @@ export interface NotesLayoutInput {
   readonly styleCascade?: StyleCascadeTable;
   readonly defaultTabStopPt?: number;
   /**
+   * Link projector seams, same as the body walk's. Normally injected by `semantic-layout`
+   * from its own options, so a note's `w:hyperlink` / HYPERLINK field carries the same
+   * sanitized record a body one does instead of painting dead text.
+   */
+  readonly projectLink?: import('./field-pieces.ts').HyperlinkProjector;
+  readonly projectFieldLink?: import('./field-pieces.ts').FieldLinkProjector;
+  /**
    * Inline drawing support per notes part. Absent means note paragraphs flow without
    * drawing records, which is what a headless caller with no image port wants.
    */
@@ -342,6 +349,8 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
     cache: input.cache,
     styleCascade: input.styleCascade,
     defaultTabStopPt: input.defaultTabStopPt,
+    projectLink: input.projectLink,
+    projectFieldLink: input.projectFieldLink,
     noteMarks,
     drawingsForPart: input.drawingsForPart,
   };

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -147,6 +147,8 @@ export interface NotesLayoutInput {
    */
   readonly projectLink?: import('./field-pieces.ts').HyperlinkProjector;
   readonly projectFieldLink?: import('./field-pieces.ts').FieldLinkProjector;
+  /** Document properties for a document-property field inside a note story. */
+  readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
   /**
    * Inline drawing support per notes part. Absent means note paragraphs flow without
    * drawing records, which is what a headless caller with no image port wants.
@@ -351,6 +353,7 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
     defaultTabStopPt: input.defaultTabStopPt,
     projectLink: input.projectLink,
     projectFieldLink: input.projectFieldLink,
+    documentProperties: input.documentProperties,
     noteMarks,
     drawingsForPart: input.drawingsForPart,
   };
@@ -2120,6 +2123,31 @@ export function provisionalNoteMarks(
     else endnoteSites.push(site);
   }
   return buildMarkContext(footnoteSites, endnoteSites, input);
+}
+
+/**
+ * Note stories run the same paragraph walk as the body, so they inherit the body's link
+ * projector seams and document properties unless the notes input pinned its own — without which
+ * a `w:hyperlink`, HYPERLINK field, or document-property field in a footnote painted as dead or
+ * blank text while the body's twin resolved.
+ */
+export function inheritNotesLayoutInput(
+  notes: NotesLayoutInput,
+  body: {
+    readonly projectLink?: NotesLayoutInput['projectLink'];
+    readonly projectFieldLink?: NotesLayoutInput['projectFieldLink'];
+    readonly documentProperties?: NotesLayoutInput['documentProperties'];
+  }
+): NotesLayoutInput {
+  const projectLink = notes.projectLink ?? body.projectLink;
+  const projectFieldLink = notes.projectFieldLink ?? body.projectFieldLink;
+  const documentProperties = notes.documentProperties ?? body.documentProperties;
+  return {
+    ...notes,
+    ...(projectLink ? { projectLink } : {}),
+    ...(projectFieldLink ? { projectFieldLink } : {}),
+    ...(documentProperties ? { documentProperties } : {}),
+  };
 }
 
 export {

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -129,6 +129,13 @@ export interface ParagraphFlowOptions {
    */
   readonly documentProperties?: DocumentProperties;
   /**
+   * True when this is BODY flow, whose PAGE/NUMPAGES/SECTIONPAGES fields are substituted at
+   * document finalize (`substituteBodyPageFields`). Only then does an empty-cache page field
+   * paint a placeholder digit; headers/footers, notes and text boxes leave it blank, keeping
+   * their own live path or their deferral, so a placeholder is never stranded unsubstituted.
+   */
+  readonly bodyPageFields?: boolean;
+  /**
    * Which revisions this break resolves away.
    *
    * A different mode is a different break — the proposed result drops deleted text, so lines
@@ -679,7 +686,8 @@ export function breakParagraph(
     flow?.inlineDrawingLayout,
     flow?.themeFonts,
     flow?.projectFieldLink,
-    flow?.documentProperties
+    flow?.documentProperties,
+    flow?.bodyPageFields ?? false
   );
   const startOffset = Math.max(0, flow?.startOffset ?? 0);
   const pieces = allPieces.flatMap((piece): FieldAwarePiece[] => {

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -12,6 +12,7 @@ import {
   type FieldAwarePiece,
   type FieldPageContext,
   type PositionalTab,
+  type FieldLinkProjector,
   type HyperlinkProjector,
   type ModelRange,
   type RunPropertyCascader,
@@ -107,6 +108,13 @@ export interface ParagraphFlowOptions {
    * link, which is what a table-cell or furniture pass without a resolver gets.
    */
   readonly projectLink?: HyperlinkProjector;
+  /**
+   * Turns a parsed HYPERLINK field instruction into the sanitized record its result carries.
+   *
+   * Same seam and same degradation as {@link projectLink}: absent, the field's cached result
+   * still measures and paints — it simply is not a link.
+   */
+  readonly projectFieldLink?: FieldLinkProjector;
   /**
    * Which revisions this break resolves away.
    *
@@ -656,7 +664,8 @@ export function breakParagraph(
     flow?.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE,
     deletedRanges,
     flow?.inlineDrawingLayout,
-    flow?.themeFonts
+    flow?.themeFonts,
+    flow?.projectFieldLink
   );
   const startOffset = Math.max(0, flow?.startOffset ?? 0);
   const pieces = allPieces.flatMap((piece): FieldAwarePiece[] => {

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -5,7 +5,12 @@
 // position-independent — span x offsets are relative to the paragraph origin — which is
 // what lets one cached break serve the same content at any x (body or any cell).
 
-import { PAGE_BREAK_CHAR, type OoxmlNode, type OoxmlProperty } from '@docx-editor.dev/core/store';
+import {
+  PAGE_BREAK_CHAR,
+  type DocumentProperties,
+  type OoxmlNode,
+  type OoxmlProperty,
+} from '@docx-editor.dev/core/store';
 import {
   piecesOfParagraph,
   propertiesOfRunContainer,
@@ -115,6 +120,14 @@ export interface ParagraphFlowOptions {
    * still measures and paints — it simply is not a link.
    */
   readonly projectFieldLink?: FieldLinkProjector;
+  /**
+   * The document's parsed metadata, for document-property fields (TITLE, AUTHOR, …).
+   *
+   * Document-global rather than per-paragraph — the surface reads it once from the store and
+   * hands the same object to every flow. Absent means such a field paints its cached result or
+   * nothing, the same degradation as a furniture-only pass.
+   */
+  readonly documentProperties?: DocumentProperties;
   /**
    * Which revisions this break resolves away.
    *
@@ -665,7 +678,8 @@ export function breakParagraph(
     deletedRanges,
     flow?.inlineDrawingLayout,
     flow?.themeFonts,
-    flow?.projectFieldLink
+    flow?.projectFieldLink,
+    flow?.documentProperties
   );
   const startOffset = Math.max(0, flow?.startOffset ?? 0);
   const pieces = allPieces.flatMap((piece): FieldAwarePiece[] => {

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -720,7 +720,14 @@ export function paragraphTextFromLayout(layout: SemanticLayout, paragraphId: str
       const key = `${span.range.start}:${span.range.end}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      pieces.push({ start: span.range.start, text: span.text });
+      // A PROJECTED atom can paint more glyphs than its model range is wide — a document-property
+      // field spells "Sample Title" over one model unit. The raw text would make this longer than
+      // the model paragraph, and since this IS the surface's `paragraphTextOf` the overshoot lands
+      // in Select All, the deletion range and the word walk. Clamp each span to its model width.
+      const width = span.range.end - span.range.start;
+      const text =
+        span.text.length === width ? span.text : span.text.slice(0, width).padEnd(width, ' ');
+      pieces.push({ start: span.range.start, text });
     }
     // Inline drawings occupy one UTF-16 unit each; they live on `line.drawings`, not in span
     // text, but selection clamp, Select All, and surface ops read length from here.

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -152,7 +152,6 @@ import {
   type ContentControlGeometryFragment,
   type ContentControlLevel,
   type ContentControlLock,
-  type ContentControlMappedType,
   type HeaderFooterStoryRecord,
   type LayoutBox,
   type LineRecord,
@@ -169,6 +168,14 @@ import {
   contentControlContentChildren,
   isContentControl,
 } from '../store/package/content-control-walk.ts';
+import {
+  contentControlPropertiesOf,
+  controlLevelOf,
+  mapContentControlType,
+  parseContentControlLock,
+  propertyChild,
+  propertyVal,
+} from './content-control-properties.ts';
 import type { NumberingIndex } from './numbering-index.ts';
 import { firstLineShift, withResolvedListItems, type ResolvedListItem } from './list-resolve.ts';
 import { publishListMarker } from './list-marker.ts';
@@ -2837,95 +2844,6 @@ function layoutBlocksWithGeometry(
 // ---------------------------------------------------------------------------------------
 // Content-control boundary records
 // ---------------------------------------------------------------------------------------
-
-const WML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const W14_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
-const W15_NS = 'http://schemas.microsoft.com/office/word/2012/wordml';
-
-function wmlValOf(node: OoxmlNode): string | undefined {
-  if (node.kind === 'textValue') return undefined;
-  for (const attribute of node.attributes) {
-    if (attribute.localName === 'val' && attribute.namespaceUri === WML_NS) return attribute.value;
-  }
-  return undefined;
-}
-
-function contentControlPropertiesOf(control: OoxmlElement): OoxmlElement | undefined {
-  for (const child of control.children) {
-    if (child.kind === 'textValue') continue;
-    if (child.kind === 'contentControlProperties' || child.localName === 'sdtPr') return child;
-  }
-  return undefined;
-}
-
-function propertyChild(
-  properties: OoxmlElement | undefined,
-  localName: string
-): OoxmlElement | undefined {
-  if (!properties) return undefined;
-  for (const child of properties.children) {
-    if (child.kind === 'textValue') continue;
-    if (child.localName === localName) return child;
-  }
-  return undefined;
-}
-
-function propertyVal(properties: OoxmlElement | undefined, localName: string): string | undefined {
-  const child = propertyChild(properties, localName);
-  return child ? wmlValOf(child) : undefined;
-}
-
-function parseContentControlLock(value: string | undefined): ContentControlLock {
-  if (value === 'sdtLocked' || value === 'contentLocked' || value === 'sdtContentLocked') {
-    return value;
-  }
-  return 'unlocked';
-}
-
-function mapContentControlType(properties: OoxmlElement | undefined): ContentControlMappedType {
-  if (!properties) return 'richText';
-  for (const child of properties.children) {
-    if (child.kind === 'textValue') continue;
-    const kind = child.kind;
-    const localName = child.localName;
-    const namespaceUri = child.namespaceUri;
-    // Typed markers after the SDT merge; `localName` covers demoted/generic fallbacks.
-    // Do not match `kind === 'text'` — that is `w:t`, not `CT_SdtText` (`contentControlText`).
-    if (kind === 'contentControlDropDownList' || localName === 'dropDownList') return 'dropdown';
-    if (kind === 'contentControlComboBox' || localName === 'comboBox') return 'comboBox';
-    if (kind === 'contentControlDate' || localName === 'date') return 'date';
-    if (localName === 'picture') return 'picture';
-    if (kind === 'contentControlText' || localName === 'text') return 'plainText';
-    if (localName === 'richText') return 'richText';
-    if (
-      kind === 'contentControlCheckbox' ||
-      (localName === 'checkbox' && namespaceUri === W14_NS)
-    ) {
-      return 'checkbox';
-    }
-    if (localName === 'repeatingSection' && namespaceUri === W15_NS) {
-      return 'repeatingSection';
-    }
-  }
-  return 'richText';
-}
-
-function controlLevelOf(control: OoxmlElement): ContentControlLevel {
-  const classify = (nodes: readonly OoxmlNode[], depth: number): ContentControlLevel | null => {
-    for (const child of nodes) {
-      if (child.kind === 'textValue') continue;
-      if (child.kind === 'tableRow') return 'row';
-      if (child.kind === 'tableCell') return 'cell';
-      if (child.kind === 'paragraph' || child.kind === 'table') return 'block';
-      if (isContentControl(child) && depth < MAX_SDT_NESTING) {
-        const nested = classify(contentControlContentChildren(child), depth + 1);
-        if (nested) return nested;
-      }
-    }
-    return null;
-  };
-  return classify(contentControlContentChildren(control), 0) ?? 'inline';
-}
 
 /**
  * Fingerprint of every control wrapper's chrome metadata — not its content.

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -20,6 +20,7 @@ import {
   finalizePageFieldProjection,
   storyNeedsPageFields,
   withPageFieldSources,
+  type FieldLinkProjector,
   type HyperlinkProjector,
 } from './field-projection.ts';
 import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
@@ -289,6 +290,14 @@ export interface SemanticLayoutOptions {
    * degradation a headless test or a furniture-only pass gets, and it is the safe one.
    */
   readonly projectLink?: HyperlinkProjector;
+  /**
+   * Turns a parsed HYPERLINK field instruction into the SANITIZED record its result carries.
+   *
+   * An option for the same reason as {@link projectLink}: the raw target must cross the
+   * surface's href trust boundary, which layout cannot see. Absent means the field's cached
+   * result still measures, breaks and paints — it simply is not clickable.
+   */
+  readonly projectFieldLink?: FieldLinkProjector;
   /**
    * Footnote/endnote layout input. When present, body layout projects note marks and a
    * post-pass attaches note areas (with bounded reflow for pageBottom reservation).
@@ -1336,6 +1345,7 @@ function layoutBlocksPass(
     listItems,
     ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
     ...(options.projectLink ? { projectLink: options.projectLink } : {}),
+    ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
     ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
     ...(options.inlineDrawingLayout ? { inlineDrawingLayout: options.inlineDrawingLayout } : {}),
     ...(options.drawingTokenForParagraph
@@ -1459,6 +1469,7 @@ function layoutBlocksPass(
         startOffset,
         marginExtent: { left: 0, right: entry.indent.left + available + entry.indent.right },
         ...(options.projectLink ? { projectLink: options.projectLink } : {}),
+        ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
         displayMode,
         ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
         ...(options.inlineDrawingLayout

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -20,6 +20,7 @@ import { WML_MAIN_DOCUMENT_PART } from '../store/package/opc-names.ts';
 import {
   finalizePageFieldProjection,
   storyNeedsPageFields,
+  summarizeFlushedPage,
   withPageFieldSources,
   type FieldLinkProjector,
   type HyperlinkProjector,
@@ -1239,10 +1240,7 @@ function layoutBlocksPass(
     const box = pageBox(index);
     const header = furnitureFor('header', index, box);
     const footer = furnitureFor('footer', index, box);
-    const usedBottom = pageFragments.reduce(
-      (bottom, fragment) => Math.max(bottom, fragment.box.y + fragment.box.height),
-      columnRegionTop
-    );
+    const { usedBottom, hasBodyPageFields } = summarizeFlushedPage(pageFragments, columnRegionTop);
     pages.push({
       id: `page-${index}`,
       index,
@@ -1254,6 +1252,7 @@ function layoutBlocksPass(
         height: baseContentHeight,
       },
       fragments: pageFragments,
+      hasBodyPageFields,
       ...(columns.separator
         ? {
             columnSeparators: columns.gaps.map((gap, separatorIndex) => ({

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1333,6 +1333,7 @@ function layoutBlocksPass(
       styleCascade,
       ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
       ...(displayMode ? { displayMode } : {}),
+      ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
       inlineDrawingLayout: options.inlineDrawingLayout,
       drawingTokenForParagraph: options.drawingTokenForParagraph,
     });

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1356,6 +1356,8 @@ function layoutBlocksPass(
     ...(options.projectLink ? { projectLink: options.projectLink } : {}),
     ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
     ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
+    // Body flow: page fields in table cells paint a placeholder for document finalize to fill.
+    bodyPageFields: true,
     ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
     ...(options.inlineDrawingLayout ? { inlineDrawingLayout: options.inlineDrawingLayout } : {}),
     ...(options.drawingTokenForParagraph
@@ -1481,6 +1483,8 @@ function layoutBlocksPass(
         ...(options.projectLink ? { projectLink: options.projectLink } : {}),
         ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
         ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
+        // Body flow: an empty-cache page field paints a placeholder finalize substitutes per page.
+        bodyPageFields: true,
         displayMode,
         ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
         ...(options.inlineDrawingLayout

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -531,8 +531,20 @@ export function layoutSemanticDocument(
     return finish(runBody(optionsWithLists));
   }
 
+  // Note stories run the same paragraph walk as the body, so they inherit the body's link
+  // projector seams unless the notes input pinned its own: without this a `w:hyperlink` or
+  // HYPERLINK field in a footnote painted as dead text while the body's twin was clickable.
+  const notesInput: import('./note-pagination.ts').NotesLayoutInput = {
+    ...options.notes,
+    ...((options.notes.projectLink ?? options.projectLink)
+      ? { projectLink: options.notes.projectLink ?? options.projectLink }
+      : {}),
+    ...((options.notes.projectFieldLink ?? options.projectFieldLink)
+      ? { projectFieldLink: options.notes.projectFieldLink ?? options.projectFieldLink }
+      : {}),
+  };
   return finish(
-    layoutSemanticDocumentWithNotes(part, sections, optionsWithLists, options.notes, runBody)
+    layoutSemanticDocumentWithNotes(part, sections, optionsWithLists, notesInput, runBody)
   );
 }
 

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -10,6 +10,7 @@
 // two boxes for pagination.
 
 import type {
+  DocumentProperties,
   OoxmlElement,
   OoxmlNode,
   OoxmlPart,
@@ -136,7 +137,7 @@ import {
   type SectionColumns,
 } from './section-properties.ts';
 import { resolveSectionColumns, type ResolvedSectionColumns } from './section-columns.ts';
-import { layoutSemanticDocumentWithNotes } from './note-pagination.ts';
+import { inheritNotesLayoutInput, layoutSemanticDocumentWithNotes } from './note-pagination.ts';
 import {
   DEFAULT_PAGE_GEOMETRY,
   effectiveContentControlLock,
@@ -298,6 +299,11 @@ export interface SemanticLayoutOptions {
    * result still measures, breaks and paints — it simply is not clickable.
    */
   readonly projectFieldLink?: FieldLinkProjector;
+  /**
+   * The document's parsed metadata, for document-property fields (TITLE, AUTHOR, …). Read once
+   * by the surface and shared across body, table, note and header/footer flows.
+   */
+  readonly documentProperties?: DocumentProperties;
   /**
    * Footnote/endnote layout input. When present, body layout projects note marks and a
    * post-pass attaches note areas (with bounded reflow for pageBottom reservation).
@@ -531,18 +537,9 @@ export function layoutSemanticDocument(
     return finish(runBody(optionsWithLists));
   }
 
-  // Note stories run the same paragraph walk as the body, so they inherit the body's link
-  // projector seams unless the notes input pinned its own: without this a `w:hyperlink` or
-  // HYPERLINK field in a footnote painted as dead text while the body's twin was clickable.
-  const notesInput: import('./note-pagination.ts').NotesLayoutInput = {
-    ...options.notes,
-    ...((options.notes.projectLink ?? options.projectLink)
-      ? { projectLink: options.notes.projectLink ?? options.projectLink }
-      : {}),
-    ...((options.notes.projectFieldLink ?? options.projectFieldLink)
-      ? { projectFieldLink: options.notes.projectFieldLink ?? options.projectFieldLink }
-      : {}),
-  };
+  // Notes inherit the body's projector seams and document properties (link, field link, doc
+  // props) unless the notes input pinned its own — see `inheritNotesLayoutInput`.
+  const notesInput = inheritNotesLayoutInput(options.notes, options);
   return finish(
     layoutSemanticDocumentWithNotes(part, sections, optionsWithLists, notesInput, runBody)
   );
@@ -1358,6 +1355,7 @@ function layoutBlocksPass(
     ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
     ...(options.projectLink ? { projectLink: options.projectLink } : {}),
     ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
+    ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
     ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
     ...(options.inlineDrawingLayout ? { inlineDrawingLayout: options.inlineDrawingLayout } : {}),
     ...(options.drawingTokenForParagraph
@@ -1482,6 +1480,7 @@ function layoutBlocksPass(
         marginExtent: { left: 0, right: entry.indent.left + available + entry.indent.right },
         ...(options.projectLink ? { projectLink: options.projectLink } : {}),
         ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
+        ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
         displayMode,
         ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
         ...(options.inlineDrawingLayout

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -719,6 +719,14 @@ export interface PageRecord {
     readonly format?: string;
   };
   /**
+   * `true` when this page's body flow (or a body table) carries a PAGE/NUMPAGES/SECTIONPAGES
+   * placeholder that document finalize must substitute. Set when the page is assembled, so it
+   * rides the record through incremental reuse. `false` lets `finalizePageFieldProjection` skip
+   * the substitution walk; `undefined` (a page built by a path that does not stamp it) still
+   * walks, which is safe.
+   */
+  readonly hasBodyPageFields?: boolean;
+  /**
    * Content-control boundaries whose geometry intersects this page.
    *
    * Carried on the page so a consumer that only holds a page record still sees current

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -210,6 +210,8 @@ export interface TableFlowDeps {
   readonly projectLink?: HyperlinkProjector;
   /** Same seam for HYPERLINK fields: a field in a table cell is an ordinary field. */
   readonly projectFieldLink?: FieldLinkProjector;
+  /** Document properties for document-property fields; the same object every flow shares. */
+  readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
   readonly inlineDrawingLayout?: import('./drawing-layout.ts').InlineDrawingLayoutContext;
   /** Per-paragraph drawing projection/resource token for break cache keys. */
   readonly drawingTokenForParagraph?: (paragraph: OoxmlNode) => string;
@@ -643,6 +645,7 @@ function placeCellParagraph(
       marginExtent: { left: 0, right: indent.left + available + indent.right },
       ...(deps.projectLink ? { projectLink: deps.projectLink } : {}),
       ...(deps.projectFieldLink ? { projectFieldLink: deps.projectFieldLink } : {}),
+      ...(deps.documentProperties ? { documentProperties: deps.documentProperties } : {}),
       displayMode: deps.displayMode,
       ...(deps.noteMarks ? { noteMarks: deps.noteMarks } : {}),
       ...(deps.inlineDrawingLayout ? { inlineDrawingLayout: deps.inlineDrawingLayout } : {}),

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -212,6 +212,12 @@ export interface TableFlowDeps {
   readonly projectFieldLink?: FieldLinkProjector;
   /** Document properties for document-property fields; the same object every flow shares. */
   readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
+  /**
+   * True when this table is in BODY flow, whose page fields are substituted at document finalize.
+   * Propagates to every cell paragraph so a body-table PAGE field paints a placeholder; a table
+   * in a header/footer keeps this false and its own live page path.
+   */
+  readonly bodyPageFields?: boolean;
   readonly inlineDrawingLayout?: import('./drawing-layout.ts').InlineDrawingLayoutContext;
   /** Per-paragraph drawing projection/resource token for break cache keys. */
   readonly drawingTokenForParagraph?: (paragraph: OoxmlNode) => string;
@@ -646,6 +652,7 @@ function placeCellParagraph(
       ...(deps.projectLink ? { projectLink: deps.projectLink } : {}),
       ...(deps.projectFieldLink ? { projectFieldLink: deps.projectFieldLink } : {}),
       ...(deps.documentProperties ? { documentProperties: deps.documentProperties } : {}),
+      ...(deps.bodyPageFields ? { bodyPageFields: true } : {}),
       displayMode: deps.displayMode,
       ...(deps.noteMarks ? { noteMarks: deps.noteMarks } : {}),
       ...(deps.inlineDrawingLayout ? { inlineDrawingLayout: deps.inlineDrawingLayout } : {}),

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -33,7 +33,11 @@ import {
   localizeExclusionZones,
   topAndBottomSkipBeforeLine,
 } from './drawing-exclusion.ts';
-import type { FieldPageContext, HyperlinkProjector } from './field-projection.ts';
+import type {
+  FieldLinkProjector,
+  FieldPageContext,
+  HyperlinkProjector,
+} from './field-projection.ts';
 import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
 import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
@@ -204,6 +208,8 @@ export interface TableFlowDeps {
    * table cell is an ordinary link; without this it would paint its text and be dead.
    */
   readonly projectLink?: HyperlinkProjector;
+  /** Same seam for HYPERLINK fields: a field in a table cell is an ordinary field. */
+  readonly projectFieldLink?: FieldLinkProjector;
   readonly inlineDrawingLayout?: import('./drawing-layout.ts').InlineDrawingLayoutContext;
   /** Per-paragraph drawing projection/resource token for break cache keys. */
   readonly drawingTokenForParagraph?: (paragraph: OoxmlNode) => string;
@@ -636,6 +642,7 @@ function placeCellParagraph(
       // A cell's own content box is the column a positional tab measures against.
       marginExtent: { left: 0, right: indent.left + available + indent.right },
       ...(deps.projectLink ? { projectLink: deps.projectLink } : {}),
+      ...(deps.projectFieldLink ? { projectFieldLink: deps.projectFieldLink } : {}),
       displayMode: deps.displayMode,
       ...(deps.noteMarks ? { noteMarks: deps.noteMarks } : {}),
       ...(deps.inlineDrawingLayout ? { inlineDrawingLayout: deps.inlineDrawingLayout } : {}),

--- a/packages/core/src/layout/symbol-run.ts
+++ b/packages/core/src/layout/symbol-run.ts
@@ -12,11 +12,11 @@ import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-s
 import { isSymbolEncodedFamily, mapSymbolPuaText } from './symbol-encoding.ts';
 
 /** PUA page Word adds to a symbol font's byte value (mirrors `symbol-encoding.ts`). */
-const SYMBOL_PUA_BASE = 0xf000;
-const SYMBOL_PUA_END = 0xf0ff;
+export const SYMBOL_PUA_BASE = 0xf000;
+export const SYMBOL_PUA_END = 0xf0ff;
 
 /** `resolveRunStyle` ignores longer family names; match its cap so the override can land. */
-const MAX_SYMBOL_FONT_LENGTH = 128;
+export const MAX_SYMBOL_FONT_LENGTH = 128;
 
 /** One resolved `w:sym` glyph. */
 export interface SymbolGlyph {
@@ -55,11 +55,21 @@ function parseSymbolChar(value: string | undefined): number | null {
   return Number.parseInt(value, 16);
 }
 
-/** A codepoint no glyph should ever be: lone surrogates and BMP noncharacters. */
-function isRenderableCodePoint(code: number): boolean {
-  if (code < 0x20) return false;
+/**
+ * A codepoint no glyph should ever be: controls, lone surrogates, noncharacters — and
+ * U+FFFC, because paragraph flow uses the object replacement character as its inline-object
+ * sentinel, so a file-supplied one would be swallowed as a phantom drawing.
+ *
+ * Shared by `w:sym` resolution and SYMBOL field rendering (`field-symbol.ts`); both feed it
+ * attacker-controlled numbers, so it answers for the full Unicode range, not just the BMP.
+ */
+export function isRenderableCodePoint(code: number): boolean {
+  if (!Number.isInteger(code) || code < 0x20 || code > 0x10ffff) return false;
+  if (code >= 0x7f && code <= 0x9f) return false;
   if (code >= 0xd800 && code <= 0xdfff) return false;
-  if (code === 0xfffe || code === 0xffff) return false;
+  if (code >= 0xfdd0 && code <= 0xfdef) return false;
+  if ((code & 0xfffe) === 0xfffe) return false;
+  if (code === 0xfffc) return false;
   return true;
 }
 

--- a/packages/core/src/layout/symbol-run.ts
+++ b/packages/core/src/layout/symbol-run.ts
@@ -81,6 +81,16 @@ export function isRenderableCodePoint(code: number): boolean {
  * the PUA character with the symbol font, which the shaper may still resolve. A bare byte
  * (`@w:char="46"`) on a symbol font is normalized to the 0xF000 page first, because Word
  * accepts both encodings.
+ *
+ * DELIBERATE DIVERGENCE from list markers: `mapSymbolPuaText` takes an `isFontAvailable`
+ * oracle so an INSTALLED symbol font keeps its authentic PUA glyph, and `list-resolve.ts`
+ * accepts one — but no oracle is passed here (nor by `field-symbol.ts`). The parameter is a
+ * public affordance of `withResolvedListItems` that no engine call site supplies today:
+ * `SemanticLayoutOptions` does not carry it, so wiring it into `piecesOfParagraph` means a
+ * new public layout option threaded through paragraph flow AND folded into the fragment
+ * signature / layout cache keys (a font finishing to load must invalidate painted glyphs).
+ * Until a host actually supplies the oracle, both symbol paths always map to the Unicode
+ * equivalent, which every font can draw. Revisit when the list path gains a real producer.
  */
 export function symbolGlyphOf(node: OoxmlNode): SymbolGlyph | null {
   if (!isSymbolRunChild(node)) return null;

--- a/packages/core/src/layout/symbol-run.ts
+++ b/packages/core/src/layout/symbol-run.ts
@@ -1,0 +1,111 @@
+// `w:sym` (§17.3.3.30) glyph resolution for layout.
+//
+// The canonical tree keeps `w:sym` generic, and the store's offset authority gives a generic
+// run child ZERO model width — so a resolved symbol is a rendering-only projection: one glyph
+// standing at an insertion point, never a model character. Word stores a symbol font's byte
+// as 0xF000 + byte (the same encoding `symbol-encoding.ts` handles for list bullets); it also
+// accepts the bare byte. Both attributes are attacker-controlled, so parsing fails closed to
+// "no glyph": strict bounded hex, no surrogates, no noncharacters, capped family length.
+
+import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlProperty } from '@docx-editor.dev/core/store';
+import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
+import { isSymbolEncodedFamily, mapSymbolPuaText } from './symbol-encoding.ts';
+
+/** PUA page Word adds to a symbol font's byte value (mirrors `symbol-encoding.ts`). */
+const SYMBOL_PUA_BASE = 0xf000;
+const SYMBOL_PUA_END = 0xf0ff;
+
+/** `resolveRunStyle` ignores longer family names; match its cap so the override can land. */
+const MAX_SYMBOL_FONT_LENGTH = 128;
+
+/** One resolved `w:sym` glyph. */
+export interface SymbolGlyph {
+  /** Exactly one code point. */
+  readonly text: string;
+  /** `@w:font` when present and sane; null keeps the run's own font. */
+  readonly font: string | null;
+  /**
+   * True when {@link text} is a real Unicode character rather than a symbol-font PUA
+   * codepoint — the only kind a plain collected string (which cannot carry a font switch)
+   * may absorb.
+   */
+  readonly unicode: boolean;
+}
+
+/** Typed check for a generic `w:sym` run child. */
+export function isSymbolRunChild(node: OoxmlNode): boolean {
+  return (
+    node.kind === 'generic' && node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'sym'
+  );
+}
+
+function wmlAttribute(node: OoxmlNode, localName: string): string | undefined {
+  if (node.kind === 'textValue' || !('attributes' in node)) return undefined;
+  for (const entry of node.attributes) {
+    if (entry.localName !== localName) continue;
+    // Unprefixed attributes on WML elements are common in authored packages.
+    if (entry.namespaceUri === WML_NAMESPACE_URI || entry.namespaceUri === '') return entry.value;
+  }
+  return undefined;
+}
+
+/** ST_ShortHexNumber, parsed strictly: 1–4 hex digits, anything else is no glyph. */
+function parseSymbolChar(value: string | undefined): number | null {
+  if (!value || value.length > 4 || !/^[0-9A-Fa-f]{1,4}$/.test(value)) return null;
+  return Number.parseInt(value, 16);
+}
+
+/** A codepoint no glyph should ever be: lone surrogates and BMP noncharacters. */
+function isRenderableCodePoint(code: number): boolean {
+  if (code < 0x20) return false;
+  if (code >= 0xd800 && code <= 0xdfff) return false;
+  if (code === 0xfffe || code === 0xffff) return false;
+  return true;
+}
+
+/**
+ * Resolve a `w:sym` node to the single glyph it should paint, or null for no glyph.
+ *
+ * Symbol-encoded fonts (Symbol, Wingdings, …) resolve through `mapSymbolPuaText` so a
+ * Word-authored checkbox or bullet gets its real Unicode equivalent; an unmapped code keeps
+ * the PUA character with the symbol font, which the shaper may still resolve. A bare byte
+ * (`@w:char="46"`) on a symbol font is normalized to the 0xF000 page first, because Word
+ * accepts both encodings.
+ */
+export function symbolGlyphOf(node: OoxmlNode): SymbolGlyph | null {
+  if (!isSymbolRunChild(node)) return null;
+  const code = parseSymbolChar(wmlAttribute(node, 'char'));
+  if (code === null) return null;
+  const rawFont = wmlAttribute(node, 'font');
+  const font = rawFont && rawFont.length <= MAX_SYMBOL_FONT_LENGTH ? rawFont : null;
+
+  const symbolEncoded = isSymbolEncodedFamily(font);
+  const effective =
+    symbolEncoded && code <= 0xff && code + SYMBOL_PUA_BASE <= SYMBOL_PUA_END
+      ? code + SYMBOL_PUA_BASE
+      : code;
+  if (symbolEncoded && effective >= SYMBOL_PUA_BASE && effective <= SYMBOL_PUA_END) {
+    const mapped = mapSymbolPuaText(String.fromCodePoint(effective), font);
+    const unicode = mapped.codePointAt(0)! < SYMBOL_PUA_BASE;
+    return { text: mapped, font, unicode };
+  }
+  if (!isRenderableCodePoint(code)) return null;
+  return { text: String.fromCodePoint(code), font, unicode: code < 0xe000 || code > 0xf8ff };
+}
+
+/**
+ * The glyph's resolved style: the run's own properties with `rFonts` overridden to
+ * `@w:font`. No font keeps the run font unchanged.
+ */
+export function symbolRunStyle(
+  runProps: readonly OoxmlProperty[],
+  glyph: SymbolGlyph,
+  themeFonts?: ThemeFonts
+): { readonly props: readonly OoxmlProperty[]; readonly style: ResolvedRunStyle } {
+  if (!glyph.font) return { props: runProps, style: resolveRunStyle(runProps, themeFonts) };
+  const props: readonly OoxmlProperty[] = [
+    ...runProps,
+    { localName: 'rFonts', attributes: { ascii: glyph.font, hAnsi: glyph.font } },
+  ];
+  return { props, style: resolveRunStyle(props, themeFonts) };
+}

--- a/packages/core/src/layout/textbox-story-layout.ts
+++ b/packages/core/src/layout/textbox-story-layout.ts
@@ -82,6 +82,8 @@ export interface TextboxStoryLayoutOptions {
   /** Host story's page-field context; PAGE-family fields inside the story project against it. */
   readonly pageContext?: FieldPageContext;
   readonly displayMode?: RevisionDisplayMode;
+  /** Document properties, for a document-property field inside the text-box story. */
+  readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
   /** Story nesting depth; a textbox laid out from inside another textbox passes depth + 1. */
   readonly depth?: number;
   /**
@@ -157,6 +159,7 @@ export function layoutTextboxStory(
     nextLineId: () => `${prefix}-line-${lineCounter++}`,
     styleCascade: options.styleCascade,
     ...(options.pageContext ? { pageContext: options.pageContext } : {}),
+    ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
     ...(options.defaultTabStopPt !== undefined
       ? { defaultTabStopPt: options.defaultTabStopPt }
       : {}),

--- a/packages/core/src/output/__tests__/hyperlink-paint.test.ts
+++ b/packages/core/src/output/__tests__/hyperlink-paint.test.ts
@@ -16,7 +16,11 @@ import {
   type OoxmlNode,
   type OoxmlPackage,
 } from '@docx-editor.dev/core/store';
-import { createFixedMeasurer, layoutSemanticDocument } from '@docx-editor.dev/core/layout';
+import {
+  createFixedMeasurer,
+  layoutSemanticDocument,
+  type HyperlinkFieldSpec,
+} from '@docx-editor.dev/core/layout';
 import { paintSemanticLayout } from '../semantic-paint.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -47,11 +51,21 @@ function packageOf(body: string, rels = ''): OoxmlPackage {
   return loaded.package;
 }
 
-function paint(body: string, rels = ''): HTMLElement {
+/**
+ * A content-keyed field-link projector, like the surface registry: two fields naming the same
+ * target share one id, which is exactly the shape that used to coalesce two field anchors.
+ */
+function projectFieldLink(spec: HyperlinkFieldSpec) {
+  if (spec.target === null) return null;
+  return { id: `field:${spec.target}`, kind: 'external' as const, href: spec.target };
+}
+
+function paint(body: string, rels = '', withFieldLinks = false): HTMLElement {
   const pkg = packageOf(body, rels);
   const part = pkg.parts.get(pkg.mainDocumentPart)!;
   const layout = layoutSemanticDocument(part, 3, {
     measurer: createFixedMeasurer(6, 14),
+    ...(withFieldLinks ? { projectFieldLink } : {}),
     projectLink: (link: OoxmlNode) => {
       if (link.kind === 'textValue') return null;
       const target = hyperlinkTargetOf(link, (id) =>
@@ -188,5 +202,61 @@ describe('painted hyperlink anchors', () => {
     const anchor = container.querySelector('a.docx-hyperlink')!;
     expect(anchor.getAttribute('title')).toBe('<img src=x onerror=alert(1)>');
     expect(anchor.textContent).toBe('<script>');
+  });
+});
+
+/** A complete complex field around one instruction, with an optional cached result. */
+function complexField(instr: string, result = ''): string {
+  return (
+    '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+    `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+    '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+    result +
+    '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+  );
+}
+
+describe('each HYPERLINK field is its own anchor', () => {
+  test('two adjacent fields with an identical target paint TWO anchors', () => {
+    // Content-keyed ids make both fields share one link id; before the fix the anchor loop
+    // coalesced them into a single <a> a screen reader announced once.
+    const container = paint(
+      '<w:p>' +
+        complexField(' HYPERLINK "https://example.com" ', '<w:r><w:t>A</w:t></w:r>') +
+        complexField(' HYPERLINK "https://example.com" ', '<w:r><w:t>B</w:t></w:r>') +
+        '</w:p>',
+      '',
+      true
+    );
+    const anchors = [...container.querySelectorAll('a[data-docx-link]')];
+    expect(anchors).toHaveLength(2);
+    expect(anchors.map((a) => a.textContent)).toEqual(['A', 'B']);
+  });
+
+  test('a field followed by a typed link with the same target paints two anchors', () => {
+    const container = paint(
+      '<w:p>' +
+        complexField(' HYPERLINK "https://example.com" ', '<w:r><w:t>A</w:t></w:r>') +
+        '<w:hyperlink r:id="rId9"><w:r><w:t>B</w:t></w:r></w:hyperlink>' +
+        '</w:p>',
+      EXTERNAL_REL,
+      true
+    );
+    const anchors = [...container.querySelectorAll('a[data-docx-link]')];
+    expect(anchors).toHaveLength(2);
+    expect(anchors.map((a) => a.textContent)).toEqual(['A', 'B']);
+  });
+
+  test('a single typed link across two formatting runs is still ONE anchor', () => {
+    // The field split must not disturb ordinary run coalescing.
+    const container = paint(
+      '<w:p><w:hyperlink w:anchor="top">' +
+        '<w:r><w:rPr><w:b/></w:rPr><w:t>Bold</w:t></w:r>' +
+        '<w:r><w:t> and plain</w:t></w:r>' +
+        '</w:hyperlink></w:p>',
+      '',
+      true
+    );
+    expect(container.querySelectorAll('a[data-docx-link]')).toHaveLength(1);
   });
 });

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1208,6 +1208,12 @@ function paintLine(
   // only shape an absolutely-positioned line model can express.
   let anchor: HTMLElement | null = null;
   let anchorLinkId: string | null = null;
+  // For a FIELD anchor, the model offset of the field it paints. A field's own result can
+  // break into several spans (a space in the result, or a line wrap), all sharing one link id
+  // AND one model range, so they stay one anchor. A DIFFERENT field starts at a different
+  // offset, so it opens its own — even with an identical target and thus the same content-keyed
+  // id. Null while the current anchor is a typed link or there is none.
+  let anchorFieldStart: number | null = null;
   const inlineDrawings = [...(line.drawings ?? [])].sort((left, right) => left.start - right.start);
   let nextInlineDrawing = 0;
   const appendDrawingAdvancesBefore = (modelOffset: number): void => {
@@ -1272,12 +1278,33 @@ function paintLine(
     if (!link) {
       anchor = null;
       anchorLinkId = null;
+      anchorFieldStart = null;
       element.append(painted);
       continue;
     }
-    if (!anchor || anchorLinkId !== link.id) {
+    // A field atom joins the current anchor only when it is the SAME field: same link id and
+    // same model offset. Two adjacent fields share one content-keyed id when their targets
+    // match, so keying on the id alone would merge two discrete links into one anchor a screen
+    // reader announces once. Keying on the offset too keeps each field its own link unit while
+    // still letting one field's wrapped or space-split result stay a single anchor.
+    if (span.fieldAtom) {
+      const sameField =
+        anchor !== null && anchorLinkId === link.id && anchorFieldStart === span.range.start;
+      if (!sameField) {
+        anchor = paintHyperlinkAnchor(document, link, ctx);
+        anchorLinkId = link.id;
+        anchorFieldStart = span.range.start;
+        element.append(anchor);
+      }
+      anchor!.append(painted);
+      continue;
+    }
+    // A typed link never joins a field anchor (`anchorFieldStart !== null`), and a field never
+    // joins this one, so the two link kinds stay distinct even when adjacent.
+    if (!anchor || anchorLinkId !== link.id || anchorFieldStart !== null) {
       anchor = paintHyperlinkAnchor(document, link, ctx);
       anchorLinkId = link.id;
+      anchorFieldStart = null;
       element.append(anchor);
     }
     anchor.append(painted);

--- a/packages/core/src/store/__tests__/legacy-form-field-data.test.ts
+++ b/packages/core/src/store/__tests__/legacy-form-field-data.test.ts
@@ -1,0 +1,196 @@
+// The bounded `w:ffData` reader: legacy form-field RENDER STATE only, macros never.
+//
+// Everything in ffData is attacker-controlled. The reader walks fldChar → ffData →
+// checkBox/ddList → leaf attributes with a hard node budget, caps every collection before
+// allocating, and fails closed to null so callers keep the presence-only behavior.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '../index.ts';
+import { legacyFormFieldDataOf } from '../package/field-nodes.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const metadata = {
+  name: '/word/document.xml',
+  contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+};
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`,
+    metadata
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/** Parse a run holding one begin `w:fldChar` and return that fldChar node. */
+function fldCharOf(fldCharInner: string): OoxmlNode {
+  const part = partOf(
+    `<w:p><w:r><w:fldChar w:fldCharType="begin">${fldCharInner}</w:fldChar></w:r></w:p>`
+  );
+  const find = (node: OoxmlNode): OoxmlNode | undefined => {
+    if (node.kind !== 'textValue' && node.localName === 'fldChar') return node;
+    if (node.kind === 'textValue') return undefined;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  const fldChar = find(part.root);
+  if (!fldChar) throw new Error('no fldChar');
+  return fldChar;
+}
+
+function checkboxDataOf(checkBoxInner: string, ffDataExtra = '') {
+  return legacyFormFieldDataOf(
+    fldCharOf(`<w:ffData>${ffDataExtra}<w:checkBox>${checkBoxInner}</w:checkBox></w:ffData>`)
+  );
+}
+
+function dropdownDataOf(ddListInner: string) {
+  return legacyFormFieldDataOf(
+    fldCharOf(`<w:ffData><w:ddList>${ddListInner}</w:ddList></w:ffData>`)
+  );
+}
+
+describe('checkbox state', () => {
+  test('w:checked on/off value forms', () => {
+    expect(checkboxDataOf('<w:checked/>')).toMatchObject({ kind: 'checkbox', checked: true });
+    expect(checkboxDataOf('<w:checked w:val="1"/>')).toMatchObject({ checked: true });
+    expect(checkboxDataOf('<w:checked w:val="true"/>')).toMatchObject({ checked: true });
+    expect(checkboxDataOf('<w:checked w:val="0"/>')).toMatchObject({ checked: false });
+    expect(checkboxDataOf('<w:checked w:val="false"/>')).toMatchObject({ checked: false });
+  });
+
+  test('w:default is the fallback and w:checked wins over it', () => {
+    expect(checkboxDataOf('<w:default w:val="1"/>')).toMatchObject({ checked: true });
+    expect(checkboxDataOf('<w:default/>')).toMatchObject({ checked: true });
+    expect(checkboxDataOf('<w:default w:val="0"/>')).toMatchObject({ checked: false });
+    expect(checkboxDataOf('')).toMatchObject({ kind: 'checkbox', checked: false });
+    expect(checkboxDataOf('<w:checked w:val="0"/><w:default w:val="1"/>')).toMatchObject({
+      checked: false,
+    });
+  });
+
+  test('explicit w:size is half-points, clamped to the render range', () => {
+    expect(checkboxDataOf('<w:size w:val="24"/>')).toMatchObject({ sizeHalfPoints: 24 });
+    expect(checkboxDataOf('<w:size w:val="1"/>')).toMatchObject({ sizeHalfPoints: 2 });
+    expect(checkboxDataOf('<w:size w:val="999999"/>')).toMatchObject({ sizeHalfPoints: 288 });
+    // Malformed size falls back to auto rather than failing the whole read.
+    expect(checkboxDataOf('<w:size w:val="abc"/>')).toMatchObject({ sizeHalfPoints: null });
+    expect(checkboxDataOf('<w:size/>')).toMatchObject({ sizeHalfPoints: null });
+  });
+
+  test('w:sizeAuto means auto even beside an explicit size', () => {
+    expect(checkboxDataOf('<w:sizeAuto/>')).toMatchObject({ sizeHalfPoints: null });
+    expect(checkboxDataOf('<w:size w:val="24"/><w:sizeAuto/>')).toMatchObject({
+      sizeHalfPoints: null,
+    });
+  });
+});
+
+describe('dropdown state', () => {
+  const entries =
+    '<w:listEntry w:val="Red"/><w:listEntry w:val="Green"/><w:listEntry w:val="Blue"/>';
+
+  test('result picks the entry; default is the fallback; both-out-of-range is 0', () => {
+    expect(dropdownDataOf(`<w:result w:val="2"/>${entries}`)).toEqual({
+      kind: 'dropdown',
+      entries: ['Red', 'Green', 'Blue'],
+      selectedIndex: 2,
+    });
+    expect(dropdownDataOf(`<w:result w:val="9"/><w:default w:val="1"/>${entries}`)).toMatchObject({
+      selectedIndex: 1,
+    });
+    expect(dropdownDataOf(`<w:result w:val="9"/><w:default w:val="8"/>${entries}`)).toMatchObject({
+      selectedIndex: 0,
+    });
+    expect(dropdownDataOf(entries)).toMatchObject({ selectedIndex: 0 });
+  });
+
+  test('indices clamp into [0, 63] before range resolution', () => {
+    expect(dropdownDataOf(`<w:result w:val="-5"/>${entries}`)).toMatchObject({ selectedIndex: 0 });
+    expect(dropdownDataOf(`<w:result w:val="70"/><w:default w:val="2"/>${entries}`)).toMatchObject({
+      selectedIndex: 2,
+    });
+    expect(dropdownDataOf(`<w:result w:val="junk"/>${entries}`)).toMatchObject({
+      selectedIndex: 0,
+    });
+  });
+
+  test('an empty list still returns the dropdown shape', () => {
+    expect(dropdownDataOf('<w:result w:val="1"/>')).toEqual({
+      kind: 'dropdown',
+      entries: [],
+      selectedIndex: 0,
+    });
+  });
+
+  test('a hostile entry count caps at 64 collected entries', () => {
+    const flood = '<w:listEntry w:val="x"/>'.repeat(1000);
+    const data = dropdownDataOf(flood);
+    expect(data).not.toBeNull();
+    if (data?.kind !== 'dropdown') throw new Error('expected dropdown');
+    expect(data.entries.length).toBe(64);
+  });
+
+  test('a hostile entry length caps at 256 characters', () => {
+    const long = 'a'.repeat(10_000);
+    const data = dropdownDataOf(`<w:listEntry w:val="${long}"/>`);
+    if (data?.kind !== 'dropdown') throw new Error('expected dropdown');
+    expect(data.entries[0]!.length).toBe(256);
+  });
+});
+
+describe('the security contract', () => {
+  test('macro, name and behavior strings never surface in the result', () => {
+    const data = checkboxDataOf(
+      '<w:checked/>',
+      '<w:name w:val="SecretFieldName"/>' +
+        '<w:enabled/><w:calcOnExit w:val="1"/>' +
+        '<w:entryMacro w:val="EvilEntryMacro"/>' +
+        '<w:exitMacro w:val="EvilExitMacro"/>' +
+        '<w:helpText w:type="text" w:val="EvilHelp"/>' +
+        '<w:statusText w:type="text" w:val="EvilStatus"/>'
+    );
+    expect(data).toEqual({ kind: 'checkbox', checked: true, sizeHalfPoints: null });
+    const serialized = JSON.stringify(data);
+    for (const leak of [
+      'SecretFieldName',
+      'EvilEntryMacro',
+      'EvilExitMacro',
+      'EvilHelp',
+      'EvilStatus',
+      'enabled',
+      'calcOnExit',
+    ]) {
+      expect(serialized).not.toContain(leak);
+    }
+  });
+
+  test('deep hostile nesting inside state elements is never descended into', () => {
+    const data = checkboxDataOf(
+      '<w:checked><w:entryMacro w:val="Nested"/><w:checked w:val="0"/></w:checked>'
+    );
+    expect(data).toEqual({ kind: 'checkbox', checked: true, sizeHalfPoints: null });
+    expect(JSON.stringify(data)).not.toContain('Nested');
+    // ffData nested one level too deep is not found either.
+    const buried = legacyFormFieldDataOf(
+      fldCharOf('<w:wrapper><w:ffData><w:checkBox><w:checked/></w:checkBox></w:ffData></w:wrapper>')
+    );
+    expect(buried).toBeNull();
+  });
+
+  test('no ffData, textInput-only ffData, and non-fldChar nodes all read as null', () => {
+    expect(legacyFormFieldDataOf(fldCharOf(''))).toBeNull();
+    expect(
+      legacyFormFieldDataOf(
+        fldCharOf('<w:ffData><w:textInput><w:default w:val="x"/></w:textInput></w:ffData>')
+      )
+    ).toBeNull();
+    const part = partOf('<w:p><w:r><w:t>plain</w:t></w:r></w:p>');
+    expect(legacyFormFieldDataOf(part.root)).toBeNull();
+  });
+});

--- a/packages/core/src/store/__tests__/legacy-form-field-data.test.ts
+++ b/packages/core/src/store/__tests__/legacy-form-field-data.test.ts
@@ -137,6 +137,24 @@ describe('dropdown state', () => {
     });
   });
 
+  test('the first w:result / w:default ELEMENT wins, even when malformed', () => {
+    // Same rule as checkbox w:size: a malformed or out-of-range first element must not
+    // let a later valid sibling shadow it — `??=` could not express that.
+    expect(dropdownDataOf(`<w:result w:val="9"/><w:result w:val="1"/>${entries}`)).toMatchObject({
+      selectedIndex: 0,
+    });
+    expect(
+      dropdownDataOf(`<w:result w:val="9"/><w:result w:val="1"/><w:default w:val="2"/>${entries}`)
+    ).toMatchObject({ selectedIndex: 2 });
+    expect(
+      dropdownDataOf(`<w:result w:val="9"/><w:default w:val="-1"/><w:default w:val="1"/>${entries}`)
+    ).toMatchObject({ selectedIndex: 0 });
+    // A valid first element keeps winning, unchanged.
+    expect(dropdownDataOf(`<w:result w:val="1"/><w:result w:val="2"/>${entries}`)).toMatchObject({
+      selectedIndex: 1,
+    });
+  });
+
   test('the node budget failing closed mid-ddList still returns a sane shape', () => {
     // Flood ffData with siblings so the shared budget is exhausted while entries collect.
     // The walk must stop, never throw, and anything returned stays within collected bounds.

--- a/packages/core/src/store/__tests__/legacy-form-field-data.test.ts
+++ b/packages/core/src/store/__tests__/legacy-form-field-data.test.ts
@@ -81,6 +81,12 @@ describe('checkbox state', () => {
     // Malformed size falls back to auto rather than failing the whole read.
     expect(checkboxDataOf('<w:size w:val="abc"/>')).toMatchObject({ sizeHalfPoints: null });
     expect(checkboxDataOf('<w:size/>')).toMatchObject({ sizeHalfPoints: null });
+    // ST_HpsMeasure is UNSIGNED: a negative value is malformed (auto), never a 1pt box.
+    expect(checkboxDataOf('<w:size w:val="-5"/>')).toMatchObject({ sizeHalfPoints: null });
+    // First size wins, same rule as the other state elements.
+    expect(checkboxDataOf('<w:size w:val="24"/><w:size w:val="48"/>')).toMatchObject({
+      sizeHalfPoints: 24,
+    });
   });
 
   test('w:sizeAuto means auto even beside an explicit size', () => {
@@ -110,14 +116,42 @@ describe('dropdown state', () => {
     expect(dropdownDataOf(entries)).toMatchObject({ selectedIndex: 0 });
   });
 
-  test('indices clamp into [0, 63] before range resolution', () => {
+  test('an out-of-range index is absent — never clamped onto another entry', () => {
+    // A negative result must not clamp to 0 and shadow the authored default.
+    expect(dropdownDataOf(`<w:result w:val="-5"/><w:default w:val="1"/>${entries}`)).toMatchObject({
+      selectedIndex: 1,
+    });
     expect(dropdownDataOf(`<w:result w:val="-5"/>${entries}`)).toMatchObject({ selectedIndex: 0 });
+    // Past 63 with a FULL 64-entry list: clamping painted entry 63; absent falls to default.
+    const full = Array.from({ length: 64 }, (_, i) => `<w:listEntry w:val="e${i}"/>`).join('');
+    expect(dropdownDataOf(`<w:result w:val="200"/><w:default w:val="5"/>${full}`)).toMatchObject({
+      selectedIndex: 5,
+    });
+    expect(dropdownDataOf(`<w:result w:val="200"/>${full}`)).toMatchObject({ selectedIndex: 0 });
+    // In [0, 63] but past a short list: default when in range, else 0 (unchanged rule).
     expect(dropdownDataOf(`<w:result w:val="70"/><w:default w:val="2"/>${entries}`)).toMatchObject({
       selectedIndex: 2,
     });
     expect(dropdownDataOf(`<w:result w:val="junk"/>${entries}`)).toMatchObject({
       selectedIndex: 0,
     });
+  });
+
+  test('the node budget failing closed mid-ddList still returns a sane shape', () => {
+    // Flood ffData with siblings so the shared budget is exhausted while entries collect.
+    // The walk must stop, never throw, and anything returned stays within collected bounds.
+    const flood = '<w:listEntry w:val="x"/>'.repeat(300);
+    const data = dropdownDataOf(`<w:result w:val="1"/>${flood}`);
+    if (data !== null) {
+      if (data.kind !== 'dropdown') throw new Error('expected dropdown');
+      expect(data.entries.length).toBeLessThanOrEqual(64);
+      expect(data.selectedIndex).toBeGreaterThanOrEqual(0);
+      if (data.entries.length > 0) {
+        expect(data.selectedIndex).toBeLessThan(data.entries.length);
+      } else {
+        expect(data.selectedIndex).toBe(0);
+      }
+    }
   });
 
   test('an empty list still returns the dropdown shape', () => {

--- a/packages/core/src/store/__tests__/typed-field-nodes.test.ts
+++ b/packages/core/src/store/__tests__/typed-field-nodes.test.ts
@@ -29,7 +29,7 @@ import {
   type OoxmlPart,
 } from '../index.ts';
 import { piecesOfParagraph } from '../../layout/field-projection.ts';
-import { parsedFieldSpansOf } from '../package/field-nodes.ts';
+import { MAX_FIELD_INSTRUCTION_CHARS, parsedFieldSpansOf } from '../package/field-nodes.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -649,7 +649,7 @@ describe('w:delInstrText addressing', () => {
     // FORMTEXT instruction sitting beside it.
     const hugeDeleted = spansOf(
       fieldWith(
-        `<w:r><w:delInstrText>${'X'.repeat(300)}</w:delInstrText></w:r>` +
+        `<w:r><w:delInstrText>${'X'.repeat(MAX_FIELD_INSTRUCTION_CHARS + 40)}</w:delInstrText></w:r>` +
           '<w:r><w:instrText> FORMTEXT </w:instrText></w:r>'
       )
     );
@@ -663,5 +663,38 @@ describe('w:delInstrText addressing', () => {
     );
     expect(fullyDeleted).toHaveLength(1);
     expect(fullyDeleted[0]!.addressing).toBe('editable-result');
+  });
+
+  test('the store default cap agrees with the layout machine past the old 256 bound', () => {
+    // The store's span parser and layout's field machine share ONE instruction bound. A
+    // FORMTEXT instruction padded past the old 256-char cap must still address an editable
+    // result — before the caps were unified this raw length overflowed here while layout
+    // (called with its own constant) agreed, only by luck of both being 256.
+    const padded = ` FORMTEXT ${' '.repeat(300)}`;
+    const part = parse(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        `<w:r><w:instrText xml:space="preserve">${padded}</w:instrText></w:r>` +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>typed</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    const spans = parsedFieldSpansOf(paragraphOf(part));
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.addressing).toBe('editable-result');
+  });
+
+  test('an instruction past the shared cap still forms an atomic span, without a throw', () => {
+    const blob = 'X'.repeat(MAX_FIELD_INSTRUCTION_CHARS + 1);
+    const part = parse(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        `<w:r><w:instrText> FORMTEXT ${blob}</w:instrText></w:r>` +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>typed</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    const spans = parsedFieldSpansOf(paragraphOf(part));
+    expect(spans).toHaveLength(1);
+    // Overflow fails closed: the buffer cleared itself, so addressing stays atomic.
+    expect(spans[0]!.addressing).toBe('atomic');
   });
 });

--- a/packages/core/src/store/__tests__/typed-field-nodes.test.ts
+++ b/packages/core/src/store/__tests__/typed-field-nodes.test.ts
@@ -29,6 +29,7 @@ import {
   type OoxmlPart,
 } from '../index.ts';
 import { piecesOfParagraph } from '../../layout/field-projection.ts';
+import { parsedFieldSpansOf } from '../package/field-nodes.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -608,5 +609,59 @@ describe('w:delInstrText addressing', () => {
     expect(spans[0]!.removeNodeIds).toContain(delInstr!.id);
     // The instruction reader accepts the deleted form.
     expect(instrTextValue(delInstr!)).toBe(' PAGE ');
+  });
+
+  test('live and deleted instruction chunks never merge — the live one decides addressing', () => {
+    // A tracked field-code edit leaves `w:delInstrText` NEXT TO `w:instrText` in one field.
+    // Concatenating them read " PAGE  FORMTEXT ", which is not FORMTEXT, so the field lost
+    // its editable result. The effective instruction is the live buffer alone.
+    const fieldWith = (instructionRuns: string): OoxmlPart =>
+      parse(
+        '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+          instructionRuns +
+          '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+          '<w:r><w:t>typed</w:t></w:r>' +
+          '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+      );
+    const spansOf = (part: OoxmlPart) => parsedFieldSpansOf(paragraphOf(part));
+
+    // Deleted PAGE beside live FORMTEXT: accepting the deletion leaves FORMTEXT.
+    const mixed = spansOf(
+      fieldWith(
+        '<w:r><w:delInstrText> PAGE </w:delInstrText></w:r>' +
+          '<w:r><w:instrText> FORMTEXT </w:instrText></w:r>'
+      )
+    );
+    expect(mixed).toHaveLength(1);
+    expect(mixed[0]!.addressing).toBe('editable-result');
+
+    // The reverse: live PAGE beside a deleted FORMTEXT stays atomic.
+    const reverse = spansOf(
+      fieldWith(
+        '<w:r><w:delInstrText> FORMTEXT </w:delInstrText></w:r>' +
+          '<w:r><w:instrText> PAGE </w:instrText></w:r>'
+      )
+    );
+    expect(reverse).toHaveLength(1);
+    expect(reverse[0]!.addressing).toBe('atomic');
+
+    // Overflow accounts per buffer: a huge deleted chunk must not overflow the small live
+    // FORMTEXT instruction sitting beside it.
+    const hugeDeleted = spansOf(
+      fieldWith(
+        `<w:r><w:delInstrText>${'X'.repeat(300)}</w:delInstrText></w:r>` +
+          '<w:r><w:instrText> FORMTEXT </w:instrText></w:r>'
+      )
+    );
+    expect(hugeDeleted).toHaveLength(1);
+    expect(hugeDeleted[0]!.addressing).toBe('editable-result');
+
+    // A fully-deleted FORMTEXT keeps its meaning: the deleted buffer answers when no live
+    // element exists at all.
+    const fullyDeleted = spansOf(
+      fieldWith('<w:r><w:delInstrText> FORMTEXT </w:delInstrText></w:r>')
+    );
+    expect(fullyDeleted).toHaveLength(1);
+    expect(fullyDeleted[0]!.addressing).toBe('editable-result');
   });
 });

--- a/packages/core/src/store/__tests__/typed-field-nodes.test.ts
+++ b/packages/core/src/store/__tests__/typed-field-nodes.test.ts
@@ -574,3 +574,39 @@ describe('inertness and security', () => {
     expect(xml.includes('w:dirty')).toBe(true);
   });
 });
+
+describe('w:delInstrText addressing', () => {
+  test('a tracked-deleted field forms one atom and swallows its delInstrText', () => {
+    // Word rewrites `w:instrText` as `w:delInstrText` inside a deletion. The offset
+    // authority must treat it exactly like the live form: instruction chrome, zero model
+    // width, swallowed by the field's one reserved unit.
+    const part = parse(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        '<w:del w:id="1" w:author="X">' +
+        '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:delInstrText> PAGE </w:delInstrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:delText>3</w:delText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+        '</w:del><w:r><w:t>B</w:t></w:r></w:p>'
+    );
+    const paragraph = paragraphOf(part);
+    expect(paragraphTextOf(part, paragraph.id)).toBe(`A${FIELD_ATOM_CHAR}B`);
+    const spans = atomicFieldSpansOf(paragraph);
+    expect(spans).toHaveLength(1);
+    const findDelInstr = (node: OoxmlElement | { kind: 'textValue' }): OoxmlElement | undefined => {
+      if (node.kind === 'textValue') return undefined;
+      if (node.kind === 'generic' && node.localName === 'delInstrText') return node;
+      for (const child of node.children ?? []) {
+        const hit = findDelInstr(child as OoxmlElement);
+        if (hit) return hit;
+      }
+      return undefined;
+    };
+    const delInstr = findDelInstr(paragraph);
+    expect(delInstr).toBeDefined();
+    expect(spans[0]!.removeNodeIds).toContain(delInstr!.id);
+    // The instruction reader accepts the deleted form.
+    expect(instrTextValue(delInstr!)).toBe(' PAGE ');
+  });
+});

--- a/packages/core/src/store/package/__tests__/document-properties.test.ts
+++ b/packages/core/src/store/package/__tests__/document-properties.test.ts
@@ -4,12 +4,8 @@
 // (namespace, localName) pairs, and never keys an object by a file-supplied element name.
 
 import { describe, expect, test } from 'bun:test';
-import {
-  MAX_DOCUMENT_PROPERTY_CHARS,
-  readDocumentProperties,
-  readOoxmlPart,
-  type OoxmlNode,
-} from '@docx-editor.dev/core/store';
+import { readOoxmlPart, type OoxmlNode } from '@docx-editor.dev/core/store';
+import { MAX_DOCUMENT_PROPERTY_CHARS, readDocumentProperties } from '../document-properties.ts';
 
 const CP = 'http://schemas.openxmlformats.org/package/2006/metadata/core-properties';
 const DC = 'http://purl.org/dc/elements/1.1/';

--- a/packages/core/src/store/package/__tests__/document-properties.test.ts
+++ b/packages/core/src/store/package/__tests__/document-properties.test.ts
@@ -1,0 +1,134 @@
+// `docProps/core.xml` and `docProps/app.xml` metadata, which document-property fields render.
+//
+// Every string here is attacker-controlled: the reader caps length, matches only known
+// (namespace, localName) pairs, and never keys an object by a file-supplied element name.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  MAX_DOCUMENT_PROPERTY_CHARS,
+  readDocumentProperties,
+  readOoxmlPart,
+  type OoxmlNode,
+} from '@docx-editor.dev/core/store';
+
+const CP = 'http://schemas.openxmlformats.org/package/2006/metadata/core-properties';
+const DC = 'http://purl.org/dc/elements/1.1/';
+const EP = 'http://schemas.openxmlformats.org/officeDocument/2006/extended-properties';
+
+function coreRoot(inner: string): OoxmlNode {
+  const result = readOoxmlPart(
+    `<cp:coreProperties xmlns:cp="${CP}" xmlns:dc="${DC}">${inner}</cp:coreProperties>`,
+    { name: '/docProps/core.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part.root;
+}
+
+function appRoot(inner: string): OoxmlNode {
+  const result = readOoxmlPart(`<Properties xmlns="${EP}">${inner}</Properties>`, {
+    name: '/docProps/app.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part.root;
+}
+
+describe('reading core.xml', () => {
+  test('parses every mapped property', () => {
+    const props = readDocumentProperties(
+      coreRoot(
+        '<dc:title>Sample Title</dc:title>' +
+          '<dc:creator>A. Author</dc:creator>' +
+          '<dc:subject>Sample Subject</dc:subject>' +
+          '<dc:description>Sample Comments</dc:description>' +
+          '<cp:keywords>alpha, beta</cp:keywords>' +
+          '<cp:lastModifiedBy>B. Editor</cp:lastModifiedBy>'
+      )
+    );
+    expect(props).toEqual({
+      title: 'Sample Title',
+      creator: 'A. Author',
+      subject: 'Sample Subject',
+      description: 'Sample Comments',
+      keywords: 'alpha, beta',
+      lastModifiedBy: 'B. Editor',
+    });
+  });
+
+  test('a missing element reads as undefined', () => {
+    const props = readDocumentProperties(coreRoot('<dc:title>Only Title</dc:title>'));
+    expect(props.title).toBe('Only Title');
+    expect(props.creator).toBeUndefined();
+    expect(props.subject).toBeUndefined();
+  });
+
+  test('an empty or whitespace-only element reads as undefined', () => {
+    const props = readDocumentProperties(
+      coreRoot('<dc:title>   </dc:title><dc:creator></dc:creator>')
+    );
+    expect(props.title).toBeUndefined();
+    expect(props.creator).toBeUndefined();
+  });
+
+  test('whitespace around a value is trimmed', () => {
+    expect(readDocumentProperties(coreRoot('<dc:title>  Trimmed  </dc:title>')).title).toBe(
+      'Trimmed'
+    );
+  });
+
+  test('XML entities decode to their characters (no markup leaks in)', () => {
+    const props = readDocumentProperties(
+      coreRoot('<dc:title>A &amp; B &lt;tag&gt; "q"</dc:title>')
+    );
+    expect(props.title).toBe('A & B <tag> "q"');
+  });
+});
+
+describe('reading app.xml', () => {
+  test('parses Company and Manager', () => {
+    const props = readDocumentProperties(
+      coreRoot('<dc:title>T</dc:title>'),
+      appRoot('<Company>Sample Co</Company><Manager>C. Manager</Manager>')
+    );
+    expect(props.title).toBe('T');
+    expect(props.company).toBe('Sample Co');
+    expect(props.manager).toBe('C. Manager');
+  });
+});
+
+describe('missing parts', () => {
+  test('no core part reads as an empty object', () => {
+    expect(readDocumentProperties(null)).toEqual({});
+    expect(readDocumentProperties(undefined)).toEqual({});
+    expect(readDocumentProperties(null, null)).toEqual({});
+  });
+});
+
+describe('hostile input', () => {
+  test('an over-cap string is clamped', () => {
+    const huge = 'x'.repeat(MAX_DOCUMENT_PROPERTY_CHARS + 1000);
+    const title = readDocumentProperties(coreRoot(`<dc:title>${huge}</dc:title>`)).title;
+    expect(title).toBeDefined();
+    expect(title!.length).toBe(MAX_DOCUMENT_PROPERTY_CHARS);
+  });
+
+  test('a hostile element name is ignored and pollutes no prototype', () => {
+    const before = Object.getPrototypeOf({});
+    const props = readDocumentProperties(
+      coreRoot('<cp:__proto__>polluted</cp:__proto__><dc:title>Safe</dc:title>')
+    );
+    // The only recognized element is the title; the __proto__-named element matched nothing.
+    expect(props).toEqual({ title: 'Safe' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(({} as any).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf({})).toBe(before);
+  });
+
+  test('nested markup inside a value is not read as the value', () => {
+    // A single textValue child is read; wrapped markup contributes nothing.
+    const props = readDocumentProperties(
+      coreRoot('<dc:title><dc:inner>nested</dc:inner></dc:title>')
+    );
+    expect(props.title).toBeUndefined();
+  });
+});

--- a/packages/core/src/store/package/document-properties.ts
+++ b/packages/core/src/store/package/document-properties.ts
@@ -1,0 +1,124 @@
+// The document's own metadata — what `docProps/core.xml` and `docProps/app.xml` record.
+//
+// Word's document-property fields (TITLE, AUTHOR, SUBJECT, …) paint these strings. The values
+// are ATTACKER-CONTROLLED: a `.docx` is a zip whose XML the sender fully controls, so every
+// string is capped here at the trust boundary and the downstream paint sink writes it through
+// `textContent` (never markup). This reader only extracts the known, fixed properties by their
+// exact (namespace, localName); it never builds a map keyed by a file-supplied element name, so
+// a hostile `<__proto__>` element is simply never matched and can pollute nothing.
+
+import type { OoxmlNode } from './ooxml-tree.ts';
+
+/** Dublin Core elements namespace — `dc:title`, `dc:creator`, `dc:subject`, `dc:description`. */
+const DC_NAMESPACE_URI = 'http://purl.org/dc/elements/1.1/';
+/** Core-properties namespace — `cp:keywords`, `cp:lastModifiedBy`. */
+const CORE_PROPERTIES_NAMESPACE_URI =
+  'http://schemas.openxmlformats.org/package/2006/metadata/core-properties';
+/** Extended (app) properties namespace — `Company`, `Manager`. */
+const EXTENDED_PROPERTIES_NAMESPACE_URI =
+  'http://schemas.openxmlformats.org/officeDocument/2006/extended-properties';
+
+/**
+ * Per-value character cap. A legitimate title or author is short; anything near this is a
+ * hostile payload sized to bloat layout, and clamping it costs a well-formed file nothing.
+ */
+export const MAX_DOCUMENT_PROPERTY_CHARS = 4096;
+
+/**
+ * The document metadata Word's document-property fields render.
+ *
+ * Every member is optional: an absent part, an absent element, or an empty value all read as
+ * `undefined`, and a field over a missing property paints nothing. Keys are engine-internal
+ * names; the field → property mapping (`TITLE` → `title`, `AUTHOR` → `creator`, …) lives in
+ * `layout/field-doc-property.ts`.
+ */
+export interface DocumentProperties {
+  /** `dc:title` — TITLE. */
+  readonly title?: string;
+  /** `dc:creator` — AUTHOR. */
+  readonly creator?: string;
+  /** `dc:subject` — SUBJECT. */
+  readonly subject?: string;
+  /** `cp:keywords` — KEYWORDS. */
+  readonly keywords?: string;
+  /** `cp:lastModifiedBy` — LASTSAVEDBY. */
+  readonly lastModifiedBy?: string;
+  /** `dc:description` — COMMENTS. */
+  readonly description?: string;
+  /** `Company` from `docProps/app.xml`. No field maps to it yet; carried for completeness. */
+  readonly company?: string;
+  /** `Manager` from `docProps/app.xml`. No field maps to it yet; carried for completeness. */
+  readonly manager?: string;
+}
+
+/** The empty answer a document with no properties part gives. Frozen: a shared constant. */
+export const EMPTY_DOCUMENT_PROPERTIES: DocumentProperties = Object.freeze({});
+
+/**
+ * Text of the FIRST direct child element of `root` with this exact (namespace, localName),
+ * trimmed and length-capped, or undefined when absent or empty after trimming.
+ *
+ * Reads a single `textValue` child only — a property element carries one text node — so nested
+ * markup a hostile file wraps around the value contributes nothing.
+ */
+function childText(root: OoxmlNode, namespaceUri: string, localName: string): string | undefined {
+  if (root.kind === 'textValue') return undefined;
+  for (const child of root.children) {
+    if (child.kind === 'textValue') continue;
+    if (child.namespaceUri !== namespaceUri || child.localName !== localName) continue;
+    const text = child.children.find((node) => node.kind === 'textValue');
+    if (!text || text.kind !== 'textValue') return undefined;
+    const trimmed = text.value.trim();
+    if (trimmed.length === 0) return undefined;
+    return trimmed.length > MAX_DOCUMENT_PROPERTY_CHARS
+      ? trimmed.slice(0, MAX_DOCUMENT_PROPERTY_CHARS)
+      : trimmed;
+  }
+  return undefined;
+}
+
+/**
+ * Read the typed document properties from the parsed `docProps/core.xml` and `docProps/app.xml`
+ * roots. Either root may be null/undefined — a document without that part contributes nothing.
+ *
+ * Assigns only fixed, known keys, so no file-supplied element name ever becomes an object key.
+ */
+export function readDocumentProperties(
+  coreRoot: OoxmlNode | null | undefined,
+  appRoot?: OoxmlNode | null
+): DocumentProperties {
+  const result: {
+    title?: string;
+    creator?: string;
+    subject?: string;
+    keywords?: string;
+    lastModifiedBy?: string;
+    description?: string;
+    company?: string;
+    manager?: string;
+  } = {};
+
+  if (coreRoot && coreRoot.kind !== 'textValue') {
+    const title = childText(coreRoot, DC_NAMESPACE_URI, 'title');
+    if (title !== undefined) result.title = title;
+    const creator = childText(coreRoot, DC_NAMESPACE_URI, 'creator');
+    if (creator !== undefined) result.creator = creator;
+    const subject = childText(coreRoot, DC_NAMESPACE_URI, 'subject');
+    if (subject !== undefined) result.subject = subject;
+    const description = childText(coreRoot, DC_NAMESPACE_URI, 'description');
+    if (description !== undefined) result.description = description;
+    const keywords = childText(coreRoot, CORE_PROPERTIES_NAMESPACE_URI, 'keywords');
+    if (keywords !== undefined) result.keywords = keywords;
+    const lastModifiedBy = childText(coreRoot, CORE_PROPERTIES_NAMESPACE_URI, 'lastModifiedBy');
+    if (lastModifiedBy !== undefined) result.lastModifiedBy = lastModifiedBy;
+  }
+
+  if (appRoot && appRoot.kind !== 'textValue') {
+    const company = childText(appRoot, EXTENDED_PROPERTIES_NAMESPACE_URI, 'Company');
+    if (company !== undefined) result.company = company;
+    const manager = childText(appRoot, EXTENDED_PROPERTIES_NAMESPACE_URI, 'Manager');
+    if (manager !== undefined) result.manager = manager;
+  }
+
+  return result;
+}

--- a/packages/core/src/store/package/field-nodes.ts
+++ b/packages/core/src/store/package/field-nodes.ts
@@ -91,9 +91,20 @@ export function isFldChar(node: OoxmlNode, type: FldCharType): boolean {
   return fldCharType(node) === type;
 }
 
-/** Typed or generic `w:instrText`. */
+/**
+ * Typed or generic `w:instrText`, and `w:delInstrText` — the form a tracked deletion gives
+ * the instruction (§17.16.13), always generic in the canonical tree.
+ *
+ * One predicate for both on purpose: everything that consumes instruction text (the offset
+ * authority, the layout field machine, span collection) must treat a deleted field's
+ * instruction exactly like a live one — ingested per phase, never painted. Excluding the
+ * deleted form let its `w:delInstrText` fall through those walks as ordinary run content.
+ */
 export function isInstrText(node: OoxmlNode): boolean {
-  return node.kind === 'instrText' || (node.kind === 'generic' && isWml(node, 'instrText'));
+  return (
+    node.kind === 'instrText' ||
+    (node.kind === 'generic' && (isWml(node, 'instrText') || isWml(node, 'delInstrText')))
+  );
 }
 
 /** Typed or generic `w:fldSimple`. */
@@ -189,9 +200,11 @@ export function hasLegacyFormFieldData(node: OoxmlNode): boolean {
  * Legacy form-field render state read from `w:ffData` (§17.16.17), and nothing else.
  *
  * `checkbox`: `sizeHalfPoints` is the explicit `w:size` in half-points, clamped to a sane
- * render range, or null for auto-size (`w:sizeAuto`, absent, or malformed).
- * `dropdown`: `selectedIndex` is already resolved (`w:result`, else `w:default`, else 0) and
- * always in range when `entries` is non-empty; `entries` may be empty (layout paints nothing).
+ * render range, or null for auto-size (`w:sizeAuto`, absent, malformed, or negative —
+ * ST_HpsMeasure is unsigned, so a negative value is invalid, not small).
+ * `dropdown`: `selectedIndex` is already resolved (in-range `w:result`, else in-range
+ * `w:default`, else 0 — an out-of-range index counts as absent) and always in range when
+ * `entries` is non-empty; `entries` may be empty (layout paints nothing).
  */
 export type LegacyFormFieldData =
   | {
@@ -214,8 +227,13 @@ const MAX_DROPDOWN_ENTRY_CHARS = 256;
 /** `w:size` clamp in half-points: 1pt .. 144pt. */
 const MIN_CHECKBOX_SIZE_HALF_POINTS = 2;
 const MAX_CHECKBOX_SIZE_HALF_POINTS = 288;
-/** Largest `w:val` index for `w:result` / `w:default` on `w:ddList` (ST_UnsignedDecimalNumber cap). */
-const MAX_DROPDOWN_INDEX = 63;
+/**
+ * Largest `w:val` index accepted for `w:result` / `w:default` on `w:ddList`: the engine's own
+ * entry cap ({@link MAX_DROPDOWN_ENTRIES} collected entries → indices 0..63), not a schema
+ * limit. An index outside 0..63 is treated as ABSENT, never clamped onto an entry the file
+ * did not choose — clamping let a hostile `w:result` shadow a valid `w:default`.
+ */
+const MAX_DROPDOWN_INDEX = MAX_DROPDOWN_ENTRIES - 1;
 
 type NodeBudget = { left: number };
 
@@ -226,18 +244,36 @@ function onOffElementValue(element: OoxmlNode): boolean {
   return !(raw === '0' || raw === 'false' || raw === 'off');
 }
 
-/** Bounded `w:val` integer parse; null when absent or malformed, clamped otherwise. */
-function clampedIntAttribute(element: OoxmlNode, min: number, max: number): number | null {
+/**
+ * Bounded `w:size` parse (ST_HpsMeasure — half-points, UNSIGNED): null when absent, malformed
+ * or negative (auto size); large values clamp to the render cap. A negative value is not a
+ * small size, it is schema-invalid, so it must not clamp up to a 1pt box.
+ */
+function checkboxSizeAttribute(element: OoxmlNode): number | null {
+  const raw = attributeValue(element, 'val');
+  if (raw === undefined || !/^\d{1,7}$/.test(raw)) return null;
+  const value = Number.parseInt(raw, 10);
+  return Math.min(MAX_CHECKBOX_SIZE_HALF_POINTS, Math.max(MIN_CHECKBOX_SIZE_HALF_POINTS, value));
+}
+
+/**
+ * Bounded index parse for `w:result` / `w:default`: null when absent, malformed, negative or
+ * past {@link MAX_DROPDOWN_INDEX} — out of range means ABSENT, never a clamped neighbor.
+ */
+function dropdownIndexAttribute(element: OoxmlNode): number | null {
   const raw = attributeValue(element, 'val');
   if (raw === undefined || !/^-?\d{1,7}$/.test(raw)) return null;
   const value = Number.parseInt(raw, 10);
-  return Math.min(max, Math.max(min, value));
+  return value >= 0 && value <= MAX_DROPDOWN_INDEX ? value : null;
 }
 
 function checkboxDataOf(checkbox: OoxmlNode, budget: NodeBudget): LegacyFormFieldData {
   let checked: boolean | undefined;
   let fallback: boolean | undefined;
   let sizeHalfPoints: number | null = null;
+  // First-wins via its own flag ("first state element wins", like `checked` / `default`
+  // above): `??=` cannot express it here because a malformed first size also resolves null.
+  let sizeSeen = false;
   let sizeAuto = false;
   if (checkbox.kind !== 'textValue') {
     for (const child of checkbox.children) {
@@ -246,11 +282,10 @@ function checkboxDataOf(checkbox: OoxmlNode, budget: NodeBudget): LegacyFormFiel
       if (isWml(child, 'checked')) checked ??= onOffElementValue(child);
       else if (isWml(child, 'default')) fallback ??= onOffElementValue(child);
       else if (isWml(child, 'size')) {
-        sizeHalfPoints = clampedIntAttribute(
-          child,
-          MIN_CHECKBOX_SIZE_HALF_POINTS,
-          MAX_CHECKBOX_SIZE_HALF_POINTS
-        );
+        if (!sizeSeen) {
+          sizeSeen = true;
+          sizeHalfPoints = checkboxSizeAttribute(child);
+        }
       } else if (isWml(child, 'sizeAuto')) sizeAuto = true;
       // Anything else under checkBox is ignored — never descended into.
     }
@@ -270,9 +305,9 @@ function dropdownDataOf(list: OoxmlNode, budget: NodeBudget): LegacyFormFieldDat
     for (const child of list.children) {
       if (budget.left-- <= 0) break;
       if (child.kind === 'textValue') continue;
-      if (isWml(child, 'result')) result ??= clampedIntAttribute(child, 0, MAX_DROPDOWN_INDEX);
+      if (isWml(child, 'result')) result ??= dropdownIndexAttribute(child);
       else if (isWml(child, 'default')) {
-        fallback ??= clampedIntAttribute(child, 0, MAX_DROPDOWN_INDEX);
+        fallback ??= dropdownIndexAttribute(child);
       } else if (isWml(child, 'listEntry')) {
         if (entries.length >= MAX_DROPDOWN_ENTRIES) continue;
         const value = attributeValue(child, 'val');

--- a/packages/core/src/store/package/field-nodes.ts
+++ b/packages/core/src/store/package/field-nodes.ts
@@ -420,8 +420,24 @@ interface RunChildRef {
 
 const MERGEFORMAT_SUFFIX = /\s*\\\*\s*MERGEFORMAT\s*$/i;
 
+/**
+ * Caps hostile complex-field instruction buffers (fail closed → inert).
+ *
+ * ONE bound for the store's span parser and layout's field machine (which re-exports this
+ * constant): if they disagreed, FORMTEXT addressing here would diverge from what layout
+ * paints. Sized to admit a full-length `HYPERLINK` instruction — the same bound the
+ * `w:fldSimple` attribute lane applies (`MAX_HYPERLINK_INSTRUCTION_CHARS` in
+ * `layout/field-link.ts`), so a long URL behaves identically as a complex field and as a
+ * simple field. Short-grammar parsers (SYMBOL, MACROBUTTON) keep their own tighter local
+ * caps on purpose.
+ */
+export const MAX_FIELD_INSTRUCTION_CHARS = 4096;
+
 /** Whether a bounded instruction denotes Word's editable legacy text-form input. */
-export function isEditableFormTextInstruction(raw: string, maxChars = 256): boolean {
+export function isEditableFormTextInstruction(
+  raw: string,
+  maxChars = MAX_FIELD_INSTRUCTION_CHARS
+): boolean {
   if (raw.length > maxChars) return false;
   const collapsed = raw.replace(/\s+/g, ' ').trim().toUpperCase();
   if (collapsed.length > maxChars) return false;
@@ -446,7 +462,7 @@ export function parsedFieldSpansOf(
   options?: { readonly maxNesting?: number; readonly maxInstructionChars?: number }
 ): readonly ParsedFieldSpan[] {
   const maxNesting = options?.maxNesting ?? 4;
-  const maxInstructionChars = options?.maxInstructionChars ?? 256;
+  const maxInstructionChars = options?.maxInstructionChars ?? MAX_FIELD_INSTRUCTION_CHARS;
   const spans: ParsedFieldSpan[] = [];
 
   // Flatten run children in document order for the complex-field machine.

--- a/packages/core/src/store/package/field-nodes.ts
+++ b/packages/core/src/store/package/field-nodes.ts
@@ -1,9 +1,10 @@
 // Typed field vocabulary helpers (`w:fldChar`, `w:instrText`, `w:fldSimple`).
 //
 // Canonical nodes preserve schema order and authored attributes (`w:fldCharType`,
-// `w:dirty`, `w:fldLock`, `w:instr`). Legacy `CT_FldChar/w:ffData` (including
-// entryMacro/exitMacro) stays generic payload under `fldChar` — never walked for
-// evaluation, never auto-resolved, never executed.
+// `w:dirty`, `w:fldLock`, `w:instr`). Legacy `CT_FldChar/w:ffData` stays generic payload
+// under `fldChar`. Its render STATE (`w:checkBox` / `w:ddList`) is read through the bounded
+// {@link legacyFormFieldDataOf}; its macro references (entryMacro/exitMacro) are never read,
+// never auto-resolved, never executed.
 //
 // Well-formed computed fields (begin→end within one paragraph) and `fldSimple` each contribute
 // exactly one UTF-16 unit ({@link FIELD_ATOM_CHAR}) to paragraph addressing. A FORMTEXT field
@@ -165,13 +166,14 @@ export function isFieldChrome(node: OoxmlNode): boolean {
  * True when a `w:fldChar` carries `w:ffData` — a LEGACY FORM FIELD (§17.16.17).
  *
  * FORMTEXT, FORMCHECKBOX and FORMDROPDOWN are what a fillable Word form is made of, and Word
- * shades them on sight so a reader can find the blanks. That is the only reason to ask: it is a
- * presentation question, answered by the element's presence alone.
+ * shades them on sight so a reader can find the blanks. That is a presentation question,
+ * answered by the element's presence alone — this predicate never looks inside.
  *
- * Presence ONLY. `w:ffData` can carry entry and exit MACRO names, and the canonical tree keeps
- * its whole subtree generic and inert on purpose. Walking into it to read a name or a default
- * would be reading attacker-supplied script references for no gain — the shading does not
- * depend on what the form field says, only on it being one.
+ * Rendering STATE (a checkbox's checked bit, a dropdown's entries and selection) is different:
+ * {@link legacyFormFieldDataOf} reads exactly that, bounded, and nothing else. The contract
+ * stands: `w:ffData` macro references (`w:entryMacro` / `w:exitMacro`), `w:name`, help/status
+ * text and behavior flags are attacker-supplied script references and are NEVER read, returned
+ * or resolved by anything in this module.
  */
 export function hasLegacyFormFieldData(node: OoxmlNode): boolean {
   if (node.kind === 'textValue') return false;
@@ -181,6 +183,144 @@ export function hasLegacyFormFieldData(node: OoxmlNode): boolean {
     if (child.localName === 'ffData' && isWml(child, 'ffData')) return true;
   }
   return false;
+}
+
+/**
+ * Legacy form-field render state read from `w:ffData` (§17.16.17), and nothing else.
+ *
+ * `checkbox`: `sizeHalfPoints` is the explicit `w:size` in half-points, clamped to a sane
+ * render range, or null for auto-size (`w:sizeAuto`, absent, or malformed).
+ * `dropdown`: `selectedIndex` is already resolved (`w:result`, else `w:default`, else 0) and
+ * always in range when `entries` is non-empty; `entries` may be empty (layout paints nothing).
+ */
+export type LegacyFormFieldData =
+  | {
+      readonly kind: 'checkbox';
+      readonly checked: boolean;
+      readonly sizeHalfPoints: number | null;
+    }
+  | {
+      readonly kind: 'dropdown';
+      readonly entries: readonly string[];
+      readonly selectedIndex: number;
+    };
+
+/** Total direct-child visits the ffData walk will spend before failing closed. */
+const MAX_FF_DATA_NODES = 256;
+/** Dropdown entries collected — capped BEFORE collection, never sized by the file. */
+const MAX_DROPDOWN_ENTRIES = 64;
+/** Characters kept per dropdown entry. */
+const MAX_DROPDOWN_ENTRY_CHARS = 256;
+/** `w:size` clamp in half-points: 1pt .. 144pt. */
+const MIN_CHECKBOX_SIZE_HALF_POINTS = 2;
+const MAX_CHECKBOX_SIZE_HALF_POINTS = 288;
+/** Largest `w:val` index for `w:result` / `w:default` on `w:ddList` (ST_UnsignedDecimalNumber cap). */
+const MAX_DROPDOWN_INDEX = 63;
+
+type NodeBudget = { left: number };
+
+/** On/off child element (`w:checked` / `w:default`): present without `w:val` means true. */
+function onOffElementValue(element: OoxmlNode): boolean {
+  const raw = attributeValue(element, 'val');
+  if (raw === undefined) return true;
+  return !(raw === '0' || raw === 'false' || raw === 'off');
+}
+
+/** Bounded `w:val` integer parse; null when absent or malformed, clamped otherwise. */
+function clampedIntAttribute(element: OoxmlNode, min: number, max: number): number | null {
+  const raw = attributeValue(element, 'val');
+  if (raw === undefined || !/^-?\d{1,7}$/.test(raw)) return null;
+  const value = Number.parseInt(raw, 10);
+  return Math.min(max, Math.max(min, value));
+}
+
+function checkboxDataOf(checkbox: OoxmlNode, budget: NodeBudget): LegacyFormFieldData {
+  let checked: boolean | undefined;
+  let fallback: boolean | undefined;
+  let sizeHalfPoints: number | null = null;
+  let sizeAuto = false;
+  if (checkbox.kind !== 'textValue') {
+    for (const child of checkbox.children) {
+      if (budget.left-- <= 0) break;
+      if (child.kind === 'textValue') continue;
+      if (isWml(child, 'checked')) checked ??= onOffElementValue(child);
+      else if (isWml(child, 'default')) fallback ??= onOffElementValue(child);
+      else if (isWml(child, 'size')) {
+        sizeHalfPoints = clampedIntAttribute(
+          child,
+          MIN_CHECKBOX_SIZE_HALF_POINTS,
+          MAX_CHECKBOX_SIZE_HALF_POINTS
+        );
+      } else if (isWml(child, 'sizeAuto')) sizeAuto = true;
+      // Anything else under checkBox is ignored — never descended into.
+    }
+  }
+  return {
+    kind: 'checkbox',
+    checked: checked ?? fallback ?? false,
+    sizeHalfPoints: sizeAuto ? null : sizeHalfPoints,
+  };
+}
+
+function dropdownDataOf(list: OoxmlNode, budget: NodeBudget): LegacyFormFieldData {
+  let result: number | null = null;
+  let fallback: number | null = null;
+  const entries: string[] = [];
+  if (list.kind !== 'textValue') {
+    for (const child of list.children) {
+      if (budget.left-- <= 0) break;
+      if (child.kind === 'textValue') continue;
+      if (isWml(child, 'result')) result ??= clampedIntAttribute(child, 0, MAX_DROPDOWN_INDEX);
+      else if (isWml(child, 'default')) {
+        fallback ??= clampedIntAttribute(child, 0, MAX_DROPDOWN_INDEX);
+      } else if (isWml(child, 'listEntry')) {
+        if (entries.length >= MAX_DROPDOWN_ENTRIES) continue;
+        const value = attributeValue(child, 'val');
+        if (value !== undefined) entries.push(value.slice(0, MAX_DROPDOWN_ENTRY_CHARS));
+      }
+      // Anything else under ddList is ignored — never descended into.
+    }
+  }
+  const inRange = (index: number | null): index is number =>
+    index !== null && index >= 0 && index < entries.length;
+  return {
+    kind: 'dropdown',
+    entries,
+    selectedIndex: inRange(result) ? result : inRange(fallback) ? fallback : 0,
+  };
+}
+
+/**
+ * Read a legacy form field's RENDER STATE from the `w:ffData` under a `w:fldChar`, bounded.
+ *
+ * The one sanctioned walk into `w:ffData`: fldChar → ffData → checkBox/ddList → leaf
+ * attributes, direct children only, no recursion, at most {@link MAX_FF_DATA_NODES} child
+ * visits. It reads the checkbox checked/size state and the dropdown entries/selection —
+ * NEVER `w:name`, `w:entryMacro`, `w:exitMacro`, `w:helpText`, `w:statusText`, `w:enabled`
+ * or `w:calcOnExit`: those carry attacker-supplied macro references and behavior, which
+ * rendering must not observe.
+ *
+ * Returns null for anything else (no ffData, a FORMTEXT ffData, malformed content), so
+ * callers fall back to the presence-only behavior of {@link hasLegacyFormFieldData}.
+ */
+export function legacyFormFieldDataOf(node: OoxmlNode): LegacyFormFieldData | null {
+  if (node.kind === 'textValue') return null;
+  if (fldCharType(node) === null) return null;
+  const budget: NodeBudget = { left: MAX_FF_DATA_NODES };
+  for (const child of node.children) {
+    if (budget.left-- <= 0) return null;
+    if (child.kind === 'textValue' || !isWml(child, 'ffData')) continue;
+    // First ffData wins; inside it, the first state element wins.
+    for (const entry of child.children) {
+      if (budget.left-- <= 0) return null;
+      if (entry.kind === 'textValue') continue;
+      if (isWml(entry, 'checkBox')) return checkboxDataOf(entry, budget);
+      if (isWml(entry, 'ddList')) return dropdownDataOf(entry, budget);
+      // `w:textInput` (FORMTEXT), `w:name`, macros, help/status text: deliberately not read.
+    }
+    return null;
+  }
+  return null;
 }
 
 /**

--- a/packages/core/src/store/package/field-nodes.ts
+++ b/packages/core/src/store/package/field-nodes.ts
@@ -107,6 +107,20 @@ export function isInstrText(node: OoxmlNode): boolean {
   );
 }
 
+/**
+ * Whether an instruction node is the DELETED form `w:delInstrText` (always generic — no
+ * typed kind).
+ *
+ * Consumers that ingest instruction text must keep deleted chunks in their own buffer:
+ * a tracked field-code edit puts `w:delInstrText` next to `w:instrText` in one field, and
+ * concatenating them produces an instruction nobody authored. The effective instruction is
+ * the live text when any live element exists, else the deleted text (a fully-deleted field
+ * keeps its meaning, with delete attribution).
+ */
+export function isDeletedInstrText(node: OoxmlNode): boolean {
+  return node.kind === 'generic' && isWml(node, 'delInstrText');
+}
+
 /** Typed or generic `w:fldSimple`. */
 export function isFldSimple(node: OoxmlNode): boolean {
   return node.kind === 'fldSimple' || (node.kind === 'generic' && isWml(node, 'fldSimple'));
@@ -203,8 +217,9 @@ export function hasLegacyFormFieldData(node: OoxmlNode): boolean {
  * render range, or null for auto-size (`w:sizeAuto`, absent, malformed, or negative —
  * ST_HpsMeasure is unsigned, so a negative value is invalid, not small).
  * `dropdown`: `selectedIndex` is already resolved (in-range `w:result`, else in-range
- * `w:default`, else 0 — an out-of-range index counts as absent) and always in range when
- * `entries` is non-empty; `entries` may be empty (layout paints nothing).
+ * `w:default`, else 0 — an out-of-range index counts as absent, and the FIRST `w:result` /
+ * `w:default` element wins even when malformed) and always in range when `entries` is
+ * non-empty; `entries` may be empty (layout paints nothing).
  */
 export type LegacyFormFieldData =
   | {
@@ -300,14 +315,26 @@ function checkboxDataOf(checkbox: OoxmlNode, budget: NodeBudget): LegacyFormFiel
 function dropdownDataOf(list: OoxmlNode, budget: NodeBudget): LegacyFormFieldData {
   let result: number | null = null;
   let fallback: number | null = null;
+  // First-wins via their own flags, exactly like checkbox `w:size`: `??=` cannot express
+  // "first ELEMENT wins" because a malformed / out-of-range first value also resolves null,
+  // which let a later valid sibling shadow it.
+  let resultSeen = false;
+  let fallbackSeen = false;
   const entries: string[] = [];
   if (list.kind !== 'textValue') {
     for (const child of list.children) {
       if (budget.left-- <= 0) break;
       if (child.kind === 'textValue') continue;
-      if (isWml(child, 'result')) result ??= dropdownIndexAttribute(child);
-      else if (isWml(child, 'default')) {
-        fallback ??= dropdownIndexAttribute(child);
+      if (isWml(child, 'result')) {
+        if (!resultSeen) {
+          resultSeen = true;
+          result = dropdownIndexAttribute(child);
+        }
+      } else if (isWml(child, 'default')) {
+        if (!fallbackSeen) {
+          fallbackSeen = true;
+          fallback = dropdownIndexAttribute(child);
+        }
       } else if (isWml(child, 'listEntry')) {
         if (entries.length >= MAX_DROPDOWN_ENTRIES) continue;
         const value = attributeValue(child, 'val');
@@ -497,11 +524,20 @@ export function parsedFieldSpansOf(
     }
 
     // Scan forward for a matching outermost end; track nesting and instruction size.
+    // LIVE (`w:instrText`) and DELETED (`w:delInstrText`) chunks buffer separately, with
+    // per-buffer overflow: a tracked field-code edit puts both in one field, and the
+    // EFFECTIVE instruction is the live text when any live element exists, else the deleted
+    // text — the same rule layout's field machine applies, so addressing agrees with what
+    // is painted.
     let nesting = 0;
     let nestingOverflow = false;
     let instructionChars = 0;
     let instruction = '';
     let instructionOverflow = false;
+    let deletedChars = 0;
+    let deletedInstruction = '';
+    let deletedOverflow = false;
+    let sawLiveInstruction = false;
     let phase: 'instruction' | 'result' | 'done' = 'instruction';
     const removeIds: string[] = [];
     const resultFormatRunIds: string[] = [];
@@ -525,12 +561,25 @@ export function parsedFieldSpansOf(
       if (isInstrText(node)) {
         if (nesting === 1 && phase === 'instruction') {
           const chunk = instrTextValue(node);
-          instructionChars += chunk.length;
-          if (instructionChars > maxInstructionChars) {
-            instructionOverflow = true;
-            instruction = '';
-          } else if (!instructionOverflow) {
-            instruction += chunk;
+          if (isDeletedInstrText(node)) {
+            deletedChars += chunk.length;
+            if (deletedChars > maxInstructionChars) {
+              deletedOverflow = true;
+              deletedInstruction = '';
+            } else if (!deletedOverflow) {
+              deletedInstruction += chunk;
+            }
+          } else {
+            // A live element counts even when empty: accepting the tracked deletion
+            // leaves exactly that instruction.
+            sawLiveInstruction = true;
+            instructionChars += chunk.length;
+            if (instructionChars > maxInstructionChars) {
+              instructionOverflow = true;
+              instruction = '';
+            } else if (!instructionOverflow) {
+              instruction += chunk;
+            }
           }
         }
         if (nesting >= 1) removeIds.push(node.id);
@@ -596,9 +645,9 @@ export function parsedFieldSpansOf(
     }
 
     // Instruction overflow still yields an atomic unit (content stays one selectable
-    // object); evaluation elsewhere fails closed. `instructionOverflow` is retained for
-    // callers that want the signal via a separate scan.
-    void instructionOverflow;
+    // object); evaluation elsewhere fails closed — an overflowed buffer already cleared
+    // itself to '', so the effective instruction resolves inert without another check.
+    const effectiveInstruction = sawLiveInstruction ? instruction : deletedInstruction;
 
     // Empty result: format the separate run when present, else the begin run (matches
     // projection's style fallback when no result run donates `rPr`).
@@ -617,7 +666,7 @@ export function parsedFieldSpansOf(
       runId: current.runId,
       removeNodeIds: [...new Set(removeIds)],
       formatRunIds,
-      addressing: isEditableFormTextInstruction(instruction, maxInstructionChars)
+      addressing: isEditableFormTextInstruction(effectiveInstruction, maxInstructionChars)
         ? 'editable-result'
         : 'atomic',
     });

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -440,6 +440,12 @@ export {
   type DocumentViewSettings,
 } from './view-settings.ts';
 export {
+  EMPTY_DOCUMENT_PROPERTIES,
+  MAX_DOCUMENT_PROPERTY_CHARS,
+  readDocumentProperties,
+  type DocumentProperties,
+} from './document-properties.ts';
+export {
   CONTENT_CONTROL_ID_MAX,
   CONTENT_CONTROL_PROPERTY_ORDER,
   MAX_CONTENT_CONTROLS_PER_PART,

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -439,12 +439,10 @@ export {
   readViewSettings,
   type DocumentViewSettings,
 } from './view-settings.ts';
-export {
-  EMPTY_DOCUMENT_PROPERTIES,
-  MAX_DOCUMENT_PROPERTY_CHARS,
-  readDocumentProperties,
-  type DocumentProperties,
-} from './document-properties.ts';
+// Only the result type is public — it names `SemanticLayoutOptions.documentProperties` and the
+// session accessor. The reader and its caps stay engine-internal; `binding` and tests import them
+// directly from `./document-properties.ts`.
+export { type DocumentProperties } from './document-properties.ts';
 export {
   CONTENT_CONTROL_ID_MAX,
   CONTENT_CONTROL_PROPERTY_ORDER,

--- a/packages/core/src/store/package/opc-names.ts
+++ b/packages/core/src/store/package/opc-names.ts
@@ -34,7 +34,19 @@ export type NameResult =
   | { readonly ok: true; readonly partName: string }
   | { readonly ok: false; readonly reason: NameRejection };
 
-const CONTROL_RE = /[\x00-\x1f\x7f]/;
+/** ASCII/DEL control characters. `test` rejects; {@link stripControlChars} drops. */
+export const CONTROL_RE = /[\x00-\x1f\x7f]/;
+const CONTROL_RE_GLOBAL = new RegExp(CONTROL_RE.source, 'g');
+
+/**
+ * Drop every control character from a value. The external-target path REJECTS these
+ * ({@link validateExternalTarget}); a `\l` anchor fragment and a `\o` tooltip are inert sinks,
+ * so they scrub for consistency rather than fail closed — the char is removed, never smuggled on.
+ */
+export function stripControlChars(value: string): string {
+  return value.replace(CONTROL_RE_GLOBAL, '');
+}
+
 const ENCODED_SEP_RE = /%(2f|5c)/i; // %2f "/", %5c "\"
 const ENCODED_DOT_RE = /%2e/i; // %2e "."
 const DRIVE_RE = /^[a-zA-Z]:/;

--- a/packages/react/src/editor/DocxEditorHyperLink.tsx
+++ b/packages/react/src/editor/DocxEditorHyperLink.tsx
@@ -32,7 +32,11 @@ import {
 import type { CSSProperties, ReactNode } from 'react';
 import { useTranslation } from '../i18n';
 import { absolutePointInScroller } from './scroller-geometry.ts';
-import { HyperlinkPopupContext, type UseHyperlinkPopupResult } from './useHyperlinkPopup';
+import {
+  HyperlinkPopupContext,
+  isFieldLink,
+  type UseHyperlinkPopupResult,
+} from './useHyperlinkPopup';
 import { Slot } from './toolbar/Slot';
 
 /** Keeps the caret: a mousedown that bubbles to the editor moves it. Inputs are exempt. */
@@ -210,15 +214,17 @@ function HyperLinkPreset({ children }: { children?: ReactNode }) {
       </>
     );
   }
+  // Editing actions are absent, not disabled, when they could never do anything: a control
+  // that can never work is chrome pretending to be a capability. A read-only document trims
+  // both; so does a FIELD link, whose id the typed lane (edit / unlink) can never resolve.
+  const editable = state.canEdit && !(state.link && isFieldLink(state.link));
   return (
     <>
       {take('Url', <HyperLinkUrl />)}
       <div className="docx-hyperlink-popup__actions">
         {take('Copy', <HyperLinkCopy />)}
-        {/* Editing actions are absent, not disabled, in a read-only document: a control
-            that can never do anything is chrome pretending to be a capability. */}
-        {state.canEdit ? take('Edit', <HyperLinkEdit />) : null}
-        {state.canEdit ? take('Unlink', <HyperLinkUnlink />) : null}
+        {editable ? take('Edit', <HyperLinkEdit />) : null}
+        {editable ? take('Unlink', <HyperLinkUnlink />) : null}
       </div>
       {overrides.__extra}
     </>

--- a/packages/react/src/editor/useHyperlinkPopup.ts
+++ b/packages/react/src/editor/useHyperlinkPopup.ts
@@ -94,8 +94,9 @@ export interface UseHyperlinkPopupResult {
  * A field-derived link (a `HYPERLINK` field's instruction) rather than a typed
  * `w:hyperlink`. Structurally signalled: the field registry mints every record with no
  * addressable range (`paragraphId` stays empty), because no `w:hyperlink` node backs it.
- * The caret can never sit inside one, and the typed editing lane (edit / unlink) can never
- * resolve its id — chrome must neither caret-dismiss on it nor offer those actions.
+ * The typed editing lane (edit / unlink) can never resolve its id, so chrome offers neither
+ * action. Caret dismissal DOES apply: the field is a one-unit atom, and `fieldLinkAtCaret`
+ * resolves the caret onto it (boundary-inclusive) so the panel closes when the caret leaves.
  */
 export function isFieldLink(link: SurfaceHyperlink): boolean {
   return link.paragraphId === '';
@@ -235,9 +236,18 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
    */
   const openAtCaret = useCallback(() => {
     const anchor = caretViewportAnchor();
-    const link = editor?.surface?.hyperlinks.linkAtCaret() ?? null;
+    const link =
+      editor?.surface?.hyperlinks.linkAtCaret() ??
+      editor?.surface?.hyperlinks.fieldLinkAtCaret() ??
+      null;
+    if (link && isFieldLink(link)) {
+      // A FIELD link has no editable tree node — Edit and Unlink cannot apply to it — so Ctrl+K
+      // opens the same READING panel a click produces (Open / Copy only), never an edit panel.
+      open(link, anchor);
+      return;
+    }
     if (link) {
-      // Ctrl+K on an existing link goes straight to EDIT — the user pressed the key to
+      // Ctrl+K on an existing TYPED link goes straight to EDIT — the user pressed the key to
       // change it, and making them press Edit as well is a step for nothing.
       setState({
         mode: 'editing',
@@ -267,7 +277,7 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
       error: false,
       canEdit: editor ? editor.can({ type: 'insertText', text: '' }).ok : false,
     });
-  }, [editor]);
+  }, [editor, open]);
 
   // Register with the engine: a plain click on an external link opens the popover under it,
   // Ctrl/Cmd+K opens insert-or-edit. The cleanup restores whatever was registered before, so
@@ -296,12 +306,15 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
   useEffect(() => {
     const current = stateRef.current;
     if (current.mode !== 'reading' || !current.link) return;
-    // A FIELD link is an atom with no range the caret could sit in, so "did the caret leave
-    // it" has no honest answer — `linkAtCaret` walks the typed lane and never returns one,
-    // and asking anyway closed the panel on the very tick that followed the opening click.
-    // Escape and an outside mousedown still dismiss it; those paths never ask the caret.
-    if (isFieldLink(current.link)) return;
-    const atCaret = editor?.surface?.hyperlinks.linkAtCaret() ?? null;
+    // A FIELD link is a painted atom, not a tree node, so `linkAtCaret` (the typed tree walk)
+    // never returns one. `fieldLinkAtCaret` resolves it from the layout at the caret, and it is
+    // boundary-INCLUSIVE: a field atom is `[start, start + 1)`, and the click that opens the
+    // panel lands the caret on that boundary. The inclusive test keeps the panel open on the
+    // opening tick and closes it only once the caret truly moves off the atom. Escape and an
+    // outside mousedown still dismiss through paths that never ask the caret.
+    const atCaret = isFieldLink(current.link)
+      ? (editor?.surface?.hyperlinks.fieldLinkAtCaret() ?? null)
+      : (editor?.surface?.hyperlinks.linkAtCaret() ?? null);
     if (atCaret && atCaret.id === current.link.id) return;
     setState(CLOSED);
   }, [snapshot, editor]);

--- a/packages/react/src/editor/useHyperlinkPopup.ts
+++ b/packages/react/src/editor/useHyperlinkPopup.ts
@@ -90,6 +90,17 @@ export interface UseHyperlinkPopupResult {
   openTarget: () => boolean;
 }
 
+/**
+ * A field-derived link (a `HYPERLINK` field's instruction) rather than a typed
+ * `w:hyperlink`. Structurally signalled: the field registry mints every record with no
+ * addressable range (`paragraphId` stays empty), because no `w:hyperlink` node backs it.
+ * The caret can never sit inside one, and the typed editing lane (edit / unlink) can never
+ * resolve its id — chrome must neither caret-dismiss on it nor offer those actions.
+ */
+export function isFieldLink(link: SurfaceHyperlink): boolean {
+  return link.paragraphId === '';
+}
+
 const CLOSED: HyperlinkPopupState = Object.freeze({
   mode: 'closed' as const,
   link: null,
@@ -285,6 +296,11 @@ export function useHyperlinkPopupInstance(active = true): UseHyperlinkPopupResul
   useEffect(() => {
     const current = stateRef.current;
     if (current.mode !== 'reading' || !current.link) return;
+    // A FIELD link is an atom with no range the caret could sit in, so "did the caret leave
+    // it" has no honest answer — `linkAtCaret` walks the typed lane and never returns one,
+    // and asking anyway closed the panel on the very tick that followed the opening click.
+    // Escape and an outside mousedown still dismiss it; those paths never ask the caret.
+    if (isFieldLink(current.link)) return;
     const atCaret = editor?.surface?.hyperlinks.linkAtCaret() ?? null;
     if (atCaret && atCaret.id === current.link.id) return;
     setState(CLOSED);

--- a/packages/react/test/hyperlink-popup.test.tsx
+++ b/packages/react/test/hyperlink-popup.test.tsx
@@ -37,7 +37,9 @@ function docx(body: string, rels = ''): Uint8Array {
     '_rels/.rels': strToU8(
       `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
     ),
-    'word/_rels/document.xml.rels': strToU8(`<Relationships xmlns="${REL}">${rels}</Relationships>`),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">${rels}</Relationships>`
+    ),
     'word/document.xml': strToU8(
       `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}</w:body></w:document>`
     ),
@@ -119,6 +121,17 @@ function pressCommandK(mounted: Mounted): void {
   if (!pages) throw new Error('no pages layer');
   act(() => {
     fireEvent.keyDown(pages, { key: 'k', metaKey: true });
+  });
+}
+
+/**
+ * Flush the store's DEFERRED notification. `useEditorState` coalesces `change` /
+ * `selectionChange` into a microtask (a task under input pressure), so a caret move that
+ * should re-run the popover's dismiss effect only lands after one asynchronous tick.
+ */
+async function tick(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 }
 
@@ -269,26 +282,36 @@ describe('DocxEditor.HyperLink', () => {
   });
 });
 
+// 'See ' is four characters; the field result projects as ONE atom over [4, 5). A real click
+// lands the caret ON that atom, which is where these tests place it before clicking.
+const FIELD_ATOM = 4;
+
 describe('a HYPERLINK field link', () => {
-  test('the popover survives the snapshot ticks after the click', () => {
+  test('the panel stays open on the opening tick and closes when the caret leaves the atom', async () => {
     const mounted = mount(FIELD_LINKED);
-    caret(mounted, 2);
+    // Where a real click lands the caret: on the field atom.
+    caret(mounted, FIELD_ATOM);
     clickLink(mounted, 'FieldLink');
-    // The caret can never sit inside a field link (`linkAtCaret` walks the typed lane), so
-    // the caret-based dismissal must not run: the panel is still standing after the click's
-    // own ticks, and stays standing across a further selection tick.
     const panel = mounted.view.getByTestId('hyperlink-popup');
     expect(panel.dataset.mode).toBe('reading');
     expect(mounted.view.getByTestId('hyperlink-popup-url').textContent).toContain(
       'https://field.example'
     );
-    caret(mounted, 1);
+    // The opening tick must NOT self-close it: the boundary-inclusive resolver still finds the
+    // field at the atom edge the click landed the caret on. A selection tick that keeps the
+    // caret on the atom (its trailing edge is inclusive) leaves the panel standing.
+    caret(mounted, 5);
+    await tick();
     expect(mounted.view.queryByTestId('hyperlink-popup')).not.toBeNull();
+    // Moving the caret OFF the atom closes it, the same rule a typed link follows.
+    caret(mounted, 1);
+    await tick();
+    expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
   });
 
   test('offers open and copy, but not edit or unlink', () => {
     const mounted = mount(FIELD_LINKED);
-    caret(mounted, 2);
+    caret(mounted, FIELD_ATOM);
     clickLink(mounted, 'FieldLink');
     expect(mounted.view.getByTestId('hyperlink-popup-copy')).toBeTruthy();
     expect(mounted.view.getByTestId('hyperlink-popup-url')).toBeTruthy();
@@ -300,12 +323,13 @@ describe('a HYPERLINK field link', () => {
 
   test('escape and an outside mousedown still dismiss it', () => {
     const mounted = mount(FIELD_LINKED);
-    caret(mounted, 2);
+    caret(mounted, FIELD_ATOM);
     clickLink(mounted, 'FieldLink');
     act(() => {
       fireEvent.keyDown(document, { key: 'Escape' });
     });
     expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
+    caret(mounted, FIELD_ATOM);
     clickLink(mounted, 'FieldLink');
     act(() => {
       fireEvent.mouseDown(document.body);
@@ -338,6 +362,21 @@ describe('Ctrl/Cmd+K', () => {
     expect((mounted.view.getByTestId('hyperlink-popup-text') as HTMLInputElement).value).toBe(
       'Example'
     );
+  });
+
+  test('on a field link it opens the READING panel, not editing', () => {
+    const mounted = mount(FIELD_LINKED);
+    caret(mounted, FIELD_ATOM);
+    pressCommandK(mounted);
+    const panel = mounted.view.getByTestId('hyperlink-popup');
+    // Edit and Unlink cannot apply to a field link, so Ctrl+K reaches it read-only.
+    expect(panel.dataset.mode).toBe('reading');
+    expect(mounted.view.getByTestId('hyperlink-popup-url').textContent).toContain(
+      'https://field.example'
+    );
+    expect(mounted.view.queryByTestId('hyperlink-popup-copy')).not.toBeNull();
+    expect(mounted.view.queryByTestId('hyperlink-popup-edit')).toBeNull();
+    expect(mounted.view.queryByTestId('hyperlink-popup-unlink')).toBeNull();
   });
 });
 

--- a/packages/react/test/hyperlink-popup.test.tsx
+++ b/packages/react/test/hyperlink-popup.test.tsx
@@ -52,6 +52,13 @@ const LINKED = docx(
   EXTERNAL_REL
 );
 const PLAIN = docx('<w:p><w:r><w:t>Visit example today</w:t></w:r></w:p>');
+// A HYPERLINK field, not a typed `w:hyperlink`: its link record comes from the field-link
+// registry, is an atom with no caret-addressable range, and no relationship backs it.
+const FIELD_LINKED = docx(
+  `<w:p><w:r><w:t>See </w:t></w:r>` +
+    `<w:fldSimple w:instr=" HYPERLINK &quot;https://field.example&quot; ">` +
+    `<w:r><w:t>FieldLink</w:t></w:r></w:fldSimple></w:p>`
+);
 const PID = '/word/document.xml#0.0.0';
 
 interface Mounted {
@@ -259,6 +266,51 @@ describe('DocxEditor.HyperLink', () => {
     expect(readout.tagName).toBe('SPAN');
     // Copy needs a safe target; there is none.
     expect(mounted.view.queryByTestId('hyperlink-popup-copy')).toBeNull();
+  });
+});
+
+describe('a HYPERLINK field link', () => {
+  test('the popover survives the snapshot ticks after the click', () => {
+    const mounted = mount(FIELD_LINKED);
+    caret(mounted, 2);
+    clickLink(mounted, 'FieldLink');
+    // The caret can never sit inside a field link (`linkAtCaret` walks the typed lane), so
+    // the caret-based dismissal must not run: the panel is still standing after the click's
+    // own ticks, and stays standing across a further selection tick.
+    const panel = mounted.view.getByTestId('hyperlink-popup');
+    expect(panel.dataset.mode).toBe('reading');
+    expect(mounted.view.getByTestId('hyperlink-popup-url').textContent).toContain(
+      'https://field.example'
+    );
+    caret(mounted, 1);
+    expect(mounted.view.queryByTestId('hyperlink-popup')).not.toBeNull();
+  });
+
+  test('offers open and copy, but not edit or unlink', () => {
+    const mounted = mount(FIELD_LINKED);
+    caret(mounted, 2);
+    clickLink(mounted, 'FieldLink');
+    expect(mounted.view.getByTestId('hyperlink-popup-copy')).toBeTruthy();
+    expect(mounted.view.getByTestId('hyperlink-popup-url')).toBeTruthy();
+    // The typed editing lane can never resolve a field-link id: unlink would silently do
+    // nothing and edit would insert a typed link BESIDE the field. Absent, not disabled.
+    expect(mounted.view.queryByTestId('hyperlink-popup-edit')).toBeNull();
+    expect(mounted.view.queryByTestId('hyperlink-popup-unlink')).toBeNull();
+  });
+
+  test('escape and an outside mousedown still dismiss it', () => {
+    const mounted = mount(FIELD_LINKED);
+    caret(mounted, 2);
+    clickLink(mounted, 'FieldLink');
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
+    clickLink(mounted, 'FieldLink');
+    act(() => {
+      fireEvent.mouseDown(document.body);
+    });
+    expect(mounted.view.queryByTestId('hyperlink-popup')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fields whose display Word derives from the instruction or from `w:ffData` painted nothing. This lands the remaining text-like kinds on top of the cached-result baseline:

- `w:sym` runs and the SYMBOL field render (symbol-page normalization, PUA mapping, `\f`/`\s`/`\u` switches). The glyph is a zero-model-width projected piece, so store offsets do not move.
- HYPERLINK fields (complex and `w:fldSimple`) are live links. The instruction parser stays in layout and produces strings only; the href is built once, at the surface, through the same `sanitizeHref` + absolute-URI gate as typed hyperlinks, with a fail-closed registry and a read-only link panel. Footnote and endnote stories now project links too.
- FORMCHECKBOX and FORMDROPDOWN paint from `w:ffData` state through a bounded reader that never touches macro, name, or help entries. FORMTEXT keeps its editable cached result.
- MACROBUTTON and GOTOBUTTON render their display text; the macro name and jump target are discarded at parse.
- A nested complex PAGE/NUMPAGES/SECTIONPAGES inside another field now evaluates per sheet at depths 2-4, and story detection agrees with what projection can replace, so header reuse keys stay honest.
- Tracked field code (`w:delInstrText`) is recognized: live chunks win, a fully deleted field keeps evaluating with delete attribution, and synthesis respects the display mode's revision rules.

Every parser is a bounded single pass over a capped instruction; overflow, bad code points, and malformed `w:ffData` fail closed to the previous behavior. The complex-lane instruction cap now matches the simple-field lane (4096), with the SYMBOL and button parsers pinned locally to 256.

Each commit was adversarially reviewed in isolation and the findings were folded back in; a final whole-branch pass checked the sink grep, lane parity, and offset-authority agreement. Feature matrix, an OpenSpec change (amending the ratified "empty result paints nothing" scenario), and a minor changeset are included.

Known deferrals, recorded in the matrix: AUTONUM/LISTNUM/EQ are not evaluated; DATE/REF/SEQ stay cached-result-only; form fields render but are not interactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789604557&installation_model_id=422592&pr_number=308&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F308&signature=10a2546f9ec7bfa4bf62e889cf398f12022f064cbd85c5da00684565d1babc88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->