### PR TITLE
bench: lead typing latency with the 521-page fixture and frame medians

### DIFF
--- a/e2e/edit-browser-bench-gates.ts
+++ b/e2e/edit-browser-bench-gates.ts
@@ -33,6 +33,17 @@ export const TRACKED_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = 
   'tracked-suggesting-wrap': { placed: 311, total: 620, reusedPages: 72, fullPasses: 1 },
 };
 
+/**
+ * Pinned per scenario for the 521-page reported reproduction (typing-perf-521pp.docx).
+ * Bootstrapped from a local Chromium run; a change means the engine performs different
+ * work on the huge document, which is exactly what these exist to catch.
+ */
+export const PINNED_HUGE_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = {
+  '521pp-editing-character': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 2 },
+  '521pp-editing-wrap': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 2 },
+  '521pp-suggesting-character': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 2 },
+};
+
 /** Pinned for the ~1,000-page stress fixture (synthetic-huge-tracked.docx). */
 export const HUGE_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = {
   'huge-suggesting-character': { placed: 2, total: 4250, reusedPages: 995, fullPasses: 1 },

--- a/e2e/edit-browser-bench-harness.ts
+++ b/e2e/edit-browser-bench-harness.ts
@@ -15,6 +15,14 @@ export const EDIT_BROWSER_TRACKED_FIXTURE = 'synthetic-tracked-numbered.docx';
  * uncommitted — regenerate with `bun scripts/create-synthetic-tracked-fixture.mjs --huge`.
  */
 export const EDIT_BROWSER_HUGE_FIXTURE = 'synthetic-huge-tracked.docx';
+/**
+ * The pinned 521-page reported reproduction (SHA-256 in
+ * `e2e/fixtures/typing-perf-521pp.manifest.json`) — 12,820 paragraphs, 81 sections, tables,
+ * drawings, notes and TOCs. The synthetic fixtures above are sized for deterministic gates;
+ * this is the shape where per-keystroke costs that scale with the document actually show,
+ * and its rows lead the typing-latency table.
+ */
+export const EDIT_BROWSER_PINNED_HUGE_FIXTURE = 'typing-perf-521pp.docx';
 export const REVIEW_RAIL_ENABLED = process.env.EDIT_BROWSER_BENCH_REVIEW_RAIL !== '0';
 
 export function editBrowserBenchUrl(fixture: string = FIXTURE): string {

--- a/e2e/edit-browser.bench.spec.ts
+++ b/e2e/edit-browser.bench.spec.ts
@@ -9,11 +9,13 @@ import {
   assertScenarioLatencyGates,
   assertSustainedLatencyGates,
   HUGE_EXPECTED_LAYOUT_WORK,
+  PINNED_HUGE_EXPECTED_LAYOUT_WORK,
   TRACKED_EXPECTED_LAYOUT_WORK,
 } from './edit-browser-bench-gates.js';
 import {
   EDIT_BROWSER_FIXTURE,
   EDIT_BROWSER_HUGE_FIXTURE,
+  EDIT_BROWSER_PINNED_HUGE_FIXTURE,
   EDIT_BROWSER_TRACKED_FIXTURE,
   REPO_ROOT,
   REVIEW_RAIL_ENABLED,
@@ -199,7 +201,31 @@ test('browser editing latency is measurable and structurally stable', async ({
   // distinct so both sets share one report; work counters are pinned to this
   // fixture's own values. Skipped in the injected-delay self-test, which
   // validates the measurement itself, not the document.
+  const pinnedHugeReports: ScenarioReport[] = [];
   if (INJECTED_DELAY_MS === 0) {
+    // ---- The pinned huge-document pass FIRST in the report: the 521-page reported
+    // reproduction (12,820 paragraphs, 81 sections, tables, drawings, notes, TOCs).
+    // The synthetic fixtures are sized for deterministic gates and their keystroke
+    // numbers sit near the clock floor; this is the shape where a per-keystroke cost
+    // that scales with the document reads as milliseconds instead of noise, so its
+    // rows lead the typing-latency table.
+    await loadHarness(
+      page,
+      (benchPage) => installMeasurementProbe(benchPage, 0),
+      true,
+      EDIT_BROWSER_PINNED_HUGE_FIXTURE
+    );
+    const pinnedHugeScenarios = [
+      { name: '521pp-editing-character', mode: 'edit' as const, text: 'X' },
+      { name: '521pp-editing-wrap', mode: 'edit' as const, text: 'word '.repeat(20) },
+      { name: '521pp-suggesting-character', mode: 'suggest' as const, text: 'X' },
+    ];
+    for (const scenario of pinnedHugeScenarios) {
+      const report = await measureScenario(scenario);
+      pinnedHugeReports.push(report);
+      assertScenarioLatencyGates(report, PINNED_HUGE_EXPECTED_LAYOUT_WORK[scenario.name]!);
+    }
+
     await loadHarness(
       page,
       (benchPage) => installMeasurementProbe(benchPage, 0),
@@ -321,7 +347,9 @@ test('browser editing latency is measurable and structurally stable', async ({
       viewport: '1440x1000@1x',
       injectedDelayMs: INJECTED_DELAY_MS,
     },
-    scenarios: reports,
+    // Pinned-huge rows first: they are the headline typing latency; the synthetic
+    // rows below them are the deterministic-gate detail.
+    scenarios: [...pinnedHugeReports, ...reports],
     sustained,
   };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "build:vue": "cd examples/vue && USE_PUBLISHED_PACKAGES=true ENABLE_FRAMEWORK_SWITCHER=true VITE_ENABLE_FRAMEWORK_SWITCHER=true VITE_BASE_PATH=/vue/ vite build",
     "bench:edit": "bun scripts/bench/edit-bench.ts",
     "bench:edit:browser": "playwright test --config e2e/edit-browser-bench.config.ts",
+    "bench:huge": "bun scripts/bench/settle-bench.ts",
+    "bench:huge:browser": "bun scripts/bench/typing-url-audit.mjs",
     "bench:scope-waste": "bun scripts/bench/scope-waste-bench.ts",
     "changeset": "changeset",
     "check:adapter-css-thin": "node scripts/check-adapter-css-thin.mjs",

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -61,6 +61,51 @@ when validating those layers.
 Run timing comparisons sequentially. Concurrent benchmark processes compete for CPU and can hide
 or exaggerate timing changes; the structural work counters remain deterministic either way.
 
+## Huge-document benchmarks
+
+Prefer these when the question is typing latency. The synthetic fixtures above are built for
+deterministic work-counter gates; they are small enough that a whole-document regression
+hides inside their noise floor. The huge-document section runs the pinned 521-page
+reproduction (`e2e/fixtures/typing-perf-521pp.docx`, SHA-256 in
+`e2e/fixtures/typing-perf-521pp.manifest.json`): 12,820 paragraphs, 81 sections, tables,
+drawings, notes and TOCs — the shape where per-keystroke costs that scale with the document
+actually show. A change that looks flat on a 5-page example and saves 50 ms per keystroke
+here is a change worth landing; the reverse is a regression the small fixtures cannot see.
+
+```bash
+# Headless: keystroke-to-settled latency through the FULL mounted surface —
+# input, flush, layout, paint, selection — on the pinned huge fixture.
+bun run bench:huge
+
+# Capture before/after results
+bun run bench:huge --json > /tmp/settle-before.json
+bun run bench:huge --compare /tmp/settle-before.json
+
+# Any other document, or shorter runs
+bun run bench:huge path/to/document.docx --keystrokes 10 --warmup 1
+
+# Browser: the same fixture through the real demo UI (needs `bun run dev` on :5173).
+# Fail-closed — latency prints only when the structural evidence validates.
+bun run bench:huge:browser
+```
+
+The headless half runs under happy-dom with the fixed measurer, so its absolute paint
+milliseconds are inflated relative to a browser: compare runs on the same machine and read
+the work counters as the hardware-independent evidence. Pagination is deterministic, so
+`settle-bench-gates.test.ts` pins the per-keystroke work (placed paragraphs, reused pages,
+full passes) inside `bun run test` — a regression on the huge document fails CI even though
+the wall-clock numbers stay a manual comparison. The browser half is
+`typing-url-audit.mjs`, which validates that trusted input reached a painted revision before
+it reports anything.
+
+The same fixture also leads the CI browser benchmark: `edit-browser.bench.spec.ts` runs a
+`521pp-*` scenario pass on it and lists those rows FIRST in the PR-comment typing-latency
+table, with its work counters pinned in `edit-browser-bench-gates.ts`
+(`PINNED_HUGE_EXPECTED_LAYOUT_WORK`). The table itself leads with the FRAME median — the
+time from the keystroke until the edit is visible — because the input-task median it used
+to lead with pinned at the clock floor (0.00–0.05 ms) once typing buffered its work off the
+input task, and a table led by it colored nothing.
+
 ## Wasted-layout-work benchmark
 
 ```bash

--- a/scripts/bench/edit-bench-comment.mjs
+++ b/scripts/bench/edit-bench-comment.mjs
@@ -164,8 +164,12 @@ function legendBlock() {
     '',
     '- **Base**: the `main` commit this PR builds on. **Head**: this PR.',
     '- **Median**: the typical sample. **p95**: 95 of 100 samples were faster than this.',
-    '- Browser table: **median/p95** time the keystroke handler blocks the page;',
-    '  **Frame p95** time until the edit is visible on screen.',
+    '- Browser table: **frame** is the time from the keystroke until the edit is',
+    '  visible on screen — the number a typing user feels. **Input p95** is how long',
+    '  the keystroke handler blocked the page (typing buffers its work off the input',
+    '  task, so this stays near zero by design).',
+    '- `521pp-*` rows run the pinned 521-page reproduction; the other rows run the',
+    '  small synthetic fixtures that exist for deterministic work-counter gates.',
     '- **Δ**: 🟢 faster, 🔴 slower, ⚪ inside the noise. Each side runs interleaved',
     '  rounds; a delta smaller than the run-to-run spread renders neutral.',
     '- **Work counters**: exact counts of layout work (paragraphs placed, pages',
@@ -237,32 +241,34 @@ function renderUxSection(headUx, baseUx) {
   if (!headUx) return [];
   const lines = ['### Typing latency (browser)', ''];
   const comparable = baseUx && baseUx.fixtureSha256 === headUx.fixtureSha256;
+  // FRAME latency leads every row: the time until the edit is visible. The input-task
+  // median used to lead, and the type buffer moved typing's work off the input task, so
+  // it pinned at the clock floor (0.00–0.05 ms) and colored nothing — a table of noise.
+  const frameOf = (scenario) => scenario.frame ?? scenario.inputTask;
   if (comparable) {
     lines.push(
-      '| Scenario | Base median | Head median | Δ | Head p95 | Frame p95 |',
+      '| Scenario | Base frame | Head frame | Δ | Frame p95 | Input p95 |',
       '| --- | --- | --- | --- | --- | --- |'
     );
     const baseByName = new Map(baseUx.scenarios.map((scenario) => [scenario.name, scenario]));
     for (const scenario of headUx.scenarios) {
       const baseScenario = baseByName.get(scenario.name);
       lines.push(
-        `| ${scenario.name} | ${formatMs(baseScenario?.inputTask.medianMs)} | ${formatMs(scenario.inputTask.medianMs)} | ${baseScenario ? formatDelta(baseScenario.inputTask.medianMs, scenario.inputTask.medianMs, spreadFloor(headUx, baseUx, scenario.name)) : 'n/a'} | ${formatMs(scenario.inputTask.p95Ms)} | ${formatMs(scenario.frame?.p95Ms)} |`
+        `| ${scenario.name} | ${formatMs(baseScenario ? frameOf(baseScenario).medianMs : undefined)} | ${formatMs(frameOf(scenario).medianMs)} | ${baseScenario ? formatDelta(frameOf(baseScenario).medianMs, frameOf(scenario).medianMs, spreadFloor(headUx, baseUx, scenario.name)) : 'n/a'} | ${formatMs(frameOf(scenario).p95Ms)} | ${formatMs(scenario.inputTask.p95Ms)} |`
       );
     }
     const headNames = new Set(headUx.scenarios.map((scenario) => scenario.name));
     for (const scenario of baseUx.scenarios) {
       if (headNames.has(scenario.name)) continue;
-      lines.push(
-        `| ${scenario.name} | ${formatMs(scenario.inputTask.medianMs)} | — | n/a | — | — |`
-      );
+      lines.push(`| ${scenario.name} | ${formatMs(frameOf(scenario).medianMs)} | — | n/a | — | — |`);
     }
     lines.push('');
   } else {
     if (baseUx) lines.push('> Browser baseline not comparable (fixture differs).', '');
-    lines.push('| Scenario | Median | p95 | Frame p95 |', '| --- | --- | --- | --- |');
+    lines.push('| Scenario | Frame median | Frame p95 | Input p95 |', '| --- | --- | --- | --- |');
     for (const scenario of headUx.scenarios) {
       lines.push(
-        `| ${scenario.name} | ${formatMs(scenario.inputTask.medianMs)} | ${formatMs(scenario.inputTask.p95Ms)} | ${formatMs(scenario.frame?.p95Ms)} |`
+        `| ${scenario.name} | ${formatMs(frameOf(scenario).medianMs)} | ${formatMs(frameOf(scenario).p95Ms)} | ${formatMs(scenario.inputTask.p95Ms)} |`
       );
     }
     lines.push('');
@@ -359,7 +365,9 @@ function readAll(paths, reader, label) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const engine = (scenario) => scenario.total;
-  const input = (scenario) => scenario.inputTask;
+  // Spread (and therefore delta coloring) keys on the FRAME median — the headline
+  // metric — not the input task, whose medians sit at the clock floor.
+  const input = (scenario) => scenario.frame ?? scenario.inputTask;
   const headRuns = readAll(args.head, readReport, 'head report');
   if (headRuns.length === 0) throw new Error('no readable --head report');
   const head = aggregateReports(headRuns, engine);

--- a/scripts/bench/edit-bench-comment.test.ts
+++ b/scripts/bench/edit-bench-comment.test.ts
@@ -167,14 +167,17 @@ describe('browser typing-latency section', () => {
     expect(body).toContain('### Typing latency (browser)');
     expect(body).toContain('### Engine layout (headless)');
     expect(body.indexOf('Typing latency')).toBeLessThan(body.indexOf('Engine layout'));
-    expect(body).toContain('| editing-character | 40.00 ms | 30.00 ms | 🟢 -25.0% |');
+    // FRAME medians lead the row (48 = base input 40 + 8, 38 = head input 30 + 8): the
+    // input-task median pinned at the clock floor once typing buffered its work off the
+    // input task, so a table led by it colored nothing.
+    expect(body).toContain('| editing-character | 48.00 ms | 38.00 ms | 🟢 -20.8% |');
   });
 
   test('head-only browser report renders without deltas', () => {
     const body = renderComment(report({}), undefined, { headUx: uxReport({}) });
     expect(body).toContain('### Typing latency (browser)');
-    expect(body).toContain('| editing-character | 40.00 ms |');
-    expect(body).not.toContain('| Base median | Head median | Δ | Head p95 | Frame p95 |');
+    expect(body).toContain('| editing-character | 48.00 ms |');
+    expect(body).not.toContain('| Base frame | Head frame | Δ | Frame p95 | Input p95 |');
   });
 
   test('a browser fixture mismatch degrades that section to head-only', () => {
@@ -196,7 +199,7 @@ describe('browser typing-latency section', () => {
     const head = uxReport({});
     (head.scenarios as Array<{ name: string }>)[0]!.name = 'renamed-ux-scenario';
     const body = renderComment(report({}), report({}), { headUx: head, baseUx: base });
-    expect(body).toContain('| editing-character | 40.00 ms | — | n/a | — | — |');
+    expect(body).toContain('| editing-character | 48.00 ms | — | n/a | — | — |');
   });
 
   test('four oversized reports stay under the GitHub comment cap', () => {

--- a/scripts/bench/settle-bench-gates.test.ts
+++ b/scripts/bench/settle-bench-gates.test.ts
@@ -1,0 +1,63 @@
+// Deterministic gates for the huge-document settle benchmark.
+//
+// Wall-clock settle numbers are hardware-sensitive and stay a manual comparison; what CI can
+// hold still is the WORK a keystroke performs on the pinned 521-page fixture. A change that
+// re-places more paragraphs, reuses fewer pages, or triggers full passes on the huge document
+// fails here — where a small synthetic fixture would hide it in the noise.
+
+import { expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface Report {
+  readonly fixtureSha256: string;
+  readonly pages: number;
+  readonly paragraphs: number;
+  readonly work: {
+    readonly placed: number;
+    readonly total: number;
+    readonly reusedPages: number;
+    readonly fullPasses: number;
+    readonly staleDiscards: number;
+    readonly cancelledRuns: number;
+  };
+}
+
+const root = resolve(import.meta.dir, '../..');
+const fixture = resolve(root, 'e2e/fixtures/typing-perf-521pp.docx');
+
+test('a keystroke on the huge document performs the pinned amount of work', () => {
+  expect(existsSync(fixture)).toBe(true);
+  const run = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      'scripts/bench/settle-bench.ts',
+      '--keystrokes',
+      '2',
+      '--warmup',
+      '1',
+      '--json',
+    ],
+    cwd: root,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  expect(run.exitCode, run.stderr.toString()).toBe(0);
+  const report = JSON.parse(run.stdout.toString()) as Report;
+
+  // Fixed measurer under happy-dom: pagination differs from the browser manifest count and
+  // that is fine — what matters is that it never MOVES without a deliberate baseline update.
+  expect(report.pages).toBe(561);
+  expect(report.paragraphs).toBe(12820);
+  expect(report.work).toEqual({
+    // The last pass of a one-character keystroke: a handful of re-placed paragraphs against
+    // the document's total, everything else reused. `fullPasses` counts the two passes the
+    // OPEN performs; typing must add none.
+    placed: 7,
+    total: 6540,
+    reusedPages: 555,
+    fullPasses: 2,
+    staleDiscards: 0,
+    cancelledRuns: 0,
+  });
+}, 120_000);

--- a/scripts/bench/settle-bench.ts
+++ b/scripts/bench/settle-bench.ts
@@ -1,0 +1,255 @@
+// Keystroke-to-settled latency through the FULL mounted surface, on a huge document.
+//
+// `bench:edit` measures the store and layout pipeline in isolation; this measures what a
+// user feels: one `type()` through the surface's own input, flush, layout, paint and
+// selection machinery, until the published state stops moving. It runs headless under
+// happy-dom, so absolute paint milliseconds are inflated relative to a browser — compare
+// runs on the same machine, and treat the work counters as the hardware-independent part.
+// The browser-truth counterpart is `bench:huge:browser` (`typing-url-audit.mjs`).
+//
+// The default fixture is the pinned 521-page reproduction the browser audit uses, so both
+// halves of the huge-document section measure the same bytes. Its SHA-256 is verified
+// before a run, and a `--compare` against a baseline taken from different bytes refuses.
+//
+// Usage:
+//   bun scripts/bench/settle-bench.ts [fixture] [--keystrokes 25] [--warmup 3] [--json]
+//   bun scripts/bench/settle-bench.ts --json > /tmp/settle-before.json
+//   bun scripts/bench/settle-bench.ts --compare /tmp/settle-before.json
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+import { createFixedMeasurer } from '../../packages/core/src/layout/index.ts';
+import { mountPaginatedSurface } from '../../packages/core/src/editor/paginated-surface.ts';
+import type { PaginatedSurface } from '../../packages/core/src/editor/paginated-surface-contract.ts';
+import { DEFAULT_FIXTURE, loadTypingPerfFixtureManifest } from './typing-url-audit-lib.mjs';
+
+interface Args {
+  fixture: string;
+  keystrokes: number;
+  warmup: number;
+  json: boolean;
+  compare?: string;
+}
+
+interface TimingSummary {
+  medianMs: number;
+  p95Ms: number;
+}
+
+interface SettleReport {
+  schema: 1;
+  fixture: string;
+  fixtureSha256: string;
+  pages: number;
+  paragraphs: number;
+  openMs: number;
+  keystrokes: number;
+  settle: TimingSummary;
+  layout: TimingSummary;
+  paint: TimingSummary;
+  work: {
+    placed: number;
+    total: number;
+    reusedPages: number;
+    fullPasses: number;
+    staleDiscards: number;
+    cancelledRuns: number;
+  };
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    fixture: resolve(import.meta.dir, '../../e2e/fixtures', DEFAULT_FIXTURE),
+    keystrokes: 25,
+    warmup: 3,
+    json: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]!;
+    if (value === '--json') args.json = true;
+    else if (value === '--keystrokes') args.keystrokes = Number(argv[++index]);
+    else if (value === '--warmup') args.warmup = Number(argv[++index]);
+    else if (value === '--compare') args.compare = argv[++index]!;
+    else if (!value.startsWith('--')) args.fixture = resolve(value);
+    else throw new Error(`unknown option ${value}`);
+  }
+  if (!Number.isInteger(args.keystrokes) || args.keystrokes < 1) {
+    throw new Error('--keystrokes must be a positive integer');
+  }
+  if (!Number.isInteger(args.warmup) || args.warmup < 0) {
+    throw new Error('--warmup must be a non-negative integer');
+  }
+  return args;
+}
+
+const tick = (): Promise<void> => new Promise((done) => setTimeout(done, 0));
+
+/**
+ * Wait until the surface state stops changing for `quiet` consecutive macrotasks, and
+ * return the timestamp of the LAST observed change — the moment the keystroke settled.
+ * The quiet tail itself is idle waiting, not latency, so it is excluded from the sample.
+ */
+async function settle(surface: PaginatedSurface, quiet = 25, maxMs = 120_000): Promise<number> {
+  const start = performance.now();
+  let lastRevision = surface.state().revision;
+  let lastChangeAt = performance.now();
+  let quietTicks = 0;
+  while (quietTicks < quiet) {
+    if (performance.now() - start > maxMs) throw new Error('settle timeout');
+    await tick();
+    const revision = surface.state().revision;
+    if (revision !== lastRevision) {
+      lastRevision = revision;
+      lastChangeAt = performance.now();
+      quietTicks = 0;
+    } else {
+      quietTicks += 1;
+    }
+  }
+  return lastChangeAt;
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)]!;
+}
+
+function p95(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.max(0, Math.ceil(sorted.length * 0.95) - 1)]!;
+}
+
+async function run(args: Args): Promise<SettleReport> {
+  const bytes = new Uint8Array(readFileSync(args.fixture));
+  const fixtureSha256 = createHash('sha256').update(bytes).digest('hex');
+  if (args.fixture.endsWith(DEFAULT_FIXTURE)) {
+    const { entry } = loadTypingPerfFixtureManifest();
+    if (entry.sha256 !== fixtureSha256) {
+      throw new Error(
+        `the pinned fixture's bytes moved: expected sha256 ${entry.sha256}, got ${fixtureSha256}`
+      );
+    }
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  // The fixed measurer, not happy-dom's canvas: pagination stays deterministic across
+  // environments, so the work counters can be pinned and compared.
+  const mounted = mountPaginatedSurface(container, bytes, {
+    scale: 1,
+    measurer: createFixedMeasurer(6, 14),
+  });
+  if (!mounted.ok) throw new Error(`mount refused: ${mounted.reason} ${mounted.detail ?? ''}`);
+  const surface = mounted.surface;
+
+  try {
+    const openStart = performance.now();
+    await settle(surface);
+    const openMs = performance.now() - openStart;
+
+    const ids = surface.session.paragraphIds();
+    const middle = ids[Math.floor(ids.length / 2)]!;
+    surface.setSelection({
+      anchor: { paragraphId: middle, offset: 0 },
+      head: { paragraphId: middle, offset: 0 },
+    });
+    await settle(surface);
+
+    for (let index = 0; index < args.warmup; index += 1) {
+      surface.type('w');
+      await settle(surface);
+    }
+
+    const settleMs: number[] = [];
+    const layoutMs: number[] = [];
+    const paintMs: number[] = [];
+    for (let index = 0; index < args.keystrokes; index += 1) {
+      const typedAt = performance.now();
+      surface.type('x');
+      const settledAt = await settle(surface);
+      settleMs.push(settledAt - typedAt);
+      const perf = surface.state().perf;
+      layoutMs.push(perf.layoutMs);
+      paintMs.push(perf.paintMs);
+    }
+
+    const state = surface.state();
+    return {
+      schema: 1,
+      fixture: args.fixture,
+      fixtureSha256,
+      pages: state.pageCount,
+      paragraphs: ids.length,
+      openMs: Math.round(openMs),
+      keystrokes: args.keystrokes,
+      settle: { medianMs: median(settleMs), p95Ms: p95(settleMs) },
+      layout: { medianMs: median(layoutMs), p95Ms: p95(layoutMs) },
+      paint: { medianMs: median(paintMs), p95Ms: p95(paintMs) },
+      work: {
+        placed: state.perf.placed,
+        total: state.perf.total,
+        reusedPages: state.perf.reusedPages,
+        fullPasses: state.perf.fullPasses,
+        staleDiscards: state.perf.staleDiscards,
+        cancelledRuns: state.perf.cancelledRuns,
+      },
+    };
+  } finally {
+    surface.destroy();
+    container.remove();
+  }
+}
+
+function printHuman(report: SettleReport): void {
+  const line = (label: string, timing: TimingSummary): string =>
+    `  ${label} median ${timing.medianMs.toFixed(1)} ms, p95 ${timing.p95Ms.toFixed(1)} ms`;
+  console.log(`fixture ${report.fixture}`);
+  console.log(
+    `pages ${report.pages}, paragraphs ${report.paragraphs}, open ${report.openMs} ms, ` +
+      `${report.keystrokes} keystrokes`
+  );
+  console.log(line('settle', report.settle));
+  console.log(line('layout', report.layout));
+  console.log(line('paint ', report.paint));
+  const work = report.work;
+  console.log(
+    `  work  placed ${work.placed}/${work.total}, reused ${work.reusedPages} pages, ` +
+      `full passes ${work.fullPasses}, stale discards ${work.staleDiscards}`
+  );
+}
+
+function printComparison(baseline: SettleReport, current: SettleReport): void {
+  if (baseline.fixtureSha256 !== current.fixtureSha256) {
+    throw new Error('the baseline was taken from different document bytes; refusing to compare');
+  }
+  const delta = (before: number, after: number): string =>
+    `${(((after - before) / before) * 100).toFixed(1)}%`;
+  console.log('comparison (negative is faster):');
+  console.log(`  settle ${delta(baseline.settle.medianMs, current.settle.medianMs)}`);
+  console.log(`  layout ${delta(baseline.layout.medianMs, current.layout.medianMs)}`);
+  console.log(`  paint  ${delta(baseline.paint.medianMs, current.paint.medianMs)}`);
+  const before = baseline.work;
+  const after = current.work;
+  console.log(
+    `  work   placed ${after.placed - before.placed >= 0 ? '+' : ''}${after.placed - before.placed}, ` +
+      `reused ${after.reusedPages - before.reusedPages >= 0 ? '+' : ''}${after.reusedPages - before.reusedPages}, ` +
+      `full passes ${after.fullPasses - before.fullPasses >= 0 ? '+' : ''}${after.fullPasses - before.fullPasses}`
+  );
+}
+
+const args = parseArgs(process.argv.slice(2));
+const report = await run(args);
+if (args.json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  printHuman(report);
+  if (args.compare) {
+    const baseline = JSON.parse(readFileSync(resolve(args.compare), 'utf8')) as SettleReport;
+    printComparison(baseline, report);
+  }
+}
+process.exit(0);


### PR DESCRIPTION
The PR-comment typing table led with the input-task median. Typing buffers its work off the input task, so every row read 0.00–0.05 ms and the deltas colored nothing — the real latency hid in the trailing Frame p95 column.

- The table now leads with the frame median (keystroke to visible edit) and colors deltas on the frame spread. The input task demotes to a trailing p95 column, with the legend explaining why it stays near zero by design.
- The browser benchmark runs a new pass on the pinned 521-page reproduction (`typing-perf-521pp.docx`) and lists its `521pp-*` rows first. The synthetic fixtures exist for deterministic gates; their keystroke numbers sit near the clock floor, where a cost that scales with the document reads as noise. The pass pins its own work counters (`PINNED_HUGE_EXPECTED_LAYOUT_WORK`), bootstrapped and verified in Chromium.
- `bench:huge` adds the headless half: keystroke-to-settled latency through the full mounted surface on the same fixture, with SHA verification, `--compare`, and deterministic work gates in `settle-bench-gates.test.ts`. `bench:huge:browser` aliases the fail-closed typing URL audit.

On the local verification run, the new table reads 60–76 ms frame medians for the 521-page rows instead of 0.00 ms input medians.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790168372&installation_model_id=422592&pr_number=402&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F402&signature=5b3315c45b1c2dfa1f41e331a79a354cb693edb665e117b60d859bf7844247b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->