### PR TITLE
docs: list the Vue adapter in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@
   <a href="https://www.docx-editor.dev/docs"><img src="https://img.shields.io/badge/Docs-3B5BDB?style=flat-square&logo=readthedocs&logoColor=white" alt="Documentation" /></a>
 </p>
 
-Open-source WYSIWYG `.docx` editor for React. Word-faithful pagination, tracked changes, comments — and **lossless round-trip**: untouched content and unsupported OOXML survive editing and save. **[Live demo](https://docx-editor.dev/editor)** | **[Documentation](https://www.docx-editor.dev/docs)**
+Open-source WYSIWYG `.docx` editor for React and Vue. Word-faithful pagination, tracked changes, comments — and **lossless round-trip**: untouched content and unsupported OOXML survive editing and save. **[Live demo](https://docx-editor.dev/editor)** | **[Documentation](https://www.docx-editor.dev/docs)**
 
 ## Quick Start
 
 ```bash
-npm install @docx-editor.dev/react @docx-editor.dev/core
+npm install @docx-editor.dev/react @docx-editor.dev/core   # React
+npm install @docx-editor.dev/vue @docx-editor.dev/core     # Vue
 ```
 
-See the [React quick start](#react) below.
+See the [React](#react) or [Vue](#vue) quick start below.
 
 <p align="center">
   <a href="https://docx-editor.dev/editor">
@@ -34,7 +35,8 @@ See the [React quick start](#react) below.
 | Package                                                                                    | Description                                                                                                                                                                    | Docs                                                    |
 | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
 | [`@docx-editor.dev/react`](https://www.npmjs.com/package/@docx-editor.dev/react)           | <img src="https://cdn.simpleicons.org/react/61DAFB" width="20" align="middle" /> &nbsp; React adapter. Root component, provider primitives, shared hooks, and compound chrome. | [Docs](https://www.docx-editor.dev/docs/2.x/react)      |
-| [`@docx-editor.dev/core`](https://www.npmjs.com/package/@docx-editor.dev/core)             | Framework-agnostic engine: OOXML read/write, canonical document tree, layout, paint. Depend on this if you fork the React adapter.                                             | [Docs](https://www.docx-editor.dev/docs/2.x/core)       |
+| [`@docx-editor.dev/vue`](https://www.npmjs.com/package/@docx-editor.dev/vue)               | <img src="https://cdn.simpleicons.org/vuedotjs/4FC08D" width="20" align="middle" /> &nbsp; Vue 3 adapter. Root component, composition primitives, shared composables, and compound chrome.  | [Docs](https://www.docx-editor.dev/docs/2.x/vue)        |
+| [`@docx-editor.dev/core`](https://www.npmjs.com/package/@docx-editor.dev/core)             | Framework-agnostic engine: OOXML read/write, canonical document tree, layout, paint. Depend on this if you fork an adapter.                                             | [Docs](https://www.docx-editor.dev/docs/2.x/core)       |
 | [`@docx-editor.dev/i18n`](https://www.npmjs.com/package/@docx-editor.dev/i18n)             | Shared locale strings and types consumed by the adapter.                                                                                                                       | [Docs](https://www.docx-editor.dev/docs/2.x/i18n)       |
 | [`@docx-editor.dev/pro`](https://www.npmjs.com/package/@docx-editor.dev/pro)               | Tracked changes, comments, and custom nodes.                                                                                                                                   | [Docs](https://www.docx-editor.dev/docs/2.x/pro)        |
 | [`@docx-editor.dev/editor-api`](https://www.npmjs.com/package/@docx-editor.dev/editor-api) | Office.js-compatible editing API: a batching object model that edits a document from a server, or an editor already open in a page.                                            | [Docs](https://www.docx-editor.dev/docs/2.x/editor-api) |
@@ -73,7 +75,37 @@ export function App() {
 
 > **Next.js / SSR:** Use dynamic import. The editor requires the DOM.
 
-Full docs: [`packages/react`](packages/react) · [API reference](https://www.docx-editor.dev/docs/props).
+Full docs: [`packages/react`](packages/react) · [API reference](https://www.docx-editor.dev/docs/2.x/react/props).
+
+## Vue
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { DocxEditor } from '@docx-editor.dev/vue';
+import '@docx-editor.dev/vue/styles.css';
+
+const doc = ref<Uint8Array>();
+
+async function onPick(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  doc.value = file ? new Uint8Array(await file.arrayBuffer()) : undefined;
+}
+</script>
+
+<template>
+  <div style="height: 100vh; display: flex; flex-direction: column">
+    <input type="file" accept=".docx" @change="onPick" />
+    <div style="flex: 1; min-height: 0">
+      <DocxEditor v-if="doc" :document="doc" mode="edit" />
+    </div>
+  </div>
+</template>
+```
+
+> **Nuxt / SSR:** Load the editor in a client-only component. The editor requires the DOM.
+
+Full docs: [`packages/vue`](packages/vue) · [API reference](https://www.docx-editor.dev/docs/2.x/vue/props).
 
 ## Development
 
@@ -86,9 +118,9 @@ bun run typecheck
 
 A live preview of `main` is auto-deployed at **[latest.docx-editor.dev](https://latest.docx-editor.dev/)** — useful for trying out changes before they ship to npm.
 
-Examples: [Vite](examples/vite) | [Next.js](examples/nextjs) | [Remix](examples/remix) | [Astro](examples/astro)
+Examples: [Vite](examples/vite) | [Next.js](examples/nextjs) | [Remix](examples/remix) | [Astro](examples/astro) | [Vue](examples/vue)
 
-**[Documentation](https://www.docx-editor.dev/docs)** | **[Props & Ref Methods](https://www.docx-editor.dev/docs/props)** | **[Architecture](https://www.docx-editor.dev/docs/architecture)**
+**[Documentation](https://www.docx-editor.dev/docs)** | **[React props & ref methods](https://www.docx-editor.dev/docs/2.x/react/props)** | **[Vue props & ref methods](https://www.docx-editor.dev/docs/2.x/vue/props)**
 
 ## Contributing
 


### PR DESCRIPTION
The README described the project as React only. It now covers both adapters: `@docx-editor.dev/vue` has a row in the packages table, a quick start section that mirrors the React one, and an entry in the examples list.

Two footer links pointed at pages that don't exist in `docs/site/content/`: `/docs/props` and `/docs/architecture`. They now point at `/docs/2.x/react/props` and `/docs/2.x/vue/props`.

No changeset, because this changes documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkZMP5Uv5yRmaH4aerkcT9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891773&installation_model_id=422592&pr_number=366&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F366&signature=5a430290ceb0ed66e2967c1011ca1790ee7830407a91a813d97fd1cb2595d3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->