### PR TITLE
feat(core): ship Word's built-in styles on a blank document

### DIFF
--- a/.changeset/blank-document-styles.md
+++ b/.changeset/blank-document-styles.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-A blank document now ships Word's built-in style gallery, so the style picker offers Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing and List Paragraph. Turning on a list applies List Paragraph the way Word does, which closes the space between consecutive items.
+A blank document now ships Word's built-in style gallery, so the style picker offers Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing, and List Paragraph. Turning a list on applies List Paragraph the way Word does, which closes the space between consecutive items and leaves the paragraph indented when you turn the list back off.

--- a/.changeset/blank-document-styles.md
+++ b/.changeset/blank-document-styles.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-A blank document now ships Word's built-in style gallery — Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing and List Paragraph — so the style picker offers what Word offers. Turning on a bulleted or numbered list applies List Paragraph the way Word does, which closes the space between consecutive list items.
+A blank document now ships Word's built-in style gallery, so the style picker offers Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing and List Paragraph. Turning on a list applies List Paragraph the way Word does, which closes the space between consecutive items.

--- a/.changeset/blank-document-styles.md
+++ b/.changeset/blank-document-styles.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+A blank document now ships Word's built-in style gallery — Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing and List Paragraph — so the style picker offers what Word offers. Turning on a bulleted or numbered list applies List Paragraph the way Word does, which closes the space between consecutive list items.

--- a/.changeset/contextual-spacing-incremental.md
+++ b/.changeset/contextual-spacing-incremental.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fixed `w:contextualSpacing` going stale while you edit. Adding a paragraph below the last one of a styled run now removes that paragraph's space-after straight away, instead of keeping it until the document was reopened. This is what makes list items close up as you type them.
+Fixed list items and other same-style paragraphs not closing up until you reopened the document.

--- a/.changeset/contextual-spacing-incremental.md
+++ b/.changeset/contextual-spacing-incremental.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixed `w:contextualSpacing` going stale while you edit. Adding a paragraph below the last one of a styled run now removes that paragraph's space-after straight away, instead of keeping it until the document was reopened. This is what makes list items close up as you type them.

--- a/.changeset/style-picker-heading-labels.md
+++ b/.changeset/style-picker-heading-labels.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+The style picker now labels built-in headings `Heading 4` through `Heading 9` instead of the lowercase name Word writes into `styles.xml`.

--- a/docs/site/content/guides/loading-and-saving.mdx
+++ b/docs/site/content/guides/loading-and-saving.mdx
@@ -31,8 +31,9 @@ The editor takes the document through the `document` prop. The most common value
 ### Starting empty
 
 To open the editor on an empty page, pass `'blank'`. It is Word's blank template, with the
-same Calibri 11pt defaults a new document in Word has, and Word's built-in style gallery:
-Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing, and List Paragraph.
+same Calibri 11pt defaults a new document in Word has. It also carries Word's built-in
+style gallery: Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing, and List
+Paragraph.
 
 <FrameworkTabs>
 <Framework value="react">

--- a/docs/site/content/guides/loading-and-saving.mdx
+++ b/docs/site/content/guides/loading-and-saving.mdx
@@ -31,7 +31,8 @@ The editor takes the document through the `document` prop. The most common value
 ### Starting empty
 
 To open the editor on an empty page, pass `'blank'`. It is Word's blank template, with the
-same Calibri 11pt defaults a new document in Word has:
+same Calibri 11pt defaults a new document in Word has, and Word's built-in style gallery:
+Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing, and List Paragraph.
 
 <FrameworkTabs>
 <Framework value="react">

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -295,7 +295,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'The toolbar toggle creates the numbering definition on first use, so a document that never carried a list can start one. It also applies the List Paragraph style, the way Word does, which is what closes the space between consecutive items. Tab and the indent buttons change the level, and the marker changes with it.',
+      'The toolbar toggle creates the numbering definition on first use, so a document that never carried a list can start one. It also applies the List Paragraph style, the way Word does, which is what closes the space between consecutive items. Turning the list off leaves the paragraph in List Paragraph, and indented, as Word does; pressing Enter on an empty item leaves the list and returns to the margin. Tab and the indent buttons change the level, and the marker changes with it.',
   },
   {
     id: 'lists.numbered',
@@ -305,6 +305,8 @@ export const wordFeatures: WordFeature[] = [
     rendering: 'full',
     roundTrip: 'full',
     tier: 'community',
+    notes:
+      'Numbered lists take the List Paragraph style on the same terms as bulleted ones, so consecutive items close up.',
   },
   {
     id: 'lists.custom-numbering',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -295,7 +295,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'The toolbar toggle creates the numbering definition on first use, so a document that never carried a list can start one. Tab and the indent buttons change the level, and the marker changes with it.',
+      'The toolbar toggle creates the numbering definition on first use, so a document that never carried a list can start one. It also applies the List Paragraph style, the way Word does, which is what closes the space between consecutive items. Tab and the indent buttons change the level, and the marker changes with it.',
   },
   {
     id: 'lists.numbered',

--- a/packages/core/src/editor/__tests__/blank-document-styles.test.ts
+++ b/packages/core/src/editor/__tests__/blank-document-styles.test.ts
@@ -11,7 +11,7 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
 import { blankDocumentBytes } from '../blank-document.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
@@ -45,12 +45,28 @@ function docx(styles: string, body: string): Uint8Array {
   });
 }
 
+/** Torn down after each test: a container left on `document` leaks into the serial run. */
+const mounted: { editor: DocxEditorInstance; container: HTMLElement }[] = [];
+
+afterEach(() => {
+  for (const entry of mounted.splice(0)) {
+    entry.editor.destroy();
+    entry.container.remove();
+  }
+});
+
 function mount(bytes: Uint8Array): { editor: DocxEditorInstance; surface: PaginatedSurface } {
   const container = document.createElement('div');
   document.body.append(container);
   const editor = createDocxEditor({ container, document: bytes });
+  mounted.push({ editor, container });
   if (!editor.surface) throw new Error('surface failed to mount');
   return { editor, surface: editor.surface };
+}
+
+/** The painted left edge of each block on page 1, in points. */
+function blockLefts(surface: PaginatedSurface): number[] {
+  return surface.layout().pages[0]!.fragments.map((fragment) => fragment.box.x);
 }
 
 /** Select from the start of one paragraph to the end of another, by document order. */
