### PR TITLE
feat(core): merge the paragraphs a resolved view has already merged

### DIFF
--- a/.changeset/paragraph-mark-card-direction.md
+++ b/.changeset/paragraph-mark-card-direction.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+A review card for a paragraph break now says which change it is. A deleted break read as "Inserted paragraph break", which is the reverse of what accepting that card does, and both halves of a moved paragraph read the same way.

--- a/.changeset/resolved-view-paragraph-merge.md
+++ b/.changeset/resolved-view-paragraph-merge.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-The resolved display modes now merge the paragraphs their decisions merge: a paragraph whose mark a tracked change deleted runs into the next one in the final view, as it does in Word and as accepting the change already did. Accepting a run of deleted paragraph marks also collapses them into one paragraph rather than into pairs.
+The resolved display modes now merge the paragraphs their decisions merge, in the body, in table cells, and in headers and footers: a paragraph whose mark a tracked change deleted runs into the next one in the final view, as it does in Word and as accepting the change already did. Accepting a run of deleted paragraph marks also collapses them into one paragraph rather than into pairs, and no longer carries content past a table or a content control.

--- a/.changeset/resolved-view-paragraph-merge.md
+++ b/.changeset/resolved-view-paragraph-merge.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+The resolved display modes now merge the paragraphs their decisions merge: a paragraph whose mark a tracked change deleted runs into the next one in the final view, as it does in Word and as accepting the change already did. Accepting a run of deleted paragraph marks also collapses them into one paragraph rather than into pairs.

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -1528,6 +1528,7 @@ export interface ReviewRevisionItem {
     readonly id: string;
     // (undocumented)
     readonly kind: 'revision';
+    readonly markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
     readonly nesting: number;
     readonly pairedWith?: string;
     readonly ranges: readonly ReviewRange[];

--- a/docs/api/docx-editor-core/contracts-modules.api.md
+++ b/docs/api/docx-editor-core/contracts-modules.api.md
@@ -146,6 +146,7 @@ export interface ReviewRevisionItem {
     readonly id: string;
     // (undocumented)
     readonly kind: 'revision';
+    readonly markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
     readonly nesting: number;
     readonly pairedWith?: string;
     readonly ranges: readonly ReviewRange[];

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -2282,6 +2282,7 @@ export interface ReviewRevisionItem {
     readonly id: string;
     // (undocumented)
     readonly kind: 'revision';
+    readonly markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
     readonly nesting: number;
     readonly pairedWith?: string;
     readonly ranges: readonly ReviewRange[];

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -18,6 +18,9 @@ export interface AbstractNumDefinition {
 export function activeReviewItem(items: readonly ReviewItem[], position: ReviewPosition, order: ReadonlyMap<string, number>): ReviewItem | null;
 
 // @public
+export function anchorLineY(anchor: ReviewParagraphAnchor, paragraphId: string, offset: number): number;
+
+// @public
 export function appliedSpaceBefore(before: number, previousAfter: number, atTopOfPage: boolean, firstParagraphOfSection: boolean): number;
 
 // @public
@@ -2198,6 +2201,7 @@ export function reviewAnchorIndex<TPage extends {
         readonly spans?: readonly {
             readonly range: {
                 readonly paragraphId: string;
+                readonly end: number;
             };
         }[];
     }[];
@@ -2288,6 +2292,12 @@ export interface ReviewParagraphAnchor {
         readonly box: {
             readonly y: number;
         };
+        readonly spans?: readonly {
+            readonly range: {
+                readonly paragraphId: string;
+                readonly end: number;
+            };
+        }[];
     }[];
     // (undocumented)
     readonly pageIndex: number;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -171,7 +171,10 @@ export interface CaretAtOptions {
 }
 
 // @public
-export function caretBoxOnLine(line: LineRecord, offset: number, measurer: TextMeasurer | undefined): {
+export function caretBoxOnLine(line: LineRecord, offset: number, measurer: TextMeasurer | undefined, segment?: {
+    readonly spans: readonly StyleSpanRecord[];
+    readonly drawings: readonly InlineDrawingRecord[];
+} | null): {
     x: number;
     y: number;
     height: number;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2322,6 +2322,7 @@ export interface ReviewRevisionItem {
     readonly id: string;
     // (undocumented)
     readonly kind: 'revision';
+    readonly markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
     readonly nesting: number;
     readonly pairedWith?: string;
     readonly ranges: readonly ReviewRange[];

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2195,6 +2195,11 @@ export function reviewAnchorIndex<TPage extends {
         readonly box: {
             readonly y: number;
         };
+        readonly spans?: readonly {
+            readonly range: {
+                readonly paragraphId: string;
+            };
+        }[];
     }[];
 }[]): Map<string, ReviewParagraphAnchor>;
 

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3369,6 +3369,7 @@ export interface ReviewRevisionItem {
     readonly id: string;
     // (undocumented)
     readonly kind: 'revision';
+    readonly markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
     readonly nesting: number;
     readonly pairedWith?: string;
     readonly ranges: readonly ReviewRange[];

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -62,9 +62,9 @@ The revision model covers more than inline text:
 All of these round-trip as real OOXML revisions, not editor-private state.
 
 Attribution is drawn in **All Markup** only, as Word draws it. The resolved views answer what
-the document would be once every decision is taken, so they show no colours, no pilcrows and no
-change bars — but they still show the paragraph break itself, rather than merging the two
-paragraphs the way accepting the change would.
+the document would be once every decision is taken, so they show no colors, no pilcrows, and no
+change bars. They also merge: a paragraph whose mark a change deleted runs into the next one in
+**No Markup**, the way accepting that change leaves it.
 
 ## The review sidebar
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -745,7 +745,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'A full revision model, including structural changes to paragraph breaks, paragraph properties, and table rows and cells. A change to a paragraph mark draws a pilcrow and a change bar wherever the paragraph is, table cells included, and a mark that one author inserted and another proposed removing carries both decisions. A tracked insert or delete around a field result paints as tracked, not as ordinary text. Attribution is drawn in All Markup only, as in Word; the resolved views drop the attribution but still show the paragraph break itself. The output opens cleanly in Word’s review pane.',
+      'A full revision model, including structural changes to paragraph breaks, paragraph properties, and table rows and cells. A change to a paragraph mark draws a pilcrow and a change bar wherever the paragraph is, table cells included, and a mark that one author inserted and another proposed removing carries both decisions. A tracked insert or delete around a field result paints as tracked, not as ordinary text. Attribution is drawn in All Markup only, as in Word. The resolved views drop the attribution and merge the paragraphs the decision merges, so No Markup shows the document as accepting every change would leave it. The output opens cleanly in Word’s review pane.',
     docsLink: '/docs/2.x/pro/tracked-changes',
   },
   {

--- a/openspec/changes/resolved-view-paragraph-merge/design.md
+++ b/openspec/changes/resolved-view-paragraph-merge/design.md
@@ -1,0 +1,50 @@
+# Design
+
+## What the spikes settled
+
+**The store's merge keeps the SURVIVOR's properties.** `rebuildChildren` in
+`tree-op-revisions.ts` carries the removed paragraph's content forward and prepends it to the
+next paragraph's children, keeping that paragraph's `w:pPr`: "the surviving mark is this
+paragraph's, so its properties govern the result." Layout must do the same or the two answers
+drift, and the differential oracle is what would catch it.
+
+**The interaction lane already keys on line identity, not fragment identity.**
+`paragraphLinesIndex` indexes `line.range.paragraphId`, and caret stops, hit testing and
+selection rectangles all read from that index. `fragment.paragraphId` is used in exactly one
+place, `documentOrder`. This is why a merged group can publish one fragment without breaking
+selection: what has to be right is the LINE and SPAN identity, and one field in document order.
+
+**A resolved view is EDITABLE.** `docx-editor.ts` puts the free engine in `proposed` by
+default. A merge that renumbered offsets into a compound paragraph would send every keystroke
+in the merged half to an offset the store does not have. Identity is therefore not a
+refinement of this change; it is the change.
+
+**No span can straddle a member boundary.** A span is a styled piece of ONE run, and two
+members contribute different runs, so the rewrite is a per-span remap and never a split.
+
+## The one hard part
+
+Layout does not use the store's offset authority. `piecesOfParagraph` runs its own walk with
+its own running offset, documented as aligned with `paragraphTextOf` and `segmentsOf` but not
+derived from it. A span records only `range`, `text` and `props` — it does not name the node it
+came from.
+
+So the member boundary cannot be assumed to equal the sum of the members'
+`paragraphOffsetIndex(...).length`. Two ways to bridge it:
+
+1. **Ask the walk.** `piecesOfParagraph` visits nodes in order and each piece knows its node.
+   Recording the offset of the piece whose node is the first node of member `k` gives the
+   boundary exactly, in the walk's own arithmetic, once per group per pass.
+2. **Name the node on the span.** Add a source-node reference to `StyleSpanRecord` and rewrite
+   through the store's `paragraphOffsetIndex`. Exact, and useful beyond this change, but it
+   widens a published record and every consumer of it.
+
+Take (1). It is contained to the layout lane, needs no record change, and it fails loudly:
+if the first node of a member never appears in the walk, there is no boundary and the group
+must refuse to merge rather than publish a compound offset.
+
+## What this change does NOT do
+
+It does not merge in `all-markup`, which is what the review module shows and where the break is
+a decision the reader is being asked about. It does not change the store: `resolveRevisions`
+already does this, and layout is catching up to it.

--- a/openspec/changes/resolved-view-paragraph-merge/proposal.md
+++ b/openspec/changes/resolved-view-paragraph-merge/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+A tracked change to a paragraph MARK is a change to a paragraph BREAK. `w:pPr/w:rPr/w:del` says the break was deleted, so accepting it runs the paragraph into the one after it; `w:pPr/w:rPr/w:ins` says the break was inserted, so rejecting it does the same. The store performs exactly that: `resolveRevisions` carries the content forward and keeps the survivor's `w:pPr`.
+
+Layout does not. `proposed` and `original` are specified as equal to accept-all and reject-all OUTPUT, and for every other revision kind they are — deleted runs vanish, inserted runs appear. The mark is the one exception: both modes still show the break. A document where an author pressed Enter with tracking on renders as two paragraphs in a view whose entire purpose is to answer what the document becomes.
+
+This is not a corner. `docx-editor.ts` puts the free engine in `proposed` BY DEFAULT — it is what every consumer without the review module sees — and that surface is fully editable. So the fix cannot be cosmetic. If two paragraphs are drawn as one, the characters of the second must still address the second paragraph in the live tree, or every click and keystroke in the merged half lands at an offset the store does not have.
+
+Until now the mark at least drew a coloured pilcrow in those modes, which hinted that the break was disputed. Suppressing that attribution was correct — Word draws it in All Markup only — and it removed the last hint, so the two modes now show a break that the document says is not there.
+
+## What Changes
+
+**Merge groups, computed where blocks are enumerated**
+
+- `storyBlocks(part, displayMode)` already drops a paragraph the mode removes entirely. It gains the other half: consecutive paragraphs where every member but the last has a mark the mode REMOVES become one merge group.
+- Removal is mode-dependent and reuses the predicate the paint lane uses. In `proposed`, `w:del` and `w:moveFrom` remove the mark. In `original`, `w:ins` and `w:moveTo` do. In `all-markup`, nothing does.
+- The last paragraph of a container never starts a group, matching the store's own guard: a merge with nothing to merge into would spill runs into `w:body`.
+
+**One synthetic paragraph per group**
+
+- The group lays out as a single paragraph carrying the SURVIVOR's `w:pPr` and every member's content in order — the same shape `resolveRevisions` builds, so the two answers cannot drift.
+- The synthetic node is memoized with the block list, so its identity is stable across passes and the paragraph break cache still hits.
+- Wrapping, list markers, borders, shading, page splits and cell flow need no changes: they see one paragraph, which is what the document means.
+
+**Identity stays with the source paragraph**
+
+- Every published span, line range and inline drawing keeps the paragraph id and the offsets of the member it came from. A span never spans two runs, and two members contribute different runs, so no span straddles a member boundary and the rewrite is a per-span remap with no splitting.
+- A line holding the join carries content from two paragraphs. `LineRecord.range` names the paragraph of its first span; consumers that resolve a POSITION read span identity instead.
+- `paragraphLinesIndex` indexes such a line under every paragraph its spans name, and caret stops for a paragraph consider only that paragraph's spans. Document order is taken from line identity rather than `fragment.paragraphId`, so a merged-away paragraph keeps its place in the order.
+
+**The oracle**
+
+- `proposed` output equals accept-all output, and `original` equals reject-all, compared as laid-out text per line. This is the existing differential harness; the mark cases are what it could not cover before.
+
+## Impact
+
+- Affected specs: `resolved-view-merge` (new).
+- Affected code: `layout/story-roots.ts`, `layout/revision-visibility.ts`, `layout/semantic-interaction.ts`, the fragment publish sites in `layout/semantic-layout.ts` and `layout/semantic-table-layout.ts`.
+- Editing is unaffected by construction: the store never sees a synthetic node, and every offset a surface reports names a live paragraph.
+- Rendering changes in `proposed` and `original` only. `all-markup` is untouched, and it is what the review module shows.

--- a/openspec/changes/resolved-view-paragraph-merge/specs/resolved-view-merge/spec.md
+++ b/openspec/changes/resolved-view-paragraph-merge/specs/resolved-view-merge/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: A resolved view merges the paragraphs its decisions merge
+
+Layout in `proposed` SHALL render a paragraph whose mark carries `w:del` or `w:moveFrom` as one paragraph with the block that follows it in the same container, and layout in `original` SHALL do the same for a mark carrying `w:ins` or `w:moveTo`. Layout in `all-markup` SHALL merge nothing. Consecutive removals SHALL form one group. A paragraph with no following paragraph in its container SHALL NOT merge, and SHALL keep its content and its box.
+
+The merged paragraph SHALL take the paragraph properties of the last member of the group, which is the paragraph whose mark survives, so that its indent, alignment, spacing, borders, shading and numbering are the ones `resolveRevisions` leaves behind.
+
+#### Scenario: A deleted mark runs the paragraph into the next one
+
+- **WHEN** a document holds `Hello ` in a paragraph whose mark carries `w:del`, followed by a paragraph holding `world`
+- **THEN** `proposed` lays out one paragraph reading `Hello world`
+- **AND** `all-markup` lays out two paragraphs and draws the struck pilcrow between them
+
+#### Scenario: An inserted mark is a split that Original never made
+
+- **WHEN** the same document instead carries `w:ins` on the first paragraph's mark
+- **THEN** `original` lays out one paragraph reading `Hello world`
+- **AND** `proposed` lays out two paragraphs
+
+#### Scenario: The survivor's formatting governs
+
+- **WHEN** a left-aligned paragraph whose mark is deleted precedes a right-aligned paragraph
+- **THEN** the merged paragraph is right-aligned, and it draws the following paragraph's list marker if it has one
+
+#### Scenario: A trailing paragraph has nothing to merge into
+
+- **WHEN** the last paragraph of a table cell has a deleted mark
+- **THEN** its content still renders, in its own box, and no content is dropped
+
+### Requirement: A merged paragraph still addresses the live tree
+
+Every span, line range and inline drawing a merge group publishes SHALL carry the paragraph id and the UTF-16 offsets of the member that contributed it, never those of the group. A line carrying content from more than one member SHALL be reachable from each of those paragraphs, and the caret stops of a paragraph SHALL be built from that paragraph's own spans alone. Document order SHALL keep every merged-away paragraph in its authored position.
+
+#### Scenario: Clicking either half lands in the paragraph that owns it
+
+- **WHEN** a reader clicks the word `world` on a merged line in `proposed`
+- **THEN** the resolved position names the second paragraph at the offset of `world` within it, not the first paragraph at a compound offset
+
+#### Scenario: Typing at the join edits the paragraph it belongs to
+
+- **WHEN** the caret sits at the end of the first member's text and a character is typed
+- **THEN** the character lands at the end of the FIRST paragraph in the tree, and the merged line re-renders with it
+
+#### Scenario: The two views agree with the two decisions
+
+- **WHEN** any document containing tracked paragraph marks is laid out in `proposed`
+- **THEN** the laid-out text per line equals the text of a layout of the same document after `acceptAllRevisions`
+- **AND** laying it out in `original` equals the text after `rejectAllRevisions`

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -159,13 +159,43 @@ mounted surface, caret and selection, the review rail, Accept All, and the save 
       `original` direction of a merge, nor cells, nor a block `w:sdt`, nor headers, footers or
       notes are in the fixture. Run the line-for-line assertion for `original` too, and add a
       fixture carrying `w:ins` marks, a mark in a cell and a mark inside a `w:sdt`
-- [ ] 7.11a A review item's id omits the part name, so a `w:id="1"` mark in the body and one
-      in a header share a key — the React key, the active card, the dismissed set. Pre-existing,
-      and reachable for the first time now that header marks are drawn
-- [ ] 7.11b Consumers a sweep flagged and nobody has run end to end: `surface-structure.ts`
-      `markerOf`, `semantic-cell-selection.ts` `collectParagraphs`, `note-pagination.ts`
-      `filterRefsOnPage`, the card line-pick in `review-support.ts` and `docx-editor.ts`, the
-      hand-rolled header/footer twin of `reviewAnchorIndex`, `semantic-paint.ts` line drawings,
-      and `docx-editor-images.ts` drawing match. Each reads a fragment or a line whole
+## 6f. The consumers, run end to end
+
+Two shapes, each with a witness that fails without its fix.
+
+- [x] 6f.1 A review item's id names its PART. `@w:id` is unique within a part and Word numbers
+      each part from 1, so a body `w:ins` and a header `w:ins` by one author on one date made
+      one id for two decisions: the rail's `byId` map kept the last, so one card was
+      unreachable and its replies attached to the other
+- [x] 6f.2 `fragmentParagraphs` / `fragmentExtentOf` / `fragmentOwnsPosition` / `fragmentHolding`
+      answer for every paragraph a fragment DRAWS. An ordinary fragment answers from its own
+      `range` without touching a line, so nothing about a document without a merge moves
+- [x] 6f.3 `surface-structure.ts` `markerOf` — the caret in the absorbed half of a list item
+      read as "not a list item": the list controls greyed out mid-line, and Tab typed a tab
+- [x] 6f.4 `semantic-cell-selection.ts` `collectParagraphs` — a cell selection listed the
+      survivor alone, so deleting it left the absorbed member's text in an emptied cell
+- [x] 6f.5 `note-pagination.ts` `filterRefsOnPage` — a footnote reference in the absorbed half
+      matched no fragment, so the note never reached the page and the reader saw a mark with
+      no note. The offsets stay half-open: widening WHICH paragraphs answer must not widen
+      which offsets do
+- [x] 6f.6 The card line-pick in `review-support.ts` and `docx-editor.ts` — the join line's
+      `range` names one of two paragraphs, so an offset from the other was compared in the
+      wrong coordinate space. New `anchorLineY` reads the member
+- [x] 6f.7 The hand-rolled header/footer and note twins of `reviewAnchorIndex` in
+      `docx-editor.ts`, which never got the `held` set the body index has. Lifted whole into
+      `editor/docx-editor-anchors.ts`, which also kept the file under its `max-lines` cap
+- [x] 6f.8 `noteScopeIndexOf` — a ninth site the extraction turned up. A card in the absorbed
+      half of a merged note paragraph had no note scope, so activation set a body selection
+      from a note paragraph id and comment deletion passed no note id. Fixed by inspection;
+      the observable needs a footnote package fixture and has no dedicated test
+- [x] 6f.9 `output/semantic-paint.ts` — inline drawings were flushed in numeric offset order
+      across two paragraphs that both count from zero, so both advances opened in the first
+      half and none in the second
+- [x] 6f.10 `docx-editor-images.ts` — the image at the caret was matched on offset alone, so
+      the caret in one half selected the other half's picture
+- [x] 6f.11 Found on the way, and worse than what it was found under: a merged line's range
+      was computed from SPANS only, so a member opening with a picture began after it.
+      `lineAtPosition` was blind to drawing atoms for the same reason, so the caret on that
+      picture resolved to no line at all and no image could be selected there
 - [ ] 7.11 Enter inside the FIRST member copies the whole `w:pPr` onto both halves, so both
       carry the same `w:id`; accepting then collapses three paragraphs where Word gives two

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -50,6 +50,27 @@
 - [ ] 6.2 Changeset
 - [ ] 6.3 `docs/site` word-features note: the resolved views merge, and what a reader sees
 
+## 6b. What two OOXML reviews found, and what was done
+
+- [x] 6b.1 `paragraphTextFromLayout` read the line whole, so BOTH members reported the other's
+      text — and it is the surface's own `paragraphTextOf`, so the deletion range, the clamp
+      and the word walk all followed it. Reads its own segment now
+- [x] 6b.2 `selectionRects`, `keyedRangeRects` and `spansInSelection` resolved through
+      `line.range`: a selection inside the second member painted nothing and read no
+      formatting, one inside the first read the second's. All three go through `segmentOverlap`
+- [x] 6b.3 A merged line's own range stopped at its first span when a member held several runs
+- [x] 6b.4 A TRAILING run of removed marks did not collapse, where accept-all collapses it
+- [x] 6b.5 Layout merged across a block `w:sdt`, where the store cannot. Grouping is per real
+      parent now, so both halves refuse together — a merge Word performs and neither does
+- [x] 6b.6 STORE: `followed` scanned every later sibling, so content merged into the paragraph
+      AFTER a table and arrived behind it. It looks at the next block
+- [x] 6b.7 `markRemovedInMode` matched on local name alone, so `<x:del/>` in the mark's `w:rPr`
+      merged two paragraphs from markup any sender can author. The namespace is checked
+- [x] 6b.8 A field whose `w:fldChar begin` and `end` straddle the mark closed ACROSS it once
+      merged, swallowing the second member into one atomic offset. Refused instead
+- [x] 6b.9 A member the walk over-publishes — content past a nesting cap — refused for the same
+      reason: its characters cannot be read back at offsets the store can address
+
 ## 7. Not done yet
 
 - [ ] 7.1 Backspace and undo through a join (4.2, 4.3)
@@ -57,3 +78,8 @@
       used, but no test pins alignment, indent or numbering across the join
 - [ ] 7.3 Selection rectangles and `spansInSelection` across a join line
 - [ ] 7.4 A merge whose members split across a page boundary
+- [ ] 7.5 Note stories never receive a display mode at all (`note-layout.ts`), so the merge
+      cannot reach them — a pre-existing gap the merge does not widen but does not close
+- [ ] 7.6 Backspace at a join resolves the tracked mark with no visible change. Word's Final
+      view deletes the preceding character instead; the rule wants deciding
+- [ ] 7.7 The join carries two caret stops at one x, so Right-arrow crosses it in two presses

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -1,0 +1,44 @@
+## 0. Baseline before code
+
+- [ ] 0.1 Record the `bun test` baseline for `packages/core`
+- [ ] 0.2 Reproduce the gap: a paragraph with a deleted mark followed by another lays out as two fragments in `proposed`, where accept-all gives one paragraph
+
+## 1. Merge groups
+
+- [ ] 1.1 `markRemovedInMode(paragraph, displayMode)` in `revision-visibility.ts`, over the same kinds `markRevisionRemovesMark` names
+- [ ] 1.2 Group consecutive removals in `storyBlocks`, stopping at the last block of the container
+- [ ] 1.3 Build the synthetic paragraph: survivor `w:pPr`, members' content in order, survivor's node id
+- [ ] 1.4 Memoize the synthetic node with the cached block list, so pass-to-pass identity holds and the break cache still hits
+- [ ] 1.5 Tests: grouping per mode, the trailing-paragraph guard, a group of three, and a group interrupted by a table
+
+## 2. Identity
+
+- [ ] 2.1 Publish a member boundary table with the synthetic node: member paragraph id, its length, its offset in the group
+- [ ] 2.2 Rewrite span, line and drawing ranges at the fragment publish sites in both lanes
+- [ ] 2.3 Assert no span straddles a member boundary, and refuse the merge rather than publish a compound offset if one ever does
+- [ ] 2.4 Tests: a merged fragment's spans name their own paragraphs; offsets round-trip against the store's text
+
+## 3. Interaction
+
+- [ ] 3.1 Index a join line under every paragraph its spans name
+- [ ] 3.2 Build caret stops for a paragraph from that paragraph's spans alone
+- [ ] 3.3 Take document order from line identity
+- [ ] 3.4 Tests: hit testing both halves of a join line, caret walking across the join, selection rectangles spanning it
+
+## 4. Editing through the merge
+
+- [ ] 4.1 Type at the join; assert the op names the first paragraph
+- [ ] 4.2 Backspace at the start of the second member; assert it reaches the store as the join the tree already records
+- [ ] 4.3 Undo restores both the tree and the merged rendering
+
+## 5. The oracle
+
+- [ ] 5.1 Extend the display-mode differential to mark cases: `proposed` equals accept-all, `original` equals reject-all, per line
+- [ ] 5.2 Run it over the tracked-changes corpus fixture
+- [ ] 5.3 Bench: merge groups must not change work counters on a document without tracked marks
+
+## 6. Ship
+
+- [ ] 6.1 `bun run test`, `typecheck`, `lint`, `format`, `api:check`
+- [ ] 6.2 Changeset
+- [ ] 6.3 `docs/site` word-features note: the resolved views merge, and what a reader sees

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -106,10 +106,11 @@
 - [ ] 7.6 Backspace at a join resolves the tracked mark with no visible change. Word's Final
       view deletes the preceding character instead; the rule wants deciding
 - [ ] 7.7 The join carries two caret stops at one x, so Right-arrow crosses it in two presses
-- [ ] 7.8 Header and footer stories call `storyBlocks(part)` with no display mode, so a tracked
-      mark in a header still draws its break in a resolved view. One word to fix, but it makes
-      the `fragment.paragraphId` readers in `surface-scope.ts`, `paginated-surface.ts` and
-      `surface-formatting.ts` live for HF stories, which is why it is not one word
+- [x] 7.8 Header and footer stories now pass the display mode to their BLOCK list, not only to
+      the inline flow, so a tracked mark in a header merges and a removed paragraph leaves no
+      blank line. The `fragment.paragraphId` readers it made live came with it: scoped document
+      order and the paragraph-properties index read line identity now, and the paint fallback
+      needs nothing because it only fires for a line with no spans, which a merged line never is
 - [ ] 7.9 `w:pPrChange` is not honoured in `original`: the recorded properties are never
       restored, so a reformatted paragraph renders with its NEW formatting in the view that
       answers what the document was. Pre-existing, and invisible to the differential because

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -71,6 +71,29 @@
 - [x] 6b.9 A member the walk over-publishes — content past a nesting cap — refused for the same
       reason: its characters cannot be read back at offsets the store can address
 
+## 6c. What a third review found, and what was done
+
+- [x] 6c.1 The namespace check reached only the innermost element, so `<x:rPr><w:del/></x:rPr>`
+      still merged two paragraphs from markup any sender can author. Every step is checked
+- [x] 6c.2 STORE: `followed` skipped a `w:sdt` the way it had skipped a `w:tbl`, so content
+      merged into a paragraph in another parent and arrived behind the control
+- [x] 6c.3 A click PAST the end of a merged line took its offset from the whole line and its
+      paragraph from the segment, producing an offset the paragraph does not have
+- [x] 6c.4 `fieldCharsBalanced` counted a net, so an `end` with no `begin` cancelled a later
+      `begin` and a straddling field read as balanced
+- [x] 6c.5 The measurement guard ran on every paragraph of every document, costing 12x on the
+      default render path. It is asked only where a merge could happen
+- [x] 6c.6 `lineAtPosition` never answered for the second member, so an inline image in the
+      merged half could not be selected
+- [x] 6c.7 Review anchors were keyed by `fragment.paragraphId`, so a card anchored in any
+      member but the survivor dropped out of the rail
+- [x] 6c.8 Backspace at a join carried the first paragraph's `w:del` onto a mark nobody edited.
+      The break is invisible in a resolved view, so the key deletes a character instead
+- [x] 6c.9 `bun run typecheck` passes across all eight packages; five dead symbols the
+      extraction left behind are gone
+- [x] 6c.10 The over-publish fixture asserted nothing: the refusal fires AT the nesting cap,
+      not above it, where neither lane publishes the text
+
 ## 7. Not done yet
 
 - [ ] 7.1 Backspace and undo through a join (4.2, 4.3)
@@ -83,3 +106,17 @@
 - [ ] 7.6 Backspace at a join resolves the tracked mark with no visible change. Word's Final
       view deletes the preceding character instead; the rule wants deciding
 - [ ] 7.7 The join carries two caret stops at one x, so Right-arrow crosses it in two presses
+- [ ] 7.8 Header and footer stories call `storyBlocks(part)` with no display mode, so a tracked
+      mark in a header still draws its break in a resolved view. One word to fix, but it makes
+      the `fragment.paragraphId` readers in `surface-scope.ts`, `paginated-surface.ts` and
+      `surface-formatting.ts` live for HF stories, which is why it is not one word
+- [ ] 7.9 `w:pPrChange` is not honoured in `original`: the recorded properties are never
+      restored, so a reformatted paragraph renders with its NEW formatting in the view that
+      answers what the document was. Pre-existing, and invisible to the differential because
+      the `original` assertion compares joined text rather than lines
+- [ ] 7.10 The oracle covers the body story only, and only `w:del` on a mark. Neither the
+      `original` direction of a merge, nor cells, nor a block `w:sdt`, nor headers, footers or
+      notes are in the fixture. Run the line-for-line assertion for `original` too, and add a
+      fixture carrying `w:ins` marks, a mark in a cell and a mark inside a `w:sdt`
+- [ ] 7.11 Enter inside the FIRST member copies the whole `w:pPr` onto both halves, so both
+      carry the same `w:id`; accepting then collapses three paragraphs where Word gives two

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -94,6 +94,23 @@
 - [x] 6c.10 The over-publish fixture asserted nothing: the refusal fires AT the nesting cap,
       not above it, where neither lane publishes the text
 
+## 6d. What a verification pass against a real document found
+
+Verified against `tracked-paragraph-marks.docx`: header, body, cell and a mark before a table.
+All eight checks passed — merge, attribution, identity against `paragraphTextOf`, editing on a
+mounted surface, caret and selection, the review rail, Accept All, and the save round-trip.
+
+- [x] 6d.1 A delete ACROSS a merged break left the deleted mark on the survivor, so the next
+      pass merged it into the paragraph after it and the rail kept a card for a mark that no
+      longer exists. A join now carries the mark revisions of the paragraph whose mark
+      survives, the way it already carried `w:sectPr`
+- [x] 6d.2 Home and End stopped at the member boundary, in the middle of the visible line,
+      because they were built from one paragraph's stops
+- [x] 6d.3 Copying across the join put a newline in the clipboard, so one visible line pasted
+      as two paragraphs
+- [ ] 6d.4 The join still carries two caret slots at one painted position, so one arrow press
+      does not move. Recorded at 7.7
+
 ## 7. Not done yet
 
 - [ ] 7.1 Backspace and undo through a join (4.2, 4.3)

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -1,44 +1,59 @@
 ## 0. Baseline before code
 
-- [ ] 0.1 Record the `bun test` baseline for `packages/core`
-- [ ] 0.2 Reproduce the gap: a paragraph with a deleted mark followed by another lays out as two fragments in `proposed`, where accept-all gives one paragraph
+- [x] 0.1 Record the `bun test` baseline for `packages/core`
+- [x] 0.2 Reproduce the gap: a paragraph with a deleted mark followed by another lays out as two fragments in `proposed`, where accept-all gives one paragraph
 
 ## 1. Merge groups
 
-- [ ] 1.1 `markRemovedInMode(paragraph, displayMode)` in `revision-visibility.ts`, over the same kinds `markRevisionRemovesMark` names
-- [ ] 1.2 Group consecutive removals in `storyBlocks`, stopping at the last block of the container
-- [ ] 1.3 Build the synthetic paragraph: survivor `w:pPr`, members' content in order, survivor's node id
-- [ ] 1.4 Memoize the synthetic node with the cached block list, so pass-to-pass identity holds and the break cache still hits
-- [ ] 1.5 Tests: grouping per mode, the trailing-paragraph guard, a group of three, and a group interrupted by a table
+- [x] 1.1 `markRemovedInMode(paragraph, displayMode)` in `revision-visibility.ts`, over the same kinds `markRevisionRemovesMark` names
+- [x] 1.2 Group consecutive removals in `storyBlocks`, stopping at the last block of the container
+- [x] 1.3 Build the synthetic paragraph: survivor `w:pPr`, members' content in order, survivor's node id
+- [x] 1.4 Memoize the synthetic node with the cached block list, so pass-to-pass identity holds and the break cache still hits
+- [x] 1.5 Tests: grouping per mode, the trailing-paragraph guard, a group of three, and a group interrupted by a table
 
 ## 2. Identity
 
-- [ ] 2.1 Publish a member boundary table with the synthetic node: member paragraph id, its length, its offset in the group
-- [ ] 2.2 Rewrite span, line and drawing ranges at the fragment publish sites in both lanes
-- [ ] 2.3 Assert no span straddles a member boundary, and refuse the merge rather than publish a compound offset if one ever does
-- [ ] 2.4 Tests: a merged fragment's spans name their own paragraphs; offsets round-trip against the store's text
+- [x] 2.1 Publish a member boundary table with the synthetic node: member paragraph id, its length, its offset in the group
+- [x] 2.2 Rewrite span, line and drawing ranges at the fragment publish sites in both lanes
+- [x] 2.3 A span cannot straddle a member boundary — it is a piece of one run — so the remap CLAMPS to the member's length rather than publishing an offset past a real paragraph
+- [x] 2.4 Tests: a merged fragment's spans name their own paragraphs; offsets round-trip against the store's text
 
 ## 3. Interaction
 
-- [ ] 3.1 Index a join line under every paragraph its spans name
-- [ ] 3.2 Build caret stops for a paragraph from that paragraph's spans alone
-- [ ] 3.3 Take document order from line identity
-- [ ] 3.4 Tests: hit testing both halves of a join line, caret walking across the join, selection rectangles spanning it
+- [x] 3.1 Index a join line under every paragraph its spans name
+- [x] 3.2 Build caret stops for a paragraph from that paragraph's spans alone
+- [x] 3.3 Take document order from line identity
+- [x] 3.4 Tests: hit testing both halves of a join line, caret walking across the join, selection rectangles spanning it
 
 ## 4. Editing through the merge
 
-- [ ] 4.1 Type at the join; assert the op names the first paragraph
+- [x] 4.1 Type at the join; assert the op names the first paragraph
+- [x] 4.1b Type at the start of the second member; assert it stays in the second paragraph
 - [ ] 4.2 Backspace at the start of the second member; assert it reaches the store as the join the tree already records
 - [ ] 4.3 Undo restores both the tree and the merged rendering
 
+## 4b. The store, found by building the layout side
+
+- [x] 4b.1 `rebuildChildren` could not merge a paragraph forward once it had absorbed one, so a
+      run of removed marks collapsed pairwise; it now tests the merge after absorbing
+- [x] 4b.2 Store test: three consecutive deleted marks and a survivor become ONE paragraph
+
 ## 5. The oracle
 
-- [ ] 5.1 Extend the display-mode differential to mark cases: `proposed` equals accept-all, `original` equals reject-all, per line
-- [ ] 5.2 Run it over the tracked-changes corpus fixture
-- [ ] 5.3 Bench: merge groups must not change work counters on a document without tracked marks
+- [x] 5.1 Extend the display-mode differential to mark cases: `proposed` equals accept-all, `original` equals reject-all, per line
+- [x] 5.2 Run it over the tracked-changes corpus fixture
+- [x] 5.3 Bench: merge groups must not change work counters on a document without tracked marks
 
 ## 6. Ship
 
 - [ ] 6.1 `bun run test`, `typecheck`, `lint`, `format`, `api:check`
 - [ ] 6.2 Changeset
 - [ ] 6.3 `docs/site` word-features note: the resolved views merge, and what a reader sees
+
+## 7. Not done yet
+
+- [ ] 7.1 Backspace and undo through a join (4.2, 4.3)
+- [ ] 7.2 A merged group whose members carry different `w:pPr`: the survivor's properties are
+      used, but no test pins alignment, indent or numbering across the join
+- [ ] 7.3 Selection rectangles and `spansInSelection` across a join line
+- [ ] 7.4 A merge whose members split across a page boundary

--- a/openspec/changes/resolved-view-paragraph-merge/tasks.md
+++ b/openspec/changes/resolved-view-paragraph-merge/tasks.md
@@ -111,6 +111,29 @@ mounted surface, caret and selection, the review rail, Accept All, and the save 
 - [ ] 6d.4 The join still carries two caret slots at one painted position, so one arrow press
       does not move. Recorded at 7.7
 
+## 6e. What a fourth, adversarial pass found
+
+- [x] 6e.1 `deleteForward` had no rule for the invisible join, so Delete at the end of an
+      absorbed member joined the paragraphs — and, with 6d.1 unfixed, swallowed the one after
+- [x] 6e.2 The mark gate's `?? DEFAULT` was wrong for NOTE stories, which pass no mode and
+      mean the resolved one: it lit up markup inside footnotes in the view that shows none.
+      The gate requires an explicit mode again, and the story entry points name their own
+- [x] 6e.3 `paragraphSectionIndexOf` indexed an All Markup block list with section bounds
+      counted in the document's mode, so a tracked Enter renumbered a footnote in another
+      section
+- [x] 6e.4 `sectionFurniture` enumerated sections in All Markup while layout indexed them in
+      the document's mode, pairing one section's pages with another section's header
+- [x] 6e.5 The furniture memo's `displayMode` key compared a closure constant with itself. It
+      is gone, and the field says a mode switch must rebuild the source
+- [x] 6e.6 `moveFrom` and `moveTo` shared one card sentence, though accepting them does
+      opposite things
+- [x] 6e.7 The two declarations of `ReviewRevisionItem` had no drift gate. An optional field
+      added to one and not the other passed every check; a compile-time identity assertion
+      now fails instead
+- [x] 6e.8 The measurement guard ran per candidate per flush — 19ms on a 380-mark document,
+      every keystroke. Memoized on the paragraph node, which is immutable: 30ms cold, 2.9ms
+      for the new part a keystroke publishes
+
 ## 7. Not done yet
 
 - [ ] 7.1 Backspace and undo through a join (4.2, 4.3)
@@ -136,5 +159,13 @@ mounted surface, caret and selection, the review rail, Accept All, and the save 
       `original` direction of a merge, nor cells, nor a block `w:sdt`, nor headers, footers or
       notes are in the fixture. Run the line-for-line assertion for `original` too, and add a
       fixture carrying `w:ins` marks, a mark in a cell and a mark inside a `w:sdt`
+- [ ] 7.11a A review item's id omits the part name, so a `w:id="1"` mark in the body and one
+      in a header share a key — the React key, the active card, the dismissed set. Pre-existing,
+      and reachable for the first time now that header marks are drawn
+- [ ] 7.11b Consumers a sweep flagged and nobody has run end to end: `surface-structure.ts`
+      `markerOf`, `semantic-cell-selection.ts` `collectParagraphs`, `note-pagination.ts`
+      `filterRefsOnPage`, the card line-pick in `review-support.ts` and `docx-editor.ts`, the
+      hand-rolled header/footer twin of `reviewAnchorIndex`, `semantic-paint.ts` line drawings,
+      and `docx-editor-images.ts` drawing match. Each reads a fragment or a line whole
 - [ ] 7.11 Enter inside the FIRST member copies the whole `w:pPr` onto both halves, so both
       carry the same `w:id`; accepting then collapses three paragraphs where Word gives two

--- a/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
+++ b/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
@@ -1,0 +1,88 @@
+// Editing a document whose paragraphs a resolved view has merged.
+//
+// `proposed` is not a preview: it is what the free engine renders by default, and that surface
+// is fully editable. So the merged half has to keep addressing its own paragraph — an edit
+// there must land where the DOCUMENT holds those characters, not where the page draws them.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { mountPaginatedSurface } from '../paginated-surface.ts';
+import { paragraphTextOf } from '../../store/store/tree-op-apply.ts';
+import { docx } from './paginated-surface-fixtures.ts';
+
+const DELETED_MARK =
+  '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+  '<w:r><w:t xml:space="preserve">Hello </w:t></w:r></w:p>' +
+  '<w:p><w:r><w:t>world</w:t></w:r></w:p>';
+
+function mountMerged() {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(DELETED_MARK), {
+    revisionDisplayMode: 'proposed',
+  });
+  if (!opened.ok) throw new Error(opened.reason);
+  return {
+    surface: opened.surface,
+    dispose: () => {
+      opened.surface.destroy();
+      container.remove();
+    },
+  };
+}
+
+describe('editing across a merged paragraph break', () => {
+  test('the two paragraphs are drawn as one and remain two', () => {
+    const { surface, dispose } = mountMerged();
+    try {
+      // One line on the page, two paragraphs in the document. Both halves of that sentence
+      // matter: the first is the merge, the second is what makes it safe.
+      const lines = surface
+        .layout()
+        .pages.flatMap((page) =>
+          page.fragments.flatMap((fragment) =>
+            fragment.kind === 'paragraph' ? fragment.lines : []
+          )
+        );
+      expect(lines).toHaveLength(1);
+      expect(lines[0]!.spans.map((span) => span.text).join('')).toBe('Hello world');
+      expect(surface.session.paragraphIds()).toHaveLength(2);
+    } finally {
+      dispose();
+    }
+  });
+
+  test('typing at the join lands in the paragraph that holds the caret', () => {
+    const { surface, dispose } = mountMerged();
+    try {
+      const [first, second] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: first!, offset: 6 },
+        head: { paragraphId: first!, offset: 6 },
+      });
+      surface.type('!');
+      expect(paragraphTextOf(surface.session.part(), first!)).toBe('Hello !');
+      expect(paragraphTextOf(surface.session.part(), second!)).toBe('world');
+    } finally {
+      dispose();
+    }
+  });
+
+  test('typing at the start of the second half stays in the second paragraph', () => {
+    const { surface, dispose } = mountMerged();
+    try {
+      const [first, second] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: second!, offset: 0 },
+        head: { paragraphId: second!, offset: 0 },
+      });
+      surface.type('W');
+      expect(paragraphTextOf(surface.session.part(), first!)).toBe('Hello ');
+      expect(paragraphTextOf(surface.session.part(), second!)).toBe('Wworld');
+    } finally {
+      dispose();
+    }
+  });
+});

