### PR TITLE
fix(core): keep the caret in place while typing in a header or footer

### DIFF
--- a/.changeset/header-footer-typing-caret.md
+++ b/.changeset/header-footer-typing-caret.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixed the caret jumping back to the start of a header or footer after each character typed. Fixes #361

--- a/.changeset/header-footer-typing-caret.md
+++ b/.changeset/header-footer-typing-caret.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fixed the caret jumping back to the start of a header or footer after each character typed. Fixes #361
+Fixed the caret jumping back to the start of a header or footer after each character typed. The `change` event's revision and `getDocumentHandle().revision` now rise for every edit, including one made in a header, footer or note, and an explicit table target is no longer refused as stale after such an edit. Fixes #361

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build:vue": "cd examples/vue && USE_PUBLISHED_PACKAGES=true ENABLE_FRAMEWORK_SWITCHER=true VITE_ENABLE_FRAMEWORK_SWITCHER=true VITE_BASE_PATH=/vue/ vite build",
     "bench:edit": "bun scripts/bench/edit-bench.ts",
     "bench:edit:browser": "playwright test --config e2e/edit-browser-bench.config.ts",
+    "bench:scope-waste": "bun scripts/bench/scope-waste-bench.ts",
     "changeset": "changeset",
     "check:adapter-css-thin": "node scripts/check-adapter-css-thin.mjs",
     "check:pro-license-headers": "bun run --filter '@docx-editor.dev/pro' license:check",

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -989,9 +989,9 @@ export type TableCellVerticalAlignment = 'top' | 'center' | 'bottom';
 /**
  * Adjacent grid columns addressed by an internal divider resize gesture.
  *
- * `sourceRevision` is captured from the store revision when the target is built.
- * Commit MUST refuse when it does not equal the current store revision, even if an older layout
- * remains published for geometry.
+ * `sourceRevision` is the PACKAGE revision of the layout the target was read from — the number
+ * `getDocumentHandle()` reports, never one story's own. Commit MUST refuse when it no longer
+ * equals the current one, even if an older layout remains published for geometry.
  */
 export interface TableColumnDividerResizeTarget {
   readonly sourceRevision: number;
@@ -1004,9 +1004,9 @@ export interface TableColumnDividerResizeTarget {
 /**
  * Last grid column and table width addressed by an outer-right-edge resize gesture.
  *
- * `sourceRevision` is captured from the store revision when the target is built.
- * Commit MUST refuse when it does not equal the current store revision, even if an older layout
- * remains published for geometry.
+ * `sourceRevision` follows the same rule as {@link TableColumnDividerResizeTarget}: the package
+ * revision of the layout the target was read from, and commit refuses once it no longer equals
+ * the current one.
  */
 export interface TableRightEdgeResizeTarget {
   readonly sourceRevision: number;
@@ -1015,7 +1015,7 @@ export interface TableRightEdgeResizeTarget {
   readonly isHeaderRepeat: boolean;
 }
 
-/** Explicit row occurrence for furniture/context commands. */
+/** Explicit row occurrence. `sourceRevision` per {@link TableColumnDividerResizeTarget}. */
 export interface TableRowOccurrenceTarget {
   readonly sourceRevision: number;
   readonly tableId: string;
@@ -1023,7 +1023,7 @@ export interface TableRowOccurrenceTarget {
   readonly isHeaderRepeat: boolean;
 }
 
-/** Explicit column occurrence for furniture/context commands. */
+/** Explicit column occurrence. `sourceRevision` per {@link TableColumnDividerResizeTarget}. */
 export interface TableColumnOccurrenceTarget {
   readonly sourceRevision: number;
   readonly tableId: string;

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -107,7 +107,7 @@ export type {
  * breaking change.
  */
 export interface DocumentHandle {
-  /** The document's current store revision. */
+  /** Package revision: rises for every edit, wherever it landed. Safe to compare. */
   readonly revision: number;
 }
 
@@ -223,7 +223,7 @@ export class EditorFontError extends Error {
  * be prohibitive for large documents. Call `save()` to get bytes on demand.
  */
 export interface DocumentChange {
-  /** The store revision after this change. */
+  /** Package revision after this change — `getDocumentHandle()`'s number, monotonic. */
   readonly revision: number;
   /** Block ids created/deleted/edited by this change, when the engine reports them. */
   readonly created?: readonly string[];

--- a/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
+++ b/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
@@ -160,8 +160,13 @@ describe('embedded fonts auto-wire into shaped measurement', () => {
       onFontError: (error) => errors.push(error),
     });
     await mounted(editor);
+    // The document is READABLE before its fonts resolve — that is the property, and it is
+    // what `measurer: 'fixed'` here stood for. Asserting the measurer is still fixed at
+    // this point asserts that an async resolution has not landed yet, which nothing
+    // promises: `mounted` polls on a timer, and under a loaded parallel run the upgrade
+    // can arrive inside one of its sleeps.
     expect(editor.surface).not.toBeNull();
-    expect(editor.fontMeasurement().measurer).toBe('fixed');
+    expect(container.textContent).toContain('shaped hello');
     await fontsSettled(editor);
     expect(editor.fontMeasurement()).toMatchObject({ measurer: 'shaped', resolving: false });
     expect(errors).toHaveLength(0);

--- a/packages/core/src/editor/__tests__/header-footer-lifecycle-commands.test.ts
+++ b/packages/core/src/editor/__tests__/header-footer-lifecycle-commands.test.ts
@@ -121,6 +121,26 @@ describe('Editor header/footer lifecycle commands', () => {
     host.remove();
   });
 
+  test('typing into a created header keeps the caret after each character', () => {
+    const { editor, host } = mountEditor(blankDoc());
+    expect(editor.exec({ type: 'editHeaderFooter', position: 'header' }).ok).toBe(true);
+
+    for (const character of ['a', 'b', 'c']) {
+      expect(editor.exec({ type: 'insertText', text: character }).ok).toBe(true);
+      // What a host does on every change, and what made this fail: reading the snapshot
+      // lays the pending revision out. A header part counts its own revisions, so the
+      // scope the keystroke scheduled used to be tagged BELOW the package revision and was
+      // discarded as stale — the commit painted the previous revision, the post-edit caret
+      // could not be written into pre-edit nodes, and this later pass read that stale DOM
+      // caret back. Every character then landed at the start of the story.
+      editor.snapshot();
+    }
+
+    expect(host.querySelector('[data-docx-hf-active]')?.textContent).toBe('abc');
+    editor.destroy();
+    host.remove();
+  });
+
   test('editHeaderFooter firstPage create+titlePg undoes/redoes as one unit', async () => {
     const { editor, host } = mountEditor(blankDoc());
     expect(editor.exec({ type: 'editHeaderFooter', position: 'header', firstPage: true }).ok).toBe(

--- a/packages/core/src/editor/__tests__/paginated-surface.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface.test.ts
@@ -569,4 +569,19 @@ describe('a hard break occupies a model offset in layout too', () => {
     const { surface } = mount('<w:p><w:r><w:t>ab</w:t><w:br/></w:r></w:p>');
     expect(surface.session.bodyText()).toBe('ab\n');
   });
+
+  test('a commit made outside this surface still reaches the screen', async () => {
+    // The shape an undo from another editor sharing the store takes, or a host writing
+    // straight to the session: nothing calls the surface's own `commit`, so the only route
+    // to the pages is the scheduler publishing on its own. Without a `schedule` there was
+    // no such route — the model moved and the painted pages kept the old revision for good.
+    const { surface, container } = mount(paragraph('ORIGINAL'));
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    surface.session.applyTreeOps([{ op: 'insertText', paragraphId, offset: 0, text: 'EXT-' }]);
+    expect(surface.session.bodyText()).toContain('EXT-ORIGINAL');
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(container.textContent).toContain('EXT-ORIGINAL');
+    surface.destroy();
+  });
 });

--- a/packages/core/src/editor/__tests__/revision-space.test.ts
+++ b/packages/core/src/editor/__tests__/revision-space.test.ts
@@ -1,0 +1,136 @@
+// One revision space reaches the outside, and it is the PACKAGE one.
+//
+// Every story part — the body, each header/footer, the notes part — counts its own
+// revisions, and a header/footer part starts from zero when it is created. Anything that
+// compares a revision against `packageRevision()`, or hands one to a host as "the
+// document's revision", must therefore read the package counter and not a story's.
+//
+// A body-only fixture cannot catch a mistake here: the two counters coincide until a
+// package-level op or a non-body edit moves one without the other. Every test below edits a
+// header on purpose so the counters are apart when the assertion runs.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import type { DocumentChange } from '../../contracts/editor.ts';
+import { tableRowOccurrenceTargetFrom } from '../../layout/table-interaction-targets.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const TABLE_2X2 =
+  '<w:tbl><w:tblGrid><w:gridCol w:w="2400"/><w:gridCol w:w="3600"/></w:tblGrid>' +
+  `<w:tr><w:tc>${p('A1')}</w:tc><w:tc>${p('B1')}</w:tc></w:tr>` +
+  `<w:tr><w:tc>${p('A2')}</w:tc><w:tc>${p('B2')}</w:tc></w:tr></w:tbl>`;
+
+/** A document with a declared header part, so the two counters can be driven apart. */
+function docxWithHeader(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/></Relationships>`
+    ),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('HDR')}</w:hdr>`),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}` +
+        '<w:sectPr><w:headerReference w:type="default" r:id="rId10"/></w:sectPr>' +
+        '</w:body></w:document>'
+    ),
+  });
+}
+
+function mount(body: string): DocxEditorInstance {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: docxWithHeader(body) });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+/** Open the declared header and type one character into it. */
+function editTheHeader(editor: DocxEditorInstance): void {
+  expect(editor.exec({ type: 'editHeaderFooter', position: 'header' }).ok).toBe(true);
+  expect(editor.exec({ type: 'insertText', text: 'H' }).ok).toBe(true);
+  expect(editor.exec({ type: 'exitHeaderFooter' }).ok).toBe(true);
+}
+
+describe('the revision a host sees is the package revision', () => {
+  test('change events keep rising across a header edit', () => {
+    const editor = mount(p('body'));
+    const seen: number[] = [];
+    editor.on('change', (change: DocumentChange) => seen.push(change.revision));
+
+    const surface = editor.surface!;
+    const bodyId = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId: bodyId, offset: 0 },
+      head: { paragraphId: bodyId, offset: 0 },
+    });
+    editor.exec({ type: 'insertText', text: 'a' });
+    editTheHeader(editor);
+    surface.setSelection({
+      anchor: { paragraphId: bodyId, offset: 0 },
+      head: { paragraphId: bodyId, offset: 0 },
+    });
+    editor.exec({ type: 'insertText', text: 'b' });
+
+    expect(seen.length).toBeGreaterThanOrEqual(3);
+    // Reporting the story's own counter made this go BACKWARDS on the first header edit and
+    // then repeat numbers it had already emitted, so a host using it as a version key for a
+    // dirty flag, dedupe or autosave read the document as unchanged.
+    for (let index = 1; index < seen.length; index += 1) {
+      expect(seen[index]!).toBeGreaterThan(seen[index - 1]!);
+    }
+    expect(new Set(seen).size).toBe(seen.length);
+    editor.destroy();
+  });
+
+  test('the document handle moves when only a header changed', () => {
+    const editor = mount(p('body'));
+    const before = editor.getDocumentHandle().revision;
+    editTheHeader(editor);
+    expect(editor.getDocumentHandle().revision).toBeGreaterThan(before);
+    editor.destroy();
+  });
+
+  test('a fresh explicit table target is accepted after a header edit', () => {
+    const editor = mount(TABLE_2X2);
+    const surface = editor.surface!;
+    // FIRST, so the body and package counters are apart for the rest of the test. From here
+    // the body store never catches up again.
+    editTheHeader(editor);
+
+    const layout = surface.layout();
+    const table = layout.pages
+      .flatMap((page) => page.fragments)
+      .find((block) => block.kind === 'table');
+    if (table?.kind !== 'table') throw new Error('no table in layout');
+    const row = table.rows[0]!;
+    // Stamped from the CURRENT `layout.revision`, which is the package revision — the only
+    // number a host can read off the layout it is pointing at.
+    const target = tableRowOccurrenceTargetFrom(layout.revision, { table, row, rowIndex: 0 });
+
+    // Planning compared that against a BODY-store revision, so once the two had diverged
+    // even a freshly stamped target read as stale: every explicit-target table command
+    // refused and mutated nothing, permanently.
+    const command = { type: 'insertRow' as const, where: 'below' as const, target };
+    expect(editor.can(command).ok).toBe(true);
+    expect(editor.exec(command).ok).toBe(true);
+    editor.destroy();
+  });
+});

--- a/packages/core/src/editor/__tests__/table-command-plan.test.ts
+++ b/packages/core/src/editor/__tests__/table-command-plan.test.ts
@@ -1,4 +1,10 @@
 // Table command planning and editor execution (table-editing task 7).
+//
+// Targets are stamped from `layout().revision` and planner input from `packageRevision()`,
+// never from `session.revision()`. The fixtures here are body-only, where the body store's
+// counter happens to equal the package's, so a body-space stamp passes every test in this
+// file and refuses every real command the moment a header, footer or note edit moves the
+// two apart. `revision-space.test.ts` is what actually holds that line.
 
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
@@ -312,7 +318,7 @@ describe('table command planner and editor parity', () => {
     const topo = readEditableTableTopology(surface.session.part().root, table.tableId);
     expect(topo.ok).toBe(true);
     if (!topo.ok) return;
-    const revision = surface.session.revision();
+    const revision = surface.layout().revision;
     const target = tableColumnDividerResizeTargetOf(
       surface.layout(),
       revision,
@@ -378,7 +384,7 @@ describe('table command planner and editor parity', () => {
       command: { type: 'insertColumn', where: 'right' },
       part: surface.session.part(),
       layout: surface.layout(),
-      storeRevision: surface.session.revision(),
+      storeRevision: surface.session.packageRevision(),
       selection: surface.state().selection,
       cellSelection: surface.state().cellSelection,
       themeColors: surface.session.documentThemeColors(),
@@ -420,7 +426,7 @@ describe('table command planner and editor parity', () => {
         command: { type: 'insertRow', where: 'below' },
         part: surface.session.part(),
         layout: surface.layout(),
-        storeRevision: surface.session.revision(),
+        storeRevision: surface.session.packageRevision(),
         selection: surface.state().selection,
         cellSelection: surface.state().cellSelection,
         themeColors: surface.session.documentThemeColors(),
@@ -473,7 +479,7 @@ describe('table command planner and editor parity', () => {
     let repeatTarget: ReturnType<typeof tableRowOccurrenceTargetFrom> | null = null;
     visitTableOccurrences(surface.layout(), (ref) => {
       if (ref.row.isHeaderRepeat) {
-        repeatTarget = tableRowOccurrenceTargetFrom(surface.session.revision(), ref);
+        repeatTarget = tableRowOccurrenceTargetFrom(surface.layout().revision, ref);
       }
     });
     expect(repeatTarget?.isHeaderRepeat).toBe(true);
@@ -524,14 +530,14 @@ describe('table command planner and editor parity', () => {
     const layoutRevision = surface.layout().revision;
     const target = tableColumnDividerResizeTargetOf(
       surface.layout(),
-      surface.session.revision(),
+      surface.layout().revision,
       table.tableId,
       table.rows[0]!.id,
       false,
       topo.topology.gridColumns[0]!.id,
       topo.topology.gridColumns[1]!.id
     );
-    expect(target?.sourceRevision).toBe(surface.session.revision());
+    expect(target?.sourceRevision).toBe(layoutRevision);
     expect(layoutRevision).toBeGreaterThanOrEqual(0);
     surface.type('X');
     const cmd = {
@@ -634,7 +640,7 @@ describe('color lowering for table commands', () => {
       command: { type: 'setTableBorders', scope: 'none', target: 'top' },
       part: surface.session.part(),
       layout: surface.layout(),
-      storeRevision: surface.session.revision(),
+      storeRevision: surface.session.packageRevision(),
       selection: surface.state().selection,
       cellSelection: surface.state().cellSelection,
       themeColors: surface.session.documentThemeColors(),
@@ -706,7 +712,7 @@ describe('occurrence targets and provenance', () => {
     if (!topo.ok) return;
     const ref = { table, row: table.rows[0]!, rowIndex: 0 };
     const bCell = table.rows[0]!.cells.find((c) => c.gridColumn === 1)!;
-    const target = tableColumnOccurrenceTargetFrom(surface.session.revision(), ref, bCell)!;
+    const target = tableColumnOccurrenceTargetFrom(surface.layout().revision, ref, bCell)!;
     expect(target.gridColumnId).toBe(topo.topology.gridColumns[1]!.id);
     const beforeB1 = paragraphByText('B1', surface);
     const cmd = { type: 'deleteColumn' as const, target };
@@ -736,7 +742,7 @@ describe('occurrence targets and provenance', () => {
     });
     expect(foreignGridColumnId).toBeTruthy();
     const target = {
-      sourceRevision: surface.session.revision(),
+      sourceRevision: surface.layout().revision,
       tableId: firstTable.tableId,
       gridColumnId: foreignGridColumnId,
       isHeaderRepeat: false,
@@ -765,7 +771,7 @@ describe('occurrence targets and provenance', () => {
             b.kind === 'paragraph' && b.lines.some((l) => l.spans.some((s) => s.text === 'inner'))
         )
       ) {
-        innerTarget = tableRowOccurrenceTargetFrom(surface.session.revision(), ref);
+        innerTarget = tableRowOccurrenceTargetFrom(surface.layout().revision, ref);
       }
     });
     expect(innerTarget).not.toBeNull();
@@ -779,7 +785,7 @@ describe('occurrence targets and provenance', () => {
     const surface = editor.surface!;
     const table = tableFragment(surface);
     const ref = { table, row: table.rows[0]!, rowIndex: 0 };
-    const target = tableRowOccurrenceTargetFrom(surface.session.revision(), ref);
+    const target = tableRowOccurrenceTargetFrom(surface.layout().revision, ref);
     surface.type('X');
     const cmd = { type: 'insertRow' as const, where: 'below' as const, target };
     const can = editor.can(cmd);
@@ -809,7 +815,7 @@ describe('merge and resource refusals at editor seam', () => {
     if (!topo.ok) return;
     const target = tableColumnDividerResizeTargetOf(
       surface.layout(),
-      surface.session.revision(),
+      surface.layout().revision,
       table.tableId,
       table.rows[0]!.id,
       false,
@@ -885,7 +891,7 @@ describe('transaction and selection preservation', () => {
     if (!topo.ok) throw new Error('topology failed');
     const target = tableColumnDividerResizeTargetOf(
       surface.layout(),
-      surface.session.revision(),
+      surface.layout().revision,
       table.tableId,
       table.rows[0]!.id,
       false,
@@ -907,7 +913,7 @@ describe('transaction and selection preservation', () => {
     const last = topo.topology.gridColumns[topo.topology.gridColumns.length - 1]!;
     const target = tableRightEdgeResizeTargetOf(
       surface.layout(),
-      surface.session.revision(),
+      surface.layout().revision,
       table.tableId,
       table.rows[0]!.id,
       false,

--- a/packages/core/src/editor/docx-editor-derive.ts
+++ b/packages/core/src/editor/docx-editor-derive.ts
@@ -208,7 +208,7 @@ export function buildTableCommandPlannerInput(
     command,
     part: surface.session.part(),
     layout: surface.layout(),
-    storeRevision: surface.session.revision(),
+    storeRevision: surface.session.packageRevision(),
     selection: surface.state().selection,
     cellSelection: surface.state().cellSelection,
     themeColors: surface.session.documentThemeColors(),

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -325,7 +325,7 @@ export function execEditorCommand(
           command,
           part: mounted.session.part(),
           layout: mounted.layout(),
-          storeRevision: mounted.session.revision(),
+          storeRevision: mounted.session.packageRevision(),
           selection: mounted.state().selection,
           cellSelection: mounted.state().cellSelection,
           themeColors: mounted.session.documentThemeColors(),

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -616,9 +616,13 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       surface.setReviewActivationExclusions(reviewActivationExclusions);
     }
     lastSelection = surface.state().selection;
-    unsubscribeSession = surface.session.subscribe((change) => {
+    // `result.surface`, not the reassignable `surface`: this subscription is THIS session's.
+    unsubscribeSession = result.surface.session.subscribe((change) => {
       const documentChange: DocumentChange = {
-        revision: change.toRevision,
+        // The PACKAGE revision, never `change.toRevision`: a header/footer or notes change
+        // carries THAT part's counter, which starts at zero, so reporting it sent this
+        // number backwards and then repeated values it had already emitted.
+        revision: result.surface.session.packageRevision(),
         created: change.created,
         deleted: change.deleted,
         dirty: change.dirty,
@@ -644,7 +648,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // must learn about it, exactly as it learns about any later commit. Without these a
     // store bound before `load()` never re-reads and keeps rendering "no document".
     bump();
-    emitDocumentChange({ revision: surface.session.revision() });
+    emitDocumentChange({ revision: surface.session.packageRevision() });
     emitSelectionChange();
     // Fonts resolve per DOCUMENT (embedded faces live in the file), and only once per
     // load: the shaped remount re-enters this function with `fontKickSeq` already
@@ -1838,7 +1842,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     },
 
     getDocumentHandle(): DocumentHandle {
-      return Object.freeze({ revision: surface?.session.revision() ?? 0 });
+      // Package revision: the body's own stands still for header/footer/note work.
+      return Object.freeze({ revision: surface?.session.packageRevision() ?? 0 });
     },
 
     exec(command, options) {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -919,6 +919,28 @@ export function mountPaginatedSurface(
       return layout;
     },
     currentRevision: () => session.packageRevision(),
+    // THE BACKSTOP, not the normal route. Every edit this surface makes still lays out
+    // synchronously inside `commit`, because the next edit has to read current geometry —
+    // and `flush` cancels whatever this armed, so the ordinary keystroke pays one timer
+    // arm and one cancel, never a second pass.
+    //
+    // What it buys is the two cases that reach the scheduler without a synchronous flush
+    // behind them. A commit from OUTSIDE this surface (undo, or another editor sharing the
+    // store) only ever reached the screen through `publish`, and with nothing armed it
+    // simply never got there: the model moved and the painted pages kept the old revision
+    // for good. And when `flush` abandons a pass — stale, or cancelled mid-flight — it
+    // carries the scope forward and re-arms, which was a no-op, so the surface sat on a
+    // stale paint until some unrelated call happened to flush. That second one is how the
+    // header caret bug stayed invisible: a paint one revision behind is exactly what makes
+    // the post-edit caret unwritable.
+    //
+    // A timer rather than an animation frame, like the rest of this file: rAF does not fire
+    // in a background tab, and a document that stops repainting when the tab is hidden is
+    // the same stale-paint failure by another route.
+    schedule: (run) => {
+      const handle = setTimeout(run, 0);
+      return () => clearTimeout(handle);
+    },
     publish: (layout) => {
       // Release the previous layout BEFORE the new one replaces it: the roster cache held
       // it by strong reference, and a 200-page graph kept alive beside the live one is tens

--- a/packages/core/src/editor/table-command-plan.ts
+++ b/packages/core/src/editor/table-command-plan.ts
@@ -59,6 +59,15 @@ export interface TableCommandPlannerInput {
   readonly command: EditorCommand;
   readonly part: OoxmlPart;
   readonly layout: SemanticLayout;
+  /**
+   * The PACKAGE revision, never a story's own.
+   *
+   * Explicit targets carry `sourceRevision` copied from `layout.revision`, which layout
+   * stamps from `session.packageRevision()`, and the staleness checks below compare the
+   * two. A body-store revision here reads as permanently stale the moment a header/footer
+   * or notes edit moves the package revision without moving the body's: every explicit
+   * target is then refused as stale and the command mutates nothing.
+   */
   readonly storeRevision: number;
   readonly selection: SemanticSelection;
   readonly cellSelection: CellSelection | null;

--- a/packages/core/src/layout/__tests__/layout-scheduler.test.ts
+++ b/packages/core/src/layout/__tests__/layout-scheduler.test.ts
@@ -261,6 +261,23 @@ describe('a layout computed against a superseded revision is never published (ta
     expect(h.scheduler.staleDiscards).toBe(1);
   });
 
+  test('an abandoned pass re-arms itself, so nothing waits for an unrelated flush', () => {
+    let runs = 0;
+    const h = harness({ revisionDuringRun: () => (runs++ === 0 ? 2 : 2) });
+    h.scheduler.notify(change({ dirty: ['p1'], toRevision: 1 }));
+    h.step();
+    // Discarded as stale. The carried-forward scope has to schedule its own retry: a host
+    // that supplies no `schedule` strands it until something else happens to flush, and a
+    // surface sitting on a stale paint cannot write a post-edit caret into it.
+    expect(h.published.length).toBe(0);
+    expect(h.scheduler.staleDiscards).toBe(1);
+    expect(h.queueLength()).toBe(1);
+
+    h.step();
+    expect(h.published.length).toBe(1);
+    expect(h.published[0]!.layout.revision).toBe(2);
+  });
+
   test('a current layout publishes with the scope it was computed for', () => {
     const h = harness();
     h.scheduler.notify(change({ dirty: ['p1'], toRevision: 1 }));

--- a/packages/core/src/layout/__tests__/layout-scheduler.test.ts
+++ b/packages/core/src/layout/__tests__/layout-scheduler.test.ts
@@ -71,6 +71,9 @@ describe('scope accumulates from the store, and only widens (task 9.1)', () => {
   test('two local edits in different paragraphs stay local over the union', () => {
     const h = harness();
     h.scheduler.notify(change({ dirty: ['p1'] }));
+    // The store bumps its revision before it publishes, so a second commit is a second
+    // revision by the time the subscriber runs.
+    h.setRevision(2);
     h.scheduler.notify(change({ dirty: ['p2'], toRevision: 2 }));
     const scope = h.scheduler.pending()!;
     expect(scope.impact).toBe('text-local');
@@ -97,6 +100,23 @@ describe('scope accumulates from the store, and only widens (task 9.1)', () => {
     const scope = h.scheduler.pending()!;
     expect(scope.impact).toBe('global');
     expect(scope.structural).toBe(true);
+  });
+
+  test('a story revision that trails the package revision still scopes to the package', () => {
+    const h = harness();
+    // A header/footer part counts its own revisions from zero, so its change reports a
+    // number well below the package revision the scheduler validates against. Taking the
+    // scope revision from the change discarded the pass as stale and painted the previous
+    // revision — which put the caret back where the edit started.
+    h.setRevision(7);
+    h.scheduler.notify(
+      change({ dirty: ['hf1'], impact: 'global', fromRevision: 0, toRevision: 1 })
+    );
+    expect(h.scheduler.pending()!.revision).toBe(7);
+    expect(h.scheduler.flush()).toBe(true);
+    expect(h.published.length).toBe(1);
+    expect(h.published[0]!.layout.revision).toBe(7);
+    expect(h.scheduler.staleDiscards).toBe(0);
   });
 
   test('a split marks the batch structural and names both endpoints', () => {
@@ -152,9 +172,9 @@ describe('scheduling coalesces and stays cancellable (task 9.1)', () => {
   test('many commits in one turn produce ONE layout pass', () => {
     const h = harness();
     for (let index = 0; index < 5; index += 1) {
+      h.setRevision(index + 1);
       h.scheduler.notify(change({ dirty: [`p${index}`], toRevision: index + 1 }));
     }
-    h.setRevision(5);
     expect(h.queueLength()).toBe(1);
     h.step();
     expect(h.runs.length).toBe(1);

--- a/packages/core/src/layout/layout-scheduler.ts
+++ b/packages/core/src/layout/layout-scheduler.ts
@@ -275,7 +275,15 @@ export function createLayoutScheduler(options: LayoutSchedulerOptions): LayoutSc
 
   return {
     notify(change) {
-      const state = ensure(change.toRevision);
+      // `currentRevision()`, NOT `change.toRevision`: the two count in different spaces.
+      // A change published for a header/footer or notes part carries THAT part's own
+      // revision, which starts at zero when the part is created and therefore trails the
+      // package revision this scheduler validates against. A scope tagged with the smaller
+      // number is discarded by `flush` as stale on the pass that would have published it,
+      // so the surface painted one revision behind and mirrored a post-edit caret into
+      // pre-edit nodes. `notify` runs synchronously from the publish inside the commit, so
+      // the package revision here is exactly the one the change produced.
+      const state = ensure(currentRevision());
       state.impact = widen(state.impact, change.impact);
       for (const id of change.dirty) state.paragraphIds.add(id);
       for (const id of change.created) {

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -44,6 +44,34 @@ when validating those layers.
 Run timing comparisons sequentially. Concurrent benchmark processes compete for CPU and can hide
 or exaggerate timing changes; the structural work counters remain deterministic either way.
 
+## Wasted-layout-work benchmark
+
+```bash
+bun run bench:scope-waste
+bun run bench:scope-waste --keystrokes 20 --json
+```
+
+The editing benchmark measures how much one layout pass costs. This one measures how many
+passes the engine computes and then throws away, which is a different failure and one that
+timings hide: a discarded pass is paid for in full and repeated, so a small fixture lays out
+twice per keystroke while every median still looks ordinary.
+
+That waste is also a correctness signal, which is why it is a gate rather than a report. A
+pass discarded as stale leaves the painted DOM one revision behind the model, so the
+post-edit caret cannot be written into the nodes on screen and the next repaint reads the
+pre-edit caret back — the cursor jumps to the start of the story. That was issue #361.
+
+Each scenario types a fixed burst into a DIFFERENT story — body, table cell, a header and
+footer declared in the file, a header edited after a package-level op, a header created in
+the session, and a footnote — and reports the passes discarded during the burst.
+`scope-waste-bench-gates.test.ts` pins every one of them at zero, so the normal test suite
+fails on a regression. Every counter is hardware-independent.
+
+Types into one story only, and you measure nothing: each story part counts its own
+revisions, and the body's happens to match the package's until a non-body edit or a
+package-level op moves one without the other. Adding a scenario means adding its name to
+`EXPECTED_SCENARIOS` in the gate, which fails if the list and the report disagree.
+
 ### CI performance-benchmark comment
 
 `.github/workflows/bench.yml` runs two benchmarks on every PR, each twice: once on the PR

--- a/scripts/bench/scope-waste-bench-gates.test.ts
+++ b/scripts/bench/scope-waste-bench-gates.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+
+interface Scenario {
+  readonly name: string;
+  readonly keystrokes: number;
+  readonly staleDiscards: number;
+  readonly cancelledRuns: number;
+}
+
+interface Report {
+  readonly scenarios: readonly Scenario[];
+}
+
+/** Every scope the bench types into. A missing one is a silently narrowed gate. */
+const EXPECTED_SCENARIOS = [
+  'body-paragraph',
+  'table-cell',
+  'declared-header',
+  'declared-footer',
+  'declared-header-after-package-op',
+  'created-header',
+  'footnote',
+];
+
+const KEYSTROKES = 5;
+
+test('typing wastes no layout passes, in any story', () => {
+  const root = resolve(import.meta.dir, '../..');
+  const run = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      'scripts/bench/scope-waste-bench.ts',
+      '--keystrokes',
+      String(KEYSTROKES),
+      '--json',
+    ],
+    cwd: root,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  expect(run.exitCode, run.stderr.toString()).toBe(0);
+  const report = JSON.parse(run.stdout.toString()) as Report;
+  expect(report.scenarios.map((scenario) => scenario.name)).toEqual(EXPECTED_SCENARIOS);
+
+  // Zero, not a budget. A discarded pass is not merely wasted work: the surface keeps the
+  // pre-edit paint, so the post-edit caret cannot be written into the nodes on screen and
+  // the next repaint reads the stale one back. That is issue #361, and with the header
+  // revision confusion in place these scenarios reported one discard per keystroke.
+  expect(
+    report.scenarios.map((scenario) => ({
+      name: scenario.name,
+      keystrokes: scenario.keystrokes,
+      staleDiscards: scenario.staleDiscards,
+      cancelledRuns: scenario.cancelledRuns,
+    }))
+  ).toEqual(
+    EXPECTED_SCENARIOS.map((name) => ({
+      name,
+      keystrokes: KEYSTROKES,
+      staleDiscards: 0,
+      cancelledRuns: 0,
+    }))
+  );
+}, 90_000);

--- a/scripts/bench/scope-waste-bench.ts
+++ b/scripts/bench/scope-waste-bench.ts
@@ -24,7 +24,11 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
-import { strToU8, zipSync } from 'fflate';
+// The engine's own zip writer, not `fflate` directly: `fflate` is a dependency of
+// `packages/core`, and a script in this directory resolves against the ROOT package, where
+// it is not declared. Importing it here ran fine locally on a hoisted install and failed on
+// CI with "Cannot find package 'fflate'".
+import { strToU8, writeZip } from '../../packages/core/src/store/package/zip.ts';
 import { paragraphTextOf } from '../../packages/core/src/store/index.ts';
 import { mountPaginatedSurface } from '../../packages/core/src/editor/paginated-surface.ts';
 import type { PaginatedSurface } from '../../packages/core/src/editor/paginated-surface-contract.ts';
@@ -42,45 +46,53 @@ const TABLE =
 
 /** A document carrying every story the scenarios type into, so nothing is created mid-run. */
 function fixture(): Uint8Array {
-  const part = (kind: 'header' | 'footer', name: string, text: string): [string, Uint8Array] => [
-    `word/${name}`,
-    strToU8(`<w:${kind === 'header' ? 'hdr' : 'ftr'} xmlns:w="${W}">${p(text)}</w:${
-      kind === 'header' ? 'hdr' : 'ftr'
-    }>`),
-  ];
-  return zipSync({
-    '[Content_Types].xml': strToU8(
-      `<Types xmlns="${CT}">` +
-        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
-        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
-        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
-        '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>' +
-        '</Types>'
-    ),
-    '_rels/.rels': strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
-    ),
-    'word/_rels/document.xml.rels': strToU8(
-      `<Relationships xmlns="${REL}">` +
-        `<Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/>` +
-        `<Relationship Id="rId11" Type="${R}/footer" Target="footer1.xml"/>` +
-        '</Relationships>'
-    ),
-    ...Object.fromEntries([
-      part('header', 'header1.xml', 'HDR'),
-      part('footer', 'footer1.xml', 'FTR'),
-    ]),
-    'word/document.xml': strToU8(
-      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>` +
-        p('body one') +
-        p('body two') +
-        TABLE +
-        '<w:sectPr>' +
-        '<w:headerReference w:type="default" r:id="rId10"/>' +
-        '<w:footerReference w:type="default" r:id="rId11"/>' +
-        '</w:sectPr></w:body></w:document>'
-    ),
-  });
+  const story = (kind: 'header' | 'footer', name: string, text: string): [string, Uint8Array] => {
+    const root = kind === 'header' ? 'hdr' : 'ftr';
+    return [`/word/${name}`, strToU8(`<w:${root} xmlns:w="${W}">${p(text)}</w:${root}>`)];
+  };
+  const contentTypes =
+    `<Types xmlns="${CT}">` +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+    '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>' +
+    '</Types>';
+  const documentXml =
+    `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>` +
+    p('body one') +
+    p('body two') +
+    TABLE +
+    '<w:sectPr>' +
+    '<w:headerReference w:type="default" r:id="rId10"/>' +
+    '<w:footerReference w:type="default" r:id="rId11"/>' +
+    '</w:sectPr></w:body></w:document>';
+  // Canonical part names carry a leading slash; `writeZip` validates them through the OPC
+  // profile and strips it for the zip entry.
+  return writeZip(
+    new Map<string, Uint8Array>([
+      ['/[Content_Types].xml', strToU8(contentTypes)],
+      [
+        '/_rels/.rels',
+        strToU8(
+          `<Relationships xmlns="${REL}">` +
+            `<Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/>` +
+            '</Relationships>'
+        ),
+      ],
+      [
+        '/word/_rels/document.xml.rels',
+        strToU8(
+          `<Relationships xmlns="${REL}">` +
+            `<Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/>` +
+            `<Relationship Id="rId11" Type="${R}/footer" Target="footer1.xml"/>` +
+            '</Relationships>'
+        ),
+      ],
+      story('header', 'header1.xml', 'HDR'),
+      story('footer', 'footer1.xml', 'FTR'),
+      ['/word/document.xml', strToU8(documentXml)],
+    ])
+  );
 }
 
 export interface ScopeWasteScenario {

--- a/scripts/bench/scope-waste-bench.ts
+++ b/scripts/bench/scope-waste-bench.ts
@@ -1,0 +1,233 @@
+// Wasted layout work per editing scope.
+//
+// The other benchmark in this directory measures how MUCH one layout pass costs. This one
+// measures how many passes the engine throws away, which is a different failure and one
+// that timing alone hides: a discarded pass is paid for in full and then repeated, so the
+// document is laid out twice per keystroke while every wall-clock median still looks
+// ordinary on a small fixture.
+//
+// It exists because that waste is also a correctness signal. A pass discarded as stale
+// leaves the painted DOM one revision behind the model, so the post-edit caret cannot be
+// written into the nodes that are on screen and the next repaint reads the pre-edit caret
+// back — the cursor jumps to the start of the story (issue #361). The counter reproduced
+// that bug exactly: five keystrokes in a header cost five discarded passes and zero in the
+// body, because a header part counts its own revisions and the scheduler validated them
+// against the package's.
+//
+// So every scenario types into a DIFFERENT story. A body-only benchmark cannot see any of
+// this: the body's revision and the package's coincide until a non-body edit or a
+// package-level op moves one without the other.
+//
+// Usage:
+//   bun scripts/bench/scope-waste-bench.ts [--keystrokes 5] [--json]
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { strToU8, zipSync } from 'fflate';
+import { paragraphTextOf } from '../../packages/core/src/store/index.ts';
+import { mountPaginatedSurface } from '../../packages/core/src/editor/paginated-surface.ts';
+import type { PaginatedSurface } from '../../packages/core/src/editor/paginated-surface-contract.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const TABLE =
+  '<w:tbl><w:tblGrid><w:gridCol w:w="2400"/><w:gridCol w:w="3600"/></w:tblGrid>' +
+  `<w:tr><w:tc>${p('A1')}</w:tc><w:tc>${p('B1')}</w:tc></w:tr>` +
+  `<w:tr><w:tc>${p('A2')}</w:tc><w:tc>${p('B2')}</w:tc></w:tr></w:tbl>`;
+
+/** A document carrying every story the scenarios type into, so nothing is created mid-run. */
+function fixture(): Uint8Array {
+  const part = (kind: 'header' | 'footer', name: string, text: string): [string, Uint8Array] => [
+    `word/${name}`,
+    strToU8(`<w:${kind === 'header' ? 'hdr' : 'ftr'} xmlns:w="${W}">${p(text)}</w:${
+      kind === 'header' ? 'hdr' : 'ftr'
+    }>`),
+  ];
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        `<Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/>` +
+        `<Relationship Id="rId11" Type="${R}/footer" Target="footer1.xml"/>` +
+        '</Relationships>'
+    ),
+    ...Object.fromEntries([
+      part('header', 'header1.xml', 'HDR'),
+      part('footer', 'footer1.xml', 'FTR'),
+    ]),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>` +
+        p('body one') +
+        p('body two') +
+        TABLE +
+        '<w:sectPr>' +
+        '<w:headerReference w:type="default" r:id="rId10"/>' +
+        '<w:footerReference w:type="default" r:id="rId11"/>' +
+        '</w:sectPr></w:body></w:document>'
+    ),
+  });
+}
+
+export interface ScopeWasteScenario {
+  readonly name: string;
+  /** Keystrokes typed into the scope. */
+  readonly keystrokes: number;
+  /** Layout passes computed and thrown away because the model had already moved on. */
+  readonly staleDiscards: number;
+  /** Cooperative runs abandoned mid-flight for a newer revision. */
+  readonly cancelledRuns: number;
+}
+
+export interface ScopeWasteReport {
+  readonly schema: 1;
+  readonly scenarios: readonly ScopeWasteScenario[];
+}
+
+function mount(): { surface: PaginatedSurface; container: HTMLElement } {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const result = mountPaginatedSurface(container, fixture(), { scale: 1 });
+  if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
+  return { surface: result.surface, container };
+}
+
+/** Type into whatever scope `open` left active, and count the passes thrown away. */
+function measure(
+  name: string,
+  keystrokes: number,
+  open: (surface: PaginatedSurface) => void
+): ScopeWasteScenario {
+  const { surface, container } = mount();
+  try {
+    open(surface);
+    // AFTER opening: entering a story and any lifecycle op are their own commits, and this
+    // measures typing.
+    const before = surface.state().perf;
+    for (let index = 0; index < keystrokes; index += 1) surface.type('x');
+    const after = surface.state().perf;
+    return {
+      name,
+      keystrokes,
+      staleDiscards: after.staleDiscards - before.staleDiscards,
+      cancelledRuns: after.cancelledRuns - before.cancelledRuns,
+    };
+  } finally {
+    surface.destroy();
+    container.remove();
+  }
+}
+
+function caretAtParagraph(surface: PaginatedSurface, paragraphId: string): void {
+  surface.setSelection({
+    anchor: { paragraphId, offset: 0 },
+    head: { paragraphId, offset: 0 },
+  });
+}
+
+/** Paragraph ids the fixture guarantees, in body document order. */
+function bodyParagraphs(surface: PaginatedSurface): readonly string[] {
+  return surface.session.paragraphIds();
+}
+
+/** The one paragraph carrying this text, so a scenario names its target rather than an index. */
+function paragraphWithText(surface: PaginatedSurface, text: string): string {
+  const part = surface.session.part();
+  for (const id of bodyParagraphs(surface)) {
+    if (paragraphTextOf(part, id) === text) return id;
+  }
+  throw new Error(`the fixture has no paragraph reading ${text}`);
+}
+
+/** Add a first-page header part. One package-level op; returns the new relationship id. */
+function createFirstPageHeader(surface: PaginatedSurface): string {
+  const created = surface.applyHeaderFooterLifecycle?.({
+    op: 'createHeaderFooter',
+    sectionIndex: 0,
+    kind: 'header',
+    variant: 'first',
+  });
+  if (!created?.ok) throw new Error(`create refused: ${created?.reason ?? 'unavailable'}`);
+  const slot = surface.session.headerFooterResolutionBySection()[0]?.headers.get('first');
+  if (!slot) throw new Error('the created header did not resolve');
+  return slot.rId;
+}
+
+export function runScopeWasteBench(keystrokes: number): ScopeWasteReport {
+  const scenarios: ScopeWasteScenario[] = [
+    measure('body-paragraph', keystrokes, (surface) => {
+      caretAtParagraph(surface, paragraphWithText(surface, 'body one'));
+    }),
+    measure('table-cell', keystrokes, (surface) => {
+      caretAtParagraph(surface, paragraphWithText(surface, 'A1'));
+    }),
+    measure('declared-header', keystrokes, (surface) => {
+      if (!surface.enterHeaderFooter({ rId: 'rId10' })) throw new Error('header did not open');
+    }),
+    measure('declared-footer', keystrokes, (surface) => {
+      if (!surface.enterHeaderFooter({ rId: 'rId11' })) throw new Error('footer did not open');
+    }),
+    measure('declared-header-after-package-op', keystrokes, (surface) => {
+      // A part declared in the FILE starts level with the package, so the two scenarios
+      // above pass even while the engine is confusing the counters. Any package-level op
+      // moves the package revision without touching a story's, and from then on the
+      // pre-existing header trails too — which is what a session that has been open for a
+      // while actually looks like.
+      createFirstPageHeader(surface);
+      if (!surface.enterHeaderFooter({ rId: 'rId10' })) throw new Error('header did not open');
+    }),
+    measure('created-header', keystrokes, (surface) => {
+      // The sharpest case, and the one issue #361 was reported against: a part created in
+      // this session starts its own revision counter at zero, so it trails the package's by
+      // the whole lifecycle op.
+      const rId = createFirstPageHeader(surface);
+      if (!surface.enterHeaderFooter({ rId })) throw new Error('header did not open');
+    }),
+    measure('footnote', keystrokes, (surface) => {
+      caretAtParagraph(surface, paragraphWithText(surface, 'body one'));
+      if (!surface.insertNote('footnote')) throw new Error('footnote was refused');
+      // Inserting a note opens its story, which is the third revision space: the notes part
+      // has its own counter too.
+      if (surface.activeScope().kind !== 'note') throw new Error('footnote did not open');
+    }),
+  ];
+  return { schema: 1, scenarios };
+}
+
+function parseKeystrokes(argv: readonly string[]): number {
+  const index = argv.indexOf('--keystrokes');
+  if (index < 0) return 5;
+  const value = Number(argv[index + 1]);
+  if (!Number.isInteger(value) || value < 1) throw new Error('--keystrokes needs a positive integer');
+  return value;
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const report = runScopeWasteBench(parseKeystrokes(argv));
+  if (argv.includes('--json')) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log('wasted layout passes per editing scope (lower is better; 0 is the contract)\n');
+    for (const scenario of report.scenarios) {
+      console.log(
+        `  ${scenario.name.padEnd(18)} ${scenario.keystrokes} keystrokes` +
+          ` → ${scenario.staleDiscards} discarded, ${scenario.cancelledRuns} cancelled`
+      );
+    }
+  }
+}


### PR DESCRIPTION
Typing in a header or footer moves the caret back to the start of the story. Each character you type lands before the one before it.

## What causes it

Every story part counts its own revisions. The body, each header and footer, and the notes part each keep a separate counter. A header or footer part starts its counter at zero when the editor creates the part.

The layout scheduler validates that counter against the package revision, so the two disagree for a header. The scheduler discards each keystroke's layout pass as stale, and the commit paints the previous revision. The engine cannot write the post-edit caret into pre-edit nodes, so the next render reads the stale caret back out of the DOM.

## Other code that mixes the two counters

Three more consumers compare or publish a story revision where the package revision belongs:

- `DocumentChange.revision` and `getDocumentHandle().revision` publish the story counter. Across two body edits, a header edit, and a body edit, a host receives the sequence 1, 2, 3, 1, 2. The number moves backward and then repeats values it already reported. The handle does not move at all for a header, footer, or note edit. A host that polls it for a dirty flag reads an unchanged document.
- Table command planning fills `storeRevision` from the body store, and explicit targets carry `sourceRevision` copied from `layout.revision`. Once the two counters diverge they never converge again, so `insertRow`, `deleteRow`, `insertColumn`, `deleteColumn`, and both resize commands refuse a freshly built target as stale. No chrome in this repository sends an explicit target, so this defect reaches the public API rather than the demo.
- The surface builds `createLayoutScheduler` without a `schedule` callback, which leaves `arm()` doing nothing. A commit from outside the surface reaches the pages only through `publish`, and nothing arms it, so the painted pages keep the old revision. The same gap strands the `carryForward` retry after an abandoned pass.

## Benchmark

To measure the wasted layout work, run `bun run bench:scope-waste`.

A discarded layout pass costs the work twice, and it is also what moves the caret. The benchmark types a fixed burst into each story and reports the passes the engine throws away. Its gate holds every scenario at zero. Revert the fix, and three of the seven scenarios report five discarded passes for five keystrokes. A benchmark that types only into the body reports none, because the body counter matches the package counter.

## Reference and test changes

The reference for `sourceRevision` names the revision it carries. The earlier text said "the store revision" without saying which one, which left you no way to build a target the engine accepts.

The table tests stamp targets from `layout().revision` and planner input from `packageRevision()`. Their fixtures hold body content only, where the two counters match, so a body-space stamp passes every test in that file while refusing every real command.

One font test asserted that an asynchronous font resolution had not yet finished. Nothing guarantees that ordering, and a loaded parallel run beats it. The test asserts the property that assertion stood for: you can read the document before its fonts resolve.

## Verification

Verified in the browser against the demo. These checks pass: `typecheck`, `test`, `lint`, `format`, `check:parity`, `i18n:validate`, `build:packages`, and `api:check`.

The added timer leaves typing cost unchanged, because `flush` cancels whatever a commit arms. Across 300 keystrokes over 150 paragraphs, the difference falls inside the run-to-run spread.

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fUnyPrb5yaFaU6wSsP64V
