### PR TITLE
fix(core): only warn about fonts that actually cost fidelity

### DIFF
--- a/.changeset/blank-document-font-notice.md
+++ b/.changeset/blank-document-font-notice.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
 The font compatibility notice no longer reports a document that renders no text, or a family whose metric-compatible substitute is available on the platform.

--- a/.changeset/blank-document-font-notice.md
+++ b/.changeset/blank-document-font-notice.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+The font compatibility notice no longer reports a document that renders no text, or a family whose metric-compatible substitute is available on the platform.

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -164,6 +164,7 @@ export interface TreeDocxSession {
         readonly external: boolean;
     } | null;
     removeCustomNode(controlNodeId: string, scope?: StoryScope): CustomNodeWriteResult;
+    rendersText(): boolean;
     replaceImage(scope: StoryScope, drawingNodeId: string, bytes: Uint8Array, mime: SupportedImageMime, decodePort: ImageDecodePort, options: ReplaceImageOptions): Promise<ImageIntentResult>;
     replyToComment(parentCommentId: string | null, anchor: {
         paragraphId: string;

--- a/packages/core/src/binding/__tests__/document-catalog.test.ts
+++ b/packages/core/src/binding/__tests__/document-catalog.test.ts
@@ -159,6 +159,63 @@ describe('documentFonts', () => {
   });
 });
 
