### PR TITLE
perf(core): keep untouched section pages identical across passes

### DIFF
--- a/.changeset/page-record-publish-memo.md
+++ b/.changeset/page-record-publish-memo.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typing in a multi-page section keeps the section's untouched sheets identical across passes, so paint skips them, and repaints no longer walk the whole document to collect drawing keys.

--- a/packages/core/src/layout/__tests__/field-body-page-incremental.test.ts
+++ b/packages/core/src/layout/__tests__/field-body-page-incremental.test.ts
@@ -114,6 +114,64 @@ describe('body page fields across an incremental re-layout in one session', () =
   });
 });
 
+describe('page fields on section pages the edit did not touch', () => {
+  // Both tests run TWO sections so the multi-section publish path (and its per-page memo) is
+  // the one under test — single-section fixtures never reach it.
+  const twoSections = (s1Filler: number, s2Filler: number, mutate?: (body: string) => string) => {
+    const body =
+      simpleField('SECTIONPAGES') +
+      simpleField('NUMPAGES') +
+      filler(s1Filler, 's1') +
+      `<w:p><w:pPr>${tightSectPr()}</w:pPr><w:r><w:t>s1 end</w:t></w:r></w:p>` +
+      filler(s2Filler, 's2') +
+      tightSectPr();
+    return partOf(mutate ? mutate(body) : body);
+  };
+
+  test('SECTIONPAGES on the section first page updates when the section tail grows', () => {
+    // The field's own page is untouched by the edit, so its section-local record is reused
+    // and the publish memo answers for it — `sectionPageCount` is the one memo-key component
+    // nothing else pins, and dropping it left this exact stale value.
+    const session = createLayoutSession();
+    const first = lay(twoSections(16, 6), 1, session);
+    const firstCount = Number(spanOfKind(first, 'SECTIONPAGES').span.text);
+    expect(firstCount).toBeGreaterThan(1);
+
+    const second = lay(twoSections(36, 6), 2, session);
+    const secondCount = Number(spanOfKind(second, 'SECTIONPAGES').span.text);
+    expect(secondCount).toBeGreaterThan(firstCount);
+    expect(secondCount).toBe(
+      spanOfKind(second, 'SECTIONPAGES').page.pageFieldSource?.sectionPageCount
+    );
+  });
+
+  test('NUMPAGES on an untouched section updates with the total, and holds identity without it', () => {
+    const session = createLayoutSession();
+    const first = lay(twoSections(16, 6), 1, session);
+    const firstTotal = first.pages.length;
+    expect(spanOfKind(first, 'NUMPAGES').span.text).toBe(String(firstTotal));
+
+    // Grow the OTHER section: the NUMPAGES sheet is untouched, but the total moved, so the
+    // substituted text must move with it — through a fresh record, or paint never repaints.
+    const second = lay(twoSections(16, 26), 2, session);
+    expect(second.pages.length).toBeGreaterThan(firstTotal);
+    const grown = spanOfKind(second, 'NUMPAGES');
+    expect(grown.span.text).toBe(String(second.pages.length));
+    expect(grown.page).not.toBe(spanOfKind(first, 'NUMPAGES').page);
+
+    // A count-stable edit in the other section keeps the NUMPAGES sheet by identity.
+    const third = lay(
+      twoSections(16, 26, (body) => body.replace('s2 3', 's2 3!')),
+      3,
+      session
+    );
+    expect(third.pages.length).toBe(second.pages.length);
+    const held = spanOfKind(third, 'NUMPAGES');
+    expect(held.span.text).toBe(String(third.pages.length));
+    expect(held.page).toBe(grown.page);
+  });
+});
+
 describe('body page fields in a genuine two-section document', () => {
   test('section 2 PAGE restarts and SECTIONPAGES counts section 2, distinct from NUMPAGES', () => {
     // Section 1: enough one-line paragraphs to fill more than one page, ended by a mid-body sectPr.

--- a/packages/core/src/layout/__tests__/incremental-multi-section-layout.test.ts
+++ b/packages/core/src/layout/__tests__/incremental-multi-section-layout.test.ts
@@ -142,6 +142,36 @@ describe('multi-section page identity and invalidation', () => {
     expect(session.stats.reusedPages).toBeGreaterThan(0);
   });
 
+  test('an edit keeps the untouched pages of ITS OWN section by identity', () => {
+    // The rebuilt section republishes every sheet it laid, including the ones its own
+    // incremental pass carried over by reference — and the remap used to mint fresh box and
+    // furniture wrappers on all of them. Paint skips a page only by record identity, so a
+    // one-character edit repainted the whole section. The publish memo returns the previous
+    // sheet when nothing about it changed; only the edited page may change identity.
+    const session = createLayoutSession();
+    const before = lay(load(twoSectionDocument()), 1, session);
+    expect(before.pages.length).toBeGreaterThan(3);
+    // Edit a paragraph that lays out on a LATER page of section 0, so earlier section-0
+    // pages are provably untouched.
+    const after = lay(
+      load(twoSectionDocument((body) => body.replace('s0p10 ', 's0p10-changed '))),
+      2,
+      session
+    );
+    expect(after.pages.length).toBe(before.pages.length);
+    const changed = after.pages
+      .filter((page, index) => before.pages[index] !== page)
+      .map((page) => page.index);
+    // The page carrying the edit, and nothing else — not its section siblings.
+    expect(changed.length).toBe(1);
+    const changedText = after.pages[changed[0]!]!.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph'
+        ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+        : []
+    ).join('');
+    expect(changedText).toContain('s0p10-changed');
+  });
+
   test('a line-count change before a next-page section keeps later-section pages', () => {
     const session = createLayoutSession();
     const before = lay(load(twoSectionDocument()), 1, session);

--- a/packages/core/src/layout/multi-section-layout.ts
+++ b/packages/core/src/layout/multi-section-layout.ts
@@ -320,7 +320,6 @@ function publishSectionPage(
  * An empty final section is still laid out when its break type requires a new sheet: that
  * materializes the blank page Word keeps for the section's geometry and furniture.
  */
-
 export function layoutMultiSectionDocument(
   blocks: readonly OoxmlElement[],
   sections: readonly DocumentSection[],
@@ -456,6 +455,20 @@ export function layoutMultiSectionDocument(
     const displayedStart = numbering?.start !== undefined ? numbering.start : nextDisplayed;
     const format = numbering?.fmt;
 
+    // The stack checks prove the sheets did not MOVE; this proves their displayed numbering
+    // did not either. `displayedStart` is inherited through every section before this one, so
+    // a continuous section merging into its host (indices and counts unchanged here) can still
+    // shift a later span's PAGE values. The published pages carry what they were stamped with,
+    // so the first one answers for the whole span.
+    const firstPrevious = prevSpan?.remappedPages[0];
+    const numberingUnchanged =
+      prevSpan === undefined ||
+      prevSpan.remappedPages.length === 0 ||
+      (firstPrevious?.pageFieldSource !== undefined &&
+        firstPrevious.pageFieldSource.pageNumber === displayedStart &&
+        firstPrevious.pageFieldSource.sectionPageCount === prevSpan.remappedPages.length &&
+        firstPrevious.pageFieldSource.format === format);
+
     let remapped: readonly PageRecord[];
     if (continues) {
       // The section's first page is not a sheet: it is the tail of the one before it. Its
@@ -489,7 +502,7 @@ export function layoutMultiSectionDocument(
         remappedAll.push(page);
       }
       nextDisplayed = displayedStart + sectionPageCount;
-    } else if (localUnchanged && stackUnchanged) {
+    } else if (localUnchanged && stackUnchanged && numberingUnchanged) {
       remapped = prevSpan.remappedPages;
       reusedPages += remapped.length;
       for (const page of remapped) {

--- a/packages/core/src/layout/multi-section-layout.ts
+++ b/packages/core/src/layout/multi-section-layout.ts
@@ -258,6 +258,58 @@ function adoptMultiSectionResult(
 }
 
 /**
+ * The published (remapped + PAGE-field-stamped) sheet a section-local page last produced.
+ *
+ * A rebuilt section remaps EVERY page it laid, including the ones its own incremental pass
+ * carried over by reference — and `remapPage` mints fresh box and furniture wrappers even
+ * when nothing moved. Paint skips a page only by record identity, so a one-character edit
+ * repainted every sheet of its section. Keyed on the section-local record: an edit replaces
+ * it, and any changed publish parameter misses, so the memo can only return a twin the same
+ * inputs would rebuild.
+ */
+interface PublishedPageMemo {
+  readonly globalIndex: number;
+  readonly sheetY: number;
+  readonly pageNumber: number;
+  readonly sectionPageCount: number;
+  readonly format: string | undefined;
+  readonly published: PageRecord;
+}
+const publishedPageMemos = new WeakMap<PageRecord, PublishedPageMemo>();
+
+function publishSectionPage(
+  page: PageRecord,
+  globalIndex: number,
+  sheetY: number,
+  pageNumber: number,
+  sectionPageCount: number,
+  format: string | undefined
+): PageRecord {
+  const memo = publishedPageMemos.get(page);
+  if (
+    memo &&
+    memo.globalIndex === globalIndex &&
+    memo.sheetY === sheetY &&
+    memo.pageNumber === pageNumber &&
+    memo.sectionPageCount === sectionPageCount &&
+    memo.format === format
+  ) {
+    return memo.published;
+  }
+  const remapped = remapPage(page, globalIndex, sheetY);
+  const published = withPageFieldSources([remapped], pageNumber, sectionPageCount, format)[0]!;
+  publishedPageMemos.set(page, {
+    globalIndex,
+    sheetY,
+    pageNumber,
+    sectionPageCount,
+    format,
+    published,
+  });
+  return published;
+}
+
+/**
  * Lay a multi-section part out section by section, with per-section incremental sessions.
  *
  * `w:type` on a section (default `nextPage`) controls whether that section starts on a new
@@ -268,6 +320,7 @@ function adoptMultiSectionResult(
  * An empty final section is still laid out when its break type requires a new sheet: that
  * materializes the blank page Word keeps for the section's geometry and furniture.
  */
+
 export function layoutMultiSectionDocument(
   blocks: readonly OoxmlElement[],
   sections: readonly DocumentSection[],
@@ -448,11 +501,18 @@ export function layoutMultiSectionDocument(
     } else {
       const built: PageRecord[] = [];
       for (const page of laid.pages) {
-        const next = remapPage(page, pages.length + built.length, sheetY);
+        const next = publishSectionPage(
+          page,
+          pages.length + built.length,
+          sheetY,
+          displayedStart + built.length,
+          laid.pages.length,
+          format
+        );
         built.push(next);
         sheetY = next.box.y + next.box.height + 24;
       }
-      remapped = withPageFieldSources(built, displayedStart, built.length, format);
+      remapped = built;
       for (const page of remapped) {
         pages.push(page);
         remappedAll.push(page);

--- a/packages/core/src/layout/page-reuse-guards.ts
+++ b/packages/core/src/layout/page-reuse-guards.ts
@@ -69,8 +69,10 @@ export const PAGE_REUSE_GUARDS = {
   footnotes: 'rebuilt',
   endnotes: 'rebuilt',
   noteStream: 'rebuilt',
-  // `withPageFieldSources` re-annotates every page every pass, which is what keeps PAGE and
-  // SECTIONPAGES right when only the numbering moved.
+  // Every reuse path revalidates the stamped numbering before returning a prior record: the
+  // publish memo keys on (pageNumber, sectionPageCount, format), and the span-identity branch
+  // checks the same values against its first page — so a PAGE or SECTIONPAGES move always
+  // reaches `withPageFieldSources` for a fresh stamp.
   pageFieldSource: 'rebuilt',
   // `attachContentControlBoundaries`, from `finish()`, rebuilds the per-page boundaries every
   // pass and early-returns only on a matching control-context token.

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -13,6 +13,7 @@ import type { DrawingPoint } from '../layout/drawing-geometry.ts';
 import { cssTransformForDrawingImage } from '../layout/drawing-geometry.ts';
 import type {
   LayoutBox,
+  PageRecord,
   ParagraphFragmentRecord,
   TableFragmentRecord,
 } from '../layout/semantic-records.ts';
@@ -707,38 +708,32 @@ export function paintAnchoredDrawingsLayer(
 const MAX_TEXTBOX_STORY_DEPTH = 16;
 
 /**
- * Every drawing a page paints, whatever story it is in.
+ * Every drawing one page paints, whatever story it is in.
  *
  * `paintPageNoteAreas` paints note fragments through the same `paintFragment` the body uses, so
  * a picture in a footnote gets a cached element and a blob URL like any other. Walking only the
  * body and the furniture stories meant the reconcile pass never saw those keys and treated them
  * as unused — so every repaint revoked the note image's resource and stripped its `src`. Typing
  * one character in the body blanked a picture in a footnote.
- *
- * `visitDrawing` receives the page so a caller can key on it; the resource walk ignores it.
  */
-function forEachPaintedDrawing(
-  layout: SemanticLayout,
-  visitDrawing: (pageIndex: number, drawing: InlineDrawingRecord | AnchoredDrawingRecord) => void
+function forEachPageDrawing(
+  page: PageRecord,
+  visitDrawing: (drawing: InlineDrawingRecord | AnchoredDrawingRecord) => void
 ): void {
-  const visitBlock = (
-    pageIndex: number,
-    block: ParagraphFragmentRecord | TableFragmentRecord
-  ): void => {
+  const visitBlock = (block: ParagraphFragmentRecord | TableFragmentRecord): void => {
     if (block.kind === 'table') {
       for (const row of block.rows) {
         for (const cell of row.cells) {
-          for (const inner of cell.blocks) visitBlock(pageIndex, inner);
+          for (const inner of cell.blocks) visitBlock(inner);
         }
       }
       return;
     }
     for (const line of block.lines) {
-      for (const drawing of line.drawings ?? []) visitDrawing(pageIndex, drawing);
+      for (const drawing of line.drawings ?? []) visitDrawing(drawing);
     }
   };
   const visitStory = (
-    pageIndex: number,
     story: {
       readonly fragments: readonly (ParagraphFragmentRecord | TableFragmentRecord)[];
       readonly anchoredDrawings?: readonly AnchoredDrawingRecord[];
@@ -750,43 +745,74 @@ function forEachPaintedDrawing(
     // to trust it, since the cost of the bound is nothing.
     if (depth > MAX_TEXTBOX_STORY_DEPTH) return;
     for (const drawing of story.anchoredDrawings ?? []) {
-      visitDrawing(pageIndex, drawing);
+      visitDrawing(drawing);
       // A text box is a story of its own, nested in the drawing that anchors it.
-      if (drawing.textboxStory) visitStory(pageIndex, drawing.textboxStory, depth + 1);
+      if (drawing.textboxStory) visitStory(drawing.textboxStory, depth + 1);
     }
-    for (const fragment of story.fragments) visitBlock(pageIndex, fragment);
+    for (const fragment of story.fragments) visitBlock(fragment);
   };
 
-  for (const page of layout.pages) {
-    visitStory(page.index, {
-      fragments: page.fragments,
-      ...(page.anchoredDrawings ? { anchoredDrawings: page.anchoredDrawings } : {}),
-    });
-    for (const story of [page.header, page.footer]) {
-      if (story) visitStory(page.index, story);
-    }
-    for (const area of [page.footnotes, page.endnotes]) {
-      if (!area) continue;
-      // The separator is an authored story too, and `paintPageNoteAreas` paints it.
-      if (area.separator) visitStory(page.index, area.separator);
-      for (const note of area.notes) visitStory(page.index, note);
-    }
+  visitStory({
+    fragments: page.fragments,
+    ...(page.anchoredDrawings ? { anchoredDrawings: page.anchoredDrawings } : {}),
+  });
+  for (const story of [page.header, page.footer]) {
+    if (story) visitStory(story);
   }
+  for (const area of [page.footnotes, page.endnotes]) {
+    if (!area) continue;
+    // The separator is an authored story too, and `paintPageNoteAreas` paints it.
+    if (area.separator) visitStory(area.separator);
+    for (const note of area.notes) visitStory(note);
+  }
+}
+
+interface PageDrawingKeys {
+  readonly resourceKeys: readonly string[];
+  readonly elementKeys: readonly string[];
+}
+
+/**
+ * Drawing keys per immutable page record.
+ *
+ * Both collectors run on every paint, and each walked every fragment of every page — two
+ * whole-document walks per keystroke for answers that cannot change on an untouched page.
+ * Page records are reused by identity across incremental passes, and everything a key reads
+ * (fragments, resource state, the page index the element key embeds) lives inside the record,
+ * so the record's identity is the complete cache key.
+ */
+const drawingKeysByPage = new WeakMap<PageRecord, PageDrawingKeys>();
+
+function pageDrawingKeys(page: PageRecord): PageDrawingKeys {
+  const cached = drawingKeysByPage.get(page);
+  if (cached) return cached;
+  const resourceKeys: string[] = [];
+  const elementKeys: string[] = [];
+  forEachPageDrawing(page, (drawing) => {
+    if (drawing.resource.kind === 'ready') resourceKeys.push(drawing.resource.resourceKey);
+    elementKeys.push(`p${page.index}|${drawing.drawingNodeId}`);
+  });
+  const keys: PageDrawingKeys = Object.freeze({
+    resourceKeys: Object.freeze(resourceKeys),
+    elementKeys: Object.freeze(elementKeys),
+  });
+  drawingKeysByPage.set(page, keys);
+  return keys;
 }
 
 export function collectUsedDrawingResourceKeys(layout: SemanticLayout): ReadonlySet<string> {
   const keys = new Set<string>();
-  forEachPaintedDrawing(layout, (_pageIndex, drawing) => {
-    if (drawing.resource.kind === 'ready') keys.add(drawing.resource.resourceKey);
-  });
+  for (const page of layout.pages) {
+    for (const key of pageDrawingKeys(page).resourceKeys) keys.add(key);
+  }
   return keys;
 }
 
 export function collectUsedDrawingElementKeys(layout: SemanticLayout): ReadonlySet<string> {
   const keys = new Set<string>();
-  forEachPaintedDrawing(layout, (pageIndex, drawing) => {
-    keys.add(`p${pageIndex}|${drawing.drawingNodeId}`);
-  });
+  for (const page of layout.pages) {
+    for (const key of pageDrawingKeys(page).elementKeys) keys.add(key);
+  }
   return keys;
 }
 


### PR DESCRIPTION
A rebuilt section remapped every sheet it laid, including the ones its own incremental pass carried over by reference, and the remap minted fresh box and furniture wrappers even when nothing moved. Paint skips a page only by record identity, so a one-character edit repainted the section's whole span of sheets.

- `publishSectionPage` memoizes the remapped, PAGE-field-stamped sheet per section-local page record. Any changed publish parameter — global index, sheet offset, page number, section page count, or format — misses, so the memo can only return a twin the same inputs would rebuild. A mid-document keystroke now changes exactly one page record instead of four.
- The paint reconcile pass walked every fragment of every page twice per repaint to collect drawing resource and element keys. The keys now memoize per page record, whose identity covers everything a key reads.

On a 561-page document with 12,820 paragraphs, the median keystroke-to-settled time drops from 451 ms to 383 ms in a headless surface benchmark, with paint down from 318 ms to 255 ms. Layout work counters are unchanged.

Follow-up to #393, #398, and #399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790164855&installation_model_id=422592&pr_number=400&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F400&signature=115c93549c43c690aae28f757f9d90760a1b8764f9c97428dac517d944c28322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->