### PR TITLE
fix(core): adjacent paragraph spacing adds, it does not collapse

### DIFF
--- a/.changeset/paragraph-spacing-adds.md
+++ b/.changeset/paragraph-spacing-adds.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Space before and space after between two paragraphs now add, the way Word differs from CSS, instead of collapsing to the larger of the two.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -296,7 +296,7 @@ export type CellVerticalAlign = 'top' | 'center' | 'bottom';
 export function clampListValue(value: number): number;
 
 // @public
-export function collapsedSpaceBefore(before: number, previousAfter: number): number;
+export function collapsedSpaceBefore(before: number, _previousAfter: number): number;
 
 // @public
 export function collectFlowBlocks(children: readonly OoxmlNode[], depth?: number, accept?: (block: OoxmlElement) => boolean): OoxmlElement[];

--- a/e2e/edit-browser-bench-gates.ts
+++ b/e2e/edit-browser-bench-gates.ts
@@ -25,8 +25,14 @@ export interface ExpectedLayoutWork {
  * single character.
  */
 export const TRACKED_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = {
-  'tracked-editing-character': { placed: 3, total: 620, reusedPages: 145, fullPasses: 1 },
-  'tracked-suggesting-character': { placed: 3, total: 620, reusedPages: 145, fullPasses: 1 },
+  // Two, not three, since adjacent paragraph spacing started ADDING rather than collapsing
+  // to the larger gap: this fixture's `ClauseHeading` asks for 12pt before under a 6pt
+  // `w:docDefaults` after, so every heading opened 6pt further down, the page boundaries
+  // moved, and a one-character edit now settles one paragraph sooner. Fewer placements for
+  // the same edit — the counter moved because the GEOMETRY did, not because the incremental
+  // path started skipping work.
+  'tracked-editing-character': { placed: 2, total: 620, reusedPages: 145, fullPasses: 1 },
+  'tracked-suggesting-character': { placed: 2, total: 620, reusedPages: 145, fullPasses: 1 },
   // A 100-character tracked insert reflows roughly half the numbered clauses —
   // the going rate for a wrap in a dense review document, and exactly the load
   // this fixture exists to keep honest.
@@ -35,7 +41,10 @@ export const TRACKED_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = 
 
 /** Pinned for the ~1,000-page stress fixture (synthetic-huge-tracked.docx). */
 export const HUGE_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = {
-  'huge-suggesting-character': { placed: 2, total: 4250, reusedPages: 995, fullPasses: 1 },
+  // `reusedPages` up by six for the same reason the tracked fixture's placements went down:
+  // additive paragraph spacing moved this fixture's page boundaries, so the edit's reflow
+  // settles inside pages that were already laid out.
+  'huge-suggesting-character': { placed: 2, total: 4250, reusedPages: 1001, fullPasses: 1 },
   'huge-suggesting-wrap': { placed: 6, total: 4250, reusedPages: 994, fullPasses: 1 },
   // A 50k-character paste re-places 2,126 paragraphs and reflows half the
   // thousand pages — the standing tough case this fixture exists to watch.

--- a/e2e/edit-browser-bench-gates.ts
+++ b/e2e/edit-browser-bench-gates.ts
@@ -45,10 +45,14 @@ export const HUGE_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = {
   // additive paragraph spacing moved this fixture's page boundaries, so the edit's reflow
   // settles inside pages that were already laid out.
   'huge-suggesting-character': { placed: 2, total: 4250, reusedPages: 1001, fullPasses: 1 },
-  'huge-suggesting-wrap': { placed: 6, total: 4250, reusedPages: 994, fullPasses: 1 },
-  // A 50k-character paste re-places 2,126 paragraphs and reflows half the
-  // thousand pages — the standing tough case this fixture exists to watch.
-  'huge-paste-50k': { placed: 2126, total: 4250, reusedPages: 497, fullPasses: 1 },
+  // These two counters are KNIFE-EDGE, not a stable measure of cost: the huge scenarios run
+  // in sequence against one document, so each measures an edit on the previous one's output,
+  // and a small geometry shift flips which side of a page boundary the wrap lands on. Both
+  // moved when adjacent paragraph spacing started adding. On a FRESH document the same edit
+  // went the other way by two orders of magnitude — 2,125 placed under the old rule, 22 under
+  // the new one — so the direction of travel is good even though these numbers rose.
+  'huge-suggesting-wrap': { placed: 2126, total: 4250, reusedPages: 500, fullPasses: 1 },
+  'huge-paste-50k': { placed: 2126, total: 4250, reusedPages: 500, fullPasses: 1 },
 };
 
 /** p95 may spike on loaded CI; 3× median plus 50 ms catches sustained regressions without pinning wall clock. */

--- a/packages/core/src/layout/__tests__/paragraph-spacing-borders.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-spacing-borders.test.ts
@@ -63,16 +63,19 @@ describe('paragraphSpacing resolves w:spacing before/after', () => {
     ).toEqual({ before: 0, after: 0 });
   });
 
-  test('adjacent collapse takes the larger gap, not the sum', () => {
-    expect(collapsedSpaceBefore(12, 10)).toBe(2);
-    expect(collapsedSpaceBefore(8, 10)).toBe(0);
+  test('adjacent before and after ADD, the way Word differs from CSS', () => {
+    // Measured against an OOXML consumer: `w:after="240"` above `w:before="240"` lays the two
+    // paragraphs 24pt apart, not 12pt. Collapsing to the larger gap made "add space before"
+    // move a paragraph by the DIFFERENCE, which reads as a control that does nothing.
+    expect(collapsedSpaceBefore(12, 10)).toBe(12);
+    expect(collapsedSpaceBefore(8, 10)).toBe(8);
     expect(collapsedSpaceBefore(10, 0)).toBe(10);
   });
 
   test('appliedSpaceBefore suppresses mid-section top-of-page before', () => {
     expect(appliedSpaceBefore(18, 0, true, false)).toBe(0);
     expect(appliedSpaceBefore(18, 0, true, true)).toBe(18);
-    expect(appliedSpaceBefore(18, 10, false, false)).toBe(8);
+    expect(appliedSpaceBefore(18, 10, false, false)).toBe(18);
   });
 });
 
@@ -150,13 +153,16 @@ describe('layout applies Word’s auto spacing, not the twips beside the flag', 
   const AUTO_PPR =
     '<w:spacing w:after="100" w:afterAutospacing="1" w:before="100" w:beforeAutospacing="1"/>';
 
-  test('two body paragraphs sit 14pt apart, not 5pt', () => {
+  test('two body paragraphs open 14pt each, not the 5pt beside the flag', () => {
     const layout = lay(load(paragraph('one', AUTO_PPR) + paragraph('two', AUTO_PPR)));
     const [first, second] = layout.pages[0]!.fragments;
     if (first!.kind !== 'paragraph' || second!.kind !== 'paragraph') throw new Error('paragraphs');
     expect(first!.spacing.after).toBe(AUTO_PARAGRAPH_SPACING_PT);
-    // Collapsed against the previous after, so the gap is one 14pt band and not two.
-    expect(second!.lines[0]!.box.y - first!.lines[0]!.box.y).toBe(14 + AUTO_PARAGRAPH_SPACING_PT);
+    // The flag substitutes 14pt for the 5pt authored beside it, and the two bands ADD like
+    // any other pair — measured at 28pt against an OOXML consumer, not one 14pt band.
+    expect(second!.lines[0]!.box.y - first!.lines[0]!.box.y).toBe(
+      14 + AUTO_PARAGRAPH_SPACING_PT * 2
+    );
   });
 
   test('the same paragraphs in a table cell get no auto spacing at all', () => {
@@ -209,6 +215,31 @@ describe('paragraphBorders resolves w:pBdr bottom', () => {
 });
 
 describe('layout accounts for spacing in pagination and fragment geometry', () => {
+  test('the measured gaps: after alone, before alone, and both together', () => {
+    // Measured against an OOXML consumer (LibreOffice → PDF → `pdftotext -bbox`), single line
+    // spacing, 11pt Calibri, one word per paragraph, no inherited spacing:
+    //
+    //   w:after="240" alone            gap 25.45pt  = 13.45 pitch + 12
+    //   w:before="240" alone           gap 25.45pt  = 13.45 pitch + 12
+    //   both                           gap 37.45pt  = 13.45 pitch + 12 + 12
+    //   both auto-spaced (14pt each)   gap 41.45pt  = 13.45 pitch + 14 + 14
+    //
+    // The third line is the whole point: 37.45, not 25.45. Taking the larger of the two made
+    // "add space before paragraph" move a paragraph by the DIFFERENCE — 10pt asked for above a
+    // predecessor already stating 8pt after moved the text 2pt, which is indistinguishable
+    // from a control that does nothing.
+    const gap = (first: string, second: string): number => {
+      const layout = lay(load(paragraph('one', first) + paragraph('two', second)));
+      const [a, b] = layout.pages[0]!.fragments;
+      if (a!.kind !== 'paragraph' || b!.kind !== 'paragraph') throw new Error('paragraphs');
+      return b!.lines[0]!.box.y - a!.lines[0]!.box.y;
+    };
+    const pitch = gap('<w:spacing w:after="0"/>', '<w:spacing w:before="0"/>');
+    expect(gap('<w:spacing w:after="240"/>', '<w:spacing w:before="0"/>')).toBe(pitch + 12);
+    expect(gap('<w:spacing w:after="0"/>', '<w:spacing w:before="240"/>')).toBe(pitch + 12);
+    expect(gap('<w:spacing w:after="240"/>', '<w:spacing w:before="240"/>')).toBe(pitch + 24);
+  });
+
   test('before/after shift fragment boxes and the flow cursor', () => {
     const part = load(
       paragraph('one', '<w:spacing w:after="240"/>') +
@@ -219,11 +250,11 @@ describe('layout accounts for spacing in pagination and fragment geometry', () =
     expect(first!.kind).toBe('paragraph');
     expect(second!.kind).toBe('paragraph');
     if (first!.kind !== 'paragraph' || second!.kind !== 'paragraph') return;
-    // First ends with 12pt after; second asks for 6pt before → collapsed gap is 12pt.
+    // First ends with 12pt after; second asks for 6pt before → the gap is both, 18pt.
     expect(first!.spacing).toEqual({ before: 0, after: 12 });
-    expect(second!.spacing.before).toBe(0); // fully collapsed into the prior after
+    expect(second!.spacing.before).toBe(6);
     expect(second!.box.y).toBe(first!.box.y + first!.box.height);
-    expect(second!.lines[0]!.box.y - first!.lines[0]!.box.y).toBe(14 + 12);
+    expect(second!.lines[0]!.box.y - first!.lines[0]!.box.y).toBe(14 + 12 + 6);
   });
 
   test('explicit before is honoured on the first paragraph of a document/section', () => {
@@ -287,7 +318,7 @@ describe('comprehensive fixture: bottom border rule and vertical spacing', () =>
     expect(empty.box.height).toBe(empty.spacing.before + 14 + 2 + 2 + empty.spacing.after);
   });
 
-  test('vertical spacing collapses against the prior after and advances the next paragraph', () => {
+  test('vertical spacing adds to the prior after and advances the next paragraph', () => {
     const part = load(FIXTURE);
     const layout = lay(part);
     const fragments = layout.pages[0]!.fragments.filter((f) => f.kind === 'paragraph');
@@ -295,15 +326,15 @@ describe('comprehensive fixture: bottom border rule and vertical spacing', () =>
     if (above!.kind !== 'paragraph' || empty!.kind !== 'paragraph' || below!.kind !== 'paragraph')
       return;
 
-    // above after=10pt, empty before=5pt → empty's applied before collapses to 0.
+    // above after=10pt, empty before=5pt → 15pt between them, both applied.
     expect(above!.spacing.after).toBe(10);
-    expect(empty!.spacing.before).toBe(0);
-    // empty after=6pt, below before=2pt → below collapses to 0; gap is empty's after.
+    expect(empty!.spacing.before).toBe(5);
+    // empty after=6pt, below before=2pt → 8pt, likewise.
     expect(empty!.spacing.after).toBe(6);
-    expect(below!.spacing.before).toBe(0);
+    expect(below!.spacing.before).toBe(2);
     expect(below!.box.y).toBe(empty!.box.y + empty!.box.height);
     expect(below!.lines[0]!.box.y).toBe(
-      empty!.bottomBorder!.box.y + empty!.bottomBorder!.box.height + 6
+      empty!.bottomBorder!.box.y + empty!.bottomBorder!.box.height + 6 + 2
     );
   });
 

--- a/packages/core/src/layout/paragraph-style.ts
+++ b/packages/core/src/layout/paragraph-style.ts
@@ -471,19 +471,35 @@ export function paragraphBordersFingerprint(borders: ParagraphBorders): string {
 
 /**
  * Gap to insert before a paragraph once the previous paragraph's `after` is already in the
- * flow cursor — Word takes the larger of the two rather than summing them.
+ * flow cursor.
+ *
+ * The two ADD. This is the well-known way Word differs from CSS, where adjoining margins
+ * collapse: a paragraph with 12pt after followed by one with 12pt before opens 24pt, which is
+ * why Word carries a separate "don't add space between paragraphs of the same style" control
+ * (`w:contextualSpacing`) instead of relying on a collapse rule.
+ *
+ * This engine used to take the larger of the two. The visible effect was that adding space
+ * before a paragraph moved it by the DIFFERENCE — asking for 10pt above a paragraph whose
+ * predecessor already stated 8pt after moved the text 2pt, which reads as a control that does
+ * not work. Confirmed against an OOXML consumer: `w:after="240"` + `w:before="240"` lays out
+ * 24pt apart, not 12pt, and two auto-spaced paragraphs open 28pt, not 14pt.
+ *
+ * The second argument is taken and IGNORED — it is what is already in the flow cursor, and
+ * under an additive rule that no longer changes the answer. It stays in the signature
+ * because removing a `@public` export is a breaking change for a helper this small; the
+ * name is likewise kept and is now a misnomer worth retiring on the next major.
+ * Suppressing the gap entirely is {@link appliedSpaceBefore}'s job.
  */
-export function collapsedSpaceBefore(before: number, previousAfter: number): number {
-  return Math.max(before, previousAfter) - previousAfter;
+export function collapsedSpaceBefore(before: number, _previousAfter: number): number {
+  return before;
 }
 
 /**
  * Applied before-spacing for placement (Word 2013+ / compat mode 15).
  *
- * Adjacent before/after still collapse to the larger gap, but before is dropped entirely when
- * the paragraph begins at the top of a page mid-section. The first paragraph of a document or
- * section retains before. Callers publish this applied value on the fragment so shading, borders,
- * selection, and paint share one geometry.
+ * Before is dropped entirely when the paragraph begins at the top of a page mid-section; the
+ * first paragraph of a document or section retains it. Callers publish this applied value on
+ * the fragment so shading, borders, selection, and paint share one geometry.
  */
 export function appliedSpaceBefore(
   before: number,


### PR DESCRIPTION
Space after and space before between two paragraphs both apply. The engine took the larger of the two, so "add space before paragraph" moved a paragraph by the **difference**: 10pt asked for above a predecessor already stating 8pt after moved the text 2pt, which is indistinguishable from a control that does nothing.

That is the second half of #360. The first half — the toolbar reading a paragraph's document defaults instead of its own formatting — is #368; this is what was still wrong once the value reached the page.

## The measurement

The old rule was asserted in a comment ("Word takes the larger of the two rather than summing them") and pinned by a test that checked the function against itself. Measured instead, against an OOXML consumer rendering to PDF, single line spacing, 11pt Calibri, one word per paragraph, no inherited spacing:

| document | gap | |
| --- | --- | --- |
| `w:after="240"` alone | 25.45pt | 13.45 pitch + 12 |
| `w:before="240"` alone | 25.45pt | 13.45 pitch + 12 |
| **both** | **37.45pt** | 13.45 pitch + 12 + **12** |
| **both auto-spaced** | **41.45pt** | 13.45 pitch + 14 + **14** |

It adds. This is the well-known way Word differs from CSS, and it is why Word carries a separate "don't add space between paragraphs of the same style" control (`w:contextualSpacing`) rather than relying on a collapse rule. The auto-spaced pair adds too, so the HTML margin model does not apply there either — worth knowing, since `w:beforeAutospacing` exists to emulate HTML.

Five tests asserted the old rule. Each is a test *of* the rule, and each now carries the measurement it stands for.

## Why the bench counters moved

Four pinned counters in `e2e/edit-browser-bench-gates.ts` shift, and one shifts alarmingly: `huge-suggesting-wrap` goes from 6 placements to 2,126. That is a knife-edge, not a cost.

The huge scenarios run **in sequence against one document**, so each measures an edit on the previous one's output. A small geometry change flips which side of a page boundary the wrap lands on. Measured on a **fresh** document instead, with the style cascade resolved — same fixture, same middle-wrap edit:

| rule | pages | placed | reusedPages |
| --- | --- | --- | --- |
| collapse (old) | 1409 | **2125** | 704 |
| additive (new) | 1417 | **22** | 1410 |

Two orders of magnitude **cheaper**, in the direction that matters. The counters that rose are an artefact of the chain; the ones that fell (`tracked-*` placing one paragraph fewer, `huge-suggesting-character` reusing six pages more) are the same geometry shift read the other way.

## A separate finding, not fixed here

`scripts/bench/edit-bench.ts` never builds a style cascade. It lays the huge fixture out at **1169 pages where the editor renders 1417**, so every style-driven layout change is invisible to the headless perf harness — including this one. My first A/B "proved" the change had no effect for exactly that reason.

Not fixed in this PR: passing the cascade moves every headless pin, which deserves its own change. Worth an issue.

## Note

`collapsedSpaceBefore` keeps its name and arity so a `@public` export is not broken. Both are now misnomers worth retiring on the next major.

Refs #360
