### PR TITLE
fix: raise the tsconfig ES lib floor to match core

### DIFF
--- a/.changeset/adapter-tsconfig-es2022-lib.md
+++ b/.changeset/adapter-tsconfig-es2022-lib.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Fixed the type declaration build for the react, vue, pro, and fonts packages, which could fail depending on which ambient type packages were installed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: tsconfig lib floor check
+        # Several packages map core to `../core/src`, so they type-check core's
+        # sources and core's `lib` is their floor. Below it, `build:packages`
+        # fails in the dts build with a raw TS2550 — this reports the cause, and
+        # sits here so it lands before that build runs.
+        run: bun run check:tsconfig-lib-floor
+
       - name: Format check
         run: bun run format:check
 

--- a/examples/vue/tsconfig.json
+++ b/examples/vue/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    // ES2022 because `paths` below map core to its ES2022 sources.
+    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
@@ -8,7 +9,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "paths": {
       "@docx-editor.dev/vue": ["../../packages/vue/src/index.ts"],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "check:parity-contract": "node scripts/check-parity-contract.mjs",
     "check:public-docs-surface": "node scripts/check-public-docs-surface.mjs",
     "check:shipped-advisories": "node scripts/check-shipped-advisories.mjs",
+    "check:tsconfig-lib-floor": "node scripts/check-tsconfig-lib-floor.mjs",
     "demo-doc:build": "bun scripts/demo-doc/build.ts",
     "dev": "ENABLE_FRAMEWORK_SWITCHER=true VITE_ENABLE_FRAMEWORK_SWITCHER=true bun run --filter './examples/vite' --filter './examples/vue' dev",
     "dev:agent": "cd examples/agent && npm run dev",

--- a/packages/fonts/tsconfig.json
+++ b/packages/fonts/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    // ES2022 rather than ES2020 because this program contains core's sources through the
+    // `paths` below, and they use ES2022 features (`Array.prototype.at`, `Error.cause`).
+    // An ES2020 floor only appears to work: `@types/bun` pulls in `@types/node`, whose
+    // `compatibility/indexable.d.ts` back-declares `.at` for older libs, so the gap hides
+    // until something type-checks without those ambient types — such as the dts build.
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,

--- a/packages/pro/tsconfig.json
+++ b/packages/pro/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    // ES2022 rather than ES2020 because this program contains core's sources through the
+    // `paths` below, and they use ES2022 features (`Array.prototype.at`, `Error.cause`).
+    // An ES2020 floor only appears to work: `@types/bun` pulls in `@types/node`, whose
+    // `compatibility/indexable.d.ts` back-declares `.at` for older libs, so the gap hides
+    // until something type-checks without those ambient types — such as the dts build.
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    // ES2022 rather than ES2020 because this program contains core's sources through the
+    // `paths` below, and they use ES2022 features (`Array.prototype.at`, `Error.cause`).
+    // An ES2020 floor only appears to work: `@types/bun` pulls in `@types/node`, whose
+    // `compatibility/indexable.d.ts` back-declares `.at` for older libs, so the gap hides
+    // until something type-checks without those ambient types — such as the dts build.
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    // ES2022 rather than ES2020 because this program contains core's sources through the
+    // `paths` below, and they use ES2022 features (`Array.prototype.at`, `Error.cause`).
+    // An ES2020 floor only appears to work: `@types/bun` pulls in `@types/node`, whose
+    // `compatibility/indexable.d.ts` back-declares `.at` for older libs, so the gap hides
+    // until something type-checks without those ambient types — such as the dts build.
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "jsx": "preserve",
     "jsxImportSource": "vue",

--- a/scripts/check-tsconfig-lib-floor.mjs
+++ b/scripts/check-tsconfig-lib-floor.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Guards the ES `lib` floor of every TypeScript program that contains core's SOURCE.
+ *
+ * The adapter and satellite packages map `@docx-editor.dev/core` (and its subpaths)
+ * through tsconfig `paths` to `../core/src/*.ts` rather than to the built `.d.ts`, so
+ * core's sources are part of those programs. That makes core's `lib` their floor:
+ * core is ES2022 and its sources use ES2022 features (`Array.prototype.at`,
+ * `Error.cause`), which a program on ES2020 cannot compile.
+ *
+ * This needs its own gate because the failure hides. An ambient `@types/*` package
+ * that references a newer `lib` (`@types/bun` does, and it is installed here) puts
+ * those globals in scope, so `bun run typecheck` and `bun run build:packages` can
+ * both pass locally while a tree without that types package fails the dts build.
+ *
+ * If this fails, raise `target` and `lib` in the offending tsconfig to match core.
+ * Do not rewrite the call sites: the floor is set by what core's source uses, so
+ * patching one `.at(-1)` only defers the next break.
+ */
+import { readdirSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import ts from 'typescript';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CORE_SRC = join(repoRoot, 'packages', 'core', 'src');
+
+/**
+ * An ES level as a comparable number. `es5` → 5, `es6`/`es2015` → 2015,
+ * `es2022` → 2022, `esnext` → Infinity. Numeric so a future `es2025` ranks
+ * itself instead of needing a table entry.
+ */
+function esRank(name) {
+  const n = String(name).toLowerCase();
+  if (n === 'esnext') return Infinity;
+  if (n === 'es6') return 2015;
+  const m = /^es(\d+)$/.exec(n);
+  return m ? Number(m[1]) : null;
+}
+
+/** Resolve a tsconfig the way tsc does, following `extends`. Null if unreadable. */
+function parseConfig(configPath) {
+  const host = {
+    ...ts.sys,
+    onUnRecoverableConfigFileDiagnostic: () => {},
+  };
+  const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, host);
+  if (!parsed) return null;
+  // Missing `extends` targets (a generated `.nuxt/tsconfig.json`, say) make the
+  // program meaningless rather than wrong. Skip instead of failing the gate.
+  const fatal = parsed.errors.some((d) => d.code === 5083 || d.code === 6053);
+  return fatal ? null : parsed;
+}
+
+/** The ES level of a program: the ES entry of `lib`, else `target`. */
+function esLevelOf(parsed, label) {
+  const libs = (parsed.options.lib ?? [])
+    .map((l) => /^lib\.([a-z0-9]+)\.d\.ts$/.exec(l)?.[1])
+    .filter((l) => l && esRank(l) !== null);
+  if (libs.length > 1) throw new Error(`${label}: more than one ES level in "lib": ${libs.join(', ')}`);
+  const name = libs[0] ?? ts.ScriptTarget[parsed.options.target ?? ts.ScriptTarget.ES5];
+  const rank = esRank(name);
+  if (rank === null) throw new Error(`${label}: cannot read an ES level from "lib"/"target"`);
+  return { name: String(name).toUpperCase(), rank };
+}
+
+/** True when the config's `paths` point into `packages/core/src`. */
+function mapsCoreSource(parsed, configPath) {
+  const { paths, baseUrl } = parsed.options;
+  if (!paths) return false;
+  const base = baseUrl ?? dirname(configPath);
+  return Object.values(paths).some((targets) =>
+    targets.some((t) => {
+      const abs = resolve(base, t);
+      return abs === CORE_SRC || abs.startsWith(CORE_SRC + sep);
+    })
+  );
+}
+
+/** Every tsconfig worth checking: the root one, and one level down in each workspace. */
+function candidates() {
+  const found = [];
+  if (existsSync(join(repoRoot, 'tsconfig.json'))) found.push(join(repoRoot, 'tsconfig.json'));
+  for (const group of ['packages', 'examples']) {
+    const groupDir = join(repoRoot, group);
+    if (!existsSync(groupDir)) continue;
+    for (const pkg of readdirSync(groupDir, { withFileTypes: true })) {
+      if (!pkg.isDirectory()) continue;
+      // core defines the floor; it cannot be below itself.
+      if (group === 'packages' && pkg.name === 'core') continue;
+      const pkgDir = join(groupDir, pkg.name);
+      for (const entry of readdirSync(pkgDir)) {
+        if (/^tsconfig(\..+)?\.json$/.test(entry)) found.push(join(pkgDir, entry));
+      }
+    }
+  }
+  return found;
+}
+
+const core = esLevelOf(parseConfig(join(repoRoot, 'packages', 'core', 'tsconfig.json')), 'packages/core');
+
+const configs = [];
+for (const configPath of candidates()) {
+  const parsed = parseConfig(configPath);
+  if (!parsed) continue;
+  configs.push({ configPath, parsed, direct: mapsCoreSource(parsed, configPath) });
+}
+
+// A config that includes the sources of a package which itself maps core's source
+// also compiles core. The root tsconfig reaches core this way: it includes
+// `packages/react/src`, and react maps core to source.
+const consumerSrcDirs = configs
+  .filter((c) => c.direct)
+  .map((c) => join(dirname(c.configPath), 'src'));
+
+const failures = [];
+for (const { configPath, parsed, direct } of configs) {
+  const label = relative(repoRoot, configPath);
+  const indirect =
+    !direct &&
+    parsed.fileNames.some((f) => consumerSrcDirs.some((d) => f.startsWith(d + sep)));
+  if (!direct && !indirect) continue;
+
+  const { name, rank } = esLevelOf(parsed, label);
+  if (rank < core.rank) {
+    failures.push(
+      `${label} is ${name}, below core's ${core.name}. It compiles core's source ` +
+        `${direct ? 'through "paths"' : 'by including a package that maps it'}, ` +
+        `so it must be ${core.name} or higher.`
+    );
+  }
+}
+
+if (failures.length) {
+  console.error(`✘ tsconfig lib floor violated (core is ${core.name}):\n`);
+  console.error(failures.map((f) => `  ${f}`).join('\n'));
+  console.error(`\nRaise "target" and "lib" in the offending tsconfig to match core.`);
+  process.exit(1);
+}
+console.log(`✓ every tsconfig that compiles core's source is at or above ${core.name}.`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    // ES2022 rather than ES2020 because `include` below pulls in `packages/react/src`,
+    // which reaches core's ES2022 sources. Same floor as the packages themselves.
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
@@ -23,12 +25,6 @@
       "@docx-editor.dev/react": ["./packages/react/src/index.ts"]
     }
   },
-  "include": [
-    "src",
-    "packages/react/src",
-    "examples/shared",
-    "examples/vite",
-    "examples/plugins"
-  ],
+  "include": ["src", "packages/react/src", "examples/shared", "examples/vite", "examples/plugins"],
   "exclude": ["node_modules", "dist", "examples/nextjs", "examples/remix", "examples/astro"]
 }


### PR DESCRIPTION
core is ES2022 and its sources use `Array.prototype.at` and `Error.cause`. The packages that map core through tsconfig `paths` compile those sources, so an ES2020 floor breaks their declaration build. Ambient `@types` packages can back-declare the missing members, which is why this passed on some trees and not others.

Adds a gate so the floor cannot drift back.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789833150&installation_model_id=422592&pr_number=340&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F340&signature=7a2eef298d1b084d05e2df736a3c06c97b47173b2a0ae5886e55c2059df30e5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->