### PR TITLE
fix(core): typing, and every command, lands where the user is looking

### DIFF
--- a/.changeset/caret-and-command-scope.md
+++ b/.changeset/caret-and-command-scope.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixes a group of caret and scope defects: undo after editing a header no longer leaves the editor unable to type, opening a header while a footnote is open no longer refuses every keystroke, inserting a footnote over a selection replaces it instead of destroying the note on the next keystroke, redo puts the caret where the redone edit ends, resolving a tracked change keeps the caret on the text it was in, accepting the deletion of a table's only row removes the table, a selection ending at a field no longer collapses, Backspace after a table is a quiet no-op instead of a dropped keystroke, and the paragraph, delete-row and delete-column commands act on every cell of a selected rectangle.

--- a/.changeset/keystroke-page-reuse.md
+++ b/.changeset/keystroke-page-reuse.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typing no longer rebuilds every visible page. A document carrying a footnotes part — which is nearly every file Word writes, even with no notes in it — discarded every page record on every layout pass, and pressing Enter in a list re-measured every paragraph in the document.

--- a/.changeset/repaint-caret-authority.md
+++ b/.changeset/repaint-caret-authority.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typed characters now stay in order after a repaint. A repaint that followed an edit could read the browser's own selection back as the paragraph start, so the first character landed and every one after it was inserted in front of it.

--- a/.changeset/retract-own-paragraph-break.md
+++ b/.changeset/retract-own-paragraph-break.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Backspace now takes back a paragraph break you proposed a moment earlier, instead of proposing to delete your own proposal. Enter then Backspace in suggesting mode left an empty paragraph behind and two entries in the review pane.

--- a/.changeset/type-over-own-suggestion.md
+++ b/.changeset/type-over-own-suggestion.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typing over your own pending suggestion now replaces it. The keystroke was refused and silently dropped, because a suggestion the same author retracts leaves the paragraph instead of staying struck in place.

--- a/.changeset/write-lane-rules.md
+++ b/.changeset/write-lane-rules.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixes four write lanes that had drifted from the rules the others follow: Enter inside a tracked insertion now breaks the paragraph at the caret, a table inside a header or footer can be deleted, IME text in suggesting mode is proposed rather than written, and a multi-line paste proposes its paragraph breaks and leaves the caret after the pasted text.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,7 +367,11 @@ fails until it gets an attribution path; `packages/fonts` carries OFL text in
 
 - **PRs** — short factual title (conventional-commit prefix); body is the minimum
   the diff doesn't show, often one sentence. No `@`-mentions, unrelated issue
