### PR TITLE
test(bench): stop the sustained median gate failing on a clock tick

### DIFF
--- a/e2e/edit-browser-bench-gates.ts
+++ b/e2e/edit-browser-bench-gates.ts
@@ -51,7 +51,7 @@ const TIMING_P95_FLOOR_MS = 50;
  * p95-vs-median and the sustained max-sample ceilings — to console warnings. On a
  * shared CI runner one scheduler stall is enough to trip them, and the CI benchmark
  * job treats wall clock as advisory. Everything median-based or structural (work
- * counters, growth percentages, heap, DOM size) stays a hard assertion in every mode.
+ * counters, median growth, heap, DOM size) stays a hard assertion in every mode.
  */
 const TIMING_TAILS_WARN = process.env.EDIT_BROWSER_BENCH_TIMING_TAILS === 'warn';
 
@@ -69,8 +69,46 @@ function expectTailCeiling(actual: number, ceiling: number, label: string): void
 const ENGINE_TO_INPUT_FACTOR = 5;
 const ENGINE_TO_INPUT_FLOOR_MS = 500;
 
-/** Sustained typing compares first/last windows; 100% median growth flags unbounded backlog. */
-const SUSTAINED_MEDIAN_GROWTH_PCT = 100;
+/**
+ * Sustained typing compares the first and last 10-sample windows: a median that
+ * doubles over the run is the shape of an unbounded backlog.
+ *
+ * The ratio cannot carry the gate on its own. Outside a cross-origin-isolated page
+ * Chromium clamps `performance.now()` to 100 µs, and what this measures — the
+ * SYNCHRONOUS `beforeinput` handler, with nothing waiting on a frame inside it —
+ * medians at 0.1 to 0.3 ms on CI, with 0.4 ms the worst single sample across 120
+ * edits. On that grid one clock tick IS "+100%", which is where the runs that
+ * failed pull requests with an exact `Received: 100` came from. A bigger window or
+ * a mean would not fix it: every sample is already quantised to the same 0.1 ms,
+ * and the median is the statistic that survives a scheduler stall on a shared
+ * runner. The threshold is what was wrong, not the statistic.
+ *
+ * So each median gate pairs the ratio with an absolute floor — the same
+ * `Math.max(ratio, floor)` shape as the tail gates above. Growth has to be a
+ * doubling AND larger than anything the clock could have invented.
+ */
+const SUSTAINED_MEDIAN_GROWTH_FACTOR = 2;
+/**
+ * Ten clock ticks, and more than twice the worst single input-task sample CI has
+ * produced. Quantisation cannot reach it; a handler whose cost grows with the
+ * number of edits leaves it behind within a few dozen keystrokes.
+ */
+const SUSTAINED_INPUT_MEDIAN_FLOOR_MS = 1;
+/**
+ * Frame medians run 80-260 ms — two frames plus layout and paint — so the clock
+ * grid is nowhere near them and this floor almost never binds. It keeps the two
+ * median gates one shape, and covers a frame median that ever does get small.
+ */
+const SUSTAINED_FRAME_MEDIAN_FLOOR_MS = 16;
+/**
+ * The floor trades away sensitivity to small growth; this takes back the case that
+ * matters, which no ratio can see at all: a regression already present in the FIRST
+ * window reads as 0% growth forever. Half a frame of synchronous work per keystroke
+ * is a typing regression whether or not it grew. 8 ms is 20× the worst single
+ * sample observed, so it stays quiet until something is genuinely wrong — the same
+ * bargain as the absolute burst-navigation median ceiling below.
+ */
+const SUSTAINED_INPUT_MEDIAN_CEILING_MS = 8;
 
 /** Post-GC heap after 180 edits should stay below 50 MiB on the synthetic fixture. */
 const SUSTAINED_HEAP_CEILING_BYTES = 50 * 1024 * 1024;
@@ -138,15 +176,49 @@ export function assertCrossScenarioLatencyGates(reports: readonly ScenarioReport
   }
 }
 
