### PR TITLE
docs: specify sub-frame large-document typing

### DIFF
--- a/openspec/changes/sub-frame-large-document-typing/.openspec.yaml
+++ b/openspec/changes/sub-frame-large-document-typing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/sub-frame-large-document-typing/design.md
+++ b/openspec/changes/sub-frame-large-document-typing/design.md
@@ -1,0 +1,407 @@
+## Context
+
+The current editor already limits detailed DOM materialization and incremental block placement. On the 521-page profiling document, one middle text edit places 11 of 6,540 layout blocks, reuses 517 pages, and materializes four pages. Production Chromium still measures 97.6 ms median from `beforeinput` to the second presentation frame. The corresponding 27-page document measures 16.6 ms.
+
+The remaining cost is revision-wide work around the changed block:
+
+- canonical mutation copies and freezes a wide `w:body` child array;
+- index patching and delta validation compare every body child;
+- root- or revision-keyed paragraph, review, content-control, note, section, table, drawing, and page indexes rebuild or rescan;
+- layout reuses page records but still performs document-wide notes, drawing, revision, and page bookkeeping;
+- paint walks every page shell and rebuilds layout-keyed presentation indexes;
+- repeated arrays, maps, and layout wrappers create substantial garbage-collection work.
+
+The current input path batches queued characters, commits the canonical tree, runs layout synchronously, publishes a complete `SemanticLayout`, paints, and mirrors selection. Batching improves throughput, but an isolated key still waits for the complete path.
+
+This design must preserve these constraints:
+
+- The canonical tree is the only authored state.
+- Every accepted edit commits through validated `TreeDocOp`s.
+- Save reads the committed canonical tree only.
+- Layout publishes one complete revision or keeps the last complete revision.
+- DOM and ProseMirror remain projections.
+- Semantic selection and stable text positions remain authoritative.
+- Changed attacker-controlled content receives the same validation and escaping rules.
+- React, Vue, Pro review, and automation use one engine implementation.
+
+The active `typed-ooxml-paragraph-editor` authority previously used absolute complete-only wording for layout, output, and interaction publication. This change modifies `typed-ooxml-canonical-tree`, `semantic-paragraph-layout`, and `paragraph-editor-binding` to distinguish complete publication from private provisional presentation. Complete `SemanticLayout`, cross-paragraph interaction geometry, review anchors, save authority, and semantic history remain unchanged in authority.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep warm, text-local canonical mutation independent of total body width.
+- Present eligible ordinary typing within one 16.7 ms frame on the reference performance profile.
+- Keep complete layout publication atomic and differential-oracle equivalent.
+- Preserve exact typed character order, caret position, history, review attribution, save output, and unknown OOXML.
+- Move complete-layout settle work off the immediate input frame and make it cancellable and cooperative.
+- Reconcile only changed materialized pages and changed presentation indexes.
+- Gate the design with deterministic work counters before relying on wall-clock results.
+- Keep every public adapter and automation contract compatible.
+
+**Non-Goals:**
+
+- Making DOM, ProseMirror, or a provisional display authoritative.
+- Publishing a mixed-revision `SemanticLayout`.
+- Weakening XML, package, namespace, relationship, lock, forms, or content validation.
+- Using worker layout before font, HarfBuzz, resource, and cache-transfer contracts exist.
+- Providing provisional display for every script, object type, or structural operation in the first implementation.
+- Changing public save, print, editor, adapter, or package APIs.
+- Hiding slow work behind delayed input, dropped input, or stale interaction geometry.
+- Replacing structural work gates with hardware-dependent timing gates.
+
+## Decisions
+
+### Decision 1: Separate model, complete layout, and provisional display state
+
+The surface will track three distinct states:
+
+1. `modelRevision`: the latest committed canonical-tree revision.
+2. `layoutRevision`: the latest complete, atomically published semantic layout revision.
+3. `displayRevision`: the model revision represented by editable document DOM.
+4. `provisionalDisplay`: an optional private display patch for a bounded region at `displayRevision`.
+
+`provisionalDisplay` is not a `SemanticLayout`. It is not exposed to layout consumers, page-count readers, print, geometry automation, or adapters. It contains only the committed text, resolved style inputs, provisional line records, DOM ownership evidence, and caret geometry needed for one materialized paragraph or page interval.
+
+One atomic surface transition publishes a committed model revision, its `ModelChange`, mapped model selection, and a monotonic selection epoch. Installed DOM selection carries the same epoch. Native selection evidence from an older epoch is ignored.
+
+The internal snapshot classifies every field by provenance. Document handles, text, formatting derived without geometry, and canonical selection use `modelRevision`. Pages, page count, review geometry, table geometry, and layout-derived selection use `layoutRevision`. Editable DOM uses `displayRevision`. Provisional state never enters a public snapshot. A selector that needs both model and layout data crosses the settle barrier first.
+
+The existing public `revision` remains the model change token. Existing page fields remain tied to complete `layoutRevision`. Internal snapshots carry both revisions so adapters cannot cache an incomplete mixed derivation.
+
+For an accepted editor intent, observable ordering is fixed:
+
+1. The store commits canonical state.
+2. The surface maps selection and installs verified provisional or complete DOM.
+3. The surface replaces its coherent snapshot.
+4. The editor queues public events.
+5. The next microtask emits `change`, then `selectionChange`.
+
+Public event handlers always read the completed surface transition. Reentrant editor mutations enqueue after the current transition and receive a later input sequence. Lower-level store subscribers remain store-only observers and cannot assume display completion.
+
+An external store commit immediately suspends document editing and the native caret in its synchronous surface subscription. It restores editing only after `displayRevision` reaches the external `modelRevision`. This prevents editable stale DOM while preserving asynchronous complete layout.
+
+**Alternative considered:** Publish a partially updated `SemanticLayout`.
+
+This would make interaction consumers observe mixed page revisions and would violate current atomic publication rules. The design rejects it.
+
+### Decision 2: Prepare locally, then commit and present
+
+Eligibility and local shaping run against a store-produced candidate paragraph before publication. This preflight cannot mutate canonical state or DOM. It returns a candidate fingerprint, exact local record, and checked geometry proof.
+
+The preflight result includes a private `CandidateChange`: expected predecessor revision, paragraph identity and fingerprint, candidate normalized effects, source layout revision, and every shaping resource fingerprint. Commit is compare-and-swap. Any changed predecessor, paragraph, resource, or layout input discards the candidate and retries or uses the synchronous authoritative path.
+
+Each accepted `beforeinput` intent commits immediately as its own semantic intent and history entry. The same surface transition publishes canonical text and mapped model selection. Only after commit succeeds can output install the precomputed record, and it first verifies the committed paragraph fingerprint. A rejected transaction produces no provisional output.
+
+Presentation and settle work can coalesce across several committed intents. Canonical transactions and history boundaries cannot coalesce.
+
+```mermaid
+sequenceDiagram
+  participant Input as beforeinput
+  participant Store as canonical store
+  participant Local as provisional layout
+  participant DOM as materialized page
+  participant Full as complete layout job
+
+  Input->>Store: prepare validated text-local candidate
+  alt preparation rejected
+    Store-->>Input: typed rejection
+  else candidate prepared
+    Store-->>Local: candidate paragraph and mutation witness
+    Local->>Local: shape and prove provisional safety
+    alt safety proven
+      Local->>Store: commit exact candidate and selection
+      alt commit accepted
+        Store-->>DOM: verified record, model revision, selection epoch
+        DOM->>Full: schedule cancellable settle
+      else commit rejected
+        Store-->>Input: typed rejection
+      end
+    else safety not proven
+      Local->>Store: commit through synchronous authoritative path
+      Store->>Full: complete layout before editable control returns
+      Full->>DOM: publish and paint complete revision
+    end
+  end
+```
+
+An ineligible edit retains the current synchronous commit-layout-paint path. A provisional installation failure also completes authoritative presentation synchronously or makes the document surface non-editable until it does. The editor never returns control with editable DOM older than a successful canonical commit.
+
+**Alternative considered:** Draw input-event text before commit.
+
+That can show rejected or unsaved text and makes the display an authored source. The design rejects it.
+
+### Decision 3: Replace wide child-array rebuilding with a bounded-touch canonical sequence
+
+`OoxmlNode.children` remains a public `readonly OoxmlNode[]`. Repeated public reads return the same frozen array for one node, and `Array.isArray(node.children)` remains true. This compatibility contract is not a hot internal storage contract.
+
+High-fanout canonical containers will use one internal persistent child sequence as their authority. `children` becomes a derived, memoized public projection from that sequence. Core lanes cannot read the projection on the typing path. Low-fanout nodes can retain flat internal arrays when counters show no scaling cost.
+
+The sequence must provide:
+
+- stable ordered traversal;
+- indexed lookup and replacement;
+- immutable snapshots with structural sharing;
+- bounded path-copy cost;
+- deterministic serialization order;
+- cheap prefix, suffix, and changed-chunk identity checks;
+- one-way materialization of the compatible frozen public array;
+- no mutation of an older revision.
+
+Core store, layout, validation, and serialization lanes will use sequence traversal helpers. The projection cannot become mutation, validation, serialization, or cache authority. A compatibility projection materialization increments a counter and is forbidden during warm typing.
+
+The implementation must first compare a persistent vector, a chunked rope, and a store-owned immutable overlay through the complete transaction. The selected representation must satisfy API extraction, `Array.isArray`, stable projection identity, serialization, memory, and random-operation differential tests. If no representation preserves the public contract, implementation stops and proposes an explicit major API change.
+
+**Alternative considered:** Keep flat arrays and optimize loops.
+
+Every immutable replacement still copies the complete body array. This cannot make mutation independent of body width.
+
+### Decision 4: Carry an internal mutation proof into commit validation
+
+Only sanctioned store mutation primitives can construct an opaque `TreeMutationProof`. Arbitrary replacement roots cannot enter scoped validation. Each primitive emits an exact old-to-new path witness beside `TreeOpEffect`. It identifies:
+
+- the previous and next part roots;
+- rebuilt ancestor identities;
+- replaced, created, deleted, and moved subtree roots;
+- new node identities;
+- namespace-context changes;
+- package-shell changes;
+- the operation impact and dependency keys.
+
+Validation migration has two stages. Flat-array operations first produce operation-owned ancestry, splice-window, identity, namespace, and package-shell evidence. They still use complete fallback where local ancestry checks cannot prove validity.
+
+After sequence selection, each persistent sequence node carries non-security summary metadata for size, identity membership, namespace dependency, and package-shell version. Commit validation checks the local edit witness at every rebuilt sequence node, validates changed nodes and each rebuilt ancestor's local invariants, then reuses prior proof only for object-identical subtrees reached through an unchanged sequence node. It never scans every descendant merely because a high-fanout ancestor was rebuilt.
+
+The validator will avoid a body-wide sibling map. Duplicate identity checks will use the prior validated node index plus created, deleted, and moved identity sets. Namespace changes escalate validation to the complete affected namespace scope. Missing lineage, inconsistent summaries, unsupported proof, or an arbitrary replacement root falls back to complete validation.
+
+Hashes can accelerate comparisons but cannot serve as security evidence. Exact node identity, sequence lineage, and validated path witnesses decide proof reuse.
+
+Text-local replacement of an existing part will skip package relationship and content-type validation only when package structure, relationships, content types, part names, and part membership are unchanged by identity. Any package-shell edit runs complete package invariant checks.
+
+**Alternative considered:** Trust `dirty` node IDs without proof.
+
+An incomplete dirty set could publish malformed content. Sealed mutation primitives and local lineage witnesses make omitted sibling replacement impossible on the scoped path. Differential full validation remains the oracle.
+
+### Decision 5: Make derived indexes persistent revision sidecars
+
+Indexes remain derived and non-authoritative. Baseline profiles first identify aggregates on the eligible typing path. Only a measured document-size cost receives an incremental sidecar. Cold and uncommon reads retain complete rebuilding.
+
+Each immutable tree identity can retain index sidecars that share unchanged entries with the prior tree. Publication revision is provenance, not the cache key. Undo and redo can reuse a sidecar from the restored immutable tree and retag it for the new monotonic publication revision.
+
+`TreeMutationProof` stays private to the store. Published `ModelChange` gains normalized, part-scoped effects for created, deleted, moved, and changed identities, replaced ancestry, package-shell effects, dependency invalidations, and impact. Layout produces `LayoutChangeSet` from actual layout output rather than store guesses.
+
+Store-level indexes patch from `TreeMutationProof` and `ModelChange`:
+
+- node and parent identity;
+- paragraph identity and reading order;
+- story blocks and section ownership;
+- content-control membership and lock ancestry;
+- note and field references;
+- bookmarks and drawing references;
+- review sites, paragraph order, and local review items.
+
+Layout-level indexes patch from page and fragment identity changes:
+
+- paragraph-to-page;
+- table, row, and cell placement;
+- note references and reserves;
+- revision-author slots;
+- drawing resource use;
+- review geometry ownership;
+- page-shell and materialized-page paint state.
+
+Every incremental index has a complete rebuild function. Tests compare both results after randomized operations, undo, redo, split, join, table edits, package edits, and malformed-operation rejection.
+
+History retains sidecars only through bounded weak or tree-owned references. Retained complexity is `O(live index + undoable changes)`, not `O(history × document)`.
+
+**Alternative considered:** Add more root-keyed `WeakMap` caches.
+
+A one-character edit creates a new root and still misses every root-keyed aggregate. Node-local memos remain useful, but aggregate indexes need delta patching.
+
+### Decision 6: Use proof-based provisional eligibility
+
+The first provisional lane covers collapsed, body-story `insertText` operations that meet all conditions:
+
+- The precommit `CandidateChange` predicts `text-local` impact, and the committed `ModelChange` matches it exactly.
+- One existing paragraph is dirty, with no created, deleted, moved, split, or joined block.
+- The paragraph and its complete prior fragment interval are materialized.
+- The paragraph has no unsupported provisional dependency.
+- Composition is inactive.
+- The insertion does not require a structural review wrapper.
+- The local layout function can resolve every style, list, and shaping dependency from stable inputs.
+- Candidate grapheme segmentation, glyph IDs, positions, clusters, caret stops, bidirectional levels, visual order, source-to-glyph mapping, and fallback-font identities equal a clean local shape of the candidate.
+- The geometry envelope preserves fragment count, page ownership, line breaks, vertical metrics, and flow extent against the previous complete layout.
+- The previous complete layout is the direct predecessor of the committed revision, or the existing provisional chain has complete source mapping to it.
+
+The first implementation treats these features as ineligible unless a focused follow-up proves them:
+
+- bidirectional or complex-script reshaping;
+- tabs, fields, notes, drawings, inline controls, and page or column breaks;
+- comments, tracked changes, or revision display that changes wrapper structure;
+- table cells, headers, footers, notes stories, and text boxes;
+- paragraph property, list, style, or resource changes;
+- deletion, replacement, Enter, join, and other structural input;
+- a line-break, line-height, fragment, page, or flow-extent change.
+
+Eligibility must finish before canonical publication and fail closed. Its elapsed time counts in every attempted fast-path sample. An ineligible edit uses the synchronous authoritative path and remains correct.
+
+**Alternative considered:** Paint a glyph overlay from estimated advance widths.
+
+Estimated glyphs can double-paint, break kerning, mishandle graphemes and bidirectional text, and move the caret incorrectly. A locally shaped record with an unchanged geometry proof is narrower but exact.
+
+### Decision 7: Provisional display is a paragraph-local semantic record
+
+The layout lane will expose a DOM-free local function that reshapes one committed paragraph against the exact prior fragment width, style cascade, list marker, font resources, revision display, and shaping configuration.
+
+The result contains source-addressable lines and spans for the dirty paragraph. It also returns exact grapheme, glyph, cluster, caret-stop, bidirectional, fallback-font, and geometry equivalence evidence against the prior complete fragment interval.
+
+The output lane can replace or adopt only that paragraph's DOM inside an already materialized page. It cannot create page shells, change page geometry, move furniture, update page counts, or modify unrelated overlays. The semantic caret uses the provisional line record. The native caret remains suppressed only when provisional geometry is valid.
+
+The provisional DOM is tagged with model revision and source complete-layout revision. The authoritative paint removes the tag and patch in the same task that installs the complete layout.
+
+Review activation, review geometry, table context, object controls, and other layout-derived chrome remain frozen at `layoutRevision` while provisional display exists. Their actions are disabled until a complete latest-revision layout publishes.
+
+### Decision 8: Geometry-dependent operations cross a settle barrier
+
+Plain insertion can continue from model selection and the provisional paragraph. Every geometry operation first captures an intent token containing model revision, selection epoch, and input queue sequence. The surface queues later mutations while settle runs. After latest-revision layout publishes, the operation captures a separate geometry token containing that layout revision and re-hit-tests. It validates the intent token before replay and the geometry token before any resulting commit.
+
+Event handlers that return `void` queue and replay their intent after latest-revision layout publishes. Existing query APIs that already support unavailability return their typed stale result. Print and export await or force completion through their existing asynchronous boundary. A method-by-method matrix must resolve every operation before staged state implementation.
+
+Settle barriers include:
+
+- pointer hit testing and drag selection;
+- vertical arrow movement and page navigation;
+- table, ruler, drawing, content-control, and review geometry;
+- scroll-to-caret and geometry automation;
+- print, PDF, screenshot, and paginated export;
+- zoom or viewport changes that alter available width;
+- switching story scope;
+- any structural or property-changing command;
+- composition start;
+- teardown of a mounted surface.
+
+Save to DOCX does not need layout. It captures one input queue sequence, commits all accepted events through that sequence, excludes later events, and reads the resulting canonical package. Concurrent or reentrant saves at the same sequence share one serialization promise. A save at a later sequence follows it.
+
+IME uses a separate private composition draft anchored to complete latest-revision layout. Intermediate composition text remains outside canonical state, save, layout, history, and automation. `compositionend` commits one semantic intent. Cancellation, blur, detach, or failure removes the draft. Public `Editor.save()` rejects with typed `composition-active` while the draft remains unresolved. Geometry reads return their existing unavailable result.
+
+When composition starts during provisional display, the surface synchronously restores complete latest-revision editable DOM before native composition updates. If it cannot do so, it prevents draft readback, restores canonical DOM, and reports composition cancellation. It never reads composition text from stale painted DOM. This change does not add a hidden asynchronous public contract.
+
+### Decision 9: Make complete settle cooperative and latest-revision-only
+
+After provisional paint, complete layout runs as a cancellable job bound to an immutable `{ packageSnapshot, modelRevision, scope, resourceFingerprints }` input. No continuation reads a later mutable session.
+
+Layout exposes DOM-free resumable iterators. The editor lane injects `now()`, a deadline, `scheduleContinuation()`, cancellation ownership, visibility state, and an optional `isInputPending` hint. Hidden tabs use timer continuations rather than animation frames. Tests inject a deterministic clock and continuation queue. Every long loop checks its deadline; phase boundaries alone are insufficient.
+
+The layout job will separate:
+
+- changed-block preparation and placement;
+- convergence checks;
+- reused-page remap and finalization;
+- note and section bookkeeping;
+- drawing and revision index patching;
+- page-shell reconciliation planning.
+
+On the reference profile, cooperative slices target 4 ms at p95 and 8 ms maximum. Any non-yielding leaf that breaches 8 ms must be split or excluded from the cooperative lane. The scheduler returns to the browser event loop after every slice and grants at least one settle slice per 50 ms during sustained input. A newer model revision cancels or supersedes older work. Only the newest complete revision can publish.
+
+Job accumulators remain private until publication. Shared cache writes require complete input fingerprints and cannot depend on job liveness. Cancellation checks run before every resumed phase and publication. `finally` releases timers, tasks, animation frames, resource callbacks, temporary sequences, and index builders.
+
+Worker layout remains deferred. The cooperative job preserves current font, HarfBuzz, object-identity, and resource-cache authority on one thread.
+
+**Alternative considered:** Run the current 30 ms settle in one later timer.
+
+That timer still blocks later input and creates visible frame gaps. Deferral without cooperation does not solve interaction latency.
+
+### Decision 10: Reconcile settled output from page and index deltas
+
+Complete layout will use an internal persistent page directory and persistent checkpoint sequence. Both support indexed access, range replacement, cumulative page offsets, and structural sharing without copying every page or checkpoint slot. `SemanticLayout.pages` remains a stable frozen public array projection, but core layout, output, and editor hot paths cannot materialize or scan it.
+
+The layout lane owns an immutable `InternalLayoutRevision` containing model revision, page directory, checkpoint directory, `LayoutChangeSet`, and a lazy public `SemanticLayout` projection. Output receives read-only page accessors plus `LayoutChangeSet`. The editor stores the opaque revision handle and can request public projection. Neither output nor editor can mutate or reconstruct layout directories.
+
+Complete-layout publication will include a `LayoutChangeSet` that identifies:
+
+- changed, created, deleted, remapped, and reused page records;
+- changed materialized fragment intervals;
+- changed page-shell geometry;
+- changed drawing, revision, note, field, and review dependencies;
+- changed paragraph-page and table indexes.
+
+Page shells move to normal document flow. Their width and height remain explicit, so unmaterialized shells preserve complete scroll geometry without authored absolute top positions. The page directory supplies semantic cumulative offsets for hit testing and scroll queries. A middle insertion that preserves page sequence changes no later shell style.
+
+`paintSemanticLayout` will preserve unchanged shell and materialized-page DOM. It will scan or rebuild complete-layout resources only when their dependency key changes.
+
+A converged text-local settle must perform `O(log pages + changed pages + changed dependencies)` page-directory and checkpoint work. It cannot copy a complete page array, copy a checkpoint tail, or map every page merely to publish a new revision.
+
+A clean full paint remains the visual and semantic oracle. Differential tests compare DOM-independent paint records, source mappings, and selected serialized DOM attributes.
+
+### Decision 11: Use structural gates and a separate reference latency budget
+
+Continuous integration will gate deterministic counters:
+
+- no wide child sequence materialization for warm text-local mutation;
+- no complete node-index or paragraph-index rebuild;
+- validation visits only the proved changed scope;
+- no package invariant scan for a package-shell-identical text edit;
+- no complete-page scan before provisional presentation;
+- no complete page-array or checkpoint-tail copy during converged settle;
+- page and checkpoint visits bounded by changed intervals plus logarithmic directory work;
+- no changed DOM outside the provisional paragraph;
+- no stale or mixed layout publication;
+- zero dropped, duplicated, or reordered input;
+- bounded retained heap after sustained editing.
+
+The repository will also define a reference browser profile for interaction budgets. Shared-runner timing remains informational because CPU scheduling is not stable.
+
+The target reference profile is:
+
+- production Chromium;
+- shaped text measurement;
+- 1440 × 1000 viewport at 1× scale;
+- reduced motion;
+- review module and rail enabled;
+- the repository-owned 521-page fixture;
+- fixed caret position and warm caches.
+
+Every attempted fast-path insertion is timed from trusted `beforeinput`, including eligibility. A sample completes only after the benchmark verifies expected text, caret, model revision, display revision, and source layout revision at the first paint opportunity.
+
+At least 100 isolated samples and 180 unpaced sustained characters run across multiple paragraph lengths, caret positions, style boundaries, and line-edge positions. Eligible insertion must meet 16.7 ms median and 33.4 ms p95. The defined ordinary-typing corpus must achieve at least 80% eligibility before default enablement. Ineligible presentation cannot regress its recorded synchronous baseline by more than 10%.
+
+After 1,000 edits beyond history capacity and three forced collection cycles on the reference profile, retained growth must not exceed the greater of 32 MiB or 10% of opened-document heap. The same run reports authoritative settle latency, cancelled-job buffers, live sequence nodes, sidecar entries, and fallback reasons separately.
+
+## Risks / Trade-offs
+
+- **[Persistent sequence changes a foundational node representation]** → Start with a measured `w:body` prototype, preserve ordered traversal, and require full serialization and random-operation differential oracles.
+- **[Compatibility `children` reads materialize a wide array]** → Remove such reads from hot internal lanes, count materializations, and document the compatibility view as a non-hot API.
+- **[A mutation proof omits affected structure]** → Seal mutation primitives, verify local sequence lineage, fail closed to complete validation, and fuzz against the oracle.
+- **[Provisional eligibility shows incorrect wrap or shaping]** → Require exact local shaping and unchanged geometry proof; reject unsupported scripts and dependencies until proven.
+- **[Model revision moves while complete layout remains old]** → Keep provisional state private, tag every display source revision, and settle before geometry-dependent operations.
+- **[A long settle repeatedly restarts during typing]** → Coalesce only presentation and settle work, reuse checkpoints, preserve per-intent commits, and guarantee fair idle progress.
+- **[Cooperative layout adds overhead to short documents]** → Keep the current synchronous path when no provisional lane is active or measured work fits below the slice budget.
+- **[Review or content-control behavior diverges]** → Treat those paragraphs as ineligible first, then add focused local-patch support with exact review and lock tests.
+- **[Undo history retains index and sequence graphs]** → Use structural sharing, bounded sidecar retention, heap gates, and explicit cache release on history eviction.
+- **[Page-local paint leaves stale resources]** → Dependency-key every global paint resource and compare incremental paint plans with clean full paint.
+- **[Timing gates become flaky]** → Gate structural counters in continuous integration and run absolute budgets only on the documented reference profile.
+- **[Fast-path restrictions cover too little real typing]** → Record eligibility and refusal counters by reason, then expand only the highest-volume safe classes.
+
+## Migration Plan
+
+1. Add counters, full flame and allocation profiles, scan inventories, and corrected presentation markers.
+2. Define revision provenance, per-input history, selection epochs, save linearization, composition drafts, and the complete barrier matrix.
+3. Seal mutation primitives and prove scoped validation against complete validation while retaining flat arrays.
+4. Define the exact public child-storage compatibility contract.
+5. Prototype bounded-touch sequences through the complete transaction and select one from evidence.
+6. Add only measured store sidecars and remove remaining warm text-local O(document) store work.
+7. Add persistent page and checkpoint directories, `LayoutChangeSet`, and page-local settled paint.
+8. Add immutable cooperative jobs, cancellation cleanup, and scheduler fairness.
+9. Add local paragraph shaping and exact eligibility proof.
+10. Add atomic surface transitions and private provisional state for collapsed insertion only.
+11. Expand browser correctness, differential, memory, accessibility, burst, and reference gates.
+12. Enable by default only after the full suite, 80% corpus eligibility, zero correctness events, and all performance gates pass.
+13. Remove flags after one release cycle without correctness fallback events.
+
+Rollback disables provisional display and returns to synchronous complete layout. The persistent tree and incremental indexes remain only if their full-oracle tests pass independently. No document migration is required.
+
+## Open Questions
+
+- Which persistent sequence wins the complete-transaction prototype while preserving the fixed public array contract?
+- Can complete settle reuse a fingerprinted provisional paragraph record without adding a second cache authority?
+- Which exact Apple M-series machine and Chromium revision become the maintained reference profile?

