### PR TITLE
fix(core): paragraph spacing, alignment and indent follow the paragraph

### DIFF
--- a/.changeset/paragraph-spacing-cascade.md
+++ b/.changeset/paragraph-spacing-cascade.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fixed "Add space before/after paragraph" leaving the page unchanged, along with the line-spacing tick, the alignment button and Increase Indent reading a paragraph's document defaults instead of its own formatting. A paragraph that switches its style's page break off no longer starts a new page, and Ctrl+1/5/2 no longer deletes the paragraph's space before and after. Fixes #360
+Fixed "Add space before/after paragraph" leaving the page unchanged, along with the line-spacing tick, the alignment button and Increase Indent reading a paragraph's document defaults instead of its own formatting. Paragraph formatting controls now answer for an open header, footer or note instead of reading the body, structural edits act on the cells a rectangle selects rather than everything between its corners, and a font pick, an underline toggle and a list conversion keep the settings they do not name. Fixes #360

--- a/.changeset/paragraph-spacing-cascade.md
+++ b/.changeset/paragraph-spacing-cascade.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
-Fixed "Add space before/after paragraph" leaving the page unchanged, along with the line-spacing tick, the alignment button and Increase Indent reading a paragraph's document defaults instead of its own formatting. Paragraph formatting controls now answer for an open header, footer or note instead of reading the body, structural edits act on the cells a rectangle selects rather than everything between its corners, and a font pick, an underline toggle and a list conversion keep the settings they do not name. Fixes #360
+Fixed paragraph formatting controls reading a paragraph's document defaults instead of its own formatting, which left "Add space before/after paragraph" with no effect on the page. `PaginatedDocxEditorHandle.setParagraphProperty` takes an `options.mergeAttributes` flag so a line-spacing pick keeps the paragraph's spacing. Fixes #360

--- a/.changeset/paragraph-spacing-cascade.md
+++ b/.changeset/paragraph-spacing-cascade.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixed "Add space before/after paragraph" leaving the page unchanged, along with the line-spacing tick, the alignment button and Increase Indent reading a paragraph's document defaults instead of its own formatting. Fixes #360

--- a/.changeset/paragraph-spacing-cascade.md
+++ b/.changeset/paragraph-spacing-cascade.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fixed "Add space before/after paragraph" leaving the page unchanged, along with the line-spacing tick, the alignment button and Increase Indent reading a paragraph's document defaults instead of its own formatting. Fixes #360
+Fixed "Add space before/after paragraph" leaving the page unchanged, along with the line-spacing tick, the alignment button and Increase Indent reading a paragraph's document defaults instead of its own formatting. A paragraph that switches its style's page break off no longer starts a new page, and Ctrl+1/5/2 no longer deletes the paragraph's space before and after. Fixes #360

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -1953,6 +1953,12 @@ export const MAX_STORY_SDT_NESTING = 32;
 export const MAX_SVG_SNIFF_BYTES = 512;
 
 // @public
+export function mergedFontProperty(authored: readonly OoxmlProperty[], incoming: OoxmlProperty): OoxmlProperty;
+
+// @public
+export function mergedMultiSettingProperty(authored: readonly OoxmlProperty[], incoming: OoxmlProperty): OoxmlProperty;
+
+// @public
 export function mergedProperties(existing: readonly OoxmlProperty[], incoming: OoxmlProperty | readonly OoxmlProperty[]): OoxmlProperty[];
 
 // @public

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -1959,6 +1959,9 @@ export function mergedFontProperty(authored: readonly OoxmlProperty[], incoming:
 export function mergedMultiSettingProperty(authored: readonly OoxmlProperty[], incoming: OoxmlProperty): OoxmlProperty;
 
 // @public
+export function mergedParagraphMarkProperties(part: OoxmlPart, paragraphId: string, incoming: OoxmlProperty | readonly OoxmlProperty[]): OoxmlProperty[];
+
+// @public
 export function mergedProperties(existing: readonly OoxmlProperty[], incoming: OoxmlProperty | readonly OoxmlProperty[]): OoxmlProperty[];
 
 // @public

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -1495,8 +1495,9 @@ export interface PaginatedDocxEditorHandle {
     sectionProperties(): SectionProperties | null;
     // (undocumented)
     selectAll(): void;
-    // (undocumented)
-    setParagraphProperty(localName: string, attributes?: Record<string, string>): void;
+    setParagraphProperty(localName: string, attributes?: Record<string, string | null>, options?: {
+        readonly mergeAttributes?: boolean;
+    }): void;
     // (undocumented)
     setRunProperty(localName: string, attributes?: Record<string, string>): void;
     // (undocumented)

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -4072,8 +4072,9 @@ export interface PaginatedDocxEditorHandle {
     sectionProperties(): SectionProperties | null;
     // (undocumented)
     selectAll(): void;
-    // (undocumented)
-    setParagraphProperty(localName: string, attributes?: Record<string, string>): void;
+    setParagraphProperty(localName: string, attributes?: Record<string, string | null>, options?: {
+        readonly mergeAttributes?: boolean;
+    }): void;
     // (undocumented)
     setRunProperty(localName: string, attributes?: Record<string, string>): void;
     // (undocumented)

--- a/packages/core/src/automation/__tests__/automation-formatting.test.ts
+++ b/packages/core/src/automation/__tests__/automation-formatting.test.ts
@@ -304,6 +304,42 @@ describe('reading a paragraph format', () => {
   });
 });
 
+describe('a font write keeps the slots it does not name', () => {
+  // `w:rFonts` carries a font per script. Replacing the element to change the Latin face
+  // deleted the East Asian and complex-script ones — on the RUN and on the paragraph MARK,
+  // which the marker of a list item inherits from.
+  const MULTI_SCRIPT = docx(
+    `<w:p><w:pPr><w:rPr>` +
+      '<w:rFonts w:ascii="Georgia" w:hAnsi="Georgia" w:eastAsia="MS Mincho" w:cs="Arabic Typesetting"/>' +
+      `</w:rPr></w:pPr>` +
+      run(
+        'text',
+        '<w:rFonts w:ascii="Georgia" w:hAnsi="Georgia" w:eastAsia="MS Mincho" w:cs="Arabic Typesetting"/>'
+      ) +
+      '</w:p>'
+  );
+
+  test('the run and the mark both keep eastAsia and cs', () => {
+    const host = open(MULTI_SCRIPT);
+    const body = roots(host).body;
+    const [first] = paragraphsOf(host, body);
+    const response = host.execute({
+      operations: [{ op: 'setFont', span: { paragraph: first! }, font: { name: 'Verdana' } }],
+    });
+    expect(response.ok).toBe(true);
+
+    const xml = savedMainXml(host);
+    // Two `w:rFonts` — the mark's and the run's — and neither may have lost a slot.
+    const fonts = [...xml.matchAll(/<w:rFonts [^>]*\/>/g)].map((match) => match[0]);
+    expect(fonts).toHaveLength(2);
+    for (const font of fonts) {
+      expect(font).toContain('w:ascii="Verdana"');
+      expect(font).toContain('w:eastAsia="MS Mincho"');
+      expect(font).toContain('w:cs="Arabic Typesetting"');
+    }
+  });
+});
+
 describe('writing a paragraph format', () => {
   test('authors what was asked for and leaves the rest of the properties alone', () => {
     const host = open(SPACED);

--- a/packages/core/src/automation/formatting.ts
+++ b/packages/core/src/automation/formatting.ts
@@ -300,9 +300,15 @@ export function paragraphFormatRead(
  * paragraph — and a caller who wrote that zero back would flatten the hang.
  */
 function firstLineIndentOf(indent: OoxmlElement | undefined): number | null {
+  // HANGING WINS (§17.3.1.12). The two are one setting spelled two ways, not two settings,
+  // and an element stating both is a real shape — this engine's own `writeFirstLine` emits
+  // the unused one as an explicit zero. Preferring `w:firstLine` made this lane report a
+  // positive indent for a paragraph the page hangs, and a caller writing that back flattened
+  // it. Every other reader here already resolves the pair this way.
+  const hanging = pointsFromTwips(attributeOf(indent, 'hanging'));
+  if (hanging !== null && hanging > 0) return -hanging;
   const firstLine = pointsFromTwips(attributeOf(indent, 'firstLine'));
   if (firstLine !== null) return firstLine;
-  const hanging = pointsFromTwips(attributeOf(indent, 'hanging'));
   return hanging === null ? null : -hanging;
 }
 
@@ -340,9 +346,12 @@ export function fontProperties(request: AutomationFontWrite): FormattingPlan<Oox
     // The value goes into an attribute the serializer escapes; what it must NOT carry is a
     // character XML cannot hold at all, which escaping does not fix.
     if (!isValidXmlText(name)) return { ok: false, detail: 'name: not valid XML text' };
+    // Latin and high-range slots only. Writing `cs` too meant a font pick rewrote the
+    // complex-script face as well, and the whole element replaced the run's own — see
+    // `mergedFontProperty`, which the write path merges through.
     properties.push({
       localName: 'rFonts',
-      attributes: { ascii: name, hAnsi: name, cs: name },
+      attributes: { ascii: name, hAnsi: name },
     });
   }
   if (request.size !== undefined) {

--- a/packages/core/src/automation/plan.ts
+++ b/packages/core/src/automation/plan.ts
@@ -30,8 +30,8 @@ import {
   SEARCH_MATCH_LIMIT,
 } from '../store/store/text-match.ts';
 import {
-  directParagraphMarkProperties,
   directParagraphProperties,
+  mergedParagraphMarkProperties,
   mergedProperties,
   runPropertyEdits,
 } from '../store/store/direct-properties.ts';
@@ -1200,10 +1200,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
         ops.push({
           op: 'setParagraphMarkProperties',
           paragraphId: share.paragraphId,
-          properties: mergedProperties(
-            directParagraphMarkProperties(part, share.paragraphId),
-            properties.value
-          ),
+          properties: mergedParagraphMarkProperties(part, share.paragraphId, properties.value),
         });
       }
     }

--- a/packages/core/src/contracts/types.ts
+++ b/packages/core/src/contracts/types.ts
@@ -200,7 +200,15 @@ export interface RunFormatting {
     readonly rule: 'multiple' | 'exact' | 'atLeast';
     readonly value: number;
   };
-  /** Space above and below the paragraph at the selection, in points. */
+  /**
+   * Space above and below the paragraph at the selection, in points.
+   *
+   * The measurement the cascade STATES — `w:docDefaults`, the style chain and direct
+   * formatting resolved together — not the gap the page finally draws. The two differ for a
+   * paragraph carrying `w:beforeAutospacing`, where Word substitutes its own value and
+   * ignores the measurement, and again where two paragraphs collapse their adjacent spacing.
+   * Absent when the selection's paragraphs disagree or no level states it.
+   */
   readonly spaceBeforePt?: number;
   readonly spaceAfterPt?: number;
   /**

--- a/packages/core/src/editor/__tests__/multi-setting-writes.test.ts
+++ b/packages/core/src/editor/__tests__/multi-setting-writes.test.ts
@@ -98,6 +98,27 @@ function firstRunProperties(editor: DocxEditorInstance): Record<string, Record<s
   return byName;
 }
 
+/** Every run's own `w:rFonts` attributes, keyed by run index. */
+function runFontProperties(
+  editor: DocxEditorInstance
+): Record<number, Record<string, string> | undefined> {
+  const part = editor.surface!.session.part();
+  const paragraph = findNode(part, editor.surface!.session.paragraphIds()[0]!);
+  if (!paragraph || paragraph.kind === 'textValue') throw new Error('no paragraph');
+  const byIndex: Record<number, Record<string, string> | undefined> = {};
+  let index = 0;
+  for (const child of paragraph.children) {
+    if (child.kind !== 'run') continue;
+    const found = authoredProperties(
+      propertyContainer(child, 'runProperties', 'rPr'),
+      AUTHORABLE_RUN_PROPERTIES
+    ).find((property) => property.localName === 'rFonts');
+    byIndex[index] = found?.attributes ? { ...found.attributes } : undefined;
+    index += 1;
+  }
+  return byIndex;
+}
+
 describe('w:rFonts keeps the font slots a pick does not name', () => {
   const RUN =
     '<w:p><w:r><w:rPr>' +
@@ -134,6 +155,32 @@ describe('w:rFonts keeps the font slots a pick does not name', () => {
       hAnsi: 'Georgia',
       eastAsia: 'SimSun',
     });
+  });
+});
+
+describe('a font armed at the caret merges like one applied to a selection', () => {
+  test("typing after a caret font pick keeps the run's other slots", () => {
+    // The armed path folds its properties separately from the selection path, so it kept
+    // its own copy of the replace-the-element bug: the two halves of one feature disagreed.
+    const editor = mount(
+      '<w:p><w:r><w:rPr>' +
+        '<w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:eastAsia="SimSun" w:cs="Arial"/>' +
+        '</w:rPr><w:t>text</w:t></w:r></w:p>'
+    );
+    const id = editor.surface!.session.paragraphIds()[0]!;
+    // A COLLAPSED caret inside the run arms the pick rather than writing it.
+    editor.surface!.setSelection({
+      anchor: { paragraphId: id, offset: 2 },
+      head: { paragraphId: id, offset: 2 },
+    });
+    editor.exec({ type: 'setMarkAttr', mark: 'fontFamily', value: 'Verdana' });
+    editor.exec({ type: 'insertText', text: 'XY' });
+
+    const fonts = Object.values(runFontProperties(editor)).filter(Boolean);
+    const typed = fonts.find((attributes) => attributes.ascii === 'Verdana');
+    expect(typed).toBeDefined();
+    expect(typed!.eastAsia).toBe('SimSun');
+    expect(typed!.cs).toBe('Arial');
   });
 });
 

--- a/packages/core/src/editor/__tests__/multi-setting-writes.test.ts
+++ b/packages/core/src/editor/__tests__/multi-setting-writes.test.ts
@@ -1,0 +1,208 @@
+// A write that means to change ONE setting must not replace the element carrying it.
+//
+// Most OOXML formatting elements hold a single setting and replace cleanly. A handful hold
+// several independent ones, and for those a replacing write is silent data loss:
+//
+//   * `w:rFonts` holds a font per script, so a Latin font pick deleted the run's East Asian
+//     and complex-script faces — invisible here, and visible the moment Word reopens it;
+//   * `w:numPr` holds the level AND the definition, so converting a bullet to a number reset
+//     `w:ilvl` to 0 and the item jumped out to the left margin;
+//   * `w:u` holds the underline style AND its colour, so toggling twice repainted a red
+//     underline black.
+//
+// The mirror-image mistake is merging where a SUPERSEDING twin survives: `w:beforeLines` and
+// `w:leftChars` measure the same setting in other units and outrank the twips beside them, so
+// a value written next to one is a number the file then ignores.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  AUTHORABLE_RUN_PROPERTIES,
+  authoredProperties,
+  findNode,
+  propertyContainer,
+  serializeOoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string, extra?: Record<string, Uint8Array>): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        (extra
+          ? '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>'
+          : '') +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    ...(extra
+      ? {
+          'word/_rels/document.xml.rels': strToU8(
+            `<Relationships xmlns="${REL}"><Relationship Id="rId8" Type="${OD.replace('officeDocument', 'numbering')}" Target="numbering.xml"/></Relationships>`
+          ),
+        }
+      : {}),
+    ...extra,
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function mount(body: string, extra?: Record<string, Uint8Array>): DocxEditorInstance {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: docx(body, extra) });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+const xmlOf = (editor: DocxEditorInstance) => serializeOoxmlPart(editor.surface!.session.part());
+
+/** Put the caret across the whole of the first paragraph. */
+function selectAll(editor: DocxEditorInstance): void {
+  editor.surface!.selectAll();
+}
+
+/**
+ * The first RUN's own `w:rPr`, as attributes by element name.
+ *
+ * Asserted on rather than the serialized document, which cannot tell a run's properties from
+ * the paragraph MARK's copy of the same element beside it — an assertion that only matched
+ * the mark passed while the run had lost the value.
+ */
+function firstRunProperties(editor: DocxEditorInstance): Record<string, Record<string, string>> {
+  const part = editor.surface!.session.part();
+  const paragraph = findNode(part, editor.surface!.session.paragraphIds()[0]!);
+  if (!paragraph || paragraph.kind === 'textValue') throw new Error('no paragraph');
+  const run = paragraph.children.find((child) => child.kind === 'run');
+  if (!run) throw new Error('no run');
+  const byName: Record<string, Record<string, string>> = {};
+  for (const property of authoredProperties(
+    propertyContainer(run, 'runProperties', 'rPr'),
+    AUTHORABLE_RUN_PROPERTIES
+  )) {
+    byName[property.localName] = { ...(property.attributes ?? {}) };
+  }
+  return byName;
+}
+
+describe('w:rFonts keeps the font slots a pick does not name', () => {
+  const RUN =
+    '<w:p><w:r><w:rPr>' +
+    '<w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:eastAsia="SimSun" w:cs="Arial Unicode MS" w:hint="eastAsia"/>' +
+    '</w:rPr><w:t>text</w:t></w:r></w:p>';
+
+  test('a Latin font pick leaves eastAsia, cs and hint alone', () => {
+    const editor = mount(RUN);
+    selectAll(editor);
+    expect(editor.exec({ type: 'setMarkAttr', mark: 'fontFamily', value: 'Georgia' }).ok).toBe(
+      true
+    );
+    // The three the pick never named are kept, and Word's font box does not touch them either.
+    expect(firstRunProperties(editor).rFonts).toEqual({
+      ascii: 'Georgia',
+      hAnsi: 'Georgia',
+      eastAsia: 'SimSun',
+      cs: 'Arial Unicode MS',
+      hint: 'eastAsia',
+    });
+  });
+
+  test('a pick clears the THEME reference for the slot it sets', () => {
+    // A theme attribute names the slot indirectly and outranks the explicit name beside it,
+    // so a merge that kept it would leave the pick resolving back to the theme font — the
+    // same shape as the autospacing flag swallowing a spacing write.
+    const editor = mount(
+      '<w:p><w:r><w:rPr><w:rFonts w:asciiTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:eastAsia="SimSun"/></w:rPr><w:t>text</w:t></w:r></w:p>'
+    );
+    selectAll(editor);
+    editor.exec({ type: 'setMarkAttr', mark: 'fontFamily', value: 'Georgia' });
+    expect(firstRunProperties(editor).rFonts).toEqual({
+      ascii: 'Georgia',
+      hAnsi: 'Georgia',
+      eastAsia: 'SimSun',
+    });
+  });
+});
+
+describe('w:u keeps its colour across a toggle', () => {
+  test('underline off and on again leaves the authored colour', () => {
+    const editor = mount(
+      '<w:p><w:r><w:rPr><w:u w:val="single" w:color="FF0000"/></w:rPr><w:t>text</w:t></w:r></w:p>'
+    );
+    selectAll(editor);
+    editor.exec({ type: 'toggleMark', mark: 'underline' });
+    editor.exec({ type: 'toggleMark', mark: 'underline' });
+    // Dropped, the underline came back black on the page — `run-style.ts` reads this colour
+    // and `semantic-paint.ts` paints it.
+    expect(firstRunProperties(editor).u).toEqual({ val: 'single', color: 'FF0000' });
+  });
+});
+
+describe('a superseding twin is cleared with the value it supersedes', () => {
+  test('setParagraphSpacing clears w:beforeLines beside the twips it writes', () => {
+    const editor = mount(
+      '<w:p><w:pPr><w:spacing w:before="480" w:beforeLines="200"/></w:pPr>' +
+        '<w:r><w:t>text</w:t></w:r></w:p>'
+    );
+    selectAll(editor);
+    editor.exec({ type: 'setParagraphSpacing', beforePt: 0 });
+    const xml = xmlOf(editor);
+    expect(xml).toContain('w:before="0"');
+    // Left in place, the line-unit value outranks the twips (§17.3.1.33) and "space before
+    // 0" did not close the gap in Word.
+    expect(xml).not.toContain('beforeLines');
+  });
+
+  test('setIndent clears w:leftChars beside the twips it writes', () => {
+    const editor = mount(
+      '<w:p><w:pPr><w:ind w:left="1440" w:leftChars="400"/></w:pPr>' +
+        '<w:r><w:t>text</w:t></w:r></w:p>'
+    );
+    selectAll(editor);
+    expect(editor.surface!.setIndent({ left: 0 })).toBe(true);
+    const xml = xmlOf(editor);
+    expect(xml).not.toContain('leftChars');
+  });
+});
+
+describe('w:numPr keeps the level when the list kind changes', () => {
+  const NUMBERING = strToU8(
+    `<w:numbering xmlns:w="${W}">` +
+      '<w:abstractNum w:abstractNumId="0">' +
+      '<w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="&#8226;"/>' +
+      '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>' +
+      '<w:lvl w:ilvl="1"><w:numFmt w:val="bullet"/><w:lvlText w:val="o"/>' +
+      '<w:pPr><w:ind w:left="1440" w:hanging="360"/></w:pPr></w:lvl>' +
+      '<w:lvl w:ilvl="2"><w:numFmt w:val="bullet"/><w:lvlText w:val="&#9642;"/>' +
+      '<w:pPr><w:ind w:left="2160" w:hanging="360"/></w:pPr></w:lvl>' +
+      '</w:abstractNum>' +
+      '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>' +
+      '</w:numbering>'
+  );
+
+  test('a level-2 bullet becomes a level-2 number, not a level-0 one', () => {
+    const editor = mount(
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="2"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+        '<w:r><w:t>item</w:t></w:r></w:p>',
+      { 'word/numbering.xml': NUMBERING }
+    );
+    selectAll(editor);
+    expect(editor.surface!.toggleList('ordered')).toBe(true);
+    // `w:numPr` carries the level and the definition together, and the op mints a fresh
+    // one: naming no level reset `w:ilvl` to 0 and the item jumped two levels out.
+    expect(xmlOf(editor)).toContain('w:ilvl w:val="2"');
+  });
+});

