### PR TITLE
fix(core): keep the selection band continuous across justified spaces

### DIFF
--- a/.changeset/join-line-drawing-gaps.md
+++ b/.changeset/join-line-drawing-gaps.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix inter-word gap painting on lines that merge two paragraphs in a resolved revision view: a drawing in one half no longer shifts or doubles gaps in the other half.

--- a/.changeset/justified-selection-band.md
+++ b/.changeset/justified-selection-band.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix the selection highlight in justified paragraphs: the band is now continuous across stretched inter-word spaces instead of breaking into one block per word. Underline and character shading also continue across those spaces, as Word draws them.

--- a/packages/core/src/output/__tests__/hyperlink-paint.test.ts
+++ b/packages/core/src/output/__tests__/hyperlink-paint.test.ts
@@ -259,4 +259,58 @@ describe('each HYPERLINK field is its own anchor', () => {
     );
     expect(container.querySelectorAll('a[data-docx-link]')).toHaveLength(1);
   });
+
+  test('a justify gap never stretches a link over the following plain text', () => {
+    // The stretch lives inside the span's box AND its anchor. A link's last span absorbing
+    // the gap would widen the <a> hit target across blank slack, so a click there would
+    // follow the link. That boundary keeps the margin; gaps INSIDE the link still stretch.
+    const words = Array.from({ length: 16 }, (_, index) => `w${index}`).join(' ');
+    const body =
+      '<w:p><w:pPr><w:jc w:val="both"/></w:pPr>' +
+      '<w:hyperlink r:id="rId9"><w:r><w:t xml:space="preserve">link text </w:t></w:r></w:hyperlink>' +
+      `<w:r><w:t xml:space="preserve">${words}</w:t></w:r>` +
+      '</w:p>';
+    const pkg = packageOf(body, EXTERNAL_REL);
+    const part = pkg.parts.get(pkg.mainDocumentPart)!;
+    const layout = layoutSemanticDocument(part, 3, {
+      measurer: createFixedMeasurer(6, 14),
+      geometry: { width: 220, height: 400, margin: { top: 10, right: 10, bottom: 10, left: 10 } },
+      projectLink: (link: OoxmlNode) => {
+        if (link.kind === 'textValue') return null;
+        const target = hyperlinkTargetOf(link, (id) =>
+          relationshipTargetIn(pkg, pkg.mainDocumentPart, id)
+        );
+        return { id: link.id, kind: target.kind, href: target.href };
+      },
+    });
+    const fragment = layout.pages[0]!.fragments[0]!;
+    if (fragment.kind !== 'paragraph') throw new Error('expected paragraph');
+    const line = fragment.lines[0]!;
+    const gapAfter = (index: number): number => {
+      const span = line.spans[index]!;
+      const next = line.spans[index + 1]!;
+      return next.box.x - (span.box.x + span.box.width);
+    };
+    // "link " → "text ": both in the anchor, with justify slack between them.
+    expect(line.spans[0]!.link).toBeDefined();
+    expect(line.spans[1]!.link).toBeDefined();
+    expect(gapAfter(0)).toBeGreaterThan(0.25);
+    // "text " → first plain word: the anchor boundary, also with slack.
+    expect(line.spans[2]!.link).toBeUndefined();
+    expect(gapAfter(1)).toBeGreaterThan(0.25);
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1, ariaHidden: false });
+    const painted = [
+      ...container
+        .querySelector<HTMLElement>('.docx-line')!
+        .querySelectorAll<HTMLElement>('.layout-run'),
+    ];
+    // Inside the anchor: the gap stretches, so the band and the hit target stay one piece.
+    expect(Number.parseFloat(painted[0]!.style.wordSpacing)).toBeCloseTo(gapAfter(0), 5);
+    // At the boundary: no stretch on the link's last span — the gap is the margin again.
+    expect(painted[1]!.style.wordSpacing).toBe('');
+    expect(Number.parseFloat(painted[2]!.style.marginLeft)).toBeCloseTo(gapAfter(1), 5);
+    // And the anchor's own text still ends at the link text; the slack is outside it.
+    expect(container.querySelector('a.docx-hyperlink')!.textContent).toBe('link text ');
+  });
 });