--- a/openspec/changes/sub-frame-large-document-typing/proposal.md
+++ b/openspec/changes/sub-frame-large-document-typing/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Typing in the 521-page profiling document presents after 97.6 ms at the median, although only four pages are materialized and incremental layout places 11 of 6,540 blocks. The remaining work scales with the document revision, so ordinary typing cannot stay within one 16.7 ms frame as documents grow.
+
+## What Changes
+
+- Add a bounded-cost canonical mutation path for text-local edits. It preserves canonical-tree authority, atomic history, fail-closed validation, unknown OOXML fidelity, and immutable revision snapshots.
+- Remove body-width work from ordinary text insertion. Wide child-sequence updates, delta validation, and edit indexes touch only the edited path and bounded metadata.
+- Inventory every typing-path aggregate before selecting storage. Patch only indexes and page structures whose measured cost scales with document size.
+- Keep complete `SemanticLayout` publication atomic while adding a private staged display for proven-safe text-local typing. The canonical tree commits first, the visible caret region presents provisionally, and the complete layout replaces it atomically.
+- Restrict provisional display to a narrow safety envelope. Composition, complex shaping, structural edits, uncertain wrapping, notes, fields, drawings, tables, content controls, review markup, and stale geometry use the authoritative settle path.
+- Reconcile only changed materialized pages after layout settles. Reused page shells, DOM, drawing resources, review geometry, and layout-derived indexes remain stable when their inputs remain stable.
+- Add deterministic work counters, differential oracles, browser burst checks, and a reference performance budget for large-document typing.
+- Preserve the public editor, adapter, save, print, automation, and package APIs. This change introduces no intentional breaking API change.
+
+## Capabilities
+
+### New Capabilities
+
+- `staged-typing-presentation`: Canonical-first typing, a proven-safe provisional display, atomic authoritative layout publication, geometry-read barriers, and page-local settled paint.
+- `large-document-typing-acceptance`: Deterministic work gates, differential conformance, sustained and burst input correctness, memory bounds, and reference interaction budgets.
+
+### Modified Capabilities
+
+- `typed-ooxml-canonical-tree`: Atomic mutation and derived indexes gain bounded-touch sequences, checked mutation proof, scoped validation, incremental index sidecars, complete rebuild oracles, and fail-closed fallback.
+- `semantic-paragraph-layout`: Complete `SemanticLayout` publication remains atomic, but the output contract now distinguishes private committed provisional presentation from published layout and adds cooperative settle plus page-local reconciliation.
+- `paragraph-editor-binding`: Transaction mapping, canonical history, and projection exclusion now define how staged presentation follows committed input without becoming save, layout, or history authority.
+
+## Impact
+
+- Primary code areas: `packages/core/src/store`, `packages/core/src/binding`, `packages/core/src/layout`, `packages/core/src/output`, and `packages/core/src/editor`.
+- The canonical node child-sequence implementation and internal index ownership can change. Public `OoxmlNode` behavior and ordered traversal remain compatible.
+- The editor gains private model-revision and display-revision state. Hosts continue to observe committed canonical state and complete published layout state.
+- React, Vue, Pro review, and editor API packages consume the same engine behavior without adapter-owned fast paths.
+- Save drains its captured input sequence and serializes canonical state without layout. Active composition rejects save; geometry-dependent operations cross the settle barrier.
+- Security checks remain mandatory for changed input. Untouched validated subtrees can reuse prior proof, but malformed edited content never publishes.
+- Benchmark tooling gains structural counters for touched child slots, validation visits, index patches, page reconciliation, provisional eligibility, settle latency, and stale work.

