### PR TITLE
ci: report published-package sizes on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,21 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 
+      # Sizes of the exact artifacts `npm publish` ships (`npm pack --dry-run`
+      # per published package). Uploaded as an artifact: main-branch runs are
+      # the baseline the `package-size` job below diffs PRs against.
+      - name: Package size report
+        run: bun run check:package-size --out package-sizes.json
+
+      # `overwrite` because artifact names are unique per RUN, not per attempt:
+      # without it, "Re-run all jobs" 409s here and fails the build job.
+      - name: Upload package size report
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-sizes
+          path: package-sizes.json
+          overwrite: true
+
       - name: API report check
         run: bun run api:check
 
@@ -184,3 +199,82 @@ jobs:
         # the docs site prerenders it. Same reasoning as the step above: catch
         # it on the PR, not in `docx-editor-page`'s build.
         run: bun run check:docs-mdx
+
+  # Diffs the PR's published-package sizes against the latest successful main
+  # run and keeps ONE sticky PR comment up to date. Fails on huge tarball
+  # growth (thresholds in scripts/check-package-size.mjs) unless the PR
+  # carries the `size-increase-expected` label. Separate from `build` so that
+  # job keeps its read-only token; only this one gets `pull-requests: write`.
+  package-size:
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: build
+    permissions:
+      contents: read
+      actions: read # download the baseline artifact from a main run
+      pull-requests: write # sticky size comment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Download current size report
+        uses: actions/download-artifact@v4
+        with:
+          name: package-sizes
+
+      # Baseline = the `package-sizes` artifact from the newest successful
+      # push run on main. Missing baseline (first run, expired artifact) is
+      # not an error: the compare degrades to a report without deltas.
+      - name: Download baseline size report from main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # `|| true` so a transient API error degrades to no-baseline instead
+          # of failing the job (the shell runs with -e).
+          run_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&event=push&status=success&per_page=1" \
+            --jq '.workflow_runs[0].id // empty' || true)
+          if [ -n "$run_id" ]; then
+            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" -n package-sizes -D baseline \
+              || echo "Run $run_id has no package-sizes artifact yet; reporting without deltas."
+          else
+            echo "No successful main run found; reporting without deltas."
+          fi
+
+      # The allow-label is read LIVE from the API, not from
+      # `github.event.pull_request.labels`: a re-run reuses the frozen event
+      # payload, so a label added after the gate failed would be invisible and
+      # "label + re-run" could never pass. An API blip leaves `allow` empty,
+      # which only makes the gate strict, never lax.
+      - name: Compare against baseline (gate)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          allow=""
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --jq '.[].name' \
+            | grep -qx 'size-increase-expected'; then
+            allow=1
+          fi
+          PACKAGE_SIZE_ALLOW_GROWTH="$allow" node scripts/check-package-size.mjs \
+            --compare package-sizes.json \
+            --baseline baseline/package-sizes.json --comment size-comment.md
+
+      # `always()` so the comment still lands when the gate above fails — the
+      # comment is where the failure explains itself. Fork PRs get a read-only
+      # token and are skipped; they still see the table in the job summary.
+      - name: Post sticky PR comment
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Author-filtered so a user comment that starts with the marker can
+          # never be adopted (and overwritten) as the bot's sticky comment.
+          comment_id=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- package-size-report -->"))][0].id // empty')
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -F body=@size-comment.md
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -F body=@size-comment.md
+          fi

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check:lane-boundaries": "node scripts/check-lane-boundaries.mjs",
     "check:core-css-compiled": "node scripts/check-core-css-compiled.mjs",
     "check:package-artifacts": "node scripts/check-package-artifacts.mjs && node scripts/check-core-css-compiled.mjs",
+    "check:package-size": "node scripts/check-package-size.mjs",
     "check:shipped-shaper": "node scripts/check-shipped-shaper.mjs",
     "check:parity": "bun run check:export-parity && bun run check:editor-contract && bun run check:public-docs-surface && bun run check:parity-contract && bun run check:adapter-css-thin",
     "check:license-headers": "bun run check:pro-license-headers && bun run check:editor-api-license-headers",

