### PR TITLE
fix(editor-api): align revision views with Word terminology

### DIFF
--- a/.changeset/editor-api-text-projection.md
+++ b/.changeset/editor-api-text-projection.md
@@ -5,10 +5,10 @@
 
 Add agent-safe document writing and revision APIs.
 
-- Add an explicit `vanilla` text projection for automation reads and searches. Pending deletions
-  remain visible, while pending insertions stay hidden.
+- Add an explicit `original` text projection. Pending deletions remain visible, while pending
+  insertions stay hidden. This matches Word's Original review view.
 - Add the atomic `replaceStoryBlocks` automation operation with stable paragraph identities.
-- Add `revisionTextView` runtime configuration while preserving the Office.js object-model shape.
+- Add the DocxEditor `revisionTextView` runtime option outside the Office.js object model.
 - Implement `proposeInsertion`, `proposeDeletion`, and `proposeReplacement` editor commands.
 
 Projected search ranges map back to editable model offsets and retain their projection for later

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -1132,7 +1132,7 @@ export type AutomationStoryId = {
 };
 
 // @public
-export type AutomationTextProjection = 'all' | 'vanilla';
+export type AutomationTextProjection = 'allMarkup' | 'original';
 
 // @public
 export type AutomationUnsubscribe = () => void;

--- a/docs/api/docx-editor-editor-api/browser.api.md
+++ b/docs/api/docx-editor-editor-api/browser.api.md
@@ -705,7 +705,7 @@ export class RevisionCollection extends HandleCollection<Revision> {
 }
 
 // @public
-export type RevisionTextView = 'all' | 'vanilla';
+export type RevisionTextView = 'allMarkup' | 'original';
 
 // @public
 export type RevisionType = 'None' | 'Insert' | 'Delete' | 'Property' | 'ParagraphNumber' | 'DisplayField' | 'Reconcile' | 'Conflict' | 'Style' | 'Replace' | 'ParagraphProperty' | 'TableProperty' | 'SectionProperty' | 'StyleDefinition' | 'MovedFrom' | 'MovedTo' | 'CellInsertion' | 'CellDeletion' | 'CellMerge' | 'CellSplit' | 'ConflictInsert' | 'ConflictDelete';

--- a/docs/api/docx-editor-editor-api/index.api.md
+++ b/docs/api/docx-editor-editor-api/index.api.md
@@ -697,7 +697,7 @@ export class RevisionCollection extends HandleCollection<Revision> {
 }
 
 // @public
-export type RevisionTextView = 'all' | 'vanilla';
+export type RevisionTextView = 'allMarkup' | 'original';
 
 // @public
 export type RevisionType = 'None' | 'Insert' | 'Delete' | 'Property' | 'ParagraphNumber' | 'DisplayField' | 'Reconcile' | 'Conflict' | 'Style' | 'Replace' | 'ParagraphProperty' | 'TableProperty' | 'SectionProperty' | 'StyleDefinition' | 'MovedFrom' | 'MovedTo' | 'CellInsertion' | 'CellDeletion' | 'CellMerge' | 'CellSplit' | 'ConflictInsert' | 'ConflictDelete';

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -165,22 +165,22 @@ application's other chrome.
 
 ### Choose one revision text projection
 
-The runtime uses the `all` revision view by default. This view includes ordinary text, pending
-deletions, pending insertions, and both sides of a pending replacement.
+The runtime uses the `allMarkup` text projection by default. This projection includes ordinary
+text, pending deletions, pending insertions, and both sides of a pending replacement.
 
-Use the `vanilla` projection when an agent must read the document before pending changes are
-accepted. It has these rules:
+Use the `original` projection when an agent must read the document before pending changes are
+accepted. This projection matches Word's **Original** review view. It has these rules:
 
 - Ordinary text remains unchanged.
 - A pending deletion remains visible and searchable.
 - A pending insertion is hidden and is not searchable.
 - A pending replacement shows its deleted original and hides its inserted replacement.
 