--- a/openspec/changes/sub-frame-large-document-typing/specs/large-document-typing-acceptance/spec.md
+++ b/openspec/changes/sub-frame-large-document-typing/specs/large-document-typing-acceptance/spec.md
@@ -1,0 +1,195 @@
+## ADDED Requirements
+
+### Requirement: Deterministic large-document fixture
+
+The repository SHALL own or deterministically generate a sanitized large-document typing fixture with pinned semantic shape and hash. The fixture SHALL exercise hundreds of pages, thousands of paragraphs, multiple sections, tables, drawings, notes, content controls, fields, and review content without containing personal or confidential source data.
+
+#### Scenario: Fixture is generated
+
+- **WHEN** the fixture generator runs from a clean checkout
+- **THEN** it produces the pinned package hash, page count, block count, paragraph count, and feature inventory
+
+#### Scenario: Supplied document informs a fixture
+
+- **WHEN** a user-supplied DOCX reveals a performance shape worth preserving
+- **THEN** the repository fixture reproduces that structure with synthetic content and excludes supplied names, text, metadata, media, and identifiers
+
+### Requirement: Reference typing profile
+
+The benchmark suite SHALL define a reproducible reference browser profile and pinned ordinary-typing corpus before default-enable measurements. It SHALL record browser version, production build, viewport, device scale, reduced-motion setting, shaped measurer, review-module state, fixture hash, corpus hash, caret positions, warmup count, run count, and machine class.
+
+#### Scenario: Reference run begins
+
+- **WHEN** a maintainer runs the large-document reference benchmark
+- **THEN** the report contains every profile field required to compare the result with another run
+
+#### Scenario: Shared continuous-integration runner executes
+
+- **WHEN** the benchmark runs on hardware outside the reference profile
+- **THEN** absolute timings are reported as informational while deterministic correctness and work gates remain enforced
+
+### Requirement: One-frame eligible typing budget
+
+On the maintained reference profile, every attempted fast-path insertion SHALL be measured from trusted `beforeinput`, including eligibility. A private benchmark event stream keyed by input queue sequence SHALL mark candidate decision, model commit, display patch, first paint, and settle. Public `change` SHALL NOT serve as a presentation marker. Eligible insertion SHALL present within 16.7 ms median and 33.4 ms p95. A sample completes only after expected text, caret, and revisions are verified.
+
+#### Scenario: Isolated insertion is measured
+
+- **WHEN** at least 100 warm attempts run across pinned paragraph lengths, caret positions, style boundaries, and line-edge positions with undo between samples
+- **THEN** median and p95 provisional presentation latency meet the reference budget
+
+#### Scenario: Sustained insertion is measured
+
+- **WHEN** the benchmark types at least 180 eligible characters without waiting for authoritative settle after each character
+- **THEN** presentation latency meets the reference budget, every character appears once in order, and the final model caret equals the inserted text length
+
+#### Scenario: Edit is ineligible
+
+- **WHEN** an insertion fails provisional eligibility
+- **THEN** the report includes eligibility-decision time, refusal reason, and synchronous authoritative presentation without removing the attempted sample from overall reporting
+
+#### Scenario: Default enablement is evaluated
+
+- **WHEN** the defined ordinary-typing corpus completes
+- **THEN** at least 80% of attempted insertions are eligible and ineligible p95 does not regress its recorded synchronous baseline by more than 10%
+
+### Requirement: Text-local mutation work is document-size independent
+
+Warm eligible insertion SHALL satisfy deterministic counters that exclude work proportional to total body width or paragraph count. The benchmark SHALL report wide-sequence materializations, child slots touched, validation visits, package invariant runs, complete index rebuilds, and created temporary bytes or objects where measurable.
+
+#### Scenario: Warm middle insertion runs
+
+- **WHEN** one eligible character commits under a body with thousands of sibling blocks
+- **THEN** no wide compatibility child array materializes, no complete node or paragraph index rebuild runs, and validation work is bounded by the changed subtree and ancestor depth
+
+#### Scenario: Package shell remains identical
+
+- **WHEN** eligible insertion changes only an existing canonical part root
+- **THEN** the package-invariant-run counter remains zero for that transaction
+
+### Requirement: First presentation performs bounded display work
+
+Eligible first presentation SHALL reshape and paint only the proved provisional region. It SHALL NOT scan every page, rebuild complete-layout indexes, repaint unrelated materialized pages, or mirror selection through unrelated DOM.
+
+#### Scenario: One paragraph presents provisionally
+
+- **WHEN** the local geometry proof accepts an eligible middle-document insertion
+- **THEN** counters name one provisional paragraph interval, bounded DOM mutations, and no complete-page scan before presentation
+
+#### Scenario: Viewport contains neighbouring pages
+
+- **WHEN** overscan materializes pages beside the caret page
+- **THEN** their detailed DOM identity remains unchanged during provisional presentation
+
+### Requirement: Complete settle remains differentially correct
+
+Every staged typing scenario SHALL compare the final incremental result with clean full layout and clean full paint at the same canonical revision. Canonical fingerprints, semantic digests, page records, source ranges, selection, drawing and review dependencies, normalized save/reopen output, page-directory order, checkpoint state, and cumulative offsets SHALL agree.
+
+#### Scenario: Provisional insertion settles
+
+- **WHEN** eligible provisional content is replaced by complete authoritative layout
+- **THEN** the final semantic layout and display plan equal clean full computation for that committed revision
+
+#### Scenario: Pagination changes during settle
+
+- **WHEN** later input makes local geometry ineligible and complete layout changes page count
+- **THEN** no mixed layout publishes and the final result equals clean full computation
+
+#### Scenario: Middle edit converges
+
+- **WHEN** a text-local edit settles after changing a bounded middle interval
+- **THEN** counters show no complete page-array copy, checkpoint-tail copy, page-shell offset rewrite, or all-page map
+
+### Requirement: Burst input remains exact
+
+Staged presentation SHALL preserve character order, selection epochs, revision attribution, per-intent history boundaries, and input completeness under rapid input and delayed selection echoes. Presentation and settle work MAY coalesce. Canonical input transactions SHALL NOT coalesce. No optimization MAY drop, duplicate, reorder, or silently refuse accepted input.
+
+#### Scenario: Ordered burst arrives
+
+- **WHEN** trusted input sends a known sequence at 100 Hz while selection echoes are delayed
+- **THEN** canonical text, visible text, final caret, history entries, and saved text contain exactly that sequence in order
+
+#### Scenario: Suggesting mode burst arrives
+
+- **WHEN** eligible staged support is later enabled for suggesting mode
+- **THEN** one or more valid tracked insertion groups contain every accepted character once and undo restores the prior canonical revision
+
+### Requirement: Geometry barriers remain correct
+
+Browser acceptance SHALL exercise pointer selection, vertical navigation, structural commands, table interaction, story switching, composition, print, screenshot, save, accessibility selection, review actions, undo, redo, external edits, and teardown while provisional display is active. Each operation SHALL queue, settle, refuse, or use canonical state according to the staged-presentation contract.
+
+#### Scenario: Vertical arrow interrupts typing
+
+- **WHEN** ArrowDown arrives before authoritative settle
+- **THEN** the editor queues the intent, resolves movement from complete latest-revision geometry, and applies it only while its barrier token remains current
+
+#### Scenario: Save interrupts typing
+
+- **WHEN** save runs during a staged typing burst
+- **THEN** buffered input commits first and reopened bytes contain the exact canonical text
+
+#### Scenario: Composition starts
+
+- **WHEN** IME composition begins while provisional display is active
+- **THEN** the editor restores complete editable DOM or enters the existing composition-safe path before draft text appears
+
+#### Scenario: Pointer races with keyboard input
+
+- **WHEN** keyboard input changes the model after a pointer barrier settles
+- **THEN** the barrier token rejects stale geometry and the pointer is re-hit-tested or cancelled
+
+#### Scenario: Undo occurs before settle
+
+- **WHEN** undo or redo runs during provisional display
+- **THEN** stale work is cancelled and visible text, selection, history, and later save reflect only the restored revision
+
+### Requirement: Memory and stale-work bounds
+
+Sustained and burst benchmarks SHALL report retained heap, live sequence nodes, sidecar entries, provisional allocations, cancelled-job buffers, stale discards, and retained revision sidecars. The reference run SHALL reach quiescence with no pending jobs or resource callbacks, force collection, record baseline, execute 1,000 edits beyond history capacity, reach quiescence again, then force and measure three collection cycles. Retained growth SHALL NOT exceed the greater of 32 MiB or 10% of baseline opened-document heap. No cancelled or stale job may publish or mutate an unfingerprinted shared cache.
+
+#### Scenario: Sustained typing exceeds history limit
+
+- **WHEN** a benchmark types beyond the configured history capacity and forces collection
+- **THEN** evicted revision metadata is collectible and retained heap stays below the configured large-document bound
+
+#### Scenario: Settle jobs are repeatedly superseded
+
+- **WHEN** rapid input cancels several complete layout jobs
+- **THEN** cancelled work releases callbacks, accumulators, temporary sequences, and builders, and only the latest complete revision publishes
+
+#### Scenario: External commit arrives during editing
+
+- **WHEN** automation or another store client commits while editable DOM names an older revision
+- **THEN** editing suspends synchronously and resumes only after visible DOM reaches the external model revision
+
+### Requirement: Security and rejection behavior are unchanged
+
+Performance acceptance SHALL run malformed text, duplicate identity, namespace mutation, content-control lock, forms protection, unsafe package edit, and invalid relationship cases through incremental paths. Each case SHALL match complete validation and existing typed rejection behavior.
+
+#### Scenario: Incremental validator receives malicious changed content
+
+- **WHEN** changed content violates a canonical or package invariant
+- **THEN** it is rejected before provisional display, publication, history, notification, or save output
+
+#### Scenario: Untouched malicious-looking generic content is preserved
+
+- **WHEN** a previously validated generic subtree remains object-identical beside an eligible text edit
+- **THEN** prior proof is reused, the subtree remains unchanged, and normalized save preserves it safely
+
+#### Scenario: Operation replaces an undeclared sibling
+
+- **WHEN** a malformed or faulty mutation cannot prove exact sequence lineage for every rebuilt ancestor
+- **THEN** scoped validation refuses it or complete validation detects it before publication
+
+#### Scenario: Cancelled job attempts a cache write
+
+- **WHEN** a cancelled settle callback resumes with stale resource inputs
+- **THEN** complete fingerprints prevent the write from poisoning a later revision cache
+
+### Requirement: Performance reports separate throughput from responsiveness
+
+Benchmark reports SHALL distinguish input-handler duration, eligibility-decision time, canonical transaction time, provisional presentation latency, complete settle time, layout work, paint work, selection work, queue delay, long tasks, memory, and deterministic counters. A throughput improvement SHALL NOT be described as responsive typing when first presentation misses its budget.
+
+#### Scenario: Presentation work coalesces
+
+- **WHEN** a burst keeps separate canonical intent transactions but coalesces provisional paint or settle work
+- **THEN** the report records transaction count, presentation throughput, and responsiveness separately

