### PR TITLE
feat(core): show a loading screen while a large document opens

### DIFF
--- a/.changeset/deferred-open-loading-screen.md
+++ b/.changeset/deferred-open-loading-screen.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Opening a large document now shows a loading screen instead of freezing the page: the engine mounts it behind one painted frame, `snapshot().isOpening` reports that window, and `DocxEditor.Loading` gains an `overlay` variant that the packaged React frame mounts by default.

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -1051,6 +1051,7 @@ export interface EditorSnapshot {
     // (undocumented)
     readonly image: ImageContext | null;
     readonly isLoading: boolean;
+    readonly isOpening?: boolean;
     readonly lastRejection?: string | null;
     // (undocumented)
     readonly page: {

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1673,6 +1673,7 @@ export interface EditorSnapshot {
     // (undocumented)
     readonly image: ImageContext | null;
     readonly isLoading: boolean;
+    readonly isOpening?: boolean;
     readonly lastRejection?: string | null;
     // (undocumented)
     readonly page: {

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -464,6 +464,7 @@ export interface DocxEditorLoadingComponent {
 export interface DocxEditorLoadingProps {
     children?: ReactNode;
     className?: string;
+    overlay?: boolean;
     style?: CSSProperties;
     when?: boolean;
 }

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -267,7 +267,7 @@ The pane's parts are statics, so you can hang your own class on each one instead
 
 ## Custom loading screen
 
-`DocxEditor.Loading` renders only while there is no document:
+`DocxEditor.Loading` renders while there is no document to show. It covers two windows with no conditions to wire up: before bytes arrive, and while a large document opens. The engine mounts a big file behind one painted frame and reports `snapshot().isOpening` for that window, so this screen paints instead of the page freezing.
 
 ```tsx
 <DocxEditor.Viewport>
@@ -281,7 +281,18 @@ The pane's parts are statics, so you can hang your own class on each one instead
 </DocxEditor.Viewport>
 ```
 
-To keep the packaged spinner and restyle only it, `DocxEditor.Loading.Spinner` takes a `className`.
+Pass `overlay` to pin it over the nearest positioned ancestor. The overlay is opaque, so it covers the previous document while the next one opens, and it carries a short appearance delay so fast opens never flash it. The sugar `<DocxEditor />` mounts this overlay for you.
+
+```tsx
+<div style={{ position: 'relative' }}>
+  <DocxEditor.Viewport>
+    <DocxEditor.Content />
+  </DocxEditor.Viewport>
+  <DocxEditor.Loading overlay />
+</div>
+```
+
+To keep the packaged spinner and restyle only it, `DocxEditor.Loading.Spinner` takes a `className`. If you gate your own mount point, key that on `snapshot().isLoading`, never on `isOpening`: the scheduled mount needs `DocxEditor.Content` to stay in the tree.
 
 ## Custom link popover
 

--- a/docs/site/content/react/hooks.mdx
+++ b/docs/site/content/react/hooks.mdx
@@ -79,7 +79,7 @@ const formatting = useEditorState(
 );
 ```
 
-Select narrowly. A page-number selector should not re-render when someone toggles bold. Useful snapshot fields include `page`, `selection`, `selectionCollapsed`, `formatting`, `table`, `image`, `editable`, `isLoading`, `parseError`, `editingMode`, `canUndo` / `canRedo`, `pageSetup`, `fontSubstitutions`, `hasReviewContent`, and `lastRejection`.
+Select narrowly. A page-number selector should not re-render when someone toggles bold. Useful snapshot fields include `page`, `selection`, `selectionCollapsed`, `formatting`, `table`, `image`, `editable`, `isLoading`, `isOpening`, `parseError`, `editingMode`, `canUndo` / `canRedo`, `pageSetup`, `fontSubstitutions`, `hasReviewContent`, and `lastRejection`.
 
 ## useDocxEditor
 

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -737,6 +737,15 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
               </DocxEditorReview>
             </DocxEditor.Viewport>
             <DocxEditor.PageNumber />
+            {/* The library's loading overlay, pinned over the workspace (`.demo-main` is
+                the positioned ancestor). Zero conditions wired here: the engine opens a
+                big file behind one painted frame and reports `isOpening`, so picking a
+                large document through Open DOCX shows this screen instead of freezing
+                on the old one. It renders nothing while the document is on screen. */}
+            <DocxEditor.Loading overlay>
+              <DocxEditor.Loading.Spinner />
+              <span>Loading document…</span>
+            </DocxEditor.Loading>
             {/* Floating diagnostics chrome, above the overlay panels. */}
             <PerfHud />
             <CitationPopover

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -330,7 +330,14 @@ export type CanResult = { ok: true } | { ok: false; code: ExecErrorCode; reason:
  * ```
  */
 export interface Editor {
-  /** Load a new document (DOCX bytes or a handle), replacing the current one. */
+  /**
+   * Load a new document (DOCX bytes or a handle), replacing the current one.
+   *
+   * A large document mounts behind one painted frame, so a loading screen keyed on
+   * `snapshot().isOpening` can show instead of a frozen page; a small one mounts before
+   * this returns. Callers that need the document synchronously do not have to care:
+   * `save`, `exec` and `selectMatch` complete a scheduled open before they run.
+   */
   load(document: DocumentSource): void;
   /** Serialize the current canonical document to DOCX bytes — on demand, never per keystroke. */
   save(): Promise<ArrayBuffer>;
@@ -1499,6 +1506,16 @@ export interface EditorSnapshot {
    *  pages paint, so this stays false across a detach and remount. Safe to gate a mount
    *  point on — it never depends on one existing. */
   readonly isLoading: boolean;
+  /**
+   * Whether a supplied document is still on its way to painted pages. Opening a large
+   * document mounts behind one painted frame so a loading screen can show instead of a
+   * frozen page; this is true for exactly that window, and across it the previous
+   * document (if any) stays on screen. Show a loading overlay while it holds — but gate
+   * only chrome on it, never the mount point, which must stay mounted for the open to
+   * complete ({@link EditorSnapshot.isLoading} is the gate-safe flag). Optional and
+   * additive: absent means the implementation has not derived it, read as `false`.
+   */
+  readonly isOpening?: boolean;
   readonly parseError: string | null;
   /** Whether the loaded document is being edited: a patchable document opened in edit mode. A
    *  read-only document (tables/SDTs/unpreservable) or `mode: 'view'` reports false. */

--- a/packages/core/src/editor/__tests__/deferred-open.test.ts
+++ b/packages/core/src/editor/__tests__/deferred-open.test.ts
@@ -1,0 +1,175 @@
+// Opening a LARGE document yields one painted frame before the blocking mount.
+//
+// What these tests pin down: a document past the yield threshold mounts behind
+// `requestAnimationFrame` + a task, and `snapshot().isOpening` is true for exactly that
+// window while `isLoading` stays false (the gate-safe flag must not flicker); the
+// previous document stays mounted under the window; `save`/`exec` inside the window
+// flush the scheduled mount instead of refusing; detach hands the scheduled document to
+// the next attach; destroy cancels it; and a SMALL document keeps the synchronous path,
+// because every existing synchronous caller depends on it.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+/**
+ * Deterministic high-entropy bytes (xorshift32). Deflate cannot compress them, so a
+ * small filler PART pushes the ZIP past the yield threshold without a body large enough
+ * to make the mount itself slow in the test.
+ */
+function incompressible(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  let state = 0x9e3779b9;
+  for (let i = 0; i < length; i += 1) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    bytes[i] = state & 0xff;
+  }
+  return bytes;
+}
+
+function docx(body: string, filler?: Uint8Array): Uint8Array {
+  const fillerDefault = filler
+    ? '<Default Extension="bin" ContentType="application/octet-stream"/>'
+    : '';
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>${fillerDefault}` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+    ...(filler ? { 'word/media/filler.bin': filler } : {}),
+  });
+}
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+/** Past the 128 KiB yield threshold, mostly via the incompressible filler part. */
+const LARGE = docx(p('large document body'), incompressible(192 * 1024));
+const SMALL = docx(p('small document body'));
+
+async function until(check: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) throw new Error('condition not reached in time');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('deferred open of a large document', () => {
+  test('the large fixture actually crosses the yield threshold', () => {
+    expect(LARGE.byteLength).toBeGreaterThanOrEqual(128 * 1024);
+  });
+
+  test('a small document still mounts synchronously', () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({ container, document: SMALL });
+    expect(editor.surface).not.toBeNull();
+    expect(editor.snapshot().isOpening).toBe(false);
+    editor.destroy();
+  });
+
+  test('attach schedules the mount: isOpening holds the window, isLoading stays false', async () => {
+    const editor = createDocxEditor({ document: LARGE });
+    const container = document.createElement('div');
+    editor.attach(container);
+
+    expect(editor.surface).toBeNull();
+    expect(editor.snapshot().isOpening).toBe(true);
+    // The gate-safe flag must not flicker: a host gating its mount point on it would
+    // unmount the container the scheduled mount needs.
+    expect(editor.snapshot().isLoading).toBe(false);
+
+    await until(() => editor.surface !== null);
+    expect(editor.snapshot().isOpening).toBe(false);
+    expect(container.textContent).toContain('large document body');
+    editor.destroy();
+  });
+
+  test('load() over a mounted document keeps the old pages through the window', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({ container, document: SMALL });
+    let selectionEvents = 0;
+    editor.on('selectionChange', () => {
+      selectionEvents += 1;
+    });
+
+    editor.load(LARGE);
+    // The old document is still what is on screen; the overlay state says why.
+    expect(editor.snapshot().isOpening).toBe(true);
+    expect(container.textContent).toContain('small document body');
+    // Scheduling emitted, so a subscribed host re-reads and shows its overlay.
+    expect(selectionEvents).toBeGreaterThan(0);
+
+    await until(() => container.textContent?.includes('large document body') === true);
+    expect(editor.snapshot().isOpening).toBe(false);
+    editor.destroy();
+  });
+
+  test('save() inside the window flushes the scheduled mount and answers the new document', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({ container, document: SMALL });
+    editor.load(LARGE);
+    expect(editor.snapshot().isOpening).toBe(true);
+
+    const buffer = await editor.save();
+    expect(editor.snapshot().isOpening).toBe(false);
+    expect(container.textContent).toContain('large document body');
+    expect(buffer.byteLength).toBeGreaterThanOrEqual(128 * 1024);
+    editor.destroy();
+  });
+
+  test('exec inside the window flushes the scheduled mount first', () => {
+    const editor = createDocxEditor({ document: LARGE });
+    const container = document.createElement('div');
+    editor.attach(container);
+    expect(editor.surface).toBeNull();
+
+    editor.exec({ type: 'setEditingMode', mode: 'viewing' });
+    expect(editor.surface).not.toBeNull();
+    expect(editor.snapshot().isOpening).toBe(false);
+    editor.destroy();
+  });
+
+  test('detach inside the window hands the scheduled document to the next attach', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({ container, document: SMALL });
+    editor.load(LARGE);
+    expect(editor.snapshot().isOpening).toBe(true);
+
+    editor.detach();
+    expect(editor.snapshot().isOpening).toBe(false);
+    // The scheduled document outranks the bytes saved off the old surface.
+    const next = document.createElement('div');
+    editor.attach(next);
+    await until(() => next.textContent?.includes('large document body') === true);
+    editor.destroy();
+  });
+
+  test('destroy inside the window cancels the scheduled mount', async () => {
+    const editor = createDocxEditor({ document: LARGE });
+    const container = document.createElement('div');
+    editor.attach(container);
+    expect(editor.snapshot().isOpening).toBe(true);
+
+    editor.destroy();
+    // Give the cancelled frame/task time to (not) fire.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(editor.surface).toBeNull();
+    expect(container.textContent ?? '').not.toContain('large document body');
+  });
+});

--- a/packages/core/src/editor/__tests__/deferred-open.test.ts
+++ b/packages/core/src/editor/__tests__/deferred-open.test.ts
@@ -22,8 +22,8 @@ const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/
 
 /**
  * Deterministic high-entropy bytes (xorshift32). Deflate cannot compress them, so a
- * small filler PART pushes the ZIP past the yield threshold without a body large enough
- * to make the mount itself slow in the test.
+ * filler PART pushes the ZIPPED size past the yield threshold without a body large
+ * enough to make the mount itself slow in the test.
  */
 function incompressible(length: number): Uint8Array {
   const bytes = new Uint8Array(length);
@@ -58,8 +58,30 @@ function docx(body: string, filler?: Uint8Array): Uint8Array {
 
 const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
-/** Past the 128 KiB yield threshold, mostly via the incompressible filler part. */
-const LARGE = docx(p('large document body'), incompressible(192 * 1024));
+/**
+ * ~`length` bytes of numbered text: zips well (like real WordprocessingML, ~10–20×)
+ * while staying far under the 200× per-entry zip-bomb ratio cap that plain zero-fill
+ * trips — the parse must ACCEPT these fixtures, not refuse them.
+ */
+function compressibleText(length: number): Uint8Array {
+  const lines: string[] = [];
+  let total = 0;
+  for (let line = 1; total < length; line += 1) {
+    const text = `filler line ${line} carrying a little ordinary sentence text.\n`;
+    lines.push(text);
+    total += text.length;
+  }
+  return strToU8(lines.join('').slice(0, length));
+}
+
+/**
+ * The shape that motivated the content-size measure: a text-heavy document. It zips
+ * SMALL but its UNCOMPRESSED entries cross the threshold, exactly like a 200-page
+ * tracked-changes file that zips under 90 KiB.
+ */
+const LARGE = docx(p('large document body'), compressibleText(1024 * 1024));
+/** Past the threshold ZIPPED as well — the shortcut branch of `shouldYield`. */
+const LARGE_ZIPPED = docx(p('large zipped body'), incompressible(600 * 1024));
 const SMALL = docx(p('small document body'));
 
 async function until(check: () => boolean, timeoutMs = 3000): Promise<void> {
@@ -71,8 +93,27 @@ async function until(check: () => boolean, timeoutMs = 3000): Promise<void> {
 }
 
 describe('deferred open of a large document', () => {
-  test('the large fixture actually crosses the yield threshold', () => {
-    expect(LARGE.byteLength).toBeGreaterThanOrEqual(128 * 1024);
+  test('a text-heavy document defers on its CONTENT size, not its zipped size', async () => {
+    // The regression this pins: a long tracked-changes document zips far under any
+    // sensible zipped-size threshold, and the open froze with no loading state.
+    expect(LARGE.byteLength).toBeLessThan(512 * 1024);
+    const editor = createDocxEditor({ document: LARGE });
+    const container = document.createElement('div');
+    editor.attach(container);
+    expect(editor.snapshot().isOpening).toBe(true);
+    await until(() => editor.surface !== null);
+    editor.destroy();
+  });
+
+  test('a document past the threshold ZIPPED defers too', async () => {
+    expect(LARGE_ZIPPED.byteLength).toBeGreaterThanOrEqual(512 * 1024);
+    const editor = createDocxEditor({ document: LARGE_ZIPPED });
+    const container = document.createElement('div');
+    editor.attach(container);
+    expect(editor.snapshot().isOpening).toBe(true);
+    await until(() => editor.surface !== null);
+    expect(container.textContent).toContain('large zipped body');
+    editor.destroy();
   });
 
   test('a small document still mounts synchronously', () => {
@@ -129,7 +170,7 @@ describe('deferred open of a large document', () => {
     const buffer = await editor.save();
     expect(editor.snapshot().isOpening).toBe(false);
     expect(container.textContent).toContain('large document body');
-    expect(buffer.byteLength).toBeGreaterThanOrEqual(128 * 1024);
+    expect(buffer.byteLength).toBeGreaterThan(0);
     editor.destroy();
   });
 
@@ -140,6 +181,21 @@ describe('deferred open of a large document', () => {
     expect(editor.surface).toBeNull();
 
     editor.exec({ type: 'setEditingMode', mode: 'viewing' });
+    expect(editor.surface).not.toBeNull();
+    expect(editor.snapshot().isOpening).toBe(false);
+    editor.destroy();
+  });
+
+  test('scrollToPage inside the window flushes the scheduled mount and lands', () => {
+    const editor = createDocxEditor({ document: LARGE });
+    const container = document.createElement('div');
+    editor.attach(container);
+    expect(editor.snapshot().isOpening).toBe(true);
+
+    // A host's onReady-style scroll must address the just-loaded document. The reveal
+    // itself needs real scroller geometry this bare container does not have; what this
+    // pins is the flush — the call finds a MOUNTED document, not the yield window.
+    editor.scrollToPage(1);
     expect(editor.surface).not.toBeNull();
     expect(editor.snapshot().isOpening).toBe(false);
     editor.destroy();

--- a/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
+++ b/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
@@ -125,6 +125,16 @@ function mockCanvasContext(): CanvasRenderingContext2D {
   } as CanvasRenderingContext2D;
 }
 
+/** Wait out the open yield: the embedded-font fixtures cross the size threshold past
+ *  which a document mounts behind one painted frame (see `docx-editor-open-scheduler`). */
+async function mounted(editor: DocxEditorInstance): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (editor.surface) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('the deferred open never mounted');
+}
+
 /** Wait until shaped resolution lands (or the editor settles on fixed). */
 async function fontsSettled(editor: DocxEditorInstance): Promise<void> {
   for (let attempt = 0; attempt < 200; attempt += 1) {
@@ -149,6 +159,7 @@ describe('embedded fonts auto-wire into shaped measurement', () => {
       document: docxWithEmbeds(p('shaped hello'), EMBED_BOTH),
       onFontError: (error) => errors.push(error),
     });
+    await mounted(editor);
     expect(editor.surface).not.toBeNull();
     expect(editor.fontMeasurement().measurer).toBe('fixed');
     await fontsSettled(editor);
@@ -218,6 +229,7 @@ describe('embedded fonts auto-wire into shaped measurement', () => {
       container,
       document: docxWithEmbeds(p('select this text'), EMBED_BOTH),
     });
+    await mounted(editor);
     const paragraphId = editor.surface!.session.paragraphIds()[0]!;
     const paraId = editor.surface!.session.paraIdOf(paragraphId)!;
     const range = {
@@ -271,6 +283,7 @@ describe('embedded fonts auto-wire into shaped measurement', () => {
       ]),
       onFontError: (error) => errors.push(error),
     });
+    await mounted(editor);
     expect(editor.surface).not.toBeNull();
     await fontsSettled(editor);
     // The valid face admitted…
@@ -393,6 +406,9 @@ describe('embedded fonts auto-wire into shaped measurement', () => {
       container,
       document: docxWithEmbeds(p('first'), EMBED_BOTH),
     });
+    // Font work starts at the mount, which this big fixture defers — flush it through
+    // the public path so the in-flight window is still open when the next load lands.
+    editor.exec({ type: 'setEditingMode', mode: 'editing' });
     // Immediately supersede with a document that starts NO font work of its own.
     expect(editor.fontMeasurement().resolving).toBe(true);
     editor.load(
@@ -514,6 +530,7 @@ describe('a hostile run family cannot destroy the mounted document', () => {
       document: docxWithEmbeds(HOSTILE_RUN + p('normal'), EMBED_BOTH),
       onFontError: () => {},
     });
+    await mounted(editor);
     expect(container.textContent).toContain('crafted');
     await fontsSettled(editor);
     // Still mounted, still showing the document, still saveable.

--- a/packages/core/src/editor/docx-editor-open-scheduler.ts
+++ b/packages/core/src/editor/docx-editor-open-scheduler.ts
@@ -1,0 +1,108 @@
+// The open-yield scheduler: one painted frame between "open this document" and the
+// blocking mount, so a host's loading screen can actually show.
+//
+// Opening a document parses, lays out and paints in one synchronous pass — seconds of
+// blocked main thread on a long file — and a mount that runs in the same task as
+// `load()`/`attach()` blocks the very frame that would have painted the host's loading
+// screen. Documents past {@link OPEN_PAINT_YIELD_BYTES} therefore schedule the mount
+// behind one painted frame, and `snapshot().isOpening` is true for exactly that window.
+// Small documents keep the synchronous path: they need no loading flash, and every
+// existing synchronous caller stays as it was. So does every environment without
+// `requestAnimationFrame` — headless and server hosts mount synchronously by definition.
+
+/**
+ * The size past which an open earns a painted loading frame before the blocking mount.
+ *
+ * Zipped size is the only cheap proxy for mount cost. Documents under this mount well
+ * inside one frame's budget on current hardware, so deferring them would buy nothing
+ * and flash a loading screen; documents over it are the ones whose synchronous mount
+ * visibly freezes the page they were opened from.
+ */
+const OPEN_PAINT_YIELD_BYTES = 128 * 1024;
+
+/** What the facade hands the scheduler; both close over facade-owned state. */
+export interface OpenSchedulerHooks {
+  /** The real synchronous mount (`mountBytes`). */
+  readonly mount: (bytes: Uint8Array) => void;
+  /** Called once when a mount is scheduled — the facade bumps and emits here. */
+  readonly scheduled: () => void;
+}
+
+/** The deferred-mount window, owned by the facade. See the module comment. */
+export interface OpenScheduler {
+  /** Whether this open is worth (and able to get) a painted frame before the mount. */
+  shouldYield(bytes: Uint8Array): boolean;
+  /** Schedule the mount behind one painted frame and report the state move. */
+  schedule(bytes: Uint8Array): void;
+  /** Cancel a scheduled open and hand its bytes back to the caller to re-route. */
+  cancel(): Uint8Array | null;
+  /**
+   * Run a scheduled open NOW. For callers that need the document synchronously — a
+   * `save()` or `exec` issued inside the yield window must see the document that was
+   * just loaded, not a "no document is loaded" refusal the next frame would disprove.
+   */
+  flush(): void;
+  /** Whether a mount is currently waiting on its frame — `snapshot().isOpening`. */
+  isScheduled(): boolean;
+}
+
+export function createOpenScheduler(hooks: OpenSchedulerHooks): OpenScheduler {
+  let scheduled: { readonly bytes: Uint8Array; cancel(): void } | null = null;
+
+  const cancel = (): Uint8Array | null => {
+    if (!scheduled) return null;
+    const { bytes } = scheduled;
+    scheduled.cancel();
+    scheduled = null;
+    return bytes;
+  };
+
+  return {
+    shouldYield: (bytes) =>
+      bytes.byteLength >= OPEN_PAINT_YIELD_BYTES &&
+      typeof requestAnimationFrame === 'function' &&
+      typeof cancelAnimationFrame === 'function',
+
+    // `requestAnimationFrame` fires BEFORE the pending paint, so the heavy work goes
+    // into a task queued from inside it — the first slot guaranteed to run after the
+    // loading screen is on screen. Until then the previous document (if any) stays
+    // mounted under the host's overlay. A HIDDEN tab never fires rAF at all, so a
+    // plain-timer fallback mounts anyway: a document opened in the background must be
+    // there when the tab is next looked at, not still waiting for a frame.
+    schedule(bytes) {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      let fallback: ReturnType<typeof setTimeout> | null = null;
+      const run = () => {
+        scheduled = null;
+        hooks.mount(bytes);
+      };
+      const raf = requestAnimationFrame(() => {
+        if (fallback !== null) clearTimeout(fallback);
+        fallback = null;
+        timer = setTimeout(run, 0);
+      });
+      fallback = setTimeout(() => {
+        cancelAnimationFrame(raf);
+        run();
+      }, 250);
+      scheduled = {
+        bytes,
+        cancel: () => {
+          cancelAnimationFrame(raf);
+          if (timer !== null) clearTimeout(timer);
+          if (fallback !== null) clearTimeout(fallback);
+        },
+      };
+      hooks.scheduled();
+    },
+
+    cancel,
+
+    flush() {
+      const bytes = cancel();
+      if (bytes) hooks.mount(bytes);
+    },
+
+    isScheduled: () => scheduled !== null,
+  };
+}

--- a/packages/core/src/editor/docx-editor-open-scheduler.ts
+++ b/packages/core/src/editor/docx-editor-open-scheduler.ts
@@ -4,21 +4,68 @@
 // Opening a document parses, lays out and paints in one synchronous pass — seconds of
 // blocked main thread on a long file — and a mount that runs in the same task as
 // `load()`/`attach()` blocks the very frame that would have painted the host's loading
-// screen. Documents past {@link OPEN_PAINT_YIELD_BYTES} therefore schedule the mount
-// behind one painted frame, and `snapshot().isOpening` is true for exactly that window.
-// Small documents keep the synchronous path: they need no loading flash, and every
-// existing synchronous caller stays as it was. So does every environment without
-// `requestAnimationFrame` — headless and server hosts mount synchronously by definition.
+// screen. Documents past {@link OPEN_PAINT_YIELD_CONTENT_BYTES} of CONTENT therefore
+// schedule the mount behind one painted frame, and `snapshot().isOpening` is true for
+// exactly that window. Small documents keep the synchronous path: they need no loading
+// flash, and every existing synchronous caller stays as it was. So does every
+// environment without `requestAnimationFrame` — headless and server hosts mount
+// synchronously by definition.
 
 /**
- * The size past which an open earns a painted loading frame before the blocking mount.
+ * The UNCOMPRESSED size past which an open earns a painted loading frame first.
  *
- * Zipped size is the only cheap proxy for mount cost. Documents under this mount well
- * inside one frame's budget on current hardware, so deferring them would buy nothing
- * and flash a loading screen; documents over it are the ones whose synchronous mount
- * visibly freezes the page they were opened from.
+ * Mount cost tracks the content, and the zipped size lies about it: a 200-page
+ * tracked-changes document is ~1.6 MB of XML but zips under 90 KiB, while WordprocessingML
+ * routinely compresses 10–20×. So the threshold reads the true entry sizes from the ZIP
+ * central directory (see {@link zipContentExceeds} — a bounded scan, no decompression).
+ * Documents under this mount well inside a frame or two on current hardware; over it,
+ * the synchronous mount visibly freezes the page the document was opened from.
  */
-const OPEN_PAINT_YIELD_BYTES = 128 * 1024;
+const OPEN_PAINT_YIELD_CONTENT_BYTES = 512 * 1024;
+
+/**
+ * Whether the ZIP's entries sum past `limit` uncompressed — WITHOUT inflating anything.
+ * The central directory records every entry's uncompressed size; walking it costs
+ * microseconds on any real document.
+ *
+ * Attacker-controlled input rules (the bytes come straight from a file): the entry
+ * count is a bounded uint16, the walk advances monotonically and bounds-checks every
+ * read, the sizes are only summed and compared — never fed to an allocation — and the
+ * sum exits early at the limit, so a forged huge size simply means "defer", which the
+ * real parser then judges. Anything malformed answers `false` and the open proceeds on
+ * the synchronous path, where the parser reports the actual error.
+ */
+function zipContentExceeds(bytes: Uint8Array, limit: number): boolean {
+  const length = bytes.byteLength;
+  if (length < 22) return false;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, length);
+  // End-of-central-directory: signature PK\x05\x06, at most 64 KiB of trailing comment.
+  const scanFloor = Math.max(0, length - (64 * 1024 + 22));
+  let eocd = -1;
+  for (let at = length - 22; at >= scanFloor; at -= 1) {
+    if (view.getUint32(at, true) === 0x06054b50) {
+      eocd = at;
+      break;
+    }
+  }
+  if (eocd < 0) return false;
+  const entryCount = view.getUint16(eocd + 10, true);
+  let offset = view.getUint32(eocd + 16, true);
+  let total = 0;
+  for (let entry = 0; entry < entryCount; entry += 1) {
+    if (offset + 46 > length) return false;
+    if (view.getUint32(offset, true) !== 0x02014b50) return false;
+    // A ZIP64 sentinel (0xFFFFFFFF) sums as huge and exits below: correct — it IS huge.
+    total += view.getUint32(offset + 24, true);
+    if (total >= limit) return true;
+    offset +=
+      46 +
+      view.getUint16(offset + 28, true) +
+      view.getUint16(offset + 30, true) +
+      view.getUint16(offset + 32, true);
+  }
+  return false;
+}
 
 /** What the facade hands the scheduler; both close over facade-owned state. */
 export interface OpenSchedulerHooks {
@@ -58,10 +105,13 @@ export function createOpenScheduler(hooks: OpenSchedulerHooks): OpenScheduler {
   };
 
   return {
+    // The zipped size is a shortcut, not the measure: a file already past the limit
+    // zipped cannot be under it unpacked in any way that mounts fast.
     shouldYield: (bytes) =>
-      bytes.byteLength >= OPEN_PAINT_YIELD_BYTES &&
       typeof requestAnimationFrame === 'function' &&
-      typeof cancelAnimationFrame === 'function',
+      typeof cancelAnimationFrame === 'function' &&
+      (bytes.byteLength >= OPEN_PAINT_YIELD_CONTENT_BYTES ||
+        zipContentExceeds(bytes, OPEN_PAINT_YIELD_CONTENT_BYTES)),
 
     // `requestAnimationFrame` fires BEFORE the pending paint, so the heavy work goes
     // into a task queued from inside it — the first slot guaranteed to run after the

--- a/packages/core/src/editor/docx-editor-support.ts
+++ b/packages/core/src/editor/docx-editor-support.ts
@@ -835,6 +835,7 @@ export function snapshotsEqual(a: EditorSnapshot, b: EditorSnapshot): boolean {
   return (
     a.scope === b.scope &&
     a.isLoading === b.isLoading &&
+    a.isOpening === b.isOpening &&
     a.parseError === b.parseError &&
     a.editable === b.editable &&
     a.zoom === b.zoom &&

--- a/packages/core/src/editor/docx-editor-support.ts
+++ b/packages/core/src/editor/docx-editor-support.ts
@@ -827,6 +827,22 @@ export function docRangeEqual(a: DocRange | null, b: DocRange | null): boolean {
 }
 
 /**
+ * A reference-stable cache for the right-click TOC context.
+ *
+ * A fresh object per derivation would make {@link snapshotsEqual} report every tick as
+ * a change and hand every subscriber a new snapshot, which is the opposite of what the
+ * snapshot cache is for. The id is the only value, so one object per id is enough.
+ */
+export function createTocContextCache(): (id: string | null) => { readonly id: string } | null {
+  let cached: { readonly id: string } | null = null;
+  return (id) => {
+    if (id === null) cached = null;
+    else if (cached?.id !== id) cached = Object.freeze({ id });
+    return cached;
+  };
+}
+
+/**
  * Whether two snapshots are value-equal AFTER sub-object reuse — i.e. every field can be
  * compared by reference or primitive. When true, the previous snapshot object itself is
  * kept, so `snapshot()` returns the same reference across ticks that changed nothing.

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -97,6 +97,7 @@ import {
   classifyCommand,
   deepFreezeValue,
   docRangeEqual,
+  createTocContextCache,
   editorError,
   formattingEqual,
   normalizeSource,
@@ -950,19 +951,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     }
   }
 
-  /**
-   * The right-click TOC context, reference-stable while the id holds.
-   *
-   * A fresh object per derivation would make `snapshotsEqual` report every tick as a change
-   * and hand every subscriber a new snapshot, which is the opposite of what the cache is
-   * for. The id is the only value, so one object per id is enough.
-   */
-  let cachedTocContext: { readonly id: string } | null = null;
-  function tocContextOf(id: string | null): { readonly id: string } | null {
-    if (id === null) cachedTocContext = null;
-    else if (cachedTocContext?.id !== id) cachedTocContext = Object.freeze({ id });
-    return cachedTocContext;
-  }
+  /** The right-click TOC context, reference-stable while the id holds — see support. */
+  const tocContextOf = createTocContextCache();
 
   function deriveSnapshot(): EditorSnapshot {
     const state = surface?.state() ?? null;
@@ -2530,12 +2520,17 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     getCurrentPage: (mode) => currentPageOf(surface, mode),
 
     // Page NUMBERS are 1-based in this contract; the layout indexes from 0.
-    scrollToPage: (pageNumber: number) =>
-      Number.isInteger(pageNumber) && pageNumber >= 1
-        ? (surface?.revealPage(pageNumber - 1) ?? false)
-        : false,
+    scrollToPage: (pageNumber: number) => {
+      if (!Number.isInteger(pageNumber) || pageNumber < 1) return false;
+      // A scroll aimed into the open's yield window addresses the just-loaded document:
+      // mount it now, or the call would silently report "no such page".
+      openScheduler.flush();
+      return surface?.revealPage(pageNumber - 1) ?? false;
+    },
     scrollToBlock: (blockId: string) => {
       if (typeof blockId !== 'string' || blockId.length === 0) return false;
+      // Same yield-window rule as `scrollToPage`.
+      openScheduler.flush();
       // Revealing a body block is a move OUT of an open header or note: the outline and the
       // search pane both drive this, and leaving the scope on the furniture left the reader
       // looking at the body with every keystroke going to a story off screen.
@@ -2556,6 +2551,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     },
 
     focus(scope?: EditorScope) {
+      // Same yield-window rule as `exec`: focusing the just-loaded document mounts it.
+      openScheduler.flush();
       if (!surface) {
         return { ok: false, code: 'invalidTarget', reason: 'no document is loaded' };
       }

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -114,6 +114,7 @@ import {
   type LocaleStrings,
 } from '@docx-editor.dev/i18n';
 import { execEditorCommand } from './docx-editor-exec.ts';
+import { createOpenScheduler } from './docx-editor-open-scheduler.ts';
 import {
   customNodeDiagnosticReporter,
   sweepCustomNodePayloadsOnOpen,
@@ -241,6 +242,15 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   const reviewEnabled = modules.review !== null;
   /** Document bytes waiting for a container — set when constructed or loaded detached. */
   let pendingBytes: Uint8Array | null = null;
+  /** A big document's mount, deferred behind one painted frame so a loading screen can
+   *  show — `snapshot().isOpening` holds for that window. See `docx-editor-open-scheduler.ts`. */
+  const openScheduler = createOpenScheduler({
+    mount: (bytes) => mountBytes(bytes),
+    scheduled: () => {
+      bump();
+      emitSelectionChange();
+    },
+  });
   /**
    * How edits are written. `mode: 'view'` at construction opens in viewing; everything else
    * opens in editing, and the toolbar moves between all three. Declared here because the
@@ -619,6 +629,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
 
   /** A NEW document: forget the previous document's measurer, then mount. */
   function loadBytes(bytes: Uint8Array): void {
+    // A load supersedes any open still waiting on its frame: drop the superseded bytes.
+    openScheduler.cancel();
     loadSeq += 1;
     shapedMeasurer = undefined;
     shapedProducer = undefined;
@@ -643,7 +655,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         scroller.scrollLeft = 0;
       }
     }
-    mountBytes(bytes);
+    // A big document into a live container yields one painted frame first. Detached
+    // loads only stash bytes; the later `attach` decides whether the mount earns a yield.
+    if (container && openScheduler.shouldYield(bytes)) openScheduler.schedule(bytes);
+    else mountBytes(bytes);
   }
 
   function reportFontError(error: EditorFontError): void {
@@ -964,7 +979,16 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // painted would deadlock — nothing paints until Content mounts, and Content never
       // mounts while the flag is set. A parse failure clears it too; a document that
       // cannot open is not still arriving, and `parseError` is how that is reported.
-      isLoading: parseError === null && surface === null && pendingBytes === null,
+      // A scheduled open counts as "bytes handed over" too, or a host gating its mount
+      // point on this flag would unmount the container the scheduled mount needs.
+      isLoading:
+        parseError === null &&
+        surface === null &&
+        pendingBytes === null &&
+        !openScheduler.isScheduled(),
+      // A supplied document on its way to painted pages. OVERLAY state only — gate
+      // chrome on it, never the mount point; `isLoading` remains the gate-safe flag.
+      isOpening: openScheduler.isScheduled(),
       parseError,
       // The LIVE mode, not only the construction-time one: hosts gate their chrome on this,
       // and it read `true` while every command was being refused with `locked`.
@@ -1766,6 +1790,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         pendingBytes = surface.session.save();
         teardownSurface();
       }
+      // A scheduled open was aimed at the PREVIOUS container — and being the newer
+      // document, it outranks any bytes saved off the old surface.
+      const reclaimed = openScheduler.cancel();
+      if (reclaimed) pendingBytes = reclaimed;
       // BEFORE the container moves, unconditionally. The observer is on a scroller found
       // through the OLD container, and only the successful-mount path below re-targets it: a
       // load that failed to parse leaves no surface and no pending bytes, so attaching to a
@@ -1778,8 +1806,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       localFontProbe = null;
       const bytes = pendingBytes;
       pendingBytes = null;
-      // A mount bumps the tick and emits change/selectionChange itself.
-      if (bytes) mountBytes(bytes);
+      // A mount bumps the tick and emits change/selectionChange itself. A big document
+      // yields one painted frame first, instead of freezing the commit the attach ran in.
+      if (bytes && openScheduler.shouldYield(bytes)) openScheduler.schedule(bytes);
+      else if (bytes) mountBytes(bytes);
       else bump();
     },
 
@@ -1788,11 +1818,15 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // Before the container goes: the observer is on an element found THROUGH it, and one
       // left running would keep re-fitting a document that is no longer mounted.
       zoomLane.detach();
+      // Reclaimed before the surface save, applied after: the scheduled document is
+      // the newer one, so it wins the pending slot.
+      const reclaimed = openScheduler.cancel();
       if (surface) {
         surface.flushPendingInput();
         pendingBytes = surface.session.save();
         teardownSurface();
       }
+      if (reclaimed) pendingBytes = reclaimed;
       container = null;
       localFontProbe = null;
       bump();
@@ -1812,6 +1846,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     },
 
     save() {
+      // A save inside the open's yield window sees the just-loaded document: mount now.
+      openScheduler.flush();
       if (!surface) return Promise.reject(editorError('notFound', 'no document is loaded'));
       // Ctrl+S can race a typing burst: queued keystrokes belong in the bytes.
       surface.flushPendingInput();
@@ -1827,6 +1863,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     },
 
     exec(command, options) {
+      // A command inside the yield window addresses the just-loaded document: mount now.
+      // (`can` does NOT flush — chrome polls it per render; a read must not defeat the yield.)
+      openScheduler.flush();
       // A view command: it edits nothing, so it runs before the document gate, and it works
       // on a document that failed to open — the pane is still the reader's to close. Not on a
       // DESTROYED editor, though: there is no reader left.
@@ -2033,6 +2072,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // selecting, because moving the caret does not move the viewport: a match twenty pages
     // down would otherwise be selected where nobody could see it.
     selectMatch(match: TextMatch): ExecResult {
+      // Same rule as `exec`: a selection aimed into the yield window lands, not refuses.
+      openScheduler.flush();
       if (!surface) {
         return { ok: false, code: 'notFound', reason: 'no document is loaded' };
       }
@@ -2534,6 +2575,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
 
     destroy() {
       destroyed = true;
+      openScheduler.cancel();
       zoomLane.detach();
       disposeEmbeddedFaces();
       teardownSurface();

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4527,6 +4527,35 @@ a.docx-hyperlink:focus-visible {
   font-size: 14px;
 }
 
+/* The overlay variant (`<DocxEditor.Loading overlay />`): pinned over the nearest
+   positioned ancestor — the workspace row in the packaged frame — and opaque, so it
+   covers the previous document while the next one opens. The 150ms appearance delay
+   keeps an open that finishes inside a few frames from flashing a spinner.
+
+   The fade MUST be a real compositor animation. The engine paints exactly one frame
+   (overlay committed, still in its delay) and then blocks the main thread with the
+   mount — so only the compositor can bring the overlay in. A non-zero opacity
+   animation on a `will-change: opacity` layer runs compositor-side through the block;
+   a zero-duration delay trick would be a main-thread style jump and never show. */
+.docx-editor__loading--overlay {
+  position: absolute;
+  inset: 0;
+  z-index: var(--doc-z-overlay);
+  background: var(--doc-bg);
+  will-change: opacity;
+  animation: docx-editor-loading-appear 0.2s linear 0.15s backwards;
+}
+
+@keyframes docx-editor-loading-appear {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 /* The default screen when the host supplies no children.
    `display` and `box-sizing` are explicit rather than inherited from Tailwind's
    preflight: the part emits its own `docx-editor`, so it can be composed somewhere the
@@ -4540,6 +4569,9 @@ a.docx-hyperlink:focus-visible {
   border: 3px solid var(--doc-border);
   border-top-color: var(--doc-primary);
   border-radius: 50%;
+  /* Layer-promoted so the rotation runs on the compositor: while a big document
+     mounts, the main thread is blocked and only a composited animation still moves. */
+  will-change: transform;
   animation: docx-editor-loading-spin 0.8s linear infinite;
 }
 

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -375,6 +375,12 @@ const DocxEditorFrame = forwardRef<DocxEditorRef, DocxEditorProps>(
           <PageNumberTranslationContext.Provider value={translate}>
             <DocxEditorPageNumber />
           </PageNumberTranslationContext.Provider>
+          {/* The packaged loading screen, pinned over the workspace (this row is the
+            positioned ancestor). It shows before a document arrives AND while a large
+            one opens — the engine mounts big files behind one painted frame so this
+            overlay can paint instead of the page freezing — and renders nothing
+            otherwise, so it costs the loaded editor nothing. */}
+          <DocxEditorLoading overlay />
         </div>
       </div>
     ) : (

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -5,12 +5,18 @@
 // whether a document is ready. Renders nothing once loading ends — it is a conditional
 // wrapper, not a container that stays in the tree.
 //
-// THE CONDITION IS `isLoading`, which the facade defines as "no document handed over
+// THE CONDITION IS `isLoading || isOpening`. `isLoading` is "no document handed over
 // yet, and nothing went wrong" — NOT "nothing painted". That distinction is what makes
-// this part safe to gate a `DocxEditor.Content` on: a definition keyed on painted pages
+// `isLoading` safe to gate a `DocxEditor.Content` on: a definition keyed on painted pages
 // would deadlock, since nothing paints until Content mounts and Content would never
 // mount while the screen is up. It also means a host that unmounts its viewport does not
 // get the loading screen back over a document that is still loaded.
+//
+// `isOpening` is the second half: a LARGE document mounts behind one painted frame (the
+// engine yields so this very screen can paint before the blocking parse+layout), and
+// `isOpening` holds for exactly that window. It is OVERLAY state — this part shows for
+// it, but a host hand-gating its own mount point must key that on `isLoading` alone,
+// because the scheduled mount needs the mount point to stay in the tree.
 //
 // `when` ORs in what the editor cannot see: the host's own async, the fetch of the DOCX
 // bytes and of font faces. It is optional — the default already covers a `Root` mounted
@@ -29,9 +35,10 @@ import { useEditorState } from './useEditorState';
 /**
  * A scalar slice on purpose: `useEditorState` bails out on `Object.is`, so this part
  * re-renders only when the answer actually flips — not on every keystroke that bumps the
- * snapshot.
+ * snapshot. `isOpening` is optional and additive in the contract; absent reads `false`.
  */
-const selectIsLoading = (snapshot: EditorSnapshot) => snapshot.isLoading;
+const selectShowLoading = (snapshot: EditorSnapshot) =>
+  snapshot.isLoading || snapshot.isOpening === true;
 
 /** Props for `DocxEditor.Loading`. @public */
 export interface DocxEditorLoadingProps {
@@ -43,6 +50,16 @@ export interface DocxEditorLoadingProps {
    * provider only after those resolve.
    */
   when?: boolean;
+  /**
+   * Render as an opaque overlay pinned over the nearest positioned ancestor, covering
+   * the previous document while the next one opens. This is the shape for the big-file
+   * case: a large document mounts behind one painted frame, and the overlay is what
+   * that frame shows. It carries a short appearance delay, so an open that finishes
+   * quickly never flashes it. Compose it INSIDE a positioned box (the packaged frame
+   * puts it in the workspace row); without `overlay` the part is an in-flow box that
+   * fills whatever the host gives it.
+   */
+  overlay?: boolean;
   /** Appended after the load-bearing `docx-editor docx-editor__loading` classes. */
   className?: string;
   /** Inline styles for the loading container, as on `DocxEditor.Viewport`. */
@@ -82,21 +99,20 @@ export function DocxEditorLoadingSpinner({ className }: DocxEditorLoadingSpinner
 
 function DocxEditorLoadingImpl({
   when = false,
+  overlay = false,
   className,
   style,
   children,
 }: DocxEditorLoadingProps) {
-  const isLoading = useEditorState(selectIsLoading);
+  const showLoading = useEditorState(selectShowLoading);
   const { t } = useTranslation();
-  if (!when && !isLoading) return null;
+  if (!when && !showLoading) return null;
 
+  const classes = `docx-editor docx-editor__loading${
+    overlay ? ' docx-editor__loading--overlay' : ''
+  }${className ? ` ${className}` : ''}`;
   return (
-    <div
-      className={`docx-editor docx-editor__loading${className ? ` ${className}` : ''}`}
-      style={style}
-      role="status"
-      aria-live="polite"
-    >
+    <div className={classes} style={style} role="status" aria-live="polite">
       {children ?? (
         <>
           <DocxEditorLoadingSpinner />
@@ -136,11 +152,17 @@ export interface DocxEditorLoadingComponent {
  * </DocxEditor.Root>
  * ```
  *
- * It clears as soon as bytes are handed over — NOT when pages finish painting — so it is
- * safe to gate a `DocxEditor.Content` on, and an unmounted viewport does not bring it
- * back. A parse failure clears it too, so a broken document never spins forever; report
- * that from `snapshot().parseError` or the `error` event. Add `when` only for async the
- * editor cannot observe, typically a host that mounts the provider after its own fetch.
+ * It covers TWO windows. Before bytes arrive it is the empty-state screen. And while a
+ * LARGE document opens — the engine mounts it behind one painted frame precisely so this
+ * screen can paint before the blocking parse and layout — it holds until the pages land;
+ * pass `overlay` to pin it over the previous document for that window. A parse failure
+ * clears both, so a broken document never spins forever; report that from
+ * `snapshot().parseError` or the `error` event. Add `when` only for async the editor
+ * cannot observe, typically a host that mounts the provider after its own fetch.
+ *
+ * A host gating its own `DocxEditor.Content` must key that on `snapshot().isLoading`,
+ * which clears as soon as bytes are handed over — never on `isOpening`, whose scheduled
+ * mount needs the mount point to stay in the tree.
  *
  * Rendered OUTSIDE a `DocxEditor.Root` it always shows, because there is no editor to
  * report otherwise — the same rule `useEditorState` documents for a null editor. Place

--- a/packages/react/src/editor/DocxEditorRoot.tsx
+++ b/packages/react/src/editor/DocxEditorRoot.tsx
@@ -92,7 +92,9 @@ export interface DocxEditorRootProps {
    */
   zoomMode?: ZoomMode | 'auto';
   /** Fired once per instance, after it is published to the tree (and after any
-   *  `DocxEditor.Content` in the same commit has attached its mount point). */
+   *  `DocxEditor.Content` in the same commit has attached its mount point). A large
+   *  document mounts behind one painted frame; `onReady` fires AFTER that mount lands,
+   *  so scrolling or selecting from it works on any document size. */
   onReady?: (editor: Editor) => void;
   /** Fired when the document changes (revision + identity deltas, not bytes). */
   onChange?: (change: DocumentChange) => void;
@@ -183,9 +185,23 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
 
   // Fired AFTER the instance is published: this effect runs in the commit that rendered
   // the new editor, after child layout effects — so a `DocxEditor.Content` in the tree
-  // has already attached and `onReady` observes a mounted document.
+  // has already attached. A SMALL document is mounted by then and `onReady` observes it
+  // directly. A LARGE one is still behind the engine's open yield (`isOpening`), so the
+  // callback waits for the mount's own `change` — the first and only event that can fire
+  // inside that window — and then observes a real document too: `onReady` scrolling to a
+  // page or selecting a range works on any document size.
   useEffect(() => {
-    if (editor) propsRef.current.onReady?.(editor);
+    if (!editor) return undefined;
+    if (!editor.snapshot().isOpening) {
+      propsRef.current.onReady?.(editor);
+      return undefined;
+    }
+    const off = editor.on('change', () => {
+      off();
+      propsRef.current.onReady?.(editor);
+    });
+    // Unsubscribe is idempotent, so the self-removal above and this cleanup can both run.
+    return off;
   }, [editor]);
 
   // Zoom is a facade parameter, not a remount: tearing the editor down for a zoom

--- a/packages/react/src/editor/loading-snapshot.ts
+++ b/packages/react/src/editor/loading-snapshot.ts
@@ -13,6 +13,7 @@ import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 export const LOADING_SNAPSHOT: EditorSnapshot = Object.freeze({
   scope: Object.freeze({ kind: 'body' as const }),
   isLoading: true,
+  isOpening: false,
   parseError: null,
   editable: false,
   zoom: 1,

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -17,7 +17,7 @@ import './dom-setup.ts';
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { renderToString } from 'react-dom/server';
-import { cleanup, render } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
 import { DocxEditor } from '../src/components/DocxEditor.tsx';
 import { DocxEditorLoading } from '../src/editor/DocxEditorLoading.tsx';
@@ -49,6 +49,41 @@ function docx(body: string): Uint8Array {
 }
 
 const SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
+
+/**
+ * Deterministic high-entropy bytes (xorshift32): deflate cannot compress them, so a
+ * filler part pushes the ZIP past the engine's 128 KiB open-yield threshold without a
+ * body big enough to slow the test's mount down.
+ */
+function incompressible(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  let state = 0x9e3779b9;
+  for (let i = 0; i < length; i += 1) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    bytes[i] = state & 0xff;
+  }
+  return bytes;
+}
+
+/** Past the yield threshold: the engine mounts this one behind a painted frame. */
+const LARGE_SOURCE = zipSync({
+  '[Content_Types].xml': strToU8(
+    `<Types xmlns="${CT}">` +
+      '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+      '<Default Extension="bin" ContentType="application/octet-stream"/>' +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+      '</Types>'
+  ),
+  '_rels/.rels': strToU8(
+    `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+  ),
+  'word/document.xml': strToU8(
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>large body</w:t></w:r></w:p></w:body></w:document>`
+  ),
+  'word/media/filler.bin': incompressible(192 * 1024),
+});
 
 const LOADING = '.docx-editor__loading';
 const SPINNER = '.docx-editor__loading-spinner';
@@ -224,6 +259,43 @@ describe('DocxEditor.Loading', () => {
     expect(view.container.querySelector(LOADING)).toBeNull();
   });
 
+  test('a LARGE document holds the screen through the open yield, then yields to pages', async () => {
+    // The engine mounts a document past its yield threshold behind one painted frame,
+    // so a frozen page becomes a visible loading screen. `isOpening` is what this part
+    // reads for that window; no condition is wired up by the host.
+    const view = render(
+      <DocxEditorRoot document={LARGE_SOURCE}>
+        <DocxEditorLoading>
+          <span>opening…</span>
+        </DocxEditorLoading>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+
+    // The store notification is deferred to a microtask; flush it.
+    await act(async () => {});
+    expect(view.container.querySelector(LOADING)).not.toBeNull();
+    expect(view.container.textContent).not.toContain('large body');
+
+    await waitFor(() => {
+      expect(view.container.textContent).toContain('large body');
+    });
+    await waitFor(() => {
+      expect(view.container.querySelector(LOADING)).toBeNull();
+    });
+  });
+
+  test('overlay renders the pinned variant, className still appended last', () => {
+    const view = render(<DocxEditorLoading when overlay className="demo-overlay" />);
+    const el = view.container.querySelector(LOADING)!;
+
+    expect(el.className).toBe(
+      'docx-editor docx-editor__loading docx-editor__loading--overlay demo-overlay'
+    );
+  });
+
   test('renders the packaged spinner when the host supplies no children', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
@@ -267,9 +339,7 @@ describe('DocxEditor.Loading', () => {
 
   test('accepts style, as the other container-shaped parts do', () => {
     const view = render(<DocxEditorLoading when style={{ minHeight: '240px' }} />);
-    expect(
-      (view.container.querySelector(LOADING) as HTMLElement).style.minHeight
-    ).toBe('240px');
+    expect((view.container.querySelector(LOADING) as HTMLElement).style.minHeight).toBe('240px');
   });
 
   test('host children replace the spinner rather than sitting beside it', () => {

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -51,23 +51,25 @@ function docx(body: string): Uint8Array {
 const SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
 
 /**
- * Deterministic high-entropy bytes (xorshift32): deflate cannot compress them, so a
- * filler part pushes the ZIP past the engine's 128 KiB open-yield threshold without a
- * body big enough to slow the test's mount down.
+ * ~`length` bytes of numbered text: zips well like real WordprocessingML while staying
+ * far under the zip-bomb ratio cap the parse enforces (zero-fill would be refused).
  */
-function incompressible(length: number): Uint8Array {
-  const bytes = new Uint8Array(length);
-  let state = 0x9e3779b9;
-  for (let i = 0; i < length; i += 1) {
-    state ^= state << 13;
-    state ^= state >>> 17;
-    state ^= state << 5;
-    bytes[i] = state & 0xff;
+function compressibleText(length: number): Uint8Array {
+  const lines: string[] = [];
+  let total = 0;
+  for (let line = 1; total < length; line += 1) {
+    const text = `filler line ${line} carrying a little ordinary sentence text.\n`;
+    lines.push(text);
+    total += text.length;
   }
-  return bytes;
+  return strToU8(lines.join('').slice(0, length));
 }
 
-/** Past the yield threshold: the engine mounts this one behind a painted frame. */
+/**
+ * Past the engine's open-yield threshold by UNCOMPRESSED content while zipping small:
+ * the engine mounts this one behind a painted frame, exactly as it does a long text
+ * document that zips under any zipped-size threshold.
+ */
 const LARGE_SOURCE = zipSync({
   '[Content_Types].xml': strToU8(
     `<Types xmlns="${CT}">` +
@@ -82,7 +84,7 @@ const LARGE_SOURCE = zipSync({
   'word/document.xml': strToU8(
     `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>large body</w:t></w:r></w:p></w:body></w:document>`
   ),
-  'word/media/filler.bin': incompressible(192 * 1024),
+  'word/media/filler.bin': compressibleText(1024 * 1024),
 });
 
 const LOADING = '.docx-editor__loading';
@@ -285,6 +287,31 @@ describe('DocxEditor.Loading', () => {
     await waitFor(() => {
       expect(view.container.querySelector(LOADING)).toBeNull();
     });
+  });
+
+  test('onReady waits for a LARGE document to mount, so it can scroll a real document', async () => {
+    // The engine opens big files behind one painted frame. A host that scrolls or
+    // selects from onReady must observe the mounted document, not the yield window.
+    const readings: number[] = [];
+    render(
+      <DocxEditorRoot
+        document={LARGE_SOURCE}
+        onReady={(editor) => readings.push(editor.getTotalPages())}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+
+    await act(async () => {});
+    expect(readings).toHaveLength(0);
+
+    await waitFor(() => {
+      expect(readings.length).toBeGreaterThan(0);
+    });
+    expect(readings).toHaveLength(1);
+    expect(readings[0]).toBeGreaterThan(0);
   });
 
   test('overlay renders the pinned variant, className still appended last', () => {

--- a/packages/vue/src/DocxEditor.ts
+++ b/packages/vue/src/DocxEditor.ts
@@ -33,6 +33,7 @@ import type { DocxEditorRef, EditorMode } from './types';
 const PRE_MOUNT_SNAPSHOT: EditorSnapshot = {
   scope: { kind: 'body' },
   isLoading: true,
+  isOpening: false,
   parseError: null,
   editable: false,
   zoom: 1,


### PR DESCRIPTION
Opening a big document froze the page with no feedback: the whole parse + layout + paint ran synchronously in the same task as `load()`/`attach()`, so the browser never painted a frame the loading screen could appear in. Documents past 512 KiB of UNCOMPRESSED content (read from the ZIP central directory without decompressing — zipped size lies about text-heavy files, which compress 10–20x) now mount behind one painted frame. `snapshot().isOpening` reports that window, `DocxEditor.Loading` (new `overlay` variant, mounted by default in the packaged frame and the vite demo) covers it with zero host wiring, and `DocxEditor.Root` fires `onReady` after the deferred mount lands so scrolling or selecting from it works on any document size. The overlay fade and spinner are compositor animations because the main thread is blocked while it shows.