### PR TITLE
fix(core): collapse text selections with arrow keys

### DIFF
--- a/.changeset/selection-arrow-collapse.md
+++ b/.changeset/selection-arrow-collapse.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Plain horizontal arrow keys now collapse a text selection to its start or end without moving one extra character.

--- a/packages/core/src/editor/__tests__/paginated-surface.test.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface.test.ts
@@ -113,6 +113,31 @@ describe('painted pages, semantic interaction', () => {
     expect(surface.state().revision).toBe(0); // navigation is not an edit
   });
 
+  test('plain horizontal arrows collapse a range to the selected edge', () => {
+    const { surface } = mount(paragraph('hello'));
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId, offset: 1 },
+      head: { paragraphId, offset: 4 },
+    });
+
+    surface.navigate('right');
+    expect(surface.state().selection).toEqual({
+      anchor: { paragraphId, offset: 4 },
+      head: { paragraphId, offset: 4 },
+    });
+
+    surface.setSelection({
+      anchor: { paragraphId, offset: 4 },
+      head: { paragraphId, offset: 1 },
+    });
+    surface.navigate('left');
+    expect(surface.state().selection).toEqual({
+      anchor: { paragraphId, offset: 1 },
+      head: { paragraphId, offset: 1 },
+    });
+  });
+
   test('extending a selection reaches the browser selection as a real range', () => {
     const { surface, container } = mount(paragraph('hello world'));
     putCaret(surface, 0);

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -4047,6 +4047,20 @@ export function mountPaginatedSurface(
       // Arrow keys move from the caret AFTER the typed text, over the layout
       // that includes it.
       flushTypeBuffer();
+      if (
+        !extend &&
+        (command === 'left' || command === 'right') &&
+        (selection.anchor.paragraphId !== selection.head.paragraphId ||
+          selection.anchor.offset !== selection.head.offset)
+      ) {
+        // A plain horizontal arrow collapses a range to that arrow's edge. Starting a
+        // navigation step at `selection.head` moved one character beyond that edge, or one
+        // character from the wrong edge when the range was selected backwards.
+        const range = orderedRange();
+        desiredX = null;
+        setSelection(collapsedAt(command === 'left' ? range.from : range.to), true);
+        return;
+      }
       let moved = navigateInActiveScope(
         currentLayout,
         selection.head,


### PR DESCRIPTION
## Summary
- Collapse a text range to its start or end when you press a plain horizontal arrow key.
- Keep the caret on the selected edge without an extra character movement.

## Test plan
- [x] Run the paginated surface regression tests.
- [x] Run the pre-commit typecheck, API check, formatting check, and lint.
- [x] Run Bugbot review.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790165874&installation_model_id=422592&pr_number=401&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F401&signature=729c93d00800876c206b4ba2a4cadaa9e1e0fd0dd362655006a4ccd94f3df1d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->