@@ -135,12 +151,12 @@ describe('toggleList applies List Paragraph, as Word does', () => {
     selectParagraphs(surface, 0, 1);
     expect(surface.toggleList('bullet')).toBe(true);
 
-    const document = await savedDocument(editor);
-    expect(document).toContain(
+    const saved = await savedDocument(editor);
+    expect(saved).toContain(
       '<w:pPr><w:pStyle w:val="ListParagraph"/><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>one</w:t></w:r>'
     );
     // The paragraph the list does NOT cover keeps the defaults, with no style of its own.
-    expect(document).toContain('<w:p w14:paraId="67A062B7" w14:textId="67A062B7"><w:r>');
+    expect(saved).toMatch(/<w:p [^>]*><w:r><w:t>after<\/w:t>/);
 
     // One line each. The first item drops its 8pt space-after because the item under it is
     // the same style; the last item keeps it, because "after" is not.
@@ -149,15 +165,62 @@ describe('toggleList applies List Paragraph, as Word does', () => {
     expect(third).toBe(second);
   });
 
+  test('a numbered list gets the style too', async () => {
+    const { editor, surface } = mount(blankDocumentBytes());
+    surface.type('one');
+    surface.splitParagraph();
+    surface.type('two');
+    selectParagraphs(surface, 0, 1);
+    expect(surface.toggleList('ordered')).toBe(true);
+
+    const saved = await savedDocument(editor);
+    expect(saved.match(/<w:pStyle w:val="ListParagraph"\/>/g)).toHaveLength(2);
+    const [first, second] = blockHeights(surface);
+    expect(second! - first!).toBe(8);
+  });
+
+  test('a paragraph explicitly in the DEFAULT style is restyled, as Word does', async () => {
+    // The shape a converter writes: every paragraph stamped `<w:pStyle w:val="Normal"/>`.
+    // Reading that as "authors a style of its own" left every converted file 8pt apart.
+    const { editor, surface } = mount(blankDocumentBytes());
+    surface.type('one');
+    surface.splitParagraph();
+    surface.type('two');
+    selectParagraphs(surface, 0, 1);
+    expect(editor.exec({ type: 'setParagraphStyle', styleId: 'Normal' }).ok).toBe(true);
+    expect(surface.toggleList('bullet')).toBe(true);
+
+    const saved = await savedDocument(editor);
+    expect(saved.match(/<w:pStyle w:val="ListParagraph"\/>/g)).toHaveLength(2);
+    expect(saved).not.toContain('<w:pStyle w:val="Normal"/>');
+    const [first, second] = blockHeights(surface);
+    expect(second! - first!).toBe(8);
+  });
+
   test('bulleting a heading leaves it a heading', async () => {
     const { editor, surface } = mount(blankDocumentBytes());
     surface.type('a heading');
     expect(editor.exec({ type: 'setParagraphStyle', styleId: 'Heading1' }).ok).toBe(true);
     expect(surface.toggleList('bullet')).toBe(true);
 
-    const document = await savedDocument(editor);
-    expect(document).toContain('<w:pStyle w:val="Heading1"/>');
-    expect(document).not.toContain('ListParagraph');
+    const saved = await savedDocument(editor);
+    expect(saved).toContain('<w:pStyle w:val="Heading1"/>');
+    expect(saved).not.toContain('ListParagraph');
+  });
+
+  test('Enter on an empty item leaves the list AND returns to the margin', async () => {
+    const { editor, surface } = mount(blankDocumentBytes());
+    surface.type('one');
+    expect(surface.toggleList('bullet')).toBe(true);
+    surface.splitParagraph();
+    // The second item is empty, so this is Word's "I am done with this list".
+    expect(surface.exitListOnEmptyItem()).toBe(true);
+
+    const saved = await savedDocument(editor);
+    // The item keeps the style; the paragraph that left the list sheds it, or it would sit
+    // half an inch in with no marker beside it.
+    expect(saved.match(/<w:pStyle w:val="ListParagraph"\/>/g)).toHaveLength(1);
+    expect(blockLefts(surface)).toEqual([36, 0]);
   });
 
   test('turning the list back off keeps the style, as Word does', async () => {
@@ -166,9 +229,9 @@ describe('toggleList applies List Paragraph, as Word does', () => {
     expect(surface.toggleList('bullet')).toBe(true);
     expect(surface.toggleList('bullet')).toBe(true);
 
-    const document = await savedDocument(editor);
-    expect(document).toContain('<w:pStyle w:val="ListParagraph"/>');
-    expect(document).not.toContain('<w:numPr>');
+    const saved = await savedDocument(editor);
+    expect(saved).toContain('<w:pStyle w:val="ListParagraph"/>');
+    expect(saved).not.toContain('<w:numPr>');
   });
 
   test('a document defining no List Paragraph style still bullets, with no dangling pStyle', async () => {
@@ -180,9 +243,9 @@ describe('toggleList applies List Paragraph, as Word does', () => {
     );
     expect(surface.toggleList('bullet')).toBe(true);
 
-    const document = await savedDocument(editor);
-    expect(document).toContain('<w:numPr>');
-    expect(document).not.toContain('<w:pStyle');
+    const saved = await savedDocument(editor);
+    expect(saved).toContain('<w:numPr>');
+    expect(saved).not.toContain('<w:pStyle');
   });
 
   test('the style is found by NAME when the file spells the id its own way', async () => {

--- a/packages/core/src/editor/__tests__/blank-document-styles.test.ts
+++ b/packages/core/src/editor/__tests__/blank-document-styles.test.ts
@@ -197,6 +197,24 @@ describe('toggleList applies List Paragraph, as Word does', () => {
     expect(second! - first!).toBe(8);
   });
 
+  test('pressing Bullets FIRST and then typing closes the items up too', () => {
+    // The gesture a user actually makes, and the one the selection-then-toggle tests miss:
+    // every item after the first arrives by splitting the one above it, so the paragraph
+    // ABOVE has to lose the space-after it was laid out with when it was still the last.
+    const { surface } = mount(blankDocumentBytes());
+    expect(surface.toggleList('bullet')).toBe(true);
+    surface.type('one');
+    surface.splitParagraph();
+    surface.type('two');
+    surface.splitParagraph();
+    surface.type('three');
+
+    // Only the last item keeps the 8pt, because nothing of the same style follows it.
+    const [first, second, third] = blockHeights(surface);
+    expect(first).toBe(second);
+    expect(third! - second!).toBe(8);
+  });
+
   test('bulleting a heading leaves it a heading', async () => {
     const { editor, surface } = mount(blankDocumentBytes());
     surface.type('a heading');

--- a/packages/core/src/editor/__tests__/blank-document-styles.test.ts
+++ b/packages/core/src/editor/__tests__/blank-document-styles.test.ts
@@ -1,0 +1,200 @@
+// The blank template's style gallery, and the list gesture that depends on it.
+//
+// Word keeps its built-in styles LATENT in a new document and writes the definition the
+// first time one is used. Nothing here can materialize a latent style, so the template
+// has to ship them — otherwise a New document offers one style and cannot make a heading.
+//
+// List Paragraph is the one with a visible second job: `w:contextualSpacing` is what
+// closes the 8pt gap BETWEEN consecutive list items, and `toggleList` applies the style
+// the way Word's own list gesture does.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { blankDocumentBytes } from '../blank-document.ts';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import type { PaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const STY = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+function docx(styles: string, body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId2" Type="${STY}" Target="styles.xml"/></Relationships>`
+    ),
+    'word/styles.xml': strToU8(`<w:styles xmlns:w="${W}">${styles}</w:styles>`),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function mount(bytes: Uint8Array): { editor: DocxEditorInstance; surface: PaginatedSurface } {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: bytes });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return { editor, surface: editor.surface };
+}
+
+/** Select from the start of one paragraph to the end of another, by document order. */
+function selectParagraphs(surface: PaginatedSurface, first: number, last: number): void {
+  const ids = surface.session.paragraphIds();
+  surface.setSelection({
+    anchor: { paragraphId: ids[first]!, offset: 0 },
+    head: { paragraphId: ids[last]!, offset: 0 },
+  });
+}
+
+/** The painted height of each block on page 1, in points. */
+function blockHeights(surface: PaginatedSurface): number[] {
+  return surface
+    .layout()
+    .pages[0]!.fragments.map((fragment) => Math.round(fragment.box.height * 100) / 100);
+}
+
+async function savedDocument(editor: DocxEditorInstance): Promise<string> {
+  const files = unzipSync(new Uint8Array(await editor.save()));
+  return strFromU8(files['word/document.xml']!);
+}
+
+describe("the blank template's style gallery", () => {
+  test("it defines Word's built-in styles, in Word's gallery order", () => {
+    const { editor } = mount(blankDocumentBytes());
+    const paragraphStyles = editor
+      .getDocumentStyles()
+      .filter((style) => style.type === 'paragraph')
+      .map((style) => style.styleId);
+
+    // Order is the gallery's, not the file's: Normal, Title, Subtitle, then the headings.
+    expect(paragraphStyles).toEqual([
+      'Normal',
+      'Title',
+      'Subtitle',
+      'Heading1',
+      'Heading2',
+      'Heading3',
+      'Heading4',
+      'Heading5',
+      'Heading6',
+      'Heading7',
+      'Heading8',
+      'Heading9',
+      'Quote',
+      'NoSpacing',
+      'ListParagraph',
+    ]);
+  });
+
+  test('the default character, table and numbering styles ship too', () => {
+    const { editor } = mount(blankDocumentBytes());
+    const byType = new Map(
+      editor.getDocumentStyles().map((style) => [style.type, style.styleId] as const)
+    );
+    expect(byType.get('character')).toBe('DefaultParagraphFont');
+    expect(byType.get('table')).toBe('TableNormal');
+    expect(byType.get('numbering')).toBe('NoList');
+  });
+
+  test('a heading is pickable on a New document and paints at its own size', () => {
+    const { editor, surface } = mount(blankDocumentBytes());
+    surface.type('a heading');
+    const plain = blockHeights(surface)[0]!;
+
+    expect(editor.exec({ type: 'setParagraphStyle', styleId: 'Heading1' }).ok).toBe(true);
+    // 16pt text where the default is 11pt: the line has to grow.
+    expect(blockHeights(surface)[0]!).toBeGreaterThan(plain);
+  });
+});
+
+describe('toggleList applies List Paragraph, as Word does', () => {
+  test('consecutive items close up and the list keeps its space against what follows', async () => {
+    const { editor, surface } = mount(blankDocumentBytes());
+    surface.type('one');
+    surface.splitParagraph();
+    surface.type('two');
+    surface.splitParagraph();
+    surface.type('after');
+
+    selectParagraphs(surface, 0, 1);
+    expect(surface.toggleList('bullet')).toBe(true);
+
+    const document = await savedDocument(editor);
+    expect(document).toContain(
+      '<w:pPr><w:pStyle w:val="ListParagraph"/><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>one</w:t></w:r>'
+    );
+    // The paragraph the list does NOT cover keeps the defaults, with no style of its own.
+    expect(document).toContain('<w:p w14:paraId="67A062B7" w14:textId="67A062B7"><w:r>');
+
+    // One line each. The first item drops its 8pt space-after because the item under it is
+    // the same style; the last item keeps it, because "after" is not.
+    const [first, second, third] = blockHeights(surface);
+    expect(second! - first!).toBe(8);
+    expect(third).toBe(second);
+  });
+
+  test('bulleting a heading leaves it a heading', async () => {
+    const { editor, surface } = mount(blankDocumentBytes());
+    surface.type('a heading');
+    expect(editor.exec({ type: 'setParagraphStyle', styleId: 'Heading1' }).ok).toBe(true);
+    expect(surface.toggleList('bullet')).toBe(true);
+
+    const document = await savedDocument(editor);
+    expect(document).toContain('<w:pStyle w:val="Heading1"/>');
+    expect(document).not.toContain('ListParagraph');
+  });
+
+  test('turning the list back off keeps the style, as Word does', async () => {
+    const { editor, surface } = mount(blankDocumentBytes());
+    surface.type('one');
+    expect(surface.toggleList('bullet')).toBe(true);
+    expect(surface.toggleList('bullet')).toBe(true);
+
+    const document = await savedDocument(editor);
+    expect(document).toContain('<w:pStyle w:val="ListParagraph"/>');
+    expect(document).not.toContain('<w:numPr>');
+  });
+
+  test('a document defining no List Paragraph style still bullets, with no dangling pStyle', async () => {
+    const { editor, surface } = mount(
+      docx(
+        '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>',
+        '<w:p><w:r><w:t>one</w:t></w:r></w:p>'
+      )
+    );
+    expect(surface.toggleList('bullet')).toBe(true);
+
+    const document = await savedDocument(editor);
+    expect(document).toContain('<w:numPr>');
+    expect(document).not.toContain('<w:pStyle');
+  });
+
+  test('the style is found by NAME when the file spells the id its own way', async () => {
+    const { editor, surface } = mount(
+      docx(
+        '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>' +
+          '<w:style w:type="paragraph" w:styleId="a3"><w:name w:val="List Paragraph"/>' +
+          '<w:pPr><w:contextualSpacing/></w:pPr></w:style>',
+        '<w:p><w:r><w:t>one</w:t></w:r></w:p>'
+      )
+    );
+    expect(surface.toggleList('bullet')).toBe(true);
+    expect(await savedDocument(editor)).toContain('<w:pStyle w:val="a3"/>');
+  });
+});

--- a/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
+++ b/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
@@ -5,12 +5,9 @@
 // end, on a platform where nothing the document names is installed:
 //
 // - a brand-new blank document reports nothing. It DECLARES Calibri (Word's blank-template
-//   `w:docDefaults`) and Calibri Light (its built-in headings) over a single empty
-//   paragraph, and a declaration paints no glyph.
-// - the first typed character reports them. The gate is "no text rendered", never "this
-//   document is exempt", so a real fidelity loss is never hidden. It is one gate for the
-//   whole document, not one per family: the notice reports what is DECLARED, which for
-//   any real Word file includes faces its styles part names and its body never uses.
+//   `w:docDefaults`) over a single empty paragraph, and a declaration paints no glyph.
+// - the first typed character reports it. The gate is "no text rendered", never "this
+//   document is exempt", so a real fidelity loss is never hidden.
 // - a family whose metric-compatible twin IS installed reports nothing, because the stack
 //   both measurement and paint use falls through to it and the metrics are identical.
 
@@ -81,11 +78,7 @@ describe('font substitution notice', () => {
     });
     expect(editor.snapshot().fontSubstitutions ?? []).toEqual([]);
     expect(editor.exec({ type: 'insertText', text: 'X' })).toEqual({ ok: true, changed: true });
-    // BOTH families the template declares: Calibri from `w:docDefaults`, and the Calibri
-    // Light its built-in headings name. What the notice reports is what the document
-    // DECLARES, gated on whether it renders anything at all — the same answer it gives
-    // for a real Word file, whose styles part declares faces the body text never uses.
-    expect(editor.snapshot().fontSubstitutions ?? []).toEqual(['Calibri', 'Calibri Light']);
+    expect(editor.snapshot().fontSubstitutions ?? []).toEqual(['Calibri']);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
+++ b/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
@@ -5,9 +5,12 @@
 // end, on a platform where nothing the document names is installed:
 //
 // - a brand-new blank document reports nothing. It DECLARES Calibri (Word's blank-template
-//   `w:docDefaults`) over a single empty paragraph, and a declaration paints no glyph.
-// - the first typed character reports it. The gate is "no text rendered", never "this
-//   document is exempt", so a real fidelity loss is never hidden.
+//   `w:docDefaults`) and Calibri Light (its built-in headings) over a single empty
+//   paragraph, and a declaration paints no glyph.
+// - the first typed character reports them. The gate is "no text rendered", never "this
+//   document is exempt", so a real fidelity loss is never hidden. It is one gate for the
+//   whole document, not one per family: the notice reports what is DECLARED, which for
+//   any real Word file includes faces its styles part names and its body never uses.
 // - a family whose metric-compatible twin IS installed reports nothing, because the stack
 //   both measurement and paint use falls through to it and the metrics are identical.
 
@@ -78,7 +81,11 @@ describe('font substitution notice', () => {
     });
     expect(editor.snapshot().fontSubstitutions ?? []).toEqual([]);
     expect(editor.exec({ type: 'insertText', text: 'X' })).toEqual({ ok: true, changed: true });
-    expect(editor.snapshot().fontSubstitutions ?? []).toEqual(['Calibri']);
+    // BOTH families the template declares: Calibri from `w:docDefaults`, and the Calibri
+    // Light its built-in headings name. What the notice reports is what the document
+    // DECLARES, gated on whether it renders anything at all — the same answer it gives
+    // for a real Word file, whose styles part declares faces the body text never uses.
+    expect(editor.snapshot().fontSubstitutions ?? []).toEqual(['Calibri', 'Calibri Light']);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/blank-document.ts
+++ b/packages/core/src/editor/blank-document.ts
@@ -69,6 +69,11 @@ const DOCUMENT_RELS =
  * hex Word paints (accent1 darker 25% and 50%, then near-black for the last pair), and
  * only Heading 1 opening with a full line of space above it.
  *
+ * Literal hex, not `w:themeColor`, for the same reason the fonts are literal: no theme
+ * part ships here, so a theme reference would resolve to nothing. The cost is that these
+ * headings do not follow a theme the user picks after opening the file in Word. Write them
+ * as theme references once this template carries a `theme1.xml`.
+ *
  * Sizes are half-points, and a level with none inherits the 11pt run default — which is
  * what Word's Heading 4 to Heading 7 do.
  */

--- a/packages/core/src/editor/blank-document.ts
+++ b/packages/core/src/editor/blank-document.ts
@@ -53,12 +53,16 @@ const DOCUMENT_RELS =
   `<Relationship Id="rId1" Type="${STYLES_REL}" Target="styles.xml"/>` +
   `</Relationships>`;
 
-// The heading font. Word's built-in headings name the theme's MAJOR typeface, which the
-// Office theme sets to Calibri Light; with no theme part here the name is written out.
-const MAJOR_FONT = 'Calibri Light';
-const MAJOR_RFONTS =
-  `<w:rFonts w:ascii="${MAJOR_FONT}" w:hAnsi="${MAJOR_FONT}"` +
-  ` w:eastAsia="${MAJOR_FONT}" w:cs="${MAJOR_FONT}"/>`;
+// The headings state NO font, so they inherit Calibri from `w:docDefaults`.
+//
+// Word's own headings name the theme's MAJOR typeface, which the Office theme sets to
+// Calibri Light, and a faithful template would say so. It does not, for a reason that is
+// about this engine rather than about Word: no metric-compatible substitute for Calibri
+// Light exists in `packages/fonts`, so a heading measures and paints in Calibri anyway,
+// while the declared name lights the font-compatibility notice on a brand-new document —
+// a fidelity warning about a face nothing on the page uses. A template that says Calibri
+// says what it renders. Name Calibri Light here once the notice reports the families a
+// document RENDERS rather than the families it declares.
 
 /**
  * Heading 1-9 as Word's Office theme resolves them: the theme colors written out as the
@@ -90,7 +94,7 @@ const headingStyle = (heading: (typeof HEADINGS)[number]): string =>
   `<w:pPr><w:keepNext/><w:keepLines/>` +
   `<w:spacing w:before="${heading.before}" w:after="0"/>` +
   `<w:outlineLvl w:val="${heading.level - 1}"/></w:pPr>` +
-  `<w:rPr>${MAJOR_RFONTS}` +
+  `<w:rPr>` +
   (heading.italic ? `<w:i/><w:iCs/>` : ``) +
   `<w:color w:val="${heading.color}"/>` +
   (heading.halfPoints === null
@@ -145,19 +149,22 @@ const STYLES =
   `<w:uiPriority w:val="10"/><w:qFormat/>` +
   `<w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/>` +
   `<w:contextualSpacing/></w:pPr>` +
-  `<w:rPr>${MAJOR_RFONTS}<w:spacing w:val="-10"/><w:kern w:val="28"/>` +
+  `<w:rPr><w:spacing w:val="-10"/><w:kern w:val="28"/>` +
   `<w:sz w:val="56"/><w:szCs w:val="56"/></w:rPr>` +
   `</w:style>` +
+  // Subtitle states no spacing of its own: Word leaves it on the paragraph defaults, and
+  // stating the same 8pt here would override a Normal the user later changes.
   `<w:style w:type="paragraph" w:styleId="Subtitle">` +
   `<w:name w:val="Subtitle"/><w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
   `<w:uiPriority w:val="11"/><w:qFormat/>` +
-  `<w:pPr><w:spacing w:after="160"/></w:pPr>` +
   `<w:rPr><w:color w:val="5A5A5A"/><w:spacing w:val="15"/></w:rPr>` +
   `</w:style>` +
+  // Quote is CENTRED and full width. The half-inch indent on both sides belongs to Intense
+  // Quote, which also carries top and bottom borders and is not part of this gallery.
   `<w:style w:type="paragraph" w:styleId="Quote">` +
   `<w:name w:val="Quote"/><w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
   `<w:uiPriority w:val="29"/><w:qFormat/>` +
-  `<w:pPr><w:spacing w:before="160"/><w:ind w:left="720" w:right="720"/></w:pPr>` +
+  `<w:pPr><w:spacing w:before="160"/><w:jc w:val="center"/></w:pPr>` +
   `<w:rPr><w:i/><w:iCs/><w:color w:val="404040"/></w:rPr>` +
   `</w:style>` +
   // No Spacing is the one style that does NOT build on Normal: its whole purpose is to

--- a/packages/core/src/editor/blank-document.ts
+++ b/packages/core/src/editor/blank-document.ts
@@ -11,6 +11,17 @@
 // no theme part ships here, and layout's theme-font resolution is a separate lane. The
 // name is the Word name; rendering resolves through the host's font configuration
 // (metric substitutes or real bytes) like any other document.
+//
+// The BUILT-IN STYLE GALLERY ships with the template for the same reason the defaults do.
+// Word keeps Heading 1-9, Title, Subtitle, Quote, No Spacing and List Paragraph LATENT in
+// a new document: `styles.xml` does not define them, and Word writes the definition the
+// first time one is used. Nothing here can materialize a latent style, so a template that
+// omits them gives a New document a style picker holding one entry, and no way to make a
+// heading. Shipping the definitions is what makes the gallery match Word's.
+//
+// List Paragraph is the one with a visible second job: it carries `w:contextualSpacing`,
+// which is what drops the 8pt gap BETWEEN consecutive list items while keeping it around
+// the list. `toggleList` applies the style the way Word's list gesture does.
 
 import { strToU8, zipSync } from 'fflate';
 
@@ -42,9 +53,56 @@ const DOCUMENT_RELS =
   `<Relationship Id="rId1" Type="${STYLES_REL}" Target="styles.xml"/>` +
   `</Relationships>`;
 
+// The heading font. Word's built-in headings name the theme's MAJOR typeface, which the
+// Office theme sets to Calibri Light; with no theme part here the name is written out.
+const MAJOR_FONT = 'Calibri Light';
+const MAJOR_RFONTS =
+  `<w:rFonts w:ascii="${MAJOR_FONT}" w:hAnsi="${MAJOR_FONT}"` +
+  ` w:eastAsia="${MAJOR_FONT}" w:cs="${MAJOR_FONT}"/>`;
+
+/**
+ * Heading 1-9 as Word's Office theme resolves them: the theme colors written out as the
+ * hex Word paints (accent1 darker 25% and 50%, then near-black for the last pair), and
+ * only Heading 1 opening with a full line of space above it.
+ *
+ * Sizes are half-points, and a level with none inherits the 11pt run default — which is
+ * what Word's Heading 4 to Heading 7 do.
+ */
+const HEADINGS = [
+  { level: 1, before: 240, color: '2F5496', halfPoints: 32, italic: false },
+  { level: 2, before: 40, color: '2F5496', halfPoints: 26, italic: false },
+  { level: 3, before: 40, color: '1F3763', halfPoints: 24, italic: false },
+  { level: 4, before: 40, color: '2F5496', halfPoints: null, italic: true },
+  { level: 5, before: 40, color: '2F5496', halfPoints: null, italic: false },
+  { level: 6, before: 40, color: '1F3763', halfPoints: null, italic: false },
+  { level: 7, before: 40, color: '1F3763', halfPoints: null, italic: true },
+  { level: 8, before: 40, color: '272727', halfPoints: 21, italic: false },
+  { level: 9, before: 40, color: '272727', halfPoints: 21, italic: true },
+] as const;
+
+// `w:outlineLvl` is zero-based, so Heading 1 is level 0 — the value the navigation pane
+// and a table of contents both read.
+const headingStyle = (heading: (typeof HEADINGS)[number]): string =>
+  `<w:style w:type="paragraph" w:styleId="Heading${heading.level}">` +
+  `<w:name w:val="heading ${heading.level}"/>` +
+  `<w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
+  `<w:uiPriority w:val="9"/><w:qFormat/>` +
+  `<w:pPr><w:keepNext/><w:keepLines/>` +
+  `<w:spacing w:before="${heading.before}" w:after="0"/>` +
+  `<w:outlineLvl w:val="${heading.level - 1}"/></w:pPr>` +
+  `<w:rPr>${MAJOR_RFONTS}` +
+  (heading.italic ? `<w:i/><w:iCs/>` : ``) +
+  `<w:color w:val="${heading.color}"/>` +
+  (heading.halfPoints === null
+    ? ``
+    : `<w:sz w:val="${heading.halfPoints}"/><w:szCs w:val="${heading.halfPoints}"/>`) +
+  `</w:rPr></w:style>`;
+
 // Word's blank-template defaults: Calibri 11pt run defaults, and the Normal paragraph
 // rhythm (8pt space after, 1.08-line spacing) in the paragraph defaults — the values
-// Word writes, so a save/reopen in Word shows the same text metrics.
+// Word writes, so a save/reopen in Word shows the same text metrics. Then the built-in
+// gallery, in Word's own order: Normal, the headings, the three defaults every part
+// kind needs, and the styles the picker offers under them.
 const STYLES =
   `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
   `<w:styles xmlns:w="${W}">` +
@@ -59,6 +117,63 @@ const STYLES =
   `</w:docDefaults>` +
   `<w:style w:type="paragraph" w:default="1" w:styleId="Normal">` +
   `<w:name w:val="Normal"/><w:qFormat/>` +
+  `</w:style>` +
+  HEADINGS.map(headingStyle).join('') +
+  // The three default styles a Word part carries one of each: the character style every
+  // run falls back to, the table style every table falls back to, and the numbering style
+  // that means "no list". Word writes all three into every document it saves.
+  `<w:style w:type="character" w:default="1" w:styleId="DefaultParagraphFont">` +
+  `<w:name w:val="Default Paragraph Font"/>` +
+  `<w:uiPriority w:val="1"/><w:semiHidden/><w:unhideWhenUsed/>` +
+  `</w:style>` +
+  `<w:style w:type="table" w:default="1" w:styleId="TableNormal">` +
+  `<w:name w:val="Normal Table"/>` +
+  `<w:uiPriority w:val="99"/><w:semiHidden/><w:unhideWhenUsed/>` +
+  `<w:tblPr><w:tblInd w:w="0" w:type="dxa"/><w:tblCellMar>` +
+  `<w:top w:w="0" w:type="dxa"/><w:left w:w="108" w:type="dxa"/>` +
+  `<w:bottom w:w="0" w:type="dxa"/><w:right w:w="108" w:type="dxa"/>` +
+  `</w:tblCellMar></w:tblPr>` +
+  `</w:style>` +
+  `<w:style w:type="numbering" w:default="1" w:styleId="NoList">` +
+  `<w:name w:val="No List"/>` +
+  `<w:uiPriority w:val="99"/><w:semiHidden/><w:unhideWhenUsed/>` +
+  `</w:style>` +
+  // Title sets its own line spacing rather than inheriting the 1.08 default, and states
+  // the tight character spacing Word gives a 28pt title.
+  `<w:style w:type="paragraph" w:styleId="Title">` +
+  `<w:name w:val="Title"/><w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
+  `<w:uiPriority w:val="10"/><w:qFormat/>` +
+  `<w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/>` +
+  `<w:contextualSpacing/></w:pPr>` +
+  `<w:rPr>${MAJOR_RFONTS}<w:spacing w:val="-10"/><w:kern w:val="28"/>` +
+  `<w:sz w:val="56"/><w:szCs w:val="56"/></w:rPr>` +
+  `</w:style>` +
+  `<w:style w:type="paragraph" w:styleId="Subtitle">` +
+  `<w:name w:val="Subtitle"/><w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
+  `<w:uiPriority w:val="11"/><w:qFormat/>` +
+  `<w:pPr><w:spacing w:after="160"/></w:pPr>` +
+  `<w:rPr><w:color w:val="5A5A5A"/><w:spacing w:val="15"/></w:rPr>` +
+  `</w:style>` +
+  `<w:style w:type="paragraph" w:styleId="Quote">` +
+  `<w:name w:val="Quote"/><w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
+  `<w:uiPriority w:val="29"/><w:qFormat/>` +
+  `<w:pPr><w:spacing w:before="160"/><w:ind w:left="720" w:right="720"/></w:pPr>` +
+  `<w:rPr><w:i/><w:iCs/><w:color w:val="404040"/></w:rPr>` +
+  `</w:style>` +
+  // No Spacing is the one style that does NOT build on Normal: its whole purpose is to
+  // drop the defaults' space-after and 1.08 lines, which `w:basedOn` would reinstate.
+  `<w:style w:type="paragraph" w:styleId="NoSpacing">` +
+  `<w:name w:val="No Spacing"/><w:uiPriority w:val="1"/><w:qFormat/>` +
+  `<w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>` +
+  `</w:style>` +
+  // `w:contextualSpacing` is the point of this one: it suppresses the 8pt before and
+  // after BETWEEN neighbours of the same style, so a list closes up between its items and
+  // still keeps its space against the paragraphs above and below it. The 0.5" indent is
+  // the style's own; every list level states its own `w:ind`, which supersedes it.
+  `<w:style w:type="paragraph" w:styleId="ListParagraph">` +
+  `<w:name w:val="List Paragraph"/><w:basedOn w:val="Normal"/>` +
+  `<w:uiPriority w:val="34"/><w:qFormat/>` +
+  `<w:pPr><w:ind w:left="720"/><w:contextualSpacing/></w:pPr>` +
   `</w:style>` +
   `</w:styles>`;
 
@@ -78,8 +193,9 @@ const DOCUMENT =
 /**
  * A Word-faithful blank document, freshly zipped per call (the caller may hand the
  * bytes to a loader that takes ownership). Calibri 11pt and Word's Normal paragraph
- * spacing are authored in `w:docDefaults`, US Letter geometry in the section — a New
- * document behaves like Word's, and saving it produces a file Word opens identically.
+ * spacing are authored in `w:docDefaults`, Word's built-in style gallery in `styles.xml`,
+ * US Letter geometry in the section — a New document behaves like Word's, and saving it
+ * produces a file Word opens identically.
  *
  * @public
  */

--- a/packages/core/src/editor/surface-list-style.ts
+++ b/packages/core/src/editor/surface-list-style.ts
@@ -1,0 +1,143 @@
+// Word's List Paragraph style, and the `w:pStyle` writes the list gesture carries.
+//
+// Word's list buttons do not just add `w:numPr`: they put the paragraph in the built-in
+// List Paragraph style, and THAT style is what states `w:contextualSpacing` — the property
+// that closes the gap between consecutive items. So a list gesture is two writes, and the
+// second one is a style decision with rules of its own about which paragraphs it may touch.
+//
+// Split out of `surface-structure.ts` because it is that: a style question, answered
+// against `styles.xml` and the document's own default, rather than a structural edit at the
+// selection.
+
+import type { TreeDocxSessionView } from '@docx-editor.dev/core/binding';
+import type { OoxmlElement, OoxmlPart, TreeDocOp } from '@docx-editor.dev/core/store';
+import { buildStyleCascadeTable } from '@docx-editor.dev/core/layout';
+import { directParagraphProperties, mergedProperties } from './surface-formatting.ts';
+
+/** What this lane borrows: the session it reads styles from, and the story it writes to. */
+export interface ListStyleDeps {
+  readonly session: TreeDocxSessionView;
+  /** The part holding the paragraphs a write will name. */
+  storyPart(): OoxmlPart;
+}
+
+/** The `w:name` Word gives the built-in, case-folded for comparison. */
+const LIST_PARAGRAPH_NAME = 'list paragraph';
+/** The styleId Word gives the built-in. */
+const LIST_PARAGRAPH_STYLE_ID = 'ListParagraph';
+
+/** The `w:pStyle` a paragraph itself authors, or undefined. */
+function authoredStyleId(
+  properties: ReturnType<typeof directParagraphProperties>
+): string | undefined {
+  return properties.find((property) => property.localName === 'pStyle')?.attributes?.val;
+}
+
+/** The two writes a list gesture may need, resolved against one document's styles. */
+export interface ListStyleWrites {
+  /**
+   * The `w:pStyle` writes that turning a list ON carries, the way Word's own gesture does.
+   *
+   * A paragraph in a NON-DEFAULT style keeps it: bulleting a Heading 1 in Word leaves it a
+   * heading. A paragraph in the default style does not, and that is not the same as
+   * authoring no style at all — a converter stamps `<w:pStyle w:val="Normal"/>` on every
+   * paragraph it writes, and reading that as "has a style of its own" left the whole class
+   * of converted files with 8pt between their list items.
+   *
+   * These ops must go BEFORE the numbering ops, because `setParagraphProperties` replaces
+   * the authorable set it is handed and `setListNumbering` is surgical on `w:numPr` — the
+   * other order would drop the numbering the same transaction had just written.
+   */
+  applyOps(touched: readonly string[]): TreeDocOp[];
+  /**
+   * The write that takes a paragraph OUT of List Paragraph, or null when it is not in it.
+   *
+   * Enter on an empty item is Word's "I am done with this list", and Word returns the text
+   * to the LEFT MARGIN. Dropping only `w:numPr` leaves the style's own `w:ind w:left="720"`
+   * standing, so the paragraph would keep sitting half an inch in with no marker to explain
+   * it. The toolbar toggle deliberately does NOT do this: clicking Bullets off in Word
+   * leaves the paragraph styled, and indented.
+   */
+  clearOp(paragraphId: string): TreeDocOp | null;
+}
+
+export function createListStyleWrites(deps: ListStyleDeps): ListStyleWrites {
+  const { session } = deps;
+
+  /**
+   * The document's List Paragraph style, or null when it defines none.
+   *
+   * Matched on the built-in NAME first, then on the built-in styleId. Word identifies its
+   * built-ins by `w:name`, and a converter commonly spells the id its own way
+   * (`ListParagraph1`, `a3`) while keeping the name — while the reverse also happens, an
+   * unrelated style handed the `ListParagraph` id. Name-first lands on the right one in
+   * both files. A document that defines neither gets no `w:pStyle` write at all: writing a
+   * dangling one would render as Normal here and as a missing style everywhere else.
+   */
+  function listParagraphStyleId(): string | null {
+    let byId: string | null = null;
+    for (const style of session.documentStyles()) {
+      if (style.type !== 'paragraph') continue;
+      if (style.name.trim().toLowerCase() === LIST_PARAGRAPH_NAME) return style.styleId;
+      if (byId === null && style.styleId === LIST_PARAGRAPH_STYLE_ID) byId = style.styleId;
+    }
+    return byId;
+  }
+
+  /**
+   * The document's `w:default="1"` paragraph style, memoized on the styles root.
+   *
+   * Read through the layout cascade's own resolver rather than by matching the attribute:
+   * `w:default` is `ST_OnOff`, so `on` and `true` are legal spellings of `1`, and defaults
+   * are last-wins. The styles part is immutable for the session, so this builds once.
+   */
+  let defaultStyleMemo:
+    | { readonly root: OoxmlElement | null; readonly styleId: string | null }
+    | undefined;
+  function defaultParagraphStyleId(): string | null {
+    const root = session.stylesRoot();
+    if (defaultStyleMemo === undefined || defaultStyleMemo.root !== root) {
+      defaultStyleMemo = {
+        root,
+        styleId: buildStyleCascadeTable(root, session.documentThemeFonts()).defaultParagraphStyleId,
+      };
+    }
+    return defaultStyleMemo.styleId;
+  }
+
+  return {
+    applyOps(touched) {
+      const styleId = listParagraphStyleId();
+      if (styleId === null) return [];
+      const defaultStyleId = defaultParagraphStyleId();
+      const part = deps.storyPart();
+      const ops: TreeDocOp[] = [];
+      for (const paragraphId of touched) {
+        const properties = directParagraphProperties(part, paragraphId);
+        const authored = authoredStyleId(properties);
+        if (authored !== undefined && authored !== defaultStyleId) continue;
+        ops.push({
+          op: 'setParagraphProperties',
+          paragraphId,
+          properties: mergedProperties(properties, {
+            localName: 'pStyle',
+            attributes: { val: styleId },
+          }),
+        });
+      }
+      return ops;
+    },
+
+    clearOp(paragraphId) {
+      const styleId = listParagraphStyleId();
+      if (styleId === null) return null;
+      const properties = directParagraphProperties(deps.storyPart(), paragraphId);
+      if (authoredStyleId(properties) !== styleId) return null;
+      return {
+        op: 'setParagraphProperties',
+        paragraphId,
+        properties: properties.filter((property) => property.localName !== 'pStyle'),
+      };
+    },
+  };
+}

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -329,6 +329,61 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
   }
 
   /**
+   * The document's List Paragraph style, or null when it defines none.
+   *
+   * Matched on the built-in styleId first, then on the built-in NAME: a converted file
+   * commonly spells the id something else (`ListParagraph1`, `a3`) while keeping the name
+   * Word gave it. A document that defines neither gets no `w:pStyle` write at all —
+   * writing a dangling one would render as Normal here and as a missing style everywhere
+   * else.
+   */
+  function listParagraphStyleId(): string | null {
+    let byName: string | null = null;
+    for (const style of session.documentStyles()) {
+      if (style.type !== 'paragraph') continue;
+      if (style.styleId === 'ListParagraph') return style.styleId;
+      if (byName === null && style.name.trim().toLowerCase() === 'list paragraph') {
+        byName = style.styleId;
+      }
+    }
+    return byName;
+  }
+
+  /**
+   * The `w:pStyle` writes that turning a list ON carries, the way Word's own gesture does.
+   *
+   * Word does not just add `w:numPr`: it puts the paragraph in List Paragraph, and THAT
+   * style is what states `w:contextualSpacing`. Without it a list on a document whose
+   * defaults state `w:spacing w:after` — Word's own blank template does, at 8pt — sits a
+   * full paragraph apart between every item.
+   *
+   * Only paragraphs that author no style of their own are moved: bulleting a Heading 1 in
+   * Word leaves it a heading, and a list item already carrying List Paragraph needs no
+   * write. These ops go BEFORE the numbering ops, because `setParagraphProperties` replaces
+   * the authorable set it is handed and `setListNumbering` is surgical on `w:numPr` — the
+   * other order would drop the numbering the same transaction had just written.
+   */
+  function listParagraphStyleOps(touched: readonly string[]): TreeDocOp[] {
+    const styleId = listParagraphStyleId();
+    if (styleId === null) return [];
+    const part = storyPart();
+    const ops: TreeDocOp[] = [];
+    for (const paragraphId of touched) {
+      const properties = directParagraphProperties(part, paragraphId);
+      if (properties.some((property) => property.localName === 'pStyle')) continue;
+      ops.push({
+        op: 'setParagraphProperties',
+        paragraphId,
+        properties: mergedProperties(properties, {
+          localName: 'pStyle',
+          attributes: { val: styleId },
+        }),
+      });
+    }
+    return ops;
+  }
+
+  /**
    * Whether a list paragraph could move to `level` WITHOUT touching `numbering.xml`.
    *
    * A `w:abstractNum` need not declare all nine levels — plenty of real documents declare
@@ -497,19 +552,22 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
         ? null
         : (adjacentListNumId(touched, kind) ?? session.ensureListDefinition(kind));
       if (!turningOff && numId === null) return false;
-      const ops: TreeDocOp[] = touched.map((paragraphId) => {
+      // Turning a list OFF leaves the style alone, as Word does: an outdented item stays
+      // in List Paragraph until the user picks another style.
+      const ops: TreeDocOp[] = turningOff ? [] : listParagraphStyleOps(touched);
+      for (const paragraphId of touched) {
         // `w:numPr` carries the level AND the definition, and the op mints a fresh one, so
         // a call that names no level silently resets `w:ilvl` to 0. Word converts a bullet
         // to a number IN PLACE: pressing Numbered on a level-2 item left it at level 2,
         // where this flattened it to the left margin two levels out.
         const level = listLevelOf(paragraphId);
-        return {
-          op: 'setListNumbering' as const,
+        ops.push({
+          op: 'setListNumbering',
           paragraphId,
           numId,
           ...(level !== null ? { level } : {}),
-        };
-      });
+        });
+      }
       return commitOverTarget(() => applyOps(ops, selectionMark()));
     },
 

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -7,9 +7,8 @@
 // composition root.
 
 import type { TreeApplyResult, TreeDocxSessionView } from '@docx-editor.dev/core/binding';
-import type { TreeDocOp, StoryScope, OoxmlElement } from '@docx-editor.dev/core/store';
+import type { TreeDocOp, StoryScope } from '@docx-editor.dev/core/store';
 import {
-  buildStyleCascadeTable,
   enumerateDocumentSections,
   paragraphsInCells,
   readSectionProperties,
@@ -31,6 +30,7 @@ import {
   mergedProperties,
   paragraphPropertiesOf,
 } from './surface-formatting.ts';
+import { createListStyleWrites } from './surface-list-style.ts';
 import type {
   PaginatedSurface,
   SurfaceParagraphFormat,
@@ -213,6 +213,9 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
     before?: Parameters<TreeDocxSessionView['applyTreeOps']>[1],
     after?: Parameters<TreeDocxSessionView['applyTreeOps']>[2]
   ): TreeApplyResult => session.applyTreeOps(ops, before, after, deps.storyScope());
+  // Word's list gesture is two writes: the numbering, and the List Paragraph style that
+  // carries `w:contextualSpacing`. The style half lives in its own lane.
+  const listStyle = createListStyleWrites({ session, storyPart });
   const orderOf = () => deps.paragraphOrder();
   const currentLayout = {
     get value(): SemanticLayout {
@@ -327,109 +330,6 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       if ((marker.numFmt === 'bullet' ? 'bullet' : 'ordered') === kind) return marker.numId;
     }
     return null;
-  }
-
-  /**
-   * The document's List Paragraph style, or null when it defines none.
-   *
-   * Matched on the built-in NAME first, then on the built-in styleId. Word identifies its
-   * built-ins by `w:name`, and a converter commonly spells the id its own way
-   * (`ListParagraph1`, `a3`) while keeping the name — while the reverse also happens, an
-   * unrelated style handed the `ListParagraph` id. Name-first lands on the right one in
-   * both files. A document that defines neither gets no `w:pStyle` write at all: writing a
-   * dangling one would render as Normal here and as a missing style everywhere else.
-   */
-  function listParagraphStyleId(): string | null {
-    let byId: string | null = null;
-    for (const style of session.documentStyles()) {
-      if (style.type !== 'paragraph') continue;
-      if (style.name.trim().toLowerCase() === 'list paragraph') return style.styleId;
-      if (byId === null && style.styleId === 'ListParagraph') byId = style.styleId;
-    }
-    return byId;
-  }
-
-  /**
-   * The document's `w:default="1"` paragraph style, memoized on the styles root.
-   *
-   * Read through the layout cascade's own resolver rather than by matching the attribute:
-   * `w:default` is `ST_OnOff`, so `on` and `true` are legal spellings of `1`, and defaults
-   * are last-wins. The styles part is immutable for the session, so this builds once.
-   */
-  let defaultStyleMemo: { readonly root: OoxmlElement | null; readonly styleId: string | null };
-  function defaultParagraphStyleId(): string | null {
-    const root = session.stylesRoot();
-    if (defaultStyleMemo === undefined || defaultStyleMemo.root !== root) {
-      defaultStyleMemo = {
-        root,
-        styleId: buildStyleCascadeTable(root, session.documentThemeFonts()).defaultParagraphStyleId,
-      };
-    }
-    return defaultStyleMemo.styleId;
-  }
-
-  /**
-   * The `w:pStyle` writes that turning a list ON carries, the way Word's own gesture does.
-   *
-   * Word does not just add `w:numPr`: it puts the paragraph in List Paragraph, and THAT
-   * style is what states `w:contextualSpacing`. Without it a list on a document whose
-   * defaults state `w:spacing w:after` — Word's own blank template does, at 8pt — sits a
-   * full paragraph apart between every item.
-   *
-   * A paragraph in a NON-DEFAULT style keeps it: bulleting a Heading 1 in Word leaves it a
-   * heading. A paragraph in the default style does not, and that is not the same as
-   * authoring no style at all — a converter stamps `<w:pStyle w:val="Normal"/>` on every
-   * paragraph it writes, and reading that as "has a style of its own" left the whole class
-   * of converted files with 8pt between their list items.
-   *
-   * These ops go BEFORE the numbering ops, because `setParagraphProperties` replaces the
-   * authorable set it is handed and `setListNumbering` is surgical on `w:numPr` — the other
-   * order would drop the numbering the same transaction had just written.
-   */
-  function listParagraphStyleOps(touched: readonly string[]): TreeDocOp[] {
-    const styleId = listParagraphStyleId();
-    if (styleId === null) return [];
-    const defaultStyleId = defaultParagraphStyleId();
-    const part = storyPart();
-    const ops: TreeDocOp[] = [];
-    for (const paragraphId of touched) {
-      const properties = directParagraphProperties(part, paragraphId);
-      const authored = properties.find((property) => property.localName === 'pStyle')?.attributes
-        ?.val;
-      if (authored !== undefined && authored !== defaultStyleId) continue;
-      ops.push({
-        op: 'setParagraphProperties',
-        paragraphId,
-        properties: mergedProperties(properties, {
-          localName: 'pStyle',
-          attributes: { val: styleId },
-        }),
-      });
-    }
-    return ops;
-  }
-
-  /**
-   * The write that takes a paragraph OUT of List Paragraph, or null when it is not in it.
-   *
-   * Enter on an empty item is Word's "I am done with this list", and Word returns the text
-   * to the LEFT MARGIN. Dropping only `w:numPr` leaves the style's own `w:ind w:left="720"`
-   * standing, so the paragraph would keep sitting half an inch in with no marker to explain
-   * it. The toolbar toggle deliberately does NOT do this: clicking Bullets off in Word
-   * leaves the paragraph styled, and indented.
-   */
-  function clearListParagraphStyleOp(paragraphId: string): TreeDocOp | null {
-    const styleId = listParagraphStyleId();
-    if (styleId === null) return null;
-    const properties = directParagraphProperties(storyPart(), paragraphId);
-    const authored = properties.find((property) => property.localName === 'pStyle')?.attributes
-      ?.val;
-    if (authored !== styleId) return null;
-    return {
-      op: 'setParagraphProperties',
-      paragraphId,
-      properties: properties.filter((property) => property.localName !== 'pStyle'),
-    };
   }
 
   /**
@@ -574,7 +474,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       if (outdented) {
         ops.push({ op: 'setListLevel', paragraphId: from.paragraphId, level: marker.level - 1 });
       } else {
-        const cleared = clearListParagraphStyleOp(from.paragraphId);
+        const cleared = listStyle.clearOp(from.paragraphId);
         if (cleared) ops.push(cleared);
         ops.push({ op: 'setListNumbering', paragraphId: from.paragraphId, numId: null });
       }
@@ -613,7 +513,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       if (!turningOff && numId === null) return false;
       // Turning a list OFF leaves the style alone, as Word does: an outdented item stays
       // in List Paragraph until the user picks another style.
-      const ops: TreeDocOp[] = turningOff ? [] : listParagraphStyleOps(touched);
+      const ops: TreeDocOp[] = turningOff ? [] : listStyle.applyOps(touched);
       for (const paragraphId of touched) {
         // `w:numPr` carries the level AND the definition, and the op mints a fresh one, so
         // a call that names no level silently resets `w:ilvl` to 0. Word converts a bullet

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -7,8 +7,9 @@
 // composition root.
 
 import type { TreeApplyResult, TreeDocxSessionView } from '@docx-editor.dev/core/binding';
-import type { TreeDocOp, StoryScope } from '@docx-editor.dev/core/store';
+import type { TreeDocOp, StoryScope, OoxmlElement } from '@docx-editor.dev/core/store';
 import {
+  buildStyleCascadeTable,
   enumerateDocumentSections,
   paragraphsInCells,
   readSectionProperties,
@@ -331,22 +332,40 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
   /**
    * The document's List Paragraph style, or null when it defines none.
    *
-   * Matched on the built-in styleId first, then on the built-in NAME: a converted file
-   * commonly spells the id something else (`ListParagraph1`, `a3`) while keeping the name
-   * Word gave it. A document that defines neither gets no `w:pStyle` write at all —
-   * writing a dangling one would render as Normal here and as a missing style everywhere
-   * else.
+   * Matched on the built-in NAME first, then on the built-in styleId. Word identifies its
+   * built-ins by `w:name`, and a converter commonly spells the id its own way
+   * (`ListParagraph1`, `a3`) while keeping the name — while the reverse also happens, an
+   * unrelated style handed the `ListParagraph` id. Name-first lands on the right one in
+   * both files. A document that defines neither gets no `w:pStyle` write at all: writing a
+   * dangling one would render as Normal here and as a missing style everywhere else.
    */
   function listParagraphStyleId(): string | null {
-    let byName: string | null = null;
+    let byId: string | null = null;
     for (const style of session.documentStyles()) {
       if (style.type !== 'paragraph') continue;
-      if (style.styleId === 'ListParagraph') return style.styleId;
-      if (byName === null && style.name.trim().toLowerCase() === 'list paragraph') {
-        byName = style.styleId;
-      }
+      if (style.name.trim().toLowerCase() === 'list paragraph') return style.styleId;
+      if (byId === null && style.styleId === 'ListParagraph') byId = style.styleId;
     }
-    return byName;
+    return byId;
+  }
+
+  /**
+   * The document's `w:default="1"` paragraph style, memoized on the styles root.
+   *
+   * Read through the layout cascade's own resolver rather than by matching the attribute:
+   * `w:default` is `ST_OnOff`, so `on` and `true` are legal spellings of `1`, and defaults
+   * are last-wins. The styles part is immutable for the session, so this builds once.
+   */
+  let defaultStyleMemo: { readonly root: OoxmlElement | null; readonly styleId: string | null };
+  function defaultParagraphStyleId(): string | null {
+    const root = session.stylesRoot();
+    if (defaultStyleMemo === undefined || defaultStyleMemo.root !== root) {
+      defaultStyleMemo = {
+        root,
+        styleId: buildStyleCascadeTable(root, session.documentThemeFonts()).defaultParagraphStyleId,
+      };
+    }
+    return defaultStyleMemo.styleId;
   }
 
   /**
@@ -357,20 +376,27 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
    * defaults state `w:spacing w:after` — Word's own blank template does, at 8pt — sits a
    * full paragraph apart between every item.
    *
-   * Only paragraphs that author no style of their own are moved: bulleting a Heading 1 in
-   * Word leaves it a heading, and a list item already carrying List Paragraph needs no
-   * write. These ops go BEFORE the numbering ops, because `setParagraphProperties` replaces
-   * the authorable set it is handed and `setListNumbering` is surgical on `w:numPr` — the
-   * other order would drop the numbering the same transaction had just written.
+   * A paragraph in a NON-DEFAULT style keeps it: bulleting a Heading 1 in Word leaves it a
+   * heading. A paragraph in the default style does not, and that is not the same as
+   * authoring no style at all — a converter stamps `<w:pStyle w:val="Normal"/>` on every
+   * paragraph it writes, and reading that as "has a style of its own" left the whole class
+   * of converted files with 8pt between their list items.
+   *
+   * These ops go BEFORE the numbering ops, because `setParagraphProperties` replaces the
+   * authorable set it is handed and `setListNumbering` is surgical on `w:numPr` — the other
+   * order would drop the numbering the same transaction had just written.
    */
   function listParagraphStyleOps(touched: readonly string[]): TreeDocOp[] {
     const styleId = listParagraphStyleId();
     if (styleId === null) return [];
+    const defaultStyleId = defaultParagraphStyleId();
     const part = storyPart();
     const ops: TreeDocOp[] = [];
     for (const paragraphId of touched) {
       const properties = directParagraphProperties(part, paragraphId);
-      if (properties.some((property) => property.localName === 'pStyle')) continue;
+      const authored = properties.find((property) => property.localName === 'pStyle')?.attributes
+        ?.val;
+      if (authored !== undefined && authored !== defaultStyleId) continue;
       ops.push({
         op: 'setParagraphProperties',
         paragraphId,
@@ -381,6 +407,29 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       });
     }
     return ops;
+  }
+
+  /**
+   * The write that takes a paragraph OUT of List Paragraph, or null when it is not in it.
+   *
+   * Enter on an empty item is Word's "I am done with this list", and Word returns the text
+   * to the LEFT MARGIN. Dropping only `w:numPr` leaves the style's own `w:ind w:left="720"`
+   * standing, so the paragraph would keep sitting half an inch in with no marker to explain
+   * it. The toolbar toggle deliberately does NOT do this: clicking Bullets off in Word
+   * leaves the paragraph styled, and indented.
+   */
+  function clearListParagraphStyleOp(paragraphId: string): TreeDocOp | null {
+    const styleId = listParagraphStyleId();
+    if (styleId === null) return null;
+    const properties = directParagraphProperties(storyPart(), paragraphId);
+    const authored = properties.find((property) => property.localName === 'pStyle')?.attributes
+      ?.val;
+    if (authored !== styleId) return null;
+    return {
+      op: 'setParagraphProperties',
+      paragraphId,
+      properties: properties.filter((property) => property.localName !== 'pStyle'),
+    };
   }
 
   /**
@@ -516,12 +565,22 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       if (text.length > 0) return false;
 
       const outdented = marker.level > 0 && listLevelExists(marker, marker.level - 1);
-      const op: TreeDocOp = outdented
-        ? { op: 'setListLevel', paragraphId: from.paragraphId, level: marker.level - 1 }
-        : { op: 'setListNumbering', paragraphId: from.paragraphId, numId: null };
+      // Outdenting stays in the list, so it keeps the style. Leaving the list sheds it, or
+      // the paragraph keeps List Paragraph's half-inch indent with no marker beside it —
+      // see `clearListParagraphStyleOp`. The style write goes first for the same reason it
+      // does in `toggleList`: it carries the authored `w:numPr` forward, so running it
+      // after the numbering op would put back what that op had just removed.
+      const ops: TreeDocOp[] = [];
+      if (outdented) {
+        ops.push({ op: 'setListLevel', paragraphId: from.paragraphId, level: marker.level - 1 });
+      } else {
+        const cleared = clearListParagraphStyleOp(from.paragraphId);
+        if (cleared) ops.push(cleared);
+        ops.push({ op: 'setListNumbering', paragraphId: from.paragraphId, numId: null });
+      }
       let committed = false;
       commit(() => {
-        const result = applyOps([op], selectionMark());
+        const result = applyOps(ops, selectionMark());
         committed = result.committed;
         return result;
       });

--- a/packages/core/src/layout/__tests__/contextual-spacing-incremental.test.ts
+++ b/packages/core/src/layout/__tests__/contextual-spacing-incremental.test.ts
@@ -1,0 +1,132 @@
+// `w:contextualSpacing` across an INCREMENTAL pass.
+//
+// The property drops a paragraph's space before or after when the neighbour on that side
+// is a paragraph of the same style, so a block's height is a function of two blocks it
+// does not contain. The incremental pass resumes from the first block whose FLOW KEY moved,
+// and a content key cannot see a neighbour appear — so inserting a paragraph under the last
+// one of a run left that one still carrying the space it had when it was last, for as long
+// as the session lived. Reopening the same bytes laid it out correctly, which is the shape
+// of the bug: identical input, two answers.
+//
+// No numbering here on purpose. `w:contextualSpacing` is a paragraph-style question, and
+// keeping lists out of it isolates what actually broke.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../../editor/docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const STY = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+/** 8pt after every paragraph, and one style that suppresses it between its own. */
+const STYLES =
+  `<w:styles xmlns:w="${W}">` +
+  '<w:docDefaults><w:pPrDefault><w:pPr>' +
+  '<w:spacing w:after="160" w:line="240" w:lineRule="auto"/>' +
+  '</w:pPr></w:pPrDefault></w:docDefaults>' +
+  '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>' +
+  '<w:style w:type="paragraph" w:styleId="Tight"><w:name w:val="Tight"/>' +
+  '<w:basedOn w:val="Normal"/><w:pPr><w:contextualSpacing/></w:pPr></w:style>' +
+  '</w:styles>';
+
+const styled = (text: string) =>
+  `<w:p><w:pPr><w:pStyle w:val="Tight"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId2" Type="${STY}" Target="styles.xml"/></Relationships>`
+    ),
+    'word/styles.xml': strToU8(STYLES),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const open: DocxEditorInstance[] = [];
+
+afterEach(() => {
+  for (const editor of open.splice(0)) editor.destroy();
+});
+
+function mount(bytes: Uint8Array): DocxEditorInstance {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({ container, document: bytes });
+  open.push(editor);
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+const heights = (editor: DocxEditorInstance): number[] =>
+  editor
+    .surface!.layout()
+    .pages[0]!.fragments.map((fragment) => Math.round(fragment.box.height * 100) / 100);
+
+describe('w:contextualSpacing survives an incremental pass', () => {
+  test('a new same-style paragraph takes the space-after off the one above it', () => {
+    const editor = mount(docx(styled('one') + styled('two')));
+    const surface = editor.surface!;
+
+    // On open: the pair closes up, and only the last one carries the 8pt.
+    const [firstOnOpen, lastOnOpen] = heights(editor);
+    expect(lastOnOpen! - firstOnOpen!).toBe(8);
+
+    // Split the LAST one. The paragraph that was last is now followed by its own style, so
+    // its space-after has to go — the case a content-only key cannot see.
+    const ids = surface.session.paragraphIds();
+    surface.setSelection({
+      anchor: { paragraphId: ids[1]!, offset: 3 },
+      head: { paragraphId: ids[1]!, offset: 3 },
+    });
+    surface.splitParagraph();
+    surface.type('three');
+
+    const after = heights(editor);
+    expect(after).toHaveLength(3);
+    expect(after[0]).toBe(firstOnOpen!);
+    expect(after[1]).toBe(firstOnOpen!);
+    expect(after[2]! - firstOnOpen!).toBe(8);
+  });
+
+  test('the incremental answer equals the answer for the same bytes reopened', async () => {
+    const editor = mount(docx(styled('one') + styled('two')));
+    const surface = editor.surface!;
+    const ids = surface.session.paragraphIds();
+    surface.setSelection({
+      anchor: { paragraphId: ids[1]!, offset: 3 },
+      head: { paragraphId: ids[1]!, offset: 3 },
+    });
+    surface.splitParagraph();
+    surface.type('three');
+    const incremental = heights(editor);
+
+    // The oracle: identical bytes, laid out from scratch. Any disagreement here IS the bug,
+    // whatever the numbers happen to be.
+    const reopened = mount(new Uint8Array(await editor.save()));
+    expect(incremental).toEqual(heights(reopened));
+  });
+
+  test('a paragraph of a DIFFERENT style below still leaves the space standing', () => {
+    const editor = mount(docx(styled('one') + '<w:p><w:r><w:t>plain</w:t></w:r></w:p>'));
+    const [tight, plain] = heights(editor);
+    // Nothing to suppress against, so both keep their 8pt and the heights match.
+    expect(tight).toBe(plain);
+  });
+});

--- a/packages/core/src/layout/__tests__/pagination-keeps.test.ts
+++ b/packages/core/src/layout/__tests__/pagination-keeps.test.ts
@@ -11,6 +11,8 @@ import { createLayoutSession } from '../layout-session.ts';
 import { createParagraphLayoutCache } from '../layout-cache.ts';
 import {
   adjustedBreakIndex,
+  contextualSpacingFlowKeys,
+  keepNextFlowKeys,
   paragraphKeeps,
   DEFAULT_PARAGRAPH_KEEPS,
 } from '../pagination-keeps.ts';
@@ -358,5 +360,85 @@ describe('ISO 29500 Strict tab alignments (B12)', () => {
     expect(tabs('<w:tab w:val="sideways" w:pos="720"/>').stops).toHaveLength(0);
     // `bar` and `num` are not stops.
     expect(tabs('<w:tab w:val="bar" w:pos="720"/>').stops).toHaveLength(0);
+  });
+});
+
+// `w:contextualSpacing` (§17.3.1.9) is a CROSS-BLOCK property: it drops a paragraph's space
+// on the side where the neighbour is a paragraph of the same style, so a block's height is a
+// function of two blocks it does not contain. Incremental resume compares flow keys and
+// re-places from the first that moved, which makes the fold the whole mechanism — a verdict
+// that changes without moving a key is a paragraph that keeps its old spacing until the
+// document is reopened.
+//
+// These pin the fold's boundary answers, and the correspondence between `styleAt` here and
+// `sameStyleAs` in `semantic-layout.ts`. Everything else about the property rests on it.
+describe('contextualSpacingFlowKeys — the cross-block fold', () => {
+  const KEYS = ['a', 'b', 'c'];
+  const all = () => true;
+
+  test('nothing contextual returns the SAME array, not a copy', () => {
+    // Identity is the contract: the prepass memo and the unchanged-document exit both lean
+    // on flow keys not churning when no block reads across a boundary.
+    expect(
+      contextualSpacingFlowKeys(
+        KEYS,
+        () => false,
+        () => 'Tight'
+      )
+    ).toBe(KEYS);
+  });
+
+  test('a run of one style records which SIDES match', () => {
+    const flow = contextualSpacingFlowKeys(KEYS, all, () => 'Tight');
+    // First has no block before it, last has none after it; the middle matches on both.
+    expect(flow).toEqual(['a~cs~01', 'b~cs~11', 'c~cs~10']);
+  });
+
+  test('a neighbour of a DIFFERENT style does not match', () => {
+    const styles = ['Tight', 'Other', 'Tight'];
+    const flow = contextualSpacingFlowKeys(KEYS, all, (index) => styles[index]!);
+    expect(flow).toEqual(['a~cs~00', 'b~cs~00', 'c~cs~00']);
+  });
+
+  test('a null style is never a match on either side, and takes no token', () => {
+    // `styleAt` answers null for a table, and for a paragraph with no resolved style. That
+    // mirrors `sameStyleAs`, whose `styleId !== null` guard makes both sides false.
+    const styles: (string | null)[] = ['Tight', null, 'Tight'];
+    const flow = contextualSpacingFlowKeys(KEYS, all, (index) => styles[index]!);
+    expect(flow).toEqual(['a~cs~00', 'b', 'c~cs~00']);
+  });
+
+  test('only the contextual blocks are keyed', () => {
+    const flow = contextualSpacingFlowKeys(
+      KEYS,
+      (index) => index === 1,
+      () => 'Tight'
+    );
+    expect(flow).toEqual(['a', 'b~cs~11', 'c']);
+  });
+
+  test('the verdict MOVES when a same-style neighbour arrives — the bug this exists for', () => {
+    const before = contextualSpacingFlowKeys(['a', 'b'], all, () => 'Tight');
+    const after = contextualSpacingFlowKeys(['a', 'b', 'c'], all, () => 'Tight');
+    // `b` was last and carried its space-after; now a same-style block follows it.
+    expect(before[1]).toBe('b~cs~10');
+    expect(after[1]).toBe('b~cs~11');
+    expect(after[1]).not.toBe(before[1]);
+  });
+});
+
+// `keepNextFlowKeys` splices a neighbour's WHOLE key in, so it has to fold last or a chain
+// head carries its members' pre-fold keys.
+describe('keepNextFlowKeys folds over the other folds', () => {
+  test('a chain head carries the successor key INCLUDING its contextual verdict', () => {
+    const folded = contextualSpacingFlowKeys(
+      ['h', 'p'],
+      (index) => index === 1,
+      () => 'Tight'
+    );
+    const flow = keepNextFlowKeys(folded, (index) => index === 0);
+    // The head splices in the AUGMENTED successor key, so a verdict flip under it moves
+    // the head's own key too. Folded the other way round the head would carry a bare `p`.
+    expect(flow[0]).toBe('h~kn~p~cs~10');
   });
 });

--- a/packages/core/src/layout/pagination-keeps.ts
+++ b/packages/core/src/layout/pagination-keeps.ts
@@ -283,6 +283,14 @@ export function contextualSpacingFlowKeys(
   return flow;
 }
 
+/**
+ * Flow keys that carry a `w:keepNext` chain's SUCCESSOR KEY.
+ *
+ * RUN THIS FOLD LAST. It is the only one that splices a neighbour's whole key into a
+ * block's own, so every other fold has to have finished: run it first and a chain head
+ * carries its members' pre-fold keys, and a head that never re-places when a member's
+ * marker text or contextual verdict moves is a stale keep-next group.
+ */
 export function keepNextFlowKeys(keys: string[], keepsNext: (index: number) => boolean): string[] {
   let flow = keys;
   let chain = 0;

--- a/packages/core/src/layout/pagination-keeps.ts
+++ b/packages/core/src/layout/pagination-keeps.ts
@@ -247,6 +247,42 @@ export function listMarkerFlowKeys(
   return flow;
 }
 
+/**
+ * Flow keys that also carry each block's `w:contextualSpacing` VERDICT.
+ *
+ * `w:contextualSpacing` (§17.3.1.9) drops a paragraph's space before or after when the
+ * neighbour on that side is a paragraph of the SAME style, so the block's own height is a
+ * function of two blocks it does not contain. Its content key cannot see that: inserting a
+ * list item under the last one has to change the last one's space-after from 8pt to zero,
+ * and with the key unmoved the incremental pass resumed past it and kept the stale height —
+ * a list whose items closed up on open, and stopped closing up as soon as it was edited.
+ *
+ * The same cross-block fold as {@link keepNextFlowKeys}, and folded for the same reason.
+ * Only the two booleans go in the key, not the neighbours' style ids: what the verdict
+ * depends on is whether each side matches, so a rename that moves both sides together must
+ * not re-place a block whose spacing is identical.
+ *
+ * `styleAt` answers null for a block that can never match — a table, or a paragraph with no
+ * style — which is what makes an unstyled run of paragraphs keep its spacing.
+ */
+export function contextualSpacingFlowKeys(
+  keys: string[],
+  contextualAt: (index: number) => boolean,
+  styleAt: (index: number) => string | null
+): string[] {
+  let flow = keys;
+  for (let index = 0; index < keys.length; index += 1) {
+    if (!contextualAt(index)) continue;
+    const style = styleAt(index);
+    if (style === null) continue;
+    const before = index > 0 && styleAt(index - 1) === style;
+    const after = index + 1 < keys.length && styleAt(index + 1) === style;
+    if (flow === keys) flow = [...keys];
+    flow[index] = `${flow[index]}~cs~${before ? 1 : 0}${after ? 1 : 0}`;
+  }
+  return flow;
+}
+
 export function keepNextFlowKeys(keys: string[], keepsNext: (index: number) => boolean): string[] {
   let flow = keys;
   let chain = 0;

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1063,13 +1063,24 @@ function layoutBlocksPass(
       // stored under; the CROSS-BLOCK properties make the two differ: `w:keepNext`
       // (§17.3.1.15), the list marker, and `w:contextualSpacing` (§17.3.1.9), each of which
       // makes a block's placement depend on a block it does not contain.
-      flowKeys: listMarkerFlowKeys(
-        contextualSpacingFlowKeys(
-          keepNextFlowKeys(keys, (index) => keepsNext[index]!),
-          (index) => contextualSpacings[index]!,
-          (index) => styleIds[index] ?? null
+      //
+      // ORDER IS LOAD-BEARING, and `keepNextFlowKeys` is OUTERMOST for a reason. It is the
+      // only fold that splices a NEIGHBOUR'S WHOLE KEY into a block's own, so whatever it
+      // reads has to be finished: run it first and a chain head carries its members'
+      // pre-fold keys, which is a head that never re-places when a member's marker or
+      // contextual verdict moves. That is latent rather than live today only because
+      // `keepNextGroupHeight` prices AUTHORED spacing; folding last makes the composition
+      // correct whatever that lookahead grows into.
+      flowKeys: keepNextFlowKeys(
+        listMarkerFlowKeys(
+          contextualSpacingFlowKeys(
+            keys,
+            (index) => contextualSpacings[index]!,
+            (index) => styleIds[index] ?? null
+          ),
+          (index) => markerTexts[index]
         ),
-        (index) => markerTexts[index]
+        (index) => keepsNext[index]!
       ),
     };
   }

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -62,6 +62,7 @@ import {
   adjustedBreakIndex,
   keepNextFlowKeys,
   listMarkerFlowKeys,
+  contextualSpacingFlowKeys,
   keepNextGroupHeight,
   paragraphKeeps,
   MAX_KEEP_NEXT_CHAIN,
@@ -1035,6 +1036,12 @@ function layoutBlocksPass(
     const markerTexts = prepared.map((entry) =>
       entry.kind === 'paragraph' ? listItems?.get(entry.paragraph.id)?.markerText : undefined
     );
+    // The two inputs `w:contextualSpacing` reads from the blocks on either side. A table
+    // answers null, which is what `sameStyleAs` means by "not a paragraph of this style".
+    const contextualSpacings = prepared.map(
+      (entry) => entry.kind === 'paragraph' && entry.contextualSpacing
+    );
+    const styleIds = prepared.map((entry) => (entry.kind === 'paragraph' ? entry.styleId : null));
     return {
       bodies,
       producer,
@@ -1053,9 +1060,15 @@ function layoutBlocksPass(
       keepsNext,
       markerTexts,
       // FLOW keys — what incremental resume compares. `keys` stays what the break cache is
-      // stored under; only `w:keepNext` and list markers make the two differ (§17.3.1.15).
+      // stored under; the CROSS-BLOCK properties make the two differ: `w:keepNext`
+      // (§17.3.1.15), the list marker, and `w:contextualSpacing` (§17.3.1.9), each of which
+      // makes a block's placement depend on a block it does not contain.
       flowKeys: listMarkerFlowKeys(
-        keepNextFlowKeys(keys, (index) => keepsNext[index]!),
+        contextualSpacingFlowKeys(
+          keepNextFlowKeys(keys, (index) => keepsNext[index]!),
+          (index) => contextualSpacings[index]!,
+          (index) => styleIds[index] ?? null
+        ),
         (index) => markerTexts[index]
       ),
     };

--- a/packages/react/src/editor/toolbar/ParagraphStyle.tsx
+++ b/packages/react/src/editor/toolbar/ParagraphStyle.tsx
@@ -29,6 +29,7 @@ import { useEditorCommand } from '../useEditorCommand';
 import { useToolbarLabel } from './toolbar-context';
 import { chromeControlForSlot, guardToolbarMousedown } from './ToolbarButton';
 import { Slot } from './Slot';
+import { paragraphStyleDisplayName } from '../../lib/stylePreview';
 
 /** One pickable paragraph style, as the document defines it. @public */
 export interface ParagraphStyleOption {
@@ -106,7 +107,7 @@ export function useParagraphStyle(): UseParagraphStyleResult {
             .filter((style) => style.type === 'paragraph')
             .map((style) => ({
               styleId: style.styleId,
-              name: style.name,
+              name: paragraphStyleDisplayName(style.name, style.styleId),
               preview: style.preview,
             }))
         : EMPTY_OPTIONS,

--- a/packages/react/src/lib/stylePreview.ts
+++ b/packages/react/src/lib/stylePreview.ts
@@ -99,6 +99,27 @@ export function getStylePreviewProps(input: {
   return props;
 }
 
+/** Word's own `w:name` for a built-in heading: lowercase, with the level after it. */
+const BUILT_IN_HEADING_NAME = /^heading ([1-9])$/;
+
+/**
+ * The label a picker shows for one paragraph style.
+ *
+ * Word writes its built-in headings with a LOWERCASE `w:name` — `heading 4`, never
+ * `Heading 4` — and title-cases them in its own UI. A picker printing `w:name` verbatim
+ * reads `Heading 1, Heading 2, Heading 3, heading 4, heading 5` on any document defining
+ * more than three, because only the first three have a localized label of their own.
+ *
+ * Built-in headings only. Every other name belongs to the document and is shown exactly
+ * as it was authored, because a custom style's name is the user's own words.
+ * @public
+ */
+export function paragraphStyleDisplayName(name: string, styleId: string): string {
+  const label = name || styleId;
+  const heading = BUILT_IN_HEADING_NAME.exec(label);
+  return heading ? `Heading ${heading[1]}` : label;
+}
+
 /**
  * Filter the engine's document-style summaries to the paragraph styles and
  * shape them for the picker, keeping the catalog's own order. The summary
@@ -117,7 +138,7 @@ export function resolveParagraphStyleOptions(
     .filter((s) => s.type === 'paragraph')
     .map((s) => ({
       styleId: s.styleId,
-      name: s.name || s.styleId,
+      name: paragraphStyleDisplayName(s.name, s.styleId),
       priority: 99,
     }));
 }

--- a/packages/react/test/toolbar-composition.test.tsx
+++ b/packages/react/test/toolbar-composition.test.tsx
@@ -867,8 +867,10 @@ describe('the shaped parts', () => {
     // The selected row carries a ✓ glyph, so compare the label span rather than the row.
     const items = rows.map((row) => row.querySelector('span')?.textContent);
     // Word's gallery order, NOT the order the part lists them in, with the unranked style
-    // keeping its document position at the end.
-    expect(items).toEqual(['Normal', 'heading 1', 'Callout']);
+    // keeping its document position at the end. `Heading 1` is title-cased for display:
+    // Word writes the built-in name lowercase and title-cases it in its own UI. `Callout`
+    // is the document's own style, so its name is shown exactly as authored.
+    expect(items).toEqual(['Normal', 'Heading 1', 'Callout']);
     // The paragraph states no `w:pStyle` but IS written in the default style, so the tick
     // sits on it. Reading "no style" as "nothing selected" left every row unticked while
     // the trigger showed a placeholder for a style the list names.
@@ -899,7 +901,7 @@ describe('the shaped parts', () => {
       heading.click();
     });
     expect(editor().snapshot().formatting?.styleId).toBe('Heading1');
-    expect(trigger.textContent).toBe('heading 1');
+    expect(trigger.textContent).toBe('Heading 1');
   });
 
   test('save is NOT in the default bar (contextual slot); composed, it needs onSave to be live', async () => {

--- a/packages/vue/src/editor/toolbar/useParagraphStyle.ts
+++ b/packages/vue/src/editor/toolbar/useParagraphStyle.ts
@@ -4,6 +4,7 @@ import { commandForSlotValue } from '@docx-editor.dev/core/editor';
 import { useDocxEditor } from '../context';
 import { useEditorState } from '../useEditorState';
 import { useEditorCommand } from '../useEditorCommand';
+import { paragraphStyleDisplayName } from '../../lib/stylePreview';
 
 /** @public */
 export interface ParagraphStyleOption {
@@ -42,7 +43,7 @@ export function useParagraphStyle(): UseParagraphStyleResult {
           .filter((style) => style.type === 'paragraph')
           .map((style) => ({
             styleId: style.styleId,
-            name: style.name,
+            name: paragraphStyleDisplayName(style.name, style.styleId),
             preview: style.preview,
           }))
       : EMPTY_OPTIONS

--- a/packages/vue/src/lib/stylePreview.ts
+++ b/packages/vue/src/lib/stylePreview.ts
@@ -99,6 +99,27 @@ export function getStylePreviewProps(input: {
   return props;
 }
 
+/** Word's own `w:name` for a built-in heading: lowercase, with the level after it. */
+const BUILT_IN_HEADING_NAME = /^heading ([1-9])$/;
+
+/**
+ * The label a picker shows for one paragraph style.
+ *
+ * Word writes its built-in headings with a LOWERCASE `w:name` — `heading 4`, never
+ * `Heading 4` — and title-cases them in its own UI. A picker printing `w:name` verbatim
+ * reads `Heading 1, Heading 2, Heading 3, heading 4, heading 5` on any document defining
+ * more than three, because only the first three have a localized label of their own.
+ *
+ * Built-in headings only. Every other name belongs to the document and is shown exactly
+ * as it was authored, because a custom style's name is the user's own words.
+ * @public
+ */
+export function paragraphStyleDisplayName(name: string, styleId: string): string {
+  const label = name || styleId;
+  const heading = BUILT_IN_HEADING_NAME.exec(label);
+  return heading ? `Heading ${heading[1]}` : label;
+}
+
 /**
  * Filter the engine's document-style summaries to the paragraph styles and
  * shape them for the picker, keeping the catalog's own order. The summary
@@ -117,7 +138,7 @@ export function resolveParagraphStyleOptions(
     .filter((s) => s.type === 'paragraph')
     .map((s) => ({
       styleId: s.styleId,
-      name: s.name || s.styleId,
+      name: paragraphStyleDisplayName(s.name, s.styleId),
       priority: 99,
     }));
 }


### PR DESCRIPTION
A blank document defined `Normal` and nothing else, so a New document offered one entry in the style picker and no way to make a heading. Word keeps its built-in styles latent and writes each definition the first time it is used; nothing here can materialize a latent style, so the template ships them.

`styles.xml` now carries Heading 1 through Heading 9, Title, Subtitle, Quote, No Spacing, and List Paragraph, plus the three default styles a Word part carries one of each: `DefaultParagraphFont`, `TableNormal`, and `NoList`.

## List spacing

List Paragraph is the one with a visible second job. It states `w:contextualSpacing`, which is what suppresses the space between neighbours of the same style, and layout only applies that when both paragraphs resolve to the same `styleId`. Adding the definition alone changes nothing, because list items carried no `w:pStyle` at all.

`toggleList` now applies the style on the list gesture:

- A paragraph in a **non-default** style keeps it. Bulleting a Heading 1 leaves it a heading.
- A paragraph in the **default** style does not. That is not the same as authoring no style: a converter stamps `<w:pStyle w:val="Normal"/>` on every paragraph it writes.
- The style is found by `w:name` first, then by styleId, which is how Word identifies its built-ins. A file spelling the id `a3` still works.
- A document that defines no List Paragraph style gets no `w:pStyle` write. A dangling one would render as Normal here and as a missing style everywhere else.
- Turning the list off keeps the style. Pressing Enter on an empty item to leave the list sheds it, or the text would keep the style's half-inch indent with no marker beside it.

On a blank document, two bulleted items now paint 15.11pt and 23.11pt: the 8pt drops between the items and stays under the last one.

## Two fidelity notes

The headings state no font. Word's headings name the theme's major typeface, Calibri Light, and a faithful template would say so. No metric-compatible substitute for Calibri Light exists in `packages/fonts`, so a heading measures and paints in Calibri either way, while the declared name lights the font-compatibility notice on a brand-new document for a face nothing on the page uses. Name it once that notice reports the families a document renders rather than the families it declares.

The style picker now title-cases Word's built-in heading names. Word writes `heading 4` lowercase in `w:name` and title-cases it in its own UI; a picker printing the name verbatim read `Heading 1, Heading 2, Heading 3, heading 4` on any document defining more than three. A custom style's name is still shown exactly as authored.

## Verification

The generated `styles.xml` validates against the bundled ECMA-376 schema, with only the known transitional-versus-strict differences left (`w:ind@left`, `left` and `right` cell margins, `ST_MeasurementOrPercent` on `w:w`). Style values were checked against `w:styles` that Word itself saved, in `e2e/fixtures`.

Gates run locally: `typecheck`, `lint`, `test` (7840 pass), `check:parity`, `i18n:validate`, `api:check`, `check:docs-mdx`, `openspec validate --strict`, `format`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790074552&installation_model_id=422592&pr_number=380&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F380&signature=70518a9aed1000b01fdfc2fd1cceeb86d674e4ec889750e9afec237f67c14edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->