--- a/packages/core/src/editor/__tests__/paragraph-cascade-reads.test.ts
+++ b/packages/core/src/editor/__tests__/paragraph-cascade-reads.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { createKeyDownHandler } from '../surface-input.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -142,6 +143,81 @@ describe('paragraph reads answer the cascade, not its floor', () => {
     expect(editor.exec({ type: 'adjustIndent', direction: 'decrease' }).ok).toBe(true);
     expect(left()).toBe(2160);
   });
+
+  test('Increase Indent steps forward when the two spellings of w:ind meet', () => {
+    // `w:left` is the transitional spelling, `w:start` the ISO Strict one, and they are two
+    // spellings of ONE setting. Merged per ATTRIBUTE the style's `w:left` outranked the
+    // paragraph's own `w:start`, and the press moved the paragraph BACKWARDS.
+    const editor = mount(
+      '<w:p><w:pPr><w:pStyle w:val="Fancy"/><w:ind w:start="2880"/></w:pPr>' +
+        '<w:r><w:t>alpha</w:t></w:r></w:p>'
+    );
+    const left = () => editor.snapshot().formatting?.indent?.left;
+    expect(left()).toBe(2880);
+    expect(editor.exec({ type: 'adjustIndent', direction: 'increase' }).ok).toBe(true);
+    expect(left()).toBe(3600);
+  });
+});
+
+describe('the line-spacing shortcut keeps the paragraph spacing beside it', () => {
+  test('Ctrl+2 double-spaces without deleting space before/after', () => {
+    // `w:spacing` carries three independent settings, so the chord has to MERGE the way the
+    // toolbar's own `setLineSpacing` does. Replacing the element made Ctrl+2 silently drop
+    // the paragraph's space before and after on its way to double-spacing it.
+    const editor = mount(
+      '<w:p><w:pPr><w:spacing w:before="240" w:after="240"/></w:pPr>' +
+        '<w:r><w:t>alpha</w:t></w:r></w:p>'
+    );
+    expect(paintedSpacing(editor)).toEqual({ before: 12, after: 12 });
+
+    const onKeyDown = createKeyDownHandler(editor.surface!);
+    onKeyDown({
+      key: '2',
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault: () => {},
+    } as KeyboardEvent);
+
+    expect(paintedSpacing(editor)).toEqual({ before: 12, after: 12 });
+    expect(editor.snapshot().formatting?.lineSpacing).toEqual({ rule: 'multiple', value: 2 });
+  });
+});
+
+describe('a paragraph can switch its style page break off', () => {
+  test('w:pageBreakBefore w:val="0" over a style that sets it keeps one page', () => {
+    const styles =
+      `<w:styles xmlns:w="${W}">` +
+      '<w:style w:type="paragraph" w:styleId="Normal" w:default="1"><w:name w:val="Normal"/></w:style>' +
+      '<w:style w:type="paragraph" w:styleId="Chapter"><w:name w:val="Chapter"/>' +
+      '<w:pPr><w:pageBreakBefore/></w:pPr></w:style>' +
+      '</w:styles>';
+    const breaking = mount(
+      '<w:p><w:r><w:t>alpha</w:t></w:r></w:p>' +
+        '<w:p><w:pPr><w:pStyle w:val="Chapter"/></w:pPr><w:r><w:t>beta</w:t></w:r></w:p>',
+      styles
+    );
+    expect(breaking.surface!.layout().pages.length).toBe(2);
+
+    // Word writes this when the author unchecks "Page break before" on one instance. Read
+    // any-wins, the style's own entry still matched and the document grew a blank page.
+    const cancelled = mount(
+      '<w:p><w:r><w:t>alpha</w:t></w:r></w:p>' +
+        '<w:p><w:pPr><w:pStyle w:val="Chapter"/><w:pageBreakBefore w:val="0"/></w:pPr>' +
+        '<w:r><w:t>beta</w:t></w:r></w:p>',
+      styles
+    );
+    expect(cancelled.surface!.layout().pages.length).toBe(1);
+  });
+
+  test('"off" is an off value, like every other ST_OnOff read', () => {
+    const editor = mount(
+      '<w:p><w:r><w:t>alpha</w:t></w:r></w:p>' +
+        '<w:p><w:pPr><w:pageBreakBefore w:val="off"/></w:pPr><w:r><w:t>beta</w:t></w:r></w:p>'
+    );
+    expect(editor.surface!.layout().pages.length).toBe(1);
+  });
 });
 
 describe('auto paragraph spacing yields to an explicit write', () => {
@@ -206,8 +282,16 @@ describe('auto paragraph spacing yields to an explicit write', () => {
       ),
     });
     const editor = createDocxEditor({ container, document: bytes });
+    // The flag is worth nothing inside a list, so the page draws the item flush.
     expect(paintedSpacing(editor)).toEqual({ before: 0, after: 0 });
-    // The control must not offer to REMOVE a gap the list already suppresses.
-    expect(editor.snapshot().formatting?.spaceBeforePt).toBe(0);
+    // The read answers the MEASUREMENT the cascade states (100 twips), not that resolved
+    // gap: resolving it needs list and cell membership, which this lane cannot see without
+    // guessing. Documented on `spaceBeforePt`.
+    expect(editor.snapshot().formatting?.spaceBeforePt).toBe(5);
+
+    // The write still has to land, which is the half that matters: an explicit space beats
+    // the flag even here.
+    expect(editor.exec({ type: 'setParagraphSpacing', beforePt: 18 }).ok).toBe(true);
+    expect(paintedSpacing(editor).before).toBe(18);
   });
 });

--- a/packages/core/src/editor/__tests__/paragraph-cascade-reads.test.ts
+++ b/packages/core/src/editor/__tests__/paragraph-cascade-reads.test.ts
@@ -24,6 +24,8 @@ import { zipSync, strToU8 } from 'fflate';
 import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
 import { createKeyDownHandler } from '../surface-input.ts';
+import { mountPaginatedSurface } from '../paginated-surface.ts';
+import { docx as surfaceDocx } from './paginated-surface-fixtures.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -156,6 +158,40 @@ describe('paragraph reads answer the cascade, not its floor', () => {
     expect(left()).toBe(2880);
     expect(editor.exec({ type: 'adjustIndent', direction: 'increase' }).ok).toBe(true);
     expect(left()).toBe(3600);
+  });
+});
+
+describe('a merged paragraph reports an indent for every half', () => {
+  test('the ruler keeps its handles with the caret in the absorbed half', () => {
+    // `proposed` is what the free engine renders by default, and it lays a deleted
+    // paragraph mark out as ONE paragraph under the survivor's name. The indent index
+    // recorded only that name, so the caret in the other half read no indent at all and
+    // the ruler dropped all four handles over an ordinary body paragraph.
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(
+      container,
+      surfaceDocx(
+        '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A"/></w:rPr></w:pPr>' +
+          '<w:r><w:t xml:space="preserve">Hello </w:t></w:r></w:p>' +
+          '<w:p><w:pPr><w:ind w:left="720"/></w:pPr><w:r><w:t>world</w:t></w:r></w:p>'
+      ),
+      { revisionDisplayMode: 'proposed' }
+    );
+    if (!opened.ok) throw new Error(opened.reason);
+    const surface = opened.surface;
+    const ids = surface.session.paragraphIds();
+
+    for (const id of ids) {
+      surface.setSelection({
+        anchor: { paragraphId: id, offset: 1 },
+        head: { paragraphId: id, offset: 1 },
+      });
+      // Both halves are drawn under the survivor's `w:ind`, so both report it.
+      expect(surface.formatting().indent?.left).toBe(720);
+    }
+    surface.destroy();
+    container.remove();
   });
 });
 

--- a/packages/core/src/editor/__tests__/paragraph-cascade-reads.test.ts
+++ b/packages/core/src/editor/__tests__/paragraph-cascade-reads.test.ts
@@ -1,0 +1,213 @@
+// A toolbar reads the cascade from the RIGHT END, and a spacing write survives autospacing.
+//
+// The layout hands the editor lane a paragraph's properties FLATTENED: one entry per level
+// of the cascade — `w:docDefaults`, each style in the `basedOn` chain, then the paragraph's
+// own `w:pPr` — in that order, lowest precedence first. Every read here took the FIRST
+// matching entry, which is the document's defaults and never what the paragraph is actually
+// written in. On Word's own blank template that meant:
+//
+//   * "Add space before paragraph" wrote 24pt and the menu went on saying "Add", because the
+//     read still answered the `w:docDefaults` 8pt beside it (issue #360);
+//   * the line-spacing tick never moved off the default row;
+//   * the alignment button stayed pressed on the style's alignment after a press changed it;
+//   * Increase Indent re-read the style's indent and rewrote the same single step forever.
+//
+// Separately, `w:beforeAutospacing` REPLACES the measurement beside it, so on a document
+// whose defaults carry the flag — what Word writes for HTML-shaped content — a space-before
+// write landed in the XML and moved nothing on the page at all.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const STYLE_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+/** `w:docDefaults` + a style that states its own alignment, indent and spacing. */
+const STYLES =
+  `<w:styles xmlns:w="${W}">` +
+  '<w:docDefaults><w:pPrDefault><w:pPr>' +
+  '<w:spacing w:after="160" w:line="259" w:lineRule="auto"/>' +
+  '</w:pPr></w:pPrDefault></w:docDefaults>' +
+  '<w:style w:type="paragraph" w:styleId="Normal" w:default="1"><w:name w:val="Normal"/></w:style>' +
+  '<w:style w:type="paragraph" w:styleId="Fancy"><w:name w:val="Fancy"/><w:pPr>' +
+  '<w:jc w:val="center"/><w:ind w:left="720"/><w:spacing w:before="240" w:after="240"/>' +
+  '</w:pPr></w:style>' +
+  '</w:styles>';
+
+/** Word's HTML-shaped defaults: a measurement with the autospacing flag on top of it. */
+const AUTOSPACING_STYLES =
+  `<w:styles xmlns:w="${W}">` +
+  '<w:docDefaults><w:pPrDefault><w:pPr>' +
+  '<w:spacing w:before="100" w:beforeAutospacing="1" w:after="100" w:afterAutospacing="1"/>' +
+  '</w:pPr></w:pPrDefault></w:docDefaults>' +
+  '<w:style w:type="paragraph" w:styleId="Normal" w:default="1"><w:name w:val="Normal"/></w:style>' +
+  '</w:styles>';
+
+function docx(body: string, styles: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${STYLE_REL}" Target="styles.xml"/></Relationships>`
+    ),
+    'word/styles.xml': strToU8(styles),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function mount(body: string, styles = STYLES): DocxEditorInstance {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: docx(body, styles) });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+const FANCY = '<w:p><w:pPr><w:pStyle w:val="Fancy"/></w:pPr><w:r><w:t>alpha</w:t></w:r></w:p>';
+
+/** The gap the first paragraph is laid out with, in points. */
+function paintedSpacing(editor: DocxEditorInstance): { before: number; after: number } {
+  const fragment = editor.surface!.layout().pages[0]!.fragments[0];
+  if (!fragment || fragment.kind !== 'paragraph') throw new Error('no paragraph fragment');
+  return { before: fragment.spacing.before, after: fragment.spacing.after };
+}
+
+describe('paragraph reads answer the cascade, not its floor', () => {
+  test('space before/after report what the paragraph was just given (issue #360)', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    // Word's blank template, whose `w:docDefaults` state 8pt after and nothing before.
+    const editor = createDocxEditor({ container, document: 'blank' });
+    editor.exec({ type: 'insertText', text: 'Hello world' });
+    expect(editor.snapshot().formatting?.spaceAfterPt).toBe(8);
+
+    expect(editor.exec({ type: 'setParagraphSpacing', beforePt: 24, afterPt: 24 }).ok).toBe(true);
+    expect(editor.snapshot().formatting?.spaceBeforePt).toBe(24);
+    expect(editor.snapshot().formatting?.spaceAfterPt).toBe(24);
+    expect(paintedSpacing(editor)).toEqual({ before: 24, after: 24 });
+  });
+
+  test('the line-spacing read follows the pick, not the document default', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const editor = createDocxEditor({ container, document: 'blank' });
+    editor.exec({ type: 'insertText', text: 'Hello world' });
+    // 259/240 — the blank template's own multiple, which is what the menu ticks first.
+    expect(editor.snapshot().formatting?.lineSpacing).toEqual({ rule: 'multiple', value: 1.08 });
+
+    expect(editor.exec({ type: 'setLineSpacing', rule: 'multiple', value: 2 }).ok).toBe(true);
+    expect(editor.snapshot().formatting?.lineSpacing).toEqual({ rule: 'multiple', value: 2 });
+  });
+
+  test('a style-supplied value reads through, and a press over it reads back', () => {
+    const editor = mount(FANCY);
+    expect(editor.snapshot().formatting?.alignment).toBe('center');
+    expect(editor.snapshot().formatting?.spaceBeforePt).toBe(12);
+    expect(editor.snapshot().formatting?.spaceAfterPt).toBe(12);
+
+    expect(editor.exec({ type: 'setAlignment', align: 'left' }).ok).toBe(true);
+    expect(editor.snapshot().formatting?.alignment).toBe('left');
+
+    expect(editor.exec({ type: 'setParagraphSpacing', afterPt: 0 }).ok).toBe(true);
+    // Explicit zero, the way Word's "Remove space after paragraph" writes it: it blocks the
+    // style's 12pt rather than letting it back in.
+    expect(editor.snapshot().formatting?.spaceAfterPt).toBe(0);
+    expect(paintedSpacing(editor).after).toBe(0);
+  });
+
+  test('Increase Indent keeps stepping past the style indent', () => {
+    const editor = mount(FANCY);
+    const left = () => editor.snapshot().formatting?.indent?.left;
+    expect(left()).toBe(720);
+    for (const expected of [1440, 2160, 2880]) {
+      expect(editor.exec({ type: 'adjustIndent', direction: 'increase' }).ok).toBe(true);
+      expect(left()).toBe(expected);
+    }
+    expect(editor.exec({ type: 'adjustIndent', direction: 'decrease' }).ok).toBe(true);
+    expect(left()).toBe(2160);
+  });
+});
+
+describe('auto paragraph spacing yields to an explicit write', () => {
+  test('a space-before write moves the page even under an inherited flag', () => {
+    const editor = mount('<w:p><w:r><w:t>alpha</w:t></w:r></w:p>', AUTOSPACING_STYLES);
+    // The flag REPLACES the 5pt beside it, so the paragraph opens at Word's auto gap.
+    expect(paintedSpacing(editor)).toEqual({ before: 14, after: 14 });
+
+    expect(editor.exec({ type: 'setParagraphSpacing', beforePt: 36, afterPt: 36 }).ok).toBe(true);
+    expect(paintedSpacing(editor)).toEqual({ before: 36, after: 36 });
+    expect(editor.snapshot().formatting?.spaceBeforePt).toBe(36);
+  });
+
+  test('the flag is cleared explicitly, so a save/reopen keeps the value', () => {
+    const editor = mount('<w:p><w:r><w:t>alpha</w:t></w:r></w:p>', AUTOSPACING_STYLES);
+    editor.exec({ type: 'setParagraphSpacing', beforePt: 36 });
+    const xml = serializeOoxmlPart(editor.surface!.session.part());
+    // Written as "0" rather than dropped: dropping it lets the inherited flag win again.
+    expect(xml).toContain('w:beforeAutospacing="0"');
+    expect(xml).toContain('w:before="720"');
+  });
+
+  test('removing the space removes the flag with it', () => {
+    const editor = mount('<w:p><w:r><w:t>alpha</w:t></w:r></w:p>', AUTOSPACING_STYLES);
+    editor.exec({ type: 'setParagraphSpacing', beforePt: 36 });
+    editor.exec({ type: 'setParagraphSpacing', beforePt: null });
+    // Both gone, so the paragraph inherits the pair the document defaults state.
+    expect(paintedSpacing(editor).before).toBe(14);
+  });
+
+  test('inside a list the flag is worth nothing, and the read says so', () => {
+    const numbering =
+      `<w:numbering xmlns:w="${W}">` +
+      '<w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/>' +
+      '<w:lvlText w:val="&#8226;"/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr>' +
+      '</w:lvl></w:abstractNum>' +
+      '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>' +
+      '</w:numbering>';
+    const container = document.createElement('div');
+    document.body.append(container);
+    const bytes = zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>' +
+          '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/_rels/document.xml.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${STYLE_REL}" Target="styles.xml"/>` +
+          '<Relationship Id="rId8" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/></Relationships>'
+      ),
+      'word/styles.xml': strToU8(AUTOSPACING_STYLES),
+      'word/numbering.xml': strToU8(numbering),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}"><w:body>` +
+          '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+          '<w:r><w:t>item</w:t></w:r></w:p>' +
+          `</w:body></w:document>`
+      ),
+    });
+    const editor = createDocxEditor({ container, document: bytes });
+    expect(paintedSpacing(editor)).toEqual({ before: 0, after: 0 });
+    // The control must not offer to REMOVE a gap the list already suppresses.
+    expect(editor.snapshot().formatting?.spaceBeforePt).toBe(0);
+  });
+});