+describe('rendersText', () => {
+  test('a document that only DECLARES a family renders no text', () => {
+    // Word's blank template in miniature: docDefaults name a face, the body is one empty
+    // paragraph. `documentFonts` still reports the family (the picker wants it); nothing
+    // is on the page for a substitute face to get wrong.
+    const session = open(
+      docx({
+        body: '<w:p/>',
+        styles:
+          `<w:styles xmlns:w="${W}"><w:docDefaults><w:rPrDefault><w:rPr>` +
+          '<w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/>' +
+          '</w:rPr></w:rPrDefault></w:docDefaults></w:styles>',
+      })
+    );
+    expect(session.documentFonts()).toEqual(['Calibri']);
+    expect(session.rendersText()).toBe(false);
+  });
+
+  test('an empty w:t is still no text; one character flips it', () => {
+    const empty = open(docx({ body: '<w:p><w:r><w:t></w:t></w:r></w:p>' }));
+    expect(empty.rendersText()).toBe(false);
+
+    const session = open(docx({ body: '<w:p><w:r><w:t></w:t></w:r></w:p>' }));
+    const [paragraphId] = session.paragraphIds();
+    const applied = session.applyTreeOps([
+      { op: 'insertText', paragraphId: paragraphId!, offset: 0, text: 'Z' },
+    ]);
+    expect(applied.committed).toBe(true);
+    // The answer is revision-keyed, so the first typed character must move it.
+    expect(session.rendersText()).toBe(true);
+  });
+
+  test('text in a referenced header counts, an unreferenced part does not', () => {
+    const referenced = open(
+      docx({
+        body: `<w:p/><w:sectPr><w:headerReference xmlns:r="${R}" w:type="default" r:id="rId11"/></w:sectPr>`,
+        header: `<w:hdr xmlns:w="${W}"><w:p>${run('Impact', 'head')}</w:p></w:hdr>`,
+      })
+    );
+    expect(referenced.rendersText()).toBe(true);
+
+    const unreferenced = open(
+      docx({
+        body: '<w:p/>',
+        header: `<w:hdr xmlns:w="${W}"><w:p>${run('Impact', 'head')}</w:p></w:hdr>`,
+      })
+    );
+    expect(unreferenced.rendersText()).toBe(false);
+  });
+
+  test('memoized per revision', () => {
+    const session = open(docx({ body: `<w:p>${run('Calibri', 'hello')}</w:p>` }));
+    expect(session.rendersText()).toBe(true);
+    expect(session.rendersText()).toBe(true);
+  });
+});
+
 describe('documentStyles', () => {
   test('returns the accepted definitions with name fallback and type filtering', () => {
     const session = open(docx({ body: '<w:p><w:r><w:t>x</w:t></w:r></w:p>', styles: STYLES_XML }));

--- a/packages/core/src/binding/document-catalog.ts
+++ b/packages/core/src/binding/document-catalog.ts
@@ -8,6 +8,7 @@
 // only ever receive names this module has already bounded.
 
 import type { OoxmlElement, OoxmlNode } from '../store/package/ooxml-tree.ts';
+import { WML_NAMESPACE_URI } from '../store/package/ooxml-shared.ts';
 
 /**
  * The same shape `semantic-paint.ts` enforces at the CSS sink (its `FONT_NAME`):
@@ -83,6 +84,37 @@ export function collectDocumentFonts(
   const fonts = [...byFold.values()];
   fonts.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   return fonts;
+}
+
+/**
+ * Whether any of `roots` actually puts CHARACTERS on a page.
+ *
+ * `collectDocumentFonts` answers what the document DECLARES, which is what a font picker
+ * wants: a catalog of names. A font-substitution notice asks a different question — is
+ * any text rendering in the wrong face — and a declaration alone never renders anything.
+ * A freshly created document carries Word's `w:docDefaults` (Calibri) over a single empty
+ * paragraph, so it declares a family while showing no glyph of it.
+ *
+ * Deliberately literal characters only: `w:t` (typed or demoted to generic) holding a
+ * non-empty value. A drawing, a bookmark or an empty run puts no glyph on the page, so a
+ * document made only of those has nothing a substitute face could get wrong. Same
+ * iterative, depth-safe walk as the font catalog, and the same roots, so the two
+ * derivations can never disagree about what "the document" is.
+ */
+export function documentRendersText(roots: readonly OoxmlElement[]): boolean {
+  const stack: OoxmlNode[] = [...roots];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (!isElement(node)) continue;
+    if (node.localName === 't' && node.namespaceUri === WML_NAMESPACE_URI) {
+      for (const child of node.children) {
+        if (!isElement(child) && child.value.length > 0) return true;
+      }
+      continue;
+    }
+    for (const child of node.children) stack.push(child);
+  }
+  return false;
 }
 
 /**

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -79,6 +79,7 @@ import {
 import {
   collectDocumentFonts,
   collectDocumentStyles,
+  documentRendersText,
   type DocumentStyleEntry,
 } from './document-catalog.ts';
 import {
@@ -248,6 +249,15 @@ export interface TreeDocxSession {
    * Memoized per package revision.
    */
   documentFonts(): readonly string[];
+  /**
+   * Whether the document puts any literal character on a page, over the same roots
+   * {@link TreeDocxSession.documentFonts} reads. Memoized per package revision.
+   *
+   * The font-substitution notice needs it: `documentFonts` reports what the document
+   * DECLARES, and a brand-new document declares Word's Calibri default over a single
+   * empty paragraph — a declaration with no glyph behind it.
+   */
+  rendersText(): boolean;
   /**
    * The `w:style` definitions of the styles part, validated and projected for a style
    * picker. Memoized once: the styles part is immutable for the session's lifetime.
@@ -822,9 +832,32 @@ export function openTreeSession(
   };
 
   let fontsCache: { readonly revision: number; readonly fonts: readonly string[] } | null = null;
+  let rendersTextCache: { readonly revision: number; readonly rendersText: boolean } | null = null;
   let stylesCache: readonly DocumentStyleEntry[] | null = null;
   let themeColorsCache: readonly DocumentThemeColorEntry[] | null = null;
   let themeFontsCache: DocumentThemeFonts | null = null;
+  /**
+   * The trees the document-wide catalogs read: the live body, the styles part, and every
+   * distinct header/footer part across sections. Shared so `documentFonts` and
+   * `rendersText` can never disagree about what "the document" covers. Not memoized —
+   * both callers cache their own answer per package revision, and this only gathers
+   * already-resolved roots.
+   */
+  const catalogRoots = (): OoxmlElement[] => {
+    const roots: OoxmlElement[] = [bodyStore().part.root];
+    const styles = resolveStylesRoot();
+    if (styles) roots.push(styles);
+    const seen = new Set<OoxmlPart>();
+    for (const section of resolvedHeaderFooterBySection().parts) {
+      for (const part of [...section.headers.values(), ...section.footers.values()]) {
+        if (seen.has(part)) continue;
+        seen.add(part);
+        roots.push(part.root);
+      }
+    }
+    return roots;
+  };
+
   let runDefaultsResolver:
     | ((styleId: string | null, runProperties?: readonly RunPropertyLike[]) => StyleRunDefaults)
     | null = null;
@@ -1010,28 +1043,27 @@ export function openTreeSession(
         if (fontsCache && fontsCache.revision === packageStore.packageRevision) {
           return fontsCache.fonts;
         }
-        const bySection = resolvedHeaderFooterBySection().parts;
-        const roots: OoxmlElement[] = [bodyStore().part.root];
-        const styles = resolveStylesRoot();
-        if (styles) roots.push(styles);
-        const seen = new Set<OoxmlPart>();
-        for (const section of bySection) {
-          for (const part of section.headers.values()) {
-            if (seen.has(part)) continue;
-            seen.add(part);
-            roots.push(part.root);
-          }
-          for (const part of section.footers.values()) {
-            if (seen.has(part)) continue;
-            seen.add(part);
-            roots.push(part.root);
-          }
-        }
         fontsCache = {
           revision: packageStore.packageRevision,
-          fonts: collectDocumentFonts(roots, collectDocumentThemeFonts(resolveThemeRoot())),
+          fonts: collectDocumentFonts(
+            catalogRoots(),
+            collectDocumentThemeFonts(resolveThemeRoot())
+          ),
         };
         return fontsCache.fonts;
+      },
+
+      rendersText() {
+        // Same revision key as `documentFonts`, and for the same reason: typing the first
+        // character of a document is exactly the edit this answer must notice.
+        if (rendersTextCache && rendersTextCache.revision === packageStore.packageRevision) {
+          return rendersTextCache.rendersText;
+        }
+        rendersTextCache = {
+          revision: packageStore.packageRevision,
+          rendersText: documentRendersText(catalogRoots()),
+        };
+        return rendersTextCache.rendersText;
       },
 
       documentStyles() {

--- a/packages/core/src/editor/__tests__/font-availability.test.ts
+++ b/packages/core/src/editor/__tests__/font-availability.test.ts
@@ -57,4 +57,37 @@ describe('detectFontSubstitutions', () => {
       )
     ).toEqual([]);
   });
+
+  test('a metric-compatible twin in the fallback stack is not a reportable substitution', () => {
+    // Calibri is missing but Carlito — its metric twin, and the next entry in the stack
+    // both measurement and paint use — resolves. Advances are identical, so wrap and
+    // pagination match Word and there is no fidelity loss to report.
+    expect(
+      detectFontSubstitutions(
+        ['Calibri', 'Aptos'],
+        () => false,
+        (family) => family === 'Carlito'
+      )
+    ).toEqual(['Aptos']);
+  });
+
+  test('a family whose twin is also missing is still reported', () => {
+    expect(
+      detectFontSubstitutions(
+        ['Calibri'],
+        () => false,
+        () => false
+      )
+    ).toEqual(['Calibri']);
+  });
+
+  test('the twin lookup is case-insensitive, like the document catalog', () => {
+    expect(
+      detectFontSubstitutions(
+        ['calibri'],
+        () => false,
+        (family) => family === 'Carlito'
+      )
+    ).toEqual([]);
+  });
 });

