### PR TITLE
docs: link to the docs site and the Igloo live preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.docx-editor.dev/docs"><img src="https://img.shields.io/badge/Docs-3B5BDB?style=flat-square&logo=readthedocs&logoColor=white" alt="Documentation" /></a>
 </p>
 
-Open-source WYSIWYG `.docx` editor for React and Vue. Word-faithful pagination, tracked changes, comments — and **lossless round-trip**: untouched content and unsupported OOXML survive editing and save. **[Live demo](https://docx-editor.dev/editor)** | **[Documentation](https://www.docx-editor.dev/docs)**
+Open-source WYSIWYG `.docx` editor for React and Vue. Word-faithful pagination, tracked changes, comments, and lossless round-trip: untouched content and unsupported OOXML survive the save. **[Live demo](https://docx-editor.dev/editor)** | **[Documentation](https://www.docx-editor.dev/docs)**
 
 ## Quick Start
 
@@ -75,7 +75,7 @@ export function App() {
 
 > **Next.js / SSR:** Use dynamic import. The editor requires the DOM.
 
-Full docs: [`packages/react`](packages/react) · [API reference](https://www.docx-editor.dev/docs/2.x/react/props).
+Full docs: [React adapter](https://www.docx-editor.dev/docs/2.x/react) · [Props and ref methods](https://www.docx-editor.dev/docs/2.x/react/props).
 
 ## Vue
 
@@ -105,7 +105,7 @@ async function onPick(event: Event) {
 
 > **Nuxt / SSR:** Load the editor in a client-only component. The editor requires the DOM.
 
-Full docs: [`packages/vue`](packages/vue) · [API reference](https://www.docx-editor.dev/docs/2.x/vue/props).
+Full docs: [Vue adapter](https://www.docx-editor.dev/docs/2.x/vue) · [Props and ref methods](https://www.docx-editor.dev/docs/2.x/vue/props).
 
 ## Development
 

--- a/docs/site/content/examples.mdx
+++ b/docs/site/content/examples.mdx
@@ -67,8 +67,9 @@ To use published packages, replace the `workspace:*` versions in the starter's `
     Render the editor as a React island. The client:only="react" directive disables SSR for the
     component.
   </Card>
-  <Card title="Igloo" href="https://github.com/eigenpal/docx-editor/tree/main/examples/igloo">
-    Build a themed editor. Host markup and hooks replace the packaged controls.
+  <Card title="🧊 Igloo" href="https://igloo.docx-editor.dev/">
+    Build a themed editor. Host markup and hooks replace the packaged controls. This card opens the
+    deployed demo. Its source is in `examples/igloo`.
   </Card>
   <Card
     title="Custom nodes"

--- a/docs/site/content/guides/toolbar.mdx
+++ b/docs/site/content/guides/toolbar.mdx
@@ -85,7 +85,7 @@ When the caret or a rectangular cell selection is inside a table, the formatting
 
 These controls target the **innermost** nested table under the pointer or selection. Merge and split remain unsupported; tables with merged cells refuse column resize/insert/delete with an explicit disabled reason.
 
-The [Igloo demo](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) is a worked example of every point above: it hand-orders the bar, re-icons every packaged part, and adds two host actions.
+The [Igloo demo](https://igloo.docx-editor.dev/) 🧊 is a worked example of every point above: it hand-orders the bar, re-icons every packaged part, and adds two host actions. Its [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) is in the repository.
 
 ## Next steps
 

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -12,9 +12,10 @@ The packaged toolbar uses the hooks and primitives on this page.
 Your controls can use the same command and state APIs.
 
 <Callout>
-  The [Igloo customization
-  example](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) implements these
-  patterns with custom markup. Run it with `bun run dev:igloo`.
+  🧊 The [Igloo customization example](https://igloo.docx-editor.dev/) implements these patterns
+  with custom markup. Open it to use the result, or read the
+  [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) and run it with `bun
+  run dev:igloo`.
 </Callout>
 
 ## Primitives
@@ -684,7 +685,8 @@ Apply the same behavior to custom chrome.
 
 ## Next steps
 
-- [Igloo customization example](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo)
+- [Igloo customization example](https://igloo.docx-editor.dev/) 🧊, and its
+  [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo)
 - [Custom nodes example](https://github.com/eigenpal/docx-editor/tree/main/examples/custom-nodes)
 - [React hooks](/docs/2.x/react/hooks)
 - [Toolbar guide](/docs/2.x/guides/toolbar)

--- a/docs/site/content/react/index.mdx
+++ b/docs/site/content/react/index.mdx
@@ -161,5 +161,6 @@ For object model details, see the
 - [React hooks](/docs/2.x/react/hooks)
 - [React props](/docs/2.x/react/props)
 - [React examples](/docs/2.x/react/examples)
-- [Igloo customization example](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo)
+- [Igloo customization example](https://igloo.docx-editor.dev/) 🧊, and its
+  [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo)
 - [React API reference](/docs/2.x/api/react)


### PR DESCRIPTION
Two link fixes.

In the README, the "Full docs" line under each adapter pointed at the package folder in this repository. It now points at that adapter's page on the docs site, next to the props reference. The intro sentence drops the bold and one clause.

In the docs site, every Igloo reference pointed at the source on GitHub. The reader had no way to open the result. Each reference now leads with the deployed demo at `igloo.docx-editor.dev` and keeps the source as a second link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkZMP5Uv5yRmaH4aerkcT9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789892428&installation_model_id=422592&pr_number=367&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F367&signature=64089feb64eb4dd328b0b17917d8e0c0e5b6096e3d2b240d0decd37c73299749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->