### PR TITLE
perf(core): reuse caret-derived chrome state while typing

### DIFF
--- a/.changeset/keystroke-derived-chrome.md
+++ b/.changeset/keystroke-derived-chrome.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typing in a long document no longer rebuilds the review paragraph-order index on every keystroke, and repeated state reads reuse the resolved caret content control instead of re-running the hit test.

--- a/.changeset/keystroke-derived-chrome.md
+++ b/.changeset/keystroke-derived-chrome.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Typing in a long document no longer rebuilds the review paragraph-order index on every keystroke, and repeated state reads reuse the resolved caret content control instead of re-running the hit test.
+Typing in a long document no longer rebuilds the review paragraph-order index on every keystroke, and repeated state reads reuse the resolved caret content control instead of re-running the hit test. Replacing a block content-control placeholder now reports the paragraph swap, so review items anchored in the replacement stay activatable.

--- a/packages/core/src/editor/__tests__/review-order-index-retention.test.ts
+++ b/packages/core/src/editor/__tests__/review-order-index-retention.test.ts
@@ -1,0 +1,123 @@
+// Activation stays correct while the paragraph order index is carried across keystrokes.
+//
+// The index that classifies the caret into a review card is memoized, and a text-local commit
+// re-stamps it instead of rebuilding — every keystroke rebuilt a whole-document map for an
+// answer typing cannot change. These tests pin the two sides of that bargain: a text edit must
+// not lose activation, and a structural edit must not be served the retained index, because a
+// split mints a paragraph id the old map has never seen.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor, type DocxEditorInstance } from '../index.ts';
+import type { EditorModule } from '../../contracts/modules.ts';
+import { collectReviewItems } from '../../store/index.ts';
+
+function engineReviewModule(): EditorModule {
+  return {
+    id: 'review',
+    review: {
+      displayModes: ['all-markup', 'proposed', 'original'],
+      collectReviewItems,
+      revisionItemsOfParagraph: () => [],
+    },
+  };
+}
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+/** A plain first paragraph and a second one carrying a pending tracked insertion. */
+const BODY =
+  `<w:p><w:r><w:t>plain leading paragraph</w:t></w:r></w:p>` +
+  `<w:p><w:r><w:t xml:space="preserve">before </w:t></w:r>` +
+  `<w:ins w:author="A" w:date="2026-07-08T11:32:00Z" w:id="1"><w:r><w:t>tracked</w:t></w:r></w:ins>` +
+  `<w:r><w:t xml:space="preserve"> after</w:t></w:r></w:p>`;
+
+function mount(): DocxEditorInstance {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({
+    container,
+    document: docx(BODY),
+    author: 'Grace Hopper',
+    modules: [engineReviewModule()],
+  });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+function activeKey(editor: DocxEditorInstance): string | null {
+  return editor.getReviewItems().find((entry) => entry.isActive)?.key ?? null;
+}
+
+describe('review activation across the retained order index', () => {
+  test('a text-local edit keeps every card activatable', () => {
+    const editor = mount();
+    const surface = editor.surface!;
+    const key = editor.getReviewItems().find((entry) => entry.activatable)?.key;
+    if (!key) throw new Error('the tracked insertion produced no card');
+
+    // Activate once so the order index exists and the retained slot has something to carry.
+    expect(editor.setActiveReviewItem(key).ok).toBe(true);
+    expect(activeKey(editor)).toBe(key);
+
+    // A keystroke-shaped commit: insert one character into the OTHER paragraph.
+    const [firstParagraph] = surface.session.paragraphIds();
+    const edited = surface.session.applyTreeOps([
+      { op: 'insertText', paragraphId: firstParagraph!, offset: 3, text: 'x' },
+    ]);
+    expect(edited.committed).toBe(true);
+
+    expect(editor.setActiveReviewItem(key).ok).toBe(true);
+    expect(activeKey(editor)).toBe(key);
+    editor.destroy();
+  });
+
+  test('a paragraph split rebuilds the index for the minted paragraph', () => {
+    const editor = mount();
+    const surface = editor.surface!;
+    const key = editor.getReviewItems().find((entry) => entry.activatable)?.key;
+    if (!key) throw new Error('the tracked insertion produced no card');
+    expect(editor.setActiveReviewItem(key).ok).toBe(true);
+
+    // Split the FIRST paragraph. A retained index would still classify the card's paragraph,
+    // so the sharper probe is the minted tail: select into it and confirm classification
+    // resolves against the new order rather than throwing the card into limbo.
+    const [firstParagraph] = surface.session.paragraphIds();
+    const split = surface.session.applyTreeOps([
+      { op: 'splitParagraph', paragraphId: firstParagraph!, offset: 5 },
+    ]);
+    expect(split.committed).toBe(true);
+
+    const tail = surface.session.paragraphIds()[1];
+    expect(tail).toBeDefined();
+    surface.setSelection({
+      anchor: { paragraphId: tail!, offset: 0 },
+      head: { paragraphId: tail!, offset: 0 },
+    });
+    // The caret in the minted paragraph covers no card, and the card still activates.
+    expect(activeKey(editor)).toBeNull();
+    expect(editor.setActiveReviewItem(key).ok).toBe(true);
+    expect(activeKey(editor)).toBe(key);
+    editor.destroy();
+  });
+});

--- a/packages/core/src/editor/__tests__/review-order-index-retention.test.ts
+++ b/packages/core/src/editor/__tests__/review-order-index-retention.test.ts
@@ -81,14 +81,58 @@ describe('review activation across the retained order index', () => {
     expect(activeKey(editor)).toBe(key);
 
     // A keystroke-shaped commit: insert one character into the OTHER paragraph.
-    const [firstParagraph] = surface.session.paragraphIds();
+    const [firstParagraph, trackedParagraph] = surface.session.paragraphIds();
     const edited = surface.session.applyTreeOps([
       { op: 'insertText', paragraphId: firstParagraph!, offset: 3, text: 'x' },
     ]);
     expect(edited.committed).toBe(true);
 
+    // Through the CARET, not the activation pin: a caret move clears the pin, so this read
+    // classifies the position against the re-stamped order index. The pin path never reads
+    // the index, so asserting through it would pass even against a broken retention.
+    surface.setSelection({
+      anchor: { paragraphId: trackedParagraph!, offset: 9 },
+      head: { paragraphId: trackedParagraph!, offset: 9 },
+    });
+    expect(activeKey(editor)).toBe(key);
+
     expect(editor.setActiveReviewItem(key).ok).toBe(true);
     expect(activeKey(editor)).toBe(key);
+    editor.destroy();
+  });
+
+  test('a split that moves the tracked run into the minted tail still classifies it', () => {
+    // The sharpest probe of drop-on-structural-edit: split the TRACKED paragraph before the
+    // `w:ins` run, so the tracked range lands in the paragraph the split just minted. A
+    // wrongly retained index has no entry for that paragraph and the caret inside the tracked
+    // text classifies to nothing.
+    const editor = mount();
+    const surface = editor.surface!;
+    const key = editor.getReviewItems().find((entry) => entry.activatable)?.key;
+    if (!key) throw new Error('the tracked insertion produced no card');
+    expect(editor.setActiveReviewItem(key).ok).toBe(true);
+
+    const trackedParagraph = surface.session.paragraphIds()[1];
+    const split = surface.session.applyTreeOps([
+      { op: 'splitParagraph', paragraphId: trackedParagraph!, offset: 7 },
+    ]);
+    expect(split.committed).toBe(true);
+
+    const tail = surface.session.paragraphIds()[2];
+    expect(tail).toBeDefined();
+    // "tracked" now starts the tail; offset 2 is inside it.
+    surface.setSelection({
+      anchor: { paragraphId: tail!, offset: 2 },
+      head: { paragraphId: tail!, offset: 2 },
+    });
+    const active = activeKey(editor);
+    expect(active).not.toBeNull();
+    expect(
+      editor
+        .getReviewItems()
+        .filter((entry) => entry.activatable)
+        .map((entry) => entry.key)
+    ).toContain(active);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/__tests__/surface-field-shading.test.ts
+++ b/packages/core/src/editor/__tests__/surface-field-shading.test.ts
@@ -124,6 +124,35 @@ describe('the caret marks the field it sits in', () => {
     expect(activeSpans()).toHaveLength(0);
   });
 
+  test('a repaint re-resolves the mark onto the rebuilt spans', () => {
+    // Paint replaces the span nodes, so the mark left with the old DOM. The caret has not
+    // moved — which is exactly the case `domReplaced` exists for: same caret, new nodes.
+    syncActiveFieldShading(layer, { paragraphId: 'p1', offset: 5 });
+    expect(activeSpans()).toHaveLength(1);
+    const stale = activeSpans()[0]!;
+    const fresh = document.createElement('span');
+    fresh.dataset.paragraphId = 'p1';
+    fresh.dataset.start = '5';
+    fresh.dataset.end = '6';
+    fresh.dataset.fieldAtom = 'field';
+    fresh.classList.add('docx-field-atom');
+    stale.replaceWith(fresh);
+    syncActiveFieldShading(layer, { paragraphId: 'p1', offset: 5 }, { domReplaced: true });
+    expect(activeSpans()).toHaveLength(1);
+    expect(activeSpans()[0]).not.toBe(stale);
+    expect(stale.classList.contains(ACTIVE)).toBe(false);
+  });
+
+  test('an unmoved caret against unchanged DOM is a no-op', () => {
+    // The mirror-to-DOM pass calls this right after the render pass on every keystroke. The
+    // second call must not pay a page-layer query for a caret that did not move.
+    syncActiveFieldShading(layer, { paragraphId: 'p1', offset: 5 });
+    const marked = activeSpans()[0]!;
+    syncActiveFieldShading(layer, { paragraphId: 'p1', offset: 5 });
+    expect(activeSpans()).toHaveLength(1);
+    expect(activeSpans()[0]).toBe(marked);
+  });
+
   test('every span a wrapped result broke into is marked', () => {
     // Line breaking splits a field's result at its spaces, and all of those spans publish the
     // same one-unit model range. Stopping at the first shaded half a cross-reference, while

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -24,6 +24,7 @@ import {
   type OoxmlNode,
   type StoryScope,
   type TreeDocOp,
+  type TreeModelChange,
 } from '@docx-editor.dev/core/store';
 import { retractedLengthOf } from '../store/store/tree-op-retraction.ts';
 import { syncActiveFieldShading } from './surface-field-shading.ts';
@@ -1091,6 +1092,8 @@ export function mountPaginatedSurface(
   // Every committed transaction, whatever produced it — this surface, undo, or another
   // editor sharing the store — reaches layout the same way.
   const unsubscribe = session.subscribe((modelChange) => {
+    // Before anything downstream can read the index against the new revision.
+    retainReviewOrderIndex(modelChange);
     // A commit from OUTSIDE this surface retires the armed typing format: the tree it was
     // armed against has moved, and the offsets it is anchored to no longer mean what they
     // did. This surface's own commits already cleared it before running their ops (and
@@ -1324,9 +1327,36 @@ export function mountPaginatedSurface(
    * `setValue` and `remove` then rewrote and deleted body content while the reader was
    * editing a header.
    */
+  /**
+   * Single-slot memo for the body branch of {@link contentControlAtCaret}.
+   *
+   * `state()` resolves the active control on every read, and hosts read state repeatedly
+   * between changes, so the geometry hit-test ran again and again against an unchanged layout
+   * and selection. Both inputs are replaced, never mutated, so identity is a sound key: a
+   * commit republishes the layout, a caret move reassigns the selection, and a zoom relayouts.
+   * The story branch stays unmemoized — it reads the live part, which neither key covers.
+   */
+  let contentControlAtCaretMemo: {
+    readonly layout: SemanticLayout;
+    readonly selection: SemanticSelection;
+    readonly result: ContentControlBoundaryRecord | null;
+  } | null = null;
   function contentControlAtCaret(): ContentControlBoundaryRecord | null {
     const scope = storyScope();
     if (scope.kind !== 'body') return contentControlInStoryAtCaret(scope);
+    if (
+      contentControlAtCaretMemo &&
+      contentControlAtCaretMemo.layout === currentLayout &&
+      contentControlAtCaretMemo.selection === selection
+    ) {
+      return contentControlAtCaretMemo.result;
+    }
+    const result = resolveBodyContentControlAtCaret();
+    contentControlAtCaretMemo = { layout: currentLayout, selection, result };
+    return result;
+  }
+
+  function resolveBodyContentControlAtCaret(): ContentControlBoundaryRecord | null {
     const caret = caretAt(currentLayout, selection.head, measurer);
     if (!caret) return null;
     const found = contentControlAtSemantic(currentLayout, {
@@ -2196,7 +2226,7 @@ export function mountPaginatedSurface(
       ...(contentControlChrome ? { contentControlChrome } : {}),
     });
     // Paint just rebuilt every span, so the caret's field lost its mark with the old DOM.
-    syncActiveFieldShading(pagesLayer, collapsedCaretPosition());
+    syncActiveFieldShading(pagesLayer, collapsedCaretPosition(), { domReplaced: true });
     setHeaderFooterEditingChrome(container, pagesLayer, activeHf != null);
     // Viewing mode hides write affordances the painter cannot know about — today the
     // blank header/footer "double-click to add" band.
@@ -3007,6 +3037,34 @@ export function mountPaginatedSurface(
     readonly bodyRoot: object;
     readonly index: Map<string, number>;
   } | null = null;
+  /**
+   * Carry the index across a commit that cannot reorder paragraphs.
+   *
+   * The key is (package revision, body root) and a keystroke moves both, so without this the
+   * memo guaranteed exactly one whole-document rebuild per keystroke — the #391 shape, in the
+   * render path. A text-local commit with no created, deleted, split or joined paragraphs
+   * preserves every paragraph id and their order in every story, so the index is re-stamped
+   * to the values the next read will key on. Anything wider drops it, and commits that bypass
+   * the subscription (a package-shell edit) leave a stale key the read-side check rebuilds —
+   * the safe direction.
+   */
+  function retainReviewOrderIndex(change: TreeModelChange): void {
+    if (!reviewOrderIndexCache) return;
+    if (
+      change.impact === 'text-local' &&
+      change.created.length === 0 &&
+      change.deleted.length === 0 &&
+      change.splitJoin.length === 0
+    ) {
+      reviewOrderIndexCache = {
+        packageRevision: session.packageRevision(),
+        bodyRoot: session.part().root,
+        index: reviewOrderIndexCache.index,
+      };
+    } else {
+      reviewOrderIndexCache = null;
+    }
+  }
   function reviewOrderIndex(): Map<string, number> {
     const packageRevision = session.packageRevision();
     const bodyRoot = session.part().root;
@@ -3132,6 +3190,12 @@ export function mountPaginatedSurface(
     if (pinned) return resolveReviewThread(pinned);
     const at = selection?.head;
     if (!at) return null;
+    // An empty queue still builds the order index. NOT gated: the index's `partFor` reads are
+    // what durably open the note stores on first render, and skipping them moved paraId
+    // minting into the first note edit — where undo can no longer unwind it to opening bytes
+    // (`story-parity-scope-transitions.test.ts`). The retention above makes the build a
+    // once-per-structural-change cost rather than a per-keystroke one, which is the part that
+    // was worth having.
     // The covering items, innermost first, minus the one the reader dismissed. Returning
     // null for a dismissed innermost item hid every item under it too: dismissing a comment
     // that wraps a revision meant the revision could never become active either.

--- a/packages/core/src/editor/surface-field-shading.ts
+++ b/packages/core/src/editor/surface-field-shading.ts
@@ -6,8 +6,8 @@
 // background colour.
 //
 // So layout marks which spans ARE fields (`data-field-atom`, painted once) and this toggles one
-// class as the caret moves — the same division the open review item already uses. Cost is one
-// class removal and one query per caret move, against a document that never relayouts.
+// class as the caret moves — the same division the open review item already uses. Cost is at
+// most one query per caret move, against a document that never relayouts.
 
 const ACTIVE_CLASS = 'docx-field-atom--active';
 /** What paint adds only where shading is enabled for that field. */
@@ -20,6 +20,21 @@ export interface FieldShadingCaret {
 }
 
 /**
+ * What this module last did to a layer, so the next sync starts from bookkeeping, not queries.
+ *
+ * `marked` is every element carrying {@link ACTIVE_CLASS} — this function is the class's only
+ * writer, so the list is complete and the removal sweep needs no DOM query. `caretKey` is the
+ * caret the marks were resolved for: a sync that lands on the same caret against the same DOM
+ * has nothing to do, which is the arrow-key-then-mirror double call every caret move used to
+ * pay twice. Keyed weakly so a detached surface holds nothing.
+ */
+interface LayerShadingState {
+  caretKey: string | null;
+  marked: HTMLElement[];
+}
+const shadingStateByLayer = new WeakMap<HTMLElement, LayerShadingState>();
+
+/**
  * Move the "caret is in this field" mark to whichever field atom holds `caret`.
  *
  * `caret` is null when the selection is not collapsed, and every mark then comes off: a range
@@ -27,14 +42,29 @@ export interface FieldShadingCaret {
  * selection. Focus and IME composition are deliberately NOT part of that test — Word keeps a
  * field shaded while the caret is in it, and losing the shading on every blur would flicker it
  * away each time the user reached for the toolbar.
+ *
+ * `domReplaced` says the spans the marks live on were just rebuilt — a paint — so the caret
+ * being where it already was proves nothing and the marks must be re-resolved. Every other
+ * caller leaves it off and an unmoved caret costs no query at all.
  */
 export function syncActiveFieldShading(
   pagesLayer: HTMLElement,
-  caret: FieldShadingCaret | null
+  caret: FieldShadingCaret | null,
+  options?: { readonly domReplaced?: boolean }
 ): void {
-  for (const marked of pagesLayer.querySelectorAll(`.${ACTIVE_CLASS}`)) {
-    marked.classList.remove(ACTIVE_CLASS);
+  let state = shadingStateByLayer.get(pagesLayer);
+  if (!state) {
+    state = { caretKey: null, marked: [] };
+    shadingStateByLayer.set(pagesLayer, state);
   }
+  // NUL-joined: a paragraph id cannot carry one, so the key cannot collide across ids.
+  const caretKey = caret ? `${caret.paragraphId}\u0000${caret.offset}` : null;
+  if (!options?.domReplaced && caretKey === state.caretKey) return;
+  // Removing a class from a node paint already replaced is harmless; a RETAINED page keeps
+  // its nodes, and those are exactly the marks that must come off here.
+  for (const marked of state.marked) marked.classList.remove(ACTIVE_CLASS);
+  state.marked = [];
+  state.caretKey = caretKey;
   if (!caret) return;
 
   // `.docx-field-atom`, NOT `[data-field-atom]`. The attribute marks every field result so a
@@ -65,5 +95,6 @@ export function syncActiveFieldShading(
     // other text, and all of them publish the same model range — marking one shaded half a
     // cross-reference while `always` (resolved in paint, per span) shaded all of it.
     candidate.classList.add(ACTIVE_CLASS);
+    state.marked.push(candidate);
   }
 }

--- a/packages/core/src/store/__tests__/content-control-ops.test.ts
+++ b/packages/core/src/store/__tests__/content-control-ops.test.ts
@@ -305,6 +305,43 @@ describe('placeholder and temporary state are transitions, not text', () => {
     expect(serializeOoxmlPart(next)).not.toContain('showingPlcHdr');
   });
 
+  test('a block placeholder replace reports the paragraph swap it performs', () => {
+    // A BLOCK control's prompt lives in its own paragraph, and the replace deletes it and
+    // mints a new one. Publishing that as 'text-local' with empty created/deleted told
+    // paragraph-keyed caches (the retained review order index) the paragraph set was intact,
+    // so the minted paragraph was invisible to them until the next structural commit.
+    const block = parseDoc(
+      `<w:sdt><w:sdtPr><w:tag w:val="blockPrompt"/><w:showingPlcHdr/><w:text/></w:sdtPr>` +
+        `<w:sdtContent><w:p><w:r><w:t>Click here to enter text.</w:t></w:r></w:p></w:sdtContent></w:sdt>`
+    );
+    const promptParagraph = paragraphs(block)[0]!;
+    const result = applyTreeOp(block, {
+      op: 'insertHardBreak',
+      paragraphId: promptParagraph.id,
+      offset: 0,
+    });
+    if (!result.ok) throw new Error(`refused: ${result.reason}`);
+    const nextParagraph = paragraphs(result.part)[0]!;
+    expect(nextParagraph.id).not.toBe(promptParagraph.id);
+    expect(result.effect.deleted).toContain(promptParagraph.id);
+    expect(result.effect.created).toContain(nextParagraph.id);
+    expect(result.effect.impact).toBe('flow-structural');
+  });
+
+  test('an inline placeholder replace stays text-local with the paragraph intact', () => {
+    const paragraph = paragraphs(PROMPT)[0]!;
+    const result = applyTreeOp(PROMPT, {
+      op: 'insertHardBreak',
+      paragraphId: paragraph.id,
+      offset: 0,
+    });
+    if (!result.ok) throw new Error(`refused: ${result.reason}`);
+    expect(paragraphs(result.part)[0]!.id).toBe(paragraph.id);
+    expect(result.effect.created).toEqual([]);
+    expect(result.effect.deleted).toEqual([]);
+    expect(result.effect.impact).toBe('text-local');
+  });
+
   test('typing into the prompt through an ordinary text op replaces it too', () => {
     const paragraph = paragraphs(PROMPT)[0]!;
     const next = apply(PROMPT, {

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -870,12 +870,18 @@ function applyPlaceholderReplace(
   let nextControl = replaceControlContent(control, contentChildren, nextId);
   nextControl = withUpdatedProperties(nextControl, clearShowingPlaceholder);
 
+  // A BLOCK placeholder replace deletes the prompt's paragraph(s) and mints a fresh one, so
+  // the paragraph set changes and the effect must say so. Reporting it as 'text-local' with
+  // empty created/deleted told paragraph-keyed caches they could keep their answer, and a
+  // retained review order index then had no entry for the minted paragraph — an item anchored
+  // in it listed in the rail but never activated from a caret. The inline branch really is
+  // text-local: the owner paragraph survives, only its runs are replaced.
   const effect: TreeOpEffect = {
     dirty: owner ? [owner.id] : [control.id],
-    created: [],
-    deleted: [],
+    created: inline ? [] : contentChildren.map((child) => child.id),
+    deleted: inline ? [] : placeholderParagraphIdsOf(control),
     dependencyKeys: TEXT_DEPS,
-    impact: isTemporaryControl(control) ? 'flow-structural' : 'text-local',
+    impact: !inline || isTemporaryControl(control) ? 'flow-structural' : 'text-local',
   };
 
   if (isTemporaryControl(control)) {
@@ -891,6 +897,24 @@ function applyPlaceholderReplace(
   }
 
   return fromEdit(replaceNode(part, control.id, nextControl, options), effect);
+}
+
+/** Paragraph ids a block placeholder replace removes along with the prompt content. */
+function placeholderParagraphIdsOf(control: OoxmlNode): string[] {
+  if (control.kind === 'textValue') return [];
+  const content = contentControlContentOf(control);
+  if (!content) return [];
+  const ids: string[] = [];
+  const walk = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || depth > 32) return;
+    if (node.kind === 'paragraph') {
+      ids.push(node.id);
+      return;
+    }
+    for (const child of node.children) walk(child, depth + 1);
+  };
+  for (const child of content.children) walk(child, 0);
+  return ids;
 }
 
 function findLast<T>(items: readonly T[], predicate: (item: T) => boolean): T | undefined {


### PR DESCRIPTION
Typing in a long document re-derived three caret answers from the whole document on every keystroke. Each derivation now reuses its previous answer when the commit cannot have changed it.

- The review paragraph-order index keyed on the package revision and the body root, and a keystroke moves both. A text-local commit with no created, deleted, split, or joined paragraphs now re-stamps the retained index. Structural commits still drop it.
- `state()` resolved the active content control through the caret geometry hit test on every read. The body branch now memoizes on layout and selection identity, which a commit, a caret move, or a zoom each replace.
- Field shading swept the pages layer with two `querySelectorAll` calls per sync. The sync now tracks the marks it wrote and returns early when the caret has not moved against unchanged DOM.

On a 561-page document with 12,820 paragraphs, the median keystroke-to-settled time drops from 741 ms to 484 ms in a headless surface benchmark. Layout work counters are unchanged.

Follow-up to #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790159705&installation_model_id=422592&pr_number=399&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F399&signature=21ec755b1d5bec5c526fb755cdb025debe3e5efda252194272dd42b512cf5fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->