-  numbers, file lists, tooling footers or emojis.
+  numbers, file lists, tooling footers or emojis. Write the body in the
+  [Google developer documentation style](https://developers.google.com/style),
+  the same guide the docs site follows: second person, active voice, present
+  tense, sentence-case headings, American spelling, short sentences, one idea
+  each. Code font for identifiers and filenames; bold for UI elements only.
 - **Bugs** — `gh issue view <N> --repo eigenpal/docx-editor`. Dev server `bun run
 dev` → `http://localhost:5173/`. Live demo `http://docx-editor.dev/editor`.
   Commit `fix: ... (fixes #N)`. Screenshots → `screenshots/`.

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3865,6 +3865,7 @@ export type TreeDocOp = {
     readonly op: 'splitParagraphMany';
     readonly paragraphId: string;
     readonly offsets: readonly number[];
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly op: 'joinParagraphs';
     readonly firstId: string;

--- a/packages/core/src/editor/__tests__/cell-rectangle-commands.test.ts
+++ b/packages/core/src/editor/__tests__/cell-rectangle-commands.test.ts
@@ -166,6 +166,32 @@ describe('deleting over a cell rectangle', () => {
     }
   });
 
+  test('a rectangle over EVERY row deletes the table, as Word does', () => {
+    // A table must keep one row, so the last `deleteTableRow` is refused — and a refusal
+    // takes the whole transaction, which is how selecting every row came to delete nothing.
+    const editor = mountEditor(TABLE_2X2 + p('after'));
+    try {
+      const surface = editor.surface!;
+      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      expect(editor.exec({ type: 'deleteRow' }).ok).toBe(true);
+      expect(allText(surface)).toEqual(['after']);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('and a rectangle over every COLUMN does the same', () => {
+    const editor = mountEditor(TABLE_2X2 + p('after'));
+    try {
+      const surface = editor.surface!;
+      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      expect(editor.exec({ type: 'deleteColumn' }).ok).toBe(true);
+      expect(allText(surface)).toEqual(['after']);
+    } finally {
+      editor.destroy();
+    }
+  });
+
   test('and an ordinary caret still deletes exactly one row', () => {
     const editor = mountEditor(TABLE_3X2 + p('after'));
     try {

--- a/packages/core/src/editor/__tests__/cell-rectangle-commands.test.ts
+++ b/packages/core/src/editor/__tests__/cell-rectangle-commands.test.ts
@@ -1,0 +1,184 @@
+// A CELL RECTANGLE IS NOT THE RANGE IT STANDS IN FOR.
+//
+// Read as a text range, a selected column runs through every cell between its corners in
+// document order — which is how centring the left column of a 2x2 table also centred the
+// column beside it. Read as one anchor, a two-row rectangle is one row — which is how Delete
+// Rows removed one of them and answered `ok: true`. Every command that acts on a rectangle
+// has to ask the rectangle what it covers.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import type { PaginatedSurface } from '../paginated-surface.ts';
+import { cellSelectionBetween } from '../../layout/semantic-cell-selection.ts';
+import type { TableCellAddress } from '../../layout/semantic-hit-test.ts';
+import { findNode, paragraphTextOf } from '@docx-editor.dev/core/store';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+const p = (t: string) => `<w:p><w:r><w:t>${t}</w:t></w:r></w:p>`;
+const tc = (c: string) => `<w:tc>${c}</w:tc>`;
+const tr = (c: string) => `<w:tr>${c}</w:tr>`;
+const GRID2 =
+  '<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+  '<w:tblGrid><w:gridCol w:w="3000"/><w:gridCol w:w="3000"/></w:tblGrid>';
+const GRID3 =
+  '<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+  '<w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/></w:tblGrid>';
+const TABLE_2X2 = `<w:tbl>${GRID2}${tr(tc(p('A1')) + tc(p('B1')))}${tr(tc(p('A2')) + tc(p('B2')))}</w:tbl>`;
+const TABLE_3X2 =
+  `<w:tbl>${GRID2}${tr(tc(p('A1')) + tc(p('B1')))}${tr(tc(p('A2')) + tc(p('B2')))}` +
+  `${tr(tc(p('A3')) + tc(p('B3')))}</w:tbl>`;
+const TABLE_2X3 =
+  `<w:tbl>${GRID3}${tr(tc(p('A1')) + tc(p('B1')) + tc(p('C1')))}` +
+  `${tr(tc(p('A2')) + tc(p('B2')) + tc(p('C2')))}</w:tbl>`;
+
+function docxOf(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function mountEditor(body: string): DocxEditorInstance {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: docxOf(body), author: 'Grace Hopper' });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+function tableOnPage(surface: PaginatedSurface) {
+  for (const page of surface.layout().pages) {
+    for (const fragment of page.fragments) if (fragment.kind === 'table') return fragment;
+  }
+  throw new Error('no table in layout');
+}
+
+function cellAddress(surface: PaginatedSurface, row: number, column: number): TableCellAddress {
+  const table = tableOnPage(surface);
+  const rowRecord = table.rows[row]!;
+  const cell = rowRecord.cells.find((candidate) => candidate.gridColumn === column)!;
+  return {
+    tableId: table.tableId,
+    rowId: rowRecord.id,
+    cellId: cell.id,
+    rowIndex: row,
+    gridColumn: cell.gridColumn,
+    gridSpan: cell.gridSpan,
+  };
+}
+
+function selectRect(
+  surface: PaginatedSurface,
+  from: { row: number; column: number },
+  to: { row: number; column: number }
+): void {
+  const rectangle = cellSelectionBetween(
+    surface.layout(),
+    cellAddress(surface, from.row, from.column),
+    cellAddress(surface, to.row, to.column)
+  );
+  if (!rectangle) throw new Error('cell rectangle failed');
+  surface.setCellSelection(rectangle);
+}
+
+function allText(surface: PaginatedSurface): string[] {
+  return surface.session.paragraphIds().map((id) => paragraphTextOf(surface.session.part(), id));
+}
+
+/** The `w:jc/@w:val` a paragraph authors itself, or null. */
+function alignmentOf(surface: PaginatedSurface, text: string): string | null {
+  const id = surface.session
+    .paragraphIds()
+    .find((candidate) => paragraphTextOf(surface.session.part(), candidate) === text);
+  const node = id ? findNode(surface.session.part(), id) : null;
+  if (!node || node.kind === 'textValue') return null;
+  const named = (child: unknown, name: string): boolean =>
+    (child as { localName?: string }).localName === name;
+  const pPr = node.children.find((child) => child.kind !== 'textValue' && named(child, 'pPr'));
+  if (!pPr || pPr.kind === 'textValue') return null;
+  const jc = pPr.children.find((child) => child.kind !== 'textValue' && named(child, 'jc'));
+  if (!jc || jc.kind === 'textValue') return null;
+  const attributes = jc.attributes as readonly { localName: string; value: string }[];
+  return attributes.find((attribute) => attribute.localName === 'val')?.value ?? null;
+}
+
+describe('a paragraph command over a cell rectangle', () => {
+  test('centres the selected column and leaves the one beside it alone', () => {
+    const editor = mountEditor(TABLE_2X2 + p('after'));
+    try {
+      const surface = editor.surface!;
+      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 0 });
+      expect(surface.state().cellSelection?.cellIds).toHaveLength(2);
+      surface.setParagraphProperty('jc', { val: 'center' });
+      expect(alignmentOf(surface, 'A1')).toBe('center');
+      expect(alignmentOf(surface, 'A2')).toBe('center');
+      expect(alignmentOf(surface, 'B1')).toBeNull();
+      expect(alignmentOf(surface, 'B2')).toBeNull();
+      expect(alignmentOf(surface, 'after')).toBeNull();
+      // Word keeps the cells selected afterwards, exactly as it does after Bold.
+      expect(surface.state().cellSelection?.cellIds).toHaveLength(2);
+    } finally {
+      editor.destroy();
+    }
+  });
+});
+
+describe('deleting over a cell rectangle', () => {
+  test('Delete Rows removes every row the rectangle covers', () => {
+    const editor = mountEditor(TABLE_3X2 + p('after'));
+    try {
+      const surface = editor.surface!;
+      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      expect(surface.state().cellSelection?.cellIds).toHaveLength(4);
+      expect(editor.exec({ type: 'deleteRow' }).ok).toBe(true);
+      expect(allText(surface)).toEqual(['A3', 'B3', 'after']);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('Delete Columns removes every column the rectangle covers', () => {
+    const editor = mountEditor(TABLE_2X3 + p('after'));
+    try {
+      const surface = editor.surface!;
+      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      expect(surface.state().cellSelection?.cellIds).toHaveLength(4);
+      expect(editor.exec({ type: 'deleteColumn' }).ok).toBe(true);
+      expect(allText(surface)).toEqual(['C1', 'C2', 'after']);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('and an ordinary caret still deletes exactly one row', () => {
+    const editor = mountEditor(TABLE_3X2 + p('after'));
+    try {
+      const surface = editor.surface!;
+      const ids = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: ids[0]!, offset: 0 },
+        head: { paragraphId: ids[0]!, offset: 0 },
+      });
+      expect(editor.exec({ type: 'deleteRow' }).ok).toBe(true);
+      expect(allText(surface)).toEqual(['A2', 'B2', 'A3', 'B3', 'after']);
+    } finally {
+      editor.destroy();
+    }
+  });
+});

--- a/packages/core/src/editor/__tests__/keystroke-page-reuse.test.ts
+++ b/packages/core/src/editor/__tests__/keystroke-page-reuse.test.ts
@@ -1,0 +1,94 @@
+// WHAT ONE KEYSTROKE IS ALLOWED TO COST.
+//
+// The painter reuses a page by RECORD IDENTITY, so any lane that rebuilds a page object it
+// did not change spends the whole visible document's DOM on every character typed — and
+// replacing the nodes the browser's selection lives in is how a repaint came to move the
+// caret. The notes lane did exactly that for any file carrying a footnotes part, which is
+// nearly every file Word writes, even with no notes in it.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const FN = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes';
+
+const paragraph = (text: string) => `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+/** Word writes both separators into a footnotes part even when nothing cites a note. */
+const FOOTNOTES =
+  `<w:footnotes xmlns:w="${W}">` +
+  '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
+  '<w:footnote w:type="continuationSeparator" w:id="0">' +
+  '<w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>' +
+  '</w:footnotes>';
+
+function docx(withNotesPart: boolean): Uint8Array {
+  const body = Array.from({ length: 160 }, (_, index) => paragraph(`paragraph ${index}`)).join('');
+  const entries: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        (withNotesPart
+          ? '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>'
+          : '') +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        (withNotesPart ? `<Relationship Id="rId5" Type="${FN}" Target="footnotes.xml"/>` : '') +
+        '</Relationships>'
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  };
+  if (withNotesPart) entries['word/footnotes.xml'] = strToU8(FOOTNOTES);
+  return zipSync(entries);
+}
+
+/** Pages that survive one typed character by identity, and how many there are. */
+function keptAcrossAKeystroke(withNotesPart: boolean): { total: number; kept: number } {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(withNotesPart), { scale: 1 });
+  if (!opened.ok) throw new Error(opened.reason);
+  const surface: PaginatedSurface = opened.surface;
+  try {
+    const before = new Set(surface.layout().pages);
+    const last = surface.session.paragraphIds()[surface.session.paragraphIds().length - 1]!;
+    surface.setSelection({
+      anchor: { paragraphId: last, offset: 0 },
+      head: { paragraphId: last, offset: 0 },
+    });
+    surface.type('x');
+    const after = surface.layout().pages;
+    return { total: after.length, kept: after.filter((page) => before.has(page)).length };
+  } finally {
+    surface.destroy();
+    container.remove();
+  }
+}
+
+describe('typing one character into a long document', () => {
+  test('keeps the pages it did not change, notes part or not', () => {
+    const withoutNotes = keptAcrossAKeystroke(false);
+    const withNotes = keptAcrossAKeystroke(true);
+
+    expect(withoutNotes.total).toBeGreaterThan(2);
+    // Everything but the page the edit landed on survives.
+    expect(withoutNotes.kept).toBe(withoutNotes.total - 1);
+    // And a footnotes part with nothing in it costs nothing.
+    expect(withNotes.total).toBe(withoutNotes.total);
+    expect(withNotes.kept).toBe(withoutNotes.kept);
+  });
+});

--- a/packages/core/src/editor/__tests__/repaint-selection-authority.test.ts
+++ b/packages/core/src/editor/__tests__/repaint-selection-authority.test.ts
@@ -231,3 +231,64 @@ describe('a selection ending at a field start', () => {
     }
   });
 });
+
+// A BURST IS OLDER THAN THE GESTURE THAT INTERRUPTS IT.
+//
+// Typing is held on a zero-delay task, and the position a gesture maps to is read from a DOM
+// those characters are not in yet. Every other caret mover lands the buffer first; the
+// render-time reader cannot, because it runs as the first statement of a render and a flush
+// commits — which renders. So it defers instead: the flush is the next task, and its own
+// render adopts the gesture with the provenance flag still armed.
+describe('a gesture during a typing burst', () => {
+  const twoParagraphs =
+    '<w:p><w:r><w:t xml:space="preserve">alpha</w:t></w:r></w:p>' +
+    '<w:p><w:r><w:t xml:space="preserve">beta</w:t></w:r></w:p>';
+
+  test('the typed characters stay where they were typed', async () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(container, docx(twoParagraphs), { scale: 1 });
+    if (!opened.ok) throw new Error(opened.reason);
+    const surface = opened.surface;
+    try {
+      const ids = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: ids[0]!, offset: 5 },
+        head: { paragraphId: ids[0]!, offset: 5 },
+      });
+      const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+      const keystroke = (data: string): void => {
+        pages.dispatchEvent(
+          new InputEvent('beforeinput', {
+            bubbles: true,
+            cancelable: true,
+            inputType: 'insertText',
+            data,
+          })
+        );
+      };
+      keystroke('X');
+      keystroke('Y');
+
+      // A touch tap in the other paragraph, arriving before the buffer flushes. Touch never
+      // reaches the engine pointer path, so nothing else lands the buffer for it.
+      const target = [
+        ...pages.querySelectorAll<HTMLElement>('[data-paragraph-id][data-start]'),
+      ].find((span) => span.dataset.paragraphId === ids[1])!;
+      pages.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerType: 'touch' })
+      );
+      const text = target.firstChild!;
+      document.getSelection()!.setBaseAndExtent(text, 2, text, 2);
+      surface.contentControls.setShowAll(true); // a render with no flush of its own
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(paragraphTextOf(surface.session.part(), ids[0]!)).toBe('alphaXY');
+      expect(paragraphTextOf(surface.session.part(), ids[1]!)).toBe('beta');
+    } finally {
+      surface.destroy();
+      container.remove();
+      document.getSelection()?.removeAllRanges();
+    }
+  });
+});

--- a/packages/core/src/editor/__tests__/repaint-selection-authority.test.ts
+++ b/packages/core/src/editor/__tests__/repaint-selection-authority.test.ts
@@ -1,0 +1,183 @@
+// WHO OWNS THE CARET AFTER A REPAINT.
+//
+// The model and the browser each hold a selection, and every repaint has to decide which of
+// the two is the newer. A gesture the queued `selectionchange` has not delivered yet is the
+// case the DOM wins; everything else the browser does to its own selection — re-resolving it
+// onto a container after a paint replaced the nodes it lived in — is not a move anybody made.
+//
+// The companion of `selection-integrity.test.ts`, which pins what a DOM endpoint MEANS. This
+// file pins who is allowed to act on one.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { paragraphTextOf } from '@docx-editor.dev/core/store';
+import { applySelectionToDom } from '../dom-selection.ts';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+// The selection belongs to the DOCUMENT, which every suite in this process shares.
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+});
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+/**
+ * A painted paragraph that HAS text: two lines, each with one span.
+ *
+ * The distinction the write side turns on. A paragraph with painted spans and no place for an
+ * offset must refuse; a paragraph with no spans at all still has its one caret position.
+ */
+function paintedParagraph(paragraphId: string): HTMLElement {
+  const root = document.createElement('div');
+  const fragment = document.createElement('div');
+  fragment.className = 'docx-paragraph-fragment';
+  fragment.dataset.paragraphId = paragraphId;
+  for (const source of [
+    { id: 'line-1', text: 'alpha ', start: 0 },
+    { id: 'line-2', text: 'beta', start: 6 },
+  ]) {
+    const line = document.createElement('div');
+    line.className = 'docx-line';
+    line.dataset.lineId = source.id;
+    line.dataset.paragraphId = paragraphId;
+    const span = document.createElement('span');
+    span.dataset.paragraphId = paragraphId;
+    span.dataset.start = String(source.start);
+    span.dataset.end = String(source.start + source.text.length);
+    span.textContent = source.text;
+    line.append(span);
+    fragment.append(line);
+  }
+  root.append(fragment);
+  return root;
+}
+
+// A REPAINT MAY CARRY A GESTURE; IT MAY NEVER INVENT ONE.
+//
+// An edit installs its post-edit caret and the first repaint mirrors it out. That repaint is
+// not the only one: a settled image, a deferred publish, a scroll all repaint again while the
+// caret this edit installed is still the newest thing anybody moved. Those later repaints read
+// the browser's selection, and the browser's answer after a page's DOM has been rebuilt under
+// it is a container — which reads back as the paragraph START. The reported shape: open the
+// header, type there, click back into the body, then type at the end of a paragraph. The first
+// character landed, the caret went home to offset 0, and every character after it was inserted
+// in front of the one before, so "Hello" arrived as "elloH".
+describe('a repaint never invents a selection the user did not make', () => {
+  const body =
+    '<w:p><w:r><w:t xml:space="preserve">alpha</w:t></w:r></w:p>' +
+    '<w:p><w:r><w:t xml:space="preserve">beta</w:t></w:r></w:p>';
+
+  function mounted(): { surface: PaginatedSurface; container: HTMLElement } {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(container, docx(body), { scale: 1 });
+    if (!opened.ok) throw new Error(opened.reason);
+    return { surface: opened.surface, container };
+  }
+
+  test('a caret the paint cannot express is refused, not landed at the paragraph start', () => {
+    // The write side of the same failure. A paragraph that painted text and has no place for
+    // this offset — inside a hidden run, or past what the current paint covers — used to
+    // answer the line element at child index 0. `applySelectionToDom` then reported success
+    // for a caret sitting at the paragraph start, and the next reader took that as the truth.
+    const root = paintedParagraph('p1');
+    document.body.append(root);
+    try {
+      const beyond = { paragraphId: 'p1', offset: 40 };
+      expect(
+        applySelectionToDom(root, { anchor: beyond, head: beyond }, document.getSelection())
+      ).toBe(false);
+    } finally {
+      root.remove();
+    }
+  });
+
+  test('an empty paragraph still gets its one caret position', () => {
+    // The refusal above must not take the case the fallback exists for: a paragraph with no
+    // painted spans at all has exactly one caret position, and losing it means no caret after
+    // every Enter.
+    const root = document.createElement('div');
+    const line = document.createElement('div');
+    line.className = 'docx-line';
+    line.dataset.lineId = 'line-1';
+    line.dataset.paragraphId = 'p9';
+    root.append(line);
+    document.body.append(root);
+    try {
+      const caret = { paragraphId: 'p9', offset: 0 };
+      expect(
+        applySelectionToDom(root, { anchor: caret, head: caret }, document.getSelection())
+      ).toBe(true);
+    } finally {
+      root.remove();
+    }
+  });
+
+  test('a browser selection nobody gestured for does not move the caret an edit just set', async () => {
+    const { surface, container } = mounted();
+    try {
+      const id = surface.session.paragraphIds()[0]!;
+      surface.setSelection({
+        anchor: { paragraphId: id, offset: 5 },
+        head: { paragraphId: id, offset: 5 },
+      });
+      surface.type('!');
+      expect(surface.state().selection.head.offset).toBe(6);
+
+      // What a repaint leaves behind: the browser re-resolves its selection onto the line
+      // container, which reads back as the paragraph START. No pointerdown, no selectstart —
+      // nobody gestured, so this is the DOM being fixed up, not the user moving the caret.
+      const line = container.querySelector<HTMLElement>(
+        `[data-line-id][data-paragraph-id="${id}"]`
+      )!;
+      const selection = document.getSelection()!;
+      selection.removeAllRanges();
+      const range = document.createRange();
+      range.setStart(line, 0);
+      range.collapse(true);
+      selection.addRange(range);
+      document.dispatchEvent(new Event('selectionchange'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(surface.state().selection.head.offset).toBe(6);
+
+      // The next keystroke arrives the way the browser delivers one, through the same
+      // `beforeinput` that reads the DOM selection first. It must land AFTER the character
+      // before it, not in front of it.
+      const pages = container.querySelector('.docx-pages')!;
+      pages.dispatchEvent(
+        new InputEvent('beforeinput', {
+          bubbles: true,
+          cancelable: true,
+          inputType: 'insertText',
+          data: '?',
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('alpha!?');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});

--- a/packages/core/src/editor/__tests__/repaint-selection-authority.test.ts
+++ b/packages/core/src/editor/__tests__/repaint-selection-authority.test.ts
@@ -14,7 +14,10 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { afterEach, describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { paragraphTextOf } from '@docx-editor.dev/core/store';
-import { applySelectionToDom } from '../dom-selection.ts';
+import { applySelectionToDom, semanticSelectionFromDom } from '../dom-selection.ts';
+import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semantic-layout.ts';
+import { paintSemanticLayout } from '../../output/semantic-paint.ts';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -178,6 +181,53 @@ describe('a repaint never invents a selection the user did not make', () => {
     } finally {
       surface.destroy();
       container.remove();
+    }
+  });
+});
+
+const FIELD_PARAGRAPH =
+  '<w:p><w:r><w:t xml:space="preserve">alpha </w:t></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  '<w:r><w:instrText xml:space="preserve"> REF Company </w:instrText></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  '<w:r><w:t>Street</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+  '<w:r><w:t xml:space="preserve"> omega</w:t></w:r></w:p>';
+
+function paint(): HTMLElement {
+  const parsed = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>${FIELD_PARAGRAPH}</w:body></w:document>`,
+    {
+      name: '/word/document.xml',
+      contentType: 'application/xml',
+    }
+  );
+  if (!parsed.ok) throw new Error(parsed.reason);
+  const layout = layoutSemanticDocument(parsed.part, 1, { measurer: createFixedMeasurer(6, 14) });
+  const root = document.createElement('div');
+  paintSemanticLayout(root, layout, { scale: 1, ariaHidden: false });
+  document.body.append(root);
+  return root;
+}
+
+describe('a selection ending at a field start', () => {
+  test('round-trips as the range the user made', () => {
+    const root = paint();
+    try {
+      const field = root.querySelector<HTMLElement>('[data-docx-field]')!;
+      const paragraphId = field.dataset.paragraphId!;
+      const fieldStart = Number(field.dataset.start);
+      expect(Number(field.dataset.end) - fieldStart).toBe(1);
+      const range = {
+        anchor: { paragraphId, offset: 0 },
+        head: { paragraphId, offset: fieldStart },
+      };
+      const selection = document.getSelection()!;
+      expect(applySelectionToDom(root, range, selection)).toBe(true);
+      expect(field.contains(selection.focusNode!)).toBe(false);
+      expect(semanticSelectionFromDom(root, selection)).toEqual(range);
+    } finally {
+      document.getSelection()?.removeAllRanges();
+      root.remove();
     }
   });
 });

--- a/packages/core/src/editor/__tests__/review-resolution-effects.test.ts
+++ b/packages/core/src/editor/__tests__/review-resolution-effects.test.ts
@@ -1,0 +1,123 @@
+// WHAT RESOLVING A REVISION LEAVES BEHIND.
+//
+// Accept and Reject are one click that rewrites the document under the reader's caret, and
+// two things have to survive it: the caret has to still mean the characters it meant, and the
+// markup left behind has to be markup the rest of the engine accepts.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import {
+  collectReviewItems as engineCollectReviewItems,
+  findNode,
+  paragraphTextOf,
+  revisionItemsOf,
+  serializeOoxmlPart,
+} from '@docx-editor.dev/core/store';
+import type { EditorModule } from '../../contracts/modules.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+const p = (t: string) => `<w:p><w:r><w:t xml:space="preserve">${t}</w:t></w:r></w:p>`;
+
+function docxOf(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+/** The engine's own review derivation, wired as a module (core may not import pro). */
+function reviewModule(): EditorModule {
+  return {
+    id: 'review',
+    review: {
+      displayModes: ['all-markup', 'proposed', 'original'],
+      collectReviewItems: engineCollectReviewItems,
+      revisionItemsOfParagraph: (part, paragraphId) => {
+        const paragraph = findNode(part, paragraphId);
+        if (!paragraph || paragraph.kind !== 'paragraph') return [];
+        return revisionItemsOf({
+          id: part.id,
+          name: part.name,
+          contentType: part.contentType,
+          root: paragraph,
+        });
+      },
+    },
+  };
+}
+
+function mountEditor(body: string): DocxEditorInstance {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({
+    container,
+    document: docxOf(body),
+    author: 'Grace Hopper',
+    modules: [reviewModule()],
+  });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+describe('#351 resolving a revision under the caret', () => {
+  test('the caret follows the text, so the next character lands where it looks', () => {
+    const editor = mountEditor(
+      '<w:p><w:r><w:t xml:space="preserve">Kept </w:t></w:r>' +
+        '<w:ins w:id="1" w:author="Ada" w:date="2026-01-02T03:04:05Z">' +
+        '<w:r><w:t>added</w:t></w:r></w:ins>' +
+        '<w:r><w:t xml:space="preserve"> tail</w:t></w:r></w:p>'
+    );
+    try {
+      const surface = editor.surface!;
+      const pid = surface.session.paragraphIds()[0]!;
+      surface.setSelection({
+        anchor: { paragraphId: pid, offset: 8 },
+        head: { paragraphId: pid, offset: 8 },
+      });
+      const [card] = editor.getReviewItems();
+      expect(editor.rejectReviewItem(card!.key)).toEqual({ ok: true, changed: true });
+      expect(paragraphTextOf(surface.session.part(), pid)).toBe('Kept  tail');
+      expect(surface.state().selection.head.offset).toBe(5);
+      surface.type('Z');
+      expect(paragraphTextOf(surface.session.part(), pid)).toBe('Kept Z tail');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('accepting the deletion of the only row takes the table with it', () => {
+    const editor = mountEditor(
+      '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+        '<w:tblGrid><w:gridCol w:w="3000"/></w:tblGrid>' +
+        '<w:tr><w:trPr><w:del w:id="7" w:author="Ada" w:date="2026-01-02T03:04:05Z"/></w:trPr>' +
+        '<w:tc><w:tcPr><w:cellDel w:id="7" w:author="Ada" w:date="2026-01-02T03:04:05Z"/></w:tcPr>' +
+        '<w:p><w:del w:id="8" w:author="Ada" w:date="2026-01-02T03:04:05Z">' +
+        '<w:r><w:delText>only row</w:delText></w:r></w:del></w:p>' +
+        '</w:tc></w:tr></w:tbl>' +
+        p('after')
+    );
+    try {
+      for (const item of editor.getReviewItems()) editor.acceptReviewItem(item.key);
+      const xml = serializeOoxmlPart(editor.surface!.session.part());
+      expect(xml).not.toMatch(/<w:tbl>(?:(?!<w:tr).)*<\/w:tbl>/s);
+    } finally {
+      editor.destroy();
+    }
+  });
+});

--- a/packages/core/src/editor/__tests__/selection-integrity.test.ts
+++ b/packages/core/src/editor/__tests__/selection-integrity.test.ts
@@ -360,6 +360,19 @@ function textNodeIn(element: Element): Node {
 }
 
 /**
+ * The provenance half of a gesture: what the browser fires BEFORE the selection exists.
+ *
+ * happy-dom cannot produce a native drag, so a test that only writes `document.getSelection()`
+ * produces a selection with no history — indistinguishable from the browser re-resolving its
+ * own selection after a repaint replaced the nodes it lived in. A repaint may carry a gesture
+ * and may never invent one, so the surface reads that difference from `selectstart` /
+ * `pointerdown`, and a test standing in for a real gesture has to fire them too.
+ */
+function armGesture(target: Element): void {
+  target.dispatchEvent(new Event('selectstart', { bubbles: true, cancelable: true }));
+}
+
+/**
  * Make a browser selection and tell the surface, the way a real gesture would.
  *
  * The programmatic write the surface does on every state change is suppressed for a
@@ -499,6 +512,7 @@ describe('a render never discards a gesture the model has not adopted yet', () =
 
       // The gesture: a word selected on the first page, with its event still queued.
       const run = host.querySelector('.docx-page[data-page-index="0"] [data-start]')!;
+      armGesture(run);
       const text = textNodeIn(run);
       const selection = document.getSelection()!;
       selection.removeAllRanges();
@@ -901,6 +915,7 @@ describe('a render never discards a gesture the model has not adopted yet', () =
       // The gesture, made inside the window where the surface treats `selectionchange` as
       // the echo of its own write — which is what a queued event looks like from here.
       const run = host.querySelector('.docx-page[data-page-index="0"] [data-start]')!;
+      armGesture(run);
       const text = textNodeIn(run);
       const selection = document.getSelection()!;
       selection.removeAllRanges();

--- a/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
@@ -99,6 +99,19 @@ function caretTo(surface: PaginatedSurface, index: number, offset: number): void
   });
 }
 
+function selectIn(surface: PaginatedSurface, index: number, start: number, end: number): void {
+  const paragraphId = surface.session.paragraphIds()[index]!;
+  surface.setSelection({
+    anchor: { paragraphId, offset: start },
+    head: { paragraphId, offset: end },
+  });
+}
+
+/** Type `text` one character at a time, the way a keyboard delivers it. */
+function typeEach(surface: PaginatedSurface, text: string): void {
+  for (const character of text) surface.type(character);
+}
+
 describe('Enter then type, in suggesting mode', () => {
   test('the character lands in the list item Enter just opened', () => {
     withSurface(listItem('Introduction') + listItem('Analysis'), (surface) => {
@@ -130,6 +143,47 @@ describe('Enter then type, in suggesting mode', () => {
       // `w:pPr` first (§17.3.1.26). The insertion landing ahead of it is markup the
       // paragraph invariant refuses, which is how the keystroke came to be dropped.
       expect(xml).toMatch(/<\/w:pPr><w:ins[^>]*><w:r><w:t[^>]*>Findings<\/w:t><\/w:r><\/w:ins>/);
+    });
+  });
+});
+
+// TYPING OVER YOUR OWN SUGGESTION.
+//
+// A tracked deletion does one of two things, and the replacement offset differs for each.
+// Somebody else's words are STRUCK: they stay, and the replacement goes after them. Your own
+// pending insertion is RETRACTED: the characters leave the paragraph, and aiming past them
+// aims past the end of it — which the store refuses, taking the whole transaction with it.
+// So every keystroke over your own suggestion did nothing, and the selection stayed.
+describe('typing over a pending suggestion', () => {
+  test('replaces your own insertion instead of being refused', () => {
+    withSurface(listItem('Introduction') + listItem('Analysis'), (surface) => {
+      caretTo(surface, 0, 'Introduction'.length);
+      surface.splitParagraph();
+      typeEach(surface, 'sda');
+      selectIn(surface, 1, 0, 3);
+      typeEach(surface, 'Hello');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Introduction', 'Hello', 'Analysis']);
+      // The caret follows the typing, so the NEXT character lands after it rather than in
+      // front of what was already typed.
+      expect(surface.state().selection.head.offset).toBe('Hello'.length);
+    });
+  });
+
+  test('keeps the struck half of a mixed range and lands after it', () => {
+    withSurface(listItem('Analysis'), (surface) => {
+      caretTo(surface, 0, 0);
+      typeEach(surface, 'New ');
+      // "New " is this author's own insertion; "Ana" is the file's own text.
+      selectIn(surface, 0, 0, 'New Ana'.length);
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      // The retracted half is gone, the struck half stays, and the replacement sits after it.
+      expect(paragraphTexts(surface)).toEqual(['AnaXlysis']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:del[^>]*><w:r><w:delText[^>]*>Ana<\/w:delText><\/w:r><\/w:del>/);
+      expect(xml).toMatch(/<w:ins[^>]*><w:r><w:t[^>]*>X<\/w:t><\/w:r><\/w:ins>/);
+      expect(xml).not.toMatch(/New/);
     });
   });
 });

--- a/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
@@ -187,3 +187,50 @@ describe('typing over a pending suggestion', () => {
     });
   });
 });
+
+// TAKING A BREAK BACK IS NOT A SECOND PROPOSAL.
+//
+// A join is addressed by the SECOND paragraph, because the mark between two paragraphs
+// belongs to the first — so Backspace at the start of a paragraph reaches the mark through
+// `proposeParagraphMerge`, which never asked whether the mark was this author's own. Enter
+// then Backspace therefore wrote a `w:del` on top of the `w:ins` from a second earlier: two
+// cards in the rail for a decision nobody made, an empty paragraph left standing, and a mark
+// whose Reject makes permanent the very break the user had just taken back. Word retracts it.
+describe('Enter then Backspace, in suggesting mode', () => {
+  test('the paragraph break goes away instead of stacking a deletion on it', () => {
+    withSurface(listItem('Introduction') + listItem('Analysis'), (surface) => {
+      caretTo(surface, 0, 'Introduction'.length);
+      surface.splitParagraph();
+      expect(surface.session.paragraphIds()).toHaveLength(3);
+
+      surface.deleteBackward();
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.paragraphIds()).toHaveLength(2);
+      expect(paragraphTexts(surface)).toEqual(['Introduction', 'Analysis']);
+
+      // Nothing is left to review: the proposal and its retraction cancel out.
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).not.toMatch(/<w:ins/);
+      expect(xml).not.toMatch(/<w:del/);
+    });
+  });
+
+  test('somebody ELSE’s proposed break is still proposed away, not joined', () => {
+    // The rule is about YOUR OWN proposal. A break another reviewer proposed is theirs to
+    // keep until someone decides on it, so Backspace over it stays a proposal.
+    withSurface(
+      '<w:p><w:pPr><w:rPr><w:ins w:id="7" w:author="Grace Hopper" w:date="2026-01-01T00:00:00Z"/></w:rPr></w:pPr>' +
+        '<w:r><w:t>Introduction</w:t></w:r></w:p>' +
+        listItem('Analysis'),
+      (surface) => {
+        caretTo(surface, 1, 0);
+        surface.deleteBackward();
+        expect(surface.state().lastRejection).toBeNull();
+        expect(surface.session.paragraphIds()).toHaveLength(2);
+        const xml = serializeOoxmlPart(surface.session.part());
+        expect(xml).toMatch(/<w:ins[^>]*w:author="Grace Hopper"/);
+        expect(xml).toMatch(/<w:del[^>]*w:author="Ada Lovelace"/);
+      }
+    );
+  });
+});

--- a/packages/core/src/editor/__tests__/write-lane-rules.test.ts
+++ b/packages/core/src/editor/__tests__/write-lane-rules.test.ts
@@ -1,0 +1,271 @@
+// EVERY WRITE LANE OBEYS THE SAME RULES.
+//
+// The surface has more than one way into the tree — typing, paste, the IME readback, the
+// structural ops — and each one that grew its own path to the store drifted from the rules
+// the others enforce. This file pins the shared ones per lane: a paragraph breaks at the
+// caret whatever wraps it, a story that is not the body can still lose a block, composed
+// text is attributed and refused like typed text, and a paste proposes its breaks as well as
+// its words.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { serializeOoxmlPart, type OoxmlNode } from '@docx-editor.dev/core/store';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const p = (text: string) => `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+function withSurface(
+  body: string,
+  run: (surface: PaginatedSurface, container: HTMLElement) => void,
+  opts: { author?: string; mode?: 'edit' | 'suggest' } = {}
+): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(body), {
+    scale: 1,
+    ...(opts.author ? { author: opts.author } : {}),
+  });
+  if (!opened.ok) throw new Error(opened.reason);
+  try {
+    if (opts.mode === 'suggest') opened.surface.setEditingMode('suggest');
+    run(opened.surface, container);
+  } finally {
+    opened.surface.destroy();
+    container.remove();
+    document.getSelection()?.removeAllRanges();
+  }
+}
+
+function paragraphTexts(surface: PaginatedSurface): string[] {
+  const out: string[] = [];
+  const collect = (n: OoxmlNode, into: string[]): void => {
+    if (n.kind === 'textValue') {
+      into.push(n.value);
+      return;
+    }
+    for (const c of n.children) collect(c, into);
+  };
+  const walk = (n: OoxmlNode): void => {
+    if (n.kind === 'textValue') return;
+    if (n.kind === 'paragraph') {
+      const parts: string[] = [];
+      collect(n, parts);
+      out.push(parts.join(''));
+      return;
+    }
+    for (const c of n.children) walk(c);
+  };
+  walk(surface.session.part().root);
+  return out;
+}
+
+function caretTo(s: PaginatedSurface, i: number, offset: number): void {
+  const paragraphId = s.session.paragraphIds()[i]!;
+  s.setSelection({ anchor: { paragraphId, offset }, head: { paragraphId, offset } });
+}
+
+const TRACKED_PARAGRAPH =
+  '<w:p><w:r><w:t xml:space="preserve">Hello</w:t></w:r>' +
+  '<w:ins w:id="1" w:author="Grace Hopper" w:date="2026-01-01T00:00:00Z">' +
+  '<w:r><w:t xml:space="preserve">onetwo</w:t></w:r></w:ins>' +
+  '<w:r><w:t xml:space="preserve"> World</w:t></w:r></w:p>';
+
+describe('#348 Enter inside a tracked insertion', () => {
+  test('breaks at the caret, and both halves keep the attribution', () => {
+    withSurface(TRACKED_PARAGRAPH, (surface) => {
+      caretTo(surface, 0, 8);
+      surface.splitParagraph();
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Helloone', 'two World']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:ins[^>]*w:author="Grace Hopper"[^>]*><w:r><w:t[^>]*>one</);
+      expect(xml).toMatch(/<w:ins[^>]*w:author="Grace Hopper"[^>]*><w:r><w:t[^>]*>two</);
+    });
+  });
+
+  test('and the same in suggesting mode over your own words', () => {
+    withSurface(
+      p('Hello World'),
+      (surface) => {
+        caretTo(surface, 0, 5);
+        surface.type('onetwo');
+        caretTo(surface, 0, 8);
+        surface.splitParagraph();
+        expect(paragraphTexts(surface)).toEqual(['Helloone', 'two World']);
+      },
+      { author: 'Ada Lovelace', mode: 'suggest' }
+    );
+  });
+
+  test('control: an untracked paragraph still breaks at the caret', () => {
+    withSurface(p('Helloonetwo World'), (surface) => {
+      caretTo(surface, 0, 8);
+      surface.splitParagraph();
+      expect(paragraphTexts(surface)).toEqual(['Helloone', 'two World']);
+    });
+  });
+});
+
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const TABLE =
+  '<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="dxa"/></w:tblPr>' +
+  '<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>' +
+  '<w:tr><w:tc><w:tcPr><w:tcW w:w="5000" w:type="dxa"/></w:tcPr>' +
+  '<w:p><w:r><w:t>CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+
+function headerDocx(headerContent: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${p('body text')}` +
+        '<w:sectPr><w:headerReference w:type="default" r:id="rId10"/></w:sectPr></w:body></w:document>'
+    ),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${headerContent}</w:hdr>`),
+  });
+}
+
+describe('#344 deleteBlock inside a header story', () => {
+  test('a table in the header can be removed', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(container, headerDocx(`${TABLE}${p('AFTER')}`), {
+      scale: 1,
+    });
+    if (!opened.ok) throw new Error(opened.reason);
+    const surface = opened.surface;
+    try {
+      expect(surface.enterHeaderFooter({ rId: 'rId10' })).toBe(true);
+      const scope = { kind: 'headerFooter', rId: 'rId10' } as const;
+      expect(surface.session.storyText(scope)).toBe('CELL\nAFTER');
+      const ids = surface.session.paragraphIdsIn(scope);
+      surface.setSelection({
+        anchor: { paragraphId: ids[0]!, offset: 0 },
+        head: { paragraphId: ids[1]!, offset: 5 },
+      });
+      surface.deleteSelection();
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.storyText(scope)).toBe('');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});
+
+/** What the browser does during a composition: it writes the painted spans itself. */
+function compose(container: HTMLElement, paragraphId: string, paintedAfter: string): void {
+  const pages = container.querySelector('.docx-pages')!;
+  pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+  const spans = [...container.querySelectorAll('[data-paragraph-id][data-start]')].filter(
+    (span) => (span as HTMLElement).dataset.paragraphId === paragraphId
+  ) as HTMLElement[];
+  if (spans.length === 0) throw new Error(`no painted span for ${paragraphId}`);
+  spans[0]!.textContent = paintedAfter;
+  for (const extra of spans.slice(1)) extra.textContent = '';
+  pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+}
+
+describe('#349 IME input in suggesting mode', () => {
+  test('composed text is a proposal, like typed text', () => {
+    withSurface(
+      p('abc'),
+      (surface, container) => {
+        const id = surface.session.paragraphIds()[0]!;
+        caretTo(surface, 0, 3);
+        compose(container, id, 'abc\u4e2d\u6587');
+        expect(surface.session.bodyText()).toBe('abc\u4e2d\u6587');
+        expect(serializeOoxmlPart(surface.session.part())).toContain('<w:ins');
+      },
+      { author: 'Ada Lovelace', mode: 'suggest' }
+    );
+  });
+
+  test('and viewing mode refuses it, like every other lane', () => {
+    withSurface(
+      p('abc'),
+      (surface, container) => {
+        const id = surface.session.paragraphIds()[0]!;
+        caretTo(surface, 0, 3);
+        surface.setEditingMode('view');
+        compose(container, id, 'abc\u4e2d\u6587');
+        expect(surface.session.bodyText()).toBe('abc');
+      },
+      { author: 'Ada Lovelace' }
+    );
+  });
+});
+
+describe('#353 paste in suggesting mode', () => {
+  test('the paragraph break it makes is a proposal too', () => {
+    withSurface(
+      p('Hello'),
+      (surface) => {
+        caretTo(surface, 0, 5);
+        surface.insertPlainText('\nGamma');
+        expect(surface.state().lastRejection).toBeNull();
+        expect(paragraphTexts(surface)).toEqual(['Hello', 'Gamma']);
+        expect(serializeOoxmlPart(surface.session.part())).toMatch(
+          /<w:rPr><w:ins[^>]*w:author="Ada Lovelace"/
+        );
+      },
+      { author: 'Ada Lovelace', mode: 'suggest' }
+    );
+  });
+
+  test('and the caret lands after the pasted text, not inside it', () => {
+    withSurface(
+      p('Hello World'),
+      (surface) => {
+        surface.setSelection({
+          anchor: { paragraphId: surface.session.paragraphIds()[0]!, offset: 0 },
+          head: { paragraphId: surface.session.paragraphIds()[0]!, offset: 5 },
+        });
+        surface.insertPlainText('Goodbye');
+        surface.type('!');
+        expect(paragraphTexts(surface)).toEqual(['HelloGoodbye! World']);
+      },
+      { author: 'Ada Lovelace', mode: 'suggest' }
+    );
+  });
+
+  test('control: in edit mode the break stays untracked', () => {
+    withSurface(p('Hello'), (surface) => {
+      caretTo(surface, 0, 5);
+      surface.insertPlainText('\nGamma');
+      expect(serializeOoxmlPart(surface.session.part())).not.toMatch(/<w:ins/);
+    });
+  });
+});

--- a/packages/core/src/editor/__tests__/write-lane-rules.test.ts
+++ b/packages/core/src/editor/__tests__/write-lane-rules.test.ts
@@ -213,6 +213,25 @@ describe('#349 IME input in suggesting mode', () => {
     );
   });
 
