### PR TITLE
fix(core): commit IME text composed into an empty paragraph

### DIFF
--- a/.changeset/ime-empty-paragraph-readback.md
+++ b/.changeset/ime-empty-paragraph-readback.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixed IME text being dropped when you compose into an empty paragraph, and header text being duplicated when you compose into a header that repeats on several pages.

--- a/.changeset/ime-empty-paragraph-readback.md
+++ b/.changeset/ime-empty-paragraph-readback.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fixed IME text being dropped when you compose into an empty paragraph, and fixed a composition deleting an inline image or hidden text elsewhere in the same paragraph. Text in a header, a repeating table header row, or a footnote referenced twice no longer duplicates when you compose into it.
+Fixed IME text being dropped when you compose into an empty paragraph, and fixed a composition deleting an inline image or hidden text elsewhere in the same paragraph. Composing over a selection that spans two paragraphs now replaces the whole range in one step. Text in a header, a repeating table header row, or a footnote referenced twice no longer duplicates when you compose into it.

--- a/.changeset/ime-empty-paragraph-readback.md
+++ b/.changeset/ime-empty-paragraph-readback.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fixed IME text being dropped when you compose into an empty paragraph, and header text being duplicated when you compose into a header that repeats on several pages.
+Fixed IME text being dropped when you compose into an empty paragraph, and fixed a composition deleting an inline image or hidden text elsewhere in the same paragraph. Text in a header, a repeating table header row, or a footnote referenced twice no longer duplicates when you compose into it.

