### PR TITLE
perf(core): keep painted pages when entering a header

### DIFF
--- a/.changeset/hf-paint-reuse-in-place.md
+++ b/.changeset/hf-paint-reuse-in-place.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Entering a header or moving between shared header copies no longer rebuilds every visible page. The active band is retinted in place.

--- a/packages/core/src/editor/__tests__/hf-page-reuse.test.ts
+++ b/packages/core/src/editor/__tests__/hf-page-reuse.test.ts
@@ -1,0 +1,86 @@
+// Entering a header must not replace painted page sheets (#355 cause 3).
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function headeredPages(pageCount: number): Uint8Array {
+  const pages: string[] = [];
+  for (let index = 0; index < pageCount; index += 1) {
+    pages.push(p(`body page ${index + 1}`));
+    if (index < pageCount - 1) pages.push('<w:p><w:r><w:br w:type="page"/></w:r></w:p>');
+  }
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/></Relationships>`
+    ),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('HEADER')}</w:hdr>`),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${pages.join('')}` +
+        `<w:sectPr><w:headerReference w:type="default" r:id="rId10"/></w:sectPr>` +
+        '</w:body></w:document>'
+    ),
+  });
+}
+
+describe('header entry keeps painted pages', () => {
+  test('enterHeaderFooter and crossing copies retint chrome without replacing sheets', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const mounted = mountPaginatedSurface(container, headeredPages(6), { scale: 1 });
+    if (!mounted.ok) throw new Error(`${mounted.reason}: ${mounted.detail ?? ''}`);
+    const { surface } = mounted;
+    const before = [...container.querySelectorAll<HTMLElement>('.docx-page')];
+    expect(before.length).toBe(6);
+
+    expect(surface.enterHeaderFooter({ rId: 'rId10', pageIndex: 0 })).toBe(true);
+    const entered = [...container.querySelectorAll<HTMLElement>('.docx-page')];
+    expect(entered).toHaveLength(before.length);
+    for (let index = 0; index < before.length; index += 1) {
+      expect(entered[index]).toBe(before[index]);
+    }
+    expect(before[0]!.querySelector('[data-docx-hf-active]')?.getAttribute('data-docx-hf')).toBe(
+      'header'
+    );
+    expect(before[1]!.querySelector('[data-docx-hf-active]')).toBeNull();
+    expect(container.querySelector('.docx-page-content')?.getAttribute('contenteditable')).toBe(
+      'false'
+    );
+
+    expect(surface.enterHeaderFooter({ rId: 'rId10', pageIndex: 1 })).toBe(true);
+    const moved = [...container.querySelectorAll<HTMLElement>('.docx-page')];
+    for (let index = 0; index < before.length; index += 1) {
+      expect(moved[index]).toBe(before[index]);
+    }
+    expect(before[0]!.querySelector('[data-docx-hf-active]')).toBeNull();
+    expect(before[1]!.querySelector('[data-docx-hf-active]')).not.toBeNull();
+
+    surface.exitHeaderFooter();
+    const exited = [...container.querySelectorAll<HTMLElement>('.docx-page')];
+    for (let index = 0; index < before.length; index += 1) {
+      expect(exited[index]).toBe(before[index]);
+    }
+    expect(container.querySelector('[data-docx-hf-active]')).toBeNull();
+    surface.destroy();
+  });
+});

--- a/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts
@@ -341,4 +341,34 @@ describe('header band ink overflows instead of clipping', () => {
       expect(element.style.pointerEvents).toBe('none');
     }
   });
+
+  test('toggling the active band on a retained page does not replace the sheet', () => {
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const page = container.querySelector<HTMLElement>('.docx-page')!;
+    const band = container.querySelector<HTMLElement>('[data-docx-hf="header"]')!;
+    const drawing = container.querySelector<HTMLElement>(
+      '[data-docx-hf="header"] .docx-drawing-layer > *'
+    )!;
+    expect(band.hasAttribute('data-docx-hf-active')).toBe(false);
+    expect(drawing.style.pointerEvents).toBe('none');
+
+    paintSemanticLayout(container, layout, {
+      scale: 1,
+      activeHeaderFooterRId: 'rId1',
+      activeHeaderFooterPageIndex: 0,
+    });
+    expect(container.querySelector('.docx-page')).toBe(page);
+    expect(band.hasAttribute('data-docx-hf-active')).toBe(true);
+    expect(band.getAttribute('contenteditable')).toBe('true');
+    expect(drawing.style.pointerEvents).toBe('auto');
+    expect(container.querySelector('.docx-page-content')?.getAttribute('contenteditable')).toBe(
+      'false'
+    );
+
+    paintSemanticLayout(container, layout, { scale: 1 });
+    expect(container.querySelector('.docx-page')).toBe(page);
+    expect(band.hasAttribute('data-docx-hf-active')).toBe(false);
+    expect(drawing.style.pointerEvents).toBe('none');
+  });
 });

--- a/packages/core/src/output/__tests__/semantic-paint-hf-reuse.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-hf-reuse.test.ts
@@ -1,0 +1,82 @@
+// Opening a header used to fold rId + page index into the paint-reuse key (#355),
+// which rebuilt every visible sheet even though the body ink had not moved.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  buildStyleCascadeTable,
+  createFixedMeasurer,
+  layoutSemanticDocument,
+} from '@docx-editor.dev/core/layout';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function elevenPointDefaults(): ReturnType<typeof buildStyleCascadeTable> {
+  const styles = readOoxmlPart(
+    `<w:styles xmlns:w="${W}"><w:docDefaults><w:rPrDefault><w:rPr>` +
+      '<w:sz w:val="22"/>' +
+      '</w:rPr></w:rPrDefault></w:docDefaults></w:styles>',
+    { name: '/word/styles.xml', contentType: 'app/xml' }
+  );
+  if (!styles.ok) throw new Error(styles.reason);
+  return buildStyleCascadeTable(styles.part.root);
+}
+
+function layoutOf(body: string) {
+  const read = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!read.ok) throw new Error(read.reason);
+  return layoutSemanticDocument(read.part, 7, {
+    measurer: createFixedMeasurer(6, 14),
+    styleCascade: elevenPointDefaults(),
+  });
+}
+
+function pagesOf(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>('.docx-page')];
+}
+
+describe('header context stays off the paint-reuse key', () => {
+  const long = `<w:p><w:r><w:t>${'word '.repeat(3000)}</w:t></w:r></w:p>`;
+
+  test('setting the active header keeps every retained page', () => {
+    const layout = layoutOf(long);
+    expect(layout.pages.length).toBeGreaterThan(2);
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const first = pagesOf(container);
+
+    paintSemanticLayout(container, layout, {
+      scale: 1,
+      activeHeaderFooterRId: 'rId10',
+      activeHeaderFooterPageIndex: 0,
+    });
+    const entered = pagesOf(container);
+    expect(entered).toHaveLength(first.length);
+    for (let index = 0; index < first.length; index += 1) {
+      expect(entered[index]).toBe(first[index]);
+    }
+
+    paintSemanticLayout(container, layout, {
+      scale: 1,
+      activeHeaderFooterRId: 'rId10',
+      activeHeaderFooterPageIndex: 1,
+    });
+    const moved = pagesOf(container);
+    for (let index = 0; index < first.length; index += 1) {
+      expect(moved[index]).toBe(first[index]);
+    }
+
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const exited = pagesOf(container);
+    for (let index = 0; index < first.length; index += 1) {
+      expect(exited[index]).toBe(first[index]);
+    }
+  });
+});

--- a/packages/core/src/output/semantic-paint-hf-chrome.ts
+++ b/packages/core/src/output/semantic-paint-hf-chrome.ts
@@ -1,0 +1,121 @@
+// Header/footer edit chrome applied to already-painted pages.
+//
+// Opening a header used to fold rId + page index into the paint-reuse key, which rebuilt
+// every visible sheet even though the body ink had not moved. Dimming is CSS on
+// `.docx-pages--hf-editing`. This module moves `data-docx-hf-active`, contenteditable, the
+// active-band height, and drawing hit-testing onto the nodes the painter already has —
+// the same in-place pattern as TOC hover.
+
+import type { HeaderFooterStoryRecord, PageRecord } from '../layout/semantic-records.ts';
+
+export type HeaderFooterPaintChrome = {
+  readonly scale: number;
+  readonly activeHeaderFooterRId?: string;
+  readonly activeHeaderFooterPageIndex?: number;
+};
+
+export type HeaderFooterPaintTarget = {
+  readonly record: PageRecord;
+  readonly element: HTMLElement;
+  readonly materialized: boolean;
+};
+
+export function headerFooterBandIsActive(
+  story: HeaderFooterStoryRecord,
+  pageIndex: number,
+  chrome: HeaderFooterPaintChrome
+): boolean {
+  return (
+    !!chrome.activeHeaderFooterRId &&
+    !!story.rId &&
+    chrome.activeHeaderFooterRId === story.rId &&
+    (chrome.activeHeaderFooterPageIndex === undefined ||
+      chrome.activeHeaderFooterPageIndex === pageIndex)
+  );
+}
+
+export function headerFooterBandHeightPt(
+  story: HeaderFooterStoryRecord,
+  page: PageRecord,
+  active: boolean
+): number {
+  if (!active) return story.box.height;
+  return story.kind === 'footer'
+    ? Math.max(story.box.height, page.box.y + page.box.height - story.box.y)
+    : Math.max(story.box.height, page.contentBox.y - story.box.y);
+}
+
+/** Retint furniture chrome on retained pages. Newly painted pages go through the same path. */
+export function applyHeaderFooterPaintChrome(
+  pages: readonly HeaderFooterPaintTarget[],
+  chrome: HeaderFooterPaintChrome
+): void {
+  for (const { record: page, element, materialized } of pages) {
+    if (!materialized) continue;
+    const content = element.querySelector<HTMLElement>(':scope > .docx-page-content');
+    if (content) {
+      if (chrome.activeHeaderFooterRId) content.setAttribute('contenteditable', 'false');
+      else content.removeAttribute('contenteditable');
+    }
+    for (const band of element.querySelectorAll<HTMLElement>(
+      ':scope > .docx-hf:not(.docx-hf--placeholder)'
+    )) {
+      const story = storyOfBand(page, band);
+      if (!story) continue;
+      const active = headerFooterBandIsActive(story, page.index, chrome);
+      applyBandChrome(band, page, story, active, chrome.scale);
+    }
+    for (const layer of element.querySelectorAll<HTMLElement>(':scope > [data-docx-hf-front]')) {
+      const story = storyOfKind(page, layer.dataset.docxHfFront);
+      setDrawingInteractivity(
+        layer,
+        !!story && headerFooterBandIsActive(story, page.index, chrome)
+      );
+    }
+  }
+}
+
+function storyOfBand(page: PageRecord, band: HTMLElement): HeaderFooterStoryRecord | undefined {
+  return storyOfKind(page, band.dataset.docxHf);
+}
+
+function storyOfKind(
+  page: PageRecord,
+  kind: string | undefined
+): HeaderFooterStoryRecord | undefined {
+  if (kind === 'header') return page.header;
+  if (kind === 'footer') return page.footer;
+  return undefined;
+}
+
+function applyBandChrome(
+  band: HTMLElement,
+  page: PageRecord,
+  story: HeaderFooterStoryRecord,
+  active: boolean,
+  scale: number
+): void {
+  if (active) {
+    band.dataset.docxHfActive = '';
+    band.setAttribute('contenteditable', 'true');
+  } else {
+    delete band.dataset.docxHfActive;
+    band.setAttribute('contenteditable', 'false');
+  }
+  band.style.height = `${headerFooterBandHeightPt(story, page, active) * scale}px`;
+  setDrawingInteractivity(band, active);
+}
+
+function setDrawingInteractivity(root: ParentNode, interactive: boolean): void {
+  const nodes = root.querySelectorAll<HTMLElement>(
+    root instanceof Element && root.classList.contains('docx-drawing-layer')
+      ? ':scope > *'
+      : ':scope > .docx-drawing-layer > *'
+  );
+  for (const node of nodes) {
+    node.style.pointerEvents = interactive ? 'auto' : 'none';
+    for (const nested of node.querySelectorAll<HTMLElement>('.docx-drawing')) {
+      nested.style.pointerEvents = interactive ? 'auto' : 'none';
+    }
+  }
+}

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -47,6 +47,11 @@ import type {
   TableFragmentRecord,
 } from '@docx-editor.dev/core/layout';
 import { paintPageNoteAreas } from './semantic-paint-notes.ts';
+import {
+  applyHeaderFooterPaintChrome,
+  headerFooterBandHeightPt,
+  headerFooterBandIsActive,
+} from './semantic-paint-hf-chrome.ts';
 import { anchoredDrawingsOf } from '../layout/semantic-records.ts';
 import { lineSegments } from '../layout/line-segments.ts';
 import type { AnchoredDrawingRecord } from '../layout/drawing-layout.ts';
@@ -203,6 +208,10 @@ export interface PaintOptions {
    *
    * When set, the matching `[data-docx-hf]` container is editable and every body
    * `.docx-page-content` box is inert; all other furniture stays read-only.
+   *
+   * Deliberately OUTSIDE the paint-reuse key: entering a header must not rebuild
+   * body sheets. Chrome is applied to already-painted nodes in place, the way TOC
+   * hover is.
    */
   readonly activeHeaderFooterRId?: string;
   /**
@@ -210,6 +219,8 @@ export interface PaintOptions {
    *
    * Required with {@link activeHeaderFooterRId} so only one painted copy receives
    * `data-docx-hf-active` / the engine caret when the same rId appears on many pages.
+   * Also outside the paint-reuse key — moving the caret across shared copies retints
+   * markers in place rather than replacing every page.
    */
   readonly activeHeaderFooterPageIndex?: number;
   /**
@@ -353,7 +364,9 @@ function appendAnchoredDrawingsForRecords(
   // the band is not being edited: their box overflows are VISIBLE (Word draws header ink
   // into the margins and over the body), so a shape hanging past the band must not
   // swallow clicks meant for the document text underneath (#856).
-  interactive = true
+  interactive = true,
+  /** Marks a page-relative furniture layer so in-place chrome can retint hit-testing. */
+  hfFrontKind?: 'header' | 'footer'
 ): void {
   if (drawings.length === 0) return;
   const drawing = drawingContextOf(ctx);
@@ -366,6 +379,7 @@ function appendAnchoredDrawingsForRecords(
   layerElement.style.position = 'absolute';
   layerElement.style.inset = '0';
   layerElement.style.pointerEvents = 'none';
+  if (hfFrontKind) layerElement.dataset.docxHfFront = hfFrontKind;
   for (const element of paintAnchoredDrawingsLayer(
     document,
     drawings,
@@ -500,7 +514,8 @@ function appendHfPageRelativeDrawingLayer(
     ctx,
     pageOrigin,
     layer,
-    interactive
+    interactive,
+    layer === 'inFront' ? story.kind : undefined
   );
 }
 
@@ -2289,12 +2304,7 @@ function paintPage(
     const anchored = story.anchoredDrawings ?? [];
     // Ahead of the layers below, which BOTH need it: furniture ink is inert while the band
     // is not being edited, wherever on the sheet it was lifted to.
-    const active =
-      !!options.activeHeaderFooterRId &&
-      !!story.rId &&
-      options.activeHeaderFooterRId === story.rId &&
-      (options.activeHeaderFooterPageIndex === undefined ||
-        options.activeHeaderFooterPageIndex === page.index);
+    const active = headerFooterBandIsActive(story, page.index, options);
     // The BEHIND half was already painted, on the sheet and ahead of the body content —
     // see `appendHfBehindDrawingLayer`. Only the in-front ink belongs to the band.
     const container = document.createElement('div');
@@ -2315,11 +2325,7 @@ function paintPage(
     // flows to a hairline, which makes the ACTIVE edit band invisible. Editing extends the
     // band down to the sheet edge — origin unchanged, so fragment and caret geometry stay
     // put, and normal-mode sizing keeps the flow-height rule (#856) intact.
-    const bandHeight = !active
-      ? story.box.height
-      : story.kind === 'footer'
-        ? Math.max(story.box.height, page.box.y + page.box.height - story.box.y)
-        : Math.max(story.box.height, page.contentBox.y - story.box.y);
+    const bandHeight = headerFooterBandHeightPt(story, page, active);
     container.style.height = `${bandHeight * options.scale}px`;
     // VISIBLE, exactly because the box is sized by flow height alone (#856). Word paints
     // header ink wherever it lands — a negative indent hangs into the left margin, an
@@ -2859,17 +2865,16 @@ export function paintSemanticLayout(
   };
   const document = container.ownerDocument;
   // The alias lookup is part of the paint parameters: a page painted before fonts
-  // registered must not be reused verbatim afterwards. Occurrence page is included so
-  // moving the caret host across shared furniture copies rebuilds active markers.
+  // registered must not be reused verbatim afterwards. Header/footer occurrence is
+  // applied in place (see applyHeaderFooterPaintChrome) so entering a header, or
+  // moving the caret across shared furniture copies, does not rebuild body sheets.
   // Content-control chrome is furniture only, but toggling it must rebuild painted pages
-  // so show-all / caret chrome appear. Hover is the one exception: it is applied to the
-  // painted nodes in place, because a pointer crossing a region may not move it.
+  // so show-all / caret chrome appear. Hover is the one other exception: it is applied
+  // to the painted nodes in place, because a pointer crossing a region may not move it.
   const parameters =
     `${resolved.scale}|${resolved.ariaHidden}|` +
     `${resolved.fontAlias ? aliasIdentity(resolved.fontAlias) : ''}|` +
     `${resolved.defaultFontFamily ?? ''}|` +
-    `${resolved.activeHeaderFooterRId ?? ''}|` +
-    `${resolved.activeHeaderFooterPageIndex ?? ''}|` +
     `cc:${chromeKey}:${additionalKey}|toc:${tocKey}|` +
     `ro:${readOnlyKey}|tocEmpty:${emptyTocKey}|` +
     `${options.imageUrlPort ? 'url' : ''}|` +
@@ -2950,4 +2955,5 @@ export function paintSemanticLayout(
     }
     container.insertBefore(entry.element, cursor);
   }
+  applyHeaderFooterPaintChrome(pages, resolved);
 }


### PR DESCRIPTION
## Summary

This is a **performance** issue, not a caret or edit-correctness bug. After #339 and #364, body typing already reused painted pages. Entering a header (or moving between shared header copies) still folded `activeHeaderFooterRId` and `activeHeaderFooterPageIndex` into the global paint-reuse key, so every visible page DOM was rebuilt even though body ink had not moved. The dimming was already CSS (`.docx-pages--hf-editing`); the params only flipped `data-docx-hf-active`, `contenteditable`, active-band height, and drawing pointer-events.

On a 12-page layout (happy-dom, this machine):

| Path | Median paint time |
| --- | --- |
| Enter-header on reused pages (this PR) | **3.4 ms** |
| Full rebuild of the same layout (old behaviour) | **210 ms** |

That is about **60×** on the paint pass. On a 20-page headered surface: **0/20** page nodes kept on enter and on crossing copies before (Jedr's original #355 table; same on our 6-page repro), **20/20** kept after. Enter was 3.1 ms and the copy-cross 2.0 ms. Only the chrome attributes move in place.

## Test plan

- [ ] `bun test packages/core/src/output/__tests__/semantic-paint-hf-reuse.test.ts packages/core/src/editor/__tests__/hf-page-reuse.test.ts packages/core/src/output/__tests__/semantic-paint-hf-drawings.test.ts`
- [ ] Open a headered document, double-click the header, confirm `.docx-page` nodes keep identity in DevTools while `data-docx-hf-active` moves

Fixes #355

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789896092&installation_model_id=422592&pr_number=369&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F369&signature=85f8e9491336d468b5e91d640f6f69b673bed3ccd361fb0063565276048ccffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->