### PR TITLE
fix(core): navigate freely through tracked deletions, insert beside them

### DIFF
--- a/.changeset/caret-out-of-deletion.md
+++ b/.changeset/caret-out-of-deletion.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-A click on tracked-deleted text no longer strands the caret: it snaps to the edge of the deletion, so arrow keys keep working and typed text can never land inside deleted content.
+The caret now moves freely through tracked-deleted text, one character at a time, as Word does. Text typed with the caret inside a deletion lands beside the deletion instead of corrupting it.

--- a/.changeset/caret-out-of-deletion.md
+++ b/.changeset/caret-out-of-deletion.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+A click on tracked-deleted text no longer strands the caret: it snaps to the edge of the deletion, so arrow keys keep working and typed text can never land inside deleted content.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1951,6 +1951,9 @@ export interface PlacedCell {
 }
 
 // @public
+export function positionPastDeletion(layout: SemanticLayout, position: SemanticPosition): SemanticPosition;
+
+// @public
 export interface PreferredWidth {
     // (undocumented)
     readonly type: PreferredWidthType;
@@ -2861,9 +2864,6 @@ export function shownMarkRevision(revisions: readonly RevisionAttribution[]): Re
 
 // @public
 export const SINGLE_LINE_SPACING: ParagraphLineSpacing;
-
-// @public
-export function snapCaretOutOfDeletion(layout: SemanticLayout, position: SemanticPosition): SemanticPosition;
 
 // @public
 export interface SourceRange {

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2863,6 +2863,9 @@ export function shownMarkRevision(revisions: readonly RevisionAttribution[]): Re
 export const SINGLE_LINE_SPACING: ParagraphLineSpacing;
 
 // @public
+export function snapCaretOutOfDeletion(layout: SemanticLayout, position: SemanticPosition): SemanticPosition;
+
+// @public
 export interface SourceRange {
     // (undocumented)
     readonly end: number;

--- a/packages/core/src/editor/__tests__/revision-caret-surface.test.ts
+++ b/packages/core/src/editor/__tests__/revision-caret-surface.test.ts
@@ -1,15 +1,15 @@
-// The surface never lets a collapsed caret rest inside deleted content.
+// The caret moves freely through struck text; edits never land inside the deletion.
 //
-// A click on struck text resolves to the character under the pointer — an offset no caret
-// stop owns. Left there, the caret was dead to every arrow key, and the next keystroke
-// inserted characters INSIDE the deletion: text that exists in neither the original nor the
-// proposed document. `setSelection` snaps a collapsed caret to the start of the deleted
-// region; ranges pass through so a drag can still cover struck text.
+// Word's split of responsibilities, and now this surface's: navigation treats visible
+// deleted characters as ordinary caret stops, while the INSERT lanes relocate a collapsed
+// insertion point past the deletion it rests in — new content beside a `w:del`, never
+// inside it, where it would serialize as `w:t` under a wrapper that requires `w:delText`.
 
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test, afterEach } from 'bun:test';
+import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
 import { mount } from './paginated-surface-fixtures.ts';
 
 afterEach(() => {
@@ -23,31 +23,23 @@ const MIXED =
   '<w:r><w:delText>CDE</w:delText></w:r></w:del>' +
   '<w:r><w:t>FG</w:t></w:r></w:p>';
 
-describe('collapsed carets and deleted content', () => {
-  test('a collapsed caret inside a deletion snaps to the region start', () => {
+describe('caret and edits around deleted content', () => {
+  test('a collapsed caret rests inside struck text, and arrows move one character', () => {
     const { surface } = mount(MIXED);
     const paragraphId = surface.session.paragraphIds()[0]!;
     surface.setSelection({
       anchor: { paragraphId, offset: 3 },
       head: { paragraphId, offset: 3 },
     });
-    expect(surface.state().selection.head.offset).toBe(2);
-  });
-
-  test('arrow keys work from the snapped caret', () => {
-    const { surface } = mount(MIXED);
-    const paragraphId = surface.session.paragraphIds()[0]!;
-    surface.setSelection({
-      anchor: { paragraphId, offset: 4 },
-      head: { paragraphId, offset: 4 },
-    });
+    expect(surface.state().selection.head.offset).toBe(3);
     surface.navigate('right');
-    expect(surface.state().selection.head.offset).toBe(5);
+    expect(surface.state().selection.head.offset).toBe(4);
+    surface.navigate('left');
     surface.navigate('left');
     expect(surface.state().selection.head.offset).toBe(2);
   });
 
-  test('typing after a click on struck text never lands inside the deletion', () => {
+  test('typing at an interior caret lands past the deletion, never inside it', () => {
     const { surface } = mount(MIXED);
     const paragraphId = surface.session.paragraphIds()[0]!;
     surface.setSelection({
@@ -55,13 +47,16 @@ describe('collapsed carets and deleted content', () => {
       head: { paragraphId, offset: 3 },
     });
     surface.type('X');
-    // Inserted at the region start: before the deletion, never inside `w:delText`.
-    expect(surface.session.bodyText()).toBe('ABXCDEFG');
+    expect(surface.session.bodyText()).toBe('ABCDEXFG');
+    // The deletion's own content is untouched; the typed character sits outside the wrapper.
+    const xml = serializeOoxmlPart(surface.session.part());
+    expect(xml).toContain('<w:delText>CDE</w:delText>');
+    expect(xml).not.toMatch(/<w:del [^>]*>(?:(?!<\/w:del>).)*X/);
+    // The caret follows the typed character.
+    expect(surface.state().selection.head.offset).toBe(6);
   });
 
-  test('word navigation crosses a deletion instead of dying at its edge', () => {
-    // The word walk over the full paragraph text can target an offset inside the deletion;
-    // unclamped, the snap bounced it back to where it started and Ctrl/Alt+Right was dead.
+  test('repeated word jumps always advance across a deletion', () => {
     const body =
       '<w:p><w:r><w:t xml:space="preserve">AB </w:t></w:r>' +
       '<w:del w:id="1" w:author="Dev" w:date="2026-03-26T11:00:00Z">' +
@@ -70,23 +65,26 @@ describe('collapsed carets and deleted content', () => {
     const { surface } = mount(body);
     const paragraphId = surface.session.paragraphIds()[0]!;
     surface.setSelection({
-      anchor: { paragraphId, offset: 3 },
-      head: { paragraphId, offset: 3 },
+      anchor: { paragraphId, offset: 0 },
+      head: { paragraphId, offset: 0 },
     });
-    surface.navigate('wordRight');
-    expect(surface.state().selection.head.offset).toBe(9);
-    surface.navigate('wordLeft');
-    expect(surface.state().selection.head.offset).toBe(3);
+    let previous = 0;
+    for (let press = 0; press < 8 && previous < 11; press += 1) {
+      surface.navigate('wordRight');
+      const at = surface.state().selection.head.offset;
+      expect(at).toBeGreaterThan(previous);
+      previous = at;
+    }
+    expect(previous).toBe(11);
   });
 
   test('a range over deleted text passes through untouched', () => {
     const { surface } = mount(MIXED);
     const paragraphId = surface.session.paragraphIds()[0]!;
-    const range = {
+    surface.setSelection({
       anchor: { paragraphId, offset: 2 },
       head: { paragraphId, offset: 4 },
-    };
-    surface.setSelection(range);
+    });
     expect(surface.state().selection.head.offset).toBe(4);
   });
 });

--- a/packages/core/src/editor/__tests__/revision-caret-surface.test.ts
+++ b/packages/core/src/editor/__tests__/revision-caret-surface.test.ts
@@ -1,0 +1,92 @@
+// The surface never lets a collapsed caret rest inside deleted content.
+//
+// A click on struck text resolves to the character under the pointer — an offset no caret
+// stop owns. Left there, the caret was dead to every arrow key, and the next keystroke
+// inserted characters INSIDE the deletion: text that exists in neither the original nor the
+// proposed document. `setSelection` snaps a collapsed caret to the start of the deleted
+// region; ranges pass through so a drag can still cover struck text.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test, afterEach } from 'bun:test';
+import { mount } from './paginated-surface-fixtures.ts';
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+});
+
+/** `AB` + deleted `CDE` + `FG` — model offsets 0..7, with 2..5 deleted. */
+const MIXED =
+  '<w:p><w:r><w:t>AB</w:t></w:r>' +
+  '<w:del w:id="1" w:author="Dev" w:date="2026-03-26T11:00:00Z">' +
+  '<w:r><w:delText>CDE</w:delText></w:r></w:del>' +
+  '<w:r><w:t>FG</w:t></w:r></w:p>';
+
+describe('collapsed carets and deleted content', () => {
+  test('a collapsed caret inside a deletion snaps to the region start', () => {
+    const { surface } = mount(MIXED);
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId, offset: 3 },
+      head: { paragraphId, offset: 3 },
+    });
+    expect(surface.state().selection.head.offset).toBe(2);
+  });
+
+  test('arrow keys work from the snapped caret', () => {
+    const { surface } = mount(MIXED);
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId, offset: 4 },
+      head: { paragraphId, offset: 4 },
+    });
+    surface.navigate('right');
+    expect(surface.state().selection.head.offset).toBe(5);
+    surface.navigate('left');
+    expect(surface.state().selection.head.offset).toBe(2);
+  });
+
+  test('typing after a click on struck text never lands inside the deletion', () => {
+    const { surface } = mount(MIXED);
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId, offset: 3 },
+      head: { paragraphId, offset: 3 },
+    });
+    surface.type('X');
+    // Inserted at the region start: before the deletion, never inside `w:delText`.
+    expect(surface.session.bodyText()).toBe('ABXCDEFG');
+  });
+
+  test('word navigation crosses a deletion instead of dying at its edge', () => {
+    // The word walk over the full paragraph text can target an offset inside the deletion;
+    // unclamped, the snap bounced it back to where it started and Ctrl/Alt+Right was dead.
+    const body =
+      '<w:p><w:r><w:t xml:space="preserve">AB </w:t></w:r>' +
+      '<w:del w:id="1" w:author="Dev" w:date="2026-03-26T11:00:00Z">' +
+      '<w:r><w:delText xml:space="preserve">CD EF </w:delText></w:r></w:del>' +
+      '<w:r><w:t>GH</w:t></w:r></w:p>';
+    const { surface } = mount(body);
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId, offset: 3 },
+      head: { paragraphId, offset: 3 },
+    });
+    surface.navigate('wordRight');
+    expect(surface.state().selection.head.offset).toBe(9);
+    surface.navigate('wordLeft');
+    expect(surface.state().selection.head.offset).toBe(3);
+  });
+
+  test('a range over deleted text passes through untouched', () => {
+    const { surface } = mount(MIXED);
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    const range = {
+      anchor: { paragraphId, offset: 2 },
+      head: { paragraphId, offset: 4 },
+    };
+    surface.setSelection(range);
+    expect(surface.state().selection.head.offset).toBe(4);
+  });
+});

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -47,6 +47,7 @@ import {
   paragraphsInCells,
   resolveNumberingLevel,
   paragraphTextFromLayout,
+  snapCaretOutOfDeletion,
   withNumberingStyleLinks,
   wordBoundary,
   type CellSelection,
@@ -2289,7 +2290,23 @@ export function mountPaginatedSurface(
     return true;
   }
 
+  /**
+   * A collapsed caret never rests strictly inside deleted content.
+   *
+   * A click on struck text resolves to the character under the pointer — an offset no caret
+   * stop owns. Installed as-is, that caret was dead to every arrow key and, worse, the next
+   * keystroke inserted INSIDE the deletion. Ranges pass through untouched: a drag may cover
+   * deleted text, and a review activation selects exactly the revision's own range.
+   */
+  function snapCollapsedOutOfDeletion(next: SemanticSelection): SemanticSelection {
+    const { anchor, head } = next;
+    if (anchor.paragraphId !== head.paragraphId || anchor.offset !== head.offset) return next;
+    const snapped = snapCaretOutOfDeletion(currentLayout, head);
+    return snapped.offset === head.offset ? next : { anchor: snapped, head: snapped };
+  }
+
   function setSelection(next: SemanticSelection, keepDesiredX = false): void {
+    next = snapCollapsedOutOfDeletion(next);
     // Buffered typing lands at the OLD caret before a MOVE takes effect —
     // typing then clicking must not teleport the typed text to the click. A
     // same-position set (the selection mirror re-adopting the caret it painted,
@@ -2381,6 +2398,7 @@ export function mountPaginatedSurface(
     // The raw take-up, without the mirror or the report `setSelection` performs: the render
     // this runs inside is about to do both.
     adoptSelection: (next) => {
+      next = snapCollapsedOutOfDeletion(next);
       reconcilePendingWith(next);
       releaseRetainedIfEscaped(next);
       retireActivationPin();

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -47,7 +47,7 @@ import {
   paragraphsInCells,
   resolveNumberingLevel,
   paragraphTextFromLayout,
-  snapCaretOutOfDeletion,
+  positionPastDeletion,
   withNumberingStyleLinks,
   wordBoundary,
   type CellSelection,
@@ -2290,23 +2290,7 @@ export function mountPaginatedSurface(
     return true;
   }
 
-  /**
-   * A collapsed caret never rests strictly inside deleted content.
-   *
-   * A click on struck text resolves to the character under the pointer — an offset no caret
-   * stop owns. Installed as-is, that caret was dead to every arrow key and, worse, the next
-   * keystroke inserted INSIDE the deletion. Ranges pass through untouched: a drag may cover
-   * deleted text, and a review activation selects exactly the revision's own range.
-   */
-  function snapCollapsedOutOfDeletion(next: SemanticSelection): SemanticSelection {
-    const { anchor, head } = next;
-    if (anchor.paragraphId !== head.paragraphId || anchor.offset !== head.offset) return next;
-    const snapped = snapCaretOutOfDeletion(currentLayout, head);
-    return snapped.offset === head.offset ? next : { anchor: snapped, head: snapped };
-  }
-
   function setSelection(next: SemanticSelection, keepDesiredX = false): void {
-    next = snapCollapsedOutOfDeletion(next);
     // Buffered typing lands at the OLD caret before a MOVE takes effect —
     // typing then clicking must not teleport the typed text to the click. A
     // same-position set (the selection mirror re-adopting the caret it painted,
@@ -2398,7 +2382,6 @@ export function mountPaginatedSurface(
     // The raw take-up, without the mirror or the report `setSelection` performs: the render
     // this runs inside is about to do both.
     adoptSelection: (next) => {
-      next = snapCollapsedOutOfDeletion(next);
       reconcilePendingWith(next);
       releaseRetainedIfEscaped(next);
       retireActivationPin();
@@ -4392,7 +4375,11 @@ export function mountPaginatedSurface(
       selection.anchor.paragraphId === selection.head.paragraphId &&
       selection.anchor.offset === selection.head.offset
     ) {
-      return { ops: [], collapseTo: selection.head };
+      // The caret may rest anywhere in struck text — Word's rule — but new content must
+      // never land INSIDE the `w:del`, so an insert aimed at an interior offset relocates
+      // past the deletion. The store enforces the same rule; adjusting here as well lands
+      // the post-edit caret beside the typed text instead of back among the struck words.
+      return { ops: [], collapseTo: positionPastDeletion(currentLayout, selection.head) };
     }
     const { from, to } = orderedRange();
     return planRangeDeletion(

--- a/packages/core/src/layout/__tests__/revision-caret.test.ts
+++ b/packages/core/src/layout/__tests__/revision-caret.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
-import { caretStops, moveCaret } from '../semantic-interaction.ts';
+import { caretStops, moveCaret, snapCaretOutOfDeletion } from '../semantic-interaction.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
 import type { RevisionDisplayMode } from '../revision-projection.ts';
 
@@ -91,5 +91,84 @@ describe('the caret does not enter deleted content', () => {
   test('two adjacent deletions are stepped over as one region', () => {
     const body = `<w:p>${run('A')}${del('1', delRun('BC'))}${del('2', delRun('DE'))}${run('F')}</w:p>`;
     expect(offsets(body)).toEqual([0, 1, 5, 6]);
+  });
+});
+
+describe('a caret left inside a deletion is not a dead end', () => {
+  // A gesture can still RESOLVE to an interior offset — the browser reports the struck
+  // character a click or drag endpoint landed on. The surface snaps a collapsed caret out
+  // (`snapCaretOutOfDeletion`), and navigation resolves rather than refusing, so neither
+  // lane depends on the other having run.
+  const layout = layoutSemanticDocument(load(MIXED), 1, { measurer });
+  const paragraphId = caretStops(layout)[0]!.position.paragraphId;
+
+  test('arrow right resolves to the stop past the deletion', () => {
+    expect(moveCaret(layout, { paragraphId, offset: 3 }, 'right')?.position.offset).toBe(5);
+  });
+
+  test('arrow left resolves to the stop before it', () => {
+    expect(moveCaret(layout, { paragraphId, offset: 4 }, 'left')?.position.offset).toBe(2);
+  });
+
+  test('the snap moves an interior caret to the start of the deleted region', () => {
+    expect(snapCaretOutOfDeletion(layout, { paragraphId, offset: 3 })).toEqual({
+      paragraphId,
+      offset: 2,
+    });
+  });
+
+  test('the snap leaves boundaries and live text where they are', () => {
+    for (const offset of [0, 2, 5, 7]) {
+      expect(snapCaretOutOfDeletion(layout, { paragraphId, offset }).offset).toBe(offset);
+    }
+  });
+
+  test('a deletion that wraps across lines is ONE region, not one per line', () => {
+    // `LineRecord.deletedRanges` is clipped per line, so a wrapping deletion publishes one
+    // slice per line and every wrap boundary looks like a range edge. Read per line, those
+    // false edges were caret stops in the middle of struck text — and a keystroke there
+    // landed inside the `w:del`.
+    const long = 'word '.repeat(40).trimEnd(); // 199 chars, wraps at the fixed 6pt advance
+    const body = `<w:p>${run('AB ')}${del('1', delRun(long))}${run('YZ')}</w:p>`;
+    const wrapped = layoutSemanticDocument(load(body), 1, { measurer });
+    const id = caretStops(wrapped)[0]!.position.paragraphId;
+    const all = caretStops(wrapped).map((stop) => stop.position.offset);
+    expect(all.filter((offset) => offset > 3 && offset < 3 + long.length)).toEqual([]);
+    expect(moveCaret(wrapped, { paragraphId: id, offset: 3 }, 'right')?.position.offset).toBe(
+      3 + long.length
+    );
+    expect(snapCaretOutOfDeletion(wrapped, { paragraphId: id, offset: 100 })).toEqual({
+      paragraphId: id,
+      offset: 3,
+    });
+  });
+
+  test('word navigation steps over a deletion instead of targeting its interior', () => {
+    // The word walk reads the paragraph text, which includes deleted characters, so a word
+    // boundary can land inside a deletion — where the surface's collapsed-caret snap would
+    // bounce it straight back: a permanently dead key.
+    const body = `<w:p>${run('AB ')}${del('1', delRun('CD EF '))}${run('GH')}</w:p>`;
+    const words = layoutSemanticDocument(load(body), 1, { measurer });
+    const id = caretStops(words)[0]!.position.paragraphId;
+    expect(moveCaret(words, { paragraphId: id, offset: 3 }, 'wordRight')?.position.offset).toBe(9);
+    expect(moveCaret(words, { paragraphId: id, offset: 9 }, 'wordLeft')?.position.offset).toBe(3);
+  });
+
+  test('nested revisions form one region for both the walk and the snap', () => {
+    // `w:ins` wrapping `w:del` twice over, the shape a second reviewer striking a first
+    // reviewer's insertions writes: AB + ins(del CD) + ins(del EF) + GH, deleted 2..6.
+    const nested =
+      `<w:p>${run('AB')}${ins('1', del('2', delRun('CD')))}` +
+      `${ins('3', del('4', delRun('EF')))}${run('GH')}</w:p>`;
+    const nestedLayout = layoutSemanticDocument(load(nested), 1, { measurer });
+    const id = caretStops(nestedLayout)[0]!.position.paragraphId;
+    expect(offsets(nested)).toEqual([0, 1, 2, 6, 7, 8]);
+    expect(moveCaret(nestedLayout, { paragraphId: id, offset: 4 }, 'right')?.position.offset).toBe(
+      6
+    );
+    expect(moveCaret(nestedLayout, { paragraphId: id, offset: 4 }, 'left')?.position.offset).toBe(
+      2
+    );
+    expect(snapCaretOutOfDeletion(nestedLayout, { paragraphId: id, offset: 4 }).offset).toBe(2);
   });
 });

--- a/packages/core/src/layout/__tests__/revision-caret.test.ts
+++ b/packages/core/src/layout/__tests__/revision-caret.test.ts
@@ -1,13 +1,15 @@
-// Deleted content leaves the caret space.
+// The caret moves freely through visible deleted content — Word's rule.
 //
-// Excluding `w:delText` from layout is not enough on its own. If the caret can enter deleted
-// content, a user types inside text that exists in neither the original nor the proposal, and
-// there is no valid tree for the result. Stepping over a deletion is the same treatment a note
-// reference gets.
+// All-markup shows the struck words, so the reader can put the caret between any two of
+// them, character by character. What the caret space excludes is a deleted offset the
+// display mode resolved AWAY: in the proposed result those characters paint nothing, and an
+// offset-by-offset walk would stop at invisible positions. Keeping the tree valid is the
+// WRITE path's job, not navigation's: an insert aimed inside a deletion relocates past it
+// (`positionPastDeletion`, and the same rule in the store).
 
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
-import { caretStops, moveCaret, snapCaretOutOfDeletion } from '../semantic-interaction.ts';
+import { caretStops, moveCaret, positionPastDeletion } from '../semantic-interaction.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
 import type { RevisionDisplayMode } from '../revision-projection.ts';
 
@@ -33,142 +35,105 @@ const ins = (id: string, inner: string) =>
 /** `AB` + deleted `CDE` + `FG` — model offsets 0..7, with 2..5 deleted. */
 const MIXED = `<w:p>${run('AB')}${del('1', delRun('CDE'))}${run('FG')}</w:p>`;
 
+const ALL = [0, 1, 2, 3, 4, 5, 6, 7];
+
 function offsets(body: string, mode: RevisionDisplayMode = 'all-markup'): number[] {
   const layout = layoutSemanticDocument(load(body), 1, { measurer, displayMode: mode });
   return caretStops(layout).map((stop) => stop.position.offset);
 }
 
-describe('the caret does not enter deleted content', () => {
-  test('offsets inside a deletion have no caret stop', () => {
-    // 3 and 4 sit between the deleted characters; 2 and 5 are the positions immediately
-    // before and after the deletion, which are real places to put a caret.
-    expect(offsets(MIXED)).toEqual([0, 1, 2, 5, 6, 7]);
+describe('visible deleted content is fully navigable', () => {
+  test('every offset of a shown deletion is a caret stop', () => {
+    expect(offsets(MIXED)).toEqual(ALL);
   });
 
   test('inserted content stays fully addressable', () => {
-    // An insertion is live text. Only deletions leave the caret space.
-    expect(offsets(`<w:p>${run('AB')}${ins('1', run('CDE'))}${run('FG')}</w:p>`)).toEqual([
-      0, 1, 2, 3, 4, 5, 6, 7,
-    ]);
+    expect(offsets(`<w:p>${run('AB')}${ins('1', run('CDE'))}${run('FG')}</w:p>`)).toEqual(ALL);
   });
 
-  test('a moveFrom is treated as deleted for caret purposes', () => {
+  test('a moveFrom is navigable exactly like a deletion', () => {
     const moved =
       `<w:p>${run('AB')}<w:moveFrom w:id="1" w:author="QA">` +
       `${delRun('CDE')}</w:moveFrom>${run('FG')}</w:p>`;
-    expect(offsets(moved)).toEqual([0, 1, 2, 5, 6, 7]);
+    expect(offsets(moved)).toEqual(ALL);
   });
 
-  test('arrow right steps over the whole deletion in one press', () => {
+  test('arrows step through struck text one character at a time', () => {
     const layout = layoutSemanticDocument(load(MIXED), 1, { measurer });
     const paragraphId = caretStops(layout)[0]!.position.paragraphId;
-    const moved = moveCaret(layout, { paragraphId, offset: 2 }, 'right');
-    expect(moved?.position.offset).toBe(5);
+    expect(moveCaret(layout, { paragraphId, offset: 2 }, 'right')?.position.offset).toBe(3);
+    expect(moveCaret(layout, { paragraphId, offset: 4 }, 'left')?.position.offset).toBe(3);
   });
 
-  test('arrow left steps back over it just as cleanly', () => {
-    const layout = layoutSemanticDocument(load(MIXED), 1, { measurer });
-    const paragraphId = caretStops(layout)[0]!.position.paragraphId;
-    const moved = moveCaret(layout, { paragraphId, offset: 5 }, 'left');
-    expect(moved?.position.offset).toBe(2);
+  test('the ORIGINAL view lays deleted text out as live, so it stays navigable', () => {
+    expect(offsets(MIXED, 'original')).toEqual(ALL);
   });
 
-  test('the rule holds in every display mode', () => {
-    // In the proposed result the deleted text is not laid out at all, so its offsets are
-    // absent for that reason. In the original it IS laid out, and must still be uneditable:
-    // there is no valid tree for text typed inside a deletion.
+  test('the PROPOSED view paints no glyphs for the deletion, so its interior is skipped', () => {
+    // 2 and 5 survive as the positions beside the (invisible) deletion; 3 and 4 would be
+    // caret stops between characters nothing paints.
     expect(offsets(MIXED, 'proposed')).toEqual([0, 1, 2, 5, 6, 7]);
-    expect(offsets(MIXED, 'original')).toEqual([0, 1, 2, 5, 6, 7]);
   });
 
-  test('a paragraph that is entirely deleted keeps its boundary caret targets', () => {
-    // Both ends survive: the caret can sit before the struck text or after it, which is what
-    // makes the paragraph reachable at all — including for the accept or reject that resolves
-    // the deletion covering it. Only the eight interior offsets are removed.
-    expect(offsets(`<w:p>${del('1', delRun('all gone'))}</w:p>`)).toEqual([0, 8]);
-  });
-
-  test('two adjacent deletions are stepped over as one region', () => {
-    const body = `<w:p>${run('A')}${del('1', delRun('BC'))}${del('2', delRun('DE'))}${run('F')}</w:p>`;
-    expect(offsets(body)).toEqual([0, 1, 5, 6]);
-  });
-});
-
-describe('a caret left inside a deletion is not a dead end', () => {
-  // A gesture can still RESOLVE to an interior offset — the browser reports the struck
-  // character a click or drag endpoint landed on. The surface snaps a collapsed caret out
-  // (`snapCaretOutOfDeletion`), and navigation resolves rather than refusing, so neither
-  // lane depends on the other having run.
-  const layout = layoutSemanticDocument(load(MIXED), 1, { measurer });
-  const paragraphId = caretStops(layout)[0]!.position.paragraphId;
-
-  test('arrow right resolves to the stop past the deletion', () => {
-    expect(moveCaret(layout, { paragraphId, offset: 3 }, 'right')?.position.offset).toBe(5);
-  });
-
-  test('arrow left resolves to the stop before it', () => {
-    expect(moveCaret(layout, { paragraphId, offset: 4 }, 'left')?.position.offset).toBe(2);
-  });
-
-  test('the snap moves an interior caret to the start of the deleted region', () => {
-    expect(snapCaretOutOfDeletion(layout, { paragraphId, offset: 3 })).toEqual({
-      paragraphId,
-      offset: 2,
+  test('an unowned position still navigates instead of dying', () => {
+    // In the proposed view offset 3 is not a stop. A caret can still be parked there — a
+    // stale selection, a host call — and arrows resolve in the direction of travel.
+    const layout = layoutSemanticDocument(load(MIXED), 1, {
+      measurer,
+      displayMode: 'proposed',
     });
+    const paragraphId = caretStops(layout)[0]!.position.paragraphId;
+    expect(moveCaret(layout, { paragraphId, offset: 3 }, 'right')?.position.offset).toBe(5);
+    expect(moveCaret(layout, { paragraphId, offset: 3 }, 'left')?.position.offset).toBe(2);
   });
 
-  test('the snap leaves boundaries and live text where they are', () => {
-    for (const offset of [0, 2, 5, 7]) {
-      expect(snapCaretOutOfDeletion(layout, { paragraphId, offset }).offset).toBe(offset);
-    }
+  test('a wholly deleted paragraph is navigable end to end', () => {
+    expect(offsets(`<w:p>${del('1', delRun('all gone'))}</w:p>`)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8,
+    ]);
   });
 
-  test('a deletion that wraps across lines is ONE region, not one per line', () => {
-    // `LineRecord.deletedRanges` is clipped per line, so a wrapping deletion publishes one
-    // slice per line and every wrap boundary looks like a range edge. Read per line, those
-    // false edges were caret stops in the middle of struck text — and a keystroke there
-    // landed inside the `w:del`.
+  test('a deletion that wraps across lines keeps every interior stop', () => {
     const long = 'word '.repeat(40).trimEnd(); // 199 chars, wraps at the fixed 6pt advance
     const body = `<w:p>${run('AB ')}${del('1', delRun(long))}${run('YZ')}</w:p>`;
-    const wrapped = layoutSemanticDocument(load(body), 1, { measurer });
-    const id = caretStops(wrapped)[0]!.position.paragraphId;
-    const all = caretStops(wrapped).map((stop) => stop.position.offset);
-    expect(all.filter((offset) => offset > 3 && offset < 3 + long.length)).toEqual([]);
-    expect(moveCaret(wrapped, { paragraphId: id, offset: 3 }, 'right')?.position.offset).toBe(
-      3 + long.length
-    );
-    expect(snapCaretOutOfDeletion(wrapped, { paragraphId: id, offset: 100 })).toEqual({
-      paragraphId: id,
-      offset: 3,
-    });
+    const stops = offsets(body);
+    for (const probe of [50, 100, 150]) expect(stops).toContain(probe);
   });
 
-  test('word navigation steps over a deletion instead of targeting its interior', () => {
-    // The word walk reads the paragraph text, which includes deleted characters, so a word
-    // boundary can land inside a deletion — where the surface's collapsed-caret snap would
-    // bounce it straight back: a permanently dead key.
-    const body = `<w:p>${run('AB ')}${del('1', delRun('CD EF '))}${run('GH')}</w:p>`;
-    const words = layoutSemanticDocument(load(body), 1, { measurer });
-    const id = caretStops(words)[0]!.position.paragraphId;
-    expect(moveCaret(words, { paragraphId: id, offset: 3 }, 'wordRight')?.position.offset).toBe(9);
-    expect(moveCaret(words, { paragraphId: id, offset: 9 }, 'wordLeft')?.position.offset).toBe(3);
-  });
-
-  test('nested revisions form one region for both the walk and the snap', () => {
-    // `w:ins` wrapping `w:del` twice over, the shape a second reviewer striking a first
-    // reviewer's insertions writes: AB + ins(del CD) + ins(del EF) + GH, deleted 2..6.
+  test('nested revisions (ins wrapping del) walk the same way', () => {
     const nested =
       `<w:p>${run('AB')}${ins('1', del('2', delRun('CD')))}` +
       `${ins('3', del('4', delRun('EF')))}${run('GH')}</w:p>`;
-    const nestedLayout = layoutSemanticDocument(load(nested), 1, { measurer });
-    const id = caretStops(nestedLayout)[0]!.position.paragraphId;
-    expect(offsets(nested)).toEqual([0, 1, 2, 6, 7, 8]);
-    expect(moveCaret(nestedLayout, { paragraphId: id, offset: 4 }, 'right')?.position.offset).toBe(
-      6
+    expect(offsets(nested)).toEqual(ALL.concat(8));
+  });
+});
+
+describe('inserts relocate past the deletion the caret rests in', () => {
+  const layout = layoutSemanticDocument(load(MIXED), 1, { measurer });
+  const paragraphId = caretStops(layout)[0]!.position.paragraphId;
+
+  test('an interior insertion point resolves to the region end', () => {
+    expect(positionPastDeletion(layout, { paragraphId, offset: 3 })).toEqual({
+      paragraphId,
+      offset: 5,
+    });
+  });
+
+  test('boundaries and live text stay where they are', () => {
+    for (const offset of [0, 2, 5, 7]) {
+      expect(positionPastDeletion(layout, { paragraphId, offset }).offset).toBe(offset);
+    }
+  });
+
+  test('a wrapping deletion is one region, not one slice per line', () => {
+    const long = 'word '.repeat(40).trimEnd();
+    const body = `<w:p>${run('AB ')}${del('1', delRun(long))}${run('YZ')}</w:p>`;
+    const wrapped = layoutSemanticDocument(load(body), 1, { measurer });
+    const id = caretStops(wrapped)[0]!.position.paragraphId;
+    // Mid-region, past the first wrap boundary: the answer is the TRUE end of the deletion,
+    // never the nearest per-line slice edge.
+    expect(positionPastDeletion(wrapped, { paragraphId: id, offset: 100 }).offset).toBe(
+      3 + long.length
     );
-    expect(moveCaret(nestedLayout, { paragraphId: id, offset: 4 }, 'left')?.position.offset).toBe(
-      2
-    );
-    expect(snapCaretOutOfDeletion(nestedLayout, { paragraphId: id, offset: 4 }).offset).toBe(2);
   });
 });

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -517,7 +517,7 @@ export {
   hitTestSemantic,
   moveCaret,
   paragraphTextFromLayout,
-  snapCaretOutOfDeletion,
+  positionPastDeletion,
   keyedRangeRects,
   selectionRects,
   spansInSelection,

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -517,6 +517,7 @@ export {
   hitTestSemantic,
   moveCaret,
   paragraphTextFromLayout,
+  snapCaretOutOfDeletion,
   keyedRangeRects,
   selectionRects,
   spansInSelection,

--- a/packages/core/src/layout/paragraph-lines.ts
+++ b/packages/core/src/layout/paragraph-lines.ts
@@ -1,0 +1,195 @@
+// The per-paragraph line index and the deleted-range projection derived from it.
+//
+// Extracted from semantic-interaction.ts, which owns the caret stops, hit regions and
+// navigation built ON these: everything here is a pure read of one immutable layout,
+// memoized per revision, with no knowledge of stops or selections.
+
+import { lineSegments } from './line-segments.ts';
+import type { LineRecord, SemanticLayout } from './semantic-records.ts';
+import { paragraphFragmentsOf } from './semantic-records.ts';
+import type { SemanticPosition } from './semantic-interaction.ts';
+
+/**
+ * Lines grouped by the paragraph they render, with the page each sits on.
+ *
+ * Memoized PER LAYOUT — a published layout is immutable, so the grouping is computed once
+ * per revision instead of once per read. The reads this serves — caret geometry, span
+ * lookup for a selection, text reconstruction — are all "the lines of ONE paragraph", and
+ * answering them by scanning every line of every page made each one O(document); the
+ * toolbar asks after every commit, so the scans multiplied per keystroke.
+ */
+export interface PlacedLine {
+  readonly line: LineRecord;
+  readonly pageIndex: number;
+}
+
+const paragraphLinesCache = new WeakMap<SemanticLayout, Map<string, PlacedLine[]>>();
+
+export function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedLine[]> {
+  const cached = paragraphLinesCache.get(layout);
+  if (cached) return cached;
+  const index = new Map<string, PlacedLine[]>();
+  /**
+   * Under every paragraph the line carries, not just the one it names.
+   *
+   * A merged line belongs to two paragraphs, and a caret walking either of them has to find
+   * it. An ordinary line has one segment and lands in exactly the one bucket it always did.
+   */
+  const indexLine = (line: LineRecord, pageIndex: number): void => {
+    for (const segment of lineSegments(line)) {
+      const placed = { line, pageIndex };
+      const entry = index.get(segment.paragraphId);
+      if (entry) entry.push(placed);
+      else index.set(segment.paragraphId, [placed]);
+    }
+  };
+  const indexFragments = (
+    fragments: readonly import('./semantic-records.ts').BlockFragmentRecord[],
+    pageIndex: number
+  ): void => {
+    const visit = (
+      blocks: readonly import('./semantic-records.ts').BlockFragmentRecord[]
+    ): void => {
+      for (const block of blocks) {
+        if (block.kind === 'paragraph') {
+          for (const line of block.lines) indexLine(line, pageIndex);
+          continue;
+        }
+        for (const row of block.rows) {
+          if (row.isHeaderRepeat) continue;
+          for (const cell of row.cells) visit(cell.blocks);
+        }
+      }
+    };
+    visit(fragments);
+  };
+  for (const page of layout.pages) {
+    // Body first — primary story for caret stops built elsewhere via paragraphFragmentsOf.
+    for (const fragment of paragraphFragmentsOf(page)) {
+      for (const line of fragment.lines) indexLine(line, page.index);
+    }
+    // Furniture paragraphs share this index so formatting / paragraphTextFromLayout can
+    // resolve an open header/footer selection. documentOrder and caretStops stay body-only.
+    if (page.header) indexFragments(page.header.fragments, page.index);
+    if (page.footer) indexFragments(page.footer.fragments, page.index);
+    // Note stories (footnotes/endnotes) — same formatting lane as furniture; not body order.
+    for (const area of [page.footnotes, page.endnotes]) {
+      if (!area) continue;
+      for (const note of area.notes) indexFragments(note.fragments, page.index);
+    }
+  }
+  paragraphLinesCache.set(layout, index);
+  return index;
+}
+
+/**
+ * A paragraph's deleted model ranges, coalesced across every line that carries them.
+ *
+ * `LineRecord.deletedRanges` is CLIPPED to each line, so a deletion that wraps publishes one
+ * slice per line and every wrap boundary looks like a range edge. Read per line, those false
+ * edges became caret stops in the middle of struck text — navigable, and worse, typable:
+ * a keystroke there landed inside the `w:del`. Merging adjacent and overlapping slices
+ * restores the deletion's true extent, so only its real boundaries survive as caret targets.
+ *
+ * Memoized per layout: a published layout is immutable, and the stop builder asks once per
+ * line of the paragraph.
+ */
+const paragraphDeletedRangesCache = new WeakMap<
+  SemanticLayout,
+  Map<string, readonly { start: number; end: number }[]>
+>();
+
+export function paragraphDeletedRanges(
+  layout: SemanticLayout,
+  paragraphId: string
+): readonly { start: number; end: number }[] {
+  let byParagraph = paragraphDeletedRangesCache.get(layout);
+  if (!byParagraph) {
+    byParagraph = new Map();
+    paragraphDeletedRangesCache.set(layout, byParagraph);
+  }
+  const cached = byParagraph.get(paragraphId);
+  if (cached) return cached;
+  const collected: { start: number; end: number }[] = [];
+  for (const { line } of paragraphLinesIndex(layout).get(paragraphId) ?? []) {
+    // A merged line indexes under both members but expresses `deletedRanges` in the offsets
+    // of the paragraph it NAMES (merged-paragraph-ranges.ts); the other member's are dropped.
+    if (line.range.paragraphId !== paragraphId) continue;
+    for (const range of line.deletedRanges ?? []) {
+      collected.push({ start: range.start, end: range.end });
+    }
+  }
+  collected.sort((a, b) => a.start - b.start);
+  const merged: { start: number; end: number }[] = [];
+  for (const range of collected) {
+    const last = merged[merged.length - 1];
+    // `<=` merges the wrap slices AND identical copies — a shared header/footer part paints
+    // its lines once per page, so the same slice arrives once per sheet.
+    if (last && range.start <= last.end) last.end = Math.max(last.end, range.end);
+    else merged.push(range);
+  }
+  byParagraph.set(paragraphId, merged);
+  return merged;
+}
+
+/**
+ * True when this offset sits strictly INSIDE deleted content.
+ *
+ * The boundaries are kept: the position immediately before a deletion and the one immediately
+ * after it are both real places to put a caret, and dropping them would make the deletion
+ * unreachable — including for the accept or reject that resolves it.
+ */
+export function insideDeletedContent(
+  ranges: readonly { start: number; end: number }[],
+  offset: number
+): boolean {
+  for (const range of ranges) {
+    if (offset > range.start && offset < range.end) return true;
+  }
+  return false;
+}
+
+/**
+ * A word-boundary target that landed inside deleted content resolves to the region's edge in
+ * the direction of travel — the same "step over, never into" answer the stop list gives a
+ * plain arrow. Left as-is, the word walk handed back an interior offset and the surface's
+ * collapsed-caret snap bounced it straight back to where it started: a permanently dead key.
+ */
+export function skipDeletedRegion(
+  ranges: readonly { start: number; end: number }[],
+  offset: number,
+  direction: -1 | 1
+): number {
+  for (const range of ranges) {
+    if (offset > range.start && offset < range.end) {
+      return direction === 1 ? range.end : range.start;
+    }
+  }
+  return offset;
+}
+
+/**
+ * Where a collapsed caret may actually rest: never strictly inside deleted content.
+ *
+ * A gesture can resolve to such an offset — the browser reports the struck character a click
+ * landed on — but no caret stop owns it. A caret adopted there is a dead one: every arrow
+ * asks the stop list where it is and gets no answer, and an edit committed there writes
+ * characters INSIDE the deletion, text that exists in neither the original nor the proposal.
+ * Snapped to the START of the deleted region, which is a real stop, and which
+ * keeps a click anywhere on struck text activating the deletion's own review card (a range
+ * grips its start boundary as firmly as its interior — see review-support's `rangeGrip`).
+ *
+ * RANGE endpoints are not this function's business: a drag may legitimately cover deleted
+ * text, so callers snap only collapsed selections.
+ */
+export function snapCaretOutOfDeletion(
+  layout: SemanticLayout,
+  position: SemanticPosition
+): SemanticPosition {
+  for (const range of paragraphDeletedRanges(layout, position.paragraphId)) {
+    if (position.offset > range.start && position.offset < range.end) {
+      return { paragraphId: position.paragraphId, offset: range.start };
+    }
+  }
+  return position;
+}

--- a/packages/core/src/layout/paragraph-lines.ts
+++ b/packages/core/src/layout/paragraph-lines.ts
@@ -86,10 +86,9 @@ export function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedL
  * A paragraph's deleted model ranges, coalesced across every line that carries them.
  *
  * `LineRecord.deletedRanges` is CLIPPED to each line, so a deletion that wraps publishes one
- * slice per line and every wrap boundary looks like a range edge. Read per line, those false
- * edges became caret stops in the middle of struck text — navigable, and worse, typable:
- * a keystroke there landed inside the `w:del`. Merging adjacent and overlapping slices
- * restores the deletion's true extent, so only its real boundaries survive as caret targets.
+ * slice per line and every wrap boundary looks like a range edge. Merging adjacent and
+ * overlapping slices restores the deletion's true extent, so an insertion aimed inside the
+ * region relocates past ALL of it rather than to the nearest wrap boundary.
  *
  * Memoized per layout: a published layout is immutable, and the stop builder asks once per
  * line of the paragraph.
@@ -150,45 +149,25 @@ export function insideDeletedContent(
 }
 
 /**
- * A word-boundary target that landed inside deleted content resolves to the region's edge in
- * the direction of travel — the same "step over, never into" answer the stop list gives a
- * plain arrow. Left as-is, the word walk handed back an interior offset and the surface's
- * collapsed-caret snap bounced it straight back to where it started: a permanently dead key.
- */
-export function skipDeletedRegion(
-  ranges: readonly { start: number; end: number }[],
-  offset: number,
-  direction: -1 | 1
-): number {
-  for (const range of ranges) {
-    if (offset > range.start && offset < range.end) {
-      return direction === 1 ? range.end : range.start;
-    }
-  }
-  return offset;
-}
-
-/**
- * Where a collapsed caret may actually rest: never strictly inside deleted content.
+ * Where an INSERT aimed at this position actually lands: past any deletion it sits inside.
  *
- * A gesture can resolve to such an offset — the browser reports the struck character a click
- * landed on — but no caret stop owns it. A caret adopted there is a dead one: every arrow
- * asks the stop list where it is and gets no answer, and an edit committed there writes
- * characters INSIDE the deletion, text that exists in neither the original nor the proposal.
- * Snapped to the START of the deleted region, which is a real stop, and which
- * keeps a click anywhere on struck text activating the deletion's own review card (a range
- * grips its start boundary as firmly as its interior — see review-support's `rangeGrip`).
+ * The caret may rest anywhere in struck text — Word's rule, and the tracked lane's
+ * (`tree-op-tracked.ts`): all-markup shows the words, so the reader can put the caret
+ * between two of them. What may NOT happen is new content landing inside the `w:del`,
+ * where it would serialize as `w:t` under a wrapper that requires `w:delText` and be taken
+ * down by an accept of someone else's deletion. A deletion stays contiguous, so the words
+ * go after it — the order a replacement reads in.
  *
  * RANGE endpoints are not this function's business: a drag may legitimately cover deleted
- * text, so callers snap only collapsed selections.
+ * text, so callers adjust only collapsed insertion points.
  */
-export function snapCaretOutOfDeletion(
+export function positionPastDeletion(
   layout: SemanticLayout,
   position: SemanticPosition
 ): SemanticPosition {
   for (const range of paragraphDeletedRanges(layout, position.paragraphId)) {
     if (position.offset > range.start && position.offset < range.end) {
-      return { paragraphId: position.paragraphId, offset: range.start };
+      return { paragraphId: position.paragraphId, offset: range.end };
     }
   }
   return position;

--- a/packages/core/src/layout/semantic-caret-navigation.ts
+++ b/packages/core/src/layout/semantic-caret-navigation.ts
@@ -30,6 +30,57 @@ function nearestOnLine<T extends VerticalCaretStop>(
   return best;
 }
 
+/**
+ * The stop nearest a position that NO stop owns, in the same paragraph, or null.
+ *
+ * A gesture can leave the caret at such an offset — a drag or shift-click endpoint resolves
+ * to the character the browser saw, and the interior of deleted content is deliberately not
+ * a caret stop. Refusing to move from there made every arrow a dead press. Ties go to the
+ * earlier stop, matching the "before the region" answer a step-over gives.
+ */
+export function nearestStop<T extends VerticalCaretStop>(
+  stops: readonly T[],
+  position: VerticalCaretStop['position']
+): T | null {
+  let best: T | null = null;
+  for (const stop of stops) {
+    if (stop.position.paragraphId !== position.paragraphId) continue;
+    if (
+      !best ||
+      Math.abs(stop.position.offset - position.offset) <
+        Math.abs(best.position.offset - position.offset)
+    ) {
+      best = stop;
+    }
+  }
+  return best;
+}
+
+/**
+ * The first stop past an unowned position in the direction of travel, or null.
+ *
+ * For horizontal motion the resolution IS the move: from inside a deleted region, Right goes
+ * to the stop just past it and Left to the one just before, exactly where a step-over from
+ * the boundary would have landed.
+ */
+export function stopInDirection<T extends VerticalCaretStop>(
+  stops: readonly T[],
+  position: VerticalCaretStop['position'],
+  direction: -1 | 1
+): T | null {
+  let best: T | null = null;
+  for (const stop of stops) {
+    if (stop.position.paragraphId !== position.paragraphId) continue;
+    const offset = stop.position.offset;
+    if (direction === 1) {
+      if (offset > position.offset && (!best || offset < best.position.offset)) best = stop;
+    } else if (offset < position.offset && (!best || offset > best.position.offset)) {
+      best = stop;
+    }
+  }
+  return best;
+}
+
 /** Home/End within the active paragraph's current visual line. */
 export function moveToLineEdge<T extends VerticalCaretStop>(
   position: VerticalCaretStop['position'],
@@ -37,8 +88,10 @@ export function moveToLineEdge<T extends VerticalCaretStop>(
   indexed: IndexedCaretStops<T>
 ): VerticalCaretStop['position'] | null {
   const stopIndex = indexed.index.get(position.paragraphId)?.get(position.offset);
-  if (stopIndex === undefined) return null;
-  const lineId = indexed.stops[stopIndex]!.lineId;
+  const stop =
+    stopIndex === undefined ? nearestStop(indexed.stops, position) : indexed.stops[stopIndex]!;
+  if (!stop) return null;
+  const lineId = stop.lineId;
   const onLine = indexed.stops.filter((stop) => stop.lineId === lineId);
   return (direction === -1 ? onLine[0] : onLine[onLine.length - 1])?.position ?? null;
 }
@@ -53,10 +106,15 @@ export function moveHorizontalCaret<T extends VerticalCaretStop>(
 ): { position: VerticalCaretStop['position']; desiredX: null } | null {
   const current = stopsForParagraph(position.paragraphId);
   const stopIndex = current.index.get(position.paragraphId)?.get(position.offset);
-  if (stopIndex === undefined) return null;
-  const localTarget = stopIndex + direction;
-  if (localTarget >= 0 && localTarget < current.stops.length) {
-    return { position: current.stops[localTarget]!.position, desiredX: null };
+  if (stopIndex === undefined) {
+    const resolved = stopInDirection(current.stops, position, direction);
+    if (resolved) return { position: resolved.position, desiredX: null };
+    // Past every stop of this paragraph in that direction: the neighbour, like an edge step.
+  } else {
+    const localTarget = stopIndex + direction;
+    if (localTarget >= 0 && localTarget < current.stops.length) {
+      return { position: current.stops[localTarget]!.position, desiredX: null };
+    }
   }
   const neighbourId = order[paragraphIndex + direction];
   if (!neighbourId) return { position, desiredX: null };
@@ -88,8 +146,9 @@ export function moveVerticalCaret<T extends VerticalCaretStop>(
 ): { position: VerticalCaretStop['position']; desiredX: number } | null {
   const current = stopsForParagraph(position.paragraphId);
   const stopIndex = current.index.get(position.paragraphId)?.get(position.offset);
-  if (stopIndex === undefined) return null;
-  const currentStop = current.stops[stopIndex]!;
+  const currentStop =
+    stopIndex === undefined ? nearestStop(current.stops, position) : current.stops[stopIndex]!;
+  if (!currentStop) return null;
   const targetX = desiredX ?? currentStop.x;
   const currentLines = lineIdsOf(current.stops);
   const currentLineIndex = currentLines.indexOf(currentStop.lineId);

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -33,11 +33,20 @@ import {
   moveToDocumentEdge,
   moveToLineEdge,
   moveVerticalCaret,
+  nearestStop,
+  stopInDirection,
 } from './semantic-caret-navigation.ts';
+import {
+  insideDeletedContent,
+  paragraphDeletedRanges,
+  paragraphLinesIndex,
+  skipDeletedRegion,
+} from './paragraph-lines.ts';
 import { wordBoundary } from './semantic-word-navigation.ts';
 import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
 
 export { wordBoundary } from './semantic-word-navigation.ts';
+export { snapCaretOutOfDeletion } from './paragraph-lines.ts';
 
 /** A caret position in the model. */
 export interface SemanticPosition {
@@ -78,79 +87,6 @@ export interface SelectionRect {
 }
 
 /**
- * Lines grouped by the paragraph they render, with the page each sits on.
- *
- * Memoized PER LAYOUT — a published layout is immutable, so the grouping is computed once
- * per revision instead of once per read. The reads this serves — caret geometry, span
- * lookup for a selection, text reconstruction — are all "the lines of ONE paragraph", and
- * answering them by scanning every line of every page made each one O(document); the
- * toolbar asks after every commit, so the scans multiplied per keystroke.
- */
-interface PlacedLine {
-  readonly line: LineRecord;
-  readonly pageIndex: number;
-}
-
-const paragraphLinesCache = new WeakMap<SemanticLayout, Map<string, PlacedLine[]>>();
-
-function paragraphLinesIndex(layout: SemanticLayout): Map<string, PlacedLine[]> {
-  const cached = paragraphLinesCache.get(layout);
-  if (cached) return cached;
-  const index = new Map<string, PlacedLine[]>();
-  /**
-   * Under every paragraph the line carries, not just the one it names.
-   *
-   * A merged line belongs to two paragraphs, and a caret walking either of them has to find
-   * it. An ordinary line has one segment and lands in exactly the one bucket it always did.
-   */
-  const indexLine = (line: LineRecord, pageIndex: number): void => {
-    for (const segment of lineSegments(line)) {
-      const placed = { line, pageIndex };
-      const entry = index.get(segment.paragraphId);
-      if (entry) entry.push(placed);
-      else index.set(segment.paragraphId, [placed]);
-    }
-  };
-  const indexFragments = (
-    fragments: readonly import('./semantic-records.ts').BlockFragmentRecord[],
-    pageIndex: number
-  ): void => {
-    const visit = (
-      blocks: readonly import('./semantic-records.ts').BlockFragmentRecord[]
-    ): void => {
-      for (const block of blocks) {
-        if (block.kind === 'paragraph') {
-          for (const line of block.lines) indexLine(line, pageIndex);
-          continue;
-        }
-        for (const row of block.rows) {
-          if (row.isHeaderRepeat) continue;
-          for (const cell of row.cells) visit(cell.blocks);
-        }
-      }
-    };
-    visit(fragments);
-  };
-  for (const page of layout.pages) {
-    // Body first — primary story for caret stops built elsewhere via paragraphFragmentsOf.
-    for (const fragment of paragraphFragmentsOf(page)) {
-      for (const line of fragment.lines) indexLine(line, page.index);
-    }
-    // Furniture paragraphs share this index so formatting / paragraphTextFromLayout can
-    // resolve an open header/footer selection. documentOrder and caretStops stay body-only.
-    if (page.header) indexFragments(page.header.fragments, page.index);
-    if (page.footer) indexFragments(page.footer.fragments, page.index);
-    // Note stories (footnotes/endnotes) — same formatting lane as furniture; not body order.
-    for (const area of [page.footnotes, page.endnotes]) {
-      if (!area) continue;
-      for (const note of area.notes) indexFragments(note.fragments, page.index);
-    }
-  }
-  paragraphLinesCache.set(layout, index);
-  return index;
-}
-
-/**
  * Whether a LATER line of the same paragraph starts at this offset, and so owns it.
  *
  * Asked across the whole paragraph rather than the current fragment: a paragraph split by a
@@ -183,22 +119,6 @@ function laterLineWithDrawingAt(
     if (line.drawings?.some((drawing) => drawing.start === offset)) return line;
   }
   return null;
-}
-
-/**
- * True when this offset sits strictly INSIDE deleted content on the line.
- *
- * The boundaries are kept: the position immediately before a deletion and the one immediately
- * after it are both real places to put a caret, and dropping them would make the deletion
- * unreachable — including for the accept or reject that resolves it.
- */
-function insideDeletedContent(line: LineRecord, offset: number): boolean {
-  const ranges = line.deletedRanges;
-  if (ranges === undefined) return false;
-  for (const range of ranges) {
-    if (offset > range.start && offset < range.end) return true;
-  }
-  return false;
 }
 
 /**
@@ -261,6 +181,9 @@ function pushSegmentCaretStops(
   measurer?: TextMeasurer
 ): void {
   const mixed = lineSegments(line).length > 1;
+  // Paragraph-wide, not this line's own slices: a deletion that wraps is clipped per line,
+  // and its wrap boundaries must not read as region edges (see paragraphDeletedRanges).
+  const deleted = paragraphDeletedRanges(layout, segment.paragraphId);
   for (let offset = segment.start; offset <= segment.end; offset += 1) {
     // A line ENDED BY A HARD BREAK does not own the position after it — the line the
     // break opened does, and `caretAt` places the caret there. Emitting it here too
@@ -292,7 +215,7 @@ function pushSegmentCaretStops(
     // Deleted content is skipped for the same reason and by the same lane: `moveCaret` reads
     // this list and nothing else, so arrow keys, word jumps, page jumps and Home/End all
     // inherit "step over a deletion, never into it" from one place.
-    if (insideDeletedContent(line, offset)) continue;
+    if (insideDeletedContent(deleted, offset)) continue;
     stops.push({
       position: { paragraphId: segment.paragraphId, offset },
       x: xWithinLine(line, offset, measurer, segment),
@@ -680,9 +603,15 @@ export function moveCaret(
   }
   if (!options.stops && (command === 'wordLeft' || command === 'wordRight')) {
     const direction = command === 'wordLeft' ? -1 : 1;
-    const target = wordBoundary(
-      paragraphTextFromLayout(layout, position.paragraphId),
-      position.offset,
+    // The paragraph text includes deleted characters — they occupy model offsets in every
+    // mode — so a word boundary can land inside a deletion. Skip to its edge instead.
+    const target = skipDeletedRegion(
+      paragraphDeletedRanges(layout, position.paragraphId),
+      wordBoundary(
+        paragraphTextFromLayout(layout, position.paragraphId),
+        position.offset,
+        direction
+      ),
       direction
     );
     return target === position.offset
@@ -723,11 +652,25 @@ export function moveCaret(
   }
   const stops = options.stops ? [...options.stops] : caretStops(layout, options.measurer);
   if (stops.length === 0) return null;
-  const index = stops.findIndex(
+  let index = stops.findIndex(
     (stop) =>
       stop.position.paragraphId === position.paragraphId && stop.position.offset === position.offset
   );
-  if (index === -1) return null;
+  if (index === -1) {
+    // NO stop owns this position — a gesture endpoint left inside deleted content, whose
+    // interior is deliberately not navigable. Refusing made every key from there a dead
+    // press. For horizontal motion the nearest stop in the direction of travel IS the move;
+    // everything else proceeds from the nearest stop of the same paragraph.
+    if (command === 'left' || command === 'right') {
+      const resolved =
+        stopInDirection(stops, position, command === 'left' ? -1 : 1) ??
+        nearestStop(stops, position);
+      return resolved ? { position: resolved.position, desiredX: null } : null;
+    }
+    const resolved = nearestStop(stops, position);
+    if (!resolved) return null;
+    index = stops.indexOf(resolved);
+  }
   const current = stops[index]!;
 
   switch (command) {
@@ -751,7 +694,11 @@ export function moveCaret(
     case 'wordRight': {
       const text = paragraphTextFromLayout(layout, position.paragraphId);
       const direction = command === 'wordLeft' ? -1 : 1;
-      const target = wordBoundary(text, position.offset, direction);
+      const target = skipDeletedRegion(
+        paragraphDeletedRanges(layout, position.paragraphId),
+        wordBoundary(text, position.offset, direction),
+        direction
+      );
       // Already at the paragraph edge: step into the neighbouring paragraph the way a plain
       // arrow would, so the key is never a dead press at a boundary.
       if (target === position.offset) {

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -40,13 +40,12 @@ import {
   insideDeletedContent,
   paragraphDeletedRanges,
   paragraphLinesIndex,
-  skipDeletedRegion,
 } from './paragraph-lines.ts';
 import { wordBoundary } from './semantic-word-navigation.ts';
 import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
 
 export { wordBoundary } from './semantic-word-navigation.ts';
-export { snapCaretOutOfDeletion } from './paragraph-lines.ts';
+export { positionPastDeletion } from './paragraph-lines.ts';
 
 /** A caret position in the model. */
 export interface SemanticPosition {
@@ -184,6 +183,9 @@ function pushSegmentCaretStops(
   // Paragraph-wide, not this line's own slices: a deletion that wraps is clipped per line,
   // and its wrap boundaries must not read as region edges (see paragraphDeletedRanges).
   const deleted = paragraphDeletedRanges(layout, segment.paragraphId);
+  /** Whether some painted span covers this offset — the glyphs the caret would sit between. */
+  const painted = (offset: number): boolean =>
+    segment.spans.some((span) => span.range.start <= offset && offset <= span.range.end);
   for (let offset = segment.start; offset <= segment.end; offset += 1) {
     // A line ENDED BY A HARD BREAK does not own the position after it — the line the
     // break opened does, and `caretAt` places the caret there. Emitting it here too
@@ -212,10 +214,13 @@ function pushSegmentCaretStops(
       }
     }
     if (isNonNavigableInterior(line, offset, segment)) continue;
-    // Deleted content is skipped for the same reason and by the same lane: `moveCaret` reads
-    // this list and nothing else, so arrow keys, word jumps, page jumps and Home/End all
-    // inherit "step over a deletion, never into it" from one place.
-    if (insideDeletedContent(deleted, offset)) continue;
+    // VISIBLE deleted content is fully navigable — Word lets the caret rest between struck
+    // characters, and the tracked lane already accepts inserts there (`tree-op-tracked.ts`).
+    // What is skipped is a deleted offset the display mode resolved AWAY: in the proposed
+    // result those characters paint no span at all, and an offset-by-offset walk would stop
+    // at invisible positions. Derived from the spans rather than from the mode, so the rule
+    // holds in any mode that suppresses them.
+    if (insideDeletedContent(deleted, offset) && !painted(offset)) continue;
     stops.push({
       position: { paragraphId: segment.paragraphId, offset },
       x: xWithinLine(line, offset, measurer, segment),
@@ -603,15 +608,9 @@ export function moveCaret(
   }
   if (!options.stops && (command === 'wordLeft' || command === 'wordRight')) {
     const direction = command === 'wordLeft' ? -1 : 1;
-    // The paragraph text includes deleted characters — they occupy model offsets in every
-    // mode — so a word boundary can land inside a deletion. Skip to its edge instead.
-    const target = skipDeletedRegion(
-      paragraphDeletedRanges(layout, position.paragraphId),
-      wordBoundary(
-        paragraphTextFromLayout(layout, position.paragraphId),
-        position.offset,
-        direction
-      ),
+    const target = wordBoundary(
+      paragraphTextFromLayout(layout, position.paragraphId),
+      position.offset,
       direction
     );
     return target === position.offset
@@ -694,11 +693,7 @@ export function moveCaret(
     case 'wordRight': {
       const text = paragraphTextFromLayout(layout, position.paragraphId);
       const direction = command === 'wordLeft' ? -1 : 1;
-      const target = skipDeletedRegion(
-        paragraphDeletedRanges(layout, position.paragraphId),
-        wordBoundary(text, position.offset, direction),
-        direction
-      );
+      const target = wordBoundary(text, position.offset, direction);
       // Already at the paragraph edge: step into the neighbouring paragraph the way a plain
       // arrow would, so the key is never a dead press at a boundary.
       if (target === position.offset) {

--- a/packages/core/src/store/__tests__/insert-beside-deletion.test.ts
+++ b/packages/core/src/store/__tests__/insert-beside-deletion.test.ts
@@ -1,0 +1,104 @@
+// An insert aimed inside a deletion lands BESIDE it, never in it.
+//
+// The caret may rest anywhere in struck text, so `insertText` can arrive with an offset in
+// the middle of a `w:delText`. Splitting the value in place put the new `w:t` inside the
+// `w:del` — §17.3.3.7 requires `w:delText` there, and accepting that unrelated deletion
+// would take the typed words with it. The tracked lane already states the rule
+// (`tree-op-tracked.ts`); this pins the plain lane to the same one.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  serializeOoxmlPart,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../package/ooxml-tree.ts';
+import { applyTreeOp } from '../store/tree-ops.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function firstParagraphId(part: OoxmlPart): string {
+  let found: string | null = null;
+  const walk = (node: OoxmlNode): void => {
+    if (found || node.kind === 'textValue') return;
+    if (node.kind === 'paragraph') {
+      found = node.id;
+      return;
+    }
+    for (const child of node.children) walk(child);
+  };
+  walk(part.root);
+  if (!found) throw new Error('no paragraph');
+  return found;
+}
+
+describe('insertText into deleted content', () => {
+  test('the new text lands after the w:del, and the deletion stays whole', () => {
+    // `AB` + deleted `CDE` + `FG`; offset 3 is between the deleted C and D.
+    const part = load(
+      '<w:p><w:r><w:t>AB</w:t></w:r>' +
+        '<w:del w:id="1" w:author="Dev" w:date="2026-03-26T11:00:00Z">' +
+        '<w:r><w:delText>CDE</w:delText></w:r></w:del>' +
+        '<w:r><w:t>FG</w:t></w:r></w:p>'
+    );
+    const result = applyTreeOp(part, {
+      op: 'insertText',
+      paragraphId: firstParagraphId(part),
+      offset: 3,
+      text: 'X',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const xml = serializeOoxmlPart(result.part);
+    expect(xml).toContain('<w:delText>CDE</w:delText>');
+    expect(xml).toMatch(/<\/w:del><w:r><w:t>X<\/w:t><\/w:r>/);
+  });
+
+  test('under ins-wrapping-del, the text lands outside BOTH wrappers', () => {
+    // Placed between the two would put the words inside someone else's insertion, where
+    // rejecting their proposal deletes yours.
+    const part = load(
+      '<w:p><w:r><w:t>AB</w:t></w:r>' +
+        '<w:ins w:id="1" w:author="QA" w:date="2026-03-26T11:00:00Z">' +
+        '<w:del w:id="2" w:author="Dev" w:date="2026-03-26T11:00:00Z">' +
+        '<w:r><w:delText>CDE</w:delText></w:r></w:del></w:ins>' +
+        '<w:r><w:t>FG</w:t></w:r></w:p>'
+    );
+    const result = applyTreeOp(part, {
+      op: 'insertText',
+      paragraphId: firstParagraphId(part),
+      offset: 3,
+      text: 'X',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const xml = serializeOoxmlPart(result.part);
+    expect(xml).toMatch(/<\/w:del><\/w:ins><w:r><w:t>X<\/w:t><\/w:r>/);
+  });
+
+  test('the run properties of the struck run carry over to the new run', () => {
+    const part = load(
+      '<w:p><w:del w:id="1" w:author="Dev" w:date="2026-03-26T11:00:00Z">' +
+        '<w:r><w:rPr><w:b/></w:rPr><w:delText>CDE</w:delText></w:r></w:del></w:p>'
+    );
+    const result = applyTreeOp(part, {
+      op: 'insertText',
+      paragraphId: firstParagraphId(part),
+      offset: 1,
+      text: 'X',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const xml = serializeOoxmlPart(result.part);
+    expect(xml).toMatch(/<\/w:del><w:r><w:rPr><w:b\/><\/w:rPr><w:t>X<\/w:t><\/w:r>/);
+  });
+});

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -508,6 +508,19 @@ function applyInsertContent(
     if (!textNode) return { ok: false, reason: 'tree-invariant', detail: 'orphan text value' };
     const run = findNode(part, segment.runId);
     if (!run || run.kind !== 'run') return { ok: false, reason: 'tree-invariant' };
+    // INSIDE struck text: the caret may rest there, but new content goes BESIDE the deletion,
+    // never into it — the same rule the tracked lane states (`tree-op-tracked.ts`). Split in
+    // place, the new nodes serialized as `w:t` under a wrapper that requires `w:delText`, and
+    // an accept of that unrelated deletion took the typed words with it.
+    if (textNode.kind === 'deletedText') {
+      const relocated = insertBesideDeletion(part, paragraph, run, nodes, 'after', {
+        nextId,
+        effect,
+        control,
+        options,
+      });
+      if (relocated) return relocated;
+    }
     const kind = textNode.kind === 'deletedText' ? 'deletedText' : 'text';
     const head = textElement(nextId, value.slice(0, local), kind);
     const tail = textElement(nextId, value.slice(local), kind);
@@ -583,6 +596,16 @@ function applyInsertContent(
   ) {
     const run = findNode(part, before.runId);
     if (!run || run.kind !== 'run') return { ok: false, reason: 'tree-invariant' };
+    // The end boundary of a deletion: the left run's characters are struck, and joining it
+    // would put the new text inside the `w:del`. Beside it instead — same rule as the
+    // interior case above.
+    const relocated = insertBesideDeletion(part, paragraph, run, nodes, 'after', {
+      nextId,
+      effect,
+      control,
+      options,
+    });
+    if (relocated) return relocated;
     const index = run.children.findIndex((child) => contains(child, before.node.id));
     inserted = fromEdit(
       insertChildren(
@@ -599,6 +622,15 @@ function applyInsertContent(
   if (after) {
     const run = findNode(part, after.runId);
     if (!run || run.kind !== 'run') return { ok: false, reason: 'tree-invariant' };
+    // The START boundary of a deletion, reached when nothing to the left takes the text:
+    // the new content goes before the wrapper, never into the struck run's head.
+    const relocated = insertBesideDeletion(part, paragraph, run, nodes, 'before', {
+      nextId,
+      effect,
+      control,
+      options,
+    });
+    if (relocated) return relocated;
     const index = run.children.findIndex((child) => contains(child, after.node.id));
     inserted = fromEdit(
       insertChildren(part, run.id, Math.max(0, index), nodes, deferOptions(options, control)),
@@ -659,6 +691,63 @@ function applyInsertContent(
     effect
   );
   return finishContentEdit(inserted, control, options);
+}
+
+/**
+ * Insert content BESIDE the deletion a run belongs to, or null when the run is not deleted.
+ *
+ * New content must never land inside a `w:del`/`w:moveFrom`: it would serialize as `w:t`
+ * under a wrapper that requires `w:delText` (§17.3.3.7), and an accept of that unrelated
+ * deletion would take the typed words with it. Placed beside the OUTERMOST enclosing
+ * revision wrapper: for `w:ins` wrapping `w:del`, landing between the two would put the
+ * words inside someone else's insertion, where rejecting their proposal deletes yours. The
+ * struck run's own `w:rPr` carries over, so the text keeps the formatting the caret showed.
+ */
+function insertBesideDeletion(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  run: OoxmlNode,
+  nodes: readonly OoxmlNode[],
+  side: 'before' | 'after',
+  context: {
+    readonly nextId: () => string;
+    readonly effect: TreeOpEffect;
+    readonly control: OoxmlNode | null;
+    readonly options?: EditOptions;
+  }
+): TreeOpResult | null {
+  let wrapper: OoxmlNode | null = null;
+  let deleted = false;
+  for (
+    let ancestor = parentOf(part, run.id);
+    ancestor && ancestor.id !== paragraph.id;
+    ancestor = parentOf(part, ancestor.id)
+  ) {
+    if (!isContentRevisionKind(ancestor.kind)) continue;
+    wrapper = ancestor;
+    if (ancestor.kind === 'revisionDelete' || ancestor.kind === 'revisionMoveFrom') {
+      deleted = true;
+    }
+  }
+  if (!deleted || !wrapper) return null;
+  const holder = parentOf(part, wrapper.id);
+  if (!holder) return { ok: false, reason: 'tree-invariant' };
+  const at = holder.children.findIndex((child) => child.id === wrapper.id);
+  if (at < 0) return { ok: false, reason: 'tree-invariant' };
+  const properties = (run.kind === 'textValue' ? [] : run.children)
+    .filter((child) => isRunPropertiesNode(child))
+    .map((child) => cloneWithNewIds(child, context.nextId));
+  const inserted = fromEdit(
+    insertChildren(
+      part,
+      holder.id,
+      side === 'after' ? at + 1 : at,
+      [runElement(context.nextId, [...properties, ...nodes])],
+      deferOptions(context.options, context.control)
+    ),
+    context.effect
+  );
+  return finishContentEdit(inserted, context.control, context.options);
 }
 
 /** Defer validation when a temporary unwrap still has to run in this op. */


### PR DESCRIPTION
Arrow keys jumped over a whole tracked deletion in one press, and a click inside struck text left a caret no arrow key could move. Word moves through deleted text one character at a time, so now the engine does too: visible deleted offsets are ordinary caret stops, skipped only when the display mode paints no glyphs for them (the proposed result).

Keeping the tree valid is the write path's job instead of navigation's. An insert aimed at or inside a deletion relocates beside the `w:del` — never into it, where it serialized as `w:t` under a wrapper that requires `w:delText` and would be taken down by accepting that unrelated deletion. Under `w:ins` wrapping `w:del` the text lands outside both wrappers. Per-line deleted ranges coalesce so a deletion that wraps across lines is one region, and the caret movers resolve an unowned position in the direction of travel instead of refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)