### PR TITLE
fix(core): bundle the text shaper so browser builds resolve

### DIFF
--- a/.changeset/bundled-text-shaper.md
+++ b/.changeset/bundled-text-shaper.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+The text shaper and its WASM now ship inside the package, so browser builds no longer fail with `Module not found: Can't resolve 'module'`, and the new `setHarfBuzzWasmUrl` from `@docx-editor.dev/core/layout` points bundlers that do not emit `new URL(..., import.meta.url)` assets (esbuild, Bun) at a self-hosted `harfbuzz.wasm`. Server-side shaping over ESM now needs Node 20.16 or 22.3 and later, declared in `engines`. Fixes #282

--- a/.changeset/bundled-text-shaper.md
+++ b/.changeset/bundled-text-shaper.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-The text shaper and its WASM now ship inside the package, so browser builds no longer fail with `Module not found: Can't resolve 'module'`, and the new `setHarfBuzzWasmUrl` from `@docx-editor.dev/core/layout` points bundlers that do not emit `new URL(..., import.meta.url)` assets (esbuild, Bun) at a self-hosted `harfbuzz.wasm`. Server-side shaping over ESM now needs Node 20.16 or 22.3 and later, declared in `engines`. Fixes #282
+Browser builds no longer fail to resolve `module`, and the new `setHarfBuzzWasmUrl` points bundlers that emit no WASM asset (esbuild, Bun) at a self-hosted `harfbuzz.wasm`. Upgrade `@docx-editor.dev/core` itself to get the fix. Fixes #282

--- a/.changeset/bundled-text-shaper.md
+++ b/.changeset/bundled-text-shaper.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-Browser builds no longer fail to resolve `module`, and the new `setHarfBuzzWasmUrl` points bundlers that emit no WASM asset (esbuild, Bun) at a self-hosted `harfbuzz.wasm`. Upgrade `@docx-editor.dev/core` itself to get the fix. Fixes #282
+ESM browser builds no longer fail with `Module not found: Can't resolve 'module'`, and the new `setHarfBuzzWasmUrl` points bundlers that emit no WASM asset (esbuild, Bun) at a self-hosted `harfbuzz.wasm`. Server-side shaping over ESM now needs Node 20.16 or 22.3 and later. Fixes #282

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Published-package artifact check
         run: bun run check:package-artifacts
 
+      - name: Shipped text-shaper check
+        run: bun run check:shipped-shaper
+
       - name: Published-package consumer check
         run: SKIP_CONSUMER_INSTALL_BUILD=1 bun run check:consumer-install
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,9 +346,11 @@ Never push the `chore: release` commit by hand, delete `.changeset/*.md` outside
 into its bundles, because MIT/Apache-2.0 both require the notice to travel with
 the copy. Only genuinely inlined code counts: core declares fast-xml-parser,
 fflate and prosemirror-\* as real `dependencies` with no `noExternal`, so esbuild
-leaves them external, npm installs them with their own licenses, and every
-package currently generates an empty notice. An empty run is the correct result
-here, not a broken generator — what would be wrong is a bundled dependency
+leaves them external and npm installs them with their own licenses. The one
+exception is harfbuzzjs, which core's ESM build inlines (`noExternal`) so browser
+bundlers never see its Node-only `module` import — core's notice reproduces its
+MIT text, and every other package generates an empty notice. Both results are
+correct, not a broken generator — what would be wrong is a bundled dependency
 missing its text, which fails the run outright. The Release
 workflow generates it from `dist/metafile-*.json` just before publishing; the
 file is gitignored, so regenerate with `bun run build:packages && bun run

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -874,7 +874,7 @@ export class EditorFontError extends Error {
 }
 
 // @public
-export type EditorFontErrorCode = 'initializationFailed' | 'missing' | 'forbidden' | 'overLimit' | 'malformed' | 'hashMismatch' | 'metadataMismatch' | 'fontFaceLoadFailed' | 'unsupportedFaceIndex' | 'missingFont' | 'hashInvalid' | 'fontMismatch' | 'unsupportedFace' | 'loadFailed';
+export type EditorFontErrorCode = 'initializationFailed' | 'wasmUnavailable' | 'missing' | 'forbidden' | 'overLimit' | 'malformed' | 'hashMismatch' | 'metadataMismatch' | 'fontFaceLoadFailed' | 'unsupportedFaceIndex' | 'missingFont' | 'hashInvalid' | 'fontMismatch' | 'unsupportedFace' | 'loadFailed';
 
 // @public
 export interface EditorHeaderFooterCommands {

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1487,7 +1487,7 @@ export class EditorFontError extends Error {
 }
 
 // @public
-export type EditorFontErrorCode = 'initializationFailed' | 'missing' | 'forbidden' | 'overLimit' | 'malformed' | 'hashMismatch' | 'metadataMismatch' | 'fontFaceLoadFailed' | 'unsupportedFaceIndex' | 'missingFont' | 'hashInvalid' | 'fontMismatch' | 'unsupportedFace' | 'loadFailed';
+export type EditorFontErrorCode = 'initializationFailed' | 'wasmUnavailable' | 'missing' | 'forbidden' | 'overLimit' | 'malformed' | 'hashMismatch' | 'metadataMismatch' | 'fontFaceLoadFailed' | 'unsupportedFaceIndex' | 'missingFont' | 'hashInvalid' | 'fontMismatch' | 'unsupportedFace' | 'loadFailed';
 
 // @public
 export interface EditorHeaderFooterCommands {

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -903,6 +903,7 @@ export class HarfBuzzShapingError extends Error {
         readonly limit?: number;
         readonly actual?: number;
         readonly diagnostic?: string;
+        readonly cause?: unknown;
     });
     // (undocumented)
     readonly actual?: number;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -917,7 +917,7 @@ export class HarfBuzzShapingError extends Error {
 }
 
 // @public
-export type HarfBuzzShapingErrorCode = 'notInitialized' | 'fontOverLimit' | 'malformedFont' | 'textOverLimit' | 'codepointsOverLimit' | 'glyphOverLimit' | 'outlineOverLimit' | 'shapedRunOverLimit' | 'unsupportedVariationAxes' | 'unsupportedFallback' | 'unsupportedColorFont' | 'unsupportedNormalization' | 'invalidBidiLevel' | 'shapingLibraryMismatch' | 'disposed';
+export type HarfBuzzShapingErrorCode = 'notInitialized' | 'wasmUnavailable' | 'fontOverLimit' | 'malformedFont' | 'textOverLimit' | 'codepointsOverLimit' | 'glyphOverLimit' | 'outlineOverLimit' | 'shapedRunOverLimit' | 'unsupportedVariationAxes' | 'unsupportedFallback' | 'unsupportedColorFont' | 'unsupportedNormalization' | 'invalidBidiLevel' | 'shapingLibraryMismatch' | 'disposed';
 
 // @public
 export interface HarfBuzzTextShaper extends TextShaper {
@@ -2647,6 +2647,9 @@ export interface SemanticTableStructure {
 
 // @public
 export function setGraphemeBoundary(boundary: GraphemeBoundary): void;
+
+// @public
+export function setHarfBuzzWasmUrl(url: string | URL): void;
 
 // @public
 export const sha256FontBytes: (bytes: Uint8Array) => string;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -918,7 +918,7 @@ export class HarfBuzzShapingError extends Error {
 }
 
 // @public
-export type HarfBuzzShapingErrorCode = 'notInitialized' | 'wasmUnavailable' | 'fontOverLimit' | 'malformedFont' | 'textOverLimit' | 'codepointsOverLimit' | 'glyphOverLimit' | 'outlineOverLimit' | 'shapedRunOverLimit' | 'unsupportedVariationAxes' | 'unsupportedFallback' | 'unsupportedColorFont' | 'unsupportedNormalization' | 'invalidBidiLevel' | 'shapingLibraryMismatch' | 'disposed';
+export type HarfBuzzShapingErrorCode = 'notInitialized' | 'wasmUnavailable' | 'unsupportedRuntime' | 'fontOverLimit' | 'malformedFont' | 'textOverLimit' | 'codepointsOverLimit' | 'glyphOverLimit' | 'outlineOverLimit' | 'shapedRunOverLimit' | 'unsupportedVariationAxes' | 'unsupportedFallback' | 'unsupportedColorFont' | 'unsupportedNormalization' | 'invalidBidiLevel' | 'shapingLibraryMismatch' | 'disposed';
 
 // @public
 export interface HarfBuzzTextShaper extends TextShaper {

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -247,6 +247,29 @@ editor?.fontMeasurement();
 `{ measurer: 'fixed', resolving: false }` is the steady state for a document with no
 usable font source; `resolving: true` means shaped resolution is still in flight.
 
+## Serving the shaper's WASM yourself
+
+The text shaper is a WASM binary that ships inside `@docx-editor.dev/core` and
+loads lazily when fonts resolve. Webpack, Turbopack, and Vite emit it as an
+asset automatically, so most apps need no setup.
+
+Bundlers that don't emit `new URL(..., import.meta.url)` assets (esbuild and
+Bun) build cleanly but fail at runtime with
+`Aborted(both async and sync fetching of the wasm failed)`. The failure reaches
+`onFontError` as an `EditorFontError` with code `initializationFailed` whose
+`diagnostic` names the fix. If you see that error, copy
+`node_modules/@docx-editor.dev/core/dist/harfbuzz.wasm` into your served assets
+and point the shaper at it before creating an editor:
+
+```ts
+import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
+
+setHarfBuzzWasmUrl('/static/harfbuzz.wasm');
+```
+
+Serve the copy from the installed package version. The shaper refuses a
+version mismatch at load instead of measuring text with unverified metrics.
+
 ## Caveats
 
 - **Metric-compatible is not identical.** Advance widths match, so wrap points match;

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -258,7 +258,7 @@ are the common ones, and so is any build that inlines dynamic imports, such as a
 library bundle. Those builds succeed and then fail at runtime, reaching
 `onFontError` as an `EditorFontError` with code `wasmUnavailable`:
 
-```ts
+```tsx
 <DocxEditor
   onFontError={(error) => {
     if (error.code === 'wasmUnavailable') showSetupError(error.diagnostic);
@@ -279,8 +279,22 @@ import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
 setHarfBuzzWasmUrl('/static/harfbuzz.wasm');
 ```
 
-Resolve the file at `@docx-editor.dev/core/harfbuzz.wasm`, which also works
-under Yarn Plug'n'Play, where there's no `node_modules` directory to copy from.
+Copy it as a build step. Resolving the package subpath works under Yarn
+Plug'n'Play too, where there's no `node_modules` directory to read from:
+
+```js
+// scripts/copy-shaper.mjs — run before your bundler
+import { copyFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+await copyFile(
+  fileURLToPath(import.meta.resolve('@docx-editor.dev/core/harfbuzz.wasm')),
+  'public/static/harfbuzz.wasm'
+);
+```
+
+Re-run that step on every upgrade. The shaper refuses a binary from a different
+version, so a stale copy fails the same way a missing one does.
 
 Call `setHarfBuzzWasmUrl` before the first editor. The shaper reads the location
 once and caches it, so a later call warns and does nothing: move the call and

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -235,7 +235,7 @@ instance:
 <DocxEditor.Root
   document={bytes}
   fonts={fragment}
-  onFontError={(error) => report(error.code, error.message)}
+  onFontError={(error) => report(error.code, error.diagnostic ?? error.message)}
 />;
 
 // Inside the tree:
@@ -253,13 +253,25 @@ The text shaper is a WASM binary that ships inside `@docx-editor.dev/core` and
 loads lazily when fonts resolve. Webpack, Turbopack, and Vite emit it as an
 asset automatically, so most apps need no setup.
 
-Bundlers that don't emit `new URL(..., import.meta.url)` assets (esbuild and
-Bun) build cleanly but fail at runtime with
-`Aborted(both async and sync fetching of the wasm failed)`. The failure reaches
-`onFontError` as an `EditorFontError` with code `initializationFailed` whose
-`diagnostic` names the fix. If you see that error, copy
-`node_modules/@docx-editor.dev/core/dist/harfbuzz.wasm` into your served assets
-and point the shaper at it before creating an editor:
+Some bundlers don't emit `new URL(..., import.meta.url)` assets. esbuild and Bun
+are the common ones, and so is any build that inlines dynamic imports, such as a
+library bundle. Those builds succeed and then fail at runtime, reaching
+`onFontError` as an `EditorFontError` with code `wasmUnavailable`:
+
+```ts
+<DocxEditor
+  onFontError={(error) => {
+    if (error.code === 'wasmUnavailable') showSetupError(error.diagnostic);
+  }}
+/>
+```
+
+Without that binary the editor keeps rendering, but it measures text with
+fallback metrics, so line breaks and page breaks no longer match Word. The
+engine also logs the failure once, so you see it even with no handler attached.
+
+To fix it, copy `harfbuzz.wasm` into your served assets and point the shaper at
+it before you create an editor:
 
 ```ts
 import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
@@ -267,8 +279,27 @@ import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
 setHarfBuzzWasmUrl('/static/harfbuzz.wasm');
 ```
 
-Serve the copy from the installed package version. The shaper refuses a
-version mismatch at load instead of measuring text with unverified metrics.
+Resolve the file at `@docx-editor.dev/core/harfbuzz.wasm`, which also works
+under Yarn Plug'n'Play, where there's no `node_modules` directory to copy from.
+
+Call `setHarfBuzzWasmUrl` before the first editor. The shaper reads the location
+once and caches it, so a later call warns and does nothing: move the call and
+reload the page. A Web Worker gets its own module instance, so a worker that
+runs layout needs its own call.
+
+Pass a URL your application controls. The file is fetched and instantiated as
+WebAssembly, so never build it from user input, a query parameter, or remote
+configuration. Serving it from another origin needs that origin in your
+`connect-src` directive, and WebAssembly needs `wasm-unsafe-eval` in `script-src`
+either way.
+
+Serve the copy from the installed package version. The shaper compares the
+HarfBuzz library version it loads against the one it was built for, and refuses a
+mismatch instead of measuring text with unverified metrics.
+
+Because the shaper is bundled into the package, an npm `overrides` entry for
+`harfbuzzjs` doesn't change the code that runs. Upgrade `@docx-editor.dev/core`
+instead.
 
 ## Caveats
 

--- a/examples/agent/next.config.ts
+++ b/examples/agent/next.config.ts
@@ -6,16 +6,6 @@ const nextConfig: NextConfig = {
   // sit above its own directory. Without this Next traces from `examples/agent`
   // and warns about files it cannot reach.
   outputFileTracingRoot: path.resolve(__dirname, '../..'),
-  turbopack: {
-    resolveAlias: {
-      // The text shaper ships one file for both runtimes and reaches for Node's
-      // `module` behind an `IS_NODE` guard. The guard is false in a browser, but
-      // the import still has to RESOLVE or the client build fails. Webpack
-      // stubs node builtins for the browser target; Turbopack does not, so
-      // point it at a stub.
-      module: { browser: './stub/node-module.js' },
-    },
-  },
 };
 
 export default nextConfig;

--- a/examples/agent/stub/node-module.js
+++ b/examples/agent/stub/node-module.js
@@ -1,6 +1,0 @@
-// Browser stub for Node's `module`. harfbuzzjs imports it behind an
-// IS_NODE guard that never runs in a browser, but the import must still resolve.
-export function createRequire() {
-  throw new Error('createRequire is not available in the browser');
-}
-export default { createRequire };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "check:lane-boundaries": "node scripts/check-lane-boundaries.mjs",
     "check:core-css-compiled": "node scripts/check-core-css-compiled.mjs",
     "check:package-artifacts": "node scripts/check-package-artifacts.mjs && node scripts/check-core-css-compiled.mjs",
