### PR TITLE
docs: read Vue composable refs with .value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,13 @@ jobs:
         # it on the PR, not in `docx-editor-page`'s build.
         run: bun run check:docs-mdx
 
+      - name: Docs Vue ref check
+        # A Vue template unwraps a ref only when the ref is a top-level binding.
+        # Most composables return a plain object of refs, so a sample that drops
+        # `.value` renders a control that never disables. Nothing type-checks
+        # this prose, so the wrong sample would ship as written.
+        run: bun run check:docs-vue-refs
+
   # Diffs the PR's published-package sizes against the latest successful main
   # run and keeps ONE sticky PR comment up to date. Fails on huge tarball
   # growth (thresholds in scripts/check-package-size.mjs) unless the PR

--- a/docs/site/content/vue/composables.mdx
+++ b/docs/site/content/vue/composables.mdx
@@ -8,8 +8,10 @@ order: 38
 Call each composable during `setup()` inside `DocxEditor.Root`. The packaged
 `<DocxEditor>` also renders this root.
 
-These composables use Vue refs and computed refs. Vue unwraps those values in
-templates. Use `.value` when you read them in script code.
+These composables return a ref, or a plain object that holds refs. A template
+unwraps a ref only when the ref is a top-level binding. A ref that sits on a
+returned object stays a ref, so read it with `.value` in the template and in
+script code.
 
 ## useEditorCommand
 
@@ -25,9 +27,9 @@ const bold = useEditorCommand('text.bold');
 <template>
   <button
     @mousedown.prevent
-    :disabled="!bold.isEnabled"
-    :data-active="bold.isActive || undefined"
-    :title="bold.disabledReason ?? 'Bold'"
+    :disabled="!bold.isEnabled.value"
+    :data-active="bold.isActive.value || undefined"
+    :title="bold.disabledReason.value ?? 'Bold'"
     @click="bold.execute()"
   >
     B
@@ -36,8 +38,8 @@ const bold = useEditorCommand('text.bold');
 ```
 
 `execute()` returns `true` when the editor applies the command. `isActive`,
-`isEnabled`, and `disabledReason` are computed refs. The template unwraps them.
-Use `bold.isEnabled.value` in script code.
+`isEnabled`, and `disabledReason` are computed refs on a plain object. The
+template does not unwrap them, so read each one with `.value`.
 
 The engine is the only source for enabled state. Show `disabledReason` when a
 control cannot run.
@@ -158,16 +160,19 @@ const font = useFontFamily();
 
 <template>
   <select
-    :value="font.value ?? ''"
-    :disabled="!font.isEnabled"
+    :value="font.value.value ?? ''"
+    :disabled="!font.isEnabled.value"
     @change="font.setValue(($event.target as HTMLSelectElement).value)"
   >
-    <option v-for="family in font.options" :key="family" :value="family">
+    <option v-for="family in font.options.value" :key="family" :value="family">
       {{ family }}
     </option>
   </select>
 </template>
 ```
+
+The current family sits on the `value` member, and that member is a computed
+ref. Read it as `font.value.value`.
 
 `useParagraphStyle` provides the same pattern for paragraph styles.
 
