### PR TITLE
feat(core): let an explicit mode decide the opening editing mode

### DIFF
--- a/.changeset/spotty-moons-shake.md
+++ b/.changeset/spotty-moons-shake.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+The `mode` option accepts `'suggesting'` and now decides the mode a document opens in; the React and Vue `<DocxEditor>` components default it to `'edit'`, so a document carrying `w:trackRevisions` opens ready to type there. Omit `mode` on `createDocxEditor` or `DocxEditor.Root` to keep following the document's request.

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -776,7 +776,7 @@ export interface DocxEditorConfig {
     imageDecodePort?: ImageDecodePort;
     // (undocumented)
     locale?: string;
-    mode?: 'edit' | 'view';
+    mode?: 'edit' | 'view' | 'suggesting';
     modules?: readonly EditorModule[];
     // (undocumented)
     onFontError?: (error: EditorFontError) => void;

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1004,7 +1004,7 @@ export interface DocxEditorConfig {
     imageDecodePort?: ImageDecodePort;
     // (undocumented)
     locale?: string;
-    mode?: 'edit' | 'view';
+    mode?: 'edit' | 'view' | 'suggesting';
     modules?: readonly EditorModule[];
     // (undocumented)
     onFontError?: (error: EditorFontError) => void;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -676,7 +676,7 @@ export interface DocxEditorRootProps {
     imageDecodePort?: ImageDecodePort;
     // (undocumented)
     locale?: string;
-    mode?: 'edit' | 'view';
+    mode?: 'edit' | 'view' | 'suggesting';
     modules?: readonly EditorModule[];
     onChange?: (change: DocumentChange) => void;
     onFontError?: (error: EditorFontError) => void;
@@ -888,7 +888,7 @@ export { EditorFontError }
 export { EditorFontErrorCode }
 
 // @public (undocumented)
-export type EditorMode = 'edit' | 'view';
+export type EditorMode = 'edit' | 'view' | 'suggesting';
 
 export { EditorQuery }
 

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -649,7 +649,7 @@ export interface EditorHost {
 }
 
 // @public (undocumented)
-export type EditorMode = 'edit' | 'view';
+export type EditorMode = 'edit' | 'view' | 'suggesting';
 
 // @public (undocumented)
 export type EditorQuery = {

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -47,6 +47,20 @@ export function Reviewer({ bytes }: { bytes: Uint8Array }) {
 
 `DocumentEditingMode` is `'editing' | 'suggesting' | 'viewing'`. The packaged toolbar already ships this control as the `review.editingMode` slot, so `<DocxEditor.Toolbar />` gives you the same thing without writing the toggle.
 
+## Choose the opening mode
+
+The `mode` prop decides how a document opens, matching the toolbar's pill: `'edit'`, `'suggesting'`, or `'view'`.
+
+```tsx
+<DocxEditor.Root document={bytes} author="Jess Lin" mode="suggesting">
+```
+
+A document can also ask for tracked changes itself: Word writes `w:trackRevisions` into `word/settings.xml` when its author turns the feature on. If you omit `mode` on `DocxEditor.Root`, the editor honors that request and opens the document in suggesting mode. Following the request needs the same two things as `mode="suggesting"`: a review module and an `author`.
+
+An explicit `mode` wins over that request. With `'edit'` or `'suggesting'`, the reader still switches modes from the toolbar; with `'view'`, the editor stays read-only. One exception: a document whose enforced protection permits editing only as tracked changes still opens in suggesting mode.
+
+The `<DocxEditor>` component defaults `mode` to `'edit'`, so the packaged editor opens every document ready to type.
+
 ## What gets tracked
 
 The revision model covers more than inline text:

--- a/docs/site/content/quickstart.mdx
+++ b/docs/site/content/quickstart.mdx
@@ -76,7 +76,7 @@ export default function App() {
 Four things to know about this code:
 
 - `document` takes a `Uint8Array`, an `ArrayBuffer`, or a `DocumentHandle`. Omit it to mount an empty editor.
-- `mode` is `'edit'` or `'view'`, and is read at mount. Remount to change it.
+- `mode` is `'edit'` (default), `'view'`, or `'suggesting'`, and is read at mount. Remount to change it.
 - `save()` on the ref returns `Promise<ArrayBuffer | null>`: a complete `.docx`, or `null` when there is no document. Parsing and serialization both happen in the browser; the document never touches a server.
 - `<DocxEditor>` fills its parent, so give it a box with a real height. The stylesheet import is required once per app.
 

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -11,14 +11,14 @@ order: 31
 
 Use `document` for the current document source and `fonts` for measurement fidelity.
 
-| Prop       | Type                                                             | Description                                                                                                                    |
-| ---------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `document` | `DocumentSource`                                                 | DOCX bytes or an existing `DocumentHandle`.                                                                                    |
-| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes used for Word-accurate shaping and pagination, or a resolver called per load with the document's declared families. |
-| `author`   | `string`                                                         | Ambient author for authored commands such as comments and review actions.                                                      |
-| `locale`   | `string`                                                         | Locale passed to the underlying editor instance.                                                                               |
-| `mode`     | `'edit' \| 'view'`                                               | Mount-time editing mode. Remount to change it.                                                                                 |
-| `zoom`     | `number`                                                         | Mount-time zoom value.                                                                                                         |
+| Prop       | Type                                                             | Description                                                                                                                                        |
+| ---------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `document` | `DocumentSource`                                                 | DOCX bytes or an existing `DocumentHandle`.                                                                                                        |
+| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes used for Word-accurate shaping and pagination, or a resolver called per load with the document's declared families.                     |
+| `author`   | `string`                                                         | Ambient author for authored commands such as comments and review actions.                                                                          |
+| `locale`   | `string`                                                         | Locale passed to the underlying editor instance.                                                                                                   |
+| `mode`     | `'edit' \| 'view' \| 'suggesting'`                               | The mode the editor opens in. Defaults to `'edit'`, so a document that carries `w:trackRevisions` still opens ready to type. Remount to change it. |
+| `zoom`     | `number`                                                         | Mount-time zoom value.                                                                                                                             |
 
 ```tsx
 const bytes = new Uint8Array(await fetch('/template.docx').then((r) => r.arrayBuffer()));

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -666,6 +666,9 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
         <DocxEditor.Root
           document={bytes}
           author="Demo Reviewer"
+          // The demo always opens ready to type: without an explicit mode, a document
+          // carrying `w:trackRevisions` opens in suggesting (the Root follows the file).
+          mode="edit"
           modules={PRO_MODULES}
           {...(fonts ? { fonts } : {})}
           onFontError={(error) => console.warn(`[fonts] ${error.code}: ${error.message}`)}

--- a/packages/core/src/editor/content-controls.ts
+++ b/packages/core/src/editor/content-controls.ts
@@ -577,7 +577,7 @@ function treeOpRejectionToExecResult(
 function gateContentControlCommand(
   command: ContentControlEditorCommand,
   surface: PaginatedSurface | null,
-  mode: 'edit' | 'view',
+  mode: 'edit' | 'view' | 'suggesting',
   options?: { scope?: EditorScope }
 ): CommandGate {
   if (options?.scope && options.scope.kind !== 'body') {
@@ -618,7 +618,7 @@ function gateContentControlCommand(
 export function canContentControlCommand(
   command: ContentControlEditorCommand,
   surface: PaginatedSurface | null,
-  mode: 'edit' | 'view',
+  mode: 'edit' | 'view' | 'suggesting',
   options?: { scope?: EditorScope }
 ): CanResult {
   const gated = gateContentControlCommand(command, surface, mode, options);

--- a/packages/core/src/editor/docx-editor-derive.ts
+++ b/packages/core/src/editor/docx-editor-derive.ts
@@ -231,7 +231,7 @@ export function tableCommandState(
 export function gateCommand(
   command: EditorCommand,
   surface: PaginatedSurface | null,
-  mode: 'edit' | 'view',
+  mode: 'edit' | 'view' | 'suggesting',
   options?: { scope?: EditorScope }
 ): CommandGate {
   // Scope option: body and the currently open furniture story are writable; `all` and

--- a/packages/core/src/editor/docx-editor-types.ts
+++ b/packages/core/src/editor/docx-editor-types.ts
@@ -69,8 +69,20 @@ export interface DocxEditorConfig {
    * reason. See {@link EditorModule}.
    */
   modules?: readonly EditorModule[];
-  /** `'view'` refuses every mutating command through the facade; default `'edit'`. */
-  mode?: 'edit' | 'view';
+  /**
+   * The mode the editor opens in — one prop, matching the toolbar's three-state pill.
+   *
+   * - `'edit'` — opens in editing, even when the document's `w:trackRevisions` asks for
+   *   tracked changes; the reader still moves between modes from the toolbar.
+   * - `'suggesting'` — opens in suggesting. It needs what suggesting always needs — a
+   *   review module and an {@link DocxEditorConfig.author} — and falls back to editing
+   *   with the reason published when either is missing.
+   * - `'view'` — read-only: every mutating command through the facade is refused, and
+   *   the toolbar cannot leave viewing.
+   * - Omitted — the DOCUMENT decides: a package carrying `w:trackRevisions` opens in
+   *   suggesting, everything else in editing.
+   */
+  mode?: 'edit' | 'view' | 'suggesting';
   /** Override raster decode for insert/replace image commands; defaults to browser/headless. */
   imageDecodePort?: import('../store/package/image-resources.ts').ImageDecodePort;
   /**

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -179,6 +179,11 @@ import {
 import { drawingPaintStringsFromTranslate } from '../output/semantic-paint-drawings.ts';
 import { surfaceScroller } from './surface-pages.ts';
 import { createZoomLane, zoomFacadeMembers } from './docx-editor-zoom.ts';
+import {
+  documentTrackingAdoption,
+  PRO_REVIEW_REASON,
+  resolveOpeningEditingMode,
+} from './opening-editing-mode.ts';
 import type {
   DocxEditorConfig,
   DocxEditorInstance,
@@ -196,15 +201,6 @@ export type {
 const SCOPE_BODY: EditorScope = Object.freeze({ kind: 'body' as const });
 /** One frozen empty answer, so "nothing substituted" never mints a new reference. */
 const EMPTY_FONT_SUBSTITUTIONS: readonly string[] = Object.freeze([]);
-
-/**
- * The refusal every review write gets when no review module is registered.
- *
- * One string, quoted verbatim by `toolbarCommandState` as the disabled tooltip — the
- * same "the engine's own reason" channel every other unavailable control uses.
- */
-const PRO_REVIEW_REASON =
-  'comments and tracked changes require the pro review module (@docx-editor.dev/pro)';
 
 /**
  * Build an editor: the full `Editor` contract over a paginated surface.
@@ -253,9 +249,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     },
   });
   /**
-   * How edits are written. `mode: 'view'` at construction opens in viewing; everything else
-   * opens in editing, and the toolbar moves between all three. Declared here because the
-   * surface is handed it at mount, and a document reload keeps the reader's choice.
+   * How edits are written. `mode: 'view'` opens in viewing; everything else starts editing
+   * and the opening-mode decision below may move it. Declared here because the surface is
+   * handed it at mount, and a document reload keeps the reader's choice.
    */
   let editingMode: DocumentEditingMode = config.mode === 'view' ? 'viewing' : 'editing';
 
@@ -275,6 +271,15 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   /** A refusal this facade made before the surface could see the request; see `snapshot`. */
   let facadeRejection: string | null = null;
   const mode = config.mode ?? 'edit';
+
+  // The HOST's opening mode, when `config.mode` is explicit — precedence and reasons live
+  // in `opening-editing-mode.ts`. Applied before the first mount reads `editingMode`.
+  const openingModeDecision = resolveOpeningEditingMode(config.mode, {
+    reviewEnabled,
+    hasAuthor: Boolean(config.author),
+  });
+  if (openingModeDecision.mode !== null) editingMode = openingModeDecision.mode;
+  if (openingModeDecision.rejection !== null) facadeRejection = openingModeDecision.rejection;
 
   let surface: PaginatedSurface | null = null;
   let parseError: string | null = null;
@@ -1628,30 +1633,25 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   }
 
   /**
-   * Enter suggesting mode when the DOCUMENT asked for it.
-   *
-   * `w:trackRevisions` is a property of the file, not of the reader, so a package that
-   * carries it opens in suggesting — otherwise the first keystroke is an untracked edit in a
-   * document whose author asked for the opposite, with the pill reading "Editing".
-   *
-   * Two things override it, and both are the reader's own decision rather than the file's:
-   * a document opened `mode: 'view'` stays viewing, and a mode the reader has already moved
-   * off is not moved back on a reload. With no author configured the mode is not entered —
-   * suggesting refuses every edit without one — and the reason is published rather than the
-   * request being dropped in silence.
+   * Enter suggesting mode when the DOCUMENT asked for it — `w:trackRevisions` asks, and
+   * enforced trackedChanges protection requires. What overrides what, and why a refusal
+   * is published, lives with the decision: `documentTrackingAdoption` in
+   * `opening-editing-mode.ts`.
    */
   function adoptDocumentTracking(): void {
-    // Suggesting writes `w:ins`/`w:del` — authoring tracked changes, which is the
-    // review module's capability. Without one the document still opens and edits
-    // normally; the edits are simply untracked, exactly as `can(setEditingMode:
-    // 'suggesting')` reports.
-    if (!reviewEnabled) return;
-    if (mode === 'view' || editingMode !== 'editing' || readerChoseMode) return;
-    if (!documentTracking().trackRevisions) return;
-    if (!config.author) {
-      facadeRejection = 'this document asks for tracked changes, but no author is configured';
-      return;
-    }
+    const tracking = documentTracking();
+    const decision = documentTrackingAdoption({
+      viewOnly: mode === 'view',
+      reviewEnabled,
+      hasAuthor: Boolean(config.author),
+      hostChoseMode: config.mode !== undefined,
+      readerChoseMode,
+      currentMode: editingMode,
+      trackRevisions: tracking.trackRevisions,
+      restrictedToTrackedChanges: tracking.restrictedToTrackedChanges,
+    });
+    if (decision.rejection !== null) facadeRejection = decision.rejection;
+    if (decision.mode !== 'suggesting') return;
     editingMode = 'suggesting';
     surface?.setEditingMode('suggest');
   }

--- a/packages/core/src/editor/opening-editing-mode.ts
+++ b/packages/core/src/editor/opening-editing-mode.ts
@@ -1,0 +1,106 @@
+/**
+ * How a document's opening editing mode is decided — pure decisions over the facade's
+ * state, kept out of `docx-editor.ts` so the composition root stays under its line cap.
+ *
+ * Two callers, in order:
+ *
+ * 1. `resolveOpeningEditingMode` at CONSTRUCTION: an explicit `config.mode` is the
+ *    host's standing choice for every open and wins over the document's own request.
+ *    (`'view'` is handled where `editingMode` is initialized; it needs no decision here.)
+ * 2. `documentTrackingAdoption` at each MOUNT, once the document's settings are
+ *    readable. `w:trackRevisions` ASKS for suggesting: it is a property of the file, not
+ *    of the reader, so a package that carries it opens in suggesting — otherwise the
+ *    first keystroke is an untracked edit in a document whose author asked for the
+ *    opposite, with the pill reading "Editing". An enforced
+ *    `w:documentProtection w:edit="trackedChanges"` REQUIRES it: that protection makes
+ *    `setEditingMode('editing')` refuse `locked`, so it outranks even an explicit
+ *    `mode: 'edit'` — opening in editing there would put the editor in a mode its own
+ *    gate refuses to enter.
+ *
+ * Suggesting has preconditions either way: writing `w:ins`/`w:del` is the review
+ * module's capability, and a proposal needs an author to be attributed to. With no
+ * module the document opens and edits normally — the edits are simply untracked,
+ * exactly as `can(setEditingMode: 'suggesting')` reports. With a module but no author,
+ * the editor opens editing and the REASON is published (`rejection`) rather than the
+ * request being dropped in silence.
+ */
+
+import type { DocumentEditingMode } from '../contracts/editor.ts';
+
+/**
+ * The refusal every review write gets when no review module is registered.
+ *
+ * One string, quoted verbatim by `toolbarCommandState` as the disabled tooltip — the
+ * same "the engine's own reason" channel every other unavailable control uses.
+ */
+export const PRO_REVIEW_REASON =
+  'comments and tracked changes require the pro review module (@docx-editor.dev/pro)';
+
+/** What a decision asks the facade to do: adopt a mode, publish a refusal, or neither. */
+export interface OpeningModeDecision {
+  /** The mode to open in, or null to leave the current mode alone. */
+  readonly mode: DocumentEditingMode | null;
+  /** The published reason a requested mode was not entered, or null. */
+  readonly rejection: string | null;
+}
+
+const NO_DECISION: OpeningModeDecision = { mode: null, rejection: null };
+
+/** Suggesting's preconditions, read by both decisions. */
+export interface OpeningModeGuards {
+  /** True when a review module is registered (suggesting writes `w:ins`/`w:del`). */
+  readonly reviewEnabled: boolean;
+  /** True when `config.author` names someone a proposal can be attributed to. */
+  readonly hasAuthor: boolean;
+}
+
+/**
+ * The host's construction-time choice, or nothing when `config.mode` is omitted.
+ * Runs before the first mount reads the mode, so the surface comes up in it directly.
+ */
+export function resolveOpeningEditingMode(
+  requested: 'edit' | 'view' | 'suggesting' | undefined,
+  guards: OpeningModeGuards
+): OpeningModeDecision {
+  if (requested === undefined || requested === 'view') return NO_DECISION;
+  if (requested === 'edit') return { mode: 'editing', rejection: null };
+  if (!guards.reviewEnabled) return { mode: null, rejection: PRO_REVIEW_REASON };
+  if (!guards.hasAuthor) {
+    return { mode: null, rejection: 'suggesting mode was requested, but no author is configured' };
+  }
+  return { mode: 'suggesting', rejection: null };
+}
+
+/**
+ * The document's own tracking request at mount, or nothing. See the module comment for
+ * the ask/require split; the reader-side overrides are `viewOnly`, a mode the reader
+ * has already moved off (`readerChoseMode` — a reload must not undo their choice), and,
+ * for the ASK only, an explicit `config.mode` (`hostChoseMode`).
+ */
+export function documentTrackingAdoption(
+  input: OpeningModeGuards & {
+    /** True when the facade was constructed `mode: 'view'` — outranks every request. */
+    readonly viewOnly: boolean;
+    readonly hostChoseMode: boolean;
+    readonly readerChoseMode: boolean;
+    readonly currentMode: DocumentEditingMode;
+    /** The document's `w:trackRevisions` request. */
+    readonly trackRevisions: boolean;
+    /** Enforced `w:documentProtection w:edit="trackedChanges"` — see the module comment. */
+    readonly restrictedToTrackedChanges: boolean;
+  }
+): OpeningModeDecision {
+  if (input.viewOnly || input.currentMode !== 'editing' || input.readerChoseMode) {
+    return NO_DECISION;
+  }
+  const asks = input.trackRevisions && !input.hostChoseMode;
+  if (!asks && !input.restrictedToTrackedChanges) return NO_DECISION;
+  if (!input.reviewEnabled) return NO_DECISION;
+  if (!input.hasAuthor) {
+    return {
+      mode: null,
+      rejection: 'this document asks for tracked changes, but no author is configured',
+    };
+  }
+  return { mode: 'suggesting', rejection: null };
+}

--- a/packages/pro/src/__tests__/document-tracking-settings.test.ts
+++ b/packages/pro/src/__tests__/document-tracking-settings.test.ts
@@ -63,13 +63,18 @@ function docx(settings: string | null): Uint8Array {
 
 // `null` for "no author", not `undefined`: a default parameter fills in for an explicit
 // `undefined`, so passing it would have silently kept the default author.
-function mount(settings: string | null, author: string | null = 'Grace Hopper') {
+function mount(
+  settings: string | null,
+  author: string | null = 'Grace Hopper',
+  mode?: 'edit' | 'view' | 'suggesting'
+) {
   const container = document.createElement('div');
   const editor: DocxEditorInstance = createDocxEditor({
     container,
     document: docx(settings),
     modules: [testReviewModule()],
     ...(author === null ? {} : { author }),
+    ...(mode === undefined ? {} : { mode }),
   });
   if (!editor.surface) throw new Error('surface failed to mount');
   return editor;
@@ -173,6 +178,43 @@ describe('honouring what the document asks for', () => {
   });
 });
 
+describe('an explicit `mode` outranks the file', () => {
+  test("`mode: 'edit'` opens editing even when the document asks for tracked changes", () => {
+    const editor = mount('<w:trackRevisions/>', 'Grace Hopper', 'edit');
+    expect(editor.getEditingMode()).toBe('editing');
+    expect(editor.snapshot().lastRejection).toBeNull();
+  });
+
+  test('the toolbar still reaches suggesting afterwards', () => {
+    const editor = mount('<w:trackRevisions/>', 'Grace Hopper', 'edit');
+    expect(editor.setEditingMode('suggesting').ok).toBe(true);
+    expect(editor.getEditingMode()).toBe('suggesting');
+  });
+
+  test("`mode: 'suggesting'` opens suggesting in a document that asked for nothing", () => {
+    const editor = mount(null, 'Grace Hopper', 'suggesting');
+    expect(editor.getEditingMode()).toBe('suggesting');
+  });
+
+  test("`mode: 'suggesting'` with no author falls back to editing, and the reason is published", () => {
+    const editor = mount(null, null, 'suggesting');
+    expect(editor.getEditingMode()).toBe('editing');
+    expect(editor.snapshot().lastRejection).toContain('author');
+  });
+
+  test("`mode: 'suggesting'` with no review module falls back to editing, and the reason is published", () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      document: docx(null),
+      author: 'Grace Hopper',
+      mode: 'suggesting',
+    });
+    expect(editor.getEditingMode()).toBe('editing');
+    expect(editor.snapshot().lastRejection).toContain('review module');
+  });
+});
+
 describe('protection restricted to tracked changes', () => {
   const PROTECTED =
     '<w:trackRevisions/><w:documentProtection w:edit="trackedChanges" w:enforcement="1"/>';
@@ -197,5 +239,23 @@ describe('protection restricted to tracked changes', () => {
     const editor = mount(PROTECTED);
     expect(editor.setEditingMode('viewing').ok).toBe(true);
     expect(editor.getEditingMode()).toBe('viewing');
+  });
+
+  test("the protection outranks an explicit `mode: 'edit'`", () => {
+    // `setEditingMode('editing')` is refused `locked` in this document, so opening in
+    // editing would put the editor in a mode its own gate refuses to enter.
+    const editor = mount(PROTECTED, 'Grace Hopper', 'edit');
+    expect(editor.getEditingMode()).toBe('suggesting');
+  });
+
+  test('without a review module the same document still opens editable, untracked', () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      document: docx(PROTECTED),
+      author: 'Grace Hopper',
+      mode: 'edit',
+    });
+    expect(editor.getEditingMode()).toBe('editing');
   });
 });

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -219,7 +219,10 @@ const DocxEditorFrame = forwardRef<DocxEditorRef, DocxEditorProps>(
       colorMode = 'light',
       author,
       locale,
-      mode,
+      // The packaged editor opens ready to type, even when the file's `w:trackRevisions`
+      // asks for suggesting — the sugar's opinionated default. `DocxEditor.Root` stays
+      // neutral and follows the document's request when given no mode.
+      mode = 'edit',
       modules,
       zoom,
       zoomMode,
@@ -401,7 +404,7 @@ const DocxEditorFrame = forwardRef<DocxEditorRef, DocxEditorProps>(
         {...(author !== undefined ? { author } : {})}
         {...(locale !== undefined ? { locale } : {})}
         translate={translate}
-        {...(mode !== undefined ? { mode } : {})}
+        mode={mode}
         {...(modules !== undefined ? { modules } : {})}
         {...(zoom !== undefined ? { zoom } : {})}
         {...(zoomMode !== undefined ? { zoomMode } : {})}

--- a/packages/react/src/editor/DocxEditorRoot.tsx
+++ b/packages/react/src/editor/DocxEditorRoot.tsx
@@ -75,8 +75,16 @@ export interface DocxEditorRootProps {
    * construction-time in the engine.
    */
   modules?: readonly EditorModule[];
-  /** `'edit'` (default) or `'view'` (read-only). Sampled at mount only. */
-  mode?: 'edit' | 'view';
+  /**
+   * The mode the editor opens in, matching the toolbar's three-state pill. Sampled at
+   * mount only.
+   *
+   * `'edit'` opens in editing even when the document's `w:trackRevisions` asks for
+   * tracked changes; `'suggesting'` opens in suggesting (needs a review module and an
+   * `author`); `'view'` is read-only and the toolbar cannot leave it. Omitted, the
+   * DOCUMENT decides: a package carrying `w:trackRevisions` opens in suggesting.
+   */
+  mode?: 'edit' | 'view' | 'suggesting';
   /**
    * A fixed scale. Supplying one also means the mode is fixed, unless `zoomMode` says
    * otherwise: an app that pinned 100% keeps 100% on every window size.

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -29,7 +29,7 @@ export type {
   FontSourceSubstitution,
 } from '@docx-editor.dev/core/contracts/editor';
 
-export type EditorMode = 'edit' | 'view';
+export type EditorMode = 'edit' | 'view' | 'suggesting';
 
 /**
  * Props for the React `DocxEditor`. The adapter is a thin renderer over the
@@ -176,7 +176,17 @@ export interface DocxEditorProps {
   rulers?: boolean;
   /** A document to load: DOCX bytes or an existing handle. */
   document?: DocumentSource;
-  /** 'edit' (default) or 'view' (read-only). Applied at mount only — not reactive; remount to change. */
+  /**
+   * The mode the editor opens in, matching the toolbar's three-state pill. Applied at
+   * mount only — not reactive; remount to change.
+   *
+   * Defaults to `'edit'`: the packaged editor opens every document ready to type, even
+   * one whose `w:trackRevisions` asks for tracked changes. Pass `'suggesting'` (needs
+   * `modules` with a review module and an `author`) to open in suggesting, or `'view'`
+   * for read-only. To let the DOCUMENT decide — Word's behavior, where
+   * `w:trackRevisions` opens in suggesting — compose `DocxEditor.Root`, which follows
+   * the file's request when `mode` is omitted.
+   */
   mode?: EditorMode;
   /** A fixed scale. Supplying one also makes the mode fixed unless `zoomMode` says otherwise. */
   zoom?: number;

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -23,7 +23,7 @@ export type {
   FontSourceSubstitution,
 } from '@docx-editor.dev/core/contracts/editor';
 
-export type EditorMode = 'edit' | 'view';
+export type EditorMode = 'edit' | 'view' | 'suggesting';
 
 /**
  * Props for the Vue `DocxEditor`. The adapter is a thin renderer over the
@@ -40,7 +40,11 @@ export interface DocxEditorProps {
   fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
   /** A document to load: DOCX bytes or an existing handle. */
   document?: DocumentSource;
-  /** 'edit' (default) or 'view' (read-only). Applied at mount only — not reactive; remount to change. */
+  /**
+   * The mode the editor opens in: 'edit' (default), 'suggesting' (needs a review module
+   * and an `author`), or 'view' (read-only). Applied at mount only — not reactive;
+   * remount to change.
+   */
   mode?: EditorMode;
   zoom?: number;
   locale?: string;


### PR DESCRIPTION
`mode` accepts `'suggesting'` and, when explicit, decides the mode a document opens in instead of `w:trackRevisions`; omitted, the document still decides. The packaged `<DocxEditor>` components default to `'edit'`, and the vite demo opens in editing. A document whose enforced protection permits editing only as tracked changes still opens in suggesting, matching the `setEditingMode` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789640309&installation_model_id=422592&pr_number=313&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F313&signature=73a3d16392bcadc2b1431ee41e6c6bc4bccec212af56ce79e8219af3f198470a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->