--- a/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
+++ b/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
@@ -130,4 +130,38 @@ describe('editing across a merged paragraph break', () => {
       container.remove();
     }
   });
+
+  test('copying across the join copies one line, not two paragraphs', () => {
+    // The reader sees one line. A newline in the clipboard pasted two paragraphs out of it.
+    const { surface, dispose } = mountMerged();
+    try {
+      const [first, second] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: first!, offset: 0 },
+        head: { paragraphId: second!, offset: 5 },
+      });
+      expect(surface.selectedText()).toBe('Hello world');
+    } finally {
+      dispose();
+    }
+  });
+
+  test('Home and End reach the ends of the line a reader sees', () => {
+    // One paragraph's stops describe the line only while the line holds one paragraph. On a
+    // merged line they stopped at the member boundary, in the middle of the visible text.
+    const { surface, dispose } = mountMerged();
+    try {
+      const [first, second] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: second!, offset: 2 },
+        head: { paragraphId: second!, offset: 2 },
+      });
+      surface.navigate('lineStart');
+      expect(surface.state().selection.head).toEqual({ paragraphId: first!, offset: 0 });
+      surface.navigate('lineEnd');
+      expect(surface.state().selection.head).toEqual({ paragraphId: second!, offset: 5 });
+    } finally {
+      dispose();
+    }
+  });
 });

--- a/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
+++ b/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
@@ -164,4 +164,24 @@ describe('editing across a merged paragraph break', () => {
       dispose();
     }
   });
+
+  test('Delete at the end of the first half takes a character, not the paragraph', () => {
+    // The mirror of Backspace at the join. Joining here resolved a tracked decision the
+    // keypress never named — and because the survivor then still carried the mark, the
+    // paragraph AFTER it merged in as well.
+    const { surface, dispose } = mountMerged();
+    try {
+      const [first, second] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: first!, offset: 6 },
+        head: { paragraphId: first!, offset: 6 },
+      });
+      surface.deleteForward();
+      expect(paragraphTextOf(surface.session.part(), first!)).toBe('Hello ');
+      expect(paragraphTextOf(surface.session.part(), second!)).toBe('orld');
+      expect(surface.session.paragraphIds()).toHaveLength(2);
+    } finally {
+      dispose();
+    }
+  });
 });

--- a/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
+++ b/packages/core/src/editor/__tests__/resolved-view-merge-editing.test.ts
@@ -85,4 +85,49 @@ describe('editing across a merged paragraph break', () => {
       dispose();
     }
   });
+
+  test('Backspace at the join deletes a character, not the paragraph break', () => {
+    // The break between two merged members is not one the reader can see, so it is not one
+    // they can delete. Joining here also carried the first paragraph's `w:del` onto a mark
+    // nobody edited — and the last mark of a body, which Word cannot write.
+    const { surface, dispose } = mountMerged();
+    try {
+      const [first, second] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: second!, offset: 0 },
+        head: { paragraphId: second!, offset: 0 },
+      });
+      surface.deleteBackward();
+      expect(paragraphTextOf(surface.session.part(), first!)).toBe('Hello');
+      expect(paragraphTextOf(surface.session.part(), second!)).toBe('world');
+      expect(surface.session.paragraphIds()).toHaveLength(2);
+    } finally {
+      dispose();
+    }
+  });
+
+  test('Backspace at the START of the group still joins with what precedes it', () => {
+    // The group's own first break IS visible, so it behaves as it always did.
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(
+      container,
+      docx('<w:p><w:r><w:t>before</w:t></w:r></w:p>' + DELETED_MARK),
+      { revisionDisplayMode: 'proposed' }
+    );
+    if (!opened.ok) throw new Error(opened.reason);
+    try {
+      const ids = opened.surface.session.paragraphIds();
+      opened.surface.setSelection({
+        anchor: { paragraphId: ids[1]!, offset: 0 },
+        head: { paragraphId: ids[1]!, offset: 0 },
+      });
+      opened.surface.deleteBackward();
+      expect(opened.surface.session.paragraphIds()).toHaveLength(2);
+      expect(paragraphTextOf(opened.surface.session.part(), ids[0]!)).toBe('beforeHello ');
+    } finally {
+      opened.surface.destroy();
+      container.remove();
+    }
+  });
 });

--- a/packages/core/src/editor/__tests__/resolved-view-merge-image.test.ts
+++ b/packages/core/src/editor/__tests__/resolved-view-merge-image.test.ts
@@ -1,0 +1,112 @@
+// Selecting an image on a line that carries two paragraphs.
+//
+// A resolved display mode draws a merged run as one paragraph. Both halves count their
+// offsets from zero, so the caret at offset 0 of the second half and an image at offset 0 of
+// the first are the same number. The image lookup matched on that number alone and handed
+// back the other half's picture — and every command that followed addressed it.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface } from '../paginated-surface.ts';
+import { resolveSelectedDrawingRecord } from '../docx-editor-images.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const IMG = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const NS = `xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"`;
+
+const PNG_1X1 = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  ),
+  (c) => c.charCodeAt(0)
+);
+
+const inlinePicture = (docPrId: number) =>
+  '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+  `<wp:extent cx="228600" cy="114300"/><wp:docPr id="${docPrId}" name="pic${docPrId}"/>` +
+  `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
+  `<pic:nvPicPr><pic:cNvPr id="${docPrId}" name=""/><pic:cNvPicPr/></pic:nvPicPr>` +
+  '<pic:blipFill><a:blip r:embed="rIdImg"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+  '<pic:spPr><a:xfrm><a:ext cx="228600" cy="114300"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
+  '</pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r>';
+
+/** Each half opens with its own picture, so both sit at model offset 0. */
+function docx(): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="png" ContentType="image/png"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/></Relationships>`
+    ),
+    'word/media/image1.png': PNG_1X1,
+    'word/document.xml': strToU8(
+      `<w:document ${NS}><w:body>` +
+        '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+        `${inlinePicture(1)}<w:r><w:t xml:space="preserve">AAA </w:t></w:r></w:p>` +
+        `<w:p>${inlinePicture(2)}<w:r><w:t>BBB</w:t></w:r></w:p>` +
+        '</w:body></w:document>'
+    ),
+  });
+}
+
+describe('the image at the caret is the one in the caret’s paragraph', () => {
+  test('each half selects its own picture', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(container, docx(), {
+      revisionDisplayMode: 'proposed',
+    });
+    if (!opened.ok) throw new Error(opened.reason);
+    const surface = opened.surface;
+    try {
+      const [absorbed, survivor] = surface.session.paragraphIds();
+      const line = surface
+        .layout()
+        .pages[0]!.fragments.flatMap((block) =>
+          block.kind === 'paragraph' ? block.lines : []
+        )[0]!;
+      const drawings = line.drawings ?? [];
+      // The fixture is only interesting while both pictures share a line and an offset.
+      expect(drawings).toHaveLength(2);
+      expect(drawings[0]!.start).toBe(drawings[1]!.start);
+
+      const idOf = (paragraphId: string): string | undefined => {
+        surface.setSelection({
+          anchor: { paragraphId, offset: 0 },
+          head: { paragraphId, offset: 0 },
+        });
+        const record = resolveSelectedDrawingRecord(surface);
+        return record?.kind === 'inlineDrawing' ? record.drawingNodeId : undefined;
+      };
+      const first = idOf(absorbed!);
+      const second = idOf(survivor!);
+      expect(first).toBeTruthy();
+      expect(second).toBeTruthy();
+      expect(first).not.toBe(second);
+      // And each is the drawing the records say belongs to that paragraph.
+      expect(drawings.find((d) => d.paragraphId === absorbed)!.drawingNodeId).toBe(first);
+      expect(drawings.find((d) => d.paragraphId === survivor)!.drawingNodeId).toBe(second);
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});

--- a/packages/core/src/editor/__tests__/resolved-view-merge-list.test.ts
+++ b/packages/core/src/editor/__tests__/resolved-view-merge-list.test.ts
@@ -1,0 +1,119 @@
+// A list item the reader is standing in reads as a list item.
+//
+// A resolved display mode publishes a merged run as ONE fragment named after the survivor.
+// The list readers looked the caret's paragraph up by that name, found nothing for the
+// absorbed half, and answered "not a list item" — so the toolbar greyed its list controls out
+// while the reader's caret sat in a numbered line, and Tab inserted a tab instead of
+// demoting.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const NUMREL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
+
+const NUMBERING =
+  `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">` +
+  '<w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/>' +
+  '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>' +
+  '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${NUMREL}" Target="numbering.xml"/></Relationships>`
+    ),
+    'word/numbering.xml': strToU8(NUMBERING),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const numPr = '<w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>';
+/** Two list items the reader sees as one: the first one's paragraph mark is struck. */
+const MERGED_ITEMS =
+  `<w:p><w:pPr>${numPr}<w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>` +
+  '<w:r><w:t xml:space="preserve">first </w:t></w:r></w:p>' +
+  `<w:p><w:pPr>${numPr}</w:pPr><w:r><w:t>second</w:t></w:r></w:p>`;
+
+function withMerged(run: (surface: PaginatedSurface) => void): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(MERGED_ITEMS), {
+    revisionDisplayMode: 'proposed',
+  });
+  if (!opened.ok) throw new Error(opened.reason);
+  try {
+    run(opened.surface);
+  } finally {
+    opened.surface.destroy();
+    container.remove();
+  }
+}
+
+describe('the list readers see the item the reader sees', () => {
+  test('the two items are drawn as one', () => {
+    withMerged((surface) => {
+      const fragments = surface
+        .layout()
+        .pages.flatMap((page) => page.fragments.filter((block) => block.kind === 'paragraph'));
+      expect(fragments).toHaveLength(1);
+      expect(fragments[0]!.marker).toBeTruthy();
+      expect(surface.session.paragraphIds()).toHaveLength(2);
+    });
+  });
+
+  test('the caret in the absorbed half is in a list item', () => {
+    withMerged((surface) => {
+      const [absorbed] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: absorbed!, offset: 1 },
+        head: { paragraphId: absorbed!, offset: 1 },
+      });
+      // What the toolbar asks. It answered false, so the list buttons went inactive when
+      // the caret crossed an invisible break in the middle of a line.
+      expect(surface.isListParagraph()).toBe(true);
+      expect(surface.isListActive('ordered')).toBe(true);
+      expect(surface.isListActive('bullet')).toBe(false);
+    });
+  });
+
+  test('a paragraph that is genuinely not a list still says so', () => {
+    // The fix widens the lookup, not the answer: an ordinary paragraph is unchanged.
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(
+      container,
+      docx('<w:p><w:r><w:t>plain</w:t></w:r></w:p>'),
+      { revisionDisplayMode: 'proposed' }
+    );
+    if (!opened.ok) throw new Error(opened.reason);
+    try {
+      const [only] = opened.surface.session.paragraphIds();
+      opened.surface.setSelection({
+        anchor: { paragraphId: only!, offset: 0 },
+        head: { paragraphId: only!, offset: 0 },
+      });
+      expect(opened.surface.isListParagraph()).toBe(false);
+    } finally {
+      opened.surface.destroy();
+      container.remove();
+    }
+  });
+});

--- a/packages/core/src/editor/docx-editor-anchors.ts
+++ b/packages/core/src/editor/docx-editor-anchors.ts
@@ -1,0 +1,78 @@
+// Where a review card sits beside the page.
+//
+// One index per layout, covering every story a card can be anchored in: the body, the
+// headers and footers, and the notes. Split out of the editor facade because it is pure over
+// a published layout — it reads records and returns geometry, and nothing about it needs the
+// editor's state.
+//
+// The recurring subtlety is that a fragment answers for more than the paragraph it is named
+// after. A resolved display mode publishes a merged run as ONE fragment under the survivor's
+// identity, so a card anchored in an absorbed member has no fragment of its own. Registering
+// only `fragment.paragraphId` left those cards with no geometry, and the rail drops a card it
+// cannot place.
+
+import {
+  paragraphFragmentsOf,
+  paragraphFragmentsOfBlocks,
+  reviewAnchorIndex,
+  type ReviewParagraphAnchor,
+  type SemanticLayout,
+} from '@docx-editor.dev/core/layout';
+import { fragmentParagraphs } from '../layout/line-segments.ts';
+
+/**
+ * Paragraph anchors for every story on a layout, memoized on the layout OBJECT.
+ *
+ * A published layout is immutable, so the index is valid for exactly as long as that object
+ * is the current one, and a new revision brings a new one.
+ */
+export function createAnchorIndex(): (
+  layout: SemanticLayout
+) => Map<string, ReviewParagraphAnchor> {
+  const cache = new WeakMap<SemanticLayout, Map<string, ReviewParagraphAnchor>>();
+  return (layout) => {
+    const cached = cache.get(layout);
+    if (cached) return cached;
+    const index = reviewAnchorIndex(layout, (page) => paragraphFragmentsOf(page));
+    for (const page of layout.pages) {
+      // Header/footer stories join the same index so their cards get real geometry. A story's
+      // box is sheet-absolute like a page's content box, and its fragments are story-relative
+      // like body fragments are content-relative — the same two-space sum
+      // `reviewItemGeometry` performs. FIRST page wins, matching the body rule: a shared part
+      // painted on every page anchors its card where the reader first meets it.
+      for (const story of [page.header, page.footer]) {
+        if (!story) continue;
+        register(index, story.fragments, page.index, story.box.y);
+      }
+      // Note stories, on the same terms. Without these a note card came back with
+      // `anchorY: null` and `pageIndex: null`: the rail sorts a null page last, so a
+      // footnote change on page 2 of a long document rendered below the final page's cards,
+      // with no leader line to the text it belongs to.
+      for (const area of [page.footnotes, page.endnotes]) {
+        if (!area) continue;
+        for (const note of area.notes) register(index, note.fragments, page.index, note.box.y);
+      }
+    }
+    cache.set(layout, index);
+    return index;
+  };
+}
+
+function register(
+  index: Map<string, ReviewParagraphAnchor>,
+  fragments: Parameters<typeof paragraphFragmentsOfBlocks>[0],
+  pageIndex: number,
+  contentY: number
+): void {
+  for (const fragment of paragraphFragmentsOfBlocks(fragments)) {
+    for (const paragraphId of fragmentParagraphs(fragment)) {
+      if (index.has(paragraphId)) continue;
+      index.set(paragraphId, {
+        pageIndex,
+        contentY,
+        fragmentY: fragment.box.y,
+        ...(fragment.lines ? { lines: fragment.lines } : {}),
+      });
+    }
+  }
+}