+    "check:shipped-shaper": "node scripts/check-shipped-shaper.mjs",
     "check:parity": "bun run check:export-parity && bun run check:editor-contract && bun run check:public-docs-surface && bun run check:parity-contract && bun run check:adapter-css-thin",
     "check:license-headers": "bun run check:pro-license-headers && bun run check:editor-api-license-headers",
     "check:parity-contract": "node scripts/check-parity-contract.mjs",

--- a/packages/core/licenses/HarfBuzz-COPYING.txt
+++ b/packages/core/licenses/HarfBuzz-COPYING.txt
@@ -1,0 +1,42 @@
+HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.
+For parts of HarfBuzz that are licensed under different licenses see individual
+files names COPYING in subdirectories where applicable.
+
+Copyright © 2010-2022  Google, Inc.
+Copyright © 2015-2020  Ebrahim Byagowi
+Copyright © 2019,2020  Facebook, Inc.
+Copyright © 2012,2015  Mozilla Foundation
+Copyright © 2011  Codethink Limited
+Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)
+Copyright © 2009  Keith Stribley
+Copyright © 2011  Martin Hosken and SIL International
+Copyright © 2007  Chris Wilson
+Copyright © 2005,2006,2020,2021,2022,2023  Behdad Esfahbod
+Copyright © 2004,2007,2008,2009,2010,2013,2021,2022,2023  Red Hat, Inc.
+Copyright © 1998-2005  David Turner and Werner Lemberg
+Copyright © 2016  Igalia S.L.
+Copyright © 2022  Matthias Clasen
+Copyright © 2018,2021  Khaled Hosny
+Copyright © 2018,2019,2020  Adobe, Inc
+Copyright © 2013-2015  Alexei Podtelezhnikov
+
+For full copyright notices consult the individual files in the package.
+
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,11 +65,11 @@
       "require": "./dist/editor.cjs"
     },
     "./styles/editor.css": "./dist/editor.css",
-    "./dist/harfbuzz.wasm": "./dist/harfbuzz.wasm",
+    "./harfbuzz.wasm": "./dist/harfbuzz.wasm",
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rm -rf dist && tsup && node ../../scripts/build-core-styles.mjs",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsup && node ../../scripts/build-core-styles.mjs",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
@@ -80,9 +80,6 @@
     "typescript": "^5.3.3"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": "^20.16.0 || >=22.3.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/eigenpal/docx-editor.git",
@@ -116,6 +113,7 @@
   },
   "files": [
     "dist",
+    "licenses",
     "!dist/metafile-*.json",
     "README.md",
     "THIRD_PARTY_NOTICES.md"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,10 +65,11 @@
       "require": "./dist/editor.cjs"
     },
     "./styles/editor.css": "./dist/editor.css",
+    "./dist/harfbuzz.wasm": "./dist/harfbuzz.wasm",
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsup && node ../../scripts/build-core-styles.mjs",
+    "build": "rm -rf dist && tsup && node ../../scripts/build-core-styles.mjs",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
@@ -79,6 +80,9 @@
     "typescript": "^5.3.3"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": "^20.16.0 || >=22.3.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/eigenpal/docx-editor.git",

--- a/packages/core/src/__tests__/subpath-tables.test.ts
+++ b/packages/core/src/__tests__/subpath-tables.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import tsupConfig from '../../tsup.config.ts';
+import tsupConfig, { WASM_URL_EXPRESSION } from '../../tsup.config.ts';
 
 const CORE = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -30,16 +30,39 @@ const tsconfig = JSON.parse(readFileSync(join(CORE, 'tsconfig.json'), 'utf8')) a
   compilerOptions: { paths: Record<string, string[]> };
 };
 
-const config = tsupConfig as unknown as {
+type BuildConfig = {
   entry: Record<string, string>;
   esbuildOptions: (options: { alias?: Record<string, string> }) => void;
 };
 
-/** The alias table, read by running the hook the way tsup does. */
-function esbuildAlias(): Record<string, string> {
+/**
+ * The two format builds — ESM and CJS. They exist separately only because the ESM one
+ * inlines harfbuzzjs and the CJS one cannot; every table below has to be identical across
+ * them, which the last test in this file asserts outright.
+ */
+const configs = tsupConfig as unknown as readonly BuildConfig[];
+const config = configs[0]!;
+
+/** The alias table of one build, read by running the hook the way tsup does. */
+function esbuildAliasOf(build: BuildConfig): Record<string, string> {
   const options: { alias?: Record<string, string> } = {};
-  config.esbuildOptions(options);
+  build.esbuildOptions(options);
   return options.alias ?? {};
+}
+
+/**
+ * The SELF-reference aliases: the `@docx-editor.dev/core/*` rows the four tables are about.
+ *
+ * The table also carries `module`, which is not a subpath of this package at all — it is
+ * what the inlined HarfBuzz runtime's `await import("module")` resolves to, so that no
+ * consumer's browser bundler has to answer for it (#282). It has no export map entry, no
+ * build entry and no tsconfig path, and it must not be compared against any of them.
+ */
+function esbuildAlias(): Record<string, string> {
+  const alias = esbuildAliasOf(config);
+  return Object.fromEntries(
+    Object.entries(alias).filter(([specifier]) => specifier.startsWith('@docx-editor.dev/core'))
+  );
 }
 
 /** `./contracts/editor` → `contracts/editor`; `.` → `index`. Package-relative, no extension. */
@@ -53,11 +76,13 @@ const asSpecifier = (subpath: string): string =>
 /**
  * The JS subpaths, which is what the four tables are about.
  *
- * `./styles/editor.css` is a copied asset with no build entry, and `./package.json` is the
- * conventional self-reference; neither is a module and neither belongs in the other three.
+ * `./styles/editor.css` and `./dist/harfbuzz.wasm` are copied assets with no build entry,
+ * and `./package.json` is the conventional self-reference; none is a module and none
+ * belongs in the other three tables.
  */
 const jsSubpaths = Object.keys(manifest.exports).filter(
-  (subpath) => subpath !== './package.json' && !subpath.endsWith('.css')
+  (subpath) =>
+    subpath !== './package.json' && !subpath.endsWith('.css') && !subpath.endsWith('.wasm')
 );
 
 describe('the published subpath tables agree', () => {
@@ -112,5 +137,78 @@ describe('the published subpath tables agree', () => {
       }
     }
     expect({ disagreements }).toEqual({ disagreements: [] });
+  });
+
+  test('the format builds publish the same subpaths from the same sources', () => {
+    // The ESM and CJS builds differ in ONE thing — whether harfbuzzjs is inlined — and the
+    // split makes it possible to change one and forget the other. A subpath added to only
+    // one of them ships an export map entry that resolves under `import` and 404s under
+    // `require`, or the reverse.
+    expect(configs).toHaveLength(2);
+    for (const build of configs.slice(1)) {
+      expect(build.entry).toEqual(config.entry);
+      expect(esbuildAliasOf(build)).toEqual(esbuildAliasOf(config));
+    }
+  });
+
+  test('the split carries its reason: exactly the ESM build inlines and patches harfbuzzjs', () => {
+    // Everything that makes the two-build split WORTH having lives on the ESM side: the
+    // inline (no `module` specifier reaches a consumer bundler, #282), the escape-hatch
+    // plugin (setHarfBuzzWasmUrl is wired into the glue), and the wasm copy. Dropping any
+    // of them still builds and still passes every other test — the regression only shows
+    // in a consumer's app. And neither build may clean: tsup runs an array config
+    // concurrently, so cleaning belongs to the package `build` script alone.
+    const [esm, cjs] = configs as readonly (BuildConfig & {
+      format?: readonly string[];
+      clean?: boolean;
+      noExternal?: readonly string[];
+      esbuildPlugins?: readonly unknown[];
+      onSuccess?: unknown;
+    })[];
+    expect({
+      esm: {
+        format: esm!.format,
+        clean: esm!.clean,
+        noExternal: esm!.noExternal,
+        patchesGlue: (esm!.esbuildPlugins?.length ?? 0) > 0,
+        copiesWasm: typeof esm!.onSuccess === 'function',
+      },
+      cjs: {
+        format: cjs!.format,
+        clean: cjs!.clean,
+        noExternal: cjs!.noExternal,
+        patchesGlue: (cjs!.esbuildPlugins?.length ?? 0) > 0,
+        copiesWasm: typeof cjs!.onSuccess === 'function',
+      },
+    }).toEqual({
+      esm: {
+        format: ['esm'],
+        clean: false,
+        noExternal: ['harfbuzzjs'],
+        patchesGlue: true,
+        copiesWasm: true,
+      },
+      cjs: {
+        format: ['cjs'],
+        clean: false,
+        noExternal: undefined,
+        patchesGlue: false,
+        copiesWasm: false,
+      },
+    });
+  });
+
+  test('the installed harfbuzzjs glue still contains the exact expression the plugin patches', () => {
+    // The escape-hatch plugin rewrites ONE exact string in harfbuzzjs's minified glue. The
+    // build refuses when the count is not exactly one, but that guard fires at build time;
+    // this puts the same tripwire in the test suite, so a harfbuzzjs bump that reshapes
+    // the glue fails here first — with the same remedy: re-point the plugin.
+    //
+    // Resolved through the export map like `copyHarfBuzzBinary` does, not a hand-written
+    // node_modules path, so a hoisted or re-laid-out install cannot fail this test while
+    // the build still passes.
+    const entry = fileURLToPath(import.meta.resolve('harfbuzzjs'));
+    const glue = readFileSync(join(dirname(entry), 'harfbuzz.js'), 'utf8');
+    expect(glue.split(WASM_URL_EXPRESSION).length - 1).toBe(1);
   });
 });