--- a/packages/core/src/editor/__tests__/composition-readback-integrity.test.ts
+++ b/packages/core/src/editor/__tests__/composition-readback-integrity.test.ts
@@ -1,0 +1,401 @@
+// A COMPOSITION MUST NOT DESTROY WHAT IT DID NOT TOUCH.
+//
+// The IME readback diffs the painted text against the paragraph's model text and commits the
+// difference. So anything the model holds that the page does not show as editable text is a
+// character the diff will explain by deleting it — and anything the page shows that the model
+// does not hold is a character the diff will write in.
+//
+// Both halves cost documents, silently, on a keystroke nobody would connect to the damage:
+//
+//   - An inline drawing occupies one UTF-16 unit and publishes no span; it is painted BESIDE
+//     the text, not as it. A `w:vanish` run advances offsets and paints nothing at all. Each
+//     leaves a hole between one span's model end and the next one's start, and a hole read as
+//     absent reads as deleted.
+//   - A drawing that has not resolved paints a placeholder card whose label says "Loading
+//     image". The card is only `aria-hidden` when the drawing has NO alt text, so a `.docx`
+//     supplying `wp:docPr/@descr` put a UI string into the paragraph.
+//   - A paragraph the page repeats — a shared header, a `w:tblHeader` row, a twice-referenced
+//     footnote — was read back once per copy and joined.
+//   - A resolved display mode lays a mark-deleted paragraph out on the same line as the
+//     survivor that absorbed it, and stamps the line with only ONE of the two ids.
+//
+// The rule underneath all of them: this readback is the mirror of `paragraphTextFromLayout`,
+// which builds the model side of the same diff. Where the browser has not written, the two
+// must agree exactly.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { paintedTextOf } from '../surface-input.ts';
+import { paragraphTextFromLayout } from '../../layout/semantic-interaction.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const IMG = `${R}/image`;
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const DRAW_NS = `xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"`;
+
+const COMPOSED = '中文';
+
+const PNG_1X1 = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  ),
+  (c) => c.charCodeAt(0)
+);
+
+function types(...overrides: string[]): string {
+  return (
+    `<Types xmlns="${CT}">` +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="png" ContentType="image/png"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    overrides.join('') +
+    '</Types>'
+  );
+}
+
+const ROOT_RELS = `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`;
+
+function withSurface(
+  bytes: Uint8Array,
+  run: (surface: PaginatedSurface, container: HTMLElement) => void,
+  options: { revisionDisplayMode?: 'proposed' } = {}
+): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, bytes, { scale: 1, ...options });
+  if (!opened.ok) throw new Error(opened.reason);
+  try {
+    run(opened.surface, container);
+  } finally {
+    opened.surface.destroy();
+    container.remove();
+    document.getSelection()?.removeAllRanges();
+  }
+}
+
+function caretAt(surface: PaginatedSurface, paragraphId: string, offset: number): void {
+  surface.setSelection({ anchor: { paragraphId, offset }, head: { paragraphId, offset } });
+}
+
+/** Every painted span of one paragraph, in document order. */
+function spansOf(root: ParentNode, paragraphId: string): HTMLElement[] {
+  return [...root.querySelectorAll('[data-paragraph-id][data-start]')].filter(
+    (element) => (element as HTMLElement).dataset.paragraphId === paragraphId
+  ) as HTMLElement[];
+}
+
+/**
+ * Compose into one painted span, leaving the caret in it.
+ *
+ * The caret is what says WHICH painted copy was written, for a paragraph the page repeats —
+ * the IME leaves it in the text it just committed, so the readback asks the same question.
+ */
+function composeInto(container: HTMLElement, span: HTMLElement, text: string): void {
+  const pages = container.querySelector('.docx-pages')!;
+  pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+  span.textContent = text;
+  const range = document.createRange();
+  range.selectNodeContents(span);
+  range.collapse(false);
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+}
+
+// ---------------------------------------------------------------- unpainted model offsets
+
+const INLINE_PICTURE =
+  '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+  '<wp:extent cx="228600" cy="114300"/><wp:docPr id="1" name="pic1" descr="ALTTEXT"/>' +
+  `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
+  '<pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr>' +
+  '<pic:blipFill><a:blip r:embed="rIdImg"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+  '<pic:spPr><a:xfrm><a:ext cx="228600" cy="114300"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
+  '</pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r>';
+
+function pictureDocx(): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(types()),
+    '_rels/.rels': strToU8(ROOT_RELS),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/></Relationships>`
+    ),
+    'word/media/image1.png': PNG_1X1,
+    'word/document.xml': strToU8(
+      `<w:document ${DRAW_NS}><w:body>` +
+        `<w:p>${INLINE_PICTURE}<w:r><w:t xml:space="preserve">abc</w:t></w:r></w:p>` +
+        '</w:body></w:document>'
+    ),
+  });
+}
+
+describe('an offset the page does not paint is not an offset the browser deleted', () => {
+  test('an inline drawing survives a composition elsewhere in its paragraph', () => {
+    // The drawing occupies model offset 0 and publishes no span of its own, so the readback
+    // saw "abc" where the model holds "￼abc" — and the diff deleted the image to explain
+    // the difference. One composition, and the picture was gone with no way to connect the
+    // two.
+    withSurface(pictureDocx(), (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      expect(surface.session.bodyText()).toBe('￼abc');
+      caretAt(surface, id, 4);
+      composeInto(container, spansOf(container, id)[0]!, `abc${COMPOSED}`);
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.bodyText()).toBe(`￼abc${COMPOSED}`);
+      expect(container.querySelector('[data-drawing-node-id]')).not.toBeNull();
+    });
+  });
+
+  test("a drawing's placeholder label is never composed into the document", () => {
+    // `applyAccessibility` marks a drawing `aria-hidden` only when it has NO alt text; with
+    // `descr` it gets `aria-label` instead. The pending/refused card paints a real label
+    // ("Loading image") inside the LINE, so a file supplying alt text could put a string of
+    // its own choosing into the paragraph on the reader's next composition.
+    withSurface(pictureDocx(), (surface, container) => {
+      const card = container.querySelector('[data-drawing-node-id]')!;
+      expect(card.getAttribute('aria-hidden')).toBeNull();
+      expect(card.textContent).not.toBe('');
+      expect(card.closest('[data-line-id]')).not.toBeNull();
+
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 4);
+      composeInto(container, spansOf(container, id)[0]!, `abc${COMPOSED}`);
+      expect(surface.session.bodyText()).not.toContain(card.textContent!);
+    });
+  });
+
+  test('a w:vanish hidden run survives a composition elsewhere in its paragraph', () => {
+    const body =
+      '<w:p><w:r><w:t xml:space="preserve">abc</w:t></w:r>' +
+      '<w:r><w:rPr><w:vanish/></w:rPr><w:t xml:space="preserve">XYZ</w:t></w:r>' +
+      '<w:r><w:t xml:space="preserve">def</w:t></w:r></w:p>';
+    const bytes = zipSync({
+      '[Content_Types].xml': strToU8(types()),
+      '_rels/.rels': strToU8(ROOT_RELS),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+      ),
+    });
+    withSurface(bytes, (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      expect(surface.session.bodyText()).toBe('abcXYZdef');
+      // Hidden text is not measured and not painted, so the spans jump 3 -> 6.
+      expect(spansOf(container, id).map((span) => span.dataset.start)).toEqual(['0', '6']);
+      caretAt(surface, id, 3);
+      composeInto(container, spansOf(container, id)[0]!, `abc${COMPOSED}`);
+      expect(surface.session.bodyText()).toBe(`abc${COMPOSED}XYZdef`);
+    });
+  });
+});
+
+// ------------------------------------------------------------------ a paragraph painted twice
+
+const headerCell = (text: string, repeats: boolean) =>
+  '<w:tr>' +
+  (repeats ? '<w:trPr><w:tblHeader/></w:trPr>' : '') +
+  '<w:tc><w:tcPr><w:tcW w:w="5000" w:type="dxa"/></w:tcPr>' +
+  `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p></w:tc></w:tr>`;
+
+function repeatingHeaderDocx(): Uint8Array {
+  const rows = [headerCell('HEAD', true)];
+  for (let index = 0; index < 90; index += 1) rows.push(headerCell(`row ${index}`, false));
+  const table =
+    '<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="dxa"/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>' +
+    rows.join('') +
+    '</w:tbl>';
+  return zipSync({
+    '[Content_Types].xml': strToU8(types()),
+    '_rels/.rels': strToU8(ROOT_RELS),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${table}</w:body></w:document>`
+    ),
+  });
+}
+
+const noteReference =
+  '<w:p><w:r><w:t xml:space="preserve">see </w:t></w:r>' +
+  '<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr>' +
+  '<w:footnoteReference w:id="1"/></w:r></w:p>';
+
+function twiceReferencedNoteDocx(): Uint8Array {
+  const separators =
+    '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
+    '<w:footnote w:type="continuationSeparator" w:id="0">' +
+    '<w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>';
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      types(
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>'
+      )
+    ),
+    '_rels/.rels': strToU8(ROOT_RELS),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId20" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${noteReference}${noteReference}</w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}">${separators}` +
+        '<w:footnote w:id="1"><w:p><w:r><w:t xml:space="preserve">Note text</w:t></w:r></w:p></w:footnote>' +
+        '</w:footnotes>'
+    ),
+  });
+}
+
+describe('a paragraph the page repeats is read back ONCE, from the copy the caret is in', () => {
+  test('a repeating w:tblHeader row', () => {
+    // The row repeats on every page the table crosses, and no active-scope attribute tells the
+    // copies apart — each is ordinary body content on a different sheet. Joining them stored
+    // "HEAD中文HEADHEAD" in a cell the user typed two characters into.
+    withSurface(repeatingHeaderDocx(), (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      const copies = spansOf(container, id);
+      expect(container.querySelectorAll('.docx-page').length).toBeGreaterThan(1);
+      expect(copies.length).toBeGreaterThan(1);
+      caretAt(surface, id, 4);
+      // The IME writes into the copy the caret is in, which is not the first one on the page.
+      composeInto(container, copies[copies.length - 1]!, `HEAD${COMPOSED}`);
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.bodyText().startsWith(`HEAD${COMPOSED}\n`)).toBe(true);
+    });
+  });
+
+  test('a footnote referenced twice, whose copies share ONE sheet', () => {
+    // Both copies are on the same page, so the sheet cannot tell them apart and the container
+    // holding the caret has to be asked directly. Getting that wrong does not duplicate the
+    // text — it drops the composition, which is just as lost.
+    withSurface(twiceReferencedNoteDocx(), (surface, container) => {
+      const scope = { kind: 'notesPart', noteKind: 'footnote' } as const;
+      expect(surface.enterNote('footnote:1')).toBe(true);
+      const id = surface.session.paragraphIdsIn(scope)[0]!;
+      const copies = spansOf(container, id);
+      expect(copies.length).toBeGreaterThan(2);
+      caretAt(surface, id, 9);
+      composeInto(container, copies[copies.length - 1]!, `text${COMPOSED}`);
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.storyText(scope)).toBe(`Note text${COMPOSED}`);
+    });
+  });
+});
+
+// --------------------------------------------------------------- resolved-display join lines
+
+const LONG = `${'The quick brown fox jumps over the lazy dog. '.repeat(8)}END`;
+
+/** A paragraph whose MARK is deleted folds into the one after it in a resolved view. */
+const absorbed = (text: string) =>
+  '<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z"/></w:rPr></w:pPr>' +
+  `<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+function mergedDocx(): Uint8Array {
+  const body =
+    absorbed('AA ') +
+    absorbed(LONG) +
+    '<w:p><w:r><w:t xml:space="preserve">SURVIVOR</w:t></w:r></w:p>';
+  return zipSync({
+    '[Content_Types].xml': strToU8(types()),
+    '_rels/.rels': strToU8(ROOT_RELS),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+describe('a paragraph absorbed into another in a resolved view', () => {
+  test('reads back whole, though it owns no container for the line it starts in', () => {
+    // The line is stamped with its FIRST span's paragraph and the fragment with the
+    // survivor's id, so a member whose text begins mid-line has spans inside a container
+    // belonging to someone else. Reading containers alone lost 81 of its 363 characters, and
+    // the diff then took the composition as licence to delete them.
+    withSurface(
+      mergedDocx(),
+      (surface, container) => {
+        const id = surface.session.paragraphIds()[1]!;
+        const model = paragraphTextFromLayout(surface.layout(), id);
+        expect(model.length).toBe(LONG.length);
+        expect(paintedTextOf(container.querySelector('.docx-pages')!, id, model, null)).toBe(model);
+      },
+      { revisionDisplayMode: 'proposed' }
+    );
+  });
+
+  test('and a composition inside it adds text rather than truncating it', () => {
+    withSurface(
+      mergedDocx(),
+      (surface, container) => {
+        const id = surface.session.paragraphIds()[1]!;
+        const before = surface.session.bodyText();
+        caretAt(surface, id, 0);
+        const first = spansOf(container, id).find((span) => span.dataset.start === '0')!;
+        composeInto(container, first, `${COMPOSED}${first.textContent}`);
+        expect(surface.state().lastRejection).toBeNull();
+        expect(surface.session.bodyText().length).toBe(before.length + COMPOSED.length);
+      },
+      { revisionDisplayMode: 'proposed' }
+    );
+  });
+});
+
+/** A minimal painted paragraph: one fragment, one line, one span over "alpha beta". */
+function paintedParagraph(paragraphId: string): HTMLElement {
+  const root = document.createElement('div');
+  const fragment = document.createElement('div');
+  fragment.className = 'docx-paragraph-fragment';
+  fragment.dataset.paragraphId = paragraphId;
+  fragment.dataset.fragmentIndex = '0';
+  const line = document.createElement('div');
+  line.className = 'docx-line';
+  line.dataset.lineId = 'line-1';
+  line.dataset.paragraphId = paragraphId;
+  const run = document.createElement('span');
+  run.dataset.paragraphId = paragraphId;
+  run.dataset.start = '0';
+  run.dataset.end = '10';
+  run.textContent = 'alpha beta';
+  line.append(run);
+  fragment.append(line);
+  root.append(fragment);
+  return root;
+}
+
+describe('a story painted inside another paragraph is not that paragraph', () => {
+  test('an inline TEXT BOX inside the line contributes nothing to the paragraph', () => {
+    // A text box's story is painted INSIDE the line, so another part's words sit in the
+    // middle of this paragraph's subtree. The readback walks that subtree in DOM order to
+    // find text an IME wrote outside any span — and would otherwise have taken the whole
+    // box with it, inserting it into the paragraph on the next composition.
+    const root = paintedParagraph('p1');
+    const line = root.querySelector('[data-line-id="line-1"]')!;
+
+    const drawing = document.createElement('div');
+    drawing.className = 'docx-drawing docx-drawing-textbox';
+    drawing.dataset.drawingNodeId = 'd1';
+    // `paintTextboxStory` marks the box inert and strips `data-paragraph-id` off the story's
+    // own fragments, so its spans publish a range that belongs to no paragraph on this page.
+    drawing.setAttribute('contenteditable', 'false');
+    const content = document.createElement('div');
+    content.className = 'docx-drawing-textbox-content';
+    const storyRun = document.createElement('span');
+    storyRun.dataset.start = '0';
+    storyRun.dataset.end = '9';
+    storyRun.textContent = 'BOXED ...';
+    const stray = document.createTextNode('loose');
+    content.append(storyRun, stray);
+    drawing.append(content);
+    line.append(drawing);
+
+    expect(paintedTextOf(root, 'p1', 'alpha beta')).toBe('alpha beta');
+  });
+});

--- a/packages/core/src/editor/__tests__/composition-readback.test.ts
+++ b/packages/core/src/editor/__tests__/composition-readback.test.ts
@@ -16,9 +16,9 @@
 //     three concatenated copies of itself and then wrote the extra two into the part.
 //   - The composition began over a range spanning TWO paragraphs, which the browser replaces
 //     with a join. One paragraph's diff cannot express that, so half the edit committed and
-//     half did not (#383). The range is deleted at `compositionstart` instead, which is what
-//     typing over a selection means anyway, and the composition then starts inside one
-//     paragraph — the case everything below is about.
+//     half did not (#383). Those compositions do not read the painted DOM at all: the
+//     finished string arrives on `compositionend` itself, and replacing the still-untouched
+//     selection with it is the same call typing over a selection makes.
 //
 // The other half of the contract is what must NEVER reach the model: a list marker's bullet,
 // a tab leader's dots, the revision pilcrow, and a field's painted result are all painted
@@ -121,6 +121,18 @@ function caretAt(surface: PaginatedSurface, paragraphId: string, offset: number)
     anchor: { paragraphId, offset },
     head: { paragraphId, offset },
   });
+}
+
+/**
+ * A `compositionend` carrying the finished composed string, which is where a browser puts it.
+ *
+ * Assigned rather than passed to the constructor: happy-dom accepts `data` in the init dict
+ * and then reports `undefined`, so a test built the ordinary way would assert nothing.
+ */
+function compositionEnd(data: string): CompositionEvent {
+  const event = new CompositionEvent('compositionend', { bubbles: true });
+  Object.defineProperty(event, 'data', { value: data, configurable: true });
+  return event;
 }
 
 /**
@@ -281,35 +293,90 @@ describe('the ordinary case still holds', () => {
 });
 
 describe('#383 a composition begun over a range spanning two paragraphs', () => {
-  test('replaces the whole range, rather than committing half of it', () => {
-    // The browser replaces a cross-paragraph selection with a JOIN, and the readback
-    // describes ONE paragraph. Reconciling the head alone committed `beta` -> `ta` and left
-    // `alpha` untouched, so the document matched neither what the user had nor what the
-    // screen showed, and the composed characters went with the next repaint.
-    //
-    // The range is deleted at `compositionstart` instead, through the ordinary write lane,
-    // so the composition begins collapsed inside one paragraph.
-    withSurface(docx(`${p('alpha')}${p('beta')}`), (surface, container) => {
-      const [first, second] = surface.session.paragraphIds();
-      surface.setSelection({
-        anchor: { paragraphId: first!, offset: 2 },
-        head: { paragraphId: second!, offset: 2 },
-      });
-      const pages = container.querySelector('.docx-pages')!;
-      pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
-      // The two paragraphs are one by now, and the caret sits between "al" and "ta".
-      expect(surface.session.bodyText()).toBe('alta');
-      const joined = surface.state().selection.head.paragraphId;
-      repaintParagraphAs(container, joined, `al${COMPOSED}ta`);
-      pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+  /** Drive a composition whose text the browser reports on the event, as browsers do. */
+  function composeOverRange(container: HTMLElement, data: string): void {
+    const pages = container.querySelector('.docx-pages')!;
+    pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    pages.dispatchEvent(compositionEnd(data));
+  }
+
+  /** Select from offset 2 of the first paragraph through offset 2 of the second. */
+  function selectAcross(surface: PaginatedSurface): void {
+    const [first, second] = surface.session.paragraphIds();
+    surface.setSelection({
+      anchor: { paragraphId: first!, offset: 2 },
+      head: { paragraphId: second!, offset: 2 },
+    });
+  }
+
+  const TWO = `${p('alpha')}${p('beta')}`;
+
+  test('replaces the whole range, in one transaction', () => {
+    // Reconciling the head paragraph alone committed `beta` -> `ta` and left `alpha`
+    // untouched, so the document matched neither what the user had nor what the screen
+    // showed, and the composed characters went with the next repaint.
+    withSurface(docx(TWO), (surface, container) => {
+      selectAcross(surface);
+      composeOverRange(container, COMPOSED);
       expect(surface.state().lastRejection).toBeNull();
       expect(surface.session.bodyText()).toBe(`al${COMPOSED}ta`);
     });
   });
 
+  test('and it is ONE undo, like typing over the same range', () => {
+    // Deleting the range at compositionstart put it OUTSIDE the composition's own history
+    // entry, so the first undo landed on `alta` — a document the user never asked for.
+    withSurface(docx(TWO), (surface, container) => {
+      selectAcross(surface);
+      composeOverRange(container, COMPOSED);
+      surface.undo();
+      expect(surface.session.bodyText()).toBe('alpha\nbeta');
+    });
+  });
+
+  test('nothing is touched at compositionstart', () => {
+    // The tempting fix deletes the range there. `commit` may DEFER its paint, so the browser
+    // would still hold the two-paragraph selection on return, and the paint would then land
+    // mid-composition on the very nodes the IME is composing into.
+    withSurface(docx(TWO), (surface, container) => {
+      selectAcross(surface);
+      const pages = container.querySelector('.docx-pages')!;
+      pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      expect(surface.session.bodyText()).toBe('alpha\nbeta');
+      pages.dispatchEvent(compositionEnd(COMPOSED));
+    });
+  });
+
+  test('an abandoned composition leaves the range alone', () => {
+    // Escape, a click away, an app switch: `compositionend` arrives with no text. Deleting
+    // the range up front destroyed the selection for every one of those.
+    withSurface(docx(TWO), (surface, container) => {
+      selectAcross(surface);
+      composeOverRange(container, '');
+      expect(surface.session.bodyText()).toBe('alpha\nbeta');
+    });
+  });
+
+  test('a composition that changes nothing does not leave its text on the page', () => {
+    // An unchanged layout repaints nothing by design, so the browser's characters would stay
+    // on screen — and in a document nobody can edit, no later pass would ever remove them.
+    withSurface(docx(TWO), (surface, container) => {
+      surface.setEditingMode('view');
+      const [first] = surface.session.paragraphIds();
+      selectAcross(surface);
+      const pages = container.querySelector('.docx-pages')!;
+      pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      // The browser writes into the page whatever the model does.
+      repaintParagraphAs(container, first!, `al${COMPOSED}`);
+      pages.dispatchEvent(compositionEnd(COMPOSED));
+      expect(surface.session.bodyText()).toBe('alpha\nbeta');
+      expect(container.textContent).not.toContain(COMPOSED);
+    });
+  });
+
   test('a same-paragraph range is still left to the readback', () => {
-    // Deleting eagerly here would lose suggesting mode's rule that a deletion keeps the
-    // characters it strikes and the replacement lands after them.
+    // That lane keeps suggesting mode's rule that a deletion holds on to the characters it
+    // strikes and the replacement lands after them.
     withSurface(docx(p('alpha beta')), (surface, container) => {
       const id = surface.session.paragraphIds()[0]!;
       surface.setSelection({
@@ -318,7 +385,6 @@ describe('#383 a composition begun over a range spanning two paragraphs', () => 
       });
       const pages = container.querySelector('.docx-pages')!;
       pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
-      // Untouched by compositionstart: the browser still owns this replacement.
       expect(surface.session.bodyText()).toBe('alpha beta');
       repaintParagraphAs(container, id, `${COMPOSED} beta`);
       pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));

--- a/packages/core/src/editor/__tests__/composition-readback.test.ts
+++ b/packages/core/src/editor/__tests__/composition-readback.test.ts
@@ -1,0 +1,261 @@
+// WHAT AN IME WROTE INTO THE PAINTED DOM, READ BACK IN THE MODEL'S OFFSET SPACE.
+//
+// `beforeinput` for `insertCompositionText` is not cancelable, so composed text unavoidably
+// lands in the painted DOM and the readback at `compositionend` is the ONLY route by which it
+// reaches the tree. Everything that route cannot see is an edit the user made and the document
+// never got.
+//
+// Two ways it could not see one:
+//
+//   - The text is not inside a `[data-start]` span. An empty paragraph paints a line holding
+//     nothing but a `<br>`, so the browser is handed the LINE as the selection node and
+//     composes a bare text node into it. Chinese could not be typed at the start of an empty
+//     paragraph at all (#190).
+//   - The paragraph is painted MORE THAN ONCE. A shared header or footer repaints the same
+//     paragraph ids on every page, so a document-wide scan read a three-page header back as
+//     three concatenated copies of itself and then wrote the extra two into the part.
+//
+// The other half of the contract is what must NEVER reach the model: a list marker's bullet,
+// a tab leader's dots, the revision pilcrow, and a field's painted result are all painted
+// inside the paragraph and are not characters the document has.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const NUMREL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
+
+/** Two Chinese characters, the input the report was written against. */
+const COMPOSED = '中文';
+
+const NUMBERING =
+  `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">` +
+  '<w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/>' +
+  '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>' +
+  '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>';
+
+const LIST_ITEM =
+  '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr></w:p>';
+
+const CELL =
+  '<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="dxa"/></w:tblPr>' +
+  '<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>' +
+  '<w:tr><w:tc><w:tcPr><w:tcW w:w="5000" w:type="dxa"/></w:tcPr><w:p/></w:tc></w:tr></w:tbl>';
+
+const p = (text: string) => `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+const PAGE_BREAK = '<w:p><w:r><w:br w:type="page"/></w:r></w:p>';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${NUMREL}" Target="numbering.xml"/></Relationships>`
+    ),
+    'word/numbering.xml': strToU8(NUMBERING),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function headerDocx(header: string, body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId10" Type="${R}/header" Target="header1.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}` +
+        '<w:sectPr><w:headerReference w:type="default" r:id="rId10"/></w:sectPr></w:body></w:document>'
+    ),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${header}</w:hdr>`),
+  });
+}
+
+function withSurface(
+  bytes: Uint8Array,
+  run: (surface: PaginatedSurface, container: HTMLElement) => void
+): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, bytes, { scale: 1 });
+  if (!opened.ok) throw new Error(opened.reason);
+  try {
+    run(opened.surface, container);
+  } finally {
+    opened.surface.destroy();
+    container.remove();
+    document.getSelection()?.removeAllRanges();
+  }
+}
+
+function caretAt(surface: PaginatedSurface, paragraphId: string, offset: number): void {
+  surface.setSelection({
+    anchor: { paragraphId, offset },
+    head: { paragraphId, offset },
+  });
+}
+
+/**
+ * What the browser does for a composition the surface could not intercept: it writes the
+ * painted DOM itself, and only then says it is finished.
+ *
+ * `write` receives the painted copy the caret is in — the ACTIVE header/footer when one is
+ * open, which is the one copy an IME can reach.
+ */
+function compose(container: HTMLElement, write: (scope: Element) => void): void {
+  const pages = container.querySelector('.docx-pages')!;
+  pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+  write(container.querySelector('[data-docx-hf-active]') ?? pages);
+  pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+}
+
+/** The painted line of a paragraph — the node an empty paragraph hands the browser. */
+function lineOf(scope: Element, paragraphId: string): HTMLElement {
+  for (const element of scope.querySelectorAll('[data-paragraph-id][data-line-id]')) {
+    if ((element as HTMLElement).dataset.paragraphId === paragraphId) return element as HTMLElement;
+  }
+  throw new Error(`no painted line for ${paragraphId}`);
+}
+
+/** The IME composes a bare text node at the head of the line, which is where the caret was. */
+function composeIntoLine(scope: Element, paragraphId: string, text: string): void {
+  const line = lineOf(scope, paragraphId);
+  line.insertBefore(document.createTextNode(text), line.firstChild);
+}
+
+describe('#190 composition at offset 0 of an empty paragraph', () => {
+  test('the composed text is committed', () => {
+    withSurface(docx('<w:p/>'), (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 0);
+      compose(container, (scope) => composeIntoLine(scope, id, COMPOSED));
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.bodyText()).toBe(COMPOSED);
+      // The caret lands after the composed text, not back at the paragraph start.
+      expect(surface.state().selection.head).toEqual({ paragraphId: id, offset: COMPOSED.length });
+    });
+  });
+
+  test('an empty paragraph AFTER one with text still composes into itself', () => {
+    // The readback addresses one paragraph, but a document-wide scan for its spans found the
+    // neighbours' too. The empty one has none, which is exactly the case that used to fall
+    // through to "nothing painted, nothing to commit".
+    withSurface(docx(`${p('alpha')}<w:p/>${p('beta')}`), (surface, container) => {
+      const id = surface.session.paragraphIds()[1]!;
+      caretAt(surface, id, 0);
+      compose(container, (scope) => composeIntoLine(scope, id, COMPOSED));
+      expect(surface.session.bodyText()).toBe(`alpha\n${COMPOSED}\nbeta`);
+    });
+  });
+
+  test('an empty paragraph in a TABLE CELL composes like any other', () => {
+    withSurface(docx(CELL), (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 0);
+      compose(container, (scope) => composeIntoLine(scope, id, COMPOSED));
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.bodyText()).toBe(COMPOSED);
+    });
+  });
+
+  test('a composition that writes nothing commits nothing', () => {
+    withSurface(docx('<w:p/>'), (surface) => {
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 0);
+      const container = document.querySelector('.docx-pages')!;
+      container.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      container.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+      expect(surface.session.bodyText()).toBe('');
+    });
+  });
+});
+
+describe('painted furniture is never composed into the document', () => {
+  test('an empty LIST item commits the composed text without its marker', () => {
+    // The marker is painted inside the paragraph fragment and carries the numbering glyph.
+    // Reading the fragment's text content wholesale would have written "1." into the list
+    // item as real characters — and the next repaint would number it "2." beside them.
+    withSurface(docx(LIST_ITEM), (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 0);
+      const marker = container.querySelector('.docx-list-marker');
+      expect(marker?.textContent).toBe('1.');
+      compose(container, (scope) => composeIntoLine(scope, id, COMPOSED));
+      expect(surface.session.bodyText()).toBe(COMPOSED);
+    });
+  });
+});
+
+describe('a paragraph painted on more than one page', () => {
+  test('a shared header reads back ONE copy, not one per page', () => {
+    withSurface(
+      headerDocx(p('HDR'), p('one') + PAGE_BREAK + p('two') + PAGE_BREAK + p('three')),
+      (surface, container) => {
+        expect(container.querySelectorAll('.docx-page').length).toBe(3);
+        expect(surface.enterHeaderFooter({ rId: 'rId10' })).toBe(true);
+        const scope = { kind: 'headerFooter', rId: 'rId10' } as const;
+        const id = surface.session.paragraphIdsIn(scope)[0]!;
+        caretAt(surface, id, 3);
+        compose(container, (active) => {
+          const span = [...active.querySelectorAll('[data-paragraph-id][data-start]')].find(
+            (element) => (element as HTMLElement).dataset.paragraphId === id
+          ) as HTMLElement;
+          span.textContent = `HDR${COMPOSED}`;
+        });
+        expect(surface.state().lastRejection).toBeNull();
+        expect(surface.session.storyText(scope)).toBe(`HDR${COMPOSED}`);
+      }
+    );
+  });
+
+  test('an EMPTY shared header paragraph composes into itself once', () => {
+    withSurface(headerDocx('<w:p/>', p('one') + PAGE_BREAK + p('two')), (surface, container) => {
+      expect(surface.enterHeaderFooter({ rId: 'rId10' })).toBe(true);
+      const scope = { kind: 'headerFooter', rId: 'rId10' } as const;
+      const id = surface.session.paragraphIdsIn(scope)[0]!;
+      caretAt(surface, id, 0);
+      compose(container, (active) => composeIntoLine(active, id, COMPOSED));
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.storyText(scope)).toBe(COMPOSED);
+    });
+  });
+});
+
+describe('the ordinary case still holds', () => {
+  test('composing inside an existing run commits the difference', () => {
+    withSurface(docx(p('abc')), (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 3);
+      compose(container, (scope) => {
+        const span = [...scope.querySelectorAll('[data-paragraph-id][data-start]')].find(
+          (element) => (element as HTMLElement).dataset.paragraphId === id
+        ) as HTMLElement;
+        span.textContent = `abc${COMPOSED}`;
+      });
+      expect(surface.session.bodyText()).toBe(`abc${COMPOSED}`);
+    });
+  });
+});