--- a/openspec/changes/sub-frame-large-document-typing/specs/paragraph-editor-binding/spec.md
+++ b/openspec/changes/sub-frame-large-document-typing/specs/paragraph-editor-binding/spec.md
@@ -1,0 +1,98 @@
+## MODIFIED Requirements
+
+### Requirement: Transaction-to-DocOp mapping
+
+`EditorBinding` SHALL map complete supported ProseMirror transactions and supported painted-surface input into typed `DocOp`s using transaction step mappings, stable semantic identities, model selection, and revision-tagged selection evidence. It MAY prepare a store-owned `CandidateChange`, but commit SHALL compare its predecessor revision, paragraph fingerprint, source layout revision, normalized effects, and shaping resources before canonical mutation. The binding SHALL commit mapped selection before provisional presentation and SHALL never derive later input from browser-mutated DOM.
+
+#### Scenario: Text transaction commits
+
+- **WHEN** a user inserts text into a projected paragraph
+- **THEN** the binding commits the corresponding semantic operation before reconciling the view or presenting provisional committed text from its `ModelChange`
+
+#### Scenario: Native deletion commits
+
+- **WHEN** a user presses Backspace or Delete at a caret or over a browser-native selection
+- **THEN** the binding commits precise semantic deletion operations, including supported run-boundary deletion and paragraph join
+
+#### Scenario: Word-like keymap command commits
+
+- **WHEN** a repository-specified ProseMirror keymap handles Enter, Backspace, Delete, Mod-B/I/U, or select-all
+- **THEN** the command uses the current projection and commits authored effects only through typed `DocOp`s
+
+#### Scenario: Unsupported transaction is rejected
+
+- **WHEN** a transaction contains a step with no supported semantic mapping
+- **THEN** no canonical mutation or provisional presentation occurs and the projection is restored to committed state with a diagnostic result
+
+#### Scenario: Later character arrives before layout settles
+
+- **WHEN** another eligible insertion arrives while provisional presentation is active
+- **THEN** the binding maps it from committed model selection and the provisional source map rather than stale complete-layout or DOM positions
+
+#### Scenario: Delayed selection evidence arrives
+
+- **WHEN** browser selection evidence carries an older selection epoch
+- **THEN** the binding rejects it before mapping another input operation
+
+### Requirement: Canonical semantic history
+
+Undo and redo SHALL operate through semantic store history and committed revisions. Each accepted user intent SHALL create one semantic history entry: one supported ProseMirror transaction, one complete IME composition, or one toolbar/command invocation. Projection reconciliation and provisional presentation SHALL create no entry. Presentation coalescing and complete-layout job coalescing SHALL NOT merge or redefine semantic history. The ProseMirror history plugin and time-based PM grouping MUST NOT be canonical authority.
+
+#### Scenario: Undo paragraph edit
+
+- **WHEN** the user undoes a committed paragraph insertion
+- **THEN** a semantic operation changes the canonical tree and every projection follows that commit
+
+#### Scenario: One transaction is atomic history
+
+- **WHEN** one accepted ProseMirror transaction maps to multiple `DocOp`s
+- **THEN** all operations commit atomically as one semantic history entry
+
+#### Scenario: IME composition spans transactions
+
+- **WHEN** ProseMirror emits multiple transactions between `compositionstart` and `compositionend`
+- **THEN** the accepted composition commits as one semantic history entry
+
+#### Scenario: Toolbar command is one intent
+
+- **WHEN** one toolbar or command invocation changes multiple accepted properties
+- **THEN** the changes commit atomically as one semantic history entry
+
+#### Scenario: Projection reconciliation has no history
+
+- **WHEN** the binding reconciles ProseMirror from a committed `ModelChange`
+- **THEN** no semantic history entry is created
+
+#### Scenario: Consecutive typing keeps intent boundaries
+
+- **WHEN** ordinary typing produces consecutive accepted ProseMirror transactions outside composition
+- **THEN** each accepted `beforeinput` intent creates its own semantic history entry even when presentation or settle work is coalesced
+
+#### Scenario: Provisional display is replaced
+
+- **WHEN** complete layout atomically replaces provisional presentation
+- **THEN** no semantic history entry is created
+
+### Requirement: Projection excluded from save and layout
+
+Save and complete layout code MUST NOT consume `EditorState`, `EditorView`, ProseMirror document content, composition draft DOM, provisional DOM, provisional display tags, or mounted DOM as document input. A provisional paragraph computation SHALL consume only a store-produced candidate and revision-matched semantic dependencies, then verify the committed candidate fingerprint before presentation.
+
+#### Scenario: Editor view is absent
+
+- **WHEN** a committed paragraph document is saved or laid out without mounting ProseMirror
+- **THEN** the result is produced from the same canonical tree used by an interactive editor
+
+#### Scenario: Save runs during provisional display
+
+- **WHEN** DOCX save captures an input queue sequence before complete layout settles
+- **THEN** save commits every accepted event through that sequence, excludes later events, and serializes that canonical revision without reading provisional DOM
+
+#### Scenario: Complete layout follows provisional display
+
+- **WHEN** complete layout starts after a provisional paragraph is visible
+- **THEN** it reads the committed canonical revision and semantic caches rather than provisional DOM or display records as authored input
+
+#### Scenario: Save runs during composition
+
+- **WHEN** an unresolved private composition draft exists
+- **THEN** public `Editor.save()` rejects with typed `composition-active` and never serializes draft content

