### PR TITLE
fix(core): refuse and hide write affordances in viewing mode

### DIFF
--- a/.changeset/view-mode-header-affordance.md
+++ b/.changeset/view-mode-header-affordance.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Viewing mode no longer shows the header and footer hover invitation. Switching to viewing hides the affordance right away, instead of waiting for the next repaint.

--- a/.changeset/view-mode-header-affordance.md
+++ b/.changeset/view-mode-header-affordance.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
-Viewing mode no longer shows the header and footer hover invitation. Switching to viewing hides the affordance right away, instead of waiting for the next repaint.
+Viewing mode no longer offers write affordances it refuses: the header and footer hover invitation, content-control widgets, image resize handles, and the custom-node and comment context-menu rows. Content-control edits are now refused in viewing instead of committing.

--- a/docs/api/docx-editor-core/output.api.md
+++ b/docs/api/docx-editor-core/output.api.md
@@ -39,6 +39,7 @@ export interface PaintOptions {
         readonly checkedIds?: ReadonlySet<string>;
         readonly additionalBoundaries?: readonly ContentControlBoundaryRecord[];
         readonly tocControlIds?: ReadonlySet<string>;
+        readonly readOnly?: boolean;
     };
     readonly defaultFontFamily?: string;
     // (undocumented)

--- a/packages/core/src/editor/__tests__/content-control-surface.test.ts
+++ b/packages/core/src/editor/__tests__/content-control-surface.test.ts
@@ -369,6 +369,75 @@ describe('content-control surface chrome', () => {
     expect(surface.session.bodyText()).toContain('O');
   });
 
