### PR TITLE
fix(core): border groups survive unequal column widths

### DIFF
--- a/.changeset/border-group-column-width.md
+++ b/.changeset/border-group-column-width.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fixed bordered paragraphs drawing a separate box each instead of one box, in a section whose columns have different widths.

--- a/packages/core/src/layout/__tests__/border-group-columns.test.ts
+++ b/packages/core/src/layout/__tests__/border-group-columns.test.ts
@@ -1,0 +1,164 @@
+// Paragraph border groups in a MULTI-COLUMN section (ECMA-376 §17.3.1.24, §17.6.4).
+//
+// Consecutive paragraphs with identical `w:pBdr` are one bordered block: the box opens above
+// the first and closes below the last. Which COLUMN a paragraph lands in is a layout outcome,
+// not an authored property, so it must not decide who is in the group — a run of boxed
+// paragraphs flowing into the next column carries on as one box, exactly as it does across a
+// page break.
+//
+// It did not, in a section with unequal column widths. The group key was built from the box's
+// resolved right EDGE (`indent.left + available`, and `available` is
+// `contentWidth - indent.left - indent.right`), so it folded the content width in. The prepass
+// prepares every block at column 0's width while placement prepares each block at the width of
+// the column it actually lands in, and with unequal columns those two never agreed: grouping
+// collapsed outside column 0 and every paragraph there drew its own box.
+//
+// The tests below assert the STROKE PATTERN, because that is what a reader sees: one box is
+// `top` … `bottom` with bare sides between, and a broken group is `top,bottom` repeated.
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { readOoxmlPackage, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function packageWithBody(body: string): OoxmlPart {
+  const bytes = zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.error.message);
+  return loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+}
+
+const rule = (side: string) => `<w:${side} w:val="single" w:sz="8" w:space="4" w:color="000000"/>`;
+const BOX = `<w:pBdr>${rule('top')}${rule('left')}${rule('bottom')}${rule('right')}</w:pBdr>`;
+
+const bordered = (text: string, extra = '') =>
+  `<w:p><w:pPr>${BOX}${extra}</w:pPr>` +
+  `<w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
+
+// Short enough that a run of eight boxed paragraphs overflows column 1 into column 2.
+const PAGE =
+  '<w:pgSz w:w="7200" w:h="2600"/>' +
+  '<w:pgMar w:top="360" w:right="720" w:bottom="360" w:left="720"/>';
+
+const EQUAL = '<w:cols w:num="2" w:space="720"/>';
+/** 90pt and 150pt: the two columns disagree, which is the whole point. */
+const UNEQUAL =
+  '<w:cols w:num="2" w:equalWidth="0"><w:col w:w="1800" w:space="600"/><w:col w:w="3000"/></w:cols>';
+
+const sectionOf = (cols: string) => `<w:sectPr>${PAGE}${cols}</w:sectPr>`;
+
+interface Row {
+  readonly text: string;
+  readonly width: number;
+  readonly sides: string;
+}
+
+function rowsOf(body: string): Row[] {
+  const layout = layoutSemanticDocument(packageWithBody(body), 1, {
+    measurer: createFixedMeasurer(6, 14),
+  });
+  return layout.pages.flatMap((page) =>
+    page.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph'
+        ? [
+            {
+              text: fragment.lines.flatMap((line) => line.spans.map((span) => span.text)).join(''),
+              width: Math.round(fragment.box.width),
+              sides: (fragment.borders ?? []).map((stroke) => stroke.side).join(','),
+            },
+          ]
+        : []
+    )
+  );
+}
+
+const run = (count: number) =>
+  Array.from({ length: count }, (_, index) => bordered(`p${index}`)).join('');
+
+/** One box: the first opens it, the last closes it, everything between draws bare sides. */
+const oneBox = (count: number): string[] => [
+  'top,left,right',
+  ...Array.from({ length: count - 2 }, () => 'left,right'),
+  'bottom,left,right',
+];
+
+describe('a bordered run flowing into the next column', () => {
+  test('unequal column widths keep it ONE box', () => {
+    const rows = rowsOf(run(8) + sectionOf(UNEQUAL));
+    // Proof the fixture does what it claims: the run really does reach the second column,
+    // and the two columns really are different widths.
+    const widths = [...new Set(rows.map((row) => row.width))];
+    expect(widths).toHaveLength(2);
+    expect(rows.map((row) => row.sides)).toEqual(oneBox(8));
+  });
+
+  test('the paragraphs that land in the SECOND column group with each other', () => {
+    // The sharpest statement of the bug. These two share a column and a width, so nothing
+    // about geometry can excuse them drawing separate boxes.
+    const rows = rowsOf(run(8) + sectionOf(UNEQUAL));
+    const second = rows.filter((row) => row.width === Math.max(...rows.map((r) => r.width)));
+    expect(second.length).toBeGreaterThan(1);
+    expect(second.map((row) => row.sides)).toEqual([
+      ...Array.from({ length: second.length - 1 }, () => 'left,right'),
+      'bottom,left,right',
+    ]);
+  });
+
+  test('equal column widths are unchanged, and the two agree', () => {
+    expect(rowsOf(run(8) + sectionOf(EQUAL)).map((row) => row.sides)).toEqual(oneBox(8));
+    expect(rowsOf(run(8) + sectionOf(EQUAL)).map((row) => row.sides)).toEqual(
+      rowsOf(run(8) + sectionOf(UNEQUAL)).map((row) => row.sides)
+    );
+  });
+});
+
+describe('what still splits a group', () => {
+  test('a different left indent, in a single column', () => {
+    const body =
+      bordered('a') + bordered('b') + bordered('c', '<w:ind w:left="720"/>') + sectionOf(EQUAL);
+    expect(rowsOf(body).map((row) => row.sides)).toEqual([
+      'top,left,right',
+      'bottom,left,right',
+      'top,bottom,left,right',
+    ]);
+  });
+
+  test('a different RIGHT indent, which the old key carried only through the width', () => {
+    const body =
+      bordered('a') + bordered('b') + bordered('c', '<w:ind w:right="720"/>') + sectionOf(EQUAL);
+    expect(rowsOf(body).map((row) => row.sides)).toEqual([
+      'top,left,right',
+      'bottom,left,right',
+      'top,bottom,left,right',
+    ]);
+  });
+
+  test('a different left indent inside a MULTI-column section', () => {
+    // The indent has to keep splitting the group after the width stopped being in the key.
+    const body =
+      bordered('a') + bordered('b') + bordered('c', '<w:ind w:left="720"/>') + sectionOf(UNEQUAL);
+    expect(rowsOf(body).map((row) => row.sides)).toEqual([
+      'top,left,right',
+      'bottom,left,right',
+      'top,bottom,left,right',
+    ]);
+  });
+});

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -970,8 +970,15 @@ function layoutBlocksPass(
         contextualSpacing,
         styleId,
         borders,
-        borderGroupKey:
-          bordersToken === '' ? '' : `${bordersToken}@${indent.left},${indent.left + available}`,
+        // The box's own INSETS, not its resolved edges. `available` is
+        // `contentWidth - indent.left - indent.right`, so keying on `indent.left + available`
+        // folded the CONTENT WIDTH into the group's identity — and a multi-column section
+        // prepares the prepass at column 0's width while placing each block at the width of
+        // the column it lands in. With unequal columns those two never agreed, so grouping
+        // collapsed outside column 0 and every paragraph there drew its own box. Which
+        // column a paragraph lands in is a layout outcome; the group is an authored
+        // relationship between neighbours, and only the authored insets may decide it.
+        borderGroupKey: bordersToken === '' ? '' : `${bordersToken}@${indent.left},${indent.right}`,
         shading,
         inheritedRunProperties,
         markRunProperties,


### PR DESCRIPTION
Closes #385. Independent of #384 — the two branches merge cleanly, and this one is based on `main`.

## What was wrong

Consecutive paragraphs with identical `w:pBdr` are one bordered block (ECMA-376 §17.3.1.24). The group key carried the box's resolved right *edge*:

```ts
`${bordersToken}@${indent.left},${indent.left + available}`
```

`available` is `contentWidth - indent.left - indent.right`, so `indent.left + available` is `contentWidth - indent.right` — the content width folded into the group's identity.

A multi-column section prepares its prepass at column 0's width and prepares each block for placement at the width of the column it lands in. With equal columns those agree by accident. With unequal columns they never do, so grouping collapsed outside column 0: eight boxed paragraphs flowing into a second column drew `top,bottom` for each paragraph there instead of carrying the box on.

## The fix

Key the group on the authored insets, `indent.left` and `indent.right`. Which column a paragraph lands in is a layout outcome; the group is a relationship between neighbours, and only what the document states may decide it. Unequal columns now behave exactly as equal ones already did, and as a group flowing across a page break already did.

The two keys have identical discriminating power at a fixed width — `indent.left + available` *is* `contentWidth - indent.right` — so nothing that split a group before stops splitting it. An indent still does, and a group still stops at a section boundary. The new key is also strictly more faithful at the margins: `available` clamps to a minimum of 1, which silently discarded `indent.right` on a paragraph whose indents exceed the content width.

## Tests

`border-group-columns.test.ts` asserts the stroke pattern, which is what a reader sees. The three column tests fail without the fix; the three "what still splits a group" tests are regression guards and pass in both states by design — including the right-indent case, which the old key carried only through the width and the new one carries directly.

## Verification

`bun run test` (7755 pass, 0 fail), `typecheck`, `lint` (0 errors), `format`. `bench:edit` places 11-14 blocks of 3200 per keystroke, unchanged.

## Note for #384

That PR folds `borderGroupKey` into `flowKeys` from the prepass. This change makes the key width-independent, so the folded value and the placement-time value now agree in a multi-column section too. Neither PR depends on the other.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790094983&installation_model_id=422592&pr_number=387&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F387&signature=9ee91e07caa5ec9b5fbbf6b54da5af2baacba8e84fed3150e288d05a6d63f1d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->