### PR TITLE
fix(core): write repeating header selection to the viewed page

### DIFF
--- a/.changeset/repeated-header-selection-page.md
+++ b/.changeset/repeated-header-selection-page.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Selection writes in a repeating table header now land on the page the user is looking at, so copy and typing no longer target the first painted copy.

--- a/packages/core/src/editor/__tests__/header-repeat-selection.test.ts
+++ b/packages/core/src/editor/__tests__/header-repeat-selection.test.ts
@@ -1,0 +1,234 @@
+// A repeating table header shares one paragraph id on every page it appears.
+//
+// The read accepts any copy. The write used to take the first copy in document order, so a
+// caret on page 3 landed on page 0 — and with page 0 dematerialized, on the first built
+// sheet. Clipboard and beforeinput follow the native range, so they acted on the wrong page.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semantic-layout.ts';
+import { paintSemanticLayout } from '../../output/semantic-paint.ts';
+import { applySelectionToDom, pageIndexOfNode, positionFromDomPoint } from '../dom-selection.ts';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+});
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+const TYPES =
+  `<Types xmlns="${CT}">` +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+  '</Types>';
+
+const ROOT_RELS = `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`;
+
+const headerCell = (text: string, repeats: boolean) =>
+  '<w:tr>' +
+  (repeats ? '<w:trPr><w:tblHeader/></w:trPr>' : '') +
+  '<w:tc><w:tcPr><w:tcW w:w="5000" w:type="dxa"/></w:tcPr>' +
+  `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p></w:tc></w:tr>`;
+
+function repeatingHeaderXml(): string {
+  const rows = [headerCell('HEAD', true)];
+  for (let index = 0; index < 90; index += 1) rows.push(headerCell(`row ${index}`, false));
+  return (
+    '<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="dxa"/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>' +
+    rows.join('') +
+    '</w:tbl>'
+  );
+}
+
+function repeatingHeaderDocx(): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(TYPES),
+    '_rels/.rels': strToU8(ROOT_RELS),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${repeatingHeaderXml()}</w:body></w:document>`
+    ),
+  });
+}
+
+function paintRepeatingHeader(materialize?: ReadonlySet<number>): HTMLElement {
+  const parsed = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>${repeatingHeaderXml()}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'application/xml' }
+  );
+  if (!parsed.ok) throw new Error(parsed.reason);
+  const layout = layoutSemanticDocument(parsed.part, 1, {
+    measurer: createFixedMeasurer(6, 14),
+  });
+  const root = document.createElement('div');
+  paintSemanticLayout(root, layout, {
+    scale: 1,
+    ariaHidden: false,
+    ...(materialize ? { materialize } : {}),
+  });
+  return root;
+}
+
+function copiesOf(root: Element, paragraphId: string): HTMLElement[] {
+  return [...root.querySelectorAll('[data-paragraph-id][data-start]')].filter(
+    (element) => (element as HTMLElement).dataset.paragraphId === paragraphId
+  ) as HTMLElement[];
+}
+
+function pageOf(node: Node | null | undefined, root?: Element): string | undefined {
+  const page = pageIndexOfNode(node, root);
+  return page === undefined ? undefined : String(page);
+}
+
+function headerParagraphId(root: Element): string {
+  const span = root.querySelector('[data-header-repeat] [data-paragraph-id][data-start]');
+  const id = (span as HTMLElement | null)?.dataset.paragraphId;
+  if (!id) throw new Error('expected a repeating header paragraph');
+  return id;
+}
+
+function textNodeIn(element: Element): Node {
+  let node: Node = element;
+  while (node.firstChild) node = node.firstChild;
+  return node;
+}
+
+describe('a repeating w:tblHeader row is written to the copy on the named page', () => {
+  test('a read from a later copy is accepted', () => {
+    const root = paintRepeatingHeader();
+    const id = headerParagraphId(root);
+    const copies = copiesOf(root, id);
+    expect(root.querySelectorAll('[data-page-index]').length).toBeGreaterThan(1);
+    expect(copies.length).toBeGreaterThan(1);
+    const later = copies.find((copy) => pageOf(copy, root) !== '0');
+    expect(later).toBeDefined();
+    const position = { paragraphId: id, offset: 3 };
+    expect(positionFromDomPoint(textNodeIn(later!), 3, root)).toEqual(position);
+  });
+
+  test('a write without a page hint lands on the first built copy', () => {
+    const root = paintRepeatingHeader();
+    document.body.append(root);
+    const id = headerParagraphId(root);
+    const position = { paragraphId: id, offset: 3 };
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    expect(applySelectionToDom(root, { anchor: position, head: position }, selection)).toBe(true);
+    expect(pageOf(selection.anchorNode, root)).toBe('0');
+    root.remove();
+  });
+
+  test('a write moves a same-model caret off the first copy onto the named page', () => {
+    const root = paintRepeatingHeader();
+    document.body.append(root);
+    const id = headerParagraphId(root);
+    const later = copiesOf(root, id).find((copy) => pageOf(copy, root) !== '0')!;
+    const preferredPageIndex = pageIndexOfNode(later, root)!;
+    const position = { paragraphId: id, offset: 3 };
+    const selection = document.getSelection()!;
+    expect(applySelectionToDom(root, { anchor: position, head: position }, selection)).toBe(true);
+    expect(pageOf(selection.anchorNode, root)).toBe('0');
+    expect(
+      applySelectionToDom(root, { anchor: position, head: position }, selection, {
+        preferredPageIndex,
+      })
+    ).toBe(true);
+    expect(pageOf(selection.anchorNode, root)).toBe(String(preferredPageIndex));
+    root.remove();
+  });
+
+  test('a write prefers the copy on the named page', () => {
+    const root = paintRepeatingHeader();
+    document.body.append(root);
+    const id = headerParagraphId(root);
+    const later = copiesOf(root, id).find((copy) => pageOf(copy, root) !== '0')!;
+    const preferredPageIndex = pageIndexOfNode(later, root)!;
+    expect(preferredPageIndex).toBeGreaterThan(0);
+    const position = { paragraphId: id, offset: 3 };
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    expect(
+      applySelectionToDom(root, { anchor: position, head: position }, selection, {
+        preferredPageIndex,
+      })
+    ).toBe(true);
+    expect(pageOf(selection.anchorNode, root)).toBe(String(preferredPageIndex));
+    root.remove();
+  });
+
+  test('with page 0 dematerialized, a named later page still wins', () => {
+    const root = paintRepeatingHeader(new Set([2]));
+    document.body.append(root);
+    const pages = [...root.querySelectorAll('[data-page-index]')] as HTMLElement[];
+    expect(
+      pages.some((page) => page.dataset.pageIndex === '0' && page.dataset.materialized === 'false')
+    ).toBe(true);
+    const id = headerParagraphId(root);
+    const onPageTwo = copiesOf(root, id).find((copy) => pageOf(copy, root) === '2');
+    expect(onPageTwo).toBeDefined();
+    const position = { paragraphId: id, offset: 3 };
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    expect(applySelectionToDom(root, { anchor: position, head: position }, selection)).toBe(true);
+    expect(pageOf(selection.anchorNode, root)).toBe('2');
+    selection.removeAllRanges();
+    expect(
+      applySelectionToDom(root, { anchor: position, head: position }, selection, {
+        preferredPageIndex: 2,
+      })
+    ).toBe(true);
+    expect(pageOf(selection.anchorNode, root)).toBe('2');
+    root.remove();
+  });
+});
+
+function mount(bytes: Uint8Array): { surface: PaginatedSurface; container: HTMLElement } {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, bytes, { scale: 1 });
+  if (!opened.ok) throw new Error(opened.reason);
+  return { surface: opened.surface, container };
+}
+
+function armGesture(target: Element): void {
+  target.dispatchEvent(new Event('selectstart', { bubbles: true, cancelable: true }));
+}
+
+async function gesture(anchor: [Node, number], head: [Node, number]): Promise<void> {
+  await Promise.resolve();
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  const range = document.createRange();
+  range.setStart(anchor[0], anchor[1]);
+  range.setEnd(head[0], head[1]);
+  selection.addRange(range);
+  document.dispatchEvent(new Event('selectionchange'));
+}
+
+describe('the surface remirrors a repeating header onto the copy the user clicked', () => {
+  test('a later write stays on the sheet the gesture mapped', async () => {
+    const { surface, container } = mount(repeatingHeaderDocx());
+    const pages = container.querySelector('.docx-pages')!;
+    const id = headerParagraphId(pages);
+    const later = copiesOf(pages, id).find((copy) => pageOf(copy, pages) !== '0');
+    expect(later).toBeDefined();
+    const preferredPageIndex = pageIndexOfNode(later!, pages)!;
+    const text = textNodeIn(later!);
+    armGesture(later!);
+    await gesture([text, 3], [text, 3]);
+    expect(surface.state().selection.head).toEqual({ paragraphId: id, offset: 3 });
+    document.getSelection()?.removeAllRanges();
+    surface.setSelection(surface.state().selection);
+    expect(pageOf(document.getSelection()?.anchorNode, pages)).toBe(String(preferredPageIndex));
+    surface.destroy();
+    container.remove();
+  });
+});

--- a/packages/core/src/editor/__tests__/header-repeat-selection.test.ts
+++ b/packages/core/src/editor/__tests__/header-repeat-selection.test.ts
@@ -10,7 +10,9 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { afterEach, describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import { caretAt } from '../../layout/semantic-interaction.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semantic-layout.ts';
+import type { SemanticLayout } from '../../layout/semantic-records.ts';
 import { paintSemanticLayout } from '../../output/semantic-paint.ts';
 import { applySelectionToDom, pageIndexOfNode, positionFromDomPoint } from '../dom-selection.ts';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
@@ -59,7 +61,10 @@ function repeatingHeaderDocx(): Uint8Array {
   });
 }
 
-function paintRepeatingHeader(materialize?: ReadonlySet<number>): HTMLElement {
+function paintRepeatingHeader(materialize?: ReadonlySet<number>): {
+  readonly root: HTMLElement;
+  readonly layout: SemanticLayout;
+} {
   const parsed = readOoxmlPart(
     `<w:document xmlns:w="${W}"><w:body>${repeatingHeaderXml()}</w:body></w:document>`,
     { name: '/word/document.xml', contentType: 'application/xml' }
@@ -74,7 +79,7 @@ function paintRepeatingHeader(materialize?: ReadonlySet<number>): HTMLElement {
     ariaHidden: false,
     ...(materialize ? { materialize } : {}),
   });
-  return root;
+  return { root, layout };
 }
 
 function copiesOf(root: Element, paragraphId: string): HTMLElement[] {
@@ -103,7 +108,7 @@ function textNodeIn(element: Element): Node {
 
 describe('a repeating w:tblHeader row is written to the copy on the named page', () => {
   test('a read from a later copy is accepted', () => {
-    const root = paintRepeatingHeader();
+    const { root } = paintRepeatingHeader();
     const id = headerParagraphId(root);
     const copies = copiesOf(root, id);
     expect(root.querySelectorAll('[data-page-index]').length).toBeGreaterThan(1);
@@ -115,7 +120,7 @@ describe('a repeating w:tblHeader row is written to the copy on the named page',
   });
 
   test('a write without a page hint lands on the first built copy', () => {
-    const root = paintRepeatingHeader();
+    const { root } = paintRepeatingHeader();
     document.body.append(root);
     const id = headerParagraphId(root);
     const position = { paragraphId: id, offset: 3 };
@@ -127,7 +132,7 @@ describe('a repeating w:tblHeader row is written to the copy on the named page',
   });
 
   test('a write moves a same-model caret off the first copy onto the named page', () => {
-    const root = paintRepeatingHeader();
+    const { root } = paintRepeatingHeader();
     document.body.append(root);
     const id = headerParagraphId(root);
     const later = copiesOf(root, id).find((copy) => pageOf(copy, root) !== '0')!;
@@ -146,7 +151,7 @@ describe('a repeating w:tblHeader row is written to the copy on the named page',
   });
 
   test('a write prefers the copy on the named page', () => {
-    const root = paintRepeatingHeader();
+    const { root } = paintRepeatingHeader();
     document.body.append(root);
     const id = headerParagraphId(root);
     const later = copiesOf(root, id).find((copy) => pageOf(copy, root) !== '0')!;
@@ -164,8 +169,18 @@ describe('a repeating w:tblHeader row is written to the copy on the named page',
     root.remove();
   });
 
+  test('caretAt without a page hint names the authored sheet', () => {
+    const { root, layout } = paintRepeatingHeader();
+    const id = headerParagraphId(root);
+    const later = copiesOf(root, id).find((copy) => pageOf(copy, root) !== '0')!;
+    const preferredPageIndex = pageIndexOfNode(later, root)!;
+    const position = { paragraphId: id, offset: 3 };
+    expect(caretAt(layout, position)?.pageIndex).toBe(0);
+    expect(caretAt(layout, position, { preferredPageIndex })?.pageIndex).toBe(preferredPageIndex);
+  });
+
   test('with page 0 dematerialized, a named later page still wins', () => {
-    const root = paintRepeatingHeader(new Set([2]));
+    const { root } = paintRepeatingHeader(new Set([2]));
     document.body.append(root);
     const pages = [...root.querySelectorAll('[data-page-index]')] as HTMLElement[];
     expect(
@@ -228,6 +243,29 @@ describe('the surface remirrors a repeating header onto the copy the user clicke
     document.getSelection()?.removeAllRanges();
     surface.setSelection(surface.state().selection);
     expect(pageOf(document.getSelection()?.anchorNode, pages)).toBe(String(preferredPageIndex));
+    surface.destroy();
+    container.remove();
+  });
+
+  test('the painted caret sits on the sheet the gesture mapped', async () => {
+    const { surface, container } = mount(repeatingHeaderDocx());
+    const pages = container.querySelector('.docx-pages')!;
+    surface.focus();
+    const id = headerParagraphId(pages);
+    const later = copiesOf(pages, id).find((copy) => pageOf(copy, pages) !== '0');
+    expect(later).toBeDefined();
+    const preferredPageIndex = pageIndexOfNode(later!, pages)!;
+    const text = textNodeIn(later!);
+    armGesture(later!);
+    await gesture([text, 3], [text, 3]);
+    surface.setSelection(surface.state().selection);
+    const caret = container.querySelector('[data-docx-caret]');
+    expect(caret).not.toBeNull();
+    expect(pageOf(caret, pages)).toBe(String(preferredPageIndex));
+    expect(caretAt(surface.layout(), { paragraphId: id, offset: 3 })?.pageIndex).toBe(0);
+    expect(
+      caretAt(surface.layout(), { paragraphId: id, offset: 3 }, { preferredPageIndex })?.pageIndex
+    ).toBe(preferredPageIndex);
     surface.destroy();
     container.remove();
   });

--- a/packages/core/src/editor/dom-selection.ts
+++ b/packages/core/src/editor/dom-selection.ts
@@ -100,14 +100,39 @@ function activeHeaderFooterRoot(root: Element): Element | null {
 }
 
 /**
+ * The page a painted node sits on, or undefined when it is not inside a sheet.
+ *
+ * Repeated table header rows share one paragraph id on every page they appear. The write
+ * path uses this to prefer the copy on the sheet the user is looking at.
+ */
+export function pageIndexOfNode(node: Node | null | undefined, root?: Element): number | undefined {
+  if (!node) return undefined;
+  if (root && !root.contains(node)) return undefined;
+  const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  const page = element?.closest('[data-page-index]');
+  const raw = (page as HTMLElement | null | undefined)?.dataset?.pageIndex;
+  if (raw === undefined || !/^\d{1,9}$/.test(raw)) return undefined;
+  return Number(raw);
+}
+
+/** The painted sheet for a page index, or null when that sheet is not in this tree. */
+function pageRoot(root: Element, pageIndex: number | undefined): Element | null {
+  if (pageIndex === undefined || !Number.isInteger(pageIndex) || pageIndex < 0) return null;
+  return root.querySelector(`[data-page-index="${pageIndex}"]`);
+}
+
+/**
  * Search roots for painted spans, preferring the active header/footer when one is open.
  *
  * Shared header/footer parts paint the same paragraph ids on every page; the active
- * container is the caret target the user entered.
+ * container is the caret target the user entered. A preferred page does the same job for
+ * body copies that share an id — a `w:tblHeader` row that repeats on later sheets.
  */
-export function spanSearchRoots(root: Element): readonly Element[] {
+export function spanSearchRoots(root: Element, preferredPageIndex?: number): readonly Element[] {
   const active = activeHeaderFooterRoot(root);
-  return active ? [active, root] : [root];
+  if (active) return [active, root];
+  const page = pageRoot(root, preferredPageIndex);
+  return page && page !== root ? [page, root] : [root];
 }
 
 /** The first painted span at, above, or inside a node — whichever comes first in DOM order. */
@@ -292,9 +317,10 @@ export function domSelectionTouchesPages(root: Element, domSelection: Selection 
  */
 function domPointFromPosition(
   root: Element,
-  position: SemanticPosition
+  position: SemanticPosition,
+  preferredPageIndex?: number
 ): { node: Node; offset: number } | null {
-  for (const searchRoot of spanSearchRoots(root)) {
+  for (const searchRoot of spanSearchRoots(root, preferredPageIndex)) {
     const point = domPointFromPositionIn(searchRoot, position);
     if (point) return point;
   }
@@ -425,20 +451,29 @@ function emptyLinePosition(element: Element): SemanticPosition | null {
  * Write a model selection into the browser's own selection.
  *
  * Returns false when either endpoint is not painted — a position inside a page that is not
- * currently rendered, once virtualization lands.
+ * currently rendered, once virtualization lands. `preferredPageIndex` picks among painted
+ * copies of the same paragraph — a repeating `w:tblHeader` row — when the model cannot.
  */
 export function applySelectionToDom(
   root: Element,
   selection: SemanticSelection,
-  domSelection: Selection | null
+  domSelection: Selection | null,
+  options?: { readonly preferredPageIndex?: number }
 ): boolean {
   if (!domSelection) return false;
-  const anchor = domPointFromPosition(root, selection.anchor);
-  const head = domPointFromPosition(root, selection.head);
+  const preferredPageIndex =
+    options?.preferredPageIndex ?? pageIndexOfNode(domSelection.anchorNode, root);
+  const anchor = domPointFromPosition(root, selection.anchor, preferredPageIndex);
+  const head = domPointFromPosition(root, selection.head, preferredPageIndex);
   if (!anchor || !head) return false;
   const current = semanticSelectionFromDom(root, domSelection);
   // Already correct: re-setting it would collapse an in-progress drag and fight the user.
-  if (current && selectionsEqual(current, selection)) return true;
+  // Same model offsets on a DIFFERENT sheet are not correct — a repeating header paints
+  // those offsets on every page, and leaving the native range on page 0 is the bug.
+  if (current && selectionsEqual(current, selection)) {
+    const currentPage = pageIndexOfNode(domSelection.anchorNode, root);
+    if (preferredPageIndex === undefined || currentPage === preferredPageIndex) return true;
+  }
   try {
     // `setBaseAndExtent` keeps the anchor/head ORDER, which is what shift-arrow extends
     // from; collapsing and extending would lose the direction.

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -352,7 +352,9 @@ export function mountPaginatedSurface(
           ? { preferredPageIndex: active.pageIndex }
           : notePageIndex !== null
             ? { preferredPageIndex: notePageIndex }
-            : {}),
+            : selectionSync.selectionPageIndex() !== undefined
+              ? { preferredPageIndex: selectionSync.selectionPageIndex() }
+              : {}),
         scopedHost,
         ...(active
           ? { scopedHostKind: 'headerFooter' as const }
@@ -1100,9 +1102,9 @@ export function mountPaginatedSurface(
 
   function visiblePages(): ReadonlySet<number> | undefined {
     const set = visiblePageSet(container, currentLayout, selection, scale);
-    const occurrence = hfScope?.getActive()?.pageIndex;
-    if (occurrence === undefined || set === undefined || set.has(occurrence)) return set;
-    return new Set([...set, occurrence]);
+    const extra = hfScope?.getActive()?.pageIndex ?? selectionSync.selectionPageIndex();
+    if (extra === undefined || set === undefined || set.has(extra)) return set;
+    return new Set([...set, extra]);
   }
 
   /** Publish any pending layout. Returns whether it did, so callers can avoid a double paint. */
@@ -2277,7 +2279,12 @@ export function mountPaginatedSurface(
     const active = document.activeElement;
     if (active !== pagesLayer && (!active || !pagesLayer.contains(active))) return;
 
-    const geometry = caretAt(currentLayout, selection.head, { measurer });
+    const geometry = caretAt(currentLayout, selection.head, {
+      measurer,
+      ...(selectionSync.selectionPageIndex() !== undefined
+        ? { preferredPageIndex: selectionSync.selectionPageIndex() }
+        : {}),
+    });
     if (!geometry) return;
     const changedPage = lastCaretPageIndex !== null && lastCaretPageIndex !== geometry.pageIndex;
     lastCaretPageIndex = geometry.pageIndex;

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -18,6 +18,7 @@ import type { TreeDocOp } from '@docx-editor.dev/core/store';
 import {
   applySelectionToDom,
   domSelectionTouchesPages,
+  pageIndexOfNode,
   selectionsEqual,
   semanticSelectionFromDom,
 } from './dom-selection.ts';
@@ -178,6 +179,29 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
   let applyingSelection = false;
   let lastMirroredSelection: SemanticSelection | null = null;
   /**
+   * The sheet the last mapped gesture sat on.
+   *
+   * A `w:tblHeader` row paints the same paragraph id on every page it repeats. The model
+   * position cannot name a copy, so a later remirror must prefer this sheet or it writes
+   * the first built one — usually page 0.
+   */
+  let lastSelectionPageIndex: number | undefined;
+
+  function rememberSelectionPage(domSelection: Selection | null): void {
+    const page =
+      pageIndexOfNode(domSelection?.anchorNode, pagesLayer) ??
+      pageIndexOfNode(domSelection?.focusNode, pagesLayer);
+    if (page !== undefined) lastSelectionPageIndex = page;
+  }
+
+  function preferredSelectionPage(domSelection: Selection | null): number | undefined {
+    return (
+      lastSelectionPageIndex ??
+      pageIndexOfNode(domSelection?.anchorNode, pagesLayer) ??
+      pageIndexOfNode(domSelection?.focusNode, pagesLayer)
+    );
+  }
+  /**
    * Whether a user selection gesture has an unused adoption opportunity.
    *
    * A deferred paint leaves the DOM caret at `lastMirroredSelection`. Equality with that
@@ -225,8 +249,11 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
    * mirror the selection into the DOM and report the new state anyway.
    */
   function adoptPendingDomSelection(): boolean {
-    const next = semanticSelectionFromDom(pagesLayer, document.getSelection());
-    if (!next || selectionsEqual(next, deps.selection())) return false;
+    const domSelection = document.getSelection();
+    const next = semanticSelectionFromDom(pagesLayer, domSelection);
+    if (!next) return false;
+    rememberSelectionPage(domSelection);
+    if (selectionsEqual(next, deps.selection())) return false;
     deps.adoptSelection(next);
     return true;
   }
@@ -277,6 +304,7 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
     // empty selectionchange (removeAllRanges mid-gesture) cannot spend it, and so a click
     // on the already-current caret cannot authorize a later stale echo.
     userSelectionGesture = false;
+    rememberSelectionPage(domSelection);
     if (selectionsEqual(next, deps.selection())) return;
     deps.setSelection(next);
   };
@@ -475,7 +503,15 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // This write is the new baseline. Matching DOM carets after it are echoes until the
       // user starts another selection gesture.
       userSelectionGesture = false;
-      const wrote = applySelectionToDom(pagesLayer, next, document.getSelection());
+      const native = document.getSelection();
+      const preferredPageIndex = preferredSelectionPage(native);
+      const wrote = applySelectionToDom(
+        pagesLayer,
+        next,
+        native,
+        preferredPageIndex !== undefined ? { preferredPageIndex } : undefined
+      );
+      if (wrote) rememberSelectionPage(native);
       // A REFUSED write is not a baseline. `applySelectionToDom` answers false when either
       // endpoint has no painted place to land — a caret in a paragraph that painted no spans,
       // an offset no span covers, a page that is not built — and the browser then keeps

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -171,6 +171,13 @@ export interface SurfaceSelectionSync {
   readonly onCompositionEnd: (event?: CompositionEvent) => void;
   /** Drop capture listeners. Safe to call once from surface destroy/detach. */
   destroy(): void;
+  /**
+   * The sheet the last mapped gesture sat on.
+   *
+   * A repeating `w:tblHeader` row shares one paragraph id on every page. Caret paint and
+   * scroll-follow need this page or they jump to the authored copy on page 0.
+   */
+  selectionPageIndex(): number | undefined;
 }
 
 export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): SurfaceSelectionSync {
@@ -621,6 +628,7 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       deps.render();
     },
 
+    selectionPageIndex: () => lastSelectionPageIndex,
     destroy() {
       pagesLayer.removeEventListener('pointerdown', noteUserSelectionGesture, true);
       pagesLayer.removeEventListener('selectstart', noteUserSelectionGesture, true);

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -354,6 +354,28 @@ function resolveCaretAtOptions(measurerOrOptions?: TextMeasurer | CaretAtOptions
   return measurerOrOptions as CaretAtOptions;
 }
 
+/**
+ * Header-repeat lines of one paragraph on one sheet.
+ *
+ * The main line index skips `w:tblHeader` repeats so keyboard stops visit each offset once.
+ * A click on a later copy still needs geometry on THAT sheet, or the painted caret and
+ * scroll-follow jump back to the authored row on page 0.
+ */
+function headerRepeatLinesOnPage(
+  layout: SemanticLayout,
+  pageIndex: number,
+  paragraphId: string
+): { line: LineRecord; pageIndex: number }[] {
+  const page = layout.pages[pageIndex];
+  if (!page) return [];
+  const found: { line: LineRecord; pageIndex: number }[] = [];
+  for (const fragment of paragraphFragmentsOf(page, true)) {
+    if (fragment.paragraphId !== paragraphId) continue;
+    for (const line of fragment.lines) found.push({ line, pageIndex });
+  }
+  return found;
+}
+
 /** Geometry for one model position, or null when it is not laid out. */
 export function caretAt(
   layout: SemanticLayout,
@@ -363,10 +385,15 @@ export function caretAt(
   const options = resolveCaretAtOptions(measurerOrOptions);
   const placed = paragraphLinesIndex(layout).get(position.paragraphId) ?? [];
   const preferred = options.preferredPageIndex;
+  const repeats =
+    preferred === undefined ? [] : headerRepeatLinesOnPage(layout, preferred, position.paragraphId);
+  const seen = new Set(placed.map((entry) => entry.line.id));
+  const extra = repeats.filter((entry) => !seen.has(entry.line.id));
+  const catalog = extra.length > 0 ? [...placed, ...extra] : placed;
   const ordered =
     preferred === undefined
-      ? placed
-      : [...placed].sort((a, b) => {
+      ? catalog
+      : [...catalog].sort((a, b) => {
           const aHit = a.pageIndex === preferred ? 0 : 1;
           const bHit = b.pageIndex === preferred ? 0 : 1;
           return aHit - bHit;


### PR DESCRIPTION
## Summary
- A repeating `w:tblHeader` row shares one paragraph id on every page. The selection write used to take the first painted copy, so copy and `beforeinput` acted on page 0 (or the first built page).
- The write now prefers the copy on the sheet the user last mapped. A later remirror keeps that sheet even when the model offsets already match.
- Fixes #357.

## Test plan
- [ ] Open a multi-page table with a repeating header row
- [ ] Select text in the header on a later page
- [ ] Confirm the browser highlight stays on that page
- [ ] Copy the selection and confirm the clipboard text comes from that copy
- [ ] Type in the header on a later page and confirm the insert lands there
- [ ] Scroll so page 0 is dematerialized, then select the header on a later built page


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790146771&installation_model_id=422592&pr_number=389&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F389&signature=72f3ac11e3ec5d3890f90ee31461a7d6f6ad8869e72d54f2ba1f1cb43dfe095a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->