--- a/packages/core/src/output/__tests__/resolved-view-merge-paint.test.ts
+++ b/packages/core/src/output/__tests__/resolved-view-merge-paint.test.ts
@@ -116,4 +116,101 @@ describe('two paragraphs of images on one line', () => {
     }
     expect(shape).toEqual(['advance', 'AAA', 'advance', 'BBB']);
   });
+
+  test('a second-half drawing between the halves is not ALSO painted as a gap', () => {
+    // The second half's image advance separates "AAA " from "BBB" geometrically, and its
+    // spacer is flushed exactly there. An offset-only occupies-gap test missed it (offset 0
+    // sits numerically below the first half's ranges), so the same advance was painted
+    // twice: once as the spacer and once as a justify-style gap on the boundary.
+    const layout = layoutMerged();
+    const fragment = paragraphFragmentsOf(layout.pages[0]!)[0]!;
+    const line = fragment.lines[0]!;
+    // The records state the trap: the boundary gap between the halves IS the image advance.
+    const first = line.spans[0]!;
+    const second = line.spans[1]!;
+    expect(second.box.x - (first.box.x + first.box.width)).toBeGreaterThan(0.25);
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, {
+      scale: 1,
+      imageUrlPort: urlPort,
+      ariaHidden: false,
+    });
+    const painted = [
+      ...container
+        .querySelector<HTMLElement>('.docx-line')!
+        .querySelectorAll<HTMLElement>('.layout-run'),
+    ];
+    expect(painted.map((span) => span.textContent)).toEqual(['AAA ', 'BBB']);
+    // Only the spacer carries the advance — no stretch, no margin.
+    expect(painted[0]!.style.wordSpacing).toBe('');
+    expect(painted[1]!.style.marginLeft).toBe('');
+  });
+
+  test('a second-half drawing cannot zero a first-half justify gap it does not occupy', () => {
+    // Both halves count offsets from zero, so the second half's drawing offset can fall
+    // numerically inside a first-half span hole (here: a proposed deletion). Matching the
+    // offset without the paragraph zeroed the first half's justify gap, and every span
+    // after it painted a step too far left.
+    const tail = Array.from({ length: 18 }, (_, index) => `w${index}`).join(' ');
+    const xml =
+      `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+      `xmlns:pic="${PIC}" xmlns:r="${R}"><w:body>` +
+      '<w:p><w:pPr><w:jc w:val="both"/><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+      '<w:r><w:t xml:space="preserve">aa </w:t></w:r>' +
+      '<w:del w:id="2" w:author="A"><w:r><w:delText>DDD</w:delText></w:r></w:del>' +
+      '<w:r><w:t xml:space="preserve">cc </w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:jc w:val="both"/></w:pPr>' +
+      '<w:r><w:t xml:space="preserve">wxyz</w:t></w:r>' +
+      `${picture}` +
+      `<w:r><w:t xml:space="preserve"> ${tail}</w:t></w:r></w:p>` +
+      '</w:body></w:document>';
+    const result = readOoxmlPart(xml, {
+      name: OWNER,
+      contentType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+    });
+    if (!result.ok) throw new Error(result.reason);
+    const layout = layoutSemanticDocument(result.part, 1, {
+      measurer: createFixedMeasurer(6, 14),
+      displayMode: 'proposed',
+      geometry: { width: 220, height: 400, margin: { top: 10, right: 10, bottom: 10, left: 10 } },
+      inlineDrawingLayout: {
+        ownerPartName: OWNER,
+        project: (node) =>
+          projectDrawing(node, { ownerPartName: OWNER, limits: DEFAULT_DRAWING_PROJECTION_LIMITS }),
+        resourceOf: () => READY,
+      },
+    });
+    const fragment = paragraphFragmentsOf(layout.pages[0]!)[0]!;
+    const line = fragment.lines[0]!;
+    expect(fragment.lines.length).toBeGreaterThan(1);
+    // The trap, stated as records: the first-half hole spans the deletion, and the
+    // second-half drawing's offset falls numerically inside it.
+    const aa = line.spans[0]!;
+    const cc = line.spans[1]!;
+    expect(aa.text).toBe('aa ');
+    expect(cc.text).toBe('cc ');
+    expect(cc.range.start).toBeGreaterThan(aa.range.end);
+    const drawing = (line.drawings ?? []).find((d) => d.paragraphId !== aa.range.paragraphId)!;
+    expect(drawing).toBeDefined();
+    expect(drawing.start).toBeGreaterThanOrEqual(aa.range.end);
+    expect(drawing.start).toBeLessThan(cc.range.start);
+    // The join line is justified, so a real gap sits between the first half's words.
+    const gap = cc.box.x - (aa.box.x + aa.box.width);
+    expect(gap).toBeGreaterThan(0.25);
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, {
+      scale: 1,
+      imageUrlPort: urlPort,
+      ariaHidden: false,
+    });
+    const painted = [
+      ...container
+        .querySelector<HTMLElement>('.docx-line')!
+        .querySelectorAll<HTMLElement>('.layout-run'),
+    ];
+    expect(painted[0]!.textContent).toBe('aa ');
+    // The gap survives: the first half's stretch carries it, drawing or no drawing.
+    expect(Number.parseFloat(painted[0]!.style.wordSpacing)).toBeCloseTo(gap, 5);
+  });
 });

--- a/packages/core/src/output/__tests__/semantic-paint.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint.test.ts
@@ -99,10 +99,12 @@ describe('the painter is a non-authoritative consumer', () => {
     for (const span of spans) expect(span.style.left).toBe('');
   });
 
-  test('justified paint follows published gaps without expanding nonbreaking spaces', () => {
-    // CSS word-spacing expands NBSPs in Chromium, but layout only justifies ordinary spaces.
-    // Paint each published gap explicitly so later carets stay on their semantic boxes.
-    // Enough words that the paragraph wraps: the first line is justified, the last is not.
+  test('justified paint stretches trailing spaces so the selection band stays continuous', () => {
+    // A justify gap is painted as `word-spacing` on the span BEFORE it: the browser
+    // highlights a space's advance but never a margin, so margin gaps broke the native
+    // selection into one block per word. Layout only justifies ordinary spaces — the NBSPs
+    // here must not stretch. Enough words that the paragraph wraps: the first line is
+    // justified, the last is not.
     const words = Array.from({ length: 20 }, (_, index) => `w${index}`).join(' ');
     const body =
       `<w:p><w:pPr><w:jc w:val="both"/></w:pPr>` +
@@ -146,9 +148,56 @@ describe('the painter is a non-authoritative consumer', () => {
     for (let index = 1; index < line.spans.length; index += 1) {
       const previous = line.spans[index - 1]!;
       const expected = line.spans[index]!.box.x - (previous.box.x + previous.box.width);
-      const actual = Number.parseFloat(paintedSpans[index]!.style.marginLeft || '0');
-      expect(actual).toBeCloseTo(expected > 0.25 ? expected : 0, 5);
+      const stretch = Number.parseFloat(paintedSpans[index - 1]!.style.wordSpacing || '0');
+      const margin = Number.parseFloat(paintedSpans[index]!.style.marginLeft || '0');
+      // Each gap is painted exactly once — a stretched space AND a margin would double it.
+      expect(stretch + margin).toBeCloseTo(expected > 0.25 ? expected : 0, 5);
+      // Every gap in this fixture follows a plain-space word, so every gap is a stretch.
+      expect(margin).toBe(0);
+      // Selection mapping requires the span's characters to stay in ONE text node.
+      expect(paintedSpans[index]!.childNodes).toHaveLength(1);
     }
+  });
+
+  test('a justify gap after a span holding an NBSP falls back to the margin', () => {
+    // Every engine's `word-spacing` expands NBSP too, which would shift painted glyphs off
+    // their published boxes — such a span keeps the margin on its neighbour instead.
+    const words = Array.from({ length: 20 }, (_, index) => `w${index}`).join(' ');
+    const body =
+      `<w:p><w:pPr><w:jc w:val="both"/></w:pPr>` +
+      `<w:r><w:t xml:space="preserve">a b ${words}</w:t></w:r>` +
+      `</w:p>`;
+    const read = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+      name: '/word/document.xml',
+      contentType: 'app/xml',
+    });
+    if (!read.ok) throw new Error(read.reason);
+    const layout = layoutSemanticDocument(read.part, 7, {
+      measurer: createFixedMeasurer(6, 14),
+      geometry: {
+        width: 220,
+        height: 400,
+        margin: { top: 10, right: 10, bottom: 10, left: 10 },
+      },
+    });
+    const fragment = layout.pages[0]!.fragments[0]!;
+    if (fragment.kind !== 'paragraph') throw new Error('expected paragraph');
+    const line = fragment.lines[0]!;
+    const nbspIndex = line.spans.findIndex((span) => span.text.includes(' '));
+    expect(nbspIndex).toBeGreaterThanOrEqual(0);
+    const nbspSpan = line.spans[nbspIndex]!;
+    const next = line.spans[nbspIndex + 1]!;
+    const gap = next.box.x - (nbspSpan.box.x + nbspSpan.box.width);
+    expect(gap).toBeGreaterThan(0.25);
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const paintedSpans = [
+      ...container
+        .querySelector<HTMLElement>('.docx-line')!
+        .querySelectorAll<HTMLElement>('.layout-run'),
+    ];
+    expect(paintedSpans[nbspIndex]!.style.wordSpacing).toBe('');
+    expect(Number.parseFloat(paintedSpans[nbspIndex + 1]!.style.marginLeft)).toBeCloseTo(gap, 5);
   });
 
   test('a line is as tall as the record says, so lines cannot drift apart', () => {

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1425,7 +1425,7 @@ function paintLine(
     // trailing space: the browser highlights a space's advance but never a margin, so a
     // margin gap broke the selection band into one block per word on justified lines.
     const next = line.spans[spanIndex + 1];
-    const gapAfter = interSpanGapBefore(line, spanIndex + 1);
+    const gapAfter = interSpanGapBefore(line, spanIndex + 1, rankOf);
     previousSpanAbsorbedGap = gapAfter > 0 && next !== undefined && absorbsFollowingGap(span, next);
     if (previousSpanAbsorbedGap) painted.style.wordSpacing = `${gapAfter * scale}px`;
     pendingGap = gapAfter;
@@ -1501,13 +1501,31 @@ function paintLine(
 }
 
 /** The layout-published gap before one span, excluding separately painted advances. */
-function interSpanGapBefore(line: LineRecord, index: number): number {
+function interSpanGapBefore(
+  line: LineRecord,
+  index: number,
+  rankOf: (paragraphId: string) => number
+): number {
   if (index <= 0 || index >= line.spans.length) return 0;
   const previous = line.spans[index - 1]!;
   const current = line.spans[index]!;
-  const drawingOccupiesGap = line.drawings?.some(
-    (drawing) => drawing.start >= previous.range.end && drawing.start < current.range.start
-  );
+  // A drawing occupies this gap exactly when its spacer is FLUSHED between these two spans,
+  // so the test is the same reader-order window `appendDrawingAdvancesBefore` walks: rank
+  // first, then offset. Matching the raw offset alone was wrong twice on a resolved join
+  // line, where each half counts offsets from zero: a second-half drawing whose offset fell
+  // inside a first-half hole zeroed a gap it does not occupy, and a second-half drawing
+  // BEFORE its own text — numerically below the first half's ranges — was flushed here yet
+  // not counted, so its advance was painted twice.
+  const previousRank = rankOf(previous.range.paragraphId);
+  const currentRank = rankOf(current.range.paragraphId);
+  const drawingOccupiesGap = line.drawings?.some((drawing) => {
+    const rank = rankOf(drawing.paragraphId);
+    const afterPrevious =
+      rank > previousRank || (rank === previousRank && drawing.start >= previous.range.start);
+    const beforeCurrent =
+      rank < currentRank || (rank === currentRank && drawing.start < current.range.start);
+    return afterPrevious && beforeCurrent;
+  });
   if (drawingOccupiesGap) return 0;
   const gap =
     current.box.x - (previous.box.x + previous.box.width) - (current.wrapAdvanceBefore ?? 0);

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1301,8 +1301,10 @@ function paintLine(
   element.style.overflow = 'visible';
 
   // Justified lines carry their slack in the gaps BETWEEN spans. Inline flow has no gaps,
-  // so each span receives its own published advance below. CSS `word-spacing` is not an
-  // equivalent: Chromium expands NBSPs too, moving painted glyphs away from layout geometry.
+  // so each span receives its own published advance below — as `word-spacing` stretching its
+  // own trailing space where that is safe, and as a margin on the next span otherwise (see
+  // `absorbsFollowingGap`). The stretch is what keeps the native selection band continuous:
+  // a margin is never highlighted, but a space character's advance is.
   // Per-run band heights, chosen so the browser's line-box math cannot move a glyph:
   // the tallest run's band is the glyph band (own height + space-above leading), and any
   // remaining line-box depth is padding-bottom — Word's auto/atLeast extras sit BELOW the
@@ -1407,13 +1409,26 @@ function paintLine(
     anchorLinkId = null;
   };
 
+  // Each boundary's gap is computed ONCE and carried into the next iteration, so a gap is
+  // painted exactly once — as a stretch or as a margin, never both, never neither.
+  let pendingGap = 0;
+  let previousSpanAbsorbedGap = false;
   for (const [spanIndex, span] of line.spans.entries()) {
     appendDrawingAdvancesBefore(span.range.paragraphId, span.range.start);
     appendWrapAdvance(span);
     const band = Math.min(span.box.height + leading, line.box.height);
     const painted = paintSpan(document, span, ctx, band, leading);
-    const gap = interSpanGapBefore(line, spanIndex);
-    if (gap > 0) painted.style.marginLeft = `${gap * scale}px`;
+    if (pendingGap > 0 && !previousSpanAbsorbedGap) {
+      painted.style.marginLeft = `${pendingGap * scale}px`;
+    }
+    // A justify gap is drawn INSIDE the span before it wherever that span can stretch its
+    // trailing space: the browser highlights a space's advance but never a margin, so a
+    // margin gap broke the selection band into one block per word on justified lines.
+    const next = line.spans[spanIndex + 1];
+    const gapAfter = interSpanGapBefore(line, spanIndex + 1);
+    previousSpanAbsorbedGap = gapAfter > 0 && next !== undefined && absorbsFollowingGap(span, next);
+    if (previousSpanAbsorbedGap) painted.style.wordSpacing = `${gapAfter * scale}px`;
+    pendingGap = gapAfter;
     const link = span.link;
     if (!link) {
       anchor = null;
@@ -1487,7 +1502,7 @@ function paintLine(
 
 /** The layout-published gap before one span, excluding separately painted advances. */
 function interSpanGapBefore(line: LineRecord, index: number): number {
-  if (index <= 0) return 0;
+  if (index <= 0 || index >= line.spans.length) return 0;
   const previous = line.spans[index - 1]!;
   const current = line.spans[index]!;
   const drawingOccupiesGap = line.drawings?.some(
@@ -1497,6 +1512,52 @@ function interSpanGapBefore(line: LineRecord, index: number): number {
   const gap =
     current.box.x - (previous.box.x + previous.box.width) - (current.wrapAdvanceBefore ?? 0);
   return gap > 0.25 ? gap : 0;
+}
+
+/**
+ * Every character an engine's `word-spacing` may move. U+0020 and NBSP expand in Chromium,
+ * WebKit and Gecko alike; a tab expands in Chromium and Gecko (fourfold — it is four
+ * advances). The rest is the CSS Text 3 word-separator list, kept in case an engine starts
+ * honouring it; U+3000 is deliberately absent — no engine expands it, and refusing it would
+ * forfeit the stretch on CJK text for nothing.
+ */
+const WORD_SEPARATOR = /[\t\n\r \u00A0\u1361\u{10100}-\u{10102}\u{1039F}\u{1091F}]/u;
+
+/**
+ * Whether the justify gap AFTER this span can be painted as `word-spacing` on the span
+ * itself, stretching its trailing space, instead of as a margin on the next span.
+ *
+ * The stretch must move ONLY the trailing space. Layout puts justify slack after expandable
+ * U+0020s and word-breaks after every one of them, so an ordinary word-span qualifies —
+ * including a projected field result, whose box was reserved from the drawn text like any
+ * other. A span carrying any OTHER word separator keeps the margin, whose only cost is a
+ * seam in the native selection band. A span with a forced width (`w:w` horizontal scaling)
+ * cannot grow its box, so it keeps the margin too.
+ *
+ * The stretch also lives inside the span's ANCHOR and on its side of a float. A link's last
+ * span stretching over the gap would extend the `<a>` hit target across blank slack — a
+ * click there would follow the link — so both spans must share one anchor, or have none.
+ * And a wrap advance is painted BETWEEN the spans, so stretching across it would draw the
+ * slack (and this span's underline and shading) inside the float's exclusion zone.
+ */
+function absorbsFollowingGap(span: StyleSpanRecord, next: StyleSpanRecord): boolean {
+  if (!span.text.endsWith(' ')) return false;
+  if (span.style.horizontalScalePercent !== 100) return false;
+  if (!sharesAnchor(span, next)) return false;
+  if ((next.wrapAdvanceBefore ?? 0) > 0.001) return false;
+  return !WORD_SEPARATOR.test(span.text.slice(0, -1));
+}
+
+/**
+ * Whether two adjacent spans land in the same painted anchor, mirroring the anchor-opening
+ * rules in {@link paintLine}: both linkless, or the same link id — and for field atoms the
+ * same field (same model start), because two discrete fields share a content-keyed id.
+ */
+function sharesAnchor(a: StyleSpanRecord, b: StyleSpanRecord): boolean {
+  if (!a.link && !b.link) return true;
+  if (!a.link || !b.link || a.link.id !== b.link.id) return false;
+  if (Boolean(a.fieldAtom) !== Boolean(b.fieldAtom)) return false;
+  return !a.fieldAtom || a.range.start === b.range.start;
 }
 
 function paintFragment(


### PR DESCRIPTION
Justify slack was painted as `margin-left` on the span after each gap, and the native selection highlight never covers a margin — so selecting a justified paragraph showed a white seam at every stretched space, including inside multi-word content controls. The gap is now painted as `word-spacing` on the span before it, so the trailing space's advance carries the slack and the highlight, underline and shading cover it, as Word draws them. The margin remains as a fallback wherever the stretch is unsafe: a span holding another word-separator character, a forced width, a hyperlink boundary (the anchor's hit target must not grow over blank slack), or a float wrap advance. Verified geometrically identical in Chromium, WebKit and Gecko.

Also fixes the drawing-occupies-gap test on resolved join lines: it matched `drawing.start` alone, so a drawing in one half could zero a justify gap in the other half or double-paint its own advance; it now walks the same segment-ranked window the spacer flush uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)