### PR TITLE
fix(core): reuse derived state while typing

### DIFF
--- a/.changeset/incremental-note-toc-derivations.md
+++ b/.changeset/incremental-note-toc-derivations.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typing now skips unused note pagination and reuses unchanged document layout data in large documents. Fixes #391.

--- a/packages/core/src/binding/__tests__/tree-session.test.ts
+++ b/packages/core/src/binding/__tests__/tree-session.test.ts
@@ -271,6 +271,29 @@ describe('w14 paragraph identity through the session', () => {
     expect(session.nodeIdOf('no such id')).toBeNull();
     expect(session.paraIdOf('/word/document.xml#nope')).toBeNull();
   });
+
+  test('a text edit reuses address maps and refreshes the live part', () => {
+    const session = open(
+      docx('<w:p><w:r><w:t>one</w:t></w:r></w:p><w:p><w:r><w:t>two</w:t></w:r></w:p>')
+    );
+    const [firstId] = session.paragraphIds();
+    const beforePart = session.part();
+    const before = session.paragraphAnchors();
+
+    const edited = session.applyTreeOps([
+      { op: 'insertText', paragraphId: firstId!, offset: 3, text: '!' },
+    ]);
+    expect(edited.committed).toBe(true);
+    const after = session.paragraphAnchors();
+
+    expect(after).not.toBe(before);
+    expect(after.paraIdByNode).toBe(before.paraIdByNode);
+    expect(after.nodeByParaId).toBe(before.nodeByParaId);
+    expect(after.ordinalByNode).toBe(before.ordinalByNode);
+    expect(after.partByNode.get(firstId!)).toBe(session.part());
+    expect(after.partByNode.get(firstId!)).not.toBe(beforePart);
+    expect([...after.partByNode.keys()]).toEqual([...before.partByNode.keys()]);
+  });
 });
 
 describe('hostile prefix shadowing end to end', () => {

--- a/packages/core/src/binding/paragraph-anchors.ts
+++ b/packages/core/src/binding/paragraph-anchors.ts
@@ -73,6 +73,70 @@ export interface ParagraphAnchorIndex {
   readonly claimantsByParaId: ReadonlyMap<string, readonly string[]>;
 }
 
+class LivePartByNodeMap implements ReadonlyMap<string, OoxmlPart> {
+  readonly #nodeIds: ReadonlyMap<string, number>;
+  readonly #parts: readonly OoxmlPart[];
+
+  constructor(nodeIds: ReadonlyMap<string, number>, parts: readonly OoxmlPart[]) {
+    this.#nodeIds = nodeIds;
+    this.#parts = parts;
+  }
+
+  get size(): number {
+    return this.#nodeIds.size;
+  }
+
+  get(nodeId: string): OoxmlPart | undefined {
+    if (!this.#nodeIds.has(nodeId)) return undefined;
+    return this.#parts.find((part) => nodeId.startsWith(`${part.name}#`));
+  }
+
+  has(nodeId: string): boolean {
+    return this.get(nodeId) !== undefined;
+  }
+
+  *entries(): MapIterator<[string, OoxmlPart]> {
+    for (const nodeId of this.#nodeIds.keys()) {
+      const part = this.get(nodeId);
+      if (part) yield [nodeId, part];
+    }
+  }
+
+  keys(): MapIterator<string> {
+    return this.#nodeIds.keys();
+  }
+
+  *values(): MapIterator<OoxmlPart> {
+    for (const [, part] of this.entries()) yield part;
+  }
+
+  [Symbol.iterator](): MapIterator<[string, OoxmlPart]> {
+    return this.entries();
+  }
+
+  forEach(
+    callbackfn: (value: OoxmlPart, key: string, map: ReadonlyMap<string, OoxmlPart>) => void,
+    thisArg?: unknown
+  ): void {
+    for (const [nodeId, part] of this.entries()) callbackfn.call(thisArg, part, nodeId, this);
+  }
+}
+
+/**
+ * Reuse all paragraph-address maps while pointing node reads at the current immutable parts.
+ *
+ * Safe only when the paragraph id and paraId sets are unchanged, as enforced by the session.
+ */
+export function refreshParagraphAnchorParts(
+  index: ParagraphAnchorIndex,
+  parts: readonly OoxmlPart[]
+): ParagraphAnchorIndex {
+  return Object.freeze({
+    ...index,
+    partByNode: new LivePartByNodeMap(index.ordinalByNode, parts),
+  });
+}
+
 /** Build the index over every editable paragraph of every story, in reading order. */
 export function buildParagraphAnchorIndex(parts: readonly OoxmlPart[]): ParagraphAnchorIndex {
   const paraIdByNode = new Map<string, string>();

--- a/packages/core/src/binding/tree-binding.ts
+++ b/packages/core/src/binding/tree-binding.ts
@@ -198,6 +198,18 @@ export function bodyParagraphs(part: OoxmlPart): OoxmlNode[] {
  * revision, so a bare map would grow with the history rather than with the document.
  */
 const paragraphsByPart = createRecentRootCache<OoxmlNode[]>(16);
+const paragraphsByStoryChild = new WeakMap<OoxmlNode, readonly OoxmlNode[]>();
+
+function appendStoryChildParagraphs(child: OoxmlNode, into: OoxmlNode[]): void {
+  let paragraphs = paragraphsByStoryChild.get(child);
+  if (!paragraphs) {
+    const collected: OoxmlNode[] = [];
+    collectStoryParagraphs([child], collected, 0);
+    paragraphs = Object.freeze(collected);
+    paragraphsByStoryChild.set(child, paragraphs);
+  }
+  for (const paragraph of paragraphs) into.push(paragraph);
+}
 
 export function allParagraphs(part: OoxmlPart): OoxmlNode[] {
   const cached = paragraphsByPart.get(part);
@@ -209,7 +221,7 @@ export function allParagraphs(part: OoxmlPart): OoxmlNode[] {
   const paragraphs: OoxmlNode[] = [];
   for (const story of storyRootsOf(part)) {
     if (story.root.kind === 'textValue') continue;
-    collectStoryParagraphs(story.root.children, paragraphs, 0);
+    for (const child of story.root.children) appendStoryChildParagraphs(child, paragraphs);
   }
   paragraphsByPart.set(part, paragraphs);
   return paragraphs;

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -47,7 +47,6 @@ import {
   readEmbeddedFonts,
   readOoxmlPackage,
   resolveHeaderFooterParts,
-  resolveHeaderFooterPartsBySection,
   resolveHeaderFooterResolutionBySection,
   resolveRelationship,
   writeOoxmlPackage,
@@ -77,6 +76,7 @@ import {
   type TreeDocumentStore,
   type TreeModelChange,
 } from '@docx-editor.dev/core/store';
+import { headerFooterPartsFromResolution } from '../store/package/hf-references.ts';
 import {
   collectDocumentFonts,
   collectDocumentStyles,
@@ -106,7 +106,11 @@ import {
 } from './document-run-defaults.ts';
 import { allParagraphs, docToTreeOps, reconcileDoc, treeToDoc } from './tree-binding.ts';
 import type { TreeBindingRejection } from './tree-binding.ts';
-import { buildParagraphAnchorIndex, type ParagraphAnchorIndex } from './paragraph-anchors.ts';
+import {
+  buildParagraphAnchorIndex,
+  refreshParagraphAnchorParts,
+  type ParagraphAnchorIndex,
+} from './paragraph-anchors.ts';
 import {
   readTrackingSettings,
   type DocumentTrackingSettings,
@@ -675,6 +679,22 @@ export function openTreeSession(
     readonly resolution: readonly HeaderFooterSectionResolution[];
   } => {
     if (
+      headerFooterBySection &&
+      lastChange &&
+      headerFooterBySection.packageRevision === lastChange.fromRevision &&
+      packageStore.packageRevision === lastChange.toRevision &&
+      lastChange.story?.kind === 'body' &&
+      lastChange.impact === 'text-local' &&
+      lastChange.created.length === 0 &&
+      lastChange.deleted.length === 0 &&
+      lastChange.splitJoin.length === 0
+    ) {
+      headerFooterBySection = {
+        ...headerFooterBySection,
+        packageRevision: packageStore.packageRevision,
+      };
+    }
+    if (
       !headerFooterBySection ||
       headerFooterBySection.packageRevision !== packageStore.packageRevision
     ) {
@@ -682,7 +702,7 @@ export function openTreeSession(
       headerFooterBySection = {
         packageRevision: packageStore.packageRevision,
         resolution,
-        parts: resolveHeaderFooterPartsBySection(currentPackage()),
+        parts: headerFooterPartsFromResolution(resolution),
       };
     }
     return headerFooterBySection;
@@ -895,6 +915,7 @@ export function openTreeSession(
   let anchorsCache: {
     readonly revision: number;
     readonly openStories: string;
+    readonly parts: readonly OoxmlPart[];
     readonly index: ParagraphAnchorIndex;
   } | null = null;
   const readNormalizedParts = new WeakMap<OoxmlPart, OoxmlPart>();
@@ -930,10 +951,6 @@ export function openTreeSession(
     // over every paragraph rather than on the walk (memoizing `allParagraphs` per part takes
     // only ~7% off).
     //
-    // If it ever needs to come down, the fix is a composed index that resolves a lookup across
-    // per-part sub-maps instead of merging them, so a `.get` costs O(parts) rather than
-    // O(paragraphs), and every production caller reads by key. Not done here: it changes the
-    // shape every consumer of `ParagraphAnchorIndex` sees, for a cost this branch did not add.
     const revision = packageStore.packageRevision;
     // AND which stories are open. Opening one mints its paraIds without publishing an edit, so
     // the package revision does not move and an index built a moment earlier would be served
@@ -959,10 +976,28 @@ export function openTreeSession(
       const rest = furnitureAndNoteParts()
         .filter((part) => !seen.has(part.name))
         .map(normalizedForRead);
+      const parts = [bodyStore().part, ...open, ...rest];
+      const previousAnchors = anchorsCache;
+      const canReuseMaps =
+        previousAnchors !== null &&
+        lastChange !== null &&
+        previousAnchors.openStories === openStories &&
+        previousAnchors.revision === lastChange.fromRevision &&
+        revision === lastChange.toRevision &&
+        lastChange.impact === 'text-local' &&
+        lastChange.created.length === 0 &&
+        lastChange.deleted.length === 0 &&
+        lastChange.splitJoin.length === 0 &&
+        previousAnchors.parts.length === parts.length &&
+        previousAnchors.parts.every((part, index) => part.name === parts[index]?.name);
       anchorsCache = {
         revision,
         openStories,
-        index: buildParagraphAnchorIndex([bodyStore().part, ...open, ...rest]),
+        parts,
+        index:
+          canReuseMaps && previousAnchors
+            ? refreshParagraphAnchorParts(previousAnchors.index, parts)
+            : buildParagraphAnchorIndex(parts),
       };
     }
     return anchorsCache.index;

--- a/packages/core/src/editor/__tests__/notes-layout-input.test.ts
+++ b/packages/core/src/editor/__tests__/notes-layout-input.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { createFixedMeasurer, createParagraphLayoutCache } from '../../layout/index.ts';
+import { readOoxmlPackage, type OoxmlPackage } from '../../store/package/index.ts';
+import { createNotesLayoutInput } from '../surface-pages.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function load(body: string): OoxmlPackage {
+  const bytes = zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}">` +
+        '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
+        '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>' +
+        '<w:footnote w:id="1"><w:p><w:r><w:t>Note</w:t></w:r></w:p></w:footnote>' +
+        '</w:footnotes>'
+    ),
+  });
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  return loaded.package;
+}
+
+function notesInput(pkg: OoxmlPackage) {
+  const part = pkg.parts.get(pkg.mainDocumentPart)!;
+  return createNotesLayoutInput({
+    session: {
+      currentPackage: () => pkg,
+      part: () => part,
+    } as never,
+    measurer: createFixedMeasurer(),
+    producer: 'test',
+    cache: createParagraphLayoutCache(),
+  });
+}
+
+describe('notes layout input gate', () => {
+  test('separator-only notes parts do not start note pagination', () => {
+    const pkg = load('<w:p><w:r><w:t>Plain body</w:t></w:r></w:p>');
+    expect(notesInput(pkg)).toBeUndefined();
+  });
+
+  test('a body citation still starts note pagination', () => {
+    const pkg = load('<w:p><w:r><w:t>Body</w:t><w:footnoteReference w:id="1"/></w:r></w:p>');
+    expect(notesInput(pkg)).toBeDefined();
+  });
+});

--- a/packages/core/src/editor/section-scope.ts
+++ b/packages/core/src/editor/section-scope.ts
@@ -135,15 +135,9 @@ function firstParagraphIn(block: OoxmlNode | undefined): string | null {
   return walk(block, 0);
 }
 
-/**
- * Every body paragraph's section, built once per block list.
- *
- * Keyed on the `storyBlocks` array, which is memoized per `(part, displayMode)` and therefore
- * identity-stable across reads of one revision. Scanning per call instead made this O(document)
- * for a BODY caret — the per-keystroke common case, because `sectionPropertiesAt` sits on the
- * `snapshot()` path — and it is the same walk either way, so doing it once is free.
- */
-const sectionIndexByParagraph = new WeakMap<object, ReadonlyMap<string, number>>();
+/** Lazy paragraph answers per revision, instead of one O(document) map for one caret lookup. */
+const sectionIndexByParagraph = new WeakMap<object, Map<string, number | null>>();
+const paragraphIdsByBlock = new WeakMap<OoxmlNode, ReadonlySet<string>>();
 
 /** The section index of a BODY paragraph, or `null` when the body does not hold it. */
 export function bodySectionIndexOf(
@@ -156,37 +150,42 @@ export function bodySectionIndexOf(
   // before returning `null` — and a furniture caret paid that per keystroke.
   if (!paragraphId.startsWith(`${part.name}#`)) return null;
   const blocks = storyBlocks(part);
-  const cached = sectionIndexByParagraph.get(blocks);
-  if (cached) return cached.get(paragraphId) ?? null;
+  let cached = sectionIndexByParagraph.get(blocks);
+  if (cached?.has(paragraphId)) return cached.get(paragraphId) ?? null;
+  cached ??= new Map<string, number | null>();
 
   const sections = enumerateDocumentSections(part);
-  const map = new Map<string, number>();
   for (let index = 0; index < sections.length; index += 1) {
     const section = sections[index]!;
     for (let i = section.blockStart; i < section.blockEndExclusive; i += 1) {
       const block = blocks[i];
-      if (block) collectParagraphs(block, index, map, 0);
+      if (!block || !paragraphIdsOfBlock(block).has(paragraphId)) continue;
+      cached.set(paragraphId, index);
+      sectionIndexByParagraph.set(blocks, cached);
+      return index;
     }
   }
-  sectionIndexByParagraph.set(blocks, map);
-  return map.get(paragraphId) ?? null;
+  cached.set(paragraphId, null);
+  sectionIndexByParagraph.set(blocks, cached);
+  return null;
 }
 
-/** Record every paragraph under a block against its section, within the shared depth cap. */
-function collectParagraphs(
-  node: OoxmlNode,
-  sectionIndex: number,
-  into: Map<string, number>,
-  depth: number
-): void {
-  if (node.kind === 'textValue' || depth > MAX_NOTE_WALK_DEPTH) return;
-  // FIRST WINS, matching the scan this replaces: it returned the earliest section whose blocks
-  // held the paragraph, and a paragraph cannot legitimately be in two.
-  if (node.kind === 'paragraph') {
-    if (!into.has(node.id)) into.set(node.id, sectionIndex);
-    return;
-  }
-  for (const child of node.children) collectParagraphs(child, sectionIndex, into, depth + 1);
+/** Paragraph ids under one immutable block, reused across body revisions. */
+function paragraphIdsOfBlock(block: OoxmlNode): ReadonlySet<string> {
+  const cached = paragraphIdsByBlock.get(block);
+  if (cached) return cached;
+  const ids = new Set<string>();
+  const collect = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || depth > MAX_NOTE_WALK_DEPTH) return;
+    if (node.kind === 'paragraph') {
+      ids.add(node.id);
+      return;
+    }
+    for (const child of node.children) collect(child, depth + 1);
+  };
+  collect(block, 0);
+  paragraphIdsByBlock.set(block, ids);
+  return ids;
 }
 
 /**

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -15,6 +15,7 @@ import {
   caretAt,
   defaultTabIntervalFromSettings,
   enumerateDocumentSections,
+  enumerateDocumentSectionsBounded,
   geometryOfSection,
   layoutHeaderFooterStory,
   pagesToMaterialize,
@@ -38,7 +39,7 @@ import {
   resolveFootnoteProperties,
   settingsPartOf,
 } from '../store/package/note-properties.ts';
-import { resolveNotesPart } from '../store/package/note-references.ts';
+import { collectNoteReferences, resolveNotesPart } from '../store/package/note-references.ts';
 
 export interface FurnitureSource {
   /** Single-section / final-section furniture fallback. */
@@ -512,15 +513,20 @@ export function createNotesLayoutInput(env: {
   const endnotesPart = resolveNotesPart(pkg, 'endnote');
   if (!footnotesPart && !endnotesPart) return undefined;
 
+  const part = env.session.part();
+  // Word commonly writes separator-only note parts. Skip note pagination unless the body
+  // contains a real citation. The collector reuses unchanged container answers by identity.
+  if (collectNoteReferences(part).length === 0) return undefined;
+
   const settings = settingsPartOf(pkg);
   const docFnAuthored = authoredDocumentFootnoteProperties(settings);
   const docEnAuthored = authoredDocumentEndnoteProperties(settings);
   const documentFootnoteProps = resolveFootnoteProperties(undefined, docFnAuthored);
   const documentEndnoteProps = resolveEndnoteProperties(undefined, docEnAuthored);
 
-  const part = env.session.part();
-  const sections = enumerateDocumentSections(part);
-  const sectPrBySection = sectionSectPrNodes(part, sections);
+  const sectionEnumeration = enumerateDocumentSectionsBounded(part);
+  const sections = sectionEnumeration.sections;
+  const sectPrBySection = sectionSectPrNodes(part, sections, sectionEnumeration.truncated);
   const footnotePropsBySection = sections.map((_, index) =>
     resolveFootnoteProperties(
       authoredFootnotePropertiesFromSectPr(sectPrBySection[index]),
@@ -585,9 +591,17 @@ export function createNotesLayoutInput(env: {
 /** SectPr nodes index-aligned with {@link enumerateDocumentSections}. */
 function sectionSectPrNodes(
   part: OoxmlPart,
-  sections: ReturnType<typeof enumerateDocumentSections>
+  sections: ReturnType<typeof enumerateDocumentSections>,
+  truncated: boolean
 ): readonly (OoxmlElement | undefined)[] {
   const blocks = storyBlocks(part);
+  if (!truncated) {
+    return sections.map((section) => {
+      if (section.blockStart === section.blockEndExclusive) return undefined;
+      const block = blocks[section.blockEndExclusive - 1];
+      return block?.kind === 'paragraph' ? paragraphSectionNode(block) : undefined;
+    });
+  }
   const nodes: (OoxmlElement | undefined)[] = [];
   for (let index = 0; index < blocks.length; index += 1) {
     const block = blocks[index]!;

--- a/packages/core/src/layout/__tests__/list-resolve-memo.test.ts
+++ b/packages/core/src/layout/__tests__/list-resolve-memo.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import { applyTreeOp } from '../../store/store/tree-ops.ts';
 import { buildNumberingIndex } from '../numbering-index.ts';
 import { withResolvedListItems } from '../list-resolve.ts';
 import { storyBlocks } from '../story-roots.ts';
@@ -36,6 +37,18 @@ function loadBodyPart() {
       '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
       '<w:r><w:t>two</w:t></w:r></w:p>' +
       '</w:body></w:document>',
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function loadThreeItemBodyPart() {
+  const item = (text: string) =>
+    '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+    `<w:r><w:t>${text}</w:t></w:r></w:p>`;
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>${item('one')}${item('two')}${item('three')}</w:body></w:document>`,
     { name: '/word/document.xml', contentType: 'app/xml' }
   );
   if (!result.ok) throw new Error(result.reason);
@@ -75,6 +88,27 @@ describe('withResolvedListItems memo', () => {
     const supplied = new Map();
     const result = withResolvedListItems({ numberingIndex, listItems: supplied }, blocks);
     expect(result.listItems).toBe(supplied);
+  });
+
+  test('typing in a list item reuses the sequential list result', () => {
+    const numberingIndex = loadNumbering(DECIMAL);
+    const part = loadThreeItemBodyPart();
+    const blocks = storyBlocks(part);
+    const first = withResolvedListItems({ numberingIndex }, blocks);
+    const edited = applyTreeOp(part, {
+      op: 'insertText',
+      paragraphId: blocks[1]!.id,
+      offset: 3,
+      text: '!',
+    });
+    expect(edited.ok).toBe(true);
+    if (!edited.ok) return;
+
+    const editedBlocks = storyBlocks(edited.part);
+    expect(editedBlocks[0]).toBe(blocks[0]);
+    expect(editedBlocks[2]).toBe(blocks[2]);
+    const second = withResolvedListItems({ numberingIndex }, editedBlocks);
+    expect(second.listItems).toBe(first.listItems!);
   });
 
   test('with a style cascade: repeated resolves stay identity-stable, edits stay correct', () => {

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -553,6 +553,7 @@ interface NumberedBlockMemo {
   readonly numbered: readonly OoxmlElement[];
 }
 const numberedBlockMemos = new WeakMap<OoxmlElement, NumberedBlockMemo>();
+const NO_NUMBERED_PARAGRAPHS: readonly OoxmlElement[] = Object.freeze([]);
 
 function numberedParagraphsOfBlock(
   block: OoxmlElement,
@@ -560,9 +561,10 @@ function numberedParagraphsOfBlock(
 ): readonly OoxmlElement[] {
   const cached = numberedBlockMemos.get(block);
   if (cached && cached.styleCascade === styleCascade) return cached.numbered;
-  const numbered = walkStoryParagraphs([block]).filter(
+  const collected = walkStoryParagraphs([block]).filter(
     (paragraph) => paragraphListPrelude(paragraph, styleCascade).numPr !== null
   );
+  const numbered = collected.length > 0 ? collected : NO_NUMBERED_PARAGRAPHS;
   numberedBlockMemos.set(block, { styleCascade, numbered });
   return numbered;
 }
@@ -588,10 +590,26 @@ interface LastStoryResolve {
   readonly rawIndex: NumberingIndex | undefined;
   readonly styleCascade: StyleCascadeTable | undefined;
   readonly isFontAvailable: ((family: string) => boolean) | undefined;
-  readonly numbered: readonly OoxmlElement[];
+  readonly blocks: readonly OoxmlElement[];
+  readonly numberedByBlock: readonly (readonly OoxmlElement[])[];
   readonly listItems: ReadonlyMap<string, ResolvedListItem>;
 }
 const lastStoryResolves = new WeakMap<OoxmlElement, LastStoryResolve>();
+
+function sameNumberingSequence(a: readonly OoxmlElement[], b: readonly OoxmlElement[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((paragraph, index) => {
+      const previous = b[index];
+      if (!previous || paragraph.id !== previous.id) return false;
+      const properties = paragraph.children.find((child) => child.kind === 'paragraphProperties');
+      const previousProperties = previous.children.find(
+        (child) => child.kind === 'paragraphProperties'
+      );
+      return properties === previousProperties;
+    })
+  );
+}
 
 function resolveStoryListItemsStable(
   blocks: readonly OoxmlElement[],
@@ -600,27 +618,42 @@ function resolveStoryListItemsStable(
   styleCascade: StyleCascadeTable | undefined,
   isFontAvailable?: (family: string) => boolean
 ): ReadonlyMap<string, ResolvedListItem> {
-  const anchor = blocks[0];
-  const numbered: OoxmlElement[] = [];
-  for (const block of blocks) {
-    const blockNumbered = numberedParagraphsOfBlock(block, styleCascade);
-    for (const paragraph of blockNumbered) numbered.push(paragraph);
-  }
-  const last = anchor ? lastStoryResolves.get(anchor) : undefined;
-  if (
-    last &&
+  const first = blocks[0];
+  const lastBlock = blocks[blocks.length - 1];
+  const last =
+    (first ? lastStoryResolves.get(first) : undefined) ??
+    (lastBlock ? lastStoryResolves.get(lastBlock) : undefined);
+  const numberedByBlock = new Array<readonly OoxmlElement[]>(blocks.length);
+  let numberedSequenceUnchanged =
+    last !== undefined &&
     last.rawIndex === rawIndex &&
     last.styleCascade === styleCascade &&
     last.isFontAvailable === isFontAvailable &&
-    last.numbered.length === numbered.length &&
-    last.numbered.every((node, index) => node === numbered[index])
-  ) {
+    last.blocks.length === blocks.length;
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index]!;
+    const numbered =
+      last && last.blocks[index] === block
+        ? last.numberedByBlock[index]!
+        : numberedParagraphsOfBlock(block, styleCascade);
+    numberedByBlock[index] = numbered;
+    if (
+      numberedSequenceUnchanged &&
+      !sameNumberingSequence(numbered, last!.numberedByBlock[index]!)
+    ) {
+      numberedSequenceUnchanged = false;
+    }
+  }
+  if (last && numberedSequenceUnchanged) {
+    const next = { ...last, blocks, numberedByBlock };
+    if (first) lastStoryResolves.set(first, next);
+    if (lastBlock && lastBlock !== first) lastStoryResolves.set(lastBlock, next);
     return last.listItems;
   }
   const listItems = resolveStoryListItems(blocks, linkedIndex, styleCascade, isFontAvailable);
-  if (anchor) {
-    lastStoryResolves.set(anchor, { rawIndex, styleCascade, isFontAvailable, numbered, listItems });
-  }
+  const next = { rawIndex, styleCascade, isFontAvailable, blocks, numberedByBlock, listItems };
+  if (first) lastStoryResolves.set(first, next);
+  if (lastBlock && lastBlock !== first) lastStoryResolves.set(lastBlock, next);
   return listItems;
 }
 

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -2336,6 +2336,17 @@ export function layoutSemanticDocumentWithNotes<
   runBody: (opts: Opts) => SemanticLayout
 ): SemanticLayout {
   const packageRefs = collectBodyNoteReferences(part);
+  if (packageRefs.length === 0) {
+    if (optionsWithLists.session) {
+      optionsWithLists.session.notes = null;
+      optionsWithLists.session.notePageBottomReserves = null;
+    }
+    return runBody({
+      ...optionsWithLists,
+      noteMarks: undefined,
+      pageBottomReserves: undefined,
+    });
+  }
   const paragraphSectionIndex = paragraphSectionIndexOf(
     part,
     sections,

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -649,6 +649,10 @@ export function layoutSemanticDocument(
   };
 
   if (!options.notes) {
+    if (options.session) {
+      options.session.notes = null;
+      options.session.notePageBottomReserves = null;
+    }
     return finish(runBody(optionsWithLists));
   }
 

--- a/packages/core/src/layout/toc-layout.ts
+++ b/packages/core/src/layout/toc-layout.ts
@@ -5,8 +5,18 @@ import { findNode } from '../store/package/ooxml-edit.ts';
 import { detectBodyTocs, type DetectedToc } from '../store/package/toc-detect.ts';
 import type { OoxmlElement, OoxmlNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
 
+const visibleTextByParagraph = new WeakMap<OoxmlElement, boolean>();
+
 /** True when a paragraph carries visible `w:t` text outside field chrome. */
 function paragraphHasVisibleText(paragraph: OoxmlElement): boolean {
+  const cached = visibleTextByParagraph.get(paragraph);
+  if (cached !== undefined) return cached;
+  const result = computeParagraphHasVisibleText(paragraph);
+  visibleTextByParagraph.set(paragraph, result);
+  return result;
+}
+
+function computeParagraphHasVisibleText(paragraph: OoxmlElement): boolean {
   const walk = (node: OoxmlNode): boolean => {
     if (node.kind === 'textValue') return false;
     if (isInstrTextNode(node) || fldCharType(node) !== null) return false;

--- a/packages/core/src/store/__tests__/hf-references.test.ts
+++ b/packages/core/src/store/__tests__/hf-references.test.ts
@@ -12,6 +12,7 @@ import { readOoxmlPackage, withPart, writeOoxmlPackage } from '../package/ooxml-
 import {
   resolveHeaderFooterParts,
   resolveHeaderFooterPartsBySection,
+  resolveHeaderFooterResolutionBySection,
 } from '../package/hf-references.ts';
 import { applyTreeOp } from '../store/tree-ops.ts';
 
@@ -280,5 +281,28 @@ describe('fidelity with header parts', () => {
     if (!edited.ok) throw new Error(edited.reason);
     const reopened = load(writeOoxmlPackage(withPart(pkg, edited.part)));
     expect(canonicalOoxmlFingerprint(reopened.parts.get('/word/header1.xml')!)).toBe(headerBefore);
+  });
+
+  test('editing body text reuses header and footer resolution', () => {
+    const pkg = load(packed());
+    const main = pkg.parts.get(pkg.mainDocumentPart)!;
+    const paragraphId = JSON.stringify(main).match(
+      /"(\/word\/document\.xml#[0-9.]+)","kind":"paragraph"/
+    )?.[1];
+    if (!paragraphId) throw new Error('no paragraph id found');
+    const beforeResolution = resolveHeaderFooterResolutionBySection(pkg);
+    const beforeParts = resolveHeaderFooterPartsBySection(pkg);
+
+    const edited = applyTreeOp(main, {
+      op: 'insertText',
+      paragraphId,
+      offset: 0,
+      text: 'Z',
+    });
+    if (!edited.ok) throw new Error(edited.reason);
+    const editedPackage = withPart(pkg, edited.part);
+
+    expect(resolveHeaderFooterResolutionBySection(editedPackage)).toBe(beforeResolution);
+    expect(resolveHeaderFooterPartsBySection(editedPackage)).toBe(beforeParts);
   });
 });

--- a/packages/core/src/store/__tests__/toc-detect.test.ts
+++ b/packages/core/src/store/__tests__/toc-detect.test.ts
@@ -52,6 +52,32 @@ describe('detectBodyTocs memoization', () => {
     expect(noTocFirst).toEqual([]);
   });
 
+  test('reuses an unchanged content-control TOC across an outside edit', () => {
+    const part = load(
+      '<w:p><w:r><w:t>Before</w:t></w:r></w:p>' +
+        `<w:sdt><w:sdtPr/><w:sdtContent>${TOC}</w:sdtContent></w:sdt>`
+    );
+    const before = detectBodyTocs(part);
+    const body = part.root.children.find((child) => child.kind === 'body');
+    if (!body || body.kind === 'textValue') throw new Error('missing body');
+    const paragraph = body.children.find((child) => child.kind === 'paragraph');
+    if (!paragraph) throw new Error('missing paragraph');
+
+    const edited = applyTreeOp(part, {
+      op: 'insertText',
+      paragraphId: paragraph.id,
+      offset: 6,
+      text: '!',
+    });
+    expect(edited.ok).toBe(true);
+    if (!edited.ok) return;
+
+    const after = detectBodyTocs(edited.part);
+    expect(after).not.toBe(before);
+    expect(after).toEqual(before);
+    expect(after[0]).toBe(before[0]);
+  });
+
   test('recomputes after an edit replaces the part identity', () => {
     const part = load(TOC);
     const before = detectBodyTocs(part);
@@ -76,6 +102,7 @@ describe('detectBodyTocs memoization', () => {
     const after = detectBodyTocs(edited.part);
     expect(after).not.toBe(before);
     expect(after).toHaveLength(1);
+    expect(after[0]).not.toBe(before[0]);
     expect(detectBodyTocs(edited.part)).toBe(after);
   });
 });

--- a/packages/core/src/store/__tests__/tree-package-store.test.ts
+++ b/packages/core/src/store/__tests__/tree-package-store.test.ts
@@ -379,6 +379,22 @@ describe('TreeDocxSession — package-aware HF mutation', () => {
     expect(reopened.session.storyText({ kind: 'headerFooter', rId: 'rId7' })).toBe('Z-SHARED');
   });
 
+  test('a body text edit keeps header and footer resolution by identity', () => {
+    const opened = openTreeSession(sharedHeaderDoc());
+    if (!opened.ok) throw new Error(opened.reason);
+    const session = opened.session;
+    const beforeParts = session.headerFooterPartsBySection();
+    const beforeResolution = session.headerFooterResolutionBySection();
+    const bodyId = session.paragraphIds()[0]!;
+
+    const result = session.applyTreeOps([
+      { op: 'insertText', paragraphId: bodyId, offset: 0, text: 'Z-' },
+    ]);
+    expect(result.committed).toBe(true);
+    expect(session.headerFooterPartsBySection()).toBe(beforeParts);
+    expect(session.headerFooterResolutionBySection()).toBe(beforeResolution);
+  });
+
   test('invalid HF rId is rejected without mutating the body', () => {
     const opened = openTreeSession(bodyAndHeaderDoc());
     if (!opened.ok) throw new Error(opened.reason);

--- a/packages/core/src/store/package/hf-references.ts
+++ b/packages/core/src/store/package/hf-references.ts
@@ -28,6 +28,9 @@ const FOOTER_REL_TYPE =
   'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
 const SETTINGS_REL_TYPE =
   'http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings';
+const NO_RELATIONSHIPS: readonly RelationshipRecord[] = Object.freeze([]);
+// Keep this equal to layout's MAX_DOCUMENT_SECTIONS without adding a store → layout edge.
+const MAX_SECTION_PROPERTY_NODES = 4_096;
 
 /** `w:headerReference w:type` vocabulary (ECMA-376 §17.10.5): default, first page, even pages. */
 export type HeaderFooterVariant = 'default' | 'first' | 'even';
@@ -108,22 +111,49 @@ function findBody(root: OoxmlNode): OoxmlElement | undefined {
   return undefined;
 }
 
-/**
- * Body story blocks in document order, flattening block SDTs — same shape as layout's
- * `storyBlocks`, duplicated here so the store package does not import layout.
- */
-function bodyBlocks(body: OoxmlElement): OoxmlElement[] {
-  const blocks: OoxmlElement[] = [];
-  walkStoryBlocks(body.children, 0, (block) => blocks.push(block));
-  return blocks;
-}
-
 function paragraphSectPr(paragraph: OoxmlElement): OoxmlElement | undefined {
   const pPr =
     paragraph.children.find((child) => child.kind === 'paragraphProperties') ??
     childNamed(paragraph, 'pPr');
   if (!pPr || pPr.kind === 'textValue') return undefined;
   return childNamed(pPr, 'sectPr');
+}
+
+interface SectionPropertySubtreeSummary {
+  readonly blockCount: number;
+  readonly sectionProperties: readonly OoxmlElement[];
+  readonly lastBlockEndsSection: boolean;
+}
+
+const sectionPropertySubtreeSummaries = new WeakMap<OoxmlNode, SectionPropertySubtreeSummary>();
+
+/**
+ * Section markers under one immutable direct body child.
+ *
+ * A text edit rebuilds one child and the body ancestry. Unchanged siblings keep these summaries,
+ * so header/footer resolution does not flatten every table and content-control subtree again.
+ */
+function sectionPropertySummaryOf(node: OoxmlNode): SectionPropertySubtreeSummary {
+  const cached = sectionPropertySubtreeSummaries.get(node);
+  if (cached) return cached;
+  let blockCount = 0;
+  let lastBlockEndsSection = false;
+  const sectionProperties: OoxmlElement[] = [];
+  walkStoryBlocks([node], 0, (block) => {
+    blockCount += 1;
+    const sectPr = block.kind === 'paragraph' ? paragraphSectPr(block) : undefined;
+    lastBlockEndsSection = sectPr !== undefined;
+    if (sectPr && sectionProperties.length < MAX_SECTION_PROPERTY_NODES) {
+      sectionProperties.push(sectPr);
+    }
+  });
+  const result = Object.freeze({
+    blockCount,
+    sectionProperties: Object.freeze(sectionProperties),
+    lastBlockEndsSection,
+  });
+  sectionPropertySubtreeSummaries.set(node, result);
+  return result;
 }
 
 /**
@@ -135,18 +165,21 @@ function paragraphSectPr(paragraph: OoxmlElement): OoxmlElement | undefined {
 export function collectSectionPropertyNodes(root: OoxmlNode): Array<OoxmlElement | null> {
   const body = findBody(root);
   if (!body) return [];
-  const blocks = bodyBlocks(body);
   const found: Array<OoxmlElement | null> = [];
-  let blockStart = 0;
-  for (let index = 0; index < blocks.length; index += 1) {
-    const block = blocks[index]!;
-    if (block.kind !== 'paragraph') continue;
-    const sectPr = paragraphSectPr(block);
-    if (!sectPr) continue;
-    found.push(sectPr);
-    blockStart = index + 1;
+  let blockCount = 0;
+  let lastBlockEndsSection = false;
+  for (const child of body.children) {
+    const summary = sectionPropertySummaryOf(child);
+    if (summary.blockCount === 0) continue;
+    blockCount += summary.blockCount;
+    for (const sectPr of summary.sectionProperties) {
+      if (found.length >= MAX_SECTION_PROPERTY_NODES) return found;
+      found.push(sectPr);
+    }
+    lastBlockEndsSection = summary.lastBlockEndsSection;
   }
-  if (blockStart < blocks.length || found.length === 0) {
+  if (found.length >= MAX_SECTION_PROPERTY_NODES) return found;
+  if (blockCount === 0 || !lastBlockEndsSection) {
     found.push(childNamed(body, 'sectPr') ?? null);
   } else {
     const bodySectPr = childNamed(body, 'sectPr');
@@ -227,20 +260,70 @@ function partsFromSlots(
   return result;
 }
 
-/**
- * Resolve header/footer parts for every section with declared-vs-inherited metadata.
- *
- * Index aligns with `enumerateDocumentSections` in the layout package. Existing merged
- * maps stay available via {@link resolveHeaderFooterPartsBySection}.
- */
-export function resolveHeaderFooterResolutionBySection(
-  pkg: OoxmlPackage
-): readonly HeaderFooterSectionResolution[] {
-  const main = pkg.parts.get(pkg.mainDocumentPart);
-  if (!main) return [];
+/** Convert resolved metadata without repeating section discovery and relationship resolution. */
+export function headerFooterPartsFromResolution(
+  resolution: readonly HeaderFooterSectionResolution[]
+): readonly HeaderFooterParts[] {
+  return resolution.map((section) => ({
+    headers: partsFromSlots(section.headers),
+    footers: partsFromSlots(section.footers),
+    evenAndOddHeaders: section.evenAndOddHeaders,
+    titlePage: section.titlePage,
+  }));
+}
 
-  const relationships = pkg.relationships.get(pkg.mainDocumentPart) ?? [];
+interface HeaderFooterResolutionMemo {
+  readonly sectionProperties: readonly (OoxmlElement | null)[];
+  readonly evenAndOddHeaders: boolean;
+  readonly slotParts: readonly OoxmlPart[];
+  readonly resolution: readonly HeaderFooterSectionResolution[];
+  readonly parts: readonly HeaderFooterParts[];
+}
+
+const headerFooterResolutionByRelationships = new WeakMap<object, HeaderFooterResolutionMemo>();
+
+function sameSectionProperties(
+  left: readonly (OoxmlElement | null)[],
+  right: readonly (OoxmlElement | null)[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((sectionProperties, index) => sectionProperties === right[index])
+  );
+}
+
+function slotPartsOf(resolution: readonly HeaderFooterSectionResolution[]): readonly OoxmlPart[] {
+  const parts = new Set<OoxmlPart>();
+  for (const section of resolution) {
+    for (const slots of [section.headers, section.footers]) {
+      for (const slot of slots.values()) parts.add(slot.part);
+    }
+  }
+  return [...parts];
+}
+
+function resolveHeaderFooterBySection(pkg: OoxmlPackage): HeaderFooterResolutionMemo | null {
+  const main = pkg.parts.get(pkg.mainDocumentPart);
+  if (!main) return null;
+
+  const packageRelationships = pkg.relationships.get(pkg.mainDocumentPart);
+  const relationships = packageRelationships ?? NO_RELATIONSHIPS;
   const evenAndOddHeaders = readEvenAndOddHeaders(pkg, relationships);
+  const sectionProperties = collectSectionPropertyNodes(main.root);
+  const memoKey =
+    packageRelationships ??
+    sectionProperties.find((node): node is OoxmlElement => node !== null) ??
+    NO_RELATIONSHIPS;
+  const cached = headerFooterResolutionByRelationships.get(memoKey);
+  if (
+    cached &&
+    cached.evenAndOddHeaders === evenAndOddHeaders &&
+    sameSectionProperties(cached.sectionProperties, sectionProperties) &&
+    cached.slotParts.every((part) => pkg.parts.get(part.name) === part)
+  ) {
+    return cached;
+  }
+
   const partForReference = (
     relId: string | undefined,
     typeUri: string
@@ -251,25 +334,13 @@ export function resolveHeaderFooterResolutionBySection(
     const resolved = resolveRelationship(record);
     if (resolved.mode !== 'Internal' || !resolved.target.ok) return undefined;
     const part = pkg.parts.get(resolved.target.partName);
-    if (!part) return undefined;
-    return { part, rId: relId };
+    return part ? { part, rId: relId } : undefined;
   };
-
-  const sectPrNodes = collectSectionPropertyNodes(main.root);
-  if (sectPrNodes.length === 0) {
-    return [
-      Object.freeze({
-        headers: new Map(),
-        footers: new Map(),
-        evenAndOddHeaders,
-        titlePage: false,
-      }),
-    ];
-  }
 
   const result: HeaderFooterSectionResolution[] = [];
   let previous: HeaderFooterSectionResolution | undefined;
-  for (const sectPr of sectPrNodes) {
+  const nodes = sectionProperties.length > 0 ? sectionProperties : [null];
+  for (const sectPr of nodes) {
     const declared = sectPr
       ? referencesFromSectPr(sectPr, partForReference)
       : { headers: new Map(), footers: new Map(), titlePage: false };
@@ -282,7 +353,28 @@ export function resolveHeaderFooterResolutionBySection(
     result.push(resolved);
     previous = resolved;
   }
-  return result;
+  const resolution = Object.freeze(result);
+  const memo = Object.freeze({
+    sectionProperties,
+    evenAndOddHeaders,
+    slotParts: Object.freeze(slotPartsOf(resolution)),
+    resolution,
+    parts: Object.freeze(headerFooterPartsFromResolution(resolution)),
+  });
+  headerFooterResolutionByRelationships.set(memoKey, memo);
+  return memo;
+}
+
+/**
+ * Resolve header/footer parts for every section with declared-vs-inherited metadata.
+ *
+ * Index aligns with `enumerateDocumentSections` in the layout package. Existing merged
+ * maps stay available via {@link resolveHeaderFooterPartsBySection}.
+ */
+export function resolveHeaderFooterResolutionBySection(
+  pkg: OoxmlPackage
+): readonly HeaderFooterSectionResolution[] {
+  return resolveHeaderFooterBySection(pkg)?.resolution ?? [];
 }
 
 /**
@@ -291,12 +383,7 @@ export function resolveHeaderFooterResolutionBySection(
  * Index aligns with `enumerateDocumentSections` in the layout package.
  */
 export function resolveHeaderFooterPartsBySection(pkg: OoxmlPackage): readonly HeaderFooterParts[] {
-  return resolveHeaderFooterResolutionBySection(pkg).map((section) => ({
-    headers: partsFromSlots(section.headers),
-    footers: partsFromSlots(section.footers),
-    evenAndOddHeaders: section.evenAndOddHeaders,
-    titlePage: section.titlePage,
-  }));
+  return resolveHeaderFooterBySection(pkg)?.parts ?? [];
 }
 
 /**

--- a/packages/core/src/store/package/note-references.ts
+++ b/packages/core/src/store/package/note-references.ts
@@ -245,6 +245,40 @@ function paragraphNoteHitsOf(
   return hits;
 }
 
+const NO_NOTE_HITS: readonly NoteReferenceHit[] = Object.freeze([]);
+
+/**
+ * Note-reference hits under one immutable container.
+ *
+ * A text edit replaces one paragraph and its ancestors. Unchanged sibling containers keep
+ * their identity, so their complete answer remains reusable across part revisions.
+ */
+const containerNoteHitMemos = new WeakMap<OoxmlNode, readonly NoteReferenceHit[]>();
+
+function subtreeNoteHitsOf(
+  node: OoxmlNode,
+  partName: string,
+  depth: number
+): readonly NoteReferenceHit[] {
+  if (node.kind === 'textValue' || depth > 64) return NO_NOTE_HITS;
+  if (node.kind === 'paragraph') return paragraphNoteHitsOf(node, partName);
+  const cached = containerNoteHitMemos.get(node);
+  if (cached) return cached;
+
+  let hits: NoteReferenceHit[] | null = null;
+  for (const child of node.children) {
+    const childHits = subtreeNoteHitsOf(child, partName, depth + 1);
+    if (childHits.length === 0) continue;
+    hits ??= [];
+    const remaining = MAX_NOTE_REFERENCE_SCAN - hits.length;
+    if (remaining <= 0) break;
+    hits.push(...childHits.slice(0, remaining));
+  }
+  const result: readonly NoteReferenceHit[] = hits ? Object.freeze(hits) : NO_NOTE_HITS;
+  containerNoteHitMemos.set(node, result);
+  return result;
+}
+
 export function collectNoteReferences(
   part: OoxmlPart,
   options?: {
@@ -256,6 +290,11 @@ export function collectNoteReferences(
   // unbounded maxHits and rely on the visited-node budget (+ truncation) instead.
   const maxHits = options?.maxHits ?? MAX_NOTE_REFERENCE_SCAN;
   const budget = options?.budget;
+  if (maxHits <= 0) return NO_NOTE_HITS;
+  if (budget === undefined && maxHits <= MAX_NOTE_REFERENCE_SCAN) {
+    const all = subtreeNoteHitsOf(part.root, part.name, 0);
+    return all.length > maxHits ? all.slice(0, maxHits) : all;
+  }
   const memoized = budget === undefined;
   const hits: NoteReferenceHit[] = [];
 

--- a/packages/core/src/store/package/toc-detect.ts
+++ b/packages/core/src/store/package/toc-detect.ts
@@ -24,12 +24,6 @@ export interface DetectedToc {
   readonly instruction: TocInstruction;
 }
 
-interface ParagraphSite {
-  readonly paragraph: OoxmlElement;
-  readonly containerId: string;
-  readonly contentControlId?: string;
-}
-
 interface OpenField {
   readonly beginNodeId: string;
   readonly beginParagraphId: string;
@@ -48,34 +42,6 @@ function bodyOf(part: OoxmlPart): OoxmlElement | null {
     if (child.kind === 'body') return child;
   }
   return null;
-}
-
-function paragraphSites(part: OoxmlPart): ParagraphSite[] {
-  const body = bodyOf(part);
-  if (!body) return [];
-  const sites: ParagraphSite[] = [];
-
-  const collect = (
-    children: readonly OoxmlNode[],
-    containerId: string,
-    contentControlId: string | undefined,
-    depth: number
-  ): void => {
-    for (const child of children) {
-      if (child.kind === 'paragraph') {
-        sites.push({ paragraph: child, containerId, contentControlId });
-        continue;
-      }
-      if (!isContentControl(child) || depth >= TOC_MAX_FIELD_NESTING) continue;
-      for (const content of child.children) {
-        if (isContentControlContent(content)) {
-          collect(content.children, content.id, child.id, depth + 1);
-        }
-      }
-    }
-  };
-  collect(body.children, body.id, undefined, 0);
-  return sites;
 }
 
 const fieldTokensByParagraph = new WeakMap<OoxmlElement, readonly OoxmlNode[]>();
@@ -97,15 +63,30 @@ function fieldTokens(paragraph: OoxmlElement): readonly OoxmlNode[] {
   return tokens;
 }
 
-/** Memoized per immutable part identity; a commit replaces the part object. */
-const detectBodyTocsCache = new WeakMap<OoxmlPart, readonly DetectedToc[]>();
+type DetectedTocCandidate = Omit<DetectedToc, 'id'>;
+type ContainerTocResult = DetectedToc | DetectedTocCandidate;
 
-function detectBodyTocsUncached(part: OoxmlPart): readonly DetectedToc[] {
+const EMPTY_TOCS: readonly DetectedToc[] = Object.freeze([]);
+const detectedTocsByContainer = new WeakMap<OoxmlElement, readonly DetectedToc[]>();
+
+/**
+ * Detect fields whose paragraphs share one direct container.
+ *
+ * A commit rebuilds the edited ancestor chain. Unchanged content-control containers retain
+ * their identity, so their complete TOC answers remain reusable across part revisions.
+ */
+function detectTocsInContainer(
+  container: OoxmlElement,
+  contentControlId: string | undefined,
+  depth: number
+): readonly DetectedToc[] {
+  const cached = detectedTocsByContainer.get(container);
+  if (cached) return cached;
   const stack: (OpenField | null)[] = [];
-  const completed: Omit<DetectedToc, 'id'>[] = [];
+  const completed: ContainerTocResult[] = [];
 
-  for (const site of paragraphSites(part)) {
-    for (const token of fieldTokens(site.paragraph)) {
+  const processParagraph = (paragraph: OoxmlElement): void => {
+    for (const token of fieldTokens(paragraph)) {
       const type = fldCharType(token);
       if (type === 'begin') {
         if (stack.length >= TOC_MAX_FIELD_NESTING) {
@@ -113,9 +94,9 @@ function detectBodyTocsUncached(part: OoxmlPart): readonly DetectedToc[] {
         } else {
           stack.push({
             beginNodeId: token.id,
-            beginParagraphId: site.paragraph.id,
-            containerId: site.containerId,
-            contentControlId: site.contentControlId,
+            beginParagraphId: paragraph.id,
+            containerId: container.id,
+            contentControlId,
             instructionChunks: [],
             resultParagraphIds: [],
             instructionLength: 0,
@@ -147,15 +128,15 @@ function detectBodyTocsUncached(part: OoxmlPart): readonly DetectedToc[] {
         ended &&
         ended.separated &&
         !ended.invalid &&
-        ended.containerId === site.containerId &&
-        ended.beginParagraphId !== site.paragraph.id
+        ended.containerId === container.id &&
+        ended.beginParagraphId !== paragraph.id
       ) {
         const instruction = parseTocInstruction(ended.instructionChunks.join(''));
         if (instruction) {
           completed.push({
             beginNodeId: ended.beginNodeId,
             beginParagraphId: ended.beginParagraphId,
-            endParagraphId: site.paragraph.id,
+            endParagraphId: paragraph.id,
             resultParagraphIds: ended.resultParagraphIds,
             containerId: ended.containerId,
             ...(ended.contentControlId ? { contentControlId: ended.contentControlId } : {}),
@@ -169,34 +150,58 @@ function detectBodyTocsUncached(part: OoxmlPart): readonly DetectedToc[] {
       if (
         field &&
         field.separated &&
-        field.beginParagraphId !== site.paragraph.id &&
-        field.containerId === site.containerId
+        field.beginParagraphId !== paragraph.id &&
+        field.containerId === container.id
       ) {
-        field.resultParagraphIds.push(site.paragraph.id);
+        field.resultParagraphIds.push(paragraph.id);
       }
+    }
+  };
+
+  for (const child of container.children) {
+    if (child.kind === 'paragraph') {
+      processParagraph(child);
+      continue;
+    }
+    if (!isContentControl(child) || depth >= TOC_MAX_FIELD_NESTING) continue;
+    for (const content of child.children) {
+      if (!isContentControlContent(content)) continue;
+      completed.push(...detectTocsInContainer(content, child.id, depth + 1));
     }
   }
 
   const controlCounts = new Map<string, number>();
   for (const toc of completed) {
-    if (toc.contentControlId) {
+    if (!('id' in toc) && toc.contentControlId) {
       controlCounts.set(toc.contentControlId, (controlCounts.get(toc.contentControlId) ?? 0) + 1);
     }
   }
-  return completed.map((toc) => ({
-    ...toc,
-    id:
-      toc.contentControlId && controlCounts.get(toc.contentControlId) === 1
-        ? toc.contentControlId
-        : toc.beginNodeId,
-  }));
+  const result = completed.map(
+    (toc): DetectedToc =>
+      'id' in toc
+        ? toc
+        : {
+            ...toc,
+            id:
+              toc.contentControlId && controlCounts.get(toc.contentControlId) === 1
+                ? toc.contentControlId
+                : toc.beginNodeId,
+          }
+  );
+  const immutable = result.length > 0 ? Object.freeze(result) : EMPTY_TOCS;
+  detectedTocsByContainer.set(container, immutable);
+  return immutable;
 }
+
+/** Memoized per immutable part identity for repeated reads within one revision. */
+const detectBodyTocsCache = new WeakMap<OoxmlPart, readonly DetectedToc[]>();
 
 /** Discover refreshable body TOCs without evaluating any field instruction. */
 export function detectBodyTocs(part: OoxmlPart): readonly DetectedToc[] {
   const cached = detectBodyTocsCache.get(part);
   if (cached) return cached;
-  const result = detectBodyTocsUncached(part);
+  const body = bodyOf(part);
+  const result = body ? detectTocsInContainer(body, undefined, 0) : EMPTY_TOCS;
   detectBodyTocsCache.set(part, result);
   return result;
 }


### PR DESCRIPTION
## Summary
- Reuse structurally unchanged layout and document derivations during typing.
- Skip note pagination when the body has no note references.
- Preserve safe invalidation for structural edits and story changes.

Fixes #391.

## Test plan
- [x] Run `bun run format`.
- [x] Run `bun run lint`.
- [x] Run `bun run typecheck`.
- [x] Run `bun run test`.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790154598&installation_model_id=422592&pr_number=393&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F393&signature=7ac7233178228f5135c2933c335c6dcf3223514987191c339e11890965628384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->