--- a/packages/core/src/editor/__tests__/story-and-rectangle-writes.test.ts
+++ b/packages/core/src/editor/__tests__/story-and-rectangle-writes.test.ts
@@ -30,22 +30,28 @@ const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
 
 const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
-/** A body with one default header, whose single paragraph is the one under test. */
-function headerDocx(headerParagraph: string): Uint8Array {
+/** A body with one default header, whose paragraphs are the ones under test. */
+function headerDocx(headerParagraph: string, extra?: Record<string, Uint8Array>): Uint8Array {
   return zipSync({
     '[Content_Types].xml': strToU8(
       `<Types xmlns="${CT}">` +
         '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
         '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
         '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        (extra
+          ? '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>'
+          : '') +
         '</Types>'
     ),
     '_rels/.rels': strToU8(
       `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
     ),
     'word/_rels/document.xml.rels': strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/></Relationships>`
+      `<Relationships xmlns="${REL}"><Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/>` +
+        (extra ? `<Relationship Id="rId8" Type="${R}/numbering" Target="numbering.xml"/>` : '') +
+        '</Relationships>'
     ),
+    ...extra,
     'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${headerParagraph}</w:hdr>`),
     'word/document.xml': strToU8(
       `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${p('body')}` +
@@ -107,6 +113,28 @@ describe('formatting reads answer the open story', () => {
     // never in the order and the call returned false without writing.
     expect(surface.setIndent({ left: 2880 })).toBe(true);
     expect(surface.formatting().indent?.left).toBe(2880);
+  });
+});
+
+describe('the read sweeps the story the write does', () => {
+  test('a two-paragraph header selection reports disagreement, not the head', () => {
+    const surface = mount(
+      headerDocx(
+        '<w:p><w:pPr><w:jc w:val="center"/><w:ind w:left="1440"/></w:pPr>' +
+          '<w:r><w:t>one</w:t></w:r></w:p>' +
+          '<w:p><w:r><w:t>two</w:t></w:r></w:p>'
+      )
+    );
+    expect(surface.enterHeaderFooter({ rId: 'rId10' })).toBe(true);
+    const ids = surface.session.paragraphIdsIn({ kind: 'headerFooter', rId: 'rId10' });
+    surface.setSelection({
+      anchor: { paragraphId: ids[0]!, offset: 0 },
+      head: { paragraphId: ids[1]!, offset: 3 },
+    });
+    // Falling back to the BODY order left the header ids at -1, so the read answered for the
+    // head paragraph alone while the write acted on both.
+    expect(surface.formatting().alignment).toBeNull();
+    expect(surface.formatting().indent?.mixed.left).toBe(true);
   });
 });
 

--- a/packages/core/src/editor/__tests__/story-and-rectangle-writes.test.ts
+++ b/packages/core/src/editor/__tests__/story-and-rectangle-writes.test.ts
@@ -1,0 +1,197 @@
+// Paragraph formatting answers for the story the caret is in, and acts on the cells the
+// user actually selected.
+//
+// Two holes in the same read, both of which made a control disagree with the page:
+//
+//   * the paragraph indexes walked `layout.pages[].fragments`, which is the BODY. With a
+//     header, footer or note open the toolbar read defaults over a centred paragraph, and
+//     Increase Indent — which steps from what it reads — moved header text BACKWARDS;
+//   * a cell RECTANGLE was honoured by `setParagraphProperty` and by nothing else, so
+//     bulleting one selected column also bulleted the cells between its corners in document
+//     order, and the read swept that same range so the button never lit.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { docx as bodyDocx } from './paginated-surface-fixtures.ts';
+import { cellSelectionBetween } from '../../layout/semantic-cell-selection.ts';
+import { paragraphIndentOf } from '../surface-formatting.ts';
+import { paragraphTextOf } from '../../store/store/tree-op-apply.ts';
+import { findNode } from '@docx-editor.dev/core/store';
+import type { TableCellAddress } from '@docx-editor.dev/core/layout';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+/** A body with one default header, whose single paragraph is the one under test. */
+function headerDocx(headerParagraph: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/></Relationships>`
+    ),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${headerParagraph}</w:hdr>`),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${p('body')}` +
+        `<w:sectPr><w:headerReference w:type="default" r:id="rId10"/></w:sectPr>` +
+        '</w:body></w:document>'
+    ),
+  });
+}
+
+function mount(bytes: Uint8Array): PaginatedSurface {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const result = mountPaginatedSurface(container, bytes, { scale: 1 });
+  if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
+  return result.surface;
+}
+
+/** Open the header and put the caret in its first paragraph. */
+function openHeader(surface: PaginatedSurface): string {
+  expect(surface.enterHeaderFooter({ rId: 'rId10' })).toBe(true);
+  // `paragraphIds()` is the BODY's; the header story has its own.
+  const id = surface.session.paragraphIdsIn({ kind: 'headerFooter', rId: 'rId10' })[0]!;
+  surface.setSelection({
+    anchor: { paragraphId: id, offset: 0 },
+    head: { paragraphId: id, offset: 0 },
+  });
+  return id;
+}
+
+describe('formatting reads answer the open story', () => {
+  const HEADER = `<w:p><w:pPr><w:jc w:val="center"/><w:ind w:left="1440"/>${''}
+      <w:spacing w:before="240" w:after="120" w:line="480" w:lineRule="auto"/>
+    </w:pPr><w:r><w:t>header text</w:t></w:r></w:p>`.replace(/\n\s*/g, '');
+
+  test('a header paragraph reports its own alignment, indent and spacing', () => {
+    const surface = mount(headerDocx(HEADER));
+    openHeader(surface);
+    const formatting = surface.formatting();
+    expect(formatting.alignment).toBe('center');
+    expect(formatting.indent?.left).toBe(1440);
+    expect(formatting.spaceBeforePt).toBe(12);
+    expect(formatting.spaceAfterPt).toBe(6);
+    expect(formatting.lineSpacing).toEqual({ rule: 'multiple', value: 2 });
+  });
+
+  test('Increase Indent steps forward from the header indent, not from zero', () => {
+    const surface = mount(headerDocx(HEADER));
+    openHeader(surface);
+    // Read as zero, the step wrote 720 and the paragraph moved LEFT from 1440.
+    expect(surface.canAdjustIndent('decrease')).toBe(true);
+    expect(surface.adjustIndent('increase')).toBe(true);
+    expect(surface.formatting().indent?.left).toBe(2160);
+  });
+
+  test('a ruler drag inside a header lands instead of silently doing nothing', () => {
+    const surface = mount(headerDocx(HEADER));
+    openHeader(surface);
+    // `setIndent` alone read the BODY order and the BODY part, so the header paragraph was
+    // never in the order and the call returned false without writing.
+    expect(surface.setIndent({ left: 2880 })).toBe(true);
+    expect(surface.formatting().indent?.left).toBe(2880);
+  });
+});
+
+describe('a cell rectangle is not the range it stands in for', () => {
+  const tc = (c: string) => `<w:tc>${c}</w:tc>`;
+  const tr = (c: string) => `<w:tr>${c}</w:tr>`;
+  const GRID2 =
+    '<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="3000"/><w:gridCol w:w="3000"/></w:tblGrid>';
+  const centred = (t: string) =>
+    `<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>${t}</w:t></w:r></w:p>`;
+
+  /** A 2x2 table with column A centred, plus the rectangle over that column. */
+  function mountColumnA(cellBody: (label: string) => string): PaginatedSurface {
+    const table =
+      `<w:tbl>${GRID2}` +
+      tr(tc(cellBody('A1')) + tc(p('B1'))) +
+      tr(tc(cellBody('A2')) + tc(p('B2'))) +
+      '</w:tbl>';
+    const surface = mount(bodyDocx(table + p('after')));
+    selectColumn(surface, 0);
+    return surface;
+  }
+
+  function selectColumn(surface: PaginatedSurface, column: number): void {
+    const table = surface
+      .layout()
+      .pages.flatMap((page) => page.fragments.filter((fragment) => fragment.kind === 'table'))[0];
+    if (!table || table.kind !== 'table') throw new Error('no table in layout');
+    const address = (rowIndex: number): TableCellAddress => {
+      const row = table.rows[rowIndex]!;
+      const cell = row.cells.find((candidate) => candidate.gridColumn === column)!;
+      return {
+        tableId: table.tableId,
+        rowId: row.id,
+        cellId: cell.id,
+        rowIndex,
+        gridColumn: cell.gridColumn,
+        gridSpan: cell.gridSpan,
+      };
+    };
+    const rectangle = cellSelectionBetween(surface.layout(), address(0), address(1));
+    if (!rectangle) throw new Error('cell rectangle failed');
+    surface.setCellSelection(rectangle);
+  }
+
+  const textOf = (surface: PaginatedSurface, id: string) =>
+    paragraphTextOf(surface.session.part(), id);
+  const idFor = (surface: PaginatedSurface, text: string) =>
+    surface.session.paragraphIds().find((id) => textOf(surface, id) === text)!;
+
+  /** Whether a paragraph authors `w:numPr` — the mark `toggleList` leaves. */
+  function isNumbered(surface: PaginatedSurface, text: string): boolean {
+    const node = findNode(surface.session.part(), idFor(surface, text));
+    if (!node || node.kind === 'textValue') return false;
+    const pPr = node.children.find(
+      (child) => child.kind !== 'textValue' && child.localName === 'pPr'
+    );
+    if (!pPr || pPr.kind === 'textValue') return false;
+    return pPr.children.some((child) => child.kind !== 'textValue' && child.localName === 'numPr');
+  }
+
+  test('bulleting a selected column leaves the column beside it alone', () => {
+    const surface = mountColumnA((label) => p(label));
+    expect(surface.toggleList('bullet')).toBe(true);
+    expect(isNumbered(surface, 'A1')).toBe(true);
+    expect(isNumbered(surface, 'A2')).toBe(true);
+    // B1 sits between A1 and A2 in document order, and the user never selected it.
+    expect(isNumbered(surface, 'B1')).toBe(false);
+    expect(isNumbered(surface, 'B2')).toBe(false);
+  });
+
+  test('indenting a selected column leaves the column beside it alone', () => {
+    const surface = mountColumnA((label) => p(label));
+    expect(surface.adjustIndent('increase')).toBe(true);
+    const indentOf = (text: string) =>
+      paragraphIndentOf(surface.layout(), idFor(surface, text))?.indent.left;
+    expect(indentOf('A1')).toBeGreaterThan(0);
+    expect(indentOf('B1')).toBe(0);
+  });
+
+  test('the read answers the rectangle, so the button lights over a centred column', () => {
+    const surface = mountColumnA(centred);
+    // Read as a range, B1 joined the sweep and the alignment came back mixed — the Centre
+    // button never lit over a column that was uniformly centred.
+    expect(surface.formatting().alignment).toBe('center');
+  });
+});

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -39,9 +39,14 @@ import { execImageCommand, isImageCommand } from './docx-editor-images.ts';
  * (§17.3.1.33): `w:beforeAutospacing` substitutes Word's own gap, and `w:beforeLines`
  * measures in hundredths of a line instead of twips. A merging write that left either in
  * place wrote a number the file then ignored — the same way the autospacing flag swallowed
- * this command whole before. Cleared to an explicit `"0"` rather than dropped where the
- * cascade can supply them again, and dropped entirely when the measurement itself is
- * dropped, so the paragraph inherits a consistent set.
+ * this command whole before.
+ *
+ * They are cleared DIFFERENTLY, because their off values differ. `w:beforeAutospacing="0"`
+ * is a real off, so it is written explicitly and blocks an inherited flag. `w:beforeLines`
+ * has no off value — `"0"` means zero lines of space, which would supersede the twips beside
+ * it and flatten the gap the caller just asked for — so the attribute is dropped instead.
+ * That leaves one residual: a STYLE that states `w:beforeLines` still supersedes a direct
+ * `w:before`, which this command cannot express and Word's own points-entry does not either.
  */
 function spacingSide(
   side: 'before' | 'after',

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -30,6 +30,22 @@ import { isTableEditorCommand, planTableCommand } from './table-command-plan.ts'
 import { execImageCommand, isImageCommand } from './docx-editor-images.ts';
 
 /**
+ * One side of `w:spacing`, as the attributes a `setParagraphSpacing` write states.
+ *
+ * `undefined` states nothing at all: the command names one side or both, and the side it
+ * does not name keeps whatever the paragraph already authored.
+ */
+function spacingSide(
+  side: 'before' | 'after',
+  points: number | null | undefined
+): Record<string, string | null> {
+  if (points === undefined) return {};
+  const autospacing = `${side}Autospacing`;
+  if (points === null) return { [side]: null, [autospacing]: null };
+  return { [side]: String(Math.round(points * 20)), [autospacing]: '0' };
+}
+
+/**
  * Run one admitted command against the surface.
  *
  * Returns an `ExecResult` when the command answers for itself (a refusal, or a read-only
@@ -84,15 +100,16 @@ export function execEditorCommand(
         {
           // `null` REMOVES the attribute (Word's "Remove space before paragraph"), which is
           // not the same as writing a zero: a removed value inherits from the style again.
-          ...(command.beforePt !== undefined
-            ? {
-                before:
-                  command.beforePt === null ? null : String(Math.round(command.beforePt * 20)),
-              }
-            : {}),
-          ...(command.afterPt !== undefined
-            ? { after: command.afterPt === null ? null : String(Math.round(command.afterPt * 20)) }
-            : {}),
+          //
+          // The autospacing flag on the same side goes with the measurement, because it
+          // REPLACES it: `w:beforeAutospacing="1"` is worth 14pt whatever `w:before` says, so
+          // a paragraph inheriting the flag — which is what Word writes for HTML-shaped
+          // content, as `w:before="100" w:beforeAutospacing="1"` — swallowed this write
+          // whole and the page did not move. Word clears the flag the same way when a value
+          // is typed. An explicit `0` is written rather than the attribute dropped: dropping
+          // it would let the inherited flag come back and win again.
+          ...spacingSide('before', command.beforePt),
+          ...spacingSide('after', command.afterPt),
         },
         { mergeAttributes: true }
       );

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -98,8 +98,9 @@ export function execEditorCommand(
       mounted.setParagraphProperty(
         'spacing',
         {
-          // `null` REMOVES the attribute (Word's "Remove space before paragraph"), which is
-          // not the same as writing a zero: a removed value inherits from the style again.
+          // `null` REMOVES the attribute, which is not the same as writing a zero: a removed
+          // value inherits from the style again, while a zero blocks the cascade. Word's
+          // "Remove space before paragraph" is the ZERO — the toolbar sends 0, not null.
           //
           // The autospacing flag on the same side goes with the measurement, because it
           // REPLACES it: `w:beforeAutospacing="1"` is worth 14pt whatever `w:before` says, so

--- a/packages/core/src/editor/docx-editor-exec.ts
+++ b/packages/core/src/editor/docx-editor-exec.ts
@@ -34,6 +34,14 @@ import { execImageCommand, isImageCommand } from './docx-editor-images.ts';
  *
  * `undefined` states nothing at all: the command names one side or both, and the side it
  * does not name keeps whatever the paragraph already authored.
+ *
+ * The other two attributes on the side go WITH the measurement, because each supersedes it
+ * (§17.3.1.33): `w:beforeAutospacing` substitutes Word's own gap, and `w:beforeLines`
+ * measures in hundredths of a line instead of twips. A merging write that left either in
+ * place wrote a number the file then ignored — the same way the autospacing flag swallowed
+ * this command whole before. Cleared to an explicit `"0"` rather than dropped where the
+ * cascade can supply them again, and dropped entirely when the measurement itself is
+ * dropped, so the paragraph inherits a consistent set.
  */
 function spacingSide(
   side: 'before' | 'after',
@@ -41,8 +49,9 @@ function spacingSide(
 ): Record<string, string | null> {
   if (points === undefined) return {};
   const autospacing = `${side}Autospacing`;
-  if (points === null) return { [side]: null, [autospacing]: null };
-  return { [side]: String(Math.round(points * 20)), [autospacing]: '0' };
+  const lines = `${side}Lines`;
+  if (points === null) return { [side]: null, [autospacing]: null, [lines]: null };
+  return { [side]: String(Math.round(points * 20)), [autospacing]: '0', [lines]: null };
 }
 
 /**

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -134,6 +134,7 @@ import { createSurfaceFormat } from './surface-format.ts';
 import {
   authoredRunPropertiesAt,
   mergedProperties,
+  mergedMultiSettingProperty,
   type SurfaceProperty,
 } from './surface-formatting.ts';
 import { createPointerController, type PointerController } from './surface-pointer.ts';
@@ -504,8 +505,12 @@ export function mountPaginatedSurface(
         paragraphId,
         start: offset,
         end: offset + length,
+        // Merged per attribute for the multi-setting properties, exactly as the selection
+        // path does: a font armed at a caret and then typed must keep the run's other font
+        // slots, or the two halves of one feature disagree.
         properties: armed.properties.reduce(
-          (merged, property) => mergedProperties(merged, property),
+          (merged, property) =>
+            mergedProperties(merged, mergedMultiSettingProperty(merged, property)),
           [...armed.base]
         ),
       },
@@ -722,8 +727,11 @@ export function mountPaginatedSurface(
     // Shift+Enter line break, a Tab, a page break or turning the paragraph into a list item
     // all leave the user typing at a new caret in the face they armed. Captured before the
     // ops run, re-anchored at the post-edit caret.
-    commit: (run, nextSelection) =>
-      commit(run, nextSelection, { rearmPending: armedAtCaret() ?? undefined }),
+    commit: (run, nextSelection, options) =>
+      commit(run, nextSelection, {
+        rearmPending: armedAtCaret() ?? undefined,
+        ...(options?.keepCellSelection ? { keepCellSelection: true } : {}),
+      }),
     orderedStart: () => orderedStart(),
     orderedRange: () => orderedRange(),
     selectionMark: () => selectionMark(),

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -713,6 +713,10 @@ export function mountPaginatedSurface(
     session: gatedSession,
     storyScope,
     paragraphOrder,
+    // A rectangle is not the range it stands in for — the same question `createSurfaceFormat`
+    // asks. Without it, bulleting or indenting one selected column also hit the cells between
+    // its corners in document order.
+    selectedCells: () => cellSelection?.cellIds,
     layout: () => currentLayout,
     // Structural edits at the caret KEEP the armed typing format, the way Word does: a
     // Shift+Enter line break, a Tab, a page break or turning the paragraph into a list item

--- a/packages/core/src/editor/surface-format.ts
+++ b/packages/core/src/editor/surface-format.ts
@@ -28,6 +28,7 @@ import {
 } from './surface-formatting.ts';
 import type { TreeDocOp } from '@docx-editor.dev/core/store';
 import { paragraphsInCells } from '@docx-editor.dev/core/layout';
+import { mergedMultiSettingProperty } from '@docx-editor.dev/core/store';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 
 /** What the composition root lends this lane. */
@@ -79,6 +80,20 @@ type FormatMethods = Pick<
   'setRunProperty' | 'setParagraphProperty' | 'toggleRunProperty' | 'formatting' | 'clearFormatting'
 >;
 
+/**
+ * A paragraph MARK's properties with one write merged in.
+ *
+ * The mark carries a `w:rPr` like any run, so a font pick has to keep its other font slots
+ * for the same reason a run does — see `mergedFontProperty`. Without this the marker of a
+ * bulleted CJK paragraph lost its East Asian face while the text beside it kept one.
+ */
+function markPropertiesWith(
+  authored: readonly SurfaceProperty[],
+  incoming: SurfaceProperty
+): SurfaceProperty[] {
+  return mergedProperties(authored, mergedMultiSettingProperty(authored, incoming));
+}
+
 export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
   const { session, commit, orderedRange, selectionMark, textOf } = deps;
   const storyPart = () => session.partFor(deps.storyScope()) ?? session.part();
@@ -125,7 +140,7 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
       const edits = runPropertyEdits(part, from.paragraphId, from.offset, to.offset, incoming);
       // No run in range means nothing was formatted, so the mark must not move either.
       if (edits.length === 0) return;
-      const markProperties = mergedProperties(
+      const markProperties = markPropertiesWith(
         directParagraphMarkProperties(part, from.paragraphId),
         incoming
       );
@@ -195,7 +210,10 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
         ops.push({
           op: 'setParagraphMarkProperties',
           paragraphId,
-          properties: mergedProperties(directParagraphMarkProperties(part, paragraphId), incoming),
+          properties: markPropertiesWith(
+            directParagraphMarkProperties(part, paragraphId),
+            incoming
+          ),
         });
       }
     }
@@ -236,7 +254,7 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
       ops.push({
         op: 'setParagraphMarkProperties' as const,
         paragraphId,
-        properties: mergedProperties(directParagraphMarkProperties(part, paragraphId), incoming),
+        properties: markPropertiesWith(directParagraphMarkProperties(part, paragraphId), incoming),
       });
     }
     if (ops.length === 0) return false;

--- a/packages/core/src/editor/surface-format.ts
+++ b/packages/core/src/editor/surface-format.ts
@@ -28,7 +28,7 @@ import {
 } from './surface-formatting.ts';
 import type { TreeDocOp } from '@docx-editor.dev/core/store';
 import { paragraphsInCells } from '@docx-editor.dev/core/layout';
-import { mergedMultiSettingProperty } from '@docx-editor.dev/core/store';
+import { mergedParagraphMarkProperties } from '@docx-editor.dev/core/store';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 
 /** What the composition root lends this lane. */
@@ -80,20 +80,6 @@ type FormatMethods = Pick<
   'setRunProperty' | 'setParagraphProperty' | 'toggleRunProperty' | 'formatting' | 'clearFormatting'
 >;
 
-/**
- * A paragraph MARK's properties with one write merged in.
- *
- * The mark carries a `w:rPr` like any run, so a font pick has to keep its other font slots
- * for the same reason a run does — see `mergedFontProperty`. Without this the marker of a
- * bulleted CJK paragraph lost its East Asian face while the text beside it kept one.
- */
-function markPropertiesWith(
-  authored: readonly SurfaceProperty[],
-  incoming: SurfaceProperty
-): SurfaceProperty[] {
-  return mergedProperties(authored, mergedMultiSettingProperty(authored, incoming));
-}
-
 export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
   const { session, commit, orderedRange, selectionMark, textOf } = deps;
   const storyPart = () => session.partFor(deps.storyScope()) ?? session.part();
@@ -140,10 +126,7 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
       const edits = runPropertyEdits(part, from.paragraphId, from.offset, to.offset, incoming);
       // No run in range means nothing was formatted, so the mark must not move either.
       if (edits.length === 0) return;
-      const markProperties = markPropertiesWith(
-        directParagraphMarkProperties(part, from.paragraphId),
-        incoming
-      );
+      const markProperties = mergedParagraphMarkProperties(part, from.paragraphId, incoming);
       commit(() =>
         applyOps(
           [
@@ -210,10 +193,7 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
         ops.push({
           op: 'setParagraphMarkProperties',
           paragraphId,
-          properties: markPropertiesWith(
-            directParagraphMarkProperties(part, paragraphId),
-            incoming
-          ),
+          properties: mergedParagraphMarkProperties(part, paragraphId, incoming),
         });
       }
     }
@@ -254,7 +234,7 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
       ops.push({
         op: 'setParagraphMarkProperties' as const,
         paragraphId,
-        properties: markPropertiesWith(directParagraphMarkProperties(part, paragraphId), incoming),
+        properties: mergedParagraphMarkProperties(part, paragraphId, incoming),
       });
     }
     if (ops.length === 0) return false;
@@ -369,7 +349,8 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
             return fallback === null ? resolved : { ...resolved, fontFamily: fallback };
           },
           deps.selectedCells?.(),
-          deps.defaultParagraphStyleId?.() ?? null
+          deps.defaultParagraphStyleId?.() ?? null,
+          deps.paragraphOrder()
         ),
         deps.pendingFormats()
       ),

--- a/packages/core/src/editor/surface-format.ts
+++ b/packages/core/src/editor/surface-format.ts
@@ -28,7 +28,6 @@ import {
 } from './surface-formatting.ts';
 import type { TreeDocOp } from '@docx-editor.dev/core/store';
 import { paragraphsInCells } from '@docx-editor.dev/core/layout';
-import { cascadedParagraphAttributes } from '../layout/paragraph-style.ts';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 
 /** What the composition root lends this lane. */
@@ -309,7 +308,10 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
         // attribute REMOVES that one, which is how Word's "Remove space before paragraph"
         // differs from setting it to zero.
         const merged = options?.mergeAttributes
-          ? { ...(cascadedParagraphAttributes(own, localName) ?? {}), ...attributes }
+          ? {
+              ...(own.find((property) => property.localName === localName)?.attributes ?? {}),
+              ...attributes,
+            }
           : (attributes ?? {});
         const kept = Object.fromEntries(
           Object.entries(merged).filter(([, value]) => value !== null && value !== undefined)

--- a/packages/core/src/editor/surface-format.ts
+++ b/packages/core/src/editor/surface-format.ts
@@ -28,6 +28,7 @@ import {
 } from './surface-formatting.ts';
 import type { TreeDocOp } from '@docx-editor.dev/core/store';
 import { paragraphsInCells } from '@docx-editor.dev/core/layout';
+import { cascadedParagraphAttributes } from '../layout/paragraph-style.ts';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 
 /** What the composition root lends this lane. */
@@ -308,10 +309,7 @@ export function createSurfaceFormat(deps: SurfaceFormatDeps): FormatMethods {
         // attribute REMOVES that one, which is how Word's "Remove space before paragraph"
         // differs from setting it to zero.
         const merged = options?.mergeAttributes
-          ? {
-              ...(own.find((property) => property.localName === localName)?.attributes ?? {}),
-              ...attributes,
-            }
+          ? { ...(cascadedParagraphAttributes(own, localName) ?? {}), ...attributes }
           : (attributes ?? {});
         const kept = Object.fromEntries(
           Object.entries(merged).filter(([, value]) => value !== null && value !== undefined)

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -9,10 +9,11 @@
 
 import {
   documentOrder,
-  paragraphFragmentsOf,
+  paragraphsInCells,
   spansInCells,
   spansInSelection,
   type BlockFragmentRecord,
+  type ParagraphFragmentRecord,
   type ParagraphIndent,
   type SemanticLayout,
   type SemanticSelection,
@@ -31,6 +32,7 @@ import {
   type OoxmlPart,
   type RunPropertyEdit,
 } from '@docx-editor.dev/core/store';
+import { mergedMultiSettingProperty } from '@docx-editor.dev/core/store';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { SurfaceFormatting } from './paginated-surface-contract.ts';
 import { lineSegments } from '../layout/line-segments.ts';
@@ -41,6 +43,70 @@ import { cascadedParagraphAttributes } from '../layout/paragraph-style.ts';
 export interface SurfaceProperty {
   readonly localName: string;
   readonly attributes?: Record<string, string>;
+}
+
+/**
+ * Every paragraph fragment the layout publishes, in EVERY story the caret can reach.
+ *
+ * `layout.pages[].fragments` is the BODY. Headers, footers, footnotes and endnotes are
+ * editable scopes of their own (`enterHeaderFooter`, `enterNote`), and a paragraph index
+ * built from the body alone answers nothing for a caret inside one — so the toolbar read
+ * defaults over a centred header and Increase Indent stepped from an indent of zero,
+ * moving header text BACKWARDS. `paragraphLinesIndex` already walks the same four stories
+ * for exactly this reason; these two indexes did not.
+ *
+ * Header-repeat rows are skipped: a repeated row is the SAME paragraph drawn again, and it
+ * carries the header row's properties rather than its own.
+ *
+ * `inTable` rides along because it is the ruler's gate and this is the walk that knows it.
+ */
+function eachParagraphFragment(
+  layout: SemanticLayout,
+  visit: (fragment: ParagraphFragmentRecord, inTable: boolean) => void
+): void {
+  const walk = (blocks: readonly BlockFragmentRecord[], inTable: boolean): void => {
+    for (const block of blocks) {
+      if (block.kind === 'paragraph') {
+        visit(block, inTable);
+        continue;
+      }
+      for (const row of block.rows) {
+        if (row.isHeaderRepeat) continue;
+        for (const cell of row.cells) walk(cell.blocks, true);
+      }
+    }
+  };
+  for (const page of layout.pages) {
+    walk(page.fragments, false);
+    if (page.header) walk(page.header.fragments, false);
+    if (page.footer) walk(page.footer.fragments, false);
+    for (const area of [page.footnotes, page.endnotes]) {
+      if (!area) continue;
+      for (const note of area.notes) walk(note.fragments, false);
+    }
+  }
+}
+
+/**
+ * Record one paragraph under EVERY id it is drawn for: its own, and every member of a
+ * merged run laid out under it.
+ *
+ * A resolved view draws a run of paragraphs as one fragment under the survivor's name, and
+ * each member is being shown with that fragment's properties — so each has to be reachable
+ * by them. First-wins, so a continuation fragment on a later page never displaces the one
+ * that opened the paragraph.
+ */
+function recordFragment<T>(
+  index: Map<string, T>,
+  fragment: ParagraphFragmentRecord,
+  value: T
+): void {
+  if (!index.has(fragment.paragraphId)) index.set(fragment.paragraphId, value);
+  for (const line of fragment.lines) {
+    for (const segment of lineSegments(line)) {
+      if (!index.has(segment.paragraphId)) index.set(segment.paragraphId, value);
+    }
+  }
 }
 
 /**
@@ -69,21 +135,10 @@ export function paragraphPropertiesOf(
   // pages for one paragraph's `w:pPr` projection made that read O(document).
   let index = fragmentPropsByLayout.get(layout);
   if (!index) {
-    index = new Map();
-    for (const page of layout.pages) {
-      for (const fragment of paragraphFragmentsOf(page)) {
-        if (!index.has(fragment.paragraphId)) index.set(fragment.paragraphId, fragment.props);
-        // A merged fragment lays every member out under the SURVIVOR's `w:pPr`, so that is
-        // the projection each member is being shown with. Without this a member the fragment
-        // is not named after read no properties at all, and the toolbar showed defaults.
-        for (const line of fragment.lines) {
-          for (const segment of lineSegments(line)) {
-            if (!index.has(segment.paragraphId)) index.set(segment.paragraphId, fragment.props);
-          }
-        }
-      }
-    }
-    fragmentPropsByLayout.set(layout, index);
+    const built = new Map<string, readonly SurfaceProperty[]>();
+    eachParagraphFragment(layout, (fragment) => recordFragment(built, fragment, fragment.props));
+    index = built;
+    fragmentPropsByLayout.set(layout, built);
   }
   return index.get(paragraphId) ?? [];
 }
@@ -114,32 +169,9 @@ export function paragraphIndentOf(
   let index = fragmentIndentByLayout.get(layout);
   if (!index) {
     const built = new Map<string, ParagraphIndentEntry>();
-    // Walked here rather than through `paragraphFragmentsOf`, which flattens cell
-    // paragraphs in with body ones — that difference is exactly what this index carries.
-    const visit = (blocks: readonly BlockFragmentRecord[], inTable: boolean): void => {
-      for (const block of blocks) {
-        if (block.kind === 'paragraph') {
-          if (!built.has(block.paragraphId)) {
-            built.set(block.paragraphId, { indent: block.indent, inTable });
-          }
-          // A resolved view lays a run of paragraphs out as ONE, under the survivor's name,
-          // and every member is drawn with that fragment's indent — so every member has to
-          // be reachable by it. Without this the caret in the other half read no indent at
-          // all and the ruler dropped all four handles, which is the same miss
-          // `paragraphPropertiesOf` maps out through `lineSegments`.
-          for (const line of block.lines) {
-            for (const segment of lineSegments(line)) {
-              if (!built.has(segment.paragraphId)) {
-                built.set(segment.paragraphId, { indent: block.indent, inTable });
-              }
-            }
-          }
-          continue;
-        }
-        for (const row of block.rows) for (const cell of row.cells) visit(cell.blocks, true);
-      }
-    };
-    for (const page of layout.pages) visit(page.fragments, false);
+    eachParagraphFragment(layout, (fragment, inTable) =>
+      recordFragment(built, fragment, { indent: fragment.indent, inTable })
+    );
     index = built;
     fragmentIndentByLayout.set(layout, built);
   }
@@ -187,16 +219,17 @@ export function runPropertyEdits(
     const from = Math.max(range.start, start);
     const to = Math.min(range.end, end);
     if (from >= to) return;
+    const authored = authoredProperties(
+      propertyContainer(child, 'runProperties', 'rPr'),
+      AUTHORABLE_RUN_PROPERTIES
+    );
     edits.push({
       start: from,
       end: to,
-      properties: mergedProperties(
-        authoredProperties(
-          propertyContainer(child, 'runProperties', 'rPr'),
-          AUTHORABLE_RUN_PROPERTIES
-        ),
-        incoming
-      ),
+      // Merged per attribute for the two run properties carrying several independent
+      // settings, the same rule the store lane's own walk applies — see
+      // `mergedMultiSettingProperty`.
+      properties: mergedProperties(authored, mergedMultiSettingProperty(authored, incoming)),
       ...(formatOwned.has(child.id) ? { targetRunIds: [child.id] } : {}),
     });
   });
@@ -485,7 +518,7 @@ export function formattingAt(
   // alignment control depend on the DIRECTION the user dragged: a centred paragraph
   // selected together with a left one showed Centre pressed one way and Left the other,
   // and pressing either was a change to both. Word shows none of the four pressed.
-  const touchedParagraphs = paragraphsTouched(layout, selection);
+  const touchedParagraphs = paragraphsTouched(layout, selection, cells);
   const paragraphValue = <T>(read: (properties: readonly SurfaceProperty[]) => T): T | null =>
     agreedOver(touchedParagraphs.map((id) => read(paragraphPropertiesOf(layout, id))));
   // Normalized BEFORE agreement: `w:jc` absent and `w:jc val="left"` are the same
@@ -610,8 +643,14 @@ export function formattingAt(
  */
 function paragraphsTouched(
   layout: SemanticLayout,
-  selection: SemanticSelection
+  selection: SemanticSelection,
+  cells?: readonly string[]
 ): readonly string[] {
+  // A RECTANGLE first, for the same reason the write takes it first: a selected column read
+  // as a range runs through the cells between its corners, so the toolbar answered "mixed"
+  // over a column that was uniformly centred — and would then have centred it correctly.
+  // The button never lit, before a press or after one.
+  if (cells && cells.length > 0) return [...paragraphsInCells(layout, cells)];
   if (selection.anchor.paragraphId === selection.head.paragraphId) {
     return [selection.head.paragraphId];
   }

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -33,7 +33,9 @@ import {
 } from '@docx-editor.dev/core/store';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { SurfaceFormatting } from './paginated-surface-contract.ts';
-import { lineSegments } from '../layout/line-segments.ts';
+import { fragmentHolding, lineSegments } from '../layout/line-segments.ts';
+import { paragraphAlignment } from '../layout/paragraph-flow.ts';
+import { cascadedParagraphAttributes, paragraphSpacing } from '../layout/paragraph-style.ts';
 
 /** One property as the ops and the layout records carry it: an element name plus attributes. */
 export interface SurfaceProperty {
@@ -84,6 +86,24 @@ export function paragraphPropertiesOf(
     fragmentPropsByLayout.set(layout, index);
   }
   return index.get(paragraphId) ?? [];
+}
+
+/**
+ * What auto paragraph spacing resolves against for one paragraph.
+ *
+ * The flag is worth 14pt in the body and nothing at all inside a list or a table cell, so
+ * the same `w:beforeAutospacing="1"` means two different gaps and the reader has to be told
+ * which. Both answers come from the published layout — the marker record for list membership
+ * (a `w:numPr` that resolves to nothing is not a list), the fragment walk for the cell.
+ */
+function autoSpacingContextOf(
+  layout: SemanticLayout,
+  paragraphId: string
+): { inList: boolean; inTableCell: boolean } {
+  return {
+    inList: fragmentHolding(layout, paragraphId)?.marker !== undefined,
+    inTableCell: paragraphIndentOf(layout, paragraphId)?.inTable === true,
+  };
 }
 
 /** A paragraph's effective indent, plus whether it sits inside a table. */
@@ -472,18 +492,17 @@ export function formattingAt(
   // selected together with a left one showed Centre pressed one way and Left the other,
   // and pressing either was a change to both. Word shows none of the four pressed.
   const touchedParagraphs = paragraphsTouched(layout, selection);
-  const paragraphValue = <T>(read: (properties: readonly SurfaceProperty[]) => T): T | null =>
-    agreedOver(touchedParagraphs.map((id) => read(paragraphPropertiesOf(layout, id))));
+  const paragraphValue = <T>(
+    read: (properties: readonly SurfaceProperty[], paragraphId: string) => T
+  ): T | null =>
+    agreedOver(touchedParagraphs.map((id) => read(paragraphPropertiesOf(layout, id), id)));
   // Normalized BEFORE agreement: `w:jc` absent and `w:jc val="left"` are the same
   // alignment, and comparing the raw attribute would call them a mixed selection.
-  const alignment = paragraphValue((properties) => {
-    const jc = properties.find((property) => property.localName === 'jc')?.attributes?.val;
-    return jc === 'center' || jc === 'right' || jc === 'both'
-      ? jc
-      : jc === 'end'
-        ? ('right' as const)
-        : ('left' as const);
-  });
+  //
+  // Read through the LAYOUT's own resolver, so the pressed button and the painted line can
+  // never disagree about the same paragraph. It also folds the cascade the way a cascade has
+  // to be folded — see `cascadedParagraphAttributes`.
+  const alignment = paragraphValue((properties) => paragraphAlignment(properties));
   // Resolved per paragraph BEFORE agreement, so a styled paragraph selected together with
   // an unstyled one still reads as mixed (two different styles), while an unstyled
   // paragraph on its own reports the default rather than nothing. Comparing raw `w:pStyle`
@@ -493,7 +512,7 @@ export function formattingAt(
   const style =
     paragraphValue(
       (properties) =>
-        properties.find((property) => property.localName === 'pStyle')?.attributes?.val ??
+        cascadedParagraphAttributes(properties, 'pStyle')?.val ??
         defaultParagraphStyleId ??
         undefined
     ) ?? null;
@@ -503,7 +522,7 @@ export function formattingAt(
   // 240ths are the same attribute meaning two different quantities, and a control that
   // showed the raw number would be right half the time.
   const spacing = (properties: readonly SurfaceProperty[]) =>
-    properties.find((property) => property.localName === 'spacing')?.attributes;
+    cascadedParagraphAttributes(properties, 'spacing') ?? undefined;
   const lineSpacingText = paragraphValue((properties) => {
     const attributes = spacing(properties);
     const line = Number(attributes?.line);
@@ -518,10 +537,21 @@ export function formattingAt(
     const [rule, value] = lineSpacingText.split(':');
     return { rule: rule as 'multiple' | 'exact' | 'atLeast', value: Number(value) };
   })();
+  // The EFFECTIVE gap, in points, or null when no level of the cascade states it.
+  //
+  // `w:beforeAutospacing` / `w:afterAutospacing` REPLACE the measurement beside them, so a
+  // paragraph carrying the flag has a gap the twips do not describe — Word's own value there
+  // is `w:before="100"` with the flag on, which reads 5pt and paints 14. A control acting on
+  // the twips offered to ADD space to a paragraph that already had some.
   const spacePt = (attribute: 'before' | 'after') =>
-    paragraphValue((properties) => {
-      const raw = Number(spacing(properties)?.[attribute]);
-      return Number.isFinite(raw) ? Math.round((raw / 20) * 100) / 100 : null;
+    paragraphValue((properties, paragraphId) => {
+      const attributes = spacing(properties);
+      const stated =
+        attributes?.[attribute] !== undefined ||
+        attributes?.[`${attribute}Autospacing`] !== undefined;
+      if (!stated) return null;
+      const resolved = paragraphSpacing(properties, autoSpacingContextOf(layout, paragraphId));
+      return Math.round(resolved[attribute] * 100) / 100;
     });
   // Indent does NOT go null on disagreement, unlike everything above it: the values are the
   // FIRST touched paragraph's and `mixed` reports the rest per field. A ruler has to draw

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -33,9 +33,9 @@ import {
 } from '@docx-editor.dev/core/store';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { SurfaceFormatting } from './paginated-surface-contract.ts';
-import { fragmentHolding, lineSegments } from '../layout/line-segments.ts';
+import { lineSegments } from '../layout/line-segments.ts';
 import { paragraphAlignment } from '../layout/paragraph-flow.ts';
-import { cascadedParagraphAttributes, paragraphSpacing } from '../layout/paragraph-style.ts';
+import { cascadedParagraphAttributes } from '../layout/paragraph-style.ts';
 
 /** One property as the ops and the layout records carry it: an element name plus attributes. */
 export interface SurfaceProperty {
@@ -86,24 +86,6 @@ export function paragraphPropertiesOf(
     fragmentPropsByLayout.set(layout, index);
   }
   return index.get(paragraphId) ?? [];
-}
-
-/**
- * What auto paragraph spacing resolves against for one paragraph.
- *
- * The flag is worth 14pt in the body and nothing at all inside a list or a table cell, so
- * the same `w:beforeAutospacing="1"` means two different gaps and the reader has to be told
- * which. Both answers come from the published layout — the marker record for list membership
- * (a `w:numPr` that resolves to nothing is not a list), the fragment walk for the cell.
- */
-function autoSpacingContextOf(
-  layout: SemanticLayout,
-  paragraphId: string
-): { inList: boolean; inTableCell: boolean } {
-  return {
-    inList: fragmentHolding(layout, paragraphId)?.marker !== undefined,
-    inTableCell: paragraphIndentOf(layout, paragraphId)?.inTable === true,
-  };
 }
 
 /** A paragraph's effective indent, plus whether it sits inside a table. */
@@ -492,10 +474,8 @@ export function formattingAt(
   // selected together with a left one showed Centre pressed one way and Left the other,
   // and pressing either was a change to both. Word shows none of the four pressed.
   const touchedParagraphs = paragraphsTouched(layout, selection);
-  const paragraphValue = <T>(
-    read: (properties: readonly SurfaceProperty[], paragraphId: string) => T
-  ): T | null =>
-    agreedOver(touchedParagraphs.map((id) => read(paragraphPropertiesOf(layout, id), id)));
+  const paragraphValue = <T>(read: (properties: readonly SurfaceProperty[]) => T): T | null =>
+    agreedOver(touchedParagraphs.map((id) => read(paragraphPropertiesOf(layout, id))));
   // Normalized BEFORE agreement: `w:jc` absent and `w:jc val="left"` are the same
   // alignment, and comparing the raw attribute would call them a mixed selection.
   //
@@ -537,21 +517,19 @@ export function formattingAt(
     const [rule, value] = lineSpacingText.split(':');
     return { rule: rule as 'multiple' | 'exact' | 'atLeast', value: Number(value) };
   })();
-  // The EFFECTIVE gap, in points, or null when no level of the cascade states it.
+  // The gap the cascade states, in points, or null when no level states it.
   //
-  // `w:beforeAutospacing` / `w:afterAutospacing` REPLACE the measurement beside them, so a
-  // paragraph carrying the flag has a gap the twips do not describe — Word's own value there
-  // is `w:before="100"` with the flag on, which reads 5pt and paints 14. A control acting on
-  // the twips offered to ADD space to a paragraph that already had some.
+  // The MEASUREMENT, not the resolved gap: `w:beforeAutospacing` replaces the twips beside
+  // it with Word's auto value, and resolving that here needs to know whether the paragraph
+  // is in a list or a cell — two answers only the layout holds, and guessing either one
+  // makes the control disagree with the page it sits above. The measurement is the honest
+  // answer, and it is the same answer for the one question asked of it today: Word writes
+  // `w:before="100"` beside the flag, so an auto-spaced paragraph reads non-zero and the
+  // menu offers Remove, as Word's does.
   const spacePt = (attribute: 'before' | 'after') =>
-    paragraphValue((properties, paragraphId) => {
-      const attributes = spacing(properties);
-      const stated =
-        attributes?.[attribute] !== undefined ||
-        attributes?.[`${attribute}Autospacing`] !== undefined;
-      if (!stated) return null;
-      const resolved = paragraphSpacing(properties, autoSpacingContextOf(layout, paragraphId));
-      return Math.round(resolved[attribute] * 100) / 100;
+    paragraphValue((properties) => {
+      const raw = Number(spacing(properties)?.[attribute]);
+      return Number.isFinite(raw) ? Math.round((raw / 20) * 100) / 100 : null;
     });
   // Indent does NOT go null on disagreement, unlike everything above it: the values are the
   // FIRST touched paragraph's and `mixed` reports the rest per field. A ruler has to draw

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -228,6 +228,7 @@ export {
   directParagraphMarkProperties,
   directParagraphProperties,
   isAuthorableRunProperty,
+  mergedMultiSettingProperty,
   mergedProperties,
   propertyContainer,
   runAddressRanges,
@@ -523,7 +524,16 @@ export function formattingAt(
    * is actually written in. Word's style box shows THAT (normally "Normal"), not a blank:
    * "no `w:pStyle`" is a statement about the file, not about what the user is looking at.
    */
-  defaultParagraphStyleId?: string | null
+  defaultParagraphStyleId?: string | null,
+  /**
+   * Paragraph ids in reading order for the ACTIVE story.
+   *
+   * The read has to sweep the same order the write does, or the two disagree about which
+   * paragraphs are involved: falling back to the body order answered for a header selection
+   * with the head paragraph alone, so a two-paragraph header selection reported the first
+   * one's alignment as if the pair agreed — and the following press changed both.
+   */
+  paragraphOrder?: readonly string[]
 ): SurfaceFormatting {
   const spans = selectionSpans(layout, selection, cells);
   const styles = spans.map((span) => span.style);
@@ -557,7 +567,7 @@ export function formattingAt(
   // alignment control depend on the DIRECTION the user dragged: a centred paragraph
   // selected together with a left one showed Centre pressed one way and Left the other,
   // and pressing either was a change to both. Word shows none of the four pressed.
-  const touchedParagraphs = paragraphsTouched(layout, selection, cells);
+  const touchedParagraphs = paragraphsTouched(layout, selection, cells, paragraphOrder);
   const paragraphValue = <T>(read: (properties: readonly SurfaceProperty[]) => T): T | null =>
     agreedOver(touchedParagraphs.map((id) => read(paragraphPropertiesOf(layout, id))));
   // Normalized BEFORE agreement: `w:jc` absent and `w:jc val="left"` are the same
@@ -683,7 +693,8 @@ export function formattingAt(
 function paragraphsTouched(
   layout: SemanticLayout,
   selection: SemanticSelection,
-  cells?: readonly string[]
+  cells?: readonly string[],
+  paragraphOrder?: readonly string[]
 ): readonly string[] {
   // A RECTANGLE first, for the same reason the write takes it first: a selected column read
   // as a range runs through the cells between its corners, so the toolbar answered "mixed"
@@ -693,7 +704,9 @@ function paragraphsTouched(
   if (selection.anchor.paragraphId === selection.head.paragraphId) {
     return [selection.head.paragraphId];
   }
-  const order = documentOrder(layout);
+  // The ACTIVE story's order when the caller knows it; `documentOrder` is the body's, and a
+  // header selection resolves to -1 in it.
+  const order = paragraphOrder ?? documentOrder(layout);
   const anchorIndex = order.indexOf(selection.anchor.paragraphId);
   const headIndex = order.indexOf(selection.head.paragraphId);
   if (anchorIndex === -1 || headIndex === -1) return [selection.head.paragraphId];

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -122,6 +122,18 @@ export function paragraphIndentOf(
           if (!built.has(block.paragraphId)) {
             built.set(block.paragraphId, { indent: block.indent, inTable });
           }
+          // A resolved view lays a run of paragraphs out as ONE, under the survivor's name,
+          // and every member is drawn with that fragment's indent — so every member has to
+          // be reachable by it. Without this the caret in the other half read no indent at
+          // all and the ruler dropped all four handles, which is the same miss
+          // `paragraphPropertiesOf` maps out through `lineSegments`.
+          for (const line of block.lines) {
+            for (const segment of lineSegments(line)) {
+              if (!built.has(segment.paragraphId)) {
+                built.set(segment.paragraphId, { indent: block.indent, inTable });
+              }
+            }
+          }
           continue;
         }
         for (const row of block.rows) for (const cell of row.cells) visit(cell.blocks, true);

--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -248,10 +248,14 @@ export function createKeyDownHandler(
       return;
     }
     if (accel && !event.shiftKey && LINE_SPACING[event.key]) {
-      surface.setParagraphProperty('spacing', {
-        line: LINE_SPACING[event.key]!,
-        lineRule: 'auto',
-      });
+      // Merged, like the toolbar's `setLineSpacing`: `w:spacing` carries the line rule AND
+      // the space before and after, so a replacing write made Ctrl+2 delete the paragraph's
+      // paragraph spacing on its way to double-spacing it.
+      surface.setParagraphProperty(
+        'spacing',
+        { line: LINE_SPACING[event.key]!, lineRule: 'auto' },
+        { mergeAttributes: true }
+      );
       event.preventDefault();
       return;
     }

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -19,7 +19,6 @@ import {
 } from '@docx-editor.dev/core/layout';
 import type { ListMarkerRecord } from '@docx-editor.dev/core/layout';
 import { fragmentHolding } from '../layout/line-segments.ts';
-import { cascadedParagraphAttributes } from '../layout/paragraph-style.ts';
 import {
   directParagraphProperties,
   mergedProperties,
@@ -273,16 +272,27 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
   /**
    * `w:ind/@left` in twips, zero when nothing states it.
    *
-   * Folded across the whole list rather than picked out of it: this reads a CASCADE, whose
+   * Resolved across the whole list rather than picked out of it: this reads a CASCADE, whose
    * entries run lowest precedence first, so taking the first `w:ind` answered the style's
    * indent for a paragraph that had already been indented past it — and Increase Indent then
-   * rewrote the same one step forever (see `cascadedParagraphAttributes`).
+   * rewrote the same one step forever.
+   *
+   * Resolved PER LEVEL, not per attribute, which is where `cascadedParagraphAttributes` is
+   * the wrong tool: `w:left` and `w:start` are two SPELLINGS OF ONE SETTING (transitional and
+   * ISO Strict), so flattening both into one bag and preferring `left` answers whichever
+   * level happened to use that word. A paragraph spelling it `w:start` over a style spelling
+   * it `w:left` then stepped BACKWARDS on Increase Indent. This is the rule `paragraphIndent`
+   * already applies, and the two must agree or the ruler and the button disagree.
    */
   function leftIndentTwipsOf(
     properties: readonly { localName: string; attributes?: Readonly<Record<string, string>> }[]
   ): number {
-    const ind = cascadedParagraphAttributes(properties, 'ind');
-    const raw = ind?.left ?? ind?.start;
+    let raw: string | undefined;
+    for (const property of properties) {
+      if (property.localName !== 'ind') continue;
+      const stated = property.attributes?.left ?? property.attributes?.start;
+      if (stated !== undefined) raw = stated;
+    }
     if (!raw || !/^-?\d{1,7}$/.test(raw)) return 0;
     return Number(raw);
   }
@@ -475,7 +485,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         // Only the paragraph's OWN `w:ind` attributes are carried over: `w:ind` cascades
         // attribute by attribute (17.3.1.12), so an inherited hanging survives untouched
         // rather than being restated here.
-        const existing = cascadedParagraphAttributes(direct, 'ind');
+        const existing = direct.find((property) => property.localName === 'ind');
         ops.push({
           op: 'setParagraphProperties',
           paragraphId,
@@ -484,7 +494,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
             // Zero is written rather than dropped: an authored `w:ind` may inherit a
             // non-zero left from its style, and removing the attribute would let that
             // come back instead of taking the outdent.
-            attributes: leftIndentAttributes(existing ?? undefined, String(next)),
+            attributes: leftIndentAttributes(existing?.attributes, String(next)),
           }),
         });
       }
@@ -512,7 +522,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         // an op whose base is the cascade is refused, and `w:ind` carries four independent
         // settings in one element, so naming one field must leave the others as authored.
         const direct = directParagraphProperties(session.part(), paragraphId);
-        const authored = cascadedParagraphAttributes(direct, 'ind') ?? {};
+        const authored = direct.find((property) => property.localName === 'ind')?.attributes ?? {};
         let attributes: Record<string, string> = { ...authored };
         if (update.left !== undefined) {
           attributes = writeIndentSide(attributes, 'left', 'start', update.left);

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -36,7 +36,8 @@ export interface SurfaceStructureDeps {
   layout(): SemanticLayout;
   commit(
     run: () => TreeApplyResult | boolean,
-    nextSelection?: () => SemanticSelection | null
+    nextSelection?: () => SemanticSelection | null,
+    options?: { readonly keepCellSelection?: boolean }
   ): void;
   orderedStart(): SemanticPosition;
   orderedRange(): { from: SemanticPosition; to: SemanticPosition };
@@ -103,9 +104,11 @@ function leftIndentAttributes(
   value: string
 ): Record<string, string> {
   const attributes: Record<string, string> = { ...(authored ?? {}) };
-  // `w:leftChars` supersedes the twips (§17.3.1.12), so the step has to clear it or the
-  // paragraph does not move.
+  // The character-unit twin supersedes the twips (§17.3.1.12), so the step has to clear it
+  // or the paragraph does not move. BOTH spellings: `CT_Ind` declares `w:startChars` too,
+  // and ISO Strict declares only that one.
   delete attributes.leftChars;
+  delete attributes.startChars;
   if (authored?.start !== undefined) attributes.start = value;
   if (authored?.start === undefined || authored.left !== undefined) attributes.left = value;
   return attributes;
@@ -126,8 +129,11 @@ function writeIndentSide(
   const attributes: Record<string, string> = { ...authored };
   // The CHARACTER-unit twin goes with the measurement either way, because it SUPERSEDES it
   // (§17.3.1.12): `w:leftChars` measures the same indent in hundredths of a character, so a
-  // merging write that left it in place wrote twips the file then ignored.
+  // merging write that left it in place wrote twips the file then ignored. Both spellings —
+  // `w:startChars`/`w:endChars` are the direction-relative names, and the only ones ISO
+  // Strict declares.
   delete attributes[`${physical}Chars`];
+  delete attributes[`${relative}Chars`];
   if (value === null) {
     delete attributes[physical];
     delete attributes[relative];
@@ -189,6 +195,33 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
     },
   };
 
+  /** The live cell rectangle, or null when the selection is an ordinary range. */
+  function rectangleCells(): readonly string[] | null {
+    const cells = deps.selectedCells?.();
+    return cells && cells.length > 0 ? cells : null;
+  }
+
+  /**
+   * Commit a structural write, keeping a cell RECTANGLE selected across it.
+   *
+   * `setParagraphProperty` already does this, so Centre left a selected column selected while
+   * Bullets and Increase Indent cleared it — the same gesture behaving two ways depending on
+   * which button was pressed.
+   */
+  function commitOverTarget(run: () => TreeApplyResult): boolean {
+    let committed = false;
+    commit(
+      () => {
+        const result = run();
+        committed = result.committed;
+        return result;
+      },
+      undefined,
+      { keepCellSelection: rectangleCells() !== null }
+    );
+    return committed;
+  }
+
   /**
    * The paragraphs a structural write acts on, in document order, or null when the
    * selection does not resolve against the active scope's order.
@@ -199,8 +232,9 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
    * last, which is what Word does and what every one of these verbs did before.
    */
   function targetParagraphs(): readonly string[] | null {
-    const cells = deps.selectedCells?.();
-    if (cells && cells.length > 0) return [...paragraphsInCells(currentLayout.value, cells)];
+    if (rectangleCells() !== null) {
+      return [...paragraphsInCells(currentLayout.value, rectangleCells()!)];
+    }
     const { from, to } = orderedRange();
     const order = orderOf();
     const firstIndex = order.indexOf(from.paragraphId);
@@ -452,13 +486,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
           ...(level !== null ? { level } : {}),
         };
       });
-      let committed = false;
-      commit(() => {
-        const result = applyOps(ops, selectionMark());
-        committed = result.committed;
-        return result;
-      });
-      return committed;
+      return commitOverTarget(() => applyOps(ops, selectionMark()));
     },
 
     canAdjustIndent(direction) {
@@ -531,13 +559,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         });
       }
       if (ops.length === 0) return false;
-      let committed = false;
-      commit(() => {
-        const result = applyOps(ops, selectionMark());
-        committed = result.committed;
-        return result;
-      });
-      return committed;
+      return commitOverTarget(() => applyOps(ops, selectionMark()));
     },
 
     setIndent(update) {
@@ -575,13 +597,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         });
       }
       if (ops.length === 0) return false;
-      let committed = false;
-      commit(() => {
-        const result = applyOps(ops, selectionMark());
-        committed = result.committed;
-        return result;
-      });
-      return committed;
+      return commitOverTarget(() => applyOps(ops, selectionMark()));
     },
 
     sectionProperties: () => readSectionProperties(session.part()),

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -9,8 +9,8 @@
 import type { TreeApplyResult, TreeDocxSessionView } from '@docx-editor.dev/core/binding';
 import type { TreeDocOp, StoryScope } from '@docx-editor.dev/core/store';
 import {
-  documentOrder,
   enumerateDocumentSections,
+  paragraphsInCells,
   readSectionProperties,
   storyBlocks,
   type SemanticLayout,
@@ -57,6 +57,15 @@ export interface SurfaceStructureDeps {
   numberingLevelExists(numId: string, level: number): boolean;
   /** Paragraph ids in reading order for the active scope. */
   paragraphOrder(): readonly string[];
+  /**
+   * The cells a RECTANGLE selection covers, when there is one.
+   *
+   * A rectangle is not the range it stands in for: read as a range, a selected column runs
+   * through every cell between its corners in document order, so bulleting the left column
+   * of a 2x2 table also bulleted the cell beside it. `setParagraphProperty` already asks
+   * this question (see `surface-format.ts`); every write here has to ask it too.
+   */
+  selectedCells?(): readonly string[] | undefined;
 }
 
 type StructureMethods = Pick<
@@ -94,6 +103,9 @@ function leftIndentAttributes(
   value: string
 ): Record<string, string> {
   const attributes: Record<string, string> = { ...(authored ?? {}) };
+  // `w:leftChars` supersedes the twips (§17.3.1.12), so the step has to clear it or the
+  // paragraph does not move.
+  delete attributes.leftChars;
   if (authored?.start !== undefined) attributes.start = value;
   if (authored?.start === undefined || authored.left !== undefined) attributes.left = value;
   return attributes;
@@ -112,6 +124,10 @@ function writeIndentSide(
   value: number | null
 ): Record<string, string> {
   const attributes: Record<string, string> = { ...authored };
+  // The CHARACTER-unit twin goes with the measurement either way, because it SUPERSEDES it
+  // (§17.3.1.12): `w:leftChars` measures the same indent in hundredths of a character, so a
+  // merging write that left it in place wrote twips the file then ignored.
+  delete attributes[`${physical}Chars`];
   if (value === null) {
     delete attributes[physical];
     delete attributes[relative];
@@ -139,6 +155,9 @@ function writeFirstLine(
   value: number | null
 ): Record<string, string> {
   const attributes: Record<string, string> = { ...authored };
+  // Both character-unit twins go too: either supersedes the twips beside it.
+  delete attributes.firstLineChars;
+  delete attributes.hangingChars;
   if (value === null) {
     delete attributes.firstLine;
     delete attributes.hanging;
@@ -169,6 +188,26 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       return deps.layout();
     },
   };
+
+  /**
+   * The paragraphs a structural write acts on, in document order, or null when the
+   * selection does not resolve against the active scope's order.
+   *
+   * A RECTANGLE takes precedence over the range, exactly as it does for
+   * `setParagraphProperty`: with a column selected, these are the column's paragraphs and
+   * nothing between them. Without one, the selection sweeps from its first paragraph to its
+   * last, which is what Word does and what every one of these verbs did before.
+   */
+  function targetParagraphs(): readonly string[] | null {
+    const cells = deps.selectedCells?.();
+    if (cells && cells.length > 0) return [...paragraphsInCells(currentLayout.value, cells)];
+    const { from, to } = orderedRange();
+    const order = orderOf();
+    const firstIndex = order.indexOf(from.paragraphId);
+    const lastIndex = order.indexOf(to.paragraphId);
+    if (firstIndex === -1 || lastIndex === -1) return null;
+    return order.slice(firstIndex, lastIndex + 1);
+  }
 
   /** Word's Increase/Decrease Indent step: one default tab stop. */
   const INDENT_STEP_TWIPS = 720;
@@ -382,26 +421,17 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
     },
 
     isListActive(kind) {
-      const { from, to } = orderedRange();
-      const order = orderOf();
-      const firstIndex = order.indexOf(from.paragraphId);
-      const lastIndex = order.indexOf(to.paragraphId);
-      if (firstIndex === -1 || lastIndex === -1) return false;
+      const touched = targetParagraphs();
+      if (touched === null) return false;
       const wanted = kind === 'bullet' ? 'bullet' : 'ordered';
-      const touched = order.slice(firstIndex, lastIndex + 1);
       return (
         touched.length > 0 && touched.every((paragraphId) => listKindOf(paragraphId) === wanted)
       );
     },
 
     toggleList(kind) {
-      const { from, to } = orderedRange();
-      const order = orderOf();
-      const firstIndex = order.indexOf(from.paragraphId);
-      const lastIndex = order.indexOf(to.paragraphId);
-      if (firstIndex === -1 || lastIndex === -1) return false;
-      const touched = order.slice(firstIndex, lastIndex + 1);
-      if (touched.length === 0) return false;
+      const touched = targetParagraphs();
+      if (touched === null || touched.length === 0) return false;
       // Word toggles OFF only when the whole selection is already that list; a mixed
       // selection becomes one list rather than clearing half of it.
       const turningOff = touched.every((paragraphId) => listKindOf(paragraphId) === kind);
@@ -409,11 +439,19 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         ? null
         : (adjacentListNumId(touched, kind) ?? session.ensureListDefinition(kind));
       if (!turningOff && numId === null) return false;
-      const ops: TreeDocOp[] = touched.map((paragraphId) => ({
-        op: 'setListNumbering',
-        paragraphId,
-        numId,
-      }));
+      const ops: TreeDocOp[] = touched.map((paragraphId) => {
+        // `w:numPr` carries the level AND the definition, and the op mints a fresh one, so
+        // a call that names no level silently resets `w:ilvl` to 0. Word converts a bullet
+        // to a number IN PLACE: pressing Numbered on a level-2 item left it at level 2,
+        // where this flattened it to the left margin two levels out.
+        const level = listLevelOf(paragraphId);
+        return {
+          op: 'setListNumbering' as const,
+          paragraphId,
+          numId,
+          ...(level !== null ? { level } : {}),
+        };
+      });
       let committed = false;
       commit(() => {
         const result = applyOps(ops, selectionMark());
@@ -424,17 +462,14 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
     },
 
     canAdjustIndent(direction) {
-      const { from, to } = orderedRange();
-      const order = orderOf();
-      const firstIndex = order.indexOf(from.paragraphId);
-      const lastIndex = order.indexOf(to.paragraphId);
-      if (firstIndex === -1 || lastIndex === -1) return false;
+      const touched = targetParagraphs();
+      if (touched === null) return false;
       const step = direction === 'increase' ? 1 : -1;
       // Enabled when ANY paragraph the selection touches could move. Word greys the
       // control out only when nothing would happen at all — and for a list item that is
       // the ENDS of the level range, never a missing definition: a level `numbering.xml`
       // does not declare gets declared on the way (see `ensureListLevel`).
-      return order.slice(firstIndex, lastIndex + 1).some((paragraphId) => {
+      return touched.some((paragraphId) => {
         const marker = markerOf(paragraphId);
         if (marker) {
           const next = marker.level + step;
@@ -446,14 +481,11 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
     },
 
     adjustIndent(direction) {
-      const { from, to } = orderedRange();
-      const order = orderOf();
-      const firstIndex = order.indexOf(from.paragraphId);
-      const lastIndex = order.indexOf(to.paragraphId);
-      if (firstIndex === -1 || lastIndex === -1) return false;
+      const touched = targetParagraphs();
+      if (touched === null) return false;
       const step = direction === 'increase' ? 1 : -1;
       const ops: TreeDocOp[] = [];
-      for (const paragraphId of order.slice(firstIndex, lastIndex + 1)) {
+      for (const paragraphId of touched) {
         const properties = paragraphPropertiesOf(currentLayout.value, paragraphId);
         const marker = markerOf(paragraphId);
         const level = marker?.level ?? null;
@@ -511,17 +543,17 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
     setIndent(update) {
       if (update.left === undefined && update.right === undefined && update.firstLine === undefined)
         return false;
-      const { from, to } = orderedRange();
-      const order = documentOrder(currentLayout.value);
-      const firstIndex = order.indexOf(from.paragraphId);
-      const lastIndex = order.indexOf(to.paragraphId);
-      if (firstIndex === -1 || lastIndex === -1) return false;
+      // The SCOPED order and the SCOPED part, like every other write in this lane. Reading
+      // the body order meant a header paragraph was never in it, so a ruler drag inside an
+      // open header or footer resolved to -1 and returned false — silently doing nothing.
+      const touched = targetParagraphs();
+      if (touched === null) return false;
       const ops: TreeDocOp[] = [];
-      for (const paragraphId of order.slice(firstIndex, lastIndex + 1)) {
+      for (const paragraphId of touched) {
         // Merged over the paragraph's OWN `w:ind`, never the cascade the layout publishes:
         // an op whose base is the cascade is refused, and `w:ind` carries four independent
         // settings in one element, so naming one field must leave the others as authored.
-        const direct = directParagraphProperties(session.part(), paragraphId);
+        const direct = directParagraphProperties(storyPart(), paragraphId);
         const authored = direct.find((property) => property.localName === 'ind')?.attributes ?? {};
         let attributes: Record<string, string> = { ...authored };
         if (update.left !== undefined) {
@@ -545,7 +577,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       if (ops.length === 0) return false;
       let committed = false;
       commit(() => {
-        const result = session.applyTreeOps(ops, selectionMark());
+        const result = applyOps(ops, selectionMark());
         committed = result.committed;
         return result;
       });

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -19,6 +19,7 @@ import {
 } from '@docx-editor.dev/core/layout';
 import type { ListMarkerRecord } from '@docx-editor.dev/core/layout';
 import { fragmentHolding } from '../layout/line-segments.ts';
+import { cascadedParagraphAttributes } from '../layout/paragraph-style.ts';
 import {
   directParagraphProperties,
   mergedProperties,
@@ -269,12 +270,19 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
     return declared && deps.numberingLevelExists(marker.numId, level);
   }
 
-  /** Authored `w:ind/@left` in twips, zero when the paragraph states none. */
+  /**
+   * `w:ind/@left` in twips, zero when nothing states it.
+   *
+   * Folded across the whole list rather than picked out of it: this reads a CASCADE, whose
+   * entries run lowest precedence first, so taking the first `w:ind` answered the style's
+   * indent for a paragraph that had already been indented past it — and Increase Indent then
+   * rewrote the same one step forever (see `cascadedParagraphAttributes`).
+   */
   function leftIndentTwipsOf(
     properties: readonly { localName: string; attributes?: Readonly<Record<string, string>> }[]
   ): number {
-    const ind = properties.find((property) => property.localName === 'ind');
-    const raw = ind?.attributes?.left ?? ind?.attributes?.start;
+    const ind = cascadedParagraphAttributes(properties, 'ind');
+    const raw = ind?.left ?? ind?.start;
     if (!raw || !/^-?\d{1,7}$/.test(raw)) return 0;
     return Number(raw);
   }
@@ -467,7 +475,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         // Only the paragraph's OWN `w:ind` attributes are carried over: `w:ind` cascades
         // attribute by attribute (17.3.1.12), so an inherited hanging survives untouched
         // rather than being restated here.
-        const existing = direct.find((property) => property.localName === 'ind');
+        const existing = cascadedParagraphAttributes(direct, 'ind');
         ops.push({
           op: 'setParagraphProperties',
           paragraphId,
@@ -476,7 +484,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
             // Zero is written rather than dropped: an authored `w:ind` may inherit a
             // non-zero left from its style, and removing the attribute would let that
             // come back instead of taking the outdent.
-            attributes: leftIndentAttributes(existing?.attributes, String(next)),
+            attributes: leftIndentAttributes(existing ?? undefined, String(next)),
           }),
         });
       }
@@ -504,7 +512,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         // an op whose base is the cascade is refused, and `w:ind` carries four independent
         // settings in one element, so naming one field must leave the others as authored.
         const direct = directParagraphProperties(session.part(), paragraphId);
-        const authored = direct.find((property) => property.localName === 'ind')?.attributes ?? {};
+        const authored = cascadedParagraphAttributes(direct, 'ind') ?? {};
         let attributes: Record<string, string> = { ...authored };
         if (update.left !== undefined) {
           attributes = writeIndentSide(attributes, 'left', 'start', update.left);

--- a/packages/core/src/layout/__tests__/attribute-vocabulary.test.ts
+++ b/packages/core/src/layout/__tests__/attribute-vocabulary.test.ts
@@ -1,0 +1,151 @@
+// Two spellings of one setting, and the whole of `ST_OnOff`.
+//
+// ISO 29500 Strict renamed the direction-relative sides: `CT_TcBorders`, `CT_TblBorders`,
+// `CT_TcMar` and `CT_TblCellMar` declare `w:start`/`w:end` and NOT `w:left`/`w:right`.
+// Reading only the transitional names lost every vertical rule and every horizontal cell
+// inset in a Strict-authored document.
+//
+// `ST_OnOff`'s off vocabulary is `0`, `false` AND `off` (§17.17.4). Readers that listed only
+// the first two read `w:val="off"` as ON.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../../editor/paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function docx(body: string, styles?: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        (styles
+          ? '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>'
+          : '') +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    ...(styles
+      ? {
+          'word/_rels/document.xml.rels': strToU8(
+            `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${OD.replace('officeDocument', 'styles')}" Target="styles.xml"/></Relationships>`
+          ),
+          'word/styles.xml': strToU8(styles),
+        }
+      : {}),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function mount(bytes: Uint8Array): PaginatedSurface {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const result = mountPaginatedSurface(container, bytes, { scale: 1 });
+  if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
+  return result.surface;
+}
+
+/** The first table fragment on the first page. */
+function firstTable(surface: PaginatedSurface) {
+  for (const page of surface.layout().pages) {
+    for (const fragment of page.fragments) if (fragment.kind === 'table') return fragment;
+  }
+  throw new Error('no table in layout');
+}
+
+const GRID = '<w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>';
+
+describe('the Strict spellings of the vertical table sides', () => {
+  const table = (tcPr: string) =>
+    `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>${GRID}` +
+    `<w:tr><w:tc>${tcPr}${p('cell')}</w:tc></w:tr></w:tbl>`;
+
+  test('w:tcBorders/w:start paints the same rule as w:left', () => {
+    const left = mount(
+      docx(
+        table(
+          '<w:tcPr><w:tcBorders><w:left w:val="single" w:sz="24" w:color="FF0000"/></w:tcBorders></w:tcPr>'
+        )
+      )
+    );
+    const start = mount(
+      docx(
+        table(
+          '<w:tcPr><w:tcBorders><w:start w:val="single" w:sz="24" w:color="FF0000"/></w:tcBorders></w:tcPr>'
+        )
+      )
+    );
+    const leftBorder = firstTable(left).rows[0]!.cells[0]!.borders.left;
+    expect(leftBorder).toBeDefined();
+    // Read only as `w:left`, the Strict spelling drew nothing at all.
+    expect(firstTable(start).rows[0]!.cells[0]!.borders.left).toEqual(leftBorder!);
+  });
+
+  test('w:tcMar/w:start insets the cell the same as w:left', () => {
+    const left = mount(
+      docx(table('<w:tcPr><w:tcMar><w:left w:w="1440" w:type="dxa"/></w:tcMar></w:tcPr>'))
+    );
+    const start = mount(
+      docx(table('<w:tcPr><w:tcMar><w:start w:w="1440" w:type="dxa"/></w:tcMar></w:tcPr>'))
+    );
+    const textLeft = (surface: PaginatedSurface) =>
+      firstTable(surface).rows[0]!.cells[0]!.blocks[0]!.box.x;
+    // 1440 twips = 72pt of inset; read only as `w:left`, the Strict cell fell back to the
+    // 3pt default pad.
+    expect(textLeft(start)).toBe(textLeft(left));
+  });
+});
+
+describe('ST_OnOff accepts "off" everywhere it accepts "0"', () => {
+  test('w:tblHeader w:val="off" does not repeat the row', () => {
+    const rows = Array.from(
+      { length: 60 },
+      (_, index) => `<w:tr><w:tc>${p(`r${index}`)}</w:tc></w:tr>`
+    );
+    const header = `<w:tr><w:trPr><w:tblHeader w:val="off"/></w:trPr><w:tc>${p('HEAD')}</w:tc></w:tr>`;
+    const surface = mount(
+      docx(
+        `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>${GRID}${header}${rows.join('')}</w:tbl>`
+      )
+    );
+    const repeats = surface
+      .layout()
+      .pages.flatMap((page) =>
+        page.fragments.flatMap((fragment) =>
+          fragment.kind === 'table' ? fragment.rows.filter((row) => row.isHeaderRepeat) : []
+        )
+      );
+    expect(surface.layout().pages.length).toBeGreaterThan(1);
+    expect(repeats).toHaveLength(0);
+  });
+
+  test('w:style w:default="on" still names the default paragraph style', () => {
+    const styles =
+      `<w:styles xmlns:w="${W}">` +
+      '<w:style w:type="paragraph" w:styleId="Normal" w:default="on"><w:name w:val="Normal"/>' +
+      '<w:rPr><w:sz w:val="48"/></w:rPr></w:style>' +
+      '</w:styles>';
+    const surface = mount(docx(p('text'), styles));
+    const id = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId: id, offset: 0 },
+      head: { paragraphId: id, offset: 1 },
+    });
+    // Read as "not the default", the style applied to nothing: 24pt text painted at 10pt
+    // and the style box went blank.
+    expect(surface.formatting().styleId).toBe('Normal');
+    expect(surface.formatting().fontSizeHalfPoints).toBe(48);
+  });
+});