--- a/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
+++ b/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
@@ -1,0 +1,109 @@
+// What `snapshot().fontSubstitutions` — the chrome font-compatibility notice — reports.
+//
+// The notice is a FIDELITY warning: these families render in a face with different
+// advance widths, so wrap and pagination will not match Word. What these pin down end to
+// end, on a platform where nothing the document names is installed:
+//
+// - a brand-new blank document reports nothing. It DECLARES Calibri (Word's blank-template
+//   `w:docDefaults`) over a single empty paragraph, and a declaration paints no glyph.
+// - the first typed character reports it. The gate is "no text rendered", never "this
+//   document is exempt", so a real fidelity loss is never hidden.
+// - a family whose metric-compatible twin IS installed reports nothing, because the stack
+//   both measurement and paint use falls through to it and the metrics are identical.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { blankDocumentBytes } from '../blank-document.ts';
+import { createDocxEditor } from '../docx-editor.ts';
+import { docx } from './paginated-surface-fixtures.ts';
+
+/**
+ * Families this fake platform has installed. A canvas measurement only changes when the
+ * shorthand names one of them, which is exactly the signal `createLocalFontProbe` reads.
+ */
+let installed: readonly string[] = [];
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+beforeAll(() => {
+  (HTMLCanvasElement.prototype as { getContext: unknown }).getContext = function getContext(
+    kind: string
+  ) {
+    if (kind !== '2d') return null;
+    let font = '';
+    return {
+      set font(value: string) {
+        font = value;
+      },
+      get font() {
+        return font;
+      },
+      measureText(text: string) {
+        const resolved = installed.some((family) => font.includes(`"${family}"`));
+        return { width: text.length * (resolved ? 7 : 10) };
+      },
+    };
+  };
+});
+
+afterAll(() => {
+  (HTMLCanvasElement.prototype as { getContext: unknown }).getContext = originalGetContext;
+  installed = [];
+});
+
+const runIn = (family: string, text: string) =>
+  `<w:p><w:r><w:rPr><w:rFonts w:ascii="${family}" w:hAnsi="${family}"/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
+
+describe('font substitution notice', () => {
+  test('a brand-new blank document reports no substitution', () => {
+    installed = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: blankDocumentBytes(),
+    });
+    // The family IS declared — the picker and the toolbar both report it — and it is NOT
+    // resolvable on this platform. The notice still stays quiet: nothing is rendered.
+    expect(editor.getDocumentFonts()).toContain('Calibri');
+    expect(editor.snapshot().fontSubstitutions ?? []).toEqual([]);
+    editor.destroy();
+  });
+
+  test('the first typed character surfaces it: the loss is deferred, never hidden', () => {
+    installed = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: blankDocumentBytes(),
+    });
+    expect(editor.snapshot().fontSubstitutions ?? []).toEqual([]);
+    expect(editor.exec({ type: 'insertText', text: 'X' })).toEqual({ ok: true, changed: true });
+    expect(editor.snapshot().fontSubstitutions ?? []).toEqual(['Calibri']);
+    editor.destroy();
+  });
+
+  test('a document whose text renders in an unavailable face reports it', () => {
+    installed = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(runIn('Garamond', 'body text')),
+    });
+    expect(editor.snapshot().fontSubstitutions ?? []).toContain('Garamond');
+    editor.destroy();
+  });
+
+  test('an installed metric twin is not a reportable substitution', () => {
+    // Carlito has Calibri's advance widths and is the next entry in the stack measurement
+    // and paint both use, so this document paginates exactly as Word paginates it.
+    installed = ['Carlito'];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(runIn('Calibri', 'body text') + runIn('Garamond', 'more')),
+    });
+    const substitutions = editor.snapshot().fontSubstitutions ?? [];
+    expect(substitutions).not.toContain('Calibri');
+    // Garamond has no twin in the stack, so it is still reported.
+    expect(substitutions).toContain('Garamond');
+    editor.destroy();
+  });
+});

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -402,9 +402,17 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   /**
    * While font work is still in flight the answer would flicker: embedded faces register
    * at resolution, so a file whose own fonts are arriving must not flash a notice first.
+   *
+   * A document that renders no character has nothing a substitute face could get wrong.
+   * That is not a special case for the blank template but the notice's own definition:
+   * `documentFonts()` reports DECLARED families, and Word's `w:docDefaults` declares
+   * Calibri over a document with no runs at all — so the first thing a user saw on a page
+   * they had just created was a warning about text that does not exist. The gate lifts on
+   * the first typed character, when the claim becomes true.
    */
   const deriveFontSubstitutions = (): readonly string[] => {
     if (!surface || fontsResolving) return EMPTY_FONT_SUBSTITUTIONS;
+    if (!surface.session.rendersText()) return EMPTY_FONT_SUBSTITUTIONS;
     return detectFontSubstitutions(
       surface.session.documentFonts(),
       fontFamilyCovered,

--- a/packages/core/src/editor/font-availability.ts
+++ b/packages/core/src/editor/font-availability.ts
@@ -13,6 +13,15 @@
 // measurements, while an unresolved one leaves both at the generic face. A family
 // metrically identical to BOTH generic defaults could in principle hide, but no real
 // text face matches a monospace grid.
+//
+// "Resolved" is not the same question as "renders in a face the author would notice".
+// A declared family the platform cannot resolve still measures and paints against the
+// surface fallback stack, and for Calibri that stack names Carlito — the metric twin.
+// Identical advance widths mean wrap and pagination land where Word puts them, so no
+// fidelity is lost and there is nothing for a fidelity notice to report. Detection asks
+// about the face measurement will really use, never about the declared name alone.
+
+import { METRIC_COMPATIBLE_FALLBACK_FAMILIES } from '../layout/canvas-measurer.ts';
 
 /** Measures a fixed sample under one CSS font shorthand; width in px. */
 export type FontProbeMeasure = (font: string) => number;
@@ -65,8 +74,9 @@ export function createLocalFontProbe(
 }
 
 /**
- * The document families that will render in a substitute: not covered by an embedded or
- * app-supplied face, and not resolvable by the platform. Order follows `families`
+ * The document families that will render in a face with DIFFERENT metrics: not covered by
+ * an embedded or app-supplied face, not resolvable by the platform, and with no
+ * metric-compatible twin in the surface fallback stack either. Order follows `families`
  * (already sorted by the catalog).
  */
 export function detectFontSubstitutions(
@@ -78,6 +88,11 @@ export function detectFontSubstitutions(
   for (const family of families) {
     if (covered(family)) continue;
     if (resolves(family)) continue;
+    // The declared face is missing, but the stack may still fall through to its metric
+    // twin. That is a substitution the user cannot measure and Word cannot out-paginate,
+    // so it is not what this notice reports.
+    const twin = METRIC_COMPATIBLE_FALLBACK_FAMILIES.get(family.toLowerCase());
+    if (twin !== undefined && resolves(twin)) continue;
     substituted.push(family);
   }
   return substituted;

--- a/packages/core/src/layout/__tests__/canvas-measurer.test.ts
+++ b/packages/core/src/layout/__tests__/canvas-measurer.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart } from '@docx-editor.dev/core/store';
 import {
+  DEFAULT_CANVAS_FONT_STACK,
   DEFAULT_RUN_STYLE,
   createFixedMeasurer,
   isCanvasMeasurementAvailable,
@@ -14,6 +15,9 @@ import {
   type PageGeometry,
   type ResolvedRunStyle,
 } from '../index.ts';
+// Not re-exported from the lane index: an internal detail of the fallback stack, and the
+// notice's detector imports it from the module for the same reason.
+import { METRIC_COMPATIBLE_FALLBACK_FAMILIES } from '../canvas-measurer.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -382,5 +386,21 @@ describe('centered cover title uses measured width, not the fixed grid', () => {
     expect(usedWidth(fixedLine)).toBeLessThan(usedWidth(canvasLine));
     // Underestimated width → larger centre slack → origin shifts right of the true centre.
     expect(fixedLine.spans[0]!.box.x).toBeGreaterThan(canvasLine.spans[0]!.box.x);
+  });
+});
+
+describe('METRIC_COMPATIBLE_FALLBACK_FAMILIES', () => {
+  test('every twin is a face the default stack actually falls through to', () => {
+    // The map is a promise about what the BROWSER will pick. A run declaring `X` measures
+    // and paints against `"X", ${DEFAULT_CANVAS_FONT_STACK}`, so a twin the stack never
+    // names would never be used — and the compatibility notice would go quiet about a
+    // real fidelity loss. Adding an entry means adding it to the stack too.
+    const stack = DEFAULT_CANVAS_FONT_STACK.split(',').map((entry) => entry.trim());
+    for (const [declared, twin] of METRIC_COMPATIBLE_FALLBACK_FAMILIES) {
+      expect(declared).toBe(declared.toLowerCase());
+      expect(stack).toContain(twin);
+      // The twin must precede nothing that would win first except the declared face.
+      expect(stack.indexOf(twin)).toBeLessThan(stack.length - 1);
+    }
   });
 });

--- a/packages/core/src/layout/canvas-measurer.ts
+++ b/packages/core/src/layout/canvas-measurer.ts
@@ -28,6 +28,26 @@ import { createFixedMeasurer } from './fixed-measurer.ts';
  */
 export const DEFAULT_CANVAS_FONT_STACK = 'Calibri, Carlito, Helvetica, Arial, sans-serif';
 
+/**
+ * Declared family (case-folded) → the METRIC-COMPATIBLE face this stack falls through to
+ * when the declared one is not installed.
+ *
+ * Only families whose substitute actually appears in {@link DEFAULT_CANVAS_FONT_STACK}
+ * belong here, because only those are what the browser will really pick: a run declaring
+ * `Times New Roman` is measured against `"Times New Roman", ${DEFAULT_CANVAS_FONT_STACK}`,
+ * which names no serif substitute, so an installed Liberation Serif never gets used and
+ * must not be claimed. Carlito is Calibri's metric twin — identical advance widths — so a
+ * Calibri run on a host with Carlito wraps and paginates exactly where Word puts it, in
+ * both measurement and paint (the paint sink trails the same stack).
+ *
+ * The compatibility notice reads this to avoid warning about a substitution that costs no
+ * fidelity. `packages/core/src/layout/__tests__/canvas-measurer.test.ts` pins every entry
+ * against the stack so the two cannot drift.
+ */
+export const METRIC_COMPATIBLE_FALLBACK_FAMILIES: ReadonlyMap<string, string> = new Map([
+  ['calibri', 'Carlito'],
+]);
+
 /** Default width-cache capacity before least-recently-used eviction. */
 export const DEFAULT_MAX_CANVAS_WIDTH_CACHE_ENTRIES = 4096;
 /** Default line-metrics cache capacity (one entry per distinct font shorthand). */


### PR DESCRIPTION
A brand-new empty document greeted the user with "Some fonts in this document aren't available, so substitutes are shown: Calibri" — on a page with no text on it.

The banner is a **fidelity** warning, not an availability report: `EditorSnapshot.fontSubstitutions` means "families rendering in a substitute face", and measurement and paint both trail the same stack, so the only thing it can usefully claim is that advance widths differ and wrap will not match Word.

Measured before changing anything: with no `fonts` prop, neither Calibri nor Carlito resolves on a stock machine, the stack lands on Helvetica, and metrics genuinely differ. On typed text the banner is **correct**, so it is not suppressed. What was wrong is that the derivation asked two different questions from the one it reports.

**Declared is not rendered.** `documentFonts()` scans `w:rFonts` declarations across body, styles and headers — right for the font picker, wrong for a fidelity notice. Word's blank template authors `w:ascii="Calibri"` in `w:docDefaults` over a single empty paragraph, so the notice fired on a document with zero glyphs and "substitutes are shown" was literally false. `documentRendersText()` now gates it on a `w:t` actually holding characters, walking the same roots as the font catalog so the two can never disagree about what "the document" is. The first typed character lifts the gate — the warning is deferred, never hidden.

**A metric twin in the stack is not a fidelity loss.** The detector probed only the declared name, so a host with Carlito installed — which measures *and* paints Calibri runs at identical advance widths — was warned anyway. `METRIC_COMPATIBLE_FALLBACK_FAMILIES` lets detection ask about the face that will really be used. Only families whose substitute actually appears in `DEFAULT_CANVAS_FONT_STACK` qualify, and a test pins every entry against that stack so the two cannot drift. Cambria, Times New Roman and the rest are deliberately absent: no serif substitute is in the stack, so an installed Liberation Serif is never picked and claiming it would silence a real loss.

Not touched: `blank-document.ts`, whose Calibri/11pt `docDefaults` are load-bearing; the notice string; and `guides/fonts.mdx`, which already tells hosts to pass `fonts`. This was a behaviour bug, not a docs gap.

`minor` rather than `patch`: `TreeDocxSession.rendersText()` lands in the published `./binding` export map and its API snapshot, so it is additive public surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789680780&installation_model_id=422592&pr_number=325&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F325&signature=1ad6390ac5bcddf87d3cb84e0f3b8f7185f1373b2dc9182de58da646052707ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->