### PR TITLE
docs: correct four claims that the code contradicts

### DIFF
--- a/docs/site/content/core/architecture.mdx
+++ b/docs/site/content/core/architecture.mdx
@@ -14,14 +14,14 @@ What you see painted and what an edit mutates are the same tree, so nothing has 
 
 ## The canonical tree
 
-Reading a `.docx` produces one tree per package part. Nodes are **typed** where layout needs them (the paragraph, run, and table vocabulary) and **generic** everywhere else, preserving the element verbatim.
+Reading a `.docx` produces one tree per XML part, up to a bounded part count. Non-XML parts stay as bytes and are never parsed. Nodes are **typed** where layout needs them (the paragraph, run, and table vocabulary) and **generic** everywhere else, preserving the element verbatim.
 
 Two consequences:
 
 - Content the engine does not model is carried, not dropped. A known element in an invalid position demotes to generic rather than erroring.
 - Unknown content never blocks editing. A document full of extensions the engine has never seen still opens, still edits, and still saves.
 
-Every write is a transaction over the tree, addressed by node id and character offset. That is the only write path. There is no second way to mutate a document, so undo, the editing API, and every command go through the same door.
+Every write is a transaction over the tree. Content edits are addressed by node id and character offset; package-level operations such as creating a header or setting section properties are addressed by section index. That is the only write path. There is no second way to mutate a document, so undo, the editing API, and every command go through the same door.
 
 ## Layout
 

--- a/docs/site/content/guides/loading-and-saving.mdx
+++ b/docs/site/content/guides/loading-and-saving.mdx
@@ -258,7 +258,7 @@ Two paths matter:
 </Framework>
 </FrameworkTabs>
 
-`save()` resolves `null` when there is no document to serialize, so guard the result.
+`save()` on the ref resolves `null` when no editor is mounted, so guard the result. `Editor.save()` on the instance always resolves an `ArrayBuffer`.
 
 ## Download helper
 

--- a/docs/site/content/react/hooks.mdx
+++ b/docs/site/content/react/hooks.mdx
@@ -107,7 +107,9 @@ Useful fields include:
 ## `useDocxEditor`
 
 `useDocxEditor` returns the editor instance.
-It returns `null` before the content mounts.
+It returns `null` before the `DocxEditor.Root` mount effect creates the
+instance.
+It also returns `null` outside a `DocxEditor.Root`.
 Use the instance for actions and one-time reads:
 
 ```tsx

--- a/docs/site/content/vue/composables.mdx
+++ b/docs/site/content/vue/composables.mdx
@@ -101,7 +101,8 @@ Useful snapshot fields include `page`, `selection`, `selectionCollapsed`,
 ## useDocxEditor
 
 This composable returns a shallow ref to the editor instance. Its value is
-`null` before the content mounts.
+`null` before the `DocxEditor.Root` mount effect creates the instance, and
+outside a `DocxEditor.Root`.
 
 ```vue
 <script setup lang="ts">


### PR DESCRIPTION
Four prose claims that the code contradicts. Each was verified against the source before the edit.

| Page | Claim | What the code does |
| --- | --- | --- |
| `core/architecture.mdx` | "one tree per package part" | Only parts with an XML content type become trees. `[Content_Types].xml` and `image/svg+xml` media are excluded, and the count is capped at `maxXmlParts: 512` (`packages/core/src/store/package/ooxml-package.ts:60,448,134`). The same page already states it correctly under "Saving". |
| `core/architecture.mdx` | writes are "addressed by node id and character offset" | Content edits are. `createHeaderFooter`, `deleteHeaderFooter`, `linkToPrevious`, `unlinkFromPrevious`, and `setSectionFurnitureOptions` are addressed by `sectionIndex` (`packages/core/src/store/store/tree-op-types.ts:673-707`). The single-write-path claim still holds. |
| `guides/loading-and-saving.mdx` | `save()` resolves `null` "when there is no document to serialize" | The ref returns `null` when no editor is mounted (`packages/react/src/types.ts:246`, `useDocxEditorRefApi.ts:38`). `Editor.save()` on the instance always resolves an `ArrayBuffer`. |
| `react/hooks.mdx`, `vue/composables.mdx` | `useDocxEditor()` returns `null` "before the content mounts" | The root's mount effect creates the instance and does not observe `DocxEditor.Content` (`packages/react/src/editor/DocxEditorRoot.tsx:239-269`). The TSDoc on the hook already says so. |

No behavior changes, so there is no changeset and no `word-features.ts` update.

Checks run: `bun run check:docs-mdx`, `bun run check:docs-vue-refs`, `bun run format` (no changes), and
`bun run lint` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQdsuqcnkto7HA8z2tsLti

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789902394&installation_model_id=422592&pr_number=371&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F371&signature=f1fc099c9aa38c333d18b1356663aac7285c5dfefc28fbf31659fc0c35f705b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->