--- a/openspec/changes/sub-frame-large-document-typing/specs/semantic-paragraph-layout/spec.md
+++ b/openspec/changes/sub-frame-large-document-typing/specs/semantic-paragraph-layout/spec.md
@@ -1,0 +1,160 @@
+## MODIFIED Requirements
+
+### Requirement: Semantic interaction authority
+
+Caret stops, hit testing, selection, keyboard navigation, and composition anchors SHALL derive from complete semantic layout records and stable text positions rather than DOM ranges or element rectangles. An eligible provisional caret MAY derive from a private source-addressable provisional paragraph record for the latest committed model revision. Pointer resolution, cross-paragraph navigation, review anchors, object geometry, and structural commands SHALL require complete latest-revision layout.
+
+#### Scenario: Pointer selects a line position
+
+- **WHEN** a pointer coordinate hits a painted paragraph line and complete latest-revision layout is available
+- **THEN** semantic hit-test data resolves a stable paragraph text position independent of DOM node identity
+
+#### Scenario: Caret follows provisional insertion
+
+- **WHEN** a committed insertion has an accepted provisional paragraph record with exact source ranges and geometry proof
+- **THEN** the caret can use that record within its paragraph without making provisional geometry available to other interaction consumers
+
+#### Scenario: Geometry operation arrives during provisional display
+
+- **WHEN** pointer, vertical navigation, review, object, table, or automation geometry is requested while complete layout is stale
+- **THEN** the editor settles complete latest-revision layout or returns a typed stale or unavailable result
+
+### Requirement: Output is a non-authoritative consumer
+
+The browser output layer SHALL safely construct and update native DOM from complete semantic layout records or private provisional paragraph records produced by the layout lane. It SHALL NOT remeasure text, repaginate content, publish canonical geometry, or expose provisional geometry as a complete `SemanticLayout`.
+
+#### Scenario: Page is repainted
+
+- **WHEN** output replaces a paragraph fragment after a new complete layout revision
+- **THEN** semantic positions and geometry remain those published by complete layout
+
+#### Scenario: Paragraph presents provisionally
+
+- **WHEN** output receives an eligible provisional paragraph record for committed text on an existing materialized page
+- **THEN** it patches only that owned paragraph and retains last-complete page geometry
+
+### Requirement: Deterministic revision publication
+
+Complete layout and complete interaction publication SHALL reject stale or mixed revisions and SHALL expose either one complete committed revision or the last complete revision. A private provisional paragraph display MAY present committed text while complete layout remains at the preceding revision, but it SHALL NOT publish a partial `SemanticLayout` or become authoritative outside its proved paragraph-local caret.
+
+#### Scenario: Stale layout completes late
+
+- **WHEN** layout for an older model revision finishes after a newer revision has been requested
+- **THEN** the older result is not published to output or interaction consumers
+
+#### Scenario: Complete layout trails committed text
+
+- **WHEN** eligible committed text is visible through a provisional paragraph record
+- **THEN** complete layout consumers retain the last complete revision until one complete latest-revision result publishes atomically
+
+### Requirement: Change-scoped incremental layout
+
+Complete layout SHALL consume the committed `ModelChange` dirty identities, created/deleted/moved and split/join effects, dependency keys, and impact class. It SHALL retain the previous complete layout, resume from a safe checkpoint before the first affected block, and reuse an unchanged suffix only after complete flow-state convergence is proven. A separate private provisional paragraph computation MAY run after commit, but it SHALL neither claim complete convergence nor publish a mixed layout.
+
+#### Scenario: One paragraph changes without repagination
+
+- **WHEN** a text-local edit changes one paragraph and the new complete layout converges with the previous flow state
+- **THEN** complete layout reuses unaffected paragraph, page, and display records outside the resume-to-convergence interval
+
+#### Scenario: Reuse cannot be proven
+
+- **WHEN** a dependency is missing, a position-sensitive feature is unsupported, or checkpoint state does not match exactly
+- **THEN** the engine falls back to a clean full layout and publishes no speculative mixed result
+
+#### Scenario: Local geometry remains equivalent
+
+- **WHEN** committed text reshapes locally and proves unchanged page ownership, fragments, line breaks, vertical metrics, and flow extent
+- **THEN** a private provisional paragraph record can present before complete convergence without entering the complete layout graph
+
+### Requirement: Viewport-bounded output materialization
+
+Output SHALL preserve page shells and complete semantic scroll geometry for every complete-layout page while materializing detailed page content only for the viewport, bounded overscan, and any page containing the logical caret or selection. Provisional and settled reconciliation SHALL preserve unchanged shells and detailed materialized-page DOM by identity.
+
+#### Scenario: Long document scrolls
+
+- **WHEN** the viewport moves through a long document
+- **THEN** mounted detailed page content remains bounded by the visible range plus configured overscan while semantic hit testing and scroll geometry remain valid
+
+#### Scenario: Selection page leaves the viewport
+
+- **WHEN** scrolling moves a page containing the logical caret or selection outside normal overscan
+- **THEN** interaction state remains semantic and resolvable without making mounted DOM canonical
+
+#### Scenario: Middle page settles without repagination
+
+- **WHEN** an edit changes one materialized page and complete layout reuses every later page
+- **THEN** output reconciles the changed page interval without rebuilding unrelated materialized pages
+
+### Requirement: Cancellable atomic global layout
+
+Global layout work SHALL capture an immutable package snapshot, model revision, scope, and resource fingerprints. It SHALL be cancellable, cooperatively scheduled, and published atomically. No continuation MAY read a later mutable session. Superseded jobs SHALL not publish. A private provisional paragraph record MAY present committed text before completion, but only a complete latest-revision layout MAY publish globally. Worker execution SHALL remain deferred until resource and font transfer contracts are specified.
+
+#### Scenario: Edit supersedes global layout
+
+- **WHEN** a newer model revision commits while a global layout job is yielding
+- **THEN** the older job is cancelled or discarded and only a complete result for the latest requested revision may publish
+
+#### Scenario: Input arrives during settle
+
+- **WHEN** browser input is pending while cooperative complete layout has remaining phases
+- **THEN** deadline-aware iteration returns to the browser event loop within its configured slice budget and resumes or is superseded without publishing partial state
+
+#### Scenario: Input stops after provisional presentation
+
+- **WHEN** no newer edit supersedes the pending model revision
+- **THEN** cooperative layout completes, publishes one complete layout, and removes provisional state atomically
+
+#### Scenario: Job is cancelled
+
+- **WHEN** input, detach, reload, font change, display-mode change, or width change cancels a layout job
+- **THEN** private accumulators and scheduled work are released, and no stale callback or unfingerprinted cache write affects later layout
+
+### Requirement: Incremental/full differential conformance
+
+Every supported complete incremental-layout class SHALL be tested against a clean full layout of the same committed revision. Settled performance gates SHALL use structural work counters and identity/mount bounds rather than hardware-dependent wall-clock thresholds. Provisional presentation SHALL have separate exact-record, input-correctness, and reference-profile latency gates.
+
+#### Scenario: Incremental fixture completes
+
+- **WHEN** text-local, paragraph-local, split/join, or flow-structural fixture edits run incrementally
+- **THEN** complete semantic layout and display output equal clean full output while recorded work remains limited to the proven invalidation and convergence window
+
+#### Scenario: Provisional fixture settles
+
+- **WHEN** an eligible paragraph presents provisionally and later settles
+- **THEN** its provisional source ranges, styles, glyph advances, and caret match the corresponding clean records, and the final complete layout equals clean full layout
+
+#### Scenario: Shared runner measures timing
+
+- **WHEN** browser timing runs outside the maintained reference profile
+- **THEN** timing remains informational while structural, identity, mount, and correctness gates remain enforced
+
+## ADDED Requirements
+
+### Requirement: Settled layout change evidence
+
+The layout lane SHALL own an immutable internal revision containing model revision, persistent page directory, persistent checkpoint directory, `LayoutChangeSet`, and lazy public `SemanticLayout` projection. Output SHALL receive read-only page accessors plus change evidence. The editor SHALL retain only an opaque handle and public projection access. Public `SemanticLayout.pages` SHALL remain a stable frozen array projection, but core typing paths SHALL NOT materialize or scan it.
+
+#### Scenario: Reused page keeps its dependencies
+
+- **WHEN** a page and every declared presentation dependency retain identity after convergence
+- **THEN** settled paint reuses that page shell, detailed DOM when materialized, and derived presentation-index entries
+
+#### Scenario: Drawing dependency changes
+
+- **WHEN** a drawing resource or placement dependency changes on a reused page
+- **THEN** layout change evidence marks every affected materialized occurrence for reconciliation
+
+#### Scenario: Middle edit converges
+
+- **WHEN** a text-local edit changes a bounded middle interval and flow state converges
+- **THEN** settle performs changed-interval plus logarithmic directory work without copying the complete page array or checkpoint tail
+
+#### Scenario: Public pages are read
+
+- **WHEN** a consumer reads `SemanticLayout.pages` repeatedly from one complete layout
+- **THEN** it receives the same frozen array projection while internal layout and output use the authoritative page directory
+
+#### Scenario: Page shells preserve scroll geometry
+
+- **WHEN** output creates materialized and unmaterialized page shells from an internal layout revision
+- **THEN** shells remain in normal document flow with explicit dimensions while semantic cumulative offsets come from the page directory

