### PR TITLE
fix(core): gate every header/footer entry lane and the opening mode

### DIFF
--- a/.changeset/viewing-mode-entry-lanes.md
+++ b/.changeset/viewing-mode-entry-lanes.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Viewing mode refuses every path into header and footer editing, not only a double-click, and a document opened in viewing no longer comes up with an editable pages layer.

--- a/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface-hf.test.ts
@@ -251,6 +251,12 @@ describe('headers and footers, read-only', () => {
     const result = mountPaginatedSurface(container, docx({}), { scale: 1, editingMode: 'view' });
     if (!result.ok) throw new Error(result.reason);
     expect(container.classList.contains('docx-paginated-surface--viewing')).toBe(true);
+    // The pages layer is created `contenteditable` unconditionally, so OPENING in viewing —
+    // as opposed to switching into it — came up writable: a caret, an IME, and a screen
+    // reader told the document takes input.
+    const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+    expect(pages.contentEditable).toBe('false');
+    expect(pages.getAttribute('aria-readonly')).toBe('true');
   });
 
   test('comprehensive fixture: HF right tabs reach the authored stop on the surface', () => {

--- a/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
+++ b/packages/core/src/editor/__tests__/scoped-header-footer-editing.test.ts
@@ -783,8 +783,13 @@ describe('surface-root pointer delegation for HF / notes', () => {
     expect(surface.activeScope()).toEqual({ kind: 'body' });
     expect(container.querySelector('[data-docx-hf-active]')).toBeNull();
 
-    // And it cannot be reopened from the surface.
+    // And it cannot be reopened — by the pointer, by the surface's own method, or by
+    // `setActiveScope`. Gating the pointer alone left the other two opening the dimmed body
+    // and the whole header options bar over a document that refuses every write.
     pressTwice();
+    expect(surface.activeScope()).toEqual({ kind: 'body' });
+    expect(surface.enterHeaderFooter({ rId: footer.rId! })).toBe(false);
+    expect(surface.setActiveScope({ kind: 'headerFooter', rId: footer.rId! })).toBe(false);
     expect(surface.activeScope()).toEqual({ kind: 'body' });
 
     // The blank band on the other page furniture stays refused too (already gated).

--- a/packages/core/src/editor/content-controls.ts
+++ b/packages/core/src/editor/content-controls.ts
@@ -610,19 +610,12 @@ function gateContentControlCommand(
 }
 
 /**
- * `can` probe for content-control commands.
- *
- * Faithfully predicts `exec`: after shape/mode/target gates, runs the same `validateTreeOp`
- * the store would apply for lock, binding, type, and value — so chrome/`Editor.can` never
- * claim a command is executable when `exec` would refuse it.
- */
-/**
  * The reader's CURRENT mode, in the vocabulary a gate takes.
  *
  * `createDocxEditor`'s `mode` is the CONSTRUCTION value and is fixed for the life of the
  * editor, so a gate given it answers the question the host asked at open time rather than
  * the one the reader is asking now: a document switched to viewing kept a fully writable
- * set of content-control commands, because this branch is dispatched above the facade's
+ * set of content-control commands, because that branch is dispatched above the facade's
  * viewing gate and was the one lane that never re-read the mode.
  *
  * @internal
@@ -632,6 +625,13 @@ export function gateModeOf(editingMode: DocumentEditingMode): 'edit' | 'view' | 
   return editingMode === 'suggesting' ? 'suggesting' : 'edit';
 }
 
+/**
+ * `can` probe for content-control commands.
+ *
+ * Faithfully predicts `exec`: after shape/mode/target gates, runs the same `validateTreeOp`
+ * the store would apply for lock, binding, type, and value — so chrome/`Editor.can` never
+ * claim a command is executable when `exec` would refuse it.
+ */
 export function canContentControlCommand(
   command: ContentControlEditorCommand,
   surface: PaginatedSurface | null,

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1786,11 +1786,18 @@ export function mountPaginatedSurface(
       }
       let committed = false;
       commit(() => {
-        // `gatedSession`, not `session`: this lane wrote straight past the mode rules, so a
-        // checkbox in a document open for viewing still toggled and still committed.
-        const result = gatedSession.applyTreeOps(
+        // `applyOps`, not `session.applyTreeOps`: this lane wrote straight past the mode
+        // rules, so a checkbox in a document open for viewing still toggled and committed.
+        // Explicitly the BODY story and no selection check, because a control op names the
+        // control it edits: the story the reader happens to have open, and where their caret
+        // sits, are answers to a different question — and `contentControlRefusal` above
+        // judges the write on exactly these terms.
+        const result = applyOps(
           [{ op: 'setContentControlValue', controlId, value }],
-          selectionMark()
+          selectionMark(),
+          undefined,
+          BODY_STORY,
+          false
         );
         committed = result.committed;
         return result;
@@ -1812,9 +1819,12 @@ export function mountPaginatedSurface(
       }
       let committed = false;
       commit(() => {
-        const result = gatedSession.applyTreeOps(
+        const result = applyOps(
           [{ op: 'removeContentControl', controlId: id }],
-          selectionMark()
+          selectionMark(),
+          undefined,
+          BODY_STORY,
+          false
         );
         committed = result.committed;
         return result;
@@ -2481,6 +2491,7 @@ export function mountPaginatedSurface(
     mirrorToDom: () => selectionSync.mirrorToDom(),
     notify: () => options.onChange?.(currentState()),
     materializedPages: () => materializedSet,
+    entryRefused: () => editingMode === 'view',
   });
 
   noteOps = createNoteOps({
@@ -3979,11 +3990,17 @@ export function mountPaginatedSurface(
       // Text typed under the OLD mode commits under it — a buffered edit must
       // not silently become a suggestion (or a viewing-mode refusal).
       flushTypeBuffer();
+      // A host wiring a mode control re-sends the value it already has — a controlled prop
+      // re-synced in an effect, a dropdown re-picking the current row. Repainting every
+      // materialized page for a mode that did not move is the cost `setRevisionStyles`
+      // guards against for the same reason. The notify below still runs: a caller asking
+      // for a mode is entitled to hear the state back.
+      const moved = editingMode !== mode;
       editingMode = mode;
       // Viewing has no furniture EDITING scope. Switching while a header was open left the
       // body dimmed and inert under an active band and its whole options bar — a write UI
       // over a document that now refuses writes. Exiting repaints, so this runs first.
-      if (mode === 'view') hfScope?.exitHeaderFooter();
+      if (moved && mode === 'view') hfScope?.exitHeaderFooter();
       // An open widget menu is a WRITE surface: a date picker left standing across the
       // switch still offered a value the new mode refuses. Nothing else closes it.
       removeExistingContentControlMenu();
@@ -3995,7 +4012,7 @@ export function mountPaginatedSurface(
       // Painted chrome reads the mode too — content-control widgets disable themselves on
       // it, and table furniture re-derives from it — so the pages have to be rebuilt even
       // though not one character moved.
-      render(false);
+      if (moved) render(false);
       // The old refusal described the old mode. Left standing, a host rendering it showed
       // "the document is open for viewing" over a document that had just become editable.
       lastRejection = null;
@@ -4674,11 +4691,8 @@ export function mountPaginatedSurface(
           : null;
       },
       enterHeaderFooter: (info) => {
-        // Opening furniture is the door to a WRITE, and this lane never passes the facade —
-        // so it refuses in viewing exactly like `enterEmptyHeaderFooter` below, and like the
-        // `editHeaderFooter` command the facade classifies as mutating. Without it the hint
-        // was hidden and the scope was still one double-click away.
-        if (editingMode === 'view') return;
+        // Viewing refuses this — in `createHeaderFooterScopeController`, which every entry
+        // lane goes through, not here where only the pointer would be covered.
         // The pointer lane flips story scope too: land buffered typing first
         // (see setActiveScope).
         flushTypeBuffer();
@@ -4776,6 +4790,10 @@ export function mountPaginatedSurface(
   });
 
   render();
+  // The pages layer is created `contenteditable` unconditionally, so a surface OPENED in
+  // viewing came up writable — a caret, an IME and a screen reader told the document takes
+  // input. `setEditingMode` was the only path that re-derived it; opening is the other one.
+  applyEditableChrome();
   // `setEditingMode` used to be wrapped here to append `tableInteraction.update()`, because
   // the setter did not repaint. It does now, and `render` updates the table furniture — so
   // the wrapper only hid the coupling from the setter that owns it.

--- a/packages/core/src/editor/surface-hf-editing.ts
+++ b/packages/core/src/editor/surface-hf-editing.ts
@@ -71,6 +71,15 @@ export function createHeaderFooterScopeController(deps: {
   notify(): void;
   /** Pages currently built in the viewport; absent/undefined treats every page as available. */
   materializedPages?(): ReadonlySet<number> | undefined;
+  /**
+   * Whether entering a furniture story is refused right now.
+   *
+   * Asked HERE rather than at each caller because there are three of them — the pointer's
+   * double click, the surface's own `enterHeaderFooter`, and `setActiveScope` — and gating
+   * one left the other two opening the dimmed body, the active band and the whole
+   * header options bar on a document open for viewing.
+   */
+  entryRefused?(): boolean;
 }): HeaderFooterScopeController {
   let activeHf: ActiveHeaderFooterScope | null = null;
   let cachedState: HeaderFooterStateSnapshot | null = null;
@@ -91,6 +100,9 @@ export function createHeaderFooterScopeController(deps: {
     readonly variant?: 'default' | 'first' | 'even';
     readonly position?: SemanticPosition;
   }): boolean => {
+    // Re-entering the story that is ALREADY open is a caret move inside it, not an entry —
+    // a mode that changed under an open band must not strand the caret there.
+    if (deps.entryRefused?.() === true && activeHf?.scope.rId !== args.rId) return false;
     if (!args.rId || deps.session.partFor({ kind: 'headerFooter', rId: args.rId }) === null) {
       return false;
     }

--- a/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
+++ b/packages/react/src/editor/contextmenu/DocxEditorContextMenu.tsx
@@ -118,7 +118,9 @@ function ContextMenuAddComment() {
       icon={chromeIcon(control?.paths)}
       slot="review.comments"
       disabled={disabled}
-      title={gate && !gate.ok ? gate.reason : undefined}
+      title={
+        gate && !gate.ok ? gate.reason : readOnly ? label('editingMode.viewingHint') : undefined
+      }
       onSelect={() => {
         if (!rail?.requestCommentDraft()) return;
         menu.setOpenMenu(null);


### PR DESCRIPTION
Follow-ups to #335, found by review.

The furniture entry gate was on the pointer's double-click only, so `surface.enterHeaderFooter` and `setActiveScope` — reached from `editor.setActiveScope` and `editor.focus({kind:'headerFooter'})` — still opened the dimmed body and the header options bar in viewing. It now lives in the scope controller, which every lane goes through. Re-entering an already-open band stays allowed, so a mode change under an open header cannot strand the caret.

Opening with `editingMode: 'view'` left the pages layer `contenteditable`; only switching into viewing re-derived it.

Content-control writes now name the body story explicitly and skip the selection check, matching the terms `disabledReason` judges them on — routing them through the mode-gated session had also changed which story they addressed.

Also: a same-value `setEditingMode` no longer repaints, and the disabled comment row explains itself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789818394&installation_model_id=422592&pr_number=337&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F337&signature=d987174ce01065322358fba75fce7776c7bcdc79b3d9d012c0569c6fbebd547c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->