-Choose the view when you create the runtime. The object model keeps the Office.js shape:
+Choose the projection when you create the runtime:
 
 ```ts
 const runtime = DocxEditor.createBrowser(editor, {
-  revisionTextView: 'vanilla',
+  revisionTextView: 'original',
 });
 
 await runtime.run(async (context) => {
@@ -194,8 +194,12 @@ await runtime.run(async (context) => {
 });
 ```
 
-A range returned by a search uses the runtime's revision view. Its `text` property and nested
-searches use the same view. The range endpoints remain model offsets, so `insertText()`,
+`revisionTextView` is a DocxEditor runtime option. It does not belong to the Office.js object model.
+Office.js provides display controls through `document.view.revisionsFilter`. It does not provide a
+text-projection API for the values returned by text reads.
+
+A range returned by a search uses the runtime's text projection. Its `text` property and nested
+searches use the same projection. The range endpoints remain model offsets, so `insertText()`,
 `insertComment()`, and `select()` target the text that the search returned.
 
 Selection does not change the insertion rule. `range.select()` selects the full range, so the

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -195,8 +195,8 @@ await runtime.run(async (context) => {
 ```
 
 `revisionTextView` is a DocxEditor runtime option. It does not belong to the Office.js object model.
-Office.js provides display controls through `document.view.revisionsFilter`. It does not provide a
-text-projection API for the values returned by text reads.
+Office.js provides display controls through `document.activeWindow.view.revisionsFilter`. It does
+not provide a text-projection API for the values returned by text reads.
 
 A range returned by a search uses the runtime's text projection. Its `text` property and nested
 searches use the same projection. The range endpoints remain model offsets, so `insertText()`,

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -163,6 +163,82 @@ model defines which operations to expose, how to describe them and how to handle
 such as `add_comment` performs its document work inside a `run` block. Keep its chat UI with the
 application's other chrome.
 
+### Expose focused tools to an agent
+
+Give each tool one document task. Validate its input before the tool reaches the document. Keep the
+complete read or write inside one `run` callback.
+
+This AI SDK example exposes one read tool and two small writing tools:
+
+```ts
+import type { DocxEditorRuntime } from '@docx-editor.dev/editor-api';
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export function createDocumentTools(runtime: DocxEditorRuntime) {
+  return {
+    read_document: tool({
+      description: 'Read the current document text.',
+      inputSchema: z.object({}),
+      execute: async () =>
+        runtime.run(async (context) => {
+          const body = context.document.body;
+          body.load('text');
+          await context.sync();
+          return { text: body.text };
+        }),
+    }),
+
+    append_paragraph: tool({
+      description: 'Add one paragraph to the end of the document.',
+      inputSchema: z.object({
+        text: z.string().min(1),
+      }),
+      execute: async ({ text }) =>
+        runtime.run(async (context) => {
+          context.document.body.insertParagraph(text, 'End');
+          await context.sync();
+          return { inserted: true };
+        }),
+    }),
+
+    replace_exact_text: tool({
+      description: 'Replace one exact phrase when it occurs once.',
+      inputSchema: z.object({
+        search: z.string().min(1),
+        replacement: z.string(),
+      }),
+      execute: async ({ search, replacement }) =>
+        runtime.run(async (context) => {
+          const matches = context.document.body.search(search, {
+            matchCase: true,
+          });
+          matches.load('items');
+          await context.sync();
+
+          if (matches.items.length !== 1) {
+            return {
+              replaced: false,
+              reason: `Expected one match, found ${matches.items.length}.`,
+            };
+          }
+
+          matches.items[0].insertText(replacement, 'Replace');
+          await context.sync();
+          return { replaced: true };
+        }),
+    }),
+  };
+}
+```
+
+Return structured results instead of free-form status text. Refuse ambiguous writes instead of
+choosing a match for the agent. Use separate tools for comments, tracked proposals, tables, and
+content controls.
+
+For a complete tool catalog, see the
+[writer agent example](https://github.com/eigenpal/docx-editor/tree/main/examples/write-agent).
+
 ### Choose one revision text projection
 
 The runtime uses the `allMarkup` text projection by default. This projection includes ordinary

--- a/examples/write-agent/README.md
+++ b/examples/write-agent/README.md
@@ -36,8 +36,8 @@ The agent then uses five visible tool calls:
 `create_document` calls the lower-level `replaceStoryBlocks` automation operation in one
 transaction. Every generated document uses all five calls.
 
-The browser runtime uses `revisionTextView: 'vanilla'`, while the Word-compatible object model
-keeps the Office.js API shape.
+The browser runtime uses `revisionTextView: 'original'`. This DocxEditor runtime option matches
+Word's Original review view. It does not belong to the Office.js object model.
 Later turns call `read_document` through the standard `text` properties and `search()` methods.
 The three proposal tools call `proposeReplacement`, `proposeInsertion`, and `proposeDeletion`.
 Insertion anchors call `range.select('End')` before the browser command.

--- a/examples/write-agent/app/agent/run-tool.ts
+++ b/examples/write-agent/app/agent/run-tool.ts
@@ -54,7 +54,7 @@ function handlesAt(response: AutomationBatchResponse, index: number): readonly A
 export function createWriterRuntime(editor: DocxEditorInstance): DocxEditorRuntime {
   return EditorApi.createBrowser(editor, {
     author: WRITER_AUTHOR,
-    revisionTextView: 'vanilla',
+    revisionTextView: 'original',
   });
 }
 

--- a/packages/core/src/automation/__tests__/automation-story-reads.test.ts
+++ b/packages/core/src/automation/__tests__/automation-story-reads.test.ts
@@ -87,15 +87,15 @@ describe('revision text projections', () => {
     '<w:del w:id="1" w:author="Ada"><w:r><w:delText>gone</w:delText></w:r></w:del>' +
     '<w:ins w:id="2" w:author="Ada"><w:r><w:t>added</w:t></w:r></w:ins></w:p>';
 
-  test('preserves all revision text by default and exposes the vanilla document explicitly', () => {
+  test('preserves all revision text by default and exposes the original document explicitly', () => {
     const host = open(docx(revisions));
     const { body } = roots(host);
     const paragraph = paragraphsOf(host, body)[0]!;
     const response = host.execute({
       operations: [
         { op: 'getText', target: body },
-        { op: 'getText', target: body, projection: 'vanilla' },
-        { op: 'getText', target: paragraph, projection: 'vanilla' },
+        { op: 'getText', target: body, projection: 'original' },
+        { op: 'getText', target: paragraph, projection: 'original' },
       ],
     });
     expect(textAt(response, 0)).toBe('keep goneadded');
@@ -103,7 +103,7 @@ describe('revision text projections', () => {
     expect(textAt(response, 2)).toBe('keep gone');
   });
 
-  test('searches, reads, and edits through one vanilla offset mapping', () => {
+  test('searches, reads, and edits through one original-view offset mapping', () => {
     const replacement =
       '<w:p><w:r><w:t xml:space="preserve">before </w:t></w:r>' +
       '<w:del w:id="1" w:author="Ada"><w:r><w:delText>old</w:delText></w:r></w:del>' +
@@ -117,9 +117,9 @@ describe('revision text projections', () => {
           op: 'search',
           scope: { body },
           text: 'before old after',
-          options: { projection: 'vanilla' },
+          options: { projection: 'original' },
         },
-        { op: 'search', scope: { body }, text: 'new', options: { projection: 'vanilla' } },
+        { op: 'search', scope: { body }, text: 'new', options: { projection: 'original' } },
       ],
     });
     const [span] = spansAt(searched, 0);
@@ -128,7 +128,7 @@ describe('revision text projections', () => {
     expect(
       textAt(
         host.execute({
-          operations: [{ op: 'getSpanText', span: span!, projection: 'vanilla' }],
+          operations: [{ op: 'getSpanText', span: span!, projection: 'original' }],
         }),
         0
       )
@@ -149,7 +149,7 @@ describe('revision text projections', () => {
           op: 'search',
           scope: { body },
           text: 'gone',
-          options: { projection: 'resolved' as 'all' },
+          options: { projection: 'resolved' as 'allMarkup' },
         },
       ],
     });

--- a/packages/core/src/automation/__tests__/text-projection.test.ts
+++ b/packages/core/src/automation/__tests__/text-projection.test.ts
@@ -14,7 +14,7 @@ describe('projected text offset mapping', () => {
       attributes: [],
       children: [],
     };
-    const projected = projectParagraphText(paragraph, 'alpha', 'all');
+    const projected = projectParagraphText(paragraph, 'alpha', 'allMarkup');
 
     expect(projected.rawRange(1, 4)).toEqual({ start: 1, end: 4 });
     expect(projected.rawRange(0, 0)).toBeNull();

--- a/packages/core/src/automation/content-controls.ts
+++ b/packages/core/src/automation/content-controls.ts
@@ -136,10 +136,10 @@ export function contentControlSpan(
 export function contentControlText(
   reads: AutomationStoryReads,
   node: OoxmlNode,
-  projection: AutomationTextProjection = 'all'
+  projection: AutomationTextProjection = 'allMarkup'
 ): string {
   // Preserve the existing content-control value semantics for ordinary reads.
-  if (projection === 'all') return contentControlTextOf(node);
+  if (projection === 'allMarkup') return contentControlTextOf(node);
   const span = contentControlSpan(reads, node);
   if (!span) return '';
   const first = reads.indexOf(span.start.paragraphId);

--- a/packages/core/src/automation/operations.ts
+++ b/packages/core/src/automation/operations.ts
@@ -123,7 +123,7 @@ export type AutomationParagraphRef =
 export interface AutomationSearchOptions {
   readonly matchCase?: boolean;
   readonly matchWholeWord?: boolean;
-  /** Text view to search. `all` preserves the historical behavior. */
+  /** Text view to search. `allMarkup` preserves the historical behavior. */
   readonly projection?: AutomationTextProjection;
   /** Not supported; `true` is refused. Punctuation-insensitive matching is not implemented. */
   readonly ignorePunct?: boolean;
@@ -138,11 +138,10 @@ export interface AutomationSearchOptions {
 /**
  * Which revision text an automation read exposes.
  *
- * `all` includes pending insertions, deletions, and both sides of replacements. `vanilla`
- * describes the document before pending changes are accepted: deletions remain and insertions
- * are hidden.
+ * `allMarkup` includes pending insertions, deletions, and both sides of replacements. `original`
+ * matches Word's Original review view: deletions remain visible and insertions are hidden.
  */
-export type AutomationTextProjection = 'all' | 'vanilla';
+export type AutomationTextProjection = 'allMarkup' | 'original';
 
 /** Where a selection lands. `start`/`end` collapse it to one edge of the span. */
 export type AutomationSelectionMode = 'select' | 'start' | 'end';

--- a/packages/core/src/automation/plan.ts
+++ b/packages/core/src/automation/plan.ts
@@ -44,6 +44,7 @@ import type {
   AutomationOperation,
   AutomationSearchOptions,
   AutomationSelectionMode,
+  AutomationTextProjection,
 } from './operations.ts';
 import { createBatchCommandPolicy } from './batch-command-policy.ts';
 import type {
@@ -714,17 +715,16 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
   const storyReadsOf = (span: ResolvedSpan): AutomationStoryReads | null =>
     span === null ? null : packageReads.story(span.start.story);
 
+  const isTextProjection = (value: unknown): value is AutomationTextProjection | undefined =>
+    value === undefined || value === 'allMarkup' || value === 'original';
+
   const searchScope = (
     reads: AutomationStoryReads,
     scope: ResolvedSpan,
     text: string,
     options: AutomationSearchOptions | undefined
   ): PlannedOperation => {
-    if (
-      options?.projection !== undefined &&
-      options.projection !== 'all' &&
-      options.projection !== 'vanilla'
-    )
+    if (!isTextProjection(options?.projection))
       return refuse('unsupported-content', 'unknown text projection', 'projection');
     if (options?.matchWildcards === true)
       return refuse(
@@ -1728,11 +1728,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
       }
 
       case 'getText': {
-        if (
-          operation.projection !== undefined &&
-          operation.projection !== 'all' &&
-          operation.projection !== 'vanilla'
-        )
+        if (!isTextProjection(operation.projection))
           return refuse('unsupported-content', 'unknown text projection', 'projection');
         const body = handles.resolve(operation.target, 'body');
         if (body) {
@@ -1741,7 +1737,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
             return refuse(story.code, 'that handle does not name a body', story.detail);
           return query({
             kind: 'text',
-            text: story.value.text(operation.projection ?? 'all'),
+            text: story.value.text(operation.projection ?? 'allMarkup'),
           });
         }
         const paragraph = resolveParagraphHandle(operation.target, handles, packageReads);
@@ -1755,16 +1751,14 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
         return query({
           kind: 'text',
           text:
-            story?.paragraphText(paragraph.value.paragraphId, operation.projection ?? 'all') ?? '',
+            story?.paragraphText(
+              paragraph.value.paragraphId,
+              operation.projection ?? 'allMarkup'
+            ) ?? '',
         });
       }
-
       case 'getSpanText': {
-        if (
-          operation.projection !== undefined &&
-          operation.projection !== 'all' &&
-          operation.projection !== 'vanilla'
-        )
+        if (!isTextProjection(operation.projection))
           return refuse('unsupported-content', 'unknown text projection', 'projection');
         const resolved = resolveSpanRef(operation.span, handles, packageReads);
         if (!resolved.ok) return refuse(resolved.code, 'that span is not a place', resolved.detail);
@@ -1776,7 +1770,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
             resolved.value,
             story.value,
             PARAGRAPH_MARK,
-            operation.projection ?? 'all'
+            operation.projection ?? 'allMarkup'
           ),
         });
       }

--- a/packages/core/src/automation/reads.ts
+++ b/packages/core/src/automation/reads.ts
@@ -257,7 +257,7 @@ function storyReadsOver(
   const projections = new Map<string, ProjectedParagraphText>();
   const projectionOf = (
     paragraphId: string,
-    projection: AutomationTextProjection = 'all'
+    projection: AutomationTextProjection = 'allMarkup'
   ): ProjectedParagraphText | null => {
     const node = byId.get(paragraphId);
     if (!node || node.kind !== 'paragraph') return null;

--- a/packages/core/src/automation/search.ts
+++ b/packages/core/src/automation/search.ts
@@ -25,7 +25,7 @@ export function projectedSearchSpans(
   const last = ids.length - 1;
   for (const [position, paragraphId] of ids.entries()) {
     if (budget <= 0) break;
-    const projected = reads.projectedText(paragraphId, options?.projection ?? 'all');
+    const projected = reads.projectedText(paragraphId, options?.projection ?? 'allMarkup');
     if (!projected) continue;
     const found = findOccurrences(projected.text, text, budget, {
       matchCase: options?.matchCase === true,

--- a/packages/core/src/automation/spans.ts
+++ b/packages/core/src/automation/spans.ts
@@ -287,7 +287,7 @@ export function spanText(
   span: ResolvedSpan,
   reads: AutomationStoryReads,
   paragraphMark: string,
-  projection: AutomationTextProjection = 'all'
+  projection: AutomationTextProjection = 'allMarkup'
 ): string {
   if (!span) return '';
   const ids = spanParagraphIds(span, reads);

--- a/packages/core/src/automation/text-projection.ts
+++ b/packages/core/src/automation/text-projection.ts
@@ -38,7 +38,7 @@ export function projectParagraphText(
   rawText: string,
   projection: AutomationTextProjection
 ): ProjectedParagraphText {
-  if (projection === 'all') return identityProjection(rawText);
+  if (projection === 'allMarkup') return identityProjection(rawText);
 
   const hidden = hiddenInsertionSpans(paragraph);
   if (hidden.length === 0) return identityProjection(rawText);
@@ -128,7 +128,7 @@ function projectionFromPieces(
   };
 }
 
-/** Pending insertions and move destinations are absent from the vanilla document. */
+/** Pending insertions and move destinations are absent from Word's Original review view. */
 function hiddenInsertionSpans(
   paragraph: OoxmlParagraphNode
 ): readonly { readonly start: number; readonly end: number }[] {

--- a/packages/core/src/editor/__tests__/automation-host-parity.test.ts
+++ b/packages/core/src/editor/__tests__/automation-host-parity.test.ts
@@ -259,7 +259,7 @@ describe('the two hosts read the same document identically', () => {
 });
 
 describe('revision projections use one automation contract in both hosts', () => {
-  test('vanilla read, search, range read, and edit agree', () => {
+  test('original-view read, search, range read, and edit agree', () => {
     const revisionDocument =
       `<w:document xmlns:w="${W}"><w:body><w:p>` +
       '<w:r><w:t xml:space="preserve">keep </w:t></w:r>' +
@@ -272,23 +272,23 @@ describe('revision projections use one automation contract in both hosts', () =>
       const reads = host.execute({
         operations: [
           { op: 'getText', target: body },
-          { op: 'getText', target: body, projection: 'vanilla' },
+          { op: 'getText', target: body, projection: 'original' },
           {
             op: 'search',
             scope: { body },
             text: 'keep gone',
-            options: { projection: 'vanilla' },
+            options: { projection: 'original' },
           },
-          { op: 'search', scope: { body }, text: 'added', options: { projection: 'vanilla' } },
+          { op: 'search', scope: { body }, text: 'added', options: { projection: 'original' } },
         ],
       });
       const hit = reads.results[2];
       if (hit?.status !== 'ok' || hit.value.kind !== 'spans' || !hit.value.spans[0]) {
-        throw new Error('expected one vanilla search result');
+        throw new Error('expected one original-view search result');
       }
       const span = hit.value.spans[0];
       const rangeRead = host.execute({
-        operations: [{ op: 'getSpanText', span, projection: 'vanilla' }],
+        operations: [{ op: 'getSpanText', span, projection: 'original' }],
       });
       const write = host.execute({
         operations: [{ op: 'replaceSpan', span, text: 'kept' }],

--- a/packages/editor-api/src/model/__tests__/model-reads.test.ts
+++ b/packages/editor-api/src/model/__tests__/model-reads.test.ts
@@ -69,7 +69,7 @@ describe('revision text projections', () => {
       '<w:ins w:id="2" w:author="Ada"><w:r><w:t>added</w:t></w:r></w:ins></w:p>'
   );
 
-  test('keeps the Office shape while a runtime selects a consistent vanilla view', async () => {
+  test('keeps the Office shape while a runtime selects a consistent original view', async () => {
     const compatibilityRuntime = await serverRuntime(document);
     const compatibility = await compatibilityRuntime.run(async (context) => {
       const body = context.document.body;
@@ -78,7 +78,7 @@ describe('revision text projections', () => {
       return body.text;
     });
 
-    const runtime = await createServer(document, { revisionTextView: 'vanilla' });
+    const runtime = await createServer(document, { revisionTextView: 'original' });
     const result = await runtime.run(async (context) => {
       const body = context.document.body;
       body.load('text');
@@ -123,7 +123,7 @@ describe('revision text projections', () => {
         '<w:ins w:id="2" w:author="Ada"><w:r><w:t>added</w:t></w:r></w:ins>' +
         '</w:sdtContent></w:sdt></w:p>'
     );
-    const runtime = await createServer(controlled, { revisionTextView: 'vanilla' });
+    const runtime = await createServer(controlled, { revisionTextView: 'original' });
     const text = await runtime.run(async (context) => {
       const controls = context.document.body.contentControls;
       controls.load();
@@ -138,7 +138,7 @@ describe('revision text projections', () => {
   });
 
   test('uses the runtime revision view for note text and its body', async () => {
-    const runtime = await createServer(WITH_REVISION_FOOTNOTE, { revisionTextView: 'vanilla' });
+    const runtime = await createServer(WITH_REVISION_FOOTNOTE, { revisionTextView: 'original' });
     const text = await runtime.run(async (context) => {
       const notes = context.document.footnotes;
       notes.load();

--- a/packages/editor-api/src/model/model-object.ts
+++ b/packages/editor-api/src/model/model-object.ts
@@ -29,7 +29,7 @@ import {
 
 export abstract class ModelObject extends ClientObject {
   /** Runtime-wide revision view behind standard Office-compatible text reads and searches. */
-  protected revisionTextView(): 'all' | 'vanilla' {
+  protected revisionTextView(): 'allMarkup' | 'original' {
     return internalsOf(this.context).revisionTextView;
   }
 

--- a/packages/editor-api/src/runtime/browser.ts
+++ b/packages/editor-api/src/runtime/browser.ts
@@ -37,7 +37,7 @@ export interface CreateBrowserOptions {
   /**
    * Revision view for ordinary Office-compatible `text` loads and `search()` calls.
    *
-   * Omitted means `all`.
+   * Omitted means `allMarkup`.
    */
   readonly revisionTextView?: RevisionTextView;
 }

--- a/packages/editor-api/src/runtime/runtime.ts
+++ b/packages/editor-api/src/runtime/runtime.ts
@@ -103,12 +103,14 @@ export interface DocxEditorServerRuntime extends DocxEditorRuntime {
 /**
  * The tracked-revision view used by this runtime's ordinary Office-compatible text reads.
  *
- * `all` preserves the historical behavior. `vanilla` keeps pending deletions visible and hides
- * pending insertions, so text returned to an agent remains a valid edit anchor.
+ * `allMarkup` preserves the historical behavior. `original` matches Word's Original review view:
+ * pending deletions remain visible and pending insertions stay hidden.
+ *
+ * This is a DocxEditor runtime option. It is not part of the Office.js object model.
  *
  * @public
  */
-export type RevisionTextView = 'all' | 'vanilla';
+export type RevisionTextView = 'allMarkup' | 'original';
 
 export interface CreateRuntimeOptions {
   readonly host: AutomationHost;
@@ -129,7 +131,7 @@ export interface CreateRuntimeOptions {
    * (`NotSupported`) instead of inventing a name that would end up in the file.
    */
   readonly author?: string;
-  /** Revision view for standard `text` loads and `search()` calls. Omitted means `all`. */
+  /** Revision view for standard `text` loads and `search()` calls. Omitted means `allMarkup`. */
   readonly revisionTextView?: RevisionTextView;
 }
 
@@ -147,8 +149,8 @@ export function createRuntime(options: CreateRuntimeOptions): DocxEditorServerRu
     typeof options.author === 'string' && options.author.trim().length > 0
       ? options.author
       : undefined;
-  const revisionTextView = options.revisionTextView ?? 'all';
-  if (revisionTextView !== 'all' && revisionTextView !== 'vanilla') {
+  const revisionTextView = options.revisionTextView ?? 'allMarkup';
+  if (revisionTextView !== 'allMarkup' && revisionTextView !== 'original') {
     fail({ code: 'InvalidArgument', target: 'revisionTextView' });
   }
   let disposed = false;

--- a/packages/editor-api/src/runtime/server.ts
+++ b/packages/editor-api/src/runtime/server.ts
@@ -85,7 +85,7 @@ export interface CreateServerOptions {
   /**
    * Revision view for ordinary Office-compatible `text` loads and `search()` calls.
    *
-   * Omitted means `all`.
+   * Omitted means `allMarkup`.
    */
   readonly revisionTextView?: RevisionTextView;
 }


### PR DESCRIPTION
## Summary
- rename the unreleased `all` and `vanilla` projections to `allMarkup` and `original`
- preserve `allMarkup` as the default and document `revisionTextView` as a DocxEditor runtime option
- clarify that Office.js display filters do not project text read results

## Test plan
- [x] `bun run build:packages`
- [x] `bun run api:extract`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test packages/editor-api/src/office-compat/__tests__`
- [x] `bun run --filter './examples/write-agent' test`