--- a/openspec/changes/sub-frame-large-document-typing/specs/staged-typing-presentation/spec.md
+++ b/openspec/changes/sub-frame-large-document-typing/specs/staged-typing-presentation/spec.md
@@ -1,0 +1,227 @@
+## ADDED Requirements
+
+### Requirement: Canonical-first provisional presentation
+
+The editor MAY preflight eligibility and local shaping against a store-produced uncommitted `CandidateChange`. Commit SHALL compare-and-swap its predecessor revision, paragraph identity and fingerprint, source layout revision, normalized effects, and shaping resource fingerprints. The editor SHALL present only after the exact candidate commits and matches. A rejected or stale candidate SHALL produce no provisional display.
+
+#### Scenario: Eligible character commits
+
+- **WHEN** a collapsed text insertion commits and passes provisional eligibility
+- **THEN** the editor presents text read from the committed paragraph before complete document layout settles
+
+#### Scenario: Text operation is rejected
+
+- **WHEN** a text insertion violates an invariant, lock, form rule, or editing-mode rule
+- **THEN** canonical state and visible document content remain unchanged
+
+#### Scenario: Provisional installation fails after commit
+
+- **WHEN** an eligible candidate commits but its provisional DOM installation fails
+- **THEN** the editor completes authoritative presentation synchronously or makes the document non-editable until `displayRevision` reaches `modelRevision`
+
+### Requirement: Provisional state is distinct from complete layout
+
+The surface SHALL track `modelRevision`, `layoutRevision`, `displayRevision`, model selection, monotonic selection epoch, and optional provisional display as distinct state. One atomic surface transition SHALL publish a committed model revision, `ModelChange`, mapped model selection, and selection epoch. A provisional display SHALL NOT publish a partial `SemanticLayout`, change complete page geometry, enter public snapshots, or appear as authoritative geometry.
+
+#### Scenario: Model is newer than complete layout
+
+- **WHEN** an eligible text edit commits and provisional content is visible while complete layout still names the preceding revision
+- **THEN** model reads observe `modelRevision`, editable DOM names `displayRevision`, page reads retain `layoutRevision`, and no consumer receives a mixed page graph
+
+#### Scenario: Complete layout publishes
+
+- **WHEN** authoritative layout for the latest model revision finishes
+- **THEN** one atomic publish replaces the provisional display and all complete layout consumers move to that revision together
+
+### Requirement: Public editor events follow completed display transitions
+
+For each accepted editor intent, the store SHALL commit first. The surface SHALL then map selection, install verified provisional or complete DOM, and replace its coherent snapshot. On the next microtask, the editor SHALL emit `change` before `selectionChange`. Reentrant editor mutations SHALL queue after the current transition.
+
+#### Scenario: Change handler reads snapshot
+
+- **WHEN** a public `change` handler reads editor state
+- **THEN** it observes committed model state, current editable display, mapped selection, and revision-tagged complete page state from one finished surface transition
+
+#### Scenario: External store commit arrives
+
+- **WHEN** the surface observes a canonical commit that did not originate from its current input transition
+- **THEN** it suspends editing synchronously and restores editing only after `displayRevision` reaches the external `modelRevision`
+
+### Requirement: Provisional eligibility fails closed
+
+Provisional eligibility SHALL finish before commit. Candidate grapheme segmentation, glyph IDs, positions, clusters, caret stops, bidirectional levels, visual order, source mappings, and fallback-font identities SHALL equal a clean local shape of that candidate. Only fragment count, page ownership, line breaks, vertical metrics, and flow extent SHALL remain unchanged against previous complete layout. Unsupported, stale, or changed geometry SHALL use the synchronous authoritative path.
+
+#### Scenario: Character stays on the same lines
+
+- **WHEN** a body-story insertion reshapes one materialized paragraph and proves unchanged line and fragment geometry
+- **THEN** the editor can patch that paragraph provisionally
+
+#### Scenario: Character causes wrapping
+
+- **WHEN** local reshaping changes a line break, line count, fragment boundary, page ownership, or flow extent
+- **THEN** provisional presentation is refused and authoritative layout determines the display
+
+#### Scenario: Paragraph has an unsupported dependency
+
+- **WHEN** the paragraph requires an unsupported script, composition state, field, note, drawing, table, content control, review wrapper, structural break, or stale resource
+- **THEN** provisional presentation is refused without weakening the normal editing behavior
+
+### Requirement: Provisional records remain semantic and DOM-free
+
+The layout lane SHALL produce provisional source-addressable line and style-span records from the store-produced candidate, exact prior width, resolved styles, font resources, and shaping configuration. After commit, output SHALL verify the candidate fingerprint and consume the record without remeasuring text or making DOM geometry canonical.
+
+#### Scenario: Mixed run formatting remains on one line
+
+- **WHEN** an eligible insertion occurs beside supported run formatting and local reshaping preserves geometry
+- **THEN** provisional spans retain ordered canonical UTF-16 ranges and exact resolved formatting
+
+#### Scenario: Output patches a paragraph
+
+- **WHEN** a valid provisional paragraph record targets an existing materialized fragment
+- **THEN** output changes only that paragraph's owned DOM and uses the record's semantic positions for caret placement
+
+### Requirement: Continued typing uses model positions
+
+While provisional display is active, each later accepted `beforeinput` intent SHALL commit independently and address the committed model selection plus provisional source map. Presentation and settle work MAY coalesce, but semantic transactions and history boundaries SHALL NOT coalesce. Browser DOM mutation and stale complete-layout geometry SHALL NOT determine insertion position.
+
+#### Scenario: Rapid characters arrive before settle
+
+- **WHEN** several eligible characters arrive while an older complete layout job is pending
+- **THEN** every character commits once in order with its history boundary, the provisional paragraph advances to the latest model revision, and stale layout work cannot overwrite it
+
+#### Scenario: Selection evidence is stale
+
+- **WHEN** a delayed browser selection event refers to DOM replaced by provisional or authoritative paint
+- **THEN** its selection epoch is rejected before it can move the model caret or affect later input
+
+### Requirement: Geometry operations cross a settle barrier
+
+Any operation that requires geometry outside the proved provisional record SHALL capture an intent token containing model revision, selection epoch, and input queue sequence. Later mutations SHALL wait while settle runs. After complete latest-revision layout publishes, the operation SHALL capture a separate geometry token containing that layout revision and re-hit-test. It SHALL validate the intent token before replay and geometry token before commit. Event handlers SHALL queue their intent. Existing queries MAY return their typed unavailable result.
+
+#### Scenario: Pointer arrives during provisional display
+
+- **WHEN** the user clicks outside the provisional paragraph before complete layout settles
+- **THEN** the editor queues the click, settles authoritative layout, re-hit-tests, and applies it only while its barrier token remains current
+
+#### Scenario: Save runs during provisional display
+
+- **WHEN** DOCX save is requested after buffered input has committed
+- **THEN** save drains accepted input through one captured queue sequence and serializes that canonical revision without reading provisional DOM
+
+#### Scenario: Print runs during provisional display
+
+- **WHEN** print or paginated export is requested
+- **THEN** the operation uses a complete authoritative layout for the latest canonical revision
+
+#### Scenario: New input races with a settled pointer
+
+- **WHEN** keyboard input changes the model after a pointer barrier settles but before selection commits
+- **THEN** the token check rejects the stale target and repeats hit testing or cancels the pointer intent
+
+### Requirement: IME composition uses a private draft
+
+Composition SHALL start from complete editable layout. Intermediate composition text SHALL remain in one private draft outside canonical state, save, complete layout, history, and automation. `compositionend` SHALL commit one semantic intent. Cancellation, blur, detach, or failure SHALL remove the draft.
+
+#### Scenario: Composition starts during provisional display
+
+- **WHEN** `compositionstart` occurs while provisional display is active
+- **THEN** the surface restores complete latest-revision editable DOM before native updates or cancels composition without reading stale painted DOM
+
+#### Scenario: Composition is cancelled
+
+- **WHEN** composition ends without accepted content
+- **THEN** no canonical revision or history entry is created and all draft DOM is removed
+
+#### Scenario: Save runs during composition
+
+- **WHEN** save is requested while a composition draft remains unresolved
+- **THEN** public `Editor.save()` rejects with typed `composition-active` and never serializes draft DOM
+
+### Requirement: Complete settle is cooperative and cancellable
+
+Authoritative layout after provisional presentation SHALL capture an immutable package snapshot, model revision, scope, and resource fingerprints. DOM-free resumable loops SHALL use injected clock, deadline, continuation, cancellation, and visibility ports; `isInputPending` MAY provide an additional hint. Hidden tabs SHALL use timer continuations. A newer model revision SHALL cancel or supersede older work, and only the latest complete revision MAY publish.
+
+#### Scenario: New input supersedes settle
+
+- **WHEN** another eligible character commits while authoritative layout for an older revision is incomplete
+- **THEN** older work is cancelled or reused only through valid checkpoints and cannot publish
+
+#### Scenario: Input stops
+
+- **WHEN** no newer edit supersedes the pending revision
+- **THEN** cooperative work completes, publishes one complete layout, and removes provisional state
+
+#### Scenario: Cooperative path is unavailable
+
+- **WHEN** a layout feature cannot execute incrementally or cooperatively
+- **THEN** the editor uses the existing complete authoritative fallback and publishes no partial result
+
+#### Scenario: Cooperative slice is measured
+
+- **WHEN** settle runs on the maintained reference profile
+- **THEN** slice duration meets 4 ms p95 and 8 ms maximum, or the responsible leaf is split or excluded from the cooperative lane
+
+#### Scenario: Cancelled work has callbacks
+
+- **WHEN** detach, reload, font change, display-mode change, width change, or newer input cancels a settle job
+- **THEN** timers, tasks, animation frames, resource callbacks, accumulators, temporary sequences, and builders are released without stale publication or unfingerprinted cache writes
+
+### Requirement: Settled paint follows layout change evidence
+
+Complete-layout publication SHALL identify changed, created, deleted, remapped, and reused page records and their presentation dependencies. Output SHALL preserve unchanged page shells and materialized-page DOM, and SHALL rebuild global presentation indexes only when their dependency keys change.
+
+#### Scenario: Middle edit converges on the same page
+
+- **WHEN** complete layout changes one materialized page and reuses all later pages
+- **THEN** output reconciles the changed page interval without scanning or rebuilding unaffected page content
+
+#### Scenario: Drawing dependency changes
+
+- **WHEN** complete layout reports a changed drawing resource or placement dependency
+- **THEN** output updates every affected materialized occurrence and does not reuse an invalid drawing index
+
+### Requirement: Provisional display clears atomically
+
+Authoritative paint SHALL remove provisional tags, records, and DOM in the same publish operation that installs the complete revision. The user SHALL never see duplicate provisional and authoritative text.
+
+#### Scenario: Authoritative paragraph matches provisional text
+
+- **WHEN** complete layout settles after eligible provisional insertion
+- **THEN** output adopts or replaces the provisional paragraph once, keeps the semantic caret, and leaves no duplicate glyphs
+
+#### Scenario: Surface detaches before settle
+
+- **WHEN** the mounted surface is destroyed with provisional display active
+- **THEN** pending layout and provisional resources are cancelled while committed canonical content remains available for save or remount
+
+#### Scenario: Undo runs before settle
+
+- **WHEN** undo or redo publishes another model revision while provisional display is active
+- **THEN** older jobs and display records are cancelled and editable DOM is regenerated from the restored canonical revision before further input
+
+### Requirement: Layout-derived chrome freezes while stale
+
+Review activation, review rail geometry, table context, object controls, and other layout-derived chrome SHALL remain tied to `layoutRevision` while provisional display exists. Geometry actions SHALL be disabled until complete latest-revision layout publishes.
+
+#### Scenario: Provisional caret enters review content
+
+- **WHEN** provisional typing changes the model selection before review geometry settles
+- **THEN** review activation remains unavailable and no stale review card action targets the changed selection
+
+### Requirement: Provisional accessibility has one text copy
+
+Provisional replacement SHALL expose one accessible text copy, preserve editor focus, and keep geometry-dependent controls unavailable. Assistive-technology selection that needs stale geometry SHALL cross the same settle barrier as pointer selection.
+
+#### Scenario: Paragraph is replaced provisionally
+
+- **WHEN** output installs provisional committed text
+- **THEN** the accessibility tree contains one paragraph copy, focus remains on the editor, and stale geometry controls report unavailable
+
+### Requirement: Adapters cannot implement independent fast paths
+
+Provisional eligibility, local shaping, settle barriers, and authoritative replacement SHALL live in the core engine. React, Vue, Pro review, and other hosts SHALL consume shared engine state and SHALL NOT patch document DOM or maintain adapter-owned typing state.
+
+#### Scenario: React and Vue host the same document
+
+- **WHEN** both adapters exercise an eligible insertion
+- **THEN** they receive equivalent canonical edits, provisional state transitions, authoritative layout, and saved bytes from the same engine implementation