+  test('composed text replacing a word lands after the words it strikes', () => {
+    withSurface(
+      p('alpha beta'),
+      (surface, container) => {
+        const id = surface.session.paragraphIds()[0]!;
+        surface.setSelection({
+          anchor: { paragraphId: id, offset: 0 },
+          head: { paragraphId: id, offset: 5 },
+        });
+        // The browser composes over the selected word: the painted text loses "alpha".
+        compose(container, id, '\u4e2d\u6587 beta');
+        expect(surface.state().lastRejection).toBeNull();
+        // Suggesting keeps the struck word, and the proposal goes after it — not in front.
+        expect(surface.session.bodyText()).toBe('alpha\u4e2d\u6587 beta');
+      },
+      { author: 'Ada Lovelace', mode: 'suggest' }
+    );
+  });
+
   test('and viewing mode refuses it, like every other lane', () => {
     withSurface(
       p('abc'),

--- a/packages/core/src/editor/__tests__/write-lane-rules.test.ts
+++ b/packages/core/src/editor/__tests__/write-lane-rules.test.ts
@@ -269,3 +269,74 @@ describe('#353 paste in suggesting mode', () => {
     });
   });
 });
+
+describe('#343 inserting a footnote', () => {
+  test('replaces the selection and leaves the caret after the reference', () => {
+    withSurface(p('Hello world'), (surface) => {
+      const id = surface.session.paragraphIds()[0]!;
+      surface.setSelection({
+        anchor: { paragraphId: id, offset: 0 },
+        head: { paragraphId: id, offset: 5 },
+      });
+      expect(surface.insertNote('footnote')).toBe(true);
+      // "Hello" is gone, the reference stands in its place.
+      expect(surface.session.bodyText()).toBe('\uFFFC world');
+      surface.exitNote();
+      // After the reference, which is where the next character belongs.
+      expect(surface.state().selection.head.offset).toBe(1);
+      surface.type('X');
+      expect(surface.session.bodyText()).toBe('\uFFFCX world');
+    });
+  });
+
+  test('at a caret, the reference keeps the text it was inserted into', () => {
+    withSurface(p('Hello world'), (surface) => {
+      caretTo(surface, 0, 5);
+      expect(surface.insertNote('footnote')).toBe(true);
+      expect(surface.session.bodyText()).toBe('Hello\uFFFC world');
+      surface.exitNote();
+      surface.type('X');
+      expect(surface.session.bodyText()).toBe('Hello\uFFFCX world');
+    });
+  });
+});
+
+describe('#354 redo puts the caret where the redone edit ends', () => {
+  test('backspace', () => {
+    withSurface(p('abcdef'), (surface) => {
+      caretTo(surface, 0, 3);
+      surface.deleteBackward();
+      surface.undo();
+      surface.redo();
+      expect(paragraphTexts(surface)).toEqual(['abdef']);
+      expect(surface.state().selection.head.offset).toBe(2);
+      surface.type('Q');
+      expect(paragraphTexts(surface)).toEqual(['abQdef']);
+    });
+  });
+
+  test('a single-line paste', () => {
+    withSurface(p('abcdef'), (surface) => {
+      caretTo(surface, 0, 3);
+      surface.insertPlainText('XY');
+      surface.undo();
+      surface.redo();
+      surface.type('Q');
+      expect(paragraphTexts(surface)).toEqual(['abcXYQdef']);
+    });
+  });
+
+  test('deleting a selection', () => {
+    withSurface(p('abcdef'), (surface) => {
+      surface.setSelection({
+        anchor: { paragraphId: surface.session.paragraphIds()[0]!, offset: 1 },
+        head: { paragraphId: surface.session.paragraphIds()[0]!, offset: 4 },
+      });
+      surface.deleteSelection();
+      surface.undo();
+      surface.redo();
+      surface.type('Q');
+      expect(paragraphTexts(surface)).toEqual(['aQef']);
+    });
+  });
+});

