### PR TITLE
fix(core): bordered paragraphs and refreshed TOCs survive an incremental pass

### DIFF
--- a/.changeset/border-group-toc-incremental.md
+++ b/.changeset/border-group-toc-incremental.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixed bordered paragraphs drawing the wrong edges, and pages breaking in the wrong place, after you edited a bordered run. Fixed a refreshed table of contents losing its empty-TOC placeholder line until you reopened the document.

--- a/packages/core/src/layout/__tests__/border-group-editing.test.ts
+++ b/packages/core/src/layout/__tests__/border-group-editing.test.ts
@@ -1,0 +1,173 @@
+// Paragraph border groups under the gestures that actually break them.
+//
+// The sibling test drives `layoutSemanticDocument` with two trees. This one drives a live
+// editor, because the failing gesture is a natural one and the test trap is specific: a test
+// that builds the content and THEN applies the property passes, since the whole run is laid
+// out once with its final structure. The gesture that fails is the other order — put the
+// borders on first, then grow the run — so each new paragraph changes the verdict of the one
+// above it. Both orders are covered.
+//
+// The oracle is the same bytes reopened. Any disagreement IS the bug.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../../editor/docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const STY = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+const STYLES =
+  `<w:styles xmlns:w="${W}">` +
+  '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>' +
+  '</w:styles>';
+
+const rule = (side: string) => `<w:${side} w:val="single" w:sz="8" w:space="4" w:color="000000"/>`;
+
+/** A paragraph inside a `w:pBdr` box, with no `w:between` — so grouping removes the rule. */
+const bordered = (text: string) =>
+  '<w:p><w:pPr><w:pBdr>' +
+  rule('top') +
+  rule('left') +
+  rule('bottom') +
+  rule('right') +
+  '</w:pBdr></w:pPr>' +
+  `<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId2" Type="${STY}" Target="styles.xml"/></Relationships>`
+    ),
+    'word/styles.xml': strToU8(STYLES),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const open: DocxEditorInstance[] = [];
+
+afterEach(() => {
+  for (const editor of open.splice(0)) editor.destroy();
+});
+
+function mount(bytes: Uint8Array): DocxEditorInstance {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({ container, document: bytes });
+  open.push(editor);
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+/** Box geometry plus which rules each fragment draws — everything the grouping decides. */
+const shapeOf = (editor: DocxEditorInstance): unknown =>
+  editor.surface!.layout().pages.map((page) =>
+    page.fragments.map((fragment) => ({
+      y: Math.round(fragment.box.y * 100) / 100,
+      height: Math.round(fragment.box.height * 100) / 100,
+      sides:
+        fragment.kind === 'paragraph'
+          ? (fragment.borders ?? []).map((stroke) => stroke.side)
+          : undefined,
+    }))
+  );
+
+/** Put the caret in the paragraph at `index`, at `offset` (default: the start). */
+function caretIn(editor: DocxEditorInstance, index: number, offset = 0): void {
+  const surface = editor.surface!;
+  const id = surface.session.paragraphIds()[index]!;
+  surface.setSelection({
+    anchor: { paragraphId: id, offset },
+    head: { paragraphId: id, offset },
+  });
+}
+
+async function reopened(editor: DocxEditorInstance): Promise<DocxEditorInstance> {
+  return mount(new Uint8Array(await editor.save()));
+}
+
+describe('growing a bordered run', () => {
+  test('splitting the last member re-places the one that was last', async () => {
+    const editor = mount(docx(bordered('one') + bordered('two')));
+    caretIn(editor, 1, 'two'.length);
+    editor.surface!.splitParagraph();
+    editor.surface!.type('three');
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+
+  test('a run grown one paragraph at a time, the order that hides the bug', async () => {
+    // Borders FIRST, then grow. Each Enter makes the paragraph above stop closing its box,
+    // which is the verdict a content key cannot see moving.
+    const editor = mount(docx(bordered('one')));
+    const surface = editor.surface!;
+    let last = 'one';
+    for (const text of ['two', 'three', 'four']) {
+      caretIn(editor, surface.session.paragraphIds().length - 1, last.length);
+      surface.splitParagraph();
+      surface.type(text);
+      last = text;
+    }
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+
+  test('typing into a member without splitting it leaves the group alone', async () => {
+    const editor = mount(docx(bordered('one') + bordered('two')));
+    caretIn(editor, 0, 'one'.length);
+    editor.surface!.type(' more');
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+});
+
+describe('splitting a bordered run', () => {
+  test('Increase Indent on the last member closes the box above it', async () => {
+    const editor = mount(docx(bordered('one') + bordered('two') + bordered('three')));
+    caretIn(editor, 2);
+    expect(editor.surface!.adjustIndent('increase')).toBe(true);
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+
+  test('Increase Indent on a MIDDLE member splits the group in two', async () => {
+    const editor = mount(docx(bordered('one') + bordered('two') + bordered('three')));
+    caretIn(editor, 1);
+    expect(editor.surface!.adjustIndent('increase')).toBe(true);
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+
+  test('toggling the last member into a list splits the group', async () => {
+    const editor = mount(docx(bordered('one') + bordered('two') + bordered('three')));
+    caretIn(editor, 2);
+    expect(editor.surface!.toggleList('bullet')).toBe(true);
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+
+  test('Backspace merging the last two members re-places what is left', async () => {
+    const editor = mount(docx(bordered('one') + bordered('two') + bordered('three')));
+    const surface = editor.surface!;
+    caretIn(editor, 2);
+    surface.deleteBackward();
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+});

--- a/packages/core/src/layout/__tests__/border-group-incremental.test.ts
+++ b/packages/core/src/layout/__tests__/border-group-incremental.test.ts
@@ -1,0 +1,293 @@
+// Paragraph border GROUPS across an incremental pass (ECMA-376 §17.3.1.24).
+//
+// Consecutive paragraphs with identical `w:pBdr` are ONE bordered block: the box opens above
+// the first and closes below the last, and each interior boundary carries `w:between` or
+// nothing at all. So a paragraph's bottom edge is decided by the paragraph AFTER it, and its
+// top edge by the one before it. Neither bit lives in the block's own content key, so the incremental pass
+// resumed past a paragraph that had just stopped being the last of its group and kept the
+// closing rule — and the rule's `w:space` padding is real height, so the error compounded
+// down the flow until whole page boundaries moved.
+//
+// Every test here is DIFFERENTIAL. The oracle is the same tree laid out cold, with no
+// session; any disagreement IS the bug, whatever the numbers happen to be.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import type { PageGeometry, SemanticLayout } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const measurer = createFixedMeasurer(6, 14);
+// 14pt lines in an 80pt content column: five bare lines to a page, fewer once rules and
+// their `w:space` padding claim height. Small on purpose — a page boundary has to be
+// reachable by a one-paragraph edit for the compounding to show.
+const SMALL: PageGeometry = {
+  width: 200,
+  height: 100,
+  margin: { top: 10, right: 10, bottom: 10, left: 10 },
+};
+
+/** One box rule, `w:sz` in eighths of a point. */
+const rule = (side: string, color: string) =>
+  `<w:${side} w:val="single" w:sz="8" w:space="4" w:color="${color}"/>`;
+
+/**
+ * A paragraph carrying a `w:pBdr` box with NO `w:between`.
+ *
+ * Word's own default when you box a selection: the group's interior boundaries draw nothing.
+ * That makes the grouping question cost real HEIGHT — a member that gains a follower stops
+ * spending its closing rule and the `w:space` padding under it — which is what lets a stale
+ * verdict compound down the flow until a page boundary moves.
+ */
+const bordered = (text: string, { color = '000000', extra = '' } = {}) =>
+  `<w:p><w:pPr><w:pBdr>` +
+  rule('top', color) +
+  rule('left', color) +
+  rule('bottom', color) +
+  rule('right', color) +
+  `</w:pBdr>${extra}</w:pPr>` +
+  `<w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
+
+/**
+ * The same box with `w:between` authored at the SAME size and spacing as `w:bottom`.
+ *
+ * Grouping then changes only WHICH rule closes a member, never how much room it claims — the
+ * height-neutral shape the convergence tail is asked about.
+ */
+const borderedBetween = (text: string, { color = '000000' } = {}) =>
+  `<w:p><w:pPr><w:pBdr>` +
+  rule('top', color) +
+  rule('left', color) +
+  rule('bottom', color) +
+  rule('right', color) +
+  rule('between', color) +
+  `</w:pBdr></w:pPr>` +
+  `<w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
+
+const plain = (text: string) =>
+  `<w:p><w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
+
+const TABLE =
+  '<w:tbl><w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>' +
+  '<w:tr><w:tc>' +
+  '<w:p><w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>cell</w:t></w:r></w:p>' +
+  '</w:tc></w:tr></w:tbl>';
+
+const cold = (part: OoxmlPart): SemanticLayout =>
+  layoutSemanticDocument(part, 1, { measurer, geometry: SMALL });
+
+/**
+ * Everything the border grouping decides, per fragment: where the box sits, how tall it is,
+ * which rules it draws and on which sides, and whether it publishes a `bottomBorder`.
+ */
+const shapeOf = (layout: SemanticLayout): unknown =>
+  layout.pages.map((page) => ({
+    index: page.index,
+    fragments: page.fragments.map((fragment) => ({
+      id: fragment.id,
+      box: fragment.box,
+      ...(fragment.kind === 'paragraph'
+        ? {
+            sides: (fragment.borders ?? []).map((stroke) => `${stroke.side}@${stroke.box.y}`),
+            bottomBorder: fragment.bottomBorder !== undefined,
+          }
+        : {}),
+    })),
+  }));
+
+/**
+ * Lay `before` out, then `after` over the same session, and compare against `after` cold.
+ *
+ * Both revisions go through one session and one cache, which is what a live editing session
+ * does. The cold pass is the oracle.
+ */
+function differential(before: string, after: string): { warm: unknown; oracle: unknown } {
+  const options = {
+    measurer,
+    geometry: SMALL,
+    session: createLayoutSession(),
+    cache: createParagraphLayoutCache(),
+  };
+  layoutSemanticDocument(load(before), 1, options);
+  const warm = layoutSemanticDocument(load(after), 2, options);
+  return { warm: shapeOf(warm), oracle: shapeOf(cold(load(after))) };
+}
+
+describe('a paragraph JOINING the group below it re-places the one above', () => {
+  test('a new bordered paragraph appended to a pair', () => {
+    // The paragraph that WAS last must give back its bottom rule and the padding under it.
+    const { warm, oracle } = differential(
+      bordered('one') + bordered('two'),
+      bordered('one') + bordered('two') + bordered('three')
+    );
+    expect(warm).toEqual(oracle);
+  });
+
+  test('a plain paragraph that later takes the same borders joins the group', () => {
+    const { warm, oracle } = differential(
+      bordered('one') + bordered('two') + plain('three'),
+      bordered('one') + bordered('two') + bordered('three')
+    );
+    expect(warm).toEqual(oracle);
+  });
+
+  test('the bottomBorder record follows the group, not the paragraph', () => {
+    const options = {
+      measurer,
+      geometry: SMALL,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    layoutSemanticDocument(load(bordered('one') + bordered('two')), 1, options);
+    const warm = layoutSemanticDocument(
+      load(bordered('one') + bordered('two') + bordered('three')),
+      2,
+      options
+    );
+    const records = warm.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment) => fragment.kind === 'paragraph');
+    // Only the LAST member of the group closes the box. A middle paragraph publishing a
+    // `bottomBorder` draws the block's frame at an interior boundary.
+    expect(records.map((fragment) => fragment.bottomBorder !== undefined)).toEqual([
+      false,
+      false,
+      true,
+    ]);
+  });
+});
+
+describe('a paragraph LEAVING the group re-places the one above', () => {
+  test('Increase Indent on the last member splits the group', () => {
+    // `borderGroupKey` carries the box geometry, so an indent that moves the box makes the
+    // paragraph a group of its own — and the one above it has to close.
+    const { warm, oracle } = differential(
+      bordered('one') + bordered('two') + bordered('three'),
+      bordered('one') + bordered('two') + bordered('three', { extra: '<w:ind w:left="720"/>' })
+    );
+    expect(warm).toEqual(oracle);
+  });
+
+  test('a table inserted INTO the group closes the box above it', () => {
+    // Into, not below. A table under the last member changes nothing — that member already
+    // closed the box — so the only version of this that can catch a stale verdict is the one
+    // where the table lands between two members and the first of them has to close.
+    const { warm, oracle } = differential(
+      bordered('one') + bordered('two') + bordered('three'),
+      bordered('one') + bordered('two') + TABLE + bordered('three')
+    );
+    expect(warm).toEqual(oracle);
+  });
+
+  test('the last member losing its borders closes the one above it', () => {
+    const { warm, oracle } = differential(
+      bordered('one') + bordered('two') + bordered('three'),
+      bordered('one') + bordered('two') + plain('three')
+    );
+    expect(warm).toEqual(oracle);
+  });
+});
+
+describe('the compounded error moves page boundaries, not only box heights', () => {
+  test('a group grown at its end paginates the way the same tree does cold', () => {
+    const before = Array.from({ length: 5 }, (_, index) => bordered(`p${index}`)).join('');
+    const after = before + bordered('p5');
+    const { warm, oracle } = differential(before, after);
+    expect(warm).toEqual(oracle);
+  });
+
+  test('the page COUNT agrees with the cold pass', () => {
+    // The claim the whole fix rests on, and the exact shape that shows it. A member that
+    // stops being last gives back its closing rule and the `w:space` padding under it; a
+    // stale verdict keeps spending both, and four of them over-fill the page by enough to
+    // spill a sheet that the same tree laid out cold does not need.
+    const before = Array.from({ length: 4 }, (_, index) => bordered(`p${index}`)).join('');
+    const after = before + bordered('p4');
+    const options = {
+      measurer,
+      geometry: SMALL,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    layoutSemanticDocument(load(before), 1, options);
+    const warm = layoutSemanticDocument(load(after), 2, options);
+    expect(cold(load(after)).pages.length).toBe(1);
+    expect(warm.pages.length).toBe(1);
+  });
+});
+
+// The BACKWARD bit. Resume is a prefix cut, which makes a backward dependency safe: the
+// earlier block moving re-places everything after it. The convergence tail is a SUFFIX cut,
+// where backward is the exposed direction — so `above` is folded too.
+//
+// BOTH CASES BELOW HOLD WITHOUT THE FOLD, and that is recorded rather than hidden: the tail's
+// guard compares fragment signatures, and `semantic-fragment-signature.ts` hashes every
+// `w:pBdr` stroke, so a recoloured group moves the signature of the paragraph that changed.
+// These are regression tests for the tail, not proofs of the fold — `borderGroupFlowKeys` in
+// `pagination-keeps.test.ts` is what pins the `above` bit itself.
+describe('a group change ABOVE a block', () => {
+  test('a height-neutral recolour that merges two groups agrees with the cold pass', () => {
+    // `borderedBetween` authors `w:between` at the same size and spacing as `w:bottom`, so
+    // the paragraph that gains a follower closes at exactly the same height — nothing about
+    // the flow moves. The paragraph BELOW still has to stop drawing its own top rule.
+    const tail = plain('tail one') + plain('tail two') + plain('tail three');
+    const before =
+      plain('head') + borderedBetween('a', { color: 'FF0000' }) + borderedBetween('b') + tail;
+    const after = plain('head') + borderedBetween('a') + borderedBetween('b') + tail;
+    const { warm, oracle } = differential(before, after);
+    expect(warm).toEqual(oracle);
+  });
+
+  test('the same recolour across a page boundary agrees with the cold pass', () => {
+    // Three fillers put the recoloured paragraph last on page 1 and the one that reads it
+    // first on page 2. The checkpoint at that block is still taken with the previous page's
+    // fragments pending — `checkpointNow` runs BEFORE placement, and the flush happens while
+    // placing the block after — so this does not reach an empty pending page. It stands as a
+    // page-boundary regression case, not as a second mechanism.
+    const fillers = Array.from({ length: 3 }, (_, index) => plain(`f${index}`)).join('');
+    const tail = plain('tail one') + plain('tail two') + plain('tail three');
+    const before =
+      fillers + borderedBetween('a', { color: 'FF0000' }) + borderedBetween('b') + tail;
+    const after = fillers + borderedBetween('a') + borderedBetween('b') + tail;
+    const { warm, oracle } = differential(before, after);
+    expect(warm).toEqual(oracle);
+  });
+});
+
+describe('a document with no borders is not made to churn', () => {
+  test('a no-change pass still returns the previous pages by identity', () => {
+    const part = load(plain('one') + plain('two') + plain('three'));
+    const options = {
+      measurer,
+      geometry: SMALL,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(part, 1, options);
+    expect(layoutSemanticDocument(part, 2, options).pages).toBe(first.pages);
+  });
+
+  test('a no-change pass over a BORDERED document also returns pages by identity', () => {
+    const part = load(bordered('one') + bordered('two') + bordered('three'));
+    const options = {
+      measurer,
+      geometry: SMALL,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(part, 1, options);
+    expect(layoutSemanticDocument(part, 2, options).pages).toBe(first.pages);
+  });
+});

--- a/packages/core/src/layout/__tests__/pagination-keeps.test.ts
+++ b/packages/core/src/layout/__tests__/pagination-keeps.test.ts
@@ -11,8 +11,10 @@ import { createLayoutSession } from '../layout-session.ts';
 import { createParagraphLayoutCache } from '../layout-cache.ts';
 import {
   adjustedBreakIndex,
+  borderGroupFlowKeys,
   contextualSpacingFlowKeys,
   keepNextFlowKeys,
+  tocFieldFlowKeys,
   paragraphKeeps,
   DEFAULT_PARAGRAPH_KEEPS,
 } from '../pagination-keeps.ts';
@@ -427,6 +429,85 @@ describe('contextualSpacingFlowKeys — the cross-block fold', () => {
   });
 });
 
+describe('borderGroupFlowKeys — the border-group fold', () => {
+  const KEYS = ['a', 'b', 'c'];
+
+  test('no borders anywhere returns the SAME array, not a copy', () => {
+    expect(borderGroupFlowKeys(KEYS, () => '')).toBe(KEYS);
+  });
+
+  test('a run of one border group records which SIDES continue', () => {
+    const flow = borderGroupFlowKeys(KEYS, () => 'box');
+    // The first has nothing above it, the last nothing below; the middle continues both ways.
+    expect(flow).toEqual(['a~bg~01', 'b~bg~11', 'c~bg~10']);
+  });
+
+  test('a DIFFERENT group on either side does not continue', () => {
+    const groups = ['box', 'other', 'box'];
+    const flow = borderGroupFlowKeys(KEYS, (index) => groups[index]!);
+    expect(flow).toEqual(['a~bg~00', 'b~bg~00', 'c~bg~00']);
+  });
+
+  test('a block with no borders takes no token and breaks the group', () => {
+    // `''` is a table, or a paragraph with no `w:pBdr` at all. Two of them are not a group
+    // with each other, which is what keeps an ordinary document out of the fold entirely.
+    const groups = ['box', '', 'box'];
+    const flow = borderGroupFlowKeys(KEYS, (index) => groups[index]!);
+    expect(flow).toEqual(['a~bg~00', 'b', 'c~bg~00']);
+  });
+
+  test('the verdict MOVES when a member arrives below — the bug this exists for', () => {
+    const before = borderGroupFlowKeys(['a', 'b'], () => 'box');
+    const after = borderGroupFlowKeys(['a', 'b', 'c'], () => 'box');
+    // `b` closed the box; now a third member does, and `b` has to draw `between` instead.
+    expect(before[1]).toBe('b~bg~10');
+    expect(after[1]).toBe('b~bg~11');
+  });
+
+  test('the verdict MOVES when the member ABOVE joins the group', () => {
+    // The backward bit. Resume never needs it — the block above moving re-places everything
+    // after — but the convergence tail is a suffix cut, where backward is the exposed side.
+    const apart = borderGroupFlowKeys(KEYS, (index) => (index === 0 ? 'other' : 'box'));
+    const together = borderGroupFlowKeys(KEYS, () => 'box');
+    expect(apart[1]).toBe('b~bg~01');
+    expect(together[1]).toBe('b~bg~11');
+  });
+
+  test('an indent that moves the box splits the group', () => {
+    // `borderGroupKey` carries the box geometry as well as the rules, so Increase Indent on
+    // one member is a different key and the paragraph above it has to close.
+    const groups = ['box@0,468', 'box@0,468', 'box@36,468'];
+    const flow = borderGroupFlowKeys(KEYS, (index) => groups[index]!);
+    expect(flow).toEqual(['a~bg~01', 'b~bg~10', 'c~bg~00']);
+  });
+});
+
+describe('tocFieldFlowKeys — the TOC field fold', () => {
+  const KEYS = ['begin', 'result', 'end'];
+
+  test('a document with no TOC returns the SAME array, not a copy', () => {
+    expect(tocFieldFlowKeys(KEYS, () => '')).toBe(KEYS);
+  });
+
+  test('only the blocks a TOC touches are keyed', () => {
+    const verdicts = ['100', '', '100'];
+    expect(tocFieldFlowKeys(KEYS, (index) => verdicts[index]!)).toEqual([
+      'begin~toc~100',
+      'result',
+      'end~toc~100',
+    ]);
+  });
+
+  test('the begin paragraph re-places when the TOC empties under it', () => {
+    // Chrome-only while the results carry text; chrome plus placeholder once they do not.
+    // The begin paragraph itself does not change one byte between the two.
+    const filled = tocFieldFlowKeys(KEYS, (index) => (index === 0 ? '100' : ''));
+    const emptied = tocFieldFlowKeys(KEYS, (index) => (index === 0 ? '110' : ''));
+    expect(filled[0]).toBe('begin~toc~100');
+    expect(emptied[0]).toBe('begin~toc~110');
+  });
+});
+
 // `keepNextFlowKeys` splices a neighbour's WHOLE key in, so it has to fold last or a chain
 // head carries its members' pre-fold keys.
 describe('keepNextFlowKeys folds over the other folds', () => {
@@ -440,5 +521,18 @@ describe('keepNextFlowKeys folds over the other folds', () => {
     // The head splices in the AUGMENTED successor key, so a verdict flip under it moves
     // the head's own key too. Folded the other way round the head would carry a bare `p`.
     expect(flow[0]).toBe('h~kn~p~cs~10');
+  });
+
+  test('a chain head carries the successor key INCLUDING its border-group verdict', () => {
+    const folded = borderGroupFlowKeys(['h', 'p'], () => 'box');
+    const flow = keepNextFlowKeys(folded, (index) => index === 0);
+    // The head carries its OWN group verdict too, then the successor's whole folded key.
+    expect(flow[0]).toBe('h~bg~01~kn~p~bg~10');
+  });
+
+  test('a chain head carries the successor key INCLUDING its TOC verdict', () => {
+    const folded = tocFieldFlowKeys(['h', 'p'], (index) => (index === 1 ? '110' : ''));
+    const flow = keepNextFlowKeys(folded, (index) => index === 0);
+    expect(flow[0]).toBe('h~kn~p~toc~110');
   });
 });

--- a/packages/core/src/layout/__tests__/toc-field-editing.test.ts
+++ b/packages/core/src/layout/__tests__/toc-field-editing.test.ts
@@ -1,0 +1,143 @@
+// Refreshing a TOC in a live editor, which is the gesture the fold exists for.
+//
+// The sibling file drives `layoutSemanticDocument` with two parsed trees. That proves the
+// fold, but it reloads XML each time, so it never puts a SECTION PREPASS MEMO under pressure —
+// and the memo is the other half of the answer, because it can hand back cached flow keys
+// built from the verdicts of a revision that is gone.
+//
+// `refreshToc` is the real trigger. It rewrites the result paragraphs and leaves the begin
+// paragraph byte-identical, so a document with no headings loses every result row and the
+// begin paragraph has to start emitting the one placeholder line that stands in for an empty
+// TOC. The oracle is the same bytes reopened.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../../editor/docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const STY = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+const STYLES =
+  `<w:styles xmlns:w="${W}">` +
+  '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>' +
+  '<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/>' +
+  '<w:basedOn w:val="Normal"/></w:style>' +
+  '<w:style w:type="paragraph" w:styleId="TOC1"><w:name w:val="toc 1"/>' +
+  '<w:basedOn w:val="Normal"/></w:style>' +
+  '</w:styles>';
+
+const BEGIN =
+  '<w:p><w:r><w:fldChar w:fldCharType="begin"/>' +
+  '<w:instrText> TOC \\o "1-3" \\h </w:instrText>' +
+  '<w:fldChar w:fldCharType="separate"/></w:r></w:p>';
+const END = '<w:p><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+const tocEntry = (text: string) =>
+  `<w:p><w:pPr><w:pStyle w:val="TOC1"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const heading = (text: string) =>
+  `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const body = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+const sdt = (inner: string) => `<w:sdt><w:sdtPr/><w:sdtContent>${inner}</w:sdtContent></w:sdt>`;
+
+function docx(bodyXml: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId2" Type="${STY}" Target="styles.xml"/></Relationships>`
+    ),
+    'word/styles.xml': strToU8(STYLES),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${bodyXml}</w:body></w:document>`
+    ),
+  });
+}
+
+const open: DocxEditorInstance[] = [];
+
+afterEach(() => {
+  for (const editor of open.splice(0)) editor.destroy();
+});
+
+function mount(bytes: Uint8Array): DocxEditorInstance {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({ container, document: bytes });
+  open.push(editor);
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+/** Which rows the flow actually emits, and where. */
+const shapeOf = (editor: DocxEditorInstance): unknown =>
+  editor.surface!.layout().pages.map((page) =>
+    page.fragments.map((fragment) => ({
+      y: Math.round(fragment.box.y * 100) / 100,
+      height: Math.round(fragment.box.height * 100) / 100,
+      text:
+        fragment.kind === 'paragraph'
+          ? fragment.lines
+              .flatMap((line) => line.spans.map((span) => span.text))
+              .join('')
+              .trim()
+          : '',
+    }))
+  );
+
+async function reopened(editor: DocxEditorInstance): Promise<DocxEditorInstance> {
+  return mount(new Uint8Array(await editor.save()));
+}
+
+describe('refreshToc through a live editor', () => {
+  test('a refresh that finds no headings gives the begin paragraph its placeholder', async () => {
+    // The document has cached rows but nothing for them to point at, so the refresh empties
+    // the TOC. Every result paragraph is rewritten; the begin paragraph is not touched.
+    const editor = mount(
+      docx(sdt(BEGIN + tocEntry('Introduction') + tocEntry('Method') + END) + body('after'))
+    );
+    expect(editor.surface!.refreshToc(undefined, 'entire')).toBe(true);
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+
+  test('a refresh that finds headings takes the placeholder back off', async () => {
+    const editor = mount(
+      docx(sdt(BEGIN + END) + heading('Introduction') + heading('Method') + body('after'))
+    );
+    expect(editor.surface!.refreshToc(undefined, 'entire')).toBe(true);
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+
+  test('typing after a refresh keeps the flow agreeing with the reopened bytes', async () => {
+    // The prepass memo is what this reaches: the refresh moves the TOC id sets, and the
+    // keystrokes after it run passes that must not serve flow keys built from the shape the
+    // document had before.
+    const editor = mount(docx(sdt(BEGIN + tocEntry('Introduction') + END) + body('after')));
+    const surface = editor.surface!;
+    expect(surface.refreshToc(undefined, 'entire')).toBe(true);
+
+    const ids = surface.session.paragraphIds();
+    const last = ids[ids.length - 1]!;
+    surface.setSelection({
+      anchor: { paragraphId: last, offset: 0 },
+      head: { paragraphId: last, offset: 0 },
+    });
+    surface.type('more ');
+
+    expect(shapeOf(editor)).toEqual(shapeOf(await reopened(editor)));
+  });
+});

--- a/packages/core/src/layout/__tests__/toc-field-incremental.test.ts
+++ b/packages/core/src/layout/__tests__/toc-field-incremental.test.ts
@@ -1,0 +1,148 @@
+// TOC field verdicts across an INCREMENTAL pass.
+//
+// A TOC is a complex field spanning paragraphs: a begin paragraph carrying `fldChar begin`
+// and the `TOC` instruction, cached result paragraphs, an end paragraph. Layout answers three
+// questions per paragraph from that shape — suppress the field chrome, keep one placeholder
+// line on a begin paragraph whose TOC resolved to nothing, suppress a blank cached result row
+// — and every answer is read from the OTHER paragraphs of the same field.
+//
+// The begin paragraph is the sharp one. Whether it keeps a placeholder line depends on
+// whether any RESULT paragraph after it still carries visible text, and refreshing a TOC that
+// comes back empty rewrites the results while leaving the begin paragraph byte-identical. Its
+// content key never moved, resume started at the first result, and the placeholder line the
+// begin paragraph had just earned simply never appeared — for the life of the session.
+//
+// Every test here is DIFFERENTIAL: the same tree laid out cold is the oracle.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import { paragraphFragmentsOf } from '../index.ts';
+import type { SemanticLayout } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const measurer = createFixedMeasurer(6, 14);
+
+const BEGIN =
+  '<w:p><w:r><w:fldChar w:fldCharType="begin"/>' +
+  '<w:instrText> TOC \\o "1-3" \\h </w:instrText>' +
+  '<w:fldChar w:fldCharType="separate"/></w:r></w:p>';
+const END = '<w:p><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+const entry = (text: string) =>
+  `<w:p><w:pPr><w:pStyle w:val="TOC1"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+/** A cached row the refresh left behind with nothing in it. */
+const BLANK_ENTRY = '<w:p><w:pPr><w:pStyle w:val="TOC1"/></w:pPr></w:p>';
+const after = '<w:p><w:r><w:t>after</w:t></w:r></w:p>';
+
+const sdt = (inner: string) => `<w:sdt><w:sdtPr/><w:sdtContent>${inner}</w:sdtContent></w:sdt>`;
+
+/**
+ * What each painted row is and where it sits.
+ *
+ * Node ids are minted per parse, so they cannot cross between two loads of the same markup.
+ * Geometry plus text is what the verdicts decide, and it is what a reader sees.
+ */
+const shapeOf = (layout: SemanticLayout): unknown =>
+  layout.pages.map((page) =>
+    paragraphFragmentsOf(page).map((fragment) => ({
+      y: fragment.box.y,
+      height: fragment.box.height,
+      text: fragment.lines
+        .flatMap((line) => line.spans.map((span) => span.text))
+        .join('')
+        .trim(),
+    }))
+  );
+
+/** Lay `before` out, then `after` over the same session; the oracle is `after` laid out cold. */
+function differential(before: string, next: string): { warm: unknown; oracle: unknown } {
+  const options = {
+    measurer,
+    session: createLayoutSession(),
+    cache: createParagraphLayoutCache(),
+  };
+  layoutSemanticDocument(load(before), 1, options);
+  const warm = layoutSemanticDocument(load(next), 2, options);
+  return {
+    warm: shapeOf(warm),
+    oracle: shapeOf(layoutSemanticDocument(load(next), 1, { measurer })),
+  };
+}
+
+describe('the empty-TOC placeholder on the begin paragraph', () => {
+  test('a refresh that empties the TOC gives the begin paragraph its placeholder line', () => {
+    // The result paragraphs go; the begin paragraph does not change one byte. Its verdict
+    // does: it now has to keep the one line that stands in for an empty TOC.
+    const { warm, oracle } = differential(
+      sdt(BEGIN + entry('Introduction') + END) + after,
+      sdt(BEGIN + END) + after
+    );
+    expect(warm).toEqual(oracle);
+  });
+
+  test('a refresh that leaves the rows blank rather than removing them', () => {
+    // Same verdict flip, reached the other way: the rows survive with no visible text, so
+    // the begin paragraph takes the placeholder and the blank rows are suppressed.
+    const { warm, oracle } = differential(
+      sdt(BEGIN + entry('Introduction') + entry('Method') + END) + after,
+      sdt(BEGIN + BLANK_ENTRY + BLANK_ENTRY + END) + after
+    );
+    expect(warm).toEqual(oracle);
+  });
+
+  test('a refresh that FILLS an empty TOC takes the placeholder back off', () => {
+    const { warm, oracle } = differential(
+      sdt(BEGIN + END) + after,
+      sdt(BEGIN + entry('Introduction') + END) + after
+    );
+    expect(warm).toEqual(oracle);
+  });
+
+  test('the placeholder is really the thing being compared', () => {
+    // Guards the differential above from passing vacuously: the two trees must genuinely
+    // disagree about what the begin paragraph emits.
+    const filled = shapeOf(
+      layoutSemanticDocument(load(sdt(BEGIN + entry('Introduction') + END) + after), 1, {
+        measurer,
+      })
+    );
+    const empty = shapeOf(layoutSemanticDocument(load(sdt(BEGIN + END) + after), 1, { measurer }));
+    expect(empty).not.toEqual(filled);
+  });
+});
+
+describe('a document with no TOC is not made to churn', () => {
+  test('a no-change pass still returns the previous pages by identity', () => {
+    const part = load(after + after + after);
+    const options = {
+      measurer,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(part, 1, options);
+    expect(layoutSemanticDocument(part, 2, options).pages).toBe(first.pages);
+  });
+
+  test('a no-change pass over a document WITH a TOC also returns pages by identity', () => {
+    const part = load(sdt(BEGIN + entry('Introduction') + END) + after);
+    const options = {
+      measurer,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(part, 1, options);
+    expect(layoutSemanticDocument(part, 2, options).pages).toBe(first.pages);
+  });
+});

--- a/packages/core/src/layout/pagination-keeps.ts
+++ b/packages/core/src/layout/pagination-keeps.ts
@@ -284,6 +284,84 @@ export function contextualSpacingFlowKeys(
 }
 
 /**
+ * Flow keys that also carry each block's PARAGRAPH BORDER GROUP membership.
+ *
+ * Consecutive paragraphs with identical border settings are ONE bordered block in Word
+ * (`w:between`, §17.3.1.24): the box opens above the first and closes below the last, and
+ * every interior boundary carries the `between` rule instead of a top and a bottom. So a
+ * paragraph's own bottom edge — which rule is drawn, how much vertical extent it claims, and
+ * whether it publishes a `bottomBorder` record at all — is a function of the block AFTER it.
+ *
+ * Nothing about that reaches the block's content key, so the incremental pass resumed past a
+ * paragraph that had just stopped being the last of its group and kept the closing edge it no
+ * longer owned. The extent is real height, so the error compounds down the flow: a
+ * three-paragraph group edited on its last member laid out over three pages where the same
+ * bytes reopened took two.
+ *
+ * Both bits go in, not only the forward one. Incremental RESUME is a prefix cut, where a
+ * backward dependency is safe because the earlier block moving re-places everything after it.
+ * The convergence tail is a SUFFIX cut, where backward is the exposed direction: a block can
+ * sit inside the common suffix while the paragraph above it joins or leaves its group.
+ *
+ * No repro is known for that, and the reason is worth writing down: the tail's guard compares
+ * fragment SIGNATURES, and `semantic-fragment-signature.ts` hashes every `w:pBdr` stroke, so
+ * even a height-neutral group change (a different `w:color` on the same `w:sz`) moves the
+ * signature of the paragraph that changed. `above` is folded anyway. That guard only sees a
+ * changed paragraph still pending on the page being built, it is not the guard that owns this
+ * question, and the bit is free — one string comparison the fold already has in hand.
+ *
+ * `groupKeyAt` answers `''` for a block that can never group: a table, or a paragraph with no
+ * borders at all. Two paragraphs group only when their keys are EQUAL, which is what makes an
+ * indent change split a group — the key carries the box geometry as well as the rules.
+ */
+export function borderGroupFlowKeys(
+  keys: string[],
+  groupKeyAt: (index: number) => string
+): string[] {
+  let flow = keys;
+  for (let index = 0; index < keys.length; index += 1) {
+    const group = groupKeyAt(index);
+    if (group === '') continue;
+    const above = index > 0 && groupKeyAt(index - 1) === group;
+    const below = index + 1 < keys.length && groupKeyAt(index + 1) === group;
+    if (flow === keys) flow = [...keys];
+    flow[index] = `${flow[index]}~bg~${above ? 1 : 0}${below ? 1 : 0}`;
+  }
+  return flow;
+}
+
+/**
+ * Flow keys that also carry each block's TOC FIELD verdict.
+ *
+ * A TOC is a complex field spanning paragraphs: a begin paragraph holding `fldChar begin` and
+ * the `TOC` instruction, cached result paragraphs, an end paragraph. Layout answers three
+ * questions per paragraph from that shape — suppress the field chrome, keep one placeholder
+ * line on the begin paragraph because the TOC resolved to nothing, suppress a blank cached
+ * result row — and each answer is read from the OTHER paragraphs of the same field.
+ *
+ * The begin paragraph is the sharp case: whether it keeps a placeholder line depends on
+ * whether any RESULT paragraph after it still carries visible text. Refreshing a TOC that
+ * comes back empty rewrites the result paragraphs and leaves the begin paragraph untouched,
+ * so resume started at the first result and reused a begin paragraph that had just gone from
+ * "emits nothing" to "emits a placeholder line" — the line simply vanished for the life of
+ * the session, and reopening the same bytes brought it back.
+ *
+ * The three raw membership bits go in rather than the two booleans layout derives from them,
+ * so the fold stays correct whatever the derivation grows into. `verdictAt` answers `''` for
+ * a block no TOC touches, which is every block of a document that has no TOC.
+ */
+export function tocFieldFlowKeys(keys: string[], verdictAt: (index: number) => string): string[] {
+  let flow = keys;
+  for (let index = 0; index < keys.length; index += 1) {
+    const verdict = verdictAt(index);
+    if (verdict === '') continue;
+    if (flow === keys) flow = [...keys];
+    flow[index] = `${flow[index]}~toc~${verdict}`;
+  }
+  return flow;
+}
+
+/**
  * Flow keys that carry a `w:keepNext` chain's SUCCESSOR KEY.
  *
  * RUN THIS FOLD LAST. It is the only one that splices a neighbour's whole key into a

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -60,9 +60,11 @@ import {
 import { resolveParagraphBorders } from './paragraph-border-resolve.ts';
 import {
   adjustedBreakIndex,
+  borderGroupFlowKeys,
   keepNextFlowKeys,
   listMarkerFlowKeys,
   contextualSpacingFlowKeys,
+  tocFieldFlowKeys,
   keepNextGroupHeight,
   paragraphKeeps,
   MAX_KEEP_NEXT_CHAIN,
@@ -447,6 +449,61 @@ function listTokenForTableBlock(
 
 const preparedBlocks = new WeakMap<OoxmlNode, PreparedBlockMemo>();
 
+/** The three TOC id sets {@link tocFieldFlowKeys} folds, as one argument. */
+interface TocIdSets {
+  readonly chrome: ReadonlySet<string> | undefined;
+  readonly placeholder: ReadonlySet<string> | undefined;
+  readonly suppressed: ReadonlySet<string> | undefined;
+}
+
+/**
+ * A CONTENT token for one TOC id set, memoized per set object.
+ *
+ * The prepass memo needs to know when the sets moved, and identity cannot answer that: the
+ * sets are derived per `OoxmlPart` and every edit publishes a new part, so a set is a new
+ * object after every keystroke while holding exactly the same ids. Comparing by identity
+ * would rebuild the prepass of every section that holds a TOC paragraph on every keystroke.
+ *
+ * Content is what the verdicts actually read, and it is cheap: a set holds a TOC's begin, end
+ * and result paragraph ids — dozens, not thousands — and the token is computed once per set
+ * object, so a whole pass over a many-section document pays for it once. Iteration order is
+ * document order out of `detectBodyTocs`, and node ids survive an edit, so the token is
+ * stable exactly while the TOCs are.
+ *
+ * `''` for an absent or empty set, which is every set of every document with no TOC.
+ */
+const tocIdSetTokens = new WeakMap<ReadonlySet<string>, string>();
+function tocIdSetToken(ids: ReadonlySet<string> | undefined): string {
+  if (ids === undefined || ids.size === 0) return '';
+  const cached = tocIdSetTokens.get(ids);
+  if (cached !== undefined) return cached;
+  const token = [...ids].join(',');
+  tocIdSetTokens.set(ids, token);
+  return token;
+}
+
+/**
+ * One token for all three sets, or `''` when the part holds no TOC at all.
+ *
+ * Compared WHOLE by the prepass memo rather than per section, which is what makes the
+ * straddling case work in BOTH directions. A TOC field can span a section break, so a
+ * section's own blocks can sit still while a paragraph in it gains or loses a verdict
+ * decided in another section — and a section that reads the sets today may have read
+ * nothing yesterday. Keying the check on whether THIS section currently reads them closes
+ * only the first of those; keying it on the part's whole TOC shape closes both.
+ *
+ * The conservative half of that trade is that a real TOC change invalidates every section's
+ * prepass. Ordinary typing does not move the token — the ids are the same paragraphs — so
+ * what pays is a refresh or an insert, which rewrites the body anyway.
+ */
+function tocIdsToken(ids: TocIdSets): string {
+  const chrome = tocIdSetToken(ids.chrome);
+  const placeholder = tocIdSetToken(ids.placeholder);
+  const suppressed = tocIdSetToken(ids.suppressed);
+  if (chrome === '' && placeholder === '' && suppressed === '') return '';
+  return `${chrome}|${placeholder}|${suppressed}`;
+}
+
 /**
  * One section's whole prepass — prepared entries, cache keys, flow keys and document
  * order — kept on the section's {@link LayoutSession} and reused verbatim while every
@@ -464,7 +521,22 @@ interface SectionPrepass {
   readonly paragraphDocumentOrder: ReadonlyMap<string, number>;
   readonly keepsNext: boolean[];
   readonly markerTexts: (string | undefined)[];
+  readonly tocToken: string;
   readonly flowKeys: string[];
+}
+
+/**
+ * One paragraph's three raw TOC id-set memberships, as {@link tocFieldFlowKeys} folds them.
+ *
+ * Raw membership rather than the two booleans `breakBlock` derives from them, so the fold
+ * stays correct if the derivation changes. `''` means no TOC touches this paragraph.
+ */
+function tocVerdictFor(paragraphId: string, ids: TocIdSets): string {
+  const chrome = ids.chrome?.has(paragraphId) ?? false;
+  const placeholder = ids.placeholder?.has(paragraphId) ?? false;
+  const suppressed = ids.suppressed?.has(paragraphId) ?? false;
+  if (!chrome && !placeholder && !suppressed) return '';
+  return `${chrome ? 1 : 0}${placeholder ? 1 : 0}${suppressed ? 1 : 0}`;
 }
 const drawingSourceOrderByContext = new WeakMap<
   InlineDrawingLayoutContext,
@@ -791,6 +863,13 @@ function layoutBlocksPass(
   const tocChromeParagraphIds = options.tocFieldChromeParagraphIds;
   const emptyTocPlaceholderIds = options.emptyTocPlaceholderParagraphIds;
   const emptyTocSuppressedResultIds = options.emptyTocSuppressedResultParagraphIds;
+  const tocIds: TocIdSets = {
+    chrome: tocChromeParagraphIds,
+    placeholder: emptyTocPlaceholderIds,
+    suppressed: emptyTocSuppressedResultIds,
+  };
+  /** `''` for a part with no TOC, which skips the per-block verdict scan entirely. */
+  const tocToken = tocIdsToken(tocIds);
   const producer =
     (options.producer ?? 'unversioned-measurer') +
     (styleCascade ? `|sc:${styleCascade.cacheToken}` : '') +
@@ -1026,6 +1105,7 @@ function layoutBlocksPass(
     prepassMemo.contentWidth === contentWidth &&
     prepassMemo.styleCascade === styleCascade &&
     prepassMemo.listItems === listItems &&
+    prepassMemo.tocToken === tocToken &&
     prepassMemo.bodies.length === bodies.length &&
     prepassMemo.bodies.every((block, index) => block === bodies[index]);
   const prepass: SectionPrepass = prepassValid ? prepassMemo : buildSectionPrepass();
@@ -1042,6 +1122,45 @@ function layoutBlocksPass(
       (entry) => entry.kind === 'paragraph' && entry.contextualSpacing
     );
     const styleIds = prepared.map((entry) => (entry.kind === 'paragraph' ? entry.styleId : null));
+    // A paragraph's bottom edge belongs to its border GROUP, which the block after it can
+    // join or leave. A table never groups, and neither does a paragraph with no borders.
+    const borderGroupKeys = prepared.map((entry) =>
+      entry.kind === 'paragraph' ? entry.borderGroupKey : ''
+    );
+    // Which lines a TOC field's paragraphs emit at all, decided by the OTHER paragraphs of
+    // the same field. A part with no TOC skips the scan outright rather than asking three
+    // empty sets about every block it holds.
+    const tocVerdicts =
+      tocToken === ''
+        ? []
+        : prepared.map((entry) =>
+            entry.kind === 'paragraph' ? tocVerdictFor(entry.paragraph.id, tocIds) : ''
+          );
+
+    // FLOW keys — what incremental resume compares. `keys` stays what the break cache is
+    // stored under; the CROSS-BLOCK properties make the two differ: `w:keepNext`
+    // (§17.3.1.15), the list marker, `w:contextualSpacing` (§17.3.1.9), paragraph border
+    // groups (§17.3.1.24) and the TOC field verdicts — each of which makes a block's
+    // placement depend on a block it does not contain.
+    //
+    // Each fold returns its input BY IDENTITY when nothing folds, so a document that reads
+    // across no boundary at all reaches the end holding the array it started with.
+    let flow = contextualSpacingFlowKeys(
+      keys,
+      (index) => contextualSpacings[index]!,
+      (index) => styleIds[index] ?? null
+    );
+    flow = borderGroupFlowKeys(flow, (index) => borderGroupKeys[index]!);
+    if (tocVerdicts.length > 0) flow = tocFieldFlowKeys(flow, (index) => tocVerdicts[index]!);
+    flow = listMarkerFlowKeys(flow, (index) => markerTexts[index]);
+    // LAST, and the order is load-bearing. `keepNextFlowKeys` is the only fold that splices
+    // a NEIGHBOUR'S WHOLE KEY into a block's own, so whatever it reads has to be finished:
+    // run it first and a chain head carries its members' pre-fold keys, which is a head that
+    // never re-places when a member's marker, contextual or border verdict moves. That is
+    // latent rather than live today only because `keepNextGroupHeight` prices AUTHORED
+    // spacing; folding last makes the composition correct whatever that lookahead grows into.
+    flow = keepNextFlowKeys(flow, (index) => keepsNext[index]!);
+
     return {
       bodies,
       producer,
@@ -1059,29 +1178,8 @@ function layoutBlocksPass(
       ),
       keepsNext,
       markerTexts,
-      // FLOW keys — what incremental resume compares. `keys` stays what the break cache is
-      // stored under; the CROSS-BLOCK properties make the two differ: `w:keepNext`
-      // (§17.3.1.15), the list marker, and `w:contextualSpacing` (§17.3.1.9), each of which
-      // makes a block's placement depend on a block it does not contain.
-      //
-      // ORDER IS LOAD-BEARING, and `keepNextFlowKeys` is OUTERMOST for a reason. It is the
-      // only fold that splices a NEIGHBOUR'S WHOLE KEY into a block's own, so whatever it
-      // reads has to be finished: run it first and a chain head carries its members'
-      // pre-fold keys, which is a head that never re-places when a member's marker or
-      // contextual verdict moves. That is latent rather than live today only because
-      // `keepNextGroupHeight` prices AUTHORED spacing; folding last makes the composition
-      // correct whatever that lookahead grows into.
-      flowKeys: keepNextFlowKeys(
-        listMarkerFlowKeys(
-          contextualSpacingFlowKeys(
-            keys,
-            (index) => contextualSpacings[index]!,
-            (index) => styleIds[index] ?? null
-          ),
-          (index) => markerTexts[index]
-        ),
-        (index) => keepsNext[index]!
-      ),
+      tocToken,
+      flowKeys: flow,
     };
   }
   if (session && drawingEpoch !== null && !prepassValid) session.prepass = prepass;


### PR DESCRIPTION
Closes #381.

Incremental layout resumes from the first block whose flow key moved and reuses everything before it. That is a prefix cut, so a block that reads a *later* block keeps a stale result: the later block changes, this block's own key does not move, and resume skips past it. Three folds already guarded that in `packages/core/src/layout/pagination-keeps.ts`. Two were missing.

## Paragraph border groups

Consecutive paragraphs with identical `w:pBdr` are one bordered block (`w:between`, ECMA-376 §17.3.1.24), so a paragraph's closing edge is decided by the block after it. The rule and the `w:space` padding under it are real height, so a stale verdict compounds down the flow: a four-paragraph group grown by one lays out over two pages where the same bytes reopened take one.

`borderGroupFlowKeys` folds `~bg~<above><below>`. It fires on the gestures that reach it in practice: split at the end of a run, apply a bordered style below, **Increase Indent** and **list toggle** (both change `borderGroupKey`, which carries the box geometry), and a table inserted into the group.

Both bits fold, not only the forward one. Resume is a prefix cut, but the convergence tail is a suffix cut, where backward is the exposed direction.

## TOC fields

The begin paragraph keeps a placeholder line only while no result paragraph after it carries visible text. `refreshToc` rewrites the results and leaves the begin paragraph byte-identical, so the placeholder never appeared for the life of the session. `tocFieldFlowKeys` folds `~toc~<chrome><placeholder><suppressed>`, which covers field-chrome suppression and blank-result suppression too.

## Prepass memo

The section prepass memo now compares the TOC id sets by content. The sets are derived per `OoxmlPart` and every edit publishes a new part, so identity comparison would rebuild the prepass of every section holding a TOC on every keystroke, and it could only notice a section that lost a verdict, never one that gained it.

## Tests

Every test is differential: the oracle is the same tree laid out cold, or the same bytes reopened. Both folds were neutered in turn to confirm the tests fail without them — 12 border tests and 6 TOC tests go red, including the apply-then-grow order that a build-then-apply test cannot detect, and the page-count case.

## Verification

`bun run test` (8403 pass, 0 fail), `typecheck`, `lint` (0 errors), `check:parity`, `api:check`, `i18n:validate`, `openspec validate --strict`. `bench:edit` still places 11-14 blocks of 3200 per keystroke and `bench:scope-waste` reports 0 discarded, both unchanged from the base commit.

## Not covered

The remaining open questions in #381 — footnote reserves, anchored drawings with wrap, and note-mark renumbering — are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790093640&installation_model_id=422592&pr_number=384&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F384&signature=fc732f17e3c19bc65b26bb8f506dab4e17a589e8db015b31fe636c91ff2d19ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->