--- a/packages/core/src/layout/paragraph-style.ts
+++ b/packages/core/src/layout/paragraph-style.ts
@@ -209,6 +209,36 @@ function childNamed(node: OoxmlElement, localName: string): OoxmlElement | undef
 }
 
 /**
+ * Fold every entry of one `w:pPr` element name in a FLATTENED CASCADE into one attribute bag.
+ *
+ * A cascaded property list carries one entry per level — `w:docDefaults`, then each style in
+ * the `basedOn` chain, then the paragraph's own `w:pPr` — in that order, LOWEST PRECEDENCE
+ * FIRST. `Array.prototype.find` therefore answers the document's defaults and never the
+ * paragraph's own formatting, which is the wrong end of the list: read that way, a paragraph
+ * that had just been given 24pt of space before still reported the 8pt its `w:docDefaults`
+ * set.
+ *
+ * Attributes merge INDEPENDENTLY, the rule {@link paragraphSpacing} and
+ * {@link paragraphLineSpacing} already follow: `w:spacing` carries the line rule, the space
+ * before and the space after in one element, and a style that states `w:before` alone must
+ * leave the `w:after` an earlier level set in place.
+ *
+ * Returns null when no level states the element at all — not the same as one stating it with
+ * no attributes.
+ */
+export function cascadedParagraphAttributes(
+  props: readonly OoxmlProperty[],
+  localName: string
+): Readonly<Record<string, string>> | null {
+  let merged: Record<string, string> | null = null;
+  for (const property of props) {
+    if (property.localName !== localName) continue;
+    merged = { ...(merged ?? {}), ...(property.attributes ?? {}) };
+  }
+  return merged;
+}
+
+/**
  * Resolve `w:spacing` before/after from flat paragraph properties.
  *
  * Line spacing (`w:line` / `w:lineRule`) is a separate concern — it changes measured line

--- a/packages/core/src/layout/paragraph-style.ts
+++ b/packages/core/src/layout/paragraph-style.ts
@@ -7,14 +7,26 @@
 import type { OoxmlElement, OoxmlNode, OoxmlProperty } from '@docx-editor.dev/core/store';
 import { borderStrokeWidthPt } from './border-metrics.ts';
 
-/** Whether a paragraph must start a new page (`w:pageBreakBefore`). */
+/**
+ * Whether a paragraph must start a new page (`w:pageBreakBefore`).
+ *
+ * LAST WINS, like every other toggle read off the cascade (`paragraphKeeps` does the same
+ * for `w:keepNext`). An any-wins `.some()` cannot be switched off: a Chapter or Heading style
+ * carries `w:pageBreakBefore`, and Word writes `w:val="0"` on the one instance whose author
+ * unchecked the box — that paragraph still broke, so the document grew a blank page and every
+ * page number after it was wrong.
+ *
+ * An absent `w:val` is on (§17.17.4), and the off vocabulary is the whole of it — `off` is a
+ * spelling too, which {@link isOn} beside this already accepts.
+ */
 export function paragraphBreaksBefore(props: readonly OoxmlProperty[]): boolean {
-  return props.some(
-    (property) =>
-      property.localName === 'pageBreakBefore' &&
-      property.attributes?.val !== '0' &&
-      property.attributes?.val !== 'false'
-  );
+  let breaks = false;
+  for (const property of props) {
+    if (property.localName !== 'pageBreakBefore') continue;
+    const val = property.attributes?.val;
+    breaks = val === undefined || isOn(val);
+  }
+  return breaks;
 }
 
 /**
@@ -44,7 +56,7 @@ export interface ParagraphSpacing {
 
 /**
  * The gap Word substitutes when `w:beforeAutospacing` / `w:afterAutospacing` is on
- * (ECMA-376 §17.3.1.2, §17.3.1.13).
+ * (ECMA-376 §17.3.1.33, the `w:spacing` clause both attributes belong to).
  *
  * The attribute means "the consumer decides", and the authored `@before` / `@after` beside it
  * is IGNORED rather than used as the value. Word's answer is HTML's default `<p>` margin,

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -364,11 +364,18 @@ function readShading(cellProperties: OoxmlElement | undefined): string | undefin
   return shadingFillFromElement(cellProperties && childNamed(cellProperties, 'shd'));
 }
 
+/**
+ * A `w:trPr` toggle (`w:tblHeader`, `w:cantSplit`), absent meaning off.
+ *
+ * `off` is an off value (§17.17.4), like `0` and `false` — the `onOff` helper below already
+ * accepts all three. Missing it here meant `<w:tblHeader w:val="off"/>` read as ON, and the
+ * row repeated as a header on every page of a long table.
+ */
 function readFlag(container: OoxmlElement | undefined, localName: string): boolean {
   const flag = container && childNamed(container, localName);
   if (!flag) return false;
   const value = attributeValue(flag, 'val');
-  return value !== '0' && value !== 'false';
+  return value === undefined || (value !== '0' && value !== 'false' && value !== 'off');
 }
 
 const AUTO_ROW_HEIGHT: TableRowHeight = Object.freeze({ rule: 'auto' });