--- a/scripts/check-package-size.mjs
+++ b/scripts/check-package-size.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+// Package size report + gate for the packages we publish.
+//
+// Measure mode (default): runs `npm pack --dry-run --json` in every
+// non-private `packages/*` directory and records the tarball (gzipped) and
+// unpacked byte sizes — the exact artifact `npm publish` ships, honoring each
+// package's `files` array. Run after `bun run build:packages`; a missing
+// `dist/` fails loudly instead of reporting a near-empty tarball.
+//
+//   node scripts/check-package-size.mjs [--out package-sizes.json]
+//
+// Compare mode: diffs a current report against a baseline report (the same
+// JSON produced on main) and writes a Markdown table for a PR comment. Exits
+// non-zero when any package's tarball grows past BOTH fail thresholds, so an
+// accidental multi-hundred-KB regression (a bundled dependency, an asset, a
+// broken tree-shake) blocks the PR instead of shipping.
+//
+//   node scripts/check-package-size.mjs --compare current.json \
+//     --baseline baseline.json [--comment comment.md]
+//
+// A deliberate size increase passes with PACKAGE_SIZE_ALLOW_GROWTH=1, which
+// CI sets from the `size-increase-expected` PR label.
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+// Warn (⚠️ in the comment) when a tarball moves by more than 5% AND 1 KB.
+const WARN_PCT = 5;
+const WARN_BYTES = 1024;
+// Fail the gate when a tarball GROWS by more than 20% AND 25 KB. Both must
+// trip: 20% of a 2 KB package is noise, and +25 KB on a 5 MB package is not
+// the regression this gate exists for.
+const FAIL_PCT = 20;
+const FAIL_BYTES = 25 * 1024;
+
+function formatBytes(n) {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+  return `${(n / 1024).toFixed(1)} KB`;
+}
+
+function formatDelta(delta, base) {
+  const sign = delta > 0 ? '+' : delta < 0 ? '−' : '±';
+  const abs = Math.abs(delta);
+  const pct = base > 0 ? ` (${sign}${((abs / base) * 100).toFixed(1)}%)` : '';
+  return `${sign}${formatBytes(abs)}${pct}`;
+}
+
+// Note: `npm pack --dry-run` runs `prepack` lifecycle scripts. All published
+// packages today have none; if a package with one (e.g. nuxt) ever drops
+// `private: true`, its `prepack` will run inside this measurement.
+function publishedPackageDirs() {
+  const dirs = [];
+  for (const entry of readdirSync(join(ROOT, 'packages'))) {
+    const manifestPath = join(ROOT, 'packages', entry, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (manifest.private) continue;
+    dirs.push({ dir: join(ROOT, 'packages', entry), name: manifest.name });
+  }
+  return dirs.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function measure() {
+  const results = [];
+  for (const { dir, name } of publishedPackageDirs()) {
+    if (!existsSync(join(dir, 'dist'))) {
+      console.error(`✗ ${name}: dist/ missing — run \`bun run build:packages\` first.`);
+      process.exit(1);
+    }
+    const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: dir,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const [packed] = JSON.parse(output);
+    if (
+      !packed?.name ||
+      typeof packed.size !== 'number' ||
+      typeof packed.unpackedSize !== 'number'
+    ) {
+      console.error(`✗ ${name}: npm pack returned no size.`);
+      process.exit(1);
+    }
+    results.push({
+      name: packed.name,
+      version: packed.version,
+      tarballBytes: packed.size,
+      unpackedBytes: packed.unpackedSize,
+      entryCount: packed.entryCount,
+    });
+  }
+  return results;
+}
+
+function printTable(results) {
+  const nameWidth = Math.max(...results.map((r) => r.name.length), 7);
+  console.log(`${'package'.padEnd(nameWidth)}  ${'tarball'.padStart(10)}  ${'unpacked'.padStart(10)}  files`);
+  for (const r of results) {
+    console.log(
+      `${r.name.padEnd(nameWidth)}  ${formatBytes(r.tarballBytes).padStart(10)}  ${formatBytes(r.unpackedBytes).padStart(10)}  ${r.entryCount}`
+    );
+  }
+}
+
+function compare(currentPath, baselinePath, commentPath) {
+  const current = JSON.parse(readFileSync(currentPath, 'utf8'));
+  // A malformed baseline (truncated artifact, interrupted upload on main)
+  // degrades to the no-baseline path instead of crashing before the comment
+  // file exists — the gate must stay explainable. A malformed CURRENT report
+  // still crashes above: that is a real error in this run.
+  let baseline = null;
+  if (existsSync(baselinePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(baselinePath, 'utf8'));
+      if (Array.isArray(parsed)) baseline = parsed;
+      else console.error(`Baseline ${baselinePath} is not an array; ignoring it.`);
+    } catch (error) {
+      console.error(`Baseline ${baselinePath} is unreadable (${error.message}); ignoring it.`);
+    }
+  }
+  const baseByName = new Map((baseline ?? []).map((r) => [r.name, r]));
+
+  const lines = [
+    '<!-- package-size-report -->',
+    '### 📦 Package size report',
+    '',
+    '| Package | Tarball | vs main | Unpacked | vs main |',
+    '| --- | ---: | ---: | ---: | ---: |',
+  ];
+  const failures = [];
+
+  for (const r of current) {
+    const base = baseByName.get(r.name);
+    baseByName.delete(r.name);
+    if (!base) {
+      const label = baseline ? '🆕 new' : '—';
+      lines.push(
+        `| \`${r.name}\` | ${formatBytes(r.tarballBytes)} | ${label} | ${formatBytes(r.unpackedBytes)} | ${label} |`
+      );
+      continue;
+    }
+    const tarballDelta = r.tarballBytes - base.tarballBytes;
+    const unpackedDelta = r.unpackedBytes - base.unpackedBytes;
+    const warn =
+      Math.abs(tarballDelta) > WARN_BYTES &&
+      Math.abs(tarballDelta) / base.tarballBytes > WARN_PCT / 100;
+    const fail =
+      tarballDelta > FAIL_BYTES && tarballDelta / base.tarballBytes > FAIL_PCT / 100;
+    if (fail) failures.push({ name: r.name, tarballDelta, base: base.tarballBytes });
+    const mark = fail ? ' 🚨' : warn ? ' ⚠️' : '';
+    lines.push(
+      `| \`${r.name}\` | ${formatBytes(r.tarballBytes)} | ${formatDelta(tarballDelta, base.tarballBytes)}${mark} | ${formatBytes(r.unpackedBytes)} | ${formatDelta(unpackedDelta, base.unpackedBytes)} |`
+    );
+  }
+  for (const name of baseByName.keys()) {
+    lines.push(`| \`${name}\` | — | 🗑️ removed | — | 🗑️ removed |`);
+  }
+
+  lines.push('');
+  if (!baseline) {
+    lines.push('_No baseline from `main` was available; sizes are reported without deltas._');
+  } else {
+    lines.push(
+      `_Tarball = \`npm pack\` gzipped size. ⚠️ over ±${WARN_PCT}%, 🚨 fails CI over +${FAIL_PCT}% and +${formatBytes(FAIL_BYTES)} (label \`size-increase-expected\` to allow)._`
+    );
+  }
+
+  const markdown = lines.join('\n');
+  if (commentPath) writeFileSync(commentPath, markdown);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+  }
+  console.log(markdown);
+
+  if (failures.length > 0) {
+    if (process.env.PACKAGE_SIZE_ALLOW_GROWTH) {
+      console.log('\nGrowth over the fail threshold allowed by PACKAGE_SIZE_ALLOW_GROWTH.');
+      return;
+    }
+    console.error('\nPackage tarball growth over the fail threshold:');
+    for (const f of failures) {
+      console.error(`  ✗ ${f.name}: ${formatDelta(f.tarballDelta, f.base)}`);
+    }
+    console.error(
+      `\nThreshold: +${FAIL_PCT}% and +${formatBytes(FAIL_BYTES)}. If the increase is intended,`
+    );
+    console.error('add the `size-increase-expected` label to the PR and re-run the job.');
+    process.exit(1);
+  }
+}
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? null : process.argv[index + 1];
+}
+
+const comparePath = argValue('--compare');
+if (comparePath) {
+  const baselinePath = argValue('--baseline');
+  if (!baselinePath) {
+    console.error('--compare requires --baseline <file>.');
+    process.exit(1);
+  }
+  compare(comparePath, baselinePath, argValue('--comment'));
+} else {
+  const results = measure();
+  printTable(results);
+  const outPath = argValue('--out');
+  if (outPath) {
+    writeFileSync(outPath, `${JSON.stringify(results, null, 2)}\n`);
+    console.log(`\nReport written to ${outPath}`);
+  }
+}


### PR DESCRIPTION
Adds `scripts/check-package-size.mjs`: the build job measures each published package with `npm pack --dry-run` and uploads the report; a new `package-size` job diffs PRs against the latest main baseline in one sticky comment. Tarball growth past +20% and +25 KB fails the gate unless the PR carries the `size-increase-expected` label (read live from the API, so label-then-re-run works). A missing or malformed baseline degrades to a report without deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789720655&installation_model_id=422592&pr_number=329&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F329&signature=108bc19132c108d39eb0a4f01ca520738565e3e2c6a8b696022232de808b58fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->