--- a/packages/core/src/editor/__tests__/composition-readback.test.ts
+++ b/packages/core/src/editor/__tests__/composition-readback.test.ts
@@ -5,7 +5,7 @@
 // reaches the tree. Everything that route cannot see is an edit the user made and the document
 // never got.
 //
-// Two ways it could not see one:
+// Three ways it could not see one:
 //
 //   - The text is not inside a `[data-start]` span. An empty paragraph paints a line holding
 //     nothing but a `<br>`, so the browser is handed the LINE as the selection node and
@@ -14,6 +14,11 @@
 //   - The paragraph is painted MORE THAN ONCE. A shared header or footer repaints the same
 //     paragraph ids on every page, so a document-wide scan read a three-page header back as
 //     three concatenated copies of itself and then wrote the extra two into the part.
+//   - The composition began over a range spanning TWO paragraphs, which the browser replaces
+//     with a join. One paragraph's diff cannot express that, so half the edit committed and
+//     half did not (#383). The range is deleted at `compositionstart` instead, which is what
+//     typing over a selection means anyway, and the composition then starts inside one
+//     paragraph — the case everything below is about.
 //
 // The other half of the contract is what must NEVER reach the model: a list marker's bullet,
 // a tab leader's dots, the revision pilcrow, and a field's painted result are all painted
@@ -146,6 +151,21 @@ function composeIntoLine(scope: Element, paragraphId: string, text: string): voi
   line.insertBefore(document.createTextNode(text), line.firstChild);
 }
 
+/**
+ * Rewrite what a paragraph paints, the way a browser rewrites it during a composition.
+ *
+ * A paragraph is more than one span whenever it holds more than one run or breaks over more
+ * than one line, so the whole text goes into the first and the rest are emptied.
+ */
+function repaintParagraphAs(scope: Element, paragraphId: string, text: string): void {
+  const spans = [...scope.querySelectorAll('[data-paragraph-id][data-start]')].filter(
+    (element) => (element as HTMLElement).dataset.paragraphId === paragraphId
+  ) as HTMLElement[];
+  if (spans.length === 0) throw new Error(`no painted span for ${paragraphId}`);
+  spans[0]!.textContent = text;
+  for (const extra of spans.slice(1)) extra.textContent = '';
+}
+
 describe('#190 composition at offset 0 of an empty paragraph', () => {
   test('the composed text is committed', () => {
     withSurface(docx('<w:p/>'), (surface, container) => {
@@ -256,6 +276,53 @@ describe('the ordinary case still holds', () => {
         span.textContent = `abc${COMPOSED}`;
       });
       expect(surface.session.bodyText()).toBe(`abc${COMPOSED}`);
+    });
+  });
+});
+
+describe('#383 a composition begun over a range spanning two paragraphs', () => {
+  test('replaces the whole range, rather than committing half of it', () => {
+    // The browser replaces a cross-paragraph selection with a JOIN, and the readback
+    // describes ONE paragraph. Reconciling the head alone committed `beta` -> `ta` and left
+    // `alpha` untouched, so the document matched neither what the user had nor what the
+    // screen showed, and the composed characters went with the next repaint.
+    //
+    // The range is deleted at `compositionstart` instead, through the ordinary write lane,
+    // so the composition begins collapsed inside one paragraph.
+    withSurface(docx(`${p('alpha')}${p('beta')}`), (surface, container) => {
+      const [first, second] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: first!, offset: 2 },
+        head: { paragraphId: second!, offset: 2 },
+      });
+      const pages = container.querySelector('.docx-pages')!;
+      pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      // The two paragraphs are one by now, and the caret sits between "al" and "ta".
+      expect(surface.session.bodyText()).toBe('alta');
+      const joined = surface.state().selection.head.paragraphId;
+      repaintParagraphAs(container, joined, `al${COMPOSED}ta`);
+      pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.bodyText()).toBe(`al${COMPOSED}ta`);
+    });
+  });
+
+  test('a same-paragraph range is still left to the readback', () => {
+    // Deleting eagerly here would lose suggesting mode's rule that a deletion keeps the
+    // characters it strikes and the replacement lands after them.
+    withSurface(docx(p('alpha beta')), (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      surface.setSelection({
+        anchor: { paragraphId: id, offset: 0 },
+        head: { paragraphId: id, offset: 5 },
+      });
+      const pages = container.querySelector('.docx-pages')!;
+      pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      // Untouched by compositionstart: the browser still owns this replacement.
+      expect(surface.session.bodyText()).toBe('alpha beta');
+      repaintParagraphAs(container, id, `${COMPOSED} beta`);
+      pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+      expect(surface.session.bodyText()).toBe(`${COMPOSED} beta`);
     });
   });
 });