+  test('viewing mode refuses every control write and disables the painted widget', () => {
+    // This lane called `session.applyTreeOps` directly rather than the gated session, so a
+    // checkbox on a document open for viewing still toggled and still committed. The widget
+    // is engine-painted, so the mode has to reach the DOM too — the pointer lane skips a
+    // widget carrying `data-disabled-reason`, which is what stops the click.
+    const body =
+      `<w:p>${sdt(
+        `<w14:checkbox><w14:checked w14:val="0"/>` +
+          `<w14:checkedState w14:val="2612" w14:font="MS Gothic"/>` +
+          `<w14:uncheckedState w14:val="2610" w14:font="MS Gothic"/></w14:checkbox>`,
+        `<w:r><w:t>x</w:t></w:r>`
+      )}</w:p>` + sdt(`<w:text/>`, p('O'));
+    const { surface, container } = mount(body);
+    const controls = surface.layout().contentControls ?? [];
+    const checkboxId = controls.find((c) => c.controlType === 'checkbox')!.id;
+    const openId = controls.find((c) => c.controlType !== 'checkbox')!.id;
+    const revision = surface.session.packageRevision();
+
+    surface.setEditingMode('view');
+
+    expect(surface.contentControls.disabledReason(checkboxId, 'edit')).toBe(
+      'the document is open for viewing'
+    );
+    expect(surface.contentControls.disabledReason(openId, 'remove')).toBe(
+      'the document is open for viewing'
+    );
+    expect(surface.contentControls.setValue(checkboxId, '1')).toBe(false);
+    expect(surface.contentControls.remove(openId)).toBe(false);
+    expect(surface.session.packageRevision()).toBe(revision);
+
+    const widget = container.querySelector<HTMLButtonElement>('[data-docx-cc-widget]');
+    expect(widget).not.toBeNull();
+    expect(widget!.disabled).toBe(true);
+    expect(widget!.dataset.disabledReason).toBe('readOnly');
+    expect(
+      container.querySelector('.docx-content-control-chrome')?.hasAttribute('data-read-only')
+    ).toBe(true);
+
+    // Reversible: the reader chose viewing and can choose again.
+    surface.setEditingMode('edit');
+    expect(surface.contentControls.disabledReason(openId, 'remove')).toBeNull();
+    const back = container.querySelector<HTMLButtonElement>('[data-docx-cc-widget]');
+    expect(back!.disabled).toBe(false);
+    expect(surface.contentControls.setValue(checkboxId, '1')).toBe(true);
+  });
+
+  test('viewing mode takes the pages layer out of contenteditable', () => {
+    // `setEditable` and `setEditingMode` were two independent writes of one state, kept in
+    // step only by the facade — so a host driving the surface itself kept a writable pages
+    // layer, a caret and an IME on a document that refuses every write.
+    const { surface, container } = mount(sdt(`<w:text/>`, p('O')));
+    const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+    expect(pages.contentEditable).toBe('true');
+
+    surface.setEditingMode('view');
+    expect(pages.contentEditable).toBe('false');
+    expect(pages.getAttribute('aria-readonly')).toBe('true');
+
+    surface.setEditingMode('edit');
+    expect(pages.contentEditable).toBe('true');
+    expect(pages.getAttribute('aria-readonly')).toBe('false');
+
+    // The host's own wish still outranks a non-viewing mode.
+    surface.setEditable(false);
+    expect(pages.contentEditable).toBe('false');
+    surface.setEditingMode('suggest');
+    expect(pages.contentEditable).toBe('false');
+  });
+
   test('foreign-namespace sdt is opaque to surface content-control ops', () => {
     const { surface } = mount(
       `<x:sdt xmlns:x="http://example.com/x"><x:sdtPr/><x:sdtContent>${p('foreign')}</x:sdtContent></x:sdt>` +

--- a/packages/core/src/editor/__tests__/content-controls-command.test.ts
+++ b/packages/core/src/editor/__tests__/content-controls-command.test.ts
@@ -179,6 +179,28 @@ describe('setContentControlValue command', () => {
     });
     expect(editor.exec(command)).toEqual(can);
   });
+
+  test('switching to viewing refuses setValue through can() and exec()', () => {
+    // The gate read `config.mode`, which is fixed for the life of the editor — so this
+    // branch, which sits ABOVE the viewing gate, answered the question the host asked at
+    // open time rather than the one the reader is asking now.
+    const editor = mount(sdt(`<w:alias w:val="field"/><w:text/>`, p('before')));
+    caretAt(editor.surface!, 0);
+    const command = { type: 'setContentControlValue' as const, value: 'after' };
+    expect(editor.can(command)).toEqual({ ok: true });
+
+    editor.exec({ type: 'setEditingMode', mode: 'viewing' });
+    const revision = editor.surface!.session.packageRevision();
+    const refusal = editor.can(command);
+    expect(refusal.ok).toBe(false);
+    expect(editor.exec(command)).toEqual(refusal);
+    expect(editor.surface!.session.packageRevision()).toBe(revision);
+
+    // Reversible, like every other viewing refusal.
+    editor.exec({ type: 'setEditingMode', mode: 'editing' });
+    expect(editor.can(command)).toEqual({ ok: true });
+    expect(editor.exec(command).ok).toBe(true);
+  });
 });
 
 describe('removeContentControl command', () => {

--- a/packages/core/src/editor/__tests__/docx-editor-images.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor-images.test.ts
@@ -17,6 +17,7 @@ import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
 import type { OoxmlDrawingNode, OoxmlElement } from '../../store/package/ooxml-tree.ts';
 import { createInlineDrawingLayoutBundle } from '../../layout/inline-drawing-source.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { selectedDrawingOverlayTargetOf } from '../docx-editor-images.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -250,6 +251,32 @@ describe('docx-editor selected image context', () => {
     expect(editor.getSelectedImage()).toBe(first.image);
     const second = editor.snapshot();
     expect(second.image).toBe(first.image);
+  });
+
+  test('viewing mode takes the resize and move handles off the overlay target', async () => {
+    // The overlay's capability flags came from the drawing's own OOXML locks alone, so a
+    // reader in viewing got eight resize handles, a `move` cursor and a live drag preview —
+    // then watched it snap back when the write was refused. The target itself stays: the
+    // image is still selectable, copyable and describable in a document open for viewing.
+    const editor = mountEditor(inlinePictureDocument());
+    selectInlineDrawing(editor);
+    await settleDrawingResources(editor);
+    const editing = selectedDrawingOverlayTargetOf(editor.surface);
+    expect(editing).not.toBeNull();
+    expect(editing!.canResize).toBe(true);
+
+    editor.exec({ type: 'setEditingMode', mode: 'viewing' });
+    const viewing = selectedDrawingOverlayTargetOf(editor.surface);
+    expect(viewing).not.toBeNull();
+    expect(viewing!.canResize).toBe(false);
+    expect(viewing!.canMove).toBe(false);
+
+    // Suggesting refuses every image property edit too, so it gets no handles either.
+    editor.exec({ type: 'setEditingMode', mode: 'suggesting' });
+    expect(selectedDrawingOverlayTargetOf(editor.surface)!.canResize).toBe(false);
+
+    editor.exec({ type: 'setEditingMode', mode: 'editing' });
+    expect(selectedDrawingOverlayTargetOf(editor.surface)!.canResize).toBe(true);
   });
 
   test('derives null for text caret and range selection', () => {

--- a/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
@@ -227,6 +227,32 @@ describe('headers and footers, read-only', () => {
     }
   });
 
+  test('viewing mode marks the surface so the blank-band affordance stays hidden', () => {
+    // The hover invitation is CSS keyed on this class, and a mode change repaints nothing —
+    // without the write here a reader who switched to Viewing kept being invited to add a
+    // header until some unrelated edit repainted the pages.
+    const { surface, container } = mount(docx({}));
+    expect(container.classList.contains('docx-paginated-surface--viewing')).toBe(false);
+
+    surface.setEditingMode('view');
+    expect(container.classList.contains('docx-paginated-surface--viewing')).toBe(true);
+
+    surface.setEditingMode('edit');
+    expect(container.classList.contains('docx-paginated-surface--viewing')).toBe(false);
+
+    surface.setEditingMode('suggest');
+    expect(container.classList.contains('docx-paginated-surface--viewing')).toBe(false);
+  });
+
+  // Already true before the class moved into a shared helper; pinned so the OPENING path
+  // cannot be lost when the mode-change path is the one being edited.
+  test('viewing mode opens with the affordance already hidden', () => {
+    const container = document.createElement('div');
+    const result = mountPaginatedSurface(container, docx({}), { scale: 1, editingMode: 'view' });
+    if (!result.ok) throw new Error(result.reason);
+    expect(container.classList.contains('docx-paginated-surface--viewing')).toBe(true);
+  });
+
   test('comprehensive fixture: HF right tabs reach the authored stop on the surface', () => {
     // Live-equivalent path: package → session → furniture layout → paint. Layout already
     // resolved the 9026-twip right stop; paint must reserve that advance or CONFIDENTIAL /

--- a/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
+++ b/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
@@ -749,6 +749,51 @@ describe('surface-root pointer delegation for HF / notes', () => {
     surface.destroy();
   });
 
+  test('viewing mode refuses the double press, and closes a band left open by a mode switch', () => {
+    // The hover invitation is hidden in viewing, but the SCOPE was still one double-click
+    // away: this lane never passes the facade, which classifies `editHeaderFooter` as
+    // mutating. An open band survived the switch too — a write UI over a read-only document.
+    const { surface, container } = mount(
+      docx({ header: p('H'), footer: p('FOOTER'), body: p('Body') })
+    );
+    const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+    stubPagesRect(pages);
+    pages.focus();
+
+    const page = surface.layout().pages[0]!;
+    const footer = page.footer!;
+    // Re-queried on every press: each repaint replaces the band, and a press dispatched on
+    // the detached node never reaches the root listener.
+    const pressTwice = (): void => {
+      for (let press = 0; press < 2; press += 1) {
+        const painted = container.querySelector('[data-docx-hf="footer"]') as HTMLElement;
+        pressAt(
+          pages,
+          painted,
+          footer.box.x + 4,
+          footer.box.y + Math.max(1, footer.box.height / 2)
+        );
+      }
+    };
+
+    // Left open in editing, then the mode moves under it.
+    pressTwice();
+    expect(surface.activeScope()).toEqual({ kind: 'headerFooter', rId: footer.rId! });
+    surface.setEditingMode('view');
+    expect(surface.activeScope()).toEqual({ kind: 'body' });
+    expect(container.querySelector('[data-docx-hf-active]')).toBeNull();
+
+    // And it cannot be reopened from the surface.
+    pressTwice();
+    expect(surface.activeScope()).toEqual({ kind: 'body' });
+
+    // The blank band on the other page furniture stays refused too (already gated).
+    surface.setEditingMode('edit');
+    pressTwice();
+    expect(surface.activeScope()).toEqual({ kind: 'headerFooter', rId: footer.rId! });
+    surface.destroy();
+  });
+
   test('root listener: double press in the BLANK header margin creates the header and opens it', () => {
     const { surface, container } = mount(docx({ body: `${p('One')}${p('Two')}` }));
     const pages = container.querySelector<HTMLElement>('.docx-pages')!;

--- a/packages/core/src/editor/content-controls.ts
+++ b/packages/core/src/editor/content-controls.ts
@@ -9,6 +9,7 @@
 import type {
   CanResult,
   DocTarget,
+  DocumentEditingMode,
   EditorScope,
   ExecErrorCode,
   ExecResult,
@@ -615,6 +616,22 @@ function gateContentControlCommand(
  * the store would apply for lock, binding, type, and value — so chrome/`Editor.can` never
  * claim a command is executable when `exec` would refuse it.
  */
+/**
+ * The reader's CURRENT mode, in the vocabulary a gate takes.
+ *
+ * `createDocxEditor`'s `mode` is the CONSTRUCTION value and is fixed for the life of the
+ * editor, so a gate given it answers the question the host asked at open time rather than
+ * the one the reader is asking now: a document switched to viewing kept a fully writable
+ * set of content-control commands, because this branch is dispatched above the facade's
+ * viewing gate and was the one lane that never re-read the mode.
+ *
+ * @internal
+ */
+export function gateModeOf(editingMode: DocumentEditingMode): 'edit' | 'view' | 'suggesting' {
+  if (editingMode === 'viewing') return 'view';
+  return editingMode === 'suggesting' ? 'suggesting' : 'edit';
+}
+
 export function canContentControlCommand(
   command: ContentControlEditorCommand,
   surface: PaginatedSurface | null,

--- a/packages/core/src/editor/docx-editor-images.ts
+++ b/packages/core/src/editor/docx-editor-images.ts
@@ -1079,6 +1079,12 @@ export function selectedDrawingOverlayTargetOf(
   const projection = projectDrawingForRecord(surface, record);
   if (!projection || projection.locks.select) return null;
   const caps = overlayCapabilityFlags(record, projection);
+  // The MODE, on top of the drawing's own OOXML locks. Without it a viewing-mode reader got
+  // eight resize handles, a `move` cursor and a live drag preview that auto-scrolled the
+  // document — then snapped back when the write was refused. The selection ring stays: the
+  // image is still selectable, copyable and describable in a document open for viewing.
+  const writable = surface.editingMode() === 'edit' && surface.session.editable;
+  const gated = writable ? caps : { ...caps, canResize: false, canMove: false };
   const anchorFrameOrigin =
     record.kind === 'anchoredDrawing'
       ? Object.freeze({
@@ -1099,7 +1105,7 @@ export function selectedDrawingOverlayTargetOf(
     position: positionInputOf(projection),
     anchorFrameOrigin,
     transform: record.transform,
-    ...caps,
+    ...gated,
   });
 }
 

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -139,6 +139,7 @@ import {
 import { setReviewCommentResolved } from './docx-editor-comment-resolution.ts';
 import {
   canContentControlCommand,
+  gateModeOf,
   contentControlAtOf,
   contentControlsOf,
   execContentControlCommand,
@@ -1886,7 +1887,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         return { ok: true, changed: false };
       }
       if (isContentControlEditorCommand(command)) {
-        const gated = canContentControlCommand(command, surface, mode, options);
+        // The LIVE mode, not the constructed one — see `gateModeOf`.
+        const gated = canContentControlCommand(command, surface, gateModeOf(editingMode), options);
         if (!gated.ok) return gated;
         return execContentControlCommand(surface!, command);
       }
@@ -1955,7 +1957,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         return { ok: true };
       }
       if (isContentControlEditorCommand(command)) {
-        return canContentControlCommand(command, surface, mode, options);
+        return canContentControlCommand(command, surface, gateModeOf(editingMode), options);
       }
       // Viewing refuses every EDIT, the same way `mode: 'view'` does at construction — but
       // reversibly, because the reader chose it and can choose again. Mutating only, so a

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -150,6 +150,7 @@ import {
   noteCaretHost,
   pointerHeaderFooterState,
   scopedDocumentOrder,
+  setEditingModeChrome,
   setHeaderFooterEditingChrome,
   storyScopeOf,
 } from './surface-scope.ts';
@@ -1943,7 +1944,7 @@ export function mountPaginatedSurface(
     setHeaderFooterEditingChrome(container, pagesLayer, activeHf != null);
     // Viewing mode hides write affordances the painter cannot know about — today the
     // blank header/footer "double-click to add" band.
-    container.classList.toggle('docx-paginated-surface--viewing', editingMode === 'view');
+    setEditingModeChrome(container, editingMode);
     // The pages are absolutely positioned, so the layer has no intrinsic size and the
     // surface would collapse to zero — pages then escape whatever centres or scrolls it.
     // Size it from the records, which is the only place the extent is known.
@@ -3932,6 +3933,14 @@ export function mountPaginatedSurface(
       // not silently become a suggestion (or a viewing-mode refusal).
       flushTypeBuffer();
       editingMode = mode;
+      // Viewing has no furniture EDITING scope. Switching while a header was open left the
+      // body dimmed and inert under an active band and its whole options bar — a write UI
+      // over a document that now refuses writes. Exiting repaints, so this runs first.
+      if (mode === 'view') hfScope?.exitHeaderFooter();
+      // A mode change moves no content, so nothing else here repaints. The chrome class
+      // still has to follow immediately: without this the blank header/footer band kept
+      // inviting a double-click to add a story that viewing mode then refused.
+      setEditingModeChrome(container, editingMode);
       // The old refusal described the old mode. Left standing, a host rendering it showed
       // "the document is open for viewing" over a document that had just become editable.
       lastRejection = null;
@@ -4610,6 +4619,11 @@ export function mountPaginatedSurface(
           : null;
       },
       enterHeaderFooter: (info) => {
+        // Opening furniture is the door to a WRITE, and this lane never passes the facade —
+        // so it refuses in viewing exactly like `enterEmptyHeaderFooter` below, and like the
+        // `editHeaderFooter` command the facade classifies as mutating. Without it the hint
+        // was hidden and the scope was still one double-click away.
+        if (editingMode === 'view') return;
         // The pointer lane flips story scope too: land buffered typing first
         // (see setActiveScope).
         flushTypeBuffer();

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -221,6 +221,8 @@ export function mountPaginatedSurface(
       options.tableInteractionLabel ?? ((key: TableInteractionLabelKey) => defaultTableLabel(key)),
   };
   const VIEWING_REFUSAL = 'the document is open for viewing';
+  /** Document protection, as opposed to the reversible mode — the wording `gateCommand` uses. */
+  const READ_ONLY_REFUSAL = 'the document is read-only';
   const TOC_READ_ONLY_REFUSAL = 'the table of contents is generated and read-only';
   /** Separates a decision's key from its per-range index. A NUL cannot occur in either. */
   const RANGE_SUFFIX = '\u0000range\u0000';
@@ -1060,6 +1062,7 @@ export function mountPaginatedSurface(
         readonly additionalBoundaries?: readonly ContentControlBoundaryRecord[];
         readonly tocControlIds?: ReadonlySet<string>;
         readonly suppressedIds?: ReadonlySet<string>;
+        readonly readOnly?: boolean;
       }
     | undefined {
     const active = contentControlAtCaret();
@@ -1089,10 +1092,15 @@ export function mountPaginatedSurface(
     const additionalBoundaries = tocBoundaries
       .filter((entry) => entry.additional && !entry.empty)
       .map((entry) => entry.boundary);
+    // Read-only is a REASON to emit chrome, not a detail of it: with no chrome object the
+    // painter still paints every widget, and an unchecked checkbox on a viewing-mode
+    // document produced no other chrome to carry the flag.
+    const readOnly = contentControlRefusal() !== null;
     if (
       !showAllContentControls &&
       !activeIds &&
       !hoverIds &&
+      !readOnly &&
       checkedIds.size === 0 &&
       additionalBoundaries.length === 0 &&
       tocControlIds.size === 0
@@ -1100,6 +1108,7 @@ export function mountPaginatedSurface(
       return undefined;
     }
     return {
+      ...(readOnly ? { readOnly: true } : {}),
       ...(showAllContentControls ? { showAll: true } : {}),
       ...(activeIds ? { activeIds } : {}),
       ...(hoverIds ? { hoverIds } : {}),
@@ -1777,7 +1786,9 @@ export function mountPaginatedSurface(
       }
       let committed = false;
       commit(() => {
-        const result = session.applyTreeOps(
+        // `gatedSession`, not `session`: this lane wrote straight past the mode rules, so a
+        // checkbox in a document open for viewing still toggled and still committed.
+        const result = gatedSession.applyTreeOps(
           [{ op: 'setContentControlValue', controlId, value }],
           selectionMark()
         );
@@ -1801,7 +1812,7 @@ export function mountPaginatedSurface(
       }
       let committed = false;
       commit(() => {
-        const result = session.applyTreeOps(
+        const result = gatedSession.applyTreeOps(
           [{ op: 'removeContentControl', controlId: id }],
           selectionMark()
         );
@@ -1811,6 +1822,11 @@ export function mountPaginatedSurface(
       return committed;
     },
     disabledReason(controlId, action) {
+      // The MODE outranks every per-control property. Asked first because this one answer
+      // reaches everything: the painted widget disables itself on it, the pointer lane skips
+      // a widget carrying it, and the toolbar's remove row reports it.
+      const refusal = contentControlRefusal();
+      if (refusal !== null) return refusal;
       const record = contentControlsInLayout(currentLayout).find((c) => c.id === controlId);
       if (record) {
         return action === 'remove' ? removalLocked(record) : contentLockedOrBound(record);
@@ -1842,6 +1858,20 @@ export function mountPaginatedSurface(
       return null;
     },
   };
+
+  /**
+   * The pages layer's `contenteditable` / `aria-readonly`, from the host's wish AND the mode.
+   *
+   * These were two independent writes of one state, reconciled only by the facade calling
+   * both. A host driving `mountPaginatedSurface` itself and switching to viewing kept a
+   * writable pages layer — a blinking caret, an IME that opens on composition, and a screen
+   * reader told the document accepts input, on a document that refuses every write.
+   */
+  function applyEditableChrome(): void {
+    const editable = hostEditable && editingMode !== 'view';
+    pagesLayer.contentEditable = editable ? 'true' : 'false';
+    pagesLayer.setAttribute('aria-readonly', editable ? 'false' : 'true');
+  }
 
   function currentState(): PaginatedSurfaceState {
     return {
@@ -2058,6 +2088,8 @@ export function mountPaginatedSurface(
   }
 
   let editingMode: SurfaceEditingMode = options.editingMode ?? 'edit';
+  /** The host's own `setEditable` wish, kept apart from the mode's — see `applyEditableChrome`. */
+  let hostEditable = true;
 
   /** The main story. Named once so the automation entry cannot drift from the session default. */
   const BODY_STORY: StoryScope = Object.freeze({ kind: 'body' as const });
@@ -2130,6 +2162,21 @@ export function mountPaginatedSurface(
       return 'suggesting needs an author before it can propose a change';
     }
     return null;
+  }
+
+  /**
+   * Why a content-control interaction is refused right now, or null.
+   *
+   * The widget is chrome the ENGINE paints, so the mode has to reach it here rather than at
+   * a host's discretion. No selection or op list to judge: a control write is aimed at a
+   * control id, so the TOC rules — which are about where the caret is — do not apply, and
+   * refusing a form field because the caret happens to sit in a table of contents would be
+   * an answer to a different question.
+   */
+  function contentControlRefusal(): string | null {
+    const refusal = writeRefusal(true, [], false);
+    if (refusal !== null) return refusal;
+    return session.editable ? null : READ_ONLY_REFUSAL;
   }
 
   /** Ops that change the DOCUMENT, as opposed to reading or resolving it. */
@@ -3767,8 +3814,8 @@ export function mountPaginatedSurface(
       // The DOM affordance, not the document's own editability: `session.editable` says
       // whether the FILE can be round-tripped, and this says whether the user may type into
       // it right now. Both have to be true for an edit to land.
-      pagesLayer.contentEditable = editable ? 'true' : 'false';
-      pagesLayer.setAttribute('aria-readonly', editable ? 'false' : 'true');
+      hostEditable = editable;
+      applyEditableChrome();
     },
 
     selectAll() {
@@ -3937,10 +3984,18 @@ export function mountPaginatedSurface(
       // body dimmed and inert under an active band and its whole options bar — a write UI
       // over a document that now refuses writes. Exiting repaints, so this runs first.
       if (mode === 'view') hfScope?.exitHeaderFooter();
+      // An open widget menu is a WRITE surface: a date picker left standing across the
+      // switch still offered a value the new mode refuses. Nothing else closes it.
+      removeExistingContentControlMenu();
+      applyEditableChrome();
       // A mode change moves no content, so nothing else here repaints. The chrome class
       // still has to follow immediately: without this the blank header/footer band kept
       // inviting a double-click to add a story that viewing mode then refused.
       setEditingModeChrome(container, editingMode);
+      // Painted chrome reads the mode too — content-control widgets disable themselves on
+      // it, and table furniture re-derives from it — so the pages have to be rebuilt even
+      // though not one character moved.
+      render(false);
       // The old refusal described the old mode. Left standing, a host rendering it showed
       // "the document is open for viewing" over a document that had just become editable.
       lastRejection = null;
@@ -4721,11 +4776,9 @@ export function mountPaginatedSurface(
   });
 
   render();
-  const originalSetEditingMode = surface.setEditingMode.bind(surface);
-  surface.setEditingMode = (mode) => {
-    originalSetEditingMode(mode);
-    tableInteraction.update();
-  };
+  // `setEditingMode` used to be wrapped here to append `tableInteraction.update()`, because
+  // the setter did not repaint. It does now, and `render` updates the table furniture — so
+  // the wrapper only hid the coupling from the setter that owns it.
   surface.setTableInteractionLabel = (resolver) => {
     tableLabelState.resolve = resolver;
     tableInteraction.refreshLabels();

--- a/packages/core/src/editor/surface-scope.ts
+++ b/packages/core/src/editor/surface-scope.ts
@@ -24,6 +24,7 @@ import type {
   TextMeasurer,
 } from '@docx-editor.dev/core/layout';
 import type { EditorScope, ViewScope } from '../contracts/editor.ts';
+import type { SurfaceEditingMode } from './paginated-surface-contract.ts';
 import type { StoryScope } from '@docx-editor.dev/core/store';
 import { hitTestFragments, pageAtY, type SemanticHit } from '../layout/semantic-hit-test.ts';
 import { parseNoteScopeId } from '../store/package/note-nodes.ts';
@@ -286,6 +287,19 @@ export function setHeaderFooterEditingChrome(
 ): void {
   container.classList.toggle('docx-paginated-surface--hf-editing', editing);
   pagesLayer.classList.toggle('docx-pages--hf-editing', editing);
+}
+
+/**
+ * Screen-only chrome for the editing mode.
+ *
+ * Viewing mode must show no WRITE affordance, and the blank header/footer band's
+ * "double-click to add" hover is one the painter cannot know about. The class has to be
+ * written on every mode change, not only on a repaint: `setEditingMode` moves the mode
+ * without moving the document, so a reader who switched to Viewing kept the invitation
+ * until some unrelated edit repainted the pages.
+ */
+export function setEditingModeChrome(container: HTMLElement, mode: SurfaceEditingMode): void {
+  container.classList.toggle('docx-paginated-surface--viewing', mode === 'view');
 }
 
 /** Move the caret within body stops or an open furniture/note story's stops. */

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -246,6 +246,15 @@ export interface PaintOptions {
     readonly additionalBoundaries?: readonly ContentControlBoundaryRecord[];
     /** Control ids that represent TOC regions (hover-only chrome; never caret-sticky). */
     readonly tocControlIds?: ReadonlySet<string>;
+    /**
+     * No control may be written right now — viewing mode, or a protected document.
+     *
+     * The widget is a `<button>` the ENGINE paints, and a click on it commits a tree op, so
+     * an enabled-looking checkbox on a read-only document is not a cosmetic lie: it is the
+     * write itself. Disabling it here also stops the pointer lane, which already skips a
+     * widget carrying `data-disabled-reason`.
+     */
+    readonly readOnly?: boolean;
   };
   readonly drawingStrings?: DrawingPaintStrings;
   readonly imageUrlPort?: PaintImageUrlPort;
@@ -2456,7 +2465,8 @@ function paintContentControlChrome(
         hovered,
         showAll || active || (isToc && hovered),
         chrome?.checkedIds?.has(control.id),
-        isToc
+        isToc,
+        chrome?.readOnly === true
       )
     );
   }
@@ -2471,7 +2481,8 @@ function paintContentControlBoundary(
   hovered: boolean,
   boundaryVisible: boolean,
   checked: boolean | undefined,
-  isToc: boolean
+  isToc: boolean,
+  readOnly: boolean
 ): HTMLElement {
   const layer = document.createElement('div');
   layer.className = 'docx-content-control-chrome';
@@ -2482,6 +2493,9 @@ function paintContentControlBoundary(
   if (control.bound) layer.dataset.bound = '';
   if (control.placeholder) layer.dataset.placeholder = '';
   if (isToc) layer.dataset.docxToc = '';
+  // Lets the stylesheet drop the "fill me in" hover invite without a second source of truth
+  // for what read-only means.
+  if (readOnly) layer.dataset.readOnly = '';
   if (active) layer.dataset.active = '';
   if (hovered) layer.dataset.hover = '';
   if (boundaryVisible) layer.dataset.boundaryVisible = '';
@@ -2561,9 +2575,11 @@ function paintContentControlBoundary(
     }
     const contentLocked =
       control.effectiveLock === 'contentLocked' || control.effectiveLock === 'sdtContentLocked';
-    if (contentLocked || control.bound) {
+    // Mode first: a document nobody may write has no writable control in it, whatever the
+    // control's own lock says.
+    if (readOnly || contentLocked || control.bound) {
       widget.disabled = true;
-      widget.dataset.disabledReason = control.bound ? 'bound' : 'locked';
+      widget.dataset.disabledReason = readOnly ? 'readOnly' : control.bound ? 'bound' : 'locked';
       widget.setAttribute('aria-disabled', 'true');
     }
     widget.style.position = 'absolute';
@@ -2648,7 +2664,7 @@ export function paintSemanticLayout(
   // `hoverIds` is absent ON PURPOSE — see its doc comment. Including it made a pointer
   // entering a TOC rebuild every page, which detached the node the gesture started on.
   const chromeKey = chrome
-    ? `${chrome.showAll === true ? '1' : '0'}:${chrome.activeIds ? [...chrome.activeIds].sort().join(',') : ''}:${chrome.checkedIds ? [...chrome.checkedIds].sort().join(',') : ''}:${chrome.tocControlIds ? [...chrome.tocControlIds].sort().join(',') : ''}:${chrome.suppressedIds ? [...chrome.suppressedIds].sort().join(',') : ''}`
+    ? `${chrome.showAll === true ? '1' : '0'}:${chrome.activeIds ? [...chrome.activeIds].sort().join(',') : ''}:${chrome.checkedIds ? [...chrome.checkedIds].sort().join(',') : ''}:${chrome.tocControlIds ? [...chrome.tocControlIds].sort().join(',') : ''}:${chrome.suppressedIds ? [...chrome.suppressedIds].sort().join(',') : ''}:${chrome.readOnly === true ? 'ro' : ''}`
     : '';
   const drawingStrings = options.drawingStrings ?? DEFAULT_DRAWING_PAINT_STRINGS;
   const urlRegistry =

--- a/packages/core/src/styles/__tests__/hf-affordance-suppression.test.ts
+++ b/packages/core/src/styles/__tests__/hf-affordance-suppression.test.ts
@@ -1,0 +1,114 @@
+// Header/footer hover affordance: the suppression contract.
+//
+// The blank band's "double-click to add header" invitation, and the tint on an existing
+// band, are pure CSS. Viewing mode (and an open furniture scope) cancels them with a second
+// rule rather than a different class on the band — so the cancel only lands if it WINS.
+//
+// It did not. The footer variant carried `[data-docx-hf='footer']` and the existing-band
+// tint carried two `:not()`s, which outweighed a plainer suppressor; a reader in Viewing
+// kept being invited to add a footer. Specificity is invisible at a glance and nothing else
+// in the suite resolves a cascade, so the contract is asserted here directly.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import postcss from 'postcss';
+
+const cssPath = resolve(import.meta.dir, '../editor.css');
+const css = readFileSync(cssPath, 'utf8');
+
+/** The two mode classes that must cancel a write affordance. */
+const SUPPRESSORS = ['.docx-pages--hf-editing', '.docx-paginated-surface--viewing'] as const;
+
+/**
+ * `(a, b, c)` per the selectors spec, packed for comparison. Enough for this stylesheet:
+ * no `!important`, no `:is()`/`:not()` nesting beyond one level.
+ */
+function specificity(selector: string): number {
+  // `:not(...)` takes the weight of its most specific argument — unwrap and count inside.
+  const flattened = selector.replace(/:not\(([^)]*)\)/g, ' $1 ');
+  const elements = flattened.match(/::[\w-]+/g)?.length ?? 0;
+  // Pseudo-ELEMENTS out of the way first, or `::after` also reads as the class-weight
+  // pseudo-class `:after` and every hint rule comes out one class too heavy.
+  const classLevel = flattened.replace(/::[\w-]+/g, ' ');
+  const ids = classLevel.match(/#[\w-]+/g)?.length ?? 0;
+  const classes =
+    (classLevel.match(/\.[\w-]+/g)?.length ?? 0) +
+    (classLevel.match(/\[[^\]]+\]/g)?.length ?? 0) +
+    (classLevel.match(/:[\w-]+/g)?.length ?? 0);
+  return ids * 10_000 + classes * 100 + elements;
+}
+
+interface Occurrence {
+  readonly selector: string;
+  readonly index: number;
+  readonly specificity: number;
+}
+
+/** Every selector in the sheet that declares `property`, in source order. */
+function declarationsOf(property: string): Occurrence[] {
+  const found: Occurrence[] = [];
+  let index = 0;
+  postcss.parse(css, { from: cssPath }).walkRules((rule) => {
+    let declares = false;
+    rule.walkDecls((decl) => {
+      if (decl.prop === property) declares = true;
+    });
+    if (!declares) return;
+    for (const selector of rule.selectors) {
+      found.push({
+        selector: selector.replace(/\s+/g, ' ').trim(),
+        index: (index += 1),
+        specificity: specificity(selector),
+      });
+    }
+  });
+  return found;
+}
+
+/**
+ * Does a mode-gated rule beat `invitation`? The cascade takes the higher specificity, and
+ * source order only on a tie — so a suppressor that ties must also come LATER.
+ */
+function isSuppressor(selector: string): boolean {
+  return SUPPRESSORS.some((mode) => selector.includes(mode));
+}
+
+function suppressed(invitation: Occurrence, property: string): boolean {
+  return declarationsOf(property).some(
+    (candidate) =>
+      isSuppressor(candidate.selector) &&
+      candidate.specificity >= invitation.specificity &&
+      (candidate.specificity > invitation.specificity || candidate.index > invitation.index)
+  );
+}
+
+describe('header/footer affordance suppression', () => {
+  test('every hover invitation is outranked by a mode-gated rule', () => {
+    // The invitations: the blank band's hint text, and the tint on any hovered band.
+    const isInvitation = (selector: string): boolean =>
+      selector.includes('.docx-hf') && selector.includes(':hover') && !isSuppressor(selector);
+    const hints = declarationsOf('content').filter((rule) => isInvitation(rule.selector));
+    expect(hints.length).toBeGreaterThanOrEqual(2);
+    const tints = declarationsOf('background').filter((rule) => isInvitation(rule.selector));
+    expect(tints.length).toBeGreaterThanOrEqual(2);
+
+    for (const hint of hints)
+      expect([hint.selector, suppressed(hint, 'content')]).toEqual([hint.selector, true]);
+    for (const tint of tints)
+      expect([tint.selector, suppressed(tint, 'background')]).toEqual([tint.selector, true]);
+  });
+
+  test('the specificity helper agrees with the spec on the shapes this sheet uses', () => {
+    expect(specificity('.docx-pages .docx-hf--placeholder:hover')).toBe(300);
+    // `[data-docx-hf='footer']` is the qualifier that used to win.
+    expect(specificity(".docx-pages .docx-hf--placeholder[data-docx-hf='footer']:hover")).toBe(400);
+    // Both `:not()` arguments count.
+    expect(
+      specificity(
+        '.docx-pages .docx-hf:not([data-docx-hf-active]):not(.docx-hf--placeholder):hover'
+      )
+    ).toBe(500);
+    expect(specificity('.docx-pages .docx-hf--placeholder:hover::after')).toBe(301);
+  });
+});

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3274,22 +3274,36 @@ a.docx-hyperlink:focus-visible {
   margin-bottom: 4px;
 }
 
-/* No affordance while another furniture scope is open, in view mode, or in print. */
+/* No affordance while another furniture scope is open, in view mode, or in print.
+ * Each selector MIRRORS the qualifiers of the rule it cancels: the existing-band tint
+ * carries two `:not()`s and the footer hint carries an attribute selector, so a plainer
+ * selector here LOST the specificity race and left the invitation on screen. */
 .docx-pages--hf-editing .docx-hf--placeholder:hover,
 .docx-paginated-surface--viewing .docx-hf--placeholder:hover,
-.docx-pages--hf-editing .docx-hf:not([data-docx-hf-active]):hover,
-.docx-paginated-surface--viewing .docx-hf:not([data-docx-hf-active]):hover {
+.docx-pages--hf-editing .docx-hf:not([data-docx-hf-active]):not(.docx-hf--placeholder):hover,
+.docx-paginated-surface--viewing
+  .docx-hf:not([data-docx-hf-active]):not(.docx-hf--placeholder):hover {
   background: none;
 }
 
-.docx-pages--hf-editing .docx-hf--placeholder:hover::after,
-.docx-paginated-surface--viewing .docx-hf--placeholder:hover::after {
+/* The extra class here is STRUCTURE, not ballast: `docx-pages` is `docx-paginated-surface`'s
+ * own child and carries `docx-pages--hf-editing` itself, so the weight that beats the
+ * footer variant comes from a fact the painter cannot drift away from. */
+.docx-pages.docx-pages--hf-editing .docx-hf--placeholder:hover::after,
+.docx-paginated-surface--viewing .docx-pages .docx-hf--placeholder:hover::after {
   content: none;
 }
 
 .docx-pages--hf-editing .docx-hf-edit-hint,
 .docx-paginated-surface--viewing .docx-hf-edit-hint {
   display: none;
+}
+
+/* The last half of the affordance: an I-beam over a band nobody can enter reads as "put a
+ * caret here", which viewing refuses. Furniture text never maps to a model position anyway
+ * — see `dom-selection` — so the arrow is the honest cursor here. */
+.docx-paginated-surface--viewing .docx-hf:not([data-docx-hf-active]) {
+  cursor: default;
 }
 
 @media print {

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -913,6 +913,22 @@ a.docx-hyperlink:focus-visible {
   opacity: 1;
 }
 
+/* A document nobody may write has nothing to fill in, so the pointer must not light a
+ * control as though it did. `data-active` and `data-boundary-visible` still show: those say
+ * WHERE a control is, which a reader may want. Only the hover invitation goes. The painter
+ * sets `data-read-only` from the same answer that disables the widget, so there is no second
+ * definition of what read-only means. */
+.docx-content-control-chrome[data-read-only]:hover .docx-content-control-boundary {
+  border-color: color-mix(in srgb, var(--doc-primary) 24%, var(--doc-page-bg-rendered));
+  background: color-mix(in srgb, var(--doc-primary) 3%, var(--doc-page-bg-rendered));
+  opacity: 0;
+}
+
+.docx-content-control-chrome[data-read-only][data-active] .docx-content-control-boundary,
+.docx-content-control-chrome[data-read-only][data-boundary-visible] .docx-content-control-boundary {
+  opacity: 1;
+}
+
 /*
  * Populated TOC: nothing at rest — no border, no background — and never sticky from the
  * caret or a click. The surface sets `data-hover` on the painted chrome while the pointer
@@ -968,6 +984,12 @@ a.docx-hyperlink:focus-visible {
 .docx-content-control-chrome:hover .docx-content-control-widget {
   background: color-mix(in srgb, var(--doc-primary) 15%, transparent);
   border-color: color-mix(in srgb, var(--doc-primary) 55%, transparent) !important;
+}
+
+/* Same rule for the widget: a disabled button that lights under the pointer reads as live. */
+.docx-content-control-chrome[data-read-only]:hover .docx-content-control-widget {
+  background: color-mix(in srgb, var(--doc-primary) 4%, var(--doc-page-bg-rendered));
+  border-color: color-mix(in srgb, var(--doc-primary) 28%, var(--doc-page-bg-rendered)) !important;
 }
 
 .docx-content-control-widget::after {

--- a/packages/pro/src/__tests__/review-sidebar.test.tsx
+++ b/packages/pro/src/__tests__/review-sidebar.test.tsx
@@ -139,6 +139,51 @@ describe('the review sidebar', () => {
     expect(view.getByTestId('review-draft')).toBeDefined();
   });
 
+  test('the context-menu comment row is disabled in viewing mode', async () => {
+    // It gated on `toggleReviewPane`, which is deliberately NON-mutating and stays `ok` in
+    // viewing — so the row rendered fully enabled, closed the menu and wrote nothing.
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={SOURCE}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorContextMenu t={(key) => key} />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const editor = instance!;
+    await act(async () => {
+      editor.surface!.selectAll();
+      editor.exec({ type: 'setEditingMode', mode: 'viewing' });
+    });
+
+    const surface = view.container.querySelector('.docx-paginated-surface');
+    if (!surface) throw new Error('no painted surface');
+    await act(async () => {
+      fireEvent.contextMenu(surface, { clientX: 100, clientY: 100, button: 2 });
+    });
+    const row = view.container.querySelector(
+      '[data-slot="review.comments"]'
+    ) as HTMLButtonElement | null;
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('aria-disabled')).toBe('true');
+
+    // Reversible, like every other viewing refusal.
+    await act(async () => {
+      editor.exec({ type: 'setEditingMode', mode: 'editing' });
+    });
+    expect(
+      view.container.querySelector('[data-slot="review.comments"]')?.getAttribute('aria-disabled')
+    ).not.toBe('true');
+  });
+
   test('opens when the add-comment affordance starts a draft', async () => {
     let instance: DocxEditorInstance | null = null;
     const view = render(

--- a/packages/pro/src/react/CustomNodeContextMenu.tsx
+++ b/packages/pro/src/react/CustomNodeContextMenu.tsx
@@ -27,8 +27,10 @@ import {
   ContextMenuItem,
   useContextMenuTarget,
   useDocxEditor,
+  useEditorState,
   useTranslation,
 } from '@docx-editor.dev/react';
+import type { EditorSnapshot } from '@docx-editor.dev/core';
 import {
   type ActivatedCustomNode,
   type CustomNodeDefinition,
@@ -39,6 +41,10 @@ import {
   resolveCustomNodeActivation,
   useCustomNodeDefinitions,
 } from './custom-node-activation.ts';
+
+/** Viewing refuses every node write, so neither row may be offered in it. */
+const selectDocumentReadOnly = (snapshot: EditorSnapshot): boolean =>
+  snapshot.editingMode === 'viewing';
 
 /**
  * Props for {@link CustomNodeContextMenu}: which definitions get menu sections, and which rows
@@ -99,6 +105,7 @@ export function CustomNodeContextMenu(props: CustomNodeContextMenuProps) {
     () => (resolved ? activatedCustomNodeOf(resolved, editor) : null),
     [resolved, editor]
   );
+  const readOnly = useEditorState(selectDocumentReadOnly);
   const card = useMemo(() => {
     if (!resolved?.definition.reviewCard || !node) return null;
     // `data` too: without it the info block silently rendered the no-payload branch of a hook
@@ -112,8 +119,11 @@ export function CustomNodeContextMenu(props: CustomNodeContextMenuProps) {
   if (!resolved || !node) return null;
   const { definition } = resolved;
   const label = definition.label ?? definition.name;
-  const editable = definition.onEdit !== undefined || onEditNode !== undefined;
-  const removable = remove && node.nodeId !== undefined && editor !== null;
+  // Both rows are WRITES — the edit hook opens a host dialog whose whole purpose is to
+  // change the node, and remove is refused by the engine. Offered enabled in viewing, the
+  // first one wrote through the host and the second closed the menu having done nothing.
+  const editable = !readOnly && (definition.onEdit !== undefined || onEditNode !== undefined);
+  const removable = !readOnly && remove && node.nodeId !== undefined && editor !== null;
   if (!card && !editable && !removable) return null;
   return (
     <>

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -557,9 +557,12 @@ function ReviewRoot({
     setDraftAnchorY(anchorY);
   }, [editor, readOnly, releaseSelectionPin, setReviewPaneOpen]);
   useEffect(() => {
-    if (hidden) return undefined;
+    // Not registered while READ-ONLY either: the registry's `requestCommentDraft` reports
+    // whether anything served the request, and a handler that accepts and then refuses made
+    // it answer yes to a draft that never opened.
+    if (hidden || readOnly) return undefined;
     return railRegistry?.registerCommentDraft(beginDraft);
-  }, [beginDraft, hidden, railRegistry]);
+  }, [beginDraft, hidden, readOnly, railRegistry]);
   const endDraft = useCallback(() => {
     releaseSelectionPin();
     setDraftAnchorY(null);

--- a/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
+++ b/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
@@ -31,6 +31,8 @@ import {
 import type { CSSProperties, ReactElement } from 'react';
 import { mergeArrangement, unwrapFragment } from '../merge-arrangement';
 import { ReviewRailContext, useDocxEditor } from '../context';
+import { useEditorState } from '../useEditorState';
+import type { EditorSnapshot } from '@docx-editor.dev/core';
 import { useTranslation } from '../../i18n';
 import type { TranslationKey } from '../../i18n';
 import type { ToolbarTranslate } from '../toolbar/toolbar-context';
@@ -89,6 +91,10 @@ export interface DocxEditorContextMenuProps {
   children?: DocxEditorChildren;
 }
 
+/** Viewing refuses every review write, comment authoring included. */
+const selectDocumentReadOnly = (snapshot: EditorSnapshot): boolean =>
+  snapshot.editingMode === 'viewing';
+
 /** The packaged set, in order. Separators are positional, so they are part of the list. */
 type DefaultEntry =
   | { readonly kind: 'row'; readonly id: string; readonly render: () => ReactElement }
@@ -100,8 +106,12 @@ function ContextMenuAddComment() {
   const menu = useMenuContext();
   const label = useMenuLabel();
   const gate = editor?.can({ type: 'toggleReviewPane' });
+  // `toggleReviewPane` is deliberately NON-mutating, so it stays `ok` in viewing — and this
+  // row, which writes a comment, rode on it and showed up fully enabled. It then closed the
+  // menu and wrote nothing, because the rail refuses a draft on a read-only document.
+  const readOnly = useEditorState(selectDocumentReadOnly);
   const disabled =
-    !gate?.ok || (rail?.mounted ?? 0) === 0 || editor?.getSelectionPlacement() === null;
+    !gate?.ok || readOnly || (rail?.mounted ?? 0) === 0 || editor?.getSelectionPlacement() === null;
   const control = chromeControlForSlot('review.comments');
   return (
     <MenuRow


### PR DESCRIPTION
Viewing mode showed affordances for writes it refuses, and in one case did not refuse the write at all.

**Content controls wrote through the raw session**, not the gated one, so a checkbox in a document open for viewing toggled and committed. The facade's own gate read the construction mode, which never moves, so `can()` reported the command enabled too. Both now read the live mode.

The affordances that lied: the blank header/footer hover invitation (the mode class was written only by a repaint, and a mode change repaints nothing), the content-control widget and its hover highlight, image resize and move handles, and the custom-node and comment context-menu rows. Viewing also refuses to open a header/footer band from a double-click, closes one left open by the switch, and takes the pages layer out of `contenteditable` — that last one was reconciled only by the facade, so a host driving the surface directly kept a caret and an IME on a read-only document.

Two suppression selectors in the stylesheet also lost the specificity race to the rules they cancel; a test now asserts that contract directly, since nothing else in the suite resolves a cascade.