### PR TITLE
fix(core): give the two undeclared review chrome tokens a fallback

### DIFF
--- a/.changeset/review-chrome-token-fallbacks.md
+++ b/.changeset/review-chrome-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Resolved comment miniatures now show a hover fill, and the reply field shows a focus outline.

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -5479,7 +5479,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 .docx-review__card[data-resolved-miniature]:not([open]):hover {
-  background: var(--doc-surface-hover);
+  background: var(--doc-surface-hover, rgb(0 0 0 / 6%));
   color: var(--doc-text);
 }
 
@@ -5771,7 +5771,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 .docx-review__input:focus-visible {
-  outline: 1px solid var(--doc-border-strong);
+  outline: 1px solid var(--doc-border-strong, #c8ccd2);
   outline-offset: -1px;
 }
 


### PR DESCRIPTION
`--doc-surface-hover` and `--doc-border-strong` are declared nowhere in `editor.css`. Every other use supplies a fallback; these two did not, so `var()` yielded the guaranteed-invalid value and the browser dropped the declaration. The resolved-miniature hover fill and the reply-field focus outline painted nothing.

`packages/core/src/editor/__tests__/editor-css-tokens.test.ts` was failing on main for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789829416&installation_model_id=422592&pr_number=338&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F338&signature=a674ed17443e0503167db81a5e22b498193c8644f493876849f052b12e591294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->