### PR TITLE
fix(build): give each pro bundle its own build metafile

### DIFF
--- a/.changeset/pro-metafile-collision.md
+++ b/.changeset/pro-metafile-collision.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Derive the third-party notice for `@docx-editor.dev/pro` from every bundle it ships, not only the Vue one.

--- a/packages/pro/package.json
+++ b/packages/pro/package.json
@@ -29,7 +29,7 @@
     "THIRD_PARTY_NOTICES.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsup",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.vue.json",
     "license:check": "license-check-and-add check -f license-check.json",
     "license:add": "license-check-and-add add -f license-check.json"

--- a/packages/pro/tsup.config.ts
+++ b/packages/pro/tsup.config.ts
@@ -1,14 +1,83 @@
-import { defineConfig } from 'tsup';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type Options } from 'tsup';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Write this build's metafile under a name of its own.
+ *
+ * tsup runs an array config CONCURRENTLY (`Promise.all`) and names the file it writes
+ * after the format alone — `dist/metafile-${format}.json`. Two configs that share a
+ * format therefore write the same two paths at the same time. The usual outcome is a
+ * clobber: whichever build finishes last owns the file, and the other build's inputs
+ * vanish from the record `scripts/generate-third-party-notices.mjs` reads. The
+ * occasional outcome is worse — the two writes interleave and the file is not JSON at
+ * all, which fails the notices gate and blocks the release.
+ *
+ * So only the first config lets tsup write the metafile. This build asks esbuild for
+ * one (`options.metafile` below) and writes it here, under a name no other config in
+ * the array claims. The generator globs `metafile-*.json`, so it reads both.
+ */
+const writeMetafileAs = (prefix: string): NonNullable<Options['esbuildPlugins']>[number] => {
+  // tsup reuses one plugin object for every format it builds from a config, so this
+  // closure sees them all. It is the guard that keeps the bug above from coming back
+  // by another route: two builds that resolve to the same name fail here, loudly,
+  // instead of overwriting each other.
+  const written = new Set<string>();
+  return {
+    name: `write-metafile-as-${prefix}`,
+    setup(build) {
+      build.onEnd(async (result) => {
+        // esbuild fills this in only because `esbuildOptions` asks it to. A config that
+        // wires up this plugin and forgets that line would write nothing and say
+        // nothing, so it fails instead.
+        if (!result.metafile) {
+          throw new Error(
+            `${prefix}: esbuild produced no metafile. Set \`options.metafile = true\` in ` +
+              "this config's `esbuildOptions`, or the third-party notice for this build " +
+              'is derived from nothing.'
+          );
+        }
+        // The build's own output extension, not its format. tsup builds CJS by asking
+        // esbuild for ESM and converting afterwards whenever `splitting` or `treeshake`
+        // is on, so `initialOptions.format` reads `esm` for BOTH builds here — the
+        // extension map is the one thing that still tells them apart.
+        const extension = build.initialOptions.outExtension?.['.js'];
+        if (!extension) {
+          throw new Error(
+            `${prefix}: tsup set no output extension for this build, so its metafile has ` +
+              'no name that another build cannot claim.'
+          );
+        }
+        const name = `metafile-${prefix}-${extension.replace('.', '')}.json`;
+        if (written.has(name)) {
+          throw new Error(
+            `${prefix}: two builds both want to write dist/${name}. One would overwrite ` +
+              "the other, and the notice would describe less than the package ships."
+          );
+        }
+        written.add(name);
+        const dist = resolve(here, 'dist');
+        await mkdir(dist, { recursive: true });
+        await writeFile(resolve(dist, name), JSON.stringify(result.metafile), 'utf8');
+      });
+    },
+  };
+};
 
 const shared = {
   platform: 'browser' as const,
   format: ['cjs', 'esm'] as ('cjs' | 'esm')[],
   splitting: true,
   sourcemap: false,
+  // Neither build may clean: the two run at once, so a `clean` here would delete the
+  // other build's output. The package `build` script empties `dist/` before tsup
+  // starts, which is the only ordering tsup actually guarantees.
   clean: false,
   treeshake: true,
   minify: true,
-  metafile: true,
   external: [
     '@docx-editor.dev/core',
     '@docx-editor.dev/i18n',
@@ -28,11 +97,12 @@ export default defineConfig([
       'react/index': 'src/react/index.ts',
     },
     dts: true,
-    clean: true,
+    // The one config in this array that may let tsup name the file. See
+    // `writeMetafileAs`.
+    metafile: true,
   },
   {
     ...shared,
-    clean: false,
     entry: {
       'vue/index': 'src/vue/index.ts',
     },
@@ -42,9 +112,16 @@ export default defineConfig([
         jsxImportSource: 'vue',
       },
     },
+    // Off, so tsup does not write `dist/metafile-${format}.json` over the build above.
+    // The plugin writes `dist/metafile-vue-${format}.json` instead.
+    metafile: false,
+    esbuildPlugins: [writeMetafileAs('vue')],
     esbuildOptions(options) {
       options.jsx = 'automatic';
       options.jsxImportSource = 'vue';
+      // Asks esbuild for the metafile that `writeMetafileAs` writes. tsup's own
+      // `metafile` option only decides whether TSUP writes one.
+      options.metafile = true;
     },
   },
 ]);

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -122,6 +122,31 @@ function licenseIdOf(manifest) {
   return null;
 }
 
