### PR TITLE
fix(react): clamp the horizontal ruler to the page edge on narrow viewports

### DIFF
--- a/.changeset/ruler-narrow-viewport-clamp.md
+++ b/.changeset/ruler-narrow-viewport-clamp.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Fix the horizontal ruler drifting off the page on narrow viewports: the ruler now clamps to the page's left edge instead of overflowing on both sides.

--- a/.changeset/ruler-narrow-viewport-clamp.md
+++ b/.changeset/ruler-narrow-viewport-clamp.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Fix the horizontal ruler drifting off the page on narrow viewports: the ruler now clamps to the page's left edge instead of overflowing on both sides.
+Fix ruler behavior on narrow viewports: the horizontal ruler now clamps to the page's left edge instead of overflowing on both sides, and the vertical ruler hides while the page is wider than the viewport instead of scrolling out of view.

--- a/examples/igloo/src/igloo.css
+++ b/examples/igloo/src/igloo.css
@@ -258,12 +258,10 @@
   color: #10788f;
 }
 
-/* The ruler sizes ITSELF to the page width and follows an open navigation pane on its own,
- * so this row only has to centre it over the page column. Without the centring the ruler
- * sits at the row's left edge and its inch marks line up with nothing. */
+/* The ruler sizes ITSELF to the page width, centres itself over the page column, and
+ * follows an open navigation pane on its own — this row is a plain block so those auto
+ * margins can clamp to the start edge on narrow hosts, exactly as the page does. */
 .igloo-rulerbar {
-  display: flex;
-  justify-content: center;
   overflow: hidden;
   padding: 4px 20px 2px;
   border-bottom-color: rgba(255, 255, 255, 0.3);

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -2402,16 +2402,22 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Sticky horizontal ruler: scrolls horizontally with the document, stays put
- * vertically, and never covers the page content. */
+ * vertically, and never covers the page content. Centred by auto margins on the
+ * child, not justify-content, so an oversized ruler clamps to the start edge
+ * like the page instead of overflowing both sides on narrow hosts. */
 .docx-editor-shell__ruler-h {
   position: sticky;
   top: 0;
   z-index: 2;
   flex: none;
   display: flex;
-  justify-content: center;
   padding: 4px 20px;
   background: var(--doc-bg);
+}
+
+.docx-editor-shell__ruler-h > * {
+  flex-shrink: 0;
+  margin-inline: auto;
 }
 
 .docx-editor-shell__canvas {
@@ -2597,16 +2603,16 @@ a.docx-hyperlink:focus-visible {
   height: 22px;
 }
 
-/* The review pane's gutter reaches the ruler as a right MARGIN and the page as the scroller's
-   right PADDING. Both move by the same distance, so both have to move on the same curve —
-   without this the sheet glided left and the ruler above it snapped, and for the length of the
+/* The pane gutters reach the ruler as PADDING on its frame and the page as the scroller's
+   padding. Both move by the same distance, so both have to move on the same curve —
+   without this the sheet glided and the ruler above it snapped, and for the length of the
    animation the ruler measured a page that was no longer under it. */
-.docx-horizontal-ruler {
-  transition: margin 0.2s ease;
+.docx-ruler-frame {
+  transition: padding 0.2s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .docx-horizontal-ruler {
+  .docx-ruler-frame {
     transition: none;
   }
 }

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -97,14 +97,22 @@ const WORKSPACE_STYLE: CSSProperties = {
  * `min-height` holds the row open before a document is loaded — the ruler draws
  * nothing without a page, and letting the row collapse made the page stack jump
  * when the ticks appeared.
+ *
+ * A block, NOT a flex row with `justify-content: center`: the ruler part centres
+ * itself clamp-safely (see `HorizontalRuler`'s base style), so on narrow screens
+ * it pins to the start edge like the page instead of overflowing both sides and
+ * losing its left inches to `overflow: hidden`.
+ *
+ * `scrollbar-gutter` mirrors the scroll container below, which reserves the same
+ * symmetric gutter — without it, on classic-scrollbar platforms the clamped page
+ * pins a gutter-width right of the clamped ruler.
  */
 const RULER_ROW_STYLE: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'center',
   flex: 'none',
   minHeight: 34,
   padding: '6px 0 2px',
   overflow: 'hidden',
+  scrollbarGutter: 'stable both-edges',
   backgroundColor: 'var(--doc-bg)',
 };
 
@@ -361,7 +369,7 @@ const DocxEditorFrame = forwardRef<DocxEditorRef, DocxEditorProps>(
           ticks drift off the page they measure. It has to sit ABOVE the
           scroller, which is a slot only this component can offer. */}
         {rulers ? (
-          <div style={RULER_ROW_STYLE}>
+          <div style={RULER_ROW_STYLE} data-testid="docx-editor-ruler-row">
             <DocxEditorHorizontalRuler />
           </div>
         ) : null}

--- a/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
+++ b/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
@@ -171,10 +171,14 @@ export function DocxEditorShell({
                       the doc. paddingRight biases the centered ruler so it
                       tracks the page when the comments sidebar shifts the
                       page left. Outline doesn't bias; the page stays centered
-                      until minLayoutWidth forces horizontal scroll. */}
+                      until minLayoutWidth forces horizontal scroll. No
+                      justify-center: the ruler centers itself clamp-safely
+                      (see HorizontalRuler's base style), so if it outgrows
+                      minLayoutWidth it pins to the start edge like the page
+                      instead of pushing its left inches out of reach. */}
                     {showRuler && (
                       <div
-                        className="flex justify-center py-1 flex-shrink-0 bg-doc-bg"
+                        className="flex py-1 flex-shrink-0 bg-doc-bg"
                         style={{
                           position: 'sticky',
                           top: 0,

--- a/packages/react/src/components/PaginatedDocxEditorShell.tsx
+++ b/packages/react/src/components/PaginatedDocxEditorShell.tsx
@@ -300,7 +300,9 @@ export function PaginatedDocxEditorShell({
         style={{ flex: 1, minHeight: 0, overflow: 'auto', background: 'var(--doc-bg)' }}
       >
         {rulerPageSetup ? (
-          <div style={{ display: 'flex', justifyContent: 'center', padding: '4px 0' }}>
+          // A block row, not flex justify-center: the ruler centres itself clamp-safely
+          // (see HorizontalRuler's base style), so it degrades like the page on narrow hosts.
+          <div style={{ padding: '4px 0' }}>
             <HorizontalRuler pageSetup={rulerPageSetup} zoom={zoom} />
           </div>
         ) : null}

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -320,6 +320,16 @@ export function HorizontalRuler({
         userSelect: 'none',
         touchAction: 'none',
         cursor: dragging ? 'ew-resize' : 'default',
+        // The clamp-safe default for every host row, block or flex. Auto margins centre
+        // the ruler in a wide row and resolve to ZERO when the ruler outgrows it, pinning
+        // it to the start edge — the same degradation as the page stack's
+        // `margin-inline: auto` (see `.docx-editor-one-surface__pages`). A row that
+        // centres with `justify-content: center` instead overflows an oversized ruler on
+        // BOTH sides, clipping its left inches while the page stays pinned left; and a
+        // flex row lets the box collapse without `flexShrink: 0`, since every child is
+        // absolutely positioned. Both sit BEFORE the spread so a host can override.
+        flexShrink: 0,
+        marginInline: 'auto',
         ...style,
       }}
       // A GROUP, not a slider: it contains sliders. It carried `aria-valuemin`/`max` with

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -198,41 +198,46 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
   const scrollLeft = useViewportScrollLeft();
   if (documentAbsent) return null;
   return (
-    <HorizontalRuler
-      pageSetup={previewed(pageSetup, pending)}
-      zoom={zoom}
-      editable={isEnabled}
-      onLeftMarginChange={preview('left')}
-      onRightMarginChange={preview('right')}
-      onMarginDragEnd={commit}
-      showIndentHandles={indentDrag.indent !== null}
-      indent={indentDrag.indent}
-      indentEditable={indentDrag.isEnabled}
-      onIndentChange={indentDrag.preview}
-      onIndentDragEnd={indentDrag.commit}
-      unit={props.unit ?? 'inch'}
-      className={props.className ?? ''}
+    // The wrapper carries the pane geometry as PADDING so the ruler's own margins stay
+    // `auto` (the primitive's clamp-safe centring — see `HorizontalRuler`): the navigation
+    // pane displaces the page from the left, the review pane reserves a gutter on the
+    // right, and padding an edge by S moves the centred ruler by S/2 — the same halves
+    // the viewport's own padding moves the centred page by. The class carries the glide
+    // (and its reduced-motion opt-out) so the ruler moves with the page rather than snaps.
+    <div
+      className="docx-ruler-frame"
       style={{
-        // A ruler always represents the full page width. In a narrow host its surrounding
-        // row overflows; shrinking the ruler would move its ticks off the document.
-        flexShrink: 0,
-        marginRight: reserved,
-        ...props.style,
-        // The ruler is centred by its host row, so the same rule applies as to the page:
-        // a left offset of S moves a centred box by S/2. Feeding the ruler the SAME px the
-        // viewport pads by keeps the two in lockstep at every window width.
-        marginInlineStart: shift,
-        // `margin`, not one edge: the review pane moves the other side, and animating only
-        // `margin-inline-start` left the ruler snapping while the page glided.
-        transition: 'margin 0.2s ease',
-        // The ruler lives above the scroller, so mirror its horizontal movement explicitly.
-        transform: `${props.style?.transform ? `${props.style.transform} ` : ''}translateX(${-scrollLeft}px)`,
-        // Navigation is below this row and cannot physically cover the ruler. Clip the
-        // scrolled portion at the same boundary so ticks never show above the pane.
-        clipPath:
-          shift > 0 && scrollLeft > 0 ? `inset(0 0 0 ${scrollLeft}px)` : props.style?.clipPath,
+        paddingInlineStart: shift,
+        // PHYSICAL right, like the pane it mirrors: the review rail is anchored
+        // `right: 0` and pads the scroller's `padding-right`, whatever the direction.
+        paddingRight: reserved,
       }}
-    />
+    >
+      <HorizontalRuler
+        pageSetup={previewed(pageSetup, pending)}
+        zoom={zoom}
+        editable={isEnabled}
+        onLeftMarginChange={preview('left')}
+        onRightMarginChange={preview('right')}
+        onMarginDragEnd={commit}
+        showIndentHandles={indentDrag.indent !== null}
+        indent={indentDrag.indent}
+        indentEditable={indentDrag.isEnabled}
+        onIndentChange={indentDrag.preview}
+        onIndentDragEnd={indentDrag.commit}
+        unit={props.unit ?? 'inch'}
+        className={props.className ?? ''}
+        style={{
+          ...props.style,
+          // The ruler lives above the scroller, so mirror its horizontal movement explicitly.
+          transform: `${props.style?.transform ? `${props.style.transform} ` : ''}translateX(${-scrollLeft}px)`,
+          // Navigation is below this row and cannot physically cover the ruler. Clip the
+          // scrolled portion at the same boundary so ticks never show above the pane.
+          clipPath:
+            shift > 0 && scrollLeft > 0 ? `inset(0 0 0 ${scrollLeft}px)` : props.style?.clipPath,
+        }}
+      />
+    </div>
   );
 }
 

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -16,6 +16,7 @@ import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import type { RulerIndent } from '@docx-editor.dev/core/editor';
 import { HorizontalRuler, type RulerPageSetup } from '../components/ui/HorizontalRuler';
 import { VerticalRuler } from '../components/ui/VerticalRuler';
+import { twipsToPixels } from '../lib/units';
 import { ReviewRailContext, useDocxEditor } from './context';
 // A ruler MEASURES the page, and while the document is absent there is no page — the
 // primitive fell back to drawing default Letter ticks over a document that was not
@@ -153,6 +154,31 @@ function useIndentDrag(): IndentDrag {
   );
 }
 
+/**
+ * The scroll container's client width, kept live by a ResizeObserver.
+ *
+ * `null` while no viewport is registered — a bare composition without
+ * `DocxEditor.Viewport` gets no measurement and must not act on one.
+ */
+function useViewportClientWidth(): number | null {
+  const viewport = useNavigationViewportElement();
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!viewport) {
+      setWidth(null);
+      return undefined;
+    }
+    const sync = () => setWidth(viewport.clientWidth);
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [viewport]);
+
+  return width;
+}
+
 /** Horizontal viewport movement shared by the painted page and the ruler above it. */
 function useViewportScrollLeft(): number {
   const viewport = useNavigationViewportElement();
@@ -269,7 +295,11 @@ const REVIEW_MARKERS_GUTTER = 44;
  * when the engine supports page-setup writes, committing one undoable step on release.
  *
  * Renders nothing while the editor holds no document — see
- * {@link selectDocumentAbsent}.
+ * {@link selectDocumentAbsent} — and nothing while the page is wider than the
+ * viewport: the ruler rides the scroller at content x=0, so a horizontal scroll
+ * would carry it out of view, and pinning it instead would paint ticks over page
+ * text. Word's web peers drop it on cramped viewports; so does this part, and it
+ * returns as soon as the page fits again.
  *
  * @public
  */
@@ -278,7 +308,18 @@ export function DocxEditorVerticalRuler(props: DocxEditorRulerProps): ReactEleme
   const { pageSetup, isEnabled } = usePageSetup();
   const zoom = useEditorState(selectZoom);
   const { pending, preview, commit } = useMarginDrag();
+  // The same reservations the scroller pads by: what is left after them is the room the
+  // page actually has, so ruler and page agree about "cramped" at every pane state.
+  const shift = useNavigationShift();
+  const reserved = useReviewGutter();
+  const viewportWidth = useViewportClientWidth();
   if (documentAbsent) return null;
+  // `> 0` guards unlaid-out environments (a hidden host, DOM test doubles), which report
+  // a zero width that means "unmeasured", not "no room".
+  if (viewportWidth !== null && viewportWidth > 0 && pageSetup) {
+    const pageWidthPx = twipsToPixels(pageSetup.pageWidthTwips) * zoom;
+    if (pageWidthPx > viewportWidth - shift - reserved) return null;
+  }
   return (
     <VerticalRuler
       pageSetup={previewed(pageSetup, pending)}

--- a/packages/react/test/sugar-chrome-band.test.tsx
+++ b/packages/react/test/sugar-chrome-band.test.tsx
@@ -58,10 +58,8 @@ describe('the packaged frame chrome band', () => {
 
   test('the ruler row stays outside the band, on the workspace', () => {
     const { container } = render(<DocxEditor />);
-    const rulerRow = [...container.querySelectorAll('div')].find(
-      (el) => el.style.minHeight === '34px' && el.style.justifyContent === 'center'
-    );
-    expect(rulerRow).toBeDefined();
+    const rulerRow = container.querySelector<HTMLElement>('[data-testid="docx-editor-ruler-row"]');
+    expect(rulerRow).not.toBeNull();
     expect(band(container)!.contains(rulerRow!)).toBe(false);
     expect(rulerRow!.style.backgroundColor).toBe('var(--doc-bg)');
   });

--- a/packages/react/test/sugar-rulers-and-save.test.tsx
+++ b/packages/react/test/sugar-rulers-and-save.test.tsx
@@ -30,17 +30,13 @@ describe('the packaged frame', () => {
     const { container } = render(<DocxEditor />);
     // The ruler paints nothing without a page, so assert the ROW is reserved
     // rather than the ticks: that is the part a host cannot place itself.
-    const rows = [...container.querySelectorAll('div')].filter(
-      (el) => el.style.minHeight === '34px' && el.style.justifyContent === 'center'
-    );
+    const rows = container.querySelectorAll('[data-testid="docx-editor-ruler-row"]');
     expect(rows.length).toBe(1);
   });
 
   test('rulers={false} removes it', () => {
     const { container } = render(<DocxEditor rulers={false} />);
-    const rows = [...container.querySelectorAll('div')].filter(
-      (el) => el.style.minHeight === '34px' && el.style.justifyContent === 'center'
-    );
+    const rows = container.querySelectorAll('[data-testid="docx-editor-ruler-row"]');
     expect(rows.length).toBe(0);
   });
 


### PR DESCRIPTION
On narrow viewports the horizontal ruler drifted about two inches off the page: the page stack centres with `margin-inline: auto` (clamps to the start edge on overflow) while the ruler rows centred with flex `justify-content: center` (overflows both sides, left half clipped by `overflow: hidden`).

The clamp-safe centring (`flex-shrink: 0` + `margin-inline: auto`) now lives once in `HorizontalRuler`'s base style, before the `...style` spread so hosts can override it. The pane gutters move to padding on a `docx-ruler-frame` wrapper (physical `padding-right` for the review rail, matching the pane), the packaged ruler row mirrors the scroller's `scrollbar-gutter`, and the same sweep covers both shells, the shared Vue row class, and the igloo example.

The vertical ruler rides the scroller at content x=0, so the same narrow viewports scrolled it out of view; it now unmounts while the page (at the current zoom, after the pane reservations) does not fit the viewport, and returns as soon as it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)