--- a/packages/core/src/__tests__/subpath-tables.test.ts
+++ b/packages/core/src/__tests__/subpath-tables.test.ts
@@ -140,15 +140,36 @@ describe('the published subpath tables agree', () => {
   });
 
   test('the format builds publish the same subpaths from the same sources', () => {
-    // The ESM and CJS builds differ in ONE thing — whether harfbuzzjs is inlined — and the
-    // split makes it possible to change one and forget the other. A subpath added to only
-    // one of them ships an export map entry that resolves under `import` and 404s under
-    // `require`, or the reverse.
+    // The ESM and CJS builds differ only in how they reach harfbuzzjs, and the split makes
+    // it possible to change one and forget the other. A subpath added to only one of them
+    // ships an export map entry that resolves under `import` and 404s under `require`, or
+    // the reverse. The SELF-REFERENCE aliases must agree for the same reason; the `module`
+    // alias is compared separately below, since it is deliberately ESM-only.
+    const selfReferenceAliases = (build: BuildConfig): Record<string, string> =>
+      Object.fromEntries(
+        Object.entries(esbuildAliasOf(build)).filter(([specifier]) =>
+          specifier.startsWith('@docx-editor.dev/core')
+        )
+      );
+
     expect(configs).toHaveLength(2);
     for (const build of configs.slice(1)) {
       expect(build.entry).toEqual(config.entry);
-      expect(esbuildAliasOf(build)).toEqual(esbuildAliasOf(config));
+      expect(selfReferenceAliases(build)).toEqual(selfReferenceAliases(config));
     }
+  });
+
+  test('only the build that inlines the runtime aliases Node’s `module`', () => {
+    // `module` is a bare Node specifier, not a subpath of this package. Aliasing it is how
+    // the inlined HarfBuzz runtime stops reaching for a builtin no browser bundler can
+    // resolve (#282) — but scoped to the ESM build alone, because a package-wide override
+    // would hand any FUTURE bundled dependency a stub silently missing `builtinModules`
+    // instead of failing the build.
+    const [esm, cjs] = configs;
+    expect({
+      esm: 'module' in esbuildAliasOf(esm!),
+      cjs: 'module' in esbuildAliasOf(cjs!),
+    }).toEqual({ esm: true, cjs: false });
   });
 
   test('the split carries its reason: exactly the ESM build inlines and patches harfbuzzjs', () => {

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -163,14 +163,8 @@ export interface FontConfiguration {
  *
  * Distinguished rather than collapsed because the responses differ: `overLimit` and `malformed`
  * are the caller's own bytes, while `forbidden` and `hashMismatch` mean the source was not what
- * it claimed and the load should not be retried.
- *
- * `wasmUnavailable` is the odd one out and the reason it is separate: every other code is a
- * DOCUMENT problem, reported per face, while that one means the text shaper's WASM never
- * loaded — unreachable, or the wrong version after a package upgrade left a self-hosted copy
- * behind — so nothing can be measured at all. It is a host deployment fault, and its
- * `diagnostic` carries the remedy, so a host wants to surface it as a setup error rather
- * than a font warning.
+ * it claimed and the load should not be retried. `wasmUnavailable` alone is a HOST fault — the
+ * shaper's WASM never loaded, `diagnostic` carries the remedy — surface it as a setup error.
  */
 export type EditorFontErrorCode =
   | 'initializationFailed'

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -167,9 +167,10 @@ export interface FontConfiguration {
  *
  * `wasmUnavailable` is the odd one out and the reason it is separate: every other code is a
  * DOCUMENT problem, reported per face, while that one means the text shaper's WASM never
- * loaded, so nothing can be measured at all. It is a host deployment fault, fixed by serving
- * `harfbuzz.wasm` and calling `setHarfBuzzWasmUrl`, and a host wants to surface it as a setup
- * error rather than a font warning.
+ * loaded — unreachable, or the wrong version after a package upgrade left a self-hosted copy
+ * behind — so nothing can be measured at all. It is a host deployment fault, and its
+ * `diagnostic` carries the remedy, so a host wants to surface it as a setup error rather
+ * than a font warning.
  */
 export type EditorFontErrorCode =
   | 'initializationFailed'

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -164,9 +164,16 @@ export interface FontConfiguration {
  * Distinguished rather than collapsed because the responses differ: `overLimit` and `malformed`
  * are the caller's own bytes, while `forbidden` and `hashMismatch` mean the source was not what
  * it claimed and the load should not be retried.
+ *
+ * `wasmUnavailable` is the odd one out and the reason it is separate: every other code is a
+ * DOCUMENT problem, reported per face, while that one means the text shaper's WASM never
+ * loaded, so nothing can be measured at all. It is a host deployment fault, fixed by serving
+ * `harfbuzz.wasm` and calling `setHarfBuzzWasmUrl`, and a host wants to surface it as a setup
+ * error rather than a font warning.
  */
 export type EditorFontErrorCode =
   | 'initializationFailed'
+  | 'wasmUnavailable'
   | 'missing'
   | 'forbidden'
   | 'overLimit'

--- a/packages/core/src/editor/__tests__/font-configuration.test.ts
+++ b/packages/core/src/editor/__tests__/font-configuration.test.ts
@@ -1,7 +1,12 @@
 import { expect, spyOn, test } from 'bun:test';
 import { EditorFontError, type FontConfiguration } from '@docx-editor.dev/core/contracts/editor';
 import { HarfBuzzShapingError, sha256FontBytes } from '@docx-editor.dev/core/layout';
-import { createLayoutShaping, toEditorFontError } from '../font-configuration.ts';
+import {
+  createLayoutShaping,
+  resetFontFailureWarningForTests,
+  toEditorFontError,
+  warnFontFailureOnce,
+} from '../font-configuration.ts';
 
 const fontUrl = new URL('../../layout/__tests__/fixtures/fonts/DejaVuSans.ttf', import.meta.url);
 
@@ -143,43 +148,63 @@ test('copies each valid source exactly once into snapshot ownership', async () =
   shaping.shaper.dispose();
 });
 
-test('a missing WASM keeps its code and remedy, and says so once without a handler', () => {
-  // Three claims, asserted together because the console warning is once-per-session and a
-  // second test could not observe it:
-  //   - the CODE survives, so a host can branch on "your bundler is misconfigured" rather
-  //     than matching English inside `diagnostic`;
-  //   - the DIAGNOSTIC survives, because it is where the remedy is written (#282);
-  //   - it reaches the console even with no `onFontError` registered. Every other font
-  //     failure degrades quietly, but this one disables shaping for the whole document,
-  //     and the same misconfiguration used to fail the BUILD — a silent console after a
-  //     green build would be strictly worse.
+test('a shaper that never loaded keeps its code and its remedy out to the host', () => {
+  // `onFontError` is the only surface a host sees. The CODE has to survive so a host can
+  // branch on "your bundler is misconfigured" rather than matching English inside
+  // `diagnostic`, and the diagnostic has to survive because it is where the remedy is
+  // written (#282). `toEditorFontError` is public API, so it stays a pure mapper —
+  // the console side of this lives in `reportFontError`, which knows who is listening.
   const failure = new HarfBuzzShapingError('wasmUnavailable', {
     diagnostic: 'serve `@docx-editor.dev/core/harfbuzz.wasm` and call `setHarfBuzzWasmUrl`',
   });
-  const error = spyOn(console, 'error').mockImplementation(() => {});
 
-  try {
-    const surfaced = toEditorFontError(failure);
+  const surfaced = toEditorFontError(failure);
 
-    expect(surfaced).toBeInstanceOf(EditorFontError);
-    expect(surfaced.code).toBe('wasmUnavailable');
-    expect(surfaced.diagnostic).toContain('setHarfBuzzWasmUrl');
-    expect(surfaced.cause).toBe(failure);
-    expect(error).toHaveBeenCalledTimes(1);
-    expect(String(error.mock.calls[0]?.[0])).toContain('text shaping is disabled');
-
-    // A document with many unshapeable runs must not turn the console into a log.
-    toEditorFontError(failure);
-    expect(error).toHaveBeenCalledTimes(1);
-  } finally {
-    error.mockRestore();
-  }
+  expect(surfaced).toBeInstanceOf(EditorFontError);
+  expect(surfaced.code).toBe('wasmUnavailable');
+  expect(surfaced.diagnostic).toContain('setHarfBuzzWasmUrl');
+  expect(surfaced.cause).toBe(failure);
 });
 
-test('shaping failures that are not the WASM keep reporting as initializationFailed', () => {
+test('a stale self-hosted binary reports as the same host-deployment fault', () => {
+  // The second step of the documented workflow: copy the wasm, then upgrade the package
+  // and forget to re-copy it. Version mismatch is the same class of problem as a missing
+  // binary — the shaper is not running — so it must not collapse into the generic code.
+  const surfaced = toEditorFontError(
+    new HarfBuzzShapingError('shapingLibraryMismatch', {
+      diagnostic: 'expected HarfBuzz 14.3.0, loaded 14.2.1. Re-copy …',
+    })
+  );
+
+  expect(surfaced.code).toBe('wasmUnavailable');
+  expect(surfaced.diagnostic).toContain('Re-copy');
+});
+
+test('shaping failures that are not the shaper keep reporting as initializationFailed', () => {
   // The new branch must not relabel the resource-limit codes, which are document faults
   // and were already mapped this way.
   const surfaced = toEditorFontError(new HarfBuzzShapingError('glyphOverLimit', { limit: 10 }));
 
   expect(surfaced.code).toBe('initializationFailed');
+});
+
+test('the shaper-failure console warning fires once, and only for the whole-document fault', () => {
+  // Every other font failure degrades quietly on purpose. This one disables shaping for the
+  // entire document, and before #282 was fixed the same misconfiguration failed the BUILD —
+  // so a green build with a silent console would be a strictly worse trade.
+  resetFontFailureWarningForTests();
+  const error = spyOn(console, 'error').mockImplementation(() => {});
+
+  try {
+    warnFontFailureOnce({ diagnostic: 'serve the binary' });
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(String(error.mock.calls[0]?.[0])).toContain('text shaping is disabled');
+
+    // A document with many unshapeable runs must not turn the console into a log.
+    warnFontFailureOnce({ diagnostic: 'serve the binary' });
+    expect(error).toHaveBeenCalledTimes(1);
+  } finally {
+    error.mockRestore();
+    resetFontFailureWarningForTests();
+  }
 });

--- a/packages/core/src/editor/__tests__/font-configuration.test.ts
+++ b/packages/core/src/editor/__tests__/font-configuration.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { EditorFontError, type FontConfiguration } from '@docx-editor.dev/core/contracts/editor';
-import { sha256FontBytes } from '@docx-editor.dev/core/layout';
-import { createLayoutShaping } from '../font-configuration.ts';
+import { HarfBuzzShapingError, sha256FontBytes } from '@docx-editor.dev/core/layout';
+import { createLayoutShaping, toEditorFontError } from '../font-configuration.ts';
 
 const fontUrl = new URL('../../layout/__tests__/fixtures/fonts/DejaVuSans.ttf', import.meta.url);
 
@@ -141,4 +141,20 @@ test('copies each valid source exactly once into snapshot ownership', async () =
 
   expect(counters).toEqual({ copies: 1, hashes: 1, admissions: 1 });
   shaping.shaper.dispose();
+});
+
+test('a HarfBuzz shaping failure keeps its remediation diagnostic through toEditorFontError', () => {
+  // The `wasmUnavailable` diagnostic names `setHarfBuzzWasmUrl` and the file to serve
+  // (#282), and `onFontError` is the only surface a host sees. Collapsed to `message`
+  // alone, the host would get "HarfBuzz shaping failed (wasmUnavailable)" and no pointer
+  // to the fix — which is exactly what the diagnostic exists to replace.
+  const failure = new HarfBuzzShapingError('wasmUnavailable', {
+    diagnostic: 'serve `@docx-editor.dev/core/dist/harfbuzz.wasm` and call `setHarfBuzzWasmUrl`',
+  });
+
+  const surfaced = toEditorFontError(failure);
+
+  expect(surfaced).toBeInstanceOf(EditorFontError);
+  expect(surfaced.code).toBe('initializationFailed');
+  expect(surfaced.diagnostic).toContain('setHarfBuzzWasmUrl');
 });

--- a/packages/core/src/editor/__tests__/font-configuration.test.ts
+++ b/packages/core/src/editor/__tests__/font-configuration.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test';
+import { expect, spyOn, test } from 'bun:test';
 import { EditorFontError, type FontConfiguration } from '@docx-editor.dev/core/contracts/editor';
 import { HarfBuzzShapingError, sha256FontBytes } from '@docx-editor.dev/core/layout';
 import { createLayoutShaping, toEditorFontError } from '../font-configuration.ts';
@@ -143,18 +143,43 @@ test('copies each valid source exactly once into snapshot ownership', async () =
   shaping.shaper.dispose();
 });
 
-test('a HarfBuzz shaping failure keeps its remediation diagnostic through toEditorFontError', () => {
-  // The `wasmUnavailable` diagnostic names `setHarfBuzzWasmUrl` and the file to serve
-  // (#282), and `onFontError` is the only surface a host sees. Collapsed to `message`
-  // alone, the host would get "HarfBuzz shaping failed (wasmUnavailable)" and no pointer
-  // to the fix — which is exactly what the diagnostic exists to replace.
+test('a missing WASM keeps its code and remedy, and says so once without a handler', () => {
+  // Three claims, asserted together because the console warning is once-per-session and a
+  // second test could not observe it:
+  //   - the CODE survives, so a host can branch on "your bundler is misconfigured" rather
+  //     than matching English inside `diagnostic`;
+  //   - the DIAGNOSTIC survives, because it is where the remedy is written (#282);
+  //   - it reaches the console even with no `onFontError` registered. Every other font
+  //     failure degrades quietly, but this one disables shaping for the whole document,
+  //     and the same misconfiguration used to fail the BUILD — a silent console after a
+  //     green build would be strictly worse.
   const failure = new HarfBuzzShapingError('wasmUnavailable', {
-    diagnostic: 'serve `@docx-editor.dev/core/dist/harfbuzz.wasm` and call `setHarfBuzzWasmUrl`',
+    diagnostic: 'serve `@docx-editor.dev/core/harfbuzz.wasm` and call `setHarfBuzzWasmUrl`',
   });
+  const error = spyOn(console, 'error').mockImplementation(() => {});
 
-  const surfaced = toEditorFontError(failure);
+  try {
+    const surfaced = toEditorFontError(failure);
 
-  expect(surfaced).toBeInstanceOf(EditorFontError);
+    expect(surfaced).toBeInstanceOf(EditorFontError);
+    expect(surfaced.code).toBe('wasmUnavailable');
+    expect(surfaced.diagnostic).toContain('setHarfBuzzWasmUrl');
+    expect(surfaced.cause).toBe(failure);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(String(error.mock.calls[0]?.[0])).toContain('text shaping is disabled');
+
+    // A document with many unshapeable runs must not turn the console into a log.
+    toEditorFontError(failure);
+    expect(error).toHaveBeenCalledTimes(1);
+  } finally {
+    error.mockRestore();
+  }
+});
+
+test('shaping failures that are not the WASM keep reporting as initializationFailed', () => {
+  // The new branch must not relabel the resource-limit codes, which are document faults
+  // and were already mapped this way.
+  const surfaced = toEditorFontError(new HarfBuzzShapingError('glyphOverLimit', { limit: 10 }));
+
   expect(surfaced.code).toBe('initializationFailed');
-  expect(surfaced.diagnostic).toContain('setHarfBuzzWasmUrl');
 });

--- a/packages/core/src/editor/__tests__/font-configuration.test.ts
+++ b/packages/core/src/editor/__tests__/font-configuration.test.ts
@@ -180,6 +180,20 @@ test('a stale self-hosted binary reports as the same host-deployment fault', () 
   expect(surfaced.diagnostic).toContain('Re-copy');
 });
 
+test('an unsupported Node runtime is NOT labeled wasmUnavailable', () => {
+  // A host branching on `wasmUnavailable` shows the serve-the-binary remedy. On a Node
+  // that predates `process.getBuiltinModule` no URL helps, so that failure keeps the
+  // generic code and carries the upgrade advice in `diagnostic` instead.
+  const surfaced = toEditorFontError(
+    new HarfBuzzShapingError('unsupportedRuntime', {
+      diagnostic: 'upgrade Node; `setHarfBuzzWasmUrl` does not apply here',
+    })
+  );
+
+  expect(surfaced.code).toBe('initializationFailed');
+  expect(surfaced.diagnostic).toContain('upgrade Node');
+});
+
 test('shaping failures that are not the shaper keep reporting as initializationFailed', () => {
   // The new branch must not relabel the resource-limit codes, which are document faults
   // and were already mapped this way.

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -157,6 +157,7 @@ import {
   createLayoutShaping,
   disposeLayoutShaping,
   toEditorFontError,
+  warnFontFailureOnce,
 } from './font-configuration.ts';
 import {
   MAX_RESOLVER_FAMILIES,
@@ -669,6 +670,15 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   }
 
   function reportFontError(error: EditorFontError): void {
+    // A shaper that never loaded is not a per-face degradation: NOTHING measures correctly,
+    // and the fault is the host's build rather than the document's content. Said out loud
+    // exactly once, and only when nobody is listening — a host that reports it in its own
+    // UI does not need library noise it cannot switch off. Before this was fixed the same
+    // misconfiguration failed the BUILD, so a green build with a silent console would be a
+    // strictly worse trade (#282).
+    if (error.code === 'wasmUnavailable' && !config.onFontError && handlers.error.size === 0) {
+      warnFontFailureOnce(error);
+    }
     // A host handler that throws must not abort font resolution — reporting a dropped
     // face would then cost the whole shaped measurer, and the catch's own report would
     // throw again as an unhandled rejection.

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -86,6 +86,7 @@ import {
   HARD_MAX_AGGREGATE_FONT_BYTES,
   HARD_MAX_FONT_BYTES,
   HARFBUZZ_SHAPING_LIBRARY,
+  HarfBuzzShapingError,
   fontRequestKey,
   createShapedMeasurer,
   resolveDefaultSurfaceMeasurer,
@@ -676,7 +677,10 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // UI does not need library noise it cannot switch off. Before this was fixed the same
     // misconfiguration failed the BUILD, so a green build with a silent console would be a
     // strictly worse trade (#282).
-    if (error.code === 'wasmUnavailable' && !config.onFontError && handlers.error.size === 0) {
+    const shaperNeverLoaded =
+      error.code === 'wasmUnavailable' ||
+      (error.cause instanceof HarfBuzzShapingError && error.cause.code === 'unsupportedRuntime');
+    if (shaperNeverLoaded && !config.onFontError && handlers.error.size === 0) {
       warnFontFailureOnce(error);
     }
     // A host handler that throws must not abort font resolution — reporting a dropped

--- a/packages/core/src/editor/font-configuration.ts
+++ b/packages/core/src/editor/font-configuration.ts
@@ -10,6 +10,7 @@ import {
   HARD_MAX_FONT_BYTES,
   HARD_MAX_FONT_SOURCES,
   FontResolutionError,
+  HarfBuzzShapingError,
   createFontResourceSnapshot,
   createHarfBuzzTextShaper,
   harfBuzzFontValidator,
@@ -45,6 +46,16 @@ export function toEditorFontError(error: unknown): EditorFontError {
     return new EditorFontError(error.code as EditorFontErrorCode, error.message, {
       request: publicRequest(error.request),
       diagnostic: error.diagnostic,
+    });
+  }
+  if (error instanceof HarfBuzzShapingError) {
+    // The shaping error's `diagnostic` is the actionable half — for `wasmUnavailable` it
+    // names `setHarfBuzzWasmUrl` and the file to serve (#282). Collapsing to `message`
+    // alone would hand `onFontError` "HarfBuzz shaping failed (wasmUnavailable)" and
+    // nothing else, which is precisely the unactionable surface that diagnostic exists
+    // to replace.
+    return new EditorFontError('initializationFailed', error.message, {
+      diagnostic: error.diagnostic ?? error.message,
     });
   }
   return new EditorFontError(

--- a/packages/core/src/editor/font-configuration.ts
+++ b/packages/core/src/editor/font-configuration.ts
@@ -34,6 +34,29 @@ function publicRequest(request: FontFaceRequest): FontFaceRequest {
   });
 }
 
+let warnedWasmUnavailable = false;
+
+/**
+ * Say it out loud once, even with no `onFontError` registered.
+ *
+ * Every other font failure degrades quietly on purpose: one refused embedded face is
+ * document data, and the document still renders correctly enough to read. This one is not
+ * that. The shaper is gone, so every line break, page break and caret position in the
+ * document is computed from fallback metrics, and the host that could report it is the
+ * host that misconfigured its bundler. Before this was fixed the same misconfiguration
+ * failed the BUILD; degrading to a silent console after a green build would be a strictly
+ * worse trade.
+ */
+function warnWasmUnavailableOnce(error: { readonly diagnostic?: string }): void {
+  if (warnedWasmUnavailable) return;
+  warnedWasmUnavailable = true;
+  console.error(
+    `[@docx-editor.dev/core] text shaping is disabled: ${error.diagnostic ?? ''}\n` +
+      'Text is being measured with fallback metrics, so line and page breaks will not ' +
+      'match Word.'
+  );
+}
+
 /**
  * Normalize anything thrown during font work into an {@link EditorFontError}.
  *
@@ -49,13 +72,16 @@ export function toEditorFontError(error: unknown): EditorFontError {
     });
   }
   if (error instanceof HarfBuzzShapingError) {
-    // The shaping error's `diagnostic` is the actionable half — for `wasmUnavailable` it
-    // names `setHarfBuzzWasmUrl` and the file to serve (#282). Collapsing to `message`
-    // alone would hand `onFontError` "HarfBuzz shaping failed (wasmUnavailable)" and
-    // nothing else, which is precisely the unactionable surface that diagnostic exists
-    // to replace.
-    return new EditorFontError('initializationFailed', error.message, {
+    // `wasmUnavailable` keeps its own code out to the host. Every other shaping code maps
+    // to `initializationFailed` as before, but this one is a HOST deployment fault rather
+    // than a document fault, and a host must be able to branch on it — matching on the
+    // prose of `diagnostic` would be an API made of an English sentence.
+    const code: EditorFontErrorCode =
+      error.code === 'wasmUnavailable' ? 'wasmUnavailable' : 'initializationFailed';
+    if (error.code === 'wasmUnavailable') warnWasmUnavailableOnce(error);
+    return new EditorFontError(code, error.message, {
       diagnostic: error.diagnostic ?? error.message,
+      cause: error,
     });
   }
   return new EditorFontError(

--- a/packages/core/src/editor/font-configuration.ts
+++ b/packages/core/src/editor/font-configuration.ts
@@ -34,27 +34,31 @@ function publicRequest(request: FontFaceRequest): FontFaceRequest {
   });
 }
 
-let warnedWasmUnavailable = false;
+let warnedFontFailure = false;
 
 /**
- * Say it out loud once, even with no `onFontError` registered.
+ * Say a shaper-level failure out loud once, for hosts that registered no reporting at all.
  *
  * Every other font failure degrades quietly on purpose: one refused embedded face is
- * document data, and the document still renders correctly enough to read. This one is not
- * that. The shaper is gone, so every line break, page break and caret position in the
- * document is computed from fallback metrics, and the host that could report it is the
- * host that misconfigured its bundler. Before this was fixed the same misconfiguration
- * failed the BUILD; degrading to a silent console after a green build would be a strictly
- * worse trade.
+ * document data, and the document still renders well enough to read. This one is not that.
+ * The shaper is gone, so every line break, page break and caret position comes from
+ * fallback metrics. Called only from `reportFontError`, which knows whether anyone is
+ * listening — a host reporting it in its own UI must not also get library console noise.
  */
-function warnWasmUnavailableOnce(error: { readonly diagnostic?: string }): void {
-  if (warnedWasmUnavailable) return;
-  warnedWasmUnavailable = true;
+export function warnFontFailureOnce(error: { readonly diagnostic?: string }): void {
+  if (warnedFontFailure) return;
+  warnedFontFailure = true;
+  const detail = error.diagnostic ? `: ${error.diagnostic}` : '.';
   console.error(
-    `[@docx-editor.dev/core] text shaping is disabled: ${error.diagnostic ?? ''}\n` +
+    `[@docx-editor.dev/core] text shaping is disabled${detail}\n` +
       'Text is being measured with fallback metrics, so line and page breaks will not ' +
       'match Word.'
   );
+}
+
+/** Test seam: the warning is once-per-process, so a test asserting it must clear the latch. */
+export function resetFontFailureWarningForTests(): void {
+  warnedFontFailure = false;
 }
 
 /**
@@ -72,13 +76,16 @@ export function toEditorFontError(error: unknown): EditorFontError {
     });
   }
   if (error instanceof HarfBuzzShapingError) {
-    // `wasmUnavailable` keeps its own code out to the host. Every other shaping code maps
-    // to `initializationFailed` as before, but this one is a HOST deployment fault rather
-    // than a document fault, and a host must be able to branch on it — matching on the
-    // prose of `diagnostic` would be an API made of an English sentence.
+    // Both ways the shaper can fail to come up keep their own code out to the host: the
+    // binary was unreachable, or the one that loaded is the wrong version — which is the
+    // same fault after a package upgrade left a self-hosted copy behind. Every other
+    // shaping code stays `initializationFailed`, because those are document faults. A host
+    // must be able to branch on this one, and matching the prose of `diagnostic` would be
+    // an API made of an English sentence.
     const code: EditorFontErrorCode =
-      error.code === 'wasmUnavailable' ? 'wasmUnavailable' : 'initializationFailed';
-    if (error.code === 'wasmUnavailable') warnWasmUnavailableOnce(error);
+      error.code === 'wasmUnavailable' || error.code === 'shapingLibraryMismatch'
+        ? 'wasmUnavailable'
+        : 'initializationFailed';
     return new EditorFontError(code, error.message, {
       diagnostic: error.diagnostic ?? error.message,
       cause: error,

--- a/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
+++ b/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
@@ -103,6 +103,55 @@ describe('harfBuzzWasmUnavailableDiagnostic', () => {
   });
 });
 
+describe('setHarfBuzzWasmUrl with two disagreeing callers before the first read', () => {
+  test('the conflict is said out loud and the later caller wins', () => {
+    // Silent last-write-wins hid a real integration bug: two modules configuring one host
+    // with different locations, and whichever loaded second decided the outcome.
+    setHarfBuzzWasmUrl('https://app.example/a/harfbuzz.wasm');
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      setHarfBuzzWasmUrl(SERVED_URL);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain('later one wins');
+    } finally {
+      warn.mockRestore();
+    }
+    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(SERVED_URL);
+  });
+});
+
+describe('URL redaction in diagnostics', () => {
+  test('a signed URL loses its query string before reaching an error message', () => {
+    // Signed asset URLs carry their credential in the query, and diagnostics end up in
+    // logs and bug reports.
+    setHarfBuzzWasmUrl('https://cdn.example/assets/harfbuzz.wasm?token=SECRET123');
+    resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
+
+    const diagnostic = harfBuzzWasmUnavailableDiagnostic(new Error('404'));
+
+    expect(diagnostic).not.toContain('SECRET123');
+    expect(diagnostic).toContain('https://cdn.example/assets/harfbuzz.wasm');
+  });
+});
+
+describe('a Node runtime without process.getBuiltinModule', () => {
+  test('is told to upgrade Node, not to serve a WASM file', () => {
+    // The shim's throw is the marker. Serving a binary cannot fix a missing builtin, so
+    // the standard remedy would send that consumer chasing an asset problem they do not
+    // have.
+    const diagnostic = harfBuzzWasmUnavailableDiagnostic(
+      new Error(
+        "Aborted(Error: createRequire is unavailable: this build reaches Node's `module` " +
+          'through process.getBuiltinModule, which needs Node 20.16+ or 22.3+.)'
+      )
+    );
+
+    expect(diagnostic).toContain('Upgrade Node');
+    expect(diagnostic).toContain('does not apply');
+    expect(diagnostic).not.toContain('serve `@docx-editor.dev/core/harfbuzz.wasm` yourself');
+  });
+});
+
 describe('harfBuzzVersionMismatchDiagnostic', () => {
   test('a self-hosted copy is told which file went stale and what to do', () => {
     // The second step of the workflow the docs send esbuild/Bun consumers down: copy the

--- a/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
+++ b/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
@@ -8,8 +8,10 @@
 
 import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import {
+  harfBuzzUnsupportedRuntimeDiagnostic,
   harfBuzzVersionMismatchDiagnostic,
   harfBuzzWasmUnavailableDiagnostic,
+  isUnsupportedNodeRuntime,
   resetHarfBuzzWasmUrlForTests,
   resolveHarfBuzzWasmBinaryUrl,
   setHarfBuzzWasmUrl,
@@ -135,20 +137,50 @@ describe('URL redaction in diagnostics', () => {
 });
 
 describe('a Node runtime without process.getBuiltinModule', () => {
+  const shimAbort = new Error(
+    "Aborted(Error: createRequire is unavailable: this build reaches Node's `module` " +
+      'through process.getBuiltinModule, which needs Node 20.16+ or 22.3+.)'
+  );
+
+  test('is recognised by the shim marker, and nothing else is', () => {
+    // Serving a binary cannot fix a missing builtin, so this failure gets its own
+    // `unsupportedRuntime` code — a host branching on `wasmUnavailable` must not
+    // prescribe a WASM fix for a Node-version problem.
+    expect(isUnsupportedNodeRuntime(shimAbort)).toBe(true);
+    expect(isUnsupportedNodeRuntime(new Error('404 not found'))).toBe(false);
+    expect(isUnsupportedNodeRuntime('not an error')).toBe(false);
+  });
+
   test('is told to upgrade Node, not to serve a WASM file', () => {
-    // The shim's throw is the marker. Serving a binary cannot fix a missing builtin, so
-    // the standard remedy would send that consumer chasing an asset problem they do not
-    // have.
-    const diagnostic = harfBuzzWasmUnavailableDiagnostic(
-      new Error(
-        "Aborted(Error: createRequire is unavailable: this build reaches Node's `module` " +
-          'through process.getBuiltinModule, which needs Node 20.16+ or 22.3+.)'
-      )
-    );
+    const diagnostic = harfBuzzUnsupportedRuntimeDiagnostic(shimAbort);
 
     expect(diagnostic).toContain('Upgrade Node');
     expect(diagnostic).toContain('does not apply');
     expect(diagnostic).not.toContain('serve `@docx-editor.dev/core/harfbuzz.wasm` yourself');
+  });
+});
+
+describe('URL redaction of credentials', () => {
+  test('userinfo is stripped even with no query or fragment', () => {
+    // `user:password@host` is a credential without a `?` for the query check to catch.
+    setHarfBuzzWasmUrl('https://user:hunter2@cdn.example/assets/harfbuzz.wasm');
+    resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
+
+    const diagnostic = harfBuzzWasmUnavailableDiagnostic(new Error('404'));
+
+    expect(diagnostic).not.toContain('hunter2');
+    expect(diagnostic).toContain('cdn.example');
+  });
+
+  test('a signed URL inside the cause message is redacted too', () => {
+    // The cause is written by whoever threw — a fetch error can embed the full URL it
+    // tried, which would put back exactly what redacting our own fields took out.
+    const diagnostic = harfBuzzWasmUnavailableDiagnostic(
+      new Error('fetch of https://cdn.example/harfbuzz.wasm?sig=SECRET456 failed')
+    );
+
+    expect(diagnostic).not.toContain('SECRET456');
+    expect(diagnostic).toContain('https://cdn.example/harfbuzz.wasm');
   });
 });
 

--- a/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
+++ b/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
@@ -1,0 +1,63 @@
+// The WASM URL escape hatch (#282).
+//
+// The inlined HarfBuzz runtime locates its binary through
+// `resolveHarfBuzzWasmBinaryUrl`, wired in by the build. These tests pin the contract the
+// runtime and `setHarfBuzzWasmUrl` share: the override wins, the bundler's URL is the
+// fallback, the location is read once, and a change after that read REFUSES instead of
+// silently doing nothing.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  resetHarfBuzzWasmUrlForTests,
+  resolveHarfBuzzWasmBinaryUrl,
+  setHarfBuzzWasmUrl,
+} from '../harfbuzz-wasm-binary.ts';
+
+const BUNDLER_URL = 'https://app.example/assets/harfbuzz-abc123.wasm';
+
+afterEach(() => {
+  resetHarfBuzzWasmUrlForTests();
+});
+
+describe('resolveHarfBuzzWasmBinaryUrl', () => {
+  test('without an override, the bundler-resolved URL passes through untouched', () => {
+    // The webpack/Turbopack/Vite path: those bundlers emit the asset and rewrite the URL
+    // themselves, and the escape hatch must not get in their way.
+    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(BUNDLER_URL);
+  });
+
+  test('an override set before the runtime reads wins over the bundler URL', () => {
+    // The esbuild/Bun path: nothing was emitted, the argument would 404, and the
+    // consumer-served copy is the one that loads.
+    setHarfBuzzWasmUrl('https://app.example/static/harfbuzz.wasm');
+    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(
+      'https://app.example/static/harfbuzz.wasm'
+    );
+  });
+
+  test('a URL object is accepted and normalised to its string form', () => {
+    setHarfBuzzWasmUrl(new URL('https://app.example/static/harfbuzz.wasm'));
+    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(
+      'https://app.example/static/harfbuzz.wasm'
+    );
+  });
+});
+
+describe('setHarfBuzzWasmUrl after the runtime has read its location', () => {
+  test('a different URL throws instead of being silently ignored', () => {
+    // The runtime reads the location once, at first WASM instantiation. A later set would
+    // change nothing, and "set but unused" is the failure mode this API exists to avoid.
+    resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
+    expect(() => setHarfBuzzWasmUrl('https://app.example/elsewhere/harfbuzz.wasm')).toThrow(
+      /already resolved its binary/
+    );
+  });
+
+  test('re-setting the URL the runtime already resolved is a no-op, not an error', () => {
+    // Two independent module inits racing to configure the same host should not blow up
+    // when they agree.
+    setHarfBuzzWasmUrl('https://app.example/static/harfbuzz.wasm');
+    resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
+    expect(() => setHarfBuzzWasmUrl('https://app.example/static/harfbuzz.wasm')).not.toThrow();
+  });
+});

--- a/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
+++ b/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
@@ -3,17 +3,19 @@
 // The inlined HarfBuzz runtime locates its binary through
 // `resolveHarfBuzzWasmBinaryUrl`, wired in by the build. These tests pin the contract the
 // runtime and `setHarfBuzzWasmUrl` share: the override wins, the bundler's URL is the
-// fallback, the location is read once, and a change after that read REFUSES instead of
-// silently doing nothing.
+// fallback, the location is read once, and a call that arrives too late says so instead of
+// throwing at a consumer who is following the error's own advice.
 
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import {
+  harfBuzzWasmUnavailableDiagnostic,
   resetHarfBuzzWasmUrlForTests,
   resolveHarfBuzzWasmBinaryUrl,
   setHarfBuzzWasmUrl,
 } from '../harfbuzz-wasm-binary.ts';
 
 const BUNDLER_URL = 'https://app.example/assets/harfbuzz-abc123.wasm';
+const SERVED_URL = 'https://app.example/static/harfbuzz.wasm';
 
 afterEach(() => {
   resetHarfBuzzWasmUrlForTests();
@@ -29,35 +31,73 @@ describe('resolveHarfBuzzWasmBinaryUrl', () => {
   test('an override set before the runtime reads wins over the bundler URL', () => {
     // The esbuild/Bun path: nothing was emitted, the argument would 404, and the
     // consumer-served copy is the one that loads.
-    setHarfBuzzWasmUrl('https://app.example/static/harfbuzz.wasm');
-    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(
-      'https://app.example/static/harfbuzz.wasm'
-    );
+    setHarfBuzzWasmUrl(SERVED_URL);
+    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(SERVED_URL);
   });
 
   test('a URL object is accepted and normalised to its string form', () => {
-    setHarfBuzzWasmUrl(new URL('https://app.example/static/harfbuzz.wasm'));
-    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(
-      'https://app.example/static/harfbuzz.wasm'
-    );
+    setHarfBuzzWasmUrl(new URL(SERVED_URL));
+    expect(resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL)).toBe(SERVED_URL);
   });
 });
 
 describe('setHarfBuzzWasmUrl after the runtime has read its location', () => {
-  test('a different URL throws instead of being silently ignored', () => {
-    // The runtime reads the location once, at first WASM instantiation. A later set would
-    // change nothing, and "set but unused" is the failure mode this API exists to avoid.
+  test('a late call warns and does not throw', () => {
+    // The documented remedy for `wasmUnavailable` is to call this function. A consumer who
+    // does that from an error handler must not be met with a second exception — the module
+    // cache pins the runtime either way, so the honest answer is "noted, reload".
     resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
-    expect(() => setHarfBuzzWasmUrl('https://app.example/elsewhere/harfbuzz.wasm')).toThrow(
-      /already resolved its binary/
-    );
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(() => setHarfBuzzWasmUrl(SERVED_URL)).not.toThrow();
+      expect(warn.mock.calls[0]?.[0]).toContain('reload');
+    } finally {
+      warn.mockRestore();
+    }
   });
 
-  test('re-setting the URL the runtime already resolved is a no-op, not an error', () => {
-    // Two independent module inits racing to configure the same host should not blow up
-    // when they agree.
-    setHarfBuzzWasmUrl('https://app.example/static/harfbuzz.wasm');
+  test('re-setting the URL the runtime already resolved is silent', () => {
+    setHarfBuzzWasmUrl(SERVED_URL);
     resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
-    expect(() => setHarfBuzzWasmUrl('https://app.example/static/harfbuzz.wasm')).not.toThrow();
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      setHarfBuzzWasmUrl(SERVED_URL);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe('setHarfBuzzWasmUrl input validation', () => {
+  test.each([
+    ['a number', 42],
+    ['null', null],
+    ['an object', {}],
+  ])('%s is refused with a TypeError', (_label, value) => {
+    // The failure this API exists to fix already surfaces three steps away from its cause.
+    // Coercing junk with String() would add a fourth.
+    expect(() => setHarfBuzzWasmUrl(value as unknown as string)).toThrow(TypeError);
+  });
+
+  test('an empty string is refused rather than resolving to the current page', () => {
+    expect(() => setHarfBuzzWasmUrl('   ')).toThrow(TypeError);
+  });
+});
+
+describe('harfBuzzWasmUnavailableDiagnostic', () => {
+  test('names the API that fixes it, the file to serve, and the underlying cause', () => {
+    // This string is the ONLY thing a consumer sees when their bundler emits no asset, so
+    // every part of the remedy has to survive in it.
+    const diagnostic = harfBuzzWasmUnavailableDiagnostic(new Error('ENOENT: no such file'));
+
+    expect(diagnostic).toContain('setHarfBuzzWasmUrl');
+    expect(diagnostic).toContain('@docx-editor.dev/core/harfbuzz.wasm');
+    expect(diagnostic).toContain('ENOENT: no such file');
+  });
+
+  test('reports the location actually read, so the advice points somewhere real', () => {
+    resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
+    expect(harfBuzzWasmUnavailableDiagnostic(new Error('404'))).toContain(BUNDLER_URL);
   });
 });

--- a/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
+++ b/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import {
+  harfBuzzVersionMismatchDiagnostic,
   harfBuzzWasmUnavailableDiagnostic,
   resetHarfBuzzWasmUrlForTests,
   resolveHarfBuzzWasmBinaryUrl,
@@ -99,5 +100,28 @@ describe('harfBuzzWasmUnavailableDiagnostic', () => {
   test('reports the location actually read, so the advice points somewhere real', () => {
     resolveHarfBuzzWasmBinaryUrl(BUNDLER_URL);
     expect(harfBuzzWasmUnavailableDiagnostic(new Error('404'))).toContain(BUNDLER_URL);
+  });
+});
+
+describe('harfBuzzVersionMismatchDiagnostic', () => {
+  test('a self-hosted copy is told which file went stale and what to do', () => {
+    // The second step of the workflow the docs send esbuild/Bun consumers down: copy the
+    // binary, then upgrade the package. Two version numbers alone name no remedy.
+    setHarfBuzzWasmUrl(SERVED_URL);
+
+    const diagnostic = harfBuzzVersionMismatchDiagnostic('14.3.0', '14.2.1');
+
+    expect(diagnostic).toContain(SERVED_URL);
+    expect(diagnostic).toContain('Re-copy');
+    expect(diagnostic).toContain('14.2.1');
+  });
+
+  test('a bundled copy is not told to re-copy a file it never served', () => {
+    // Without an override the binary came from the bundler, so the re-copy advice would
+    // send the reader looking for a file they never created.
+    const diagnostic = harfBuzzVersionMismatchDiagnostic('14.3.0', '14.2.1');
+
+    expect(diagnostic).not.toContain('Re-copy');
+    expect(diagnostic).toContain('does not match this build');
   });
 });

--- a/packages/core/src/layout/harfbuzz-shaper.ts
+++ b/packages/core/src/layout/harfbuzz-shaper.ts
@@ -22,8 +22,10 @@ import {
   type VersionedShapingLibrary,
 } from './shaped-run.ts';
 import {
+  harfBuzzUnsupportedRuntimeDiagnostic,
   harfBuzzVersionMismatchDiagnostic,
   harfBuzzWasmUnavailableDiagnostic,
+  isUnsupportedNodeRuntime,
 } from './harfbuzz-wasm-binary.ts';
 
 type HarfBuzzModule = typeof import('harfbuzzjs');
@@ -77,6 +79,15 @@ export function initializeHarfBuzz(): Promise<void> {
       // under a CSP without `wasm-unsafe-eval`. Matching phrases meant the two most likely
       // server and enterprise failures fell through to a raw abort with no remedy attached.
       if (error instanceof HarfBuzzShapingError) throw error;
+      // Except the one failure no URL fixes: a Node that predates `process.getBuiltinModule`.
+      // Its own code keeps hosts branching on `wasmUnavailable` from prescribing a WASM fix
+      // for a runtime problem.
+      if (isUnsupportedNodeRuntime(error)) {
+        throw new HarfBuzzShapingError('unsupportedRuntime', {
+          diagnostic: harfBuzzUnsupportedRuntimeDiagnostic(error),
+          cause: error,
+        });
+      }
       throw new HarfBuzzShapingError('wasmUnavailable', {
         diagnostic: harfBuzzWasmUnavailableDiagnostic(error),
         cause: error,
@@ -109,6 +120,7 @@ function requireHarfBuzz(): HarfBuzzModule {
 export type HarfBuzzShapingErrorCode =
   | 'notInitialized'
   | 'wasmUnavailable'
+  | 'unsupportedRuntime'
   | 'fontOverLimit'
   | 'malformedFont'
   | 'textOverLimit'

--- a/packages/core/src/layout/harfbuzz-shaper.ts
+++ b/packages/core/src/layout/harfbuzz-shaper.ts
@@ -21,6 +21,7 @@ import {
   type TextShaper,
   type VersionedShapingLibrary,
 } from './shaped-run.ts';
+import { harfBuzzWasmUnavailableDiagnostic } from './harfbuzz-wasm-binary.ts';
 
 type HarfBuzzModule = typeof import('harfbuzzjs');
 type HarfBuzzBlob = InstanceType<HarfBuzzModule['Blob']>;
@@ -57,31 +58,22 @@ export function initializeHarfBuzz(): Promise<void> {
       }
       harfBuzzModule = module;
     })
-    .catch((error) => {
+    .catch((error: unknown) => {
       harfBuzzInitialization = null;
-      // The runtime aborts with `Aborted(both async and sync fetching of the wasm failed)`
-      // when its binary cannot be fetched — under a bundler that does not emit
-      // `new URL(..., import.meta.url)` assets (esbuild, Bun), that is a clean build 404ing
-      // at runtime (#282). Left as-is, the raw abort surfaces through `onFontError` with
-      // nothing connecting it to the fix, so it is renamed here to the API that fixes it.
+      // Anything that is not the version pin above means the runtime did not come up, and
+      // the reason is always the same class of problem: the WASM could not be loaded.
       //
-      // `expected magic word` is the same misconfiguration behind a SPA dev server: the
-      // missing path answers 200 with the HTML fallback page, and instantiation dies on
-      // the bytes instead of the fetch.
-      if (
-        error instanceof Error &&
-        /fetching of the wasm failed|expected magic word/.test(error.message)
-      ) {
-        throw new HarfBuzzShapingError('wasmUnavailable', {
-          diagnostic:
-            'the HarfBuzz WASM binary could not be fetched. If this bundler does not emit ' +
-            '`new URL(..., import.meta.url)` assets (esbuild, Bun), serve ' +
-            '`@docx-editor.dev/core/dist/harfbuzz.wasm` yourself, point `setHarfBuzzWasmUrl` ' +
-            "from '@docx-editor.dev/core/layout' at it before creating an editor, and reload " +
-            `the page. (${error.message})`,
-        });
-      }
-      throw error;
+      // Deliberately NOT a match on the abort text. Emscripten words each failure
+      // differently — `both async and sync fetching of the wasm failed` for a 404,
+      // `expected magic word` when a SPA dev server answers with its HTML fallback,
+      // `ENOENT` when a deploy step copied the JS but not the asset, and an `EvalError`
+      // under a CSP without `wasm-unsafe-eval`. Matching phrases meant the two most likely
+      // server and enterprise failures fell through to a raw abort with no remedy attached.
+      if (error instanceof HarfBuzzShapingError) throw error;
+      throw new HarfBuzzShapingError('wasmUnavailable', {
+        diagnostic: harfBuzzWasmUnavailableDiagnostic(error),
+        cause: error,
+      });
     });
   return harfBuzzInitialization;
 }
@@ -144,9 +136,10 @@ export class HarfBuzzShapingError extends Error {
       readonly limit?: number;
       readonly actual?: number;
       readonly diagnostic?: string;
+      readonly cause?: unknown;
     } = {}
   ) {
-    super(`HarfBuzz shaping failed (${code})`);
+    super(`HarfBuzz shaping failed (${code})`, { cause: details.cause });
     this.code = code;
     this.limit = details.limit;
     this.actual = details.actual;

--- a/packages/core/src/layout/harfbuzz-shaper.ts
+++ b/packages/core/src/layout/harfbuzz-shaper.ts
@@ -59,6 +59,28 @@ export function initializeHarfBuzz(): Promise<void> {
     })
     .catch((error) => {
       harfBuzzInitialization = null;
+      // The runtime aborts with `Aborted(both async and sync fetching of the wasm failed)`
+      // when its binary cannot be fetched — under a bundler that does not emit
+      // `new URL(..., import.meta.url)` assets (esbuild, Bun), that is a clean build 404ing
+      // at runtime (#282). Left as-is, the raw abort surfaces through `onFontError` with
+      // nothing connecting it to the fix, so it is renamed here to the API that fixes it.
+      //
+      // `expected magic word` is the same misconfiguration behind a SPA dev server: the
+      // missing path answers 200 with the HTML fallback page, and instantiation dies on
+      // the bytes instead of the fetch.
+      if (
+        error instanceof Error &&
+        /fetching of the wasm failed|expected magic word/.test(error.message)
+      ) {
+        throw new HarfBuzzShapingError('wasmUnavailable', {
+          diagnostic:
+            'the HarfBuzz WASM binary could not be fetched. If this bundler does not emit ' +
+            '`new URL(..., import.meta.url)` assets (esbuild, Bun), serve ' +
+            '`@docx-editor.dev/core/dist/harfbuzz.wasm` yourself, point `setHarfBuzzWasmUrl` ' +
+            "from '@docx-editor.dev/core/layout' at it before creating an editor, and reload " +
+            `the page. (${error.message})`,
+        });
+      }
       throw error;
     });
   return harfBuzzInitialization;
@@ -87,6 +109,7 @@ function requireHarfBuzz(): HarfBuzzModule {
  */
 export type HarfBuzzShapingErrorCode =
   | 'notInitialized'
+  | 'wasmUnavailable'
   | 'fontOverLimit'
   | 'malformedFont'
   | 'textOverLimit'

--- a/packages/core/src/layout/harfbuzz-shaper.ts
+++ b/packages/core/src/layout/harfbuzz-shaper.ts
@@ -21,7 +21,10 @@ import {
   type TextShaper,
   type VersionedShapingLibrary,
 } from './shaped-run.ts';
-import { harfBuzzWasmUnavailableDiagnostic } from './harfbuzz-wasm-binary.ts';
+import {
+  harfBuzzVersionMismatchDiagnostic,
+  harfBuzzWasmUnavailableDiagnostic,
+} from './harfbuzz-wasm-binary.ts';
 
 type HarfBuzzModule = typeof import('harfbuzzjs');
 type HarfBuzzBlob = InstanceType<HarfBuzzModule['Blob']>;
@@ -53,7 +56,11 @@ export function initializeHarfBuzz(): Promise<void> {
       const version = module.versionString();
       if (version !== HARFBUZZ_SHAPING_LIBRARY.version) {
         throw new HarfBuzzShapingError('shapingLibraryMismatch', {
-          diagnostic: `expected ${HARFBUZZ_SHAPING_LIBRARY.version}, loaded ${version}`,
+          // A self-hosted binary makes this the SECOND step of the workflow the docs send
+          // esbuild and Bun consumers down: copy the file, then upgrade the package and
+          // forget to re-copy it. `expected X, loaded Y` alone names no file and no remedy,
+          // which is the dead end the rest of this error handling exists to remove.
+          diagnostic: harfBuzzVersionMismatchDiagnostic(HARFBUZZ_SHAPING_LIBRARY.version, version),
         });
       }
       harfBuzzModule = module;

--- a/packages/core/src/layout/harfbuzz-wasm-binary.ts
+++ b/packages/core/src/layout/harfbuzz-wasm-binary.ts
@@ -3,60 +3,99 @@
 //
 // The runtime ships inlined in this package's ESM build, and its loader locates the
 // binary with `new URL('harfbuzz.wasm', import.meta.url)`. Webpack, Turbopack and
-// Vite all recognise that expression, emit `dist/harfbuzz.wasm` as an asset and
-// rewrite the URL — the reason a Next or Vite app needs no configuration. But the
-// pattern is a convention, not a standard: esbuild and Bun leave the expression
-// untouched and emit nothing, so the fetch 404s at runtime with
-// `Aborted(both async and sync fetching of the wasm failed)` after a clean build.
+// Vite recognise that expression, emit `harfbuzz.wasm` as an asset and rewrite the
+// URL — the reason a Next or Vite app needs no configuration. But the pattern is a
+// convention, not a standard: esbuild and Bun leave the expression untouched and
+// emit nothing, so the fetch 404s at runtime after a clean build.
 //
-// {@link setHarfBuzzWasmUrl} exists for exactly those hosts: copy `harfbuzz.wasm`
-// out of this package, serve it, and point the runtime at it before the first
-// editor is created. The build cannot do this part for the consumer, because only
-// the consumer knows where their assets are served from.
-//
-// The loader reads the URL ONCE, at WASM instantiation inside the runtime's first
-// import. That is why the setter refuses late calls instead of ignoring them: a
-// call after the read would change nothing, silently, and the resulting "it is set
-// but not used" is far harder to debug than an immediate error.
+// This module is the canonical explanation of that; everything else points here.
+
+/** Set by the build. False in the CJS output, where the loader is never patched. */
+declare const __DOCX_HARFBUZZ_WASM_URL_SUPPORTED__: boolean | undefined;
+
+/**
+ * Whether the loader in THIS build was patched to read the override.
+ *
+ * Only the ESM build inlines harfbuzzjs and rewrites its glue, so only there does anything
+ * read what the setter stores. Running from source — tests, and any consumer compiling
+ * `src` — has no `define` and behaves like the ESM build, which is the one it mirrors.
+ */
+const wasmUrlSupported = (): boolean =>
+  typeof __DOCX_HARFBUZZ_WASM_URL_SUPPORTED__ === 'undefined' ||
+  __DOCX_HARFBUZZ_WASM_URL_SUPPORTED__;
 
 let overrideUrl: string | null = null;
-let resolvedUrl: string | null = null;
+let readUrl: string | null = null;
+
+/** Absolute where possible, so two spellings of one location compare equal. */
+function normalize(url: string | URL): string {
+  if (url instanceof URL) return url.href;
+  const base = (globalThis as { location?: { href?: string } }).location?.href;
+  try {
+    return base ? new URL(url, base).href : url;
+  } catch {
+    return url;
+  }
+}
 
 /**
  * Point the text shaper at an externally hosted copy of `harfbuzz.wasm`.
  *
  * Needed only under bundlers that do not emit `new URL(..., import.meta.url)`
- * assets — esbuild and Bun today. There, the build succeeds and the shaper fails
- * at runtime with `Aborted(both async and sync fetching of the wasm failed)`
- * (surfaced as a `HarfBuzzShapingError` with code `wasmUnavailable`); this
- * function is the fix. Webpack, Turbopack and Vite emit the binary on their own,
- * and passing a URL there simply overrides theirs.
+ * assets. esbuild and Bun are the common ones, and so is any build that inlines
+ * dynamic imports, such as a library bundle. There, the build succeeds and the
+ * shaper fails at runtime with an `EditorFontError` whose code is
+ * `wasmUnavailable`; this function is the fix. Webpack, Turbopack and Vite emit
+ * the binary on their own, and passing a URL there simply overrides theirs.
  *
  * ```ts
  * import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
  * setHarfBuzzWasmUrl('/static/harfbuzz.wasm');
  * ```
  *
- * Call it before the first editor (or {@link initializeHarfBuzz}) so the runtime
- * has not read its location yet; a later call throws rather than being silently
- * ignored. After a failed load in the same session, reload the page — the module
- * cache pins the errored runtime. The file to serve is exported as
- * `@docx-editor.dev/core/dist/harfbuzz.wasm`, and it must be the copy from the
- * installed package version: the runtime refuses a version mismatch at load
- * rather than shaping with unverified metrics.
+ * Pass a URL your application controls. It is fetched and instantiated as
+ * WebAssembly, so never derive it from user input, a query parameter, or remote
+ * configuration. Serving it cross-origin needs that origin in your `connect-src`
+ * CSP directive, and WebAssembly needs `wasm-unsafe-eval` in `script-src` either
+ * way.
  *
- * Applies to the ESM build. The CJS build loads harfbuzzjs externally, which is
- * a Node path where the default on-disk location already works.
+ * Call it before the first editor is created. The runtime reads the location once
+ * and caches the result, so a call afterwards warns and does nothing: fix the
+ * call site and reload. The file to serve is exported as
+ * `@docx-editor.dev/core/harfbuzz.wasm`, and it must be the copy from the
+ * installed package version, because the runtime refuses a version mismatch at
+ * load rather than shaping with unverified metrics.
  *
  * @public
  */
 export function setHarfBuzzWasmUrl(url: string | URL): void {
-  const next = String(url);
-  if (resolvedUrl !== null && resolvedUrl !== next) {
+  if (typeof url !== 'string' && !(url instanceof URL)) {
+    throw new TypeError(`setHarfBuzzWasmUrl: expected a string or URL, received ${typeof url}`);
+  }
+  if (typeof url === 'string' && url.trim() === '') {
+    throw new TypeError('setHarfBuzzWasmUrl: expected a non-empty URL');
+  }
+  if (!wasmUrlSupported()) {
+    // Refused rather than ignored. The CommonJS build loads harfbuzzjs from node_modules
+    // instead of inlining it, so nothing here would ever be read — and a setter that
+    // silently does nothing is the exact failure this module exists to prevent.
     throw new Error(
-      'setHarfBuzzWasmUrl: the HarfBuzz runtime already resolved its binary from ' +
-        `${resolvedUrl}. Set the URL before the first editor is created.`
+      'setHarfBuzzWasmUrl is not supported by the CommonJS build, which loads the shaper ' +
+        'from node_modules and finds its binary on disk. Import the ESM build instead.'
     );
+  }
+  const next = normalize(url);
+  if (readUrl !== null && readUrl !== next) {
+    // A warning, not a throw. The documented remedy for `wasmUnavailable` is to call this
+    // function, and a consumer who does so from an error handler must not be met with a
+    // second exception — the module cache pins the runtime either way, so the honest
+    // answer is "noted, reload".
+    console.warn(
+      `setHarfBuzzWasmUrl: the shaper already read its binary location from ${readUrl}, ` +
+        'so this call has no effect in the current session. Move the call before the first ' +
+        'editor is created and reload the page.'
+    );
+    return;
   }
   overrideUrl = next;
 }
@@ -70,12 +109,29 @@ export function setHarfBuzzWasmUrl(url: string | URL): void {
  * inlined runtime is its only intended caller.
  */
 export function resolveHarfBuzzWasmBinaryUrl(bundlerResolvedUrl: string): string {
-  resolvedUrl = overrideUrl ?? bundlerResolvedUrl;
-  return resolvedUrl;
+  readUrl = overrideUrl ?? bundlerResolvedUrl;
+  return readUrl;
+}
+
+/**
+ * The remedy text for a runtime that could not load its binary.
+ *
+ * Lives here, beside the API it names, so the advice and the setter cannot drift apart.
+ */
+export function harfBuzzWasmUnavailableDiagnostic(cause: unknown): string {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  const location = readUrl === null ? 'its bundled location' : readUrl;
+  return (
+    `the HarfBuzz WASM binary could not be loaded from ${location}. If this bundler does ` +
+    'not emit `new URL(..., import.meta.url)` assets (esbuild, Bun, and library builds ' +
+    'that inline dynamic imports), serve `@docx-editor.dev/core/harfbuzz.wasm` yourself, ' +
+    "point `setHarfBuzzWasmUrl` from '@docx-editor.dev/core/layout' at it before creating " +
+    `an editor, and reload the page. (${detail})`
+  );
 }
 
 /** Test seam: forget both URLs so one test's override cannot leak into the next. */
 export function resetHarfBuzzWasmUrlForTests(): void {
   overrideUrl = null;
-  resolvedUrl = null;
+  readUrl = null;
 }

--- a/packages/core/src/layout/harfbuzz-wasm-binary.ts
+++ b/packages/core/src/layout/harfbuzz-wasm-binary.ts
@@ -130,6 +130,26 @@ export function harfBuzzWasmUnavailableDiagnostic(cause: unknown): string {
   );
 }
 
+/**
+ * Why the loaded runtime is the wrong version, and what to do about it.
+ *
+ * Worth its own text because the likely cause differs by how the binary got there. A
+ * self-hosted copy (the esbuild/Bun path) goes stale the moment the package is upgraded and
+ * nobody re-copies it — so that case names the file and the step, rather than leaving the
+ * consumer with two version numbers and no instruction.
+ */
+export function harfBuzzVersionMismatchDiagnostic(expected: string, loaded: string): string {
+  const mismatch = `expected HarfBuzz ${expected}, loaded ${loaded}`;
+  if (overrideUrl === null) {
+    return `${mismatch}. The bundled binary does not match this build of the engine.`;
+  }
+  return (
+    `${mismatch}. The copy served at ${overrideUrl} is from a different version of ` +
+    '`@docx-editor.dev/core`. Re-copy `@docx-editor.dev/core/harfbuzz.wasm` from the ' +
+    'installed package into your served assets, and reload the page.'
+  );
+}
+
 /** Test seam: forget both URLs so one test's override cannot leak into the next. */
 export function resetHarfBuzzWasmUrlForTests(): void {
   overrideUrl = null;

--- a/packages/core/src/layout/harfbuzz-wasm-binary.ts
+++ b/packages/core/src/layout/harfbuzz-wasm-binary.ts
@@ -37,11 +37,30 @@ let readUrl: string | null = null;
 function redact(url: string): string {
   try {
     const parsed = new URL(url);
-    return parsed.search || parsed.hash ? `${parsed.origin}${parsed.pathname}…` : url;
+    const carriesSecret =
+      parsed.username !== '' ||
+      parsed.password !== '' ||
+      parsed.search !== '' ||
+      parsed.hash !== '';
+    if (!carriesSecret) return url;
+    // Rebuilt rather than `origin`, which is the string "null" for non-special schemes,
+    // and which would silently keep `user:password@` in the userinfo case.
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}…`;
   } catch {
     const cut = url.search(/[?#]/);
     return cut === -1 ? url : `${url.slice(0, cut)}…`;
   }
+}
+
+/**
+ * `redact` applied to every URL inside free text.
+ *
+ * The `cause` message appended to a diagnostic is written by whoever threw — a fetch error
+ * or an Emscripten abort can embed the full URL it tried, signature and all, which would
+ * put back exactly what redacting our own fields took out.
+ */
+function redactUrlsIn(text: string): string {
+  return text.replace(/[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi, (match) => redact(match));
 }
 
 /** Absolute where possible, so two spellings of one location compare equal. */
@@ -140,22 +159,34 @@ export function resolveHarfBuzzWasmBinaryUrl(bundlerResolvedUrl: string): string
 }
 
 /**
+ * Whether a load failure is the Node runtime itself, not the binary.
+ *
+ * The shim's throw is the marker: a Node that predates `process.getBuiltinModule` cannot
+ * reach the builtin the inlined runtime needs. No URL fixes that, so it must not classify
+ * as `wasmUnavailable` — a host branching on that code would suggest serving a WASM file
+ * to someone whose problem is their Node version.
+ */
+export function isUnsupportedNodeRuntime(cause: unknown): boolean {
+  return cause instanceof Error && /process\.getBuiltinModule/.test(cause.message);
+}
+
+/** The remedy text for {@link isUnsupportedNodeRuntime}: upgrade Node, nothing else. */
+export function harfBuzzUnsupportedRuntimeDiagnostic(cause: unknown): string {
+  const detail = redactUrlsIn(cause instanceof Error ? cause.message : String(cause));
+  return (
+    'the text shaper cannot start on this Node version: the ESM build reaches Node ' +
+    'builtins through `process.getBuiltinModule`, added in Node 20.16 and 22.3. Upgrade ' +
+    `Node; \`setHarfBuzzWasmUrl\` does not apply here. (${detail})`
+  );
+}
+
+/**
  * The remedy text for a runtime that could not load its binary.
  *
  * Lives here, beside the API it names, so the advice and the setter cannot drift apart.
  */
 export function harfBuzzWasmUnavailableDiagnostic(cause: unknown): string {
-  const detail = cause instanceof Error ? cause.message : String(cause);
-  // The one failure in this class that no URL can fix: the Node running this build predates
-  // `process.getBuiltinModule` (the shim's message is the marker). Advising that consumer to
-  // serve a WASM file would send them chasing an asset problem they do not have.
-  if (/process\.getBuiltinModule/.test(detail)) {
-    return (
-      'the text shaper cannot start on this Node version: the ESM build reaches Node ' +
-      'builtins through `process.getBuiltinModule`, added in Node 20.16 and 22.3. Upgrade ' +
-      `Node; \`setHarfBuzzWasmUrl\` does not apply here. (${detail})`
-    );
-  }
+  const detail = redactUrlsIn(cause instanceof Error ? cause.message : String(cause));
   const location = readUrl === null ? 'its bundled location' : redact(readUrl);
   return (
     `the HarfBuzz WASM binary could not be loaded from ${location}. If this bundler does ` +

--- a/packages/core/src/layout/harfbuzz-wasm-binary.ts
+++ b/packages/core/src/layout/harfbuzz-wasm-binary.ts
@@ -1,0 +1,81 @@
+// Where the HarfBuzz runtime finds its `.wasm`, and the one escape hatch for
+// bundlers that lose it.
+//
+// The runtime ships inlined in this package's ESM build, and its loader locates the
+// binary with `new URL('harfbuzz.wasm', import.meta.url)`. Webpack, Turbopack and
+// Vite all recognise that expression, emit `dist/harfbuzz.wasm` as an asset and
+// rewrite the URL — the reason a Next or Vite app needs no configuration. But the
+// pattern is a convention, not a standard: esbuild and Bun leave the expression
+// untouched and emit nothing, so the fetch 404s at runtime with
+// `Aborted(both async and sync fetching of the wasm failed)` after a clean build.
+//
+// {@link setHarfBuzzWasmUrl} exists for exactly those hosts: copy `harfbuzz.wasm`
+// out of this package, serve it, and point the runtime at it before the first
+// editor is created. The build cannot do this part for the consumer, because only
+// the consumer knows where their assets are served from.
+//
+// The loader reads the URL ONCE, at WASM instantiation inside the runtime's first
+// import. That is why the setter refuses late calls instead of ignoring them: a
+// call after the read would change nothing, silently, and the resulting "it is set
+// but not used" is far harder to debug than an immediate error.
+
+let overrideUrl: string | null = null;
+let resolvedUrl: string | null = null;
+
+/**
+ * Point the text shaper at an externally hosted copy of `harfbuzz.wasm`.
+ *
+ * Needed only under bundlers that do not emit `new URL(..., import.meta.url)`
+ * assets — esbuild and Bun today. There, the build succeeds and the shaper fails
+ * at runtime with `Aborted(both async and sync fetching of the wasm failed)`
+ * (surfaced as a `HarfBuzzShapingError` with code `wasmUnavailable`); this
+ * function is the fix. Webpack, Turbopack and Vite emit the binary on their own,
+ * and passing a URL there simply overrides theirs.
+ *
+ * ```ts
+ * import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
+ * setHarfBuzzWasmUrl('/static/harfbuzz.wasm');
+ * ```
+ *
+ * Call it before the first editor (or {@link initializeHarfBuzz}) so the runtime
+ * has not read its location yet; a later call throws rather than being silently
+ * ignored. After a failed load in the same session, reload the page — the module
+ * cache pins the errored runtime. The file to serve is exported as
+ * `@docx-editor.dev/core/dist/harfbuzz.wasm`, and it must be the copy from the
+ * installed package version: the runtime refuses a version mismatch at load
+ * rather than shaping with unverified metrics.
+ *
+ * Applies to the ESM build. The CJS build loads harfbuzzjs externally, which is
+ * a Node path where the default on-disk location already works.
+ *
+ * @public
+ */
+export function setHarfBuzzWasmUrl(url: string | URL): void {
+  const next = String(url);
+  if (resolvedUrl !== null && resolvedUrl !== next) {
+    throw new Error(
+      'setHarfBuzzWasmUrl: the HarfBuzz runtime already resolved its binary from ' +
+        `${resolvedUrl}. Set the URL before the first editor is created.`
+    );
+  }
+  overrideUrl = next;
+}
+
+/**
+ * What the runtime's loader actually reads, wired in at build time.
+ *
+ * The build rewrites the loader's `new URL('harfbuzz.wasm', import.meta.url).href`
+ * into a call through here, keeping the original expression as the argument so
+ * asset-emitting bundlers still see the pattern they rewrite. Not public API: the
+ * inlined runtime is its only intended caller.
+ */
+export function resolveHarfBuzzWasmBinaryUrl(bundlerResolvedUrl: string): string {
+  resolvedUrl = overrideUrl ?? bundlerResolvedUrl;
+  return resolvedUrl;
+}
+
+/** Test seam: forget both URLs so one test's override cannot leak into the next. */
+export function resetHarfBuzzWasmUrlForTests(): void {
+  overrideUrl = null;
+  resolvedUrl = null;
+}

--- a/packages/core/src/layout/harfbuzz-wasm-binary.ts
+++ b/packages/core/src/layout/harfbuzz-wasm-binary.ts
@@ -27,6 +27,23 @@ const wasmUrlSupported = (): boolean =>
 let overrideUrl: string | null = null;
 let readUrl: string | null = null;
 
+/**
+ * A URL safe to put in an error message or the console.
+ *
+ * Signed asset URLs carry their credential in the query string, and diagnostics end up in
+ * logs and bug reports. The path is what a reader needs to recognise the file; the query
+ * and fragment are dropped, with a marker so a redacted URL is not mistaken for the whole.
+ */
+function redact(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.search || parsed.hash ? `${parsed.origin}${parsed.pathname}…` : url;
+  } catch {
+    const cut = url.search(/[?#]/);
+    return cut === -1 ? url : `${url.slice(0, cut)}…`;
+  }
+}
+
 /** Absolute where possible, so two spellings of one location compare equal. */
 function normalize(url: string | URL): string {
   if (url instanceof URL) return url.href;
@@ -91,11 +108,20 @@ export function setHarfBuzzWasmUrl(url: string | URL): void {
     // second exception — the module cache pins the runtime either way, so the honest
     // answer is "noted, reload".
     console.warn(
-      `setHarfBuzzWasmUrl: the shaper already read its binary location from ${readUrl}, ` +
+      `setHarfBuzzWasmUrl: the shaper already read its binary location from ${redact(readUrl)}, ` +
         'so this call has no effect in the current session. Move the call before the first ' +
         'editor is created and reload the page.'
     );
     return;
+  }
+  if (overrideUrl !== null && overrideUrl !== next) {
+    // Two modules configuring one host with DIFFERENT locations is a programming error worth
+    // hearing about, but not worth crashing over: last write wins, said out loud, matching
+    // how the after-read case is handled.
+    console.warn(
+      `setHarfBuzzWasmUrl: replacing ${redact(overrideUrl)} with ${redact(next)}. ` +
+        'Two callers are configuring the shaper with different URLs; the later one wins.'
+    );
   }
   overrideUrl = next;
 }
@@ -120,7 +146,17 @@ export function resolveHarfBuzzWasmBinaryUrl(bundlerResolvedUrl: string): string
  */
 export function harfBuzzWasmUnavailableDiagnostic(cause: unknown): string {
   const detail = cause instanceof Error ? cause.message : String(cause);
-  const location = readUrl === null ? 'its bundled location' : readUrl;
+  // The one failure in this class that no URL can fix: the Node running this build predates
+  // `process.getBuiltinModule` (the shim's message is the marker). Advising that consumer to
+  // serve a WASM file would send them chasing an asset problem they do not have.
+  if (/process\.getBuiltinModule/.test(detail)) {
+    return (
+      'the text shaper cannot start on this Node version: the ESM build reaches Node ' +
+      'builtins through `process.getBuiltinModule`, added in Node 20.16 and 22.3. Upgrade ' +
+      `Node; \`setHarfBuzzWasmUrl\` does not apply here. (${detail})`
+    );
+  }
+  const location = readUrl === null ? 'its bundled location' : redact(readUrl);
   return (
     `the HarfBuzz WASM binary could not be loaded from ${location}. If this bundler does ` +
     'not emit `new URL(..., import.meta.url)` assets (esbuild, Bun, and library builds ' +
@@ -144,7 +180,7 @@ export function harfBuzzVersionMismatchDiagnostic(expected: string, loaded: stri
     return `${mismatch}. The bundled binary does not match this build of the engine.`;
   }
   return (
-    `${mismatch}. The copy served at ${overrideUrl} is from a different version of ` +
+    `${mismatch}. The copy served at ${redact(overrideUrl)} is from a different version of ` +
     '`@docx-editor.dev/core`. Re-copy `@docx-editor.dev/core/harfbuzz.wasm` from the ' +
     'installed package into your served assets, and reload the page.'
   );

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -80,6 +80,7 @@ export {
   type HarfBuzzTextShaperInstrumentation,
   type HarfBuzzTextShaperOptions,
 } from './harfbuzz-shaper.ts';
+export { setHarfBuzzWasmUrl } from './harfbuzz-wasm-binary.ts';
 export {
   UnsupportedScriptError,
   itemizeScriptFontSlots,

--- a/packages/core/src/layout/node-module-shim.ts
+++ b/packages/core/src/layout/node-module-shim.ts
@@ -1,0 +1,50 @@
+// What `module` resolves to inside the shipped bundle.
+//
+// The HarfBuzz runtime's Emscripten glue opens with, in one file serving both runtimes:
+//
+//   if (ENVIRONMENT_IS_NODE) { const { createRequire } = await import("module"); … }
+//
+// The guard is false in a browser, but the specifier still has to RESOLVE, and a browser
+// bundler has nothing to resolve it to. Webpack's Next.js client config stubs `assert`,
+// `buffer`, `crypto`, `path` and a dozen more — not `module`; Turbopack stubs no builtin at
+// all. Both fail the build outright:
+//
+//   Module not found: Can't resolve 'module'
+//
+// Which is a build error every consumer of this package would have to answer for
+// themselves, in a config file, for a branch their code never runs (#282). So the bundle
+// carries harfbuzzjs INLINE with this file aliased over `module`: nothing named `module` is
+// left to resolve, and no host needs a `resolve.fallback` or a `turbopack.resolveAlias`.
+//
+// It still has to be RIGHT under Node, where that branch does run and the runtime reads the
+// `.wasm` off disk through the `require` it builds here. `process.getBuiltinModule` reaches
+// the real builtin with no specifier for a bundler to see (Node 20.16+ / 22.3+), so one
+// bundle serves both: the browser never calls this, and Node gets the genuine article.
+
+interface NodeModuleBuiltin {
+  createRequire(path: string | URL): (id: string) => unknown;
+}
+
+function nodeModuleBuiltin(): NodeModuleBuiltin | undefined {
+  const runtime = globalThis.process as { getBuiltinModule?: (id: string) => unknown } | undefined;
+  if (typeof runtime?.getBuiltinModule !== 'function') return undefined;
+  return runtime.getBuiltinModule('module') as NodeModuleBuiltin;
+}
+
+/**
+ * Node's `module.createRequire`, or a thrower off Node.
+ *
+ * Reached only from the runtime's `ENVIRONMENT_IS_NODE` branch, so the throw is unreachable
+ * in a browser. It is a loud one rather than a silent stub because a Node build that lands
+ * here has lost its file access, and shaping would fail later with a stranger message.
+ */
+export function createRequire(path: string | URL): (id: string) => unknown {
+  const builtin = nodeModuleBuiltin();
+  if (!builtin) {
+    throw new Error(
+      "createRequire is unavailable: this build reaches Node's `module` through " +
+        'process.getBuiltinModule, which needs Node 20.16+ or 22.3+.'
+    );
+  }
+  return builtin.createRequire(path);
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,10 +1,97 @@
+import { copyFile, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'tsup';
+import { defineConfig, type Options } from 'tsup';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig({
+/**
+ * How the inlined HarfBuzz runtime locates its binary, verbatim from the minified glue.
+ *
+ * Two separate exactness claims, easy to conflate: the string must match the glue SOURCE
+ * character for character (that is what the plugin's needle search is), while consumer
+ * bundlers match the emitted `new URL(<literal>, import.meta.url)` pattern syntactically —
+ * output whitespace does not matter to them, only that the rewrite keeps the expression a
+ * recognisable URL construction rather than folding it into something else.
+ *
+ * Exported for `subpath-tables.test.ts`, which asserts the installed glue still contains it
+ * exactly once — so a harfbuzzjs bump that reshapes the glue fails in the TEST suite, not
+ * only later in the build.
+ */
+export const WASM_URL_EXPRESSION = 'new URL("harfbuzz.wasm",import.meta.url).href';
+
+/**
+ * Route the runtime's WASM URL through `setHarfBuzzWasmUrl` (#282's escape hatch).
+ *
+ * The glue reads `new URL("harfbuzz.wasm", import.meta.url)` once at instantiation.
+ * Bundlers that emit that pattern as an asset (webpack, Turbopack, Vite) need nothing else;
+ * bundlers that do not (esbuild, Bun) build clean and then 404 the fetch at runtime. The
+ * consumer-facing fix for those is `setHarfBuzzWasmUrl` in `src/layout/harfbuzz-wasm-binary.ts`,
+ * and this plugin is its other half: it wraps the glue's expression in a call through that
+ * module, override first, original expression as the fallback argument — still syntactically
+ * intact for the bundlers that rewrite it.
+ *
+ * The count guard is a version-bump tripwire: a harfbuzzjs release that renames the binary or
+ * builds different glue must fail THIS build, not ship an escape hatch that silently stopped
+ * being wired to anything.
+ */
+const harfBuzzWasmUrlEscapeHatch: NonNullable<Options['esbuildPlugins']>[number] = {
+  name: 'harfbuzz-wasm-url-escape-hatch',
+  setup(build) {
+    build.onLoad({ filter: /harfbuzzjs[/\\]dist[/\\]harfbuzz\.js$/ }, async (args) => {
+      const source = await readFile(args.path, 'utf8');
+      const occurrences = source.split(WASM_URL_EXPRESSION).length - 1;
+      if (occurrences !== 1) {
+        throw new Error(
+          `expected exactly one \`${WASM_URL_EXPRESSION}\` in ${args.path}, found ${occurrences}. ` +
+            'The harfbuzzjs glue changed shape; re-point this plugin before shipping, or ' +
+            'setHarfBuzzWasmUrl silently stops working.'
+        );
+      }
+      const resolver = JSON.stringify(resolve(here, 'src/layout/harfbuzz-wasm-binary.ts'));
+      const contents =
+        `import{resolveHarfBuzzWasmBinaryUrl as __docxResolveHarfBuzzWasmBinaryUrl}from${resolver};` +
+        source.replace(
+          WASM_URL_EXPRESSION,
+          `__docxResolveHarfBuzzWasmBinaryUrl(${WASM_URL_EXPRESSION})`
+        );
+      return { contents, loader: 'js' };
+    });
+  },
+};
+
+/**
+ * Put HarfBuzz's `.wasm` beside the bundle that now contains its loader.
+ *
+ * The loader finds its binary with `new URL('harfbuzz.wasm', import.meta.url)`. Inlining the
+ * loader into the ESM bundle moves that URL from harfbuzzjs's own directory to this
+ * package's `dist/`, so the file has to be there — for Node, which reads it off disk, and
+ * for every consumer bundler, which rewrites that expression into an emitted asset only if
+ * the target exists at build time. Resolved through harfbuzzjs's export map rather than a
+ * hand-written node_modules path, so a hoisted or linked install finds it the same way.
+ */
+async function copyHarfBuzzBinary(): Promise<void> {
+  // Two assumptions worth naming when they break: `import.meta.resolve` survives only while
+  // this config loads as ESM (a `.cts` rename or dropping `"type": "module"` kills it), and
+  // the binary is assumed to sit beside harfbuzzjs's export-map entry.
+  try {
+    const entry = fileURLToPath(import.meta.resolve('harfbuzzjs'));
+    await copyFile(resolve(dirname(entry), 'harfbuzz.wasm'), resolve(here, 'dist/harfbuzz.wasm'));
+  } catch (error) {
+    throw new Error(
+      `copyHarfBuzzBinary: could not copy harfbuzz.wasm into dist/. Either import.meta.resolve ` +
+        `is unavailable in this config's module format, or harfbuzzjs moved its binary. (${String(error)})`
+    );
+  }
+}
+
+/**
+ * Everything the two format builds agree on.
+ *
+ * They are separate builds for ONE reason, spelled out at `esm` below: the ESM bundle
+ * inlines harfbuzzjs and the CJS bundle cannot.
+ */
+const shared = {
   // One entry per published subpath. Keep this in step with `exports` in
   // package.json: a subpath with no entry here resolves to a missing file.
   entry: {
@@ -25,13 +112,11 @@ export default defineConfig({
   // bundled deps through their `node` export condition, and fflate's node build
   // runs `createRequire` at module top level and throws in a browser.
   platform: 'browser',
-  format: ['cjs', 'esm'],
   dts: true,
   // Many entries share the engine's internals. Splitting emits them once into
   // shared chunks instead of copying them into all fourteen bundles.
   splitting: true,
   sourcemap: false,
-  clean: true,
   treeshake: true,
   minify: true,
   // `scripts/generate-third-party-notices.mjs` reads `dist/metafile-*.json` to learn
@@ -40,7 +125,7 @@ export default defineConfig({
   // the most of them: fast-xml-parser, fflate and the prosemirror-* family all end up as
   // source inside `dist/`.
   metafile: true,
-  external: ['harfbuzzjs', 'emf-converter', 'utif2'],
+  external: ['emf-converter', 'utif2'],
   // The engine's own files import it by package name ('@docx-editor.dev/core/store'
   // and friends), which resolved through the export map back when that map pointed
   // at src. Now that it points at dist, the build has to be told where source is,
@@ -51,6 +136,10 @@ export default defineConfig({
   // because core-lane-graph.test.ts reads that file with a plain JSON.parse.
   esbuildOptions(options) {
     options.alias = {
+      // See `src/layout/node-module-shim.ts`: the inlined HarfBuzz runtime asks for Node's
+      // `module` behind a guard no browser runs, and this is what it gets instead. Harmless
+      // in the CJS build, which inlines nothing that asks for it.
+      module: resolve(here, 'src/layout/node-module-shim.ts'),
       '@docx-editor.dev/core': resolve(here, 'src/index.ts'),
       '@docx-editor.dev/core/automation': resolve(here, 'src/automation/index.ts'),
       '@docx-editor.dev/core/binding': resolve(here, 'src/binding/index.ts'),
@@ -65,4 +154,40 @@ export default defineConfig({
       '@docx-editor.dev/core/editor': resolve(here, 'src/editor/index.ts'),
     };
   },
-});
+} satisfies Options;
+
+export default defineConfig([
+  // tsup runs an array config CONCURRENTLY (Promise.all), so neither build may clean:
+  // a `clean: true` here would race the other build's output. The package `build`
+  // script empties `dist/` before tsup starts, which is the only ordering tsup
+  // actually guarantees.
+  {
+    ...shared,
+    format: ['esm'],
+    clean: false,
+    onSuccess: copyHarfBuzzBinary,
+    // THE POINT OF THE SPLIT. Left external, harfbuzzjs reaches the consumer's bundler with
+    // an `await import("module")` that no browser target can resolve, and every host has to
+    // answer for it in its own config (#282). Inlined, the `module` alias above answers it
+    // once, here. `external` alone would not do it: tsup externalizes every `dependencies`
+    // entry by default, so it has to be named here to be pulled in.
+    //
+    // This also makes harfbuzzjs the one dependency esbuild inlines, so it is the one whose
+    // licence `notices:generate` must reproduce — which it does, from the metafile, on its
+    // own.
+    noExternal: ['harfbuzzjs'],
+    // Only meaningful here: the CJS build leaves harfbuzzjs external, so its glue never
+    // passes through esbuild there.
+    esbuildPlugins: [harfBuzzWasmUrlEscapeHatch],
+  },
+  {
+    ...shared,
+    format: ['cjs'],
+    clean: false,
+    // harfbuzzjs stays EXTERNAL here, because it cannot be inlined: its entry is a
+    // top-level `await` over the WASM instantiation, and CJS has no top-level await. That
+    // costs nothing. This output exists for `require()`, which is Node, where `module`
+    // resolves natively and #282 cannot happen. Browser bundlers take the `import`
+    // condition and get the bundle above.
+  },
+]);

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -31,13 +31,14 @@ export const WASM_URL_EXPRESSION = 'new URL("harfbuzz.wasm",import.meta.url).hre
  * module, override first, original expression as the fallback argument — still syntactically
  * intact for the bundlers that rewrite it.
  *
- * The count guard is a version-bump tripwire: a harfbuzzjs release that renames the binary or
- * builds different glue must fail THIS build, not ship an escape hatch that silently stopped
- * being wired to anything.
+ * TWO guards, because either one alone fails open. The count guard catches a glue that
+ * changed shape. The applied guard catches a glue that MOVED: `onLoad` simply never fires,
+ * nothing throws, and the build would otherwise ship an escape hatch wired to nothing.
  */
 const harfBuzzWasmUrlEscapeHatch: NonNullable<Options['esbuildPlugins']>[number] = {
   name: 'harfbuzz-wasm-url-escape-hatch',
   setup(build) {
+    let applied = 0;
     build.onLoad({ filter: /harfbuzzjs[/\\]dist[/\\]harfbuzz\.js$/ }, async (args) => {
       const source = await readFile(args.path, 'utf8');
       const occurrences = source.split(WASM_URL_EXPRESSION).length - 1;
@@ -48,14 +49,27 @@ const harfBuzzWasmUrlEscapeHatch: NonNullable<Options['esbuildPlugins']>[number]
             'setHarfBuzzWasmUrl silently stops working.'
         );
       }
+      applied += 1;
       const resolver = JSON.stringify(resolve(here, 'src/layout/harfbuzz-wasm-binary.ts'));
       const contents =
         `import{resolveHarfBuzzWasmBinaryUrl as __docxResolveHarfBuzzWasmBinaryUrl}from${resolver};` +
+        // A replacement FUNCTION, not a string: `$&`, `$'` and `$1` are substitution
+        // patterns in a replacement string, so the day the needle grows a `$` a plain
+        // string would silently rewrite into something else.
         source.replace(
           WASM_URL_EXPRESSION,
-          `__docxResolveHarfBuzzWasmBinaryUrl(${WASM_URL_EXPRESSION})`
+          () => `__docxResolveHarfBuzzWasmBinaryUrl(${WASM_URL_EXPRESSION})`
         );
       return { contents, loader: 'js' };
+    });
+    build.onEnd(() => {
+      if (applied !== 1) {
+        throw new Error(
+          `harfbuzz-wasm-url-escape-hatch patched ${applied} files, expected exactly 1. ` +
+            "The glue is no longer at harfbuzzjs/dist/harfbuzz.js, so setHarfBuzzWasmUrl " +
+            'would ship wired to nothing; re-point the onLoad filter.'
+        );
+      }
     });
   },
 };
@@ -179,11 +193,15 @@ export default defineConfig([
     // Only meaningful here: the CJS build leaves harfbuzzjs external, so its glue never
     // passes through esbuild there.
     esbuildPlugins: [harfBuzzWasmUrlEscapeHatch],
+    // Which is exactly why `setHarfBuzzWasmUrl` has to know which build it is in: patched
+    // here, inert in CJS, and it refuses rather than no-ops there.
+    define: { __DOCX_HARFBUZZ_WASM_URL_SUPPORTED__: 'true' },
   },
   {
     ...shared,
     format: ['cjs'],
     clean: false,
+    define: { __DOCX_HARFBUZZ_WASM_URL_SUPPORTED__: 'false' },
     // harfbuzzjs stays EXTERNAL here, because it cannot be inlined: its entry is a
     // top-level `await` over the WASM instantiation, and CJS has no top-level await. That
     // costs nothing. This output exists for `require()`, which is Node, where `module`

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -150,10 +150,6 @@ const shared = {
   // because core-lane-graph.test.ts reads that file with a plain JSON.parse.
   esbuildOptions(options) {
     options.alias = {
-      // See `src/layout/node-module-shim.ts`: the inlined HarfBuzz runtime asks for Node's
-      // `module` behind a guard no browser runs, and this is what it gets instead. Harmless
-      // in the CJS build, which inlines nothing that asks for it.
-      module: resolve(here, 'src/layout/node-module-shim.ts'),
       '@docx-editor.dev/core': resolve(here, 'src/index.ts'),
       '@docx-editor.dev/core/automation': resolve(here, 'src/automation/index.ts'),
       '@docx-editor.dev/core/binding': resolve(here, 'src/binding/index.ts'),
@@ -193,6 +189,17 @@ export default defineConfig([
     // Only meaningful here: the CJS build leaves harfbuzzjs external, so its glue never
     // passes through esbuild there.
     esbuildPlugins: [harfBuzzWasmUrlEscapeHatch],
+    // Scoped to THIS build, not `shared`. Only the ESM bundle inlines the runtime that asks
+    // for `module`, and aliasing a bare Node specifier package-wide would hand any future
+    // bundled dependency a stub that silently lacks `builtinModules` instead of failing the
+    // build. See `src/layout/node-module-shim.ts`.
+    esbuildOptions(options) {
+      shared.esbuildOptions(options);
+      options.alias = {
+        ...options.alias,
+        module: resolve(here, 'src/layout/node-module-shim.ts'),
+      };
+    },
     // Which is exactly why `setHarfBuzzWasmUrl` has to know which build it is in: patched
     // here, inert in CJS, and it refuses rather than no-ops there.
     define: { __DOCX_HARFBUZZ_WASM_URL_SUPPORTED__: 'true' },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,7 +67,6 @@
     "@radix-ui/react-select": "^2.3.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "emf-converter": "2.0.2",
-    "harfbuzzjs": "1.6.0"
+    "emf-converter": "2.0.2"
   }
 }

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -39,5 +39,5 @@ export default defineConfig({
   // the adapter painted from another.
   // emf-converter is lazily imported; external keeps the metafile rasterizer out of
   // the main bundle.
-  external: ['react', 'react-dom', 'harfbuzzjs', 'emf-converter'],
+  external: ['react', 'react-dom', 'emf-converter'],
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@docx-editor.dev/core": "workspace:*",
     "@docx-editor.dev/i18n": "workspace:*",
-    "emf-converter": "2.0.2"
+    "emf-converter": "2.0.2",
+    "harfbuzzjs": "1.6.0"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "@docx-editor.dev/core": "workspace:*",
     "@docx-editor.dev/i18n": "workspace:*",
-    "emf-converter": "2.0.2",
-    "harfbuzzjs": "1.6.0"
+    "emf-converter": "2.0.2"
   }
 }

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -48,7 +48,11 @@ export default defineConfig({
       cssFileName: 'docx-editor-vue',
     },
     rollupOptions: {
-      external: (id) => id === 'vue' || id === 'emf-converter',
+      // harfbuzzjs must stay external HERE even though core's ESM build inlines it:
+      // this build inlines core from SOURCE and emits a CJS variant, and harfbuzzjs's
+      // entry is a top-level await, which CJS cannot carry. Removing this marker once
+      // as "dead config" broke the build outright.
+      external: (id) => id === 'vue' || id === 'harfbuzzjs' || id === 'emf-converter',
     },
     emptyOutDir: true,
   },

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
       cssFileName: 'docx-editor-vue',
     },
     rollupOptions: {
-      external: (id) => id === 'vue' || id === 'harfbuzzjs' || id === 'emf-converter',
+      external: (id) => id === 'vue' || id === 'emf-converter',
     },
     emptyOutDir: true,
   },

--- a/scripts/check-shipped-shaper.mjs
+++ b/scripts/check-shipped-shaper.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+//
+// Assert the SHIPPED bundle, not the config that produced it.
+//
+//   bun run check:shipped-shaper     # after `bun run build:packages`
+//
+// Issue #282 was a property of core's OUTPUT: a bare `module` specifier reaching a
+// consumer's bundler. Every guard added with the fix checks an input — the tsup config
+// object, the vendor's source, the plugin's own application count. None of them reads
+// `dist/`, so the one thing a consumer actually installs was the one thing nothing
+// asserted. These are the four greps that would have caught the bug, and would catch a
+// regression in a dependency bump, an esbuild upgrade, or a config refactor that still
+// type-checks.
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const dist = path.join(root, 'packages/core/dist');
+const failures = [];
+
+if (!existsSync(dist)) {
+  console.error('packages/core/dist is missing — run `bun run build:packages` first.');
+  process.exit(1);
+}
+
+const files = readdirSync(dist);
+const esm = files.filter((file) => file.endsWith('.js'));
+const cjs = files.filter((file) => file.endsWith('.cjs'));
+const read = (file) => readFileSync(path.join(dist, file), 'utf8');
+
+// 1. The bug itself. A browser bundler cannot resolve Node's `module`, and the guard that
+//    would skip it is a runtime value, so the specifier must not survive at all.
+const MODULE_SPECIFIER = /(?:from\s*["']module["']|import\(\s*["']module["']\s*\))/;
+for (const file of esm) {
+  if (MODULE_SPECIFIER.test(read(file))) {
+    failures.push(`${file} still imports Node's \`module\`; browser builds will fail (#282)`);
+  }
+}
+
+// 2. The binary the inlined loader looks for, beside the bundle that looks for it.
+const wasm = path.join(dist, 'harfbuzz.wasm');
+if (!existsSync(wasm) || statSync(wasm).size === 0) {
+  failures.push('dist/harfbuzz.wasm is missing or empty; every browser consumer 404s at runtime');
+}
+
+// 3. The escape hatch, actually wired. The build asserts the patch was APPLIED; this asserts
+//    it survived treeshaking and minification into the emitted glue.
+const glue = esm.filter((file) => read(file).includes('harfbuzz.wasm'));
+if (glue.length === 0) {
+  failures.push('no ESM chunk references harfbuzz.wasm; the runtime was not inlined');
+} else if (!glue.some((file) => /\w+\(new URL\("harfbuzz\.wasm",\s*import\.meta\.url\)\.href\)/.test(read(file)))) {
+  failures.push(
+    'the emitted glue reads harfbuzz.wasm directly; setHarfBuzzWasmUrl is wired to nothing'
+  );
+}
+
+// 4. The CJS half of the split. It CANNOT inline harfbuzzjs (top-level await), so a change
+//    that accidentally inlines it there would break `require()` consumers outright.
+if (!cjs.some((file) => /import\(\s*['"]harfbuzzjs['"]\s*\)/.test(read(file)))) {
+  failures.push('no CJS chunk imports harfbuzzjs externally; the format split has broken');
+}
+
+if (failures.length > 0) {
+  console.error('Shipped shaper checks failed:');
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+console.log(`check:shipped-shaper: core's dist ships a browser-resolvable shaper`);

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -222,6 +222,24 @@ function renderNotices(pkg, dependencies) {
     ''
   );
 
+  // A metafile only sees what esbuild READ. Binary assets copied into `dist/` after the
+  // bundle — `harfbuzz.wasm`, the font files — are shipped third-party code this generator
+  // is structurally blind to, so their attribution is carried by hand in `licenses/` and
+  // pointed at from here rather than being silently omitted.
+  if (existsSync(path.join(pkg.dir, 'licenses'))) {
+    const carried = readdirSync(path.join(pkg.dir, 'licenses')).sort();
+    if (carried.length > 0) {
+      lines.push(
+        'This package also ships prebuilt third-party assets that are not esbuild inputs,',
+        'so they cannot appear below. Their licenses travel with the package in',
+        '`licenses/`:',
+        '',
+        ...carried.map((file) => `- \`licenses/${file}\``),
+        ''
+      );
+    }
+  }
+
   if (dependencies.length === 0) {
     lines.push('No third-party code is bundled into this package.', '');
     return lines.join('\n');


### PR DESCRIPTION
Fixes #282.

harfbuzzjs's glue opens with `await import("module")` behind a Node-only guard. The guard never runs in a browser, but the specifier still has to resolve, and Next's webpack client fallback list does not cover `module` while Turbopack stubs no builtin at all. Client builds failed on resolution alone, so every consumer had to patch their own bundler config. It was never a Next.js problem: plain esbuild and Bun fail the same way, and Vite only passes because it substitutes a stub.

The ESM build now inlines harfbuzzjs with `module` aliased to a shim that reaches the real builtin through `process.getBuiltinModule`, so no specifier reaches a consumer's bundler and Node still gets the genuine article. CJS keeps harfbuzzjs external: its entry is a top-level await, which CJS cannot carry, and `require()` is Node, where `module` resolves natively.

`harfbuzz.wasm` ships with the package, exported as `./harfbuzz.wasm`, and the loader finds it through `new URL(..., import.meta.url)`. Webpack, Turbopack and Vite emit that as an asset; esbuild and Bun do not, and build clean before 404ing at runtime. For them `setHarfBuzzWasmUrl` points the shaper at a self-hosted copy.

That failure is typed rather than narrated. `EditorFontError` gains a `wasmUnavailable` code so a host branches on a code instead of matching English inside `diagnostic`, and the engine logs it once even with no `onFontError` registered — this one disables shaping for the entire document, and the same misconfiguration used to fail the build outright. Classification does not match Emscripten's wording: anything that is not the version pin is the runtime being unavailable, which also covers `ENOENT` on a server and a CSP without `wasm-unsafe-eval`. `setHarfBuzzWasmUrl` warns instead of throwing when it arrives too late, since calling it is the documented remedy, and refuses outright in the CJS build, where nothing would read it.

The shipped `harfbuzz.wasm` is compiled HarfBuzz, whose upstream notice no metafile can see, so it travels in `licenses/`. `react` and `vue` drop a `harfbuzzjs` dependency neither imports, which also removes a second version pin that could put two copies of the shaper in one tree.

No `engines` field: the Node floor binds only server-side ESM shaping, but `engines` gates install for browser-only consumers who never reach that branch, and the shim already throws precisely when it matters.

Verified against the packed tarball with no consumer configuration, each target fetching the WASM and shaping to byte-identical glyph advances under HarfBuzz 14.3.0: Next 16.2.7 webpack and Turbopack, Vite build and dev, Node ESM and CJS. esbuild and Bun verified both ways — without configuration they fail with a `wasmUnavailable` diagnostic that names the fix and the file, and with `setHarfBuzzWasmUrl` they shape identically. `examples/agent` builds under both Next bundlers with its stub and `resolveAlias` deleted here.