+/**
+ * Every JavaScript bundle in this package's `dist/`, keyed the way esbuild keys its
+ * `outputs`: a path relative to the package, with forward slashes.
+ *
+ * Only executable output counts. Declarations carry no third-party code, and assets
+ * (`harfbuzz.wasm`, `editor.css`, the font files) reach `dist/` by a copy step no
+ * metafile describes.
+ */
+function shippedBundles(dir) {
+  const bundles = [];
+  const walk = (current) => {
+    for (const item of readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, item.name);
+      if (item.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!/\.(?:js|cjs|mjs)$/.test(item.name)) continue;
+      bundles.push(path.relative(dir, full).split(path.sep).join('/'));
+    }
+  };
+  walk(path.join(dir, 'dist'));
+  return bundles.sort();
+}
+
 /** Every third-party package esbuild inlined into this package's bundles. */
 function bundledDependencies({ dir, entry }) {
   const dist = path.join(dir, 'dist');
@@ -145,9 +170,22 @@ function bundledDependencies({ dir, entry }) {
   }
 
   const found = new Map();
+  const accountedFor = new Set();
   for (const metafile of metafiles) {
-    const { inputs } = JSON.parse(readFileSync(path.join(dist, metafile), 'utf8'));
-    for (const input of Object.keys(inputs)) {
+    let build;
+    try {
+      build = JSON.parse(readFileSync(path.join(dist, metafile), 'utf8'));
+    } catch (error) {
+      problems.push(
+        `${entry}: dist/${metafile} is not valid JSON (${error.message}) — tsup names this ` +
+          `file after the build FORMAT alone, so two configs in one array config that share ` +
+          `a format write the same path at the same time and can interleave. Give one of ` +
+          `them a name of its own; \`writeMetafileAs\` in packages/pro/tsup.config.ts does that`
+      );
+      continue;
+    }
+    for (const output of Object.keys(build.outputs ?? {})) accountedFor.add(output);
+    for (const input of Object.keys(build.inputs)) {
       if (!input.includes('node_modules')) continue;
       // esbuild writes inputs relative to the build's cwd, which is the package.
       const owner = owningPackage(path.resolve(dir, input));
@@ -160,6 +198,19 @@ function bundledDependencies({ dir, entry }) {
       if (name.startsWith(WORKSPACE_SCOPE)) continue;
       found.set(`${name}@${version}`, { ...owner.manifest, dir: owner.dir });
     }
+  }
+
+  // A metafile that lost a race is still valid JSON — it just describes one build
+  // instead of two, and the notice comes out short with nothing to say so. Every
+  // shipped bundle has to appear in some metafile's `outputs`, or the list above is
+  // derived from less than the package ships.
+  for (const bundle of shippedBundles(dir)) {
+    if (accountedFor.has(bundle)) continue;
+    problems.push(
+      `${entry}: ${bundle} ships but appears in no dist/metafile-*.json, so nothing ` +
+        `records what it inlined. Either its build does not write a metafile, or two ` +
+        `builds wrote the same metafile-<format>.json and one overwrote the other`
+    );
   }
 
   // Plain comparison, not `localeCompare`: collation is locale-dependent (a


### PR DESCRIPTION
The release of 2.7.0 failed at `bun run notices:generate`, in both the CI `build` job and the `Release` prepublish gate:

```
SyntaxError: JSON Parse error: Unable to parse JSON string
  at bundledDependencies (scripts/generate-third-party-notices.mjs:149)
```

## Cause

tsup names the metafile it writes after the build format alone, `dist/metafile-${format}.json`, and it runs an array config concurrently. Both configs in `packages/pro/tsup.config.ts` declared `format: ['cjs', 'esm']`, so four builds wrote two paths at the same time.

Usually one build wins and the file stays valid, which is why this run is the first to fail. A passing run is wrong too: both metafiles in a local build describe only `dist/vue/index.*`, so the notice for `@docx-editor.dev/pro` is derived from one of its three entries. Sometimes the two writes interleave, the file is not JSON, and the gate fails.

## Fix

The Vue build writes `dist/metafile-vue-<ext>.json` from a plugin of its own, so no two builds claim a name. The extension is the discriminator, not the format: tsup builds CJS by asking esbuild for ESM whenever `splitting` or `treeshake` is on, so `initialOptions.format` reads `esm` for both builds. A `Set` in the plugin fails the build if two builds ever resolve to the same name again.

`clean` moves out of the configs and into the package `build` script, the way `packages/core` does it, because a `clean` in one config deletes the other config's output.

Two changes to `scripts/generate-third-party-notices.mjs`:

- An unparseable metafile reports the package and the file, with the cause, instead of throwing a raw stack.
- Every shipped `.js`, `.cjs`, and `.mjs` file must appear in some metafile's `outputs`. That catches the silent half of this bug, where the metafile is valid but describes less than the package ships.

## Verification

`bun run build:packages` then `bun run notices:generate` passes for all seven packages. `packages/pro/dist` now holds four metafiles covering `index`, `react/index`, and `vue/index` in both formats. Removing one, and corrupting another, makes the generator report both new errors. `bun run typecheck`, `bun run lint`, `bun run format`, `bun run check:package-artifacts`, and `bun run check:package-size` pass. The tarball still excludes every metafile.

Version 2.7.0 never reached npm, which is at 2.6.1. After this lands, the `Release` workflow re-runs on main and publishes it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789911363&installation_model_id=422592&pr_number=377&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F377&signature=391c5828db53f3095419c288fd39e43bf66f4accfbf53a4bfd06922edd9c0295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->