### PR TITLE
fix(pro): stack collapsed review rail markers that share an anchor line

### DIFF
--- a/.changeset/review-rail-marker-stacking.md
+++ b/.changeset/review-rail-marker-stacking.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Markers in the collapsed review rail now stack below each other when their anchors are closer than a marker is tall, instead of overlapping.

--- a/packages/pro/src/__tests__/review-sidebar.test.tsx
+++ b/packages/pro/src/__tests__/review-sidebar.test.tsx
@@ -758,6 +758,17 @@ const THREE_KINDS = docx(
     '<w:r><w:delText>struck</w:delText></w:r></w:del></w:p>'
 );
 
+/**
+ * An insertion and a deletion inside ONE paragraph: two markers whose anchors are the same
+ * line, which the closed rail must stack rather than draw on top of each other.
+ */
+const SAME_LINE = docx(
+  '<w:p><w:ins w:id="1" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z">' +
+    '<w:r><w:t xml:space="preserve">added </w:t></w:r></w:ins>' +
+    '<w:del w:id="2" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z">' +
+    '<w:r><w:delText>struck</w:delText></w:r></w:del></w:p>'
+);
+
 /** The glyph each marker drew, keyed by the kind it is for. */
 function markerGlyphs(view: ReturnType<typeof render>): Map<string, string> {
   const glyphs = new Map<string, string>();
@@ -797,6 +808,37 @@ describe('the collapsed rail says what each marker IS', () => {
     expect(glyphs.get('delete')).toBeTruthy();
     // The regression: every one of these used to be byte-identical.
     expect(glyphs.get('insert')).not.toBe(glyphs.get('delete'));
+  });
+
+  test('two markers anchored on one line stack instead of overlapping', () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={SAME_LINE}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    act(() => undefined);
+    act(() => {
+      instance!.exec({ type: 'toggleReviewPane' });
+    });
+
+    const tops = view
+      .queryAllByTestId('review-marker')
+      .map((marker) => Number.parseFloat((marker as HTMLElement).style.top));
+    expect(tops.length).toBe(2);
+    // Both anchors are the same line; drawn raw, the second marker sat exactly on the
+    // first. Stacked, they are at least a marker's height (28px) apart.
+    const sorted = [...tops].sort((a, b) => a - b);
+    expect(sorted[1]! - sorted[0]!).toBeGreaterThanOrEqual(28);
   });
 
   test('the Markers part takes a per-item icon and keeps the wiring it was handed', () => {

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -159,6 +159,8 @@ const COLLAPSED_CARD_HEIGHT = 64;
  * further, a full card reads as annotating whatever happens to be beside it.
  */
 const COLLAPSE_DISPLACEMENT_PX = 480;
+/** A rail marker is a 28 CSS px box; the step keeps 2px of air between stacked markers. */
+const MARKER_STEP = 30;
 
 /** Stable query for the balloon's unplaced queue read — never allocate per render. */
 const NO_PLACEMENT_REVIEW_QUERY = Object.freeze({ placement: false }) satisfies ReviewItemQuery;
@@ -958,7 +960,8 @@ export interface ReviewMarkersProps {
 }
 
 /**
- * The collapsed rail: one marker per item, at its anchor.
+ * The collapsed rail: one marker per item, at its anchor — or just below the previous
+ * marker, when the anchors are closer than a marker is tall.
  *
  * @public
  */
@@ -972,14 +975,30 @@ function ReviewMarkers({
 }: ReviewMarkersProps) {
   const { review } = useRail();
   const t = useReviewLabel();
+  // Markers stack the way the cards do: each sits at its own anchor, or just below the
+  // previous marker when the anchors are closer than a marker is tall. Raw anchors put
+  // every change on a dense line at the same `top`, and the rail drew them on top of each
+  // other. The cursor runs in CSS px, after scaling, because the marker's box does not
+  // zoom with the page.
+  const { roots, stackedTops } = useMemo(() => {
+    const present = idsOf(review.items);
+    const entries = review.items.filter((entry) => !isThreadedReply(entry, present));
+    const tops = new Map<string, number>();
+    let cursor = Number.NEGATIVE_INFINITY;
+    for (const entry of entries) {
+      if (entry.anchorY === null) continue;
+      const top = Math.max(offset + entry.anchorY * scale, cursor);
+      tops.set(entry.key, top);
+      cursor = top + MARKER_STEP;
+    }
+    return { roots: entries, stackedTops: tops };
+  }, [review.items, offset, scale]);
   if (hidden) return null;
-  const present = idsOf(review.items);
-  const roots = review.items.filter((entry) => !isThreadedReply(entry, present));
   return (
     <div className={`docx-review__markers${className ? ` ${className}` : ''}`}>
       {roots.map((entry) => {
-        if (entry.anchorY === null) return null;
-        const top = offset + entry.anchorY * scale;
+        const top = stackedTops.get(entry.key);
+        if (top === undefined) return null;
         if (visible && (top < visible.top || top > visible.bottom)) return null;
         return (
           <button


### PR DESCRIPTION
The closed rail drew each marker at its raw anchor, so changes on the same or nearby lines painted on top of each other. Markers now stack with the same forward cursor the pane's cards use (28px box + 2px air). A dense cluster can push later markers below their anchors; the rail has no analog of the cards' 480px collapse escape yet — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644674&installation_model_id=422592&pr_number=314&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F314&signature=030f7c1d5256c28b0cabf828858765fd37cdca3106834aeb57e834e12e836dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->