@@ -413,10 +420,13 @@ function twipsSide(node: OoxmlElement | undefined): number | undefined {
  */
 function readMarginSides(container: OoxmlElement | undefined): Partial<CellMarginsPt> {
   if (!container) return {};
+  // `w:start`/`w:end` are the direction-relative spellings, and the ISO Strict `CT_TcMar` /
+  // `CT_TblCellMar` declare only those. Reading `w:left`/`w:right` alone put the text of a
+  // Strict-authored cell at the fallback pad instead of its authored inset.
   const top = twipsSide(childNamed(container, 'top'));
-  const left = twipsSide(childNamed(container, 'left'));
+  const left = twipsSide(childNamed(container, 'left') ?? childNamed(container, 'start'));
   const bottom = twipsSide(childNamed(container, 'bottom'));
-  const right = twipsSide(childNamed(container, 'right'));
+  const right = twipsSide(childNamed(container, 'right') ?? childNamed(container, 'end'));
   return {
     ...(top === undefined ? {} : { top }),
     ...(left === undefined ? {} : { left }),

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -166,8 +166,16 @@ export function isValidStyleId(raw: string | undefined): raw is string {
   return true;
 }
 
+/**
+ * `w:style/@w:default` — `ST_OnOff`, so `on` is a legal spelling alongside `1` and `true`.
+ *
+ * Absent means off here, unlike a toggle ELEMENT: the attribute's presence is the statement.
+ * Reading only two of the three on-spellings meant a document whose Normal said
+ * `w:default="on"` had no default paragraph style at all — every unstyled paragraph fell to
+ * the format's own defaults and the style box went blank.
+ */
 function isDefaultFlag(raw: string | undefined): boolean {
-  return raw === '1' || raw === 'true';
+  return raw === '1' || raw === 'true' || raw === 'on';
 }
 
 function propertiesFingerprint(props: readonly OoxmlProperty[]): unknown {

--- a/packages/core/src/layout/table-borders.ts
+++ b/packages/core/src/layout/table-borders.ts
@@ -242,7 +242,14 @@ function readBox(
     right: OMITTED,
   };
   for (const side of sides) {
-    result[side] = readBorderSide(childNamed(container, side));
+    // `w:start`/`w:end` are the direction-relative spellings of the vertical sides, and in
+    // the ISO Strict schema they are the ONLY ones `CT_TcBorders` / `CT_TblBorders` declare
+    // (wml.xsd `CT_TcBorders`, `CT_TblBorders`). Reading the transitional names alone lost
+    // every vertical rule in a Strict-authored document — the cell simply drew no border.
+    const relative = side === 'left' ? 'start' : side === 'right' ? 'end' : undefined;
+    const element =
+      childNamed(container, side) ?? (relative ? childNamed(container, relative) : undefined);
+    result[side] = readBorderSide(element);
   }
   return result;
 }

--- a/packages/core/src/store/package/ooxml-indexes.ts
+++ b/packages/core/src/store/package/ooxml-indexes.ts
@@ -173,7 +173,10 @@ export function indexStyles(part: OoxmlPart | undefined): Map<string, StyleIndex
             nodeId: node.id,
             name,
             basedOn,
-            isDefault: (attr(node, 'default') ?? '') === '1',
+            // `ST_OnOff`, so all three on-spellings count — the layout lane's
+            // `isDefaultFlag` reads the same attribute and must reach the same answer, or
+            // the page paints the default style while the automation lane reports none.
+            isDefault: ['1', 'true', 'on'].includes(attr(node, 'default') ?? ''),
           });
         }
       }