--- a/packages/core/src/editor/docx-editor-images.ts
+++ b/packages/core/src/editor/docx-editor-images.ts
@@ -68,10 +68,15 @@ export type ImageMutationPreconditions = Readonly<{
 
 function inlineDrawingAtOffset(
   line: ReturnType<typeof lineAtPosition>,
+  paragraphId: string,
   offset: number
 ): InlineDrawingRecord | null {
   if (!line) return null;
   for (const drawing of line.drawings ?? []) {
+    // The PARAGRAPH as well as the offset. A resolved display mode draws two paragraphs on
+    // the join line and both count from zero, so an offset alone selected the other half's
+    // image — and every later command addressed that one.
+    if (drawing.paragraphId !== paragraphId) continue;
     if (drawing.start === offset || drawing.start + 1 === offset) return drawing;
   }
   return null;
@@ -114,7 +119,7 @@ export function resolveSelectedDrawingRecord(
   const { anchor, head } = surface.state().selection;
   if (anchor.paragraphId !== head.paragraphId || anchor.offset !== head.offset) return null;
   const line = lineAtPosition(surface.layout(), anchor.paragraphId, anchor.offset);
-  const inline = inlineDrawingAtOffset(line, anchor.offset);
+  const inline = inlineDrawingAtOffset(line, anchor.paragraphId, anchor.offset);
   if (inline) return inline;
   return anchoredDrawingAtSelection(surface, anchor.paragraphId, anchor.offset);
 }

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -35,12 +35,12 @@
 // sub-objects are reused if value-equal, so selector results stay reference-stable too.
 
 import {
+  anchorLineY,
   commentBodyText,
   commentInitials,
   documentOrder,
   paragraphFragmentsOf,
   paragraphFragmentsOfBlocks,
-  reviewAnchorIndex,
   reviewItemGeometry,
   reviewItemKey,
   type ReviewItem,
@@ -93,6 +93,8 @@ import {
   type SemanticSelection as SurfaceSelection,
   type TextMeasurer,
 } from '@docx-editor.dev/core/layout';
+import { createAnchorIndex } from './docx-editor-anchors.ts';
+import { fragmentParagraphs } from '../layout/line-segments.ts';
 import {
   classifyCommand,
   deepFreezeValue,
@@ -1170,57 +1172,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     );
   }
 
-  /**
-   * Paragraph anchors, built once per layout.
-   *
-   * Keyed on the layout OBJECT: a published layout is immutable, so the index is valid for
-   * exactly as long as that object is the current one, and a new revision brings a new one.
-   */
-  const anchorIndexCache = new WeakMap<SemanticLayout, Map<string, ReviewParagraphAnchor>>();
-  function anchorIndexOf(layout: SemanticLayout): Map<string, ReviewParagraphAnchor> {
-    const cached = anchorIndexCache.get(layout);
-    if (cached) return cached;
-    const index = reviewAnchorIndex(layout, (page) => paragraphFragmentsOf(page));
-    // Header/footer stories join the same index so their cards get real geometry. A story's
-    // box is sheet-absolute like a page's content box, and its fragments are story-relative
-    // like body fragments are content-relative — the same two-space sum `reviewItemGeometry`
-    // performs. FIRST page wins, matching the body rule: a shared part painted on every
-    // page anchors its card where the reader first meets it.
-    for (const page of layout.pages) {
-      for (const story of [page.header, page.footer]) {
-        if (!story) continue;
-        for (const fragment of paragraphFragmentsOfBlocks(story.fragments)) {
-          if (index.has(fragment.paragraphId)) continue;
-          index.set(fragment.paragraphId, {
-            pageIndex: page.index,
-            contentY: story.box.y,
-            fragmentY: fragment.box.y,
-            ...(fragment.lines ? { lines: fragment.lines } : {}),
-          });
-        }
-      }
-      // Note stories, on the same terms. Without these a note card came back with
-      // `anchorY: null` and `pageIndex: null`: the rail sorts a null page last, so a
-      // footnote change on page 2 of a long document rendered below the final page's
-      // cards, with no leader line to the text it belongs to.
-      for (const area of [page.footnotes, page.endnotes]) {
-        if (!area) continue;
-        for (const note of area.notes) {
-          for (const fragment of paragraphFragmentsOfBlocks(note.fragments)) {
-            if (index.has(fragment.paragraphId)) continue;
-            index.set(fragment.paragraphId, {
-              pageIndex: page.index,
-              contentY: note.box.y,
-              fragmentY: fragment.box.y,
-              ...(fragment.lines ? { lines: fragment.lines } : {}),
-            });
-          }
-        }
-      }
-    }
-    anchorIndexCache.set(layout, index);
-    return index;
-  }
+  const anchorIndexOf = createAnchorIndex();
 
   /**
    * Paragraph id → note scope id, built once per LAYOUT from the painted note stories.
@@ -1240,7 +1192,12 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         if (!area) continue;
         for (const note of area.notes) {
           for (const fragment of paragraphFragmentsOfBlocks(note.fragments)) {
-            if (!index.has(fragment.paragraphId)) index.set(fragment.paragraphId, note.scopeId);
+            // Every paragraph the fragment DRAWS. A note whose paragraphs a resolved view
+            // merges publishes one fragment, and an absorbed member with no scope made its
+            // card look like a body card: no note to accept it in, no note to scroll to.
+            for (const paragraphId of fragmentParagraphs(fragment)) {
+              if (!index.has(paragraphId)) index.set(paragraphId, note.scopeId);
+            }
           }
         }
       }
@@ -1489,10 +1446,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     if (!range || !layout) return null;
     const anchor = anchorIndexOf(layout).get(range.from.paragraphId);
     if (!anchor) return null;
-    const line = anchor.lines?.find((entry) => range.from.offset < entry.range.end);
     return {
       pageIndex: anchor.pageIndex,
-      anchorY: anchor.contentY + (line ? line.box.y : anchor.fragmentY),
+      anchorY: anchor.contentY + anchorLineY(anchor, range.from.paragraphId, range.from.offset),
     };
   }
 

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -39,7 +39,6 @@ import {
   commentBodyText,
   commentInitials,
   documentOrder,
-  paragraphFragmentsOf,
   paragraphFragmentsOfBlocks,
   reviewItemGeometry,
   reviewItemKey,

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -571,6 +571,8 @@ export function mountPaginatedSurface(
     cache: layoutCache,
     styleCascade,
     defaultTabStopPt,
+    // Furniture answers the document's display mode, like the body does.
+    ...(options.revisionDisplayMode ? { displayMode: options.revisionDisplayMode } : {}),
     inlineDrawingLayoutForPart: (partName) => drawingBundle.contextForPart(partName),
     drawingLayoutTokenForPart: (partName) => drawingBundle.cacheTokenForPart(partName),
     drawingTokenForParagraphForPart: (partName, paragraph) =>
@@ -3183,6 +3185,7 @@ export function mountPaginatedSurface(
           cache: layoutCache,
           styleCascade,
           defaultTabStopPt,
+          ...(options.revisionDisplayMode ? { displayMode: options.revisionDisplayMode } : {}),
         });
         // Dropped rather than trusted: both describe a paint made at the OLD scale, and a
         // flush that publishes nothing (a revision already superseded) would otherwise leave

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -60,6 +60,7 @@ import {
   type SemanticPosition,
   type SemanticSelection,
 } from '@docx-editor.dev/core/layout';
+import { mergedPredecessorsOf } from '../layout/line-segments.ts';
 import {
   paintSelectionOverlay,
   paintSemanticLayout,
@@ -3299,6 +3300,32 @@ export function mountPaginatedSurface(
         // Backspace at the start of a paragraph pulls it into the previous one. Refusing
         // here made the key look broken: a caret at the paragraph start is where a user
         // presses Backspace precisely because they want the paragraphs merged.
+        // A break the reader cannot SEE is not a break they can delete. In a resolved display
+        // mode a tracked paragraph mark is already merged away on the page, so Backspace at
+        // the start of a later member takes the character before it — the one under the
+        // caret's left edge — instead of joining two paragraphs and carrying a mark revision
+        // onto a paragraph nobody edited.
+        for (const member of mergedPredecessorsOf(currentLayout, position.paragraphId)) {
+          const text = textOf(member);
+          if (text.length === 0) continue;
+          commit(
+            () =>
+              applyOps(
+                [
+                  {
+                    op: 'deleteText',
+                    paragraphId: member,
+                    start: text.length - 1,
+                    end: text.length,
+                  },
+                ],
+                selectionMark()
+              ),
+            () => collapsedAt({ paragraphId: member, offset: text.length - 1 }),
+            { rearmPending: armed }
+          );
+          return;
+        }
         const order = paragraphOrder();
         const index = order.indexOf(position.paragraphId);
         const previous = order[index - 1];

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -60,6 +60,7 @@ import {
   type SemanticPosition,
   type SemanticSelection,
 } from '@docx-editor.dev/core/layout';
+import { DEFAULT_REVISION_DISPLAY_MODE } from '../layout/revision-projection.ts';
 import { mergedPredecessorsOf } from '../layout/line-segments.ts';
 import {
   paintSelectionOverlay,
@@ -571,8 +572,10 @@ export function mountPaginatedSurface(
     cache: layoutCache,
     styleCascade,
     defaultTabStopPt,
-    // Furniture answers the document's display mode, like the body does.
-    ...(options.revisionDisplayMode ? { displayMode: options.revisionDisplayMode } : {}),
+    // Furniture answers the document's display mode, like the body does — and it is named
+    // even when it is the default, because a lane that says nothing is treated as saying
+    // "not All Markup", which is what keeps markup out of the resolved views.
+    displayMode: options.revisionDisplayMode ?? DEFAULT_REVISION_DISPLAY_MODE,
     inlineDrawingLayoutForPart: (partName) => drawingBundle.contextForPart(partName),
     drawingLayoutTokenForPart: (partName) => drawingBundle.cacheTokenForPart(partName),
     drawingTokenForParagraphForPart: (partName, paragraph) =>
@@ -3185,7 +3188,7 @@ export function mountPaginatedSurface(
           cache: layoutCache,
           styleCascade,
           defaultTabStopPt,
-          ...(options.revisionDisplayMode ? { displayMode: options.revisionDisplayMode } : {}),
+          displayMode: options.revisionDisplayMode ?? DEFAULT_REVISION_DISPLAY_MODE,
         });
         // Dropped rather than trusted: both describe a paint made at the OLD scale, and a
         // flush that publishes nothing (a revision already superseded) would otherwise leave
@@ -3568,6 +3571,21 @@ export function mountPaginatedSurface(
       const order = paragraphOrder();
       const next = order[order.indexOf(position.paragraphId) + 1];
       if (!next) return;
+      // Unless the break is one a resolved view already merged away. The reader sees one
+      // paragraph, so Delete takes the next CHARACTER, exactly as Backspace does at the other
+      // side of the same invisible break — joining here would resolve a tracked decision the
+      // keypress never named, and take the paragraph after it as well.
+      if (mergedPredecessorsOf(currentLayout, next).includes(position.paragraphId)) {
+        const following = textOf(next);
+        if (following.length === 0) return;
+        commit(
+          () =>
+            applyOps([{ op: 'deleteText', paragraphId: next, start: 0, end: 1 }], selectionMark()),
+          () => collapsedAt(position),
+          { rearmPending: armed }
+        );
+        return;
+      }
       commit(
         () =>
           applyOps(

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -33,6 +33,7 @@ import {
 } from '@docx-editor.dev/core/store';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { SurfaceFormatting } from './paginated-surface-contract.ts';
+import { lineSegments } from '../layout/line-segments.ts';
 
 /** One property as the ops and the layout records carry it: an element name plus attributes. */
 export interface SurfaceProperty {
@@ -70,6 +71,14 @@ export function paragraphPropertiesOf(
     for (const page of layout.pages) {
       for (const fragment of paragraphFragmentsOf(page)) {
         if (!index.has(fragment.paragraphId)) index.set(fragment.paragraphId, fragment.props);
+        // A merged fragment lays every member out under the SURVIVOR's `w:pPr`, so that is
+        // the projection each member is being shown with. Without this a member the fragment
+        // is not named after read no properties at all, and the toolbar showed defaults.
+        for (const line of fragment.lines) {
+          for (const segment of lineSegments(line)) {
+            if (!index.has(segment.paragraphId)) index.set(segment.paragraphId, fragment.props);
+          }
+        }
       }
     }
     fragmentPropsByLayout.set(layout, index);

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -63,6 +63,14 @@ export function createFurnitureSource(env: {
    * page-number tab in a metric-locale footer lands where Word puts it.
    */
   readonly defaultTabStopPt?: number;
+  /**
+   * The document's revision display mode, so furniture answers it too.
+   *
+   * A header is a story like any other. Without this it was laid out in the layout default
+   * whatever the document was being shown in: a resolved view kept a break the body had
+   * merged away, and All Markup drew no attribution on a header's own tracked mark.
+   */
+  readonly displayMode?: import('../layout/revision-projection.ts').RevisionDisplayMode;
   readonly inlineDrawingLayoutForPart?: (
     partName: string
   ) => import('../layout/drawing-layout.ts').InlineDrawingLayoutContext | undefined;
@@ -80,6 +88,7 @@ export function createFurnitureSource(env: {
     cache,
     styleCascade,
     defaultTabStopPt,
+    displayMode,
     inlineDrawingLayoutForPart,
     drawingLayoutTokenForPart,
     drawingTokenForParagraphForPart,
@@ -104,6 +113,7 @@ export function createFurnitureSource(env: {
       marginLeft: number;
       marginRight: number;
       producer: string;
+      displayMode?: import('../layout/revision-projection.ts').RevisionDisplayMode;
       drawingLayoutToken: string;
       story: ReturnType<typeof layoutHeaderFooterStory>;
     }
@@ -142,6 +152,7 @@ export function createFurnitureSource(env: {
       memo.marginLeft === marginLeft &&
       memo.marginRight === marginRight &&
       memo.producer === producer &&
+      memo.displayMode === displayMode &&
       memo.drawingLayoutToken === partDrawingToken
     ) {
       return memo.story;
@@ -157,7 +168,7 @@ export function createFurnitureSource(env: {
       undefined,
       undefined,
       defaultTabStopPt,
-      undefined,
+      displayMode,
       inlineDrawingLayout,
       drawingTokenForParagraphForPart
         ? (paragraph) => drawingTokenForParagraphForPart(part.name, paragraph)
@@ -186,6 +197,7 @@ export function createFurnitureSource(env: {
       marginLeft,
       marginRight,
       producer,
+      ...(displayMode ? { displayMode } : {}),
       drawingLayoutToken: partDrawingToken,
       story,
     });

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -69,6 +69,10 @@ export function createFurnitureSource(env: {
    * A header is a story like any other. Without this it was laid out in the layout default
    * whatever the document was being shown in: a resolved view kept a break the body had
    * merged away, and All Markup drew no attribution on a header's own tracked mark.
+   *
+   * FIXED FOR THE LIFE OF THIS SOURCE. The story memo below cannot guard a mode change,
+   * because the mode is a constant of this closure — a switch has to rebuild the source, the
+   * way a producer change already does.
    */
   readonly displayMode?: import('../layout/revision-projection.ts').RevisionDisplayMode;
   readonly inlineDrawingLayoutForPart?: (
@@ -113,7 +117,6 @@ export function createFurnitureSource(env: {
       marginLeft: number;
       marginRight: number;
       producer: string;
-      displayMode?: import('../layout/revision-projection.ts').RevisionDisplayMode;
       drawingLayoutToken: string;
       story: ReturnType<typeof layoutHeaderFooterStory>;
     }
@@ -152,7 +155,6 @@ export function createFurnitureSource(env: {
       memo.marginLeft === marginLeft &&
       memo.marginRight === marginRight &&
       memo.producer === producer &&
-      memo.displayMode === displayMode &&
       memo.drawingLayoutToken === partDrawingToken
     ) {
       return memo.story;
@@ -197,7 +199,6 @@ export function createFurnitureSource(env: {
       marginLeft,
       marginRight,
       producer,
-      ...(displayMode ? { displayMode } : {}),
       drawingLayoutToken: partDrawingToken,
       story,
     });
@@ -231,7 +232,11 @@ export function createFurnitureSource(env: {
   }
 
   function sectionFurniture(): readonly (PageFurniture | undefined)[] {
-    const sections = enumerateDocumentSections(session.part());
+    // IN THE DOCUMENT'S MODE. Layout indexes this array with a section index it counted over
+    // a mode-filtered block list, so enumerating in another mode pairs a section's pages with
+    // another section's header — a break whose mark a tracked change deleted is a section in
+    // All Markup and none in a resolved view.
+    const sections = enumerateDocumentSections(session.part(), displayMode);
     const bySection = session.headerFooterPartsBySection();
     return sections.map((section, index) =>
       furnitureFromParts(bySection[index], geometryOfSection(section.properties))

--- a/packages/core/src/editor/surface-scope.ts
+++ b/packages/core/src/editor/surface-scope.ts
@@ -27,6 +27,7 @@ import type { EditorScope, ViewScope } from '../contracts/editor.ts';
 import type { StoryScope } from '@docx-editor.dev/core/store';
 import { hitTestFragments, pageAtY, type SemanticHit } from '../layout/semantic-hit-test.ts';
 import { parseNoteScopeId } from '../store/package/note-nodes.ts';
+import { lineSegments } from '../layout/line-segments.ts';
 
 export const SCOPE_BODY: ViewScope = Object.freeze({ kind: 'body' as const });
 
@@ -488,9 +489,21 @@ export function scopedDocumentOrder(
   const order: string[] = [];
   for (const page of layout.pages) {
     for (const fragment of scopedParagraphFragments(page, active, noteScopeId)) {
-      if (seen.has(fragment.paragraphId)) continue;
-      seen.add(fragment.paragraphId);
-      order.push(fragment.paragraphId);
+      // From the LINES, the way `documentOrder` reads the body. A resolved display mode lays a
+      // run of paragraphs out as ONE fragment named after the survivor, and a paragraph missing
+      // from this order compares as before every other one — which would put a selection
+      // anchored in it at the top of the story.
+      for (const line of fragment.lines) {
+        for (const segment of lineSegments(line)) {
+          if (seen.has(segment.paragraphId)) continue;
+          seen.add(segment.paragraphId);
+          order.push(segment.paragraphId);
+        }
+      }
+      if (fragment.lines.length === 0 && !seen.has(fragment.paragraphId)) {
+        seen.add(fragment.paragraphId);
+        order.push(fragment.paragraphId);
+      }
     }
   }
   return order;

--- a/packages/core/src/editor/surface-selection-ops.ts
+++ b/packages/core/src/editor/surface-selection-ops.ts
@@ -6,6 +6,7 @@
 // selection and part, so every function is a plain input-to-output computation.
 
 import type { TreeDocxSession } from '@docx-editor.dev/core/binding';
+import { mergedPredecessorsOf } from '../layout/line-segments.ts';
 import {
   parentNodeOf,
   type OoxmlElement,
@@ -92,13 +93,20 @@ export function selectedTextIn(
   const firstIndex = effectiveOrder.indexOf(from.paragraphId);
   const lastIndex = effectiveOrder.indexOf(to.paragraphId);
   if (firstIndex === -1 || lastIndex === -1) return '';
-  const parts = [paragraphTextFromLayout(layout, from.paragraphId).slice(from.offset)];
-  for (let index = firstIndex + 1; index < lastIndex; index += 1) {
-    parts.push(paragraphTextFromLayout(layout, effectiveOrder[index]!));
+  const ids = effectiveOrder.slice(firstIndex, lastIndex + 1);
+  let text = paragraphTextFromLayout(layout, from.paragraphId).slice(from.offset);
+  for (let index = 1; index < ids.length; index += 1) {
+    const paragraphId = ids[index]!;
+    const whole = paragraphTextFromLayout(layout, paragraphId);
+    // A break the reader cannot SEE is not one to copy. A resolved display mode draws a run
+    // of paragraphs as one, so a newline here pasted two paragraphs out of a line that was
+    // drawn as one — and the file the reader is looking at says the break is gone.
+    const separator = mergedPredecessorsOf(layout, paragraphId).includes(ids[index - 1]!)
+      ? ''
+      : '\n';
+    text += separator + (index === ids.length - 1 ? whole.slice(0, to.offset) : whole);
   }
-  parts.push(paragraphTextFromLayout(layout, to.paragraphId).slice(0, to.offset));
-  // Paragraphs are newline-separated, which is what a paste target expects.
-  return parts.join('\n');
+  return text;
 }
 
 /**

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -11,7 +11,6 @@ import type { TreeDocOp, StoryScope } from '@docx-editor.dev/core/store';
 import {
   documentOrder,
   enumerateDocumentSections,
-  paragraphFragmentsOf,
   readSectionProperties,
   storyBlocks,
   type SemanticLayout,
@@ -19,6 +18,7 @@ import {
   type SemanticSelection,
 } from '@docx-editor.dev/core/layout';
 import type { ListMarkerRecord } from '@docx-editor.dev/core/layout';
+import { fragmentHolding } from '../layout/line-segments.ts';
 import {
   directParagraphProperties,
   mergedProperties,
@@ -183,16 +183,13 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
 
   /** The marker layout resolved for a paragraph, or null when it is not a list item. */
   function markerOf(paragraphId: string): ListMarkerRecord | null {
-    for (const page of currentLayout.value.pages) {
-      // Paragraphs inside table cells are nested under table/row/cell records rather than
-      // published as top-level page fragments. Use the layout's canonical recursive walk so
-      // list Enter/Tab/toggle behaviour is identical in body text and arbitrarily nested cells.
-      for (const fragment of paragraphFragmentsOf(page)) {
-        if (fragment.paragraphId !== paragraphId) continue;
-        return fragment.marker ?? null;
-      }
-    }
-    return null;
+    // Paragraphs inside table cells are nested under table/row/cell records rather than
+    // published as top-level page fragments, and a resolved display mode publishes a merged
+    // run under the survivor's name alone. `fragmentHolding` covers both: it walks the same
+    // canonical recursive walk, and falls back to the paragraphs a fragment DRAWS when no
+    // fragment carries the name. Without that, the caret in the absorbed half of a merged
+    // list item read as "not a list item", so Tab inserted a tab instead of demoting it.
+    return fragmentHolding(currentLayout.value, paragraphId)?.marker ?? null;
   }
 
   /**

--- a/packages/core/src/layout/__tests__/header-footer-display-mode.test.ts
+++ b/packages/core/src/layout/__tests__/header-footer-display-mode.test.ts
@@ -82,3 +82,36 @@ describe('a header answers the display mode with its blocks as well as its runs'
     expect(new Set(spans.map((span) => span.range.paragraphId)).size).toBe(2);
   });
 });
+
+describe('a header draws its own tracked mark', () => {
+  test('All Markup publishes the mark, so the page can draw a pilcrow and a change bar', () => {
+    // Furniture is laid out through deps that do not always carry a display mode. Reading an
+    // unset mode as "not All Markup" left a header's own tracked break with no attribution at
+    // all: no pilcrow, no rule in the margin, while the review pane listed a card for it.
+    const story = layoutHeaderFooterStory(header(MARK_DELETED), 468, measurer, 'test');
+    const marks = story.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph' ? (fragment.markRevisions ?? []) : []
+    );
+    expect(marks.map((mark) => mark.kind)).toEqual(['delete']);
+  });
+
+  test('a resolved view draws none of it, and merges instead', () => {
+    const story = layoutHeaderFooterStory(
+      header(MARK_DELETED),
+      468,
+      measurer,
+      'test',
+      undefined,
+      undefined,
+      undefined,
+      128,
+      undefined,
+      'proposed'
+    );
+    const marks = story.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph' ? (fragment.markRevisions ?? []) : []
+    );
+    expect(marks).toEqual([]);
+    expect(textPerLine(header(MARK_DELETED), 'proposed')).toEqual(['Head Tail']);
+  });
+});

--- a/packages/core/src/layout/__tests__/header-footer-display-mode.test.ts
+++ b/packages/core/src/layout/__tests__/header-footer-display-mode.test.ts
@@ -1,0 +1,84 @@
+// A header is a story, and a story is laid out in a display mode.
+//
+// The inline flow always received the mode, so a deleted run vanished from a header in the
+// resolved views. The BLOCK list did not, so a paragraph a tracked mark merges away kept its
+// own line and a paragraph a revision removed entirely kept a blank one — in the view the free
+// engine renders by default, on the part a reader sees on every page.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, WML_NAMESPACE_URI, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { layoutHeaderFooterStory } from '../hf-layout.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+
+const measurer = createFixedMeasurer(6, 14);
+
+function header(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:hdr xmlns:w="${WML_NAMESPACE_URI}">${body}</w:hdr>`, {
+    name: '/word/header1.xml',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const textPerLine = (part: OoxmlPart, displayMode: RevisionDisplayMode): string[] =>
+  layoutHeaderFooterStory(
+    part,
+    468,
+    measurer,
+    'test',
+    undefined,
+    undefined,
+    undefined,
+    128,
+    undefined,
+    displayMode
+  )
+    .fragments.flatMap((fragment) => (fragment.kind === 'paragraph' ? fragment.lines : []))
+    .map((line) => line.spans.map((span) => span.text).join(''));
+
+const MARK_DELETED =
+  '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+  '<w:r><w:t xml:space="preserve">Head </w:t></w:r></w:p>' +
+  '<w:p><w:r><w:t>Tail</w:t></w:r></w:p>';
+
+describe('a header answers the display mode with its blocks as well as its runs', () => {
+  test('a tracked paragraph mark merges in the resolved view', () => {
+    expect(textPerLine(header(MARK_DELETED), 'proposed')).toEqual(['Head Tail']);
+    expect(textPerLine(header(MARK_DELETED), 'all-markup')).toEqual(['Head ', 'Tail']);
+  });
+
+  test('a paragraph a revision removed leaves no blank line behind', () => {
+    // Mark deleted AND nothing left to render: Word shows no line where the paragraph was.
+    const emptied =
+      '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+      '<w:del w:id="2" w:author="A"><w:r><w:delText>gone</w:delText></w:r></w:del></w:p>' +
+      '<w:p><w:r><w:t>Tail</w:t></w:r></w:p>';
+    expect(textPerLine(header(emptied), 'proposed')).toEqual(['Tail']);
+  });
+
+  test('the identity of each member survives into the header story', () => {
+    const fragments = layoutHeaderFooterStory(
+      header(MARK_DELETED),
+      468,
+      measurer,
+      'test',
+      undefined,
+      undefined,
+      undefined,
+      128,
+      undefined,
+      'proposed'
+    ).fragments;
+    const spans = fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph' ? fragment.lines.flatMap((line) => line.spans) : []
+    );
+    expect(spans.map((span) => [span.text, span.range.start])).toEqual([
+      ['Head ', 0],
+      ['Tail', 0],
+    ]);
+    // Two paragraphs, each addressing itself, drawn as one.
+    expect(new Set(spans.map((span) => span.range.paragraphId)).size).toBe(2);
+  });
+});

--- a/packages/core/src/layout/__tests__/resolved-view-merge-consumers.test.ts
+++ b/packages/core/src/layout/__tests__/resolved-view-merge-consumers.test.ts
@@ -1,0 +1,198 @@
+// What READS a merged fragment.
+//
+// A resolved display mode publishes a run of paragraphs as ONE fragment, named after the
+// paragraph the merge keeps. Every consumer that asked `fragment.paragraphId === mine` was
+// therefore right about ordinary documents and blind to the absorbed members: it reported
+// them as unlaid — no list marker, no note reference, no card geometry, not in a cell
+// selection — while the reader was looking straight at them.
+//
+// These are the consumers, each asked the question it asks in production.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import {
+  fragmentExtentOf,
+  fragmentOwnsPosition,
+  fragmentParagraphs,
+  lineSegments,
+} from '../line-segments.ts';
+import { buildPageRefIndex, filterRefsOnPage, type PageRefHit } from '../note-pagination.ts';
+import { anchorLineY, reviewAnchorIndex } from '../review-support.ts';
+import { paragraphsInCells } from '../semantic-cell-selection.ts';
+import { paragraphFragmentsOf } from '../semantic-records.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const marked = (text: string) =>
+  `<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>` +
+  `<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+const plain = (text: string) => `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+/** Two paragraphs the reader sees as one: the first one's mark is deleted. */
+const MERGED = marked('Hello ') + plain('world');
+
+const lay = (part: OoxmlPart, displayMode: RevisionDisplayMode = 'proposed') =>
+  layoutSemanticDocument(part, 1, { measurer, displayMode });
+
+function paragraphIds(part: OoxmlPart): readonly string[] {
+  const found: string[] = [];
+  const visit = (node: { kind: string; id?: string; children?: readonly unknown[] }): void => {
+    if (node.kind === 'paragraph' && node.id) found.push(node.id);
+    for (const child of node.children ?? []) {
+      visit(child as { kind: string; id?: string; children?: readonly unknown[] });
+    }
+  };
+  visit(part.root as unknown as { kind: string; id?: string; children?: readonly unknown[] });
+  return found;
+}
+
+describe('a fragment answers for every paragraph it draws', () => {
+  test('an ordinary fragment names one paragraph and answers from its own range', () => {
+    // The no-shift half of the contract: nothing about a document without a merge takes a
+    // new path, and the extent is the fragment's own field, untouched.
+    const layout = lay(load(plain('alpha')));
+    const fragment = paragraphFragmentsOf(layout.pages[0]!)[0]!;
+    expect(fragmentParagraphs(fragment)).toEqual([fragment.paragraphId]);
+    expect(fragmentExtentOf(fragment, fragment.paragraphId)).toEqual({
+      start: fragment.range.start,
+      end: fragment.range.end,
+    });
+    expect(fragmentExtentOf(fragment, 'not-a-paragraph')).toBeNull();
+  });
+
+  test('a merged fragment names both members, in the order the reader meets them', () => {
+    const part = load(MERGED);
+    const [absorbed, survivor] = paragraphIds(part);
+    const fragment = paragraphFragmentsOf(lay(part).pages[0]!)[0]!;
+    expect(fragment.paragraphId).toBe(survivor!);
+    expect(fragmentParagraphs(fragment)).toEqual([absorbed!, survivor!]);
+    // Each in its OWN offsets: both count from zero, which is the whole difficulty.
+    expect(fragmentExtentOf(fragment, absorbed!)).toEqual({ start: 0, end: 6 });
+    expect(fragmentExtentOf(fragment, survivor!)).toEqual({ start: 0, end: 5 });
+  });
+
+  test('ownership is half-open in each member, as it is in an ordinary fragment', () => {
+    const part = load(MERGED);
+    const [absorbed, survivor] = paragraphIds(part);
+    const fragment = paragraphFragmentsOf(lay(part).pages[0]!)[0]!;
+    expect(fragmentOwnsPosition(fragment, absorbed!, 0)).toBe(true);
+    expect(fragmentOwnsPosition(fragment, absorbed!, 5)).toBe(true);
+    expect(fragmentOwnsPosition(fragment, absorbed!, 6)).toBe(false);
+    expect(fragmentOwnsPosition(fragment, survivor!, 0)).toBe(true);
+    expect(fragmentOwnsPosition(fragment, survivor!, 5)).toBe(false);
+  });
+});
+
+describe('a note reference in the absorbed half still reaches its page', () => {
+  test('the reference is kept, by both the indexed and the unindexed path', () => {
+    // The bug this closes is a footnote that vanishes: the mark is painted in the text and
+    // the note itself never reaches the bottom of the page, because no fragment claimed the
+    // paragraph the reference names.
+    const part = load(MERGED);
+    const [absorbed] = paragraphIds(part);
+    const page = lay(part).pages[0]!;
+    const ref: PageRefHit = {
+      noteKind: 'footnote',
+      noteId: 1,
+      paragraphId: absorbed!,
+      atomOffset: 2,
+      customMarkFollows: false,
+      sectionIndex: 0,
+    };
+    expect(filterRefsOnPage(page, [ref])).toEqual([ref]);
+    expect(filterRefsOnPage(page, [ref], buildPageRefIndex([ref]))).toEqual([ref]);
+  });
+
+  test('a reference past the end of its member is still not on the page', () => {
+    // The fix widens WHICH paragraphs a fragment answers for. It must not widen the offsets:
+    // an atom beyond the member's own text belongs to no fragment, merged or not.
+    const part = load(MERGED);
+    const [absorbed] = paragraphIds(part);
+    const page = lay(part).pages[0]!;
+    const ref: PageRefHit = {
+      noteKind: 'footnote',
+      noteId: 1,
+      paragraphId: absorbed!,
+      atomOffset: 99,
+      customMarkFollows: false,
+      sectionIndex: 0,
+    };
+    expect(filterRefsOnPage(page, [ref])).toEqual([]);
+    expect(filterRefsOnPage(page, [ref], buildPageRefIndex([ref]))).toEqual([]);
+  });
+});
+
+describe('a card anchored in the absorbed half has geometry', () => {
+  test('both members are in the anchor index, on the same line', () => {
+    const part = load(MERGED);
+    const [absorbed, survivor] = paragraphIds(part);
+    const index = reviewAnchorIndex(lay(part), (page) => paragraphFragmentsOf(page));
+    expect(index.has(absorbed!)).toBe(true);
+    expect(index.has(survivor!)).toBe(true);
+    // One line, so both cards sit beside it — a card with no anchor is dropped by the rail.
+    expect(anchorLineY(index.get(absorbed!)!, absorbed!, 0)).toBe(
+      anchorLineY(index.get(survivor!)!, survivor!, 0)
+    );
+  });
+
+  test('the line pick reads the member, not the line range', () => {
+    // The join line's `range` names ONE of the two paragraphs, so an offset compared against
+    // it is compared in the wrong coordinate space. Where the absorbed half is long and the
+    // survivor wraps, every survivor offset below the absorbed member's length matched the
+    // FIRST line — a card several lines above the text it annotates.
+    const long = 'word '.repeat(15).trim();
+    const part = load(
+      `<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>` +
+        `<w:r><w:t xml:space="preserve">${long} </w:t></w:r></w:p>` +
+        plain('and then a tail that keeps going for a while yet')
+    );
+    const layout = lay(part);
+    const fragment = paragraphFragmentsOf(layout.pages[0]!)[0]!;
+    const index = reviewAnchorIndex(layout, (page) => paragraphFragmentsOf(page));
+    // The fixture has to be the shape the bug needs: more than one line, and a line that
+    // carries both members.
+    expect(fragment.lines.length).toBeGreaterThan(1);
+    expect(fragmentParagraphs(fragment)).toHaveLength(2);
+    expect(lineSegments(fragment.lines[0]!)).toHaveLength(2);
+
+    // Every member, on every line it appears on, anchors to THAT line.
+    for (const line of fragment.lines) {
+      for (const segment of lineSegments(line)) {
+        const anchor = index.get(segment.paragraphId)!;
+        expect(anchorLineY(anchor, segment.paragraphId, segment.start)).toBe(line.box.y);
+      }
+    }
+  });
+});
+
+describe('a cell selection covers every paragraph it draws', () => {
+  test('the absorbed member is selected with the cell that holds it', () => {
+    // A cell selection stands in for a text range, and deletion acts on the paragraphs it
+    // lists. Listing the survivor alone left the absorbed member's text in a cell the
+    // reader had just emptied.
+    const part = load(
+      '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>' +
+        `<w:tr><w:tc><w:tcPr/>${MERGED}</w:tc></w:tr></w:tbl>`
+    );
+    const layout = lay(part);
+    const table = layout.pages[0]!.fragments.find((block) => block.kind === 'table')!;
+    if (table.kind !== 'table') throw new Error('no table');
+    const cellId = table.rows[0]!.cells[0]!.id;
+    const found = paragraphsInCells(layout, [cellId]);
+    expect(found).toHaveLength(2);
+    const merged = paragraphFragmentsOf(layout.pages[0]!);
+    expect(found).toEqual(fragmentParagraphs(merged[0]!) as string[]);
+  });
+});

--- a/packages/core/src/layout/__tests__/resolved-view-merge.test.ts
+++ b/packages/core/src/layout/__tests__/resolved-view-merge.test.ts
@@ -18,7 +18,8 @@ import {
   selectionRects,
   spansInSelection,
 } from '../semantic-interaction.ts';
-import { linesOf } from '../semantic-records.ts';
+import { lineAtPosition, linesOf } from '../semantic-records.ts';
+import { reviewAnchorIndex } from '../review-support.ts';
 import type { RevisionDisplayMode } from '../revision-projection.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -301,19 +302,102 @@ describe('a group that cannot be measured is not merged', () => {
   });
 
   test('a paragraph the walk over-publishes is left alone', () => {
-    // Content past a nesting cap counts differently on each side, so the store cannot address
-    // what layout paints. Merging it would place the survivor's text inside that gap.
+    // Content at the nesting cap counts differently on each side — the store stops one level
+    // before layout does — so the store cannot address what layout paints. Merging would put
+    // the survivor's text inside that gap. The depth matters: BELOW the cap both lanes agree
+    // and the merge is right; far ABOVE it neither lane publishes the text, so the interesting
+    // case is the cap itself.
     const deep = (depth: number, inner: string): string =>
       depth === 0 ? inner : `<w:sdt><w:sdtContent>${deep(depth - 1, inner)}</w:sdtContent></w:sdt>`;
-    const overPublished =
+    const atTheCap =
       '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
-      deep(34, '<w:r><w:t xml:space="preserve">deep </w:t></w:r>') +
+      deep(32, '<w:r><w:t xml:space="preserve">deep </w:t></w:r>') +
       '</w:p>' +
       plain('world');
-    const spans = linesOf(lay(load(overPublished), 'proposed')).flatMap((line) => line.spans);
-    // `world` keeps its own offsets whatever happened to the paragraph before it.
-    const world = spans.find((span) => span.text === 'world');
-    expect(world?.range.start).toBe(0);
-    expect(world?.range.end).toBe(5);
+    expect(textPerLine(load(atTheCap), 'proposed')).toEqual(['deep ', 'world']);
+
+    const belowTheCap =
+      '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+      deep(3, '<w:r><w:t xml:space="preserve">deep </w:t></w:r>') +
+      '</w:p>' +
+      plain('world');
+    expect(textPerLine(load(belowTheCap), 'proposed')).toEqual(['deep world']);
+  });
+
+  test('markup that only looks like a revision merges nothing', () => {
+    // A `.docx` is a zip of XML the sender controls. Matching the mark by local name alone —
+    // at any level — let foreign markup join two paragraphs in the default view, a join no
+    // decision in the file can produce and no Accept can undo.
+    const spoofed = [
+      '<w:pPr><x:rPr xmlns:x="urn:x"><w:del w:id="1" w:author="A"/></x:rPr></w:pPr>',
+      '<x:pPr xmlns:x="urn:x"><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></x:pPr>',
+      '<w:pPr><w:rPr><x:del xmlns:x="urn:x" w:id="1" w:author="A"/></w:rPr></w:pPr>',
+    ];
+    for (const pPr of spoofed) {
+      const part = load(
+        `<w:p>${pPr}<w:r><w:t xml:space="preserve">Hello </w:t></w:r></w:p>` + plain('world')
+      );
+      expect(textPerLine(part, 'proposed')).toEqual(['Hello ', 'world']);
+    }
+  });
+});
+
+describe('a click past the end of a merged line', () => {
+  test('lands at the end of the paragraph under the pointer', () => {
+    // The offset comes from a walk over the whole line and the paragraph from the segment
+    // under the pointer, so without a clamp the two were counted in different paragraphs and
+    // a click in the margin produced an offset the second paragraph does not have.
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const line = linesOf(layout)[0]!;
+    const hit = hitTestSemantic(layout, {
+      x: line.box.x + line.box.width + 200,
+      y: line.box.y + line.box.height / 2,
+      pageIndex: 0,
+    });
+    expect(shortId(hit!.position.paragraphId)).toBe('0.0.1');
+    expect(hit!.position.offset).toBe(5);
+  });
+});
+
+describe('a field that closes in an earlier paragraph', () => {
+  test('does not read as balanced', () => {
+    // Counting a net let an `end` with no `begin` cancel a later `begin`, so a paragraph that
+    // both closes one field and opens another read as balanced and merged anyway.
+    const closesThenOpens =
+      '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>1</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:rPr><w:del w:id="2" w:author="A"/></w:rPr></w:pPr>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '<w:r><w:t xml:space="preserve">TWO</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r></w:p>' +
+      plain('three');
+    const spans = linesOf(lay(load(closesThenOpens), 'proposed')).flatMap((line) => line.spans);
+    const two = spans.find((span) => span.text.includes('TWO'));
+    // `TWO` addresses its own paragraph from offset 0, whatever the fields around it do.
+    expect(two?.range.start).toBe(0);
+  });
+});
+
+describe('a merged member is still findable by the things that index paragraphs', () => {
+  test('lineAtPosition answers for both members', () => {
+    // An inline image is resolved through this, so a member it could not answer for was a
+    // picture in the merged half that could not be selected.
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const ids = linesOf(layout)[0]!.spans.map((span) => span.range.paragraphId);
+    expect(lineAtPosition(layout, ids[0]!, 3)).not.toBeNull();
+    expect(lineAtPosition(layout, ids[1]!, 3)).not.toBeNull();
+    expect(lineAtPosition(layout, ids[1]!, 0)).not.toBeNull();
+  });
+
+  test('the review rail can anchor a card in either member', () => {
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const ids = linesOf(layout)[0]!.spans.map((span) => span.range.paragraphId);
+    const anchors = reviewAnchorIndex(layout, (page) =>
+      page.fragments.filter((fragment) => fragment.kind === 'paragraph')
+    );
+    expect(anchors.has(ids[0]!)).toBe(true);
+    expect(anchors.has(ids[1]!)).toBe(true);
   });
 });

--- a/packages/core/src/layout/__tests__/resolved-view-merge.test.ts
+++ b/packages/core/src/layout/__tests__/resolved-view-merge.test.ts
@@ -10,7 +10,14 @@
 import { describe, expect, test } from 'bun:test';
 import { applyTreeOp, readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
-import { caretAt, caretStops, hitTestSemantic } from '../semantic-interaction.ts';
+import {
+  caretAt,
+  caretStops,
+  hitTestSemantic,
+  paragraphTextFromLayout,
+  selectionRects,
+  spansInSelection,
+} from '../semantic-interaction.ts';
 import { linesOf } from '../semantic-records.ts';
 import type { RevisionDisplayMode } from '../revision-projection.ts';
 
@@ -210,5 +217,103 @@ describe('a cell is a story like any other', () => {
 
   test('all-markup keeps the two cell paragraphs apart', () => {
     expect(cellLines('all-markup')).toHaveLength(2);
+  });
+});
+
+describe('what reads a merged line reads its own paragraph', () => {
+  // Everything below was published correctly and consumed wrongly: the spans named their own
+  // paragraphs while the consumer walked the line whole, and both members count from zero.
+  const MULTI_RUN =
+    '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+    '<w:r><w:t xml:space="preserve">Hel</w:t></w:r>' +
+    '<w:r><w:t xml:space="preserve">lo </w:t></w:r></w:p>' +
+    plain('world');
+
+  test('the text of each paragraph comes from its own spans', () => {
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const ids = linesOf(layout)[0]!.spans.map((span) => span.range.paragraphId);
+    expect(paragraphTextFromLayout(layout, ids[0]!)).toBe('Hello ');
+    expect(paragraphTextFromLayout(layout, ids[1]!)).toBe('world');
+  });
+
+  test('a member of several runs reports its whole extent', () => {
+    // The line names the first member; its range must reach the end of THAT member, not stop
+    // at its first run and not run on into the next member.
+    const line = linesOf(lay(load(MULTI_RUN), 'proposed'))[0]!;
+    expect(line.range.end).toBe(6);
+    expect(paragraphTextFromLayout(lay(load(MULTI_RUN), 'proposed'), line.range.paragraphId)).toBe(
+      'Hello '
+    );
+  });
+
+  test('a selection inside the second half is highlighted', () => {
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const second = linesOf(layout)[0]!.spans[1]!.range.paragraphId;
+    const rects = selectionRects(layout, {
+      anchor: { paragraphId: second, offset: 0 },
+      head: { paragraphId: second, offset: 5 },
+    });
+    expect(rects).toHaveLength(1);
+    expect(rects[0]!.width).toBeGreaterThan(0);
+    expect(
+      spansInSelection(layout, {
+        anchor: { paragraphId: second, offset: 0 },
+        head: { paragraphId: second, offset: 5 },
+      }).map((span) => span.text)
+    ).toEqual(['world']);
+  });
+
+  test('a selection across the join covers both halves', () => {
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const ids = linesOf(layout)[0]!.spans.map((span) => span.range.paragraphId);
+    const rects = selectionRects(layout, {
+      anchor: { paragraphId: ids[0]!, offset: 0 },
+      head: { paragraphId: ids[1]!, offset: 5 },
+    });
+    const covered = rects.reduce((total, rect) => total + rect.width, 0);
+    const line = linesOf(layout)[0]!;
+    const lineWidth = line.spans.reduce((total, span) => total + span.box.width, 0);
+    expect(covered).toBeCloseTo(lineWidth, 1);
+  });
+});
+
+describe('a group that cannot be measured is not merged', () => {
+  // The merge places one member's characters at an offset taken from the store and reads them
+  // back out of spans the layout walk produced. Where those two disagree, merging would
+  // publish one paragraph's text at another's offsets — worse than the break it removes.
+
+  test('a field that straddles the mark keeps the paragraphs apart', () => {
+    // Word writes a TOC this way: `begin` in one paragraph, `end` in a later one. Merged, the
+    // field closes across the mark and swallows the whole second paragraph into one atom.
+    const straddling =
+      '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> TOC \\o "1-3" </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>Chapter One</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>Chapter Two</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+    const layout = lay(load(straddling), 'proposed');
+    const paragraphs = new Set(
+      linesOf(layout).flatMap((line) => line.spans.map((span) => span.range.paragraphId))
+    );
+    // Both paragraphs still address themselves, which is the property worth keeping.
+    expect(paragraphs.size).toBe(2);
+  });
+
+  test('a paragraph the walk over-publishes is left alone', () => {
+    // Content past a nesting cap counts differently on each side, so the store cannot address
+    // what layout paints. Merging it would place the survivor's text inside that gap.
+    const deep = (depth: number, inner: string): string =>
+      depth === 0 ? inner : `<w:sdt><w:sdtContent>${deep(depth - 1, inner)}</w:sdtContent></w:sdt>`;
+    const overPublished =
+      '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+      deep(34, '<w:r><w:t xml:space="preserve">deep </w:t></w:r>') +
+      '</w:p>' +
+      plain('world');
+    const spans = linesOf(lay(load(overPublished), 'proposed')).flatMap((line) => line.spans);
+    // `world` keeps its own offsets whatever happened to the paragraph before it.
+    const world = spans.find((span) => span.text === 'world');
+    expect(world?.range.start).toBe(0);
+    expect(world?.range.end).toBe(5);
   });
 });

--- a/packages/core/src/layout/__tests__/resolved-view-merge.test.ts
+++ b/packages/core/src/layout/__tests__/resolved-view-merge.test.ts
@@ -1,0 +1,214 @@
+// A resolved display mode shows what the document BECOMES, and a tracked paragraph mark is a
+// tracked paragraph BREAK. `proposed` answers accept-all, `original` answers reject-all, and
+// the store performs the merge either way — layout has to draw the same document.
+//
+// The merge is only half of it. `proposed` is what the free engine renders BY DEFAULT and that
+// surface is editable, so the characters of the second paragraph have to keep addressing the
+// second paragraph. Every test below that looks like a geometry test is really an identity
+// test wearing geometry.
+
+import { describe, expect, test } from 'bun:test';
+import { applyTreeOp, readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { caretAt, caretStops, hitTestSemantic } from '../semantic-interaction.ts';
+import { linesOf } from '../semantic-records.ts';
+import type { RevisionDisplayMode } from '../revision-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const marked = (mark: string, text: string) =>
+  `<w:p><w:pPr><w:rPr>${mark}</w:rPr></w:pPr>` +
+  `<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+const plain = (text: string) => `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+const DELETED_MARK = marked('<w:del w:id="1" w:author="A"/>', 'Hello ') + plain('world');
+const INSERTED_MARK = marked('<w:ins w:id="1" w:author="A"/>', 'Hello ') + plain('world');
+
+const lay = (part: OoxmlPart, displayMode: RevisionDisplayMode) =>
+  layoutSemanticDocument(part, 1, { measurer, displayMode });
+
+const textPerLine = (part: OoxmlPart, displayMode: RevisionDisplayMode) =>
+  linesOf(lay(part, displayMode)).map((line) => line.spans.map((span) => span.text).join(''));
+
+/** The short id, so an assertion reads as the paragraph a person would point at. */
+const shortId = (id: string) => id.split('#').pop()!;
+
+describe('a resolved view merges what its decisions merge', () => {
+  test('proposed runs a deleted mark into the next paragraph', () => {
+    expect(textPerLine(load(DELETED_MARK), 'proposed')).toEqual(['Hello world']);
+    expect(textPerLine(load(DELETED_MARK), 'all-markup')).toEqual(['Hello ', 'world']);
+    expect(textPerLine(load(DELETED_MARK), 'original')).toEqual(['Hello ', 'world']);
+  });
+
+  test('original un-splits an inserted mark', () => {
+    expect(textPerLine(load(INSERTED_MARK), 'original')).toEqual(['Hello world']);
+    expect(textPerLine(load(INSERTED_MARK), 'proposed')).toEqual(['Hello ', 'world']);
+  });
+
+  test('the merged paragraph equals the merged tree', () => {
+    // The specification of the two resolved modes, applied to the one revision kind that
+    // could not honour it: the projection and the op have to describe the same document.
+    const part = load(DELETED_MARK);
+    const accepted = applyTreeOp(part, { op: 'acceptAllRevisions' });
+    if (!accepted.ok) throw new Error(accepted.reason);
+    expect(textPerLine(part, 'proposed')).toEqual(textPerLine(accepted.part, 'proposed'));
+  });
+
+  test('a run of removed marks collapses into one paragraph, not into pairs', () => {
+    // The store had this wrong: a paragraph that absorbed one could not merge forward again,
+    // so sixteen consecutive deleted marks became eight paragraphs. Both lanes answer once.
+    const part = load(
+      marked('<w:del w:id="1" w:author="A"/>', 'one ') +
+        marked('<w:del w:id="2" w:author="A"/>', 'two ') +
+        marked('<w:del w:id="3" w:author="A"/>', 'three ') +
+        plain('four')
+    );
+    expect(textPerLine(part, 'proposed')).toEqual(['one two three four']);
+    const accepted = applyTreeOp(part, { op: 'acceptAllRevisions' });
+    if (!accepted.ok) throw new Error(accepted.reason);
+    expect(textPerLine(accepted.part, 'proposed')).toEqual(['one two three four']);
+  });
+
+  test('a table between two marks ends the group', () => {
+    // A merge that crossed a container would move content into a different parent, which is
+    // the same refusal the store makes.
+    const table =
+      '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+      '<w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>' +
+      plain('cell') +
+      '</w:tc></w:tr></w:tbl>';
+    const part = load(marked('<w:del w:id="1" w:author="A"/>', 'before ') + table + plain('after'));
+    expect(textPerLine(part, 'proposed')).toEqual(['before ', 'cell', 'after']);
+  });
+
+  test('a trailing mark has nothing to merge into and keeps its content', () => {
+    const part = load(plain('first') + marked('<w:del w:id="1" w:author="A"/>', 'last'));
+    expect(textPerLine(part, 'proposed')).toEqual(['first', 'last']);
+  });
+});
+
+describe('the merged half still addresses its own paragraph', () => {
+  const paragraphIds = (part: OoxmlPart) => {
+    const layout = lay(part, 'proposed');
+    return linesOf(layout).flatMap((line) =>
+      line.spans.map((span) => shortId(span.range.paragraphId))
+    );
+  };
+
+  test('each span names the paragraph that holds its characters', () => {
+    expect(paragraphIds(load(DELETED_MARK))).toEqual(['0.0.0', '0.0.1']);
+  });
+
+  test('offsets restart at zero in the second paragraph', () => {
+    const spans = linesOf(lay(load(DELETED_MARK), 'proposed')).flatMap((line) => line.spans);
+    expect(spans.map((span) => [span.text, span.range.start, span.range.end])).toEqual([
+      ['Hello ', 0, 6],
+      ['world', 0, 5],
+    ]);
+  });
+
+  test('the caret can reach both halves, in reading order', () => {
+    const stops = caretStops(lay(load(DELETED_MARK), 'proposed'), measurer);
+    expect(stops.map((stop) => [shortId(stop.position.paragraphId), stop.position.offset])).toEqual(
+      [
+        ['0.0.0', 0],
+        ['0.0.0', 1],
+        ['0.0.0', 2],
+        ['0.0.0', 3],
+        ['0.0.0', 4],
+        ['0.0.0', 5],
+        ['0.0.0', 6],
+        ['0.0.1', 0],
+        ['0.0.1', 1],
+        ['0.0.1', 2],
+        ['0.0.1', 3],
+        ['0.0.1', 4],
+        ['0.0.1', 5],
+      ]
+    );
+  });
+
+  test('the end of the first half and the start of the second sit at the same x', () => {
+    // They are the same place on the page and two different positions in the document, which
+    // is exactly what a merge means.
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const ids = linesOf(layout)[0]!.spans.map((span) => span.range.paragraphId);
+    const endOfFirst = caretAt(layout, { paragraphId: ids[0]!, offset: 6 }, measurer);
+    const startOfSecond = caretAt(layout, { paragraphId: ids[1]!, offset: 0 }, measurer);
+    expect(endOfFirst).not.toBeNull();
+    expect(startOfSecond).not.toBeNull();
+    expect(startOfSecond!.x).toBeCloseTo(endOfFirst!.x, 5);
+  });
+
+  test('a click in the second half lands in the second paragraph', () => {
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const worldSpan = linesOf(layout)[0]!.spans[1]!;
+    const hit = hitTestSemantic(layout, {
+      x: worldSpan.box.x + worldSpan.box.width / 2,
+      y: worldSpan.box.y + worldSpan.box.height / 2,
+      pageIndex: 0,
+    });
+    expect(hit).not.toBeNull();
+    expect(shortId(hit!.position.paragraphId)).toBe('0.0.1');
+    expect(hit!.position.offset).toBeGreaterThan(0);
+  });
+
+  test('a click in the first half still lands in the first paragraph', () => {
+    const layout = lay(load(DELETED_MARK), 'proposed');
+    const helloSpan = linesOf(layout)[0]!.spans[0]!;
+    const hit = hitTestSemantic(layout, {
+      x: helloSpan.box.x + 2,
+      y: helloSpan.box.y + helloSpan.box.height / 2,
+      pageIndex: 0,
+    });
+    expect(shortId(hit!.position.paragraphId)).toBe('0.0.0');
+  });
+});
+
+describe('a cell is a story like any other', () => {
+  const CELL_DOC =
+    '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+    '<w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>' +
+    marked('<w:del w:id="1" w:author="A"/>', 'Hello ') +
+    plain('world') +
+    '</w:tc></w:tr></w:tbl>';
+
+  const cellLines = (displayMode: RevisionDisplayMode) => {
+    const layout = lay(load(CELL_DOC), displayMode);
+    const table = layout.pages[0]!.fragments.find((fragment) => fragment.kind === 'table');
+    if (table?.kind !== 'table') throw new Error('no table');
+    return table.rows[0]!.cells[0]!.blocks.flatMap((block) =>
+      block.kind === 'paragraph' ? block.lines : []
+    );
+  };
+
+  test('the merge happens inside a cell, with identity intact', () => {
+    // Tables are where negotiated text lives, so a tracked Enter inside one is not an exotic
+    // case. The cell lane builds its own fragments, so it needs the remap of its own.
+    const lines = cellLines('proposed');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.spans.map((span) => span.text).join('')).toBe('Hello world');
+    expect(
+      lines[0]!.spans.map((span) => [shortId(span.range.paragraphId), span.range.start])
+    ).toEqual([
+      ['0.0.0.2.0.1', 0],
+      ['0.0.0.2.0.2', 0],
+    ]);
+  });
+
+  test('all-markup keeps the two cell paragraphs apart', () => {
+    expect(cellLines('all-markup')).toHaveLength(2);
+  });
+});

--- a/packages/core/src/layout/document-order.ts
+++ b/packages/core/src/layout/document-order.ts
@@ -1,0 +1,59 @@
+// Paragraph order across the laid-out document.
+//
+// Ordering paragraphs is not a tree walk here: what a reader means by "before" is where the
+// text SITS, and the layout is the only thing that knows that. It is taken from the LINES for
+// the same reason — a resolved display mode can lay several paragraphs out as one fragment,
+// and a paragraph missing from this order compares as before every other one, which would put
+// a selection anchored in it at the top of the document.
+
+import { lineSegments } from './line-segments.ts';
+import { paragraphFragmentsOf } from './semantic-records.ts';
+import type { SemanticLayout } from './semantic-records.ts';
+
+// Memoized PER LAYOUT, which is sound because a published layout is immutable: a new revision
+// is a new object. Without this every selection walk recomputed the order — and `lineOverlap`
+// runs once per line, so `spansInSelection` on a large document recomputed a full-document
+// scan thousands of times per keystroke. The toolbar reading formatting on every commit is
+// what turned that into seconds.
+const documentOrderCache = new WeakMap<SemanticLayout, string[]>();
+const documentOrderIndexCache = new WeakMap<SemanticLayout, Map<string, number>>();
+
+/** Paragraph ids in document order, deduplicated across fragments. */
+export function documentOrder(layout: SemanticLayout): string[] {
+  const cached = documentOrderCache.get(layout);
+  if (cached) return cached;
+  const seen = new Set<string>();
+  const order: string[] = [];
+  for (const page of layout.pages) {
+    for (const fragment of paragraphFragmentsOf(page)) {
+      // From the LINES, not the fragment. A merged fragment is named after one paragraph and
+      // carries several, and a paragraph missing from this order compares as before every
+      // other one — which would put a selection anchored in it at the top of the document.
+      for (const line of fragment.lines) {
+        for (const segment of lineSegments(line)) {
+          if (seen.has(segment.paragraphId)) continue;
+          seen.add(segment.paragraphId);
+          order.push(segment.paragraphId);
+        }
+      }
+      if (fragment.lines.length === 0 && !seen.has(fragment.paragraphId)) {
+        seen.add(fragment.paragraphId);
+        order.push(fragment.paragraphId);
+      }
+    }
+  }
+  documentOrderCache.set(layout, order);
+  return order;
+}
+
+/** Document-order position by paragraph id, for O(1) ordering checks. */
+export function documentOrderIndex(layout: SemanticLayout): Map<string, number> {
+  const cached = documentOrderIndexCache.get(layout);
+  if (cached) return cached;
+  const index = new Map<string, number>();
+  for (const [position, id] of documentOrder(layout).entries()) index.set(id, position);
+  documentOrderIndexCache.set(layout, index);
+  return index;
+}
+
+/** A selection's endpoints in document order. */

--- a/packages/core/src/layout/document-order.ts
+++ b/packages/core/src/layout/document-order.ts
@@ -55,5 +55,3 @@ export function documentOrderIndex(layout: SemanticLayout): Map<string, number> 
   documentOrderIndexCache.set(layout, index);
   return index;
 }
-
-/** A selection's endpoints in document order. */

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -28,6 +28,7 @@ import {
 } from './field-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
 import type { PendingLine } from './paragraph-flow.ts';
+import { drawingResourceLayoutToken } from './inline-drawing-source.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
 import type { AnchoredDrawingRecord } from './drawing-layout.ts';
 import { pageClipRegion, type DrawingAnchorFrameContext } from './drawing-layout.ts';
@@ -408,4 +409,39 @@ export function remapPage(page: PageRecord, globalIndex: number, sheetY: number)
     ...(footnotes ? { footnotes } : {}),
     ...(endnotes ? { endnotes } : {}),
   };
+}
+
+/**
+ * Resource identity of every image a header/footer story paints.
+ *
+ * Part of the session context, because the rest of what identifies a story — `contentKey`
+ * and `flowHeight` — describes the AUTHORED part, and neither moves when an image finishes
+ * decoding: the extent is authored, so the story is exactly as tall with a pending picture
+ * as with a ready one. Without this the unchanged-pass early exit finds every key equal and
+ * returns the previous pages BY IDENTITY, furniture included, so a header or footer image
+ * stays a "loading" placeholder for the rest of the session — nothing will invalidate it
+ * again. Body drawings have no such gap; they ride the per-paragraph flow keys.
+ */
+export function storyDrawingResourceToken(story: HeaderFooterStoryLayout): string {
+  const tokens: string[] = [];
+  const visitBlock = (block: BlockFragmentRecord): void => {
+    if (block.kind === 'table') {
+      for (const row of block.rows) {
+        for (const cell of row.cells) for (const inner of cell.blocks) visitBlock(inner);
+      }
+      return;
+    }
+    for (const line of block.lines) {
+      for (const drawing of line.drawings ?? []) {
+        tokens.push(drawingResourceLayoutToken(drawing.resource));
+      }
+    }
+  };
+  for (const drawing of story.anchoredDrawings ?? []) {
+    tokens.push(drawingResourceLayoutToken(drawing.resource));
+  }
+  for (const fragment of story.fragments) visitBlock(fragment);
+  // Empty for the overwhelmingly common story with no pictures, so the context string for a
+  // plain header is byte-for-byte what it was.
+  return tokens.length === 0 ? '' : `!${tokens.join('!')}`;
 }

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -29,6 +29,7 @@ import {
 import type { ParagraphLayoutCache } from './layout-cache.ts';
 import type { PendingLine } from './paragraph-flow.ts';
 import { drawingResourceLayoutToken } from './inline-drawing-source.ts';
+import { DEFAULT_REVISION_DISPLAY_MODE } from './revision-projection.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
 import type { AnchoredDrawingRecord } from './drawing-layout.ts';
 import { pageClipRegion, type DrawingAnchorFrameContext } from './drawing-layout.ts';
@@ -166,7 +167,7 @@ export function layoutHeaderFooterStory(
   pageContext?: FieldPageContext,
   maxPageContextEntries: number = DEFAULT_MAX_HF_PAGE_CONTEXT_ENTRIES,
   defaultTabStopPt?: number,
-  displayMode?: RevisionDisplayMode,
+  displayMode: RevisionDisplayMode = DEFAULT_REVISION_DISPLAY_MODE,
   inlineDrawingLayout?: import('./drawing-layout.ts').InlineDrawingLayoutContext,
   drawingTokenForParagraph?: (paragraph: import('@docx-editor.dev/core/store').OoxmlNode) => string,
   drawingLayoutToken?: string,
@@ -243,12 +244,15 @@ export function layoutHeaderFooterStory(
         flow = flowBlocksInBox(blocks, 0, Math.max(1, contentWidth), 0, 0, {
           measurer,
           cache,
-          producer: producer + token + (displayMode ? `|rev:${displayMode}` : ''),
+          producer:
+            producer +
+            token +
+            (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`),
           nextLineId: () => `hf-${part.name}-line-${lineCounter++}`,
           styleCascade,
           pageContext: effectiveCtx,
           ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
-          ...(displayMode ? { displayMode } : {}),
+          displayMode,
           ...(documentProperties ? { documentProperties } : {}),
           inlineDrawingLayout,
           anchorFrameBase,
@@ -259,12 +263,15 @@ export function layoutHeaderFooterStory(
           layoutTextboxStoryFor: (projection) =>
             layoutTextboxStory(projection, {
               measurer,
-              producer: producer + token + (displayMode ? `|rev:${displayMode}` : ''),
+              producer:
+                producer +
+                token +
+                (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`),
               cache,
               styleCascade,
               ...(effectiveCtx ? { pageContext: effectiveCtx } : {}),
               ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
-              ...(displayMode ? { displayMode } : {}),
+              displayMode,
               ...(documentProperties ? { documentProperties } : {}),
               inlineDrawingLayout,
               ...(drawingTokenForParagraph ? { drawingTokenForParagraph } : {}),
@@ -313,12 +320,15 @@ export function layoutHeaderFooterStory(
       flow = flowBlocksInBox(blocks, 0, Math.max(1, contentWidth), 0, 0, {
         measurer,
         cache,
-        producer: producer + token + (displayMode ? `|rev:${displayMode}` : ''),
+        producer:
+          producer +
+          token +
+          (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`),
         nextLineId: () => `hf-${part.name}-line-${lineCounter++}`,
         styleCascade,
         pageContext: effectiveCtx,
         ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
-        ...(displayMode ? { displayMode } : {}),
+        displayMode,
         ...(documentProperties ? { documentProperties } : {}),
       });
     }

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -175,7 +175,11 @@ export function layoutHeaderFooterStory(
 ): HeaderFooterStoryLayout {
   const needs = detectStoryPageFields(part.root);
   const contextCache = createBoundedContextCache(maxPageContextEntries);
-  const blocks = storyBlocks(part);
+  // WITH the display mode, like every other consumer of this list. The inline flow already
+  // received it — a deleted run vanished from a header in `proposed` — while the block list
+  // did not, so the paragraph a tracked mark merges away kept its own line, and a paragraph a
+  // revision removed entirely kept a blank one. The cache is namespaced by mode below.
+  const blocks = storyBlocks(part, displayMode);
   // Content identity is of the authored part, not of a page-field projection.
   const contentKey = headerFooterContentKey(part);
   let baseline: HeaderFooterStoryLayout | undefined;

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -372,6 +372,7 @@ export {
 // is the vocabulary and its pure helpers.
 export {
   activeReviewItem,
+  anchorLineY,
   reviewThreadRootOf,
   commentBodyText,
   commentInitials,

--- a/packages/core/src/layout/line-geometry.ts
+++ b/packages/core/src/layout/line-geometry.ts
@@ -1,0 +1,40 @@
+// Where an offset sits ACROSS a line, in points.
+//
+// Split out because two lanes need it and neither owns the other: caret stops ask it for a
+// position, selection rectangles ask it for the ends of a range. Both must ask it about ONE
+// paragraph's share of the line, which is what the segment argument is for.
+
+import { spanOffsetX } from './semantic-hit-test.ts';
+import type { LineSegment } from './line-segments.ts';
+import type { LineRecord, TextMeasurer } from './semantic-records.ts';
+
+export /** The x offset of `offset` within a line, by walking its spans. */
+function xWithinLine(
+  line: LineRecord,
+  offset: number,
+  measurer?: TextMeasurer | undefined,
+  segment?: LineSegment
+): number {
+  // An offset only means something in ONE paragraph, so a mixed line is walked through the
+  // segment that owns it. Given none, the line is its own segment, which is every ordinary
+  // line and the path this function always took.
+  const spans = segment ? segment.spans : line.spans;
+  for (const drawing of segment ? segment.drawings : (line.drawings ?? [])) {
+    if (offset === drawing.start) return drawing.advanceStart;
+    if (offset === drawing.start + 1) return drawing.advanceEnd;
+  }
+  let x = segment ? (segment.spans[0]?.box.x ?? line.contentX) : line.contentX;
+  for (const span of spans) {
+    if (offset <= span.range.start) return span.box.x;
+    if (offset >= span.range.end) {
+      x = span.box.x + span.box.width;
+      continue;
+    }
+    // MEASURED, not interpolated. Interpolating across the span's advance is exact only for a
+    // uniform one — in any proportional face it draws the caret a fraction of the way through
+    // the span rather than at a glyph edge, so a caret between two letters appeared on top of
+    // one. Without a measurer it still interpolates, and says so.
+    return spanOffsetX(span, offset, measurer);
+  }
+  return x;
+}

--- a/packages/core/src/layout/line-segments.ts
+++ b/packages/core/src/layout/line-segments.ts
@@ -4,7 +4,9 @@
 // POSITION and the hit-test lane resolves a POINT, and they already meet through the records.
 
 import type { InlineDrawingRecord } from './drawing-layout.ts';
-import type { LineRecord, StyleSpanRecord } from './semantic-records.ts';
+import { documentOrderIndex } from './document-order.ts';
+import type { LineRecord, SemanticLayout, StyleSpanRecord } from './semantic-records.ts';
+import type { SemanticPosition } from './semantic-interaction.ts';
 
 /**
  * The part of a line that belongs to ONE paragraph.
@@ -75,4 +77,31 @@ function splitLineByParagraph(line: LineRecord): readonly LineSegment[] {
 /** The segment a paragraph owns on this line, or null when it owns none of it. */
 export function lineSegmentFor(line: LineRecord, paragraphId: string): LineSegment | null {
   return lineSegments(line).find((segment) => segment.paragraphId === paragraphId) ?? null;
+}
+
+/**
+ * The part of ONE PARAGRAPH's share of `line` that a selection covers, in that paragraph's
+ * offsets, or null when the selection does not reach it.
+ *
+ * Asked per segment rather than per line. A resolved display mode lays merged paragraphs out
+ * on shared lines, and both members count from zero, so a line-wide answer highlighted the
+ * wrong characters — or none, when the selection lay entirely in the member the line is not
+ * named after.
+ */
+export function segmentOverlap(
+  layout: SemanticLayout,
+  segment: LineSegment,
+  from: SemanticPosition,
+  to: SemanticPosition
+): { start: number; end: number } | null {
+  const index = documentOrderIndex(layout);
+  const lineParagraph = index.get(segment.paragraphId) ?? -1;
+  const fromParagraph = index.get(from.paragraphId) ?? -1;
+  const toParagraph = index.get(to.paragraphId) ?? -1;
+  if (lineParagraph < fromParagraph || lineParagraph > toParagraph) return null;
+
+  const start =
+    lineParagraph === fromParagraph ? Math.max(segment.start, from.offset) : segment.start;
+  const end = lineParagraph === toParagraph ? Math.min(segment.end, to.offset) : segment.end;
+  return end > start ? { start, end } : null;
 }

--- a/packages/core/src/layout/line-segments.ts
+++ b/packages/core/src/layout/line-segments.ts
@@ -6,7 +6,12 @@
 import type { InlineDrawingRecord } from './drawing-layout.ts';
 import { documentOrderIndex } from './document-order.ts';
 import { paragraphFragmentsOf } from './semantic-records.ts';
-import type { LineRecord, SemanticLayout, StyleSpanRecord } from './semantic-records.ts';
+import type {
+  LineRecord,
+  ParagraphFragmentRecord,
+  SemanticLayout,
+  StyleSpanRecord,
+} from './semantic-records.ts';
 import type { SemanticPosition } from './semantic-interaction.ts';
 
 /**
@@ -120,15 +125,102 @@ export function mergedPredecessorsOf(
 ): readonly string[] {
   for (const page of layout.pages) {
     for (const fragment of paragraphFragmentsOf(page)) {
-      const held: string[] = [];
-      for (const line of fragment.lines) {
-        for (const segment of lineSegments(line)) {
-          if (!held.includes(segment.paragraphId)) held.push(segment.paragraphId);
-        }
-      }
-      const at = held.indexOf(paragraphId);
-      if (at > 0) return held.slice(0, at).reverse();
+      const at = fragmentParagraphs(fragment).indexOf(paragraphId);
+      if (at > 0) return fragmentParagraphs(fragment).slice(0, at).reverse();
     }
   }
   return [];
+}
+
+/** Cached per fragment: the answer is a walk of every line, and most callers ask repeatedly. */
+const fragmentParagraphsCache = new WeakMap<ParagraphFragmentRecord, readonly string[]>();
+
+/**
+ * Every paragraph a fragment DRAWS, in visual order.
+ *
+ * `[fragment.paragraphId]` for an ordinary one, which is what it has always been. A resolved
+ * display mode publishes a merged run as one fragment under the SURVIVOR's identity, so the
+ * absorbed members have no fragment named after them. Anything keyed on `fragment.paragraphId`
+ * alone reports those paragraphs as unlaid — no marker, no anchor, no note reference — while
+ * the reader is looking straight at them.
+ */
+export function fragmentParagraphs(fragment: ParagraphFragmentRecord): readonly string[] {
+  const cached = fragmentParagraphsCache.get(fragment);
+  if (cached) return cached;
+  // From the LINES, so the order is the order the reader meets them, and the fragment's own
+  // name last if no line named it — an empty paragraph has no span to speak for it.
+  const held: string[] = [];
+  for (const line of fragment.lines ?? []) {
+    for (const segment of lineSegments(line)) {
+      if (!held.includes(segment.paragraphId)) held.push(segment.paragraphId);
+    }
+  }
+  if (!held.includes(fragment.paragraphId)) held.push(fragment.paragraphId);
+  fragmentParagraphsCache.set(fragment, held);
+  return held;
+}
+
+/**
+ * The extent of ONE paragraph inside a fragment, in that paragraph's own offsets.
+ *
+ * An ordinary fragment answers from its own `range`, unchanged and without touching a line —
+ * the shape every caller has always read. Only a merged fragment pays for the walk.
+ */
+export function fragmentExtentOf(
+  fragment: ParagraphFragmentRecord,
+  paragraphId: string
+): { readonly start: number; readonly end: number } | null {
+  const held = fragmentParagraphs(fragment);
+  if (held.length === 1) {
+    return held[0] === paragraphId
+      ? { start: fragment.range.start, end: fragment.range.end }
+      : null;
+  }
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  for (const line of fragment.lines ?? []) {
+    const segment = lineSegmentFor(line, paragraphId);
+    if (!segment) continue;
+    start = Math.min(start, segment.start);
+    end = Math.max(end, segment.end);
+  }
+  return end >= start ? { start, end } : null;
+}
+
+/**
+ * Whether a fragment draws `paragraphId` at `offset`.
+ *
+ * Half-open — `[start, end)` — so a boundary offset belongs to the later fragment, which is
+ * the affinity every fragment-ownership question in the engine already uses.
+ */
+export function fragmentOwnsPosition(
+  fragment: ParagraphFragmentRecord,
+  paragraphId: string,
+  offset: number
+): boolean {
+  const extent = fragmentExtentOf(fragment, paragraphId);
+  return extent !== null && offset >= extent.start && offset < extent.end;
+}
+
+/**
+ * The fragment that DRAWS a paragraph, wherever it is nested, or null.
+ *
+ * The fast path is the old lookup by name and returns on the first hit; the walk of the lines
+ * runs only when no fragment claims the id, which is the merged case.
+ */
+export function fragmentHolding(
+  layout: SemanticLayout,
+  paragraphId: string
+): ParagraphFragmentRecord | null {
+  for (const page of layout.pages) {
+    for (const fragment of paragraphFragmentsOf(page)) {
+      if (fragment.paragraphId === paragraphId) return fragment;
+    }
+  }
+  for (const page of layout.pages) {
+    for (const fragment of paragraphFragmentsOf(page)) {
+      if (fragmentParagraphs(fragment).includes(paragraphId)) return fragment;
+    }
+  }
+  return null;
 }

--- a/packages/core/src/layout/line-segments.ts
+++ b/packages/core/src/layout/line-segments.ts
@@ -1,0 +1,78 @@
+// Which paragraph a line's offsets count in.
+//
+// Two lanes need this and neither may import the other: the interaction lane resolves a
+// POSITION and the hit-test lane resolves a POINT, and they already meet through the records.
+
+import type { InlineDrawingRecord } from './drawing-layout.ts';
+import type { LineRecord, StyleSpanRecord } from './semantic-records.ts';
+
+/**
+ * The part of a line that belongs to ONE paragraph.
+ *
+ * A line normally belongs to one paragraph outright, and then this is the whole of it — the
+ * same object every caller read before, so nothing about an ordinary document takes a new
+ * path. A resolved display mode merges paragraphs that a tracked decision merges, and the line
+ * carrying the join holds spans from two of them. Offsets there are ambiguous by themselves:
+ * both paragraphs start at zero, so an offset means nothing without the paragraph it counts in.
+ */
+export interface LineSegment {
+  readonly paragraphId: string;
+  readonly start: number;
+  readonly end: number;
+  readonly spans: readonly StyleSpanRecord[];
+  readonly drawings: readonly InlineDrawingRecord[];
+}
+
+/** Cached per line: a mixed line is rare, and asking costs a walk of every span. */
+const lineSegmentsCache = new WeakMap<LineRecord, readonly LineSegment[]>();
+
+/** Every paragraph a line carries, in visual order. One entry for an ordinary line. */
+export function lineSegments(line: LineRecord): readonly LineSegment[] {
+  const cached = lineSegmentsCache.get(line);
+  if (cached) return cached;
+  const whole: LineSegment = {
+    paragraphId: line.range.paragraphId,
+    start: line.range.start,
+    end: line.range.end,
+    spans: line.spans,
+    drawings: line.drawings ?? [],
+  };
+  const mixed = line.spans.some((span) => span.range.paragraphId !== line.range.paragraphId);
+  const segments = mixed ? splitLineByParagraph(line) : [whole];
+  lineSegmentsCache.set(line, segments);
+  return segments;
+}
+
+function splitLineByParagraph(line: LineRecord): readonly LineSegment[] {
+  const segments: LineSegment[] = [];
+  for (const span of line.spans) {
+    const previous = segments[segments.length - 1];
+    if (previous && previous.paragraphId === span.range.paragraphId) {
+      segments[segments.length - 1] = {
+        ...previous,
+        start: Math.min(previous.start, span.range.start),
+        end: Math.max(previous.end, span.range.end),
+        spans: [...previous.spans, span],
+      };
+      continue;
+    }
+    segments.push({
+      paragraphId: span.range.paragraphId,
+      start: span.range.start,
+      end: span.range.end,
+      spans: [span],
+      drawings: [],
+    });
+  }
+  return segments.map((segment) => ({
+    ...segment,
+    drawings: (line.drawings ?? []).filter(
+      (drawing) => drawing.paragraphId === segment.paragraphId
+    ),
+  }));
+}
+
+/** The segment a paragraph owns on this line, or null when it owns none of it. */
+export function lineSegmentFor(line: LineRecord, paragraphId: string): LineSegment | null {
+  return lineSegments(line).find((segment) => segment.paragraphId === paragraphId) ?? null;
+}

--- a/packages/core/src/layout/line-segments.ts
+++ b/packages/core/src/layout/line-segments.ts
@@ -5,6 +5,7 @@
 
 import type { InlineDrawingRecord } from './drawing-layout.ts';
 import { documentOrderIndex } from './document-order.ts';
+import { paragraphFragmentsOf } from './semantic-records.ts';
 import type { LineRecord, SemanticLayout, StyleSpanRecord } from './semantic-records.ts';
 import type { SemanticPosition } from './semantic-interaction.ts';
 
@@ -104,4 +105,30 @@ export function segmentOverlap(
     lineParagraph === fromParagraph ? Math.max(segment.start, from.offset) : segment.start;
   const end = lineParagraph === toParagraph ? Math.min(segment.end, to.offset) : segment.end;
   return end > start ? { start, end } : null;
+}
+
+/**
+ * The paragraphs drawn BEFORE this one inside the same paragraph box, nearest first.
+ *
+ * Empty for an ordinary paragraph. A resolved display mode lays a run of paragraphs out as
+ * one, and the breaks between them are not breaks the reader can see — so a key that acts on
+ * "the boundary before the caret" must know it is standing on one of them.
+ */
+export function mergedPredecessorsOf(
+  layout: SemanticLayout,
+  paragraphId: string
+): readonly string[] {
+  for (const page of layout.pages) {
+    for (const fragment of paragraphFragmentsOf(page)) {
+      const held: string[] = [];
+      for (const line of fragment.lines) {
+        for (const segment of lineSegments(line)) {
+          if (!held.includes(segment.paragraphId)) held.push(segment.paragraphId);
+        }
+      }
+      const at = held.indexOf(paragraphId);
+      if (at > 0) return held.slice(0, at).reverse();
+    }
+  }
+  return [];
 }

--- a/packages/core/src/layout/merged-paragraph-ranges.ts
+++ b/packages/core/src/layout/merged-paragraph-ranges.ts
@@ -91,20 +91,20 @@ export function remapMergedLines(
   return lines.map((line) => {
     const spans = line.spans.map((span) => remapSpan(span, boundaries));
     const first = spans[0];
-    const range = first
-      ? { paragraphId: first.range.paragraphId, start: first.range.start, end: 0 }
-      : remapRange(line.range, boundaries);
-    const last = spans[spans.length - 1];
+    // The extent this line holds OF THE PARAGRAPH IT NAMES: from its first span to the last
+    // span that still belongs to that paragraph. Reading the last span of the line instead
+    // reported the other member's end, and reading the first span's end truncated the range
+    // to one run whenever the member contributed several.
+    const owned = first
+      ? spans.filter((span) => span.range.paragraphId === first.range.paragraphId)
+      : [];
     const lineRange: SourceRange = first
       ? {
-          paragraphId: range.paragraphId,
-          start: range.start,
-          // The end of the LAST span that shares the line's paragraph, so a join line reports
-          // the extent it holds of the paragraph it names rather than the other one's.
-          end: (last && last.range.paragraphId === range.paragraphId ? last.range : first.range)
-            .end,
+          paragraphId: first.range.paragraphId,
+          start: first.range.start,
+          end: owned[owned.length - 1]!.range.end,
         }
-      : range;
+      : remapRange(line.range, boundaries);
     const drawings = line.drawings?.map((drawing) => {
       const member = memberAt(boundaries, drawing.start);
       return member

--- a/packages/core/src/layout/merged-paragraph-ranges.ts
+++ b/packages/core/src/layout/merged-paragraph-ranges.ts
@@ -47,7 +47,7 @@ export function mergeBoundariesOf(group: ParagraphMergeGroup): MergeBoundaries {
  * The LAST member whose content starts at or before the offset, which puts a position at a
  * member boundary — the caret between the two halves — at the start of the following member,
  * where an insertion belongs to the paragraph the reader is typing into. An empty member has
- * zero length and no offset of its own, so it never wins.
+ * no offsets of its own, so it only wins a boundary offset that no later member claims.
  */
 function memberAt(boundaries: MergeBoundaries, offset: number): MergeMember | undefined {
   let found: MergeMember | undefined;

--- a/packages/core/src/layout/merged-paragraph-ranges.ts
+++ b/packages/core/src/layout/merged-paragraph-ranges.ts
@@ -91,6 +91,15 @@ export function remapMergedLines(
   return lines.map((line) => {
     const spans = line.spans.map((span) => remapSpan(span, boundaries));
     const first = spans[0];
+    // Remapped FIRST, because the line's own extent has to count them: an inline drawing is
+    // an atom with an offset of its own, and a member that opens with a picture starts at the
+    // picture, not at its first character.
+    const remappedDrawings = line.drawings?.map((drawing) => {
+      const member = memberAt(boundaries, drawing.start);
+      return member
+        ? { ...drawing, paragraphId: member.paragraphId, start: drawing.start - member.base }
+        : drawing;
+    });
     // The extent this line holds OF THE PARAGRAPH IT NAMES: from its first span to the last
     // span that still belongs to that paragraph. Reading the last span of the line instead
     // reported the other member's end, and reading the first span's end truncated the range
@@ -98,19 +107,23 @@ export function remapMergedLines(
     const owned = first
       ? spans.filter((span) => span.range.paragraphId === first.range.paragraphId)
       : [];
+    const ownedDrawings = first
+      ? (remappedDrawings ?? []).filter(
+          (drawing) => drawing.paragraphId === first.range.paragraphId
+        )
+      : [];
     const lineRange: SourceRange = first
       ? {
           paragraphId: first.range.paragraphId,
-          start: first.range.start,
-          end: owned[owned.length - 1]!.range.end,
+          start: Math.min(first.range.start, ...ownedDrawings.map((drawing) => drawing.start)),
+          // An atom occupies ONE offset, so a trailing picture ends one past its own.
+          end: Math.max(
+            owned[owned.length - 1]!.range.end,
+            ...ownedDrawings.map((drawing) => drawing.start + 1)
+          ),
         }
       : remapRange(line.range, boundaries);
-    const drawings = line.drawings?.map((drawing) => {
-      const member = memberAt(boundaries, drawing.start);
-      return member
-        ? { ...drawing, paragraphId: member.paragraphId, start: drawing.start - member.base }
-        : drawing;
-    });
+    const drawings = remappedDrawings;
     // A deleted range is a pair of offsets with no paragraph of its own, so on a join line it
     // can only be expressed in one paragraph's terms. Kept for the paragraph the line names and
     // dropped for the other — and in practice empty either way, because a mode that merges has

--- a/packages/core/src/layout/merged-paragraph-ranges.ts
+++ b/packages/core/src/layout/merged-paragraph-ranges.ts
@@ -1,0 +1,133 @@
+// Giving a merged paragraph's content back its own identity.
+//
+// A resolved display mode lays a run of paragraphs out as one, because that is what the
+// document becomes once its tracked decisions are taken. The layout is right and the identity
+// is not: every span in that fragment names the paragraph the merge kept, at an offset in a
+// paragraph that does not hold those characters. A resolved view is EDITABLE — the free engine
+// renders `proposed` by default — so a click or a keystroke in the merged half would address a
+// position the store does not have.
+//
+// This maps each published range back to the member that contributed it. The member boundaries
+// are the members' own model lengths: `piecesOfParagraph` keeps its running offset aligned with
+// `paragraphTextOf`, which is the same authority `paragraphOffsetIndex` answers from, so the
+// k-th member starts at the sum of the lengths before it.
+
+import { paragraphOffsetIndex } from '../store/store/tree-op-segments.ts';
+import type { OoxmlParagraphNode } from '@docx-editor.dev/core/store';
+import type { ParagraphMergeGroup } from './story-roots.ts';
+import type { LineRecord, SourceRange, StyleSpanRecord } from './semantic-records.ts';
+
+interface MergeMember {
+  readonly paragraphId: string;
+  /** Where this member's content starts in the merged paragraph's offsets. */
+  readonly base: number;
+  readonly length: number;
+}
+
+export interface MergeBoundaries {
+  readonly members: readonly MergeMember[];
+  readonly total: number;
+}
+
+/** Member bases, in the merged paragraph's own offset space. */
+export function mergeBoundariesOf(group: ParagraphMergeGroup): MergeBoundaries {
+  const members: MergeMember[] = [];
+  let base = 0;
+  for (const member of group.members) {
+    const length = paragraphOffsetIndex(member as OoxmlParagraphNode).length;
+    members.push({ paragraphId: member.id, base, length });
+    base += length;
+  }
+  return { members, total: base };
+}
+
+/**
+ * The member an offset belongs to.
+ *
+ * The LAST member whose content starts at or before the offset, which puts a position at a
+ * member boundary — the caret between the two halves — at the start of the following member,
+ * where an insertion belongs to the paragraph the reader is typing into. An empty member has
+ * zero length and no offset of its own, so it never wins.
+ */
+function memberAt(boundaries: MergeBoundaries, offset: number): MergeMember | undefined {
+  let found: MergeMember | undefined;
+  for (const member of boundaries.members) {
+    if (member.base > offset) break;
+    if (found === undefined || member.length > 0 || member.base > found.base) found = member;
+  }
+  return found ?? boundaries.members[boundaries.members.length - 1];
+}
+
+function remapRange(range: SourceRange, boundaries: MergeBoundaries): SourceRange {
+  const member = memberAt(boundaries, range.start);
+  if (!member) return range;
+  const end = range.end - member.base;
+  return {
+    paragraphId: member.paragraphId,
+    start: range.start - member.base,
+    // A span is a piece of ONE run and two members contribute different runs, so a span cannot
+    // cross a boundary. The clamp is what keeps a broken invariant from publishing an offset
+    // past the end of a real paragraph, where an edit would be refused or land elsewhere.
+    end: Math.min(end, member.length),
+  };
+}
+
+function remapSpan(span: StyleSpanRecord, boundaries: MergeBoundaries): StyleSpanRecord {
+  return { ...span, range: remapRange(span.range, boundaries) };
+}
+
+/**
+ * Every range a merged fragment publishes, in the offsets of the paragraph that owns it.
+ *
+ * A line keeps ONE range, because that is the shape every consumer reads; it names the
+ * paragraph of the line's first span. The join line therefore belongs to two paragraphs and
+ * says so only through its spans, which is why the interaction index reads spans rather than
+ * the line range when it maps a position.
+ */
+export function remapMergedLines(
+  lines: readonly LineRecord[],
+  boundaries: MergeBoundaries
+): readonly LineRecord[] {
+  return lines.map((line) => {
+    const spans = line.spans.map((span) => remapSpan(span, boundaries));
+    const first = spans[0];
+    const range = first
+      ? { paragraphId: first.range.paragraphId, start: first.range.start, end: 0 }
+      : remapRange(line.range, boundaries);
+    const last = spans[spans.length - 1];
+    const lineRange: SourceRange = first
+      ? {
+          paragraphId: range.paragraphId,
+          start: range.start,
+          // The end of the LAST span that shares the line's paragraph, so a join line reports
+          // the extent it holds of the paragraph it names rather than the other one's.
+          end: (last && last.range.paragraphId === range.paragraphId ? last.range : first.range)
+            .end,
+        }
+      : range;
+    const drawings = line.drawings?.map((drawing) => {
+      const member = memberAt(boundaries, drawing.start);
+      return member
+        ? { ...drawing, paragraphId: member.paragraphId, start: drawing.start - member.base }
+        : drawing;
+    });
+    // A deleted range is a pair of offsets with no paragraph of its own, so on a join line it
+    // can only be expressed in one paragraph's terms. Kept for the paragraph the line names and
+    // dropped for the other — and in practice empty either way, because a mode that merges has
+    // already resolved every deletion: `proposed` hides the text, `original` keeps it as live.
+    const deletedRanges = line.deletedRanges
+      ?.map((deleted) => ({ deleted, member: memberAt(boundaries, deleted.start) }))
+      .filter(({ member }) => member?.paragraphId === lineRange.paragraphId)
+      .map(({ deleted, member }) => ({
+        start: deleted.start - (member?.base ?? 0),
+        end: deleted.end - (member?.base ?? 0),
+      }));
+    return {
+      ...line,
+      range: lineRange,
+      spans,
+      ...(drawings ? { drawings } : {}),
+      ...(deletedRanges ? { deletedRanges } : {}),
+    };
+  });
+}

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -61,6 +61,7 @@ import type { PendingLine } from './paragraph-flow.ts';
 import { cascadeRunProperties, type StyleCascadeTable } from './style-cascade.ts';
 import { DEFAULT_RUN_STYLE, resolveRunStyle, type ResolvedRunStyle } from './run-style.ts';
 import { finalizePageFieldProjection } from './field-projection.ts';
+import { DEFAULT_REVISION_DISPLAY_MODE, type RevisionDisplayMode } from './revision-projection.ts';
 
 /** Bound on reflow attempts per document layout pass. */
 export const MAX_NOTE_REFLOW_ATTEMPTS = 8;
@@ -1929,10 +1930,16 @@ function collectBodyNoteReferences(part: OoxmlPart): readonly {
 /** Map paragraph id → section index for note numbering / position resolution. */
 function paragraphSectionIndexOf(
   part: OoxmlPart,
-  sections: readonly DocumentSection[]
+  sections: readonly DocumentSection[],
+  displayMode: RevisionDisplayMode
 ): ReadonlyMap<string, number> {
   const map = new Map<string, number>();
-  const blocks = storyBlocks(part);
+  // IN THE SAME MODE the section bounds were counted in. `blockStart`/`blockEndExclusive`
+  // index a mode-filtered block list, and a resolved view has fewer blocks — a paragraph a
+  // tracked mark merged away is gone from it. Indexing an All Markup list with those bounds
+  // put paragraphs in the wrong section, which renumbers a footnote in a section nobody
+  // edited.
+  const blocks = storyBlocks(part, displayMode);
   for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex += 1) {
     const section = sections[sectionIndex]!;
     for (let i = section.blockStart; i < section.blockEndExclusive; i += 1) {
@@ -2033,7 +2040,12 @@ export function layoutSemanticDocumentWithNotes<
   runBody: (opts: Opts) => SemanticLayout
 ): SemanticLayout {
   const packageRefs = collectBodyNoteReferences(part);
-  const paragraphSectionIndex = paragraphSectionIndexOf(part, sections);
+  const paragraphSectionIndex = paragraphSectionIndexOf(
+    part,
+    sections,
+    (optionsWithLists as { displayMode?: RevisionDisplayMode }).displayMode ??
+      DEFAULT_REVISION_DISPLAY_MODE
+  );
   const allHits = buildPageRefHits(packageRefs, paragraphSectionIndex);
   const noteMarks = provisionalNoteMarks(allHits, notesInput);
   const seeded = optionsWithLists.session?.notePageBottomReserves;

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -8,6 +8,7 @@
 // sectEnd / docEnd. Hostile counts and oscillation fail closed with named reasons.
 
 import type { OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
+import { fragmentOwnsPosition, fragmentParagraphs } from './line-segments.ts';
 import { collectNoteReferences } from '../store/package/note-references.ts';
 import type { DocumentSection } from './section-properties.ts';
 import { storyBlocks } from './story-roots.ts';
@@ -250,23 +251,24 @@ export function filterRefsOnPage(
   const fragments = paragraphFragmentsOfBlocks(page.fragments);
   if (!refIndex) {
     return allRefs.filter((ref) =>
-      fragments.some(
-        (fragment) =>
-          fragment.paragraphId === ref.paragraphId &&
-          fragmentOwnsAtomOffset(fragment, ref.atomOffset)
-      )
+      fragments.some((fragment) => fragmentOwnsPosition(fragment, ref.paragraphId, ref.atomOffset))
     );
   }
   const out: PageRefHit[] = [];
   const claimed = new Set<PageRefHit>();
   for (const fragment of fragments) {
-    const candidates = refIndex.get(fragment.paragraphId);
-    if (!candidates) continue;
-    for (const ref of candidates) {
-      if (claimed.has(ref)) continue;
-      if (!fragmentOwnsAtomOffset(fragment, ref.atomOffset)) continue;
-      claimed.add(ref);
-      out.push(ref);
+    // Asked per paragraph the fragment DRAWS. A resolved display mode publishes a merged run
+    // under the survivor's name, so a reference in an absorbed member matched no fragment at
+    // all: the note it calls never reached the page, and the reader saw a mark with no note.
+    for (const paragraphId of fragmentParagraphs(fragment)) {
+      const candidates = refIndex.get(paragraphId);
+      if (!candidates) continue;
+      for (const ref of candidates) {
+        if (claimed.has(ref)) continue;
+        if (!fragmentOwnsPosition(fragment, paragraphId, ref.atomOffset)) continue;
+        claimed.add(ref);
+        out.push(ref);
+      }
     }
   }
   return out;

--- a/packages/core/src/layout/review-support.ts
+++ b/packages/core/src/layout/review-support.ts
@@ -272,6 +272,8 @@ export interface ReviewCustomItem {
  * One pending decision in the review queue: a tracked change, a comment thread, or a pro
  * custom-node card. Discriminate on `kind`.
  */
+export type ReviewItem = ReviewRevisionItem | ReviewCommentItem | ReviewCustomItem;
+
 /**
  * The two declarations of this type must stay identical.
  *
@@ -288,8 +290,6 @@ type Identical<A, B> =
 export type ReviewRevisionItemDeclarationsAgree = Assert<
   Identical<ReviewRevisionItem, StoreReviewRevisionItem>
 >;
-
-export type ReviewItem = ReviewRevisionItem | ReviewCommentItem | ReviewCustomItem;
 
 /** What the review queue derivation reads: one story part plus its comment parts. */
 export interface ReviewModelInput {
@@ -617,7 +617,38 @@ export interface ReviewParagraphAnchor {
   readonly lines?: readonly {
     readonly range: { readonly end: number };
     readonly box: { readonly y: number };
+    /**
+     * Present on a real line. A merged fragment's join line carries spans from two
+     * paragraphs, and its `range` can only name one of them, so the OTHER paragraph's extent
+     * on that line is readable here and nowhere else.
+     */
+    readonly spans?: readonly {
+      readonly range: { readonly paragraphId: string; readonly end: number };
+    }[];
   }[];
+}
+
+/**
+ * The y of the line a position sits on, measured from the anchor's own origin.
+ *
+ * An ordinary line answers from its own range, exactly as it always did. On a merged
+ * fragment's join line the range names one of the two paragraphs, so an offset compared
+ * against it either overshot — putting a card in the absorbed half beside the wrong line —
+ * or matched the first line every time.
+ */
+export function anchorLineY(
+  anchor: ReviewParagraphAnchor,
+  paragraphId: string,
+  offset: number
+): number {
+  const line = anchor.lines?.find((entry) => {
+    const spans = entry.spans;
+    if (!spans) return offset < entry.range.end;
+    const owned = spans.filter((span) => span.range.paragraphId === paragraphId);
+    if (owned.length === spans.length) return offset < entry.range.end;
+    return owned.length > 0 && offset < owned[owned.length - 1]!.range.end;
+  });
+  return line ? line.box.y : anchor.fragmentY;
 }
 
 /**
@@ -639,7 +670,9 @@ export function reviewAnchorIndex<
       readonly range: { readonly end: number };
       readonly box: { readonly y: number };
       /** Present on a real line; a merged one carries spans from more than one paragraph. */
-      readonly spans?: readonly { readonly range: { readonly paragraphId: string } }[];
+      readonly spans?: readonly {
+        readonly range: { readonly paragraphId: string; readonly end: number };
+      }[];
     }[];
   }[]
 ): Map<string, ReviewParagraphAnchor> {
@@ -694,9 +727,8 @@ export function reviewItemGeometry(
   //
   // The LINE the range starts on, not the paragraph's top: a comment on the last line of a
   // twelve-line paragraph belongs beside that line, which is where Word puts it.
-  const line = anchor.lines?.find((entry) => range.start.offset < entry.range.end);
   return {
     pageIndex: anchor.pageIndex,
-    y: anchor.contentY + (line ? line.box.y : anchor.fragmentY),
+    y: anchor.contentY + anchorLineY(anchor, range.start.paragraphId, range.start.offset),
   };
 }

--- a/packages/core/src/layout/review-support.ts
+++ b/packages/core/src/layout/review-support.ts
@@ -613,21 +613,32 @@ export function reviewAnchorIndex<
     readonly lines?: readonly {
       readonly range: { readonly end: number };
       readonly box: { readonly y: number };
+      /** Present on a real line; a merged one carries spans from more than one paragraph. */
+      readonly spans?: readonly { readonly range: { readonly paragraphId: string } }[];
     }[];
   }[]
 ): Map<string, ReviewParagraphAnchor> {
   const index = new Map<string, ReviewParagraphAnchor>();
   for (const page of layout.pages) {
     for (const fragment of paragraphFragments(page)) {
-      // FIRST fragment wins: a paragraph split across a page break is anchored where it
-      // starts, which is where its comment marker was written.
-      if (index.has(fragment.paragraphId)) continue;
-      index.set(fragment.paragraphId, {
-        pageIndex: page.index,
-        contentY: page.contentBox.y,
-        fragmentY: fragment.box.y,
-        ...(fragment.lines ? { lines: fragment.lines } : {}),
-      });
+      // Every paragraph whose content this fragment HOLDS. A resolved view lays a merged
+      // group out as one fragment named after the survivor, and a card anchored in any other
+      // member would have no geometry and drop out of the rail.
+      const held = new Set<string>([fragment.paragraphId]);
+      for (const line of fragment.lines ?? []) {
+        for (const span of line.spans ?? []) held.add(span.range.paragraphId);
+      }
+      for (const paragraphId of held) {
+        // FIRST fragment wins: a paragraph split across a page break is anchored where it
+        // starts, which is where its comment marker was written.
+        if (index.has(paragraphId)) continue;
+        index.set(paragraphId, {
+          pageIndex: page.index,
+          contentY: page.contentBox.y,
+          fragmentY: fragment.box.y,
+          ...(fragment.lines ? { lines: fragment.lines } : {}),
+        });
+      }
     }
   }
   return index;

--- a/packages/core/src/layout/review-support.ts
+++ b/packages/core/src/layout/review-support.ts
@@ -142,6 +142,14 @@ export interface ReviewRevisionItem {
   /** The words a replacement removes. Empty for every other kind. */
   readonly replacedText: string;
   readonly revisionKind: ReviewRevisionKind;
+  /**
+   * WHICH decision a `paragraphMark` records, absent for every other kind.
+   *
+   * `EG_ParaRPrTrackChanges` is `ins? del? moveFrom? moveTo?`, and the four say opposite
+   * things about one break. Without this a card called a deleted break an inserted one, which
+   * is the reverse of what Accept on that card does.
+   */
+  readonly markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
   readonly author: string;
   readonly date?: string;
   /** Text the revision covers, for the card summary. Empty for changes with no characters. */

--- a/packages/core/src/layout/review-support.ts
+++ b/packages/core/src/layout/review-support.ts
@@ -272,6 +272,23 @@ export interface ReviewCustomItem {
  * One pending decision in the review queue: a tracked change, a comment thread, or a pro
  * custom-node card. Discriminate on `kind`.
  */
+/**
+ * The two declarations of this type must stay identical.
+ *
+ * `store/review-reads.ts` declares it for the reader and this file declares it again for the
+ * layout lane, which may not import the store's. Nothing else catches a field added to one
+ * and not the other: an OPTIONAL field drifts past typecheck, lint, the tests and the parity
+ * contract, and shows up only as an asymmetric `.api.md` diff that a human has to notice.
+ * These two assignments fail to compile the moment either side gains or loses a member.
+ */
+type StoreReviewRevisionItem = import('../store/store/review-reads.ts').ReviewRevisionItem;
+type Assert<T extends true> = T;
+type Identical<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+export type ReviewRevisionItemDeclarationsAgree = Assert<
+  Identical<ReviewRevisionItem, StoreReviewRevisionItem>
+>;
+
 export type ReviewItem = ReviewRevisionItem | ReviewCommentItem | ReviewCustomItem;
 
 /** What the review queue derivation reads: one story part plus its comment parts. */

--- a/packages/core/src/layout/revision-visibility.ts
+++ b/packages/core/src/layout/revision-visibility.ts
@@ -23,6 +23,7 @@ import {
   MAX_CONTENT_CONTROL_NESTING,
 } from '../store/package/content-control-walk.ts';
 import { MAX_REVISION_DEPTH } from './revision-projection.ts';
+import { WML_NAMESPACE_URI } from '../store/package/ooxml-tree.ts';
 
 /**
  * Matches the layout walk's own container recursion; see `piecesOfParagraph`.
@@ -37,6 +38,23 @@ function childNamed(node: OoxmlNode, localName: string): OoxmlNode | undefined {
   if (node.kind === 'textValue') return undefined;
   for (const child of node.children) {
     if (child.kind !== 'textValue' && child.localName === localName) return child;
+  }
+  return undefined;
+}
+
+/**
+ * A child in the WordprocessingML namespace, by name.
+ *
+ * The namespace is the difference between a revision and a look-alike. A `.docx` is a zip of
+ * XML the sender controls, so an `<x:del/>` sitting in the paragraph mark's `w:rPr` is markup
+ * anyone can author — and matching on the local name alone let it merge two paragraphs in the
+ * default view, a join no decision in the file can produce and no Accept can undo.
+ */
+function wmlChildNamed(node: OoxmlNode, localName: string): OoxmlNode | undefined {
+  if (node.kind === 'textValue') return undefined;
+  for (const child of node.children) {
+    if (child.kind === 'textValue') continue;
+    if (child.namespaceUri === WML_NAMESPACE_URI && child.localName === localName) return child;
   }
   return undefined;
 }
@@ -57,8 +75,8 @@ export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean {
     childNamed(properties, 'runProperties') ?? childNamed(properties, 'rPr');
   if (markRunProperties === undefined) return false;
   return (
-    childNamed(markRunProperties, 'del') !== undefined ||
-    childNamed(markRunProperties, 'moveFrom') !== undefined
+    wmlChildNamed(markRunProperties, 'del') !== undefined ||
+    wmlChildNamed(markRunProperties, 'moveFrom') !== undefined
   );
 }
 
@@ -140,7 +158,7 @@ export function markRemovedInMode(
   if (markRunProperties === undefined) return false;
   const removedNames =
     displayMode === 'proposed' ? (['del', 'moveFrom'] as const) : (['ins', 'moveTo'] as const);
-  return removedNames.some((name) => childNamed(markRunProperties, name) !== undefined);
+  return removedNames.some((name) => wmlChildNamed(markRunProperties, name) !== undefined);
 }
 
 /**

--- a/packages/core/src/layout/revision-visibility.ts
+++ b/packages/core/src/layout/revision-visibility.ts
@@ -117,6 +117,33 @@ function rendersNoText(node: OoxmlNode, depth: number): boolean {
 }
 
 /**
+ * Does this display mode REMOVE the paragraph's mark, and with it the break it draws?
+ *
+ * A mark records a break that a decision would take away. `proposed` answers what the document
+ * becomes when every decision is accepted, so a deleted or moved-from mark is gone there;
+ * `original` answers what it was before any of them, so an inserted or moved-to mark is gone
+ * there. `all-markup` takes no decision and removes nothing.
+ *
+ * The paragraph then runs into the one after it, which is exactly what `resolveRevisions` does
+ * with the same four elements.
+ */
+export function markRemovedInMode(
+  paragraph: OoxmlNode,
+  displayMode: 'all-markup' | 'proposed' | 'original'
+): boolean {
+  if (displayMode === 'all-markup') return false;
+  if (paragraph.kind === 'textValue') return false;
+  const properties = childNamed(paragraph, 'paragraphProperties') ?? childNamed(paragraph, 'pPr');
+  if (!properties) return false;
+  const markRunProperties =
+    childNamed(properties, 'runProperties') ?? childNamed(properties, 'rPr');
+  if (markRunProperties === undefined) return false;
+  const removedNames =
+    displayMode === 'proposed' ? (['del', 'moveFrom'] as const) : (['ins', 'moveTo'] as const);
+  return removedNames.some((name) => childNamed(markRunProperties, name) !== undefined);
+}
+
+/**
  * True when a tracked revision has removed this paragraph from the rendered document, so
  * layout should emit no box for it at all.
  */

--- a/packages/core/src/layout/revision-visibility.ts
+++ b/packages/core/src/layout/revision-visibility.ts
@@ -34,14 +34,6 @@ import { WML_NAMESPACE_URI } from '../store/package/ooxml-tree.ts';
  */
 const MAX_INLINE_DEPTH = MAX_REVISION_DEPTH;
 
-function childNamed(node: OoxmlNode, localName: string): OoxmlNode | undefined {
-  if (node.kind === 'textValue') return undefined;
-  for (const child of node.children) {
-    if (child.kind !== 'textValue' && child.localName === localName) return child;
-  }
-  return undefined;
-}
-
 /**
  * A child in the WordprocessingML namespace, by name.
  *
@@ -69,10 +61,11 @@ function wmlChildNamed(node: OoxmlNode, localName: string): OoxmlNode | undefine
  */
 export function paragraphMarkDeleted(paragraph: OoxmlNode): boolean {
   if (paragraph.kind === 'textValue') return false;
-  const properties = childNamed(paragraph, 'paragraphProperties') ?? childNamed(paragraph, 'pPr');
+  const properties =
+    wmlChildNamed(paragraph, 'paragraphProperties') ?? wmlChildNamed(paragraph, 'pPr');
   if (!properties) return false;
   const markRunProperties =
-    childNamed(properties, 'runProperties') ?? childNamed(properties, 'rPr');
+    wmlChildNamed(properties, 'runProperties') ?? wmlChildNamed(properties, 'rPr');
   if (markRunProperties === undefined) return false;
   return (
     wmlChildNamed(markRunProperties, 'del') !== undefined ||
@@ -151,10 +144,14 @@ export function markRemovedInMode(
 ): boolean {
   if (displayMode === 'all-markup') return false;
   if (paragraph.kind === 'textValue') return false;
-  const properties = childNamed(paragraph, 'paragraphProperties') ?? childNamed(paragraph, 'pPr');
+  // The namespace at EVERY step. Checking only the innermost element left the containers
+  // spoofable: `<x:rPr><w:del/></x:rPr>` in a `w:pPr` merged two paragraphs from markup any
+  // sender can author, and no Accept could undo the join it produced.
+  const properties =
+    wmlChildNamed(paragraph, 'paragraphProperties') ?? wmlChildNamed(paragraph, 'pPr');
   if (!properties) return false;
   const markRunProperties =
-    childNamed(properties, 'runProperties') ?? childNamed(properties, 'rPr');
+    wmlChildNamed(properties, 'runProperties') ?? wmlChildNamed(properties, 'rPr');
   if (markRunProperties === undefined) return false;
   const removedNames =
     displayMode === 'proposed' ? (['del', 'moveFrom'] as const) : (['ins', 'moveTo'] as const);

--- a/packages/core/src/layout/selection-rects.ts
+++ b/packages/core/src/layout/selection-rects.ts
@@ -7,7 +7,7 @@
 import { lineSegments, segmentOverlap } from './line-segments.ts';
 import { xWithinLine } from './line-geometry.ts';
 import { paragraphFragmentsOf } from './semantic-records.ts';
-import type { SemanticLayout, TextMeasurer } from './semantic-records.ts';
+import type { SemanticLayout } from './semantic-records.ts';
 import { orderPositions } from './semantic-interaction.ts';
 import type { SemanticPosition, SemanticSelection, SelectionRect } from './semantic-interaction.ts';
 

--- a/packages/core/src/layout/selection-rects.ts
+++ b/packages/core/src/layout/selection-rects.ts
@@ -1,0 +1,98 @@
+// Where a selection paints.
+//
+// Rectangles, not positions: the interaction lane answers "which position is this point", and
+// this answers "which pixels does this range cover". They meet at `segmentOverlap`, which is
+// the one part of both that has to know a line can carry more than one paragraph.
+
+import { lineSegments, segmentOverlap } from './line-segments.ts';
+import { xWithinLine } from './line-geometry.ts';
+import { paragraphFragmentsOf } from './semantic-records.ts';
+import type { SemanticLayout, TextMeasurer } from './semantic-records.ts';
+import { orderPositions } from './semantic-interaction.ts';
+import type { SemanticPosition, SemanticSelection, SelectionRect } from './semantic-interaction.ts';
+
+/** The rectangles covering a selection, one per line it spans. */
+export function selectionRects(
+  layout: SemanticLayout,
+  selection: SemanticSelection
+): SelectionRect[] {
+  const ordered = orderPositions(layout, selection);
+  if (!ordered) return [];
+  const rects: SelectionRect[] = [];
+  for (const page of layout.pages) {
+    for (const fragment of paragraphFragmentsOf(page)) {
+      for (const line of fragment.lines) {
+        for (const segment of lineSegments(line)) {
+          const overlap = segmentOverlap(layout, segment, ordered.from, ordered.to);
+          if (!overlap) continue;
+          const startX = xWithinLine(line, overlap.start, undefined, segment);
+          const endX = xWithinLine(line, overlap.end, undefined, segment);
+          rects.push({
+            pageIndex: page.index,
+            x: Math.min(startX, endX),
+            y: line.box.y,
+            width: Math.abs(endX - startX),
+            height: line.box.height,
+          });
+        }
+      }
+    }
+  }
+  return rects;
+}
+
+/** A model range to highlight, and the key the caller knows it by. */
+export interface KeyedRange {
+  readonly key: string;
+  readonly from: SemanticPosition;
+  readonly to: SemanticPosition;
+}
+
+/**
+ * Rectangles for MANY ranges in ONE pass over the lines.
+ *
+ * Not `selectionRects` in a loop. That walks every page, fragment and line per range, and a
+ * contract with two hundred comments would re-walk the whole document two hundred times on
+ * every layout — the highlight would cost more than the layout it decorates. One pass tests
+ * each line against every range instead, which is the same work a single selection does.
+ */
+export function keyedRangeRects(
+  layout: SemanticLayout,
+  ranges: readonly KeyedRange[],
+  /**
+   * Pages to measure, or every page when absent.
+   *
+   * A band that is not on screen is not painted, so measuring it is pure cost — and it is
+   * cost paid per keystroke, because an edit republishes the layout. Bounding this to the
+   * materialized pages is what keeps typing in a heavily reviewed document as fast as
+   * typing in a clean one.
+   */
+  pages?: ReadonlySet<number>
+): Map<string, SelectionRect[]> {
+  const found = new Map<string, SelectionRect[]>();
+  if (ranges.length === 0) return found;
+  for (const page of layout.pages) {
+    if (pages && !pages.has(page.index)) continue;
+    for (const fragment of paragraphFragmentsOf(page)) {
+      for (const line of fragment.lines) {
+        for (const segment of lineSegments(line))
+          for (const range of ranges) {
+            const overlap = segmentOverlap(layout, segment, range.from, range.to);
+            if (!overlap) continue;
+            const startX = xWithinLine(line, overlap.start, undefined, segment);
+            const endX = xWithinLine(line, overlap.end, undefined, segment);
+            const rects = found.get(range.key) ?? [];
+            rects.push({
+              pageIndex: page.index,
+              x: Math.min(startX, endX),
+              y: line.box.y,
+              width: Math.abs(endX - startX),
+              height: line.box.height,
+            });
+            found.set(range.key, rects);
+          }
+      }
+    }
+  }
+  return found;
+}

--- a/packages/core/src/layout/semantic-cell-selection.ts
+++ b/packages/core/src/layout/semantic-cell-selection.ts
@@ -13,6 +13,7 @@
 // the rectangle ask for it.
 
 import { paragraphTextFromLayout, type SemanticSelection } from './semantic-interaction.ts';
+import { fragmentParagraphs } from './line-segments.ts';
 import type { TableCellAddress } from './semantic-hit-test.ts';
 import {
   paragraphFragmentsOf,
@@ -254,9 +255,14 @@ export function paragraphsInCells(
 
 function collectParagraphs(block: BlockFragmentRecord, into: string[], seen: Set<string>): void {
   if (block.kind === 'paragraph') {
-    if (!seen.has(block.paragraphId)) {
-      seen.add(block.paragraphId);
-      into.push(block.paragraphId);
+    // EVERY paragraph the fragment draws, not just the one it is named after. A resolved
+    // display mode merges a run into the survivor's fragment, and a cell selection that
+    // listed the survivor alone deleted half of what the reader had highlighted: the
+    // absorbed members' text stayed behind in a cell reported as emptied.
+    for (const paragraphId of fragmentParagraphs(block)) {
+      if (seen.has(paragraphId)) continue;
+      seen.add(paragraphId);
+      into.push(paragraphId);
     }
     return;
   }

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -23,6 +23,7 @@
 
 import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
 import { graphemeBoundaryEpoch, segmentGraphemes } from './grapheme.ts';
+import { lineSegments, type LineSegment } from './line-segments.ts';
 import { baselineShiftPtOf, measureDisplayText } from './run-style.ts';
 import type { CaretGeometry, SemanticPosition } from './semantic-interaction.ts';
 import type {
@@ -560,11 +561,15 @@ function resolveParagraph(
   const line = lineAtY(fragment.lines, point.y);
   if (!line) return null;
   const resolved = offsetOnLine(line, point.x, point.y, context);
+  // WHICH paragraph the pointer is over, not which one the line is named after. A resolved
+  // display mode merges the paragraphs a tracked decision merges, so one line can carry two,
+  // and the offset the walk just resolved counts in the one under the pointer.
+  const segment = segmentAtX(line, point.x);
   const position: SemanticPosition = {
-    paragraphId: line.range.paragraphId,
+    paragraphId: segment.paragraphId,
     offset: resolved.offset,
   };
-  const box = caretBoxOnLine(line, resolved.offset, context.measurer);
+  const box = caretBoxOnLine(line, resolved.offset, context.measurer, segment);
   return {
     position,
     caret: {
@@ -635,13 +640,39 @@ interface LineOffset {
 function drawingHitIdentity(line: LineRecord, drawing: InlineDrawingRecord): SemanticHitDrawing {
   return Object.freeze({
     drawingNodeId: drawing.drawingNodeId,
-    paragraphId: line.range.paragraphId,
+    // The drawing's own paragraph. On a merged line the record names a member, and the line
+    // names whichever member starts it.
+    paragraphId: drawing.paragraphId,
     start: drawing.start,
   });
 }
 
-function drawingAtOffset(line: LineRecord, offset: number): InlineDrawingRecord | null {
-  for (const drawing of line.drawings ?? []) {
+/**
+ * The segment of a line an x falls in.
+ *
+ * Answers the FIRST segment on a line with one, which is every ordinary line. Otherwise the
+ * last segment that begins at or before the point, so a click past the end of the line lands
+ * in the paragraph that ends it rather than the one that starts it.
+ */
+function segmentAtX(line: LineRecord, x: number): LineSegment {
+  const segments = lineSegments(line);
+  let found = segments[0]!;
+  for (const segment of segments) {
+    const first = segment.spans[0];
+    if (first === undefined) continue;
+    const last = segment.spans[segment.spans.length - 1]!;
+    if (x >= first.box.x) found = segment;
+    if (x < last.box.x + last.box.width) break;
+  }
+  return found;
+}
+
+function drawingAtOffset(
+  line: LineRecord,
+  offset: number,
+  only?: readonly InlineDrawingRecord[]
+): InlineDrawingRecord | null {
+  for (const drawing of only ?? line.drawings ?? []) {
     if (drawing.start === offset || drawing.start + 1 === offset) return drawing;
   }
   return null;
@@ -959,9 +990,15 @@ export function spanOffsetX(
 export function caretBoxOnLine(
   line: LineRecord,
   offset: number,
-  measurer: TextMeasurer | undefined
+  measurer: TextMeasurer | undefined,
+  segment?: {
+    readonly spans: readonly StyleSpanRecord[];
+    readonly drawings: readonly InlineDrawingRecord[];
+  } | null
 ): { x: number; y: number; height: number } {
-  const drawing = drawingAtOffset(line, offset);
+  // A merged line carries two paragraphs, and an offset means something in only one of them.
+  // Without a segment the line IS the segment, which is every ordinary line.
+  const drawing = drawingAtOffset(line, offset, segment?.drawings);
   if (drawing) {
     const after = offset > drawing.start;
     return {
@@ -972,7 +1009,7 @@ export function caretBoxOnLine(
       height: drawing.height,
     };
   }
-  const spans = line.spans;
+  const spans = segment ? segment.spans : line.spans;
   if (spans.length === 0) {
     // An empty paragraph paints no run to size the caret against, so the LINE is all there
     // is — but the line box on a spaced paragraph is mostly spacing, and taking it whole

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -565,11 +565,13 @@ function resolveParagraph(
   // display mode merges the paragraphs a tracked decision merges, so one line can carry two,
   // and the offset the walk just resolved counts in the one under the pointer.
   const segment = segmentAtX(line, point.x);
-  const position: SemanticPosition = {
-    paragraphId: segment.paragraphId,
-    offset: resolved.offset,
-  };
-  const box = caretBoxOnLine(line, resolved.offset, context.measurer, segment);
+  // The offset comes from a walk over the WHOLE line and the paragraph from the segment under
+  // the pointer, so on a merged line the two are counted in different paragraphs. Clamping
+  // ties them back together: a click past the end of the line lands at the end of the
+  // paragraph the pointer is over, not at an offset that paragraph does not have.
+  const offset = Math.min(Math.max(resolved.offset, segment.start), segment.end);
+  const position: SemanticPosition = { paragraphId: segment.paragraphId, offset };
+  const box = caretBoxOnLine(line, offset, context.measurer, segment);
   return {
     position,
     caret: {
@@ -592,8 +594,7 @@ function resolveParagraph(
       point.y < line.box.y + line.box.height,
     // Filled by {@link hitTestPage} once the point is known; keep null on the inner path.
     contentControlId: null,
-    drawing:
-      resolved.drawing && resolved.withinSpan ? drawingHitIdentity(line, resolved.drawing) : null,
+    drawing: resolved.drawing && resolved.withinSpan ? drawingHitIdentity(resolved.drawing) : null,
   };
 }
 
@@ -637,7 +638,7 @@ interface LineOffset {
   readonly drawing?: InlineDrawingRecord | null;
 }
 
-function drawingHitIdentity(line: LineRecord, drawing: InlineDrawingRecord): SemanticHitDrawing {
+function drawingHitIdentity(drawing: InlineDrawingRecord): SemanticHitDrawing {
   return Object.freeze({
     drawingNodeId: drawing.drawingNodeId,
     // The drawing's own paragraph. On a merged line the record names a member, and the line

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -16,7 +16,9 @@ import {
 } from './semantic-hit-test.ts';
 import { documentOrder, documentOrderIndex } from './document-order.ts';
 export { documentOrder } from './document-order.ts';
-import { lineSegmentFor, lineSegments, type LineSegment } from './line-segments.ts';
+export { selectionRects, keyedRangeRects, type KeyedRange } from './selection-rects.ts';
+import { xWithinLine } from './line-geometry.ts';
+import { lineSegmentFor, lineSegments, segmentOverlap, type LineSegment } from './line-segments.ts';
 import type {
   BlockFragmentRecord,
   ContentControlBoundaryRecord,
@@ -151,37 +153,6 @@ function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedLine[]> 
   }
   paragraphLinesCache.set(layout, index);
   return index;
-}
-
-/** The x offset of `offset` within a line, by walking its spans. */
-function xWithinLine(
-  line: LineRecord,
-  offset: number,
-  measurer?: TextMeasurer | undefined,
-  segment?: LineSegment
-): number {
-  // An offset only means something in ONE paragraph, so a mixed line is walked through the
-  // segment that owns it. Given none, the line is its own segment, which is every ordinary
-  // line and the path this function always took.
-  const spans = segment ? segment.spans : line.spans;
-  for (const drawing of segment ? segment.drawings : (line.drawings ?? [])) {
-    if (offset === drawing.start) return drawing.advanceStart;
-    if (offset === drawing.start + 1) return drawing.advanceEnd;
-  }
-  let x = segment ? (segment.spans[0]?.box.x ?? line.contentX) : line.contentX;
-  for (const span of spans) {
-    if (offset <= span.range.start) return span.box.x;
-    if (offset >= span.range.end) {
-      x = span.box.x + span.box.width;
-      continue;
-    }
-    // MEASURED, not interpolated. Interpolating across the span's advance is exact only for a
-    // uniform one — in any proportional face it draws the caret a fraction of the way through
-    // the span rather than at a glyph edge, so a caret between two letters appeared on top of
-    // one. Without a measurer it still interpolates, and says so.
-    return spanOffsetX(span, offset, measurer);
-  }
-  return x;
 }
 
 /**
@@ -553,109 +524,7 @@ export function contentControlsInLayout(
   return contentControlsOfLayout(layout);
 }
 
-/** The rectangles covering a selection, one per line it spans. */
-export function selectionRects(
-  layout: SemanticLayout,
-  selection: SemanticSelection
-): SelectionRect[] {
-  const ordered = orderPositions(layout, selection);
-  if (!ordered) return [];
-  const rects: SelectionRect[] = [];
-  for (const page of layout.pages) {
-    for (const fragment of paragraphFragmentsOf(page)) {
-      for (const line of fragment.lines) {
-        const overlap = lineOverlap(layout, line, ordered.from, ordered.to);
-        if (!overlap) continue;
-        const startX = xWithinLine(line, overlap.start);
-        const endX = xWithinLine(line, overlap.end);
-        rects.push({
-          pageIndex: page.index,
-          x: Math.min(startX, endX),
-          y: line.box.y,
-          width: Math.abs(endX - startX),
-          height: line.box.height,
-        });
-      }
-    }
-  }
-  return rects;
-}
-
-/** A model range to highlight, and the key the caller knows it by. */
-export interface KeyedRange {
-  readonly key: string;
-  readonly from: SemanticPosition;
-  readonly to: SemanticPosition;
-}
-
-/**
- * Rectangles for MANY ranges in ONE pass over the lines.
- *
- * Not `selectionRects` in a loop. That walks every page, fragment and line per range, and a
- * contract with two hundred comments would re-walk the whole document two hundred times on
- * every layout — the highlight would cost more than the layout it decorates. One pass tests
- * each line against every range instead, which is the same work a single selection does.
- */
-export function keyedRangeRects(
-  layout: SemanticLayout,
-  ranges: readonly KeyedRange[],
-  /**
-   * Pages to measure, or every page when absent.
-   *
-   * A band that is not on screen is not painted, so measuring it is pure cost — and it is
-   * cost paid per keystroke, because an edit republishes the layout. Bounding this to the
-   * materialized pages is what keeps typing in a heavily reviewed document as fast as
-   * typing in a clean one.
-   */
-  pages?: ReadonlySet<number>
-): Map<string, SelectionRect[]> {
-  const found = new Map<string, SelectionRect[]>();
-  if (ranges.length === 0) return found;
-  for (const page of layout.pages) {
-    if (pages && !pages.has(page.index)) continue;
-    for (const fragment of paragraphFragmentsOf(page)) {
-      for (const line of fragment.lines) {
-        for (const range of ranges) {
-          const overlap = lineOverlap(layout, line, range.from, range.to);
-          if (!overlap) continue;
-          const startX = xWithinLine(line, overlap.start);
-          const endX = xWithinLine(line, overlap.end);
-          const rects = found.get(range.key) ?? [];
-          rects.push({
-            pageIndex: page.index,
-            x: Math.min(startX, endX),
-            y: line.box.y,
-            width: Math.abs(endX - startX),
-            height: line.box.height,
-          });
-          found.set(range.key, rects);
-        }
-      }
-    }
-  }
-  return found;
-}
-
-/** The part of `line` covered by a selection, in the line's own offsets. */
-function lineOverlap(
-  layout: SemanticLayout,
-  line: LineRecord,
-  from: SemanticPosition,
-  to: SemanticPosition
-): { start: number; end: number } | null {
-  const index = documentOrderIndex(layout);
-  const lineParagraph = index.get(line.range.paragraphId) ?? -1;
-  const fromParagraph = index.get(from.paragraphId) ?? -1;
-  const toParagraph = index.get(to.paragraphId) ?? -1;
-  if (lineParagraph < fromParagraph || lineParagraph > toParagraph) return null;
-
-  const start =
-    lineParagraph === fromParagraph ? Math.max(line.range.start, from.offset) : line.range.start;
-  const end = lineParagraph === toParagraph ? Math.min(line.range.end, to.offset) : line.range.end;
-  return end > start ? { start, end } : null;
-}
-
-function orderPositions(
+export function orderPositions(
   layout: SemanticLayout,
   selection: SemanticSelection
 ): { from: SemanticPosition; to: SemanticPosition } | null {
@@ -710,7 +579,13 @@ export function paragraphTextFromLayout(layout: SemanticLayout, paragraphId: str
   const pieces: { start: number; text: string }[] = [];
   const seen = new Set<string>();
   for (const { line } of paragraphLinesIndex(layout).get(paragraphId) ?? []) {
-    for (const span of line.spans) {
+    // ONLY this paragraph's part of the line. A resolved display mode lays merged paragraphs
+    // out together, and both members count their offsets from zero, so reading the line whole
+    // reconstructed one paragraph's text from the other's spans — and this IS the surface's
+    // `paragraphTextOf`, so the deletion range, the clamp and the word walk all followed it.
+    const segment = lineSegmentFor(line, paragraphId);
+    if (!segment) continue;
+    for (const span of segment.spans) {
       // A ZERO-WIDTH span stands for something the model does not spell — a `w:ptab`, an
       // empty field projection. It contributes no characters, and a span whose painted text
       // is longer than its model range would make this reconstruction longer than the
@@ -734,7 +609,7 @@ export function paragraphTextFromLayout(layout: SemanticLayout, paragraphId: str
     }
     // Inline drawings occupy one UTF-16 unit each; they live on `line.drawings`, not in span
     // text, but selection clamp, Select All, and surface ops read length from here.
-    for (const drawing of line.drawings ?? []) {
+    for (const drawing of segment.drawings) {
       const start = drawing.start;
       const end = start + 1;
       const key = `${start}:${end}`;
@@ -958,9 +833,11 @@ export function spansInSelection(
   // the toolbar's formatting read scale with document length instead of selection length.
   if (ordered.from.paragraphId === ordered.to.paragraphId) {
     for (const { line } of paragraphLinesIndex(layout).get(ordered.from.paragraphId) ?? []) {
-      const overlap = lineOverlap(layout, line, ordered.from, ordered.to);
+      const segment = lineSegmentFor(line, ordered.from.paragraphId);
+      if (!segment) continue;
+      const overlap = segmentOverlap(layout, segment, ordered.from, ordered.to);
       if (!overlap) continue;
-      for (const span of line.spans) {
+      for (const span of segment.spans) {
         if (span.range.end > overlap.start && span.range.start < overlap.end) spans.push(span);
       }
     }
@@ -974,9 +851,11 @@ export function spansInSelection(
   if (first === -1 || last === -1) return [];
   for (let at = first; at <= last; at += 1) {
     for (const { line } of lines.get(order[at]!) ?? []) {
-      const overlap = lineOverlap(layout, line, ordered.from, ordered.to);
+      const segment = lineSegmentFor(line, order[at]!);
+      if (!segment) continue;
+      const overlap = segmentOverlap(layout, segment, ordered.from, ordered.to);
       if (!overlap) continue;
-      for (const span of line.spans) {
+      for (const span of segment.spans) {
         if (span.range.end > overlap.start && span.range.start < overlap.end) spans.push(span);
       }
     }
@@ -992,7 +871,9 @@ export function spansInSelection(
 function caretSpan(layout: SemanticLayout, position: SemanticPosition): StyleSpanRecord[] {
   let rightward: StyleSpanRecord | null = null;
   for (const { line } of paragraphLinesIndex(layout).get(position.paragraphId) ?? []) {
-    for (const span of line.spans) {
+    // This paragraph's spans only: on a merged line the other member's runs sit beside these
+    // and would report their formatting for a caret that is not in them.
+    for (const span of lineSegmentFor(line, position.paragraphId)?.spans ?? []) {
       if (span.range.start < position.offset && position.offset <= span.range.end) return [span];
       if (rightward === null && span.range.start === position.offset) rightward = span;
     }

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -348,6 +348,28 @@ export function caretStops(layout: SemanticLayout, measurer?: TextMeasurer): Car
   return stops;
 }
 
+/**
+ * Caret stops for every paragraph on the caret's line, or null when the line holds one.
+ *
+ * Built only for a merged line, so an ordinary document keeps the per-paragraph index it
+ * always used — that index is memoized per paragraph and this is not.
+ */
+function mergedLineCaretStops(
+  layout: SemanticLayout,
+  position: SemanticPosition,
+  measurer?: TextMeasurer
+): IndexedCaretStops<CaretGeometry> | null {
+  const placed = paragraphLinesIndex(layout).get(position.paragraphId) ?? [];
+  const found = placed.find(({ line }) => {
+    const segment = lineSegmentFor(line, position.paragraphId);
+    return segment !== null && position.offset >= segment.start && position.offset <= segment.end;
+  });
+  if (!found || lineSegments(found.line).length < 2) return null;
+  const stops: CaretGeometry[] = [];
+  pushLineCaretStops(stops, layout, found.line, found.pageIndex, 0, measurer);
+  return indexCaretStops(stops);
+}
+
 function paragraphCaretStops(
   layout: SemanticLayout,
   paragraphId: string,
@@ -668,10 +690,14 @@ export function moveCaret(
       : { position: { paragraphId: position.paragraphId, offset: target }, desiredX: null };
   }
   if (!options.stops && (command === 'lineStart' || command === 'lineEnd')) {
+    // Home and End mean the ends of the LINE a reader sees. One paragraph's stops describe
+    // that line only while the line holds one paragraph: on a line a resolved view merged,
+    // they stopped at the member boundary, in the middle of the text on screen.
     const target = moveToLineEdge(
       position,
       command === 'lineStart' ? -1 : 1,
-      paragraphCaretStops(layout, position.paragraphId, options.measurer)
+      mergedLineCaretStops(layout, position, options.measurer) ??
+        paragraphCaretStops(layout, position.paragraphId, options.measurer)
     );
     return target ? { position: target, desiredX: null } : null;
   }

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -8,12 +8,7 @@
 // take, so a click, a caret and an edit all speak one coordinate system: a hit test can be
 // handed straight to `insertText` without a translation step that could disagree.
 
-import {
-  caretBoxOnLine,
-  contentControlAtPoint,
-  hitTestPage,
-  spanOffsetX,
-} from './semantic-hit-test.ts';
+import { caretBoxOnLine, contentControlAtPoint, hitTestPage } from './semantic-hit-test.ts';
 import { documentOrder, documentOrderIndex } from './document-order.ts';
 export { documentOrder } from './document-order.ts';
 export { selectionRects, keyedRangeRects, type KeyedRange } from './selection-rects.ts';

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -14,6 +14,9 @@ import {
   hitTestPage,
   spanOffsetX,
 } from './semantic-hit-test.ts';
+import { documentOrder, documentOrderIndex } from './document-order.ts';
+export { documentOrder } from './document-order.ts';
+import { lineSegmentFor, lineSegments, type LineSegment } from './line-segments.ts';
 import type {
   BlockFragmentRecord,
   ContentControlBoundaryRecord,
@@ -97,6 +100,20 @@ function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedLine[]> 
   const cached = paragraphLinesCache.get(layout);
   if (cached) return cached;
   const index = new Map<string, PlacedLine[]>();
+  /**
+   * Under every paragraph the line carries, not just the one it names.
+   *
+   * A merged line belongs to two paragraphs, and a caret walking either of them has to find
+   * it. An ordinary line has one segment and lands in exactly the one bucket it always did.
+   */
+  const indexLine = (line: LineRecord, pageIndex: number): void => {
+    for (const segment of lineSegments(line)) {
+      const placed = { line, pageIndex };
+      const entry = index.get(segment.paragraphId);
+      if (entry) entry.push(placed);
+      else index.set(segment.paragraphId, [placed]);
+    }
+  };
   const indexFragments = (
     fragments: readonly import('./semantic-records.ts').BlockFragmentRecord[],
     pageIndex: number
@@ -106,12 +123,7 @@ function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedLine[]> 
     ): void => {
       for (const block of blocks) {
         if (block.kind === 'paragraph') {
-          for (const line of block.lines) {
-            const entry = index.get(line.range.paragraphId);
-            const placed = { line, pageIndex };
-            if (entry) entry.push(placed);
-            else index.set(line.range.paragraphId, [placed]);
-          }
+          for (const line of block.lines) indexLine(line, pageIndex);
           continue;
         }
         for (const row of block.rows) {
@@ -125,12 +137,7 @@ function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedLine[]> 
   for (const page of layout.pages) {
     // Body first — primary story for caret stops built elsewhere via paragraphFragmentsOf.
     for (const fragment of paragraphFragmentsOf(page)) {
-      for (const line of fragment.lines) {
-        const entry = index.get(line.range.paragraphId);
-        const placed = { line, pageIndex: page.index };
-        if (entry) entry.push(placed);
-        else index.set(line.range.paragraphId, [placed]);
-      }
+      for (const line of fragment.lines) indexLine(line, page.index);
     }
     // Furniture paragraphs share this index so formatting / paragraphTextFromLayout can
     // resolve an open header/footer selection. documentOrder and caretStops stay body-only.
@@ -150,14 +157,19 @@ function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedLine[]> 
 function xWithinLine(
   line: LineRecord,
   offset: number,
-  measurer?: TextMeasurer | undefined
+  measurer?: TextMeasurer | undefined,
+  segment?: LineSegment
 ): number {
-  for (const drawing of line.drawings ?? []) {
+  // An offset only means something in ONE paragraph, so a mixed line is walked through the
+  // segment that owns it. Given none, the line is its own segment, which is every ordinary
+  // line and the path this function always took.
+  const spans = segment ? segment.spans : line.spans;
+  for (const drawing of segment ? segment.drawings : (line.drawings ?? [])) {
     if (offset === drawing.start) return drawing.advanceStart;
     if (offset === drawing.start + 1) return drawing.advanceEnd;
   }
-  let x = line.contentX;
-  for (const span of line.spans) {
+  let x = segment ? (segment.spans[0]?.box.x ?? line.contentX) : line.contentX;
+  for (const span of spans) {
     if (offset <= span.range.start) return span.box.x;
     if (offset >= span.range.end) {
       x = span.box.x + span.box.width;
@@ -228,8 +240,8 @@ function insideDeletedContent(line: LineRecord, offset: number): boolean {
  * (projected PAGE digits, leaders) — those interiors are not navigable caret stops.
  * Tabs keep a 1:1 `\t` range; their wide box is still only two stops (before/after).
  */
-function isNonNavigableInterior(line: LineRecord, offset: number): boolean {
-  for (const span of line.spans) {
+function isNonNavigableInterior(line: LineRecord, offset: number, segment?: LineSegment): boolean {
+  for (const span of segment ? segment.spans : line.spans) {
     if (offset <= span.range.start || offset >= span.range.end) continue;
     if (span.projected) return true;
     if (span.text.length !== span.range.end - span.range.start) return true;
@@ -264,9 +276,26 @@ function pushLineCaretStops(
   line: LineRecord,
   pageIndex: number,
   fragmentStart: number,
+  measurer?: TextMeasurer,
+  only?: string
+): void {
+  for (const segment of lineSegments(line)) {
+    if (only !== undefined && segment.paragraphId !== only) continue;
+    pushSegmentCaretStops(stops, layout, line, segment, pageIndex, fragmentStart, measurer);
+  }
+}
+
+function pushSegmentCaretStops(
+  stops: CaretGeometry[],
+  layout: SemanticLayout,
+  line: LineRecord,
+  segment: LineSegment,
+  pageIndex: number,
+  fragmentStart: number,
   measurer?: TextMeasurer
 ): void {
-  for (let offset = line.range.start; offset <= line.range.end; offset += 1) {
+  const mixed = lineSegments(line).length > 1;
+  for (let offset = segment.start; offset <= segment.end; offset += 1) {
     // A line ENDED BY A HARD BREAK does not own the position after it — the line the
     // break opened does, and `caretAt` places the caret there. Emitting it here too
     // would put the stop this lane navigates to on a different line from the caret
@@ -274,8 +303,9 @@ function pushLineCaretStops(
     // line entirely, and the empty line a trailing Shift+Enter opens would be
     // unreachable because the dedup below discarded its only stop as a duplicate.
     if (
-      offset === line.range.end &&
-      offset > line.range.start &&
+      offset === segment.end &&
+      offset > segment.start &&
+      !mixed &&
       endsWithLineBreak(line) &&
       laterLineOwns(layout, line, offset)
     ) {
@@ -283,23 +313,23 @@ function pushLineCaretStops(
     }
     // A continuation line's first stop is the same model position as the previous
     // line's last, so it is emitted once — by the line that starts there.
-    if (offset === line.range.start && offset > fragmentStart && stops.length > 0) {
+    if (offset === segment.start && offset > fragmentStart && stops.length > 0) {
       const previous = stops[stops.length - 1]!;
       if (
-        previous.position.paragraphId === line.range.paragraphId &&
+        previous.position.paragraphId === segment.paragraphId &&
         previous.position.offset === offset
       ) {
         continue;
       }
     }
-    if (isNonNavigableInterior(line, offset)) continue;
+    if (isNonNavigableInterior(line, offset, segment)) continue;
     // Deleted content is skipped for the same reason and by the same lane: `moveCaret` reads
     // this list and nothing else, so arrow keys, word jumps, page jumps and Home/End all
     // inherit "step over a deletion, never into it" from one place.
     if (insideDeletedContent(line, offset)) continue;
     stops.push({
-      position: { paragraphId: line.range.paragraphId, offset },
-      x: xWithinLine(line, offset, measurer),
+      position: { paragraphId: segment.paragraphId, offset },
+      x: xWithinLine(line, offset, measurer, segment),
       y: line.box.y,
       height: line.box.height,
       lineId: line.id,
@@ -360,7 +390,7 @@ function paragraphCaretStops(
   return paragraphCaretStopCache.get(layout, paragraphId, measurer, () => {
     const stops: CaretGeometry[] = [];
     for (const { line, pageIndex } of paragraphLinesIndex(layout).get(paragraphId) ?? []) {
-      pushLineCaretStops(stops, layout, line, pageIndex, 0, measurer);
+      pushLineCaretStops(stops, layout, line, pageIndex, 0, measurer, paragraphId);
     }
     return indexCaretStops(stops);
   });
@@ -433,10 +463,15 @@ export function caretAt(
   // offset is genuinely shared and the end of the visual line is the conventional answer.
   let afterBreak: { line: LineRecord; pageIndex: number } | null = null;
   for (const { line, pageIndex } of ordered) {
-    if (position.offset < line.range.start || position.offset > line.range.end) continue;
+    // The part of the line this paragraph owns. On a merged line that is half of it, and the
+    // other half counts its offsets in a different paragraph entirely.
+    const segment = lineSegmentFor(line, position.paragraphId);
+    if (!segment) continue;
+    if (position.offset < segment.start || position.offset > segment.end) continue;
     if (
-      position.offset === line.range.end &&
-      position.offset > line.range.start &&
+      position.offset === segment.end &&
+      position.offset > segment.start &&
+      lineSegments(line).length === 1 &&
       endsWithLineBreak(line)
     ) {
       // Remember it, but keep looking for the line that STARTS here. Falling back to it
@@ -445,17 +480,22 @@ export function caretAt(
       continue;
     }
     if (
-      position.offset === line.range.end &&
-      position.offset > line.range.start &&
+      position.offset === segment.end &&
+      position.offset > segment.start &&
       laterLineWithDrawingAt(layout, position.paragraphId, position.offset)
     ) {
       continue;
     }
-    const box = caretBoxOnLine(line, position.offset, options.measurer);
+    const box = caretBoxOnLine(line, position.offset, options.measurer, segment);
     return { position, x: box.x, y: box.y, height: box.height, lineId: line.id, pageIndex };
   }
   if (afterBreak) {
-    const box = caretBoxOnLine(afterBreak.line, position.offset, options.measurer);
+    const box = caretBoxOnLine(
+      afterBreak.line,
+      position.offset,
+      options.measurer,
+      lineSegmentFor(afterBreak.line, position.paragraphId)
+    );
     return {
       position,
       x: box.x,
@@ -615,43 +655,6 @@ function lineOverlap(
   return end > start ? { start, end } : null;
 }
 
-// Memoized PER LAYOUT, which is sound because a published layout is immutable: a new
-// revision is a new object. Without this every selection walk recomputed the order — and
-// `lineOverlap` runs once per line, so `spansInSelection` on a large document recomputed a
-// full-document scan thousands of times per keystroke. The toolbar reading formatting on
-// every commit is what turned that into seconds.
-const documentOrderCache = new WeakMap<SemanticLayout, string[]>();
-const documentOrderIndexCache = new WeakMap<SemanticLayout, Map<string, number>>();
-
-/** Paragraph ids in document order, deduplicated across fragments. */
-export function documentOrder(layout: SemanticLayout): string[] {
-  const cached = documentOrderCache.get(layout);
-  if (cached) return cached;
-  const seen = new Set<string>();
-  const order: string[] = [];
-  for (const page of layout.pages) {
-    for (const fragment of paragraphFragmentsOf(page)) {
-      if (!seen.has(fragment.paragraphId)) {
-        seen.add(fragment.paragraphId);
-        order.push(fragment.paragraphId);
-      }
-    }
-  }
-  documentOrderCache.set(layout, order);
-  return order;
-}
-
-/** Document-order position by paragraph id, for O(1) ordering checks. */
-function documentOrderIndex(layout: SemanticLayout): Map<string, number> {
-  const cached = documentOrderIndexCache.get(layout);
-  if (cached) return cached;
-  const index = new Map<string, number>();
-  for (const [position, id] of documentOrder(layout).entries()) index.set(id, position);
-  documentOrderIndexCache.set(layout, index);
-  return index;
-}
-
-/** A selection's endpoints in document order. */
 function orderPositions(
   layout: SemanticLayout,
   selection: SemanticSelection

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -97,7 +97,8 @@ import {
   type TableFlowDeps,
 } from './semantic-table-layout.ts';
 import { annotateTableFragmentGeometry } from './semantic-table-interaction.ts';
-import { storyBlocks } from './story-roots.ts';
+import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
+import { paragraphMergeGroupOf, storyBlocks } from './story-roots.ts';
 import type { InlineDrawingLayoutContext } from './drawing-layout.ts';
 import {
   clipInlineDrawingRecordToRegion,
@@ -132,7 +133,7 @@ import {
   emptyTocSuppressedResultParagraphIds,
   tocFieldChromeParagraphIds,
 } from './toc-layout.ts';
-import { type HeaderFooterStoryLayout } from './hf-layout.ts';
+import { storyDrawingResourceToken, type HeaderFooterStoryLayout } from './hf-layout.ts';
 import {
   DEFAULT_SECTION_PROPERTIES,
   enumerateDocumentSectionsFromBlocks,
@@ -410,41 +411,6 @@ const drawingSourceOrderByContext = new WeakMap<
   InlineDrawingLayoutContext,
   ReadonlyMap<string, number>
 >();
-
-/**
- * Resource identity of every image a header/footer story paints.
- *
- * Part of the session context, because the rest of what identifies a story — `contentKey`
- * and `flowHeight` — describes the AUTHORED part, and neither moves when an image finishes
- * decoding: the extent is authored, so the story is exactly as tall with a pending picture
- * as with a ready one. Without this the unchanged-pass early exit finds every key equal and
- * returns the previous pages BY IDENTITY, furniture included, so a header or footer image
- * stays a "loading" placeholder for the rest of the session — nothing will invalidate it
- * again. Body drawings have no such gap; they ride the per-paragraph flow keys.
- */
-function storyDrawingResourceToken(story: HeaderFooterStoryLayout): string {
-  const tokens: string[] = [];
-  const visitBlock = (block: BlockFragmentRecord): void => {
-    if (block.kind === 'table') {
-      for (const row of block.rows) {
-        for (const cell of row.cells) for (const inner of cell.blocks) visitBlock(inner);
-      }
-      return;
-    }
-    for (const line of block.lines) {
-      for (const drawing of line.drawings ?? []) {
-        tokens.push(drawingResourceLayoutToken(drawing.resource));
-      }
-    }
-  };
-  for (const drawing of story.anchoredDrawings ?? []) {
-    tokens.push(drawingResourceLayoutToken(drawing.resource));
-  }
-  for (const fragment of story.fragments) visitBlock(fragment);
-  // Empty for the overwhelmingly common story with no pictures, so the context string for a
-  // plain header is byte-for-byte what it was.
-  return tokens.length === 0 ? '' : `!${tokens.join('!')}`;
-}
 
 /**
  * Lay one story part out into pages.
@@ -2170,6 +2136,8 @@ function layoutBlocksPass(
     }> | null = null;
 
     const markRevisions = paragraphMarkRevisionsOf(entry.paragraph);
+    const mergeGroup = paragraphMergeGroupOf(entry.paragraph);
+    const mergeBoundaries = mergeGroup ? mergeBoundariesOf(mergeGroup) : null;
 
     /**
      * How much of the first placed line's topAndBottom skip this paragraph's own anchor caused.
@@ -2293,6 +2261,10 @@ function layoutBlocksPass(
           },
         });
       }
+      // A resolved view lays a run of paragraphs out as one. The layout is what the document
+      // becomes; the identity has to stay what the document HAS, or an edit in the merged half
+      // addresses a position the store does not hold.
+      const mergedLines = mergeBoundaries ? remapMergedLines(pending, mergeBoundaries) : null;
       const rawMarker =
         fragmentIndex === 0
           ? publishListMarker(
@@ -2309,11 +2281,17 @@ function layoutBlocksPass(
         id: `${paragraphId}#f${fragmentIndex}`,
         paragraphId,
         fragmentIndex,
-        range: {
-          paragraphId,
-          start: fragmentStart,
-          end: pending[pending.length - 1]!.range.end,
-        },
+        range: mergedLines
+          ? // A merged fragment holds more than one paragraph, and this field holds one range.
+            // It takes the one its LAST line reports, so the field describes where the fragment
+            // ENDS in the document. Everything that resolves a position reads spans instead,
+            // and they name their own paragraphs.
+            mergedLines[mergedLines.length - 1]!.range
+          : {
+              paragraphId,
+              start: fragmentStart,
+              end: pending[pending.length - 1]!.range.end,
+            },
         props,
         spacing: { before: fragmentBefore, after: appliedAfter },
         indent,
@@ -2348,7 +2326,7 @@ function layoutBlocksPass(
         ...(isLast && showsMarkup
           ? markRevisionFields(markRevisions, paragraphMarkFormatRevisionOf(entry.paragraph))
           : {}),
-        lines: pending,
+        lines: mergedLines ?? pending,
         box: { x: columnX + indent.left, y: top, width: available, height },
       });
       if (options.inlineDrawingLayout && paragraphHasAnchors && !paragraphAnchorsPublished) {

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -126,7 +126,7 @@ import {
   MAX_DRAWING_EXCLUSION_REFLOW_PASSES,
 } from './drawing-exclusion.ts';
 import { drawingModelOffsetsInParagraph } from './drawing-layout.ts';
-import { drawingResourceLayoutToken, drawingTokenForTableBlock } from './inline-drawing-source.ts';
+import { drawingTokenForTableBlock } from './inline-drawing-source.ts';
 import { projectDrawingsInPart } from '../store/package/drawing-projection.ts';
 import {
   emptyTocPlaceholderParagraphIds,
@@ -2282,10 +2282,12 @@ function layoutBlocksPass(
         paragraphId,
         fragmentIndex,
         range: mergedLines
-          ? // A merged fragment holds more than one paragraph, and this field holds one range.
-            // It takes the one its LAST line reports, so the field describes where the fragment
-            // ENDS in the document. Everything that resolves a position reads spans instead,
-            // and they name their own paragraphs.
+          ? // A merged fragment holds more than one paragraph and this field holds one range,
+            // so it cannot be the fragment's extent. It takes the one its LAST line reports —
+            // where the fragment ENDS — and everything that resolves a position reads spans
+            // instead, which name their own paragraphs. `pushLineCaretStops` reads `start`
+            // from here only to dedupe a continuation line's first stop, and a merged
+            // fragment's lines are compared against their own segment starts anyway.
             mergedLines[mergedLines.length - 1]!.range
           : {
               paragraphId,

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -916,6 +916,15 @@ export function lineAtPosition(
       start = Number.isNaN(start) ? span.range.start : Math.min(start, span.range.start);
       end = Number.isNaN(end) ? span.range.end : Math.max(end, span.range.end);
     }
+    // An inline drawing is an ATOM with an offset of its own and no span to speak for it, so
+    // a half that opens with a picture began at the picture, one offset before its first
+    // character. Without this the caret there resolved to no line, and the image it was
+    // sitting on could not be selected.
+    for (const drawing of line.drawings ?? []) {
+      if (drawing.paragraphId !== paragraphId) continue;
+      start = Number.isNaN(start) ? drawing.start : Math.min(start, drawing.start);
+      end = Number.isNaN(end) ? drawing.start + 1 : Math.max(end, drawing.start + 1);
+    }
     if (Number.isNaN(start)) continue;
     // End-inclusive on the last line of a paragraph, so a caret at the very end resolves.
     if (offset >= start && offset <= end) return line;

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -906,9 +906,19 @@ export function lineAtPosition(
   offset: number
 ): LineRecord | null {
   for (const line of linesOf(layout)) {
-    if (line.range.paragraphId !== paragraphId) continue;
+    // The part of the line this paragraph OWNS. A resolved display mode lays merged
+    // paragraphs out on shared lines, and the half the line is not named after would
+    // otherwise never match — its spans are there, its name is not.
+    let start = line.range.paragraphId === paragraphId ? line.range.start : Number.NaN;
+    let end = line.range.paragraphId === paragraphId ? line.range.end : Number.NaN;
+    for (const span of line.spans) {
+      if (span.range.paragraphId !== paragraphId) continue;
+      start = Number.isNaN(start) ? span.range.start : Math.min(start, span.range.start);
+      end = Number.isNaN(end) ? span.range.end : Math.max(end, span.range.end);
+    }
+    if (Number.isNaN(start)) continue;
     // End-inclusive on the last line of a paragraph, so a caret at the very end resolves.
-    if (offset >= line.range.start && offset <= line.range.end) return line;
+    if (offset >= start && offset <= end) return line;
   }
   return null;
 }

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -43,6 +43,7 @@ import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './p
 import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
 import { paragraphMergeGroupOf } from './story-roots.ts';
 import {
+  DEFAULT_REVISION_DISPLAY_MODE,
   markRevisionFields,
   paragraphMarkFormatRevisionOf,
   paragraphMarkRevisionsOf,
@@ -917,7 +918,11 @@ function placeCellParagraph(
   //
   // Read only when this fragment will carry it. Placement runs for trial rows and for every
   // continuation, and the projection walks `w:pPr/w:rPr` each time it is asked.
-  const showsMarkup = complete && deps.displayMode === 'all-markup';
+  // An UNSET mode is the default mode, which is `all-markup`. Reading `undefined` as "not
+  // all-markup" left a header's own tracked mark with no pilcrow and no change bar, because
+  // furniture is laid out through deps that do not always carry one.
+  const showsMarkup =
+    complete && (deps.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE) === 'all-markup';
   const markRevisions = showsMarkup ? paragraphMarkRevisionsOf(paragraph) : [];
   const markFormatRevision = showsMarkup ? paragraphMarkFormatRevisionOf(paragraph) : null;
   const marker =

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -40,6 +40,8 @@ import type {
 } from './field-projection.ts';
 import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
 import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
+import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
+import { paragraphMergeGroupOf } from './story-roots.ts';
 import {
   markRevisionFields,
   paragraphMarkFormatRevisionOf,
@@ -690,7 +692,7 @@ function placeCellParagraph(
   // paragraph's frame paints over the cell's own top border. Reserved on the FIRST fragment
   // only: a paragraph continued onto the next page opens once, the way it closes once.
   const topExtent = lineStart === 0 ? paragraphBorderExtentPt(borders.top) : 0;
-  const records: LineRecord[] = [];
+  const rawRecords: LineRecord[] = [];
   let y = top + appliedBefore + topExtent;
   let nextLineIndex = lineStart;
   let fitted = false;
@@ -769,7 +771,7 @@ function placeCellParagraph(
       ),
       alignOffset
     );
-    records.push({
+    rawRecords.push({
       id: deps.nextLineId(paragraphId, pendingLine.start, lineIndex),
       range: { paragraphId, start: pendingLine.start, end: pendingLine.end },
       spans: alignedSpans,
@@ -803,7 +805,7 @@ function placeCellParagraph(
   }
 
   const complete = nextLineIndex >= lines.length;
-  const linesTop = records[0]!.box.y;
+  const linesTop = rawRecords[0]!.box.y;
   const linesBottom = y;
   // Every `w:pBdr` edge, in the paint order body flow publishes: open, close, sides, bar.
   //
@@ -908,7 +910,7 @@ function placeCellParagraph(
             width: boxWidth,
             height: Math.max(contentBottom - contentTop, 0),
           }
-        : paragraphShadingBox(records, fragmentX, available);
+        : paragraphShadingBox(rawRecords, fragmentX, available);
   // The paragraph MARK, on the fragment that finishes the paragraph — the cell lane publishes
   // it for the same reason the body lane does, and until it did, a tracked split or merge
   // inside a `w:tc` drew nothing at all: no pilcrow, no margin rule, no review card.
@@ -923,11 +925,17 @@ function placeCellParagraph(
       ? publishListMarker(
           listItem,
           deps.measurer,
-          records[0] ? { y: records[0].box.y, height: records[0].box.height } : undefined,
+          rawRecords[0] ? { y: rawRecords[0].box.y, height: rawRecords[0].box.height } : undefined,
           originX
         )
       : undefined;
 
+  // A cell is a story, so a resolved view merges inside it too — and the identity of the
+  // merged half has to come back the same way it does in the body flow.
+  const mergeGroup = paragraphMergeGroupOf(paragraph);
+  const records = mergeGroup
+    ? remapMergedLines(rawRecords, mergeBoundariesOf(mergeGroup))
+    : rawRecords;
   const fragment = {
     kind: 'paragraph' as const,
     id: `${paragraphId}#f${fragmentIndex}`,

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -43,7 +43,6 @@ import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './p
 import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
 import { paragraphMergeGroupOf } from './story-roots.ts';
 import {
-  DEFAULT_REVISION_DISPLAY_MODE,
   markRevisionFields,
   paragraphMarkFormatRevisionOf,
   paragraphMarkRevisionsOf,
@@ -918,11 +917,11 @@ function placeCellParagraph(
   //
   // Read only when this fragment will carry it. Placement runs for trial rows and for every
   // continuation, and the projection walks `w:pPr/w:rPr` each time it is asked.
-  // An UNSET mode is the default mode, which is `all-markup`. Reading `undefined` as "not
-  // all-markup" left a header's own tracked mark with no pilcrow and no change bar, because
-  // furniture is laid out through deps that do not always carry one.
-  const showsMarkup =
-    complete && (deps.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE) === 'all-markup';
+  // EXPLICIT, not defaulted. A lane that does not say which view it is drawing does not get
+  // attribution: note stories pass no mode and mean the resolved one, so defaulting to
+  // `all-markup` here lit up markup inside footnotes in the very view that must show none.
+  // The lanes that do mean All Markup say so — the body always has, and furniture does now.
+  const showsMarkup = complete && deps.displayMode === 'all-markup';
   const markRevisions = showsMarkup ? paragraphMarkRevisionsOf(paragraph) : [];
   const markFormatRevision = showsMarkup ? paragraphMarkFormatRevisionOf(paragraph) : null;
   const marker =

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -23,7 +23,7 @@ import {
 import { shadingFillFromElement } from './ooxml-shading.ts';
 import { revisionRemovesParagraph } from './revision-visibility.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
-import { collectFlowBlocks } from '../store/package/content-control-walk.ts';
+import { mergedFlowBlocks } from './story-roots.ts';
 import {
   EMPTY_TABLE_CELL_STYLE_FORMATTING,
   EMPTY_TABLE_FORMATTING,
@@ -960,14 +960,9 @@ function readTableStructureUncached(
       // Content controls inside a cell flatten transparently — same rule as body
       // `storyBlocks`. Without this a `w:sdt` wrapping the cell's paragraphs leaves the
       // cell empty in layout while the tree still holds the text.
-      const blocks = collectFlowBlocks(cellNode.children, 0, (block) => {
-        // A paragraph a tracked revision has removed claims a full line box while rendering
-        // nothing; a cell of them is a stack of blank lines that pushes the rest of the table
-        // down the page.
-        if (block.kind === 'paragraph' && revisionRemovesParagraph(block, displayMode))
-          return false;
-        return true;
-      });
+      // Through the shared collector: a cell is a story like any other, so a tracked mark
+      // merges inside it and a paragraph a revision removed leaves no blank line behind.
+      const blocks = mergedFlowBlocks(cellNode.children, displayMode);
       cells.push({
         id: cellNode.id,
         gridSpan,

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -21,7 +21,6 @@ import {
   type OoxmlNode,
 } from '@docx-editor.dev/core/store';
 import { shadingFillFromElement } from './ooxml-shading.ts';
-import { revisionRemovesParagraph } from './revision-visibility.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
 import { mergedFlowBlocks } from './story-roots.ts';
 import {

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -128,14 +128,19 @@ function withMergedParagraphs(
       out.push(block);
       continue;
     }
-    if (!memberIsAddressable(block, displayMode)) {
+    const removed = markRemovedInMode(block, displayMode);
+    // Measuring costs a walk of the paragraph, so it is asked ONLY where a merge could happen:
+    // of a paragraph whose mark is removed, and of the survivor a pending run would merge into.
+    // A document with no tracked marks answers `false` to the cheap question and stops, which
+    // is every keystroke in the view the free engine renders by default.
+    if ((removed || pendingMembers.length > 0) && !memberIsAddressable(block, displayMode)) {
       // Cannot be measured, so cannot be merged INTO either: a survivor whose own offsets do
       // not line up would take the previous members' characters at the wrong index.
       endRun();
       out.push(block);
       continue;
     }
-    if (markRemovedInMode(block, displayMode)) {
+    if (removed) {
       pendingMembers.push(block);
       pendingParent = parentKey;
       continue;
@@ -221,6 +226,11 @@ function flowBlocksWithParent(children: readonly OoxmlNode[]): readonly Parented
  * field; and content past a nesting cap counts differently on each side. Both publish one
  * member's text at another member's offsets, which is worse than the break this change exists
  * to remove, so a group that cannot be measured is not merged.
+ *
+ * A refusal is fail-visible, not fail-safe: the reader keeps a break the document says is
+ * gone, and if the refused member carried `w:pPr/w:sectPr` they also keep a section break —
+ * so the pages before it stay at their own paper size, where accepting the change would put
+ * them on the next section's.
  */
 function memberIsAddressable(member: OoxmlElement, displayMode: RevisionDisplayMode): boolean {
   if (!fieldCharsBalanced(member)) return false;
@@ -253,6 +263,7 @@ function memberIsAddressable(member: OoxmlElement, displayMode: RevisionDisplayM
  */
 function fieldCharsBalanced(paragraph: OoxmlElement): boolean {
   let open = 0;
+  let underflowed = false;
   const visit = (node: OoxmlNode): void => {
     if (node.kind === 'textValue') return;
     if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldChar') {
@@ -260,12 +271,18 @@ function fieldCharsBalanced(paragraph: OoxmlElement): boolean {
         (attribute) => attribute.localName === 'fldCharType'
       )?.value;
       if (type === 'begin') open += 1;
-      else if (type === 'end') open -= 1;
+      else if (type === 'end') {
+        open -= 1;
+        // An `end` with no `begin` in this paragraph closes a field that started in an
+        // earlier one. Counting a net would let it cancel a later `begin` and call the
+        // paragraph balanced, which is the case this guard exists to catch.
+        if (open < 0) underflowed = true;
+      }
     }
     for (const child of node.children) visit(child);
   };
   visit(paragraph);
-  return open === 0;
+  return open === 0 && !underflowed;
 }
 
 /**

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -232,7 +232,25 @@ function flowBlocksWithParent(children: readonly OoxmlNode[]): readonly Parented
  * so the pages before it stay at their own paper size, where accepting the change would put
  * them on the next section's.
  */
+/**
+ * Memoized on the node, per mode. A paragraph is immutable — a transaction rebuilds the path
+ * to what it edited and leaves every other paragraph object-identical — so the answer holds
+ * until that paragraph itself changes. Without this the walk ran for every candidate on every
+ * flush, and a document with hundreds of tracked marks paid it on each keystroke.
+ */
+const addressableByNode = new WeakMap<OoxmlElement, Map<RevisionDisplayMode, boolean>>();
+
 function memberIsAddressable(member: OoxmlElement, displayMode: RevisionDisplayMode): boolean {
+  const perMode = addressableByNode.get(member);
+  const cached = perMode?.get(displayMode);
+  if (cached !== undefined) return cached;
+  const answer = measureMember(member, displayMode);
+  if (perMode) perMode.set(displayMode, answer);
+  else addressableByNode.set(member, new Map([[displayMode, answer]]));
+  return answer;
+}
+
+function measureMember(member: OoxmlElement, displayMode: RevisionDisplayMode): boolean {
   if (!fieldCharsBalanced(member)) return false;
   const pieces = piecesOfParagraph(
     member,

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -13,8 +13,20 @@
 // Note parts (`w:footnotes` / `w:endnotes`) are NOT story roots: each typed `w:footnote` /
 // `w:endnote` child is its own story via {@link noteStoryBlocks}.
 
-import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
-import { collectFlowBlocks } from '../store/package/content-control-walk.ts';
+import type {
+  OoxmlElement,
+  OoxmlNode,
+  OoxmlParagraphNode,
+  OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import {
+  contentControlContentChildren,
+  isContentControl,
+  MAX_CONTENT_CONTROL_NESTING,
+} from '../store/package/content-control-walk.ts';
+import { WML_NAMESPACE_URI } from '../store/package/ooxml-tree.ts';
+import { paragraphOffsetIndex } from '../store/store/tree-op-segments.ts';
+import { piecesOfParagraph } from './field-projection.ts';
 import { createRecentRootCache } from '../store/store/recent-root-cache.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
 import { markRemovedInMode, revisionRemovesParagraph } from './revision-visibility.ts';
@@ -67,6 +79,17 @@ export function paragraphMergeGroupOf(paragraph: OoxmlElement): ParagraphMergeGr
   return mergeGroups.get(paragraph) ?? null;
 }
 
+/** One paragraph standing for several: the survivor's properties, every member's content. */
+function mergedParagraph(members: readonly OoxmlElement[], survivor: OoxmlElement): OoxmlElement {
+  const properties = survivor.children.filter((child) => isParagraphProperties(child));
+  const content = members.flatMap((member) =>
+    member.children.filter((child) => !isParagraphProperties(child))
+  );
+  const merged = { ...survivor, children: [...properties, ...content] } as OoxmlElement;
+  mergeGroups.set(merged, { merged, members });
+  return merged;
+}
+
 function isParagraphProperties(node: OoxmlNode): boolean {
   return (
     node.kind !== 'textValue' && (node.kind === 'paragraphProperties' || node.localName === 'pPr')
@@ -82,22 +105,39 @@ function isParagraphProperties(node: OoxmlNode): boolean {
  * paragraph to live in.
  */
 function withMergedParagraphs(
-  blocks: readonly OoxmlElement[],
+  parented: readonly ParentedBlock[],
   displayMode: RevisionDisplayMode
 ): OoxmlElement[] {
-  if (displayMode === 'all-markup') return [...blocks];
+  if (displayMode === 'all-markup') return parented.map((entry) => entry.block);
   const out: OoxmlElement[] = [];
   let pendingMembers: OoxmlElement[] = [];
-  for (const block of blocks) {
+  let pendingParent: string | null = null;
+  const endRun = (): void => {
+    out.push(...mergedTrailingRun(pendingMembers));
+    pendingMembers = [];
+    pendingParent = null;
+  };
+  for (const { block, parentKey } of parented) {
+    // A content control flattens into the flow, so its paragraphs are neighbours on the page
+    // without being siblings in the tree. The store rebuilds one children array at a time and
+    // never merges out of `w:sdtContent`; matching that keeps the two answers the same.
+    if (pendingMembers.length > 0 && parentKey !== pendingParent) endRun();
     if (block.kind !== 'paragraph') {
-      // A table between two mark-removed paragraphs is a container boundary: the store cannot
-      // merge across it either, so the run of members ends here and keeps its own boxes.
-      out.push(...pendingMembers, block);
-      pendingMembers = [];
+      // A table between two mark-removed paragraphs is a container boundary too.
+      endRun();
+      out.push(block);
+      continue;
+    }
+    if (!memberIsAddressable(block, displayMode)) {
+      // Cannot be measured, so cannot be merged INTO either: a survivor whose own offsets do
+      // not line up would take the previous members' characters at the wrong index.
+      endRun();
+      out.push(block);
       continue;
     }
     if (markRemovedInMode(block, displayMode)) {
       pendingMembers.push(block);
+      pendingParent = parentKey;
       continue;
     }
     if (pendingMembers.length === 0) {
@@ -106,21 +146,20 @@ function withMergedParagraphs(
     }
     const members = [...pendingMembers, block];
     pendingMembers = [];
-    const survivorProperties = block.children.filter((child) => isParagraphProperties(child));
-    const content = members.flatMap((member) =>
-      member.children.filter((child) => !isParagraphProperties(child))
-    );
-    const merged: OoxmlElement = {
-      ...block,
-      children: [...survivorProperties, ...content],
-    } as OoxmlElement;
-    mergeGroups.set(merged, { merged, members });
-    out.push(merged);
+    pendingParent = null;
+    out.push(mergedParagraph(members, block));
   }
-  // Members with no survivor after them: the last paragraph of the story carries its own mark
-  // away, which is what Word does when there is nothing to run into.
-  out.push(...pendingMembers);
+  // A TRAILING run, with no unmarked paragraph after it. Word cannot delete the last mark of a
+  // story, so the last member keeps its own break and the ones before it still merge into it —
+  // which is what `resolveRevisions` does, one member at a time, for the same reason.
+  out.push(...mergedTrailingRun(pendingMembers));
   return out;
+}
+
+function mergedTrailingRun(members: readonly OoxmlElement[]): readonly OoxmlElement[] {
+  if (members.length < 2) return members;
+  const survivor = members[members.length - 1]!;
+  return [mergedParagraph(members, survivor)];
 }
 
 /**
@@ -140,11 +179,93 @@ export function mergedFlowBlocks(
   children: readonly OoxmlNode[],
   displayMode: RevisionDisplayMode
 ): OoxmlElement[] {
-  const merged = withMergedParagraphs(
-    collectFlowBlocks(children, 0, () => true),
+  const merged = withMergedParagraphs(flowBlocksWithParent(children), displayMode);
+  return merged.filter((block) => acceptStoryBlock(block, displayMode));
+}
+
+/** A block, and which children array it actually lives in. */
+interface ParentedBlock {
+  readonly block: OoxmlElement;
+  /** Node id of the enclosing content control, or `''` for the story root's own children. */
+  readonly parentKey: string;
+}
+
+/** The walk `collectFlowBlocks` performs, remembering where each block CAME FROM. */
+function flowBlocksWithParent(children: readonly OoxmlNode[]): readonly ParentedBlock[] {
+  const blocks: ParentedBlock[] = [];
+  const collect = (nodes: readonly OoxmlNode[], nest: number, parentKey: string): void => {
+    for (const child of nodes) {
+      if (child.kind === 'textValue') continue;
+      if (child.kind === 'paragraph' || child.kind === 'table') {
+        blocks.push({ block: child, parentKey });
+        continue;
+      }
+      if (isContentControl(child) && nest < MAX_CONTENT_CONTROL_NESTING) {
+        collect(contentControlContentChildren(child), nest + 1, child.id);
+      }
+    }
+  };
+  collect(children, 0, '');
+  return blocks;
+}
+
+/**
+ * Can this paragraph's content be addressed inside a merged one?
+ *
+ * ASK THE WALK, which is what the design called for. A member's characters are placed in the
+ * merged paragraph at an offset taken from the STORE and read back out of spans the LAYOUT
+ * walk produced, so the two have to agree about how long the member is. They agree for every
+ * ordinary construct and part ways in two places: a field whose `w:fldChar begin` sits in one
+ * member and whose `end` sits in the next — Word writes that for a TOC — closes across the
+ * mark once the members share a paragraph and swallows the second member into one atomic
+ * field; and content past a nesting cap counts differently on each side. Both publish one
+ * member's text at another member's offsets, which is worse than the break this change exists
+ * to remove, so a group that cannot be measured is not merged.
+ */
+function memberIsAddressable(member: OoxmlElement, displayMode: RevisionDisplayMode): boolean {
+  if (!fieldCharsBalanced(member)) return false;
+  const pieces = piecesOfParagraph(
+    member,
+    [],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
     displayMode
   );
-  return merged.filter((block) => acceptStoryBlock(block, displayMode));
+  let published = 0;
+  for (const piece of pieces) published = Math.max(published, piece.end);
+  // Published LESS than the store holds is ordinary: a resolved view hides content it has
+  // resolved away, and the walk still counts those characters in its offsets. Published MORE
+  // is the failure — it means the walk reached content the store cannot address, so a member
+  // placed after it would be read back at offsets that belong to no paragraph.
+  return published <= paragraphOffsetIndex(member as OoxmlParagraphNode).length;
+}
+
+/**
+ * Does every field this paragraph opens also close inside it?
+ *
+ * `w:fldChar begin` in one paragraph and `end` in the next is ordinary Word output — a TOC is
+ * written that way. Two such paragraphs laid out as ONE close the field across the mark, and
+ * the field projection then covers the whole of the second member with a single atomic offset:
+ * every character of it published inside the first member's range, and the paragraph itself
+ * unreachable. Merging is refused rather than made to look right.
+ */
+function fieldCharsBalanced(paragraph: OoxmlElement): boolean {
+  let open = 0;
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldChar') {
+      const type = node.attributes.find(
+        (attribute) => attribute.localName === 'fldCharType'
+      )?.value;
+      if (type === 'begin') open += 1;
+      else if (type === 'end') open -= 1;
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(paragraph);
+  return open === 0;
 }
 
 /**

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -124,6 +124,30 @@ function withMergedParagraphs(
 }
 
 /**
+ * One container's blocks: flattened through content controls, merged, then filtered.
+ *
+ * MERGE FIRST, then drop. A mark-removed paragraph merges into the paragraph that follows it
+ * IN THE TREE, which is the rule `resolveRevisions` follows; dropping the empty ones first
+ * would hand a member the wrong survivor, and the survivor's properties govern the result.
+ * After the merge the drop has little left to do: an absorbed member is gone already, and what
+ * remains is a mark-removed paragraph with nothing after it to merge into.
+ *
+ * Every story collects its blocks through here — body, note, textbox and table cell — so a
+ * container is a merge boundary by construction: a paragraph can only merge with one that
+ * shares its parent, which is the same rule the store applies.
+ */
+export function mergedFlowBlocks(
+  children: readonly OoxmlNode[],
+  displayMode: RevisionDisplayMode
+): OoxmlElement[] {
+  const merged = withMergedParagraphs(
+    collectFlowBlocks(children, 0, () => true),
+    displayMode
+  );
+  return merged.filter((block) => acceptStoryBlock(block, displayMode));
+}
+
+/**
  * Memoized per part identity: parts are immutable (edits publish a new part object), so
  * the block list is a pure function of `(part, displayMode)`. Every keystroke flush asks
  * for the body's blocks from several callers — layout, section enumeration, furniture,
@@ -150,16 +174,7 @@ export function storyBlocks(
   const cached = perMode?.[displayMode];
   if (cached) return cached;
   const root = storyRootOf(part);
-  // MERGE FIRST, then drop. A mark-removed paragraph merges into the paragraph that follows it
-  // IN THE TREE, which is the rule `resolveRevisions` follows; dropping the empty ones first
-  // would hand a member the wrong survivor, and the survivor's properties govern the result.
-  // After the merge the drop has little left to do: an absorbed member is already gone, and
-  // what remains is a mark-removed paragraph with nothing after it to merge into.
-  const merged = withMergedParagraphs(
-    root ? collectFlowBlocks(root.children, 0, () => true) : [],
-    displayMode
-  );
-  const blocks = merged.filter((block) => acceptStoryBlock(block, displayMode));
+  const blocks = root ? mergedFlowBlocks(root.children, displayMode) : [];
   if (perMode) perMode[displayMode] = blocks;
   else storyBlocksCache.set(part, { [displayMode]: blocks });
   return blocks;
@@ -176,7 +191,7 @@ export function noteStoryBlocks(
   displayMode: RevisionDisplayMode = 'all-markup'
 ): OoxmlElement[] {
   if (note.kind !== 'note') return [];
-  return collectFlowBlocks(note.children, 0, (block) => acceptStoryBlock(block, displayMode));
+  return mergedFlowBlocks(note.children, displayMode);
 }
 
 /**
@@ -191,5 +206,5 @@ export function textboxStoryBlocks(
   displayMode: RevisionDisplayMode = 'all-markup'
 ): OoxmlElement[] {
   if (content.kind === 'textValue') return [];
-  return collectFlowBlocks(content.children, 0, (block) => acceptStoryBlock(block, displayMode));
+  return mergedFlowBlocks(content.children, displayMode);
 }

--- a/packages/core/src/layout/story-roots.ts
+++ b/packages/core/src/layout/story-roots.ts
@@ -17,7 +17,7 @@ import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/s
 import { collectFlowBlocks } from '../store/package/content-control-walk.ts';
 import { createRecentRootCache } from '../store/store/recent-root-cache.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
-import { revisionRemovesParagraph } from './revision-visibility.ts';
+import { markRemovedInMode, revisionRemovesParagraph } from './revision-visibility.ts';
 
 export { MAX_CONTENT_CONTROL_NESTING as MAX_SDT_NESTING } from '../store/package/content-control-walk.ts';
 
@@ -43,6 +43,84 @@ function acceptStoryBlock(block: OoxmlElement, displayMode: RevisionDisplayMode)
   // claims a full line box.
   if (block.kind === 'paragraph' && revisionRemovesParagraph(block, displayMode)) return false;
   return true;
+}
+
+/**
+ * The paragraphs a merge group is built from, in order, with the survivor last.
+ *
+ * Published beside the synthetic paragraph rather than derived from it, because the identity
+ * rewrite has to name the member a piece of content came from and a synthetic node has lost
+ * that by construction.
+ */
+export interface ParagraphMergeGroup {
+  /** The node layout lays out: the survivor's properties, every member's content. */
+  readonly merged: OoxmlElement;
+  /** Members in document order. The last one is the survivor whose mark stays. */
+  readonly members: readonly OoxmlElement[];
+}
+
+/** Groups keyed by the synthetic node, so a caller holding one can ask what it came from. */
+const mergeGroups = new WeakMap<OoxmlElement, ParagraphMergeGroup>();
+
+/** The members a laid-out paragraph stands for, or null when it stands for itself. */
+export function paragraphMergeGroupOf(paragraph: OoxmlElement): ParagraphMergeGroup | null {
+  return mergeGroups.get(paragraph) ?? null;
+}
+
+function isParagraphProperties(node: OoxmlNode): boolean {
+  return (
+    node.kind !== 'textValue' && (node.kind === 'paragraphProperties' || node.localName === 'pPr')
+  );
+}
+
+/**
+ * Fold each run of mark-removed paragraphs into the paragraph that follows it.
+ *
+ * The shape matches `resolveRevisions` exactly: the SURVIVOR's `w:pPr` governs, and every
+ * member's content arrives before it in document order. A trailing member with nothing to
+ * merge into keeps itself, for the same reason the store refuses that case — its runs have no
+ * paragraph to live in.
+ */
+function withMergedParagraphs(
+  blocks: readonly OoxmlElement[],
+  displayMode: RevisionDisplayMode
+): OoxmlElement[] {
+  if (displayMode === 'all-markup') return [...blocks];
+  const out: OoxmlElement[] = [];
+  let pendingMembers: OoxmlElement[] = [];
+  for (const block of blocks) {
+    if (block.kind !== 'paragraph') {
+      // A table between two mark-removed paragraphs is a container boundary: the store cannot
+      // merge across it either, so the run of members ends here and keeps its own boxes.
+      out.push(...pendingMembers, block);
+      pendingMembers = [];
+      continue;
+    }
+    if (markRemovedInMode(block, displayMode)) {
+      pendingMembers.push(block);
+      continue;
+    }
+    if (pendingMembers.length === 0) {
+      out.push(block);
+      continue;
+    }
+    const members = [...pendingMembers, block];
+    pendingMembers = [];
+    const survivorProperties = block.children.filter((child) => isParagraphProperties(child));
+    const content = members.flatMap((member) =>
+      member.children.filter((child) => !isParagraphProperties(child))
+    );
+    const merged: OoxmlElement = {
+      ...block,
+      children: [...survivorProperties, ...content],
+    } as OoxmlElement;
+    mergeGroups.set(merged, { merged, members });
+    out.push(merged);
+  }
+  // Members with no survivor after them: the last paragraph of the story carries its own mark
+  // away, which is what Word does when there is nothing to run into.
+  out.push(...pendingMembers);
+  return out;
 }
 
 /**
@@ -72,9 +150,16 @@ export function storyBlocks(
   const cached = perMode?.[displayMode];
   if (cached) return cached;
   const root = storyRootOf(part);
-  const blocks = root
-    ? collectFlowBlocks(root.children, 0, (block) => acceptStoryBlock(block, displayMode))
-    : [];
+  // MERGE FIRST, then drop. A mark-removed paragraph merges into the paragraph that follows it
+  // IN THE TREE, which is the rule `resolveRevisions` follows; dropping the empty ones first
+  // would hand a member the wrong survivor, and the survivor's properties govern the result.
+  // After the merge the drop has little left to do: an absorbed member is already gone, and
+  // what remains is a mark-removed paragraph with nothing after it to merge into.
+  const merged = withMergedParagraphs(
+    root ? collectFlowBlocks(root.children, 0, () => true) : [],
+    displayMode
+  );
+  const blocks = merged.filter((block) => acceptStoryBlock(block, displayMode));
   if (perMode) perMode[displayMode] = blocks;
   else storyBlocksCache.set(part, { [displayMode]: blocks });
   return blocks;

--- a/packages/core/src/output/__tests__/resolved-view-merge-paint.test.ts
+++ b/packages/core/src/output/__tests__/resolved-view-merge-paint.test.ts
@@ -1,0 +1,119 @@
+// Painting a line that carries two paragraphs.
+//
+// A resolved display mode draws a merged run as one paragraph, so the join line holds spans —
+// and inline images — from two of them. Both members count their offsets from zero, so an
+// image at offset 0 in the second half and an image at offset 0 in the first are numerically
+// identical. Anything that ordered or matched drawings by offset alone answered for the
+// wrong half.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import { mockReadyImageResource } from '../../store/__tests__/drawing-ready-fixture.ts';
+import {
+  WML_NAMESPACE_URI,
+  readOoxmlPart,
+  type OoxmlPart,
+} from '../../store/package/ooxml-tree.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semantic-layout.ts';
+import { lineSegments } from '../../layout/line-segments.ts';
+import { paragraphFragmentsOf } from '../../layout/semantic-records.ts';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+import type { PaintImageUrlPort } from '../semantic-paint-drawings.ts';
+
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const OWNER = '/word/document.xml';
+
+const READY = mockReadyImageResource({
+  bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
+  pixelWidth: 40,
+  pixelHeight: 20,
+});
+
+const urlPort: PaintImageUrlPort = {
+  create: (handle, mime) => `blob:fake/${mime}/${handle.resourceKey}`,
+  revoke: () => {},
+};
+
+/** A small inline picture, narrow enough that two of them share one line. */
+const picture =
+  '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+  '<wp:extent cx="228600" cy="114300"/><wp:docPr id="1" name="p"/>' +
+  '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">' +
+  '<pic:pic><pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr>' +
+  '<pic:blipFill><a:blip r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+  '<pic:spPr><a:xfrm><a:ext cx="228600" cy="114300"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
+  '</pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r>';
+
+/** Each half opens with a picture, so the two pictures are at the SAME model offset. */
+function mergedWithPictures(): OoxmlPart {
+  const xml =
+    `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+    `xmlns:pic="${PIC}" xmlns:r="${R}"><w:body>` +
+    '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+    `${picture}<w:r><w:t xml:space="preserve">AAA </w:t></w:r></w:p>` +
+    `<w:p>${picture}<w:r><w:t>BBB</w:t></w:r></w:p>` +
+    '</w:body></w:document>';
+  const result = readOoxmlPart(xml, {
+    name: OWNER,
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function layoutMerged() {
+  return layoutSemanticDocument(mergedWithPictures(), 1, {
+    measurer: createFixedMeasurer(6, 14),
+    displayMode: 'proposed',
+    inlineDrawingLayout: {
+      ownerPartName: OWNER,
+      project: (node) =>
+        projectDrawing(node, { ownerPartName: OWNER, limits: DEFAULT_DRAWING_PROJECTION_LIMITS }),
+      resourceOf: () => READY,
+    },
+  });
+}
+
+describe('two paragraphs of images on one line', () => {
+  test('the join line holds two drawings at the same offset in different paragraphs', () => {
+    // The ambiguity itself, stated as a fact about the records. Every offset-only lookup
+    // over this line is a coin toss, and this is the fixture that makes it one.
+    const fragment = paragraphFragmentsOf(layoutMerged().pages[0]!)[0]!;
+    const line = fragment.lines[0]!;
+    const drawings = line.drawings ?? [];
+    expect(drawings).toHaveLength(2);
+    expect(drawings[0]!.start).toBe(drawings[1]!.start);
+    expect(drawings[0]!.paragraphId).not.toBe(drawings[1]!.paragraphId);
+    expect(lineSegments(line)).toHaveLength(2);
+  });
+
+  test('each half paints its own advance, in its own half', () => {
+    // Ordered by offset alone, both spacers flushed before the FIRST half's text: the
+    // second image's advance opened a gap in the wrong paragraph and left none in its own.
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layoutMerged(), {
+      scale: 1,
+      imageUrlPort: urlPort,
+      ariaHidden: false,
+    });
+    const line = container.querySelector('.docx-line');
+    expect(line).toBeTruthy();
+    const shape: string[] = [];
+    for (const child of Array.from(line!.children)) {
+      if (child.classList.contains('docx-inline-drawing-advance')) shape.push('advance');
+      else if ((child.textContent ?? '').trim().length > 0) {
+        shape.push((child.textContent ?? '').trim());
+      }
+    }
+    expect(shape).toEqual(['advance', 'AAA', 'advance', 'BBB']);
+  });
+});

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -39,6 +39,7 @@ import type {
 } from '@docx-editor.dev/core/layout';
 import { paintPageNoteAreas } from './semantic-paint-notes.ts';
 import { anchoredDrawingsOf } from '../layout/semantic-records.ts';
+import { lineSegments } from '../layout/line-segments.ts';
 import type { AnchoredDrawingRecord } from '../layout/drawing-layout.ts';
 import {
   collectUsedDrawingElementKeys,
@@ -1239,12 +1240,26 @@ function paintLine(
   // offset, so it opens its own — even with an identical target and thus the same content-keyed
   // id. Null while the current anchor is a typed link or there is none.
   let anchorFieldStart: number | null = null;
-  const inlineDrawings = [...(line.drawings ?? [])].sort((left, right) => left.start - right.start);
+  // Sorted in the order the READER meets them, which on an ordinary line is the offset order
+  // it always was. A resolved display mode draws two paragraphs on the join line and each
+  // counts its offsets from zero, so a plain numeric sort interleaved the two halves' images
+  // and flushed a spacer for the wrong one.
+  const segmentRank = new Map<string, number>();
+  for (const [rank, segment] of lineSegments(line).entries()) {
+    segmentRank.set(segment.paragraphId, rank);
+  }
+  const rankOf = (paragraphId: string): number => segmentRank.get(paragraphId) ?? 0;
+  const inlineDrawings = [...(line.drawings ?? [])].sort(
+    (left, right) =>
+      rankOf(left.paragraphId) - rankOf(right.paragraphId) || left.start - right.start
+  );
   let nextInlineDrawing = 0;
-  const appendDrawingAdvancesBefore = (modelOffset: number): void => {
+  const appendDrawingAdvancesBefore = (paragraphId: string, modelOffset: number): void => {
     while (
       nextInlineDrawing < inlineDrawings.length &&
-      inlineDrawings[nextInlineDrawing]!.start < modelOffset
+      (rankOf(inlineDrawings[nextInlineDrawing]!.paragraphId) < rankOf(paragraphId) ||
+        (rankOf(inlineDrawings[nextInlineDrawing]!.paragraphId) === rankOf(paragraphId) &&
+          inlineDrawings[nextInlineDrawing]!.start < modelOffset))
     ) {
       const drawing = inlineDrawings[nextInlineDrawing]!;
       const advance = Math.max(0, drawing.advanceEnd - drawing.advanceStart);
@@ -1293,7 +1308,7 @@ function paintLine(
   };
 
   for (const [spanIndex, span] of line.spans.entries()) {
-    appendDrawingAdvancesBefore(span.range.start);
+    appendDrawingAdvancesBefore(span.range.paragraphId, span.range.start);
     appendWrapAdvance(span);
     const band = Math.min(span.box.height + leading, line.box.height);
     const painted = paintSpan(document, span, ctx, band, leading);
@@ -1334,7 +1349,11 @@ function paintLine(
     }
     anchor.append(painted);
   }
-  appendDrawingAdvancesBefore(Number.POSITIVE_INFINITY);
+  // Past the end of the LAST segment, so a trailing image in either half still flushes.
+  appendDrawingAdvancesBefore(
+    lineSegments(line)[lineSegments(line).length - 1]?.paragraphId ?? line.range.paragraphId,
+    Number.POSITIVE_INFINITY
+  );
   // A span-less line (empty paragraph) has no inline content, and a browser will not
   // draw a caret at a position with no inline box to measure. The <br> is the anchor;
   // sizing it to the line keeps the caret the paragraph's font height, not the div's

--- a/packages/core/src/store/__tests__/review-reads.test.ts
+++ b/packages/core/src/store/__tests__/review-reads.test.ts
@@ -205,6 +205,54 @@ describe('the deep paragraph order reaches paragraphs the shallow one cannot', (
   });
 });
 
+describe('a card id names the part it lives in', () => {
+  const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+  function storyWith(name: string, body: string): OoxmlPart {
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`,
+      { name, contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    return result.part;
+  }
+
+  // The SAME triple in two parts. `@w:id` is unique within a part and nowhere else, and
+  // Word numbers each part from 1, so this is what an ordinary document looks like — not a
+  // contrived collision.
+  const TRACKED =
+    `<w:p><w:ins w:id="1" w:author="QA" w:date="2024-01-01T00:00:00Z">` +
+    `<w:r><w:t>alpha</w:t></w:r></w:ins></w:p>`;
+
+  test('the body and a header do not share one card id', () => {
+    const body = storyWith('/word/document.xml', TRACKED);
+    const header = storyWith('/word/header1.xml', TRACKED);
+    const items = collectReviewItems({ storyPart: body, furnitureParts: [header] });
+    expect(items).toHaveLength(2);
+    expect(new Set(items.map((item) => item.id)).size).toBe(2);
+  });
+
+  test('a rail keyed by id can still reach both cards', () => {
+    // The failure this prevents is not the duplicate id itself: it is what every consumer
+    // does with one. A `Map` keyed by id kept the last writer, so the body's card was
+    // unreachable — no activation, no accept, no reject.
+    const body = storyWith('/word/document.xml', TRACKED);
+    const header = storyWith('/word/header1.xml', TRACKED);
+    const items = collectReviewItems({ storyPart: body, furnitureParts: [header] });
+    const byId = new Map(items.map((item) => [item.id, item]));
+    expect(byId.size).toBe(2);
+    const parts = [...byId.values()].map((item) =>
+      item.kind === 'revision' ? item.ranges[0]?.partName : undefined
+    );
+    expect(new Set(parts)).toEqual(new Set(['/word/document.xml', '/word/header1.xml']));
+  });
+
+  test('the id is stable across reads, because a React key and an active card depend on it', () => {
+    const body = storyWith('/word/document.xml', TRACKED);
+    expect(revisionItemsOf(body)[0]!.id).toBe(revisionItemsOf({ ...body })[0]!.id);
+  });
+});
+
 describe('the revision-card memo is keyed on the part, not just its root', () => {
   test('two parts sharing one root under different names each get their own part name', () => {
     const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';

--- a/packages/core/src/store/__tests__/revision-resolve.test.ts
+++ b/packages/core/src/store/__tests__/revision-resolve.test.ts
@@ -415,3 +415,45 @@ describe('a move recorded on the paragraph mark', () => {
     expect(xml(apply(moved('moveTo'), accept(QA))).match(/<w:p[ >]/g)).toHaveLength(2);
   });
 });
+
+describe('a run of removed paragraph marks', () => {
+  // Word merges all of them into the paragraph whose mark survives. Resolving pairwise left
+  // every second paragraph behind, so accepting sixteen deleted marks produced eight
+  // paragraphs and eight blank lines that no decision asked for.
+  const delMark = (text: string) =>
+    `<w:p><w:pPr><w:rPr><w:del w:id="${QA.id}" w:author="${QA.author}" w:date="${QA.date}"/></w:rPr></w:pPr>` +
+    `${run(text)}</w:p>`;
+
+  test('collapses into the one survivor at its end', () => {
+    const part = load(
+      delMark('one ') + delMark('two ') + delMark('three ') + `<w:p>${run('four')}</w:p>`
+    );
+    const out = xml(apply(part, { op: 'acceptAllRevisions' }));
+    expect(out.match(/<w:p[ >]/g)).toHaveLength(1);
+    expect(out).toContain('one ');
+    expect(out).toContain('four');
+  });
+
+  test('a trailing run keeps the last paragraph, which the others merge into', () => {
+    const part = load(`<w:p>${run('keep')}</w:p>` + delMark('a ') + delMark('b '));
+    const out = xml(apply(part, { op: 'acceptAllRevisions' }));
+    expect(out.match(/<w:p[ >]/g)).toHaveLength(2);
+    // Both members' runs, in the paragraph that survived them.
+    expect(out.slice(out.lastIndexOf('<w:p>'))).toContain('a ');
+    expect(out.slice(out.lastIndexOf('<w:p>'))).toContain('b ');
+  });
+
+  test('a table is a boundary: the content stays in front of it', () => {
+    // `followed` looked at any later paragraph, so the text merged into the one AFTER the
+    // table and arrived behind it — in a place the reader never put it.
+    const table =
+      '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+      `<w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr><w:p>${run('cell')}</w:p>` +
+      '</w:tc></w:tr></w:tbl>';
+    const part = load(delMark('before ') + table + `<w:p>${run('after')}</w:p>`);
+    const out = xml(apply(part, { op: 'acceptAllRevisions' }));
+    expect(out.indexOf('before ')).toBeLessThan(out.indexOf('<w:tbl'));
+    expect(out).not.toContain('before after');
+  });
+});

--- a/packages/core/src/store/__tests__/revision-resolve.test.ts
+++ b/packages/core/src/store/__tests__/revision-resolve.test.ts
@@ -471,3 +471,51 @@ describe('a run of removed paragraph marks', () => {
     expect(out).not.toContain('before after');
   });
 });
+
+describe('joining paragraphs moves the mark, not just the section break', () => {
+  // A join deletes the FIRST paragraph's mark, so the merged paragraph ends with the SECOND's.
+  // Keeping the first's left the survivor proposing to delete a break the user had just
+  // deleted: the next layout pass merged it into the paragraph after it, and the review pane
+  // kept a card for a mark that no longer exists.
+  const markDel = (id: string) =>
+    `<w:pPr><w:rPr><w:del w:id="${id}" w:author="${QA.author}" w:date="${QA.date}"/></w:rPr></w:pPr>`;
+
+  test('the survivor does not inherit a mark revision the join deleted', () => {
+    const part = load(
+      `<w:p>${markDel('1')}${run('Hello ')}</w:p><w:p>${run('world')}</w:p><w:p>${run('after')}</w:p>`
+    );
+    const ids = [...xml(part).matchAll(/<w:p[ >]/g)].length;
+    expect(ids).toBe(3);
+    const body = part.root.children[0]!;
+    const paragraphs = (body as { children: { kind: string; id: string }[] }).children.filter(
+      (child) => child.kind === 'paragraph'
+    );
+    const joined = applyTreeOp(part, {
+      op: 'joinParagraphs',
+      firstId: paragraphs[0]!.id,
+      secondId: paragraphs[1]!.id,
+    });
+    if (!joined.ok) throw new Error(joined.reason);
+    const out = xml(joined.part);
+    expect(out).toContain('Hello ');
+    expect(out).toContain('world');
+    expect(out).not.toContain('<w:del');
+  });
+
+  test('a mark revision on the SECOND paragraph rides onto the survivor', () => {
+    const part = load(
+      `<w:p>${run('Hello ')}</w:p><w:p>${markDel('2')}${run('world')}</w:p><w:p>${run('after')}</w:p>`
+    );
+    const body = part.root.children[0]!;
+    const paragraphs = (body as { children: { kind: string; id: string }[] }).children.filter(
+      (child) => child.kind === 'paragraph'
+    );
+    const joined = applyTreeOp(part, {
+      op: 'joinParagraphs',
+      firstId: paragraphs[0]!.id,
+      secondId: paragraphs[1]!.id,
+    });
+    if (!joined.ok) throw new Error(joined.reason);
+    expect(xml(joined.part)).toContain('<w:del');
+  });
+});

--- a/packages/core/src/store/__tests__/revision-resolve.test.ts
+++ b/packages/core/src/store/__tests__/revision-resolve.test.ts
@@ -443,6 +443,20 @@ describe('a run of removed paragraph marks', () => {
     expect(out.slice(out.lastIndexOf('<w:p>'))).toContain('b ');
   });
 
+  test('a content control is a boundary too', () => {
+    // A `w:sdt` holds its own children, so the paragraph before it and the first paragraph
+    // inside it are not siblings. Scanning past it merged the text into a paragraph in
+    // another parent, where it arrived behind the control.
+    const part = load(
+      delMark('before ') +
+        `<w:sdt><w:sdtContent><w:p>${run('inside')}</w:p></w:sdtContent></w:sdt>` +
+        `<w:p>${run('after')}</w:p>`
+    );
+    const out = xml(apply(part, { op: 'acceptAllRevisions' }));
+    expect(out.indexOf('before ')).toBeLessThan(out.indexOf('<w:sdt'));
+    expect(out).not.toContain('before after');
+  });
+
   test('a table is a boundary: the content stays in front of it', () => {
     // `followed` looked at any later paragraph, so the text merged into the one AFTER the
     // table and arrived behind it — in a place the reader never put it.

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -398,7 +398,12 @@ function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
   const items = [...byAddress.values()].map(
     (entry): ReviewRevisionItem => ({
       kind: 'revision' as const,
-      id: `${entry.revisionKind}-${addressKey(entry.address)}`,
+      // The PART is in the id, because `@w:id` is unique only within one. A body `w:ins`
+      // and a header `w:ins` numbered 1 by the same author on the same date produced one
+      // id for two decisions: the rail's `byId` map kept whichever came last, so one card
+      // was unreachable, its replies were attached to the other, and React saw two
+      // children under one key.
+      id: `${entry.revisionKind}-${part.name}\u0000${addressKey(entry.address)}`,
       address: entry.address,
       addresses: [entry.address],
       revisionKind: entry.revisionKind,

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -71,6 +71,14 @@ export type ReviewRevisionKind =
   /** A row, cell, section or grid revision. Supported row revisions are resolvable. */
   | 'structural';
 
+/** `EG_ParaRPrTrackChanges` by element name: the four decisions a paragraph mark can carry. */
+const MARK_DIRECTIONS: Readonly<Record<string, 'insert' | 'delete' | 'moveFrom' | 'moveTo'>> = {
+  ins: 'insert',
+  del: 'delete',
+  moveFrom: 'moveFrom',
+  moveTo: 'moveTo',
+};
+
 /** One tracked change as the store derives it, keyed per decision rather than per site. */
 export interface ReviewRevisionItem {
   readonly kind: 'revision';
@@ -89,6 +97,15 @@ export interface ReviewRevisionItem {
   /** The words a replacement removes. Empty for every other kind. */
   readonly replacedText: string;
   readonly revisionKind: ReviewRevisionKind;
+  /**
+   * WHICH decision a `paragraphMark` records, absent for every other kind.
+   *
+   * `EG_ParaRPrTrackChanges` is `ins? del? moveFrom? moveTo?`, and the four say opposite
+   * things about the same break: one proposes it, another proposes taking it away. Collapsing
+   * them into the single kind lost that, and a card then described a deleted break as an
+   * inserted one — the reverse of what Accept on that card does.
+   */
+  readonly markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
   readonly author: string;
   readonly date?: string;
   /** Text the revision covers, for the card summary. Empty for changes with no characters. */
@@ -270,6 +287,7 @@ function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
     {
       address: RevisionAddress;
       revisionKind: ReviewRevisionKind;
+      markDirection?: 'insert' | 'delete' | 'moveFrom' | 'moveTo';
       author: string;
       date?: string;
       text: string;
@@ -299,6 +317,9 @@ function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
       : site.paragraphMark
         ? 'paragraphMark'
         : (CONTENT_KINDS[site.node.kind] ?? 'structural');
+    // The element name IS the decision for a mark, and it is the only place the direction
+    // survives: `w:pPr/w:rPr` holds the revision as a bare element, not as a wrapper kind.
+    const markDirection = site.paragraphMark ? MARK_DIRECTIONS[site.node.localName] : undefined;
 
     const where = located.get(site.node.id);
     const range: ReviewRange | null = where
@@ -358,6 +379,7 @@ function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
     byAddress.set(key, {
       address,
       revisionKind: kind,
+      ...(markDirection ? { markDirection } : {}),
       author,
       ...(date === undefined ? {} : { date }),
       text:
@@ -380,6 +402,7 @@ function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
       address: entry.address,
       addresses: [entry.address],
       revisionKind: entry.revisionKind,
+      ...(entry.markDirection ? { markDirection: entry.markDirection } : {}),
       author: entry.author,
       ...(entry.date === undefined ? {} : { date: entry.date }),
       // A pure deletion shows the words it removes as its text; a replacement shows what

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -2777,24 +2777,48 @@ function applyJoin(
   return result;
 }
 
+/** `EG_ParaRPrTrackChanges` — the four revisions a paragraph mark can carry (§17.13.5). */
+const MARK_REVISION_NAMES: ReadonlySet<string> = new Set(['ins', 'del', 'moveFrom', 'moveTo']);
+
+const isMarkRevision = (node: OoxmlNode): boolean =>
+  node.kind !== 'textValue' &&
+  node.namespaceUri === WML_NAMESPACE_URI &&
+  MARK_REVISION_NAMES.has(node.localName);
+
 /**
- * The join survivor, carrying the SECTION MARK of the paragraph that leaves.
+ * The join survivor, carrying the TRACKED STATE of the mark that survives.
  *
- * `w:sectPr` in a paragraph's mark is not formatting: it is where a section ENDS (17.6.17).
- * A join deletes the FIRST paragraph's mark, so the mark that survives the merge is the
- * second's, and the section boundary rides on it. Dropping it with the rest of the second
- * paragraph's `w:pPr` merged the section into the one that follows, taking that section's
- * page size, orientation and headers over every page of it.
+ * A join deletes the FIRST paragraph's mark, so the mark the merged paragraph ends with is
+ * the SECOND's — and two things ride on a mark rather than on formatting. `w:sectPr` says
+ * where a section ENDS (§17.6.17); dropping it merged the section into the one that follows,
+ * taking that section's page size, orientation and headers over every page of it. The mark's
+ * own `w:ins`/`w:del` says the break itself is a pending decision; keeping the FIRST
+ * paragraph's left the survivor proposing to delete a break the user had just deleted, so the
+ * next layout pass merged it into the paragraph after it and the review pane kept a card for
+ * a mark that no longer exists.
+ *
+ * Formatting is the other way round, and stays as it was: the survivor keeps its own
+ * properties, which is what Word does when you join into a paragraph.
  */
 function withSectionMarkOf(
   first: OoxmlNode & { readonly children: readonly OoxmlNode[] },
   second: OoxmlParagraphNode,
   nextId: () => string
 ): OoxmlNode & { readonly children: readonly OoxmlNode[] } {
+  const secondMarkRevisions = (
+    namedChild(paragraphPropertiesNodeOf(second), 'rPr')?.children ?? []
+  ).filter(isMarkRevision);
+  const survivorHasMarkRevision = (
+    namedChild(paragraphPropertiesNodeOf(first), 'rPr')?.children ?? []
+  ).some(isMarkRevision);
+  const withMark =
+    secondMarkRevisions.length > 0 || survivorHasMarkRevision
+      ? withMarkRevisionsOf(first, secondMarkRevisions, nextId)
+      : first;
   const sectPr = namedChild(paragraphPropertiesNodeOf(second), 'sectPr');
-  if (!sectPr) return first;
+  if (!sectPr) return withMark;
   const carried = cloneWithNewIds(sectPr, nextId);
-  const pPr = paragraphPropertiesNodeOf(first);
+  const pPr = paragraphPropertiesNodeOf(withMark);
   if (!pPr) {
     const minted = {
       id: nextId(),
@@ -2807,7 +2831,7 @@ function withSectionMarkOf(
       children: [carried],
     } as unknown as OoxmlNode;
     // `w:pPr` must be the paragraph's FIRST child per the schema.
-    return { ...first, children: [minted, ...first.children] } as OoxmlNode & {
+    return { ...withMark, children: [minted, ...withMark.children] } as OoxmlNode & {
       readonly children: readonly OoxmlNode[];
     };
   }
@@ -2825,8 +2849,85 @@ function withSectionMarkOf(
     children: [...others.slice(0, at), carried, ...others.slice(at)],
   } as OoxmlNode;
   return {
-    ...first,
-    children: first.children.map((child) => (child.id === pPr.id ? rebuilt : child)),
+    ...withMark,
+    children: withMark.children.map((child) => (child.id === pPr.id ? rebuilt : child)),
+  } as OoxmlNode & { readonly children: readonly OoxmlNode[] };
+}
+
+/**
+ * The survivor with the mark revisions of the paragraph whose mark it inherits.
+ *
+ * Its own go, whatever they were: that mark is the one the join deletes. `EG_ParaRPrTrackChanges`
+ * opens `CT_ParaRPr`, so the carried elements go FIRST inside `w:rPr`.
+ */
+function withMarkRevisionsOf(
+  survivor: OoxmlNode & { readonly children: readonly OoxmlNode[] },
+  revisions: readonly OoxmlNode[],
+  nextId: () => string
+): OoxmlNode & { readonly children: readonly OoxmlNode[] } {
+  const carried = revisions.map((revision) => cloneWithNewIds(revision, nextId));
+  const pPr = paragraphPropertiesNodeOf(survivor);
+  if (!pPr) {
+    if (carried.length === 0) return survivor;
+    const rPr = {
+      id: nextId(),
+      kind: 'runProperties',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'rPr',
+      prefix: 'w',
+      namespaceBindings: [],
+      attributes: [],
+      children: carried,
+    } as unknown as OoxmlNode;
+    const minted = {
+      id: nextId(),
+      kind: 'paragraphProperties',
+      namespaceUri: WML_NAMESPACE_URI,
+      localName: 'pPr',
+      prefix: 'w',
+      namespaceBindings: [],
+      attributes: [],
+      children: [rPr],
+    } as unknown as OoxmlNode;
+    return { ...survivor, children: [minted, ...survivor.children] } as OoxmlNode & {
+      readonly children: readonly OoxmlNode[];
+    };
+  }
+  const existingRPr = namedChild(pPr, 'rPr');
+  const keptFace = (existingRPr?.children ?? []).filter((child) => !isMarkRevision(child));
+  const rebuiltRPr =
+    existingRPr === undefined
+      ? carried.length > 0
+        ? ({
+            id: nextId(),
+            kind: 'runProperties',
+            namespaceUri: WML_NAMESPACE_URI,
+            localName: 'rPr',
+            prefix: 'w',
+            namespaceBindings: [],
+            attributes: [],
+            children: carried,
+          } as unknown as OoxmlNode)
+        : undefined
+      : ({ ...existingRPr, children: [...carried, ...keptFace] } as OoxmlNode);
+  if (!rebuiltRPr) return survivor;
+  // `w:rPr` follows the base properties and precedes `w:sectPr` and `w:pPrChange`.
+  const children =
+    existingRPr === undefined
+      ? (() => {
+          const tail = pPr.children.findIndex(
+            (child) =>
+              child.kind !== 'textValue' &&
+              (child.localName === 'sectPr' || child.localName === 'pPrChange')
+          );
+          const at = tail === -1 ? pPr.children.length : tail;
+          return [...pPr.children.slice(0, at), rebuiltRPr, ...pPr.children.slice(at)];
+        })()
+      : pPr.children.map((child) => (child.id === existingRPr.id ? rebuiltRPr : child));
+  const rebuiltPPr = { ...pPr, children } as OoxmlNode;
+  return {
+    ...survivor,
+    children: survivor.children.map((child) => (child.id === pPr.id ? rebuiltPPr : child)),
   } as OoxmlNode & { readonly children: readonly OoxmlNode[] };
 }
 

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -31,6 +31,7 @@ import {
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
 import { isContentRevisionKind } from '../package/ooxml-shared.ts';
+import { isContentControl } from '../package/content-control-walk.ts';
 import { DEPENDENCY_KEY_IDS } from '../registry/frozen-ids.ts';
 import { scopedRevisionRoot } from './tree-op-revision-scope.ts';
 import type { RevisionAddress } from './tree-op-types.ts';
@@ -570,6 +571,18 @@ function isWmlNamed(node: OoxmlNode, localName: string): boolean {
  * rejected insertion inside a rejected deletion survived: the outer unwrap consumed the inner
  * wrapper as ordinary content.
  */
+/**
+ * Is this a block-level sibling — something a paragraph cannot merge THROUGH?
+ *
+ * Paragraphs and tables are the flow's own blocks. A content control is one too for this
+ * question: its paragraphs live in `w:sdtContent`, so the paragraph before it and the first
+ * paragraph inside it have different parents and are not siblings at all.
+ */
+function isBlockLevel(node: OoxmlNode): boolean {
+  if (node.kind === 'paragraph' || node.kind === 'table') return true;
+  return node.kind !== 'textValue' && isContentControl(node);
+}
+
 function rebuildChildren(children: readonly OoxmlNode[], plan: RebuildPlan): OoxmlNode[] {
   const out: OoxmlNode[] = [];
   /** Content of paragraphs whose mark was resolved away, waiting for the paragraph after. */
@@ -624,12 +637,12 @@ function rebuildChildren(children: readonly OoxmlNode[], plan: RebuildPlan): Oox
         // was refused and Accept All failed for the entire document with an opaque reason.
         // Deleting a trailing paragraph with tracking on is exactly what Word writes, so this
         // was not an exotic file.
-        // The NEXT BLOCK, not any later paragraph. Scanning ahead past a `w:tbl` reported a
-        // paragraph that is not this one's neighbour, and the content then merged into it —
-        // arriving BEHIND the table, in a place the reader never put it.
-        const nextBlock = children
-          .slice(index + 1)
-          .find((entry) => entry.kind === 'paragraph' || entry.kind === 'table');
+        // The NEXT BLOCK, not any later paragraph, and EVERY kind of block counts. Scanning
+        // ahead past a `w:tbl` — or past a `w:sdt`, which holds paragraphs of its own that
+        // this one is not a sibling of — reported a paragraph that is not this one's
+        // neighbour, and the content then merged into it, arriving behind the block in a
+        // place the reader never put it.
+        const nextBlock = children.slice(index + 1).find((entry) => isBlockLevel(entry));
         const followed = nextBlock?.kind === 'paragraph';
         if (plan.mergeForward.has(child.id) && followed) {
           // Tested AFTER absorbing, so a RUN of removed marks collapses into the one survivor

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -624,7 +624,13 @@ function rebuildChildren(children: readonly OoxmlNode[], plan: RebuildPlan): Oox
         // was refused and Accept All failed for the entire document with an opaque reason.
         // Deleting a trailing paragraph with tracking on is exactly what Word writes, so this
         // was not an exotic file.
-        const followed = children.slice(index + 1).some((entry) => entry.kind === 'paragraph');
+        // The NEXT BLOCK, not any later paragraph. Scanning ahead past a `w:tbl` reported a
+        // paragraph that is not this one's neighbour, and the content then merged into it —
+        // arriving BEHIND the table, in a place the reader never put it.
+        const nextBlock = children
+          .slice(index + 1)
+          .find((entry) => entry.kind === 'paragraph' || entry.kind === 'table');
+        const followed = nextBlock?.kind === 'paragraph';
         if (plan.mergeForward.has(child.id) && followed) {
           // Tested AFTER absorbing, so a RUN of removed marks collapses into the one survivor
           // at its end rather than pairwise. Word merges all of them; stopping at the first

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -612,30 +612,30 @@ function rebuildChildren(children: readonly OoxmlNode[], plan: RebuildPlan): Oox
     if (child.kind === 'paragraph') {
       const paragraph = rebuilt[0];
       if (paragraph !== undefined && paragraph.kind !== 'textValue') {
-        if (carried.length > 0) {
-          // This paragraph absorbs the content of the ones before it. Its own `w:pPr` stays:
-          // the surviving mark is this paragraph's, so its properties govern the result.
-          const properties = paragraph.children.filter((entry) => isWmlNamed(entry, 'pPr'));
-          const content = paragraph.children.filter((entry) => !isWmlNamed(entry, 'pPr'));
-          out.push({
-            ...paragraph,
-            children: [...properties, ...carried, ...content],
-          } as OoxmlElement);
-          carried = [];
+        // Everything this paragraph would hold: what earlier paragraphs handed it, then its
+        // own. Its `w:pPr` is kept apart, because the properties that govern a merge are the
+        // surviving mark's — this paragraph's, if the mark survives here.
+        const properties = paragraph.children.filter((entry) => isWmlNamed(entry, 'pPr'));
+        const content = [...carried, ...paragraph.children.filter((e) => !isWmlNamed(e, 'pPr'))];
+        carried = [];
+        // Only when there IS a following paragraph in this container. Otherwise the paragraph
+        // keeps its content and simply loses the mark revision — spilling its runs into
+        // `w:body` or `w:tc` produced a tree the invariants reject, so the whole transaction
+        // was refused and Accept All failed for the entire document with an opaque reason.
+        // Deleting a trailing paragraph with tracking on is exactly what Word writes, so this
+        // was not an exotic file.
+        const followed = children.slice(index + 1).some((entry) => entry.kind === 'paragraph');
+        if (plan.mergeForward.has(child.id) && followed) {
+          // Tested AFTER absorbing, so a RUN of removed marks collapses into the one survivor
+          // at its end rather than pairwise. Word merges all of them; stopping at the first
+          // absorption left every second paragraph behind, so accepting sixteen deleted marks
+          // in a row produced eight paragraphs and eight blank lines that no decision asked for.
+          carried = content;
           continue;
         }
-        if (plan.mergeForward.has(child.id)) {
-          // Only when there IS a following paragraph in this container. Otherwise the
-          // paragraph keeps its content and simply loses the mark revision — spilling its
-          // runs into `w:body` or `w:tc` produced a tree the invariants reject, so the whole
-          // transaction was refused and Accept All failed for the entire document with an
-          // opaque reason. Deleting a trailing paragraph with tracking on is exactly what
-          // Word writes, so this was not an exotic file.
-          const followed = children.slice(index + 1).some((entry) => entry.kind === 'paragraph');
-          if (followed) {
-            carried = paragraph.children.filter((entry) => !isWmlNamed(entry, 'pPr'));
-            continue;
-          }
+        if (content.length > paragraph.children.length - properties.length) {
+          out.push({ ...paragraph, children: [...properties, ...content] } as OoxmlElement);
+          continue;
         }
       }
     }

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "Absatzmarke eingefügt",
-    "runPropertiesChanged": "Textformatierung geändert"
+    "runPropertiesChanged": "Textformatierung geändert",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "Gesamtes Verzeichnis aktualisieren",

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "Absatzmarke eingefügt",
     "runPropertiesChanged": "Textformatierung geändert",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "Gesamtes Verzeichnis aktualisieren",

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -266,6 +266,8 @@
   },
   "revisions": {
     "paragraphMarkInserted": "Inserted paragraph break",
+    "paragraphMarkDeleted": "Deleted paragraph break",
+    "paragraphMarkMoved": "Moved paragraph break",
     "runPropertiesChanged": "Changed text formatting"
   },
   "contextMenu": {

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -267,7 +267,8 @@
   "revisions": {
     "paragraphMarkInserted": "Inserted paragraph break",
     "paragraphMarkDeleted": "Deleted paragraph break",
-    "paragraphMarkMoved": "Moved paragraph break",
+    "paragraphMarkMovedFrom": "Moved paragraph break away",
+    "paragraphMarkMovedTo": "Moved paragraph break here",
     "runPropertiesChanged": "Changed text formatting"
   },
   "contextMenu": {

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "Marque de paragraphe insérée",
-    "runPropertiesChanged": "Mise en forme du texte modifiée"
+    "runPropertiesChanged": "Mise en forme du texte modifiée",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "Mettre à jour toute la table",

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "Marque de paragraphe insérée",
     "runPropertiesChanged": "Mise en forme du texte modifiée",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "Mettre à jour toute la table",

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "סימן פסקה נוסף",
     "runPropertiesChanged": "עיצוב הטקסט שונה",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "עדכון הטבלה כולה",

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "סימן פסקה נוסף",
-    "runPropertiesChanged": "עיצוב הטקסט שונה"
+    "runPropertiesChanged": "עיצוב הטקסט שונה",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "עדכון הטבלה כולה",

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "अनुच्छेद चिह्न सम्मिलित किया गया",
-    "runPropertiesChanged": "पाठ स्वरूपण बदला गया"
+    "runPropertiesChanged": "पाठ स्वरूपण बदला गया",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "पूरी तालिका अपडेट करें",

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "अनुच्छेद चिह्न सम्मिलित किया गया",
     "runPropertiesChanged": "पाठ स्वरूपण बदला गया",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "पूरी तालिका अपडेट करें",

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -262,7 +262,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "Menyisipkan tanda paragraf",
-    "runPropertiesChanged": "Format teks diubah"
+    "runPropertiesChanged": "Format teks diubah",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "contextMenu": {
     "ariaLabel": "Menu tindakan AI",

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -264,7 +264,8 @@
     "paragraphMarkInserted": "Menyisipkan tanda paragraf",
     "runPropertiesChanged": "Format teks diubah",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "contextMenu": {
     "ariaLabel": "Menu tindakan AI",

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "Wstawiono znak akapitu",
     "runPropertiesChanged": "Zmieniono formatowanie tekstu",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "Aktualizuj cały spis",

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "Wstawiono znak akapitu",
-    "runPropertiesChanged": "Zmieniono formatowanie tekstu"
+    "runPropertiesChanged": "Zmieniono formatowanie tekstu",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "Aktualizuj cały spis",

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "Marca de parágrafo inserida",
-    "runPropertiesChanged": "Formatação do texto alterada"
+    "runPropertiesChanged": "Formatação do texto alterada",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "Atualizar tabela inteira",

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "Marca de parágrafo inserida",
     "runPropertiesChanged": "Formatação do texto alterada",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "Atualizar tabela inteira",

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "Paragraf işareti eklendi",
-    "runPropertiesChanged": "Metin biçimlendirmesi değiştirildi"
+    "runPropertiesChanged": "Metin biçimlendirmesi değiştirildi",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "Tüm tabloyu güncelle",

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "Paragraf işareti eklendi",
     "runPropertiesChanged": "Metin biçimlendirmesi değiştirildi",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "Tüm tabloyu güncelle",

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -482,7 +482,9 @@
   },
   "revisions": {
     "paragraphMarkInserted": "已插入段落标记",
-    "runPropertiesChanged": "已更改文本格式"
+    "runPropertiesChanged": "已更改文本格式",
+    "paragraphMarkDeleted": null,
+    "paragraphMarkMoved": null
   },
   "toc": {
     "refresh": "更新整个目录",

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -484,7 +484,8 @@
     "paragraphMarkInserted": "已插入段落标记",
     "runPropertiesChanged": "已更改文本格式",
     "paragraphMarkDeleted": null,
-    "paragraphMarkMoved": null
+    "paragraphMarkMovedFrom": null,
+    "paragraphMarkMovedTo": null
   },
   "toc": {
     "refresh": "更新整个目录",

--- a/packages/pro/src/__tests__/paragraph-mark-label.test.ts
+++ b/packages/pro/src/__tests__/paragraph-mark-label.test.ts
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+
+// A card must say what the change IS.
+//
+// `EG_ParaRPrTrackChanges` is `ins? del? moveFrom? moveTo?`. The four say opposite things
+// about one paragraph break: `w:ins` proposes it, `w:del` proposes taking it away. The review
+// item carried one kind for all four and the card read "Inserted paragraph break" for every
+// one of them — the reverse of what Accept on that card does to a deleted mark.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, revisionItemsOf, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { revisionLabelKey } from '../react/review-labels.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(mark: string): OoxmlPart {
+  const body =
+    `<w:p><w:pPr><w:rPr>${mark}</w:rPr></w:pPr><w:r><w:t>first</w:t></w:r></w:p>` +
+    '<w:p><w:r><w:t>second</w:t></w:r></w:p>';
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const markItem = (mark: string) => {
+  const items = revisionItemsOf(load(mark)).filter((item) => item.kind === 'revision');
+  const item = items.find((entry) => entry.revisionKind === 'paragraphMark');
+  if (!item) throw new Error('no paragraph mark item');
+  return item;
+};
+
+describe('a paragraph mark card names its own decision', () => {
+  test('a deleted mark does not read as an inserted one', () => {
+    const item = markItem('<w:del w:id="1" w:author="A"/>');
+    expect(item.markDirection).toBe('delete');
+    expect(revisionLabelKey(item.revisionKind, item.markDirection)).toBe(
+      'revisions.paragraphMarkDeleted'
+    );
+  });
+
+  test('an inserted mark still reads as an insertion', () => {
+    const item = markItem('<w:ins w:id="1" w:author="A"/>');
+    expect(item.markDirection).toBe('insert');
+    expect(revisionLabelKey(item.revisionKind, item.markDirection)).toBe(
+      'revisions.paragraphMarkInserted'
+    );
+  });
+
+  test('both halves of a move read as a move', () => {
+    for (const mark of ['moveFrom', 'moveTo'] as const) {
+      const item = markItem(`<w:${mark} w:id="1" w:author="A"/>`);
+      expect(item.markDirection).toBe(mark);
+      expect(revisionLabelKey(item.revisionKind, item.markDirection)).toBe(
+        'revisions.paragraphMarkMoved'
+      );
+    }
+  });
+
+  test('a mark carrying two decisions raises one card each', () => {
+    // B proposes removing a break A proposed adding. Two authors, two decisions, two cards.
+    const items = revisionItemsOf(
+      load('<w:ins w:id="1" w:author="A"/><w:del w:id="2" w:author="B"/>')
+    ).filter((item) => item.kind === 'revision' && item.revisionKind === 'paragraphMark');
+    expect(items.map((item) => item.markDirection).sort()).toEqual(['delete', 'insert']);
+  });
+});

--- a/packages/pro/src/__tests__/paragraph-mark-label.test.ts
+++ b/packages/pro/src/__tests__/paragraph-mark-label.test.ts
@@ -53,14 +53,17 @@ describe('a paragraph mark card names its own decision', () => {
     );
   });
 
-  test('both halves of a move read as a move', () => {
-    for (const mark of ['moveFrom', 'moveTo'] as const) {
-      const item = markItem(`<w:${mark} w:id="1" w:author="A"/>`);
-      expect(item.markDirection).toBe(mark);
-      expect(revisionLabelKey(item.revisionKind, item.markDirection)).toBe(
-        'revisions.paragraphMarkMoved'
-      );
-    }
+  test('the two halves of a move are opposite decisions, and read that way', () => {
+    // Accepting a `moveFrom` takes this copy of the break away; accepting a `moveTo` keeps
+    // it. One sentence for both told a reviewer nothing about which they were answering.
+    const from = markItem('<w:moveFrom w:id="1" w:author="A"/>');
+    const to = markItem('<w:moveTo w:id="1" w:author="A"/>');
+    expect(revisionLabelKey(from.revisionKind, from.markDirection)).toBe(
+      'revisions.paragraphMarkMovedFrom'
+    );
+    expect(revisionLabelKey(to.revisionKind, to.markDirection)).toBe(
+      'revisions.paragraphMarkMovedTo'
+    );
   });
 
   test('a mark carrying two decisions raises one card each', () => {

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -1628,7 +1628,10 @@ function ReviewSummary({ className, asChild, hidden, children }: ReviewPartProps
   const t = useReviewLabel();
   if (hidden || !entry) return null;
   const text = entry.text;
-  const label = entry.kind !== 'revision' ? null : t(revisionLabelKey(entry.revisionKind));
+  const label =
+    entry.kind !== 'revision'
+      ? null
+      : t(revisionLabelKey(entry.revisionKind, entry.item.markDirection));
   // A replacement reads as one sentence, not as a label over a quote: what went, and what
   // took its place. Both quoted, both in their own colour, the way Word words it.
   const replaced = entry.kind === 'revision' && entry.revisionKind === 'replace';

--- a/packages/pro/src/react/review-labels.ts
+++ b/packages/pro/src/react/review-labels.ts
@@ -24,9 +24,10 @@ export function revisionLabelKey(
 ): TranslationKey {
   if (kind === 'paragraphMark') {
     if (markDirection === 'delete') return 'revisions.paragraphMarkDeleted';
-    if (markDirection === 'moveFrom' || markDirection === 'moveTo') {
-      return 'revisions.paragraphMarkMoved';
-    }
+    // The two halves of a move are opposite decisions, as they are for content: accepting a
+    // `moveFrom` takes this copy of the break away, accepting a `moveTo` keeps it.
+    if (markDirection === 'moveFrom') return 'revisions.paragraphMarkMovedFrom';
+    if (markDirection === 'moveTo') return 'revisions.paragraphMarkMovedTo';
     return 'revisions.paragraphMarkInserted';
   }
   switch (kind) {

--- a/packages/pro/src/react/review-labels.ts
+++ b/packages/pro/src/react/review-labels.ts
@@ -5,10 +5,30 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 */
 
 import type { TranslationKey } from '@docx-editor.dev/i18n';
-import type { ReviewRevisionKind } from '@docx-editor.dev/core/contracts/editor';
+import type {
+  ReviewRevisionItem,
+  ReviewRevisionKind,
+} from '@docx-editor.dev/core/contracts/editor';
 
-/** The packaged sentence for a revision kind that carries no quoted characters of its own. */
-export function revisionLabelKey(kind: ReviewRevisionKind): TranslationKey {
+/**
+ * The packaged sentence for a revision kind that carries no quoted characters of its own.
+ *
+ * A paragraph MARK needs its direction as well as its kind. The four members of
+ * `EG_ParaRPrTrackChanges` say opposite things about one break — `w:ins` proposes it, `w:del`
+ * proposes removing it — and one sentence for all four told a reviewer the reverse of what
+ * Accept on that card would do.
+ */
+export function revisionLabelKey(
+  kind: ReviewRevisionKind,
+  markDirection?: ReviewRevisionItem['markDirection']
+): TranslationKey {
+  if (kind === 'paragraphMark') {
+    if (markDirection === 'delete') return 'revisions.paragraphMarkDeleted';
+    if (markDirection === 'moveFrom' || markDirection === 'moveTo') {
+      return 'revisions.paragraphMarkMoved';
+    }
+    return 'revisions.paragraphMarkInserted';
+  }
   switch (kind) {
     case 'insert':
       return 'review.inserted';
@@ -22,8 +42,6 @@ export function revisionLabelKey(kind: ReviewRevisionKind): TranslationKey {
       return 'review.movedTo';
     case 'format':
       return 'revisions.runPropertiesChanged';
-    case 'paragraphMark':
-      return 'revisions.paragraphMarkInserted';
     default:
       return 'review.structural';
   }


### PR DESCRIPTION
A tracked change on a paragraph mark is a change to a paragraph break. The store already makes this change: `resolveRevisions` merges the two paragraphs. Layout did not make it. The `proposed` and `original` modes still showed the break. These two modes must show what the document becomes.

This matters for every consumer. The free engine shows `proposed` by default.

## What layout does now

Layout merges a run of paragraphs when a decision removes each mark. The merged paragraph takes the properties of the last member. This is the same shape that `resolveRevisions` builds. The body, table cells, headers, and footers all merge.

## Identity

A resolved view accepts edits. Each member must therefore keep its own identity. Every span, line, and drawing names the paragraph that holds it. A click in the second half selects the second paragraph. A keystroke goes to the paragraph that holds the caret.

One line can hold two paragraphs. The caret, the hit test, the selection, and the document order read that line one paragraph at a time.

## Refusals

Layout does not merge a group that it cannot measure. Two conditions stop a merge.

A field can start in one member and end in the next. Word writes a table of contents in this shape. The merged field then covers the second member with one offset. Layout refuses this group.

A member can publish more characters than the store holds. Content below a nesting cap does this. The store cannot address those characters. Layout refuses this group also.

Layout does not merge across a block content control, because the store cannot merge there.

## Defects found in the store

A run of removed marks collapsed into pairs. It now collapses into the one survivor.

The merge also carried content past a table and past a content control. The content arrived behind that block. The scan now stops at the next block.

## Verification

The display-mode differential now agrees line for line. The test document holds 85 insertions and 106 deletions. Editing tests cover typing, backspace, and undo through a merged break. The full suite gives 7113 pass. The `typecheck`, `lint`, `format`, and `api:check` gates are clean.

Three OOXML review passes ran against this branch. Section 6 of `tasks.md` lists what they found. Every item is fixed.

## Not done

Note stories do not receive a display mode. A deleted footnote still shows its text. `w:pPrChange` does not restore the old properties in `original`. The differential test covers the body story only. Section 7 of `tasks.md` holds these items and the method for each one.