--- a/packages/core/src/editor/dom-selection.ts
+++ b/packages/core/src/editor/dom-selection.ts
@@ -315,7 +315,6 @@ function domPointFromPositionIn(
     const length = span.textContent?.length ?? 0;
     const end = identity.end;
     if (!text) continue;
-    painted = true;
     // A FIELD IS NOT A PLACE TO PUT A SELECTION END. `positionFromDomPoint` refuses every
     // endpoint under `[data-docx-field]`, and an atom is one model unit wide, so a position
     // at its START satisfied the `offset < end` test and was written inside it — where the
@@ -323,7 +322,12 @@ function domPointFromPositionIn(
     // its other end. Shift-extending onto a page number lost the selection before the next
     // command ran. Skipping the span keeps the boundary of the one before it, which reads
     // back as exactly this offset.
+    // Counted as painted only AFTER the skip: a paragraph whose first span is a field — a
+    // note citation, a page number — has no earlier boundary to fall back to, and calling it
+    // painted made the refusal below swallow offset 0 as well. The whole range then failed to
+    // map, so Select All inside a footnote drew no highlight at all.
     if ((span as HTMLElement).closest?.('[data-docx-field]')) continue;
+    painted = true;
     if (position.offset >= identity.start && position.offset <= end) {
       // A position on a boundary belongs to the span that STARTS there, so a caret between
       // two words sits before the second rather than after the first. The first match wins

--- a/packages/core/src/editor/dom-selection.ts
+++ b/packages/core/src/editor/dom-selection.ts
@@ -316,6 +316,14 @@ function domPointFromPositionIn(
     const end = identity.end;
     if (!text) continue;
     painted = true;
+    // A FIELD IS NOT A PLACE TO PUT A SELECTION END. `positionFromDomPoint` refuses every
+    // endpoint under `[data-docx-field]`, and an atom is one model unit wide, so a position
+    // at its START satisfied the `offset < end` test and was written inside it — where the
+    // reader then answered null and `semanticSelectionFromDom` collapsed the whole range to
+    // its other end. Shift-extending onto a page number lost the selection before the next
+    // command ran. Skipping the span keeps the boundary of the one before it, which reads
+    // back as exactly this offset.
+    if ((span as HTMLElement).closest?.('[data-docx-field]')) continue;
     if (position.offset >= identity.start && position.offset <= end) {
       // A position on a boundary belongs to the span that STARTS there, so a caret between
       // two words sits before the second rather than after the first. The first match wins

--- a/packages/core/src/editor/dom-selection.ts
+++ b/packages/core/src/editor/dom-selection.ts
@@ -307,6 +307,7 @@ function domPointFromPositionIn(
 ): { node: Node; offset: number } | null {
   const spans = paragraphElements(searchRoot, position.paragraphId, '[data-start]');
   let fallback: { node: Node; offset: number } | null = null;
+  let painted = false;
   for (const span of spans) {
     const identity = identityOf(span);
     if (!identity || identity.paragraphId !== position.paragraphId) continue;
@@ -314,6 +315,7 @@ function domPointFromPositionIn(
     const length = span.textContent?.length ?? 0;
     const end = identity.end;
     if (!text) continue;
+    painted = true;
     if (position.offset >= identity.start && position.offset <= end) {
       // A position on a boundary belongs to the span that STARTS there, so a caret between
       // two words sits before the second rather than after the first. The first match wins
@@ -332,6 +334,16 @@ function domPointFromPositionIn(
     }
   }
   if (fallback) return fallback;
+
+  // A paragraph that DID paint text and still has no place for this offset is a position
+  // this DOM cannot express — an offset inside a hidden run (`w:vanish` advances offsets and
+  // paints nothing), a caret past what the current paint covers, a span whose text node the
+  // paint has not built yet. Answering the line at child index 0 is not a near miss: it is
+  // the paragraph START, a legal position the readback cannot tell from a real one. The
+  // browser caret went home, the next reader took that as the truth, and every character
+  // typed after the first landed in front of the one before it. Say "cannot", and the caller
+  // keeps the model — which the engine's own painted caret draws from anyway.
+  if (painted) return null;
 
   // An EMPTY paragraph paints a line with no spans, so there is no text node to point at —
   // yet it still has exactly one caret position. Without this the caret vanished after every

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -2212,6 +2212,10 @@ export function mountPaginatedSurface(
       case 'setParagraphMarkRevision':
       case 'proposeParagraphMerge':
         return true;
+      // Paste proposes its breaks through the op itself, so a paste of newlines alone is a
+      // tracked edit with no `insertText` beside it to report for it.
+      case 'splitParagraphMany':
+        return op.revision !== undefined;
       default:
         return false;
     }
@@ -2525,12 +2529,6 @@ export function mountPaginatedSurface(
     // The raw take-up, without the mirror or the report `setSelection` performs: the render
     // this runs inside is about to do both.
     adoptSelection: (next) => {
-      // A GESTURE IS A CARET MOVE, AND EVERY CARET MOVE LANDS THE BUFFER FIRST. Typing is
-      // held on a zero-delay task, so a selection taken up before the flush makes those
-      // characters land wherever the gesture went — `rematerialize` says so at its own call.
-      // The engine pointer path flushes through `setSelection`, but touch and native pointer
-      // mode never reach it, so a tap after a burst moved the burst to the tap.
-      flushTypeBuffer();
       reconcilePendingWith(next);
       releaseRetainedIfEscaped(next);
       retireActivationPin();
@@ -2544,6 +2542,9 @@ export function mountPaginatedSurface(
     // mode landed untracked — the reviewer proposing a change was editing the document —
     // and forms protection and content-control locks did not apply to it either.
     applyOps: (ops, mark, scope) => applyOps(ops, mark, undefined, scope),
+    hasPendingInput: () => typeBuffer.length > 0,
+    replacementOffset: (paragraphId, from, to) =>
+      replacementOffset({ paragraphId, offset: from }, { paragraphId, offset: to }),
     render: () => render(),
     flushLayout: () => flushLayout(),
     updateCaret: () => {
@@ -2599,6 +2600,7 @@ export function mountPaginatedSurface(
     selectionMark: () => selectionMark(),
     orderedStart: () => orderedStart(),
     deleteSelectionPlan: () => deleteSelectionPlan(),
+    undo: () => surface.undo(),
     activeScope: () => {
       const note = noteOps?.activeNoteScope();
       if (note) return note;
@@ -4646,6 +4648,20 @@ export function mountPaginatedSurface(
    * joined, so nothing shifts within the first one), and with no author configured, which is
    * the case where nothing is tracked at all.
    */
+  /**
+   * Where a replacement for `[from, to)` belongs, once suggesting has had its say.
+   *
+   * The struck characters STAY, so the new text goes after them — minus whatever of the range
+   * was this author's own pending insertion, which leaves. Identity in editing mode, where
+   * the range simply goes. Every lane that replaces a range has to ask: `type()` was fixed
+   * first, and the paste, the IME readback and the note reference each landed in front of the
+   * words they were replacing until they asked it too.
+   */
+  function replacementOffset(from: SemanticPosition, to: SemanticPosition): number {
+    if (editingMode !== 'suggest' || from.paragraphId !== to.paragraphId) return from.offset;
+    return to.offset - retractedByOwnInsertion(from, to);
+  }
+
   function retractedByOwnInsertion(from: SemanticPosition, to: SemanticPosition): number {
     const author = options.author?.trim();
     if (editingMode !== 'suggest' || !author) return 0;

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -2237,6 +2237,9 @@ export function mountPaginatedSurface(
       // is already in two paragraphs, and what is being proposed is the break between them.
       // §17.13.5 puts the new mark on the FIRST paragraph, and rejecting it runs the two
       // back together.
+      // Paste cuts its pasted text into paragraphs with ONE op, so the proposal rides on the
+      // op itself: the store mints the paragraphs, so only the store can address their marks.
+      if (op.op === 'splitParagraphMany') return [{ ...op, revision }];
       if (op.op === 'splitParagraph') {
         return [
           op,
@@ -2447,6 +2450,12 @@ export function mountPaginatedSurface(
     // The raw take-up, without the mirror or the report `setSelection` performs: the render
     // this runs inside is about to do both.
     adoptSelection: (next) => {
+      // A GESTURE IS A CARET MOVE, AND EVERY CARET MOVE LANDS THE BUFFER FIRST. Typing is
+      // held on a zero-delay task, so a selection taken up before the flush makes those
+      // characters land wherever the gesture went — `rematerialize` says so at its own call.
+      // The engine pointer path flushes through `setSelection`, but touch and native pointer
+      // mode never reach it, so a tap after a burst moved the burst to the tap.
+      flushTypeBuffer();
       reconcilePendingWith(next);
       releaseRetainedIfEscaped(next);
       retireActivationPin();
@@ -2455,6 +2464,11 @@ export function mountPaginatedSurface(
       caretFollowPending = true;
     },
     commit: (run) => commit(run),
+    // The composition readback writes through the SAME lane as every other edit. Calling the
+    // session directly skipped `trackedOps` and `writeRefusal`, so IME text in suggesting
+    // mode landed untracked — the reviewer proposing a change was editing the document —
+    // and forms protection and content-control locks did not apply to it either.
+    applyOps: (ops, mark, scope) => applyOps(ops, mark, undefined, scope),
     render: () => render(),
     flushLayout: () => flushLayout(),
     updateCaret: () => {
@@ -4578,15 +4592,25 @@ export function mountPaginatedSurface(
     const start = plan.collapseTo;
     const joined = lines.join('');
     const ops: TreeDocOp[] = [...plan.ops];
+    // WHERE THE REPLACEMENT GOES, the same question `type()` answers. In suggesting mode a
+    // deletion keeps the characters it strikes, so the replacement belongs AFTER them — and
+    // keeps only those, since whatever of the range was this author's own pending insertion
+    // is retracted and leaves. Pasting at the range start put the new text in front of the
+    // struck words and left the caret inside it, so the next keystroke landed mid-word.
+    const struck = editingMode === 'suggest' ? orderedRange() : null;
+    const insertAt =
+      struck && struck.to.paragraphId === start.paragraphId
+        ? struck.to.offset - retractedByOwnInsertion(struck.from, struck.to)
+        : start.offset;
     // Plain text pasted at a caret takes the armed typing format, like typed text — Word
     // formats a plain paste as if you had typed it. Written over the PRE-SPLIT offsets, so
     // the op runs before `splitParagraphMany` cuts the paragraph up.
-    const pendingOps = consumePendingFormatOps(start.paragraphId, start.offset, joined.length);
+    const pendingOps = consumePendingFormatOps(start.paragraphId, insertAt, joined.length);
     if (joined.length > 0) {
       ops.push({
         op: 'insertText',
         paragraphId: start.paragraphId,
-        offset: start.offset,
+        offset: insertAt,
         text: joined,
       });
       ops.push(...pendingOps);
@@ -4595,7 +4619,7 @@ export function mountPaginatedSurface(
     let consumed = 0;
     for (let index = 0; index < lines.length - 1; index += 1) {
       consumed += lines[index]!.length;
-      boundaries.push(start.offset + consumed);
+      boundaries.push(insertAt + consumed);
     }
     if (boundaries.length > 0) {
       ops.push({ op: 'splitParagraphMany', paragraphId: start.paragraphId, offsets: boundaries });
@@ -4611,7 +4635,7 @@ export function mountPaginatedSurface(
         if (boundaries.length === 0) {
           return collapsedAt({
             paragraphId: start.paragraphId,
-            offset: start.offset + lastLine.length,
+            offset: insertAt + lastLine.length,
           });
         }
         // The caret lands at the end of the pasted text: in the LAST minted paragraph, right

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -13,6 +13,7 @@ import {
   inlineControlEndingAt,
   inlineControlStartingAt,
   isContentControl,
+  parentNodeOf,
   parseTocInstruction,
   planTocEntries,
   readViewSettings,
@@ -2265,6 +2266,80 @@ export function mountPaginatedSurface(
     });
   }
 
+  /**
+   * The history mark for a caret, which is what REDO restores.
+   *
+   * `applyOps` takes it as its third argument and the store records it on the entry. Only
+   * `type()` ever supplied one, so redo put the caret back where the edit STARTED — after
+   * redoing Enter the next character went into the paragraph above the one it belonged to.
+   */
+  /**
+   * A selection carried across a change to ONE paragraph's text.
+   *
+   * The two strings are all this needs: what survives at the front stays put, what survives
+   * at the back moves by the length difference, and an offset inside the part that changed
+   * collapses to where the change began — which is where the words the caret was in used to
+   * be. Resolving a revision under the caret is the case: the offsets are still legal, so
+   * nothing clamps them, and they now address different characters.
+   */
+  function mappedAcrossTextChange(
+    current: SemanticSelection,
+    paragraphId: string,
+    beforeText: string
+  ): SemanticSelection {
+    const afterText = textOf(paragraphId);
+    if (afterText === beforeText) return current;
+    let prefix = 0;
+    while (
+      prefix < beforeText.length &&
+      prefix < afterText.length &&
+      beforeText[prefix] === afterText[prefix]
+    ) {
+      prefix += 1;
+    }
+    let suffix = 0;
+    while (
+      suffix < beforeText.length - prefix &&
+      suffix < afterText.length - prefix &&
+      beforeText[beforeText.length - 1 - suffix] === afterText[afterText.length - 1 - suffix]
+    ) {
+      suffix += 1;
+    }
+    const delta = afterText.length - beforeText.length;
+    const move = (position: SemanticPosition): SemanticPosition => {
+      if (position.paragraphId !== paragraphId) return position;
+      if (position.offset <= prefix) return position;
+      if (position.offset >= beforeText.length - suffix) {
+        return { ...position, offset: position.offset + delta };
+      }
+      return { ...position, offset: prefix };
+    };
+    return { anchor: move(current.anchor), head: move(current.head) };
+  }
+
+  /**
+   * Whether two paragraphs are siblings in the same container, so a join is even expressible.
+   *
+   * `paragraphOrder()` is flat document order: the paragraph before the one after a table is
+   * inside the table's last cell, and the paragraph before the first cell's is outside it.
+   * Neither pair can be joined, and the store says so — but only after the op is built and
+   * the whole transaction refused.
+   */
+  function joinableSiblings(firstId: string, secondId: string): boolean {
+    const part = session.partFor(storyScope()) ?? session.part();
+    const firstParent = parentNodeOf(part, firstId);
+    const secondParent = parentNodeOf(part, secondId);
+    return firstParent !== null && secondParent !== null && firstParent.id === secondParent.id;
+  }
+
+  function caretMark(position: { paragraphId: string; offset: number }): {
+    paragraphId: string;
+    start: number;
+    end: number;
+  } {
+    return { paragraphId: position.paragraphId, start: position.offset, end: position.offset };
+  }
+
   function commit(
     run: () => ReturnType<TreeDocxSession['applyPmDoc']> | boolean,
     selectionAfter?: () => SemanticSelection | null,
@@ -2497,6 +2572,12 @@ export function mountPaginatedSurface(
       // buffered body keystrokes must land in the body first, not the header.
       flushTypeBuffer();
       retireActivationPin();
+      // The rest of what a caret move means, which this second entry point used to skip: an
+      // armed typing format belongs to the position it was armed at, and a review card the
+      // reader dismissed at one caret is not dismissed at the next. A round trip through a
+      // header rearmed Bold on re-entry and left a card that would not reopen.
+      reconcilePendingWith(next);
+      dismissedReviewKeys.clear();
       selection = next;
       cellSelection = null;
       desiredX = null;
@@ -2507,6 +2588,7 @@ export function mountPaginatedSurface(
     notify: () => options.onChange?.(currentState()),
     materializedPages: () => materializedSet,
     entryRefused: () => editingMode === 'view',
+    leaveOtherStories: () => noteOps?.exitNote(),
   });
 
   noteOps = createNoteOps({
@@ -2516,6 +2598,7 @@ export function mountPaginatedSurface(
     selection: () => selection,
     selectionMark: () => selectionMark(),
     orderedStart: () => orderedStart(),
+    deleteSelectionPlan: () => deleteSelectionPlan(),
     activeScope: () => {
       const note = noteOps?.activeNoteScope();
       if (note) return note;
@@ -3504,7 +3587,7 @@ export function mountPaginatedSurface(
       const plan = deleteSelectionPlan();
       if (plan.ops.length > 0) {
         commit(
-          () => applyOps(plan.ops, selectionMark()),
+          () => applyOps(plan.ops, selectionMark(), caretMark(plan.collapseTo)),
           () => collapsedAt(plan.collapseTo)
         );
         return;
@@ -3536,7 +3619,8 @@ export function mountPaginatedSurface(
                     end: text.length,
                   },
                 ],
-                selectionMark()
+                selectionMark(),
+                caretMark({ paragraphId: member, offset: text.length - 1 })
               ),
             () => collapsedAt({ paragraphId: member, offset: text.length - 1 }),
             { rearmPending: armed }
@@ -3547,12 +3631,23 @@ export function mountPaginatedSurface(
         const index = order.indexOf(position.paragraphId);
         const previous = order[index - 1];
         if (!previous) return;
+        // ONLY A SIBLING CAN BE JOINED. Document order walks straight into the last cell of a
+        // table, so Backspace at the start of the paragraph after one built a join the store
+        // is guaranteed to refuse — the key did nothing AND left `not-adjacent-siblings` on
+        // the surface, where a host that surfaces refusals reported an error for an ordinary
+        // Backspace. Word moves the caret into the last cell instead; doing nothing is the
+        // half of that this lane can honestly promise.
+        if (!joinableSiblings(previous, position.paragraphId)) {
+          setSelection(collapsedAt({ paragraphId: previous, offset: textOf(previous).length }));
+          return;
+        }
         const joinAt = textOf(previous).length;
         commit(
           () =>
             applyOps(
               [{ op: 'joinParagraphs', firstId: previous, secondId: position.paragraphId }],
-              selectionMark()
+              selectionMark(),
+              caretMark({ paragraphId: previous, offset: joinAt })
             ),
           () => collapsedAt({ paragraphId: previous, offset: joinAt }),
           { rearmPending: armed }
@@ -3568,7 +3663,8 @@ export function mountPaginatedSurface(
           () =>
             applyOps(
               [{ op: 'removeContentControl', controlId: chip.controlId, keepContent: false }],
-              selectionMark()
+              selectionMark(),
+              caretMark({ paragraphId: position.paragraphId, offset: chip.start })
             ),
           () => collapsedAt({ paragraphId: position.paragraphId, offset: chip.start }),
           { rearmPending: armed }
@@ -3586,7 +3682,8 @@ export function mountPaginatedSurface(
                 end: position.offset,
               },
             ],
-            selectionMark()
+            selectionMark(),
+            caretMark({ ...position, offset: position.offset - 1 })
           ),
         () => collapsedAt({ ...position, offset: position.offset - 1 }),
         { rearmPending: armed }
@@ -3904,8 +4001,14 @@ export function mountPaginatedSurface(
         pageOffsetX: materializedExtent?.pageOffsetX ?? new Map<number, number>(),
       }),
 
-    commitReviewOps: (run) =>
-      commit(
+    commitReviewOps: (run) => {
+      // The text the caret's paragraph held BEFORE the resolution, so the caret can be mapped
+      // across what Accept or Reject removed. Clamping alone only fires when the paragraph
+      // ends up shorter than the offset; a caret in the MIDDLE of a paragraph that shrank
+      // silently re-points at different characters, and the next thing typed lands there.
+      const caretParagraph = selection.head.paragraphId;
+      const beforeText = textOf(caretParagraph);
+      return commit(
         // Reported as a RESULT, not a boolean: `commit` reads the refusal reason off it, and
         // a boolean made every refused accept clear `lastRejection` instead of setting it.
         () => {
@@ -3940,9 +4043,11 @@ export function mountPaginatedSurface(
           // `unknown-paragraph`. Accepting a header card is exactly that situation.
           const order = paragraphOrder();
           if (order.length === 0) return null;
-          return clampedToDocument(currentLayout, order, selection);
+          const mapped = mappedAcrossTextChange(selection, caretParagraph, beforeText);
+          return clampedToDocument(currentLayout, order, mapped);
         }
-      ),
+      );
+    },
 
     applyAutomationOps: (staged, scope) => {
       // THE SAME PATH A KEYSTROKE TAKES, minus the keystroke. `applyOps` is where viewing
@@ -4127,7 +4232,7 @@ export function mountPaginatedSurface(
       const plan = deleteSelectionPlan();
       if (plan.ops.length === 0) return false;
       commit(
-        () => applyOps(plan.ops, selectionMark()),
+        () => applyOps(plan.ops, selectionMark(), caretMark(plan.collapseTo)),
         () => collapsedAt(plan.collapseTo)
       );
       return true;
@@ -4275,6 +4380,7 @@ export function mountPaginatedSurface(
       applyOps,
       commit,
       deleteSelectionOps,
+      deleteSelectionPlan: () => deleteSelectionPlan(),
       orderedStart,
       selectionMark,
       collapsedAt,
@@ -4368,10 +4474,29 @@ export function mountPaginatedSurface(
       setSelection(clampedToDocument(currentLayout, paragraphOrder(), selection));
       return;
     }
-    setSelection({
+    // CLAMPED LIKE THE BRANCH ABOVE. A mark addresses one paragraph of whatever story the
+    // edit was made in, and the reader may be somewhere else by the time they press Ctrl+Z:
+    // edit the header, click into the body, undo, and the caret was installed on a header
+    // paragraph while the body was the active story. The DOM caret then landed in furniture
+    // that is `contenteditable="false"`, and every keystroke after it was refused as
+    // `unknown-paragraph` — the editor looked dead until the user clicked.
+    const restored = {
       anchor: { paragraphId: mark.paragraphId, offset: mark.start },
       head: { paragraphId: mark.paragraphId, offset: mark.end },
-    });
+    };
+    // A MARK FROM ANOTHER STORY IS NOT AN ADDRESS HERE. It names one paragraph of whatever
+    // story the edit was made in, and the reader may be somewhere else by the time they press
+    // Ctrl+Z: edit the header, click into the body, undo, and the caret was installed on a
+    // header paragraph while the body was the active story. The DOM caret then landed in
+    // furniture that is `contenteditable="false"` and every keystroke after it was refused as
+    // `unknown-paragraph` — the editor looked dead until the user clicked. Clamped exactly
+    // like the no-mark branch above; a mark the active story does hold is installed verbatim,
+    // which is what keeps an ordinary undo on the offset it recorded.
+    setSelection(
+      paragraphOrder().includes(mark.paragraphId)
+        ? restored
+        : clampedToDocument(currentLayout, paragraphOrder(), restored)
+    );
   }
 
   /**
@@ -4628,9 +4753,17 @@ export function mountPaginatedSurface(
 
     const before = new Set(session.paragraphIdsIn(storyScope()));
     const lastLine = lines[lines.length - 1]!;
+    // A paste that stays in ONE paragraph knows exactly where it ends, so redo can put the
+    // caret there. A multi-line paste mints its paragraphs inside the transaction, so the
+    // landing id does not exist yet and the mark stays undefined — redo then falls back to
+    // the clamp, which is where this lane started.
+    const redoMark =
+      boundaries.length === 0
+        ? caretMark({ paragraphId: start.paragraphId, offset: insertAt + lastLine.length })
+        : undefined;
     const withoutFormat = ops.filter((op) => !pendingOps.includes(op));
     commit(
-      () => withoutPendingOnRejection(ops, withoutFormat, selectionMark()),
+      () => withoutPendingOnRejection(ops, withoutFormat, selectionMark(), redoMark),
       () => {
         if (boundaries.length === 0) {
           return collapsedAt({

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -24,6 +24,7 @@ import {
   type StoryScope,
   type TreeDocOp,
 } from '@docx-editor.dev/core/store';
+import { retractedLengthOf } from '../store/store/tree-op-retraction.ts';
 import { syncActiveFieldShading } from './surface-field-shading.ts';
 import {
   createLayoutScheduler,
@@ -3447,9 +3448,17 @@ export function mountPaginatedSurface(
       // lets the pane fold them into one `Replaced "x" with "y"` card. Mid-sentence
       // replacements were showing as two unrelated decisions, and a reviewer could accept
       // one half.
+      //
+      // It keeps only the characters it STRIKES. Whatever of the range is this author's own
+      // pending insertion is RETRACTED instead — those characters leave the paragraph — so
+      // the offset past the selection is past the end of what the insert will find there.
+      // Typing over your own suggestion was refused as `offset-out-of-range`, and since a
+      // refusal takes the whole transaction, the keystroke did nothing at all.
       const struck = editingMode === 'suggest' ? orderedRange() : null;
       const insertAt =
-        struck && struck.to.paragraphId === start.paragraphId ? struck.to.offset : start.offset;
+        struck && struck.to.paragraphId === start.paragraphId
+          ? struck.to.offset - retractedByOwnInsertion(struck.from, struck.to)
+          : start.offset;
       const insertOps: TreeDocOp[] = [
         ...plan.ops,
         { op: 'insertText', paragraphId: start.paragraphId, offset: insertAt, text },
@@ -4487,6 +4496,25 @@ export function mountPaginatedSurface(
 
   function deleteSelectionOps(): readonly TreeDocOp[] {
     return deleteSelectionPlan().ops;
+  }
+
+  /**
+   * How many characters of `[from, to)` a suggesting-mode deletion takes OUT of the
+   * paragraph, rather than striking in place.
+   *
+   * Only ever this author's own pending insertion — everything else stays and keeps its
+   * offsets. Zero outside suggesting, across a paragraph boundary (the paragraphs are not
+   * joined, so nothing shifts within the first one), and with no author configured, which is
+   * the case where nothing is tracked at all.
+   */
+  function retractedByOwnInsertion(from: SemanticPosition, to: SemanticPosition): number {
+    const author = options.author?.trim();
+    if (editingMode !== 'suggest' || !author) return 0;
+    if (from.paragraphId !== to.paragraphId) return 0;
+    const part = session.partFor(storyScope()) ?? session.part();
+    const paragraph = findNode(part, to.paragraphId);
+    if (!paragraph || paragraph.kind !== 'paragraph') return 0;
+    return retractedLengthOf(paragraph, from.offset, to.offset, author);
   }
 
   // Event wiring lives HERE rather than in each host, so React, Vue and a plain page get

--- a/packages/core/src/editor/surface-format.ts
+++ b/packages/core/src/editor/surface-format.ts
@@ -280,10 +280,17 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
     },
 
     setParagraphProperty(localName, attributes, options) {
+      // A RECTANGLE IS NOT THE RANGE IT STANDS IN FOR. Read as a range, a selected column
+      // runs through every cell between its corners in document order, so centring the left
+      // column of a 2x2 table also centred the cell beside it — content the user did not
+      // select. Every run-property write already asks this question; this one did not.
+      const cells = deps.selectedCells?.();
+      const rectangle =
+        cells && cells.length > 0 ? [...paragraphsInCells(currentLayout.value, cells)] : null;
       const { from, to } = orderedRange();
-      const order = deps.paragraphOrder();
-      const firstIndex = order.indexOf(from.paragraphId);
-      const lastIndex = order.indexOf(to.paragraphId);
+      const order = rectangle ?? deps.paragraphOrder();
+      const firstIndex = rectangle ? 0 : order.indexOf(from.paragraphId);
+      const lastIndex = rectangle ? order.length - 1 : order.indexOf(to.paragraphId);
       if (firstIndex === -1 || lastIndex === -1) return;
       // EVERY paragraph the selection touches, not just the one the caret is in: selecting
       // three paragraphs and pressing centre must centre three paragraphs.
@@ -319,7 +326,11 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
         };
       });
       if (ops.length === 0) return;
-      commit(() => applyOps(ops, selectionMark()));
+      // Word leaves the cells selected after a paragraph command, exactly as it does after
+      // Bold — the run-property writes above already say so.
+      commit(() => applyOps(ops, selectionMark()), undefined, {
+        keepCellSelection: rectangle !== null,
+      });
     },
 
     formatting: () =>

--- a/packages/core/src/editor/surface-hf-editing.ts
+++ b/packages/core/src/editor/surface-hf-editing.ts
@@ -80,6 +80,16 @@ export function createHeaderFooterScopeController(deps: {
    * header options bar on a document open for viewing.
    */
   entryRefused?(): boolean;
+  /**
+   * Close any OTHER story that is open before this one takes over.
+   *
+   * Two stories cannot both be the reader's. A note left open behind a header put the two
+   * scope resolvers into disagreement — one answers by header first, the other by note first
+   * — so `paragraphOrder()` listed the note's paragraphs while the selection sat in the
+   * header, and Select All followed by typing was refused as `unknown-paragraph`. The pointer
+   * path already refuses to cross stories; the toolbar command and the review rail did not.
+   */
+  leaveOtherStories?(): void;
 }): HeaderFooterScopeController {
   let activeHf: ActiveHeaderFooterScope | null = null;
   let cachedState: HeaderFooterStateSnapshot | null = null;
@@ -106,6 +116,9 @@ export function createHeaderFooterScopeController(deps: {
     if (!args.rId || deps.session.partFor({ kind: 'headerFooter', rId: args.rId }) === null) {
       return false;
     }
+    // Before anything is resolved against it: leaving a note re-scopes the layout this entry
+    // reads, so doing it afterwards would resolve the header against the note's order.
+    if (activeHf?.scope.rId !== args.rId) deps.leaveOtherStories?.();
     const layout = deps.layout();
     const found = findStoryForRId(layout, args.rId);
     const prior = activeHf;

--- a/packages/core/src/editor/surface-hf-ops.ts
+++ b/packages/core/src/editor/surface-hf-ops.ts
@@ -19,6 +19,17 @@ export function createHeaderFooterOps(deps: {
     selectionAfter?: () => SemanticSelection | null
   ) => void;
   deleteSelectionOps: () => readonly TreeDocOp[];
+  /**
+   * The removal ops AND the position they leave to insert at.
+   *
+   * `orderedStart()` is not that position: a plan that takes a table with it removes the
+   * paragraph the range started in, and an op naming a paragraph the same transaction
+   * deleted vetoes all of it.
+   */
+  deleteSelectionPlan: () => {
+    readonly ops: readonly TreeDocOp[];
+    readonly collapseTo: { paragraphId: string; offset: number };
+  };
   orderedStart: () => { paragraphId: string; offset: number };
   selectionMark: () => { paragraphId: string; start: number; end: number } | null;
   collapsedAt: (pos: { paragraphId: string; offset: number }) => SemanticSelection;
@@ -43,12 +54,16 @@ export function createHeaderFooterOps(deps: {
 
     insertPageField(field) {
       if (!deps.isHeaderFooterOpen()) return false;
-      const start = deps.orderedStart();
+      // The plan's `collapseTo`, never the range start: a deletion that takes a block with it
+      // leaves no paragraph at the start to insert into, and one refused op vetoes the whole
+      // transaction — so the field did not appear AND the deletion did not happen.
+      const plan = deps.deleteSelectionPlan();
+      const start = plan.collapseTo;
       deps.commit(
         () =>
           deps.applyOps(
             [
-              ...deps.deleteSelectionOps(),
+              ...plan.ops,
               {
                 op: 'insertPageField',
                 paragraphId: start.paragraphId,

--- a/packages/core/src/editor/surface-note-ops.ts
+++ b/packages/core/src/editor/surface-note-ops.ts
@@ -86,6 +86,8 @@ export function createNoteOps(deps: {
     readonly ops: readonly TreeDocOp[];
     readonly collapseTo: { paragraphId: string; offset: number };
   };
+  /** Take the deletion back when the note it was making room for never arrived. */
+  undo: () => void;
   activeScope: () => ViewScope;
   setActiveScopeBodyOrHf: (scope: ViewScope) => boolean;
   setSelection: (next: SemanticSelection) => void;
@@ -182,14 +184,15 @@ export function createNoteOps(deps: {
       // one with story ops. That costs a second undo step for a replacement, which is the
       // cheaper of the two prices.
       const plan = deps.deleteSelectionPlan();
+      // The plan's survivor, in the note op's own offset space — which counts what a reader
+      // SEES, so struck text is not in it. That is what puts the reference after the words a
+      // suggested deletion keeps, and where the removed words were in editing mode: one
+      // answer for both, without the correction the text lanes need.
       const start = plan.collapseTo;
-      if (plan.ops.length > 0) {
-        const removed = commitLifecycle(plan.ops, () => ({
-          anchor: { ...start },
-          head: { ...start },
-        }));
-        if (!removed) return false;
-      }
+      const removed =
+        plan.ops.length === 0 ||
+        commitLifecycle(plan.ops, () => ({ anchor: { ...start }, head: { ...start } }));
+      if (!removed) return false;
       const beforeIds = normalNoteIds(deps.session.currentPackage(), noteKind);
       const inserted = commitLifecycle(
         {
@@ -205,7 +208,13 @@ export function createNoteOps(deps: {
           return { anchor: after, head: after };
         }
       );
-      if (!inserted) return false;
+      if (!inserted) {
+        // A note is a package-level op, so it cannot share a transaction with the deletion
+        // that made room for it. If it refuses, the words are already gone with nothing to
+        // show for them — so the deletion goes back.
+        if (plan.ops.length > 0) deps.undo();
+        return false;
+      }
       const afterIds = normalNoteIds(deps.session.currentPackage(), noteKind);
       const noteId = [...afterIds].find((id) => !beforeIds.has(id));
       return noteId === undefined ? true : enterNote(formatNoteScopeId(noteKind, noteId));

--- a/packages/core/src/editor/surface-note-ops.ts
+++ b/packages/core/src/editor/surface-note-ops.ts
@@ -75,6 +75,17 @@ export function createNoteOps(deps: {
   selection: () => SemanticSelection;
   selectionMark: () => { paragraphId: string; start: number; end: number } | null;
   orderedStart: () => { paragraphId: string; offset: number };
+  /**
+   * The ops that remove the current selection, and the position left to insert at.
+   *
+   * `insertNote` used `orderedStart()` and deleted nothing, so a note inserted over a
+   * selection left the words in place and put the reference in front of them — and the
+   * restored range then covered the reference, so the next keystroke took the note with it.
+   */
+  deleteSelectionPlan: () => {
+    readonly ops: readonly TreeDocOp[];
+    readonly collapseTo: { paragraphId: string; offset: number };
+  };
   activeScope: () => ViewScope;
   setActiveScopeBodyOrHf: (scope: ViewScope) => boolean;
   setSelection: (next: SemanticSelection) => void;
@@ -89,15 +100,18 @@ export function createNoteOps(deps: {
   let activeNotePageIndex: number | null = null;
   let savedBodySelection: SemanticSelection | null = null;
 
-  const commitLifecycle = (op: TreeDocOp): boolean => {
+  const commitLifecycle = (
+    ops: TreeDocOp | readonly TreeDocOp[],
+    selectionAfter?: () => SemanticSelection | null
+  ): boolean => {
     deps.setLastRejection(null);
     deps.commit(() => {
-      const result = deps.applyOps([op], deps.selectionMark());
+      const result = deps.applyOps(Array.isArray(ops) ? ops : [ops], deps.selectionMark());
       if (result.rejected) {
         deps.setLastRejection(String(result.reason ?? 'rejected'));
       }
       return result;
-    });
+    }, selectionAfter);
     return deps.lastRejection() === null;
   };
 
@@ -159,14 +173,38 @@ export function createNoteOps(deps: {
         deps.setLastRejection('insertNote requires body scope');
         return false;
       }
-      const start = deps.orderedStart();
+      // A note REPLACES the selection, like every other insert. Nothing deleted it before, so
+      // the reference landed in front of the selected words and `enterNote` then froze that
+      // pre-insert range as the exit target — one keystroke after coming back deleted the
+      // reference, and the note itself was swept with it.
+      //
+      // TWO TRANSACTIONS, because a note is a package-level op and the session refuses to mix
+      // one with story ops. That costs a second undo step for a replacement, which is the
+      // cheaper of the two prices.
+      const plan = deps.deleteSelectionPlan();
+      const start = plan.collapseTo;
+      if (plan.ops.length > 0) {
+        const removed = commitLifecycle(plan.ops, () => ({
+          anchor: { ...start },
+          head: { ...start },
+        }));
+        if (!removed) return false;
+      }
       const beforeIds = normalNoteIds(deps.session.currentPackage(), noteKind);
-      const inserted = commitLifecycle({
-        op: 'insertNote',
-        noteKind,
-        paragraphId: start.paragraphId,
-        offset: start.offset,
-      } as TreeDocOp);
+      const inserted = commitLifecycle(
+        {
+          op: 'insertNote',
+          noteKind,
+          paragraphId: start.paragraphId,
+          offset: start.offset,
+        } as TreeDocOp,
+        // The reference occupies one model unit AT `start.offset`, so the caret belongs after
+        // it — where Word leaves it, and where the next character has to go.
+        () => {
+          const after = { paragraphId: start.paragraphId, offset: start.offset + 1 };
+          return { anchor: after, head: after };
+        }
+      );
       if (!inserted) return false;
       const afterIds = normalNoteIds(deps.session.currentPackage(), noteKind);
       const noteId = [...afterIds].find((id) => !beforeIds.has(id));

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -45,6 +45,17 @@ export interface SurfaceSelectionSyncDeps {
   /** Take a selection up WITHOUT mirroring or reporting — the caller is about to do both. */
   adoptSelection(next: SemanticSelection): void;
   commit(run: () => TreeApplyResult | boolean): void;
+  /**
+   * The surface's own write lane — attribution, protection and refusals included.
+   *
+   * The IME is the one edit that reaches the tree from here, and calling the session directly
+   * meant composed text skipped every rule the other lanes go through.
+   */
+  applyOps(
+    ops: readonly TreeDocOp[],
+    mark: { paragraphId: string; start: number; end: number } | null,
+    scope: import('@docx-editor.dev/core/store').StoryScope
+  ): TreeApplyResult;
   render(): void;
   flushLayout(): boolean;
   /** The engine's painted caret, repainted with every mirror. */
@@ -253,16 +264,11 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       : [];
     const scope = deps.storyScope();
     deps.commit(() => {
-      const result = session.applyTreeOps(
-        [...plan.ops, ...formatOps],
-        deps.selectionMark(),
-        undefined,
-        scope
-      );
+      const result = deps.applyOps([...plan.ops, ...formatOps], deps.selectionMark(), scope);
       // The composed text is not the armed format's hostage: a refused format op must not
       // take the IME's own edit down with it (the same rule `type()` follows).
       if (formatOps.length === 0 || !result.rejected) return result;
-      return session.applyTreeOps(plan.ops, deps.selectionMark(), undefined, scope);
+      return deps.applyOps(plan.ops, deps.selectionMark(), scope);
     });
     deps.setSelection(collapsedAt({ paragraphId, offset: plan.caret }));
   }

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -278,7 +278,13 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
    * armed pointerdown/selectstart is that gesture; a queued selectionchange echo has none.
    */
   function isStaleMirroredCaret(): boolean {
-    if (!modelMoved || !lastMirroredSelection || userSelectionGesture) return false;
+    if (!modelMoved || userSelectionGesture) return false;
+    // NO BASELINE AT ALL means the last mirror was REFUSED — the position had no painted
+    // place to land, or this surface did not own the selection. The browser is then still
+    // showing something older than the model by construction, and nobody has gestured since.
+    // Reading it back is how a caret the DOM could not express became a caret at the
+    // paragraph start.
+    if (!lastMirroredSelection) return true;
     const reported = semanticSelectionFromDom(pagesLayer, document.getSelection());
     return reported !== null && selectionsEqual(reported, lastMirroredSelection);
   }
@@ -313,8 +319,22 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // that runs on every repaint. A rectangle of cells keeps the DOM deliberately collapsed,
       // so a scroll or an undo would "adopt" that collapse, leave the overlay painting four
       // cells, and turn the next Delete into a one-character edit inside one of them.
+      //
+      // A REPAINT MAY CARRY A GESTURE; IT MAY NEVER INVENT ONE. `modelMoved` is spent by the
+      // first repaint after a commit, and an edit can produce more than one — a settled image
+      // resource, a deferred publish, a scroll all repaint again while the caret this edit
+      // installed is still the newest thing anybody moved. Those later repaints used to read
+      // the browser's selection and take it, and the browser's answer after a page's DOM has
+      // been rebuilt under it is the paragraph start. So the first character typed at the end
+      // of a paragraph landed, the caret went home to offset 0, and every character after it
+      // was inserted in front of the one before: "Hello" arrived as "elloH".
+      //
+      // The provenance is the whole test. A gesture arms `userSelectionGesture` on
+      // pointerdown/selectstart before `selectionchange` is queued, which is exactly the
+      // window this reader exists to close; a browser fix-up after a repaint arms nothing.
       const holdOff = deps.holdsCellSelection?.() === true || deps.isGesturing?.() === true;
-      const adopted = modelMoved || holdOff ? false : adoptPendingDomSelection();
+      const adopted =
+        modelMoved || holdOff || !userSelectionGesture ? false : adoptPendingDomSelection();
       modelMoved = false;
       return adopted;
     },
@@ -343,11 +363,19 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       applyingSelection = true;
       const began = deps.now();
       const next = deps.domSelection?.() ?? deps.selection();
-      lastMirroredSelection = next;
       // This write is the new baseline. Matching DOM carets after it are echoes until the
       // user starts another selection gesture.
       userSelectionGesture = false;
-      applySelectionToDom(pagesLayer, next, document.getSelection());
+      const wrote = applySelectionToDom(pagesLayer, next, document.getSelection());
+      // A REFUSED write is not a baseline. `applySelectionToDom` answers false when either
+      // endpoint has no painted place to land — a caret in a paragraph that painted no spans,
+      // an offset no span covers, a page that is not built — and the browser then keeps
+      // showing the PREVIOUS selection. Recording it anyway told `isStaleMirroredCaret` that
+      // the DOM had been given this value, so the disagreement it exists to catch read as a
+      // fresh gesture, and the stale caret won the next echo. The model is still the newer of
+      // the two here, which is exactly what `modelMoved` says.
+      lastMirroredSelection = wrote ? next : null;
+      if (!wrote) modelMoved = true;
       deps.recordSelectionMs(deps.now() - began);
       // Cleared on a LATER task, because `selectionchange` is queued rather than dispatched
       // synchronously. Clearing it here would defeat the guard in every real browser while
@@ -372,6 +400,12 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // `adoptDomSelection` spends the one-shot once it sees a mapped caret, so a click on
       // the already-current caret cannot authorize a later stale echo.
       if (isStaleMirroredCaret()) return;
+      // A KEYSTROKE IS NOT A SELECTION GESTURE. This reader exists for one case — a click or
+      // a drag whose `selectionchange` is still queued when the next key arrives — and that
+      // case always arms the flag first. Without the check, every keystroke re-read a browser
+      // selection nobody had moved, so a caret the DOM had resolved onto a container after a
+      // repaint pulled the model to the paragraph start on key after key.
+      if (!userSelectionGesture) return;
       adoptDomSelection();
     },
 

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -100,6 +100,24 @@ export interface SurfaceSelectionSyncDeps {
    * and every explicit gesture goes through `setSelection`, which clears it.
    */
   holdsCellSelection?(): boolean;
+  /**
+   * Whether typed characters are buffered and have not reached the tree yet.
+   *
+   * A burst is held on a zero-delay task, and the position a gesture maps to is read from a
+   * DOM those characters are not in — so adopting it would land the burst wherever the
+   * gesture went. The buffer cannot be flushed from here: this runs as the first statement of
+   * a render, and a flush commits, which renders. The gesture is not lost by waiting; the
+   * flush is the very next task, and its own render adopts it with the flag still armed.
+   */
+  hasPendingInput?(): boolean;
+  /**
+   * Where text replacing `[from, to)` of one paragraph belongs.
+   *
+   * In suggesting mode a deletion keeps the characters it strikes, so the replacement goes
+   * AFTER them; the diff this lane computes is against the painted text and knows nothing of
+   * that. Composed text landed in front of the word it replaced until it asked.
+   */
+  replacementOffset?(paragraphId: string, from: number, to: number): number;
 }
 
 export interface SurfaceSelectionSync {
@@ -256,21 +274,39 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
     // one undo step. Asked BEFORE the commit (which retires the armed state), and only for
     // an insert landing exactly on the armed anchor; a diff that resolved elsewhere simply
     // forgets the format. Story scope routes IME commits into an open HF/note part.
+    const remove = plan.ops.find(
+      (op): op is Extract<(typeof plan.ops)[number], { op: 'deleteText' }> => op.op === 'deleteText'
+    );
     const insert = plan.ops.find(
       (op): op is Extract<(typeof plan.ops)[number], { op: 'insertText' }> => op.op === 'insertText'
     );
+    // The diff's offset is the pre-delete one. Suggesting keeps the struck characters, so
+    // that offset now points in FRONT of them.
+    const landing =
+      insert && remove
+        ? deps.replacementOffset?.(paragraphId, remove.start, remove.end)
+        : undefined;
+    const ops =
+      insert && landing !== undefined && landing !== insert.offset
+        ? plan.ops.map((op) => (op === insert ? { ...insert, offset: landing } : op))
+        : plan.ops;
     const formatOps = insert
-      ? (deps.pendingFormatOps?.(paragraphId, insert.offset, insert.text.length) ?? [])
+      ? (deps.pendingFormatOps?.(paragraphId, landing ?? insert.offset, insert.text.length) ?? [])
       : [];
     const scope = deps.storyScope();
     deps.commit(() => {
-      const result = deps.applyOps([...plan.ops, ...formatOps], deps.selectionMark(), scope);
+      const result = deps.applyOps([...ops, ...formatOps], deps.selectionMark(), scope);
       // The composed text is not the armed format's hostage: a refused format op must not
       // take the IME's own edit down with it (the same rule `type()` follows).
       if (formatOps.length === 0 || !result.rejected) return result;
-      return deps.applyOps(plan.ops, deps.selectionMark(), scope);
+      return deps.applyOps(ops, deps.selectionMark(), scope);
     });
-    deps.setSelection(collapsedAt({ paragraphId, offset: plan.caret }));
+    deps.setSelection(
+      collapsedAt({
+        paragraphId,
+        offset: insert && landing !== undefined ? landing + insert.text.length : plan.caret,
+      })
+    );
   }
 
   /**
@@ -338,10 +374,16 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // The provenance is the whole test. A gesture arms `userSelectionGesture` on
       // pointerdown/selectstart before `selectionchange` is queued, which is exactly the
       // window this reader exists to close; a browser fix-up after a repaint arms nothing.
-      const holdOff = deps.holdsCellSelection?.() === true || deps.isGesturing?.() === true;
+      const holdOff =
+        deps.holdsCellSelection?.() === true ||
+        deps.isGesturing?.() === true ||
+        deps.hasPendingInput?.() === true;
       const adopted =
         modelMoved || holdOff || !userSelectionGesture ? false : adoptPendingDomSelection();
-      modelMoved = false;
+      // Spent only when the buffer is not holding the answer back: a repaint that deferred to
+      // the flush has not made the decision this flag records, and clearing it would let the
+      // NEXT repaint adopt a DOM the commit is about to move.
+      if (deps.hasPendingInput?.() !== true) modelMoved = false;
       return adopted;
     },
 

--- a/packages/core/src/editor/table-command-plan.ts
+++ b/packages/core/src/editor/table-command-plan.ts
@@ -381,20 +381,30 @@ function columnOccurrenceTargetOf(command: EditorCommand): TableColumnOccurrence
  * dragging across two rows and deleting removed one of them and reported success. Answers a
  * single-element list for an ordinary caret, which is the same command with a smaller set.
  */
-function rowIdsOfSelection(part: OoxmlPart, anchor: ResolvedAnchor): readonly string[] {
+function rowIdsOfSelection(
+  part: OoxmlPart,
+  anchor: ResolvedAnchor
+): { readonly rowIds: readonly string[]; readonly wholeTable: boolean } {
   const topo = readEditableTableTopology(part.root, anchor.tableId);
-  if (!topo.ok) return [anchor.rowId];
+  if (!topo.ok) return { rowIds: [anchor.rowId], wholeTable: false };
   const selected = new Set(anchor.cellIds);
-  const rows = topo.topology.rows
+  const rowIds = topo.topology.rows
     .filter((entry) => entry.cells.some((cell) => selected.has(cell.id)))
     .map((entry) => entry.row.id);
-  return rows.length > 0 ? rows : [anchor.rowId];
+  if (rowIds.length === 0) return { rowIds: [anchor.rowId], wholeTable: false };
+  // A table has to keep one row (`CT_Tbl`), and `deleteTableRow` says so by refusing the
+  // last one — a refusal that takes the whole transaction, so selecting every row and
+  // pressing Delete Rows would delete NOTHING. Word deletes the table.
+  return { rowIds, wholeTable: rowIds.length === topo.topology.rows.length };
 }
 
 /** The grid columns a cell rectangle covers, by id, left to right. */
-function gridColumnIdsOfSelection(part: OoxmlPart, anchor: ResolvedAnchor): readonly string[] {
+function gridColumnIdsOfSelection(
+  part: OoxmlPart,
+  anchor: ResolvedAnchor
+): { readonly gridColumnIds: readonly string[]; readonly wholeTable: boolean } {
   const topo = readEditableTableTopology(part.root, anchor.tableId);
-  if (!topo.ok || !topo.topology.grid) return [];
+  if (!topo.ok || !topo.topology.grid) return { gridColumnIds: [], wholeTable: false };
   const selected = new Set(anchor.cellIds);
   const columns = new Set<string>();
   for (const entry of topo.topology.rows) {
@@ -412,7 +422,12 @@ function gridColumnIdsOfSelection(part: OoxmlPart, anchor: ResolvedAnchor): read
       cursor += span;
     }
   }
-  return [...columns];
+  // The last column is refused for the reason the last row is, and would veto the whole
+  // transaction with it. Word deletes the table.
+  return {
+    gridColumnIds: [...columns],
+    wholeTable: columns.size > 0 && columns.size === topo.topology.gridColumns.length,
+  };
 }
 
 function gridColumnIdAt(part: OoxmlPart, tableId: string, columnIndex: number): string | null {
@@ -760,12 +775,15 @@ export function planTableCommand(input: TableCommandPlannerInput): TableCommandP
       if (!anchor) return refusal('unsupported', 'the selection is not inside a table');
       // EVERY row the selection covers. One op named the anchor's row alone, so a rectangle
       // spanning two rows lost one of them and the command still answered `ok: true`.
-      const ops: TreeDocOp[] = rowIdsOfSelection(part, anchor).map((rowId) => ({
-        op: 'deleteTableRow',
-        tableId: anchor.tableId,
-        rowId,
-        ...(rowId === anchor.rowId ? { referenceCellId: anchor.cellId } : {}),
-      }));
+      const selectedRows = rowIdsOfSelection(part, anchor);
+      const ops: TreeDocOp[] = selectedRows.wholeTable
+        ? [{ op: 'deleteBlock', blockId: anchor.tableId }]
+        : selectedRows.rowIds.map((rowId) => ({
+            op: 'deleteTableRow',
+            tableId: anchor.tableId,
+            rowId,
+            ...(rowId === anchor.rowId ? { referenceCellId: anchor.cellId } : {}),
+          }));
       return planValidated(part, ops, { kind: 'adoptCommittedCaret' });
     }
     case 'insertColumn': {
@@ -798,13 +816,22 @@ export function planTableCommand(input: TableCommandPlannerInput): TableCommandP
       }
       // Every column the rectangle covers, for the reason Delete Rows states above. An
       // explicit occurrence target names one column on purpose and keeps it.
-      const gridColumnIds =
+      const selectedColumns =
         columnTarget?.gridColumnId === undefined
           ? gridColumnIdsOfSelection(part, anchor)
-          : [gridColumnId];
-      const ops: TreeDocOp[] = (gridColumnIds.length > 0 ? gridColumnIds : [gridColumnId]).map(
-        (id) => ({ op: 'deleteTableColumn', tableId, gridColumnId: id })
-      );
+          : { gridColumnIds: [gridColumnId], wholeTable: false };
+      if (selectedColumns.wholeTable) {
+        return planValidated(part, [{ op: 'deleteBlock', blockId: tableId }], {
+          kind: 'adoptCommittedCaret',
+        });
+      }
+      const ids =
+        selectedColumns.gridColumnIds.length > 0 ? selectedColumns.gridColumnIds : [gridColumnId];
+      const ops: TreeDocOp[] = ids.map((id) => ({
+        op: 'deleteTableColumn',
+        tableId,
+        gridColumnId: id,
+      }));
       return planValidated(part, ops, { kind: 'adoptCommittedCaret' });
     }
     case 'deleteTable': {

--- a/packages/core/src/editor/table-command-plan.ts
+++ b/packages/core/src/editor/table-command-plan.ts
@@ -374,6 +374,47 @@ function columnOccurrenceTargetOf(command: EditorCommand): TableColumnOccurrence
   return validateColumnOccurrenceTarget(command.target) ? command.target : null;
 }
 
+/**
+ * The rows a cell RECTANGLE covers, in table order.
+ *
+ * A rectangle is a set of cells, and Delete Rows read only the row of its first one — so
+ * dragging across two rows and deleting removed one of them and reported success. Answers a
+ * single-element list for an ordinary caret, which is the same command with a smaller set.
+ */
+function rowIdsOfSelection(part: OoxmlPart, anchor: ResolvedAnchor): readonly string[] {
+  const topo = readEditableTableTopology(part.root, anchor.tableId);
+  if (!topo.ok) return [anchor.rowId];
+  const selected = new Set(anchor.cellIds);
+  const rows = topo.topology.rows
+    .filter((entry) => entry.cells.some((cell) => selected.has(cell.id)))
+    .map((entry) => entry.row.id);
+  return rows.length > 0 ? rows : [anchor.rowId];
+}
+
+/** The grid columns a cell rectangle covers, by id, left to right. */
+function gridColumnIdsOfSelection(part: OoxmlPart, anchor: ResolvedAnchor): readonly string[] {
+  const topo = readEditableTableTopology(part.root, anchor.tableId);
+  if (!topo.ok || !topo.topology.grid) return [];
+  const selected = new Set(anchor.cellIds);
+  const columns = new Set<string>();
+  for (const entry of topo.topology.rows) {
+    // The grid position is the running sum of the spans before it — the same walk
+    // `anchorForGridColumn` does, because a merged cell occupies more than one column.
+    let cursor = 0;
+    for (const cell of entry.cells) {
+      const span = readCellGridSpan(cell);
+      if (selected.has(cell.id)) {
+        for (let step = 0; step < span; step += 1) {
+          const column = topo.topology.gridColumns[cursor + step];
+          if (column) columns.add(column.id);
+        }
+      }
+      cursor += span;
+    }
+  }
+  return [...columns];
+}
+
 function gridColumnIdAt(part: OoxmlPart, tableId: string, columnIndex: number): string | null {
   const topo = readEditableTableTopology(part.root, tableId);
   if (!topo.ok || !topo.topology.grid) return null;
@@ -717,13 +758,15 @@ export function planTableCommand(input: TableCommandPlannerInput): TableCommandP
     }
     case 'deleteRow': {
       if (!anchor) return refusal('unsupported', 'the selection is not inside a table');
-      const op: TreeDocOp = {
+      // EVERY row the selection covers. One op named the anchor's row alone, so a rectangle
+      // spanning two rows lost one of them and the command still answered `ok: true`.
+      const ops: TreeDocOp[] = rowIdsOfSelection(part, anchor).map((rowId) => ({
         op: 'deleteTableRow',
         tableId: anchor.tableId,
-        rowId: anchor.rowId,
-        referenceCellId: anchor.cellId,
-      };
-      return planValidated(part, [op], { kind: 'adoptCommittedCaret' });
+        rowId,
+        ...(rowId === anchor.rowId ? { referenceCellId: anchor.cellId } : {}),
+      }));
+      return planValidated(part, ops, { kind: 'adoptCommittedCaret' });
     }
     case 'insertColumn': {
       if (!anchor) return refusal('unsupported', 'the selection is not inside a table');
@@ -753,12 +796,16 @@ export function planTableCommand(input: TableCommandPlannerInput): TableCommandP
       if (!gridColumnId) {
         return refusal('invalidArgs', 'the table has no grid column to delete');
       }
-      const op: TreeDocOp = {
-        op: 'deleteTableColumn',
-        tableId,
-        gridColumnId,
-      };
-      return planValidated(part, [op], { kind: 'adoptCommittedCaret' });
+      // Every column the rectangle covers, for the reason Delete Rows states above. An
+      // explicit occurrence target names one column on purpose and keeps it.
+      const gridColumnIds =
+        columnTarget?.gridColumnId === undefined
+          ? gridColumnIdsOfSelection(part, anchor)
+          : [gridColumnId];
+      const ops: TreeDocOp[] = (gridColumnIds.length > 0 ? gridColumnIds : [gridColumnId]).map(
+        (id) => ({ op: 'deleteTableColumn', tableId, gridColumnId: id })
+      );
+      return planValidated(part, ops, { kind: 'adoptCommittedCaret' });
     }
     case 'deleteTable': {
       if (!anchor) return refusal('unsupported', 'the selection is not inside a table');

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -406,9 +406,11 @@ export function resolveStoryListItems(
       advanced.level.lvlJc,
       advanced.level.suff,
       advanced.level.vanish ? 1 : 0,
-      // Not the ordinal — its LENGTH. The first line starts where the marker ends whenever
-      // the marker overflows its hanging slot, so `9.` and `10.` can break differently.
-      markerText.length,
+      // The MARKER ITSELF, not its length. The first line starts where the marker ends
+      // whenever the marker overflows its hanging slot, so `9.` and `10.` break differently —
+      // and so do `ii.` and `vi.`, which the length cannot tell apart. A warm cache then
+      // served the previous marker's width to the new one, and the line wrapped a word late.
+      markerText,
     ].join('|');
 
     map.set(paragraph.id, {

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -746,6 +746,20 @@ function bodyUsedHeight(page: PageRecord): number {
 
 /** Remove note-pass output before recomputing it from canonical references. */
 function bodyOnlyPage(page: PageRecord): PageRecord {
+  // IDENTITY WHEN THERE IS NOTHING TO STRIP. The rest-destructure allocates a new object
+  // every time, and a page record is what the painter reuses BY IDENTITY — so a document
+  // with a notes part and no notes at all handed the painter a whole new set of pages on
+  // every pass, and every visible page's DOM was rebuilt on every keystroke. The lane runs
+  // for any package that HAS a footnotes or endnotes part, which is nearly every Word file.
+  // Its three siblings — `withPageFieldSources`, `attachContentControlBoundaries` and
+  // `reprojectBodyNoteMarks` — all return the original page when nothing moved.
+  if (
+    page.footnotes === undefined &&
+    page.endnotes === undefined &&
+    page.noteStream === undefined
+  ) {
+    return page;
+  }
   const { footnotes, endnotes, noteStream, ...body } = page;
   void footnotes;
   void endnotes;
@@ -1825,9 +1839,12 @@ export function attachNotesToLayout(
       carry = built.nextCarry;
     }
 
+    // Same rule one level up: a page with no footnote area and nothing to strip is the page
+    // it came in as, and saying so is what lets the painter keep its DOM.
+    if (!footnotes) return bodyPage;
     return {
       ...bodyPage,
-      ...(footnotes ? { footnotes } : {}),
+      footnotes,
     };
   });
 

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -403,6 +403,16 @@ interface PreparedBlockMemo {
   readonly contentWidth: number;
   readonly producer: string;
   readonly drawingToken: string;
+  /**
+   * The resolved list item this entry was prepared under, by its own cache token.
+   *
+   * The entry embeds the item's indent, its available width and its break-cache key, and none
+   * of the other three validators can see a numbering change. The producer used to carry the
+   * item COUNT, which hid this by going cold on any list edit — and by re-laying out every
+   * paragraph in the document for one Enter in a list. With the count gone, this is the guard
+   * that has to be right.
+   */
+  readonly listToken: string;
   readonly entry: PreparedBlock;
 }
 
@@ -739,7 +749,13 @@ function layoutBlocksPass(
     // broken lines, so the break cache holds the citation's width under a key built from
     // this. Keying only the section left a warm cache serving `1`-wide slots to roman marks.
     (options.noteMarks ? `|nm:${noteMarksCacheToken(options.noteMarks)}` : '') +
-    (listItems && listItems.size > 0 ? `|num:${listItems.size}` : '') +
+    // NOT THE NUMBER OF LIST ITEMS. `producer` is in the session context, in every paragraph's
+    // break-cache key and in the prepared-block memo, so folding a COUNT in meant one Enter in
+    // a list re-measured every paragraph in the document and rebuilt every page — while two
+    // different numbering states with the same count still hashed the same. What a numbering
+    // change actually affects is each list paragraph, and each one carries its own
+    // `listItem.cacheToken` in its key and in the memo above.
+
     (defaultTabStopPt !== undefined ? `|dts:${defaultTabStopPt}` : '') +
     (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`);
 
@@ -835,12 +851,14 @@ function layoutBlocksPass(
         : block.kind === 'table' && options.drawingTokenForParagraph
           ? drawingTokenForTableBlock(block, options.drawingTokenForParagraph)
           : '';
+    const listToken = listItems?.get(block.id)?.cacheToken ?? '';
     const memo = preparedBlocks.get(block);
     if (
       memo &&
       memo.contentWidth === availableWidth &&
       memo.producer === producer &&
-      memo.drawingToken === paragraphDrawingToken
+      memo.drawingToken === paragraphDrawingToken &&
+      memo.listToken === listToken
     ) {
       return memo.entry;
     }
@@ -931,6 +949,7 @@ function layoutBlocksPass(
       contentWidth: availableWidth,
       producer,
       drawingToken: paragraphDrawingToken,
+      listToken,
       entry,
     });
     return entry;

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -416,6 +416,25 @@ interface PreparedBlockMemo {
   readonly entry: PreparedBlock;
 }
 
+/** Aggregate the list tokens of every paragraph a table contains, for its memo key. */
+function listTokenForTableBlock(
+  table: OoxmlNode,
+  listItems: ReadonlyMap<string, ResolvedListItem> | undefined
+): string {
+  if (!listItems || listItems.size === 0) return '';
+  const tokens: string[] = [];
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'paragraph') {
+      const token = listItems.get(node.id)?.cacheToken;
+      if (token) tokens.push(token);
+      return;
+    }
+    if ('children' in node) for (const child of node.children) visit(child);
+  };
+  visit(table);
+  return tokens.join(';');
+}
+
 const preparedBlocks = new WeakMap<OoxmlNode, PreparedBlockMemo>();
 const drawingSourceOrderByContext = new WeakMap<
   InlineDrawingLayoutContext,
@@ -851,7 +870,15 @@ function layoutBlocksPass(
         : block.kind === 'table' && options.drawingTokenForParagraph
           ? drawingTokenForTableBlock(block, options.drawingTokenForParagraph)
           : '';
-    const listToken = listItems?.get(block.id)?.cacheToken ?? '';
+    // A TABLE'S LIST STATE IS ITS CELLS'. `listItems` is keyed by PARAGRAPH, and a numbered
+    // list that continues inside a table cell has its markers there — so reading the table's
+    // own id gave an empty token, and a renumbering that left the table's flow key untouched
+    // reused the cell markers verbatim. The drawing token aggregates the same way, for the
+    // same reason.
+    const listToken =
+      block.kind === 'table'
+        ? listTokenForTableBlock(block, listItems)
+        : (listItems?.get(block.id)?.cacheToken ?? '');
     const memo = preparedBlocks.get(block);
     if (
       memo &&

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -403,12 +403,55 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
       }
       return applyParagraphMarkRevision(part, paragraph, op.kind, op.revision, options);
     }
-    case 'proposeParagraphMerge':
+    case 'proposeParagraphMerge': {
+      // THE SAME RULE, ON THE LANE BACKSPACE ACTUALLY TAKES. A join is addressed by the
+      // SECOND paragraph, because the mark between two paragraphs belongs to the first — so
+      // the mark being proposed away here is the PREVIOUS paragraph's, and the case above
+      // never sees it. Enter then Backspace in suggesting mode therefore stacked a `w:del`
+      // on the `w:ins` the same author had written a second earlier: two cards in the rail
+      // for a decision nobody made, an empty paragraph left standing in the document, and a
+      // mark whose Reject makes permanent the very break the user just took back.
+      const parent = parentOf(part, paragraph.id);
+      const at = parent?.children.findIndex((child) => child.id === paragraph.id) ?? -1;
+      const previous = at > 0 ? parent?.children[at - 1] : undefined;
+      if (
+        previous &&
+        previous.kind === 'paragraph' &&
+        retractsOwnParagraphMark(previous, op.revision.author)
+      ) {
+        return applyJoin(part, previous.id, paragraph.id, options);
+      }
       return applyProposeParagraphMerge(part, paragraph, op.revision, options);
+    }
     case 'splitParagraph':
       return applySplit(part, paragraph, op.offset, options);
-    case 'splitParagraphMany':
-      return applySplitMany(part, paragraph, op.offsets, options);
+    case 'splitParagraphMany': {
+      const split = applySplitMany(part, paragraph, op.offsets, options);
+      if (!op.revision || !split.ok) return split;
+      // EVERY BOUNDARY IS A MARK THIS AUTHOR IS ADDING. `splitParagraph` proposes its one
+      // break through a companion `setParagraphMarkRevision`, which the caller can address
+      // because the paragraph exists before the op. The many-split mints its paragraphs here,
+      // so the marks have to be stamped here too: on the head and on every tail except the
+      // last, which keeps the mark the original paragraph already had. Paste is the lane that
+      // emits this op, and without it a multi-line paste in suggesting mode tracked its text
+      // and not its breaks — Reject left the extra paragraphs behind for good.
+      const marked = [paragraph.id, ...split.effect.created.slice(0, -1)];
+      let current = split;
+      for (const id of marked) {
+        const target = findNode(current.part, id);
+        if (!target || target.kind !== 'paragraph') continue;
+        const stamped = applyParagraphMarkRevision(
+          current.part,
+          target,
+          'ins',
+          op.revision,
+          options
+        );
+        if (!stamped.ok) return stamped;
+        current = { ...stamped, effect: { ...split.effect } };
+      }
+      return current;
+    }
     case 'setRunProperties':
       return applySetRunProperties(
         part,
@@ -2182,7 +2225,17 @@ function divideInline(
   segments: readonly Segment[],
   nextId: () => string
 ): { readonly head: OoxmlNode | null; readonly tail: OoxmlNode | null } {
-  if (child.kind === 'hyperlink' || isContentControlNode(child)) {
+  // A REVISION WRAPPER SPLITS LIKE A HYPERLINK. `w:ins` and `w:del` are containers of run
+  // content, not run content, so the "not a run, keep it whole" answer below put an entire
+  // tracked insertion into the HEAD half however far into it the caret was: pressing Enter in
+  // the middle of somebody's suggested sentence broke the paragraph after the suggestion
+  // instead of at the caret, and said nothing. Both halves keep the same author, date and id,
+  // which is how a reader groups them back into one decision.
+  if (
+    child.kind === 'hyperlink' ||
+    isContentControlNode(child) ||
+    (child.kind !== 'textValue' && isContentRevisionKind(child.kind))
+  ) {
     // Exclude textValue so both the wrapper and its content owner expose `.children`.
     if (child.kind === 'textValue') return { head: child, tail: null };
     const contentOwner = isContentControlNode(child) ? contentControlContentOf(child) : child;
@@ -2214,7 +2267,7 @@ function divideInline(
         if (divided.tail) tailChildren.push(divided.tail);
       }
     }
-    if (child.kind === 'hyperlink') {
+    if (child.kind === 'hyperlink' || isContentRevisionKind(child.kind)) {
       return {
         head: headChildren.length > 0 ? withChildren(child, headChildren, null) : null,
         tail: tailChildren.length > 0 ? withChildren(child, tailChildren, nextId) : null,

--- a/packages/core/src/store/store/tree-op-blocks.ts
+++ b/packages/core/src/store/store/tree-op-blocks.ts
@@ -30,7 +30,7 @@ export function paragraphIdsWithin(node: OoxmlNode): string[] {
   return ids;
 }
 
-/** Body-order paragraph ids for caret recovery after a block removal. */
+/** Story-order paragraph ids for caret recovery after a block removal. */
 function paragraphIdsInDocumentOrder(part: OoxmlPart): string[] {
   const ids: string[] = [];
   const walkBlocks = (children: readonly OoxmlNode[]): void => {
@@ -53,12 +53,18 @@ function paragraphIdsInDocumentOrder(part: OoxmlPart): string[] {
       }
     }
   };
-  const bodyNode =
+  // WHICHEVER STORY THIS PART IS. A header, a footer and a notes part are roots in their own
+  // right (`w:hdr`, `w:ftr`, `w:footnotes`), and looking only for a `w:body` handed back an
+  // empty order for every one of them — so no surviving caret could be found and EVERY block
+  // removal in furniture was refused as `block-required`. Word letterheads are built on
+  // layout tables, so that was most of them: select the table, press Delete, nothing happens,
+  // and the text half of the same deletion is vetoed with it.
+  const storyRoot =
     part.root.kind === 'body'
       ? part.root
-      : part.root.children.find((child) => child.kind === 'body');
-  if (!bodyNode || bodyNode.kind === 'textValue') return ids;
-  walkBlocks(bodyNode.children);
+      : (part.root.children.find((child) => child.kind === 'body') ?? part.root);
+  if (storyRoot.kind === 'textValue') return ids;
+  walkBlocks(storyRoot.children);
   return ids;
 }
 

--- a/packages/core/src/store/store/tree-op-retraction.ts
+++ b/packages/core/src/store/store/tree-op-retraction.ts
@@ -1,0 +1,76 @@
+// Whose words are these — the two questions a tracked deletion asks (tracked-edits seam).
+//
+// `applyDeleteTracked` does one of two different things to the characters it covers, and the
+// answer turns on the run's ancestry alone: a run already inside a `w:del` is left as it is,
+// a run inside the author's OWN `w:ins` is RETRACTED (it leaves the paragraph, because those
+// words were never anyone else's to see), and everything else is STRUCK in place.
+//
+// The predicates live here rather than in the writer because a CALLER has to be able to ask
+// the same question before it builds a plan. Striking keeps offsets; retracting moves every
+// offset past it to the left. A replacement aimed past a selection that turns out to be
+// retracted is aimed past the end of the paragraph, which the store refuses — and a refusal
+// takes the whole transaction, so the keystroke does nothing at all.
+
+import type { OoxmlNode, OoxmlParagraphNode } from '../package/ooxml-tree.ts';
+import { WML_NAMESPACE_URI } from '../package/ooxml-tree.ts';
+import { paragraphOffsetIndex } from './tree-op-segments.ts';
+
+/** The author of the enclosing `w:ins`, when there is one. */
+export function insertionAuthor(stack: readonly OoxmlNode[]): string | null {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    const node = stack[index]!;
+    if (node.kind === 'textValue') continue;
+    if (node.kind !== 'revisionInsert') continue;
+    const found = node.attributes.find(
+      (attribute) =>
+        attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'author'
+    );
+    return found?.value ?? '';
+  }
+  return null;
+}
+
+/** Whether the run is already struck, in which case a deletion has nothing left to say. */
+export function insideDeletion(stack: readonly OoxmlNode[]): boolean {
+  return stack.some((node) => node.kind !== 'textValue' && node.kind === 'revisionDelete');
+}
+
+/**
+ * How much of `[start, end)` a tracked deletion RETRACTS instead of striking.
+ *
+ * Struck text stays in the paragraph and keeps its offsets, so everything after it still
+ * means what it meant. Retracted text leaves, so every offset past it moves left by its
+ * length. A caller that replaces a range needs the difference to aim the replacement.
+ *
+ * Answers from the same walk the writer uses, so the two cannot drift apart: a run outside a
+ * `w:del` whose nearest `w:ins` is this author's, measured in the paragraph's own offset
+ * space rather than in characters.
+ */
+export function retractedLengthOf(
+  paragraph: OoxmlParagraphNode,
+  start: number,
+  end: number,
+  author: string
+): number {
+  if (end <= start) return 0;
+  const offsets = paragraphOffsetIndex(paragraph);
+  let retracted = 0;
+  const walk = (nodes: readonly OoxmlNode[], stack: readonly OoxmlNode[]): void => {
+    for (const node of nodes) {
+      if (node.kind === 'textValue') continue;
+      const span = offsets.spanOf(node);
+      // No span means the offset walk never reached it: it holds no addressable characters,
+      // and a deletion leaves it standing — the same reading the writer gives a node of
+      // length zero.
+      if (!span || span.end <= start || span.start >= end) continue;
+      if (node.kind === 'run') {
+        if (insideDeletion(stack) || insertionAuthor(stack) !== author) continue;
+        retracted += Math.min(end, span.end) - Math.max(start, span.start);
+        continue;
+      }
+      walk(node.children, [...stack, node]);
+    }
+  };
+  walk(paragraph.children, []);
+  return retracted;
+}

--- a/packages/core/src/store/store/tree-op-revisions.ts
+++ b/packages/core/src/store/store/tree-op-revisions.ts
@@ -590,6 +590,18 @@ function rebuildChildren(children: readonly OoxmlNode[], plan: RebuildPlan): Oox
 
   for (const [index, child] of children.entries()) {
     if (child.kind !== 'textValue' && plan.removeRows.has(child.id)) continue;
+    // A TABLE WITHOUT ROWS IS NOT A TABLE. `CT_Tbl` requires at least one `w:tr`, and the
+    // structural op says the same by refusing to delete a table's last row (`block-required`).
+    // Accepting the tracked deletion of the only row wrote exactly that shape: an invisible
+    // zero-row block left standing above the reader's content, which the rest of the engine
+    // then treats as illegal. The table goes with its last row, as it does in Word.
+    if (
+      child.kind === 'table' &&
+      child.children.every((row) => row.kind !== 'tableRow' || plan.removeRows.has(row.id)) &&
+      child.children.some((row) => row.kind === 'tableRow')
+    ) {
+      continue;
+    }
     if (child.kind !== 'textValue' && plan.dropMarks.has(child.id)) continue;
     if (child.kind !== 'textValue' && plan.restoreProperties.has(child.id)) continue;
     const action = child.kind === 'textValue' ? undefined : plan.actions.get(child.id);

--- a/packages/core/src/store/store/tree-op-tracked.ts
+++ b/packages/core/src/store/store/tree-op-tracked.ts
@@ -41,6 +41,7 @@ import {
 import { equivalentNodes } from './ooxml-node-equality.ts';
 import { TEXT_DEPS, fromEdit } from './tree-op-nodes.ts';
 import { paragraphOffsetIndex, type ParagraphOffsetIndex } from './tree-op-segments.ts';
+import { insertionAuthor, insideDeletion } from './tree-op-retraction.ts';
 import type { RevisionAttributionInput, TreeOpEffect, TreeOpResult } from './tree-op-validate.ts';
 
 function attr(localName: string, value: string) {
@@ -244,25 +245,6 @@ function deletionId(node: OoxmlNode): string | null {
       (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id'
     )?.value ?? null
   );
-}
-
-/** The author of the enclosing `w:ins`, when there is one. */
-function insertionAuthor(stack: readonly OoxmlNode[]): string | null {
-  for (let index = stack.length - 1; index >= 0; index -= 1) {
-    const node = stack[index]!;
-    if (node.kind === 'textValue') continue;
-    if (node.kind !== 'revisionInsert') continue;
-    const found = node.attributes.find(
-      (attribute) =>
-        attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'author'
-    );
-    return found?.value ?? '';
-  }
-  return null;
-}
-
-function insideDeletion(stack: readonly OoxmlNode[]): boolean {
-  return stack.some((node) => node.kind !== 'textValue' && node.kind === 'revisionDelete');
 }
 
 interface Cursor {

--- a/packages/core/src/store/store/tree-op-types.ts
+++ b/packages/core/src/store/store/tree-op-types.ts
@@ -364,6 +364,14 @@ export type TreeDocOp =
        * offset produces an empty paragraph between the two boundaries — a blank line.
        */
       readonly offsets: readonly number[];
+      /**
+       * Propose the breaks rather than making them, exactly as the single split does.
+       *
+       * Every boundary is a paragraph mark this author is adding, so each paragraph that
+       * PRECEDES one carries `w:rPr/w:ins`. Without it a multi-line paste in suggesting mode
+       * tracked its text and not its breaks, and Reject left the extra paragraphs standing.
+       */
+      readonly revision?: RevisionAttributionInput;
     }
   | { readonly op: 'joinParagraphs'; readonly firstId: string; readonly secondId: string }
   | {


### PR DESCRIPTION
Typed characters landed somewhere other than the caret. This change fixes that report and the sixteen defects the surrounding lanes turned out to share with it. Each fix has a regression test that fails without it.

## The reported behavior

You type in a document, and the first character lands. Every character after it goes in front of the one before, so `Hello` arrives as `elloH`. To reproduce it, edit a header, click back into the body, and type at the end of a paragraph.

An edit installs its post-edit caret, and the first repaint mirrors that caret into the browser. An edit causes more than one repaint: a settled image, a deferred publish, and a scroll each cause another. Those later repaints read the browser's selection and adopt it. After a repaint rebuilds a page's DOM, the browser answers with a container, which reads back as the start of the paragraph.

Three rules close it:

- A repaint carries a gesture. It never invents one, so the speculative readers require the provenance that a `pointerdown` or `selectstart` leaves.
- A refused mirror is not a baseline. Recording one disarmed the staleness guard written for that case.
- A position that the paint cannot express is refused. Answering with the start of the paragraph gives a legal position that no reader can tell from a real one.

## Keystrokes that did nothing

- Typing over your own suggestion was refused. A tracked deletion retracts your own insertion instead of striking it, so the replacement offset sat past the end of the paragraph and the transaction was vetoed.
- Undo after a header edit installed a mark from another story. The caret landed in furniture, and the editor accepted no input until you clicked. (#342)
- Opening a header while a footnote was open left both stories open, so Select All and typing were refused as `unknown-paragraph`. (#347)
- No block could be removed from a header, footer, or note, because `paragraphIdsInDocumentOrder` walked only a `w:body`. Deleting a table from a letterhead did nothing, and the text half of the same deletion was vetoed with it. (#344)
- Backspace at the start of the paragraph after a table built a join that the store must refuse. The keystroke was dropped and `not-adjacent-siblings` was left on the surface. (#358)
- `insertPageField` addressed the start of the range instead of the survivor that the deletion plan names. (#359)

## Content in the wrong place

- Enter inside a tracked insertion broke the paragraph after the whole insertion instead of at the caret. (#348)
- Inserting a footnote over a selection deleted nothing and froze the pre-insert range as the exit target, so the next keystroke destroyed the footnote and part of the sentence. (#343)
- IME input in suggesting mode was written untracked, and it skipped the protection checks with it. (#349)
- A multi-line paste proposed its words but not its breaks, and left the caret inside the pasted text. (#353)
- Redo restored the caret from before the edit for Backspace, Delete, and paste. (#354)
- Resolving a tracked change clamped the caret instead of mapping it across the text that the resolution removed. (#351)
- Accepting the deletion of a table's only row left a `w:tbl` with no rows, which the table lane refuses. (#351)
- A selection that ended at the start of a field was written inside the field, which reads back as nothing, so the range collapsed before the next command ran. (#345)
- The paragraph command, Delete Rows, and Delete Columns each read one anchor where you had selected a rectangle of cells. Centering a column also centered its neighbor, and deleting two rows deleted one and reported success. (#352)
- Enter then Backspace in suggesting mode stacked a `w:del` on your own `w:ins` instead of taking the break back. It left an empty paragraph and two entries in the review pane.

## Cost per keystroke

Three causes made one keystroke far more expensive than it needs to be. (#355)

- The notes lane rebuilt every page record on every pass, for any file that carries a footnotes part. That is nearly every file Word writes, even with no notes in it. Measured on a 20-page document: 0 of 4 visible pages survived a keystroke before, and 3 of 4 survive after. This churn also made the caret defect above reachable, because it replaces the nodes that hold the browser's selection.
- The layout key folded the count of list items, so one Enter in a list re-measured all 141 paragraphs of the test document and reused no page.
- `ResolvedListItem.cacheToken` keyed on the length of the marker, so `ii.` and `vi.` shared a cache entry.

## Review pass

A review of this branch found eight issues, all fixed in the last commit. Two were regressions that the table fix introduced: Delete Rows and Delete Columns over a rectangle that covers the whole table emitted one op per row, the last of which is refused, and a refusal takes the transaction. The gesture deleted nothing. It now deletes the table.

The rest: the field skip refused offset 0 for a paragraph that starts with a note citation; the IME readback wrote at the pre-delete offset; the render-time adoption flushed the type buffer from inside a render; `insertNote` could leave a deletion committed with no note to show for it; a table's list token was read from the table's own id; and `splitParagraphMany` was missing from `isTrackedEdit`.

## Testing

`bun run test` reports 7698 passing and 0 failing. `typecheck`, `lint`, `format`, and `api:check` are clean. The typing, replacement, and paragraph-retraction fixes were also confirmed by hand in the demo against the document from the report.

The branch is rebased onto `main`. The two Vercel checks that failed earlier were not caused by this change: the branch predated the 2.6.0 release commit, so the `^2.6.0` peer range resolved from the registry, where the 7-day `minimumReleaseAge` gate blocks a package published that morning. The rebase brings the workspace version, and both deployments pass.

## Follow-up work

- #357: a selection in a repeated table header row is written to the wrong page copy. The write needs a page-scoped tiebreak.
- #355: entering a header changes the paint parameters and rebuilds every visible page. This happens once per entry rather than once per keystroke, and the fix risks visual regressions that this change cannot verify headlessly.
- #356: the prepared-block half is fixed here. The numbering-feature half is documented on the issue.
- #350: the remaining cosmetic half of the scope housekeeping.
- #343: the reference and the caret now land correctly. Where a suggested deletion puts the reference relative to the struck words is not yet exact, because the note op reads a different offset space from the text lanes.

## Also in this change

`CLAUDE.md` now asks for PR bodies in the Google developer documentation style, which is the guide the docs site already follows.