--- a/packages/core/src/store/store/direct-properties.ts
+++ b/packages/core/src/store/store/direct-properties.ts
@@ -158,12 +158,13 @@ export function mergedProperties(
  * indirectly and WINS over the explicit name beside it, so a slot being set has to have its
  * theme reference cleared with it or the pick resolves back to the theme font.
  */
-const FONT_SLOT_THEMES: Readonly<Record<string, string>> = {
-  ascii: 'asciiTheme',
-  hAnsi: 'hAnsiTheme',
-  eastAsia: 'eastAsiaTheme',
-  cs: 'cstheme',
-};
+const FONT_SLOT_THEMES: ReadonlyMap<string, string> = new Map([
+  ['ascii', 'asciiTheme'],
+  ['hAnsi', 'hAnsiTheme'],
+  ['eastAsia', 'eastAsiaTheme'],
+  // Lowercase `t` is the schema's own spelling, not a typo (`CT_Fonts`).
+  ['cs', 'cstheme'],
+]);
 
 /**
  * A `w:rFonts` write merged over what the run already authors, slot by slot.
@@ -184,7 +185,7 @@ export function mergedFontProperty(
   if (!existing) return incoming;
   const merged: Record<string, string> = { ...existing, ...(incoming.attributes ?? {}) };
   for (const slot of Object.keys(incoming.attributes ?? {})) {
-    const theme = FONT_SLOT_THEMES[slot];
+    const theme = FONT_SLOT_THEMES.get(slot);
     if (theme) delete merged[theme];
   }
   return { localName: 'rFonts', attributes: merged };
@@ -239,17 +240,6 @@ export interface RunPropertyEdit {
 }
 
 /**
- * A range run-property change, split into ONE edit per run it covers, each merged over that
- * run's own `w:rPr`.
- *
- * Neither half of that is optional. The base MUST be the run's own properties (see this file's
- * header). And the split MUST be per run: the op REPLACES the properties it names across its
- * whole range, so one op carrying one run's bag over a mixed selection homogenised it — bolding
- * `hello ` + `Georgia` rewrote the second run's `w:rFonts` with the first's. Runs are addressed by
- * offset rather than by id because these edits apply in sequence and the applier splits runs at
- * the range edges; offsets are unmoved by a property write, ids are not.
- */
-/**
  * One incoming write merged over what the node authors, for the properties that carry
  * SEVERAL independent settings in one element.
  *
@@ -270,6 +260,29 @@ export function mergedMultiSettingProperty(
   const existing = authored.find((entry) => entry.localName === 'u')?.attributes;
   if (!existing) return incoming;
   return { localName: 'u', attributes: { ...existing, ...(incoming.attributes ?? {}) } };
+}
+
+/**
+ * A paragraph MARK's own properties with one write merged in, per attribute where it counts.
+ *
+ * The mark carries a `w:rPr` like any run, so a font change has to keep its other font slots
+ * for the same reason a run does — without this the marker of a CJK list item lost its East
+ * Asian face while the text beside it kept one. Lives here because BOTH lanes write the mark:
+ * the editor's toolbar and the automation object model.
+ */
+export function mergedParagraphMarkProperties(
+  part: OoxmlPart,
+  paragraphId: string,
+  incoming: OoxmlProperty | readonly OoxmlProperty[]
+): OoxmlProperty[] {
+  const authored = directParagraphMarkProperties(part, paragraphId);
+  const additions = Array.isArray(incoming)
+    ? (incoming as readonly OoxmlProperty[])
+    : [incoming as OoxmlProperty];
+  return mergedProperties(
+    authored,
+    additions.map((property) => mergedMultiSettingProperty(authored, property))
+  );
 }
 
 function withMultiSettingsKept(

--- a/packages/core/src/store/store/direct-properties.ts
+++ b/packages/core/src/store/store/direct-properties.ts
@@ -150,6 +150,46 @@ export function mergedProperties(
   return [...kept, ...additions];
 }
 
+/**
+ * The four font SLOTS `w:rFonts` carries, and the theme reference that outranks each.
+ *
+ * One element, four independent scripts: Latin (`ascii`), Cyrillic and the rest of the
+ * high range (`hAnsi`), East Asian, and complex script. A theme attribute names a slot
+ * indirectly and WINS over the explicit name beside it, so a slot being set has to have its
+ * theme reference cleared with it or the pick resolves back to the theme font.
+ */
+const FONT_SLOT_THEMES: Readonly<Record<string, string>> = {
+  ascii: 'asciiTheme',
+  hAnsi: 'hAnsiTheme',
+  eastAsia: 'eastAsiaTheme',
+  cs: 'cstheme',
+};
+
+/**
+ * A `w:rFonts` write merged over what the run already authors, slot by slot.
+ *
+ * `w:rFonts` is the one run property carrying SEVERAL independent settings, so replacing it
+ * wholesale to change the Latin font deleted the run's East Asian and complex-script faces
+ * and its `w:hint`. That loss is invisible here — this engine resolves the Latin slot — and
+ * shows up on save: CJK text in that run reopens in Word in a different font.
+ *
+ * `w:hint` rides along untouched. It says which slot ambiguous characters resolve through,
+ * which is a property of the text, not of the font just picked.
+ */
+export function mergedFontProperty(
+  authored: readonly OoxmlProperty[],
+  incoming: OoxmlProperty
+): OoxmlProperty {
+  const existing = authored.find((entry) => entry.localName === 'rFonts')?.attributes;
+  if (!existing) return incoming;
+  const merged: Record<string, string> = { ...existing, ...(incoming.attributes ?? {}) };
+  for (const slot of Object.keys(incoming.attributes ?? {})) {
+    const theme = FONT_SLOT_THEMES[slot];
+    if (theme) delete merged[theme];
+  }
+  return { localName: 'rFonts', attributes: merged };
+}
+
 /** Per-run UTF-16 ranges from `segmentsOf` (fields/notes collapse to one unit on begin). */
 export function runAddressRanges(
   paragraph: Extract<OoxmlNode, { kind: 'paragraph' }>
@@ -209,6 +249,52 @@ export interface RunPropertyEdit {
  * offset rather than by id because these edits apply in sequence and the applier splits runs at
  * the range edges; offsets are unmoved by a property write, ids are not.
  */
+/**
+ * One incoming write merged over what the node authors, for the properties that carry
+ * SEVERAL independent settings in one element.
+ *
+ * Almost every run property is one setting and replaces cleanly. Two are not: `w:rFonts`
+ * carries a font per script (see {@link mergedFontProperty}), and `w:u` carries the
+ * underline style AND its colour, so toggling the style off and on again dropped an
+ * authored `w:color` and repainted a red underline black.
+ *
+ * Exported because the editor lane keeps its own content-control-aware run walk beside this
+ * one, and the two must reach the same answer.
+ */
+export function mergedMultiSettingProperty(
+  authored: readonly OoxmlProperty[],
+  incoming: OoxmlProperty
+): OoxmlProperty {
+  if (incoming.localName === 'rFonts') return mergedFontProperty(authored, incoming);
+  if (incoming.localName !== 'u') return incoming;
+  const existing = authored.find((entry) => entry.localName === 'u')?.attributes;
+  if (!existing) return incoming;
+  return { localName: 'u', attributes: { ...existing, ...(incoming.attributes ?? {}) } };
+}
+
+function withMultiSettingsKept(
+  authored: readonly OoxmlProperty[],
+  incoming: OoxmlProperty | readonly OoxmlProperty[]
+): OoxmlProperty | readonly OoxmlProperty[] {
+  if (Array.isArray(incoming)) {
+    return (incoming as readonly OoxmlProperty[]).map((property) =>
+      mergedMultiSettingProperty(authored, property)
+    );
+  }
+  return mergedMultiSettingProperty(authored, incoming as OoxmlProperty);
+}
+
+/**
+ * A range run-property change, split into ONE edit per run it covers, each merged over that
+ * run's own `w:rPr`.
+ *
+ * Neither half of that is optional. The base MUST be the run's own properties (see this file's
+ * header). And the split MUST be per run: the op REPLACES the properties it names across its
+ * whole range, so one op carrying one run's bag over a mixed selection homogenised it — bolding
+ * `hello ` + `Georgia` rewrote the second run's `w:rFonts` with the first's. Runs are addressed by
+ * offset rather than by id because these edits apply in sequence and the applier splits runs at
+ * the range edges; offsets are unmoved by a property write, ids are not.
+ */
 export function runPropertyEdits(
   part: OoxmlPart,
   paragraphId: string,
@@ -242,16 +328,14 @@ export function runPropertyEdits(
     const from = Math.max(range.start, start);
     const to = Math.min(range.end, end);
     if (from >= to) return;
+    const authored = authoredProperties(
+      propertyContainer(child, 'runProperties', 'rPr'),
+      AUTHORABLE_RUN_PROPERTIES
+    );
     edits.push({
       start: from,
       end: to,
-      properties: mergedProperties(
-        authoredProperties(
-          propertyContainer(child, 'runProperties', 'rPr'),
-          AUTHORABLE_RUN_PROPERTIES
-        ),
-        incoming
-      ),
+      properties: mergedProperties(authored, withMultiSettingsKept(authored, incoming)),
       ...(formatOwned.has(child.id) ? { targetRunIds: [child.id] } : {}),
     });
   };

--- a/packages/core/src/store/store/index.ts
+++ b/packages/core/src/store/store/index.ts
@@ -80,6 +80,8 @@ export {
   directParagraphProperties,
   formatOwnedRunIds,
   isAuthorableRunProperty,
+  mergedFontProperty,
+  mergedMultiSettingProperty,
   mergedProperties,
   propertyContainer,
   runAddressRanges,

--- a/packages/core/src/store/store/index.ts
+++ b/packages/core/src/store/store/index.ts
@@ -82,6 +82,7 @@ export {
   isAuthorableRunProperty,
   mergedFontProperty,
   mergedMultiSettingProperty,
+  mergedParagraphMarkProperties,
   mergedProperties,
   propertyContainer,
   runAddressRanges,

--- a/packages/react/src/components/PaginatedDocxEditor.tsx
+++ b/packages/react/src/components/PaginatedDocxEditor.tsx
@@ -64,7 +64,17 @@ export interface PaginatedDocxEditorHandle {
   navigate(command: NavigationCommand, extend?: boolean): void;
   toggleRunProperty(localName: string, attributes?: Record<string, string>): void;
   setRunProperty(localName: string, attributes?: Record<string, string>): void;
-  setParagraphProperty(localName: string, attributes?: Record<string, string>): void;
+  /**
+   * `options.mergeAttributes` keeps the attributes the call does not name, for the
+   * properties carrying several independent settings in one element — `w:spacing` holds the
+   * line rule AND the space before and after, so a line-spacing pick without it deleted the
+   * paragraph's spacing.
+   */
+  setParagraphProperty(
+    localName: string,
+    attributes?: Record<string, string | null>,
+    options?: { readonly mergeAttributes?: boolean }
+  ): void;
   /** Formatting at the selection, for a toolbar to reflect. */
   formatting(): SurfaceFormatting | null;
   /** The section the document declares — what a ruler is made of. */
@@ -148,8 +158,11 @@ export function PaginatedDocxEditor({
         surfaceRef.current?.toggleRunProperty(localName, attributes),
       setRunProperty: (localName: string, attributes?: Record<string, string>) =>
         surfaceRef.current?.setRunProperty(localName, attributes),
-      setParagraphProperty: (localName: string, attributes?: Record<string, string>) =>
-        surfaceRef.current?.setParagraphProperty(localName, attributes),
+      setParagraphProperty: (
+        localName: string,
+        attributes?: Record<string, string | null>,
+        options?: { readonly mergeAttributes?: boolean }
+      ) => surfaceRef.current?.setParagraphProperty(localName, attributes, options),
       formatting: () => surfaceRef.current?.formatting() ?? null,
       sectionProperties: () => surfaceRef.current?.sectionProperties() ?? null,
       save: () => {

--- a/packages/react/src/components/PaginatedDocxEditorShell.tsx
+++ b/packages/react/src/components/PaginatedDocxEditorShell.tsx
@@ -195,10 +195,14 @@ export function PaginatedDocxEditorShell({
       case 'lineSpacing':
         // The picker already speaks TWIPS (240 = single). Multiplying again turned "1.5
         // lines" into 360 lines.
-        return editor.setParagraphProperty('spacing', {
-          line: String(Math.round(action.value)),
-          lineRule: 'auto',
-        });
+        // Merged: `w:spacing` carries the line rule and the space before/after together, so
+        // a replacing write deleted the paragraph's spacing on its way to changing the line
+        // height. Same rule as the engine's own `setLineSpacing`.
+        return editor.setParagraphProperty(
+          'spacing',
+          { line: String(Math.round(action.value)), lineRule: 'auto' },
+          { mergeAttributes: true }
+        );
       case 'applyStyle':
         return editor.setParagraphProperty('pStyle', { val: action.value });
       default:

--- a/packages/react/src/editor/toolbar/LineSpacing.tsx
+++ b/packages/react/src/editor/toolbar/LineSpacing.tsx
@@ -24,6 +24,17 @@ const LINE_SPACING_PRESETS: readonly number[] = [1, 1.15, 1.5, 2, 2.5, 3];
 /** Word's "Add space before/after paragraph" writes 10pt — its Normal style's own value. */
 const DEFAULT_PARAGRAPH_SPACE_PT = 10;
 
+/**
+ * Word's "Remove space before/after paragraph" writes an explicit ZERO, not nothing.
+ *
+ * The two are different answers, and the command draws the same distinction: dropping the
+ * attribute lets the paragraph inherit again, so on a paragraph whose SPACE CAME FROM ITS
+ * STYLE — every Word default document, whose Normal states 8pt after — Remove gave the space
+ * straight back and the row went on offering to remove it. A zero blocks the cascade, which
+ * is what the row says it does.
+ */
+const REMOVED_PARAGRAPH_SPACE_PT = 0;
+
 const selectSpacing = (snapshot: EditorSnapshot) => ({
   lineSpacing: snapshot.formatting?.lineSpacing ?? null,
   spaceBeforePt: snapshot.formatting?.spaceBeforePt ?? null,
@@ -132,7 +143,12 @@ function ToolbarLineSpacingImpl({ className, hidden }: ToolbarSlotPartProps) {
             role="menuitem"
             className="docx-toolbar__menu-item"
             onMouseDown={guardToolbarMousedown}
-            onClick={() => applySpace('beforePt', hasBefore ? null : DEFAULT_PARAGRAPH_SPACE_PT)}
+            onClick={() =>
+              applySpace(
+                'beforePt',
+                hasBefore ? REMOVED_PARAGRAPH_SPACE_PT : DEFAULT_PARAGRAPH_SPACE_PT
+              )
+            }
           >
             {label(hasBefore ? 'lineSpacing.removeSpaceBefore' : 'lineSpacing.addSpaceBefore')}
           </button>
@@ -141,7 +157,12 @@ function ToolbarLineSpacingImpl({ className, hidden }: ToolbarSlotPartProps) {
             role="menuitem"
             className="docx-toolbar__menu-item"
             onMouseDown={guardToolbarMousedown}
-            onClick={() => applySpace('afterPt', hasAfter ? null : DEFAULT_PARAGRAPH_SPACE_PT)}
+            onClick={() =>
+              applySpace(
+                'afterPt',
+                hasAfter ? REMOVED_PARAGRAPH_SPACE_PT : DEFAULT_PARAGRAPH_SPACE_PT
+              )
+            }
           >
             {label(hasAfter ? 'lineSpacing.removeSpaceAfter' : 'lineSpacing.addSpaceAfter')}
           </button>

--- a/packages/react/src/editor/toolbar/LineSpacing.tsx
+++ b/packages/react/src/editor/toolbar/LineSpacing.tsx
@@ -21,7 +21,13 @@ import type { ToolbarSlotPartProps, ToolbarSlotPartComponent } from './parts';
 /** Word's line-spacing menu, in lines. */
 const LINE_SPACING_PRESETS: readonly number[] = [1, 1.15, 1.5, 2, 2.5, 3];
 
-/** Word's "Add space before/after paragraph" writes 10pt — its Normal style's own value. */
+/**
+ * What Word's "Add space before/after paragraph" writes: a flat 10pt.
+ *
+ * The ribbon command's own constant, not a value read from the document — a paragraph given
+ * space this way lands on 10pt whatever its style states, so the pair is not a round trip
+ * back to a Normal that states 8pt.
+ */
 const DEFAULT_PARAGRAPH_SPACE_PT = 10;
 
 /**

--- a/packages/react/test/toolbar-composition.test.tsx
+++ b/packages/react/test/toolbar-composition.test.tsx
@@ -535,7 +535,15 @@ describe('the shaped parts', () => {
     await act(async () => {
       rows()[0]!.click();
     });
-    expect(editor().snapshot().formatting?.spaceBeforePt).toBeUndefined();
+    // ZERO, not absent. Removing the attribute would let the paragraph inherit its style's
+    // space again — on a Word default document that gives the space straight back, and the
+    // row goes on offering to remove what removing did not remove.
+    expect(editor().snapshot().formatting?.spaceBeforePt).toBe(0);
+
+    await act(async () => {
+      trigger.click();
+    });
+    expect(rows()[0]!.textContent).toBe(label('lineSpacing.addSpaceBefore' as TranslationKey));
   });
 
   test('line spacing and paragraph space are independent settings of one w:spacing', async () => {

--- a/packages/vue/src/components/PaginatedDocxEditor.tsx
+++ b/packages/vue/src/components/PaginatedDocxEditor.tsx
@@ -42,7 +42,12 @@ export interface PaginatedDocxEditorHandle {
   navigate(command: NavigationCommand, extend?: boolean): void;
   toggleRunProperty(localName: string, attributes?: Record<string, string>): void;
   setRunProperty(localName: string, attributes?: Record<string, string>): void;
-  setParagraphProperty(localName: string, attributes?: Record<string, string>): void;
+  /** `options.mergeAttributes` keeps the attributes the call does not name — see the React twin. */
+  setParagraphProperty(
+    localName: string,
+    attributes?: Record<string, string | null>,
+    options?: { readonly mergeAttributes?: boolean }
+  ): void;
   formatting(): SurfaceFormatting | null;
   sectionProperties(): SectionProperties | null;
   save(): Uint8Array | null;
@@ -145,8 +150,11 @@ export const PaginatedDocxEditor = defineComponent({
         surfaceRef.value?.toggleRunProperty(localName, attributes),
       setRunProperty: (localName: string, attributes?: Record<string, string>) =>
         surfaceRef.value?.setRunProperty(localName, attributes),
-      setParagraphProperty: (localName: string, attributes?: Record<string, string>) =>
-        surfaceRef.value?.setParagraphProperty(localName, attributes),
+      setParagraphProperty: (
+        localName: string,
+        attributes?: Record<string, string | null>,
+        options?: { readonly mergeAttributes?: boolean }
+      ) => surfaceRef.value?.setParagraphProperty(localName, attributes, options),
       formatting: () => surfaceRef.value?.formatting() ?? null,
       sectionProperties: () => surfaceRef.value?.sectionProperties() ?? null,
       save: () => {

--- a/packages/vue/src/editor/toolbar/LineSpacing.tsx
+++ b/packages/vue/src/editor/toolbar/LineSpacing.tsx
@@ -10,6 +10,9 @@ import type { ToolbarSlotPartComponent } from './parts';
 
 const LINE_SPACING_PRESETS: readonly number[] = [1, 1.15, 1.5, 2, 2.5, 3];
 const DEFAULT_PARAGRAPH_SPACE_PT = 10;
+// Remove writes an explicit ZERO, not nothing: dropping the attribute lets the style's own
+// space come back, so on a Word default document Remove gave the space straight back.
+const REMOVED_PARAGRAPH_SPACE_PT = 0;
 
 const selectSpacing = (snapshot: EditorSnapshot) => ({
   lineSpacing: snapshot.formatting?.lineSpacing ?? null,
@@ -120,7 +123,10 @@ export const ToolbarLineSpacing = defineComponent({
                 class="docx-toolbar__menu-item"
                 onMousedown={guardToolbarMousedown}
                 onClick={() =>
-                  applySpace('beforePt', hasBefore ? null : DEFAULT_PARAGRAPH_SPACE_PT)
+                  applySpace(
+                    'beforePt',
+                    hasBefore ? REMOVED_PARAGRAPH_SPACE_PT : DEFAULT_PARAGRAPH_SPACE_PT
+                  )
                 }
               >
                 {label(hasBefore ? 'lineSpacing.removeSpaceBefore' : 'lineSpacing.addSpaceBefore')}
@@ -130,7 +136,12 @@ export const ToolbarLineSpacing = defineComponent({
                 role="menuitem"
                 class="docx-toolbar__menu-item"
                 onMousedown={guardToolbarMousedown}
-                onClick={() => applySpace('afterPt', hasAfter ? null : DEFAULT_PARAGRAPH_SPACE_PT)}
+                onClick={() =>
+                  applySpace(
+                    'afterPt',
+                    hasAfter ? REMOVED_PARAGRAPH_SPACE_PT : DEFAULT_PARAGRAPH_SPACE_PT
+                  )
+                }
               >
                 {label(hasAfter ? 'lineSpacing.removeSpaceAfter' : 'lineSpacing.addSpaceAfter')}
               </button>


### PR DESCRIPTION
The layout hands the editor lane a paragraph's properties **flattened**: one entry per cascade level — `w:docDefaults`, each style in the `basedOn` chain, then the paragraph's own `w:pPr` — ordered lowest precedence first. Every read used `Array.prototype.find`, which answers the document defaults and never the paragraph.

On Word's blank template, "Add space before paragraph" wrote 24pt and the menu went on saying "Add", because the read still answered the 8pt beside it. The same misread kept the line-spacing tick on the default row, left the alignment button pressed on the style's alignment after a press changed it, and made Increase Indent rewrite one step forever.

Two more defects produced the same symptom for different reasons. `w:beforeAutospacing` replaces the measurement beside it, so on a document that inherits the flag — what Word writes for HTML-shaped content — a space-before write landed in the XML and moved nothing. And "Remove space before/after" dropped the attribute instead of writing a zero, so a paragraph whose space came from its style got it straight back.

Four review passes found the same class in several more places.

## Formatting was blind outside the body

The two per-paragraph indexes walked `layout.pages[].fragments`. Headers, footers, footnotes and endnotes are editable scopes of their own, and `paragraphLinesIndex` already walks all four for exactly this reason. With a header open, the page drew a centred paragraph indented 72pt while the toolbar reported left and no indent at all — so **Increase Indent stepped from zero and moved header text backwards**, Decrease Indent greyed out over indented text, and `setIndent` resolved against the body order and part, making a ruler drag inside a header a silent no-op. The read also swept the body order, so a two-paragraph header selection reported the head paragraph's values as agreement while the write acted on both.

The same index missed the absorbed half of a merged paragraph, which dropped all four ruler handles in the default `proposed` view.

## A rectangle is not the range it stands in for

`setParagraphProperty` resolves a cell rectangle before sweeping the selection; the four structure writes did not. Bulleting column A of a 2×2 table also bulleted B1, which sits between A1 and A2 in document order. The formatting **read** swept that range too, so the Centre button never lit over a uniformly centred column. A selected column now also survives Bullets and Increase Indent, as it already survived Centre.

## Elements carrying several settings

A write that changes one setting must not replace the element holding it. `w:rFonts` carries a font per script, so a Latin font pick deleted the run's East Asian and complex-script faces and its `w:hint` — on the run, on the paragraph mark, and whether the pick was applied to a selection or armed at a caret. `w:numPr` carries the level and the definition, so converting a level-2 bullet to a number reset `w:ilvl` to 0 and the item jumped two levels out. `w:u` carries the underline style and its colour, so toggling twice repainted a red underline black. The React shell's line-spacing action was the unfixed twin of the Ctrl+2 bug, and its handle could not pass a merge flag.

The mirror-image mistake is merging where a **superseding** twin survives: `w:beforeLines` and the `*Chars` indents measure the same setting in other units and outrank the twips beside them, so a value written next to one is a number the file ignores.

## Attribute vocabulary

`CT_TcBorders`, `CT_TblBorders`, `CT_TcMar` and `CT_TblCellMar` declare `w:start`/`w:end` and **not** `w:left`/`w:right` in ISO Strict, so a Strict-authored document lost every vertical table rule and every horizontal cell inset. `ST_OnOff`'s off vocabulary is `0`, `false` and `off`: missing the third meant `<w:tblHeader w:val="off"/>` repeated the row on every page, and `<w:pageBreakBefore w:val="0"/>` over a style that sets it could not switch the break off — a spurious blank page, and every page number after it wrong. `w:style w:default="on"` named no default style at all, and two readers of that attribute disagreed.

## What changed

`cascadedParagraphAttributes` folds a flattened cascade last-wins per attribute, and the `w:spacing` and `w:pStyle` reads go through it. Alignment reads through the layout's own `paragraphAlignment`, so the pressed button and the painted line resolve `w:jc` the same way. `w:ind` resolves per level instead, because `w:left` and `w:start` are two spellings of one setting and folding them per attribute made Increase Indent step backwards. The multi-setting merge and the paragraph-mark write are single store primitives both the editor and automation lanes call.

## Notes for the reviewer

`setParagraphSpacing` writes `w:beforeAutospacing="0"` rather than dropping the attribute, and writes it whether or not the document mentions autospacing — dropping it would let an inherited flag come back and win. `w:beforeLines` is dropped instead of zeroed, because `"0"` there means zero lines of space and would itself supersede the twips; a style that states `w:beforeLines` therefore still wins, which Word's own points entry does not express either.

`formatting.spaceBeforePt` reports the measurement the cascade states, not the gap the page draws. Resolving auto spacing needs list and cell membership, which this lane cannot see without guessing; a first pass used marker presence as a proxy and answered wrong for a list whose level paints no marker, at a cost quadratic in paragraph count. The contract documents which of the two it is.

Two gaps left alone, both deliberate. `paragraphAlignment` maps the three kashida values and `thaiDistribute` to left, where Word justifies — pre-existing, and it changes what the page paints. And list markers are not resolved for header, footer or note stories at all, so a bullet in a header is not a list on the page either; the list controls agree with what is drawn, and the missing rendering is its own piece of work.

Fixes #360