--- a/openspec/changes/sub-frame-large-document-typing/specs/typed-ooxml-canonical-tree/spec.md
+++ b/openspec/changes/sub-frame-large-document-typing/specs/typed-ooxml-canonical-tree/spec.md
@@ -1,0 +1,163 @@
+## MODIFIED Requirements
+
+### Requirement: Derived semantic indexes
+
+Paragraph, story, relationship, style, parent, content-control, review, note, field, bookmark, drawing, section, table, and other lookup structures SHALL be derived from a specific canonical-tree revision and SHALL NOT be mutation or serialization authority. An aggregate index SHALL patch from validated mutation effects only when baseline evidence places its complete rebuild on the eligible typing path. Cold or uncommon indexes MAY retain complete rebuilding.
+
+#### Scenario: Index is rebuilt
+
+- **WHEN** a committed operation invalidates an index entry
+- **THEN** rebuilding the index from the same tree revision yields the same semantic identity, order, relationships, and content
+
+#### Scenario: Text changes without paragraph structure
+
+- **WHEN** a text-local operation changes one paragraph without changing its semantic identity or order
+- **THEN** paragraph and parent indexes reuse unaffected entries and perform no complete paragraph walk
+
+#### Scenario: Undo restores a prior revision
+
+- **WHEN** undo returns to a retained canonical revision
+- **THEN** its derived indexes are restored or patched without using indexes from another revision
+
+### Requirement: Atomic semantic mutation
+
+The `DocumentStore` SHALL accept authored changes only as validated `DocOp`s against stable semantic identities and SHALL atomically publish a new tree revision and `ModelChange`. Text-local mutation SHALL validate checked mutation evidence and SHALL preserve immutable prior revisions, source order, unaffected node identity, and complete fallback behavior.
+
+#### Scenario: Invalid operation has no effect
+
+- **WHEN** a `DocOp` targets a missing paragraph, violates a tree invariant, or carries inconsistent mutation evidence
+- **THEN** the operation is rejected without changing the revision, tree, indexes, history, or notifications
+
+#### Scenario: Middle paragraph receives one character
+
+- **WHEN** one character is inserted into an existing paragraph under a body with thousands of sibling blocks
+- **THEN** the transaction publishes one validated revision without copying or freezing every body child
+
+#### Scenario: Mutation lineage is unavailable
+
+- **WHEN** an operation supplies an arbitrary replacement root or lacks an exact store-produced path witness
+- **THEN** scoped validation refuses the operation or runs complete validation before anything publishes
+
+### Requirement: Bounded untrusted input
+
+Tree parsing and serialization SHALL enforce finite package/XML limits, safe part and relationship paths, no external entity expansion, no implicit external fetch, and escaped attacker-controlled output. Incremental validation SHALL apply the same canonical and security rules to every changed or created node and rebuilt ancestor. It MAY reuse prior proof only for object-identical untouched subtrees.
+
+#### Scenario: Malicious package is rejected
+
+- **WHEN** a package exceeds a mandatory limit or contains an unsafe traversing part path
+- **THEN** parsing fails before publishing any canonical model
+
+#### Scenario: Edited text is invalid XML
+
+- **WHEN** inserted text violates canonical XML text rules
+- **THEN** the operation is rejected before provisional display, history, notification, or save output
+
+#### Scenario: Namespace context changes
+
+- **WHEN** an operation changes a namespace binding that can affect descendant interpretation
+- **THEN** validation expands to the complete affected namespace scope rather than reusing descendant proof
+
+## ADDED Requirements
+
+### Requirement: Bounded-touch canonical child sequences
+
+Warm text-local mutation SHALL replace canonical content without work proportional to the total child count of an unchanged high-fanout ancestor. One internal persistent sequence SHALL be child-storage authority and SHALL provide stable ordered traversal, indexed edits, immutable snapshots, structural sharing, and deterministic serialization. Public `OoxmlNode.children` SHALL remain a stable frozen `readonly OoxmlNode[]` projection for one node, and `Array.isArray(node.children)` SHALL remain true.
+
+#### Scenario: Unaffected sibling survives
+
+- **WHEN** a text-local operation commits beside unknown elements and unrelated typed blocks
+- **THEN** every unaffected subtree retains object identity and normalized save preserves its content and relative order
+
+#### Scenario: Prior revision remains readable
+
+- **WHEN** a later revision replaces one child in a high-fanout container
+- **THEN** readers of the prior revision observe its original child sequence and content
+
+#### Scenario: Public children are read
+
+- **WHEN** a consumer reads `children` repeatedly from one canonical node
+- **THEN** it receives the same frozen array projection while internal mutation and serialization continue to use the authoritative sequence
+
+#### Scenario: No compatible representation passes
+
+- **WHEN** every prototype violates public array behavior, fidelity, memory, or bounded-touch gates
+- **THEN** migration stops and requires a separately specified major API change
+
+### Requirement: Scoped validation uses sealed mutation lineage
+
+Only sanctioned store mutation primitives SHALL create scoped-validation evidence. Each primitive SHALL emit exact rebuilt ancestry, child-sequence path edits, identity effects, namespace scope, and package-shell effects. Local sequence lineage SHALL be checked at every rebuilt sequence node. Collision-prone hashes SHALL NOT be security evidence.
+
+#### Scenario: Forged proof reaches validation
+
+- **WHEN** a caller supplies evidence that was not created by a sanctioned mutation primitive
+- **THEN** scoped validation rejects it or runs complete validation
+
+#### Scenario: Sequence path witness is inconsistent
+
+- **WHEN** a rebuilt sequence node does not match the exact old-to-new path edit in its witness
+- **THEN** the transaction is rejected before publication
+
+### Requirement: Incremental identity integrity
+
+Created, deleted, moved, and retained node identities SHALL be checked against the prior validated node index and checked mutation evidence. Incremental validation SHALL reject duplicate or inconsistent identities with the same observable result as complete validation.
+
+#### Scenario: New identity collides with an untouched node
+
+- **WHEN** a changed subtree introduces an identity already owned by an untouched subtree
+- **THEN** the transaction is rejected before the new revision publishes
+
+#### Scenario: Node moves between parents
+
+- **WHEN** a supported structural operation moves a node while retaining its identity
+- **THEN** the parent index and mutation proof record exactly one new parent and complete rebuilding yields the same relationship
+
+### Requirement: Package validation follows package structure
+
+Package relationship, content-type, safe-name, and part-membership validation SHALL run whenever package structure can change. A text-local replacement of an existing part MAY reuse prior package proof only when package structure, relationships, content types, part names, and membership remain identical.
+
+#### Scenario: Text changes inside an existing part
+
+- **WHEN** a validated text-local operation replaces only the canonical root of an existing part
+- **THEN** the store does not rescan unchanged package relationships and content types
+
+#### Scenario: Relationship or part changes
+
+- **WHEN** a transaction creates, removes, renames, or relates a package part
+- **THEN** complete package invariants run and any dangling relationship or missing content type rejects the transaction
+
+### Requirement: Complete rebuild remains the index oracle
+
+Every incrementally maintained index SHALL provide a complete rebuild oracle. Repository tests SHALL compare incremental and complete results after supported edits, undo, redo, rejection, and randomized operation sequences.
+
+#### Scenario: Random operation sequence completes
+
+- **WHEN** a deterministic sequence mixes text edits, split, join, table operations, undo, and redo
+- **THEN** every incremental index equals a complete rebuild at each published revision
+
+#### Scenario: Rejected operation leaves sidecars unchanged
+
+- **WHEN** validation rejects an operation
+- **THEN** canonical state and all index sidecars remain those of the prior revision
+
+### Requirement: Incremental state has bounded retention
+
+Persistent sequences, mutation proofs, and index sidecars SHALL use structural sharing and bounded retention. History eviction SHALL release revision-only metadata. Retained complexity SHALL be proportional to the live indexes plus changed entries in undoable revisions, not history length multiplied by document size.
+
+#### Scenario: Sustained typing exceeds history limit
+
+- **WHEN** a long document receives more text edits than the configured history limit
+- **THEN** evicted revisions and their unshared index metadata become collectible while live and undoable revisions remain valid
+
+### Requirement: ModelChange carries normalized part effects
+
+Published `ModelChange` SHALL carry part-scoped created, deleted, moved, and changed identities, replaced ancestry, package-shell effects, dependency invalidations, and impact. Private validation proof SHALL NOT escape the store. Undo and redo SHALL retag reused immutable-tree sidecars for their new monotonic publication revision.
+
+#### Scenario: Node moves within a part
+
+- **WHEN** a validated structural operation moves one node
+- **THEN** `ModelChange` names its part, retained identity, previous parent, new parent, and affected dependencies
+
+#### Scenario: Undo restores an immutable tree
+
+- **WHEN** undo publishes a previously retained tree under a new revision
+- **THEN** consumers receive normalized effects for the new transition and never observe the old publication revision on reused sidecars