+/**
+ * Reports the pair and the ceiling, never the bare percentage: `0.20 ms → 0.60 ms
+ * (+200.0%), ceiling 1.20 ms` tells a human what moved, by how much, and what it
+ * had to beat. A percentage of a tenth of a millisecond tells them nothing.
+ */
+function expectSustainedMedianGrowth(
+  first: TimingSummary,
+  last: TimingSummary,
+  changePct: number,
+  floorMs: number,
+  label: string
+): void {
+  const ceilingMs = Math.max(
+    first.medianMs * SUSTAINED_MEDIAN_GROWTH_FACTOR,
+    first.medianMs + floorMs
+  );
+  const sign = changePct >= 0 ? '+' : '';
+  expect(
+    last.medianMs,
+    `${label}: ${first.medianMs.toFixed(2)} ms → ${last.medianMs.toFixed(2)} ms ` +
+      `(${sign}${changePct.toFixed(1)}%), ceiling ${ceilingMs.toFixed(2)} ms`
+  ).toBeLessThanOrEqual(ceilingMs);
+}
+
 export function assertSustainedLatencyGates(sustained: SustainedReport): void {
-  expect(
+  expectSustainedMedianGrowth(
+    sustained.firstInputTask,
+    sustained.lastInputTask,
     sustained.inputMedianChangePct,
-    `${sustained.mode} sustained input median change`
-  ).toBeLessThan(SUSTAINED_MEDIAN_GROWTH_PCT);
+    SUSTAINED_INPUT_MEDIAN_FLOOR_MS,
+    `${sustained.mode} sustained input median`
+  );
   expect(
+    sustained.lastInputTask.medianMs,
+    `${sustained.mode} sustained input median after ${sustained.edits} edits`
+  ).toBeLessThanOrEqual(SUSTAINED_INPUT_MEDIAN_CEILING_MS);
+  expectSustainedMedianGrowth(
+    sustained.firstFrame,
+    sustained.lastFrame,
     sustained.frameMedianChangePct,
-    `${sustained.mode} sustained frame median change`
-  ).toBeLessThan(SUSTAINED_MEDIAN_GROWTH_PCT);
+    SUSTAINED_FRAME_MEDIAN_FLOOR_MS,
+    `${sustained.mode} sustained frame median`
+  );
   expectTailCeiling(
     sustained.maxInputTaskMs,
     Math.max(
@@ -161,7 +233,13 @@ export function assertSustainedLatencyGates(sustained: SustainedReport): void {
     `${sustained.mode} sustained max frame`
   );
   if (sustained.heapChangeBytes !== null) {
-    expect(sustained.heapChangeBytes).toBeLessThan(SUSTAINED_HEAP_CEILING_BYTES);
+    // An absolute byte delta, so the clock grid never reaches it — but it used to
+    // fail as a bare nine-digit number with no label at all.
+    expect(
+      sustained.heapChangeBytes,
+      `${sustained.mode} sustained heap growth after ${sustained.edits} edits ` +
+        `(${(sustained.heapChangeBytes / 1024 / 1024).toFixed(1)} MiB)`
+    ).toBeLessThan(SUSTAINED_HEAP_CEILING_BYTES);
   }
 }
 

--- a/scripts/bench/edit-browser-bench-gates.test.ts
+++ b/scripts/bench/edit-browser-bench-gates.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+import { assertSustainedLatencyGates } from '../../e2e/edit-browser-bench-gates.js';
+import { percentChange, type TimingSummary } from '../../e2e/edit-browser-bench-harness.js';
+import { type SustainedReport } from '../../e2e/edit-browser-bench-probe.js';
+
+/**
+ * The sustained gates decide whether a pull request lands, from numbers a browser
+ * produces in ten minutes. They are plain arithmetic over a report, so they run
+ * here in milliseconds — feed the boundary values by hand and see which side of
+ * the gate they fall on.
+ *
+ * Next to `edit-bench-gates.test.ts`, which does the same job for the headless
+ * benchmark, and not next to the module it imports: `bun run test` walks
+ * `packages/` and `scripts/`, so a test under `e2e/` would run on no machine but
+ * the one it was written on.
+ *
+ * The numbers below are the ones CI actually reports: the input-task median is the
+ * synchronous `beforeinput` handler on a clock clamped to 100 µs, so it lands on
+ * 0.1, 0.2 or 0.3 ms, and the frame median lands near 100 ms.
+ */
+function summary(medianMs: number, p95Ms = medianMs): TimingSummary {
+  return { medianMs, p95Ms, minMs: medianMs, maxMs: p95Ms };
+}
+
+function sustainedReport(overrides: {
+  firstInputTaskMs: number;
+  lastInputTaskMs: number;
+  firstFrameMs?: number;
+  lastFrameMs?: number;
+}): SustainedReport {
+  const firstInputTask = summary(overrides.firstInputTaskMs, overrides.firstInputTaskMs + 0.2);
+  const lastInputTask = summary(overrides.lastInputTaskMs, overrides.lastInputTaskMs + 0.2);
+  const firstFrame = summary(overrides.firstFrameMs ?? 100, (overrides.firstFrameMs ?? 100) + 40);
+  const lastFrame = summary(overrides.lastFrameMs ?? 100, (overrides.lastFrameMs ?? 100) + 40);
+  return {
+    mode: 'edit',
+    edits: 120,
+    warmupEdits: 20,
+    windowSize: 10,
+    firstInputTask,
+    lastInputTask,
+    inputMedianChangePct: percentChange(lastInputTask.medianMs, firstInputTask.medianMs),
+    firstFrame,
+    lastFrame,
+    frameMedianChangePct: percentChange(lastFrame.medianMs, firstFrame.medianMs),
+    // Tails and heap sit well inside their own ceilings: these cases are about the
+    // median gates and nothing else.
+    maxInputTaskMs: lastInputTask.p95Ms,
+    maxFrameMs: lastFrame.p95Ms,
+    heapBeforeBytes: 100_000_000,
+    heapAfterBytes: 100_000_000,
+    heapChangeBytes: 0,
+  };
+}
+
+describe('sustained input median gate', () => {
+  test('passes the single clock tick that reads as an exact +100%', () => {
+    // 0.1 -> 0.2 ms: one 100 µs tick, the failure that turned up three times on
+    // two unrelated branches as `Expected: < 100 / Received: 100`.
+    const report = sustainedReport({ firstInputTaskMs: 0.1, lastInputTaskMs: 0.2 });
+    expect(report.inputMedianChangePct).toBe(100);
+    expect(() => assertSustainedLatencyGates(report)).not.toThrow();
+  });
+
+  test('passes 99.9% and 200% growth while the medians stay sub-millisecond', () => {
+    const justUnder = sustainedReport({ firstInputTaskMs: 0.1, lastInputTaskMs: 0.1999 });
+    expect(justUnder.inputMedianChangePct).toBeCloseTo(99.9, 1);
+    expect(() => assertSustainedLatencyGates(justUnder)).not.toThrow();
+
+    // Two ticks on a 0.1 ms baseline. Nothing a user could feel, and nothing the
+    // clock could not have produced on its own.
+    const tripled = sustainedReport({ firstInputTaskMs: 0.1, lastInputTaskMs: 0.3 });
+    expect(tripled.inputMedianChangePct).toBeCloseTo(200, 6);
+    expect(() => assertSustainedLatencyGates(tripled)).not.toThrow();
+  });
+
+  test('fails growth past the absolute floor, however small the ratio', () => {
+    // 0.2 -> 1.4 ms is only 7×, but it is 1.2 ms of real work the first window did
+    // not do: past the floor, the doubling rule is back in charge.
+    const report = sustainedReport({ firstInputTaskMs: 0.2, lastInputTaskMs: 1.4 });
+    expect(() => assertSustainedLatencyGates(report)).toThrow(/sustained input median/);
+  });
+
+  test('fails a backlog that grows the handler into milliseconds', () => {
+    const report = sustainedReport({ firstInputTaskMs: 0.2, lastInputTaskMs: 6 });
+    expect(() => assertSustainedLatencyGates(report)).toThrow(/0\.20 ms → 6\.00 ms \(\+2900\.0%\)/);
+  });
+
+  test('holds the doubling rule once medians are large enough to mean it', () => {
+    const doubled = sustainedReport({ firstInputTaskMs: 4, lastInputTaskMs: 8.1 });
+    expect(() => assertSustainedLatencyGates(doubled)).toThrow(/sustained input median/);
+
+    const grewLess = sustainedReport({ firstInputTaskMs: 4, lastInputTaskMs: 7.9 });
+    expect(() => assertSustainedLatencyGates(grewLess)).not.toThrow();
+  });
+
+  test('fails a flat regression no ratio can see', () => {
+    // 0% growth: the handler was already blocking for 9 ms in the first window.
+    const report = sustainedReport({ firstInputTaskMs: 9, lastInputTaskMs: 9 });
+    expect(report.inputMedianChangePct).toBe(0);
+    expect(() => assertSustainedLatencyGates(report)).toThrow(
+      /sustained input median after 120 edits/
+    );
+  });
+
+  test('gates a window whose median rounds to zero instead of reporting 0%', () => {
+    // `percentChange` returns 0 when the baseline is 0, so the old ratio was blind
+    // here. The floor still holds the last window to 1 ms.
+    const idle = sustainedReport({ firstInputTaskMs: 0, lastInputTaskMs: 0.3 });
+    expect(idle.inputMedianChangePct).toBe(0);
+    expect(() => assertSustainedLatencyGates(idle)).not.toThrow();
+
+    const backlogged = sustainedReport({ firstInputTaskMs: 0, lastInputTaskMs: 3 });
+    expect(() => assertSustainedLatencyGates(backlogged)).toThrow(/sustained input median/);
+  });
+});
+
+describe('sustained frame median gate', () => {
+  test('still fails a doubled frame median', () => {
+    const report = sustainedReport({
+      firstInputTaskMs: 0.2,
+      lastInputTaskMs: 0.2,
+      firstFrameMs: 100,
+      lastFrameMs: 201,
+    });
+    expect(() => assertSustainedLatencyGates(report)).toThrow(
+      /sustained frame median: 100\.00 ms → 201\.00 ms \(\+101\.0%\)/
+    );
+  });
+
+  test('passes growth under the doubling', () => {
+    const report = sustainedReport({
+      firstInputTaskMs: 0.2,
+      lastInputTaskMs: 0.2,
+      firstFrameMs: 100,
+      lastFrameMs: 190,
+    });
+    expect(() => assertSustainedLatencyGates(report)).not.toThrow();
+  });
+
+  test('absorbs the rounding on a frame median small enough for it to matter', () => {
+    const report = sustainedReport({
+      firstInputTaskMs: 0.2,
+      lastInputTaskMs: 0.2,
+      firstFrameMs: 8,
+      lastFrameMs: 17,
+    });
+    expect(report.frameMedianChangePct).toBeGreaterThan(100);
+    expect(() => assertSustainedLatencyGates(report)).not.toThrow();
+  });
+});


### PR DESCRIPTION
The sustained-latency gate has been failing pull requests at random, always with the same value: `Expected: < 100` / `Received: 100`, in both `edit` and `suggest` modes, on branches with nothing in common.

Exactly 100.000 is not noise. It is one clock tick.

`inputTask` medians on CI run 0.05–0.3 ms and always land on a 0.1 ms grid, because Chromium clamps `performance.now()` to 100 µs outside a cross-origin-isolated page. What the probe measures is the synchronous `beforeinput` handler, with nothing awaiting a frame inside it, so the numbers are genuinely that small — the worst single sample across 120 sustained edits is 0.4 ms. Comparing two of those with a ratio means 0.1 → 0.2 reads as "+100% regression", and the gate then failed it on a strict `<` against exactly that boundary.

The threshold was wrong, not the statistic. A wider window or a mean would not help, since every sample is already on the same grid, and the median is what survives a scheduler stall on a shared runner.

Both sustained median gates now pair the ratio with an absolute floor — the same `Math.max(ratio, floor)` shape the tail, burst and cross-scenario gates in this file already use. Growth has to be a doubling *and* larger than the clock could invent. An absolute ceiling on the last input median comes with it, which buys back the case no ratio can see at all: a regression already present in the first window reads as 0% growth forever.

What it still catches, from a 0.2 ms baseline: any sustained growth past 1.2 ms of handler time, any last-window median above 8 ms whether it grew or not, and — once medians are genuinely milliseconds — the plain doubling rule again, so 4 → 8.1 ms fails and 4 → 7.9 ms passes. It also now gates a window whose median rounds to zero, where the old ratio returned a blind 0%.

What it no longer catches: growth from 0.2 to 1.2 ms, which on this clock is one to twelve ticks and cannot be told from noise; and a flat regression between 0.4 and 8 ms present in both windows, which the per-scenario and frame gates still watch.

The failure message now names both medians, the change and the ceiling — `edit sustained input median: 0.20 ms → 6.00 ms (+2900.0%), ceiling 1.20 ms` — instead of a bare percentage of a tenth of a millisecond. The heap assertion, which failed as an unlabelled nine-digit number, now reports mode, edit count and MiB.

The new test covers the gate logic without a browser: the exact +100% tick, 99.9% and 200% while sub-millisecond, growth past the floor, a backlog reaching milliseconds, the doubling rule at large medians, a flat regression, and a zero-median window.

It lives under `scripts/bench/` next to `edit-bench-gates.test.ts`, which does the same job for the headless bench, rather than beside the module it imports: `bun run test` walks only `packages/` and `scripts/`. That is worth knowing separately — three `e2e/*.test.ts` files currently run on no machine, and enrolling `e2e/` would turn the suite red because one of them imports `@docx-editor.dev/core/store`, which resolves to a `dist/` the test job does not build. Not fixed here.

No changeset: test and CI only, no published package changes behaviour.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789680084&installation_model_id=422592&pr_number=324&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F324&signature=1460f1b8fda5663181e55d77238a5d9ea624dd010456adf63a788aa143f59250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->