@@ -192,7 +197,7 @@ function toggleOrientation() {
 </script>
 
 <template>
-  <button :disabled="!page.isEnabled" @click="toggleOrientation">
+  <button :disabled="!page.isEnabled.value" @click="toggleOrientation">
     {{ landscape ? 'Use portrait' : 'Use landscape' }}
   </button>
 </template>
@@ -217,15 +222,15 @@ const outline = useDocumentOutline();
 </script>
 
 <template>
-  <p v-if="outline.isEmpty">No headings</p>
+  <p v-if="outline.isEmpty.value">No headings</p>
   <ul v-else>
     <li
-      v-for="{ heading, depth } in outline.items"
+      v-for="{ heading, depth } in outline.items.value"
       :key="heading.blockId"
       :style="{ paddingInlineStart: `${depth * 12}px` }"
     >
       <button
-        :aria-current="heading.blockId === outline.selectedBlockId ? 'location' : undefined"
+        :aria-current="heading.blockId === outline.selectedBlockId.value ? 'location' : undefined"
         @click="outline.goTo(heading.blockId)"
       >
         {{ heading.text }}
@@ -254,16 +259,16 @@ const search = useDocumentSearch();
   <label>
     Find
     <input
-      :value="search.query"
+      :value="search.query.value"
       @input="search.setQuery(($event.target as HTMLInputElement).value)"
     />
   </label>
   <span aria-live="polite">
-    {{ search.matches.length === 0 ? 0 : search.activeIndex + 1 }}
-    / {{ search.matches.length }}{{ search.truncated ? '+' : '' }}
+    {{ search.matches.value.length === 0 ? 0 : search.activeIndex.value + 1 }}
+    / {{ search.matches.value.length }}{{ search.truncated.value ? '+' : '' }}
   </span>
-  <button :disabled="search.matches.length === 0" @click="search.previous">Previous</button>
-  <button :disabled="search.matches.length === 0" @click="search.next">Next</button>
+  <button :disabled="search.matches.value.length === 0" @click="search.previous">Previous</button>
+  <button :disabled="search.matches.value.length === 0" @click="search.next">Next</button>
 </template>
 ```
 

--- a/docs/site/content/vue/examples.mdx
+++ b/docs/site/content/vue/examples.mdx
@@ -67,9 +67,9 @@ const bold = useEditorCommand('text.bold');
 <template>
   <button
     @mousedown.prevent
-    :disabled="!bold.isEnabled"
-    :aria-pressed="bold.isActive"
-    :title="bold.disabledReason ?? 'Bold'"
+    :disabled="!bold.isEnabled.value"
+    :aria-pressed="bold.isActive.value"
+    :title="bold.disabledReason.value ?? 'Bold'"
     @click="bold.execute()"
   >
     Bold

--- a/docs/site/content/vue/index.mdx
+++ b/docs/site/content/vue/index.mdx
@@ -111,9 +111,9 @@ const bold = useEditorCommand('text.bold');
 <template>
   <button
     @mousedown.prevent
-    :disabled="!bold.isEnabled"
-    :data-active="bold.isActive || undefined"
-    :title="bold.disabledReason ?? 'Bold'"
+    :disabled="!bold.isEnabled.value"
+    :data-active="bold.isActive.value || undefined"
+    :title="bold.disabledReason.value ?? 'Bold'"
     @click="bold.execute()"
   >
     Bold

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fix:pro-license-headers": "bun run --filter '@docx-editor.dev/pro' license:add",
     "check:consumer-install": "node scripts/check-consumer-install.mjs",
     "check:docs-mdx": "node scripts/check-docs-mdx.mjs",
+    "check:docs-vue-refs": "node scripts/check-docs-vue-refs.mjs",
     "check:editor-api-license-headers": "bun run --filter '@docx-editor.dev/editor-api' license:check",
     "fix:editor-api-license-headers": "bun run --filter '@docx-editor.dev/editor-api' license:add",
     "check:editor-contract": "node scripts/check-editor-contract.mjs",

--- a/scripts/check-docs-vue-refs.mjs
+++ b/scripts/check-docs-vue-refs.mjs
@@ -1,0 +1,183 @@
+/**
+ * Gate `docs/site/content/**` against Vue samples that read a ref without `.value`.
+ *
+ * A Vue template unwraps a ref only when the ref is a top-level setup binding.
+ * Most composables here return a plain object whose members are refs, so
+ * `bold.isEnabled` in a template is the `ComputedRef`, not the boolean. A
+ * `ComputedRef` is always truthy, so `:disabled="!bold.isEnabled"` renders a
+ * button that never disables, and `{{ font.value }}` prints an object. The
+ * sample stays plausible, compiles to a working page, and is wrong.
+ *
+ * Nothing else catches it: `check:docs-mdx` looks at MDX braces, not sample
+ * code, and no build type-checks this prose. The docs site (`docx-editor-page`)
+ * syncs this tree wholesale, so a wrong sample ships as written and an edit
+ * made there is deleted at its next sync.
+ *
+ * The ref members come from the API Extractor snapshots, so this file needs no
+ * hand-kept list: a composable that gains a ref member is covered at the next
+ * `bun run api:extract`. A composable that returns a ref directly (for example
+ * `useEditorState`) is skipped, because a top-level binding does unwrap.
+ *
+ * Fix a hit by appending `.value` to the read.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const contentRoot = resolve(root, 'docs/site/content');
+const apiFiles = [
+  resolve(root, 'docs/api/docx-editor-vue/index.api.md'),
+  resolve(root, 'docs/api/docx-editor-pro/vue.api.md'),
+];
+
+/** A member type that IS a ref, rather than one that merely mentions one. */
+const REF_TYPE = /^(?:Readonly<\s*)?(?:Computed|Shallow|WritableComputed)?Ref(?:_\d+)?\s*</;
+
+/** Members of every `export interface`, keyed by interface name. */
+function readInterfaces(raw) {
+  const interfaces = new Map();
+  const lines = raw.split('\n');
+  let name = null;
+  for (const line of lines) {
+    if (name === null) {
+      const open = /^export interface ([A-Za-z_$][\w$]*)(?:<[^>]*>)? \{$/.exec(line);
+      if (open) {
+        name = open[1];
+        interfaces.set(name, new Set());
+      }
+      continue;
+    }
+    if (line === '}') {
+      name = null;
+      continue;
+    }
+    const member = /^\s+(?:readonly\s+)?([A-Za-z_$][\w$]*)\??:\s*(.+?);?$/.exec(line);
+    if (member && REF_TYPE.test(member[2])) interfaces.get(name).add(member[1]);
+  }
+  return interfaces;
+}
+
+/** Return type of `export function name(...): Type;`, or null when it spans a construct we skip. */
+function returnTypeOf(raw, start) {
+  const open = raw.indexOf('(', start);
+  if (open === -1) return null;
+  let depth = 0;
+  let i = open;
+  for (; i < raw.length; i += 1) {
+    if (raw[i] === '(') depth += 1;
+    else if (raw[i] === ')') {
+      depth -= 1;
+      if (depth === 0) break;
+    }
+  }
+  const end = raw.indexOf(';', i);
+  if (end === -1) return null;
+  return raw.slice(i + 1, end).replace(/^\s*:\s*/, '').trim();
+}
+
+/** Composable name -> ref members on the plain object it returns. */
+function readComposables() {
+  const composables = new Map();
+  for (const file of apiFiles) {
+    const raw = readFileSync(file, 'utf8');
+    const interfaces = readInterfaces(raw);
+    for (const match of raw.matchAll(/^export function (use[A-Za-z_$][\w$]*)/gm)) {
+      const returnType = returnTypeOf(raw, match.index + match[0].length);
+      if (returnType === null) continue;
+      const members = interfaces.get(returnType);
+      if (members && members.size > 0) composables.set(match[1], members);
+    }
+  }
+  return composables;
+}
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir).sort()) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (name.endsWith('.mdx')) out.push(full);
+  }
+  return out;
+}
+
+/** Fenced `vue`, `ts`, and `tsx` blocks, as line arrays with their 1-based start line. */
+function codeBlocks(raw) {
+  const blocks = [];
+  let current = null;
+  raw.split('\n').forEach((line, index) => {
+    const fence = /^\s*```(\w+)?/.exec(line);
+    if (!fence) {
+      if (current) current.lines.push({ line, number: index + 1 });
+      return;
+    }
+    if (current) {
+      blocks.push(current);
+      current = null;
+      return;
+    }
+    if (fence[1] === 'vue' || fence[1] === 'ts' || fence[1] === 'tsx')
+      current = { language: fence[1], lines: [] };
+  });
+  return blocks;
+}
+
+/**
+ * React and Vue share composable names, and the React hooks return plain values.
+ * A `.value` on a React sample would be wrong, so only Vue samples are checked.
+ */
+function isVueSample(block, file) {
+  if (block.language === 'vue') return true;
+  const text = block.lines.map((entry) => entry.line).join('\n');
+  if (/@docx-editor\.dev\/(?:vue|nuxt|pro\/vue)/.test(text)) return true;
+  if (/@docx-editor\.dev\/(?:react|pro\/react)/.test(text)) return false;
+  const path = relative(contentRoot, file);
+  if (path.startsWith('vue/')) return true;
+  return path === 'frameworks/nuxt.mdx' || path === 'frameworks/vite-vue.mdx';
+}
+
+function checkFile(file, composables) {
+  const hits = [];
+  for (const block of codeBlocks(readFileSync(file, 'utf8'))) {
+    if (!isVueSample(block, file)) continue;
+    const bindings = new Map();
+    for (const { line } of block.lines) {
+      const bind = /\b(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*(use[A-Za-z_$][\w$]*)\s*\(/.exec(
+        line,
+      );
+      if (bind && composables.has(bind[2])) bindings.set(bind[1], composables.get(bind[2]));
+    }
+    if (bindings.size === 0) continue;
+    for (const { line, number } of block.lines) {
+      for (const match of line.matchAll(/\b([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\b(\.value)?/g)) {
+        const members = bindings.get(match[1]);
+        if (!members || !members.has(match[2]) || match[3]) continue;
+        hits.push({ number, read: `${match[1]}.${match[2]}`, line: line.trim() });
+      }
+    }
+  }
+  return hits;
+}
+
+const composables = readComposables();
+if (composables.size === 0) {
+  console.error('check:docs-vue-refs: no composables read from the API snapshots.');
+  process.exit(1);
+}
+
+let failed = false;
+for (const file of walk(contentRoot)) {
+  for (const hit of checkFile(file, composables)) {
+    failed = true;
+    console.error(`${relative(root, file)}:${hit.number}  ${hit.read} needs .value`);
+    console.error(`  ${hit.line}`);
+  }
+}
+
+if (failed) {
+  console.error('\nA template unwraps a ref only when the ref is a top-level binding.');
+  console.error('These refs sit on a returned object, so read them with .value.');
+  process.exit(1);
+}
+
+console.log(`check:docs-vue-refs: clean (${composables.size} composables checked).`);


### PR DESCRIPTION
The Vue composables return a plain object of refs, and a template unwraps a ref
only when the ref is a top-level binding. Every sample that read
`bold.isEnabled` therefore got the `ComputedRef`, which is always truthy, so the
button never disabled and never showed its reason. `composables.mdx` also stated
the opposite rule, which is why the samples drifted.

The new `check:docs-vue-refs` reads the ref members from the API Extractor
snapshots, so it needs no hand-kept list and covers a composable that gains a
ref member at the next `api:extract`. React samples are untouched: those hooks
return plain values.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789884805&installation_model_id=422592&pr_number=362&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F362&signature=6d2f1112080ab64e4427eb5f2789c9752a382d1d28b65411d110b1acb8b0095e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->