### PR TITLE
feat(core): render and edit mathematical equations

### DIFF
--- a/.changeset/mathematical-equations.md
+++ b/.changeset/mathematical-equations.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Display and edit Word mathematical equations through a bounded linear-math editor.

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -808,6 +808,7 @@ export interface DocxEditorInstance extends Editor {
     // @internal
     getReviewAuthorStyle(author: string): RevisionAuthorStyle | undefined;
     readonly mountGeneration: number;
+    setEquationChrome(handlers: EquationChromeHandlers): Unsubscribe;
     setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
     setRevisionStyles(styles: RevisionStyles): void;
     stateVersion(): number;
@@ -863,6 +864,43 @@ export const EMU_PER_POINT = 12700;
 
 // @public
 export function emuToOverlayPoints(emu: number): number;
+
+// @public
+export interface EquationActivation {
+    // (undocumented)
+    readonly equation: SurfaceEquation;
+    // (undocumented)
+    readonly rect: {
+        readonly left: number;
+        readonly top: number;
+        readonly right: number;
+        readonly bottom: number;
+    };
+}
+
+// @public
+export function equationAtPosition(equations: readonly SurfaceEquation[], position: SemanticPosition): SurfaceEquation | null;
+
+// @public
+export interface EquationChromeHandlers {
+    // (undocumented)
+    readonly onPopover?: (activation: EquationActivation) => void;
+}
+
+// @public
+export interface EquationOps {
+    // (undocumented)
+    applyEquation(equationId: string, linear: string): boolean;
+    can(equationId: string, action: EquationAction): EquationCanResult;
+    // (undocumented)
+    equationAtCaret(): SurfaceEquation | null;
+    // (undocumented)
+    equationById(equationId: string): SurfaceEquation | null;
+    // (undocumented)
+    equationsInCaretParagraph(): SurfaceEquation[];
+    // (undocumented)
+    removeEquation(equationId: string): boolean;
+}
 
 // @public
 export function executeImageCommand(editor: DocxEditorInstance, command: Extract<EditorCommand, {
@@ -1289,6 +1327,8 @@ export interface PaginatedSurface {
         paragraphId: string;
         offset: number;
     }): boolean;
+    // (undocumented)
+    readonly equations: EquationOps;
     exitHeaderFooter(): void;
     exitListOnEmptyItem(): boolean;
     // (undocumented)
@@ -1443,6 +1483,8 @@ export interface PaginatedSurfaceOptions {
     readonly measurer?: TextMeasurer;
     // (undocumented)
     readonly onChange?: (state: PaginatedSurfaceState) => void;
+    // (undocumented)
+    readonly onEquationPopover?: (activation: EquationActivation) => void;
     readonly onHyperlinkPopover?: (activation: HyperlinkActivation) => void;
     readonly onRequestHyperlink?: () => void;
     readonly pointer?: 'engine' | 'native';
@@ -1867,6 +1909,23 @@ export function sourceCropFromCropPercent(crop: ImageCropPercent): SourceCrop;
 
 // @public
 export type SupportedImageMime = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/bmp' | 'image/webp';
+
+// @public
+export interface SurfaceEquation {
+    // (undocumented)
+    readonly end: number;
+    // (undocumented)
+    readonly fallbackText: string;
+    // (undocumented)
+    readonly id: string;
+    // (undocumented)
+    readonly linear: string;
+    // (undocumented)
+    readonly paragraphId: string;
+    // (undocumented)
+    readonly start: number;
+    readonly supported: boolean;
+}
 
 // @public
 export interface SurfaceExtent {

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1042,6 +1042,7 @@ export interface DocxEditorInstance extends Editor {
     // @internal
     getReviewAuthorStyle(author: string): RevisionAuthorStyle | undefined;
     readonly mountGeneration: number;
+    setEquationChrome(handlers: EquationChromeHandlers): Unsubscribe;
     setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
     setRevisionStyles(styles: RevisionStyles): void;
     stateVersion(): number;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -605,6 +605,91 @@ export function enumerateDocumentSections(part: OoxmlPart, displayMode?: Revisio
 // @public
 export function enumerateDocumentSectionsBounded(part: OoxmlPart, displayMode?: RevisionDisplayMode): DocumentSectionsEnumeration;
 
+// @public (undocumented)
+export interface EquationFractionGeometry extends EquationGeometryBase {
+    // (undocumented)
+    readonly bar: LayoutBox;
+    // (undocumented)
+    readonly denominator: EquationGeometry;
+    // (undocumented)
+    readonly kind: 'fraction';
+    // (undocumented)
+    readonly numerator: EquationGeometry;
+}
+
+// @public (undocumented)
+export type EquationGeometry = EquationTextGeometry | EquationRowGeometry | EquationFractionGeometry | EquationRadicalGeometry | EquationScriptGeometry | EquationNaryGeometry;
+
+// @public (undocumented)
+export interface EquationNaryGeometry extends EquationGeometryBase {
+    // (undocumented)
+    readonly body: EquationGeometry;
+    // (undocumented)
+    readonly kind: 'nary';
+    // (undocumented)
+    readonly lowerLimit?: EquationGeometry;
+    // (undocumented)
+    readonly operator: EquationTextGeometry;
+    // (undocumented)
+    readonly upperLimit?: EquationGeometry;
+}
+
+// @public (undocumented)
+export interface EquationRadicalGeometry extends EquationGeometryBase {
+    // (undocumented)
+    readonly bar: LayoutBox;
+    // (undocumented)
+    readonly degree?: EquationGeometry;
+    // (undocumented)
+    readonly kind: 'radical';
+    // (undocumented)
+    readonly radicand: EquationGeometry;
+    // (undocumented)
+    readonly sign: EquationTextGeometry;
+}
+
+// @public (undocumented)
+export interface EquationRowGeometry extends EquationGeometryBase {
+    // (undocumented)
+    readonly items: readonly EquationGeometry[];
+    // (undocumented)
+    readonly kind: 'row';
+}
+
+// @public (undocumented)
+export interface EquationScriptGeometry extends EquationGeometryBase {
+    // (undocumented)
+    readonly base: EquationGeometry;
+    // (undocumented)
+    readonly kind: 'script';
+    // (undocumented)
+    readonly subscript?: EquationGeometry;
+    // (undocumented)
+    readonly superscript?: EquationGeometry;
+}
+
+// @public
+export interface EquationSpanRecord {
+    // (undocumented)
+    readonly fallbackText: string;
+    // (undocumented)
+    readonly geometry: EquationGeometry;
+    // (undocumented)
+    readonly sourceNodeId: string;
+    // (undocumented)
+    readonly truncated: boolean;
+}
+
+// @public (undocumented)
+export interface EquationTextGeometry extends EquationGeometryBase {
+    // (undocumented)
+    readonly fontSizePt: number;
+    // (undocumented)
+    readonly kind: 'text' | 'fallback';
+    // (undocumented)
+    readonly text: string;
+}
+
 // @public
 export function everyStoryOrder(layout: SemanticLayout): string[];
 
@@ -1127,6 +1212,9 @@ export interface LayoutCacheStats {
     // (undocumented)
     readonly size: number;
 }
+
+// @public
+export function layoutEquation(projection: OmmlEquationProjection, measurer: TextMeasurer, style: ResolvedRunStyle): EquationSpanRecord;
 
 // @public
 export function layoutHeaderFooterStory(part: OoxmlPart, contentWidth: number, measurer: TextMeasurer, producer: string, cache?: ParagraphLayoutCache<readonly PendingLine[]>, styleCascade?: StyleCascadeTable, pageContext?: FieldPageContext, maxPageContextEntries?: number, defaultTabStopPt?: number, displayMode?: RevisionDisplayMode, inlineDrawingLayout?: InlineDrawingLayoutContext, drawingTokenForParagraph?: (paragraph: OoxmlNode) => string, drawingLayoutToken?: string, hfPageContext?: HeaderFooterPageContext, documentProperties?: DocumentProperties, inputs?: HeaderFooterStoryInputs): HeaderFooterStoryLayout;
@@ -2964,6 +3052,7 @@ export interface StyleSpanRecord {
     // (undocumented)
     readonly box: LayoutBox;
     readonly caretEdges?: readonly number[];
+    readonly equation?: EquationSpanRecord;
     readonly fieldAtom?: FieldAtomMarker;
     readonly link?: SpanLinkRecord;
     readonly noteNav?: {

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -977,6 +977,13 @@ export const DEFAULT_LIMITS: ResourceLimits;
 // @public
 export const DEFAULT_MAX_EDITABLE_STORY_PARTS = 64;
 
+// @public (undocumented)
+export const DEFAULT_OMML_LIMITS: Readonly<{
+    maxDepth: 24;
+    maxNodes: 256;
+    maxTextLength: 512;
+}>;
+
 // @public
 export const DEFAULT_OOXML_PACKAGE_LIMITS: Required<Pick<OoxmlPackageLimits, 'maxXmlParts' | 'maxRelationships'>>;
 
@@ -1218,6 +1225,40 @@ export function ensureListDefinition(pkg: OoxmlPackage, kind: ListKind): Ensured
 
 // @public
 export function ensureNumberingLevel(pkg: OoxmlPackage, numId: string, level: number, kind: ListKind): OoxmlPackage | null;
+
+// @public (undocumented)
+export type EquationExpression = {
+    readonly kind: 'row';
+    readonly items: readonly EquationExpression[];
+} | {
+    readonly kind: 'text';
+    readonly value: string;
+} | {
+    readonly kind: 'fraction';
+    readonly numerator: EquationExpression;
+    readonly denominator: EquationExpression;
+} | {
+    readonly kind: 'radical';
+    readonly radicand: EquationExpression;
+    readonly degree?: EquationExpression;
+} | {
+    readonly kind: 'script';
+    readonly base: EquationExpression;
+    readonly subscript?: EquationExpression;
+    readonly superscript?: EquationExpression;
+} | {
+    readonly kind: 'nary';
+    readonly operator: string;
+    readonly body: EquationExpression;
+    readonly lowerLimit?: EquationExpression;
+    readonly upperLimit?: EquationExpression;
+} | {
+    readonly kind: 'fallback';
+    readonly text: string;
+};
+
+// @public
+export function equationExpressionToLinearMath(expression: EquationExpression): string;
 
 // @public
 export function escapeCssString(value: string): string;
@@ -1887,6 +1928,31 @@ export interface LimitSpec {
 // @public
 export type LimitUnit = 'bytes' | 'count' | 'depth' | 'ratio' | 'passes';
 
+// @public (undocumented)
+export type LinearMathOmmlResult = {
+    readonly ok: true;
+    readonly expression: EquationExpression;
+    readonly equation: OoxmlGenericElementNode;
+} | {
+    readonly ok: false;
+    readonly reason: LinearMathRejection;
+};
+
+// @public (undocumented)
+export type LinearMathParseResult = {
+    readonly ok: true;
+    readonly expression: EquationExpression;
+} | {
+    readonly ok: false;
+    readonly reason: LinearMathRejection;
+};
+
+// @public (undocumented)
+export type LinearMathRejection = 'empty' | 'invalid-syntax' | 'invalid-xml-text' | 'depth-limit' | 'node-limit' | 'text-limit';
+
+// @public
+export function linearMathToOmml(input: string, nextId: NextNodeId, limits?: OmmlLimits): LinearMathOmmlResult;
+
 // @public
 export interface LinkableReviewItem {
     // (undocumented)
@@ -2169,6 +2235,9 @@ export function noteTypeOf(node: OoxmlNode): NoteType | undefined;
 export function nullRecord<T = unknown>(): Record<string, T>;
 
 // @public
+export const OFFICE_MATH_NAMESPACE_URI = "http://schemas.openxmlformats.org/officeDocument/2006/math";
+
+// @public
 export const OFFICE_RELATIONSHIP_NAMESPACE_URI = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
 // @public
@@ -2177,6 +2246,30 @@ export interface OffsetSpan {
     readonly end: number;
     // (undocumented)
     readonly start: number;
+}
+
+// @public (undocumented)
+export interface OmmlEquationProjection {
+    // (undocumented)
+    readonly expression: EquationExpression;
+    // (undocumented)
+    readonly fallbackText: string;
+    // (undocumented)
+    readonly sourceNodeId: OoxmlNodeId;
+    // (undocumented)
+    readonly truncated: boolean;
+    // (undocumented)
+    readonly visitedNodes: number;
+}
+
+// @public
+export interface OmmlLimits {
+    // (undocumented)
+    readonly maxDepth?: number;
+    // (undocumented)
+    readonly maxNodes?: number;
+    // (undocumented)
+    readonly maxTextLength?: number;
 }
 
 // @public
@@ -2947,6 +3040,9 @@ export function parseAuthoredNoteProperties(propsNode: OoxmlNode | null | undefi
 export function parseContentControlId(raw: string | undefined): number | undefined;
 
 // @public
+export function parseLinearMath(input: string, limits?: OmmlLimits): LinearMathParseResult;
+
+// @public
 export function parseNoteId(raw: string | undefined): number | null;
 
 // @public
@@ -3023,6 +3119,9 @@ export function projectDrawing(drawing: OoxmlDrawingNode, context: Readonly<{
     namespaceScope?: ReadonlyMap<string, string>;
     resolveRelationship?: RelationshipTargetResolver;
 }>): DrawingProjection | null;
+
+// @public
+export function projectOmmlEquation(node: OoxmlNode, limits?: OmmlLimits): OmmlEquationProjection | null;
 
 // @public
 export function propertyContainer(parent: OoxmlNode | null | undefined, kind: 'paragraphProperties' | 'runProperties', localName: 'pPr' | 'rPr'): OoxmlNode | undefined;
@@ -3781,7 +3880,7 @@ export interface TransportPort {
 }
 
 // @public
-export const TREE_DOC_OP_KINDS: readonly ["insertText", "deleteText", "setParagraphMarkRevision", "proposeParagraphMerge", "insertCommentMarker", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "insertTab", "insertHardBreak", "insertPageBreak", "insertPageField", "setListLevel", "setListNumbering", "setParagraphTabStops", "setParagraphMarkProperties", "splitParagraph", "splitParagraphMany", "joinParagraphs", "setRunProperties", "setParagraphProperties", "setSectionProperties", "setSectionMark", "insertHyperlink", "setHyperlinkTarget", "removeHyperlink", "setContentControlValue", "removeContentControl", "insertInlineContentControl", "addRepeatingSectionItem", "removeRepeatingSectionItem", "deleteBlock", "insertTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn", "setTableColumnWidths", "setTableRightEdgeWidth", "setTableRowHeight", "setTableCellBorders", "setTableCellFill", "setTableCellVerticalAlignment", "createHeaderFooter", "deleteHeaderFooter", "linkToPrevious", "unlinkFromPrevious", "setSectionFurnitureOptions", "insertNote", "deleteNote", "convertNote", "convertAllNotes", "setNoteProperties", "setContentControlProperties", "insertContentControl", "insertDrawing", "replaceDrawingResource", "deleteDrawing", "resizeDrawing", "cropDrawing", "positionDrawing", "setDrawingWrap", "setDrawingMetadata", "setDrawingLocks", "transformDrawing", "insertToc", "replaceTocResult", "rewriteTocPageNumbers"];
+export const TREE_DOC_OP_KINDS: readonly ["insertText", "deleteText", "setParagraphMarkRevision", "proposeParagraphMerge", "insertCommentMarker", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "insertTab", "insertHardBreak", "insertPageBreak", "insertPageField", "setListLevel", "setListNumbering", "setParagraphTabStops", "setParagraphMarkProperties", "splitParagraph", "splitParagraphMany", "joinParagraphs", "setRunProperties", "setParagraphProperties", "setSectionProperties", "setSectionMark", "insertHyperlink", "setHyperlinkTarget", "removeHyperlink", "setMathEquation", "removeMathEquation", "setContentControlValue", "removeContentControl", "insertInlineContentControl", "addRepeatingSectionItem", "removeRepeatingSectionItem", "deleteBlock", "insertTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn", "setTableColumnWidths", "setTableRightEdgeWidth", "setTableRowHeight", "setTableCellBorders", "setTableCellFill", "setTableCellVerticalAlignment", "createHeaderFooter", "deleteHeaderFooter", "linkToPrevious", "unlinkFromPrevious", "setSectionFurnitureOptions", "insertNote", "deleteNote", "convertNote", "convertAllNotes", "setNoteProperties", "setContentControlProperties", "insertContentControl", "insertDrawing", "replaceDrawingResource", "deleteDrawing", "resizeDrawing", "cropDrawing", "positionDrawing", "setDrawingWrap", "setDrawingMetadata", "setDrawingLocks", "transformDrawing", "insertToc", "replaceTocResult", "rewriteTocPageNumbers"];
 
 // @public
 export type TreeDocOp = {
@@ -3933,6 +4032,13 @@ export type TreeDocOp = {
 } | {
     readonly op: 'removeHyperlink';
     readonly linkId: string;
+} | {
+    readonly op: 'setMathEquation';
+    readonly equationId: string;
+    readonly linear: string;
+} | {
+    readonly op: 'removeMathEquation';
+    readonly equationId: string;
 } | {
     readonly op: 'insertInlineContentControl';
     readonly paragraphId: string;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -437,6 +437,9 @@ export interface DocxEditorDocumentOutlineProps {
 }
 
 // @public
+export function DocxEditorEquation(): react.JSX.Element | null;
+
+// @public
 export function DocxEditorFontNotice(input: DocxEditorFontNoticeProps): react.JSX.Element | null;
 
 // @public
@@ -585,6 +588,7 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<DocxEdito
     readonly ContentControl: typeof DocxEditorContentControl;
     readonly ContextMenu: typeof ContextMenu;
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
+    readonly Equation: typeof DocxEditorEquation;
     readonly FontNotice: typeof DocxEditorFontNotice;
     readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
     readonly HorizontalRuler: typeof DocxEditorHorizontalRuler;

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -2045,6 +2045,11 @@ export interface DocxEditorDocumentOutlineProps {
     topOffset?: number;
 }
 
+// @public
+export const DocxEditorEquation: vue.DefineComponent<{}, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
+    [key: string]: any;
+}> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+
 // @public (undocumented)
 export const DocxEditorFontNotice: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
@@ -2354,6 +2359,7 @@ export interface DocxEditorNamespace {
     readonly ContextMenu: typeof ContextMenu;
     // (undocumented)
     readonly DocumentOutline: typeof DocxEditorDocumentOutline;
+    readonly Equation: typeof DocxEditorEquation;
     // (undocumented)
     readonly FontNotice: typeof DocxEditorFontNotice;
     // (undocumented)

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -686,6 +686,7 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
                   scrolling. `<DocxEditor>` mounts it for you; a composition like this one
                   places it by name, exactly like the rulers above. */}
               <DocxEditor.HyperLink />
+              <DocxEditor.Equation />
               {/* The review rail (PRO): tracked changes and comments as cards beside the
                   page, with accept / reject / reply. Imported from
                   `@docx-editor.dev/pro/react` and enabled by the `reviewModule()` on the

--- a/openspec/changes/mathematical-equations/.openspec.yaml
+++ b/openspec/changes/mathematical-equations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/mathematical-equations/design.md
+++ b/openspec/changes/mathematical-equations/design.md
@@ -1,0 +1,66 @@
+## Context
+
+OMML elements are preserved as generic canonical nodes. Paragraph projection ignores those nodes, so equations consume no model offset and paint no content. The sample document uses inline `m:oMath` with text runs, fractions, radicals, superscripts, and n-ary operators.
+
+Layout is DOM-free and owns all geometry. Paint cannot measure an equation after layout. The canonical tree remains the only editable authority, and adapters own transient chrome.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Display the OMML subset used by `sample.docx` with stable layout geometry.
+- Treat each equation as one selectable model atom.
+- Preserve unknown OMML and provide a visible bounded fallback.
+- Edit and delete equations through one transaction.
+- Keep React and Vue behavior equivalent.
+
+**Non-Goals:**
+
+- Implement every OMML element in the first change.
+- Execute embedded field codes or external resources.
+- Add a full visual equation builder.
+- Convert arbitrary LaTeX.
+
+## Decisions
+
+### Keep OMML generic and add a bounded semantic projector
+
+The canonical parser will continue to preserve OMML as generic nodes. A layout projector will recognize the Office Math namespace and produce an immutable equation expression tree. This avoids widening the canonical typed vocabulary before mutation needs stable identities.
+
+The projector will cap node count, nesting depth, and text length. Unsupported structures will flatten their bounded descendant text instead of disappearing.
+
+Typing every OMML element was rejected. It would add a large validation surface without improving the initial display and edit paths.
+
+### Publish equations as one model atom
+
+Each `m:oMath` will contribute one UTF-16 object-replacement unit. Its layout span will carry equation metadata, source identity, and measured geometry. Caret and hit testing will use the atom boundaries.
+
+Treating equation text as ordinary paragraph text was rejected. Internal OMML text is not an editable WordprocessingML run sequence, and exposing its offsets would create invalid tree operations.
+
+### Use a small internal equation layout engine
+
+The layout engine will measure text with the injected `TextMeasurer`. It will compose boxes for rows, fractions, radicals, scripts, and n-ary operators. Paint will consume those boxes without measuring.
+
+MathML or KaTeX was rejected. MathML geometry is browser-owned, while layout must remain DOM-free. KaTeX would add a large runtime and stylesheet dependency.
+
+### Paint safe nested DOM from semantic records
+
+Paint will create equation elements with `createElement`, `textContent`, and inline geometry. It will never insert OMML-derived HTML. The equation root will carry the source node id for selection and popover activation.
+
+### Use explicit equation tree operations
+
+The store will add operations to replace or remove an equation node. A bounded linear-math parser will build the supported OMML subset with fresh canonical ids. Apply and delete will each use one transaction.
+
+Direct adapter mutation was rejected because it would bypass undo, revision tracking, and canonical validation.
+
+### Follow the hyperlink chrome seam
+
+The surface will classify an equation click and publish the equation plus its viewport rectangle. React and Vue will register one equation popover handler and render equivalent default controls. The input will accept `^`, `_`, `{a}/{b}`, `√{x}`, and `∑[n]{x}` forms.
+
+## Risks / Trade-offs
+
+- [The first projector supports only part of OMML] → Preserve all source XML and show bounded descendant text for unsupported structures.
+- [Equation metrics can differ from Word] → Use one deterministic point-based composer and add sample geometry tests.
+- [Large hostile OMML can consume CPU] → Enforce depth, node, and text budgets before composition.
+- [One atom prevents internal caret editing] → Open the linear editor for the complete equation and replace it atomically.
+- [Adapter chrome can drift] → Share engine state and add cross-adapter behavior tests.

--- a/openspec/changes/mathematical-equations/proposal.md
+++ b/openspec/changes/mathematical-equations/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The editor preserves Office Math Markup Language (OMML), but it does not display or edit equations. The equations in `sample.docx` therefore disappear from the editable page.
+
+## What Changes
+
+- Project bounded OMML equation trees into layout-owned inline equation atoms.
+- Display fractions, radicals, scripts, and n-ary operators used by `sample.docx`.
+- Keep unsupported OMML content visible through a bounded text fallback.
+- Let users select an equation and edit it with a compact linear-math syntax.
+- Apply or delete an equation as one document transaction.
+- Preserve unedited OMML during save and reopen.
+
+## Capabilities
+
+### New Capabilities
+
+- `mathematical-equations`: Defines bounded OMML projection, equation display, selection, editing, deletion, and save fidelity.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This change affects the canonical tree operation vocabulary, semantic layout records, semantic paint, editor surface interaction, React and Vue chrome, and shared styles. It adds no runtime dependency.

--- a/openspec/changes/mathematical-equations/specs/mathematical-equations/spec.md
+++ b/openspec/changes/mathematical-equations/specs/mathematical-equations/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Bounded OMML projection
+
+The engine SHALL project inline `m:oMath` content with bounded work. It SHALL preserve unsupported OMML in the canonical tree.
+
+#### Scenario: Supported sample equations
+
+- **WHEN** the engine opens `sample.docx`
+- **THEN** it projects the quadratic formula, Einstein equation, and summation equation
+
+#### Scenario: Unsupported OMML element
+
+- **WHEN** an equation contains an unsupported OMML structure
+- **THEN** the engine displays its bounded descendant text without changing the source tree
+
+#### Scenario: Hostile equation depth
+
+- **WHEN** an equation exceeds the configured nesting or node budget
+- **THEN** the projector stops boundedly and returns a safe fallback
+
+### Requirement: Equation layout and paint
+
+The engine SHALL publish equation geometry from DOM-free layout. Paint SHALL use that geometry without parsing source OMML.
+
+#### Scenario: Fraction and radical display
+
+- **WHEN** an equation contains `m:f` and `m:rad`
+- **THEN** paint displays a fraction bar and radical around the projected operands
+
+#### Scenario: Script and n-ary display
+
+- **WHEN** an equation contains `m:sSup` or `m:nary`
+- **THEN** paint places scripts and limits around the projected base or operator
+
+#### Scenario: Safe paint
+
+- **WHEN** OMML text contains markup-like attacker-controlled characters
+- **THEN** paint writes them through text nodes and creates no HTML from the string
+
+### Requirement: Atomic equation interaction
+
+The editor SHALL treat each inline equation as one selectable model atom.
+
+#### Scenario: Click equation
+
+- **WHEN** a user clicks a painted equation
+- **THEN** the editor selects its atom and requests the equation editor at its viewport rectangle
+
+#### Scenario: Caret navigation
+
+- **WHEN** a caret moves across an equation
+- **THEN** it moves between the equation atom boundaries without entering internal OMML nodes
+
+### Requirement: Linear equation editing
+
+The editor SHALL let a user replace a selected equation through a bounded linear-math syntax.
+
+#### Scenario: Apply supported syntax
+
+- **WHEN** a user applies text containing supported fractions, radicals, scripts, or summations
+- **THEN** the editor replaces the equation in one undoable transaction
+
+#### Scenario: Refuse invalid syntax
+
+- **WHEN** a user applies malformed or over-budget linear math
+- **THEN** the editor keeps the prior equation and reports the refusal
+
+#### Scenario: Delete equation
+
+- **WHEN** a user selects Delete in the equation editor
+- **THEN** the editor removes the equation in one undoable transaction
+
+### Requirement: Save fidelity
+
+The editor SHALL preserve unedited OMML and serialize edited equations as valid namespaced OMML.
+
+#### Scenario: Unedited equation round trip
+
+- **WHEN** a document with equations is saved without equation edits
+- **THEN** its canonical OOXML fingerprint remains unchanged
+
+#### Scenario: Edited equation round trip
+
+- **WHEN** an edited equation is saved and reopened
+- **THEN** the reopened equation projects to the applied expression
+
+### Requirement: Adapter parity
+
+React and Vue SHALL provide equivalent default equation popovers over the same engine operations.
+
+#### Scenario: Default popover
+
+- **WHEN** a user clicks an equation in either packaged editor
+- **THEN** a popover shows the linear input, Apply action, Delete action, and syntax help

--- a/openspec/changes/mathematical-equations/tasks.md
+++ b/openspec/changes/mathematical-equations/tasks.md
@@ -1,0 +1,29 @@
+## 1. OMML projection
+
+- [x] 1.1 Add bounded OMML expression projection with text fallback
+- [x] 1.2 Add linear-math parsing and OMML serialization for the supported subset
+- [x] 1.3 Add projector and parser tests for sample, malformed, and hostile inputs
+
+## 2. Layout and paint
+
+- [x] 2.1 Publish each inline equation as one model atom with deterministic geometry
+- [x] 2.2 Paint fraction, radical, script, and n-ary expression boxes safely
+- [x] 2.3 Add sample layout, paint, offset, and round-trip tests
+
+## 3. Editing
+
+- [x] 3.1 Add atomic equation replace and remove tree operations
+- [x] 3.2 Add equation discovery, selection, click activation, and surface operations
+- [x] 3.3 Add editor operation and undo tests
+
+## 4. Adapter chrome
+
+- [x] 4.1 Add shared i18n strings and styles for equation editing
+- [x] 4.2 Add the default React equation popover and behavior tests
+- [x] 4.3 Add the equivalent Vue equation popover and parity tests
+
+## 5. Verification
+
+- [x] 5.1 Run focused equation tests and package type checks
+- [x] 5.2 Run formatting, lint, parity, API, i18n, and strict OpenSpec validation
+- [x] 5.3 Add a minor changeset for additive equation support

--- a/packages/core/src/editor/__tests__/equation-editing.test.ts
+++ b/packages/core/src/editor/__tests__/equation-editing.test.ts
@@ -118,6 +118,17 @@ describe('atomic equation editing', () => {
     expect(editor.surface!.session.packageRevision()).toBe(revision);
   });
 
+  test('reuses equation metadata without exposing the cached paragraph array', () => {
+    const { editor } = mounted();
+    const first = editor.surface!.equations.equationsInCaretParagraph();
+    const second = editor.surface!.equations.equationsInCaretParagraph();
+
+    expect(second).not.toBe(first);
+    expect(second[0]).toBe(first[0]);
+    first.splice(0);
+    expect(editor.surface!.equations.equationsInCaretParagraph()).toHaveLength(1);
+  });
+
   test('a painted equation click selects its atom and requests chrome', () => {
     const { editor, paragraphId, container } = mounted();
     const seen: string[] = [];

--- a/packages/core/src/editor/__tests__/equation-editing.test.ts
+++ b/packages/core/src/editor/__tests__/equation-editing.test.ts
@@ -1,0 +1,154 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { createDocxEditor } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const M = 'http://schemas.openxmlformats.org/officeDocument/2006/math';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function docx(): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(`<Relationships xmlns="${REL}"/>`),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:m="${M}"><w:body><w:p>` +
+        '<w:r><w:t>A</w:t></w:r>' +
+        '<m:oMath><m:r><m:t>x</m:t></m:r></m:oMath>' +
+        '<w:r><w:t>Z</w:t></w:r>' +
+        '</w:p></w:body></w:document>'
+    ),
+  });
+}
+
+function mounted(author?: string) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({
+    container,
+    document: docx(),
+    ...(author ? { author } : {}),
+  });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  const paragraphId = '/word/document.xml#0.0.0';
+  editor.surface.setSelection({
+    anchor: { paragraphId, offset: 1 },
+    head: { paragraphId, offset: 1 },
+  });
+  return { editor, paragraphId, container };
+}
+
+describe('atomic equation editing', () => {
+  test('discovers and replaces the equation at the caret', () => {
+    const { editor } = mounted();
+    const equation = editor.surface!.equations.equationAtCaret();
+    expect(equation).toMatchObject({ start: 1, end: 2, linear: 'x' });
+    expect(editor.surface!.equations.applyEquation(equation!.id, '{a+b}/{2}')).toBe(true);
+    expect(editor.surface!.session.bodyText()).toBe('A\uFFFCZ');
+    expect(editor.surface!.equations.equationById(equation!.id)?.linear).toBe('{a+b}/{2}');
+  });
+
+  test('replace and remove are each one undo step', () => {
+    const { editor, paragraphId } = mounted();
+    const equation = editor.surface!.equations.equationAtCaret()!;
+    editor.surface!.equations.applyEquation(equation.id, 'x^2');
+    editor.exec({ type: 'undo' });
+    editor.surface!.setSelection({
+      anchor: { paragraphId, offset: 1 },
+      head: { paragraphId, offset: 1 },
+    });
+    expect(editor.surface!.equations.equationAtCaret()?.linear).toBe('x');
+
+    expect(editor.surface!.equations.removeEquation(equation.id)).toBe(true);
+    expect(editor.surface!.session.bodyText()).toBe('AZ');
+    editor.exec({ type: 'undo' });
+    expect(editor.surface!.session.bodyText()).toBe('A\uFFFCZ');
+  });
+
+  test('refuses malformed input without changing the equation', () => {
+    const { editor } = mounted();
+    const equation = editor.surface!.equations.equationAtCaret()!;
+    expect(editor.surface!.equations.applyEquation(equation.id, 'x^')).toBe(false);
+    expect(editor.surface!.equations.equationById(equation.id)?.linear).toBe('x');
+  });
+
+  test('refuses replace and remove while suggesting without an untracked edit', () => {
+    const { editor } = mounted('Revision Author');
+    const surface = editor.surface!;
+    const equation = surface.equations.equationAtCaret()!;
+    const reason = 'equation replacement and removal are not supported in suggesting mode';
+    const revision = surface.session.packageRevision();
+    surface.setEditingMode('suggest');
+
+    expect(surface.equations.can(equation.id, 'replace')).toEqual({
+      ok: false,
+      code: 'unsupported',
+      reason,
+    });
+    expect(surface.equations.can(equation.id, 'remove')).toEqual({
+      ok: false,
+      code: 'unsupported',
+      reason,
+    });
+    expect(surface.equations.applyEquation(equation.id, 'x^2')).toBe(false);
+    expect(surface.equations.removeEquation(equation.id)).toBe(false);
+
+    expect(surface.session.packageRevision()).toBe(revision);
+    expect(surface.equations.equationById(equation.id)?.linear).toBe('x');
+    expect(surface.session.bodyText()).toBe('A\uFFFCZ');
+    expect(surface.state().lastRejection).toBe(reason);
+  });
+
+  test('does not invalidate layout for unchanged supported math', () => {
+    const { editor } = mounted();
+    const equation = editor.surface!.equations.equationAtCaret()!;
+    const revision = editor.surface!.session.packageRevision();
+    expect(editor.surface!.equations.applyEquation(equation.id, equation.linear)).toBe(true);
+    expect(editor.surface!.session.packageRevision()).toBe(revision);
+  });
+
+  test('a painted equation click selects its atom and requests chrome', () => {
+    const { editor, paragraphId, container } = mounted();
+    const seen: string[] = [];
+    editor.setEquationChrome({
+      onPopover: (activation) => seen.push(activation.equation.id),
+    });
+    const equation = editor.surface!.equations.equationAtCaret()!;
+    const painted = container.querySelector<HTMLElement>('[data-docx-equation]')!;
+    painted.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(seen).toEqual([equation.id]);
+    expect(editor.surface!.state().selection).toEqual({
+      anchor: { paragraphId, offset: 1 },
+      head: { paragraphId, offset: 2 },
+    });
+  });
+
+  test('a press survives the selection repaint before click activation', () => {
+    const { editor, container } = mounted();
+    const seen: string[] = [];
+    editor.setEquationChrome({
+      onPopover: (activation) => seen.push(activation.equation.id),
+    });
+    const equation = editor.surface!.equations.equationAtCaret()!;
+    const painted = container.querySelector<HTMLElement>('[data-docx-equation]')!;
+    const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+
+    painted.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
+    painted.remove();
+    pages.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(seen).toEqual([equation.id]);
+  });
+});

--- a/packages/core/src/editor/__tests__/equation-sample-integration.test.ts
+++ b/packages/core/src/editor/__tests__/equation-sample-integration.test.ts
@@ -1,0 +1,259 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import {
+  OFFICE_MATH_NAMESPACE_URI,
+  applyTreeOp,
+  canonicalOoxmlFingerprint,
+  equationExpressionToLinearMath,
+  findNode,
+  projectOmmlEquation,
+  readOoxmlPackage,
+  type EquationExpression,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  createParagraphLayoutCache,
+  layoutSemanticDocument,
+  type SemanticLayout,
+} from '@docx-editor.dev/core/layout';
+import { openTreeSession } from '../../binding/tree-session.ts';
+import { createDocxEditor } from '../docx-editor.ts';
+import { createKeyDownHandler } from '../surface-input.ts';
+
+const sample = (): Uint8Array =>
+  new Uint8Array(
+    readFileSync(new URL('../../../../../examples/vite/public/sample.docx', import.meta.url))
+  );
+
+function* walk(node: OoxmlNode): Generator<OoxmlNode> {
+  yield node;
+  if (node.kind === 'textValue') return;
+  for (const child of node.children) yield* walk(child);
+}
+
+function equationsOf(part: OoxmlPart): OoxmlElement[] {
+  return [...walk(part.root)].filter(
+    (node): node is OoxmlElement =>
+      node.kind !== 'textValue' &&
+      node.namespaceUri === OFFICE_MATH_NAMESPACE_URI &&
+      node.localName === 'oMath'
+  );
+}
+
+function expressionKinds(expression: EquationExpression): string[] {
+  switch (expression.kind) {
+    case 'row':
+      return [expression.kind, ...expression.items.flatMap(expressionKinds)];
+    case 'fraction':
+      return [
+        expression.kind,
+        ...expressionKinds(expression.numerator),
+        ...expressionKinds(expression.denominator),
+      ];
+    case 'radical':
+      return [
+        expression.kind,
+        ...(expression.degree ? expressionKinds(expression.degree) : []),
+        ...expressionKinds(expression.radicand),
+      ];
+    case 'script':
+      return [
+        expression.kind,
+        ...expressionKinds(expression.base),
+        ...(expression.subscript ? expressionKinds(expression.subscript) : []),
+        ...(expression.superscript ? expressionKinds(expression.superscript) : []),
+      ];
+    case 'nary':
+      return [
+        expression.kind,
+        ...expressionKinds(expression.body),
+        ...(expression.lowerLimit ? expressionKinds(expression.lowerLimit) : []),
+        ...(expression.upperLimit ? expressionKinds(expression.upperLimit) : []),
+      ];
+    default:
+      return [expression.kind];
+  }
+}
+
+function openSamplePart(): OoxmlPart {
+  const opened = readOoxmlPackage(sample());
+  if (!opened.ok) throw new Error(opened.reason);
+  const part = opened.package.parts.get(opened.package.mainDocumentPart);
+  if (!part) throw new Error('sample.docx has no main document part');
+  return part;
+}
+
+const shapeOf = (layout: SemanticLayout): string => JSON.stringify(layout.pages);
+
+function pageWithEquation(layout: SemanticLayout, equationId: string): number {
+  return layout.pages.findIndex((page) =>
+    page.fragments.some(
+      (fragment) =>
+        'lines' in fragment &&
+        fragment.lines.some((line) =>
+          line.spans.some((span) => span.equation?.sourceNodeId === equationId)
+        )
+    )
+  );
+}
+
+const mountedEditors: ReturnType<typeof createDocxEditor>[] = [];
+
+afterEach(() => {
+  for (const editor of mountedEditors.splice(0)) editor.destroy();
+  document.body.innerHTML = '';
+});
+
+describe('sample.docx equation integration', () => {
+  test('projects the authored quadratic, Einstein, and summation structures', () => {
+    const equations = equationsOf(openSamplePart());
+    expect(equations).toHaveLength(3);
+
+    const projections = equations.map((equation) => {
+      const projection = projectOmmlEquation(equation);
+      if (!projection) throw new Error(`could not project ${equation.id}`);
+      return {
+        fallbackText: projection.fallbackText,
+        kinds: expressionKinds(projection.expression),
+        linear: equationExpressionToLinearMath(projection.expression),
+      };
+    });
+
+    const [quadratic, einstein, summation] = projections;
+    expect(quadratic?.kinds).toEqual(expect.arrayContaining(['fraction', 'radical']));
+    expect(quadratic?.linear).toBe('x = {-b ± √{b² - 4ac}}/{2a}');
+    expect(einstein?.kinds).toContain('script');
+    expect(einstein?.fallbackText).toBe('E = mc2');
+    expect(summation?.kinds).toContain('nary');
+    expect(summation?.linear).toBe('∑[i=1]^[n]{i}');
+  });
+
+  test('exposes a reversible linear form for the authored Einstein equation', () => {
+    const equation = equationsOf(openSamplePart())[1]!;
+    const projection = projectOmmlEquation(equation);
+    if (!projection) throw new Error(`could not project ${equation.id}`);
+    expect(equationExpressionToLinearMath(projection.expression)).toBe('E = mc^{2}');
+  });
+
+  test('preserves unedited OMML and reopens an edited equation from package bytes', () => {
+    const opened = openTreeSession(sample());
+    if (!opened.ok) throw new Error(opened.reason);
+    const session = opened.session;
+    const before = canonicalOoxmlFingerprint(session.part());
+
+    const unedited = readOoxmlPackage(session.save());
+    if (!unedited.ok) throw new Error(unedited.reason);
+    const uneditedPart = unedited.package.parts.get(unedited.package.mainDocumentPart)!;
+    expect(canonicalOoxmlFingerprint(uneditedPart)).toBe(before);
+
+    const equation = equationsOf(session.part())[0]!;
+    const applied = session.applyTreeOps([
+      { op: 'setMathEquation', equationId: equation.id, linear: '{a+b}/{2}' },
+    ]);
+    expect(applied).toMatchObject({ committed: true, rejected: false });
+
+    const edited = readOoxmlPackage(session.save());
+    if (!edited.ok) throw new Error(edited.reason);
+    const editedPart = edited.package.parts.get(edited.package.mainDocumentPart)!;
+    const reopenedEquation = findNode(editedPart, equation.id);
+    if (!reopenedEquation || reopenedEquation.kind === 'textValue') {
+      throw new Error('edited equation did not reopen');
+    }
+    const projection = projectOmmlEquation(reopenedEquation);
+    expect(projection?.expression.kind).toBe('fraction');
+    expect(equationExpressionToLinearMath(projection!.expression)).toBe('{a+b}/{2}');
+  });
+
+  test('reconverges equation layout and preserves page identity', () => {
+    const part = openSamplePart();
+    const equation = equationsOf(part)[0]!;
+    const measurer = createFixedMeasurer(6, 14);
+    const cache = createParagraphLayoutCache<never>();
+    const session = createLayoutSession();
+    const options = { measurer, cache: cache as never, session };
+
+    const first = layoutSemanticDocument(part, 1, options);
+    const unchanged = layoutSemanticDocument(part, 2, options);
+    expect(session.stats.placed).toBe(0);
+    expect(unchanged.pages.every((page, index) => page === first.pages[index])).toBe(true);
+
+    const changed = applyTreeOp(part, {
+      op: 'setMathEquation',
+      equationId: equation.id,
+      linear: '{a+b}/{2}+√{x}+x^2',
+    });
+    if (!changed.ok) throw new Error(changed.reason);
+    const incremental = layoutSemanticDocument(changed.part, 3, options);
+    const clean = layoutSemanticDocument(changed.part, 3, { measurer });
+    expect(shapeOf(incremental)).toBe(shapeOf(clean));
+
+    const equationPage = pageWithEquation(first, equation.id);
+    expect(equationPage).toBeGreaterThanOrEqual(0);
+    expect(incremental.pages[equationPage]).not.toBe(first.pages[equationPage]);
+    expect(
+      incremental.pages.some((page, index) => index !== equationPage && page === first.pages[index])
+    ).toBe(true);
+
+    const converged = layoutSemanticDocument(changed.part, 4, options);
+    expect(session.stats.placed).toBe(0);
+    expect(converged.pages.every((page, index) => page === incremental.pages[index])).toBe(true);
+  });
+
+  test('moves ArrowRight across one atom and reports the painted activation rect', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const editor = createDocxEditor({ container, document: sample() });
+    mountedEditors.push(editor);
+    const surface = editor.surface;
+    if (!surface) throw new Error('sample.docx surface did not mount');
+
+    const source = equationsOf(surface.session.part())[0]!;
+    const equation = surface.equations.equationById(source.id);
+    if (!equation) throw new Error('sample equation is not addressable');
+    surface.setSelection({
+      anchor: { paragraphId: equation.paragraphId, offset: equation.start },
+      head: { paragraphId: equation.paragraphId, offset: equation.start },
+    });
+
+    createKeyDownHandler(surface)(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+    );
+    expect(surface.state().selection).toEqual({
+      anchor: { paragraphId: equation.paragraphId, offset: equation.end },
+      head: { paragraphId: equation.paragraphId, offset: equation.end },
+    });
+
+    const painted = [...container.querySelectorAll<HTMLElement>('[data-docx-equation]')].find(
+      (element) => element.dataset.docxEquation === equation.id
+    );
+    if (!painted) throw new Error('sample equation was not painted');
+    Object.defineProperty(painted, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({
+          left: 11,
+          top: 22,
+          right: 44,
+          bottom: 66,
+          x: 11,
+          y: 22,
+          width: 33,
+          height: 44,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    });
+    const activations: { rect: { left: number; top: number; right: number; bottom: number } }[] =
+      [];
+    editor.setEquationChrome({ onPopover: (activation) => activations.push(activation) });
+    painted.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    expect(activations).toHaveLength(1);
+    expect(activations[0]!.rect).toEqual({ left: 11, top: 22, right: 44, bottom: 66 });
+  });
+});

--- a/packages/core/src/editor/chrome-handler-stack.ts
+++ b/packages/core/src/editor/chrome-handler-stack.ts
@@ -1,0 +1,19 @@
+/** Last-mounted chrome handlers with order-independent disposal. */
+export function createChromeHandlerStack<T extends object>(
+  empty: T
+): {
+  readonly current: () => T;
+  readonly push: (handlers: T) => () => void;
+} {
+  const stack: T[] = [];
+  return {
+    current: () => stack[stack.length - 1] ?? empty,
+    push: (handlers) => {
+      stack.push(handlers);
+      return () => {
+        const at = stack.lastIndexOf(handlers);
+        if (at >= 0) stack.splice(at, 1);
+      };
+    },
+  };
+}

--- a/packages/core/src/editor/docx-editor-types.ts
+++ b/packages/core/src/editor/docx-editor-types.ts
@@ -21,6 +21,7 @@ import type {
 import type { FontConfigurationFragment, FontResolver } from './font-composition.ts';
 import type { PaginatedSurface } from './paginated-surface.ts';
 import type { HyperlinkActivation } from './surface-navigation.ts';
+import type { EquationActivation } from './surface-equations.ts';
 
 /**
  * Everything {@link createDocxEditor} accepts. Every field is optional.
@@ -159,6 +160,11 @@ export interface HyperlinkChromeHandlers {
   readonly onRequest?: () => void;
 }
 
+/** Host chrome that edits a clicked Office Math equation. */
+export interface EquationChromeHandlers {
+  readonly onPopover?: (activation: EquationActivation) => void;
+}
+
 /**
  * The concrete facade type: the full `Editor` contract plus the instance-only surface.
  *
@@ -183,6 +189,8 @@ export interface DocxEditorInstance extends Editor {
    * command needs.
    */
   setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
+  /** Wire the host equation popover to painted equation clicks. */
+  setEquationChrome(handlers: EquationChromeHandlers): Unsubscribe;
   /**
    * Monotonic version of the observable editor state. Bumps whenever anything
    * `snapshot()` reports could have moved — a committed change, a selection move, zoom,

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -191,15 +191,18 @@ import {
   resolveOpeningEditingMode,
 } from './opening-editing-mode.ts';
 import { createRevisionStyleState, EMPTY_AUTHOR_SLOTS } from './revision-style-state.ts';
+import { createChromeHandlerStack } from './chrome-handler-stack.ts';
 import type {
   DocxEditorConfig,
   DocxEditorInstance,
+  EquationChromeHandlers,
   HyperlinkChromeHandlers,
 } from './docx-editor-types.ts';
 
 export type {
   DocxEditorConfig,
   DocxEditorInstance,
+  EquationChromeHandlers,
   FontMeasurementState,
   HyperlinkChromeHandlers,
 } from './docx-editor-types.ts';
@@ -305,19 +308,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   let lastPendingFormat: PaginatedSurfaceState['pendingFormat'] = null;
   /** Furniture scope key — chrome must wake even when caret text offsets did not move. */
   let lastHeaderFooterKey: string | null = null;
-  /**
-   * Registered hyperlink chrome, as a STACK — the top entry is live.
-   *
-   * Save-and-restore only survives strictly nested teardown. Two hosts registering and then
-   * unregistering out of order (React does not promise effect-cleanup order between
-   * siblings) had the outer one's cleanup resurrect a handler whose owner had already
-   * unmounted: the engine went on reporting chrome as wired while every click and Ctrl+K
-   * called into a dead component, and the popover silently stopped opening. Splicing by
-   * identity is order-independent.
-   */
-  const hyperlinkChromeStack: HyperlinkChromeHandlers[] = [];
-  const liveHyperlinkChrome = (): HyperlinkChromeHandlers =>
-    hyperlinkChromeStack[hyperlinkChromeStack.length - 1] ?? {};
+  const hyperlinkChrome = createChromeHandlerStack<HyperlinkChromeHandlers>({});
+  const equationChrome = createChromeHandlerStack<EquationChromeHandlers>({});
   let destroyed = false;
 
   /** The measurer built per LOAD from `config.fonts` plus the document's embedded faces. */
@@ -555,8 +547,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // Read through the holder rather than captured: the popover mounts AFTER the editor
       // exists (the provider-first shape), and a document that reloads must not leave the
       // host's chrome wired to the surface it replaced.
-      onHyperlinkPopover: (activation) => liveHyperlinkChrome().onPopover?.(activation),
-      onRequestHyperlink: () => liveHyperlinkChrome().onRequest?.(),
+      onHyperlinkPopover: (activation) => hyperlinkChrome.current().onPopover?.(activation),
+      onRequestHyperlink: () => hyperlinkChrome.current().onRequest?.(),
+      onEquationPopover: (activation) => equationChrome.current().onPopover?.(activation),
       onTrackedChange: () => {
         if (reviewPaneOpen) return;
         reviewPaneOpen = true;
@@ -1739,16 +1732,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       return surface;
     },
 
-    setHyperlinkChrome(handlers) {
-      hyperlinkChromeStack.push(handlers);
-      return () => {
-        // Splice by IDENTITY, not by position: unregistering out of order must remove this
-        // entry and leave whatever else is registered alone, never resurrect a handler whose
-        // owner has already torn down.
-        const at = hyperlinkChromeStack.lastIndexOf(handlers);
-        if (at >= 0) hyperlinkChromeStack.splice(at, 1);
-      };
-    },
+    setHyperlinkChrome: hyperlinkChrome.push,
+
+    setEquationChrome: equationChrome.push,
 
     stateVersion: () => stateVersion,
 

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -155,6 +155,7 @@ export {
   createDocxEditor,
   type DocxEditorInstance,
   type DocxEditorConfig,
+  type EquationChromeHandlers,
   type HyperlinkChromeHandlers,
 } from './docx-editor.ts';
 // `DocxEditorInstance.fontMeasurement()` returns it, so the lane that exports the instance
@@ -274,6 +275,12 @@ export {
   type ImageResourceLimits,
 } from '../store/runtime/limits.ts';
 export type { HyperlinkOps, SurfaceHyperlink } from './surface-hyperlinks.ts';
+export {
+  equationAtPosition,
+  type EquationActivation,
+  type EquationOps,
+  type SurfaceEquation,
+} from './surface-equations.ts';
 export type { HyperlinkActivation, SurfaceNavigation } from './surface-navigation.ts';
 // The types an adapter needs to CALL the surface, re-exported from the composition root.
 // Adapters may depend on this package and not on the layout lane, so a host reaching into

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -20,6 +20,7 @@ import type { RevisionStyles } from '../output/revision-presentation.ts';
 import type { FieldShadingMode } from '../output/semantic-paint.ts';
 import type { ReviewModuleContribution } from '../contracts/modules.ts';
 import type { HyperlinkOps } from './surface-hyperlinks.ts';
+import type { EquationActivation, EquationOps } from './surface-equations.ts';
 import type { HyperlinkActivation, SurfaceNavigation } from './surface-navigation.ts';
 import type {
   CellSelection,
@@ -165,6 +166,7 @@ export interface PaginatedSurfaceOptions {
    * activation (see the navigation module's single `window.open` gate).
    */
   readonly onHyperlinkPopover?: (activation: HyperlinkActivation) => void;
+  readonly onEquationPopover?: (activation: EquationActivation) => void;
   /**
    * Ctrl/Cmd+K — Word's Insert Hyperlink. The engine reports the request; the host's chrome
    * decides what a link dialog looks like. A host that passes nothing leaves the key alone
@@ -680,6 +682,7 @@ export interface PaginatedSurface {
    * projection, so a caller cannot accidentally hand a refused scheme to a sink.
    */
   readonly hyperlinks: HyperlinkOps;
+  readonly equations: EquationOps;
   /**
    * Content-control chrome, form-fill navigation, and value / remove verbs.
    *

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -151,6 +151,7 @@ import { createSurfaceStructure } from './surface-structure.ts';
 import { MIN_TABLE_COLUMN_WIDTH_TWIPS } from '../store/store/table-constraints.ts';
 import { createFieldLinkRegistry } from './surface-field-links.ts';
 import { createHyperlinkOps } from './surface-hyperlinks.ts';
+import { createEquationInteraction, createEquationOps } from './surface-equations.ts';
 import { createSurfaceNavigation } from './surface-navigation.ts';
 import { drawingLinkByIdFromLayout } from './drawing-link-index.ts';
 import {
@@ -814,6 +815,15 @@ export function mountPaginatedSurface(
     textOf: (paragraphId) => textOf(paragraphId),
     commit: (run, selectionAfter) => commit(run, selectionAfter),
   });
+  const equations = createEquationOps({
+    session: gatedSession,
+    storyScope,
+    editingMode: () => editingMode,
+    writeRefusal: (op) => writeRefusal(true, [op]),
+    selection: () => selection,
+    selectionMark: () => selectionMark(),
+    commit: (run, selectionAfter) => commit(run, selectionAfter),
+  });
   /**
    * Put the surface in the story that holds `paragraphId`, for a JUMP.
    *
@@ -879,6 +889,12 @@ export function mountPaginatedSurface(
       selection.anchor.offset === selection.head.offset,
     onScrolled: () => rematerialize(),
     ...(options.onHyperlinkPopover ? { onPopover: options.onHyperlinkPopover } : {}),
+  });
+  const equationInteraction = createEquationInteraction({
+    pagesLayer,
+    equationById: (equationId) => equations.equationById(equationId),
+    setSelection,
+    ...(options.onEquationPopover ? { onPopover: options.onEquationPopover } : {}),
   });
   pagesLayer.addEventListener('contextmenu', onTocContextMenu);
   pagesLayer.addEventListener('click', onTocRowClick);
@@ -4204,6 +4220,7 @@ export function mountPaginatedSurface(
     },
 
     hyperlinks,
+    equations,
     contentControls: contentControlsOps,
     canInsertTable,
     insertTable,
@@ -4669,6 +4686,7 @@ export function mountPaginatedSurface(
       pointer?.destroy();
       tableInteraction.destroy();
       navigation.destroy();
+      equationInteraction.destroy();
       selectionSync.destroy();
       pagesLayer.removeEventListener('contextmenu', onTocContextMenu);
       pagesLayer.removeEventListener('click', onTocRowClick);

--- a/packages/core/src/editor/surface-equations.ts
+++ b/packages/core/src/editor/surface-equations.ts
@@ -1,0 +1,329 @@
+// Atomic Office Math reads and writes for the paginated surface.
+
+import type { TreeApplyResult, TreeDocxSessionView } from '@docx-editor.dev/core/binding';
+import type { SemanticPosition, SemanticSelection } from '@docx-editor.dev/core/layout';
+import {
+  OFFICE_MATH_NAMESPACE_URI,
+  equationExpressionToLinearMath,
+  findNode,
+  parentNodeOf as parentOf,
+  projectOmmlEquation,
+  segmentsOf,
+  type OoxmlNode,
+  type OoxmlPart,
+  type StoryScope,
+  type EquationExpression,
+} from '@docx-editor.dev/core/store';
+
+const SUGGESTING_EQUATION_REFUSAL =
+  'equation replacement and removal are not supported in suggesting mode';
+
+/** One addressable inline equation and its compact editable projection. */
+export interface SurfaceEquation {
+  readonly id: string;
+  readonly paragraphId: string;
+  readonly start: number;
+  readonly end: number;
+  readonly linear: string;
+  readonly fallbackText: string;
+  /** True when every source construct belongs to the editable subset. */
+  readonly supported: boolean;
+}
+
+/** A user click on one painted equation. */
+export interface EquationActivation {
+  readonly equation: SurfaceEquation;
+  readonly rect: {
+    readonly left: number;
+    readonly top: number;
+    readonly right: number;
+    readonly bottom: number;
+  };
+}
+
+function equationsInParagraph(part: OoxmlPart, paragraphId: string): SurfaceEquation[] {
+  const paragraph = findNode(part, paragraphId);
+  if (!paragraph || paragraph.kind !== 'paragraph') return [];
+  const equations: SurfaceEquation[] = [];
+  for (const segment of segmentsOf(paragraph)) {
+    const node = segment.node;
+    if (
+      node.kind === 'textValue' ||
+      node.kind !== 'generic' ||
+      node.namespaceUri !== OFFICE_MATH_NAMESPACE_URI ||
+      node.localName !== 'oMath'
+    ) {
+      continue;
+    }
+    const projection = projectOmmlEquation(node);
+    if (!projection) continue;
+    equations.push({
+      id: node.id,
+      paragraphId,
+      start: segment.start,
+      end: segment.end,
+      linear: equationExpressionToLinearMath(projection.expression),
+      fallbackText: projection.fallbackText,
+      supported: expressionIsSupported(projection.expression),
+    });
+  }
+  return equations;
+}
+
+function expressionIsSupported(expression: EquationExpression): boolean {
+  switch (expression.kind) {
+    case 'fallback':
+      return false;
+    case 'text':
+      return true;
+    case 'row':
+      return expression.items.every(expressionIsSupported);
+    case 'fraction':
+      return (
+        expressionIsSupported(expression.numerator) && expressionIsSupported(expression.denominator)
+      );
+    case 'radical':
+      return (
+        expressionIsSupported(expression.radicand) &&
+        (expression.degree === undefined || expressionIsSupported(expression.degree))
+      );
+    case 'script':
+      return (
+        expressionIsSupported(expression.base) &&
+        (expression.subscript === undefined || expressionIsSupported(expression.subscript)) &&
+        (expression.superscript === undefined || expressionIsSupported(expression.superscript))
+      );
+    case 'nary':
+      return (
+        expressionIsSupported(expression.body) &&
+        (expression.lowerLimit === undefined || expressionIsSupported(expression.lowerLimit)) &&
+        (expression.upperLimit === undefined || expressionIsSupported(expression.upperLimit))
+      );
+  }
+}
+
+/** Boundary-inclusive lookup, matching the hyperlink and field atom popovers. */
+export function equationAtPosition(
+  equations: readonly SurfaceEquation[],
+  position: SemanticPosition
+): SurfaceEquation | null {
+  return (
+    equations.find(
+      (equation) =>
+        equation.paragraphId === position.paragraphId &&
+        position.offset >= equation.start &&
+        position.offset <= equation.end
+    ) ?? null
+  );
+}
+
+export interface EquationOpsDeps {
+  readonly session: TreeDocxSessionView;
+  storyScope(): StoryScope;
+  editingMode(): 'edit' | 'suggest' | 'view';
+  writeRefusal(op: EquationTreeOp): string | null;
+  selection(): SemanticSelection;
+  selectionMark(): { paragraphId: string; start: number; end: number } | null;
+  commit(
+    run: () => TreeApplyResult | boolean,
+    selectionAfter?: () => SemanticSelection | null
+  ): void;
+}
+
+export type EquationAction = 'replace' | 'remove';
+
+/** Engine-owned capability result for equation editing chrome. */
+export type EquationCanResult =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly code: 'locked' | 'notFound' | 'unsupported';
+      readonly reason: string;
+    };
+
+type EquationTreeOp =
+  | { readonly op: 'setMathEquation'; readonly equationId: string; readonly linear: string }
+  | { readonly op: 'removeMathEquation'; readonly equationId: string };
+
+/** Surface equation reads and atomic replace/remove writes. */
+export interface EquationOps {
+  equationsInCaretParagraph(): SurfaceEquation[];
+  equationAtCaret(): SurfaceEquation | null;
+  equationById(equationId: string): SurfaceEquation | null;
+  /** Whether equation chrome can run an action, with the engine-owned refusal reason. */
+  can(equationId: string, action: EquationAction): EquationCanResult;
+  applyEquation(equationId: string, linear: string): boolean;
+  removeEquation(equationId: string): boolean;
+}
+
+export interface EquationInteraction {
+  destroy(): void;
+}
+
+/** Connect painted equation metadata to atomic selection and host chrome. */
+export function createEquationInteraction(deps: {
+  readonly pagesLayer: HTMLElement;
+  readonly equationById: (equationId: string) => SurfaceEquation | null;
+  readonly setSelection: (selection: SemanticSelection) => void;
+  readonly onPopover?: (activation: EquationActivation) => void;
+}): EquationInteraction {
+  let pressed: { readonly equationId: string; readonly rect: EquationActivation['rect'] } | null =
+    null;
+  const targetFrom = (value: EventTarget | null): HTMLElement | null => {
+    const view = deps.pagesLayer.ownerDocument.defaultView;
+    if (!view || !(value instanceof view.Element)) return null;
+    const target = value.closest<HTMLElement>('[data-docx-equation]');
+    return target && deps.pagesLayer.contains(target) ? target : null;
+  };
+  const activate = (equationId: string, rect: EquationActivation['rect']): void => {
+    const equation = deps.equationById(equationId);
+    if (!equation) return;
+    deps.setSelection({
+      anchor: { paragraphId: equation.paragraphId, offset: equation.start },
+      head: { paragraphId: equation.paragraphId, offset: equation.end },
+    });
+    deps.onPopover?.({ equation, rect });
+  };
+  const onPointerDown = (event: PointerEvent): void => {
+    pressed = null;
+    const target = targetFrom(event.target);
+    const equationId = target?.dataset.docxEquation;
+    if (!target || !equationId) return;
+    const rect = target.getBoundingClientRect();
+    pressed = {
+      equationId,
+      rect: { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom },
+    };
+  };
+  const onClick = (event: MouseEvent): void => {
+    const target = targetFrom(event.target);
+    const equationId = target?.dataset.docxEquation;
+    const remembered = pressed;
+    pressed = null;
+    if (!target || !equationId) {
+      if (!remembered) return;
+      event.preventDefault();
+      activate(remembered.equationId, remembered.rect);
+      return;
+    }
+    const rect = target.getBoundingClientRect();
+    event.preventDefault();
+    activate(equationId, {
+      left: rect.left,
+      top: rect.top,
+      right: rect.right,
+      bottom: rect.bottom,
+    });
+  };
+  deps.pagesLayer.addEventListener('pointerdown', onPointerDown, true);
+  deps.pagesLayer.addEventListener('click', onClick);
+  return {
+    destroy: () => {
+      deps.pagesLayer.removeEventListener('pointerdown', onPointerDown, true);
+      deps.pagesLayer.removeEventListener('click', onClick);
+    },
+  };
+}
+
+export function createEquationOps(deps: EquationOpsDeps): EquationOps {
+  const activePart = (): OoxmlPart | null => deps.session.partFor(deps.storyScope());
+  const equationsIn = (paragraphId: string): SurfaceEquation[] => {
+    const part = activePart();
+    return part ? equationsInParagraph(part, paragraphId) : [];
+  };
+  const atCaret = (): SurfaceEquation | null => {
+    const head = deps.selection().head;
+    return equationAtPosition(equationsIn(head.paragraphId), head);
+  };
+  const byId = (equationId: string): SurfaceEquation | null => {
+    const near = equationsIn(deps.selection().head.paragraphId).find(
+      (equation) => equation.id === equationId
+    );
+    if (near) return near;
+    for (const part of deps.session.storyParts()) {
+      const node = findNode(part, equationId);
+      if (
+        !node ||
+        node.kind !== 'generic' ||
+        node.namespaceUri !== OFFICE_MATH_NAMESPACE_URI ||
+        node.localName !== 'oMath'
+      ) {
+        continue;
+      }
+      let ancestor: OoxmlNode | null = node;
+      while (ancestor && ancestor.kind !== 'paragraph') {
+        ancestor = parentOf(part, ancestor.id);
+      }
+      if (!ancestor || ancestor.kind !== 'paragraph') return null;
+      return (
+        equationsInParagraph(part, ancestor.id).find((equation) => equation.id === equationId) ??
+        null
+      );
+    }
+    return null;
+  };
+  const transact = (equation: SurfaceEquation, op: EquationTreeOp): boolean => {
+    let committed = false;
+    const after = { paragraphId: equation.paragraphId, offset: equation.start };
+    deps.commit(
+      () => {
+        const result = deps.session.applyTreeOps(
+          [op],
+          deps.selectionMark(),
+          { paragraphId: after.paragraphId, start: after.offset, end: after.offset },
+          deps.storyScope()
+        );
+        committed = result.committed;
+        return result;
+      },
+      () => ({ anchor: after, head: after })
+    );
+    return committed;
+  };
+  const capability = (equationId: string, action: EquationAction): EquationCanResult => {
+    const equation = byId(equationId);
+    if (!equation) return { ok: false, code: 'notFound', reason: 'no equation with that id' };
+    // `trackedOps` cannot safely wrap an OMML replacement or removal today. Refuse before
+    // `applyTreeOps`, or Suggesting would make the change permanent and unreviewable.
+    if (deps.editingMode() === 'suggest') {
+      return { ok: false, code: 'unsupported', reason: SUGGESTING_EQUATION_REFUSAL };
+    }
+    const op: EquationTreeOp =
+      action === 'replace'
+        ? { op: 'setMathEquation', equationId, linear: equation.linear }
+        : { op: 'removeMathEquation', equationId };
+    const reason = deps.writeRefusal(op);
+    return reason === null ? { ok: true } : { ok: false, code: 'locked', reason };
+  };
+  const refuse = (result: Exclude<EquationCanResult, { readonly ok: true }>): false => {
+    deps.commit(() => ({
+      committed: false,
+      rejected: true,
+      opCount: 0,
+      reason: result.reason,
+    }));
+    return false;
+  };
+
+  return {
+    equationsInCaretParagraph: () => equationsIn(deps.selection().head.paragraphId),
+    equationAtCaret: atCaret,
+    equationById: byId,
+    can: capability,
+    applyEquation(equationId, linear) {
+      const equation = byId(equationId);
+      if (!equation) return false;
+      const allowed = capability(equationId, 'replace');
+      if (!allowed.ok) return refuse(allowed);
+      if (equation.supported && equation.linear === linear) return true;
+      return transact(equation, { op: 'setMathEquation', equationId, linear });
+    },
+    removeEquation(equationId) {
+      const equation = byId(equationId);
+      if (!equation) return false;
+      const allowed = capability(equationId, 'remove');
+      if (!allowed.ok) return refuse(allowed);
+      return transact(equation, { op: 'removeMathEquation', equationId });
+    },
+  };
+}

--- a/packages/core/src/editor/surface-equations.ts
+++ b/packages/core/src/editor/surface-equations.ts
@@ -10,6 +10,7 @@ import {
   projectOmmlEquation,
   segmentsOf,
   type OoxmlNode,
+  type OoxmlParagraphNode,
   type OoxmlPart,
   type StoryScope,
   type EquationExpression,
@@ -17,6 +18,7 @@ import {
 
 const SUGGESTING_EQUATION_REFUSAL =
   'equation replacement and removal are not supported in suggesting mode';
+const paragraphEquationCache = new WeakMap<OoxmlParagraphNode, readonly SurfaceEquation[]>();
 
 /** One addressable inline equation and its compact editable projection. */
 export interface SurfaceEquation {
@@ -41,9 +43,11 @@ export interface EquationActivation {
   };
 }
 
-function equationsInParagraph(part: OoxmlPart, paragraphId: string): SurfaceEquation[] {
+function equationsInParagraph(part: OoxmlPart, paragraphId: string): readonly SurfaceEquation[] {
   const paragraph = findNode(part, paragraphId);
   if (!paragraph || paragraph.kind !== 'paragraph') return [];
+  const cached = paragraphEquationCache.get(paragraph);
+  if (cached) return cached;
   const equations: SurfaceEquation[] = [];
   for (const segment of segmentsOf(paragraph)) {
     const node = segment.node;
@@ -57,17 +61,21 @@ function equationsInParagraph(part: OoxmlPart, paragraphId: string): SurfaceEqua
     }
     const projection = projectOmmlEquation(node);
     if (!projection) continue;
-    equations.push({
-      id: node.id,
-      paragraphId,
-      start: segment.start,
-      end: segment.end,
-      linear: equationExpressionToLinearMath(projection.expression),
-      fallbackText: projection.fallbackText,
-      supported: expressionIsSupported(projection.expression),
-    });
+    equations.push(
+      Object.freeze({
+        id: node.id,
+        paragraphId,
+        start: segment.start,
+        end: segment.end,
+        linear: equationExpressionToLinearMath(projection.expression),
+        fallbackText: projection.fallbackText,
+        supported: expressionIsSupported(projection.expression),
+      })
+    );
   }
-  return equations;
+  const result = Object.freeze(equations);
+  paragraphEquationCache.set(paragraph, result);
+  return result;
 }
 
 function expressionIsSupported(expression: EquationExpression): boolean {
@@ -227,7 +235,7 @@ export function createEquationInteraction(deps: {
 
 export function createEquationOps(deps: EquationOpsDeps): EquationOps {
   const activePart = (): OoxmlPart | null => deps.session.partFor(deps.storyScope());
-  const equationsIn = (paragraphId: string): SurfaceEquation[] => {
+  const equationsIn = (paragraphId: string): readonly SurfaceEquation[] => {
     const part = activePart();
     return part ? equationsInParagraph(part, paragraphId) : [];
   };
@@ -306,7 +314,7 @@ export function createEquationOps(deps: EquationOpsDeps): EquationOps {
   };
 
   return {
-    equationsInCaretParagraph: () => equationsIn(deps.selection().head.paragraphId),
+    equationsInCaretParagraph: () => [...equationsIn(deps.selection().head.paragraphId)],
     equationAtCaret: atCaret,
     equationById: byId,
     can: capability,

--- a/packages/core/src/layout/__tests__/equation-layout.test.ts
+++ b/packages/core/src/layout/__tests__/equation-layout.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  OFFICE_MATH_NAMESPACE_URI,
+  WML_NAMESPACE_URI,
+  canonicalOoxmlFingerprint,
+  readOoxmlPart,
+  serializeOoxmlPart,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { piecesOfParagraph } from '../field-projection.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import { linesOf, type PageGeometry, type StyleSpanRecord } from '../semantic-records.ts';
+import type { EquationGeometry } from '../equation-layout.ts';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:m="${OFFICE_MATH_NAMESPACE_URI}">` +
+      `<w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const measurer = createFixedMeasurer(6, 14);
+
+function layout(body: string, geometry?: PageGeometry) {
+  return layoutSemanticDocument(load(body), 1, {
+    measurer,
+    ...(geometry ? { geometry } : {}),
+  });
+}
+
+function equationSpan(body: string): StyleSpanRecord {
+  const span = linesOf(layout(body))
+    .flatMap((line) => line.spans)
+    .find((candidate) => candidate.equation);
+  if (!span) throw new Error('missing equation span');
+  return span;
+}
+
+function assertFiniteGeometry(node: EquationGeometry): void {
+  for (const value of [node.box.x, node.box.y, node.box.width, node.box.height, node.baseline]) {
+    expect(Number.isFinite(value)).toBe(true);
+    expect(value).toBeGreaterThanOrEqual(0);
+  }
+  switch (node.kind) {
+    case 'row':
+      node.items.forEach(assertFiniteGeometry);
+      break;
+    case 'fraction':
+      assertFiniteGeometry(node.numerator);
+      assertFiniteGeometry(node.denominator);
+      break;
+    case 'radical':
+      assertFiniteGeometry(node.sign);
+      assertFiniteGeometry(node.radicand);
+      if (node.degree) assertFiniteGeometry(node.degree);
+      break;
+    case 'script':
+      assertFiniteGeometry(node.base);
+      if (node.subscript) assertFiniteGeometry(node.subscript);
+      if (node.superscript) assertFiniteGeometry(node.superscript);
+      break;
+    case 'nary':
+      assertFiniteGeometry(node.operator);
+      assertFiniteGeometry(node.body);
+      if (node.lowerLimit) assertFiniteGeometry(node.lowerLimit);
+      if (node.upperLimit) assertFiniteGeometry(node.upperLimit);
+      break;
+    default:
+      break;
+  }
+}
+
+const complexEquation =
+  '<m:oMath>' +
+  '<m:f><m:num><m:r><m:t>a+b</m:t></m:r></m:num>' +
+  '<m:den><m:r><m:t>2</m:t></m:r></m:den></m:f>' +
+  '<m:rad><m:deg/><m:e><m:r><m:t>x</m:t></m:r></m:e></m:rad>' +
+  '<m:sSup><m:e><m:r><m:t>x</m:t></m:r></m:e>' +
+  '<m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup>' +
+  '<m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr>' +
+  '<m:sub><m:r><m:t>n</m:t></m:r></m:sub><m:sup/>' +
+  '<m:e><m:r><m:t>x</m:t></m:r></m:e></m:nary>' +
+  '</m:oMath>';
+
+describe('atomic equation paragraph layout', () => {
+  test('publishes one model span with source metadata and deterministic geometry', () => {
+    const body = `<w:p><w:r><w:t>A</w:t></w:r>${complexEquation}` + '<w:r><w:t>Z</w:t></w:r></w:p>';
+    const first = layout(body);
+    const second = layout(body);
+    const [line] = linesOf(first);
+    const equation = line!.spans.find((span) => span.equation)!;
+
+    expect(line!.spans.map((span) => span.text)).toEqual(['A', '\uFFFC', 'Z']);
+    expect(equation.range).toMatchObject({ start: 1, end: 2 });
+    expect(equation.projected).toBe(true);
+    expect(equation.style.fontFamily).toBe('Cambria Math');
+    expect(equation.equation?.sourceNodeId).toBe('/word/document.xml#0.0.0.1');
+    expect(equation.caretEdges).toEqual([0, equation.box.width]);
+    expect(equation.equation?.geometry).toEqual(
+      linesOf(second)[0]!.spans.find((span) => span.equation)!.equation!.geometry
+    );
+    assertFiniteGeometry(equation.equation!.geometry);
+  });
+
+  test('composes fraction, radical, script, and n-ary records without DOM metrics', () => {
+    const geometry = equationSpan(`<w:p>${complexEquation}</w:p>`).equation!.geometry;
+    expect(geometry.kind).toBe('row');
+    if (geometry.kind !== 'row') return;
+    expect(geometry.items.map((child) => child.kind)).toEqual([
+      'fraction',
+      'radical',
+      'script',
+      'nary',
+    ]);
+    const fraction = geometry.items[0]!;
+    expect(fraction.kind).toBe('fraction');
+    if (fraction.kind === 'fraction') {
+      expect(fraction.bar.width).toBeGreaterThan(0);
+      expect(fraction.denominator.box.y).toBeGreaterThan(fraction.bar.y);
+    }
+  });
+
+  test('keeps nested n-ary child tops non-negative', () => {
+    const nested =
+      '<m:oMath><m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr><m:e>' +
+      '<m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr>' +
+      '<m:sup><m:f><m:num><m:r><m:t>n</m:t></m:r></m:num>' +
+      '<m:den><m:r><m:t>2</m:t></m:r></m:den></m:f></m:sup>' +
+      '<m:e><m:r><m:t>x</m:t></m:r></m:e></m:nary>' +
+      '</m:e></m:nary></m:oMath>';
+    const geometry = equationSpan(`<w:p>${nested}</w:p>`).equation!.geometry;
+
+    expect(geometry.kind).toBe('nary');
+    if (geometry.kind !== 'nary') return;
+    expect(geometry.body.box.y).toBeGreaterThanOrEqual(0);
+    assertFiniteGeometry(geometry);
+  });
+
+  test('keeps the equation atom whole when it wraps', () => {
+    const result = layout(`<w:p><w:r><w:t>prefix </w:t></w:r>${complexEquation}</w:p>`, {
+      width: 100,
+      height: 500,
+      margin: { top: 0, right: 0, bottom: 0, left: 0 },
+    });
+    const equations = linesOf(result)
+      .flatMap((line) => line.spans)
+      .filter((span) => span.equation);
+    expect(equations).toHaveLength(1);
+    expect(equations[0]!.range.end - equations[0]!.range.start).toBe(1);
+  });
+
+  test('publishes bounded fallback text geometry for unsupported OMML', () => {
+    const span = equationSpan(
+      '<w:p><m:oMath><m:bar><m:e><m:r><m:t>safe fallback</m:t></m:r>' +
+        '</m:e></m:bar></m:oMath></w:p>'
+    );
+    expect(span.equation).toMatchObject({
+      fallbackText: 'safe fallback',
+      geometry: { kind: 'fallback', text: 'safe fallback' },
+    });
+  });
+
+  test('shows a deleted equation in original and markup views and retains its range', () => {
+    const part = load(
+      '<w:p><w:del w:id="7" w:author="Reviewer">' +
+        '<m:oMath><m:r><m:t>x</m:t></m:r></m:oMath>' +
+        '</w:del></w:p>'
+    );
+    const paragraph = part.root.children[0]!.children.find((child) => child.kind === 'paragraph');
+    if (!paragraph) throw new Error('missing paragraph');
+    const project = (mode: 'all-markup' | 'proposed' | 'original') => {
+      const deletedRanges: { start: number; end: number }[] = [];
+      const pieces = piecesOfParagraph(
+        paragraph,
+        [],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        mode,
+        deletedRanges
+      );
+      return { pieces, deletedRanges };
+    };
+
+    const allMarkup = project('all-markup');
+    const proposed = project('proposed');
+    const original = project('original');
+    expect(allMarkup.pieces.map((piece) => piece.text)).toEqual(['\uFFFC']);
+    expect(allMarkup.pieces[0]?.equation).toBeDefined();
+    expect(proposed.pieces).toEqual([]);
+    expect(original.pieces.map((piece) => piece.text)).toEqual(['\uFFFC']);
+    expect(original.pieces[0]?.equation).toBeDefined();
+    expect(allMarkup.deletedRanges).toEqual([{ start: 0, end: 1 }]);
+    expect(proposed.deletedRanges).toEqual([{ start: 0, end: 1 }]);
+    expect(original.deletedRanges).toEqual([{ start: 0, end: 1 }]);
+  });
+
+  test('keeps source OMML unchanged and reproduces geometry after reopen', () => {
+    const part = load(`<w:p>${complexEquation}</w:p>`);
+    const before = canonicalOoxmlFingerprint(part);
+    const first = layoutSemanticDocument(part, 1, { measurer });
+    expect(canonicalOoxmlFingerprint(part)).toBe(before);
+
+    const reopened = readOoxmlPart(serializeOoxmlPart(part), {
+      name: '/word/document.xml',
+      contentType: 'app/xml',
+    });
+    if (!reopened.ok) throw new Error(reopened.reason);
+    const second = layoutSemanticDocument(reopened.part, 2, { measurer });
+    const firstEquation = linesOf(first)[0]!.spans.find((span) => span.equation)!.equation;
+    const secondEquation = linesOf(second)[0]!.spans.find((span) => span.equation)!.equation;
+    expect(secondEquation?.geometry).toEqual(firstEquation?.geometry);
+    expect(secondEquation?.sourceNodeId).toBe(firstEquation?.sourceNodeId);
+  });
+});

--- a/packages/core/src/layout/__tests__/equation-layout.test.ts
+++ b/packages/core/src/layout/__tests__/equation-layout.test.ts
@@ -11,7 +11,7 @@ import { createFixedMeasurer } from '../fixed-measurer.ts';
 import { piecesOfParagraph } from '../field-projection.ts';
 import { layoutSemanticDocument } from '../semantic-layout.ts';
 import { linesOf, type PageGeometry, type StyleSpanRecord } from '../semantic-records.ts';
-import type { EquationGeometry } from '../equation-layout.ts';
+import { createEquationLayouter, type EquationGeometry } from '../equation-layout.ts';
 
 function load(body: string): OoxmlPart {
   const result = readOoxmlPart(
@@ -216,5 +216,43 @@ describe('atomic equation paragraph layout', () => {
     const secondEquation = linesOf(second)[0]!.spans.find((span) => span.equation)!.equation;
     expect(secondEquation?.geometry).toEqual(firstEquation?.geometry);
     expect(secondEquation?.sourceNodeId).toBe(firstEquation?.sourceNodeId);
+  });
+
+  test('reuses geometry across paragraph breaks and invalidates changed styles', () => {
+    const part = load(`<w:p>${complexEquation}</w:p>`);
+    const paragraph = part.root.children[0]!.children.find((child) => child.kind === 'paragraph');
+    if (!paragraph) throw new Error('missing paragraph');
+    const piece = piecesOfParagraph(paragraph).find((candidate) => candidate.equation);
+    if (!piece?.equation) throw new Error('missing equation piece');
+    const fixed = createFixedMeasurer(6, 14);
+    let measureCalls = 0;
+    const counting = {
+      measure: (...args: Parameters<typeof fixed.measure>) => {
+        measureCalls += 1;
+        return fixed.measure(...args);
+      },
+      lineMetrics: (...args: Parameters<typeof fixed.lineMetrics>) => fixed.lineMetrics(...args),
+    };
+
+    const first = createEquationLayouter(counting, 'font-epoch:1')(piece.equation, piece.style);
+    const callsAfterFirst = measureCalls;
+    const second = createEquationLayouter(counting, 'font-epoch:1')(piece.equation, piece.style);
+    expect(second).toBe(first);
+    expect(measureCalls).toBe(callsAfterFirst);
+
+    const larger = createEquationLayouter(counting, 'font-epoch:1')(
+      piece.equation,
+      Object.freeze({ ...piece.style, fontSizePt: piece.style.fontSizePt + 2 })
+    );
+    expect(larger).not.toBe(first);
+    expect(measureCalls).toBeGreaterThan(callsAfterFirst);
+
+    const callsAfterStyleChange = measureCalls;
+    const nextProducer = createEquationLayouter(counting, 'font-epoch:2')(
+      piece.equation,
+      piece.style
+    );
+    expect(nextProducer).not.toBe(first);
+    expect(measureCalls).toBeGreaterThan(callsAfterStyleChange);
   });
 });

--- a/packages/core/src/layout/equation-layout.ts
+++ b/packages/core/src/layout/equation-layout.ts
@@ -94,6 +94,58 @@ interface EquationLayoutCache {
   readonly metrics: Map<number, ReturnType<TextMeasurer['lineMetrics']>>;
 }
 
+interface SharedEquationLayouts {
+  readonly projections: WeakMap<OmmlEquationProjection, Map<string, EquationSpanRecord>>;
+}
+
+const MAX_PRODUCER_CACHES_PER_MEASURER = 4;
+const MAX_STYLES_PER_PROJECTION = 8;
+const sharedLayoutsByMeasurer = new WeakMap<TextMeasurer, Map<string, SharedEquationLayouts>>();
+
+function geometryStyleToken(style: ResolvedRunStyle): string {
+  const resolved = equationRunStyle(style);
+  return [
+    resolved.fontFamily ?? '',
+    resolved.fontSizePt,
+    resolved.bold ? 1 : 0,
+    resolved.italic ? 1 : 0,
+    resolved.verticalAlign,
+    resolved.baselineShiftPt,
+    resolved.caps ? 1 : 0,
+    resolved.smallCaps ? 1 : 0,
+    resolved.characterSpacingPt,
+    resolved.horizontalScalePercent,
+    resolved.kerningMinPt,
+  ].join('|');
+}
+
+function sharedEquationLayouts(
+  measurer: TextMeasurer,
+  producer: string | undefined
+): SharedEquationLayouts {
+  if (producer === undefined) return { projections: new WeakMap() };
+  let producers = sharedLayoutsByMeasurer.get(measurer);
+  if (!producers) {
+    producers = new Map();
+    sharedLayoutsByMeasurer.set(measurer, producers);
+  }
+  const cached = producers.get(producer);
+  if (cached) {
+    producers.delete(producer);
+    producers.set(producer, cached);
+    return cached;
+  }
+  if (producers.size >= MAX_PRODUCER_CACHES_PER_MEASURER) {
+    const oldest = producers.keys().next().value;
+    if (oldest !== undefined) producers.delete(oldest);
+  }
+  const created = {
+    projections: new WeakMap<OmmlEquationProjection, Map<string, EquationSpanRecord>>(),
+  };
+  producers.set(producer, created);
+  return created;
+}
+
 function scaledStyle(
   style: ResolvedRunStyle,
   scale: number,
@@ -354,16 +406,31 @@ export function layoutEquation(
   });
 }
 
-/** Cache equation geometry for one paragraph break by immutable source identity. */
+/** Reuse equation geometry across paragraph breaks for one measurement producer. */
 export function createEquationLayouter(
-  measurer: TextMeasurer
+  measurer: TextMeasurer,
+  producer?: string
 ): (projection: OmmlEquationProjection, style: ResolvedRunStyle) => EquationSpanRecord {
-  const layouts = new Map<string, EquationSpanRecord>();
+  const layouts = sharedEquationLayouts(measurer, producer);
   return (projection, style) => {
-    const cached = layouts.get(projection.sourceNodeId);
-    if (cached) return cached;
+    const token = geometryStyleToken(style);
+    let styles = layouts.projections.get(projection);
+    const cached = styles?.get(token);
+    if (cached && styles) {
+      styles.delete(token);
+      styles.set(token, cached);
+      return cached;
+    }
     const layout = layoutEquation(projection, measurer, style);
-    layouts.set(projection.sourceNodeId, layout);
+    if (!styles) {
+      styles = new Map();
+      layouts.projections.set(projection, styles);
+    }
+    if (styles.size >= MAX_STYLES_PER_PROJECTION) {
+      const oldest = styles.keys().next().value;
+      if (oldest !== undefined) styles.delete(oldest);
+    }
+    styles.set(token, layout);
     return layout;
   };
 }

--- a/packages/core/src/layout/equation-layout.ts
+++ b/packages/core/src/layout/equation-layout.ts
@@ -1,0 +1,369 @@
+// Deterministic DOM-free geometry for the bounded equation expression tree.
+
+import type { EquationExpression, OmmlEquationProjection } from '@docx-editor.dev/core/store';
+import { measureDisplayText, type ResolvedRunStyle } from './run-style.ts';
+import type { LayoutBox, TextMeasurer } from './semantic-records.ts';
+
+const SCRIPT_SCALE = 0.7;
+const NARY_OPERATOR_SCALE = 1.25;
+const EQUATION_FONT_FAMILY = 'Cambria Math';
+
+/** Use Word's math face when installed while retaining the measurer's safe fallback stack. */
+export function equationRunStyle(style: ResolvedRunStyle): ResolvedRunStyle {
+  return style.fontFamily === EQUATION_FONT_FAMILY
+    ? style
+    : Object.freeze({ ...style, fontFamily: EQUATION_FONT_FAMILY });
+}
+
+interface EquationGeometryBase {
+  readonly box: LayoutBox;
+  /** Baseline measured from this node's top edge. */
+  readonly baseline: number;
+}
+
+export interface EquationTextGeometry extends EquationGeometryBase {
+  readonly kind: 'text' | 'fallback';
+  readonly text: string;
+  readonly fontSizePt: number;
+}
+
+export interface EquationRowGeometry extends EquationGeometryBase {
+  readonly kind: 'row';
+  readonly items: readonly EquationGeometry[];
+}
+
+export interface EquationFractionGeometry extends EquationGeometryBase {
+  readonly kind: 'fraction';
+  readonly numerator: EquationGeometry;
+  readonly denominator: EquationGeometry;
+  readonly bar: LayoutBox;
+}
+
+export interface EquationRadicalGeometry extends EquationGeometryBase {
+  readonly kind: 'radical';
+  readonly sign: EquationTextGeometry;
+  readonly radicand: EquationGeometry;
+  readonly degree?: EquationGeometry;
+  readonly bar: LayoutBox;
+}
+
+export interface EquationScriptGeometry extends EquationGeometryBase {
+  readonly kind: 'script';
+  readonly base: EquationGeometry;
+  readonly subscript?: EquationGeometry;
+  readonly superscript?: EquationGeometry;
+}
+
+export interface EquationNaryGeometry extends EquationGeometryBase {
+  readonly kind: 'nary';
+  readonly operator: EquationTextGeometry;
+  readonly body: EquationGeometry;
+  readonly lowerLimit?: EquationGeometry;
+  readonly upperLimit?: EquationGeometry;
+}
+
+export type EquationGeometry =
+  | EquationTextGeometry
+  | EquationRowGeometry
+  | EquationFractionGeometry
+  | EquationRadicalGeometry
+  | EquationScriptGeometry
+  | EquationNaryGeometry;
+
+/** Equation metadata carried by one atomic semantic span. */
+export interface EquationSpanRecord {
+  readonly sourceNodeId: string;
+  readonly geometry: EquationGeometry;
+  readonly fallbackText: string;
+  readonly truncated: boolean;
+}
+
+function box(x: number, y: number, width: number, height: number): LayoutBox {
+  return Object.freeze({ x, y, width, height });
+}
+
+function shifted<T extends EquationGeometry>(node: T, x: number, y: number): T {
+  return Object.freeze({
+    ...node,
+    box: box(x, y, node.box.width, node.box.height),
+  }) as unknown as T;
+}
+
+interface EquationLayoutCache {
+  readonly styles: Map<number, ResolvedRunStyle>;
+  readonly metrics: Map<number, ReturnType<TextMeasurer['lineMetrics']>>;
+}
+
+function scaledStyle(
+  style: ResolvedRunStyle,
+  scale: number,
+  cache: EquationLayoutCache
+): ResolvedRunStyle {
+  const cached = cache.styles.get(scale);
+  if (cached) return cached;
+  const resolved =
+    scale === 1
+      ? style
+      : Object.freeze({
+          ...style,
+          fontSizePt: style.fontSizePt * scale,
+          characterSpacingPt: style.characterSpacingPt * scale,
+        });
+  cache.styles.set(scale, resolved);
+  return resolved;
+}
+
+function metricsAt(
+  measurer: TextMeasurer,
+  style: ResolvedRunStyle,
+  scale: number,
+  cache: EquationLayoutCache
+): ReturnType<TextMeasurer['lineMetrics']> {
+  const cached = cache.metrics.get(scale);
+  if (cached) return cached;
+  const metrics = measurer.lineMetrics(scaledStyle(style, scale, cache));
+  cache.metrics.set(scale, metrics);
+  return metrics;
+}
+
+function textGeometry(
+  kind: 'text' | 'fallback',
+  text: string,
+  measurer: TextMeasurer,
+  style: ResolvedRunStyle,
+  scale: number,
+  cache: EquationLayoutCache
+): EquationTextGeometry {
+  const resolved = scaledStyle(style, scale, cache);
+  const metrics = metricsAt(measurer, style, scale, cache);
+  return Object.freeze({
+    kind,
+    text,
+    fontSizePt: resolved.fontSizePt,
+    box: box(0, 0, measureDisplayText(text, resolved, measurer), metrics.height),
+    baseline: metrics.baseline,
+  });
+}
+
+function rowGeometry(
+  items: readonly EquationGeometry[],
+  fallbackMetrics: { readonly height: number; readonly baseline: number }
+): EquationRowGeometry {
+  if (items.length === 0) {
+    return Object.freeze({
+      kind: 'row',
+      items: Object.freeze([]),
+      box: box(0, 0, 0, fallbackMetrics.height),
+      baseline: fallbackMetrics.baseline,
+    });
+  }
+  const baseline = Math.max(...items.map((child) => child.baseline));
+  const descent = Math.max(...items.map((child) => child.box.height - child.baseline));
+  let x = 0;
+  const placed = items.map((child) => {
+    const result = shifted(child, x, baseline - child.baseline);
+    x += child.box.width;
+    return result;
+  });
+  return Object.freeze({
+    kind: 'row',
+    items: Object.freeze(placed),
+    box: box(0, 0, x, baseline + descent),
+    baseline,
+  });
+}
+
+function layoutExpression(
+  expression: EquationExpression,
+  measurer: TextMeasurer,
+  style: ResolvedRunStyle,
+  scale: number,
+  cache: EquationLayoutCache
+): EquationGeometry {
+  switch (expression.kind) {
+    case 'text':
+      return textGeometry('text', expression.value, measurer, style, scale, cache);
+    case 'fallback':
+      return textGeometry('fallback', expression.text || '…', measurer, style, scale, cache);
+    case 'row':
+      return rowGeometry(
+        expression.items.map((child) => layoutExpression(child, measurer, style, scale, cache)),
+        metricsAt(measurer, style, scale, cache)
+      );
+    case 'fraction': {
+      const resolved = scaledStyle(style, scale, cache);
+      const numerator = layoutExpression(
+        expression.numerator,
+        measurer,
+        style,
+        scale * SCRIPT_SCALE,
+        cache
+      );
+      const denominator = layoutExpression(
+        expression.denominator,
+        measurer,
+        style,
+        scale * SCRIPT_SCALE,
+        cache
+      );
+      const pad = Math.max(0.75, resolved.fontSizePt * 0.08);
+      const gap = Math.max(0.75, resolved.fontSizePt * 0.08);
+      const thickness = Math.max(0.6, resolved.fontSizePt * 0.055);
+      const width = Math.max(numerator.box.width, denominator.box.width) + pad * 2;
+      const barY = numerator.box.height + gap;
+      const denominatorY = barY + thickness + gap;
+      const height = denominatorY + denominator.box.height;
+      const baseline = Math.min(height, barY + thickness / 2 + resolved.fontSizePt * 0.22);
+      return Object.freeze({
+        kind: 'fraction',
+        numerator: shifted(numerator, (width - numerator.box.width) / 2, 0),
+        denominator: shifted(denominator, (width - denominator.box.width) / 2, denominatorY),
+        bar: box(pad / 2, barY, width - pad, thickness),
+        box: box(0, 0, width, height),
+        baseline,
+      });
+    }
+    case 'radical': {
+      const resolved = scaledStyle(style, scale, cache);
+      const radicand = layoutExpression(expression.radicand, measurer, style, scale, cache);
+      const sign = textGeometry('text', '√', measurer, style, scale, cache);
+      const degree = expression.degree
+        ? layoutExpression(expression.degree, measurer, style, scale * 0.55, cache)
+        : undefined;
+      const barThickness = Math.max(0.55, resolved.fontSizePt * 0.05);
+      const barGap = Math.max(0.35, resolved.fontSizePt * 0.035);
+      const radicandY = barThickness + barGap;
+      const signX = degree ? Math.max(0, degree.box.width * 0.65) : 0;
+      const radicandX = signX + sign.box.width;
+      const baseline = radicandY + radicand.baseline;
+      const height = Math.max(
+        radicandY + radicand.box.height,
+        baseline + (sign.box.height - sign.baseline)
+      );
+      return Object.freeze({
+        kind: 'radical',
+        sign: shifted(sign, signX, baseline - sign.baseline),
+        radicand: shifted(radicand, radicandX, radicandY),
+        ...(degree ? { degree: shifted(degree, 0, 0) } : {}),
+        bar: box(radicandX, 0, radicand.box.width, barThickness),
+        box: box(0, 0, radicandX + radicand.box.width, height),
+        baseline,
+      });
+    }
+    case 'script': {
+      const resolved = scaledStyle(style, scale, cache);
+      const base = layoutExpression(expression.base, measurer, style, scale, cache);
+      const subscript = expression.subscript
+        ? layoutExpression(expression.subscript, measurer, style, scale * SCRIPT_SCALE, cache)
+        : undefined;
+      const superscript = expression.superscript
+        ? layoutExpression(expression.superscript, measurer, style, scale * SCRIPT_SCALE, cache)
+        : undefined;
+      const gap = Math.max(0.4, resolved.fontSizePt * 0.04);
+      const scriptX = base.box.width + gap;
+      const superscriptY = 0;
+      const baseY = superscript ? Math.max(0, superscript.box.height - base.baseline * 0.45) : 0;
+      const baseline = baseY + base.baseline;
+      const subscriptY = baseline + resolved.fontSizePt * 0.08;
+      const width =
+        scriptX + Math.max(subscript?.box.width ?? 0, superscript?.box.width ?? 0, -gap);
+      const height = Math.max(
+        baseY + base.box.height,
+        superscript ? superscriptY + superscript.box.height : 0,
+        subscript ? subscriptY + subscript.box.height : 0
+      );
+      return Object.freeze({
+        kind: 'script',
+        base: shifted(base, 0, baseY),
+        ...(subscript ? { subscript: shifted(subscript, scriptX, subscriptY) } : {}),
+        ...(superscript ? { superscript: shifted(superscript, scriptX, superscriptY) } : {}),
+        box: box(0, 0, width, height),
+        baseline,
+      });
+    }
+    case 'nary': {
+      const resolved = scaledStyle(style, scale, cache);
+      const operator = textGeometry(
+        'text',
+        expression.operator,
+        measurer,
+        style,
+        scale * NARY_OPERATOR_SCALE,
+        cache
+      );
+      const body = layoutExpression(expression.body, measurer, style, scale, cache);
+      const lower = expression.lowerLimit
+        ? layoutExpression(expression.lowerLimit, measurer, style, scale * SCRIPT_SCALE, cache)
+        : undefined;
+      const upper = expression.upperLimit
+        ? layoutExpression(expression.upperLimit, measurer, style, scale * SCRIPT_SCALE, cache)
+        : undefined;
+      const gap = Math.max(0.5, resolved.fontSizePt * 0.05);
+      const operatorWidth = Math.max(
+        operator.box.width,
+        lower?.box.width ?? 0,
+        upper?.box.width ?? 0
+      );
+      const upperHeight = upper ? upper.box.height + gap : 0;
+      const operatorY = upperHeight;
+      const rawBaseline = operatorY + operator.baseline;
+      const lowerY = operatorY + operator.box.height + (lower ? gap : 0);
+      const bodyX = operatorWidth + gap;
+      const bodyY = rawBaseline - body.baseline;
+      const minTop = Math.min(0, operatorY, bodyY, lower ? lowerY : 0);
+      const shiftY = -minTop;
+      const baseline = rawBaseline + shiftY;
+      const height =
+        Math.max(
+          operatorY + operator.box.height,
+          lower ? lowerY + lower.box.height : 0,
+          bodyY + body.box.height
+        ) + shiftY;
+      return Object.freeze({
+        kind: 'nary',
+        operator: shifted(operator, (operatorWidth - operator.box.width) / 2, operatorY + shiftY),
+        body: shifted(body, bodyX, bodyY + shiftY),
+        ...(lower
+          ? {
+              lowerLimit: shifted(lower, (operatorWidth - lower.box.width) / 2, lowerY + shiftY),
+            }
+          : {}),
+        ...(upper
+          ? { upperLimit: shifted(upper, (operatorWidth - upper.box.width) / 2, shiftY) }
+          : {}),
+        box: box(0, 0, bodyX + body.box.width, height),
+        baseline,
+      });
+    }
+  }
+}
+
+/** Compose one bounded OMML projection into paint-ready point geometry. */
+export function layoutEquation(
+  projection: OmmlEquationProjection,
+  measurer: TextMeasurer,
+  style: ResolvedRunStyle
+): EquationSpanRecord {
+  const mathStyle = equationRunStyle(style);
+  const cache: EquationLayoutCache = { styles: new Map(), metrics: new Map() };
+  return Object.freeze({
+    sourceNodeId: projection.sourceNodeId,
+    geometry: layoutExpression(projection.expression, measurer, mathStyle, 1, cache),
+    fallbackText: projection.fallbackText,
+    truncated: projection.truncated,
+  });
+}
+
+/** Cache equation geometry for one paragraph break by immutable source identity. */
+export function createEquationLayouter(
+  measurer: TextMeasurer
+): (projection: OmmlEquationProjection, style: ResolvedRunStyle) => EquationSpanRecord {
+  const layouts = new Map<string, EquationSpanRecord>();
+  return (projection, style) => {
+    const cached = layouts.get(projection.sourceNodeId);
+    if (cached) return cached;
+    const layout = layoutEquation(projection, measurer, style);
+    layouts.set(projection.sourceNodeId, layout);
+    return layout;
+  };
+}

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -21,6 +21,7 @@ import type { SymbolFieldSpec } from './field-symbol.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
+import type { OmmlEquationProjection } from '@docx-editor.dev/core/store';
 
 /**
  * A `w:ptab` — the ABSOLUTE-position tab (ECMA-376 §17.3.3.16), which is what a table of
@@ -103,6 +104,8 @@ export interface FieldAwarePiece {
   };
   /** Typed inline drawing occupying one UTF-16 model unit. */
   readonly inlineDrawing?: InlineDrawingLayoutInput;
+  /** Bounded paragraph-level OMML projection occupying one UTF-16 model unit. */
+  readonly equation?: OmmlEquationProjection;
   /**
    * The revision wrappers enclosing this text, outermost first, absent when untracked.
    *

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -24,6 +24,7 @@ import {
   hardBreakKind,
   hasLegacyFormFieldData,
   isFldSimple,
+  projectOmmlEquation,
   type DocumentProperties,
   type OoxmlNode,
   type OoxmlParagraphNode,
@@ -110,6 +111,7 @@ import {
   type RevisionDisplayMode,
 } from './revision-projection.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
+import { equationRunStyle } from './equation-layout.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
 import {
   contentControlContentChildren,
@@ -233,6 +235,7 @@ export function piecesOfParagraph(
       readonly measureText?: string;
       readonly noteNav?: FieldAwarePiece['noteNav'];
       readonly inlineDrawing?: InlineDrawingLayoutInput;
+      readonly equation?: FieldAwarePiece['equation'];
       /**
        * Attribution to attach INSTEAD of the walk's live stack, for text emitted after the
        * walk has left the wrapper that owns it — a buffered field result is the only such
@@ -260,6 +263,7 @@ export function piecesOfParagraph(
         ...(extras?.measureText !== undefined ? { measureText: extras.measureText } : {}),
         ...(extras?.noteNav ? { noteNav: extras.noteNav } : {}),
         ...(extras?.inlineDrawing ? { inlineDrawing: extras.inlineDrawing } : {}),
+        ...(extras?.equation ? { equation: extras.equation } : {}),
         ...(extras?.fieldAtom ? { fieldAtom: extras.fieldAtom } : {}),
         ...link,
         ...attribution,
@@ -932,6 +936,15 @@ export function piecesOfParagraph(
     namespaceScope: ReadonlyMap<string, string>,
     sdtDepth: number
   ): void => {
+    const equation = projectOmmlEquation(child);
+    if (equation) {
+      const start = offset++;
+      if (revisionsAreDeletion(revisions) && deletedRanges)
+        appendModelRange(deletedRanges, start, offset);
+      const style = equationRunStyle(resolveRunStyle(inheritedRunProperties, themeFonts));
+      if (style.hidden || !revisionsVisible(revisions, displayMode)) return;
+      return push('\uFFFC', inheritedRunProperties, style, true, start, offset, { equation });
+    }
     if (isFldSimple(child)) {
       projectSimpleField(child, depth);
       return;

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -288,6 +288,17 @@ export {
 } from './list-resolve.ts';
 export { createFixedMeasurer } from './fixed-measurer.ts';
 export {
+  layoutEquation,
+  type EquationFractionGeometry,
+  type EquationGeometry,
+  type EquationNaryGeometry,
+  type EquationRadicalGeometry,
+  type EquationRowGeometry,
+  type EquationScriptGeometry,
+  type EquationSpanRecord,
+  type EquationTextGeometry,
+} from './equation-layout.ts';
+export {
   DEFAULT_CANVAS_FONT_STACK,
   isCanvasMeasurementAvailable,
   resolveDefaultSurfaceMeasurer,

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -183,6 +183,8 @@ export interface ParagraphFlowOptions {
    * would need `cacheToken` folded into those producers too.
    */
   readonly themeFonts?: ThemeFonts;
+  /** Stable measurement producer token for cross-break equation geometry reuse. */
+  readonly equationCacheToken?: string;
   /**
    * Paragraph-mark cascade for empty-line metrics and last-line mark height.
    * When omitted, falls back to the content `inheritedRunProperties` argument.
@@ -705,7 +707,7 @@ export function breakParagraph(
       },
     ];
   });
-  const layoutEquation = createEquationLayouter(measurer);
+  const layoutEquation = createEquationLayouter(measurer, flow?.equationCacheToken);
   const equationLayoutOf = (piece: FieldAwarePiece) =>
     piece.equation ? layoutEquation(piece.equation, piece.style) : null;
   if (pieces.length === 0 && flow?.suppressEmptyPlaceholderLine) {

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -70,6 +70,7 @@ import {
   topAndBottomSkipBeforeLine,
   type ExclusionZone,
 } from './drawing-exclusion.ts';
+import { createEquationLayouter } from './equation-layout.ts';
 
 /**
  * How far past the line's right edge a span may reach before it counts as overflow.
@@ -213,6 +214,8 @@ interface Piece {
   readonly link?: import('./semantic-records.ts').SpanLinkRecord;
   /** Typed inline drawing occupying one UTF-16 model unit. */
   readonly inlineDrawing?: import('./drawing-layout.ts').InlineDrawingLayoutInput;
+  /** Bounded OMML equation occupying one UTF-16 model unit. */
+  readonly equation?: FieldAwarePiece['equation'];
 }
 
 export function propertiesOf(container: OoxmlNode | undefined): OoxmlProperty[] {
@@ -702,6 +705,9 @@ export function breakParagraph(
       },
     ];
   });
+  const layoutEquation = createEquationLayouter(measurer);
+  const equationLayoutOf = (piece: FieldAwarePiece) =>
+    piece.equation ? layoutEquation(piece.equation, piece.style) : null;
   if (pieces.length === 0 && flow?.suppressEmptyPlaceholderLine) {
     return [];
   }
@@ -795,6 +801,14 @@ export function breakParagraph(
       probeLineIndex += 1;
     };
     for (const piece of pieces) {
+      const equation = equationLayoutOf(piece);
+      if (equation) {
+        const width = equation.geometry.box.width;
+        if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
+        if (sameParagraphAnchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
+        probeWidth += width;
+        continue;
+      }
       if (piece.inlineDrawing) {
         const width = measureInlineDrawing(piece.inlineDrawing.projection).totalWidth;
         if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
@@ -1291,6 +1305,40 @@ export function breakParagraph(
       // after the break. Suppressing that remainder put "After Column Break" flush with
       // the prior column's first line.
       trailingLineBreak = true;
+      continue;
+    }
+    if (piece.equation) {
+      const equation = equationLayoutOf(piece)!;
+      const atomWidth = equation.geometry.box.width;
+      const hasContent = line.spans.length > 0 || line.drawings.length > 0;
+      if (hasContent && line.width + atomWidth > lineAvailable()) closeLine();
+      if (!ensurePlacementWidth(atomWidth)) continue;
+      const priorDescent = Math.max(0, line.height - line.baseline);
+      const equationDescent = Math.max(
+        0,
+        equation.geometry.box.height - equation.geometry.baseline
+      );
+      line.baseline = Math.max(line.baseline, equation.geometry.baseline);
+      line.height = line.baseline + Math.max(priorDescent, equationDescent);
+      line.spans.push({
+        range: { paragraphId, start: piece.start, end: piece.end },
+        text: '\uFFFC',
+        props: piece.props,
+        style: piece.style,
+        box: {
+          x: lineOrigin() + line.width,
+          y: 0,
+          width: atomWidth,
+          height: equation.geometry.box.height,
+        },
+        projected: true,
+        equation,
+        ...revisionsOf(piece),
+      });
+      line.width += atomWidth;
+      line.end = piece.end;
+      wordStartSpan = -1;
+      lastEmitted = '';
       continue;
     }
     if (piece.projected && !piece.inlineDrawing && piece.text === '\uFFFC') {

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1758,6 +1758,7 @@ function layoutBlocksPass(
         : undefined,
       {
         lineSpacing: entry.lineSpacing,
+        equationCacheToken: producer,
         firstLineOffset: startOffset === 0 ? firstLineOffsetOf(entry) : 0,
         startOffset,
         marginExtent: { left: 0, right: entry.indent.left + available + entry.indent.right },

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -25,6 +25,7 @@ import type { InlineDrawingRecord, AnchoredDrawingRecord } from './drawing-layou
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
 import type { ResolvedCellBorders } from './table-borders.ts';
+import type { EquationSpanRecord } from './equation-layout.ts';
 
 export type {
   InlineDrawingRecord,
@@ -203,6 +204,8 @@ export interface StyleSpanRecord {
    * and selection mapping refuses them the way it refuses markers.
    */
   readonly projected?: boolean;
+  /** Paint-ready geometry for one atomic Office Math equation. */
+  readonly equation?: EquationSpanRecord;
   /**
    * Footnote/endnote navigation metadata for projected note atoms.
    *

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -659,6 +659,7 @@ function placeCellParagraph(
       : undefined,
     {
       lineSpacing,
+      equationCacheToken: deps.producer,
       firstLineOffset,
       // A cell's own content box is the column a positional tab measures against.
       marginExtent: { left: 0, right: indent.left + available + indent.right },

--- a/packages/core/src/output/__tests__/semantic-paint-equation.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-equation.test.ts
@@ -60,6 +60,10 @@ describe('semantic equation paint', () => {
       record.equation!.geometry.box.height,
       5
     );
+    expect(Number.parseFloat(equation!.style.verticalAlign)).toBeCloseTo(
+      -(record.equation!.geometry.box.height - record.equation!.geometry.baseline),
+      5
+    );
     expect(equation!.querySelector('.docx-equation-fraction')).not.toBeNull();
     expect(equation!.querySelector('.docx-equation-radical')).not.toBeNull();
     expect(equation!.querySelector('.docx-equation-script')).not.toBeNull();

--- a/packages/core/src/output/__tests__/semantic-paint-equation.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-equation.test.ts
@@ -1,0 +1,82 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import {
+  OFFICE_MATH_NAMESPACE_URI,
+  WML_NAMESPACE_URI,
+  readOoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument, linesOf } from '@docx-editor.dev/core/layout';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+function layoutAndPaint(body: string) {
+  const read = readOoxmlPart(
+    `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:m="${OFFICE_MATH_NAMESPACE_URI}">` +
+      `<w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!read.ok) throw new Error(read.reason);
+  const layout = layoutSemanticDocument(read.part, 3, {
+    measurer: createFixedMeasurer(6, 14),
+  });
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, { scale: 1 });
+  return { container, layout };
+}
+
+const supported =
+  '<m:oMath>' +
+  '<m:f><m:num><m:r><m:t>a</m:t></m:r></m:num>' +
+  '<m:den><m:r><m:t>b</m:t></m:r></m:den></m:f>' +
+  '<m:rad><m:deg/><m:e><m:r><m:t>x</m:t></m:r></m:e></m:rad>' +
+  '<m:sSup><m:e><m:r><m:t>x</m:t></m:r></m:e>' +
+  '<m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup>' +
+  '<m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr>' +
+  '<m:sub><m:r><m:t>n</m:t></m:r></m:sub><m:sup/>' +
+  '<m:e><m:r><m:t>x</m:t></m:r></m:e></m:nary>' +
+  '</m:oMath>';
+
+describe('semantic equation paint', () => {
+  test('paints nested layout records with activation metadata and pointer events', () => {
+    const { container, layout } = layoutAndPaint(
+      `<w:p><w:r><w:t>A</w:t></w:r>${supported}<w:r><w:t>Z</w:t></w:r></w:p>`
+    );
+    const record = linesOf(layout)[0]!.spans.find((span) => span.equation)!;
+    const equation = container.querySelector<HTMLElement>('[data-docx-equation]');
+
+    expect(equation).not.toBeNull();
+    expect(equation!.dataset.docxEquation).toBe(record.equation!.sourceNodeId);
+    expect(equation!.dataset.paragraphId).toBe(record.range.paragraphId);
+    expect(equation!.dataset.start).toBe(String(record.range.start));
+    expect(equation!.dataset.end).toBe(String(record.range.end));
+    expect(equation!.getAttribute('contenteditable')).toBe('false');
+    expect(equation!.style.pointerEvents).toBe('auto');
+    expect(Number.parseFloat(equation!.style.width)).toBeCloseTo(
+      record.equation!.geometry.box.width,
+      5
+    );
+    expect(Number.parseFloat(equation!.style.height)).toBeCloseTo(
+      record.equation!.geometry.box.height,
+      5
+    );
+    expect(equation!.querySelector('.docx-equation-fraction')).not.toBeNull();
+    expect(equation!.querySelector('.docx-equation-radical')).not.toBeNull();
+    expect(equation!.querySelector('.docx-equation-script')).not.toBeNull();
+    expect(equation!.querySelector('.docx-equation-nary')).not.toBeNull();
+    expect(equation!.querySelector('.docx-equation-fraction-bar')).not.toBeNull();
+    expect(equation!.querySelector('.docx-equation-radical-bar')).not.toBeNull();
+  });
+
+  test('writes unsupported markup-like fallback through textContent', () => {
+    const payload = '&lt;img src=x onerror=alert(1)&gt;';
+    const { container } = layoutAndPaint(
+      `<w:p><m:oMath><m:unsupported><m:r><m:t>${payload}</m:t></m:r>` +
+        '</m:unsupported></m:oMath></w:p>'
+    );
+    const equation = container.querySelector<HTMLElement>('[data-docx-equation]')!;
+    expect(equation.textContent).toBe('<img src=x onerror=alert(1)>');
+    expect(equation.querySelector('img')).toBeNull();
+    expect(equation.querySelector('script')).toBeNull();
+  });
+});

--- a/packages/core/src/output/semantic-paint-equation.ts
+++ b/packages/core/src/output/semantic-paint-equation.ts
@@ -135,9 +135,9 @@ export function mountEquationGeometry(
   host.style.lineHeight = '0';
   host.style.pointerEvents = 'auto';
   host.style.userSelect = 'none';
-  // An inline-block with absolute children exposes its bottom edge as its CSS baseline.
-  // Raise that edge by the layout-published descent so the equation baseline meets the line.
-  host.style.verticalAlign = `${(geometry.box.height - geometry.baseline) * scale}px`;
+  // An inline-block exposes its bottom edge as its CSS baseline. Move the box down by its
+  // published descent so the equation's internal baseline meets the surrounding text.
+  host.style.verticalAlign = `${-(geometry.box.height - geometry.baseline) * scale}px`;
   const fragment = document.createDocumentFragment();
   paintNode(document, fragment, geometry, scale);
   host.append(fragment);

--- a/packages/core/src/output/semantic-paint-equation.ts
+++ b/packages/core/src/output/semantic-paint-equation.ts
@@ -1,0 +1,144 @@
+// Paint equation geometry without parsing OMML or measuring DOM.
+
+import type { EquationGeometry, EquationSpanRecord } from '@docx-editor.dev/core/layout';
+
+function place(
+  element: HTMLElement,
+  geometry: {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  },
+  scale: number
+): void {
+  element.style.position = 'absolute';
+  element.style.left = `${geometry.x * scale}px`;
+  element.style.top = `${geometry.y * scale}px`;
+  element.style.width = `${geometry.width * scale}px`;
+  element.style.height = `${geometry.height * scale}px`;
+}
+
+function rule(
+  document: Document,
+  className: string,
+  geometry: {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  },
+  scale: number
+): HTMLElement {
+  const element = document.createElement('span');
+  element.className = className;
+  element.setAttribute('aria-hidden', 'true');
+  element.style.position = 'absolute';
+  element.style.display = 'block';
+  element.style.left = `${geometry.x * scale}px`;
+  element.style.top = `${geometry.y * scale}px`;
+  element.style.width = `${geometry.width * scale}px`;
+  element.style.height = `${geometry.height * scale}px`;
+  element.style.backgroundColor = 'currentColor';
+  element.style.pointerEvents = 'none';
+  return element;
+}
+
+function paintNode(
+  document: Document,
+  host: DocumentFragment,
+  node: EquationGeometry,
+  scale: number,
+  parentX = 0,
+  parentY = 0,
+  ancestors: readonly string[] = []
+): void {
+  const x = parentX + node.box.x;
+  const y = parentY + node.box.y;
+  const classes = [...ancestors, node.kind];
+  switch (node.kind) {
+    case 'text':
+    case 'fallback': {
+      const element = document.createElement('span');
+      element.className = [
+        'docx-equation-node',
+        ...classes.map((kind) => `docx-equation-${kind}`),
+      ].join(' ');
+      place(element, { x, y, width: node.box.width, height: node.box.height }, scale);
+      element.textContent = node.text;
+      element.style.display = 'block';
+      element.style.fontSize = `${node.fontSizePt * scale}px`;
+      element.style.lineHeight = `${node.box.height * scale}px`;
+      element.style.whiteSpace = 'pre';
+      host.append(element);
+      break;
+    }
+    case 'row':
+      for (const child of node.items) paintNode(document, host, child, scale, x, y, classes);
+      break;
+    case 'fraction':
+      paintNode(document, host, node.numerator, scale, x, y, classes);
+      host.append(
+        rule(
+          document,
+          'docx-equation-fraction-bar',
+          { ...node.bar, x: x + node.bar.x, y: y + node.bar.y },
+          scale
+        )
+      );
+      paintNode(document, host, node.denominator, scale, x, y, classes);
+      break;
+    case 'radical':
+      paintNode(document, host, node.sign, scale, x, y, classes);
+      if (node.degree) paintNode(document, host, node.degree, scale, x, y, classes);
+      host.append(
+        rule(
+          document,
+          'docx-equation-radical-bar',
+          { ...node.bar, x: x + node.bar.x, y: y + node.bar.y },
+          scale
+        )
+      );
+      paintNode(document, host, node.radicand, scale, x, y, classes);
+      break;
+    case 'script':
+      paintNode(document, host, node.base, scale, x, y, classes);
+      if (node.subscript) paintNode(document, host, node.subscript, scale, x, y, classes);
+      if (node.superscript) paintNode(document, host, node.superscript, scale, x, y, classes);
+      break;
+    case 'nary':
+      paintNode(document, host, node.operator, scale, x, y, classes);
+      if (node.lowerLimit) paintNode(document, host, node.lowerLimit, scale, x, y, classes);
+      if (node.upperLimit) paintNode(document, host, node.upperLimit, scale, x, y, classes);
+      paintNode(document, host, node.body, scale, x, y, classes);
+      break;
+  }
+}
+
+/** Mount one paint-ready equation into its already styled atomic span. */
+export function mountEquationGeometry(
+  document: Document,
+  host: HTMLElement,
+  equation: EquationSpanRecord,
+  scale: number
+): void {
+  const geometry = equation.geometry;
+  host.className = 'layout-run docx-equation';
+  host.dataset.docxEquation = equation.sourceNodeId;
+  host.setAttribute('contenteditable', 'false');
+  host.setAttribute('role', 'math');
+  if (equation.fallbackText) host.setAttribute('aria-label', equation.fallbackText);
+  host.style.position = 'relative';
+  host.style.display = 'inline-block';
+  host.style.width = `${geometry.box.width * scale}px`;
+  host.style.height = `${geometry.box.height * scale}px`;
+  host.style.lineHeight = '0';
+  host.style.pointerEvents = 'auto';
+  host.style.userSelect = 'none';
+  // An inline-block with absolute children exposes its bottom edge as its CSS baseline.
+  // Raise that edge by the layout-published descent so the equation baseline meets the line.
+  host.style.verticalAlign = `${(geometry.box.height - geometry.baseline) * scale}px`;
+  const fragment = document.createDocumentFragment();
+  paintNode(document, fragment, geometry, scale);
+  host.append(fragment);
+}

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -67,6 +67,7 @@ import {
   type DrawingPaintStrings,
   type PaintImageUrlPort,
 } from './semantic-paint-drawings.ts';
+import { mountEquationGeometry } from './semantic-paint-equation.ts';
 
 /**
  * When a field's result is drawn on its grey block, following Word's own View option.
@@ -1107,6 +1108,15 @@ function paintSpan(
   extraLeadingPt: number
 ): HTMLElement {
   const element = document.createElement('span');
+  if (span.equation) {
+    element.dataset.paragraphId = span.range.paragraphId;
+    element.dataset.start = String(span.range.start);
+    element.dataset.end = String(span.range.end);
+    applyRunFaceStyle(element, span.style, ctx);
+    mountEquationGeometry(document, element, span.equation, ctx.scale);
+    applyRevisionPresentation(element, span, ctx);
+    return element;
+  }
   element.className = 'layout-run layout-run-text';
   // Each run is its OWN box, aligned on the baseline.
   //

--- a/packages/core/src/store/__tests__/math-equation-atom.test.ts
+++ b/packages/core/src/store/__tests__/math-equation-atom.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  applyTreeOp,
+  canonicalOoxmlFingerprint,
+  paragraphTextOf,
+  projectOmmlEquation,
+  readOoxmlPart,
+  segmentsOf,
+  serializeOoxmlPart,
+  type OoxmlElement,
+  type OoxmlPart,
+} from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const M = 'http://schemas.openxmlformats.org/officeDocument/2006/math';
+const metadata = {
+  name: '/word/document.xml',
+  contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+};
+
+function parse(content: string): OoxmlPart {
+  const loaded = readOoxmlPart(
+    `<w:document xmlns:w="${W}" xmlns:m="${M}"><w:body><w:p>${content}</w:p></w:body></w:document>`,
+    metadata
+  );
+  if (!loaded.ok) throw new Error(loaded.reason);
+  return loaded.part;
+}
+
+function paragraphOf(part: OoxmlPart): OoxmlElement {
+  const body = part.root.children[0] as OoxmlElement;
+  const paragraph = body.children.find((child) => child.kind === 'paragraph');
+  if (!paragraph || paragraph.kind !== 'paragraph') throw new Error('missing paragraph');
+  return paragraph;
+}
+
+const equation = '<m:oMath><m:r><m:t>x</m:t></m:r></m:oMath>';
+
+describe('OMML equation model atom', () => {
+  test('occupies one paragraph offset and round-trips without normalization', () => {
+    const part = parse(`<w:r><w:t>A</w:t></w:r>${equation}<w:r><w:t>Z</w:t></w:r>`);
+    const paragraph = paragraphOf(part);
+    const segment = segmentsOf(paragraph).find(
+      (candidate) =>
+        candidate.node.kind !== 'textValue' &&
+        candidate.node.namespaceUri === M &&
+        candidate.node.localName === 'oMath'
+    );
+
+    expect(segment).toMatchObject({ start: 1, end: 2 });
+    expect(segment?.removeNodeIds).toEqual([segment?.node.id]);
+    expect(paragraphTextOf(part, paragraph.id)).toBe('A\uFFFCZ');
+
+    const reopened = readOoxmlPart(serializeOoxmlPart(part), metadata);
+    if (!reopened.ok) throw new Error(reopened.reason);
+    expect(canonicalOoxmlFingerprint(reopened.part)).toBe(canonicalOoxmlFingerprint(part));
+  });
+
+  test('deletes the complete equation through the shared text operation', () => {
+    const part = parse(`<w:r><w:t>A</w:t></w:r>${equation}<w:r><w:t>Z</w:t></w:r>`);
+    const paragraph = paragraphOf(part);
+    const result = applyTreeOp(part, {
+      op: 'deleteText',
+      paragraphId: paragraph.id,
+      start: 1,
+      end: 2,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(paragraphTextOf(result.part, paragraph.id)).toBe('AZ');
+    expect(serializeOoxmlPart(result.part)).not.toContain('<m:oMath>');
+  });
+
+  test('typing at a leading equation boundary creates a sibling run', () => {
+    const part = parse(`${equation}<w:r><w:t>Z</w:t></w:r>`);
+    const paragraph = paragraphOf(part);
+    const result = applyTreeOp(part, {
+      op: 'insertText',
+      paragraphId: paragraph.id,
+      offset: 0,
+      text: 'A',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(paragraphTextOf(result.part, paragraph.id)).toBe('A\uFFFCZ');
+  });
+
+  test('typing after a trailing equation creates a sibling run after it', () => {
+    const part = parse(`<w:r><w:t>A</w:t></w:r>${equation}`);
+    const paragraph = paragraphOf(part);
+    const result = applyTreeOp(part, {
+      op: 'insertText',
+      paragraphId: paragraph.id,
+      offset: 2,
+      text: 'Z',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(paragraphTextOf(result.part, paragraph.id)).toBe('A\uFFFCZ');
+    expect(serializeOoxmlPart(result.part)).toContain('</m:oMath><w:r><w:t>Z</w:t></w:r>');
+  });
+
+  test('replaces and removes an equation through explicit atomic operations', () => {
+    const part = parse(`<w:r><w:t>A</w:t></w:r>${equation}<w:r><w:t>Z</w:t></w:r>`);
+    const paragraph = paragraphOf(part);
+    const original = paragraph.children.find(
+      (child) =>
+        child.kind !== 'textValue' && child.namespaceUri === M && child.localName === 'oMath'
+    );
+    if (!original) throw new Error('missing equation');
+
+    const replaced = applyTreeOp(part, {
+      op: 'setMathEquation',
+      equationId: original.id,
+      linear: '{a+b}/{2}',
+    });
+    expect(replaced.ok).toBe(true);
+    if (!replaced.ok) return;
+    const next = projectOmmlEquation(
+      paragraphOf(replaced.part).children.find((child) => child.id === original.id)!
+    );
+    expect(next?.expression.kind).toBe('fraction');
+    expect(paragraphTextOf(replaced.part, paragraph.id)).toBe('A\uFFFCZ');
+
+    const removed = applyTreeOp(replaced.part, {
+      op: 'removeMathEquation',
+      equationId: original.id,
+    });
+    expect(removed.ok).toBe(true);
+    if (!removed.ok) return;
+    expect(paragraphTextOf(removed.part, paragraph.id)).toBe('AZ');
+  });
+
+  test('refuses malformed linear math without changing the part', () => {
+    const part = parse(equation);
+    const paragraph = paragraphOf(part);
+    const original = paragraph.children.find(
+      (child) =>
+        child.kind !== 'textValue' && child.namespaceUri === M && child.localName === 'oMath'
+    );
+    if (!original) throw new Error('missing equation');
+    const result = applyTreeOp(part, {
+      op: 'setMathEquation',
+      equationId: original.id,
+      linear: 'x^',
+    });
+    expect(result).toEqual({ ok: false, reason: 'invalid-property-value' });
+    expect(canonicalOoxmlFingerprint(part)).toBe(canonicalOoxmlFingerprint(parse(equation)));
+  });
+});

--- a/packages/core/src/store/__tests__/omml-equation.test.ts
+++ b/packages/core/src/store/__tests__/omml-equation.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  OFFICE_MATH_NAMESPACE_URI,
+  WML_NAMESPACE_URI,
+  canonicalOoxmlFingerprint,
+  createNodeIdAllocator,
+  equationExpressionToLinearMath,
+  findNode,
+  insertChildren,
+  linearMathToOmml,
+  parseLinearMath,
+  projectOmmlEquation,
+  readOoxmlPart,
+  serializeOoxmlPart,
+  validateOoxmlPart,
+  type EquationExpression,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../index.ts';
+
+const metadata = {
+  name: '/word/document.xml',
+  contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+};
+
+function readDocument(paragraphContent: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:m="${OFFICE_MATH_NAMESPACE_URI}">` +
+      `<w:body><w:p>${paragraphContent}</w:p></w:body></w:document>`,
+    metadata
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function equationOf(part: OoxmlPart): OoxmlElement {
+  const body = part.root.children[0];
+  if (!body || body.kind === 'textValue') throw new Error('missing body');
+  const paragraph = body.children[0];
+  if (!paragraph || paragraph.kind === 'textValue') throw new Error('missing paragraph');
+  const equation = paragraph.children.find(
+    (node) =>
+      node.kind !== 'textValue' &&
+      node.namespaceUri === OFFICE_MATH_NAMESPACE_URI &&
+      node.localName === 'oMath'
+  );
+  if (!equation || equation.kind === 'textValue') throw new Error('missing equation');
+  return equation;
+}
+
+function paragraphOf(part: OoxmlPart): OoxmlElement {
+  const body = part.root.children[0];
+  if (!body || body.kind === 'textValue') throw new Error('missing body');
+  const paragraph = body.children[0];
+  if (!paragraph || paragraph.kind === 'textValue') throw new Error('missing paragraph');
+  return paragraph;
+}
+
+function expressionKinds(expression: EquationExpression): string[] {
+  switch (expression.kind) {
+    case 'row':
+      return expression.items.flatMap(expressionKinds);
+    case 'fraction':
+      return [
+        expression.kind,
+        ...expressionKinds(expression.numerator),
+        ...expressionKinds(expression.denominator),
+      ];
+    case 'radical':
+      return [expression.kind, ...expressionKinds(expression.radicand)];
+    case 'script':
+      return [expression.kind, ...expressionKinds(expression.base)];
+    case 'nary':
+      return [expression.kind, ...expressionKinds(expression.body)];
+    default:
+      return [expression.kind];
+  }
+}
+
+function allNodes(node: OoxmlNode): OoxmlNode[] {
+  if (node.kind === 'textValue') return [node];
+  return [node, ...node.children.flatMap(allNodes)];
+}
+
+describe('bounded OMML equation projection', () => {
+  test('projects runs, fractions, radicals, superscripts, and n-ary limits', () => {
+    const part = readDocument(
+      '<m:oMath>' +
+        '<m:r><m:t>E=mc</m:t></m:r>' +
+        '<m:sSup><m:e><m:r><m:t>2</m:t></m:r></m:e>' +
+        '<m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup>' +
+        '<m:f><m:num><m:r><m:t>a+b</m:t></m:r></m:num>' +
+        '<m:den><m:r><m:t>2</m:t></m:r></m:den></m:f>' +
+        '<m:rad><m:deg/><m:e><m:r><m:t>x</m:t></m:r></m:e></m:rad>' +
+        '<m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr>' +
+        '<m:sub><m:r><m:t>i=0</m:t></m:r></m:sub>' +
+        '<m:sup><m:r><m:t>n</m:t></m:r></m:sup>' +
+        '<m:e><m:r><m:t>x</m:t></m:r></m:e></m:nary>' +
+        '</m:oMath>'
+    );
+
+    const projection = projectOmmlEquation(equationOf(part));
+    expect(projection).not.toBeNull();
+    expect(projection?.truncated).toBe(false);
+    expect(expressionKinds(projection!.expression)).toEqual(
+      expect.arrayContaining(['text', 'script', 'fraction', 'radical', 'nary'])
+    );
+    const nary =
+      projection?.expression.kind === 'row'
+        ? projection.expression.items.find((child) => child.kind === 'nary')
+        : undefined;
+    expect(nary).toMatchObject({
+      kind: 'nary',
+      operator: '∑',
+      lowerLimit: { kind: 'text', value: 'i=0' },
+      upperLimit: { kind: 'text', value: 'n' },
+    });
+  });
+
+  test('uses descendant text for unsupported OMML without changing source', () => {
+    const part = readDocument(
+      '<m:oMath><m:bar><m:e><m:r><m:t>&lt;img onerror="x"&gt;</m:t></m:r>' +
+        '</m:e></m:bar></m:oMath>'
+    );
+    const before = canonicalOoxmlFingerprint(part);
+    const projection = projectOmmlEquation(equationOf(part));
+
+    expect(projection).toMatchObject({
+      truncated: false,
+      fallbackText: '<img onerror="x">',
+      expression: { kind: 'fallback', text: '<img onerror="x">' },
+    });
+    expect(canonicalOoxmlFingerprint(part)).toBe(before);
+  });
+
+  test.each([
+    [
+      'unknown child',
+      '<m:f><m:num><m:r><m:t>a</m:t></m:r></m:num>' +
+        '<m:den><m:r><m:t>b</m:t></m:r></m:den>' +
+        '<m:box><m:r><m:t>extra</m:t></m:r></m:box></m:f>',
+      'abextra',
+    ],
+    [
+      'duplicate numerator',
+      '<m:f><m:num><m:r><m:t>a</m:t></m:r></m:num>' +
+        '<m:num><m:r><m:t>duplicate</m:t></m:r></m:num>' +
+        '<m:den><m:r><m:t>b</m:t></m:r></m:den></m:f>',
+      'aduplicateb',
+    ],
+    [
+      'unsupported fraction property',
+      '<m:f><m:fPr><m:type m:val="lin"/></m:fPr>' +
+        '<m:num><m:r><m:t>a</m:t></m:r></m:num>' +
+        '<m:den><m:r><m:t>b</m:t></m:r></m:den></m:f>',
+      'ab',
+    ],
+  ])('falls back for structured OMML with an %s', (_, content, fallbackText) => {
+    const projection = projectOmmlEquation(
+      equationOf(readDocument(`<m:oMath>${content}</m:oMath>`))
+    );
+    expect(projection).toMatchObject({
+      expression: { kind: 'fallback', text: fallbackText },
+      fallbackText,
+      truncated: false,
+    });
+  });
+
+  test('reuses the immutable default projection by source-node identity', () => {
+    const equation = equationOf(readDocument('<m:oMath><m:r><m:t>x</m:t></m:r></m:oMath>'));
+    const first = projectOmmlEquation(equation);
+    expect(projectOmmlEquation(equation)).toBe(first);
+    expect(projectOmmlEquation(equation, { maxNodes: 256 })).not.toBe(first);
+  });
+
+  test('stops at depth, node, and text budgets with a safe fallback', () => {
+    const deep = `${'<m:box>'.repeat(30)}<m:r><m:t>hidden</m:t></m:r>${'</m:box>'.repeat(30)}`;
+    const depthProjection = projectOmmlEquation(
+      equationOf(readDocument(`<m:oMath>${deep}</m:oMath>`)),
+      {
+        maxDepth: 8,
+      }
+    );
+    expect(depthProjection).toMatchObject({
+      truncated: true,
+      expression: { kind: 'fallback' },
+    });
+
+    const wide = Array.from({ length: 40 }, (_, index) => `<m:r><m:t>${index}</m:t></m:r>`).join(
+      ''
+    );
+    const nodeProjection = projectOmmlEquation(
+      equationOf(readDocument(`<m:oMath>${wide}</m:oMath>`)),
+      {
+        maxNodes: 12,
+      }
+    );
+    expect(nodeProjection?.truncated).toBe(true);
+    expect(nodeProjection!.visitedNodes).toBeLessThanOrEqual(12);
+
+    const textProjection = projectOmmlEquation(
+      equationOf(readDocument('<m:oMath><m:r><m:t>abcdefghij</m:t></m:r></m:oMath>')),
+      { maxTextLength: 4 }
+    );
+    expect(textProjection).toMatchObject({
+      truncated: true,
+      fallbackText: 'abcd…',
+      expression: { kind: 'fallback', text: 'abcd…' },
+    });
+
+    const operatorProjection = projectOmmlEquation(
+      equationOf(
+        readDocument(
+          '<m:oMath><m:nary><m:naryPr><m:chr m:val="123456"/></m:naryPr>' +
+            '<m:sub/><m:sup/><m:e><m:r><m:t>x</m:t></m:r></m:e></m:nary></m:oMath>'
+        )
+      ),
+      { maxTextLength: 4 }
+    );
+    expect(operatorProjection).toMatchObject({
+      truncated: true,
+      fallbackText: '1234…',
+      expression: { kind: 'fallback', text: '1234…' },
+    });
+  });
+});
+
+describe('compact linear math to canonical OMML', () => {
+  test.each([
+    ['x^2', 'script'],
+    ['x_i', 'script'],
+    ['{a+b}/{2}', 'fraction'],
+    ['√{x}', 'radical'],
+    ['√[3]{x}', 'radical'],
+    ['∑[n]{x}', 'nary'],
+  ])('parses %s as %s', (source, kind) => {
+    const parsed = parseLinearMath(source);
+    expect(parsed).toMatchObject({ ok: true, expression: { kind } });
+  });
+
+  test('reuses bounded default parse results across validation and apply', () => {
+    const parsed = parseLinearMath('{a+b}/{2}');
+    expect(parseLinearMath('{a+b}/{2}')).toBe(parsed);
+    expect(parseLinearMath('{a+b}/{2}', { maxNodes: 256 })).not.toBe(parsed);
+  });
+
+  test('round-trips radical degrees through reversible linear math', () => {
+    const projected = projectOmmlEquation(
+      equationOf(
+        readDocument(
+          '<m:oMath><m:rad><m:deg><m:r><m:t>3</m:t></m:r></m:deg>' +
+            '<m:e><m:r><m:t>x</m:t></m:r></m:e></m:rad></m:oMath>'
+        )
+      )
+    );
+    expect(projected?.expression).toMatchObject({
+      kind: 'radical',
+      degree: { kind: 'text', value: '3' },
+    });
+    expect(equationExpressionToLinearMath(projected!.expression)).toBe('√[3]{x}');
+    expect(parseLinearMath('√[3]{x}')).toMatchObject({
+      ok: true,
+      expression: {
+        kind: 'radical',
+        degree: { kind: 'text', value: '3' },
+      },
+    });
+  });
+
+  test('does not expose lossy linear text for reserved literals or arbitrary n-ary operators', () => {
+    const reserved = projectOmmlEquation(
+      equationOf(readDocument('<m:oMath><m:r><m:t>√{x}</m:t></m:r></m:oMath>'))
+    );
+    const arbitraryNary = projectOmmlEquation(
+      equationOf(
+        readDocument(
+          '<m:oMath><m:nary><m:naryPr><m:chr m:val="∫"/>' +
+            '<m:limLoc m:val="undOvr"/></m:naryPr>' +
+            '<m:e><m:r><m:t>x</m:t></m:r></m:e></m:nary></m:oMath>'
+        )
+      )
+    );
+    const unsupported = projectOmmlEquation(
+      equationOf(
+        readDocument('<m:oMath><m:box><m:e><m:r><m:t>x</m:t></m:r></m:e></m:box></m:oMath>')
+      )
+    );
+
+    expect(equationExpressionToLinearMath(reserved!.expression)).toBe('');
+    expect(equationExpressionToLinearMath(arbitraryNary!.expression)).toBe('');
+    expect(equationExpressionToLinearMath(unsupported!.expression)).toBe('');
+  });
+
+  test('creates valid namespaced OMML with fresh IDs and reopens it', () => {
+    const loaded = readOoxmlPart(
+      `<w:document xmlns:w="${WML_NAMESPACE_URI}"><w:body>` +
+        '<w:p xmlns:m="urn:hostile"><w:r><w:t>before</w:t></w:r></w:p>' +
+        '</w:body></w:document>',
+      metadata
+    );
+    if (!loaded.ok) throw new Error(loaded.reason);
+    const part = loaded.part;
+    const sourceIds = new Set(allNodes(part.root).map((node) => node.id));
+    const converted = linearMathToOmml(
+      '{a+b}/{2}+√{x}+x^2+x_i+∑[n]{x}',
+      createNodeIdAllocator(part)
+    );
+    expect(converted.ok).toBe(true);
+    if (!converted.ok) return;
+
+    const generatedNodes = allNodes(converted.equation);
+    const generatedIds = generatedNodes.map((node) => node.id);
+    expect(new Set(generatedIds).size).toBe(generatedIds.length);
+    expect(generatedIds.every((id) => !sourceIds.has(id))).toBe(true);
+    const generatedNames = generatedNodes.flatMap((node) =>
+      node.kind === 'textValue' ? [] : [node.localName]
+    );
+    expect(generatedNames).toEqual(
+      expect.arrayContaining(['oMath', 'f', 'rad', 'sSup', 'sSub', 'nary'])
+    );
+
+    const paragraph = paragraphOf(part);
+    const inserted = insertChildren(part, paragraph.id, paragraph.children.length, [
+      converted.equation,
+    ]);
+    expect(inserted.ok).toBe(true);
+    if (!inserted.ok) return;
+    expect(validateOoxmlPart(inserted.part).ok).toBe(true);
+
+    const xml = serializeOoxmlPart(inserted.part);
+    expect(xml).toContain('xmlns:m="urn:hostile"');
+    expect(xml).toContain(`xmlns:m="${OFFICE_MATH_NAMESPACE_URI}"`);
+
+    const reopened = readOoxmlPart(xml, metadata);
+    expect(reopened.ok).toBe(true);
+    if (!reopened.ok) return;
+    const projection = projectOmmlEquation(equationOf(reopened.part));
+    expect(projection?.truncated).toBe(false);
+    expect(expressionKinds(projection!.expression)).toEqual(
+      expect.arrayContaining(['fraction', 'radical', 'script', 'nary'])
+    );
+    expect(findNode(reopened.part, equationOf(reopened.part).id)).not.toBeNull();
+  });
+
+  test('preserves boundary whitespace on generated math text', () => {
+    const part = readDocument('');
+    const converted = linearMathToOmml(' x ', createNodeIdAllocator(part));
+    expect(converted.ok).toBe(true);
+    if (!converted.ok) return;
+    const paragraph = paragraphOf(part);
+    const inserted = insertChildren(part, paragraph.id, 0, [converted.equation]);
+    expect(inserted.ok).toBe(true);
+    if (!inserted.ok) return;
+
+    expect(serializeOoxmlPart(inserted.part)).toContain('<m:t xml:space="preserve"> x </m:t>');
+  });
+
+  test('refuses malformed, hostile, and XML-invalid input', () => {
+    expect(parseLinearMath('')).toEqual({ ok: false, reason: 'empty' });
+    expect(parseLinearMath('x^')).toEqual({ ok: false, reason: 'invalid-syntax' });
+    expect(parseLinearMath('{a}/{')).toEqual({ ok: false, reason: 'invalid-syntax' });
+    expect(parseLinearMath('√x')).toEqual({ ok: false, reason: 'invalid-syntax' });
+    expect(parseLinearMath('∑[]{x}')).toEqual({ ok: false, reason: 'invalid-syntax' });
+    expect(parseLinearMath('a\u0000b')).toEqual({ ok: false, reason: 'invalid-xml-text' });
+    expect(parseLinearMath('abcdef', { maxTextLength: 5 })).toEqual({
+      ok: false,
+      reason: 'text-limit',
+    });
+    expect(parseLinearMath(`${'{'.repeat(30)}x${'}'.repeat(30)}`, { maxDepth: 8 })).toEqual({
+      ok: false,
+      reason: 'depth-limit',
+    });
+    expect(parseLinearMath('a^ba^ba^ba^b', { maxNodes: 5 })).toEqual({
+      ok: false,
+      reason: 'node-limit',
+    });
+  });
+
+  test('round-trips lower and upper n-ary limits through linear math', () => {
+    const projected = projectOmmlEquation(
+      equationOf(
+        readDocument(
+          '<m:oMath><m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr>' +
+            '<m:sub><m:r><m:t>i=1</m:t></m:r></m:sub>' +
+            '<m:sup><m:r><m:t>n</m:t></m:r></m:sup>' +
+            '<m:e><m:r><m:t>i</m:t></m:r></m:e></m:nary></m:oMath>'
+        )
+      )
+    );
+    if (!projected) throw new Error('missing projection');
+    const linear = equationExpressionToLinearMath(projected.expression);
+    expect(linear).toBe('∑[i=1]^[n]{i}');
+    expect(parseLinearMath(linear)).toMatchObject({
+      ok: true,
+      expression: {
+        kind: 'nary',
+        lowerLimit: { kind: 'text', value: 'i=1' },
+        upperLimit: { kind: 'text', value: 'n' },
+      },
+    });
+  });
+});

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -167,6 +167,20 @@ export {
   scrubExport,
 } from './sinks.ts';
 export {
+  DEFAULT_OMML_LIMITS,
+  OFFICE_MATH_NAMESPACE_URI,
+  equationExpressionToLinearMath,
+  linearMathToOmml,
+  parseLinearMath,
+  projectOmmlEquation,
+  type EquationExpression,
+  type LinearMathOmmlResult,
+  type LinearMathParseResult,
+  type LinearMathRejection,
+  type OmmlEquationProjection,
+  type OmmlLimits,
+} from './omml-equation.ts';
+export {
   readOoxmlPackage,
   writeOoxmlPackage,
   withPart,

--- a/packages/core/src/store/package/linear-math-render.ts
+++ b/packages/core/src/store/package/linear-math-render.ts
@@ -1,0 +1,69 @@
+import type { EquationExpression, LinearMathParseResult } from './omml-equation.ts';
+
+function reversible(value: EquationExpression): boolean {
+  switch (value.kind) {
+    case 'fallback':
+      return false;
+    case 'text':
+      return !/[{}[\]^_√∑]/u.test(value.value);
+    case 'row':
+      return value.items.every(reversible);
+    case 'fraction':
+      return reversible(value.numerator) && reversible(value.denominator);
+    case 'radical':
+      return reversible(value.radicand) && (!value.degree || reversible(value.degree));
+    case 'script':
+      return (
+        reversible(value.base) &&
+        (!value.subscript || reversible(value.subscript)) &&
+        (!value.superscript || reversible(value.superscript))
+      );
+    case 'nary':
+      return (
+        value.operator === '∑' &&
+        reversible(value.body) &&
+        (!value.lowerLimit || reversible(value.lowerLimit)) &&
+        (!value.upperLimit || reversible(value.upperLimit))
+      );
+  }
+}
+
+function render(value: EquationExpression): string {
+  switch (value.kind) {
+    case 'row':
+      return value.items.map(render).join('');
+    case 'text':
+      return value.value;
+    case 'fallback':
+      return value.text;
+    case 'fraction':
+      return `{${render(value.numerator)}}/{${render(value.denominator)}}`;
+    case 'radical':
+      return `√${value.degree ? `[${render(value.degree)}]` : ''}{${render(value.radicand)}}`;
+    case 'script':
+      return (
+        render(value.base) +
+        (value.subscript ? `_{${render(value.subscript)}}` : '') +
+        (value.superscript ? `^{${render(value.superscript)}}` : '')
+      );
+    case 'nary':
+      return (
+        value.operator +
+        (value.lowerLimit ? `[${render(value.lowerLimit)}]` : '') +
+        (value.upperLimit ? `^[${render(value.upperLimit)}]` : '') +
+        `{${render(value.body)}}`
+      );
+  }
+}
+
+/** Render only expressions that the compact parser can recover without loss. */
+export function renderReversibleLinearMath(
+  expression: EquationExpression,
+  parse: (input: string) => LinearMathParseResult
+): string {
+  if (!reversible(expression)) return '';
+  const rendered = render(expression);
+  const parsed = parse(rendered);
+  // Parsing can regroup adjacent text into one script base without moving its visible exponent.
+  return parsed.ok && render(parsed.expression) === rendered ? rendered : '';
+}

--- a/packages/core/src/store/package/omml-equation.ts
+++ b/packages/core/src/store/package/omml-equation.ts
@@ -1,0 +1,960 @@
+// Bounded Office Math projection and compact linear-math conversion.
+//
+// OMML stays generic in the canonical tree. This module reads that preserved source into a
+// small immutable expression tree and creates fresh generic OMML for supported user input.
+
+import { XML_NAMESPACE_URI } from './ooxml-shared.ts';
+import { isValidXmlText } from './sinks.ts';
+import { renderReversibleLinearMath } from './linear-math-render.ts';
+import type {
+  OoxmlAttribute,
+  OoxmlElement,
+  OoxmlGenericElementNode,
+  OoxmlNode,
+  OoxmlNodeId,
+} from './ooxml-tree.ts';
+
+/** Office Math Markup Language namespace. */
+export const OFFICE_MATH_NAMESPACE_URI =
+  'http://schemas.openxmlformats.org/officeDocument/2006/math';
+
+export const DEFAULT_OMML_LIMITS = Object.freeze({
+  maxDepth: 24,
+  maxNodes: 256,
+  maxTextLength: 512,
+});
+
+/** Shared work limits for untrusted OMML and linear-math input. */
+export interface OmmlLimits {
+  readonly maxDepth?: number;
+  readonly maxNodes?: number;
+  readonly maxTextLength?: number;
+}
+
+export type EquationExpression =
+  | { readonly kind: 'row'; readonly items: readonly EquationExpression[] }
+  | { readonly kind: 'text'; readonly value: string }
+  | {
+      readonly kind: 'fraction';
+      readonly numerator: EquationExpression;
+      readonly denominator: EquationExpression;
+    }
+  | {
+      readonly kind: 'radical';
+      readonly radicand: EquationExpression;
+      readonly degree?: EquationExpression;
+    }
+  | {
+      readonly kind: 'script';
+      readonly base: EquationExpression;
+      readonly subscript?: EquationExpression;
+      readonly superscript?: EquationExpression;
+    }
+  | {
+      readonly kind: 'nary';
+      readonly operator: string;
+      readonly body: EquationExpression;
+      readonly lowerLimit?: EquationExpression;
+      readonly upperLimit?: EquationExpression;
+    }
+  | { readonly kind: 'fallback'; readonly text: string };
+
+export interface OmmlEquationProjection {
+  readonly sourceNodeId: OoxmlNodeId;
+  readonly expression: EquationExpression;
+  readonly fallbackText: string;
+  readonly truncated: boolean;
+  readonly visitedNodes: number;
+}
+
+/**
+ * Canonical nodes are immutable and edits preserve untouched child identity.
+ *
+ * Cache the default projection by source identity. Typing beside an equation can relayout its
+ * paragraph many times, but it must not walk the same bounded OMML tree twice per keystroke.
+ * Weak keys release the projection with the document revision that owned the source node.
+ */
+const defaultProjectionCache = new WeakMap<OoxmlGenericElementNode, OmmlEquationProjection>();
+const DEFAULT_LINEAR_CACHE_LIMIT = 64;
+const defaultLinearMathCache = new Map<string, LinearMathParseResult>();
+
+export type LinearMathRejection =
+  | 'empty'
+  | 'invalid-syntax'
+  | 'invalid-xml-text'
+  | 'depth-limit'
+  | 'node-limit'
+  | 'text-limit';
+
+export type LinearMathParseResult =
+  | { readonly ok: true; readonly expression: EquationExpression }
+  | { readonly ok: false; readonly reason: LinearMathRejection };
+
+export type LinearMathOmmlResult =
+  | {
+      readonly ok: true;
+      readonly expression: EquationExpression;
+      readonly equation: OoxmlGenericElementNode;
+    }
+  | { readonly ok: false; readonly reason: LinearMathRejection };
+
+interface ResolvedLimits {
+  readonly maxDepth: number;
+  readonly maxNodes: number;
+  readonly maxTextLength: number;
+}
+
+function resolveLimits(limits: OmmlLimits | undefined): ResolvedLimits {
+  const positiveInteger = (value: number | undefined, fallback: number): number =>
+    Number.isSafeInteger(value) && value! > 0 ? value! : fallback;
+  return {
+    maxDepth: positiveInteger(limits?.maxDepth, DEFAULT_OMML_LIMITS.maxDepth),
+    maxNodes: positiveInteger(limits?.maxNodes, DEFAULT_OMML_LIMITS.maxNodes),
+    maxTextLength: positiveInteger(limits?.maxTextLength, DEFAULT_OMML_LIMITS.maxTextLength),
+  };
+}
+
+function isMathElement(node: OoxmlNode, localName?: string): node is OoxmlGenericElementNode {
+  return (
+    node.kind === 'generic' &&
+    node.namespaceUri === OFFICE_MATH_NAMESPACE_URI &&
+    (localName === undefined || node.localName === localName)
+  );
+}
+
+function frozenRow(children: readonly EquationExpression[]): EquationExpression {
+  if (children.length === 1) return children[0]!;
+  return Object.freeze({ kind: 'row', items: Object.freeze([...children]) });
+}
+
+function childrenOf(node: OoxmlElement): readonly OoxmlNode[] {
+  return node.children;
+}
+
+interface ProjectionState {
+  readonly limits: ResolvedLimits;
+  visitedNodes: number;
+  text: string;
+  truncated: boolean;
+}
+
+function appendProjectionText(state: ProjectionState, value: string): string {
+  const room = state.limits.maxTextLength - state.text.length;
+  if (room <= 0) {
+    if (value.length > 0) state.truncated = true;
+    return '';
+  }
+  const accepted = value.slice(0, room);
+  state.text += accepted;
+  if (accepted.length !== value.length) state.truncated = true;
+  return accepted;
+}
+
+function enterProjectionNode(state: ProjectionState, depth: number): boolean {
+  if (depth > state.limits.maxDepth || state.visitedNodes >= state.limits.maxNodes) {
+    state.truncated = true;
+    return false;
+  }
+  state.visitedNodes += 1;
+  return true;
+}
+
+function fallbackOf(node: OoxmlNode, state: ProjectionState, depth: number): EquationExpression {
+  const start = state.text.length;
+  collectFallbackText(node, state, depth);
+  const text = state.text.slice(start);
+  return Object.freeze({ kind: 'fallback', text: text || (state.truncated ? '…' : '') });
+}
+
+function collectFallbackText(node: OoxmlNode, state: ProjectionState, depth: number): void {
+  if (!enterProjectionNode(state, depth)) return;
+  if (node.kind === 'textValue') {
+    appendProjectionText(state, node.value);
+    return;
+  }
+  for (const child of childrenOf(node)) {
+    collectFallbackText(child, state, depth + 1);
+    if (state.truncated && state.text.length >= state.limits.maxTextLength) return;
+  }
+}
+
+function namedChild(
+  node: OoxmlGenericElementNode,
+  localName: string
+): OoxmlGenericElementNode | null {
+  for (const child of childrenOf(node)) {
+    if (isMathElement(child, localName)) return child;
+  }
+  return null;
+}
+
+function namedChildren(
+  node: OoxmlGenericElementNode,
+  localName: string
+): readonly OoxmlGenericElementNode[] {
+  return childrenOf(node).filter((child): child is OoxmlGenericElementNode =>
+    isMathElement(child, localName)
+  );
+}
+
+function hasOnlyMathChildren(
+  node: OoxmlGenericElementNode,
+  counts: Readonly<Record<string, { readonly min: number; readonly max: number }>>
+): boolean {
+  if (node.attributes.length > 0) return false;
+  const seen = new Map<string, number>();
+  for (const child of childrenOf(node)) {
+    if (!isMathElement(child) || counts[child.localName] === undefined) return false;
+    seen.set(child.localName, (seen.get(child.localName) ?? 0) + 1);
+  }
+  return Object.entries(counts).every(([name, range]) => {
+    const count = seen.get(name) ?? 0;
+    return count >= range.min && count <= range.max;
+  });
+}
+
+function isEmptyProperty(node: OoxmlGenericElementNode): boolean {
+  return node.attributes.length === 0 && childrenOf(node).length === 0;
+}
+
+function mathVal(node: OoxmlGenericElementNode): string | undefined {
+  return node.attributes.find(
+    (attribute) =>
+      attribute.namespaceUri === OFFICE_MATH_NAMESPACE_URI && attribute.localName === 'val'
+  )?.value;
+}
+
+function hasOnlyMathVal(node: OoxmlGenericElementNode, accepted?: ReadonlySet<string>): boolean {
+  if (childrenOf(node).length > 0 || node.attributes.length !== 1) return false;
+  const value = mathVal(node);
+  return value !== undefined && (accepted === undefined || accepted.has(value));
+}
+
+function isSupportedRun(node: OoxmlGenericElementNode): boolean {
+  if (node.attributes.length > 0) return false;
+  const properties = namedChildren(node, 'rPr');
+  const texts = namedChildren(node, 't');
+  if (properties.length > 1 || texts.length === 0) return false;
+  if (properties[0] && !isEmptyProperty(properties[0])) return false;
+  if (properties.length + texts.length !== childrenOf(node).length) return false;
+  return texts.every(
+    (text) =>
+      text.attributes.every(
+        (attribute) =>
+          attribute.namespaceUri === XML_NAMESPACE_URI &&
+          attribute.localName === 'space' &&
+          (attribute.value === 'preserve' || attribute.value === 'default')
+      ) && childrenOf(text).every((child) => child.kind === 'textValue')
+  );
+}
+
+function isSupportedExpressionNode(node: OoxmlNode): boolean {
+  if (node.kind === 'textValue') return true;
+  if (!isMathElement(node)) return false;
+  if (node.localName === 'r') return isSupportedRun(node);
+  if (node.localName === 't') {
+    return (
+      node.attributes.every(
+        (attribute) =>
+          attribute.namespaceUri === XML_NAMESPACE_URI &&
+          attribute.localName === 'space' &&
+          (attribute.value === 'preserve' || attribute.value === 'default')
+      ) && childrenOf(node).every((child) => child.kind === 'textValue')
+    );
+  }
+  if (node.localName === 'f') {
+    if (
+      !hasOnlyMathChildren(node, {
+        fPr: { min: 0, max: 1 },
+        num: { min: 1, max: 1 },
+        den: { min: 1, max: 1 },
+      })
+    ) {
+      return false;
+    }
+    const property = namedChild(node, 'fPr');
+    return (
+      (!property || isEmptyProperty(property)) &&
+      childrenOf(namedChildren(node, 'num')[0]!).every(isSupportedExpressionNode) &&
+      childrenOf(namedChildren(node, 'den')[0]!).every(isSupportedExpressionNode)
+    );
+  }
+  if (node.localName === 'rad') {
+    if (
+      !hasOnlyMathChildren(node, {
+        radPr: { min: 0, max: 1 },
+        deg: { min: 1, max: 1 },
+        e: { min: 1, max: 1 },
+      })
+    ) {
+      return false;
+    }
+    const degree = namedChildren(node, 'deg')[0]!;
+    const property = namedChild(node, 'radPr');
+    const propertySupported =
+      !property ||
+      isEmptyProperty(property) ||
+      (childrenOf(degree).length === 0 &&
+        hasOnlyMathChildren(property, { degHide: { min: 1, max: 1 } }) &&
+        hasOnlyMathVal(namedChildren(property, 'degHide')[0]!, new Set(['1', 'true', 'on'])));
+    return (
+      propertySupported &&
+      childrenOf(degree).every(isSupportedExpressionNode) &&
+      childrenOf(namedChildren(node, 'e')[0]!).every(isSupportedExpressionNode)
+    );
+  }
+  if (node.localName === 'sSup' || node.localName === 'sSub' || node.localName === 'sSubSup') {
+    const propertyName = `${node.localName}Pr`;
+    const expected = {
+      [propertyName]: { min: 0, max: 1 },
+      e: { min: 1, max: 1 },
+      sub: { min: node.localName === 'sSup' ? 0 : 1, max: node.localName === 'sSup' ? 0 : 1 },
+      sup: { min: node.localName === 'sSub' ? 0 : 1, max: node.localName === 'sSub' ? 0 : 1 },
+    };
+    if (!hasOnlyMathChildren(node, expected)) return false;
+    const property = namedChild(node, propertyName);
+    return (
+      (!property || isEmptyProperty(property)) &&
+      ['e', 'sub', 'sup'].every((name) =>
+        namedChildren(node, name).every((container) =>
+          childrenOf(container).every(isSupportedExpressionNode)
+        )
+      )
+    );
+  }
+  if (node.localName === 'nary') {
+    if (
+      !hasOnlyMathChildren(node, {
+        naryPr: { min: 0, max: 1 },
+        sub: { min: 0, max: 1 },
+        sup: { min: 0, max: 1 },
+        e: { min: 1, max: 1 },
+      })
+    ) {
+      return false;
+    }
+    const property = namedChild(node, 'naryPr');
+    if (property) {
+      if (
+        !hasOnlyMathChildren(property, {
+          chr: { min: 0, max: 1 },
+          limLoc: { min: 0, max: 1 },
+        })
+      ) {
+        return false;
+      }
+      const character = namedChild(property, 'chr');
+      const limitLocation = namedChild(property, 'limLoc');
+      if (character && !hasOnlyMathVal(character)) return false;
+      if (limitLocation && !hasOnlyMathVal(limitLocation, new Set(['undOvr']))) {
+        return false;
+      }
+    }
+    return ['e', 'sub', 'sup'].every((name) =>
+      namedChildren(node, name).every((container) =>
+        childrenOf(container).every(isSupportedExpressionNode)
+      )
+    );
+  }
+  return false;
+}
+
+function projectContainer(
+  node: OoxmlGenericElementNode,
+  state: ProjectionState,
+  depth: number,
+  skipLocalName?: string
+): EquationExpression {
+  const expressions: EquationExpression[] = [];
+  for (const child of childrenOf(node)) {
+    if (skipLocalName && isMathElement(child, skipLocalName)) continue;
+    expressions.push(projectNode(child, state, depth + 1));
+  }
+  return frozenRow(expressions);
+}
+
+function projectStructured(
+  node: OoxmlGenericElementNode,
+  state: ProjectionState,
+  depth: number
+): EquationExpression | null {
+  if (!isSupportedExpressionNode(node)) return null;
+  if (node.localName === 'f') {
+    const numerator = namedChild(node, 'num');
+    const denominator = namedChild(node, 'den');
+    if (!numerator || !denominator) return null;
+    return Object.freeze({
+      kind: 'fraction',
+      numerator: projectContainer(numerator, state, depth + 1),
+      denominator: projectContainer(denominator, state, depth + 1),
+    });
+  }
+  if (node.localName === 'rad') {
+    const radicand = namedChild(node, 'e');
+    if (!radicand) return null;
+    const degree = namedChild(node, 'deg');
+    const projectedDegree =
+      degree && childrenOf(degree).length > 0
+        ? projectContainer(degree, state, depth + 1)
+        : undefined;
+    return Object.freeze({
+      kind: 'radical',
+      radicand: projectContainer(radicand, state, depth + 1),
+      ...(projectedDegree === undefined ? {} : { degree: projectedDegree }),
+    });
+  }
+  if (node.localName === 'sSup' || node.localName === 'sSub' || node.localName === 'sSubSup') {
+    const base = namedChild(node, 'e');
+    const subscript = node.localName === 'sSup' ? null : namedChild(node, 'sub');
+    const superscript = node.localName === 'sSub' ? null : namedChild(node, 'sup');
+    if (
+      !base ||
+      (node.localName !== 'sSup' && !subscript) ||
+      (node.localName !== 'sSub' && !superscript)
+    ) {
+      return null;
+    }
+    return Object.freeze({
+      kind: 'script',
+      base: projectContainer(base, state, depth + 1),
+      ...(subscript ? { subscript: projectContainer(subscript, state, depth + 1) } : {}),
+      ...(superscript ? { superscript: projectContainer(superscript, state, depth + 1) } : {}),
+    });
+  }
+  if (node.localName === 'nary') {
+    const body = namedChild(node, 'e');
+    if (!body) return null;
+    const lower = namedChild(node, 'sub');
+    const upper = namedChild(node, 'sup');
+    const property = namedChild(node, 'naryPr');
+    const operatorNode = property ? namedChild(property, 'chr') : null;
+    const operator =
+      operatorNode?.attributes.find(
+        (attribute) =>
+          attribute.namespaceUri === OFFICE_MATH_NAMESPACE_URI && attribute.localName === 'val'
+      )?.value ?? '∑';
+    return Object.freeze({
+      kind: 'nary',
+      operator: appendProjectionText(state, operator),
+      body: projectContainer(body, state, depth + 1),
+      ...(lower && childrenOf(lower).length > 0
+        ? { lowerLimit: projectContainer(lower, state, depth + 1) }
+        : {}),
+      ...(upper && childrenOf(upper).length > 0
+        ? { upperLimit: projectContainer(upper, state, depth + 1) }
+        : {}),
+    });
+  }
+  return null;
+}
+
+function projectNode(node: OoxmlNode, state: ProjectionState, depth: number): EquationExpression {
+  if (!enterProjectionNode(state, depth)) {
+    return Object.freeze({ kind: 'fallback', text: '…' });
+  }
+  if (node.kind === 'textValue') {
+    return Object.freeze({ kind: 'text', value: appendProjectionText(state, node.value) });
+  }
+  if (!isMathElement(node)) return fallbackOf(node, state, depth + 1);
+  if (node.localName === 'oMath') {
+    return projectContainer(node, state, depth);
+  }
+  if (node.localName === 'r') {
+    return isSupportedExpressionNode(node)
+      ? projectContainer(node, state, depth, 'rPr')
+      : fallbackOf(node, state, depth + 1);
+  }
+  if (node.localName === 't') {
+    return isSupportedExpressionNode(node)
+      ? projectContainer(node, state, depth)
+      : fallbackOf(node, state, depth + 1);
+  }
+  const structured = projectStructured(node, state, depth);
+  return structured ?? fallbackOf(node, state, depth + 1);
+}
+
+/**
+ * Project one preserved `m:oMath` generic node without changing its canonical source.
+ */
+export function projectOmmlEquation(
+  node: OoxmlNode,
+  limits?: OmmlLimits
+): OmmlEquationProjection | null {
+  if (!isMathElement(node, 'oMath')) return null;
+  const cached = limits === undefined ? defaultProjectionCache.get(node) : undefined;
+  if (cached) return cached;
+  const publish = (projection: OmmlEquationProjection): OmmlEquationProjection => {
+    if (limits === undefined) defaultProjectionCache.set(node, projection);
+    return projection;
+  };
+  const resolved = resolveLimits(limits);
+  const scan: ProjectionState = {
+    limits: resolved,
+    visitedNodes: 0,
+    text: '',
+    truncated: false,
+  };
+  collectFallbackText(node, scan, 1);
+  const fallbackText = scan.text + (scan.truncated ? '…' : '');
+  if (scan.truncated) {
+    return publish(
+      Object.freeze({
+        sourceNodeId: node.id,
+        expression: Object.freeze({ kind: 'fallback', text: fallbackText || '…' }),
+        fallbackText,
+        truncated: true,
+        visitedNodes: scan.visitedNodes,
+      })
+    );
+  }
+  // The preflight proves the complete source is within each work limit. The structured pass
+  // can revisit wrappers while it maps their roles, but it cannot discover more source nodes.
+  const state: ProjectionState = {
+    limits: { ...resolved, maxNodes: Number.MAX_SAFE_INTEGER },
+    visitedNodes: 0,
+    text: '',
+    truncated: false,
+  };
+  const expression = projectNode(node, state, 1);
+  if (state.truncated) {
+    const structuredFallback = state.text + '…';
+    return publish(
+      Object.freeze({
+        sourceNodeId: node.id,
+        expression: Object.freeze({ kind: 'fallback', text: structuredFallback }),
+        fallbackText: structuredFallback,
+        truncated: true,
+        visitedNodes: scan.visitedNodes,
+      })
+    );
+  }
+  return publish(
+    Object.freeze({
+      sourceNodeId: node.id,
+      expression,
+      fallbackText,
+      truncated: false,
+      visitedNodes: scan.visitedNodes,
+    })
+  );
+}
+
+class LinearMathError extends Error {
+  constructor(readonly reason: LinearMathRejection) {
+    super(reason);
+  }
+}
+
+class LinearMathParser {
+  private index = 0;
+  private nodes = 0;
+
+  constructor(
+    private readonly input: string,
+    private readonly limits: ResolvedLimits
+  ) {}
+
+  parse(): EquationExpression {
+    if (this.input.length === 0) throw new LinearMathError('empty');
+    if (this.input.length > this.limits.maxTextLength) throw new LinearMathError('text-limit');
+    if (!isValidXmlText(this.input)) throw new LinearMathError('invalid-xml-text');
+    const expression = this.sequence(undefined, 1);
+    if (this.index !== this.input.length) throw new LinearMathError('invalid-syntax');
+    return expression;
+  }
+
+  private make<T extends EquationExpression>(expression: T, depth: number): T {
+    if (depth > this.limits.maxDepth) throw new LinearMathError('depth-limit');
+    this.nodes += 1;
+    if (this.nodes > this.limits.maxNodes) throw new LinearMathError('node-limit');
+    return Object.freeze(expression);
+  }
+
+  private sequence(stop: '}' | ']' | undefined, depth: number): EquationExpression {
+    if (depth > this.limits.maxDepth) throw new LinearMathError('depth-limit');
+    const children: EquationExpression[] = [];
+    while (this.index < this.input.length && this.input[this.index] !== stop) {
+      if (this.input[this.index] === '}' || this.input[this.index] === ']') {
+        throw new LinearMathError('invalid-syntax');
+      }
+      children.push(this.scripted(depth + 1));
+    }
+    if (stop !== undefined) {
+      if (this.input[this.index] !== stop) throw new LinearMathError('invalid-syntax');
+      this.index += 1;
+    }
+    if (children.length === 0) return this.make({ kind: 'row', items: Object.freeze([]) }, depth);
+    return children.length === 1
+      ? children[0]!
+      : this.make({ kind: 'row', items: Object.freeze(children) }, depth);
+  }
+
+  private scripted(depth: number): EquationExpression {
+    const groupedBase = this.input[this.index] === '{';
+    let base = this.primary(depth + 1);
+    let prefix: EquationExpression | undefined;
+    let subscript: EquationExpression | undefined;
+    let superscript: EquationExpression | undefined;
+    while (this.input[this.index] === '^' || this.input[this.index] === '_') {
+      const marker = this.input[this.index++]!;
+      const operand = this.scriptOperand(depth + 1);
+      if (marker === '^') {
+        if (superscript) throw new LinearMathError('invalid-syntax');
+        superscript = operand;
+      } else {
+        if (subscript) throw new LinearMathError('invalid-syntax');
+        subscript = operand;
+      }
+    }
+    if (subscript || superscript) {
+      if (!groupedBase && base.kind === 'text') {
+        const characters = Array.from(base.value);
+        if (characters.length > 1) {
+          prefix = this.make({ kind: 'text', value: characters.slice(0, -1).join('') }, depth + 1);
+          base = this.make({ kind: 'text', value: characters.at(-1)! }, depth + 1);
+        }
+      }
+      base = this.make(
+        {
+          kind: 'script',
+          base,
+          ...(subscript === undefined ? {} : { subscript }),
+          ...(superscript === undefined ? {} : { superscript }),
+        },
+        depth
+      );
+    }
+    return prefix ? this.make({ kind: 'row', items: [prefix, base] }, depth) : base;
+  }
+
+  private scriptOperand(depth: number): EquationExpression {
+    if (this.input[this.index] === '{') return this.braced(depth + 1);
+    const value = this.codePoint();
+    if (value === null || '^_{}[]'.includes(value)) throw new LinearMathError('invalid-syntax');
+    return this.make({ kind: 'text', value }, depth);
+  }
+
+  private braced(depth: number): EquationExpression {
+    if (this.input[this.index] !== '{') throw new LinearMathError('invalid-syntax');
+    this.index += 1;
+    const expression = this.sequence('}', depth + 1);
+    if (expression.kind === 'row' && expression.items.length === 0) {
+      throw new LinearMathError('invalid-syntax');
+    }
+    return expression;
+  }
+
+  private primary(depth: number): EquationExpression {
+    if (this.input[this.index] === '{') {
+      const numerator = this.braced(depth + 1);
+      if (this.input[this.index] === '/' && this.input[this.index + 1] === '{') {
+        this.index += 1;
+        const denominator = this.braced(depth + 1);
+        return this.make({ kind: 'fraction', numerator, denominator }, depth);
+      }
+      return numerator;
+    }
+    if (this.input[this.index] === '√') {
+      this.index += 1;
+      let degree: EquationExpression | undefined;
+      if (this.input[this.index] === '[') {
+        this.index += 1;
+        degree = this.sequence(']', depth + 1);
+        if (degree.kind === 'row' && degree.items.length === 0) {
+          throw new LinearMathError('invalid-syntax');
+        }
+      }
+      if (this.input[this.index] !== '{') throw new LinearMathError('invalid-syntax');
+      return this.make(
+        {
+          kind: 'radical',
+          radicand: this.braced(depth + 1),
+          ...(degree === undefined ? {} : { degree }),
+        },
+        depth
+      );
+    }
+    if (this.input[this.index] === '∑') {
+      this.index += 1;
+      let lowerLimit: EquationExpression | undefined;
+      let upperLimit: EquationExpression | undefined;
+      if (this.input[this.index] === '[') {
+        this.index += 1;
+        lowerLimit = this.sequence(']', depth + 1);
+        if (lowerLimit.kind === 'row' && lowerLimit.items.length === 0) {
+          throw new LinearMathError('invalid-syntax');
+        }
+      }
+      if (this.input[this.index] === '^') {
+        this.index += 1;
+        if (this.input[this.index] !== '[') throw new LinearMathError('invalid-syntax');
+        this.index += 1;
+        upperLimit = this.sequence(']', depth + 1);
+        if (upperLimit.kind === 'row' && upperLimit.items.length === 0) {
+          throw new LinearMathError('invalid-syntax');
+        }
+      }
+      if (this.input[this.index] !== '{') throw new LinearMathError('invalid-syntax');
+      return this.make(
+        {
+          kind: 'nary',
+          operator: '∑',
+          body: this.braced(depth + 1),
+          ...(lowerLimit === undefined ? {} : { lowerLimit }),
+          ...(upperLimit === undefined ? {} : { upperLimit }),
+        },
+        depth
+      );
+    }
+    const start = this.index;
+    while (this.index < this.input.length) {
+      const character = this.input[this.index]!;
+      if ('{}[]^_√∑'.includes(character)) break;
+      this.index += 1;
+    }
+    if (this.index === start) throw new LinearMathError('invalid-syntax');
+    return this.make({ kind: 'text', value: this.input.slice(start, this.index) }, depth);
+  }
+
+  private codePoint(): string | null {
+    if (this.index >= this.input.length) return null;
+    const point = this.input.codePointAt(this.index);
+    if (point === undefined) return null;
+    const value = String.fromCodePoint(point);
+    this.index += value.length;
+    return value;
+  }
+}
+
+/** Parse the supported compact linear-math subset with fixed work limits. */
+export function parseLinearMath(input: string, limits?: OmmlLimits): LinearMathParseResult {
+  const cacheable = limits === undefined && input.length <= DEFAULT_OMML_LIMITS.maxTextLength;
+  const cached = cacheable ? defaultLinearMathCache.get(input) : undefined;
+  if (cached) return cached;
+  let result: LinearMathParseResult;
+  try {
+    result = Object.freeze({
+      ok: true,
+      expression: new LinearMathParser(input, resolveLimits(limits)).parse(),
+    });
+  } catch (error) {
+    result = Object.freeze({
+      ok: false,
+      reason: error instanceof LinearMathError ? error.reason : 'invalid-syntax',
+    });
+  }
+  if (cacheable) {
+    if (defaultLinearMathCache.size >= DEFAULT_LINEAR_CACHE_LIMIT) {
+      const oldest = defaultLinearMathCache.keys().next().value;
+      if (oldest !== undefined) defaultLinearMathCache.delete(oldest);
+    }
+    defaultLinearMathCache.set(input, result);
+  }
+  return result;
+}
+
+/**
+ * Convert a projected expression into reversible compact syntax.
+ *
+ * Returns an empty string when parsing the result would change the projected meaning.
+ */
+export function equationExpressionToLinearMath(expression: EquationExpression): string {
+  return renderReversibleLinearMath(expression, parseLinearMath);
+}
+
+type NextNodeId = () => string;
+
+function mathAttribute(localName: string, value: string): OoxmlAttribute {
+  return Object.freeze({
+    kind: 'genericExtension',
+    namespaceUri: OFFICE_MATH_NAMESPACE_URI,
+    localName,
+    prefix: 'm',
+    value,
+  });
+}
+
+function textValue(value: string, nextId: NextNodeId): OoxmlNode {
+  return Object.freeze({ id: nextId(), kind: 'textValue', value });
+}
+
+function textAttributes(value: string): readonly OoxmlAttribute[] {
+  return /^\s|\s$/.test(value)
+    ? [
+        Object.freeze({
+          kind: 'xmlSpace',
+          namespaceUri: XML_NAMESPACE_URI,
+          localName: 'space',
+          prefix: 'xml',
+          value: 'preserve',
+        }),
+      ]
+    : [];
+}
+
+function mathElement(
+  localName: string,
+  children: readonly OoxmlNode[],
+  nextId: NextNodeId,
+  attributes: readonly OoxmlAttribute[] = []
+): OoxmlGenericElementNode {
+  return Object.freeze({
+    id: nextId(),
+    kind: 'generic',
+    namespaceUri: OFFICE_MATH_NAMESPACE_URI,
+    localName,
+    prefix: 'm',
+    namespaceBindings: Object.freeze([]),
+    attributes: Object.freeze([...attributes]),
+    children: Object.freeze([...children]),
+  });
+}
+
+function expressionNodes(expression: EquationExpression, nextId: NextNodeId): readonly OoxmlNode[] {
+  switch (expression.kind) {
+    case 'row':
+      return expression.items.flatMap((child) => expressionNodes(child, nextId));
+    case 'text':
+      return [
+        mathElement(
+          'r',
+          [
+            mathElement(
+              't',
+              [textValue(expression.value, nextId)],
+              nextId,
+              textAttributes(expression.value)
+            ),
+          ],
+          nextId
+        ),
+      ];
+    case 'fallback':
+      return [
+        mathElement(
+          'r',
+          [
+            mathElement(
+              't',
+              [textValue(expression.text, nextId)],
+              nextId,
+              textAttributes(expression.text)
+            ),
+          ],
+          nextId
+        ),
+      ];
+    case 'fraction':
+      return [
+        mathElement(
+          'f',
+          [
+            mathElement('num', expressionNodes(expression.numerator, nextId), nextId),
+            mathElement('den', expressionNodes(expression.denominator, nextId), nextId),
+          ],
+          nextId
+        ),
+      ];
+    case 'radical':
+      return [
+        mathElement(
+          'rad',
+          [
+            mathElement(
+              'deg',
+              expression.degree ? expressionNodes(expression.degree, nextId) : [],
+              nextId
+            ),
+            mathElement('e', expressionNodes(expression.radicand, nextId), nextId),
+          ],
+          nextId
+        ),
+      ];
+    case 'script': {
+      if (expression.subscript && expression.superscript) {
+        return [
+          mathElement(
+            'sSubSup',
+            [
+              mathElement('e', expressionNodes(expression.base, nextId), nextId),
+              mathElement('sub', expressionNodes(expression.subscript, nextId), nextId),
+              mathElement('sup', expressionNodes(expression.superscript, nextId), nextId),
+            ],
+            nextId
+          ),
+        ];
+      }
+      const superscript = expression.superscript !== undefined;
+      const script = superscript ? expression.superscript! : expression.subscript!;
+      return [
+        mathElement(
+          superscript ? 'sSup' : 'sSub',
+          [
+            mathElement('e', expressionNodes(expression.base, nextId), nextId),
+            mathElement(superscript ? 'sup' : 'sub', expressionNodes(script, nextId), nextId),
+          ],
+          nextId
+        ),
+      ];
+    }
+    case 'nary':
+      return [
+        mathElement(
+          'nary',
+          [
+            mathElement(
+              'naryPr',
+              [
+                mathElement('chr', [], nextId, [mathAttribute('val', expression.operator)]),
+                mathElement('limLoc', [], nextId, [mathAttribute('val', 'undOvr')]),
+              ],
+              nextId
+            ),
+            mathElement(
+              'sub',
+              expression.lowerLimit ? expressionNodes(expression.lowerLimit, nextId) : [],
+              nextId
+            ),
+            mathElement(
+              'sup',
+              expression.upperLimit ? expressionNodes(expression.upperLimit, nextId) : [],
+              nextId
+            ),
+            mathElement('e', expressionNodes(expression.body, nextId), nextId),
+          ],
+          nextId
+        ),
+      ];
+  }
+}
+
+/**
+ * Build a canonical `m:oMath` tree. The caller supplies the part-scoped fresh ID allocator.
+ */
+function ommlEquationFromExpression(
+  expression: EquationExpression,
+  nextId: NextNodeId
+): OoxmlGenericElementNode {
+  const equation = mathElement('oMath', expressionNodes(expression, nextId), nextId);
+  return Object.freeze({
+    ...equation,
+    namespaceBindings: Object.freeze([
+      Object.freeze({ prefix: 'm', namespaceUri: OFFICE_MATH_NAMESPACE_URI }),
+    ]),
+  });
+}
+
+/** Parse compact linear math and generate fresh canonical OMML in one bounded operation. */
+export function linearMathToOmml(
+  input: string,
+  nextId: NextNodeId,
+  limits?: OmmlLimits
+): LinearMathOmmlResult {
+  const parsed = parseLinearMath(input, limits);
+  if (!parsed.ok) return parsed;
+  return Object.freeze({
+    ok: true,
+    expression: parsed.expression,
+    equation: ommlEquationFromExpression(parsed.expression, nextId),
+  });
+}

--- a/packages/core/src/store/package/omml-equation.ts
+++ b/packages/core/src/store/package/omml-equation.ts
@@ -77,6 +77,7 @@ export interface OmmlEquationProjection {
 const defaultProjectionCache = new WeakMap<OoxmlGenericElementNode, OmmlEquationProjection>();
 const DEFAULT_LINEAR_CACHE_LIMIT = 64;
 const defaultLinearMathCache = new Map<string, LinearMathParseResult>();
+const reversibleLinearMathCache = new WeakMap<EquationExpression, string>();
 
 export type LinearMathRejection =
   | 'empty'
@@ -759,7 +760,11 @@ export function parseLinearMath(input: string, limits?: OmmlLimits): LinearMathP
  * Returns an empty string when parsing the result would change the projected meaning.
  */
 export function equationExpressionToLinearMath(expression: EquationExpression): string {
-  return renderReversibleLinearMath(expression, parseLinearMath);
+  const cached = reversibleLinearMathCache.get(expression);
+  if (cached !== undefined) return cached;
+  const linear = renderReversibleLinearMath(expression, parseLinearMath);
+  reversibleLinearMathCache.set(expression, linear);
+  return linear;
 }
 
 type NextNodeId = () => string;

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -9,6 +9,7 @@
 import { hardBreakAttributes, hardBreakText } from '../package/hard-break.ts';
 import { fieldAtomText } from '../package/field-nodes.ts';
 import { isContentRevisionKind, W14_NAMESPACE_URI } from '../package/ooxml-shared.ts';
+import { linearMathToOmml } from '../package/omml-equation.ts';
 import {
   WML_NAMESPACE_URI,
   type OoxmlAttribute,
@@ -271,6 +272,38 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
   if (op.op === 'joinParagraphs') return applyJoin(part, op.firstId, op.secondId, options);
   if (op.op === 'setHyperlinkTarget') return applySetHyperlinkTarget(part, op, options);
   if (op.op === 'removeHyperlink') return applyRemoveHyperlink(part, op.linkId, options);
+  if (op.op === 'setMathEquation' || op.op === 'removeMathEquation') {
+    const equation = findNode(part, op.equationId);
+    if (!equation || equation.kind === 'textValue') {
+      return { ok: false, reason: 'tree-invariant' };
+    }
+    let ancestor: OoxmlNode | null = equation;
+    let paragraph: OoxmlParagraphNode | null = null;
+    while (ancestor) {
+      if (ancestor.kind === 'paragraph') {
+        paragraph = ancestor;
+        break;
+      }
+      ancestor = parentOf(part, ancestor.id);
+    }
+    if (!paragraph) return { ok: false, reason: 'tree-invariant' };
+    const effect: TreeOpEffect = {
+      dirty: [paragraph.id],
+      created: [],
+      deleted: [],
+      dependencyKeys: TEXT_DEPS,
+      impact: 'text-local',
+    };
+    if (op.op === 'removeMathEquation') {
+      return fromEdit(removeNode(part, equation.id, options), effect);
+    }
+    const generated = linearMathToOmml(op.linear, createNodeIdAllocator(part));
+    if (!generated.ok) return { ok: false, reason: 'invalid-property-value' };
+    // Retain the equation identity. An open popover and an undo record both address the
+    // complete math atom, while every internal OMML node receives a fresh part-scoped id.
+    const replacement = { ...generated.equation, id: equation.id };
+    return fromEdit(replaceNode(part, equation.id, replacement, options), effect);
+  }
   if (op.op === 'insertCommentMarker') {
     const paragraph = findNode(part, op.paragraphId);
     if (!paragraph || paragraph.kind !== 'paragraph')
@@ -674,7 +707,32 @@ function applyInsertContent(
   }
   if (after) {
     const run = findNode(part, after.runId);
-    if (!run || run.kind !== 'run') return { ok: false, reason: 'tree-invariant' };
+    if (!run || run.kind !== 'run') {
+      // A paragraph-level atom, such as `m:oMath`, has no owning `w:r`. Typing at its
+      // leading edge creates a sibling run before it. Treating the atom id as a run id
+      // made the otherwise valid caret position fail with `tree-invariant`.
+      const parent = parentOf(part, after.node.id);
+      if (
+        after.removeNodeIds !== undefined &&
+        parent?.kind === 'paragraph' &&
+        parent.id === paragraph.id
+      ) {
+        const index = parent.children.findIndex((child) => child.id === after.node.id);
+        if (index < 0) return { ok: false, reason: 'tree-invariant' };
+        inserted = fromEdit(
+          insertChildren(
+            part,
+            parent.id,
+            index,
+            [runElement(nextId, nodes)],
+            deferOptions(options, control)
+          ),
+          effect
+        );
+        return finishContentEdit(inserted, control, options);
+      }
+      return { ok: false, reason: 'tree-invariant' };
+    }
     // The START boundary of a deletion, reached when nothing to the left takes the text:
     // the new content goes before the wrapper, never into the struck run's head.
     const relocated = insertBesideDeletion(part, paragraph, run, nodes, 'before', {
@@ -720,6 +778,30 @@ function applyInsertContent(
           return finishContentEdit(inserted, control, options);
         }
       }
+    }
+  }
+
+  // A paragraph-level atom has no owning run. At its trailing boundary, insert a sibling
+  // run AFTER the atom instead of appending to the paragraph's last run, which can only be
+  // before it. The atom segment names its complete removable node, and the direct-parent
+  // check keeps run-owned fields and drawings on their existing insertion paths.
+  if (before?.removeNodeIds && before.removeNodeIds.length === 1) {
+    const atom = findNode(part, before.removeNodeIds[0]!);
+    const parent = atom ? parentOf(part, atom.id) : null;
+    if (atom && parent?.kind === 'paragraph' && parent.id === paragraph.id) {
+      const index = parent.children.findIndex((child) => child.id === atom.id);
+      if (index < 0) return { ok: false, reason: 'tree-invariant' };
+      inserted = fromEdit(
+        insertChildren(
+          part,
+          parent.id,
+          index + 1,
+          [runElement(nextId, nodes)],
+          deferOptions(options, control)
+        ),
+        effect
+      );
+      return finishContentEdit(inserted, control, options);
     }
   }
 

--- a/packages/core/src/store/store/tree-op-content-controls.ts
+++ b/packages/core/src/store/store/tree-op-content-controls.ts
@@ -348,6 +348,11 @@ const TREE_OP_REACH: {
   // controls the walk passes through on its way down to the link.
   setHyperlinkTarget: (op) => whole(op.linkId),
   removeHyperlink: (op) => ({ kind: 'nodes', targets: [{ nodeId: op.linkId, structural: true }] }),
+  setMathEquation: (op) => whole(op.equationId),
+  removeMathEquation: (op) => ({
+    kind: 'nodes',
+    targets: [{ nodeId: op.equationId, structural: true }],
+  }),
   acceptRevision: (op) => ({
     kind: 'revisions',
     action: 'accept',

--- a/packages/core/src/store/store/tree-op-segments.ts
+++ b/packages/core/src/store/store/tree-op-segments.ts
@@ -28,6 +28,18 @@ import {
   isContentControlNode,
 } from './tree-op-nodes.ts';
 
+/** Office Math Markup Language namespace (ECMA-376 Part 1, §22.1). */
+const OMML_NAMESPACE_URI = 'http://schemas.openxmlformats.org/officeDocument/2006/math';
+
+/** A paragraph-level inline equation. Its internal OMML is one editable model atom. */
+function isMathEquation(node: OoxmlNode): boolean {
+  return (
+    node.kind !== 'textValue' &&
+    node.namespaceUri === OMML_NAMESPACE_URI &&
+    node.localName === 'oMath'
+  );
+}
+
 /** One addressable unit of paragraph text: text, tab, hard break, or atomic field. */
 export interface Segment {
   readonly runId: string;
@@ -277,6 +289,11 @@ function walkParagraph(
   const visitInline = (child: OoxmlNode, depth: number): void => {
     const start = offset;
     if (child.kind === 'textValue' || depth >= MAX_INLINE_CONTAINER_DEPTH) {
+      record(child, start);
+      return;
+    }
+    if (isMathEquation(child)) {
+      emitAtom({ runId: child.id, node: child, removeNodeIds: [child.id] });
       record(child, start);
       return;
     }

--- a/packages/core/src/store/store/tree-op-types.ts
+++ b/packages/core/src/store/store/tree-op-types.ts
@@ -518,6 +518,22 @@ export type TreeDocOp =
     }
   | {
       /**
+       * Replace one preserved `m:oMath` atom from bounded linear-math input.
+       *
+       * The complete equation changes as one unit. Internal OMML text never enters the
+       * paragraph offset space, so callers cannot leave a partially edited math tree.
+       */
+      readonly op: 'setMathEquation';
+      readonly equationId: string;
+      readonly linear: string;
+    }
+  | {
+      /** Remove one complete `m:oMath` atom. */
+      readonly op: 'removeMathEquation';
+      readonly equationId: string;
+    }
+  | {
+      /**
        * Insert a NEW run-level content control at a text offset: `w:sdt` with a
        * `w:sdtPr` carrying the given tag (and alias/lock) and a `w:sdtContent`
        * holding one run of `text`.
@@ -986,6 +1002,8 @@ export const TREE_DOC_OP_KINDS = [
   'insertHyperlink',
   'setHyperlinkTarget',
   'removeHyperlink',
+  'setMathEquation',
+  'removeMathEquation',
   'setContentControlValue',
   'removeContentControl',
   'insertInlineContentControl',

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -7,6 +7,7 @@
 
 import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../package/ooxml-tree.ts';
 import { findNode } from '../package/ooxml-edit.ts';
+import { OFFICE_MATH_NAMESPACE_URI, parseLinearMath } from '../package/omml-equation.ts';
 import { isValidXmlText } from '../package/sinks.ts';
 import { isAuthorableDataBinding } from '../package/custom-node-payloads.ts';
 import { validateDeleteBlock } from './tree-op-blocks.ts';
@@ -454,6 +455,25 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
       if (restriction) return restriction;
     }
     if (op.op === 'setHyperlinkTarget') return validateHyperlinkTarget(op);
+    return null;
+  }
+
+  if (op.op === 'setMathEquation' || op.op === 'removeMathEquation') {
+    const equation = findNode(part, op.equationId);
+    if (!equation) return 'unknown-paragraph';
+    if (
+      equation.kind === 'textValue' ||
+      equation.kind !== 'generic' ||
+      equation.namespaceUri !== OFFICE_MATH_NAMESPACE_URI ||
+      equation.localName !== 'oMath'
+    ) {
+      return 'not-a-paragraph';
+    }
+    const restriction = nodeTouchesContentRestriction(part, op.equationId);
+    if (restriction) return restriction;
+    if (op.op === 'setMathEquation' && !parseLinearMath(op.linear).ok) {
+      return 'invalid-property-value';
+    }
     return null;
   }
 

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4857,7 +4857,7 @@ a.docx-hyperlink:focus-visible {
   gap: 6px;
   width: min(340px, calc(100% - 16px));
   margin-top: 4px;
-  padding: 8px;
+  padding: 6px 8px;
   border: 1px solid var(--doc-border);
   border-radius: 8px;
   background: var(--doc-surface);
@@ -4868,7 +4868,7 @@ a.docx-hyperlink:focus-visible {
 
 .docx-equation-popup__input {
   width: 100%;
-  padding: 5px 7px;
+  padding: 4px 6px;
   border: 1px solid var(--doc-border-input);
   border-radius: 4px;
   background: var(--doc-bg-input);
@@ -4879,12 +4879,6 @@ a.docx-hyperlink:focus-visible {
 .docx-equation-popup__input:focus-visible {
   outline: 2px solid var(--doc-focus-ring);
   outline-offset: -1px;
-}
-
-.docx-equation-popup__help {
-  color: var(--doc-text-muted);
-  font-size: 12px;
-  line-height: 1.35;
 }
 
 .docx-equation-popup__error {
@@ -4908,16 +4902,6 @@ a.docx-hyperlink:focus-visible {
   color: var(--doc-text);
   font: inherit;
   cursor: pointer;
-}
-
-.docx-equation-popup__apply {
-  border-color: var(--doc-primary);
-  background: var(--doc-primary);
-  color: var(--doc-on-primary);
-}
-
-.docx-equation-popup__delete {
-  color: var(--doc-error);
 }
 
 /* Room for the review pane. The page centres inside the scroller's padding box, so

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4847,6 +4847,79 @@ a.docx-hyperlink:focus-visible {
   line-height: 1.35;
 }
 
+/* Compact linear-math editor for one selected equation atom. */
+.docx-equation-popup {
+  position: absolute;
+  z-index: var(--doc-z-overlay);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  width: min(340px, calc(100% - 16px));
+  margin-top: 4px;
+  padding: 8px;
+  border: 1px solid var(--doc-border);
+  border-radius: 8px;
+  background: var(--doc-surface);
+  color: var(--doc-text);
+  box-shadow: 0 2px 10px var(--doc-shadow);
+  font-size: 13px;
+}
+
+.docx-equation-popup__input {
+  width: 100%;
+  padding: 5px 7px;
+  border: 1px solid var(--doc-border-input);
+  border-radius: 4px;
+  background: var(--doc-bg-input);
+  color: var(--doc-text);
+  font: inherit;
+}
+
+.docx-equation-popup__input:focus-visible {
+  outline: 2px solid var(--doc-focus-ring);
+  outline-offset: -1px;
+}
+
+.docx-equation-popup__help {
+  color: var(--doc-text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.docx-equation-popup__error {
+  color: var(--doc-error);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.docx-equation-popup__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.docx-equation-popup__apply,
+.docx-equation-popup__delete {
+  padding: 4px 10px;
+  border: 1px solid var(--doc-border-input);
+  border-radius: 4px;
+  background: var(--doc-bg-input);
+  color: var(--doc-text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.docx-equation-popup__apply {
+  border-color: var(--doc-primary);
+  background: var(--doc-primary);
+  color: var(--doc-on-primary);
+}
+
+.docx-equation-popup__delete {
+  color: var(--doc-error);
+}
+
 /* Room for the review pane. The page centres inside the scroller's padding box, so
  * reserving the rail's width here shifts the sheet left by half of it and the document and
  * its cards read as one centred pair.

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/de.json
+++ b/packages/i18n/de.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -581,6 +581,15 @@
     "bookmarkTarget": "Goes to a place in this document",
     "refused": "That link could not be applied. Check the address and try again."
   },
+  "equationPopup": {
+    "title": "Edit equation",
+    "inputLabel": "Linear math",
+    "placeholder": "Enter an equation",
+    "syntaxHelp": "Use x^2, x_i, fractions, square roots, or sums.",
+    "apply": "Apply",
+    "delete": "Delete",
+    "refused": "That equation could not be applied. Check the syntax and try again."
+  },
   "contentControl": {
     "group": "Content controls",
     "showAll": "Show content control boundaries",

--- a/packages/i18n/en.json
+++ b/packages/i18n/en.json
@@ -585,7 +585,6 @@
     "title": "Edit equation",
     "inputLabel": "Linear math",
     "placeholder": "Enter an equation",
-    "syntaxHelp": "Use x^2, x_i, fractions, square roots, or sums.",
     "apply": "Apply",
     "delete": "Delete",
     "refused": "That equation could not be applied. Check the syntax and try again."

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/fr.json
+++ b/packages/i18n/fr.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/he.json
+++ b/packages/i18n/he.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/hi.json
+++ b/packages/i18n/hi.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/id.json
+++ b/packages/i18n/id.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/pl.json
+++ b/packages/i18n/pl.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/pt-BR.json
+++ b/packages/i18n/pt-BR.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/tr.json
+++ b/packages/i18n/tr.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -732,7 +732,6 @@
     "inputLabel": null,
     "placeholder": null,
     "refused": null,
-    "syntaxHelp": null,
     "title": null
   }
 }

--- a/packages/i18n/zh-CN.json
+++ b/packages/i18n/zh-CN.json
@@ -725,5 +725,14 @@
     "bodyOnlySectionBreak": null,
     "bodyOnlyToc": null,
     "furnitureOnlyPageField": null
+  },
+  "equationPopup": {
+    "apply": null,
+    "delete": null,
+    "inputLabel": null,
+    "placeholder": null,
+    "refused": null,
+    "syntaxHelp": null,
+    "title": null
   }
 }

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -23,6 +23,7 @@ import { DocxEditorPageNumber, PageNumberTranslationContext } from '../editor/Do
 import { DocxEditorFontNotice } from '../editor/DocxEditorFontNotice';
 import { DocxEditorHeaderFooterChrome } from '../editor/DocxEditorHeaderFooter';
 import { DocxEditorHyperLink } from '../editor/DocxEditorHyperLink';
+import { DocxEditorEquation } from '../editor/DocxEditorEquation';
 import { DocxEditorNotesChrome } from '../editor/DocxEditorNotes';
 import {
   ContextMenu as DocxEditorContextMenuCompound,
@@ -297,6 +298,7 @@ const DocxEditorFrame = forwardRef<DocxEditorRef, DocxEditorProps>(
         {chrome ? <DocxEditorNotesChrome /> : null}
         <DocxEditorContent />
         <DocxEditorHyperLink hidden={hyperlinkPopup === false} />
+        <DocxEditorEquation />
         {contextMenu === false ? null : (
           <DocxEditorContextMenu
             t={translate}
@@ -497,6 +499,8 @@ export interface DocxEditorNamespace extends ForwardRefExoticComponent<
   /** Header/footer scope chrome while editing page furniture. */
   readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
   readonly NotesChrome: typeof DocxEditorNotesChrome;
+  /** The default linear-math popover for a clicked Office Math equation. */
+  readonly Equation: typeof DocxEditorEquation;
   /**
    * The link popover — target readout, copy, edit, unlink — and its parts. Mounted by
    * default inside the viewport; `hyperlinkPopup={false}` removes it.
@@ -536,6 +540,7 @@ export const DocxEditor: DocxEditorNamespace = Object.assign(DocxEditorImpl, {
   FontNotice: DocxEditorFontNotice,
   HeaderFooterChrome: DocxEditorHeaderFooterChrome,
   NotesChrome: DocxEditorNotesChrome,
+  Equation: DocxEditorEquation,
   HyperLink: DocxEditorHyperLink,
   ContextMenu: DocxEditorContextMenuCompound,
   ContentControl: DocxEditorContentControl,

--- a/packages/react/src/editor/DocxEditorEquation.tsx
+++ b/packages/react/src/editor/DocxEditorEquation.tsx
@@ -111,15 +111,15 @@ export function DocxEditorEquation() {
       event.preventDefault();
       close(true);
     };
-    const onMouseDown = (event: MouseEvent): void => {
+    const onPointerDown = (event: PointerEvent): void => {
       if (event.target instanceof view.Node && panel.contains(event.target)) return;
       close();
     };
     ownerDocument.addEventListener('keydown', onKeyDown);
-    ownerDocument.addEventListener('mousedown', onMouseDown, true);
+    ownerDocument.addEventListener('pointerdown', onPointerDown, true);
     return () => {
       ownerDocument.removeEventListener('keydown', onKeyDown);
-      ownerDocument.removeEventListener('mousedown', onMouseDown, true);
+      ownerDocument.removeEventListener('pointerdown', onPointerDown, true);
     };
   }, [state, close]);
 

--- a/packages/react/src/editor/DocxEditorEquation.tsx
+++ b/packages/react/src/editor/DocxEditorEquation.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { EquationActivation } from '@docx-editor.dev/core/editor';
+import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
+import { localizeDisabledReason } from '@docx-editor.dev/i18n';
+import { useTranslation } from '../i18n';
+import { useDocxEditor } from './context';
+import { absolutePointInScroller } from './scroller-geometry.ts';
+import { useEditorState } from './useEditorState.ts';
+
+interface EquationPopupState {
+  readonly activation: EquationActivation;
+  readonly mountGeneration: number;
+  readonly draft: string;
+  readonly error: boolean;
+}
+
+const selectSnapshot = (snapshot: EditorSnapshot): EditorSnapshot => snapshot;
+
+/** Keeps button chrome from moving the document caret. Inputs retain normal focus behavior. */
+function guardMousedown(event: React.MouseEvent): void {
+  const tag = (event.target as HTMLElement | null)?.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  event.preventDefault();
+}
+
+/** Default equation editor mounted by the packaged React host. */
+export function DocxEditorEquation() {
+  const editor = useDocxEditor();
+  const { t } = useTranslation();
+  const [state, setState] = useState<EquationPopupState | null>(null);
+  const [placement, setPlacement] = useState<CSSProperties | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const releasePinRef = useRef<(() => void) | null>(null);
+  const inputId = useId();
+  const helpId = useId();
+  const errorId = useId();
+  const disabledReasonId = useId();
+  const activation = state?.activation ?? null;
+  const editorSnapshot = useEditorState(selectSnapshot);
+  const mutationAvailability = useMemo(() => {
+    void editorSnapshot;
+    if (!editor?.surface || !activation) {
+      return { replaceEnabled: false, removeEnabled: false, reason: null };
+    }
+    const replace = editor.surface.equations.can(activation.equation.id, 'replace');
+    const remove = editor.surface.equations.can(activation.equation.id, 'remove');
+    const refusal = !replace.ok ? replace.reason : !remove.ok ? remove.reason : null;
+    return {
+      replaceEnabled: replace.ok,
+      removeEnabled: remove.ok,
+      reason: refusal ? localizeDisabledReason(refusal, t) : null,
+    };
+  }, [activation, editor, editorSnapshot, t]);
+
+  const close = useCallback(
+    (restoreFocus = false) => {
+      releasePinRef.current?.();
+      releasePinRef.current = null;
+      setState(null);
+      if (restoreFocus && editor) queueMicrotask(() => editor.focus());
+    },
+    [editor]
+  );
+
+  useEffect(() => {
+    if (!editor) return undefined;
+    const unregister = editor.setEquationChrome({
+      onPopover: (activation) => {
+        releasePinRef.current?.();
+        const surface = editor.surface;
+        if (surface && typeof surface.retainSelection === 'function') {
+          const pin = surface.retainSelection();
+          releasePinRef.current = () => surface.releaseSelection(pin);
+        } else {
+          releasePinRef.current = null;
+        }
+        setState({
+          activation,
+          mountGeneration: editor.mountGeneration,
+          draft: activation.equation.linear,
+          error: false,
+        });
+      },
+    });
+    return () => {
+      unregister();
+      releasePinRef.current?.();
+      releasePinRef.current = null;
+      setState(null);
+    };
+  }, [editor, close]);
+
+  useEffect(() => {
+    if (!state || !editor?.surface) return;
+    const stale =
+      editor.mountGeneration !== state.mountGeneration ||
+      !editor.surface.equations.equationById(state.activation.equation.id);
+    if (stale) close();
+  }, [editor, editorSnapshot, state, close]);
+
+  useEffect(() => {
+    if (!state) return undefined;
+    const panel = panelRef.current;
+    const ownerDocument = panel?.ownerDocument;
+    const view = ownerDocument?.defaultView;
+    if (!panel || !ownerDocument || !view) return undefined;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      close(true);
+    };
+    const onMouseDown = (event: MouseEvent): void => {
+      if (event.target instanceof view.Node && panel.contains(event.target)) return;
+      close();
+    };
+    ownerDocument.addEventListener('keydown', onKeyDown);
+    ownerDocument.addEventListener('mousedown', onMouseDown, true);
+    return () => {
+      ownerDocument.removeEventListener('keydown', onKeyDown);
+      ownerDocument.removeEventListener('mousedown', onMouseDown, true);
+    };
+  }, [state, close]);
+
+  useLayoutEffect(() => {
+    if (!activation) {
+      setPlacement(null);
+      return;
+    }
+    const panel = panelRef.current;
+    if (!panel) return;
+    const container = panel.offsetParent as HTMLElement | null;
+    if (!container) {
+      setPlacement(null);
+      return;
+    }
+    const rect = activation.rect;
+    const point = absolutePointInScroller(container, rect.left, rect.bottom);
+    const maxLeft = Math.max(0, container.scrollWidth - panel.offsetWidth);
+    setPlacement({ left: Math.max(0, Math.min(point.left, maxLeft)), top: point.top });
+    inputRef.current?.focus({ preventScroll: true });
+    inputRef.current?.select();
+  }, [activation]);
+
+  const apply = useCallback((): boolean => {
+    if (!state || !editor?.surface || !mutationAvailability.replaceEnabled) return false;
+    const applied = editor.surface.equations.applyEquation(
+      state.activation.equation.id,
+      state.draft
+    );
+    if (applied) close(true);
+    else setState((current) => (current ? { ...current, error: true } : current));
+    return applied;
+  }, [editor, state, close, mutationAvailability.replaceEnabled]);
+
+  const remove = useCallback((): boolean => {
+    if (!state || !editor?.surface || !mutationAvailability.removeEnabled) return false;
+    const removed = editor.surface.equations.removeEquation(state.activation.equation.id);
+    if (removed) close(true);
+    else setState((current) => (current ? { ...current, error: true } : current));
+    return removed;
+  }, [editor, state, close, mutationAvailability.removeEnabled]);
+
+  if (!state) return null;
+  const describedBy = [
+    helpId,
+    state.error ? errorId : null,
+    mutationAvailability.reason ? disabledReasonId : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <div
+      ref={panelRef}
+      className="docx-equation-popup"
+      data-testid="equation-popup"
+      role="dialog"
+      aria-modal={false}
+      aria-label={t('equationPopup.title')}
+      style={placement ?? undefined}
+      onMouseDown={guardMousedown}
+    >
+      <label className="docx-editor-sr-only" htmlFor={inputId}>
+        {t('equationPopup.inputLabel')}
+      </label>
+      <input
+        id={inputId}
+        ref={inputRef}
+        className="docx-equation-popup__input"
+        data-testid="equation-popup-input"
+        value={state.draft}
+        placeholder={t('equationPopup.placeholder')}
+        spellCheck={false}
+        aria-describedby={describedBy}
+        onChange={(event) =>
+          setState((current) =>
+            current ? { ...current, draft: event.target.value, error: false } : current
+          )
+        }
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter' || event.nativeEvent.isComposing) return;
+          event.preventDefault();
+          apply();
+        }}
+      />
+      <div id={helpId} className="docx-equation-popup__help">
+        {t('equationPopup.syntaxHelp')}
+      </div>
+      {state.error ? (
+        <div
+          id={errorId}
+          className="docx-equation-popup__error"
+          data-testid="equation-popup-error"
+          role="alert"
+        >
+          {t('equationPopup.refused')}
+        </div>
+      ) : null}
+      {mutationAvailability.reason ? (
+        <div
+          id={disabledReasonId}
+          className="docx-equation-popup__error"
+          data-testid="equation-popup-disabled-reason"
+          role="status"
+        >
+          {mutationAvailability.reason}
+        </div>
+      ) : null}
+      <div className="docx-equation-popup__actions">
+        <button
+          type="button"
+          className="docx-equation-popup__apply"
+          data-testid="equation-popup-apply"
+          disabled={!mutationAvailability.replaceEnabled}
+          title={mutationAvailability.reason ?? undefined}
+          onMouseDown={guardMousedown}
+          onClick={apply}
+        >
+          {t('equationPopup.apply')}
+        </button>
+        <button
+          type="button"
+          className="docx-equation-popup__delete"
+          data-testid="equation-popup-delete"
+          disabled={!mutationAvailability.removeEnabled}
+          title={mutationAvailability.reason ?? undefined}
+          onMouseDown={guardMousedown}
+          onClick={remove}
+        >
+          {t('equationPopup.delete')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/editor/DocxEditorEquation.tsx
+++ b/packages/react/src/editor/DocxEditorEquation.tsx
@@ -34,7 +34,6 @@ export function DocxEditorEquation() {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const releasePinRef = useRef<(() => void) | null>(null);
   const inputId = useId();
-  const helpId = useId();
   const errorId = useId();
   const disabledReasonId = useId();
   const activation = state?.activation ?? null;
@@ -164,7 +163,6 @@ export function DocxEditorEquation() {
 
   if (!state) return null;
   const describedBy = [
-    helpId,
     state.error ? errorId : null,
     mutationAvailability.reason ? disabledReasonId : null,
   ]
@@ -192,7 +190,7 @@ export function DocxEditorEquation() {
         value={state.draft}
         placeholder={t('equationPopup.placeholder')}
         spellCheck={false}
-        aria-describedby={describedBy}
+        aria-describedby={describedBy || undefined}
         onChange={(event) =>
           setState((current) =>
             current ? { ...current, draft: event.target.value, error: false } : current
@@ -204,9 +202,6 @@ export function DocxEditorEquation() {
           apply();
         }}
       />
-      <div id={helpId} className="docx-equation-popup__help">
-        {t('equationPopup.syntaxHelp')}
-      </div>
       {state.error ? (
         <div
           id={errorId}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -28,6 +28,7 @@ export {
 } from './editor/DocxEditorRoot';
 export { DocxEditorViewport, type DocxEditorViewportProps } from './editor/DocxEditorViewport';
 export { DocxEditorContent, type DocxEditorContentProps } from './editor/DocxEditorContent';
+export { DocxEditorEquation } from './editor/DocxEditorEquation';
 export {
   DocxEditorLoading,
   DocxEditorLoadingSpinner,

--- a/packages/react/test/equation-popup.test.tsx
+++ b/packages/react/test/equation-popup.test.tsx
@@ -152,7 +152,7 @@ describe('default React equation popover', () => {
     const outside = document.createElement('button');
     mounted.view.container.append(outside);
     outside.focus();
-    fireEvent.mouseDown(outside);
+    fireEvent.pointerDown(outside);
     expect(mounted.view.queryByTestId('equation-popup')).toBeNull();
     await tick();
     expect(document.activeElement).toBe(outside);
@@ -242,11 +242,11 @@ describe('default React equation popover', () => {
     let added = 0;
     let removed = 0;
     ownerDocument.addEventListener = ((type: string, ...args: unknown[]) => {
-      if (type === 'keydown' || type === 'mousedown') added++;
+      if (type === 'keydown' || type === 'pointerdown') added++;
       return originalAdd(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
     }) as typeof ownerDocument.addEventListener;
     ownerDocument.removeEventListener = ((type: string, ...args: unknown[]) => {
-      if (type === 'keydown' || type === 'mousedown') removed++;
+      if (type === 'keydown' || type === 'pointerdown') removed++;
       return originalRemove(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
     }) as typeof ownerDocument.removeEventListener;
     try {

--- a/packages/react/test/equation-popup.test.tsx
+++ b/packages/react/test/equation-popup.test.tsx
@@ -1,0 +1,264 @@
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { strToU8, zipSync } from 'fflate';
+import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorEquation } from '../src/editor/DocxEditorEquation.tsx';
+import {
+  DocxEditor as PublicDocxEditor,
+  DocxEditorEquation as PublicDocxEditorEquation,
+} from '../src/index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const M = 'http://schemas.openxmlformats.org/officeDocument/2006/math';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function equationDocument(equation: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:m="${M}"><w:body><w:p>${equation}</w:p></w:body></w:document>`
+    ),
+  });
+}
+
+const SOURCE = equationDocument(
+  '<m:oMath><m:sSup><m:e><m:r><m:t>x</m:t></m:r></m:e>' +
+    '<m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup></m:oMath>'
+);
+const REPLACEMENT_SOURCE = equationDocument('<m:oMath><m:r><m:t>y</m:t></m:r></m:oMath>');
+
+interface Mounted {
+  readonly view: ReturnType<typeof render>;
+  editor(): DocxEditorInstance;
+}
+
+function mount(mode: 'edit' | 'view' = 'edit'): Mounted {
+  let instance: DocxEditorInstance | null = null;
+  const view = render(
+    <DocxEditorRoot
+      document={SOURCE}
+      mode={mode}
+      onReady={(editor) => {
+        instance = editor as DocxEditorInstance;
+      }}
+    >
+      <DocxEditorViewport>
+        <DocxEditorContent />
+        <DocxEditorEquation />
+      </DocxEditorViewport>
+    </DocxEditorRoot>
+  );
+  return { view, editor: () => instance! };
+}
+
+async function tick(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function open(mounted: Mounted): void {
+  const equation = mounted.view.container.querySelector('[data-docx-equation]');
+  if (!equation) throw new Error('no painted equation');
+  fireEvent.click(equation);
+}
+
+afterEach(cleanup);
+
+describe('default React equation popover', () => {
+  test('is available from the public primitive and namespace', () => {
+    expect(PublicDocxEditorEquation).toBe(DocxEditorEquation);
+    expect(PublicDocxEditor.Equation).toBe(DocxEditorEquation);
+  });
+
+  test('mounts from the packaged sugar editor', async () => {
+    const view = render(<PublicDocxEditor document={SOURCE} />);
+    await tick();
+    const equation = view.container.querySelector('[data-docx-equation]');
+    if (!equation) throw new Error('no painted equation');
+    fireEvent.click(equation);
+    await tick();
+    expect(view.queryByTestId('equation-popup')).not.toBeNull();
+  });
+
+  test('seeds the linear form and applies to the retained equation id', async () => {
+    const mounted = mount();
+    await tick();
+    open(mounted);
+    await tick();
+
+    const input = mounted.view.getByTestId('equation-popup-input') as HTMLInputElement;
+    expect(input.value).toBe('x^{2}');
+    expect(mounted.editor().surface!.retainedSelection()).not.toBeNull();
+    const equationId = mounted.editor().surface!.equations.equationAtCaret()!.id;
+
+    fireEvent.change(input, { target: { value: '{a+b}/{2}' } });
+    expect(fireEvent.mouseDown(mounted.view.getByTestId('equation-popup-apply'))).toBe(false);
+    fireEvent.click(mounted.view.getByTestId('equation-popup-apply'));
+    await tick();
+
+    expect(mounted.view.queryByTestId('equation-popup')).toBeNull();
+    expect(mounted.editor().surface!.retainedSelection()).toBeNull();
+    expect(mounted.editor().surface!.equations.equationById(equationId)?.linear).toBe('{a+b}/{2}');
+    expect(document.activeElement).toBe(mounted.view.container.querySelector('.docx-pages'));
+  });
+
+  test('describes syntax help and restores focus on Escape', async () => {
+    const mounted = mount();
+    await tick();
+    open(mounted);
+    await tick();
+
+    const input = mounted.view.getByTestId('equation-popup-input');
+    const describedBy = input.getAttribute('aria-describedby')!;
+    const helpId = describedBy.split(' ')[0]!;
+    expect(mounted.view.container.querySelector(`#${CSS.escape(helpId)}`)?.textContent).toContain(
+      'Use x^2'
+    );
+    fireEvent.change(mounted.view.getByTestId('equation-popup-input'), {
+      target: { value: 'x^' },
+    });
+    fireEvent.click(mounted.view.getByTestId('equation-popup-apply'));
+    expect(mounted.view.getByRole('alert').textContent).toContain('could not be applied');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await tick();
+    expect(mounted.view.queryByTestId('equation-popup')).toBeNull();
+    expect(document.activeElement).toBe(mounted.view.container.querySelector('.docx-pages'));
+  });
+
+  test('closes on an outside click without restoring editor focus', async () => {
+    const mounted = mount();
+    await tick();
+    open(mounted);
+    await tick();
+    const outside = document.createElement('button');
+    mounted.view.container.append(outside);
+    outside.focus();
+    fireEvent.mouseDown(outside);
+    expect(mounted.view.queryByTestId('equation-popup')).toBeNull();
+    await tick();
+    expect(document.activeElement).toBe(outside);
+  });
+
+  test('deletes the selected equation and closes', async () => {
+    const mounted = mount();
+    await tick();
+    open(mounted);
+    await tick();
+
+    fireEvent.click(mounted.view.getByTestId('equation-popup-delete'));
+    await tick();
+
+    expect(mounted.view.queryByTestId('equation-popup')).toBeNull();
+    expect(mounted.view.container.querySelector('[data-docx-equation]')).toBeNull();
+    expect(document.activeElement).toBe(mounted.view.container.querySelector('.docx-pages'));
+  });
+
+  test('closes when the same editor loads a replacement document', async () => {
+    const mounted = mount();
+    await tick();
+    open(mounted);
+    await tick();
+    fireEvent.change(mounted.view.getByTestId('equation-popup-input'), {
+      target: { value: 'stale' },
+    });
+
+    mounted.editor().load(REPLACEMENT_SOURCE);
+    await tick();
+
+    expect(mounted.view.queryByTestId('equation-popup')).toBeNull();
+    expect(mounted.editor().surface!.equations.equationAtCaret()?.linear).toBe('y');
+  });
+
+  test('closes when an external edit removes the active equation', async () => {
+    const mounted = mount();
+    await tick();
+    open(mounted);
+    await tick();
+    const equationId = mounted.editor().surface!.equations.equationAtCaret()!.id;
+
+    expect(mounted.editor().surface!.equations.removeEquation(equationId)).toBe(true);
+    await tick();
+
+    expect(mounted.view.queryByTestId('equation-popup')).toBeNull();
+  });
+
+  test('disables mutations with the localized viewing reason', async () => {
+    const mounted = mount('view');
+    await tick();
+    open(mounted);
+    await tick();
+
+    expect((mounted.view.getByTestId('equation-popup-apply') as HTMLButtonElement).disabled).toBe(
+      true
+    );
+    expect((mounted.view.getByTestId('equation-popup-delete') as HTMLButtonElement).disabled).toBe(
+      true
+    );
+    expect(mounted.view.getByTestId('equation-popup-disabled-reason').textContent).toContain(
+      'open for viewing'
+    );
+  });
+
+  test('does not apply Enter while an input method is composing', async () => {
+    const mounted = mount();
+    await tick();
+    open(mounted);
+    await tick();
+    const equationId = mounted.editor().surface!.equations.equationAtCaret()!.id;
+    const input = mounted.view.getByTestId('equation-popup-input');
+    fireEvent.change(input, { target: { value: 'y' } });
+
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+
+    expect(mounted.view.queryByTestId('equation-popup')).not.toBeNull();
+    expect(mounted.editor().surface!.equations.equationById(equationId)?.linear).toBe('x^{2}');
+  });
+
+  test('removes document listeners when the popover unmounts', async () => {
+    const mounted = mount();
+    await tick();
+    const ownerDocument = mounted.view.container.ownerDocument;
+    const originalAdd = ownerDocument.addEventListener.bind(ownerDocument);
+    const originalRemove = ownerDocument.removeEventListener.bind(ownerDocument);
+    let added = 0;
+    let removed = 0;
+    ownerDocument.addEventListener = ((type: string, ...args: unknown[]) => {
+      if (type === 'keydown' || type === 'mousedown') added++;
+      return originalAdd(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
+    }) as typeof ownerDocument.addEventListener;
+    ownerDocument.removeEventListener = ((type: string, ...args: unknown[]) => {
+      if (type === 'keydown' || type === 'mousedown') removed++;
+      return originalRemove(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
+    }) as typeof ownerDocument.removeEventListener;
+    try {
+      open(mounted);
+      await tick();
+      mounted.view.unmount();
+      expect(added).toBe(2);
+      expect(removed).toBe(2);
+    } finally {
+      ownerDocument.addEventListener = originalAdd as typeof ownerDocument.addEventListener;
+      ownerDocument.removeEventListener =
+        originalRemove as typeof ownerDocument.removeEventListener;
+    }
+  });
+});

--- a/packages/react/test/equation-popup.test.tsx
+++ b/packages/react/test/equation-popup.test.tsx
@@ -120,23 +120,21 @@ describe('default React equation popover', () => {
     expect(document.activeElement).toBe(mounted.view.container.querySelector('.docx-pages'));
   });
 
-  test('describes syntax help and restores focus on Escape', async () => {
+  test('describes apply errors and restores focus on Escape', async () => {
     const mounted = mount();
     await tick();
     open(mounted);
     await tick();
 
     const input = mounted.view.getByTestId('equation-popup-input');
-    const describedBy = input.getAttribute('aria-describedby')!;
-    const helpId = describedBy.split(' ')[0]!;
-    expect(mounted.view.container.querySelector(`#${CSS.escape(helpId)}`)?.textContent).toContain(
-      'Use x^2'
-    );
+    expect(input.getAttribute('aria-describedby')).toBeNull();
     fireEvent.change(mounted.view.getByTestId('equation-popup-input'), {
       target: { value: 'x^' },
     });
     fireEvent.click(mounted.view.getByTestId('equation-popup-apply'));
-    expect(mounted.view.getByRole('alert').textContent).toContain('could not be applied');
+    const alert = mounted.view.getByRole('alert');
+    expect(alert.textContent).toContain('could not be applied');
+    expect(input.getAttribute('aria-describedby')).toContain(alert.id);
 
     fireEvent.keyDown(document, { key: 'Escape' });
     await tick();

--- a/packages/vue/src/components/DocxEditor.tsx
+++ b/packages/vue/src/components/DocxEditor.tsx
@@ -30,6 +30,7 @@ import { DocxEditorPageNumber, PageNumberTranslationContext } from '../editor/Do
 import { DocxEditorFontNotice } from '../editor/DocxEditorFontNotice';
 import { DocxEditorHeaderFooterChrome } from '../editor/DocxEditorHeaderFooter';
 import { DocxEditorHyperLink } from '../editor/DocxEditorHyperLink';
+import { DocxEditorEquation } from '../editor/DocxEditorEquation';
 import { DocxEditorNotesChrome } from '../editor/DocxEditorNotes';
 import { DocxEditorContextMenu, ContextMenu } from '../editor/contextmenu';
 import { DocxEditorContentControl } from '../editor/DocxEditorContentControl';
@@ -160,6 +161,8 @@ export interface DocxEditorNamespace {
   readonly FontNotice: typeof DocxEditorFontNotice;
   readonly HeaderFooterChrome: typeof DocxEditorHeaderFooterChrome;
   readonly NotesChrome: typeof DocxEditorNotesChrome;
+  /** The default linear-math popover for a clicked Office Math equation. */
+  readonly Equation: typeof DocxEditorEquation;
   readonly HyperLink: typeof DocxEditorHyperLink;
   readonly ContextMenu: typeof ContextMenu;
   readonly ContentControl: typeof DocxEditorContentControl;
@@ -321,6 +324,7 @@ const DocxEditorFrame = defineComponent({
             chrome.value ? h(DocxEditorNotesChrome) : null,
             h(DocxEditorContent),
             h(DocxEditorHyperLink, { hidden: hyperlinkPopup.value === false }),
+            h(DocxEditorEquation),
             contextMenu.value === false
               ? null
               : h(DocxEditorContextMenu, {
@@ -529,6 +533,7 @@ export const DocxEditor = Object.assign(DocxEditorImpl, {
   FontNotice: DocxEditorFontNotice,
   HeaderFooterChrome: DocxEditorHeaderFooterChrome,
   NotesChrome: DocxEditorNotesChrome,
+  Equation: DocxEditorEquation,
   HyperLink: DocxEditorHyperLink,
   ContextMenu: DocxEditorContextMenu,
   ContentControl: DocxEditorContentControl,

--- a/packages/vue/src/editor/DocxEditorEquation.tsx
+++ b/packages/vue/src/editor/DocxEditorEquation.tsx
@@ -1,0 +1,310 @@
+import { computed, defineComponent, h, ref, watch, type CSSProperties } from 'vue';
+import type { EquationActivation } from '@docx-editor.dev/core/editor';
+import { localizeDisabledReason } from '@docx-editor.dev/i18n';
+import { useTranslation } from '../i18n';
+import { formatPx } from '../lib/units';
+import { useStableDocxId } from '../lib/stable-id';
+import { useDocxEditor } from './context';
+import { absolutePointInScroller } from './scroller-geometry.ts';
+import { useEditorState } from './useEditorState.ts';
+
+interface EquationPopupState {
+  readonly activation: EquationActivation;
+  readonly mountGeneration: number;
+  readonly draft: string;
+  readonly error: boolean;
+}
+
+/** Keeps button chrome from moving the document caret. Inputs retain normal focus behavior. */
+function guardMousedown(event: MouseEvent): void {
+  const tag = (event.target as HTMLElement | null)?.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  event.preventDefault();
+}
+
+/** Default equation editor mounted by the packaged Vue host. */
+export const DocxEditorEquation = defineComponent({
+  name: 'DocxEditorEquation',
+  setup() {
+    const editorRef = useDocxEditor();
+    const { t } = useTranslation();
+    const state = ref<EquationPopupState | null>(null);
+    const placement = ref<CSSProperties | null>(null);
+    const inputId = useStableDocxId('equation-input');
+    const helpId = useStableDocxId('equation-help');
+    const errorId = useStableDocxId('equation-error');
+    const disabledReasonId = useStableDocxId('equation-disabled-reason');
+    let panelElement: HTMLElement | null = null;
+    let inputElement: HTMLInputElement | null = null;
+    let releasePin: (() => void) | null = null;
+    const editorSnapshot = useEditorState((snapshot) => snapshot);
+    const mutationAvailability = computed(() => {
+      void editorSnapshot.value;
+      const editor = editorRef.value;
+      const activation = state.value?.activation;
+      if (!editor?.surface || !activation) {
+        return { replaceEnabled: false, removeEnabled: false, reason: null };
+      }
+      const replace = editor.surface.equations.can(activation.equation.id, 'replace');
+      const remove = editor.surface.equations.can(activation.equation.id, 'remove');
+      const refusal = !replace.ok ? replace.reason : !remove.ok ? remove.reason : null;
+      return {
+        replaceEnabled: replace.ok,
+        removeEnabled: remove.ok,
+        reason: refusal ? localizeDisabledReason(refusal, t) : null,
+      };
+    });
+    const close = (restoreFocus = false) => {
+      const focusEditor = editorRef.value;
+      releasePin?.();
+      releasePin = null;
+      state.value = null;
+      if (restoreFocus && focusEditor) queueMicrotask(() => focusEditor.focus());
+    };
+
+    watch(
+      editorRef,
+      (editor, _, onCleanup) => {
+        if (!editor) return;
+        const off = editor.setEquationChrome({
+          onPopover: (activation) => {
+            releasePin?.();
+            const surface = editor.surface;
+            if (surface && typeof surface.retainSelection === 'function') {
+              const pin = surface.retainSelection();
+              releasePin = () => surface.releaseSelection(pin);
+            } else {
+              releasePin = null;
+            }
+            state.value = {
+              activation,
+              mountGeneration: editor.mountGeneration,
+              draft: activation.equation.linear,
+              error: false,
+            };
+          },
+        });
+        onCleanup(() => {
+          off();
+          close();
+        });
+      },
+      { immediate: true, flush: 'post' }
+    );
+
+    watch(
+      [editorRef, editorSnapshot, () => state.value?.activation.equation.id],
+      () => {
+        const current = state.value;
+        const editor = editorRef.value;
+        if (!current || !editor?.surface) return;
+        const stale =
+          editor.mountGeneration !== current.mountGeneration ||
+          !editor.surface.equations.equationById(current.activation.equation.id);
+        if (stale) close();
+      },
+      { flush: 'post' }
+    );
+
+    watch(
+      state,
+      (current, _, onCleanup) => {
+        if (!current) return;
+        let disposed = false;
+        let ownerDocument: Document | null = null;
+        let onKeyDown: ((event: KeyboardEvent) => void) | null = null;
+        let onMouseDown: ((event: MouseEvent) => void) | null = null;
+        queueMicrotask(() => {
+          if (disposed) return;
+          const panel = panelElement;
+          ownerDocument = panel?.ownerDocument ?? null;
+          const view = ownerDocument?.defaultView;
+          if (!panel || !ownerDocument || !view) return;
+          onKeyDown = (event: KeyboardEvent): void => {
+            if (event.key !== 'Escape') return;
+            event.preventDefault();
+            close(true);
+          };
+          onMouseDown = (event: MouseEvent): void => {
+            if (event.target instanceof view.Node && panel.contains(event.target)) return;
+            close();
+          };
+          ownerDocument.addEventListener('keydown', onKeyDown);
+          ownerDocument.addEventListener('mousedown', onMouseDown, true);
+        });
+        onCleanup(() => {
+          disposed = true;
+          if (ownerDocument && onKeyDown) ownerDocument.removeEventListener('keydown', onKeyDown);
+          if (ownerDocument && onMouseDown) {
+            ownerDocument.removeEventListener('mousedown', onMouseDown, true);
+          }
+        });
+      },
+      { flush: 'post' }
+    );
+
+    watch(
+      () => state.value?.activation,
+      (activation) => {
+        if (!activation) {
+          placement.value = null;
+          return;
+        }
+        const panel = panelElement;
+        if (!panel) return;
+        const container = panel.offsetParent as HTMLElement | null;
+        if (container) {
+          const point = absolutePointInScroller(
+            container,
+            activation.rect.left,
+            activation.rect.bottom
+          );
+          const maxLeft = Math.max(0, container.scrollWidth - panel.offsetWidth);
+          placement.value = {
+            left: formatPx(Math.max(0, Math.min(point.left, maxLeft))),
+            top: formatPx(point.top),
+          };
+        } else {
+          placement.value = null;
+        }
+        inputElement?.focus({ preventScroll: true });
+        inputElement?.select();
+      },
+      { flush: 'post' }
+    );
+
+    const apply = (linear?: string): boolean => {
+      const current = state.value;
+      const equations = editorRef.value?.surface?.equations;
+      if (!current || !equations || !mutationAvailability.value.replaceEnabled) return false;
+      const applied = equations.applyEquation(
+        current.activation.equation.id,
+        linear ?? current.draft
+      );
+      if (applied) close(true);
+      else state.value = { ...current, error: true };
+      return applied;
+    };
+
+    const remove = (): boolean => {
+      const current = state.value;
+      const equations = editorRef.value?.surface?.equations;
+      if (!current || !equations || !mutationAvailability.value.removeEnabled) return false;
+      const removed = equations.removeEquation(current.activation.equation.id);
+      if (removed) close(true);
+      else state.value = { ...current, error: true };
+      return removed;
+    };
+
+    return () => {
+      const current = state.value;
+      if (!current) return null;
+      const field = h('input', {
+        id: inputId,
+        onVnodeMounted: (vnode) => {
+          inputElement = vnode.el as HTMLInputElement;
+        },
+        onVnodeUnmounted: () => {
+          inputElement = null;
+        },
+        class: 'docx-equation-popup__input',
+        'data-testid': 'equation-popup-input',
+        value: current.draft,
+        placeholder: t('equationPopup.placeholder'),
+        spellcheck: false,
+        'aria-describedby': [
+          helpId,
+          current.error ? errorId : null,
+          mutationAvailability.value.reason ? disabledReasonId : null,
+        ]
+          .filter(Boolean)
+          .join(' '),
+        onInput: (event: InputEvent) => {
+          const active = state.value;
+          if (!active) return;
+          state.value = {
+            ...active,
+            draft: (event.target as HTMLInputElement).value,
+            error: false,
+          };
+        },
+        onKeydown: (event: KeyboardEvent) => {
+          if (event.key !== 'Enter' || event.isComposing) return;
+          event.preventDefault();
+          apply((event.currentTarget as HTMLInputElement).value);
+        },
+      });
+      return h(
+        'div',
+        {
+          onVnodeMounted: (vnode) => {
+            panelElement = vnode.el as HTMLElement;
+          },
+          onVnodeUnmounted: () => {
+            panelElement = null;
+          },
+          class: 'docx-equation-popup',
+          'data-testid': 'equation-popup',
+          role: 'dialog',
+          'aria-modal': false,
+          'aria-label': t('equationPopup.title'),
+          style: placement.value ?? undefined,
+          onMousedown: guardMousedown,
+        },
+        [
+          <label class="docx-editor-sr-only" for={inputId}>
+            {t('equationPopup.inputLabel')}
+          </label>,
+          field,
+          <div id={helpId} class="docx-equation-popup__help">
+            {t('equationPopup.syntaxHelp')}
+          </div>,
+          current.error ? (
+            <div
+              id={errorId}
+              class="docx-equation-popup__error"
+              data-testid="equation-popup-error"
+              role="alert"
+            >
+              {t('equationPopup.refused')}
+            </div>
+          ) : null,
+          mutationAvailability.value.reason ? (
+            <div
+              id={disabledReasonId}
+              class="docx-equation-popup__error"
+              data-testid="equation-popup-disabled-reason"
+              role="status"
+            >
+              {mutationAvailability.value.reason}
+            </div>
+          ) : null,
+          <div class="docx-equation-popup__actions">
+            <button
+              type="button"
+              class="docx-equation-popup__apply"
+              data-testid="equation-popup-apply"
+              disabled={!mutationAvailability.value.replaceEnabled}
+              title={mutationAvailability.value.reason ?? undefined}
+              onMousedown={guardMousedown}
+              onClick={() => apply(inputElement?.value)}
+            >
+              {t('equationPopup.apply')}
+            </button>
+            <button
+              type="button"
+              class="docx-equation-popup__delete"
+              data-testid="equation-popup-delete"
+              disabled={!mutationAvailability.value.removeEnabled}
+              title={mutationAvailability.value.reason ?? undefined}
+              onMousedown={guardMousedown}
+              onClick={remove}
+            >
+              {t('equationPopup.delete')}
+            </button>
+          </div>,
+        ]
+      );
+    };
+  },
+});

--- a/packages/vue/src/editor/DocxEditorEquation.tsx
+++ b/packages/vue/src/editor/DocxEditorEquation.tsx
@@ -31,7 +31,6 @@ export const DocxEditorEquation = defineComponent({
     const state = ref<EquationPopupState | null>(null);
     const placement = ref<CSSProperties | null>(null);
     const inputId = useStableDocxId('equation-input');
-    const helpId = useStableDocxId('equation-help');
     const errorId = useStableDocxId('equation-error');
     const disabledReasonId = useStableDocxId('equation-disabled-reason');
     let panelElement: HTMLElement | null = null;
@@ -212,13 +211,13 @@ export const DocxEditorEquation = defineComponent({
         value: current.draft,
         placeholder: t('equationPopup.placeholder'),
         spellcheck: false,
-        'aria-describedby': [
-          helpId,
-          current.error ? errorId : null,
-          mutationAvailability.value.reason ? disabledReasonId : null,
-        ]
-          .filter(Boolean)
-          .join(' '),
+        'aria-describedby':
+          [
+            current.error ? errorId : null,
+            mutationAvailability.value.reason ? disabledReasonId : null,
+          ]
+            .filter(Boolean)
+            .join(' ') || undefined,
         onInput: (event: InputEvent) => {
           const active = state.value;
           if (!active) return;
@@ -256,9 +255,6 @@ export const DocxEditorEquation = defineComponent({
             {t('equationPopup.inputLabel')}
           </label>,
           field,
-          <div id={helpId} class="docx-equation-popup__help">
-            {t('equationPopup.syntaxHelp')}
-          </div>,
           current.error ? (
             <div
               id={errorId}

--- a/packages/vue/src/editor/DocxEditorEquation.tsx
+++ b/packages/vue/src/editor/DocxEditorEquation.tsx
@@ -113,7 +113,7 @@ export const DocxEditorEquation = defineComponent({
         let disposed = false;
         let ownerDocument: Document | null = null;
         let onKeyDown: ((event: KeyboardEvent) => void) | null = null;
-        let onMouseDown: ((event: MouseEvent) => void) | null = null;
+        let onPointerDown: ((event: PointerEvent) => void) | null = null;
         queueMicrotask(() => {
           if (disposed) return;
           const panel = panelElement;
@@ -125,18 +125,18 @@ export const DocxEditorEquation = defineComponent({
             event.preventDefault();
             close(true);
           };
-          onMouseDown = (event: MouseEvent): void => {
+          onPointerDown = (event: PointerEvent): void => {
             if (event.target instanceof view.Node && panel.contains(event.target)) return;
             close();
           };
           ownerDocument.addEventListener('keydown', onKeyDown);
-          ownerDocument.addEventListener('mousedown', onMouseDown, true);
+          ownerDocument.addEventListener('pointerdown', onPointerDown, true);
         });
         onCleanup(() => {
           disposed = true;
           if (ownerDocument && onKeyDown) ownerDocument.removeEventListener('keydown', onKeyDown);
-          if (ownerDocument && onMouseDown) {
-            ownerDocument.removeEventListener('mousedown', onMouseDown, true);
+          if (ownerDocument && onPointerDown) {
+            ownerDocument.removeEventListener('pointerdown', onPointerDown, true);
           }
         });
       },

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -21,6 +21,7 @@ export {
 } from './editor/DocxEditorRoot';
 export { DocxEditorViewport, type DocxEditorViewportProps } from './editor/DocxEditorViewport';
 export { DocxEditorContent, type DocxEditorContentProps } from './editor/DocxEditorContent';
+export { DocxEditorEquation } from './editor/DocxEditorEquation';
 
 export { useDocxEditor, ReviewRailContext, type ReviewRailRegistry } from './editor/context';
 export {

--- a/packages/vue/test/equation-popup.test.ts
+++ b/packages/vue/test/equation-popup.test.ts
@@ -99,7 +99,7 @@ describe('default Vue equation popover', () => {
     view.unmount();
   });
 
-  test('describes syntax help and restores focus on Escape', async () => {
+  test('describes apply errors and restores focus on Escape', async () => {
     const view = mount();
     await flush();
     await open(view);
@@ -107,15 +107,14 @@ describe('default Vue equation popover', () => {
     const field = view.container.querySelector(
       '[data-testid="equation-popup-input"]'
     ) as HTMLInputElement;
-    const helpId = field.getAttribute('aria-describedby')!.split(' ')[0]!;
-    expect(view.container.querySelector(`[id="${helpId}"]`)?.textContent).toContain('Use x^2');
+    expect(field.getAttribute('aria-describedby')).toBeNull();
     input(view, 'x^');
     await nextTick();
     click(view, 'equation-popup-apply');
     await nextTick();
-    expect(view.container.querySelector('[role="alert"]')?.textContent).toContain(
-      'could not be applied'
-    );
+    const alert = view.container.querySelector<HTMLElement>('[role="alert"]')!;
+    expect(alert.textContent).toContain('could not be applied');
+    expect(field.getAttribute('aria-describedby')).toContain(alert.id);
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     await flush();

--- a/packages/vue/test/equation-popup.test.ts
+++ b/packages/vue/test/equation-popup.test.ts
@@ -1,0 +1,241 @@
+import './dom-setup.ts';
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { h, nextTick } from 'vue';
+import { DocxEditorEquation } from '../src/editor/DocxEditorEquation';
+import {
+  DocxEditor as PublicDocxEditor,
+  DocxEditorEquation as PublicDocxEditorEquation,
+} from '../src/index';
+import { docx } from './helpers/fixtures';
+import { flush, mountEditorTree, mountSugarAsync, type MountedEditor } from './helpers/mount';
+
+const M = 'http://schemas.openxmlformats.org/officeDocument/2006/math';
+const SOURCE = docx(
+  `<w:p><m:oMath xmlns:m="${M}"><m:sSup><m:e><m:r><m:t>x</m:t></m:r></m:e>` +
+    '<m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup></m:oMath></w:p>'
+);
+const REPLACEMENT_SOURCE = docx(
+  `<w:p><m:oMath xmlns:m="${M}"><m:r><m:t>y</m:t></m:r></m:oMath></w:p>`
+);
+
+function mount(mode: 'edit' | 'view' = 'edit'): MountedEditor {
+  return mountEditorTree(
+    () => [],
+    SOURCE,
+    () => h(DocxEditorEquation),
+    undefined,
+    { mode }
+  );
+}
+
+async function open(view: MountedEditor): Promise<void> {
+  const equation = view.container.querySelector('[data-docx-equation]');
+  if (!equation) throw new Error('no painted equation');
+  equation.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  await nextTick();
+}
+
+function input(view: MountedEditor, value: string): void {
+  const element = view.container.querySelector(
+    '[data-testid="equation-popup-input"]'
+  ) as HTMLInputElement;
+  element.value = value;
+  element.dispatchEvent(new InputEvent('input', { bubbles: true, data: value }));
+}
+
+function click(view: MountedEditor, testId: string): void {
+  view.container
+    .querySelector(`[data-testid="${testId}"]`)!
+    .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('default Vue equation popover', () => {
+  test('is available from the public primitive and namespace', () => {
+    expect(PublicDocxEditorEquation).toBe(DocxEditorEquation);
+    expect(PublicDocxEditor.Equation).toBe(DocxEditorEquation);
+  });
+
+  test('mounts from the packaged sugar editor', async () => {
+    const view = await mountSugarAsync({ document: SOURCE });
+    await flush();
+    await open(view);
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).not.toBeNull();
+    view.unmount();
+  });
+
+  test('seeds the linear form and applies to the retained equation id', async () => {
+    const view = mount();
+    await flush();
+    await open(view);
+
+    const field = view.container.querySelector(
+      '[data-testid="equation-popup-input"]'
+    ) as HTMLInputElement;
+    expect(field.value).toBe('x^{2}');
+    expect(view.editor().surface!.retainedSelection()).not.toBeNull();
+    const equationId = view.editor().surface!.equations.equationAtCaret()!.id;
+
+    input(view, '{a+b}/{2}');
+    await nextTick();
+    expect(
+      (view.container.querySelector('[data-testid="equation-popup-input"]') as HTMLInputElement)
+        .value
+    ).toBe('{a+b}/{2}');
+    const button = view.container.querySelector('[data-testid="equation-popup-apply"]')!;
+    const mousedown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    expect(button.dispatchEvent(mousedown)).toBe(false);
+    click(view, 'equation-popup-apply');
+    await flush();
+
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).toBeNull();
+    expect(view.editor().surface!.retainedSelection()).toBeNull();
+    expect(view.editor().surface!.equations.equationById(equationId)?.linear).toBe('{a+b}/{2}');
+    expect(document.activeElement).toBe(view.container.querySelector('.docx-pages'));
+    view.unmount();
+  });
+
+  test('describes syntax help and restores focus on Escape', async () => {
+    const view = mount();
+    await flush();
+    await open(view);
+
+    const field = view.container.querySelector(
+      '[data-testid="equation-popup-input"]'
+    ) as HTMLInputElement;
+    const helpId = field.getAttribute('aria-describedby')!.split(' ')[0]!;
+    expect(view.container.querySelector(`[id="${helpId}"]`)?.textContent).toContain('Use x^2');
+    input(view, 'x^');
+    await nextTick();
+    click(view, 'equation-popup-apply');
+    await nextTick();
+    expect(view.container.querySelector('[role="alert"]')?.textContent).toContain(
+      'could not be applied'
+    );
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await flush();
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).toBeNull();
+    expect(document.activeElement).toBe(view.container.querySelector('.docx-pages'));
+    view.unmount();
+  });
+
+  test('closes outside without restoring focus and deletes with focus restoration', async () => {
+    const view = mount();
+    await flush();
+    await open(view);
+    const outside = document.createElement('button');
+    view.container.append(outside);
+    outside.focus();
+    outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    await nextTick();
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).toBeNull();
+    expect(document.activeElement).toBe(outside);
+
+    await open(view);
+    click(view, 'equation-popup-delete');
+    await flush();
+    expect(view.container.querySelector('[data-docx-equation]')).toBeNull();
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).toBeNull();
+    expect(document.activeElement).toBe(view.container.querySelector('.docx-pages'));
+    view.unmount();
+  });
+
+  test('closes when the same editor loads a replacement document', async () => {
+    const view = mount();
+    await flush();
+    await open(view);
+    input(view, 'stale');
+
+    view.editor().load(REPLACEMENT_SOURCE);
+    await flush();
+
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).toBeNull();
+    expect(view.editor().surface!.equations.equationAtCaret()?.linear).toBe('y');
+    view.unmount();
+  });
+
+  test('closes when an external edit removes the active equation', async () => {
+    const view = mount();
+    await flush();
+    await open(view);
+    const equationId = view.editor().surface!.equations.equationAtCaret()!.id;
+
+    expect(view.editor().surface!.equations.removeEquation(equationId)).toBe(true);
+    await flush();
+
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).toBeNull();
+    view.unmount();
+  });
+
+  test('disables mutations with the localized viewing reason', async () => {
+    const view = mount('view');
+    await flush();
+    await open(view);
+    const apply = view.container.querySelector(
+      '[data-testid="equation-popup-apply"]'
+    ) as HTMLButtonElement;
+    const remove = view.container.querySelector(
+      '[data-testid="equation-popup-delete"]'
+    ) as HTMLButtonElement;
+
+    expect(apply.disabled).toBe(true);
+    expect(remove.disabled).toBe(true);
+    expect(
+      view.container.querySelector('[data-testid="equation-popup-disabled-reason"]')?.textContent
+    ).toContain('open for viewing');
+    view.unmount();
+  });
+
+  test('does not apply Enter while an input method is composing', async () => {
+    const view = mount();
+    await flush();
+    await open(view);
+    const equationId = view.editor().surface!.equations.equationAtCaret()!.id;
+    input(view, 'y');
+    const field = view.container.querySelector(
+      '[data-testid="equation-popup-input"]'
+    ) as HTMLInputElement;
+
+    field.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, isComposing: true })
+    );
+    await nextTick();
+
+    expect(view.container.querySelector('[data-testid="equation-popup"]')).not.toBeNull();
+    expect(view.editor().surface!.equations.equationById(equationId)?.linear).toBe('x^{2}');
+    view.unmount();
+  });
+
+  test('removes document listeners when the popover unmounts', async () => {
+    const view = mount();
+    await flush();
+    const ownerDocument = view.container.ownerDocument;
+    const originalAdd = ownerDocument.addEventListener.bind(ownerDocument);
+    const originalRemove = ownerDocument.removeEventListener.bind(ownerDocument);
+    let added = 0;
+    let removed = 0;
+    ownerDocument.addEventListener = ((type: string, ...args: unknown[]) => {
+      if (type === 'keydown' || type === 'mousedown') added++;
+      return originalAdd(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
+    }) as typeof ownerDocument.addEventListener;
+    ownerDocument.removeEventListener = ((type: string, ...args: unknown[]) => {
+      if (type === 'keydown' || type === 'mousedown') removed++;
+      return originalRemove(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
+    }) as typeof ownerDocument.removeEventListener;
+    try {
+      await open(view);
+      view.unmount();
+      expect(added).toBe(2);
+      expect(removed).toBe(2);
+    } finally {
+      ownerDocument.addEventListener = originalAdd as typeof ownerDocument.addEventListener;
+      ownerDocument.removeEventListener =
+        originalRemove as typeof ownerDocument.removeEventListener;
+    }
+  });
+});

--- a/packages/vue/test/equation-popup.test.ts
+++ b/packages/vue/test/equation-popup.test.ts
@@ -131,7 +131,7 @@ describe('default Vue equation popover', () => {
     const outside = document.createElement('button');
     view.container.append(outside);
     outside.focus();
-    outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
     await nextTick();
     expect(view.container.querySelector('[data-testid="equation-popup"]')).toBeNull();
     expect(document.activeElement).toBe(outside);
@@ -220,11 +220,11 @@ describe('default Vue equation popover', () => {
     let added = 0;
     let removed = 0;
     ownerDocument.addEventListener = ((type: string, ...args: unknown[]) => {
-      if (type === 'keydown' || type === 'mousedown') added++;
+      if (type === 'keydown' || type === 'pointerdown') added++;
       return originalAdd(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
     }) as typeof ownerDocument.addEventListener;
     ownerDocument.removeEventListener = ((type: string, ...args: unknown[]) => {
-      if (type === 'keydown' || type === 'mousedown') removed++;
+      if (type === 'keydown' || type === 'pointerdown') removed++;
       return originalRemove(type, ...(args as [EventListenerOrEventListenerObject, boolean?]));
     }) as typeof ownerDocument.removeEventListener;
     try {


### PR DESCRIPTION
## Summary
- Render and edit bounded OMML equations with Cambria Math.
- Keep equations inline with surrounding text.
- Close equation popovers on outside pointer presses.

## Test plan
- [x] Run focused core, React, and Vue equation tests.
- [x] Run type checks and lint.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790155560&installation_model_id=422592&pr_number=397&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F397&signature=de01e09f92aaf04ef59be81d94845fa9368e5da409510d0c12361a08b4e3c8b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->