--- a/packages/core/src/editor/__tests__/selection-integrity.test.ts
+++ b/packages/core/src/editor/__tests__/selection-integrity.test.ts
@@ -173,8 +173,17 @@ describe('painted furniture never contributes a model offset', () => {
  */
 function paintedFieldParagraph(): HTMLElement {
   const root = document.createElement('div');
+  // The fragment is the paragraph's painted container, and `paintFragment` always stamps it
+  // with the paragraph id — the readback walks it in DOM order so that text the browser
+  // wrote OUTSIDE any span is still seen.
+  const fragment = document.createElement('div');
+  fragment.className = 'docx-paragraph-fragment';
+  fragment.dataset.paragraphId = 'p1';
+  fragment.dataset.fragmentIndex = '0';
   const line = document.createElement('div');
   line.className = 'docx-line';
+  line.dataset.lineId = 'line-1';
+  line.dataset.paragraphId = 'p1';
   const add = (text: string, start: number, end: number, projected = false): void => {
     const span = document.createElement('span');
     span.dataset.paragraphId = 'p1';
@@ -190,7 +199,8 @@ function paintedFieldParagraph(): HTMLElement {
   add('a potential ', 0, 12);
   add('Scope of the discussions', 12, 13, true);
   add(' (the ', 13, 19);
-  root.append(line);
+  fragment.append(line);
+  root.append(fragment);
   return root;
 }
 
@@ -213,8 +223,14 @@ describe('the readback over a paragraph containing a field', () => {
     // so a four-word result read back as four `￼` where the model has one — and the diff then
     // inserted the extras into the document as literal object-replacement characters.
     const root = document.createElement('div');
+    const fragment = document.createElement('div');
+    fragment.className = 'docx-paragraph-fragment';
+    fragment.dataset.paragraphId = 'p1';
+    fragment.dataset.fragmentIndex = '0';
     const line = document.createElement('div');
     line.className = 'docx-line';
+    line.dataset.lineId = 'line-1';
+    line.dataset.paragraphId = 'p1';
     const add = (text: string, start: number, end: number, projected = false): void => {
       const span = document.createElement('span');
       span.dataset.paragraphId = 'p1';
@@ -229,7 +245,8 @@ describe('the readback over a paragraph containing a field', () => {
     add('of the ', 12, 13, true);
     add('discussions', 12, 13, true);
     add(' (the ', 13, 19);
-    root.append(line);
+    fragment.append(line);
+    root.append(fragment);
 
     expect(paintedTextOf(root, 'p1', FIELD_MODEL_TEXT)).toBe(FIELD_MODEL_TEXT);
     expect(paragraphReplacePlan('p1', FIELD_MODEL_TEXT, FIELD_MODEL_TEXT)).toBeNull();

--- a/packages/core/src/editor/dom-selection.ts
+++ b/packages/core/src/editor/dom-selection.ts
@@ -69,7 +69,7 @@ function identityOf(element: Element): SpanIdentity | null {
   return { paragraphId, start, end };
 }
 
-function paragraphElements(
+export function paragraphElements(
   root: Element,
   paragraphId: string,
   suffix: string
@@ -105,7 +105,7 @@ function activeHeaderFooterRoot(root: Element): Element | null {
  * Shared header/footer parts paint the same paragraph ids on every page; the active
  * container is the caret target the user entered.
  */
-function spanSearchRoots(root: Element): readonly Element[] {
+export function spanSearchRoots(root: Element): readonly Element[] {
   const active = activeHeaderFooterRoot(root);
   return active ? [active, root] : [root];
 }

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -2771,6 +2771,17 @@ export function mountPaginatedSurface(
     isGesturing: () => pointer?.dragging() ?? false,
     domSelection: () => (cellSelection ? collapsedAt(cellSelection.text.anchor) : selection),
     holdsCellSelection: () => cellSelection !== null,
+    collapseSelectionForComposition: () => {
+      // Only a range crossing a paragraph boundary. A same-paragraph one is read back
+      // correctly as it is, and deleting it here would lose suggesting mode's rule that the
+      // struck characters stay and the replacement follows them.
+      if (selection.anchor.paragraphId === selection.head.paragraphId) return true;
+      // `surface` is assigned below; a composition can only start once a caller holds it.
+      surface.deleteSelection();
+      // Refused — protected content, a locked control, a rectangle of cells that cannot
+      // join. The range is still there, and nothing downstream can describe it.
+      return selection.anchor.paragraphId === selection.head.paragraphId;
+    },
   });
 
   hfScope = createHeaderFooterScopeController({

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -73,6 +73,9 @@ import {
   paintSemanticLayout,
   type OverlayRect,
 } from '@docx-editor.dev/core/output';
+// By module path, like the roster walk below: dropping a retained paint is an engine
+// internal for the IME lane, not something the output barrel should offer consumers.
+import { discardRetainedPaint } from '../output/semantic-paint.ts';
 // By module path: the roster walk is an engine internal, not part of the output barrel's
 // public surface. See the note there.
 import {
@@ -2771,17 +2774,9 @@ export function mountPaginatedSurface(
     isGesturing: () => pointer?.dragging() ?? false,
     domSelection: () => (cellSelection ? collapsedAt(cellSelection.text.anchor) : selection),
     holdsCellSelection: () => cellSelection !== null,
-    collapseSelectionForComposition: () => {
-      // Only a range crossing a paragraph boundary. A same-paragraph one is read back
-      // correctly as it is, and deleting it here would lose suggesting mode's rule that the
-      // struck characters stay and the replacement follows them.
-      if (selection.anchor.paragraphId === selection.head.paragraphId) return true;
-      // `surface` is assigned below; a composition can only start once a caller holds it.
-      surface.deleteSelection();
-      // Refused — protected content, a locked control, a rectangle of cells that cannot
-      // join. The range is still there, and nothing downstream can describe it.
-      return selection.anchor.paragraphId === selection.head.paragraphId;
-    },
+    // `surface` is assigned below; a composition can only end once a caller holds it.
+    replaceSelectionWith: (text) => surface.type(text),
+    discardPaint: () => discardRetainedPaint(pagesLayer),
   });
 
   hfScope = createHeaderFooterScopeController({

--- a/packages/core/src/editor/surface-composition-readback.ts
+++ b/packages/core/src/editor/surface-composition-readback.ts
@@ -1,0 +1,315 @@
+// What the browser currently shows for a paragraph, IN THE MODEL'S OWN OFFSET SPACE.
+//
+// `beforeinput` for `insertCompositionText` is not cancelable, so an IME's text unavoidably
+// lands in the painted DOM and this readback is the ONLY route by which it reaches the tree.
+// The caller diffs the string this returns against the paragraph's model text and commits the
+// difference, so every character this gets wrong is a character the document gets wrong.
+//
+// THE MIRROR OF `paragraphTextFromLayout`. That function builds the MODEL side of the same
+// diff out of the layout records, and it has already had to answer every question here: it
+// contributes each model range once (a paragraph crossing a page paints the same ranges
+// twice), clamps a projected atom to its model width, counts an inline drawing as the one
+// UTF-16 unit it occupies, and pads a gap so offsets stay aligned. This side must answer them
+// the same way, or the two disagree and the diff explains the disagreement by editing the
+// document. It differs in exactly one respect, which is the whole point: it reads the PAINTED
+// text, so wherever the browser has written something, that is what comes back.
+//
+// Four ways a naive read gets it wrong, each of which cost a document:
+//
+//   - Text that is not inside a `[data-start]` span. An empty paragraph paints a line holding
+//     nothing but a `<br>`, so the browser is handed the LINE as the selection node and
+//     composes a bare text node into it (#190).
+//   - Furniture that IS inside the paragraph. A list marker's bullet, a tab leader's dots, the
+//     revision pilcrow, a drawing's placeholder label — none are characters the model has.
+//   - The same paragraph painted more than once: a shared header, a repeating table header
+//     row, a twice-referenced footnote. Joining every copy read a three-page header back as
+//     three concatenated copies of itself.
+//   - Model offsets NOTHING paints: an inline drawing's atom, a `w:vanish` hidden run. Read as
+//     absent, they read as deleted — so one composition anywhere in the paragraph removed the
+//     image, or the hidden text, permanently and silently.
+
+import { paragraphElements } from './dom-selection.ts';
+
+/**
+ * One contribution to the readback.
+ *
+ * `end` is the MODEL end, which is not `start + text.length` for everything: a field atom is
+ * one model unit however many glyphs it paints, and a stray the browser wrote occupies no
+ * model range at all. `seq` is DOM order, which is the only thing that can say whether text
+ * the browser wrote sits before or after a span that starts at the same offset.
+ */
+interface PaintedPiece {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+  readonly seq: number;
+}
+
+/**
+ * Furniture painted INSIDE a paragraph, which is never model text.
+ *
+ * A list marker's bullet, a tab leader's dots, the revision pilcrow, the inline-drawing and
+ * float-wrap advance spacers, and a zero-width `w:ptab`'s painted `\t` all carry glyphs the
+ * model does not have.
+ *
+ * `[data-drawing-node-id]` is every painted drawing, and it is load-bearing rather than
+ * belt-and-braces. An inline drawing is appended to the LINE, and while its resource is
+ * pending — or missing, or of a format that will not decode — it paints a placeholder card
+ * whose label reads "Loading image". That card is only `aria-hidden` when the drawing has NO
+ * alt text, because `applyAccessibility` gives a labelled drawing `aria-label` instead. So a
+ * `.docx` supplying `wp:docPr/@descr` made its own label part of the paragraph on the next
+ * composition. The drawing's own model unit still arrives, from the gap fill below.
+ *
+ * `contenteditable="false"` says the same thing in the browser's own words and catches the
+ * rest. Asked only of a DESCENDANT, never of the container the walk starts at: a read-only
+ * paragraph carries the attribute on its own fragment, and the body content box carries it
+ * whenever a header is open.
+ */
+const PAINTED_FURNITURE =
+  '[data-docx-marker],[data-docx-tab-leader],[aria-hidden="true"],[contenteditable="false"],[data-drawing-node-id]';
+
+/** A `data-end` is only believed when it is a plausible model end for its own start. */
+function modelEndOf(element: HTMLElement, start: number, fallback: number): number {
+  const rawEnd = element.dataset.end;
+  if (rawEnd === undefined || !/^\d{1,9}$/.test(rawEnd)) return fallback;
+  const end = Number(rawEnd);
+  return end >= start ? end : fallback;
+}
+
+/** A span's model start, or null when it does not publish a usable one. */
+function modelStartOf(element: HTMLElement, paragraphId: string): number | null {
+  if (element.dataset.paragraphId !== paragraphId) return null;
+  const rawStart = element.dataset.start;
+  if (rawStart === undefined || !/^\d{1,9}$/.test(rawStart)) return null;
+  return Number(rawStart);
+}
+
+/**
+ * The sheet a node was painted on.
+ *
+ * WHICH COPY the caret is in is the only honest answer to a paragraph painted many times, and
+ * a repeating table header row has no active-scope attribute to ask instead — every copy is
+ * ordinary body content on a different page.
+ */
+function sheetOf(node: Node | null): Element | null {
+  if (!node) return null;
+  const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  return element?.closest('.docx-page') ?? null;
+}
+
+/**
+ * How strongly a painted copy claims to be the one that was composed into.
+ *
+ * The container itself is asked before the sheet, because the sheet cannot always tell them
+ * apart: a footnote referenced twice paints both copies on the SAME page, so a sheet test
+ * scores them equally and the first — the one the IME did not write — would win, and the
+ * composed text would be dropped rather than duplicated.
+ */
+function anchorAffinity(
+  element: Element,
+  anchor: Node | null,
+  anchorSheet: Element | null
+): number {
+  if (anchor && element.contains(anchor)) return 2;
+  if (anchorSheet?.contains(element)) return 1;
+  return 0;
+}
+
+/** What a span contributes: the model's own characters for a projected atom, else its text. */
+function spanPiece(
+  element: HTMLElement,
+  start: number,
+  modelText: string,
+  seq: number
+): PaintedPiece {
+  if (element.dataset.docxField !== undefined) {
+    // A PROJECTED atom — one layout owns the glyphs of — is one model unit however many
+    // characters it paints, and the browser cannot write inside one. So it contributes the
+    // MODEL's characters for its range: "Scope of the discussions" is 24 glyphs over a range
+    // of 1, and joining the painted text made the diff delete the field and insert its own
+    // rendering as literal text.
+    const end = modelEndOf(element, start, start);
+    return { start, end, text: modelText.slice(start, end), seq };
+  }
+  const text = element.textContent ?? '';
+  // The PUBLISHED range, not the painted length: the IME has just rewritten this text, so its
+  // length says where the caret is, not where the next model offset begins.
+  return { start, end: modelEndOf(element, start, start + text.length), text, seq };
+}
+
+/** State threaded through the DOM-order walk. */
+interface ReadbackWalk {
+  readonly paragraphId: string;
+  readonly modelText: string;
+  readonly pieces: PaintedPiece[];
+  /** Model ranges already contributed, so a repeat cannot contribute twice. */
+  readonly ranges: Set<string>;
+  /** The model offset just past the last span walked: where a stray text node sits. */
+  end: number;
+  /** DOM order, so a stray keeps the side of a span the browser put it on. */
+  seq: number;
+}
+
+/**
+ * Walk one painted container in DOM order, collecting spans AND the text between them.
+ *
+ * DOM order is what places text the browser wrote outside any span. An empty paragraph paints
+ * a line holding nothing but a `<br>`, and a paragraph whose only content is a field paints
+ * spans the caret is refused inside, so in both the browser is handed the LINE as the
+ * selection node and composes a bare text node into it. A stray contributes at the model
+ * offset the walk has reached, so it lands before or after the spans exactly as placed.
+ */
+function walkContainer(container: Element, walk: ReadbackWalk): void {
+  for (const node of container.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent ?? '';
+      // A stray occupies no model range (`end === start`), because it is text the model does
+      // not have yet — that is the whole reason it is worth reading.
+      if (text.length > 0) {
+        walk.pieces.push({ start: walk.end, end: walk.end, text, seq: walk.seq });
+        walk.seq += 1;
+      }
+      continue;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) continue;
+    const element = node as HTMLElement;
+    const start = modelStartOf(element, walk.paragraphId);
+    if (start === null) {
+      // Not one of our spans. A span published for ANOTHER paragraph is not ours to read
+      // either — a resolved display mode lays merged paragraphs out on one line, so this is
+      // an ordinary page, not a malformed one.
+      if (element.dataset?.start !== undefined) continue;
+      if (element.matches?.(PAINTED_FURNITURE)) continue;
+      // A line, a hyperlink anchor, a decoration wrapper: descend.
+      walkContainer(element, walk);
+      continue;
+    }
+    const piece = spanPiece(element, start, walk.modelText, walk.seq);
+    walk.seq += 1;
+    walk.end = Math.max(walk.end, piece.end);
+    // ONCE PER RANGE. A field's result splits at its spaces and every resulting span
+    // republishes the same model range; a paragraph crossing a page paints its ranges on both
+    // sheets. Either way the second one is the same characters, not more of them.
+    const key = `${piece.start}:${piece.end}`;
+    if (walk.ranges.has(key)) continue;
+    walk.ranges.add(key);
+    walk.pieces.push(piece);
+  }
+}
+
+/**
+ * The outermost painted containers for a paragraph, one per fragment.
+ *
+ * A paragraph that crosses a page has a fragment on each sheet and they hold DIFFERENT text,
+ * so both are walked. A paragraph painted many times over — a shared header, a repeating
+ * `w:tblHeader` row, a twice-referenced footnote — republishes the SAME fragment index, and
+ * only the copy the caret is in can have been composed into.
+ */
+function paragraphContainers(
+  root: Element,
+  paragraphId: string,
+  anchor: Node | null,
+  anchorSheet: Element | null
+): readonly Element[] {
+  const outermost: HTMLElement[] = [];
+  // Through the selection reader's own lookup, which carries the guard against an id that
+  // cannot be interpolated into a CSS selector; one copy of that rule, not two.
+  for (const candidate of paragraphElements(root, paragraphId, '')) {
+    const element = candidate as HTMLElement;
+    if (element.dataset.paragraphId !== paragraphId) continue;
+    // A span is content, not a container, and a line lives inside the fragment that already
+    // covers it — walking both would read every character twice.
+    if (element.dataset.start !== undefined) continue;
+    if (outermost.some((outer) => outer.contains(element))) continue;
+    outermost.push(element);
+  }
+  const chosen = new Map<string, { element: HTMLElement; affinity: number }>();
+  for (const element of outermost) {
+    const key = element.dataset.fragmentIndex ?? '';
+    const affinity = anchorAffinity(element, anchor, anchorSheet);
+    const held = chosen.get(key);
+    // Strictly greater, so the FIRST copy still wins a tie — including the tie every copy
+    // scores when there is no anchor at all.
+    if (!held || affinity > held.affinity) chosen.set(key, { element, affinity });
+  }
+  return [...chosen.values()].map((held) => held.element);
+}
+
+/**
+ * Spans this paragraph published that no container of its own covers.
+ *
+ * A resolved display mode folds a mark-deleted paragraph into the survivor that follows it and
+ * lays both out on one line. The line is stamped with its FIRST span's paragraph and the
+ * fragment with the survivor's id, so an absorbed member whose text starts mid-line owns no
+ * container for the line its own words are painted in. Walking containers alone therefore lost
+ * that member's text — and the diff, seeing the model hold characters the page did not, took
+ * the composition as licence to delete them.
+ */
+function sweepUncoveredSpans(root: Element, covered: readonly Element[], walk: ReadbackWalk): void {
+  for (const candidate of paragraphElements(root, walk.paragraphId, '[data-start]')) {
+    const element = candidate as HTMLElement;
+    const start = modelStartOf(element, walk.paragraphId);
+    if (start === null) continue;
+    if (covered.some((container) => container.contains(element))) continue;
+    const piece = spanPiece(element, start, walk.modelText, walk.seq);
+    walk.seq += 1;
+    const key = `${piece.start}:${piece.end}`;
+    if (walk.ranges.has(key)) continue;
+    walk.ranges.add(key);
+    walk.pieces.push(piece);
+  }
+}
+
+/**
+ * Join the pieces, filling from the model wherever nothing painted claims the offsets.
+ *
+ * A GAP IS NOT A DELETION. An inline drawing occupies one UTF-16 unit and publishes no span —
+ * it is painted beside the text, not as it. A `w:vanish` run advances offsets and paints
+ * nothing at all. Both leave a hole between one span's model end and the next one's start, and
+ * reading a hole as absent read it as deleted: one composition anywhere in the paragraph
+ * removed the image, or the hidden run, and no undo of the user's own could explain why.
+ *
+ * Filling from `modelText` says the only true thing about a range the browser has no
+ * representation of: it cannot have been touched. `paragraphTextFromLayout` pads the same
+ * holes on the model side, so the two agree and the diff describes only real edits.
+ */
+function joinPieces(pieces: readonly PaintedPiece[], modelText: string): string {
+  const ordered = [...pieces].sort((a, b) => a.start - b.start || a.seq - b.seq);
+  let out = '';
+  let covered = 0;
+  for (const piece of ordered) {
+    if (piece.start > covered) out += modelText.slice(covered, piece.start);
+    out += piece.text;
+    covered = Math.max(covered, piece.end);
+  }
+  if (covered < modelText.length) out += modelText.slice(covered);
+  return out;
+}
+
+/**
+ * The painted text of one paragraph, or null when this DOM shows the paragraph nowhere.
+ *
+ * `modelText` is the paragraph's current model text, which the caller already holds. `anchor`
+ * is the node the browser's own selection is in, which is how a paragraph painted many times
+ * says which copy was composed into; without one the first copy is read.
+ */
+export function paintedTextIn(
+  root: Element,
+  paragraphId: string,
+  modelText: string,
+  anchor: Node | null
+): string | null {
+  const containers = paragraphContainers(root, paragraphId, anchor, sheetOf(anchor));
+  const walk: ReadbackWalk = {
+    paragraphId,
+    modelText,
+    pieces: [],
+    ranges: new Set<string>(),
+    end: 0,
+    seq: 0,
+  };
+  for (const container of containers) walkContainer(container, walk);
+  sweepUncoveredSpans(root, containers, walk);
+  if (walk.pieces.length === 0) return null;
+  return joinPieces(walk.pieces, modelText);
+}

--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -11,7 +11,8 @@ import type { NavigationCommand, SemanticSelection } from '@docx-editor.dev/core
 import type { StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 import { plainTextFromTransfer } from './clipboard-plain-text.ts';
-import { paragraphElements, spanSearchRoots } from './dom-selection.ts';
+import { spanSearchRoots } from './dom-selection.ts';
+import { paintedTextIn } from './surface-composition-readback.ts';
 
 type SelectionMark = { paragraphId: string; start: number; end: number };
 const NAVIGATION: Record<string, NavigationCommand> = {
@@ -408,171 +409,32 @@ export function createBeforeInputHandler(
   };
 }
 
-/** One contribution to the readback, addressed by the model offset it starts at. */
-interface PaintedPiece {
-  readonly start: number;
-  readonly text: string;
-}
-
-/** State threaded through the walk below, so a stray text node knows where it landed. */
-interface ReadbackWalk {
-  readonly paragraphId: string;
-  readonly modelText: string;
-  readonly pieces: PaintedPiece[];
-  /** Model ranges already contributed by a projected span, keyed by start. */
-  readonly projectedRanges: Set<number>;
-  /** The model offset just past the last span walked, which is where a stray text sits. */
-  end: number;
-}
-
-/**
- * Furniture painted INSIDE a paragraph, which is never model text.
- *
- * A list marker's bullet, a tab leader's dots, the revision pilcrow, the inline-drawing and
- * float-wrap advance spacers, and a zero-width `w:ptab`'s painted `\t` all carry glyphs the
- * model does not have. Every one of them is a `data-docx-marker`, a `data-docx-tab-leader`
- * or `aria-hidden` — the same exclusion class the selection reader uses — so the walk skips
- * the subtree rather than naming each shape.
- */
-const PAINTED_FURNITURE = '[data-docx-marker],[data-docx-tab-leader],[aria-hidden="true"]';
-
-/** A `data-end` is only believed when it is a plausible model end for its own start. */
-function modelEndOf(element: HTMLElement, start: number, fallback: number): number {
-  const rawEnd = element.dataset.end;
-  if (rawEnd === undefined || !/^\d{1,9}$/.test(rawEnd)) return fallback;
-  const end = Number(rawEnd);
-  return end >= start ? end : fallback;
-}
-
-/**
- * Walk one painted container in DOM order, collecting what the browser now shows.
- *
- * DOM order is what places text the IME wrote OUTSIDE any span. An empty paragraph paints a
- * line holding nothing but a `<br>`, and a paragraph whose only content is a field paints
- * spans the caret is refused inside — so in both cases the browser is handed the LINE as the
- * selection node and composes a bare text node into it. Reading only `[data-start]` spans
- * saw nothing there, the diff had nothing to explain, and the composed text was dropped:
- * Chinese could not be typed at the start of an empty paragraph at all (#190). A stray text
- * node contributes at the model offset the walk has reached, so it lands before or after the
- * spans exactly as the browser placed it.
- */
-function collectPaintedPieces(container: Element, walk: ReadbackWalk): void {
-  for (const node of container.childNodes) {
-    if (node.nodeType === Node.TEXT_NODE) {
-      const text = node.textContent ?? '';
-      if (text.length > 0) walk.pieces.push({ start: walk.end, text });
-      continue;
-    }
-    if (node.nodeType !== Node.ELEMENT_NODE) continue;
-    const element = node as HTMLElement;
-    if (element.matches?.(PAINTED_FURNITURE)) continue;
-    const rawStart = element.dataset?.start;
-    if (rawStart === undefined) {
-      // A line, a hyperlink anchor, a decoration wrapper: not a span, so descend.
-      collectPaintedPieces(element, walk);
-      continue;
-    }
-    // A span published for ANOTHER paragraph. A resolved-display join line paints two
-    // paragraphs side by side, so this is not a malformed page — it is simply not ours,
-    // and its subtree is not ours to read either.
-    if (element.dataset.paragraphId !== walk.paragraphId) continue;
-    const start = Number(rawStart);
-    if (!Number.isInteger(start)) continue;
-    if (element.dataset.docxField !== undefined) {
-      // ONCE per range, not once per span. Line breaking splits a field's result at its
-      // spaces and every resulting span republishes the SAME model range, so emitting the
-      // slice per span repeated the field's model characters — a four-word result read back
-      // as four `￼` where the model has one, and the diff then inserted the extras as
-      // literal object-replacement characters.
-      const end = modelEndOf(element, start, start);
-      walk.end = Math.max(walk.end, end);
-      if (walk.projectedRanges.has(start)) continue;
-      walk.projectedRanges.add(start);
-      walk.pieces.push({ start, text: walk.modelText.slice(start, end) });
-      continue;
-    }
-    const text = element.textContent ?? '';
-    // The published range, not the painted length: the IME has just rewritten the text, so
-    // its length says where the CARET is, not where the next model offset begins.
-    walk.end = Math.max(walk.end, modelEndOf(element, start, start + text.length));
-    walk.pieces.push({ start, text });
-  }
-}
-
-/** The outermost painted containers for a paragraph, in page order. */
-function paragraphContainers(root: Element, paragraphId: string): readonly Element[] {
-  const containers: Element[] = [];
-  // Through the selection reader's own lookup, which carries the guard against an id that
-  // cannot be interpolated into a CSS selector: the id comes from the model but crosses a
-  // parser here, and only one copy of that rule should exist.
-  for (const candidate of paragraphElements(root, paragraphId, '')) {
-    const element = candidate as HTMLElement;
-    if (element.dataset.paragraphId !== paragraphId) continue;
-    // A span is content, not a container, and a line lives inside the fragment that already
-    // covers it — walking both would read every character twice.
-    if (element.dataset.start !== undefined) continue;
-    if (containers.some((outer) => outer.contains(element))) continue;
-    containers.push(element);
-  }
-  return containers;
-}
-
 /**
  * The text the browser currently shows for a paragraph, IN THE MODEL'S OWN OFFSET SPACE.
  *
- * Not simply the concatenated `textContent`. A span's painted text is not always as long as
- * the range it stands for: a field occupies ONE model offset and paints its whole cached
- * result, so "Scope of the discussions" is 24 glyphs over a range of 1. Joining the painted
- * text made this readback see 23 characters that the model does not have, and the diff below
- * then explained the difference the only way it could — by deleting the field and inserting
- * its own rendering as literal text. One IME composition anywhere in the paragraph destroyed
- * the field permanently and silently.
+ * The reading itself lives in surface-composition-readback.ts, which is the mirror of layout's
+ * `paragraphTextFromLayout`: same rules for repeated ranges, projected atoms and unpainted
+ * offsets, differing only in reading the PAINTED text so an IME's edit is visible.
  *
- * So a PROJECTED span — one layout owns the glyphs of, marked `data-docx-field` and painted
- * `contenteditable="false"` — contributes the MODEL's characters for its range instead. The
- * browser cannot write inside one, so whatever the model has there is still correct, and the
- * diff is left to describe only what actually changed.
- *
- * Keyed on that marker rather than on the lengths disagreeing, which is the tempting shortcut
- * and the wrong one: a browser edit is ALSO a length disagreement, so inferring it that way
- * would swallow the very keystrokes this exists to recover.
- *
- * ONE PAINTED COPY, never every copy on the sheet. A shared header or footer repaints the
- * same paragraph ids on every page it appears on, so a document-wide scan read a three-page
- * header back as three concatenated copies of itself — and the diff then wrote the extra two
- * into the part. The active header/footer container is the copy the caret entered, which is
- * the same preference the selection reader applies.
+ * This wrapper owns one thing — WHICH ROOT to read. A header or footer open for editing is
+ * searched first, because a shared part paints the same paragraph ids on every page and the
+ * active band is the copy the caret entered; that is the preference the selection reader
+ * already applies. `anchor` settles the same question where no scope attribute can: a
+ * repeating table header row is ordinary body content on every page it repeats on.
  *
  * `modelText` is the paragraph's current model text, which the caller already holds.
  */
 export function paintedTextOf(
   pagesLayer: HTMLElement,
   paragraphId: string,
-  modelText: string
+  modelText: string,
+  anchor: Node | null = null
 ): string | null {
   for (const root of spanSearchRoots(pagesLayer)) {
-    const painted = paintedTextIn(root, paragraphId, modelText);
+    const painted = paintedTextIn(root, paragraphId, modelText, anchor);
     if (painted !== null) return painted;
   }
   return null;
-}
-
-function paintedTextIn(root: Element, paragraphId: string, modelText: string): string | null {
-  const containers = paragraphContainers(root, paragraphId);
-  if (containers.length === 0) return null;
-  const walk: ReadbackWalk = {
-    paragraphId,
-    modelText,
-    pieces: [],
-    projectedRanges: new Set<number>(),
-    end: 0,
-  };
-  for (const container of containers) collectPaintedPieces(container, walk);
-  if (walk.pieces.length === 0) return null;
-  // Stable, so a stray text node keeps the side of a span the browser put it on — both
-  // address the same model offset, and only DOM order says which came first.
-  const pieces = [...walk.pieces].sort((a, b) => a.start - b.start);
-  return pieces.map((piece) => piece.text).join('');
 }
 
 /**

--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -11,6 +11,7 @@ import type { NavigationCommand, SemanticSelection } from '@docx-editor.dev/core
 import type { StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 import { plainTextFromTransfer } from './clipboard-plain-text.ts';
+import { paragraphElements, spanSearchRoots } from './dom-selection.ts';
 
 type SelectionMark = { paragraphId: string; start: number; end: number };
 const NAVIGATION: Record<string, NavigationCommand> = {
@@ -407,6 +408,115 @@ export function createBeforeInputHandler(
   };
 }
 
+/** One contribution to the readback, addressed by the model offset it starts at. */
+interface PaintedPiece {
+  readonly start: number;
+  readonly text: string;
+}
+
+/** State threaded through the walk below, so a stray text node knows where it landed. */
+interface ReadbackWalk {
+  readonly paragraphId: string;
+  readonly modelText: string;
+  readonly pieces: PaintedPiece[];
+  /** Model ranges already contributed by a projected span, keyed by start. */
+  readonly projectedRanges: Set<number>;
+  /** The model offset just past the last span walked, which is where a stray text sits. */
+  end: number;
+}
+
+/**
+ * Furniture painted INSIDE a paragraph, which is never model text.
+ *
+ * A list marker's bullet, a tab leader's dots, the revision pilcrow, the inline-drawing and
+ * float-wrap advance spacers, and a zero-width `w:ptab`'s painted `\t` all carry glyphs the
+ * model does not have. Every one of them is a `data-docx-marker`, a `data-docx-tab-leader`
+ * or `aria-hidden` — the same exclusion class the selection reader uses — so the walk skips
+ * the subtree rather than naming each shape.
+ */
+const PAINTED_FURNITURE = '[data-docx-marker],[data-docx-tab-leader],[aria-hidden="true"]';
+
+/** A `data-end` is only believed when it is a plausible model end for its own start. */
+function modelEndOf(element: HTMLElement, start: number, fallback: number): number {
+  const rawEnd = element.dataset.end;
+  if (rawEnd === undefined || !/^\d{1,9}$/.test(rawEnd)) return fallback;
+  const end = Number(rawEnd);
+  return end >= start ? end : fallback;
+}
+
+/**
+ * Walk one painted container in DOM order, collecting what the browser now shows.
+ *
+ * DOM order is what places text the IME wrote OUTSIDE any span. An empty paragraph paints a
+ * line holding nothing but a `<br>`, and a paragraph whose only content is a field paints
+ * spans the caret is refused inside — so in both cases the browser is handed the LINE as the
+ * selection node and composes a bare text node into it. Reading only `[data-start]` spans
+ * saw nothing there, the diff had nothing to explain, and the composed text was dropped:
+ * Chinese could not be typed at the start of an empty paragraph at all (#190). A stray text
+ * node contributes at the model offset the walk has reached, so it lands before or after the
+ * spans exactly as the browser placed it.
+ */
+function collectPaintedPieces(container: Element, walk: ReadbackWalk): void {
+  for (const node of container.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent ?? '';
+      if (text.length > 0) walk.pieces.push({ start: walk.end, text });
+      continue;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) continue;
+    const element = node as HTMLElement;
+    if (element.matches?.(PAINTED_FURNITURE)) continue;
+    const rawStart = element.dataset?.start;
+    if (rawStart === undefined) {
+      // A line, a hyperlink anchor, a decoration wrapper: not a span, so descend.
+      collectPaintedPieces(element, walk);
+      continue;
+    }
+    // A span published for ANOTHER paragraph. A resolved-display join line paints two
+    // paragraphs side by side, so this is not a malformed page — it is simply not ours,
+    // and its subtree is not ours to read either.
+    if (element.dataset.paragraphId !== walk.paragraphId) continue;
+    const start = Number(rawStart);
+    if (!Number.isInteger(start)) continue;
+    if (element.dataset.docxField !== undefined) {
+      // ONCE per range, not once per span. Line breaking splits a field's result at its
+      // spaces and every resulting span republishes the SAME model range, so emitting the
+      // slice per span repeated the field's model characters — a four-word result read back
+      // as four `￼` where the model has one, and the diff then inserted the extras as
+      // literal object-replacement characters.
+      const end = modelEndOf(element, start, start);
+      walk.end = Math.max(walk.end, end);
+      if (walk.projectedRanges.has(start)) continue;
+      walk.projectedRanges.add(start);
+      walk.pieces.push({ start, text: walk.modelText.slice(start, end) });
+      continue;
+    }
+    const text = element.textContent ?? '';
+    // The published range, not the painted length: the IME has just rewritten the text, so
+    // its length says where the CARET is, not where the next model offset begins.
+    walk.end = Math.max(walk.end, modelEndOf(element, start, start + text.length));
+    walk.pieces.push({ start, text });
+  }
+}
+
+/** The outermost painted containers for a paragraph, in page order. */
+function paragraphContainers(root: Element, paragraphId: string): readonly Element[] {
+  const containers: Element[] = [];
+  // Through the selection reader's own lookup, which carries the guard against an id that
+  // cannot be interpolated into a CSS selector: the id comes from the model but crosses a
+  // parser here, and only one copy of that rule should exist.
+  for (const candidate of paragraphElements(root, paragraphId, '')) {
+    const element = candidate as HTMLElement;
+    if (element.dataset.paragraphId !== paragraphId) continue;
+    // A span is content, not a container, and a line lives inside the fragment that already
+    // covers it — walking both would read every character twice.
+    if (element.dataset.start !== undefined) continue;
+    if (containers.some((outer) => outer.contains(element))) continue;
+    containers.push(element);
+  }
+  return containers;
+}
+
 /**
  * The text the browser currently shows for a paragraph, IN THE MODEL'S OWN OFFSET SPACE.
  *
@@ -427,6 +537,12 @@ export function createBeforeInputHandler(
  * and the wrong one: a browser edit is ALSO a length disagreement, so inferring it that way
  * would swallow the very keystrokes this exists to recover.
  *
+ * ONE PAINTED COPY, never every copy on the sheet. A shared header or footer repaints the
+ * same paragraph ids on every page it appears on, so a document-wide scan read a three-page
+ * header back as three concatenated copies of itself — and the diff then wrote the extra two
+ * into the part. The active header/footer container is the copy the caret entered, which is
+ * the same preference the selection reader applies.
+ *
  * `modelText` is the paragraph's current model text, which the caller already holds.
  */
 export function paintedTextOf(
@@ -434,35 +550,28 @@ export function paintedTextOf(
   paragraphId: string,
   modelText: string
 ): string | null {
-  const spans = pagesLayer.querySelectorAll('[data-paragraph-id][data-start]');
-  const pieces: { start: number; text: string }[] = [];
-  /** Model ranges already contributed by a projected span, keyed by start. */
-  const projectedRanges = new Set<number>();
-  for (const span of spans) {
-    const element = span as HTMLElement;
-    if (element.dataset.paragraphId !== paragraphId) continue;
-    const start = Number(element.dataset.start);
-    if (!Number.isInteger(start)) continue;
-    if (element.dataset.docxField !== undefined) {
-      // ONCE per range, not once per span. Line breaking splits a field's result at its
-      // spaces and every resulting span republishes the SAME model range, so emitting the
-      // slice per span repeated the field's model characters — a four-word result read back
-      // as four `￼` where the model has one, and the diff then inserted the extras as
-      // literal object-replacement characters.
-      if (projectedRanges.has(start)) continue;
-      projectedRanges.add(start);
-      const rawEnd = element.dataset.end;
-      const end =
-        rawEnd !== undefined && /^\d{1,9}$/.test(rawEnd) && Number(rawEnd) >= start
-          ? Number(rawEnd)
-          : start;
-      pieces.push({ start, text: modelText.slice(start, end) });
-      continue;
-    }
-    pieces.push({ start, text: element.textContent ?? '' });
+  for (const root of spanSearchRoots(pagesLayer)) {
+    const painted = paintedTextIn(root, paragraphId, modelText);
+    if (painted !== null) return painted;
   }
-  if (pieces.length === 0) return null;
-  pieces.sort((a, b) => a.start - b.start);
+  return null;
+}
+
+function paintedTextIn(root: Element, paragraphId: string, modelText: string): string | null {
+  const containers = paragraphContainers(root, paragraphId);
+  if (containers.length === 0) return null;
+  const walk: ReadbackWalk = {
+    paragraphId,
+    modelText,
+    pieces: [],
+    projectedRanges: new Set<number>(),
+    end: 0,
+  };
+  for (const container of containers) collectPaintedPieces(container, walk);
+  if (walk.pieces.length === 0) return null;
+  // Stable, so a stray text node keeps the side of a span the browser put it on — both
+  // address the same model offset, and only DOM order says which came first.
+  const pieces = [...walk.pieces].sort((a, b) => a.start - b.start);
   return pieces.map((piece) => piece.text).join('');
 }
 

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -118,6 +118,14 @@ export interface SurfaceSelectionSyncDeps {
    * that. Composed text landed in front of the word it replaced until it asked.
    */
   replacementOffset?(paragraphId: string, from: number, to: number): number;
+  /**
+   * Delete a selection spanning more than one paragraph, so a composition can start inside
+   * one. Returns whether the composition's range is now addressable — false only when the
+   * deletion was refused and the range still crosses a paragraph boundary.
+   *
+   * A collapsed or same-paragraph selection is left untouched and reports true.
+   */
+  collapseSelectionForComposition?(): boolean;
 }
 
 export interface SurfaceSelectionSync {
@@ -195,6 +203,18 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
   let composing = false;
   /** The paragraph the composition started in, so the right one is reconciled. */
   let composingParagraph: string | null = null;
+  /**
+   * Whether this composition began over a range the readback cannot address.
+   *
+   * A selection spanning two paragraphs is replaced by a JOIN, and the reconcile below
+   * describes ONE paragraph. `onCompositionStart` deletes such a range up front so the
+   * composition starts collapsed; when that deletion is refused — a rectangle of table
+   * cells, a locked control, protected content — the range is still there and nothing here
+   * can explain what the browser does to it. Reconciling anyway committed one half of the
+   * edit and dropped the other, leaving a document that matched neither what the user had
+   * nor what they saw (#383).
+   */
+  let compositionUnaddressable = false;
 
   /**
    * Take up a selection the user has made but the queued `selectionchange` has not delivered.
@@ -485,6 +505,20 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
     },
 
     onCompositionStart: (): void => {
+      // TYPING OVER A SELECTION DELETES IT, and doing that HERE is what keeps the readback
+      // answerable. A range spanning two paragraphs is replaced by a join, which one
+      // paragraph's diff cannot express — so the deletion goes through the ordinary write
+      // lane now, attribution and refusals included, and the composition then starts at a
+      // collapsed caret inside a single paragraph: the case the readback does handle.
+      //
+      // Before `composing`, deliberately: this commit must repaint. That is not a new risk
+      // to the IME's anchor — a buffered typing burst already commits and repaints at this
+      // same point, ahead of this handler.
+      //
+      // Same-paragraph ranges are left alone. The existing lane already reads those back
+      // correctly, and in suggesting mode it keeps the struck characters and lands the
+      // replacement AFTER them (`replacementOffset`) — a rule an eager delete would lose.
+      compositionUnaddressable = deps.collapseSelectionForComposition?.() === false;
       composing = true;
       composingParagraph = deps.selection().head.paragraphId;
       session.beginComposition(deps.storyScope());
@@ -494,10 +528,17 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       composing = false;
       const paragraphId = composingParagraph ?? deps.selection().head.paragraphId;
       composingParagraph = null;
+      const unaddressable = compositionUnaddressable;
+      compositionUnaddressable = false;
       // The composed text is in the DOM and nowhere else. Read it back, diff it against what
       // the model holds for that paragraph, and commit the difference — the only route by
       // which an IME edit can reach the tree, since it could not be intercepted.
-      reconcileParagraphFromDom(paragraphId);
+      //
+      // Unless the range it began over was never addressable. Then the repaint below is the
+      // whole answer: it discards what the browser wrote and puts the model's own text back
+      // on screen. The user loses the composition, which the refused deletion already told
+      // them about — and a refusal is recoverable in a way half an edit is not.
+      if (!unaddressable) reconcileParagraphFromDom(paragraphId);
       session.endComposition();
       deps.flushLayout();
       deps.render();

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -119,13 +119,18 @@ export interface SurfaceSelectionSyncDeps {
    */
   replacementOffset?(paragraphId: string, from: number, to: number): number;
   /**
-   * Delete a selection spanning more than one paragraph, so a composition can start inside
-   * one. Returns whether the composition's range is now addressable — false only when the
-   * deletion was refused and the range still crosses a paragraph boundary.
-   *
-   * A collapsed or same-paragraph selection is left untouched and reports true.
+   * Replace the current selection with text, exactly as typing it would — one transaction,
+   * attribution and refusals included. Used for a composition that began over a range
+   * spanning two paragraphs, which the painted DOM cannot be asked about.
    */
-  collapseSelectionForComposition?(): boolean;
+  replaceSelectionWith?(text: string): void;
+  /**
+   * Forget what the pages currently show, so the next render rebuilds them from records.
+   *
+   * The one caller is a composition that changed nothing: the browser's characters are on
+   * the page and an unchanged layout would keep them there.
+   */
+  discardPaint?(): void;
 }
 
 export interface SurfaceSelectionSync {
@@ -162,7 +167,7 @@ export interface SurfaceSelectionSync {
   isComposing(): boolean;
   readonly onSelectionChange: () => void;
   readonly onCompositionStart: () => void;
-  readonly onCompositionEnd: () => void;
+  readonly onCompositionEnd: (event?: CompositionEvent) => void;
   /** Drop capture listeners. Safe to call once from surface destroy/detach. */
   destroy(): void;
 }
@@ -204,17 +209,14 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
   /** The paragraph the composition started in, so the right one is reconciled. */
   let composingParagraph: string | null = null;
   /**
-   * Whether this composition began over a range the readback cannot address.
+   * Whether this composition began over a range spanning more than one paragraph.
    *
-   * A selection spanning two paragraphs is replaced by a JOIN, and the reconcile below
-   * describes ONE paragraph. `onCompositionStart` deletes such a range up front so the
-   * composition starts collapsed; when that deletion is refused — a rectangle of table
-   * cells, a locked control, protected content — the range is still there and nothing here
-   * can explain what the browser does to it. Reconciling anyway committed one half of the
-   * edit and dropped the other, leaving a document that matched neither what the user had
-   * nor what they saw (#383).
+   * The browser replaces such a range with a JOIN, and the readback describes ONE paragraph,
+   * so reconciling committed half the edit and dropped the other half — a document matching
+   * neither what the user had nor what they saw (#383). These compositions take the lane
+   * below instead, which never reads the painted DOM at all.
    */
-  let compositionUnaddressable = false;
+  let composingAcrossParagraphs = false;
 
   /**
    * Take up a selection the user has made but the queued `selectionchange` has not delivered.
@@ -505,41 +507,56 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
     },
 
     onCompositionStart: (): void => {
-      // TYPING OVER A SELECTION DELETES IT, and doing that HERE is what keeps the readback
-      // answerable. A range spanning two paragraphs is replaced by a join, which one
-      // paragraph's diff cannot express — so the deletion goes through the ordinary write
-      // lane now, attribution and refusals included, and the composition then starts at a
-      // collapsed caret inside a single paragraph: the case the readback does handle.
+      // NOTHING IS TOUCHED HERE. Not the model, not the DOM, not the selection.
       //
-      // Before `composing`, deliberately: this commit must repaint. That is not a new risk
-      // to the IME's anchor — a buffered typing burst already commits and repaints at this
-      // same point, ahead of this handler.
-      //
-      // Same-paragraph ranges are left alone. The existing lane already reads those back
-      // correctly, and in suggesting mode it keeps the struck characters and lands the
-      // replacement AFTER them (`replacementOffset`) — a rule an eager delete would lose.
-      compositionUnaddressable = deps.collapseSelectionForComposition?.() === false;
+      // The tempting fix for #383 is to delete the range now, so the composition starts
+      // collapsed inside one paragraph. It does not hold: `commit` may DEFER its paint
+      // (`isInputPending`, Chromium only), so the browser's own selection is still the
+      // two-paragraph range when this handler returns and the deferred paint then lands
+      // mid-composition — replacing the nodes the IME is composing into and rewriting the
+      // selection under it. That is the "repaint mid-composition destroys the IME's anchor"
+      // hazard this flag exists to prevent, and it would fire on every such composition.
       composing = true;
-      composingParagraph = deps.selection().head.paragraphId;
+      const selection = deps.selection();
+      composingAcrossParagraphs = selection.anchor.paragraphId !== selection.head.paragraphId;
+      composingParagraph = selection.head.paragraphId;
       session.beginComposition(deps.storyScope());
     },
 
-    onCompositionEnd: (): void => {
+    onCompositionEnd: (event?: CompositionEvent): void => {
       composing = false;
       const paragraphId = composingParagraph ?? deps.selection().head.paragraphId;
       composingParagraph = null;
-      const unaddressable = compositionUnaddressable;
-      compositionUnaddressable = false;
-      // The composed text is in the DOM and nowhere else. Read it back, diff it against what
-      // the model holds for that paragraph, and commit the difference — the only route by
-      // which an IME edit can reach the tree, since it could not be intercepted.
-      //
-      // Unless the range it began over was never addressable. Then the repaint below is the
-      // whole answer: it discards what the browser wrote and puts the model's own text back
-      // on screen. The user loses the composition, which the refused deletion already told
-      // them about — and a refusal is recoverable in a way half an edit is not.
-      if (!unaddressable) reconcileParagraphFromDom(paragraphId);
+      const acrossParagraphs = composingAcrossParagraphs;
+      composingAcrossParagraphs = false;
+      const before = session.revisionFor(deps.storyScope());
+
+      if (acrossParagraphs) {
+        // THE EVENT CARRIES THE ANSWER, so the painted DOM never has to be asked. `data` on
+        // `compositionend` is the finished composed string, which is the one thing a
+        // two-paragraph readback would have had to recover from a page the browser rewrote
+        // in a shape this engine did not choose.
+        //
+        // Replacing the still-untouched selection with it is what typing over a selection
+        // means, and it goes through the very same call — one transaction inside the
+        // composition's own history entry, so it is ONE undo step, with attribution,
+        // protection and refusals all applying as they do to typed text.
+        const composed = event?.data ?? '';
+        if (composed.length > 0) deps.replaceSelectionWith?.(composed);
+      } else {
+        // The composed text is in the DOM and nowhere else. Read it back, diff it against
+        // what the model holds for that paragraph, and commit the difference — the only
+        // route by which an IME edit can reach the tree, since it could not be intercepted.
+        reconcileParagraphFromDom(paragraphId);
+      }
+
       session.endComposition();
+      // THE BROWSER WROTE ON THE PAGE WHATEVER THE MODEL DID. When the model did not move —
+      // the composition was cancelled, or its edit was refused — an unchanged layout repaints
+      // nothing by design, so those characters would simply stay on screen, and in a document
+      // nobody can edit nothing would ever remove them. Forget the retained paint so the
+      // render below rebuilds from records.
+      if (session.revisionFor(deps.storyScope()) === before) deps.discardPaint?.();
       deps.flushLayout();
       deps.render();
     },

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -340,6 +340,37 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
   }
 
   /**
+   * Take up a selection the user made whose `selectionchange` has not been delivered yet.
+   *
+   * Shared by `adoptBeforeInput` and `onCompositionStart`, which need the same thing for the
+   * same reason: both are about to decide what a command edits, and `selectionchange` is
+   * queued, so the model can still hold the range from before a click or a drag.
+   */
+  function adoptPendingUserSelection(): void {
+    // Engine-owned pointer drags and cell rectangles deliberately outrank the browser's
+    // native selection. A composition already in flight has its own DOM readback.
+    if (applyingSelection || composing) return;
+    if (deps.isGesturing?.()) return;
+    if (deps.holdsCellSelection?.()) return;
+    // Same window `onSelectionChange` guards: a deferred paint leaves the DOM caret at
+    // the last mirrored (pre-edit) offset. Adopting it here — so a click that has not
+    // yet produced `selectionchange` still edits the clicked point — would otherwise
+    // insert the next character at that stale offset and reorder a typing burst.
+    // A genuine pointer/touch/selectstart gesture still wins, even if it lands on that
+    // same pre-edit offset; a queued echo has no such provenance and is skipped.
+    // `adoptDomSelection` spends the one-shot once it sees a mapped caret, so a click on
+    // the already-current caret cannot authorize a later stale echo.
+    if (isStaleMirroredCaret()) return;
+    // A KEYSTROKE IS NOT A SELECTION GESTURE. This reader exists for one case — a click or
+    // a drag whose `selectionchange` is still queued when the next key arrives — and that
+    // case always arms the flag first. Without the check, every keystroke re-read a browser
+    // selection nobody had moved, so a caret the DOM had resolved onto a container after a
+    // repaint pulled the model to the paragraph start on key after key.
+    if (!userSelectionGesture) return;
+    adoptDomSelection();
+  }
+
+  /**
    * Whether the DOM caret is still the last value this surface wrote, while the model has
    * already moved on, AND no unused user-selection gesture is authorizing this check.
    *
@@ -463,29 +494,7 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       });
     },
 
-    adoptBeforeInput() {
-      // Engine-owned pointer drags and cell rectangles deliberately outrank the browser's
-      // native selection. Composition has its own DOM readback when it ends.
-      if (applyingSelection || composing) return;
-      if (deps.isGesturing?.()) return;
-      if (deps.holdsCellSelection?.()) return;
-      // Same window `onSelectionChange` guards: a deferred paint leaves the DOM caret at
-      // the last mirrored (pre-edit) offset. Adopting it here — so a click that has not
-      // yet produced `selectionchange` still edits the clicked point — would otherwise
-      // insert the next character at that stale offset and reorder a typing burst.
-      // A genuine pointer/touch/selectstart gesture still wins, even if it lands on that
-      // same pre-edit offset; a queued echo has no such provenance and is skipped.
-      // `adoptDomSelection` spends the one-shot once it sees a mapped caret, so a click on
-      // the already-current caret cannot authorize a later stale echo.
-      if (isStaleMirroredCaret()) return;
-      // A KEYSTROKE IS NOT A SELECTION GESTURE. This reader exists for one case — a click or
-      // a drag whose `selectionchange` is still queued when the next key arrives — and that
-      // case always arms the flag first. Without the check, every keystroke re-read a browser
-      // selection nobody had moved, so a caret the DOM had resolved onto a container after a
-      // repaint pulled the model to the paragraph start on key after key.
-      if (!userSelectionGesture) return;
-      adoptDomSelection();
-    },
+    adoptBeforeInput: adoptPendingUserSelection,
 
     isComposing: () => composing,
 
@@ -516,6 +525,17 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // mid-composition — replacing the nodes the IME is composing into and rewriting the
       // selection under it. That is the "repaint mid-composition destroys the IME's anchor"
       // hazard this flag exists to prevent, and it would fire on every such composition.
+      // WHICH LANE this composition takes is decided from the selection, so it has to be the
+      // selection the USER has — not the one the model held before their click or drag, whose
+      // `selectionchange` may still be queued. Reading the model alone chose the readback lane
+      // for a range the browser had already extended across two paragraphs, and #383 came
+      // straight back. A keydown ahead of `compositionstart` happens to close that window on
+      // desktop; a touch drag on Android produces no keydown at all.
+      //
+      // NOT COVERED BY THE SUITE, deliberately noted rather than quietly assumed: happy-dom
+      // dispatches `selectionchange` synchronously, so the model is never stale there and a
+      // test of this would pass with the call removed.
+      adoptPendingUserSelection();
       composing = true;
       const selection = deps.selection();
       composingAcrossParagraphs = selection.anchor.paragraphId !== selection.head.paragraphId;
@@ -529,7 +549,11 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       composingParagraph = null;
       const acrossParagraphs = composingAcrossParagraphs;
       composingAcrossParagraphs = false;
-      const before = session.revisionFor(deps.storyScope());
+      // ONE scope, sampled once. `type()` can move the active story (a note released by the
+      // post-edit caret), and two reads either side would then compare two different stores'
+      // clocks — a number that means nothing, and a rebuild that does not happen.
+      const scope = deps.storyScope();
+      const before = session.revisionFor(scope);
 
       if (acrossParagraphs) {
         // THE EVENT CARRIES THE ANSWER, so the painted DOM never has to be asked. `data` on
@@ -556,7 +580,7 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // nothing by design, so those characters would simply stay on screen, and in a document
       // nobody can edit nothing would ever remove them. Forget the retained paint so the
       // render below rebuilds from records.
-      if (session.revisionFor(deps.storyScope()) === before) deps.discardPaint?.();
+      if (session.revisionFor(scope) === before) deps.discardPaint?.();
       deps.flushLayout();
       deps.render();
     },

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -266,7 +266,15 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
    */
   function reconcileParagraphFromDom(paragraphId: string): void {
     const modelText = deps.textOf(paragraphId);
-    const painted = paintedTextOf(pagesLayer, paragraphId, modelText);
+    // The browser's own selection says WHICH painted copy was composed into, for a paragraph
+    // the page repeats: a shared header, a `w:tblHeader` row, a twice-referenced note. The IME
+    // leaves the caret in the text it just committed, so this is that copy.
+    const painted = paintedTextOf(
+      pagesLayer,
+      paragraphId,
+      modelText,
+      document.getSelection()?.anchorNode ?? null
+    );
     if (painted === null) return;
     const plan = paragraphReplacePlan(paragraphId, modelText, painted);
     if (!plan) return;

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -2643,6 +2643,20 @@ interface RetainedPaint {
 
 const retainedPaints = new WeakMap<HTMLElement, RetainedPaint>();
 
+/**
+ * Forget what a container currently shows, so the next paint rebuilds it from records.
+ *
+ * Paint reuse assumes the DOM still holds what this module last put there — it keeps a page
+ * whose record is identical, and an unchanged layout therefore repaints nothing at all. An
+ * IME breaks that assumption: composed text lands in the painted DOM whatever the model
+ * does, so a composition that ends up changing nothing (it was cancelled, or its edit was
+ * refused) leaves the browser's characters on screen with no later pass that would remove
+ * them. In a read-only document nothing ever heals it.
+ */
+export function discardRetainedPaint(container: HTMLElement): void {
+  retainedPaints.delete(container);
+}
+
 function sameBox(left: PageRecord['box'], right: PageRecord['box']): boolean {
   return (
     left.x === right.x &&


### PR DESCRIPTION
Chinese text could not be entered at the start of an empty paragraph. An empty paragraph paints a line holding nothing but a `<br>`, so the browser is handed the line as the selection node and composes a bare text node into it. The readback looked only inside `[data-start]` spans, found nothing, and the composed text never reached the tree.

Reviewing that fix turned up four more defects in the same IME lane, each of them silent data loss on an ordinary keystroke. They are fixed here too, because they share one cause: the readback had drifted from `paragraphTextFromLayout`, which builds the model side of the same diff.

## What else this fixes

An inline drawing occupies one UTF-16 unit and publishes no span of its own, and a `w:vanish` run advances offsets and paints nothing at all. Both leave a gap between one span's model end and the next one's start. Read as absent, a gap reads as deleted, so a composition anywhere in the paragraph removed the image or the hidden text. A gap is now filled from the model, which is the only true thing about a range the browser has no way to represent.

A paragraph the page repeats was read back once per copy and joined. Composing into a header on a three-page document stored three copies of it. The same happens for a repeating `w:tblHeader` row and for a footnote referenced twice, neither of which has an active-scope attribute to tell the copies apart. Each model range now contributes once, and the copy holding the composition's own caret wins.

A drawing whose resource has not resolved paints a placeholder card reading `Loading image`. That card carries `aria-hidden` only when the drawing has no alt text, so a file supplying `wp:docPr/@descr` could put a string of its own choosing into the paragraph. Painted drawings are excluded from the readback.

Composing over a selection that spans two paragraphs committed half the edit (#383): the browser replaces such a range with a join, and a one-paragraph diff cannot express that, so the second paragraph's deletion landed while the first kept its old text and the composed characters were discarded at the next repaint. The document matched neither what you had nor what you saw. Those compositions no longer read the painted DOM at all — `compositionend` carries the finished string, and replacing the still-untouched selection with it is the same call typing over a selection makes, in one transaction and one undo step.

Underneath that: a composition that changes nothing left the browser's characters on the page. Paint reuse assumes the DOM still holds what the painter put there, so an unchanged layout repaints nothing, and in a document nobody can edit no later pass would ever remove them. A composition that moves no revision now discards the retained paint so the render rebuilds from records.

## Testing

Twenty tests across `composition-readback.test.ts` and `composition-readback-integrity.test.ts` cover the empty paragraph in the body, a list item, a table cell and a header, plus each defect above. Each was run against `main` to confirm it fails there.

Two things this suite cannot settle, both stated in the code rather than assumed:

- The cross-paragraph lane takes the composed string from `compositionend.data`. That is where every browser puts it, but Android/Chrome is documented to omit it occasionally; the code treats a missing string as a cancelled composition rather than guessing, so the failure mode is a lost composition, not a wrong document. Worth a pass on a real device with a CJK IME.
- `compositionstart` now takes up a pending selection the way `beforeinput` already does, because `selectionchange` is queued and the model can be a gesture behind. happy-dom dispatches `selectionchange` synchronously, so a test of that guard passes with the call removed and none is included.
