### PR TITLE
fix(react): narrow the review gutter on viewports too small for page and column

### DIFF
--- a/.changeset/review-gutter-narrow-viewports.md
+++ b/.changeset/review-gutter-narrow-viewports.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+The review rail's gutter now narrows on viewports too small for the page and the full card column, so the document stays centered instead of pinned against the left edge.

--- a/.changeset/review-gutter-narrow-viewports.md
+++ b/.changeset/review-gutter-narrow-viewports.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-The review rail's gutter now narrows on viewports too small for the page and the full card column, so the document stays centered instead of pinned against the left edge.
+The review rail reserves its card column only while the viewport has room for it beside the page; on narrower viewports the marker strip mirrors onto both edges so the document stays centered.

--- a/.changeset/review-gutter-narrow-viewports.md
+++ b/.changeset/review-gutter-narrow-viewports.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/react': patch
+'@docx-editor.dev/react': minor
 ---
 
-The review rail reserves its card column only while the viewport has room for it beside the page; on narrower viewports the marker strip mirrors onto both edges so the document stays centered.
+The review rail adapts to the viewport: the full card column is reserved only while there is room for it beside the page, and narrower viewports get a centered document with a compact rail — markers in a mirrored strip, with the active card floating fully visible inside the viewport's edge. Custom chrome can read the reservation through the new `useReviewGutter` hook.

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -1287,6 +1287,7 @@ export function navigationShift(input: NavigationShiftInput): number;
 export interface NavigationShiftInput {
     readonly docked?: boolean;
     readonly inlineEndReservation?: number;
+    readonly inlineStartReservation?: number;
     readonly pageWidthPx: number;
     readonly reservation: number;
     readonly viewportWidth: number;
@@ -1517,6 +1518,7 @@ export function reviewGutter(input: ReviewGutterInput): ReviewGutter;
 // @public (undocumented)
 export interface ReviewGutterInput {
     readonly docked?: boolean;
+    readonly inlineStartReservation?: number;
     readonly open: boolean;
     readonly pageWidthPx: number;
     readonly viewportWidth: number;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -1495,7 +1495,32 @@ export { PX_PER_CM }
 
 export { PX_PER_INCH }
 
+// @public
+export const REVIEW_MARKERS_GUTTER = 44;
+
+// @public
+export const REVIEW_PANE_GUTTER = 316;
+
 export { ReviewAuthorInfo }
+
+// @public
+export interface ReviewGutter {
+    // (undocumented)
+    readonly inlineEnd: number;
+    // (undocumented)
+    readonly inlineStart: number;
+}
+
+// @public
+export function reviewGutter(input: ReviewGutterInput): ReviewGutter;
+
+// @public (undocumented)
+export interface ReviewGutterInput {
+    readonly docked?: boolean;
+    readonly open: boolean;
+    readonly pageWidthPx: number;
+    readonly viewportWidth: number;
+}
 
 // @public (undocumented)
 export const ReviewRailContext: react.Context<ReviewRailRegistry | null>;
@@ -2010,6 +2035,9 @@ export interface UseParagraphStyleResult {
 
 // @public
 export function useReviewAuthors(): readonly ReviewAuthorInfo[];
+
+// @public
+export function useReviewGutter(): ReviewGutter;
 
 // @public
 export function useTableBorderTargetLabel(): string;

--- a/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
+++ b/openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-export-divergence.md
@@ -62,6 +62,16 @@ exemptions go when it lands.
   or a comment. The engine half (`getReviewAuthors`/`setRevisionStyles` on the instance) is
   shared, so a Vue host reaches the capability through the facade today; the Vue twin is a
   composable, with the rest of that layer.
+- `useReviewGutter` — the paddings the Viewport reserves for the review rail (the full
+  column, or the mirrored marker strip on a viewport too narrow for it). A hook over the
+  React layout store, so it belongs to the provider layer Vue has no twin of; the Vue
+  viewport does not reserve a review gutter at all yet.
+- `ReviewGutter` — that hook's return shape.
+- `reviewGutter` — the reservation rule as a pure function, for hosts and tests.
+- `ReviewGutterInput` — that function's input shape.
+- `REVIEW_PANE_GUTTER` — the full column's reservation width, exported so a custom rail
+  can tell which presentation the reservation can hold.
+- `REVIEW_MARKERS_GUTTER` — the marker strip's reservation width, same purpose.
 - `DocxEditorColorByChangeType` — declarative opt-out from by-author revision colouring
   (render-nothing component over the shared `setRevisionStyles`). Vue reaches the
   capability through its `revisionStyles` prop and the facade; a declarative twin lands

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4774,21 +4774,22 @@ a.docx-hyperlink:focus-visible {
 
 /* Room for the review pane. The page centres inside the scroller's padding box, so
  * reserving the rail's width here shifts the sheet left by half of it and the document and
- * its cards read as one centred pair. Closed, only the marker strip is reserved.
+ * its cards read as one centred pair.
  *
- * The open reservation is a MEASUREMENT, not a constant: `DocxEditor.Viewport` publishes
- * `--docx-review-gutter` from the viewport's width and the page's rendered width, so on a
- * host too narrow for the page and the full column the gutter narrows to what is left
- * after the sheet keeps a little clearance (never below the marker strip) instead of
- * shoving the sheet against the left edge.
- * The 316px fallback is the full column — a 300px card column plus its 16px gutter — and
- * stands only while nothing has measured. */
+ * The reservation is a MEASUREMENT, not a constant: `DocxEditor.Viewport` publishes
+ * `--docx-review-gutter` (this edge) and `--docx-review-gutter-start` (mirrored onto the
+ * inline start, composed into the navigation rule below) from the viewport's width and the
+ * page's entitled width. A viewport with room for both keeps the full column; one without
+ * gets the marker strip on BOTH edges, so the sheet sits centred instead of parked beside
+ * a mostly-empty band. The fallbacks — the full column while open, the strip while
+ * closed — are what stood before the measurement existed, so an unmeasured host paints as
+ * it always did. */
 .docx-editor__scroll-container[data-review-pane='open'] {
   padding-right: var(--docx-review-gutter, 316px);
 }
 
 .docx-editor__scroll-container[data-review-pane='closed'] {
-  padding-right: 44px;
+  padding-right: var(--docx-review-gutter, 44px);
 }
 
 /* The review rail (`DocxEditor.Review` / the Vue equivalent): one card per pending decision,
@@ -4919,7 +4920,12 @@ a.docx-hyperlink:focus-visible {
  * as scrollbar-gutter above. */
 .docx-editor .docx-editor__scroll-container,
 .docx-editor.docx-editor__scroll-container {
-  padding-inline-start: var(--docx-nav-shift, 0px);
+  /* Two reservations compose on this edge: the navigation pane's displacement, and the
+   * review gutter's mirrored strip (`--docx-review-gutter-start`, 0 whenever the full
+   * column stands on the right). One declaration, because `padding-inline-start` and
+   * `padding-left` are the same slot in LTR and a second rule would just lose the
+   * specificity fight. */
+  padding-inline-start: calc(var(--docx-nav-shift, 0px) + var(--docx-review-gutter-start, 0px));
   transition: padding-inline-start 0.2s ease;
 }
 

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4813,6 +4813,14 @@ a.docx-hyperlink:focus-visible {
   width: 32px;
 }
 
+/* Compact rail (`data-compact`: the pane is open but the viewport reserved only the
+ * mirrored marker strip). The strip shows the markers, and the ONE active card floats at
+ * column width, pinned inside the viewport's right edge — over the page, where a shadow
+ * has to separate it from the ink underneath. Its slot is positioned inline by the rail. */
+.docx-review__slot--compact .docx-review__card {
+  box-shadow: var(--doc-shadow-lg);
+}
+
 /* The "comment on this" button. Pulled OUT of the card column, onto the page's own edge:
    the column is where comments live, and a button standing in it lands on whichever card
    already annotates the text being re-selected. On the edge there is nothing to collide

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4774,9 +4774,17 @@ a.docx-hyperlink:focus-visible {
 
 /* Room for the review pane. The page centres inside the scroller's padding box, so
  * reserving the rail's width here shifts the sheet left by half of it and the document and
- * its cards read as one centred pair. Closed, only the marker strip is reserved. */
+ * its cards read as one centred pair. Closed, only the marker strip is reserved.
+ *
+ * The open reservation is a MEASUREMENT, not a constant: `DocxEditor.Viewport` publishes
+ * `--docx-review-gutter` from the viewport's width and the page's rendered width, so on a
+ * host too narrow for the page and the full column the gutter narrows to what is left
+ * after the sheet keeps a little clearance (never below the marker strip) instead of
+ * shoving the sheet against the left edge.
+ * The 316px fallback is the full column — a 300px card column plus its 16px gutter — and
+ * stands only while nothing has measured. */
 .docx-editor__scroll-container[data-review-pane='open'] {
-  padding-right: 316px;
+  padding-right: var(--docx-review-gutter, 316px);
 }
 
 .docx-editor__scroll-container[data-review-pane='closed'] {

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -2637,9 +2637,14 @@ a.docx-hyperlink:focus-visible {
 /* The pane gutters reach the ruler as PADDING on its frame and the page as the scroller's
    padding. Both move by the same distance, so both have to move on the same curve —
    without this the sheet glided and the ruler above it snapped, and for the length of the
-   animation the ruler measured a page that was no longer under it. */
+   animation the ruler measured a page that was no longer under it.
+
+   The INLINE-START edge only, because that is the only edge the scroller animates: the
+   scroller's `padding-right` (the review column) deliberately snaps, so a ruler easing
+   its right padding for 0.2s measured a page that had already jumped. One edge per curve,
+   both elements on the same one. */
 .docx-ruler-frame {
-  transition: padding 0.2s ease;
+  transition: padding-inline-start 0.2s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -4819,6 +4824,14 @@ a.docx-hyperlink:focus-visible {
  * has to separate it from the ink underneath. Its slot is positioned inline by the rail. */
 .docx-review__slot--compact .docx-review__card {
   box-shadow: var(--doc-shadow-lg);
+}
+
+/* The column's cards print BESIDE the sheet, which is harmless; the compact card floats
+ * OVER it, which would print on top of the document's own ink. Screen chrome only. */
+@media print {
+  .docx-review__slot--compact {
+    display: none !important;
+  }
 }
 
 /* The "comment on this" button. Pulled OUT of the card column, onto the page's own edge:

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -52,16 +52,19 @@ import type {
 } from '@docx-editor.dev/core/contracts/editor';
 import type { TranslationKey } from '@docx-editor.dev/i18n';
 import {
+  REVIEW_PANE_GUTTER,
   ReviewRailContext,
   Slot,
   useDocxEditor,
   useEditorState,
   useReviewAuthors,
+  useReviewGutter,
   useTranslation,
   type ReviewAuthorInfo,
   type ToolbarTranslate,
 } from '@docx-editor.dev/react';
 import { cloneReviewCard, partitionReviewChildren } from './review-composition';
+import { COMPACT_CARD_WIDTH, useRailMetrics, useRailWindow } from './use-rail-geometry';
 import { useReviewSlotSizing } from './use-review-slot-sizing';
 import { useReview, type ReviewItemView } from './useReview';
 import {
@@ -161,33 +164,8 @@ interface ReviewRailValue {
   readonly endDraft: () => void;
 }
 
-/** Where the rail is, in the coordinates of its positioning container. */
-interface RailMetrics {
-  /** Layout points to CSS pixels, from the engine. */
-  readonly scale: number;
-  /** The painted surface's own top offset, so chrome above the pages does not shift cards. */
-  readonly top: number;
-  /** Left edge, one gutter right of the sheet; null until there is a surface to measure. */
-  readonly left: number | null;
-}
-
-const INITIAL_METRICS: RailMetrics = { scale: 96 / 72, top: 0, left: null };
-
-/** Space between the page edge and the cards. */
-const RAIL_GUTTER = 16;
-
 /** The compose affordance's place in the stacking run. Not a review item; never rendered. */
 const COMPOSE_KEY = '\u0000compose';
-
-/**
- * How far outside the visible scroll window a card still mounts, in pixels.
- *
- * Enough that a normal scroll or a pane toggle never shows an empty gutter, small enough
- * that a document with two hundred comments mounts a handful of cards rather than all of
- * them. Rendering every card was the toggle's lag: two hundred cards' worth of DOM, plus a
- * `top` transition on each, in one frame.
- */
-const RAIL_OVERSCAN = 600;
 
 /** What an unmeasured, uncollapsed card reserves in the stacking run, in CSS px. */
 const DEFAULT_CARD_HEIGHT = 72;
@@ -459,6 +437,17 @@ function ReviewRoot({
   // The pane's open state is the ENGINE's, not this component's: the toolbar toggles it and
   // the viewport shifts the page for it, so a flag kept here would be a third opinion.
   const open = review.paneOpen;
+  // How much room the viewport actually reserved for that open pane. On a viewport too
+  // narrow for the full column, `DocxEditor.Viewport` mirrors the marker strip onto both
+  // edges instead — and a card drawn where the column would have been is cut off at the
+  // viewport's edge. So the rail follows the reservation: COMPACT means the pane is open
+  // but only the strip exists, and the rail presents markers with the one ACTIVE card
+  // floating pinned inside the viewport instead of the full column of cards. `inlineEnd`
+  // is 0 for one render while this rail's own registration is still in flight; that frame
+  // keeps the expanded presentation rather than flashing markers.
+  const gutter = useReviewGutter();
+  const compact = open && gutter.inlineEnd > 0 && gutter.inlineEnd < REVIEW_PANE_GUTTER;
+  const expanded = open && !compact;
 
   const items = useMemo(() => {
     return filter ? review.items.filter((entry) => filter(entry)) : review.items;
@@ -505,57 +494,10 @@ function ReviewRoot({
   // deliberate: dropping it would collapse the run and jump every card on screen.
   const observeSlot = useReviewSlotSizing(measure);
 
-  // Where the rail sits, measured from the PAINTED SURFACE rather than from the viewport.
-  //
-  // Both halves matter. Vertically, the surface's own offset inside the scroll container is
-  // whatever chrome the host put above the pages — without it every card is drawn that far
-  // too high. Horizontally, the page is centred in a viewport that is usually much wider, so
-  // a rail pinned to the right edge floats away from the page it annotates; it belongs one
-  // gutter to the right of the sheet, and it moves with the sheet when the window resizes or
-  // the zoom changes.
-  //
-  // Client rects, not `offsetLeft`/`offsetTop`: those are relative to each element's own
-  // `offsetParent`, and a host that positions its page wrapper makes the surface report
-  // `offsetLeft: 0` — landing the rail a page-width left, on top of the document. `scrollTop`
-  // and `clientTop` put the rects back into the same space the offsets used to describe.
-  const [metrics, setMetrics] = useState<RailMetrics>(INITIAL_METRICS);
-  useEffect(() => {
-    const rail = railRef.current;
-    if (!editor || !rail) return undefined;
-    const parent = rail.offsetParent as HTMLElement | null;
-    const surface = parent?.querySelector<HTMLElement>('.docx-paginated-surface') ?? null;
-    const sync = (): void => {
-      setMetrics((previous) => {
-        const box = surface && parent ? surface.getBoundingClientRect() : null;
-        const frame = box && parent ? parent.getBoundingClientRect() : null;
-        const next: RailMetrics = {
-          // The engine's own points-to-pixels factor, zoom included. Deriving it here from
-          // `getZoom()` alone dropped the 96/72 and put every card at three quarters height.
-          scale: editor.getRenderScale(),
-          top:
-            box && frame && parent ? box.top - frame.top - parent.clientTop + parent.scrollTop : 0,
-          left:
-            box && frame && parent
-              ? box.right - frame.left - parent.clientLeft + parent.scrollLeft + RAIL_GUTTER
-              : null,
-        };
-        return previous.scale === next.scale &&
-          previous.top === next.top &&
-          previous.left === next.left
-          ? previous
-          : next;
-      });
-    };
-    sync();
-    const observer = new ResizeObserver(sync);
-    if (parent) observer.observe(parent);
-    if (surface) observer.observe(surface);
-    return () => observer.disconnect();
-    // Re-measured whenever the queue could have moved: a new page above an anchor changes
-    // where its card belongs, and zoom changes every anchor at once. `documentAbsent` and
-    // `hidden` because the rail element does not exist while either holds, and a binding
-    // pass that ran against the null ref must run again once there is a rail to measure.
-  }, [editor, items, documentAbsent, hidden]);
+  // Where the rail sits and which band of the scroller is on screen — the DOM-measurement
+  // half of the rail, in `use-rail-geometry.ts`.
+  const metrics = useRailMetrics(editor, railRef, items, !documentAbsent && !hidden);
+  const window_ = useRailWindow(editor, railRef, !documentAbsent && !hidden);
 
   // Clicking the canvas AROUND the page closes the open item. The caret decides everything
   // else, but a click on the grey moves no caret, so nothing else would ever put a card away.
@@ -577,51 +519,6 @@ function ReviewRoot({
     // bubbling listener never sees a click that lands on the pages layer.
     document.addEventListener('mousedown', onMouseDown, true);
     return () => document.removeEventListener('mousedown', onMouseDown, true);
-    // `documentAbsent` and `hidden` for the same reason as the metrics effect: no rail element
-    // exists while either holds.
-  }, [editor, documentAbsent, hidden]);
-
-  // The visible band of the scroller, in the rail's own coordinates. Passive listener,
-  // coalesced into a frame: the handler runs on every wheel tick and must do nothing but
-  // record two numbers.
-  const [window_, setWindow] = useState<{ top: number; bottom: number } | null>(null);
-  useEffect(() => {
-    const rail = railRef.current;
-    const scroller = rail?.offsetParent as HTMLElement | null;
-    if (!scroller) return undefined;
-    let frame = 0;
-    const sync = (): void => {
-      frame = 0;
-      setWindow((previous) => {
-        const top = scroller.scrollTop - RAIL_OVERSCAN;
-        const bottom = scroller.scrollTop + scroller.clientHeight + RAIL_OVERSCAN;
-        return previous && previous.top === top && previous.bottom === bottom
-          ? previous
-          : { top, bottom };
-      });
-    };
-    // While the reader scrolls, the slots' `top` transition is suppressed (a DOM attribute
-    // so no React work happens at scroll frequency). Restacks DURING a scroll come from
-    // cards entering the window and correcting an estimated height to a measured one; each
-    // correction shifts every card below it, and ANIMATING those shifts while the page
-    // itself moves read as a second, faster scroll layered over the document.
-    let settle = 0;
-    const onScroll = (): void => {
-      if (frame === 0) frame = requestAnimationFrame(sync);
-      rail?.setAttribute('data-scrolling', '');
-      window.clearTimeout(settle);
-      settle = window.setTimeout(() => rail?.removeAttribute('data-scrolling'), 150);
-    };
-    sync();
-    scroller.addEventListener('scroll', onScroll, { passive: true });
-    const observer = new ResizeObserver(onScroll);
-    observer.observe(scroller);
-    return () => {
-      if (frame !== 0) cancelAnimationFrame(frame);
-      window.clearTimeout(settle);
-      scroller.removeEventListener('scroll', onScroll);
-      observer.disconnect();
-    };
     // `documentAbsent` and `hidden` for the same reason as the metrics effect: no rail element
     // exists while either holds.
   }, [editor, documentAbsent, hidden]);
@@ -769,7 +666,10 @@ function ReviewRoot({
     className: `docx-review${className ? ` ${className}` : ''}`,
     'data-testid': 'review-rail',
     'data-count': items.length,
-    'data-open': open ? '' : undefined,
+    // The COLUMN presentation, not the engine's pane state: compact keeps the strip
+    // styling (`:not([data-open])` is the 32px gutter) while the pane itself stays open.
+    'data-open': expanded ? '' : undefined,
+    'data-compact': compact ? '' : undefined,
     role: 'complementary' as const,
     'aria-label': t('review.ariaLabel'),
     onMouseDown: guardMousedown,
@@ -816,7 +716,12 @@ function ReviewRoot({
         : null}
       {!open || draftAnchorY === null || composeTop === null || (!preset && !('Draft' in rootParts))
         ? null
-        : takeRoot('Draft', <ReviewDraft top={composeTop} />)}
+        : // Compact: the compose box floats where the compact card does — at column width
+          // inside the viewport's edge — because a 300px card in the 32px strip is cut.
+          takeRoot(
+            'Draft',
+            <ReviewDraft top={composeTop} left={compact ? metrics.compactCardLeft : null} />
+          )}
       {/* Mounted open OR closed: the balloon is how a reader inspects a change whose rail
           card is filtered away, and a closed pane filters ALL of them away. */}
       {preset || 'Balloon' in rootParts ? takeRoot('Balloon', <ReviewBalloon />) : null}
@@ -836,22 +741,55 @@ function ReviewRoot({
     </ReviewList>
   );
   const markers = <ReviewMarkers scale={metrics.scale} offset={metrics.top} window={window_} />;
+  // Compact: the strip shows the markers, and only the ACTIVE decision gets a card —
+  // floated at column width, pinned just inside the viewport's right edge, over the page.
+  // The full run of cards has nowhere honest to be at this width; one at a time does.
+  const activeRoot = compact
+    ? (roots.find((entry) => entry.key === review.activeKey) ?? null)
+    : null;
+  const compactCard =
+    activeRoot && activeRoot.anchorY !== null && metrics.compactCardLeft !== null ? (
+      <ReviewItemContext.Provider value={activeRoot}>
+        <div
+          className="docx-review__slot docx-review__slot--compact"
+          data-testid="review-compact-card"
+          style={{
+            position: 'absolute',
+            top: metrics.top + activeRoot.anchorY * metrics.scale,
+            left: metrics.compactCardLeft,
+            width: COMPACT_CARD_WIDTH,
+          }}
+        >
+          {typeof rootChildren.rest === 'function' ? (
+            rootChildren.rest(activeRoot)
+          ) : (
+            <ReviewCard {...(cardClassName ? { className: cardClassName } : {})}>
+              {partitionReviewChildren(rootChildren.rest, 'list').rest}
+            </ReviewCard>
+          )}
+        </div>
+      </ReviewItemContext.Provider>
+    ) : null;
   // `preset={false}` supplies no defaults, but an explicit compound part still inherits the
   // geometry only the root can calculate. Unrecognized host nodes remain verbatim.
-  const body = open
-    ? preset || 'List' in rootParts
-      ? takeRoot('List', list)
-      : typeof rootChildren.rest === 'function'
-        ? null
-        : rootChildren.rest
-    : preset || 'Markers' in rootParts
-      ? // Closed, the rail keeps its anchors and drops everything else: a small marker per item
-        // in the margin, which is how a reader sees there is something to read without giving up
-        // the width. Clicking one opens the pane on that item.
-        takeRoot('Markers', markers)
-      : typeof rootChildren.rest === 'function'
-        ? null
-        : rootChildren.rest;
+  const body = expanded ? (
+    preset || 'List' in rootParts ? (
+      takeRoot('List', list)
+    ) : typeof rootChildren.rest === 'function' ? null : (
+      rootChildren.rest
+    )
+  ) : preset || 'Markers' in rootParts ? (
+    // Closed or compact, the rail keeps its anchors and drops everything else: a small
+    // marker per item in the margin, which is how a reader sees there is something to
+    // read without giving up the width. Clicking one opens the pane on that item —
+    // and, compact, floats that item's card.
+    <>
+      {takeRoot('Markers', markers)}
+      {compactCard}
+    </>
+  ) : typeof rootChildren.rest === 'function' ? null : (
+    rootChildren.rest
+  );
 
   return (
     <ReviewContext.Provider value={value}>
@@ -880,7 +818,7 @@ function ReviewRoot({
         </Slot>
       ) : (
         <aside {...shared}>
-          {open && furniture !== undefined ? (
+          {expanded && furniture !== undefined ? (
             <div className="docx-review__furniture" data-testid="review-furniture">
               {furniture}
             </div>

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -64,7 +64,12 @@ import {
   type ToolbarTranslate,
 } from '@docx-editor.dev/react';
 import { cloneReviewCard, partitionReviewChildren } from './review-composition';
-import { COMPACT_CARD_WIDTH, useRailMetrics, useRailWindow } from './use-rail-geometry';
+import {
+  COMPACT_CARD_WIDTH,
+  RAIL_OVERSCAN,
+  useRailMetrics,
+  useRailWindow,
+} from './use-rail-geometry';
 import { useReviewSlotSizing } from './use-review-slot-sizing';
 import { useReview, type ReviewItemView } from './useReview';
 import {
@@ -496,7 +501,7 @@ function ReviewRoot({
 
   // Where the rail sits and which band of the scroller is on screen — the DOM-measurement
   // half of the rail, in `use-rail-geometry.ts`.
-  const metrics = useRailMetrics(editor, railRef, items, !documentAbsent && !hidden);
+  const metrics = useRailMetrics(editor, railRef, items, !documentAbsent && !hidden, compact);
   const window_ = useRailWindow(editor, railRef, !documentAbsent && !hidden);
 
   // Clicking the canvas AROUND the page closes the open item. The caret decides everything
@@ -619,10 +624,14 @@ function ReviewRoot({
     }
     return { stacked: positions, collapsedKeys: collapsed };
   }, [stackInput, estimatedHeights, gap, metrics.scale]);
+  // Compact takes the RAW anchor: the stacking run pushes the box below the estimated
+  // heights of cards that, compact, render as small markers — phantom content, so a box
+  // stacked below it floated far under the selection it is about.
   const composeTop =
     composeAnchorY === null
       ? null
-      : metrics.top + (stacked.get(COMPOSE_KEY) ?? composeAnchorY) * metrics.scale;
+      : metrics.top +
+        (compact ? composeAnchorY : (stacked.get(COMPOSE_KEY) ?? composeAnchorY)) * metrics.scale;
 
   const cardClassName = card?.className;
   // The facade's resolved roster (reference-stable, live through `setRevisionStyles`),
@@ -747,26 +756,49 @@ function ReviewRoot({
   const activeRoot = compact
     ? (roots.find((entry) => entry.key === review.activeKey) ?? null)
     : null;
+  // An active item whose page has produced no placement yet has no anchor; the card still
+  // has to appear (the click asked for it), so it takes the top of the visible band the
+  // way the expanded list keeps unplaced cards in the column.
+  const compactTop =
+    activeRoot === null
+      ? null
+      : activeRoot.anchorY !== null
+        ? metrics.top + activeRoot.anchorY * metrics.scale
+        : window_ !== null
+          ? window_.top + RAIL_OVERSCAN + 24
+          : null;
+  // The same card resolution as ReviewList: a host's `Card` part (or render prop) must
+  // reach the floating card too, or compact silently swaps in the packaged card the host
+  // replaced. With `preset={false}` and no Card part there is no card to float — the host
+  // opted out of packaged defaults. Under `asChild` the child is the rail ELEMENT, never
+  // a card template, so the packaged card stands there (as it does in that branch's list).
+  const cardTemplate = asChild ? null : rootChildren.rest;
+  const listParts =
+    typeof cardTemplate === 'function' ? null : partitionReviewChildren(cardTemplate, 'list');
+  const compactCardInner =
+    typeof cardTemplate === 'function' ? (
+      activeRoot && cardTemplate(activeRoot)
+    ) : listParts?.parts.Card && isValidElement<{ className?: string }>(listParts.parts.Card) ? (
+      cloneReviewCard(listParts.parts.Card, cardClassName)
+    ) : preset ? (
+      <ReviewCard {...(cardClassName ? { className: cardClassName } : {})}>
+        {listParts?.rest}
+      </ReviewCard>
+    ) : null;
   const compactCard =
-    activeRoot && activeRoot.anchorY !== null && metrics.compactCardLeft !== null ? (
+    activeRoot && compactTop !== null && metrics.compactCardLeft !== null && compactCardInner ? (
       <ReviewItemContext.Provider value={activeRoot}>
         <div
           className="docx-review__slot docx-review__slot--compact"
           data-testid="review-compact-card"
           style={{
             position: 'absolute',
-            top: metrics.top + activeRoot.anchorY * metrics.scale,
+            top: compactTop,
             left: metrics.compactCardLeft,
             width: COMPACT_CARD_WIDTH,
           }}
         >
-          {typeof rootChildren.rest === 'function' ? (
-            rootChildren.rest(activeRoot)
-          ) : (
-            <ReviewCard {...(cardClassName ? { className: cardClassName } : {})}>
-              {partitionReviewChildren(rootChildren.rest, 'list').rest}
-            </ReviewCard>
-          )}
+          {compactCardInner}
         </div>
       </ReviewItemContext.Provider>
     ) : null;
@@ -803,15 +835,25 @@ function ReviewRoot({
             children as React.ReactElement<{ children?: ReactNode }>,
             undefined,
             (children as React.ReactElement<{ children?: ReactNode }>).props.children,
+            // The same presentation switch as the packaged element: a compact rail is
+            // 32px wide (`:not([data-open])`), and mounting the full list inside it
+            // rendered every card squeezed to that width over the page.
             preset ? (
-              <ReviewList
-                stack={stack}
-                positions={stacked}
-                collapsed={collapsedKeys}
-                scale={metrics.scale}
-                offset={metrics.top}
-                window={window_}
-              />
+              expanded ? (
+                <ReviewList
+                  stack={stack}
+                  positions={stacked}
+                  collapsed={collapsedKeys}
+                  scale={metrics.scale}
+                  offset={metrics.top}
+                  window={window_}
+                />
+              ) : (
+                <>
+                  {markers}
+                  {compactCard}
+                </>
+              )
             ) : null,
             affordances
           )}

--- a/packages/pro/src/react/review-compose-boxes.tsx
+++ b/packages/pro/src/react/review-compose-boxes.tsx
@@ -9,6 +9,7 @@ import type { MouseEvent as ReactMouseEvent } from 'react';
 import type { TranslationKey } from '@docx-editor.dev/i18n';
 import type { ReviewPartProps } from './DocxEditorReview.tsx';
 import type { ReviewItemView } from './useReview.ts';
+import { COMPACT_CARD_WIDTH } from './use-rail-geometry.ts';
 
 interface ComposePartDeps {
   readonly useRail: () => {
@@ -74,7 +75,11 @@ export function createReviewComposeParts(deps: ComposePartDeps) {
     return (
       <div
         className={`docx-review__slot${className ? ` ${className}` : ''}${left === null ? '' : ' docx-review__slot--compact'}`}
-        style={{ position: 'absolute', top, ...(left === null ? {} : { left, width: 300 }) }}
+        style={{
+          position: 'absolute',
+          top,
+          ...(left === null ? {} : { left, width: COMPACT_CARD_WIDTH }),
+        }}
         ref={(node) => {
           measure(node, deps.composeKey);
         }}

--- a/packages/pro/src/react/review-compose-boxes.tsx
+++ b/packages/pro/src/react/review-compose-boxes.tsx
@@ -30,7 +30,20 @@ interface ComposePartDeps {
 /** Build the draft and reply compose boxes against the rail's private contexts. */
 export function createReviewComposeParts(deps: ComposePartDeps) {
   /** The compose box for a new comment. @public */
-  function ReviewDraft({ top = 0, className, hidden }: ReviewPartProps & { top?: number }) {
+  function ReviewDraft({
+    top = 0,
+    left = null,
+    className,
+    hidden,
+  }: ReviewPartProps & {
+    top?: number;
+    /**
+     * Rail-local `left` for the COMPACT rail, where the strip is 32px wide and a box laid
+     * out at column width would be cut by the viewport's edge. Null keeps the box in the
+     * rail's own column, which is right whenever the column exists.
+     */
+    left?: number | null;
+  }) {
     const { review, endDraft, measure, readOnly } = deps.useRail();
     const t = deps.useLabel();
     const [text, setText] = useState('');
@@ -60,8 +73,8 @@ export function createReviewComposeParts(deps: ComposePartDeps) {
     if (hidden) return null;
     return (
       <div
-        className={`docx-review__slot${className ? ` ${className}` : ''}`}
-        style={{ position: 'absolute', top }}
+        className={`docx-review__slot${className ? ` ${className}` : ''}${left === null ? '' : ' docx-review__slot--compact'}`}
+        style={{ position: 'absolute', top, ...(left === null ? {} : { left, width: 300 }) }}
         ref={(node) => {
           measure(node, deps.composeKey);
         }}

--- a/packages/pro/src/react/use-rail-geometry.ts
+++ b/packages/pro/src/react/use-rail-geometry.ts
@@ -1,0 +1,183 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// The rail's geometry, measured from the DOM it hangs beside: where the rail sits
+// (`useRailMetrics`) and which vertical band of the scroller is on screen
+// (`useRailWindow`). Split out of `DocxEditorReview.tsx`, which is at its max-lines cap —
+// these two hooks are the DOM-measurement half of the rail and share nothing with its
+// composition logic.
+
+import { useEffect, useState } from 'react';
+
+/** Where the rail is, in the coordinates of its positioning container. */
+export interface RailMetrics {
+  /** Layout points to CSS pixels, from the engine. */
+  readonly scale: number;
+  /** The painted surface's own top offset, so chrome above the pages does not shift cards. */
+  readonly top: number;
+  /** Left edge, one gutter right of the sheet; null until there is a surface to measure. */
+  readonly left: number | null;
+  /**
+   * Rail-local `left` that puts a compact card's RIGHT edge just inside the viewport's,
+   * so the one floating card is fully visible instead of cut where the column would have
+   * been. Null until there is a surface and a scroller to measure.
+   */
+  readonly compactCardLeft: number | null;
+}
+
+const INITIAL_METRICS: RailMetrics = { scale: 96 / 72, top: 0, left: null, compactCardLeft: null };
+
+/** Space between the page edge and the cards. */
+const RAIL_GUTTER = 16;
+
+/** A compact card is one column-card wide — the width `.docx-review` gives the open rail. */
+export const COMPACT_CARD_WIDTH = 300;
+/** Air between a compact card's right edge and the viewport's. */
+const COMPACT_CARD_INSET = 12;
+
+/**
+ * How far outside the visible scroll window a card still mounts, in pixels.
+ *
+ * Enough that a normal scroll or a pane toggle never shows an empty gutter, small enough
+ * that a document with two hundred comments mounts a handful of cards rather than all of
+ * them. Rendering every card was the toggle's lag: two hundred cards' worth of DOM, plus a
+ * `top` transition on each, in one frame.
+ */
+const RAIL_OVERSCAN = 600;
+
+/** The one engine read the measurement needs. */
+interface RenderScaleSource {
+  getRenderScale(): number;
+}
+
+/**
+ * Where the rail sits, measured from the PAINTED SURFACE rather than from the viewport.
+ *
+ * Both halves matter. Vertically, the surface's own offset inside the scroll container is
+ * whatever chrome the host put above the pages — without it every card is drawn that far
+ * too high. Horizontally, the page is centred in a viewport that is usually much wider, so
+ * a rail pinned to the right edge floats away from the page it annotates; it belongs one
+ * gutter to the right of the sheet, and it moves with the sheet when the window resizes or
+ * the zoom changes.
+ *
+ * Client rects, not `offsetLeft`/`offsetTop`: those are relative to each element's own
+ * `offsetParent`, and a host that positions its page wrapper makes the surface report
+ * `offsetLeft: 0` — landing the rail a page-width left, on top of the document. `scrollTop`
+ * and `clientTop` put the rects back into the same space the offsets used to describe.
+ *
+ * `remeasure` re-runs the binding whenever the queue could have moved: a new page above an
+ * anchor changes where its card belongs, and zoom changes every anchor at once. `mounted`
+ * must be false while the rail element does not exist (document absent, `hidden`), so a
+ * binding pass that ran against the null ref runs again once there is a rail to measure.
+ */
+export function useRailMetrics(
+  editor: RenderScaleSource | null,
+  railRef: React.RefObject<HTMLElement | null>,
+  remeasure: unknown,
+  mounted: boolean
+): RailMetrics {
+  const [metrics, setMetrics] = useState<RailMetrics>(INITIAL_METRICS);
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!editor || !rail) return undefined;
+    const parent = rail.offsetParent as HTMLElement | null;
+    const surface = parent?.querySelector<HTMLElement>('.docx-paginated-surface') ?? null;
+    const sync = (): void => {
+      setMetrics((previous) => {
+        const box = surface && parent ? surface.getBoundingClientRect() : null;
+        const frame = box && parent ? parent.getBoundingClientRect() : null;
+        const left =
+          box && frame && parent
+            ? box.right - frame.left - parent.clientLeft + parent.scrollLeft + RAIL_GUTTER
+            : null;
+        const next: RailMetrics = {
+          // The engine's own points-to-pixels factor, zoom included. Deriving it here from
+          // `getZoom()` alone dropped the 96/72 and put every card at three quarters height.
+          scale: editor.getRenderScale(),
+          top:
+            box && frame && parent ? box.top - frame.top - parent.clientTop + parent.scrollTop : 0,
+          left,
+          // The viewport's right edge in rail-local coordinates, minus a card and its
+          // inset: where the compact floating card starts so nothing of it is cut off.
+          compactCardLeft:
+            left === null || !parent
+              ? null
+              : parent.scrollLeft +
+                parent.clientWidth -
+                left -
+                COMPACT_CARD_WIDTH -
+                COMPACT_CARD_INSET,
+        };
+        return previous.scale === next.scale &&
+          previous.top === next.top &&
+          previous.left === next.left &&
+          previous.compactCardLeft === next.compactCardLeft
+          ? previous
+          : next;
+      });
+    };
+    sync();
+    const observer = new ResizeObserver(sync);
+    if (parent) observer.observe(parent);
+    if (surface) observer.observe(surface);
+    return () => observer.disconnect();
+  }, [editor, railRef, remeasure, mounted]);
+  return metrics;
+}
+
+/**
+ * The visible band of the scroller, in the rail's own coordinates. Passive listener,
+ * coalesced into a frame: the handler runs on every wheel tick and must do nothing but
+ * record two numbers. Null until there is a scroller to measure.
+ *
+ * `mounted` for the same reason as `useRailMetrics`: no rail element exists while the
+ * document is absent or the rail is hidden, and the binding must re-run once one does.
+ */
+export function useRailWindow(
+  editor: unknown,
+  railRef: React.RefObject<HTMLElement | null>,
+  mounted: boolean
+): { top: number; bottom: number } | null {
+  const [window_, setWindow] = useState<{ top: number; bottom: number } | null>(null);
+  useEffect(() => {
+    const rail = railRef.current;
+    const scroller = rail?.offsetParent as HTMLElement | null;
+    if (!scroller) return undefined;
+    let frame = 0;
+    const sync = (): void => {
+      frame = 0;
+      setWindow((previous) => {
+        const top = scroller.scrollTop - RAIL_OVERSCAN;
+        const bottom = scroller.scrollTop + scroller.clientHeight + RAIL_OVERSCAN;
+        return previous && previous.top === top && previous.bottom === bottom
+          ? previous
+          : { top, bottom };
+      });
+    };
+    // While the reader scrolls, the slots' `top` transition is suppressed (a DOM attribute
+    // so no React work happens at scroll frequency). Restacks DURING a scroll come from
+    // cards entering the window and correcting an estimated height to a measured one; each
+    // correction shifts every card below it, and ANIMATING those shifts while the page
+    // itself moves read as a second, faster scroll layered over the document.
+    let settle = 0;
+    const onScroll = (): void => {
+      if (frame === 0) frame = requestAnimationFrame(sync);
+      rail?.setAttribute('data-scrolling', '');
+      window.clearTimeout(settle);
+      settle = window.setTimeout(() => rail?.removeAttribute('data-scrolling'), 150);
+    };
+    sync();
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    const observer = new ResizeObserver(onScroll);
+    observer.observe(scroller);
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      window.clearTimeout(settle);
+      scroller.removeEventListener('scroll', onScroll);
+      observer.disconnect();
+    };
+  }, [editor, railRef, mounted]);
+  return window_;
+}

--- a/packages/pro/src/react/use-rail-geometry.ts
+++ b/packages/pro/src/react/use-rail-geometry.ts
@@ -45,7 +45,7 @@ const COMPACT_CARD_INSET = 12;
  * them. Rendering every card was the toggle's lag: two hundred cards' worth of DOM, plus a
  * `top` transition on each, in one frame.
  */
-const RAIL_OVERSCAN = 600;
+export const RAIL_OVERSCAN = 600;
 
 /** The one engine read the measurement needs. */
 interface RenderScaleSource {
@@ -71,12 +71,19 @@ interface RenderScaleSource {
  * anchor changes where its card belongs, and zoom changes every anchor at once. `mounted`
  * must be false while the rail element does not exist (document absent, `hidden`), so a
  * binding pass that ran against the null ref runs again once there is a rail to measure.
+ *
+ * `trackScroll` re-measures on the scroller's own scroll, rAF-coalesced. `top` and `left`
+ * never need it — the rect delta cancels the scroll term, so they are scroll-invariant —
+ * but `compactCardLeft` is genuinely scroll-VARIANT (the viewport's right edge moves
+ * through content space), and the compact rail is exactly the regime where the page can
+ * overflow horizontally. Off outside compact, so ordinary scrolling costs no rect reads.
  */
 export function useRailMetrics(
   editor: RenderScaleSource | null,
   railRef: React.RefObject<HTMLElement | null>,
   remeasure: unknown,
-  mounted: boolean
+  mounted: boolean,
+  trackScroll = false
 ): RailMetrics {
   const [metrics, setMetrics] = useState<RailMetrics>(INITIAL_METRICS);
   useEffect(() => {
@@ -122,8 +129,22 @@ export function useRailMetrics(
     const observer = new ResizeObserver(sync);
     if (parent) observer.observe(parent);
     if (surface) observer.observe(surface);
-    return () => observer.disconnect();
-  }, [editor, railRef, remeasure, mounted]);
+    if (!trackScroll || !parent) return () => observer.disconnect();
+    let frame = 0;
+    const onScroll = (): void => {
+      if (frame === 0)
+        frame = requestAnimationFrame(() => {
+          frame = 0;
+          sync();
+        });
+    };
+    parent.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      parent.removeEventListener('scroll', onScroll);
+      observer.disconnect();
+    };
+  }, [editor, railRef, remeasure, mounted, trackScroll]);
   return metrics;
 }
 

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -10,14 +10,14 @@
 // no relayout storm at mousemove frequency. Editability follows what the engine reports
 // (`usePageSetup().isEnabled`), so against a read-only document the handles stay inert.
 
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactElement } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import type { RulerIndent } from '@docx-editor.dev/core/editor';
 import { HorizontalRuler, type RulerPageSetup } from '../components/ui/HorizontalRuler';
 import { VerticalRuler } from '../components/ui/VerticalRuler';
 import { twipsToPixels } from '../lib/units';
-import { ReviewRailContext, useDocxEditor } from './context';
+import { useDocxEditor } from './context';
 // A ruler MEASURES the page, and while the document is absent there is no page — the
 // primitive fell back to drawing default Letter ticks over a document that was not
 // there. Render nothing instead; a host that wants the bar to hold its height sizes the
@@ -27,6 +27,10 @@ import { useEditorState } from './useEditorState';
 import { usePageSetup } from './usePageSetup';
 import { useParagraphIndent } from './useParagraphIndent';
 import { useNavigationShift, useNavigationViewportElement } from './navigation/navigation-layout';
+// The gutter the review pane reserves. Read from the shared measurement rather than a
+// local constant, because the ruler and the scroller must agree: two components deciding
+// independently is how a ruler ends up an inch off the page it is measuring.
+import { useReviewGutter, useViewportClientWidth } from './review-gutter';
 
 const selectZoom = (snapshot: EditorSnapshot): number => snapshot.zoom;
 
@@ -154,31 +158,6 @@ function useIndentDrag(): IndentDrag {
   );
 }
 
-/**
- * The scroll container's client width, kept live by a ResizeObserver.
- *
- * `null` while no viewport is registered — a bare composition without
- * `DocxEditor.Viewport` gets no measurement and must not act on one.
- */
-function useViewportClientWidth(): number | null {
-  const viewport = useNavigationViewportElement();
-  const [width, setWidth] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (!viewport) {
-      setWidth(null);
-      return undefined;
-    }
-    const sync = () => setWidth(viewport.clientWidth);
-    sync();
-    const observer = new ResizeObserver(sync);
-    observer.observe(viewport);
-    return () => observer.disconnect();
-  }, [viewport]);
-
-  return width;
-}
-
 /** Horizontal viewport movement shared by the painted page and the ruler above it. */
 function useViewportScrollLeft(): number {
   const viewport = useNavigationViewportElement();
@@ -266,28 +245,6 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
     </div>
   );
 }
-
-/**
- * The gutter the review pane reserves, in pixels.
- *
- * Read from the engine's pane state rather than from a prop, because the ruler and the
- * scroller must agree: two components deciding independently is how a ruler ends up an inch
- * off the page it is measuring.
- */
-function useReviewGutter(): number {
-  // The SNAPSHOT, not the review hook — the ruler needs one boolean, not the queue. And no
-  // gutter at all unless a rail is mounted to occupy it.
-  const paneOpen = useEditorState(selectPaneOpen);
-  const rail = useContext(ReviewRailContext);
-  if ((rail?.mounted ?? 0) === 0) return 0;
-  return paneOpen ? REVIEW_PANE_GUTTER : REVIEW_MARKERS_GUTTER;
-}
-
-const selectPaneOpen = (snapshot: EditorSnapshot): boolean => snapshot.reviewPaneOpen ?? true;
-
-/** Kept in step with the `[data-review-pane]` rules in the core stylesheet. */
-const REVIEW_PANE_GUTTER = 316;
-const REVIEW_MARKERS_GUTTER = 44;
 
 /**
  * The vertical ruler as a context-fed part (`DocxEditor.VerticalRuler`): page height,

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -212,10 +212,12 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
     <div
       className="docx-ruler-frame"
       style={{
-        paddingInlineStart: shift,
+        // The review gutter's inline-start half composes with the navigation shift, the
+        // same way the scroll container adds the two into one `padding-inline-start`.
+        paddingInlineStart: shift + reserved.inlineStart,
         // PHYSICAL right, like the pane it mirrors: the review rail is anchored
         // `right: 0` and pads the scroller's `padding-right`, whatever the direction.
-        paddingRight: reserved,
+        paddingRight: reserved.inlineEnd,
       }}
     >
       <HorizontalRuler
@@ -275,7 +277,9 @@ export function DocxEditorVerticalRuler(props: DocxEditorRulerProps): ReactEleme
   // a zero width that means "unmeasured", not "no room".
   if (viewportWidth !== null && viewportWidth > 0 && pageSetup) {
     const pageWidthPx = twipsToPixels(pageSetup.pageWidthTwips) * zoom;
-    if (pageWidthPx > viewportWidth - shift - reserved) return null;
+    if (pageWidthPx > viewportWidth - shift - reserved.inlineStart - reserved.inlineEnd) {
+      return null;
+    }
   }
   return (
     <VerticalRuler

--- a/packages/react/src/editor/DocxEditorViewport.tsx
+++ b/packages/react/src/editor/DocxEditorViewport.tsx
@@ -14,6 +14,7 @@ import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { ReviewRailContext, useDocxEditor } from './context';
 import { useEditorState } from './useEditorState';
 import { useNavigationLayoutStore, useNavigationShift } from './navigation/navigation-layout';
+import { useReviewGutter } from './review-gutter';
 import { zoomLevelForShortcut } from './zoom-levels';
 import { ScopedByAncestorContext, useScopeClassName } from './scope-context';
 
@@ -46,6 +47,11 @@ export function DocxEditorViewport({ className, style, children }: DocxEditorVie
   // whole placement derivation — anchors and all — inside the parent of the painted document,
   // on every selection change, to learn one boolean.
   const paneOpen = useEditorState(selectPaneOpen);
+  // How wide that gutter may actually be. A fixed reservation shoved the sheet against the
+  // viewport's left edge on narrow hosts, with a mostly-empty band standing where the page
+  // should be; the measured value narrows to the leftover width instead (never below the
+  // marker strip), and the stylesheet consumes it through `--docx-review-gutter`.
+  const reviewGutter = useReviewGutter();
   const fitting = useEditorState(selectZoomFitting);
   const rail = useContext(ReviewRailContext);
   const reserve = (rail?.mounted ?? 0) > 0;
@@ -90,7 +96,13 @@ export function DocxEditorViewport({ className, style, children }: DocxEditorVie
       className={`${scopeClassName}docx-editor-one-surface docx-editor-one-surface__viewport docx-editor__scroll-container${
         className ? ` ${className}` : ''
       }`}
-      style={{ ...style, ['--docx-nav-shift' as string]: `${shift}px` } as CSSProperties}
+      style={
+        {
+          ...style,
+          ['--docx-nav-shift' as string]: `${shift}px`,
+          ...(reserve ? { ['--docx-review-gutter' as string]: `${reviewGutter}px` } : {}),
+        } as CSSProperties
+      }
     >
       {/* Everything below this div has a scoped ancestor: either the packaged
           wrapper above us, or this element, which scoped itself just now. Say

--- a/packages/react/src/editor/DocxEditorViewport.tsx
+++ b/packages/react/src/editor/DocxEditorViewport.tsx
@@ -49,8 +49,9 @@ export function DocxEditorViewport({ className, style, children }: DocxEditorVie
   const paneOpen = useEditorState(selectPaneOpen);
   // How wide that gutter may actually be. A fixed reservation shoved the sheet against the
   // viewport's left edge on narrow hosts, with a mostly-empty band standing where the page
-  // should be; the measured value narrows to the leftover width instead (never below the
-  // marker strip), and the stylesheet consumes it through `--docx-review-gutter`.
+  // should be; the measured pair keeps the full column only while the viewport affords it
+  // and mirrors the marker strip onto both edges otherwise, so the sheet stays centred.
+  // The stylesheet consumes it through `--docx-review-gutter`/`--docx-review-gutter-start`.
   const reviewGutter = useReviewGutter();
   const fitting = useEditorState(selectZoomFitting);
   const rail = useContext(ReviewRailContext);
@@ -100,7 +101,12 @@ export function DocxEditorViewport({ className, style, children }: DocxEditorVie
         {
           ...style,
           ['--docx-nav-shift' as string]: `${shift}px`,
-          ...(reserve ? { ['--docx-review-gutter' as string]: `${reviewGutter}px` } : {}),
+          ...(reserve
+            ? {
+                ['--docx-review-gutter' as string]: `${reviewGutter.inlineEnd}px`,
+                ['--docx-review-gutter-start' as string]: `${reviewGutter.inlineStart}px`,
+              }
+            : {}),
         } as CSSProperties
       }
     >

--- a/packages/react/src/editor/navigation/navigation-geometry.ts
+++ b/packages/react/src/editor/navigation/navigation-geometry.ts
@@ -41,6 +41,12 @@ export interface NavigationShiftInput {
   /** Padding already reserved at the inline end, for example by the review rail. */
   readonly inlineEndReservation?: number;
   /**
+   * Padding already standing at the inline START besides the shift itself — the review
+   * gutter's mirrored strip. It moves the page exactly as the shift does, so a shift
+   * computed without it lands the page that far past the reservation.
+   */
+  readonly inlineStartReservation?: number;
+  /**
    * Whether the page's WIDTH follows the padding right now.
    *
    * This turns the answer binary, and it has to. The proportional branch below assumes a page
@@ -72,30 +78,38 @@ export function navigationShift({
   pageWidthPx,
   reservation,
   inlineEndReservation = 0,
+  inlineStartReservation = 0,
   docked = false,
 }: NavigationShiftInput): number {
   if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return 0;
   if (!Number.isFinite(pageWidthPx) || pageWidthPx <= 0) return 0;
   if (!Number.isFinite(reservation) || reservation <= 0) return 0;
   if (!Number.isFinite(inlineEndReservation) || inlineEndReservation < 0) return 0;
+  if (!Number.isFinite(inlineStartReservation) || inlineStartReservation < 0) return 0;
 
   // A review rail (or other inline-end chrome) reduces the box in which the page centres.
   // Ignoring it makes the left gutter look wider than it is, so navigation can cover the
   // page instead of pushing the combined layout into horizontal overflow.
   const gutter = (viewportWidth - inlineEndReservation - pageWidthPx) / 2;
-  // Already room to the left of the page: the pane overlays empty space, the page holds
-  // still. This is the common case on any reasonably wide window, and it is the whole
-  // point of computing a shift instead of hard-coding one.
-  if (gutter >= reservation) return 0;
-
-  // Still centred: padding P moves the page by P/2, so twice the deficit lands it exactly
-  // on the reservation. Valid while the padded box is still at least a page wide, which
-  // is the same condition as `reservation <= 2 * gutter` — and only while the page's width
-  // is independent of the padding, which a fit mode is exactly the case where it is not.
-  if (!docked && reservation <= 2 * gutter) return Math.ceil(2 * (reservation - gutter));
-
-  // The padded box is narrower than the page: `margin-inline: auto` resolves to zero, the
-  // page pins to the padding edge, and the padding IS the offset. Horizontal scrolling
-  // appears here, which is correct — there is genuinely not enough room for both.
-  return Math.ceil(reservation);
+  // The TOTAL start padding the page needs; the shift is what remains of it after the
+  // padding already standing there. Solving for the shift alone and adding it on top of
+  // the mirrored strip landed the page past the reservation by the strip's width.
+  const total =
+    // Already room to the left of the page: the pane overlays empty space, the page holds
+    // still. This is the common case on any reasonably wide window, and it is the whole
+    // point of computing a shift instead of hard-coding one.
+    gutter >= reservation
+      ? 0
+      : // Still centred: total padding S moves the page by S/2, so twice the deficit lands it
+        // exactly on the reservation. Valid while the padded box is still at least a page
+        // wide, which is the same condition as `reservation <= 2 * gutter` — and only while
+        // the page's width is independent of the padding, which a fit mode is exactly the
+        // case where it is not.
+        !docked && reservation <= 2 * gutter
+        ? 2 * (reservation - gutter)
+        : // The padded box is narrower than the page: `margin-inline: auto` resolves to zero,
+          // the page pins to the padding edge, and the padding IS the offset. Horizontal
+          // scrolling appears here, which is correct — there is genuinely not enough room.
+          reservation;
+  return Math.ceil(Math.max(0, total - inlineStartReservation));
 }

--- a/packages/react/src/editor/navigation/navigation-layout.ts
+++ b/packages/react/src/editor/navigation/navigation-layout.ts
@@ -19,6 +19,16 @@ export interface NavigationLayoutStore {
   getShift(): number;
   setShift(px: number): void;
   subscribeShift(listener: () => void): () => void;
+  /**
+   * The start-edge room an OPEN pane asks for (`navigationPaneReservation`), 0 while it
+   * is closed or unmounted. STATIC on purpose — a function of the pane's own state, never
+   * of the measured shift: the review gutter reads this to decide whether its column is
+   * affordable, and the shift in turn depends on the gutter, so publishing the shift here
+   * instead would close a cycle the two reservations then chase around.
+   */
+  getReservation(): number;
+  setReservation(px: number): void;
+  subscribeReservation(listener: () => void): () => void;
   /** The scroll container, registered by `DocxEditor.Viewport` so the pane can measure it. */
   getViewport(): HTMLElement | null;
   setViewport(element: HTMLElement | null): void;
@@ -27,8 +37,10 @@ export interface NavigationLayoutStore {
 
 export function createNavigationLayoutStore(): NavigationLayoutStore {
   let shift = 0;
+  let reservation = 0;
   let viewport: HTMLElement | null = null;
   const shiftListeners = new Set<() => void>();
+  const reservationListeners = new Set<() => void>();
   const viewportListeners = new Set<() => void>();
   const notify = (listeners: Set<() => void>) => {
     for (const listener of [...listeners]) listener();
@@ -46,6 +58,17 @@ export function createNavigationLayoutStore(): NavigationLayoutStore {
     subscribeShift(listener) {
       shiftListeners.add(listener);
       return () => shiftListeners.delete(listener);
+    },
+    getReservation: () => reservation,
+    setReservation(px) {
+      const next = Math.max(0, Math.round(px));
+      if (next === reservation) return;
+      reservation = next;
+      notify(reservationListeners);
+    },
+    subscribeReservation(listener) {
+      reservationListeners.add(listener);
+      return () => reservationListeners.delete(listener);
     },
     getViewport: () => viewport,
     setViewport(element) {
@@ -82,6 +105,21 @@ export function useNavigationShift(): number {
     [store]
   );
   const getSnapshot = useCallback(() => (store ? store.getShift() : 0), [store]);
+  return useSyncExternalStore(subscribe, getSnapshot, ZERO);
+}
+
+/**
+ * The start-edge room the navigation pane is asking for right now — 0 while it is closed
+ * or unmounted. Internal: the review gutter subtracts it before judging whether its card
+ * column is affordable, so the two panes never claim the same pixels.
+ */
+export function useNavigationReservation(): number {
+  const store = useNavigationLayoutStore();
+  const subscribe = useCallback(
+    (listener: () => void) => (store ? store.subscribeReservation(listener) : NOOP_UNSUBSCRIBE()),
+    [store]
+  );
+  const getSnapshot = useCallback(() => (store ? store.getReservation() : 0), [store]);
   return useSyncExternalStore(subscribe, getSnapshot, ZERO);
 }
 

--- a/packages/react/src/editor/navigation/useNavigationPane.ts
+++ b/packages/react/src/editor/navigation/useNavigationPane.ts
@@ -148,6 +148,7 @@ export function useNavigationPane(options: UseNavigationPaneOptions = {}): UseNa
   );
   const [viewportWidth, setViewportWidth] = useState(0);
   const [inlineEndReservation, setInlineEndReservation] = useState(0);
+  const [inlineStartReservation, setInlineStartReservation] = useState(0);
 
   // `open` is a dependency as well as `viewport`: a window resized while the pane was
   // closed leaves no observation to react to (a hidden or throttled tab delivers no
@@ -157,12 +158,19 @@ export function useNavigationPane(options: UseNavigationPaneOptions = {}): UseNa
     if (!viewport) {
       setViewportWidth(0);
       setInlineEndReservation(0);
+      setInlineStartReservation(0);
       return undefined;
     }
     const measure = () => {
       setViewportWidth(viewport.clientWidth);
-      const padding = Number.parseFloat(getComputedStyle(viewport).paddingInlineEnd);
+      const style = getComputedStyle(viewport);
+      const padding = Number.parseFloat(style.paddingInlineEnd);
       setInlineEndReservation(Number.isFinite(padding) ? padding : 0);
+      // The review gutter's mirrored strip, standing on the SAME edge the shift pads. The
+      // custom property, not `paddingInlineStart` — that computed value already contains
+      // this hook's own published shift, and measuring it back would be circular.
+      const strip = Number.parseFloat(style.getPropertyValue('--docx-review-gutter-start'));
+      setInlineStartReservation(Number.isFinite(strip) ? strip : 0);
     };
     measure();
     if (typeof ResizeObserver === 'undefined') return undefined;
@@ -187,9 +195,19 @@ export function useNavigationPane(options: UseNavigationPaneOptions = {}): UseNa
       pageWidthPx: twipsToPixels(pageWidthTwips) * zoom,
       reservation: navigationPaneReservation(paneWidth),
       inlineEndReservation,
+      inlineStartReservation,
       docked: fitting,
     });
-  }, [open, pageWidthTwips, zoom, viewportWidth, paneWidth, inlineEndReservation, fitting]);
+  }, [
+    open,
+    pageWidthTwips,
+    zoom,
+    viewportWidth,
+    paneWidth,
+    inlineEndReservation,
+    inlineStartReservation,
+    fitting,
+  ]);
 
   useEffect(() => {
     if (!store) return undefined;
@@ -197,6 +215,15 @@ export function useNavigationPane(options: UseNavigationPaneOptions = {}): UseNa
     // A pane unmounting mid-shift would otherwise leave the chrome permanently displaced.
     return () => store.setShift(0);
   }, [store, shift]);
+
+  // What an OPEN pane is asking for, published for the review gutter's affordability
+  // check. The STATIC reservation, never the measured shift — the shift depends on the
+  // gutter, and publishing it here would close a cycle (see the store's own comment).
+  useEffect(() => {
+    if (!store) return undefined;
+    store.setReservation(open ? navigationPaneReservation(paneWidth) : 0);
+    return () => store.setReservation(0);
+  }, [store, open, paneWidth]);
 
   return { open, setOpen, toggle, tab, setTab, paneWidth, shift };
 }

--- a/packages/react/src/editor/review-gutter.ts
+++ b/packages/react/src/editor/review-gutter.ts
@@ -36,7 +36,10 @@ import { ZOOM_MAX } from '@docx-editor.dev/core/editor';
 import { twipsToPixels } from '../lib/units';
 import { ReviewRailContext } from './context';
 import { useEditorState } from './useEditorState';
-import { useNavigationViewportElement } from './navigation/navigation-layout';
+import {
+  useNavigationReservation,
+  useNavigationViewportElement,
+} from './navigation/navigation-layout';
 
 /** Full reservation: the 300px card column plus its 16px gutter off the page edge. */
 export const REVIEW_PANE_GUTTER = 316;
@@ -81,6 +84,15 @@ export interface ReviewGutterInput {
   /** The width the page is entitled to paint at — authored width times the entitled zoom. */
   readonly pageWidthPx: number;
   /**
+   * Start-edge room OTHER chrome is asking for — an open navigation pane's reservation.
+   * Without it the column judged only page-against-viewport, stood in the two-pane case,
+   * and the pane's displacement then squeezed the fit below the page's entitlement — the
+   * very symptom the measurement exists to remove. The STATIC ask (open pane × width),
+   * never the pane's computed shift: the shift depends on this gutter, and reading it
+   * back would close a cycle the two reservations then chase around.
+   */
+  readonly inlineStartReservation?: number;
+  /**
    * An uncapped fit is in force: the page fills whatever box it is given, so there is no
    * entitlement to measure the leftover against. The full column stands.
    */
@@ -100,13 +112,18 @@ export function reviewGutter({
   open,
   viewportWidth,
   pageWidthPx,
+  inlineStartReservation = 0,
   docked = false,
 }: ReviewGutterInput): ReviewGutter {
   if (!open) return BALANCED_STRIP;
   if (docked) return FULL_COLUMN;
   if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return FULL_COLUMN;
   if (!Number.isFinite(pageWidthPx) || pageWidthPx <= 0) return FULL_COLUMN;
-  const leftover = viewportWidth - pageWidthPx - 2 * REVIEW_GUTTER_PAGE_CLEARANCE;
+  const start =
+    Number.isFinite(inlineStartReservation) && inlineStartReservation > 0
+      ? inlineStartReservation
+      : 0;
+  const leftover = viewportWidth - start - pageWidthPx - 2 * REVIEW_GUTTER_PAGE_CLEARANCE;
   return leftover >= REVIEW_PANE_GUTTER ? FULL_COLUMN : BALANCED_STRIP;
 }
 
@@ -189,6 +206,9 @@ export function useReviewGutter(): ReviewGutter {
     sameGutterGeometry
   );
   const viewport = useNavigationViewportElement();
+  // An open navigation pane's STATIC ask, from the shared layout store — see the input's
+  // own doc for why it is never the pane's computed shift.
+  const navigationReservation = useNavigationReservation();
   // The snapshot reports `pageSetup` as null on some ticks even with a document loaded,
   // and a gutter derived from one of those would snap to the full column and back inside
   // one frame. The last width a document actually had is the honest answer for a tick
@@ -208,10 +228,11 @@ export function useReviewGutter(): ReviewGutter {
           pageWidthTwips === null || entitledZoom === null
             ? 0
             : twipsToPixels(pageWidthTwips) * entitledZoom,
+        inlineStartReservation: navigationReservation,
         docked: entitledZoom === null,
       });
     },
-    [mounted, reviewPaneOpen, pageWidthTwips, entitledZoom]
+    [mounted, reviewPaneOpen, pageWidthTwips, entitledZoom, navigationReservation]
   );
 
   const [gutter, setGutter] = useState<ReviewGutter>(() =>

--- a/packages/react/src/editor/review-gutter.ts
+++ b/packages/react/src/editor/review-gutter.ts
@@ -1,0 +1,186 @@
+// The gutter the review rail reserves beside the page, and no more.
+//
+// THE RULE, the same one `navigation-geometry.ts` states for the left side: the open
+// pane must not move the page further than the viewport forces it to. The page stack
+// centres itself in the scroller's padding box, so a right padding P shifts the sheet
+// left by P/2 — pleasant on a wide window, where the sheet and its card column read as
+// one centred pair, and wrong on a narrow one, where a fixed 316px shoved the sheet
+// against the left edge (or, under the default fit, shrank the page toward its floor)
+// beside a mostly-empty band standing where the page should be.
+//
+// So the reservation follows the measurement: the full column while the viewport holds
+// the page, the column, and a little clearance around the sheet; the leftover width less
+// that clearance while it holds less; and never below the marker strip — the anchors and
+// the "comment on this" affordance keep working at every width, with the cards reachable
+// by the horizontal scroll the page already needs on a viewport that small.
+//
+// THE PAGE'S WIDTH IN THAT ARITHMETIC IS ITS ENTITLEMENT, NOT ITS PAINT. Under a fit the
+// painted width follows the padded box, so a gutter computed from it chases itself:
+// shrinking the gutter widens the box, which widens the page, which asks for a smaller
+// gutter again. The width the page is ENTITLED to — the authored width at the fit's own
+// cap, or at the fixed zoom in force — is independent of the padding, so the pair settles
+// in one pass: the gutter yields first, and only when it has given everything down to the
+// marker strip does the fit start shrinking the page toward its floor. A fit with NO cap
+// has no entitlement to measure against — it fills whatever box it is given — so the full
+// column stands and the page absorbs it, exactly as it always has.
+//
+// ONE value, three consumers. The scroll container pads by it, the horizontal ruler
+// mirrors it to stay over the page, and the vertical ruler subtracts it to decide
+// "cramped". Two components deciding independently is how a ruler ends up an inch off
+// the page it is measuring, so they all read `useReviewGutter`.
+
+import { useContext, useEffect, useRef, useState } from 'react';
+import type { EditorSnapshot, PageSetup } from '@docx-editor.dev/core/contracts/editor';
+import { ZOOM_MAX } from '@docx-editor.dev/core/editor';
+import { twipsToPixels } from '../lib/units';
+import { ReviewRailContext } from './context';
+import { useEditorState } from './useEditorState';
+import { useNavigationViewportElement } from './navigation/navigation-layout';
+
+/** Full reservation: the 300px card column plus its 16px gutter off the page edge. */
+export const REVIEW_PANE_GUTTER = 316;
+
+/** The closed pane's strip: markers and the add-comment button, no cards. */
+export const REVIEW_MARKERS_GUTTER = 44;
+
+/**
+ * Breathing room the page keeps on EACH side before the column may take the rest.
+ *
+ * Without it the sliding regime below hands the column every leftover pixel, and just
+ * above the full-column threshold the sheet sits flush against the viewport's left edge —
+ * technically the centred pair, visually a page shoved into the corner. 24px is the
+ * vertical breathing the viewport already gives the page (`padding: 24px 0`) and the
+ * `--doc-page-gap` between sheets, so the horizontal minimum matches what the layout
+ * already calls "clear of the edge".
+ */
+export const REVIEW_GUTTER_PAGE_CLEARANCE = 24;
+
+export interface ReviewGutterInput {
+  /** Whether the pane is showing its cards (`snapshot.reviewPaneOpen`). */
+  readonly open: boolean;
+  /** Client width of the scroll container. */
+  readonly viewportWidth: number;
+  /** The width the page is entitled to paint at — authored width times the entitled zoom. */
+  readonly pageWidthPx: number;
+  /**
+   * An uncapped fit is in force: the page fills whatever box it is given, so there is no
+   * entitlement to measure the leftover against. The full column stands.
+   */
+  readonly docked?: boolean;
+}
+
+/**
+ * The right padding, in px, the scroll container reserves for the review rail while the
+ * pane is open.
+ *
+ * Returns the FULL column for a degenerate measurement (a viewport that has not been
+ * laid out yet, a document with no page setup) rather than guessing: that is the value
+ * the stylesheet fell back to before this measurement existed, so an unmeasured first
+ * frame paints exactly as it always did and narrows only once there is a real width to
+ * narrow to.
+ */
+export function reviewGutterWidth({
+  open,
+  viewportWidth,
+  pageWidthPx,
+  docked = false,
+}: ReviewGutterInput): number {
+  if (!open) return REVIEW_MARKERS_GUTTER;
+  if (docked) return REVIEW_PANE_GUTTER;
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return REVIEW_PANE_GUTTER;
+  if (!Number.isFinite(pageWidthPx) || pageWidthPx <= 0) return REVIEW_PANE_GUTTER;
+  const leftover = viewportWidth - pageWidthPx - 2 * REVIEW_GUTTER_PAGE_CLEARANCE;
+  return Math.round(Math.min(REVIEW_PANE_GUTTER, Math.max(REVIEW_MARKERS_GUTTER, leftover)));
+}
+
+interface GutterGeometry {
+  readonly pageSetup: PageSetup | null;
+  readonly reviewPaneOpen: boolean;
+  /**
+   * The zoom the page is entitled to, whatever it paints at right now: a fit's own cap
+   * (`'auto'` caps at 1), or the fixed scale in force. Reading the LIVE zoom instead
+   * re-creates the feedback loop the module comment describes — under a fit the live
+   * zoom already includes whatever this gutter reserved last frame. `null` marks an
+   * uncapped fit, which has no entitlement to measure against.
+   */
+  readonly entitledZoom: number | null;
+}
+
+const selectGutterGeometry = (snapshot: EditorSnapshot): GutterGeometry => {
+  const mode = snapshot.zoomMode;
+  return {
+    pageSetup: snapshot.pageSetup ?? null,
+    reviewPaneOpen: snapshot.reviewPaneOpen ?? true,
+    entitledZoom:
+      mode?.type === 'fit'
+        ? mode.maxZoom !== undefined && mode.maxZoom < ZOOM_MAX
+          ? mode.maxZoom
+          : null
+        : snapshot.zoom,
+  };
+};
+
+const sameGutterGeometry = (a: GutterGeometry, b: GutterGeometry) =>
+  a.reviewPaneOpen === b.reviewPaneOpen &&
+  a.entitledZoom === b.entitledZoom &&
+  a.pageSetup?.pageWidthTwips === b.pageSetup?.pageWidthTwips;
+
+/**
+ * The scroll container's client width, kept live by a ResizeObserver.
+ *
+ * `null` while no viewport is registered — a bare composition without
+ * `DocxEditor.Viewport` gets no measurement and must not act on one.
+ */
+export function useViewportClientWidth(): number | null {
+  const viewport = useNavigationViewportElement();
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!viewport) {
+      setWidth(null);
+      return undefined;
+    }
+    const sync = () => setWidth(viewport.clientWidth);
+    sync();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(sync);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [viewport]);
+
+  return width;
+}
+
+/**
+ * The gutter the review rail reserves right now, in px: `0` with no rail mounted, the
+ * marker strip while the pane is closed, and the measured `reviewGutterWidth` while it
+ * is open. The one source for the scroll container's padding and both rulers.
+ */
+export function useReviewGutter(): number {
+  // The SNAPSHOT, not the review hook — this needs a boolean and the page's width, not
+  // the queue. And no gutter at all unless a rail is mounted to occupy it.
+  const rail = useContext(ReviewRailContext);
+  const { pageSetup, reviewPaneOpen, entitledZoom } = useEditorState(
+    selectGutterGeometry,
+    sameGutterGeometry
+  );
+  const viewportWidth = useViewportClientWidth();
+  // The snapshot reports `pageSetup` as null on some ticks even with a document loaded,
+  // and a gutter derived from one of those would snap to the full column and back inside
+  // one frame. The last width a document actually had is the honest answer for a tick
+  // that reports none — same rule as the navigation pane's shift.
+  const lastPageWidthTwips = useRef<number | null>(null);
+  if (pageSetup) lastPageWidthTwips.current = pageSetup.pageWidthTwips;
+  const pageWidthTwips = pageSetup?.pageWidthTwips ?? lastPageWidthTwips.current;
+
+  if ((rail?.mounted ?? 0) === 0) return 0;
+  return reviewGutterWidth({
+    open: reviewPaneOpen,
+    viewportWidth: viewportWidth ?? 0,
+    pageWidthPx:
+      pageWidthTwips === null || entitledZoom === null
+        ? 0
+        : twipsToPixels(pageWidthTwips) * entitledZoom,
+    docked: entitledZoom === null,
+  });
+}

--- a/packages/react/src/editor/review-gutter.ts
+++ b/packages/react/src/editor/review-gutter.ts
@@ -30,7 +30,7 @@
 // "cramped". Two components deciding independently is how a ruler ends up an inch off
 // the page it is measuring, so they all read `useReviewGutter`.
 
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import type { EditorSnapshot, PageSetup } from '@docx-editor.dev/core/contracts/editor';
 import { ZOOM_MAX } from '@docx-editor.dev/core/editor';
 import { twipsToPixels } from '../lib/units';
@@ -171,8 +171,14 @@ export function useViewportClientWidth(): number | null {
 /**
  * The gutter the review rail reserves right now: nothing with no rail mounted, and the
  * measured `reviewGutter` pair otherwise. The one source for the scroll container's
- * paddings and both rulers. The result is reference-stable — the pure function answers
- * with one of three shared constants — so consumers may depend on it directly.
+ * paddings and both rulers.
+ *
+ * The result is reference-stable — the pure function answers with one of three shared
+ * constants — and the hook stores THAT, never the raw width: a resize sweeps through
+ * hundreds of widths that all resolve to the same constant, and holding the width as
+ * state re-rendered every consumer (the review rail among them) once per pixel. Storing
+ * the derived constant lets the state setter bail on identity, so consumers re-render
+ * only when the reservation actually flips.
  */
 export function useReviewGutter(): ReviewGutter {
   // The SNAPSHOT, not the review hook — this needs a boolean and the page's width, not
@@ -182,7 +188,7 @@ export function useReviewGutter(): ReviewGutter {
     selectGutterGeometry,
     sameGutterGeometry
   );
-  const viewportWidth = useViewportClientWidth();
+  const viewport = useNavigationViewportElement();
   // The snapshot reports `pageSetup` as null on some ticks even with a document loaded,
   // and a gutter derived from one of those would snap to the full column and back inside
   // one frame. The last width a document actually had is the honest answer for a tick
@@ -192,16 +198,32 @@ export function useReviewGutter(): ReviewGutter {
   const pageWidthTwips = pageSetup?.pageWidthTwips ?? lastPageWidthTwips.current;
 
   const mounted = (rail?.mounted ?? 0) > 0;
-  return useMemo(() => {
-    if (!mounted) return NO_GUTTER;
-    return reviewGutter({
-      open: reviewPaneOpen,
-      viewportWidth: viewportWidth ?? 0,
-      pageWidthPx:
-        pageWidthTwips === null || entitledZoom === null
-          ? 0
-          : twipsToPixels(pageWidthTwips) * entitledZoom,
-      docked: entitledZoom === null,
-    });
-  }, [mounted, reviewPaneOpen, viewportWidth, pageWidthTwips, entitledZoom]);
+  const compute = useCallback(
+    (width: number | null): ReviewGutter => {
+      if (!mounted) return NO_GUTTER;
+      return reviewGutter({
+        open: reviewPaneOpen,
+        viewportWidth: width ?? 0,
+        pageWidthPx:
+          pageWidthTwips === null || entitledZoom === null
+            ? 0
+            : twipsToPixels(pageWidthTwips) * entitledZoom,
+        docked: entitledZoom === null,
+      });
+    },
+    [mounted, reviewPaneOpen, pageWidthTwips, entitledZoom]
+  );
+
+  const [gutter, setGutter] = useState<ReviewGutter>(() =>
+    compute(viewport ? viewport.clientWidth : null)
+  );
+  useEffect(() => {
+    const sync = () => setGutter(compute(viewport ? viewport.clientWidth : null));
+    sync();
+    if (!viewport || typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(sync);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [viewport, compute]);
+  return gutter;
 }

--- a/packages/react/src/editor/review-gutter.ts
+++ b/packages/react/src/editor/review-gutter.ts
@@ -1,35 +1,36 @@
 // The gutter the review rail reserves beside the page, and no more.
 //
-// THE RULE, the same one `navigation-geometry.ts` states for the left side: the open
-// pane must not move the page further than the viewport forces it to. The page stack
-// centres itself in the scroller's padding box, so a right padding P shifts the sheet
-// left by P/2 — pleasant on a wide window, where the sheet and its card column read as
-// one centred pair, and wrong on a narrow one, where a fixed 316px shoved the sheet
-// against the left edge (or, under the default fit, shrank the page toward its floor)
-// beside a mostly-empty band standing where the page should be.
+// THE RULE: the reservation is BINARY and, when the column cannot be afforded, SYMMETRIC.
+// The page stack centres itself in the scroller's padding box, so padding one edge by P
+// shifts the sheet left by P/2 — pleasant on a wide window, where the sheet and its card
+// column read as one centred pair, and wrong on a narrow one, where any one-sided
+// reservation (the fixed 316px, or a proportional slice of the leftover) parks the sheet
+// visibly off-centre beside a mostly-empty band. There is no width at which a partial
+// column looks right: it is too narrow for a card and still wide enough to unbalance the
+// page. So the column is either fully affordable or it is not:
 //
-// So the reservation follows the measurement: the full column while the viewport holds
-// the page, the column, and a little clearance around the sheet; the leftover width less
-// that clearance while it holds less; and never below the marker strip — the anchors and
-// the "comment on this" affordance keep working at every width, with the cards reachable
-// by the horizontal scroll the page already needs on a viewport that small.
+//   - Affordable (the viewport holds the page at its entitled width, the full column,
+//     and a little clearance): the column stands and the pair centres, as it always has.
+//   - Not affordable: the SAME marker strip is reserved on BOTH edges, so the sheet sits
+//     dead-centre and the strip still guarantees room for the markers and the
+//     add-comment affordance beside the page. Cards then overlay the right gap and the
+//     ordinary horizontal scroll reaches whatever sticks out.
 //
 // THE PAGE'S WIDTH IN THAT ARITHMETIC IS ITS ENTITLEMENT, NOT ITS PAINT. Under a fit the
-// painted width follows the padded box, so a gutter computed from it chases itself:
-// shrinking the gutter widens the box, which widens the page, which asks for a smaller
-// gutter again. The width the page is ENTITLED to — the authored width at the fit's own
-// cap, or at the fixed zoom in force — is independent of the padding, so the pair settles
-// in one pass: the gutter yields first, and only when it has given everything down to the
-// marker strip does the fit start shrinking the page toward its floor. A fit with NO cap
-// has no entitlement to measure against — it fills whatever box it is given — so the full
-// column stands and the page absorbs it, exactly as it always has.
+// painted width follows the padded box, so a threshold computed from it chases itself:
+// collapsing the column widens the box, which widens the page, which asks the column
+// back. The width the page is ENTITLED to — the authored width at the fit's own cap, or
+// at the fixed zoom in force — is independent of the padding, so the mode settles in one
+// pass. A fit with NO cap has no entitlement to measure against — it fills whatever box
+// it is given — so the full column stands and the page absorbs it, exactly as it always
+// has.
 //
 // ONE value, three consumers. The scroll container pads by it, the horizontal ruler
 // mirrors it to stay over the page, and the vertical ruler subtracts it to decide
 // "cramped". Two components deciding independently is how a ruler ends up an inch off
 // the page it is measuring, so they all read `useReviewGutter`.
 
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { EditorSnapshot, PageSetup } from '@docx-editor.dev/core/contracts/editor';
 import { ZOOM_MAX } from '@docx-editor.dev/core/editor';
 import { twipsToPixels } from '../lib/units';
@@ -40,20 +41,37 @@ import { useNavigationViewportElement } from './navigation/navigation-layout';
 /** Full reservation: the 300px card column plus its 16px gutter off the page edge. */
 export const REVIEW_PANE_GUTTER = 316;
 
-/** The closed pane's strip: markers and the add-comment button, no cards. */
+/** The marker strip: anchors and the add-comment button, no cards. */
 export const REVIEW_MARKERS_GUTTER = 44;
 
 /**
- * Breathing room the page keeps on EACH side before the column may take the rest.
+ * Breathing room the page keeps on EACH side for the full column to count as affordable.
  *
- * Without it the sliding regime below hands the column every leftover pixel, and just
- * above the full-column threshold the sheet sits flush against the viewport's left edge —
- * technically the centred pair, visually a page shoved into the corner. 24px is the
- * vertical breathing the viewport already gives the page (`padding: 24px 0`) and the
- * `--doc-page-gap` between sheets, so the horizontal minimum matches what the layout
- * already calls "clear of the edge".
+ * Without it the column flips in at the exact break-even width and the sheet lands flush
+ * against the viewport's left edge — technically the centred pair, visually a page shoved
+ * into the corner. 24px is the vertical breathing the viewport already gives the page
+ * (`padding: 24px 0`) and the `--doc-page-gap` between sheets, so the horizontal minimum
+ * matches what the layout already calls "clear of the edge".
  */
 export const REVIEW_GUTTER_PAGE_CLEARANCE = 24;
+
+/** What the scroll container reserves on each edge, in px. */
+export interface ReviewGutter {
+  readonly inlineStart: number;
+  readonly inlineEnd: number;
+}
+
+/** The affordable pair: nothing at the start, the full column at the end. */
+const FULL_COLUMN: ReviewGutter = { inlineStart: 0, inlineEnd: REVIEW_PANE_GUTTER };
+
+/** The symmetric pair: the marker strip mirrored, so the sheet centres exactly. */
+const BALANCED_STRIP: ReviewGutter = {
+  inlineStart: REVIEW_MARKERS_GUTTER,
+  inlineEnd: REVIEW_MARKERS_GUTTER,
+};
+
+/** No rail mounted: nothing reserved anywhere. */
+const NO_GUTTER: ReviewGutter = { inlineStart: 0, inlineEnd: 0 };
 
 export interface ReviewGutterInput {
   /** Whether the pane is showing its cards (`snapshot.reviewPaneOpen`). */
@@ -70,27 +88,26 @@ export interface ReviewGutterInput {
 }
 
 /**
- * The right padding, in px, the scroll container reserves for the review rail while the
- * pane is open.
+ * The paddings, in px, the scroll container reserves for the review rail.
  *
  * Returns the FULL column for a degenerate measurement (a viewport that has not been
  * laid out yet, a document with no page setup) rather than guessing: that is the value
  * the stylesheet fell back to before this measurement existed, so an unmeasured first
- * frame paints exactly as it always did and narrows only once there is a real width to
- * narrow to.
+ * frame paints exactly as it always did and collapses only once there is a real width
+ * to decide by.
  */
-export function reviewGutterWidth({
+export function reviewGutter({
   open,
   viewportWidth,
   pageWidthPx,
   docked = false,
-}: ReviewGutterInput): number {
-  if (!open) return REVIEW_MARKERS_GUTTER;
-  if (docked) return REVIEW_PANE_GUTTER;
-  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return REVIEW_PANE_GUTTER;
-  if (!Number.isFinite(pageWidthPx) || pageWidthPx <= 0) return REVIEW_PANE_GUTTER;
+}: ReviewGutterInput): ReviewGutter {
+  if (!open) return BALANCED_STRIP;
+  if (docked) return FULL_COLUMN;
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return FULL_COLUMN;
+  if (!Number.isFinite(pageWidthPx) || pageWidthPx <= 0) return FULL_COLUMN;
   const leftover = viewportWidth - pageWidthPx - 2 * REVIEW_GUTTER_PAGE_CLEARANCE;
-  return Math.round(Math.min(REVIEW_PANE_GUTTER, Math.max(REVIEW_MARKERS_GUTTER, leftover)));
+  return leftover >= REVIEW_PANE_GUTTER ? FULL_COLUMN : BALANCED_STRIP;
 }
 
 interface GutterGeometry {
@@ -152,11 +169,12 @@ export function useViewportClientWidth(): number | null {
 }
 
 /**
- * The gutter the review rail reserves right now, in px: `0` with no rail mounted, the
- * marker strip while the pane is closed, and the measured `reviewGutterWidth` while it
- * is open. The one source for the scroll container's padding and both rulers.
+ * The gutter the review rail reserves right now: nothing with no rail mounted, and the
+ * measured `reviewGutter` pair otherwise. The one source for the scroll container's
+ * paddings and both rulers. The result is reference-stable — the pure function answers
+ * with one of three shared constants — so consumers may depend on it directly.
  */
-export function useReviewGutter(): number {
+export function useReviewGutter(): ReviewGutter {
   // The SNAPSHOT, not the review hook — this needs a boolean and the page's width, not
   // the queue. And no gutter at all unless a rail is mounted to occupy it.
   const rail = useContext(ReviewRailContext);
@@ -173,14 +191,17 @@ export function useReviewGutter(): number {
   if (pageSetup) lastPageWidthTwips.current = pageSetup.pageWidthTwips;
   const pageWidthTwips = pageSetup?.pageWidthTwips ?? lastPageWidthTwips.current;
 
-  if ((rail?.mounted ?? 0) === 0) return 0;
-  return reviewGutterWidth({
-    open: reviewPaneOpen,
-    viewportWidth: viewportWidth ?? 0,
-    pageWidthPx:
-      pageWidthTwips === null || entitledZoom === null
-        ? 0
-        : twipsToPixels(pageWidthTwips) * entitledZoom,
-    docked: entitledZoom === null,
-  });
+  const mounted = (rail?.mounted ?? 0) > 0;
+  return useMemo(() => {
+    if (!mounted) return NO_GUTTER;
+    return reviewGutter({
+      open: reviewPaneOpen,
+      viewportWidth: viewportWidth ?? 0,
+      pageWidthPx:
+        pageWidthTwips === null || entitledZoom === null
+          ? 0
+          : twipsToPixels(pageWidthTwips) * entitledZoom,
+      docked: entitledZoom === null,
+    });
+  }, [mounted, reviewPaneOpen, viewportWidth, pageWidthTwips, entitledZoom]);
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -52,6 +52,16 @@ export {
 // or any external chrome — composes with: the rail registry the Viewport and rulers
 // reserve gutter space through, the in-tree Slot, and the locale binding.
 export { ReviewRailContext, type ReviewRailRegistry } from './editor/context';
+// The gutter the Viewport reserves for that rail — the pane composes with it to pick a
+// presentation the reservation can actually hold (the full column, or the compact strip).
+export {
+  REVIEW_MARKERS_GUTTER,
+  REVIEW_PANE_GUTTER,
+  reviewGutter,
+  useReviewGutter,
+  type ReviewGutter,
+  type ReviewGutterInput,
+} from './editor/review-gutter';
 export { Slot, type SlotProps } from './editor/toolbar/Slot';
 export { LocaleProvider, useTranslation } from './i18n';
 export { useChromeTranslate, type ChromeTranslate } from './i18n';

--- a/packages/react/test/navigation-pane.test.tsx
+++ b/packages/react/test/navigation-pane.test.tsx
@@ -117,6 +117,43 @@ describe('navigationShift', () => {
     }
   });
 
+  test('padding already standing at the inline start comes off the shift', () => {
+    // The review gutter's mirrored 44px strip moves the page exactly as the shift does.
+    // Solving for the shift alone and adding it ON TOP of the strip landed the page 22px
+    // (proportional) to 44px (docked) past the reservation.
+    const strip = 44;
+    // Proportional: 1200px viewport, 192px gutter. The TOTAL start padding the page needs
+    // is 272 (see the test above); the strip supplies 44 of it.
+    const shift = navigationShift({
+      viewportWidth: 1200,
+      pageWidthPx: PAGE,
+      reservation: RESERVATION,
+      inlineStartReservation: strip,
+    });
+    expect(shift).toBe(272 - strip);
+    // The page still lands exactly on the reservation: total padding over two, plus gutter.
+    expect((shift + strip) / 2 + (1200 - PAGE) / 2).toBe(RESERVATION);
+    // Docked: the page pins at the total padding, so the shift is the remainder.
+    expect(
+      navigationShift({
+        viewportWidth: 900,
+        pageWidthPx: PAGE,
+        reservation: RESERVATION,
+        inlineStartReservation: strip,
+        docked: true,
+      })
+    ).toBe(RESERVATION - strip);
+    // A strip that already clears the whole deficit asks for no shift at all.
+    expect(
+      navigationShift({
+        viewportWidth: 1200,
+        pageWidthPx: PAGE,
+        reservation: RESERVATION,
+        inlineStartReservation: 300,
+      })
+    ).toBe(0);
+  });
+
   test('answers zero for a measurement it does not have yet', () => {
     // A viewport that has not been laid out, or a document with no page setup. Shifting on
     // a zero measurement would make the pane jump on the first frame and settle on the

--- a/packages/react/test/review-gutter-integration.test.tsx
+++ b/packages/react/test/review-gutter-integration.test.tsx
@@ -1,0 +1,147 @@
+// The review gutter's React wiring, against the real engine: the rail registry gating,
+// the snapshot-fed geometry, the viewport measurement, and the CSS custom properties the
+// Viewport publishes. The pure `reviewGutter` rule is pinned in review-gutter.test.ts;
+// none of that file touches the wiring, which is where the registry timing and the
+// measurement fallbacks live.
+
+// MUST be first: happy-dom registration happens on import.
+import './dom-setup.ts';
+
+// React's `act` refuses to run outside an act-configured environment.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { useContext, useEffect } from 'react';
+import { act, cleanup, render } from '@testing-library/react';
+import { zipSync, strToU8 } from 'fflate';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { ReviewRailContext } from '../src/editor/context.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
+
+/** A rail with no UI: claims the gutter exactly the way `DocxEditor.Review` does. */
+function RailStub() {
+  const registry = useContext(ReviewRailContext);
+  useEffect(() => registry?.register(), [registry]);
+  return null;
+}
+
+// happy-dom lays nothing out, so every element reports `clientWidth` 0 — which the hook
+// correctly treats as "unmeasured" and answers with the full-column fallback. To exercise
+// the measured path, the scroll container reports a chosen width instead. Restored after
+// the suite; other files run in their own process (the sharded runner), so nothing leaks.
+let scrollerWidth = 0;
+let originalClientWidth: PropertyDescriptor | undefined;
+let clientWidthOwner: object | null = null;
+
+beforeAll(() => {
+  for (const proto of [Element.prototype, HTMLElement.prototype] as object[]) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, 'clientWidth');
+    if (descriptor) {
+      originalClientWidth = descriptor;
+      clientWidthOwner = proto;
+      break;
+    }
+  }
+  const target = clientWidthOwner ?? Element.prototype;
+  Object.defineProperty(target, 'clientWidth', {
+    configurable: true,
+    get(this: Element) {
+      if (this.classList?.contains('docx-editor__scroll-container')) return scrollerWidth;
+      return originalClientWidth?.get ? (originalClientWidth.get.call(this) as number) : 0;
+    },
+  });
+  if (!clientWidthOwner) clientWidthOwner = target;
+});
+
+afterAll(() => {
+  if (clientWidthOwner && originalClientWidth) {
+    Object.defineProperty(clientWidthOwner, 'clientWidth', originalClientWidth);
+  }
+});
+
+afterEach(cleanup);
+
+/** Effects (registration, measurement) plus the engine's open tick. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+}
+
+describe('the viewport’s review gutter', () => {
+  test('no rail composed: no reservation attribute and no custom properties', async () => {
+    scrollerWidth = 1000;
+    const { container } = render(
+      <DocxEditorRoot document={SOURCE}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    await settle();
+    const scroller = container.querySelector('.docx-editor__scroll-container')!;
+    expect(scroller.hasAttribute('data-review-pane')).toBe(false);
+    expect((scroller as HTMLElement).style.getPropertyValue('--docx-review-gutter')).toBe('');
+  });
+
+  test('a rail on a viewport too narrow for the column settles on the mirrored strip', async () => {
+    // Letter page (816px at 100%) in a 1000px scroller: 184px leftover against the 364
+    // the column and the clearance need together, so the strip mirrors onto both edges.
+    scrollerWidth = 1000;
+    const { container } = render(
+      <DocxEditorRoot document={SOURCE}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+        <RailStub />
+      </DocxEditorRoot>
+    );
+    await settle();
+    const scroller = container.querySelector('.docx-editor__scroll-container') as HTMLElement;
+    expect(scroller.getAttribute('data-review-pane')).toBe('open');
+    expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('44px');
+    expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('44px');
+  });
+
+  test('a rail on a wide viewport keeps the full column, with nothing at the start', async () => {
+    scrollerWidth = 1728;
+    const { container } = render(
+      <DocxEditorRoot document={SOURCE}>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+        <RailStub />
+      </DocxEditorRoot>
+    );
+    await settle();
+    const scroller = container.querySelector('.docx-editor__scroll-container') as HTMLElement;
+    expect(scroller.getAttribute('data-review-pane')).toBe('open');
+    expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('316px');
+    expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('0px');
+  });
+});

--- a/packages/react/test/review-gutter.test.ts
+++ b/packages/react/test/review-gutter.test.ts
@@ -1,117 +1,110 @@
-// The review gutter — the right padding the scroll container reserves for the rail.
+// The review gutter — the paddings the scroll container reserves for the rail.
 //
-// The load-bearing claim mirrors the navigation pane's: the open pane must not move the
-// document further than the viewport forces it to. On a wide host the full 316px column
-// stands and the sheet and its cards read as one centred pair; on a narrow one the
-// reservation narrows to what is left after the sheet keeps a little clearance, and it
-// never drops below the marker strip — the anchors and the add-comment affordance keep
-// working at every width. `reviewGutterWidth` is that rule as a pure function.
+// The load-bearing claim: the reservation is BINARY and, when the full column cannot be
+// afforded, SYMMETRIC. On a wide host the 316px column stands and the sheet and its cards
+// read as one centred pair; on a narrow one the marker strip is mirrored onto both edges,
+// so the sheet sits dead-centre while the anchors and the add-comment affordance keep
+// their room. There is no width at which a partial, one-sided column looks right — it is
+// too narrow for a card and still wide enough to park the page off-centre — so no width
+// gets one. `reviewGutter` is that rule as a pure function.
 
 import { describe, expect, test } from 'bun:test';
 import {
   REVIEW_GUTTER_PAGE_CLEARANCE,
   REVIEW_MARKERS_GUTTER,
   REVIEW_PANE_GUTTER,
-  reviewGutterWidth,
+  reviewGutter,
 } from '../src/editor/review-gutter.ts';
 
 // Letter at 100%: 8.5in x 96dpi.
 const PAGE = 816;
 const CLEARANCE = 2 * REVIEW_GUTTER_PAGE_CLEARANCE;
+const FULL = { inlineStart: 0, inlineEnd: REVIEW_PANE_GUTTER };
+const STRIP = { inlineStart: REVIEW_MARKERS_GUTTER, inlineEnd: REVIEW_MARKERS_GUTTER };
 
-describe('reviewGutterWidth', () => {
-  test('a closed pane reserves the marker strip, at any width', () => {
-    expect(reviewGutterWidth({ open: false, viewportWidth: 1728, pageWidthPx: PAGE })).toBe(
-      REVIEW_MARKERS_GUTTER
-    );
-    expect(reviewGutterWidth({ open: false, viewportWidth: 500, pageWidthPx: PAGE })).toBe(
-      REVIEW_MARKERS_GUTTER
-    );
+describe('reviewGutter', () => {
+  test('a closed pane reserves the mirrored strip, at any width', () => {
+    // Symmetric on purpose: the one-sided 44px strip used to nudge the sheet 22px off
+    // centre for as long as the pane stayed closed.
+    expect(reviewGutter({ open: false, viewportWidth: 1728, pageWidthPx: PAGE })).toEqual(STRIP);
+    expect(reviewGutter({ open: false, viewportWidth: 500, pageWidthPx: PAGE })).toEqual(STRIP);
   });
 
   test('the full column stands while the viewport holds page, column, and clearance', () => {
-    // 1728px viewport, 816px page: 912px to spare, the column needs 316 plus the sheet's
-    // clearance. This is the wide case the reservation was designed for — nothing changes.
-    expect(reviewGutterWidth({ open: true, viewportWidth: 1728, pageWidthPx: PAGE })).toBe(
-      REVIEW_PANE_GUTTER
-    );
-    // Break-even: exactly page + column + clearance. Still the full column.
+    // 1728px viewport, 816px page: 912px to spare against the 364 the column and the
+    // sheet's clearance need. This is the wide case the reservation was designed for.
+    expect(reviewGutter({ open: true, viewportWidth: 1728, pageWidthPx: PAGE })).toEqual(FULL);
+    // Break-even: exactly page + column + clearance. Still the full column, and the
+    // sheet's left gap is exactly the clearance.
     expect(
-      reviewGutterWidth({
+      reviewGutter({
         open: true,
         viewportWidth: PAGE + REVIEW_PANE_GUTTER + CLEARANCE,
         pageWidthPx: PAGE,
       })
-    ).toBe(REVIEW_PANE_GUTTER);
+    ).toEqual(FULL);
   });
 
-  test('narrows to the leftover width when the viewport holds less', () => {
-    // 1147px viewport, 816px page: 331px left over — just under the 364 the full column
-    // and the clearance need together. Reserving 316 anyway left the sheet 7px off the
-    // viewport's left edge with a mostly-empty band standing where the page should be —
-    // the bug this measurement exists to fix. The column takes what remains after the
-    // sheet keeps its clearance.
-    expect(reviewGutterWidth({ open: true, viewportWidth: 1147, pageWidthPx: PAGE })).toBe(
-      1147 - PAGE - CLEARANCE
-    );
-    expect(reviewGutterWidth({ open: true, viewportWidth: 1000, pageWidthPx: PAGE })).toBe(
-      1000 - PAGE - CLEARANCE
-    );
+  test('below the threshold the strip mirrors onto both edges and the sheet centres', () => {
+    // One pixel under break-even. A partial column here would be too narrow for a card
+    // and would still park the sheet off-centre beside a mostly-empty band — the bug
+    // this measurement exists to fix. The mirrored strip keeps the sheet dead-centre.
+    const gutter = reviewGutter({
+      open: true,
+      viewportWidth: PAGE + REVIEW_PANE_GUTTER + CLEARANCE - 1,
+      pageWidthPx: PAGE,
+    });
+    expect(gutter).toEqual(STRIP);
+    expect(gutter.inlineStart).toBe(gutter.inlineEnd);
   });
 
-  test('never drops below the marker strip, even when the page itself overflows', () => {
+  test('the strip holds even when the page itself overflows', () => {
     // A phone-width host: the page already scrolls horizontally, and the strip keeps the
-    // markers and the add-comment button reachable without reserving a dead column.
-    expect(reviewGutterWidth({ open: true, viewportWidth: 390, pageWidthPx: PAGE })).toBe(
-      REVIEW_MARKERS_GUTTER
-    );
+    // markers and the add-comment button placeable without reserving a dead column.
+    expect(reviewGutter({ open: true, viewportWidth: 390, pageWidthPx: PAGE })).toEqual(STRIP);
   });
 
   test('an uncapped fit keeps the full column', () => {
     // An uncapped fit fills whatever box it is given, so there is no page entitlement to
     // measure the leftover against. The full column stands and the page absorbs it,
     // exactly as it always has.
-    expect(
-      reviewGutterWidth({ open: true, viewportWidth: 900, pageWidthPx: 0, docked: true })
-    ).toBe(REVIEW_PANE_GUTTER);
+    expect(reviewGutter({ open: true, viewportWidth: 900, pageWidthPx: 0, docked: true })).toEqual(
+      FULL
+    );
   });
 
   test('a capped fit yields the column before the fit shrinks the page', () => {
     // The default `'auto'` fit caps at 100%, so the page's entitlement is its authored
     // width. On a 1150px viewport the old fixed column left the fit a 786px box and the
-    // page painted at 96% beside a mostly-empty band; measured, the column narrows to
-    // 286px and the fit's box holds the page at 100% with its clearance intact.
-    const gutter = reviewGutterWidth({ open: true, viewportWidth: 1150, pageWidthPx: PAGE });
-    expect(gutter).toBe(1150 - PAGE - CLEARANCE);
-    expect(1150 - gutter - CLEARANCE).toBeGreaterThanOrEqual(PAGE);
+    // page painted at 96% beside a mostly-empty band; with the strip mirrored, the fit's
+    // box holds the page at 100% and the sheet centres.
+    const gutter = reviewGutter({ open: true, viewportWidth: 1150, pageWidthPx: PAGE });
+    expect(gutter).toEqual(STRIP);
+    expect(1150 - gutter.inlineStart - gutter.inlineEnd).toBeGreaterThanOrEqual(PAGE + CLEARANCE);
   });
 
   test('answers the stylesheet fallback for a measurement it does not have yet', () => {
     // A viewport that has not been laid out, or a document with no page setup. The full
     // column is what the stylesheet painted before this measurement existed, so an
     // unmeasured first frame looks exactly as it always did instead of jumping.
-    expect(reviewGutterWidth({ open: true, viewportWidth: 0, pageWidthPx: PAGE })).toBe(
-      REVIEW_PANE_GUTTER
-    );
-    expect(reviewGutterWidth({ open: true, viewportWidth: 1200, pageWidthPx: 0 })).toBe(
-      REVIEW_PANE_GUTTER
-    );
-    expect(reviewGutterWidth({ open: true, viewportWidth: Number.NaN, pageWidthPx: PAGE })).toBe(
-      REVIEW_PANE_GUTTER
+    expect(reviewGutter({ open: true, viewportWidth: 0, pageWidthPx: PAGE })).toEqual(FULL);
+    expect(reviewGutter({ open: true, viewportWidth: 1200, pageWidthPx: 0 })).toEqual(FULL);
+    expect(reviewGutter({ open: true, viewportWidth: Number.NaN, pageWidthPx: PAGE })).toEqual(
+      FULL
     );
   });
 
-  test('the sheet keeps its footing at every width', () => {
+  test('the sheet is never parked off-centre by a partial column, at any width', () => {
     for (let viewportWidth = 500; viewportWidth <= 2400; viewportWidth += 17) {
-      const gutter = reviewGutterWidth({ open: true, viewportWidth, pageWidthPx: PAGE });
-      // Bounded by the strip and the column...
-      expect(gutter).toBeGreaterThanOrEqual(REVIEW_MARKERS_GUTTER);
-      expect(gutter).toBeLessThanOrEqual(REVIEW_PANE_GUTTER);
-      // ...and whenever the viewport holds the page, the strip, and the clearance, the
-      // padded box still holds the page with its clearance intact — the sheet never sits
-      // against the edge to feed the column.
-      if (viewportWidth - PAGE - CLEARANCE >= REVIEW_MARKERS_GUTTER) {
-        expect(viewportWidth - gutter).toBeGreaterThanOrEqual(PAGE + CLEARANCE);
+      const gutter = reviewGutter({ open: true, viewportWidth, pageWidthPx: PAGE });
+      if (gutter.inlineEnd === REVIEW_PANE_GUTTER) {
+        // Full column: the padded box still holds the page with its clearance intact.
+        expect(gutter.inlineStart).toBe(0);
+        expect(viewportWidth - gutter.inlineEnd).toBeGreaterThanOrEqual(PAGE + CLEARANCE);
+      } else {
+        // Otherwise the reservation is exactly the mirrored strip — symmetric, so the
+        // auto margins centre the sheet in what remains.
+        expect(gutter).toEqual(STRIP);
       }
     }
   });

--- a/packages/react/test/review-gutter.test.ts
+++ b/packages/react/test/review-gutter.test.ts
@@ -1,0 +1,118 @@
+// The review gutter — the right padding the scroll container reserves for the rail.
+//
+// The load-bearing claim mirrors the navigation pane's: the open pane must not move the
+// document further than the viewport forces it to. On a wide host the full 316px column
+// stands and the sheet and its cards read as one centred pair; on a narrow one the
+// reservation narrows to what is left after the sheet keeps a little clearance, and it
+// never drops below the marker strip — the anchors and the add-comment affordance keep
+// working at every width. `reviewGutterWidth` is that rule as a pure function.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  REVIEW_GUTTER_PAGE_CLEARANCE,
+  REVIEW_MARKERS_GUTTER,
+  REVIEW_PANE_GUTTER,
+  reviewGutterWidth,
+} from '../src/editor/review-gutter.ts';
+
+// Letter at 100%: 8.5in x 96dpi.
+const PAGE = 816;
+const CLEARANCE = 2 * REVIEW_GUTTER_PAGE_CLEARANCE;
+
+describe('reviewGutterWidth', () => {
+  test('a closed pane reserves the marker strip, at any width', () => {
+    expect(reviewGutterWidth({ open: false, viewportWidth: 1728, pageWidthPx: PAGE })).toBe(
+      REVIEW_MARKERS_GUTTER
+    );
+    expect(reviewGutterWidth({ open: false, viewportWidth: 500, pageWidthPx: PAGE })).toBe(
+      REVIEW_MARKERS_GUTTER
+    );
+  });
+
+  test('the full column stands while the viewport holds page, column, and clearance', () => {
+    // 1728px viewport, 816px page: 912px to spare, the column needs 316 plus the sheet's
+    // clearance. This is the wide case the reservation was designed for — nothing changes.
+    expect(reviewGutterWidth({ open: true, viewportWidth: 1728, pageWidthPx: PAGE })).toBe(
+      REVIEW_PANE_GUTTER
+    );
+    // Break-even: exactly page + column + clearance. Still the full column.
+    expect(
+      reviewGutterWidth({
+        open: true,
+        viewportWidth: PAGE + REVIEW_PANE_GUTTER + CLEARANCE,
+        pageWidthPx: PAGE,
+      })
+    ).toBe(REVIEW_PANE_GUTTER);
+  });
+
+  test('narrows to the leftover width when the viewport holds less', () => {
+    // 1147px viewport, 816px page: 331px left over — just under the 364 the full column
+    // and the clearance need together. Reserving 316 anyway left the sheet 7px off the
+    // viewport's left edge with a mostly-empty band standing where the page should be —
+    // the bug this measurement exists to fix. The column takes what remains after the
+    // sheet keeps its clearance.
+    expect(reviewGutterWidth({ open: true, viewportWidth: 1147, pageWidthPx: PAGE })).toBe(
+      1147 - PAGE - CLEARANCE
+    );
+    expect(reviewGutterWidth({ open: true, viewportWidth: 1000, pageWidthPx: PAGE })).toBe(
+      1000 - PAGE - CLEARANCE
+    );
+  });
+
+  test('never drops below the marker strip, even when the page itself overflows', () => {
+    // A phone-width host: the page already scrolls horizontally, and the strip keeps the
+    // markers and the add-comment button reachable without reserving a dead column.
+    expect(reviewGutterWidth({ open: true, viewportWidth: 390, pageWidthPx: PAGE })).toBe(
+      REVIEW_MARKERS_GUTTER
+    );
+  });
+
+  test('an uncapped fit keeps the full column', () => {
+    // An uncapped fit fills whatever box it is given, so there is no page entitlement to
+    // measure the leftover against. The full column stands and the page absorbs it,
+    // exactly as it always has.
+    expect(
+      reviewGutterWidth({ open: true, viewportWidth: 900, pageWidthPx: 0, docked: true })
+    ).toBe(REVIEW_PANE_GUTTER);
+  });
+
+  test('a capped fit yields the column before the fit shrinks the page', () => {
+    // The default `'auto'` fit caps at 100%, so the page's entitlement is its authored
+    // width. On a 1150px viewport the old fixed column left the fit a 786px box and the
+    // page painted at 96% beside a mostly-empty band; measured, the column narrows to
+    // 286px and the fit's box holds the page at 100% with its clearance intact.
+    const gutter = reviewGutterWidth({ open: true, viewportWidth: 1150, pageWidthPx: PAGE });
+    expect(gutter).toBe(1150 - PAGE - CLEARANCE);
+    expect(1150 - gutter - CLEARANCE).toBeGreaterThanOrEqual(PAGE);
+  });
+
+  test('answers the stylesheet fallback for a measurement it does not have yet', () => {
+    // A viewport that has not been laid out, or a document with no page setup. The full
+    // column is what the stylesheet painted before this measurement existed, so an
+    // unmeasured first frame looks exactly as it always did instead of jumping.
+    expect(reviewGutterWidth({ open: true, viewportWidth: 0, pageWidthPx: PAGE })).toBe(
+      REVIEW_PANE_GUTTER
+    );
+    expect(reviewGutterWidth({ open: true, viewportWidth: 1200, pageWidthPx: 0 })).toBe(
+      REVIEW_PANE_GUTTER
+    );
+    expect(reviewGutterWidth({ open: true, viewportWidth: Number.NaN, pageWidthPx: PAGE })).toBe(
+      REVIEW_PANE_GUTTER
+    );
+  });
+
+  test('the sheet keeps its footing at every width', () => {
+    for (let viewportWidth = 500; viewportWidth <= 2400; viewportWidth += 17) {
+      const gutter = reviewGutterWidth({ open: true, viewportWidth, pageWidthPx: PAGE });
+      // Bounded by the strip and the column...
+      expect(gutter).toBeGreaterThanOrEqual(REVIEW_MARKERS_GUTTER);
+      expect(gutter).toBeLessThanOrEqual(REVIEW_PANE_GUTTER);
+      // ...and whenever the viewport holds the page, the strip, and the clearance, the
+      // padded box still holds the page with its clearance intact — the sheet never sits
+      // against the edge to feed the column.
+      if (viewportWidth - PAGE - CLEARANCE >= REVIEW_MARKERS_GUTTER) {
+        expect(viewportWidth - gutter).toBeGreaterThanOrEqual(PAGE + CLEARANCE);
+      }
+    }
+  });
+});

--- a/packages/react/test/review-gutter.test.ts
+++ b/packages/react/test/review-gutter.test.ts
@@ -83,6 +83,30 @@ describe('reviewGutter', () => {
     expect(1150 - gutter.inlineStart - gutter.inlineEnd).toBeGreaterThanOrEqual(PAGE + CLEARANCE);
   });
 
+  test('an open navigation pane counts against the column', () => {
+    // Navigation asks for 328px at the start. Judged against the raw viewport, the column
+    // stood at 1500px and the pane's displacement then squeezed the fit below the page's
+    // entitlement — the two-pane composition of the very bug this rule removes. The ask
+    // is subtracted first: page + column + pane + clearance need 1508.
+    const NAV = 328;
+    expect(
+      reviewGutter({
+        open: true,
+        viewportWidth: 1500,
+        pageWidthPx: PAGE,
+        inlineStartReservation: NAV,
+      })
+    ).toEqual(STRIP);
+    expect(
+      reviewGutter({
+        open: true,
+        viewportWidth: PAGE + REVIEW_PANE_GUTTER + CLEARANCE + NAV,
+        pageWidthPx: PAGE,
+        inlineStartReservation: NAV,
+      })
+    ).toEqual(FULL);
+  });
+
   test('answers the stylesheet fallback for a measurement it does not have yet', () => {
     // A viewport that has not been laid out, or a document with no page setup. The full
     // column is what the stylesheet painted before this measurement existed, so an


### PR DESCRIPTION
The scroll container reserved a fixed 316px for the open review pane at every width, so a narrow viewport parked the sheet against the left edge (or, under the default fit, shrank the page toward its floor) beside a mostly-empty band.

The reservation is now measured and binary. `DocxEditor.Viewport` publishes `--docx-review-gutter` / `--docx-review-gutter-start` from the viewport's width and the page's entitled width (the fit's own cap, or the fixed zoom in force). While the viewport holds the page, the full column, and a little clearance, the 316px column stands and the sheet and its cards read as one centred pair. Otherwise the 44px marker strip mirrors onto both edges, so the sheet sits dead-centre; the closed pane gets the same mirrored strip, removing its former 22px off-centre nudge. Both rulers read the same shared value.

The rail follows the reservation it is given (via the new public `useReviewGutter`): while only the strip exists, the pane presents its markers, and the active decision floats as a full card pinned just inside the viewport's right edge — tracked through horizontal scroll, honouring a host's `Card` part and `preset={false}`, in the `asChild` branch too, and hidden in print. The compose box floats the same way, anchored to its own selection.

The two panes also stop claiming the same pixels: the navigation pane publishes its static ask on the shared layout store and the column yields to the strip when both cannot fit (the page keeps its full size instead of the fit shrinking it), while `navigationShift` subtracts the mirrored strip already standing on its edge instead of overshooting by it. The dependency stays one-directional, so nothing oscillates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)