--- a/openspec/changes/sub-frame-large-document-typing/tasks.md
+++ b/openspec/changes/sub-frame-large-document-typing/tasks.md
@@ -1,0 +1,184 @@
+## 1. Evidence and complete hot-path inventory
+
+- [ ] 1.1 Add counters for child-sequence visits, sequence summaries, validation visits, fallback validation, index rebuilds, page visits, page-array copies, checkpoint copies, shell-offset writes, DOM mutations, queue delay, and allocations.
+- [ ] 1.2 Inventory every store, binding, layout, output, selection, review, and adapter scan reached by eligible typing.
+- [ ] 1.3 Record each aggregate's owner, dependency key, invalidation class, retained size, and current complete-rebuild cost.
+- [ ] 1.4 Capture production flame profiles and allocation profiles for isolated, sustained, and 100 Hz burst typing in small and large documents.
+- [ ] 1.5 Replace the supplied profiling document with a deterministic synthetic fixture that preserves scale and feature shape without source content or metadata.
+- [ ] 1.6 Pin fixture hash, semantic counts, feature inventory, caret positions, paragraph classes, viewport, warmup, run count, browser version, and machine class.
+- [ ] 1.7 Fix the benchmark probe to mark model commit and provisional patch separately and verify text, caret, model revision, display revision, and layout revision before recording.
+- [ ] 1.8 Make sustained input run without waiting for each presentation and require at least 100 samples for every reported p95.
+- [ ] 1.9 Record the complete non-clean functional and performance baseline before architecture changes.
+
+## 2. Revision, input, selection, and barrier protocols
+
+- [ ] 2.1 Define `modelRevision`, `layoutRevision`, `displayRevision`, selection epoch, and input queue sequence in one internal surface-state contract.
+- [ ] 2.2 Classify every snapshot field as model-derived, layout-derived, or private display state and preserve compatible public `revision` semantics.
+- [ ] 2.3 Publish committed model revision, `ModelChange`, mapped model selection, and selection epoch as one atomic surface transition.
+- [ ] 2.4 Tag installed DOM selection with its epoch and reject delayed native selection evidence from older epochs.
+- [ ] 2.5 Define one accepted `beforeinput` event as one semantic intent and history entry while permitting only presentation and settle coalescing.
+- [ ] 2.6 Define undo, redo, external store edits, and automation edits during provisional state.
+- [ ] 2.7 Define save linearization through one captured input queue sequence, including reentrant save and later input exclusion.
+- [ ] 2.8 Create a method-by-method barrier matrix for pointer, keyboard, table, object, review, automation, print, screenshot, export, zoom, resize, scope switching, structural commands, composition, and teardown.
+- [ ] 2.9 Assign each barrier operation to queued replay, synchronous settle, existing typed unavailability, or canonical-only execution.
+- [ ] 2.10 Define barrier tokens, mutation queuing, revision rechecks, re-hit-testing, cancellation, timeout, and teardown behavior.
+- [ ] 2.11 Define the private IME composition draft lifecycle, single commit, cancellation, blur, detach, failure, save refusal, and geometry refusal.
+- [ ] 2.12 Pin public ordering for store commit, display transition, snapshot replacement, `change`, `selectionChange`, and reentrant mutations.
+- [ ] 2.13 Specify concurrent and reentrant save promise sharing plus typed `composition-active` rejection.
+- [ ] 2.14 Add model-level protocol tests before introducing provisional DOM.
+
+## 3. Sealed mutation lineage and validation
+
+- [ ] 3.1 Encapsulate scoped tree construction behind sanctioned store mutation primitives.
+- [ ] 3.2 Define flat-array `TreeMutationProof` witnesses for rebuilt ancestry, exact splice windows, identity effects, namespace scope, package-shell effects, and dependency invalidations.
+- [ ] 3.3 Reject arbitrary replacement roots and require complete validation when flat-array ancestry cannot prove local invariants.
+- [ ] 3.4 Validate changed subtrees and rebuilt ancestors' local invariants without treating ancestor validation as a descendant-wide scan.
+- [ ] 3.5 Patch duplicate identity and parent checks from the prior validated index without a body-width sibling map.
+- [ ] 3.6 Escalate missing lineage, namespace changes, and unsupported operations to complete validation.
+- [ ] 3.7 Skip package invariant scans only for package-shell-identical text replacement.
+- [ ] 3.8 Prove flat-array scoped validation against complete validation with valid edits, forged proof, invalid XML, duplicate identities, namespace changes, and unsafe package changes.
+- [ ] 3.9 Gate sequence prototyping on zero mismatches across deterministic and randomized validation sequences.
+
+## 4. Public child contract and sequence selection
+
+- [ ] 4.1 Pin `OoxmlNode.children` as a stable frozen `readonly OoxmlNode[]` projection with true `Array.isArray` behavior.
+- [ ] 4.2 Define one authoritative internal child sequence and forbid public projection use by mutation, validation, serialization, and hot internal traversal.
+- [ ] 4.3 Define non-security sequence summaries and exact local path-lineage witnesses for every candidate representation.
+- [ ] 4.4 Prototype persistent vector, chunked rope, and immutable overlay through complete transaction, layout traversal, save, undo, and memory workloads.
+- [ ] 4.5 Test ordered iteration, indexed edits, structural sharing, immutable old revisions, generic fidelity, deterministic serialization, and public projection identity.
+- [ ] 4.6 Test API extraction, package consumers, array methods, enumeration, frozen behavior, and repeated public reads.
+- [ ] 4.7 Compare end-to-end transaction time, sequence nodes, materialized arrays, temporary bytes, save time, and retained heap.
+- [ ] 4.8 Select one representation from measured evidence and record chunking, lineage, projection, and rejection decisions in `design.md`.
+- [ ] 4.9 Stop and propose an explicit major API change if no representation preserves the pinned public contract.
+- [ ] 4.10 Add property-based and randomized sequence differential tests against a flat-array oracle.
+
+## 5. Canonical sequence migration
+
+- [ ] 5.1 Introduce internal sequence traversal, lookup, replace, insert, remove, split, join, cumulative-size, and projection helpers.
+- [ ] 5.2 Migrate `w:body` canonical construction and text-local replacement behind a private rollout flag.
+- [ ] 5.3 Add exact sequence-node lineage checks and summary validation before enabling scoped sequence validation.
+- [ ] 5.4 Differentially compare sequence-scoped and complete validation, including undeclared sibling replacement and inconsistent summaries.
+- [ ] 5.5 Migrate node indexing, serialization, semantic digest, layout story traversal, and binding reads away from hot public projection materialization.
+- [ ] 5.6 Keep low-fanout nodes on flat storage unless measured evidence supports migration.
+- [ ] 5.7 Preserve namespace behavior, unknown elements, source order, unaffected identity, undo, redo, save, reopen, and D9 oracles.
+- [ ] 5.8 Add a warm middle-body insertion gate with zero wide projection materialization and no body-width slot copying.
+
+## 6. Normalized ModelChange and measured sidecars
+
+- [ ] 6.1 Extend `ModelChange` with part-scoped created, deleted, moved, changed, replaced-ancestry, package-shell, dependency, and impact effects.
+- [ ] 6.2 Keep private validation proof inside the store and produce `LayoutChangeSet` from actual layout output.
+- [ ] 6.3 Introduce immutable-tree-owned sidecars with monotonic publication retagging and bounded weak or history ownership.
+- [ ] 6.4 Patch node, parent, paragraph identity, paragraph order, and story-block indexes only where section 1 proves typing-path cost.
+- [ ] 6.5 Add content-control, review, note, field, bookmark, drawing, section, or table sidecars one at a time behind separate measured gates.
+- [ ] 6.6 Keep complete rebuilding for cold and uncommon indexes.
+- [ ] 6.7 Restore or reuse correct tree sidecars during undo and redo without reusing old publication provenance.
+- [ ] 6.8 Release revision-only metadata when history entries expire.
+- [ ] 6.9 Differentially compare every incremental sidecar with complete rebuilding after edits, split, join, table operations, package edits, undo, redo, and rejection.
+- [ ] 6.10 Gate warm typing on zero complete rebuilds for each enabled hot-path sidecar.
+
+## 7. Persistent page and checkpoint directories
+
+- [ ] 7.1 Define layout-owned `InternalLayoutRevision` with model revision, page directory, checkpoint directory, `LayoutChangeSet`, and lazy public projection.
+- [ ] 7.2 Preserve `SemanticLayout.pages` as one stable frozen public array projection and forbid that projection on core typing paths.
+- [ ] 7.3 Expose read-only page accessors to output and an opaque internal revision handle to editor.
+- [ ] 7.4 Define persistent page and checkpoint directory contracts for indexed access, range replacement, cumulative offsets, and structural sharing.
+- [ ] 7.5 Migrate incremental layout checkpoints and page publication behind a private rollout flag.
+- [ ] 7.6 Define `LayoutChangeSet` for changed, created, deleted, remapped, reused, and materialized pages plus dependency changes.
+- [ ] 7.7 Move page shells to normal document flow with explicit dimensions and semantic offsets from the page directory.
+- [ ] 7.8 Patch paragraph-page, table geometry, note reserve, drawing-use, revision-slot, field, and review indexes from actual changed intervals.
+- [ ] 7.9 Remove unconditional page maps, checkpoint-tail copies, reused-page scans, and page-array copies from converged text-local settle.
+- [ ] 7.10 Gate converged settle on changed intervals plus logarithmic directory work.
+- [ ] 7.11 Compare page order, shell flow, page records, checkpoint state, cumulative offsets, and every patched layout index with clean full layout.
+
+## 8. Page-local authoritative paint
+
+- [ ] 8.1 Make settled output consume `LayoutChangeSet` and preserve unchanged page shells, materialized DOM, and source maps by identity.
+- [ ] 8.2 Dependency-key drawing resources, revision slots, note furniture, field display, and review geometry.
+- [ ] 8.3 Remove complete-page maps and shell loops from converged settled paint.
+- [ ] 8.4 Scope selection and caret synchronization to changed fragments while retaining semantic authority.
+- [ ] 8.5 Add incremental-versus-clean paint-plan tests for page creation, deletion, remap, resource changes, and stale materialized DOM.
+- [ ] 8.6 Gate middle-page settle on zero unrelated materialized mutations and zero complete shell-offset rewrites.
+
+## 9. Immutable cooperative layout jobs
+
+- [ ] 9.1 Bind each job to an immutable package snapshot, model revision, scope, and resource fingerprints.
+- [ ] 9.2 Refactor preparation, placement, convergence, page finalization, and dependency patching into DOM-free resumable iterators.
+- [ ] 9.3 Add deadline checks inside long loops instead of only between phases.
+- [ ] 9.4 Inject clock, deadline, continuation scheduler, cancellation owner, and visibility state from the editor lane; use `isInputPending` only as a hint.
+- [ ] 9.5 Use timer continuations in hidden tabs and a deterministic clock and continuation queue in tests.
+- [ ] 9.6 Meet 4 ms p95 and 8 ms maximum reference slices; split or exclude any slower non-yielding leaf.
+- [ ] 9.7 Grant at least one settle slice per 50 ms during sustained input.
+- [ ] 9.8 Keep accumulators private until latest-revision publication.
+- [ ] 9.9 Fingerprint every shared cache write independently of job liveness.
+- [ ] 9.10 Cancel timers, tasks, animation frames, resource callbacks, temporary sequences, and builders in `finally`.
+- [ ] 9.11 Cover newer input, detach, reload, font changes, display-mode changes, zoom, and viewport width changes.
+- [ ] 9.12 Add deterministic fairness, hidden-tab, starvation, cancellation, stale-discard, immutable-input, and latest-only publication tests.
+
+## 10. Provisional candidate records
+
+- [ ] 10.1 Define private `CandidateChange` and record contracts with predecessor revision, paragraph identity and fingerprint, normalized effects, source layout revision, resource fingerprints, source ranges, lines, styles, caret geometry, and ownership evidence.
+- [ ] 10.2 Shape the candidate against exact prior width, style cascade, list, font, HarfBuzz, revision display, and resource fingerprints before commit.
+- [ ] 10.3 Compare candidate shaping with a clean candidate oracle and require only fragment, page, line-break, vertical, and flow geometry to remain unchanged from prior complete layout.
+- [ ] 10.4 Add fail-closed refusal codes for composition, changed shaping, review wrappers, controls, fields, notes, drawings, tables, breaks, resources, and geometry.
+- [ ] 10.5 Commit `CandidateChange` through compare-and-swap across predecessor, paragraph, source layout, normalized effects, and resources.
+- [ ] 10.6 Verify committed `ModelChange` and paragraph fingerprint exactly match the candidate before output installation.
+- [ ] 10.7 Test reentrant measurers, stale predecessors, resource changes, Latin, ligatures, style boundaries, combining marks, ZWJ, emoji flags, bidi controls, wrapping, and fallback fonts.
+- [ ] 10.8 Prove accepted candidate records equal clean full paragraph records.
+
+## 11. Atomic staged-presentation state
+
+- [ ] 11.1 Add private model, layout, display, selection-epoch, input-sequence, and provisional state to `PaginatedSurface`.
+- [ ] 11.2 Commit every accepted `beforeinput` intent separately with mapped selection before provisional presentation.
+- [ ] 11.3 Patch only the owned paragraph DOM and tag it with model, display, layout, and selection provenance.
+- [ ] 11.4 Place the caret from candidate geometry and preserve native-caret fail-soft behavior.
+- [ ] 11.5 Chain later insertion from committed selection and candidate source maps without reading stale DOM.
+- [ ] 11.6 Coalesce only candidate shaping, provisional paint, and complete settle work.
+- [ ] 11.7 Complete synchronous authoritative presentation or freeze editing if provisional installation fails after commit.
+- [ ] 11.8 Atomically adopt or replace provisional DOM during latest complete paint.
+- [ ] 11.9 Cancel or regenerate provisional state for undo, redo, external edits, automation edits, detach, reload, and remount.
+- [ ] 11.10 Suspend editing synchronously on external commits until display catches the external model revision.
+- [ ] 11.11 Queue public `change` then `selectionChange` only after snapshot and display transition complete.
+- [ ] 11.12 Queue reentrant editor mutations after the current surface transition.
+- [ ] 11.13 Add race tests for rejection, stale selection epochs, reentrant handlers, external commits, rapid input, install failure, undo, detach, and stale jobs.
+
+## 12. Barriers, composition, review, accessibility, and hosts
+
+- [ ] 12.1 Implement the approved barrier matrix with revision tokens, mutation queuing, re-hit-testing, and final token checks.
+- [ ] 12.2 Implement input-sequence save linearization without reading provisional or composition DOM.
+- [ ] 12.3 Implement private composition drafts with one `compositionend` commit and full cancellation cleanup.
+- [ ] 12.4 Restore complete latest-revision editable DOM before composition or cancel composition without stale DOM readback.
+- [ ] 12.5 Freeze review activation, rail geometry, table context, object controls, and layout-derived chrome while layout is stale.
+- [ ] 12.6 Disable stale geometry actions until complete latest-revision publication.
+- [ ] 12.7 Preserve one accessible text copy, editor focus, control availability, and assistive-technology selection barriers.
+- [ ] 12.8 Preserve reference-stable complete page snapshots while model-only selectors observe committed state.
+- [ ] 12.9 Verify React, Vue, Pro review, and editor API packages use the core state machine without adapter-owned fast paths.
+- [ ] 12.10 Add browser tests for pointer, arrows, tables, objects, review cards, automation, print, screenshot, export, zoom, resize, save, composition, accessibility, and teardown races.
+
+## 13. Correctness, performance, and memory acceptance
+
+- [ ] 13.1 Add at least 100 isolated attempts across paragraph lengths, caret positions, style boundaries, scripts, and line-edge positions.
+- [ ] 13.2 Add at least 180 unpaced sustained characters and 100 Hz burst tests for exact order, per-intent history, selection epochs, final caret, save, and reopen.
+- [ ] 13.3 Report every attempted fast path, including eligibility decision time and refusal reason.
+- [ ] 13.4 Add a private benchmark event stream keyed by input sequence; never use public `change` as the presentation marker.
+- [ ] 13.5 Verify expected text, caret, model revision, display revision, and layout revision before recording presentation.
+- [ ] 13.6 Pin the ordinary-typing corpus hash before measuring its eligibility rate.
+- [ ] 13.7 Meet 16.7 ms median and 33.4 ms p95 eligible presentation on the maintained reference profile.
+- [ ] 13.8 Achieve at least 80% eligibility on the pinned ordinary-typing corpus.
+- [ ] 13.9 Keep ineligible p95 within 10% of its recorded synchronous baseline.
+- [ ] 13.10 Add large-document incremental-versus-full canonical, layout, paint, selection, review, save, reopen, and security oracles.
+- [ ] 13.11 Reach quiescence, force baseline collection, execute 1,000 edits beyond history capacity, reach quiescence, then measure three forced collection cycles.
+- [ ] 13.12 Keep retained growth below the greater of 32 MiB or 10% of opened-document baseline heap.
+- [ ] 13.13 Prove cancelled jobs release callbacks, buffers, accumulators, sequences, and builders without stale cache writes.
+- [ ] 13.14 Keep shared-runner absolute timing informational while enforcing structural and correctness gates.
+
+## 14. Rollout and repository gates
+
+- [ ] 14.1 Place validation lineage, child sequence, sidecars, page directories, local paint, scheduler, and staged presentation behind independent private flags.
+- [ ] 14.2 Enable each flag only after its differential, security, memory, API compatibility, and structural work gates pass.
+- [ ] 14.3 Enable staged presentation by default only after 80% eligibility, zero correctness events, and all reference budgets pass.
+- [ ] 14.4 Update benchmark documentation with the reference machine, browser, metrics, markers, corpus, refusal reporting, and baseline rules.
+- [ ] 14.5 Add a consumer-facing changeset after staged presentation becomes default without claiming support for optimized deferred features.
+- [ ] 14.6 Run focused store, layout, output, surface, adapter, browser, serial DOM-leak, benchmark, and strict OpenSpec checks.
+- [ ] 14.7 Run `bun run format`, `bun run typecheck`, `bun run lint`, `bun run test`, `bun run check:parity`, `bun run api:check`, and `bun run i18n:validate`.
+- [ ] 14.8 Compare every result with the recorded non-clean baseline and separate pre-existing failures from regressions.
+- [ ] 14.9 Remove rollout flags only after one release cycle without correctness fallback events and with tested rollback paths.


### PR DESCRIPTION
## Summary

- Define bounded canonical mutation and settled layout work for large documents.
- Specify canonical-first provisional typing with revision, safety, and acceptance gates.

## Test plan

- [x] `openspec validate sub-frame-large-document-typing --strict`
- [x] Pre-commit type, API, format, and lint checks

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789911011&installation_model_id=422592&pr_number=376&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F376&signature=eaa89bf2492128c00f1366cb28019b82a34a4480961763514ff94f116c8a67cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->