### PR TITLE
docs: use technical language across documentation

### DIFF
--- a/docs/site/content/core/architecture.mdx
+++ b/docs/site/content/core/architecture.mdx
@@ -10,7 +10,7 @@ There is one document model and one pipeline:
 bytes → bounded OPC/XML read → canonical OOXML tree → layout → painted pages → serialize
 ```
 
-What you see painted and what an edit mutates are the same tree, so nothing has to be kept in sync.
+What you see painted and what an edit mutates are the same tree, so there is no separate view model to synchronize.
 
 ## The canonical tree
 
@@ -19,27 +19,27 @@ Reading a `.docx` produces one tree per XML part, up to a bounded part count. No
 Two consequences:
 
 - Content the engine does not model is carried, not dropped. A known element in an invalid position demotes to generic rather than erroring.
-- Unknown content never blocks editing. A document full of extensions the engine has never seen still opens, still edits, and still saves.
+- Unknown content never blocks editing. A document full of extensions the engine does not recognize opens, accepts edits, and saves.
 
-Every write is a transaction over the tree. Content edits are addressed by node id and character offset; package-level operations such as creating a header or setting section properties are addressed by section index. That is the only write path. There is no second way to mutate a document, so undo, the editing API, and every command go through the same door.
+Every write is a transaction over the tree. Content edits are addressed by node id and character offset; package-level operations such as creating a header or setting section properties are addressed by section index. That is the only write path. There is no second way to mutate a document, so undo, the editing API, and every command use the same write path.
 
 ## Layout
 
 The layout pass is DOM-free. It takes the tree and a text measurer and returns positioned pages, working in the document's own units (twips, half-points, EMUs) rather than approximating from browser layout.
 
-Because it is not constrained by what `contenteditable` can express, it lays text out the way Word does:
+Because it is not constrained by what `contenteditable` can express, it lays text out according to Word layout rules:
 
-- Pagination is computed, not approximated: lines are measured, blocks split where Word splits them, and tables fragment across page boundaries with the right border treatment at the cut.
+- Pagination is computed, not approximated: lines are measured, blocks split where Word splits them, and tables fragment across page boundaries with Word-compatible border treatment at the split.
 - Paragraph fidelity resolves through the real style cascade: `w:spacing` line rules, first-line and hanging indents, `w:contextualSpacing`, paragraph borders, tab stops and leaders, list markers from `numbering.xml`, and table styles through their `basedOn` chain gated by `w:tblLook`.
-- Headers and footers lay out once per variant and attach per page. Editing one behaves exactly like editing the body.
+- Headers and footers lay out once per variant and attach per page. Editing one uses the same edit path as body content.
 
 The pass is incremental: per-block cache keys and flow checkpoints mean a keystroke re-lays out what changed, and a pass with no changes returns the previous pages by identity.
 
 ## Paint and interaction
 
-The painted pages are `contenteditable`, but the DOM is a **picture**. Browser mutations are prevented and re-expressed as tree operations, so the browser never gets to invent markup inside your document.
+The painted pages are `contenteditable`, but the DOM is a non-authoritative rendering. Browser mutations are prevented and re-expressed as tree operations, so the browser cannot insert markup inside your document.
 
-The editor also paints its own caret, from layout geometry rather than from the DOM, which is why an empty paragraph gets a caret at all. It fails soft: range selection, IME composition, or a position it cannot place all hand the native caret back rather than leaving none.
+The editor also paints its own caret, from layout geometry rather than from the DOM, which is why an empty paragraph gets a caret. On failure it falls back: range selection, IME composition, or a position it cannot place all restore the native caret instead of showing no caret.
 
 Selection maps through paragraph identity and offsets, never through DOM traversal. Page furniture (headers, footers, page numbers) is marked non-editable and excluded from selection.
 
@@ -51,7 +51,7 @@ That is what "structural fidelity" means here: unsupported XML and package paylo
 
 ## Adapters
 
-`@docx-editor.dev/core` contains everything above and no framework code. An adapter supplies DOM and paints the engine's positioned display list; it holds no editing state of its own. `@docx-editor.dev/react` is one such adapter, and it is thin by design. Every control it ships is a consumer of the same public contract your own controls would use.
+`@docx-editor.dev/core` contains everything above and no framework code. An adapter supplies DOM and paints the engine's positioned display list; it holds no editing state of its own. `@docx-editor.dev/react` provides React providers, hooks, and chrome over the engine contract. Every control it includes is a consumer of the same public contract that custom controls use.
 
 ## Next steps
 

--- a/docs/site/content/core/index.mdx
+++ b/docs/site/content/core/index.mdx
@@ -7,9 +7,9 @@ order: 70
 
 <PackageStats name="@docx-editor.dev/core" />
 
-The engine. It reads a `.docx` into a canonical document tree, lays that tree out into pages, paints them, and writes the tree back to OOXML. It has no framework dependency and no UI.
+This package is the engine. It reads a `.docx` into a canonical document tree, lays that tree out into pages, paints them, and writes the tree back to OOXML. It has no framework dependency and no UI.
 
-Most apps never import it directly: `@docx-editor.dev/react` carries it. Reach for it when you are writing your own adapter, or when you need the contract types to type a function signature.
+Most apps never import it directly: `@docx-editor.dev/react` carries it. Import it when you are writing your own adapter, or when you need the contract types to type a function signature.
 
 ```bash
 npm install @docx-editor.dev/core
@@ -17,16 +17,16 @@ npm install @docx-editor.dev/core
 
 ## Entry points
 
-The root is the entry point for most work: create an editor over bytes, the contract it implements, fonts, and the chrome registry.
+The root is the entry point for typical editor creation and typing: create an editor over bytes, the contract it implements, fonts, and the chrome registry.
 
 ```ts
 import { createDocxEditor, loadFonts, WORD_DEFAULT_FONT } from '@docx-editor.dev/core';
 import type { Editor, EditorSnapshot } from '@docx-editor.dev/core';
 ```
 
-Reach for a subpath when you need the canonical tree, the layout pass, or the paint step directly.
+Import a subpath when you need the canonical tree, the layout pass, or the paint step directly.
 
-| Subpath                   | What's there                                                                                                                |
+| Subpath                   | Contents                                                                                                                    |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `.`                       | Create an editor, the `Editor` contract, fonts, the chrome registry, the document model types.                              |
 | `./editor`                | Everything the root re-exports, plus the paginated surface, ruler geometry, and module resolution.                          |
@@ -34,20 +34,19 @@ Reach for a subpath when you need the canonical tree, the layout pass, or the pa
 | `./contracts/document`    | The document-level edit and query vocabulary.                                                                               |
 | `./contracts/types`       | Document model types.                                                                                                       |
 | `./contracts/modules`     | `EditorModule`, the shape [`@docx-editor.dev/pro`](/docs/2.x/pro) implements.                                               |
-| `./contracts/interaction` | Semantic addressing (`SemanticTarget`) and the `InteractionOutcome` an attempt answers with.                                |
+| `./contracts/interaction` | Semantic addressing (`SemanticTarget`) and the `InteractionOutcome` that an attempt returns.                                |
 | `./store`                 | The canonical tree and its transactional store.                                                                             |
 | `./layout`                | The DOM-free layout pass.                                                                                                   |
 | `./output`                | Paint: turning a laid-out document into page DOM, and the selection overlay over it.                                        |
 | `./automation`            | The document object model behind [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api).                                     |
-| `./styles/editor.css`     | The one editor stylesheet. The packaged chrome and your own chrome both use it.                                             |
+| `./styles/editor.css`     | The editor stylesheet. The packaged chrome and your own chrome both use it.                                                 |
 
-**Root or `./editor`?** Import from the root. `./editor` is the same engine with its
-internals attached (the paginated surface, ruler geometry, module resolution), and you want
-those only when you are building an adapter rather than using one.
+Prefer the root import. Use `./editor` only when you build an adapter and need
+surface internals (the paginated surface, ruler geometry, module resolution).
 
 ## The contract
 
-`Editor` is the whole public surface an adapter talks to. Commands go in through `exec`, reads come out through `query` and `snapshot`:
+`Editor` is the whole public surface an adapter uses. Call `exec` for commands. Call `query` and `snapshot` for reads:
 
 ```ts
 import type { Editor, EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
@@ -58,23 +57,23 @@ function pageLabel(editor: Editor): string {
 }
 ```
 
-`snapshot()` is version-cached: it returns the same reference until state actually moves, and its sub-objects are reference-stable. That is what makes `useSyncExternalStore` (and therefore [`useEditorState`](/docs/2.x/react/hooks)) correct without a deep compare on every tick.
+`snapshot()` is version-cached: it returns the same reference until editor state changes, and its sub-objects are reference-stable. That is what makes `useSyncExternalStore` (and therefore [`useEditorState`](/docs/2.x/react/hooks)) correct without a deep compare on every store notification.
 
 ## The pipeline
 
-One path, in one direction:
+The pipeline has one direction:
 
 ```text
 bytes → bounded OPC/XML read → canonical document tree → layout → painted pages → serialize
 ```
 
-The painted pages _are_ the editable surface. There is no shadow document model to keep in sync with what you see.
+The painted pages are the editable surface. There is no shadow document model to keep in sync with what you see.
 
 Fidelity is structural. The canonical tree preserves XML content and package payloads pass through untouched. Content the engine cannot type (an unknown element, or a known one in an invalid position) becomes a generic node rather than being dropped, so unknown content never blocks editing and never disappears on save.
 
 ## Untrusted input
 
-A `.docx` is a zip of XML that whoever sent it controls end to end. The engine sanitizes at the parse boundary (URL allowlisting, entity and zip-bomb limits, recursion and element caps, no zero-click external fetches, escaping on the way back out) so everything downstream receives an already-sanitized projection.
+A `.docx` is a zip of XML that whoever sent it fully controls. The engine sanitizes at the parse boundary (URL allowlisting, entity and zip-bomb limits, recursion and element caps, no zero-click external fetches, escaping on the way back out) so everything downstream receives an already-sanitized projection.
 
 Anything you then render from document data (a font name, a hyperlink target, a comment body, a custom node's attributes) is still attacker-controlled at your boundary. Render it as text; do not build markup or URLs from it.
 

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -18,7 +18,7 @@ npm install @docx-editor.dev/editor-api
 
 ## On a server
 
-Runs headless: it takes bytes and returns bytes.
+The server runtime is headless. It accepts bytes and returns bytes.
 
 ```ts
 import { readFile, writeFile } from 'node:fs/promises';
@@ -47,7 +47,7 @@ try {
 caller-owned `Uint8Array`. Mutating or transferring one save result cannot change the runtime or a
 later save.
 
-The server runtime is detached from every live editor. To hand its result back to a reader, make
+The server runtime is detached from every live editor. To load the result into a live editor, make
 that replacement explicit:
 
 ```ts
@@ -82,7 +82,7 @@ collection; this accessor never combines separate stories into a document-wide a
 
 ## In the browser
 
-The browser entry takes an editor the host already created (from `@docx-editor.dev/react` or a plain page) and drives it in place. Edits land in the open document with the reader's undo stack intact, so there is no `save()`: the host saves the way it already did.
+The browser entry takes an editor the host already created (from `@docx-editor.dev/react` or a plain page) and drives it in place. Edits apply to the open document with the reader's undo stack intact, so there is no `save()`: the host continues to call its existing save path.
 
 ```ts
 import { DocxEditor } from '@docx-editor.dev/editor-api/browser';
@@ -123,18 +123,18 @@ await context.sync(); // one transaction; editor Undo restores both threads
 ```
 
 Browser deletion requires the Pro review module and a writable, attached editor. The server runtime
-supports the same object-model calls without a browser module. Creation remains intentionally absent.
+supports the same object-model calls without a browser module. This section covers deletion only.
 
 ## Programming model
 
 - Reading a property you did not `load()` throws. This catches typos before they affect later writes.
-- Navigation-property expansion is not supported yet. A non-empty `LoadQueryOptions.expand` is
+- Navigation-property expansion is not supported. A non-empty `LoadQueryOptions.expand` is
   rejected with `InvalidArgument`; load the navigation object or collection explicitly instead.
 - `sync()` is the only round trip. Everything queued between two syncs is one ordered transaction. If any operation in it is refused, none of them happened.
-- Objects are proxies into a document the runtime owns. They survive `sync()` calls within one
+- Objects are proxies into a document the runtime owns. They remain valid across `sync()` calls within one
   `run`. To carry one into a later `run`, track it and pass it to
-  `runtime.run(object, callback)` for adoption. No proxy survives `dispose()`.
-- `getFirstOrNullObject` and `getLastOrNullObject` answer an object whose `isNullObject` is `true` after the sync, which is the difference between "no such heading" and a crash.
+  `runtime.run(object, callback)` for adoption. No proxy remains valid after `dispose()`.
+- `getFirstOrNullObject` and `getLastOrNullObject` return an object whose `isNullObject` is `true` after the sync, which is the difference between an absent heading and a thrown error.
 
 For content-control writes, load `isBound` with the other properties and skip controls where it is
 true. That boolean is safe preflight metadata, not a write guarantee: `sync()` always checks the
@@ -156,7 +156,7 @@ module registration, editing mode, and document state can change.
 
 Both export the same vocabulary (the lifecycle types, the object model, the error type) so consumer code compiles against either. They differ by one member: `createBrowser`.
 
-## Building an AI feature on this
+## Integrate with an application model
 
 This package ships no model integration, tool catalog or chat UI. The application that owns the
 model defines which operations to expose, how to describe them and how to handle refusals. A tool
@@ -290,7 +290,7 @@ and insert after the phrase.
 
 ## License
 
-This package is not Apache 2.0 like the editor packages. It is licensed under the [EigenPal Pro Evaluation License 1.0](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/LICENSE.md), which lets you read, run and modify it internally, free of charge, to evaluate it. Browser comment replies and deletions additionally require the separately installed Pro review module, which carries the same evaluation-only production boundary. Production use (a live or customer-facing environment, live or business-operational data, or either package inside something you offer to others) requires a written commercial agreement, and so does redistribution. Commercial licensing: [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
+This package is not Apache 2.0 like the editor packages. It is licensed under the [EigenPal Pro Evaluation License 1.0](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/LICENSE.md), which lets you read, run and modify it internally, free of charge, to evaluate it. Browser comment replies and deletions additionally require the separately installed Pro review module, which carries the same evaluation-only production boundary. Production use (a live or customer-facing environment, live or business-operational data, or either package inside a product you distribute to customers) requires a written commercial agreement, and so does redistribution. Commercial licensing: [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
 
 ## Next steps
 

--- a/docs/site/content/editor-api/office-js-api.mdx
+++ b/docs/site/content/editor-api/office-js-api.mdx
@@ -7,9 +7,9 @@ order: 53
 
 `@docx-editor.dev/editor-api` implements an Office.js-compatible object model.
 `context.document.body.paragraphs`, `load()` then `sync()`, `search(text, options)`,
-`getFirstOrNullObject()` and `isNullObject` are the same members you already write. To port Word
-add-in code, change how the batch opens, then read the divergences below: a few of them cost your
-batch an extra `sync()`.
+`getFirstOrNullObject()` and `isNullObject` are the same members as Office.js Word add-in code. To
+port Word add-in code, change how the batch opens, then read
+[Divergences](#divergences): some divergences require one extra `sync()` per batch.
 
 ## Compatibility boundaries
 
@@ -18,7 +18,7 @@ batch an extra `sync()`.
   callback uses the same object model.
 - This repository authors every public type. The package does not vendor, copy or generate code
   from Microsoft's declarations.
-- The API implements the subset listed below.
+- The API implements the subset in [What is implemented](#what-is-implemented).
 
 ## How compatibility is verified
 
@@ -40,13 +40,13 @@ reference declarations, and the published package contains no reference data.
 The document, its body, paragraphs, ranges and the collections over them; search with `matchCase` / `matchWholeWord`; character formatting through `font`; paragraph formatting (style, alignment, indents, spacing); lists and list items; bookmarks; sections and page setup; footnotes and endnotes; comments with replies and a resolved flag; revisions with accept and reject, individually or all at once; and content controls, addressed by id, tag or title.
 
 The lifecycle around them carries over unchanged: `load()` declares reads, `sync()` is the only
-round trip, and `getFirstOrNullObject` / `getLastOrNullObject` answer an object rather than throwing.
-A proxy survives every `sync()` inside the `run` that created it. To use it in a later `run`, add it
-to `context.trackedObjects`, return it, then adopt it with `runtime.run(object, callback)`. A proxy
-that is not tracked is released when its `run` ends.
+round trip, and `getFirstOrNullObject` / `getLastOrNullObject` return an object rather than throwing.
+A proxy remains valid across every `sync()` inside the `run` that created it. To use it in a later
+`run`, add it to `context.trackedObjects`, return it, then adopt it with
+`runtime.run(object, callback)`. A proxy that is not tracked is released when its `run` ends.
 
 `LoadQueryOptions.expand` remains in the public type for source compatibility, but navigation-property
-expansion is not supported yet. A non-empty `expand` is rejected immediately with
+expansion is not supported. A non-empty `expand` is rejected immediately with
 `InvalidArgument` targeting the object's `.expand` option; omit it or pass `expand: []`. Load a
 navigation object or collection explicitly and sync it in the usual way.
 
@@ -63,7 +63,7 @@ structured story for traversal and edits.
 
 In a browser runtime, `Range.select()` and `Bookmark.select()` also navigate the editor viewport to
 the selected content, matching Word's contract. Selection capability is the only preflight required:
-each operation owns its reveal and verifies selection again at `sync()`. The reveal uses paginated
+each operation performs its own reveal and verifies selection again at `sync()`. The reveal uses paginated
 layout coordinates, so it works when the target page is virtualized and has no painted element yet.
 A server runtime refuses either `select()` with `NotSupported` because it has no reader or viewport.
 
@@ -168,7 +168,7 @@ The following APIs are absent from the public types, so code that uses them fail
 
 - `ContentControl.id` is a string because DOCX files can repeat or omit the value.
 - `ContentControl.subtype` reports the file format's terms.
-- An item accessor answers an object that is not usable yet. `getFirst()`, `getLast()` and their
+- An item accessor returns an object that is not usable yet. `getFirst()`, `getLast()` and their
   `OrNullObject` forms need one `await context.sync()` before you can load or write through the
   object they return. Which object it is comes back from a read, and a batch has to name its targets
   before it is sent, so resolving it in place would mean several round trips per `sync()`. Using it
@@ -188,7 +188,7 @@ The following APIs are absent from the public types, so code that uses them fail
 - A collection loads its items, not their properties. `paragraphs.load('text')` and
   `paragraphs.load('items/text')` are refused with `InvalidArgument`. Load the collection, sync, then
   load what you want from the items, for the same reason: the items are not addressable until the
-  first read has answered.
+  first read returns.
 
   ```ts
   const paragraphs = context.document.body.paragraphs;
@@ -209,9 +209,9 @@ document and still refuses a bound control if the file changed after `isBound` w
 ## Migrating an add-in
 
 1. Replace `Word.run(async (context) => { … })` with a runtime you construct: `DocxEditor.createServer(bytes, { author })` on a server, `DocxEditor.createBrowser(editor, { author })` in a page when the script replies to comments. The callback body is the part that stays the same.
-2. Expect the same load/sync discipline you already write. Reads still have to be declared, and a property you did not load still fails.
-3. Add the syncs the divergences above describe. The statements stay the same; a batch that reaches an item accessor or a collection's item properties needs one more round trip than it does in an add-in.
-4. Check the omissions above. If your add-in walks tables or inserts pictures, that work has no equivalent here yet.
+2. Expect the same load/sync discipline as Office.js Word add-in code. Reads still have to be declared, and a property you did not load still fails.
+3. Add the syncs that [Divergences](#divergences) describe. The statements stay the same; a batch that reaches an item accessor or a collection's item properties needs one more round trip than it does in an add-in.
+4. Check [Omissions](#omissions). If your add-in walks tables or inserts pictures, that work has no equivalent in this API.
 
 ## Next steps
 

--- a/docs/site/content/examples.mdx
+++ b/docs/site/content/examples.mdx
@@ -40,11 +40,11 @@ To use published packages, replace the `workspace:*` versions in the starter's `
 
 <Cards>
   <Card
-    title="Happy path"
+    title="Packaged editor"
     href="https://github.com/eigenpal/docx-editor/tree/main/examples/happy-path"
   >
-    Use the packaged `<DocxEditor>` component in one file. The host adds New, Open, Save, and two
-    lines for the review rail.
+    Use the packaged `<DocxEditor>` component in one file. The host adds New, Open, Save, and a
+    minimal review-rail host.
   </Card>
   <Card title="Vite + React" href="https://github.com/eigenpal/docx-editor/tree/main/examples/vite">
     Build a Vite and React single-page app. This starter includes composed controls, the review
@@ -67,7 +67,7 @@ To use published packages, replace the `workspace:*` versions in the starter's `
     Render the editor as a React island. The client:only="react" directive disables SSR for the
     component.
   </Card>
-  <Card title="🧊 Igloo" href="https://igloo.docx-editor.dev/">
+  <Card title="Igloo" href="https://igloo.docx-editor.dev/">
     Build a themed editor. Host markup and hooks replace the packaged controls. This card opens the
     deployed demo. Its source is in `examples/igloo`.
   </Card>
@@ -82,8 +82,8 @@ To use published packages, replace the `workspace:*` versions in the starter's `
     title="Headless editing"
     href="https://github.com/eigenpal/docx-editor/tree/main/examples/automation"
   >
-    Fill a template without a browser or framework. The browser entry can also edit an open
-    document.
+    Fill a template without a browser or framework. The browser entry can also edit a mounted
+    editor document.
   </Card>
   <Card title="Agent" href="https://github.com/eigenpal/docx-editor/tree/main/examples/agent">
     Use a large language model (LLM) to read an open document and add anchored comments. Tool calls

--- a/docs/site/content/frameworks/astro.mdx
+++ b/docs/site/content/frameworks/astro.mdx
@@ -5,7 +5,7 @@ category: 'Frameworks'
 seoTitle: 'Astro DOCX editor setup'
 ---
 
-By the end of this page you have an Astro page that mounts the editor as a React island, opens a `.docx` from disk, and downloads the edited result.
+This guide shows an Astro page that mounts the editor as a React island, opens a `.docx` from disk, and downloads the edited result.
 
 ## Install
 
@@ -14,7 +14,7 @@ npm install @docx-editor.dev/react @docx-editor.dev/core
 npx astro add react
 ```
 
-`astro add react` wires `@astrojs/react` into `astro.config.mjs` for you.
+`astro add react` adds `@astrojs/react` to `astro.config.mjs`.
 
 ## Mount the editor
 
@@ -83,7 +83,7 @@ export function Editor() {
 
 ## Why this pattern
 
-`client:only="react"` is the key directive. `client:load` would still server-render the component once to produce static HTML, and the editor crashes on `window` during that pass. `client:only` skips SSR for the island entirely and renders it in the browser only. The rest of the page stays zero-JS static HTML.
+`client:only="react"` is required. `client:load` would still server-render the component once to produce static HTML, and SSR throws when `window` is undefined during that pass. `client:only` skips SSR for the island entirely and renders it in the browser only. The rest of the page stays zero-JS static HTML.
 
 Styles need no extra setup: the stylesheet import sits inside the island component, and Astro's Vite pipeline bundles CSS imported from `client:only` components like any other module.
 
@@ -103,5 +103,5 @@ bun run dev:astro   # http://localhost:4321
 
 - [Quickstart](/docs/2.x/quickstart): the load, edit, save flow in detail
 - [Loading and saving](/docs/2.x/guides/loading-and-saving): URLs, autosave, upload to your API
-- [Astro DOCX editor guide](/blog/astro-docx-editor): the long-form walkthrough
+- [Astro DOCX editor guide](/blog/astro-docx-editor): the detailed walkthrough
 - [Astro example on GitHub](https://github.com/eigenpal/docx-editor/tree/main/examples/astro)

--- a/docs/site/content/frameworks/nextjs.mdx
+++ b/docs/site/content/frameworks/nextjs.mdx
@@ -5,7 +5,7 @@ category: 'Frameworks'
 seoTitle: 'Next.js DOCX editor setup'
 ---
 
-By the end of this page you have an App Router route that opens a `.docx` from disk, edits it in the browser, and downloads the result as a `.docx`.
+This guide shows an App Router route that opens a `.docx` from disk, edits it in the browser, and downloads the result as a `.docx`.
 
 ## Install
 
@@ -15,7 +15,7 @@ npm install @docx-editor.dev/react @docx-editor.dev/core
 
 ## Mount the editor
 
-Two files. The route stays a thin client shell; the editor itself lives in a separate component loaded with `dynamic()` and `ssr: false`. This is the structure of [`examples/nextjs`](https://github.com/eigenpal/docx-editor/tree/main/examples/nextjs).
+Two files. The route stays a client route shell; the editor itself loads from a separate component with `dynamic()` and `ssr: false`. This is the structure of [`examples/nextjs`](https://github.com/eigenpal/docx-editor/tree/main/examples/nextjs).
 
 ```tsx
 // app/page.tsx
@@ -115,5 +115,5 @@ bun run dev:nextjs   # http://localhost:3000
 
 - [Quickstart](/docs/2.x/quickstart): the load, edit, save flow in detail
 - [Loading and saving](/docs/2.x/guides/loading-and-saving): URLs, autosave, upload to your API
-- [Next.js DOCX editor guide](/blog/nextjs-docx-editor): the long-form walkthrough
+- [Next.js DOCX editor guide](/blog/nextjs-docx-editor): the detailed walkthrough
 - [Next.js example on GitHub](https://github.com/eigenpal/docx-editor/tree/main/examples/nextjs)

--- a/docs/site/content/frameworks/remix.mdx
+++ b/docs/site/content/frameworks/remix.mdx
@@ -5,7 +5,7 @@ category: 'Frameworks'
 seoTitle: 'Remix DOCX editor setup'
 ---
 
-This page builds a Remix route that loads a `.docx`, keeps SSR and hydration intact, and downloads the edited file.
+This guide shows a Remix route that loads a `.docx`, keeps SSR and hydration intact, and downloads the edited file.
 
 ## Install
 
@@ -84,9 +84,9 @@ export function Editor() {
 
 ## Why this pattern
 
-The pattern solves two problems, one per half:
+The pattern solves two problems, one for SSR hydration and one for bundling:
 
-- The `mounted` guard renders the same loading markup on the server and on the first client paint, so hydration never mismatches. Without it the editor would try to render during SSR and crash on `window`.
+- The `mounted` guard renders the same loading markup on the server and on the first client paint, so hydration never mismatches. Without it, SSR would evaluate the editor and throw when `window` is undefined.
 - `lazy()` keeps the editor bundle out of the server build and out of the route's initial chunk.
 
 ## Run the example
@@ -105,5 +105,5 @@ bun run dev:remix   # http://localhost:3001
 
 - [Quickstart](/docs/2.x/quickstart): the load, edit, save flow in detail
 - [Loading and saving](/docs/2.x/guides/loading-and-saving): URLs, autosave, upload to your API
-- [Remix DOCX editor guide](/blog/remix-docx-editor): the long-form walkthrough
+- [Remix DOCX editor guide](/blog/remix-docx-editor): the detailed walkthrough
 - [Remix example on GitHub](https://github.com/eigenpal/docx-editor/tree/main/examples/remix)

--- a/docs/site/content/frameworks/vite.mdx
+++ b/docs/site/content/frameworks/vite.mdx
@@ -5,7 +5,7 @@ category: 'Frameworks'
 seoTitle: 'Vite DOCX editor setup'
 ---
 
-This page builds the open-edit-download flow in a Vite + React app. Vite is client-rendered, so there is no SSR boundary to set up.
+This guide shows an open-edit-download flow in a Vite + React app. Vite is client-rendered, so there is no SSR boundary to set up.
 
 ## Install
 
@@ -76,7 +76,7 @@ export function App() {
 
 `document` and `save()` work as described in the [Quickstart](/docs/2.x/quickstart); the only Vite-specific fact is that there is no SSR boundary to manage.
 
-The full example goes further: composed chrome, the review sidebar and a custom node. See [`examples/vite`](https://github.com/eigenpal/docx-editor/tree/main/examples/vite) in the repo. For an LLM driving the editor, see [`examples/agent`](https://github.com/eigenpal/docx-editor/tree/main/examples/agent).
+The full example also includes composed chrome, the review sidebar, and a custom node. See [`examples/vite`](https://github.com/eigenpal/docx-editor/tree/main/examples/vite) in the repo. For agent-driven editing, see [`examples/agent`](https://github.com/eigenpal/docx-editor/tree/main/examples/agent).
 
 ## Run the example
 
@@ -93,5 +93,5 @@ bun run dev:react   # http://localhost:5173
 
 - [Quickstart](/docs/2.x/quickstart): the load, edit, save flow in detail
 - [Loading and saving](/docs/2.x/guides/loading-and-saving): URLs, autosave, upload to your API
-- [Vite DOCX editor guide](/blog/vite-docx-editor): the long-form walkthrough
+- [Vite DOCX editor guide](/blog/vite-docx-editor): the detailed walkthrough
 - [Vite example on GitHub](https://github.com/eigenpal/docx-editor/tree/main/examples/vite)

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -5,7 +5,7 @@ category: 'Guides'
 seoTitle: 'Content controls (SDTs)'
 ---
 
-Word content controls (`w:sdt`, Structured Document Tags) are labeled, bounded regions of a document. A control carries a stable `tag`, `title`, and `id`. That stability makes them the natural anchor for templates and programmatic filling: design the template in Word, tag the fillable regions, then fill them by tag from code.
+Word content controls (`w:sdt`, Structured Document Tags) are labeled, bounded regions of a document. A control carries a stable `tag`, `title`, and `id`. Use those identifiers as addresses for templates and programmatic filling: design the template in Word, tag the fillable regions, then fill them by tag from code.
 
 The editor parses controls into the canonical tree, keeps them editable, renders their boundary, and round-trips them with structural fidelity. Properties it does not model, such as `w:dataBinding` and `w15:repeatingSection`, remain as generic nodes and survive editing and save.
 
@@ -140,7 +140,7 @@ The inspector state carries `tag`, `alias`, `id`, `controlType`, `locked`, `remo
 
 `showAll` / `setShowAll` toggles boundary rendering for every control, and `formFill` / `setFormFill` puts the document into fill-only mode, where the caret can enter controls but not the text around them. The packaged `ContentControl` part is the inspector panel over exactly this API, and `CONTENT_CONTROL_SLOTS` lists the matching chrome slot ids.
 
-A data-bound control refuses a direct write: its content comes from the Custom XML store, so writing it here would not persist in Word. `setValueDisabledReason` says so rather than failing silently.
+A data-bound control rejects a direct write: its content comes from the Custom XML store, so writing it here would not persist in Word. `setValueDisabledReason` reports the reason instead of dropping the write.
 
 ## Creating a control in the editor
 
@@ -204,7 +204,7 @@ function insertField() {
 </FrameworkTabs>
 
 `tag` is the identity you look the control back up by, and `title` is the label Word shows. An
-empty control holds its prompt until somebody types: the first character replaces the whole
+empty control holds its prompt until the user types: the first character replaces the whole
 prompt, the way it does in Word.
 
 To address text other than the selection, pass a `target` that names a paragraph by its
@@ -221,12 +221,12 @@ editor.exec({
 
 You can author `richText`, `plainText`, `dropdown` (also spelled `dropDownList`, as OOXML
 spells it), `comboBox`, and `date` controls. Checkbox, picture, and repeating-section controls
-carry content an insertion would have to invent, so they aren't authored here. A dropdown or
+carry content an insertion would have to invent, so they are not authored here. A dropdown or
 combo box starts with no items: add them in Word, or design the template there and fill it
 from code.
 
 `editor.can()` answers the same refusal `exec` would, so a button can disable itself and show
-the reason. The command refuses rather than guessing when:
+the reason. The command rejects the operation when:
 
 - The selection crosses two paragraphs. A control over several paragraphs is a block wrapper,
   which is a different element.
@@ -235,7 +235,7 @@ the reason. The command refuses rather than guessing when:
 
 ## Typed control chrome
 
-In the editor, typed controls get an interactive trigger at the top-right of their box: it toggles the checkbox, opens the dropdown's item menu, or opens a date picker, each as a normal undoable edit. No wiring required.
+In the editor, typed controls get an interactive trigger at the top-right of their box: it toggles the checkbox, opens the dropdown's item menu, or opens a date picker, each as a normal undoable edit. These controls work without host event handlers.
 
 ## Current limits
 

--- a/docs/site/content/guides/custom-styles.mdx
+++ b/docs/site/content/guides/custom-styles.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Custom styles & branding'
-description: 'Use a branded DOCX template to control headings, fonts, and table styles. Documents inherit your styles automatically and preserve them when saved.'
+description: 'Use a branded DOCX template to control headings, fonts, and table styles. Documents inherit your styles from the template and preserve them when saved.'
 category: 'Guides'
 seoTitle: 'Custom styles, fonts, and branded DOCX templates'
 ---
 
-Load a styled `.docx` template to give documents your branding. The editor uses the styles defined in the document itself (headings, fonts, colors, spacing, and table styles) and preserves them when users save.
+Load a styled `.docx` template to apply your styles and fonts from a template. The editor uses the styles defined in the document itself (headings, fonts, colors, spacing, and table styles) and preserves them when users save.
 
 Templates can define:
 
@@ -14,7 +14,7 @@ Templates can define:
 - Fonts and themes
 - Table styles and the default table style
 
-Any content users create or insert inherits those styles automatically.
+Any content users create or insert inherits those styles from the document style definitions.
 
 ## Quick start
 

--- a/docs/site/content/guides/dark-mode.mdx
+++ b/docs/site/content/guides/dark-mode.mdx
@@ -5,11 +5,11 @@ category: 'Guides'
 seoTitle: 'Dark mode'
 ---
 
-The editor ships a native dark mode. One prop, `colorMode`, themes the whole UI and renders the document the way Word's dark view does.
+Set `colorMode` to theme the chrome and document canvas the way Word's dark view does.
 
 ## Enabling dark mode
 
-`colorMode` is a controlled prop. There is no internal toggle button; you set the value and the editor follows it.
+`colorMode` is a controlled prop. There is no internal toggle button; you set the value and the editor uses that value.
 
 | Value      | Behavior                                                                                             |
 | ---------- | ---------------------------------------------------------------------------------------------------- |
@@ -36,7 +36,7 @@ The editor ships a native dark mode. One prop, `colorMode`, themes the whole UI 
 
 ## Toggling from your own UI
 
-Wire `colorMode` to your own control: a switch, a settings menu, a segmented button. The editor re-themes instantly when the value changes.
+Wire `colorMode` to your own control: a switch, a settings menu, a segmented button. The editor applies the new theme when the value changes.
 
 <FrameworkTabs>
 <Framework value="react">
@@ -79,7 +79,7 @@ To follow the operating system instead, pass `colorMode="system"`.
 Dark mode has two layers:
 
 - **Editor chrome** (toolbar, title bar, dialogs, dropdowns, sidebar, menus) re-themes through the shared design tokens, so every surface tracks the theme.
-- **The document canvas** is rendered like Word's dark view: the page turns dark and text turns light. Rather than swapping two fixed colors, the canvas applies a perceptual transform that inverts each authored color's lightness while preserving its hue: black body text becomes near-white, a dark-navy heading becomes light blue, a dark red stays red. Nothing on the page becomes unreadable.
+- **The document canvas** is rendered like Word's dark view: the page turns dark and text turns light. Rather than swapping two fixed colors, the canvas applies a perceptual transform that inverts each authored color's lightness while preserving its hue: black body text becomes near-white, a dark-navy heading becomes light blue, a dark red stays red. Authored colors keep contrast under the lightness transform.
 
 It is a display transform only. Dark mode never changes the document itself:
 
@@ -91,7 +91,7 @@ The light theme is unchanged when `colorMode` is `'light'`.
 
 ## Reporting issues
 
-Dark mode covers a large surface, and the canvas transform is heuristic. If you find a control that doesn't theme correctly, text that's hard to read, or a color that transforms badly, please open an issue at [github.com/eigenpal/docx-editor/issues](https://github.com/eigenpal/docx-editor/issues). Mention `colorMode` and include a screenshot.
+Dark mode covers chrome and the document canvas, and the canvas transform is heuristic. If a control does not use the theme correctly, open an issue at [GitHub issues](https://github.com/eigenpal/docx-editor/issues). Also report text with low contrast or colors that transform incorrectly. Mention `colorMode` and include a screenshot.
 
 ## Next steps
 

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -6,7 +6,7 @@ seoTitle: 'Fonts and text measurement'
 ---
 
 The editor measures text with a real shaping engine (HarfBuzz) whenever it has font
-bytes to measure with. With no fonts at all it still works: layout falls back to a
+bytes to measure with. With no fonts, the editor still opens: layout falls back to a
 fixed-width estimate, but wrap and page-break points are then approximations rather
 than Word's. This guide covers the three ways fonts reach the editor, the two ways of
 timing them, and how they combine.
@@ -16,7 +16,7 @@ timing them, and how they combine.
 **1. Fonts embedded in the document, automatic.** A `.docx` can carry the faces it was
 written in. When it does, the editor extracts them on load and measures with them. No
 configuration, no assets, no network: a document that brings its own fonts is
-Word-accurate out of the box, in metrics and in pixels. The editor also registers the
+Word-accurate without extra font configuration, in metrics and in pixels. The editor also registers the
 embedded bytes with the browser so the painted pages show the real glyphs, not a platform
 substitute.
 
@@ -25,9 +25,9 @@ declares. A `.docx` controls its own font names, and the browser's font registry
 page-wide, so registering a document's `Segoe UI` would repaint your application's own
 buttons and dialogs with glyphs from that file.
 
-**2. Metric-compatible substitutes, one call.** Most documents use Word's default
+**2. Metric-compatible substitutes via `loadDefaultFonts`.** Most documents use Word's default
 fonts (Calibri, Cambria, Times New Roman, Arial, Courier New), which are proprietary
-and cannot be bundled. The optional `@docx-editor.dev/fonts` package ships open-licensed
+and cannot be bundled. The optional `@docx-editor.dev/fonts` package provides open-licensed
 faces built to match their metrics: identical advance widths, so lines wrap where Word
 wraps them:
 
@@ -127,7 +127,7 @@ Importing the package fetches nothing.
 
 **3. Your own fonts, explicit URLs.** For brand fonts or licensed copies of the real
 faces, `loadFonts` fetches URLs you specify and caches them locally. When you pin a
-`sha256:` hash it gates admission hard. Pin it for any URL not under your sole
+`sha256:` hash it rejects the bytes when the hash does not match. Pin it for any URL not under your sole
 control:
 
 ```ts
@@ -153,8 +153,8 @@ const fonts = composeFontConfiguration(brand, await loadDefaultFonts());
 `loadFonts` never rejects for a single bad source: it returns the admitted sources plus
 a typed `failures` list, so the editor can open with partial coverage.
 
-You never have to compute a hash by hand. Pins are optional: omit `hash` for URLs on
-your own origin and `loadFonts` computes one for you. When you do want to pin a
+You do not need to supply a hash. Pins are optional: omit `hash` for URLs on
+your own origin and `loadFonts` computes one. When you do want to pin a
 third-party URL, run it once without a pin and read the values back off the result:
 
 ```ts
@@ -165,8 +165,8 @@ console.log(result.sources.map((source) => `${source.id}: ${source.hash}`));
 Paste those into your source list (or generate the list at build time, which is how
 `@docx-editor.dev/fonts` bakes the hashes for its own assets).
 
-Already hold the bytes, from a file input, IndexedDB, or a bundler import? `createFontSource`
-turns them into a source directly, with the hash computed for you. It returns a typed
+If you already have font bytes from a file input, IndexedDB, or a bundler import, `createFontSource`
+turns them into a source directly, with the hash computed. It returns a typed
 failure rather than throwing when the descriptor or the bytes are unusable:
 
 ```ts
@@ -255,8 +255,8 @@ const fonts = useFonts(async ({ families, defaultFamily }) => {
 </Callout>
 
 `useFonts` exists because the editor root rebuilds its instance when `fonts` changes
-identity. An inline resolver is a new function on every render, which would rebuild the
-editor forever. `useFonts` returns one resolver for the component's life. It also merges
+identity. An inline resolver is a new function on every render, which rebuilds the
+editor on every render. `useFonts` returns one resolver for the component's life. It also merges
 origins, so on-demand and upfront faces compose:
 
 ```ts
@@ -296,7 +296,7 @@ measuring accurately.
 Font errors reach you as `onFontError` on the React root, as the `@font-error` emit on
 the Vue root, and as an option on `createDocxEditor`. Each error carries a typed `code`
 (`missing`, `malformed`, `overLimit`, `hashMismatch`, …) and, where known, the face
-`request` it concerns. To answer "am I measuring Word-accurately right now?", read
+`request` it concerns. To check whether measurement uses shaped fonts, read
 `fontMeasurement()` on the editor instance:
 
 <FrameworkTabs>
@@ -351,11 +351,11 @@ usable font source; `resolving: true` means shaped resolution is still in flight
 
 ## Serving the shaper's WASM yourself
 
-The text shaper is a WASM binary that ships inside `@docx-editor.dev/core` and
+The text shaper is a WASM binary included in `@docx-editor.dev/core` and
 loads lazily when fonts resolve. Webpack, Turbopack, and Vite emit it as an
-asset automatically, so most apps need no setup.
+asset automatically, so those bundlers need no extra setup for this asset.
 
-Some bundlers don't emit `new URL(..., import.meta.url)` assets. esbuild and Bun
+Some bundlers do not emit `new URL(..., import.meta.url)` assets. esbuild and Bun
 are the common ones, and so is any build that inlines dynamic imports, such as a
 library bundle. Those builds succeed and then fail at runtime, reaching
 `onFontError` as an `EditorFontError` with code `wasmUnavailable`:
@@ -410,7 +410,7 @@ await copyFile(
 );
 ```
 
-Re-run that step on every upgrade. The shaper refuses a binary from a different
+Re-run that step on every upgrade. The shaper rejects a binary from a different
 version, so a stale copy fails the same way a missing one does.
 
 Call `setHarfBuzzWasmUrl` before the first editor. The shaper reads the location
@@ -425,11 +425,11 @@ configuration. Serving it from another origin needs that origin in your
 either way.
 
 Serve the copy from the installed package version. The shaper compares the
-HarfBuzz library version it loads against the one it was built for, and refuses a
+HarfBuzz library version it loads against the one it was built for, and rejects a
 mismatch instead of measuring text with unverified metrics.
 
 Because the shaper is bundled into the package, an npm `overrides` entry for
-`harfbuzzjs` doesn't change the code that runs. Upgrade `@docx-editor.dev/core`
+`harfbuzzjs` does not change the code that runs. Upgrade `@docx-editor.dev/core`
 instead.
 
 ## Caveats

--- a/docs/site/content/guides/headers-footers.mdx
+++ b/docs/site/content/guides/headers-footers.mdx
@@ -21,13 +21,13 @@ Press Escape or click the close action to save and leave header/footer editing.
 
 ## PAGE and NUMPAGES fields
 
-Page-number fields are stored as real Word fields, not static text. The page view renders the resolved value on each page (page 3 of a 10-page document shows "3" and "10"), values update as the document reflows, and the fields round-trip to OOXML so Word keeps them live.
+Page-number fields are stored as real Word fields, not static text. The page view renders the resolved value on each page (page 3 of a 10-page document shows "3" and "10"), values update as the document reflows, and the fields round-trip to OOXML so Word continues to evaluate them as fields.
 
 A "Page X of Y" footer is the two inserts with literal text between them: type the text "Page ", insert the page number, type " of " with the surrounding spaces, insert the total page count.
 
 ## Per-section headers and footers
 
-The OOXML model attaches header and footer references to sections, and the editor honors it:
+The OOXML model attaches header and footer references to sections, and the editor implements that model:
 
 - Each section can reference `default`, `first`, and `even` header and footer parts (`w:headerReference` / `w:footerReference`).
 - **Different first page** (`w:titlePg`) shows the `first` variant on a section's first page. Typical use: no header on a title page.
@@ -42,7 +42,7 @@ Watermarks live in header parts (that is how Word models them). Their VML or
 DrawingML markup and image payloads are preserved through editing and save.
 
 Dedicated watermark rendering, insertion, editing, and headless authoring are not
-supported yet. Existing watermarks remain inert rather than being dropped.
+supported. Existing watermarks remain inert rather than being dropped.
 
 ## Next steps
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -5,7 +5,7 @@ category: 'Guides'
 seoTitle: 'Images and floating pictures'
 ---
 
-DrawingML pictures (`w:drawing` with `pic:pic`) lay out, paint, and round-trip through the engine. Both adapters ship insert, wrap, properties, alt text, and selection-overlay authoring.
+DrawingML pictures (`w:drawing` with `pic:pic`) lay out, paint, and round-trip through the engine. Both adapters provide insert, wrap, properties, alt text, and selection-overlay authoring.
 
 ## Supported formats
 
@@ -17,7 +17,7 @@ DrawingML pictures (`w:drawing` with `pic:pic`) lay out, paint, and round-trip t
 | TIFF, EMF, WMF                              | No insert                            | Rasterized when conversion succeeds; labeled placeholder otherwise | Preserved; no zero-click fetch            |
 | External `r:link` / `TargetMode="External"` | No auto-load                         | Placeholder + preserved rel                                        | Preserved; explicit user gesture to embed |
 
-Insert accepts PNG/JPEG/GIF only. Other payloads stay in the package and participate in pagination through their authored extent.
+Insert accepts PNG/JPEG/GIF only. Other payloads stay in the package and affect pagination through their authored extent.
 
 BMP and WebP decode in the browser and paint like PNG or JPEG. BMP support includes top-down
 bitmaps and the 12-byte `BITMAPCOREHEADER`. WebP support includes lossy, lossless, and extended
@@ -30,7 +30,7 @@ image keeps its extent and shows a labeled placeholder.
 SVG is painted through an `<img>`, which puts the browser in secure static mode: scripts in the
 file never run and external references in it are never fetched. Its intrinsic size is read from
 `width`/`height`/`viewBox` for reset-to-natural-size; layout always uses the authored `wp:extent`.
-An SVG whose root element cannot be read renders as a placeholder rather than being guessed at.
+An SVG whose root element cannot be read renders as a placeholder rather than inferring missing dimensions.
 
 ## Reading selection state
 
@@ -148,7 +148,7 @@ Partially rendered:
 
 Preserved inertly:
 
-- VML (`w:pict`); watermark rendering and editing remain planned
+- VML (`w:pict`); watermark rendering and editing are not supported
 - `w:object` / `w:altChunk`: generic preservation with diagnostics
 - Tracked-change accept/reject on drawings
 

--- a/docs/site/content/guides/loading-and-saving.mdx
+++ b/docs/site/content/guides/loading-and-saving.mdx
@@ -5,7 +5,7 @@ category: 'Guides'
 seoTitle: 'Loading and saving DOCX documents'
 ---
 
-The editor takes a `.docx` file in and gives a `.docx` file back. Everything happens client-side: no upload, no conversion service.
+The editor accepts `.docx` data and serializes the edited document to `.docx`. Load and save run in the browser. The editor does not upload or convert through a service.
 
 ## Input formats
 
@@ -52,7 +52,7 @@ Paragraph.
 </Framework>
 </FrameworkTabs>
 
-Omitting `document` is not the same thing. It means no document at all, so the editor shows
+Omitting `document` differs from `'blank'`. It means no document at all, so the editor shows
 its loading screen and every control stays disabled. Use `undefined` only while your own
 fetch is still running.
 
@@ -237,7 +237,7 @@ editorRef.value?.load(nextBytes);
 
 ## Saving
 
-Two paths matter:
+Use one of these save paths:
 
 - `save()` on the ref returns `Promise<ArrayBuffer | null>`
 - The packaged File → Save action, which you override with `onSave` in React and the
@@ -345,7 +345,7 @@ onBeforeUnmount(() => {
 </Framework>
 </FrameworkTabs>
 
-Pick a debounce window that matches your backend's write tolerance. 1 to 2 seconds is a reasonable default.
+Pick a debounce window that matches your backend's write tolerance. Use a 1–2 second debounce unless your API requires another interval.
 
 ## Next steps
 

--- a/docs/site/content/guides/toolbar.mdx
+++ b/docs/site/content/guides/toolbar.mdx
@@ -11,7 +11,7 @@ The packaged host has two levels of chrome: a title bar (`title`, the title bar 
 
 ## Use the packaged chrome
 
-The fastest path is still the packaged host:
+Use the packaged host for the default chrome:
 
 <FrameworkTabs>
 <Framework value="react">
@@ -34,7 +34,7 @@ The fastest path is still the packaged host:
 </Framework>
 </FrameworkTabs>
 
-Use these root props to steer the packaged frame:
+Use these root props to configure the packaged frame:
 
 <FrameworkTabs variant="block">
 <Framework value="react">
@@ -67,7 +67,7 @@ Use these root props to steer the packaged frame:
 </Framework>
 </FrameworkTabs>
 
-## Drop to the provider primitives
+## Use the provider primitives
 
 When you want your own frame, use the same provider primitives the packaged host uses internally:
 
@@ -130,7 +130,7 @@ The root owns the editor instance, the viewport is the scroll container, and the
 
 ## Add root-level command buttons
 
-For small custom controls, reach the shared command API from the package root:
+For small custom controls, call the shared command API from the package root:
 
 <FrameworkTabs>
 <Framework value="react">
@@ -184,7 +184,7 @@ When the caret or a rectangular cell selection is inside a table, the formatting
 
 These controls target the **innermost** nested table under the pointer or selection. Merge and split remain unsupported; tables with merged cells refuse column resize/insert/delete with an explicit disabled reason.
 
-The [Igloo demo](https://igloo.docx-editor.dev/) 🧊 is a worked example of every point above: it hand-orders the bar, re-icons every packaged part, and adds two host actions. Its [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) is in the repository.
+The [Igloo demo](https://igloo.docx-editor.dev/) is a worked example of every point above: it hand-orders the bar, re-icons every packaged part, and adds two host actions. Its [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) is in the repository.
 
 ## Next steps
 

--- a/docs/site/content/guides/zoom.mdx
+++ b/docs/site/content/guides/zoom.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Zoom and fit to screen'
-description: 'Fit the document to the viewport, drive the zoom lifecycle from your own UI with useZoom, and let the comments pane shrink the page instead of hiding it.'
+description: 'Fit the document to the viewport, control zoom from your UI with useZoom, and let the comments pane shrink the page instead of covering it.'
 category: 'Guides'
 seoTitle: 'Zoom and fit to screen'
 ---
 
-The editor fits the page to its container by default. A window with room for the sheet renders at 100%; a narrower one shrinks the document instead of growing a horizontal scrollbar.
+The editor fits the page to its container by default. A container wide enough for the page renders at 100%. A narrower container shrinks the document instead of creating a horizontal scrollbar.
 
 ## The two modes
 
@@ -15,7 +15,7 @@ Zoom has a value and a mode. The value is the scale the pages paint at; the mode
 | ----------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `'auto'` (default)                  | Fit the page width, between 50% and 100%. Shrinks a page that does not fit, leaves one that does. |
 | `{ type: 'fit', fit: 'pageWidth' }` | Fit the page width in both directions, so a wide window magnifies the page.                       |
-| `{ type: 'fixed' }`                 | Hold whatever `zoom` is set to. This is the pre-fit behavior.                                     |
+| `{ type: 'fixed' }`                 | Hold whatever `zoom` is set to. This keeps a fixed scale (the behavior before fit modes).         |
 
 <FrameworkTabs>
 <Framework value="react">
@@ -41,13 +41,13 @@ Zoom has a value and a mode. The value is the scale the pages paint at; the mode
 
 Passing `zoom` on its own also means fixed, so an app that pinned a scale keeps it.
 
-A fit tracks the container. Resizing the window, opening the comments pane, docking the navigation pane: anything that changes the room beside the page changes the scale, in the engine, with nothing to wire up.
+Fit mode updates when the container size changes. Resizing the window, opening the comments pane, or docking the navigation pane changes the space beside the page. The engine updates the scale without additional host code.
 
-Setting a level ends the fit. That is what you want from a zoom control: a reader who picks 150% has said so, and a resize must not take it back.
+Setting a level ends the fit. A fixed zoom replaces fit mode. Container resize must not override an explicit scale.
 
 ## Driving it yourself
 
-`useZoom` is the whole lifecycle in one call.
+`useZoom` returns zoom state and controls in one hook.
 
 <FrameworkTabs>
 <Framework value="react">
@@ -108,21 +108,21 @@ read them with `.value` only in script code.
 | `setZoom(n)`              | A fixed scale. Leaves any fit.                                                            |
 | `setMode(m)`              | `'auto'`, a fit, or `{ type: 'fixed' }`.                                                  |
 | `auto()`, `fitToWidth()`  | The two fits, by name.                                                                    |
-| `reset()`                 | Back to a plain, untracked 100%.                                                          |
-| `zoomIn()`, `zoomOut()`   | Walk the preset ladder in `levels`.                                                       |
-| `canZoomIn`, `canZoomOut` | Whether there is a rung left in that direction.                                           |
+| `reset()`                 | Reset to fixed 100% zoom.                                                                 |
+| `zoomIn()`, `zoomOut()`   | Move to the next preset in `levels`.                                                      |
+| `canZoomIn`, `canZoomOut` | Whether a higher or lower preset remains.                                                 |
 
-Render the selected state from `mode`, not from `zoom`. A menu that ticks the level matching the percentage will light up "75%" while the editor is tracking the viewport and about to move off it.
+Render the selected state from `mode`, not from `zoom`. A menu that ticks the level matching the percentage marks "75%" as selected while fit mode still owns the scale.
 
 The packaged toolbar's zoom control already does all of this: **Automatic** and **Fit width** sit above the preset levels, and the tick follows the mode rather than the percentage.
 
-It ticks those two modes and the preset levels — the things it can put a reader into. A fit with bounds of your own is not one of them, so the menu shows the resolved percentage with nothing ticked, rather than lighting up a row that would silently replace your bounds when clicked.
+It ticks those two modes and the preset levels — the modes the menu can select. A fit with bounds of your own is not one of them, so the menu shows the resolved percentage with nothing ticked, rather than marking a preset that would replace custom fit bounds on click.
 
 ## Comments, and narrow screens
 
 The comments rail reserves a gutter beside the page. Under a fit that gutter comes out of the document's width, so opening comments shrinks the page rather than pushing it off screen: the two sit side by side and both stay readable.
 
-There is a width below which that stops helping. The rail takes a fixed 316px whether or not the container can spare it, so on a phone with comments open the page would be fitted into a sliver — a document nobody can read, to avoid a scrollbar nobody minds. So `'auto'` has a floor of 50%: below that the page keeps a legible size and the container scrolls sideways, which is the ordinary answer to "this does not fit".
+Below a container width, reserving the rail width no longer keeps the page readable. The rail takes a fixed 316px whether or not the container can spare it. On a phone with comments open, fit would shrink the page below a readable width. So `'auto'` has a floor of 50%: below that the page keeps a legible size and the container scrolls sideways, which matches the usual layout response when content exceeds the container.
 
 Set your own floor if 50% is not where you want it:
 
@@ -145,7 +145,7 @@ Set your own floor if 50% is not where you want it:
 
 ## Without an adapter
 
-Zoom lives in the engine, so every host reaches it the same way:
+Zoom APIs are on the engine. Every host calls the same methods:
 
 ```ts
 editor.setZoomMode('auto');

--- a/docs/site/content/i18n/contributing.mdx
+++ b/docs/site/content/i18n/contributing.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'Contributing a translation'
-description: 'Add a new editor language to @docx-editor.dev/i18n: scaffold the locale JSON, fill the strings, validate, and open a PR. Partial translations welcome.'
+description: 'Add a new editor language to @docx-editor.dev/i18n: scaffold the locale JSON, fill the strings, validate, and open a PR. Partial translations are accepted.'
 category: 'Reference'
 ---
 
-The editor UI ships in ten languages. Adding an eleventh is a single JSON file
+The editor UI ships in ten languages. To add another language, add one JSON file
 in the [monorepo](https://github.com/eigenpal/docx-editor).
 
 ## How locales work
@@ -27,8 +27,8 @@ bun run i18n:validate     # CI runs this; missing keys fail
 ```
 
 Use a BCP 47 code (`pl`, `pt-BR`, `zh-CN`). Open a PR with the filled JSON.
-Partial translations are fine: anything left `null` renders in English, so a
-locale can land incomplete and improve over time.
+Partial translations are valid: anything left `null` renders in English, so a
+locale can ship incomplete and improve over time.
 
 ## Fixing an existing locale
 

--- a/docs/site/content/i18n/index.mdx
+++ b/docs/site/content/i18n/index.mdx
@@ -13,7 +13,7 @@ Locale data for the editor UI. Both adapters consume it through the `i18n` prop.
 npm install @docx-editor.dev/i18n
 ```
 
-You usually don't install this directly. The adapter you install pulls it in transitively. Install it explicitly only when you're using the locale data outside the editor (a custom toolbar, a search dropdown, that kind of thing).
+You usually do not install this package directly. The adapter installs it as a transitive dependency. Install it explicitly only when you use locale data outside the editor, such as in a custom toolbar or search dropdown.
 
 ## Available locales
 
@@ -106,7 +106,7 @@ import { pl } from '@docx-editor.dev/i18n';
 </Framework>
 </FrameworkTabs>
 
-Either way the catalog merges over English, so a locale that has not translated every key falls back per key rather than per language. Providers nest: an inner one, or an `i18n` prop under an outer provider, overrides only the keys it names. Chrome you write from scratch reads the same catalog through `useTranslation()`:
+In both cases, the catalog merges over English, so a locale that has not translated every key falls back per key rather than per language. Providers nest: an inner one, or an `i18n` prop under an outer provider, overrides only the keys it names. Chrome you write from scratch reads the same catalog through `useTranslation()`:
 
 <FrameworkTabs>
 <Framework value="react">

--- a/docs/site/content/installation.mdx
+++ b/docs/site/content/installation.mdx
@@ -40,7 +40,7 @@ The other packages are the same for both adapters:
 # Commercially licensed: free to evaluate, production use needs an agreement
 npm install @docx-editor.dev/pro
 
-# Office.js-compatible editing API, on a server or beside an open editor
+# Office.js-compatible editing API, on a server or with an active editor instance
 # Commercially licensed: same terms
 npm install @docx-editor.dev/editor-api
 
@@ -100,7 +100,7 @@ Your app does not need Tailwind or an icon font.
 
 `document` accepts an `ArrayBuffer`, `Uint8Array`, `DocumentHandle`, or `'blank'`.
 Use `'blank'` for an empty document.
-If you omit `document`, the editor waits for document bytes.
+If you omit `document`, the editor stays idle until you pass document bytes.
 
 Meet these layout requirements in both adapters:
 

--- a/docs/site/content/pro/custom-nodes-reference.mdx
+++ b/docs/site/content/pro/custom-nodes-reference.mdx
@@ -8,7 +8,7 @@ order: 64
 The API surface of [custom nodes](/docs/2.x/pro/custom-nodes). Start with the guide if you have not
 built one yet.
 
-A node stores what it knows in two places:
+A node stores data in two places:
 
 | Location    | Holds               | Limit                                              |
 | ----------- | ------------------- | -------------------------------------------------- |
@@ -29,10 +29,10 @@ preserves both.
 
 ### Payload and text
 
-| Parameter | Type                                                       | Description                                                                                                  |
-| --------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `schema`  | zod (or any [Standard Schema](https://standardschema.dev)) | Shape of the payload. Nothing is bundled; bring your own. A schema that validates asynchronously is refused. |
-| `text`    | `(data) => string`                                         | What the document shows, from the payload. Reads the schema's output type.                                   |
+| Parameter | Type                                                       | Description                                                                                                                              |
+| --------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `schema`  | zod (or any [Standard Schema](https://standardschema.dev)) | Shape of the payload. The package does not include a schema library; supply your own. A schema that validates asynchronously is refused. |
+| `text`    | `(data) => string`                                         | What the document shows, from the payload. Reads the schema's output type.                                                               |
 
 ### Chrome
 
@@ -51,7 +51,7 @@ preserves both.
 | `preserveOnExport` | `boolean \| 'text'`                        | Controls whether export keeps, unwraps or removes the node. See [preserveOnExport](#preserveonexport).                                                                      |
 | `tagAttrs`         | `(data) => Record<string, string>`         | A reader without the payload store should still identify the node.                                                                                                          |
 | `payloadNamespace` | `string`                                   | You need a specific customXml namespace. Defaults to one from `tagPrefix`. It goes into an XPath prefix declaration, so quotes, angle brackets and ampersands are rejected. |
-| `fromDocx`         | `({ attrs, text, data }) => attrs \| null` | The node has **no** schema and keeps its data in the tag, or you need to disown a control by returning `null`.                                                              |
+| `fromDocx`         | `({ attrs, text, data }) => attrs \| null` | The node has **no** schema and keeps its data in the tag, or you need to leave a control unrecognized by returning `null`.                                                  |
 
 The returned `CustomNode` carries [`dataOf`](#dataof) alongside the definition.
 
@@ -67,8 +67,8 @@ customNodesModule({ nodes: [Citation], onDiagnostic });
 | `onDiagnostic` | `({ code, name, nodeId, issues }) => void` | `'payload-invalid'` or `'payload-missing'` on a node it read. |
 | `licenseKey`   | `string`                                   | Never validated at construction, never touches the network.   |
 
-The listener belongs to the editor the module is registered on. Two editors on one page hear only
-their own documents, and a listener goes when its editor does.
+The listener belongs to the editor the module is registered on. Each editor invokes only its own
+listener. Disposing the editor removes that listener.
 
 ## Writes
 
@@ -107,17 +107,17 @@ control, so it returns no `nodeId`.
 
 A refusal carries a `code`:
 
-| `code`        | Meaning                                                                                                               |
-| ------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `invalidArgs` | Fixable by passing something else: a payload past the cap, a tag over 64 characters, an offset outside the paragraph. |
-| `unsupported` | A fact about the document: a lock, a protected form, viewing mode.                                                    |
-| `notFound`    | No document is mounted, or `updateCustomNode` was given an id no node has.                                            |
+| `code`        | Meaning                                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `invalidArgs` | Caused by invalid arguments: a payload past the cap, a tag over 64 characters, an offset outside the paragraph. |
+| `unsupported` | Blocked by document state: a lock, a protected form, viewing mode.                                              |
+| `notFound`    | No document is mounted, or `updateCustomNode` was given an id no node has.                                      |
 
 A payload the schema rejected also carries `issues`:
 
 | Field     | Type                            | Description                           |
 | --------- | ------------------------------- | ------------------------------------- |
-| `message` | `string`                        | What the schema said.                 |
+| `message` | `string`                        | Validation message from the schema.   |
 | `path`    | `readonly (string \| number)[]` | Route to the field: `['authors', 0]`. |
 | `pointer` | `string`                        | The same path joined: `authors.0`.    |
 
@@ -129,7 +129,7 @@ A payload the schema rejected also carries `issues`:
 editor, in document order. Pass `{ nodes }` to narrow it. It derives from the document each time it
 is called. There is no change event, so re-read after an edit rather than holding the array.
 
-A payload with no `schema` comes back as parsed JSON on a null-prototype object, so
+A payload with no `schema` returns as parsed JSON on a null-prototype object, so
 `hasOwnProperty` and `instanceof Object` do not hold on it.
 
 ### dataOf
@@ -227,7 +227,7 @@ await email.attach(outgoing.bytes);
 ```
 
 List every definition whose nodes might be in the document. **A definition you do not pass is not
-touched**, and an untouched node travels whole.
+touched**, and an unmatched node remains unchanged.
 
 `customNodeXml` and `prepareForExport` run without DOM globals, so a backend can author, store and
 strip custom nodes in Node.
@@ -281,7 +281,7 @@ They are rendered as text, never as markup; do not build URLs or DOM from them w
 A recognized node is an ordinary inline content control. Word renders its text, honors the lock, and
 preserves the tag, the binding and the payload. A document edited in Word and reopened here is
 recognized from the same tag. If a Word user edited the text of an unbound node despite the lock,
-`fromDocx` sees the drift.
+`fromDocx` receives the changed text.
 
 A document opened without your definition registered renders the control's content literally, as
 Word does. Nothing is lost.

--- a/docs/site/content/pro/custom-nodes.mdx
+++ b/docs/site/content/pro/custom-nodes.mdx
@@ -7,11 +7,11 @@ order: 63
 
 Use a custom node for an element DOCX has no type for: a citation, an @mention, a merge field, a
 signature placeholder. Each is stored as an inline Word content control (`w:sdt`), so Word renders
-its text and hands it back unchanged.
+its text and returns the control unchanged.
 
 Requires the custom-nodes module from [`@docx-editor.dev/pro`](/docs/2.x/pro).
 
-## A citation, end to end
+## Citation example
 
 <FrameworkTabs>
 <Framework value="react">
@@ -138,17 +138,18 @@ defineProps<{ bytes: Uint8Array }>();
 </Framework>
 </FrameworkTabs>
 
-Cite drops `(Smith 2024)` at the caret as a chip. Save, open in Word, bring it back: the chip is
-recognized again, payload included.
+Insert places `(Smith 2024)` at the caret as a chip. After you save, open the file in Word, and
+reopen it here, the editor recognizes the chip and its payload again.
 
-## I want to
+## Common tasks
 
 <Cards>
   <Card title="Store data on a node" href="#define-a-node">
     A payload validated by your schema, up to 262,144 UTF-16 code units, kept in a customXml part.
   </Card>
   <Card title="Show a chip and react to clicks" href="#render-the-chips">
-    `CustomNodeChrome` paints recognized nodes and gives you the click, hover and rect.
+    `CustomNodeChrome` paints recognized nodes and exposes click and hover handlers and the node
+    rect.
   </Card>
   <Card title="Insert, edit or delete a node" href="#insert-update-remove">
     Three functions, one transaction and one undo step each.
@@ -156,7 +157,7 @@ recognized again, payload included.
   <Card title="Find every node in the document" href="#read-the-nodes">
     `customNodesOf(editor)` in body order, `dataOf` to get your type back.
   </Card>
-  <Card title="Strip my markup before sending a file out" href="#save-vs-export">
+  <Card title="Remove custom-node markup before export" href="#save-vs-export">
     `saveForExport` applies each definition's `preserveOnExport`.
   </Card>
   <Card title="Write nodes on a server" href="#common-configurations">
@@ -179,23 +180,23 @@ const Citation = defineCustomNode({
 ```
 
 `schema` is any [Standard Schema](https://standardschema.dev): zod, valibot, arktype. The pro
-package bundles none of them, so bring the one you already use.
+package bundles none of them, so install the schema library your project already uses.
 
 - Invalid data is rejected before anything is written to the document.
 - Data read back out is returned as your type instead of `unknown`.
 
-Payloads also arrive from `.docx` files someone else wrote, so the schema is what stands between
-that JSON and your code. Async validation is refused.
+Payloads also arrive from `.docx` files someone else wrote, so the schema validates that JSON
+before your code uses it. Async validation is refused.
 
 `text` reads the schema's _output_, so a `.default()` or a `.transform()` has already run.
 
 A node can skip `schema` and keep everything in its tag, which Word caps at 64 characters. See
 [nodes without a payload](/docs/2.x/pro/custom-nodes-reference#nodes-without-a-payload).
 
-Modules are read once, at construction. Changing the array afterwards does nothing; remount the Root.
+Modules are read once, at construction. Changing the array after construction has no effect; remount the Root.
 
 Everything else is optional: `label` and `chrome.color` for the chip, `onClick` / `onHover` /
-`onEdit`, `reviewCard` for a sidebar card, `preserveOnExport` for what leaves. See the
+`onEdit`, `reviewCard` for a sidebar card, `preserveOnExport` for export behavior. See the
 [reference](/docs/2.x/pro/custom-nodes-reference#definecustomnode).
 
 ## Render the chips
@@ -255,7 +256,7 @@ An activated node carries `name`, `attrs`, `tag`, `data` and `rect` (viewport-re
 anchoring your own popover), plus `nodeId` and `text` when they resolve.
 
 Remove can be refused, by a locked wrapper or a document open for viewing. Pass
-`onRemoveRefused(node, reason)` to show the engine's reason; without it the menu just closes.
+`onRemoveRefused(node, reason)` to show the engine's reason; without it, the menu closes.
 
 ## Insert, update, remove
 
@@ -279,7 +280,7 @@ const result = updateCustomNode(editor, Citation, card.nodeId, { data: next });
 if (result.ok && result.nodeId) setCard({ ...card, nodeId: result.nodeId });
 ```
 
-A payload the schema rejected comes back with `issues`, each pointing at a field:
+A payload the schema rejected returns with `issues`, each pointing at a field:
 
 ```ts
 const result = insertCustomNode(editor, Citation, { data: form });
@@ -365,7 +366,7 @@ if (!outgoing.ok) throw new Error(outgoing.reason);
 download(outgoing.bytes);
 ```
 
-`preserveOnExport` decides per definition: `true` (default) travels whole, `'text'` keeps the words
+`preserveOnExport` decides per definition: `true` (default) keeps the full control, `'text'` keeps the words
 and drops the control, `false` removes the node and its content. A tag no definition claims is never
 touched.
 
@@ -381,7 +382,7 @@ not become a node again.
 ## Common configurations
 
 **A mention, no payload.** Everything fits in the tag, so there is no schema and no customXml part.
-`fromDocx` clamps the untrusted strings a `.docx` hands you, or returns `null` to leave the control
+`fromDocx` clamps the untrusted strings a `.docx` supplies, or returns `null` to leave the control
 literal:
 
 ```ts
@@ -406,8 +407,8 @@ const InternalNote = defineCustomNode({
 
 **A node written on a server.** `customNodeXml` builds the same control as XML without an editor or
 DOM. For a payload-bearing node, server authoring must also add the payload package parts, their
-relationships and the properties part's content-type override. The document opens here with the
-node recognized:
+relationships and the properties part's content-type override. When the document opens in this
+editor, the node is recognized:
 
 ```ts
 import { customNodeXml } from '@docx-editor.dev/pro';

--- a/docs/site/content/pro/review-styling.mdx
+++ b/docs/site/content/pro/review-styling.mdx
@@ -5,8 +5,8 @@ category: 'Pro'
 order: 62
 ---
 
-The editor assigns a color to each reviewer, and gives you three ways to change
-that: CSS tokens, declarative style components, and one imperative call. Every
+The editor assigns a color to each reviewer. It provides three ways to change
+that assignment: CSS tokens, declarative style components, and one imperative call. Every
 option is display-only. None of them changes the document file.
 
 These styles apply to [tracked changes](/docs/2.x/pro/tracked-changes) and
@@ -214,7 +214,7 @@ Each declaration accepts more than a color. This example sets all supported pres
 ```
 
 `color` sets the ink and decoration in the document, and the card accent. `background` is the
-wash behind their changes. `span-class-name` adds classes to their painted changes.
+background tint behind their changes. `span-class-name` adds classes to their painted changes.
 `avatar-url` sets their avatar in the review sidebar.
 
 </Framework>

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -117,7 +117,7 @@ An explicit `mode` overrides the document setting. The toolbar can switch betwee
 
 The `'view'` mode keeps the editor read-only. Enforced protection overrides this rule when the document permits only tracked changes.
 
-The `<DocxEditor>` component defaults `mode` to `'edit'`, so the packaged editor opens every document ready to type.
+The `<DocxEditor>` component defaults `mode` to `'edit'`, so the packaged editor opens every document in editing mode.
 
 ## What gets tracked
 
@@ -145,7 +145,7 @@ Resolved views also merge paragraphs when a revision deletes the paragraph mark.
 The editor colors each reviewer's changes, and you can override the ramp, declare
 per-author colors and avatars, or color by change type instead.
 
-For all of it, see [Review colors and styling](/docs/2.x/pro/review-styling).
+For details, see [Review colors and styling](/docs/2.x/pro/review-styling).
 
 ## The review sidebar
 
@@ -345,7 +345,7 @@ Use `useStackedReviewPositions(items, heights, { gap, scale })` for the packaged
 
 Pass the editor render scale from `editor.getRenderScale()` as `scale`.
 
-Card heights use CSS pixels, while anchors use document points. The default scale of `1` makes spacing about one-third too large.
+Card heights use CSS pixels, while anchors use document points. The default scale of `1` makes spacing approximately one-third too large.
 
 ## Host content inside a card
 
@@ -581,7 +581,7 @@ Filtering and activation use these rules:
 8. `setActive` returns `false` without moving the caret when activation is excluded or no range exists.
 9. `setActive` can also return `false` when the item's story cannot open.
 
-### Where an activated item lands
+### Scroll position after activation
 
 `setActive` centers an item when scrolling is required. It does not move an item that is already visible.
 

--- a/docs/site/content/quickstart.mdx
+++ b/docs/site/content/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Quickstart'
-description: 'Load, edit, and save a .docx in the browser with React or Vue. Copy-paste setup: a file input, the editor component, and a download button, in one file.'
+description: 'Load, edit, and save a .docx in the browser with React or Vue. Minimal setup: a file input, the editor component, and a download button, in one file.'
 category: 'Getting Started'
 ---
 
@@ -12,7 +12,7 @@ This page builds a browser editor that opens a local `.docx` and downloads the e
 
 ### Install
 
-The adapter carries the string catalog and holds the engine as a peer, so install both.
+The adapter includes the string catalog and declares the engine as a peer dependency, so install both.
 
 <FrameworkTabs>
 <Framework value="react">
@@ -31,7 +31,7 @@ npm install @docx-editor.dev/vue @docx-editor.dev/core
 </Framework>
 </FrameworkTabs>
 
-On Next.js, Nuxt, Remix, or other SSR frameworks the editor must render client-side; mounting it during SSR throws `window is not defined`. Use the recipe in [Installation](/docs/2.x/installation). The code below works as-is in client-rendered apps such as Vite.
+On Next.js, Nuxt, Remix, or other SSR frameworks the editor must render client-side; mounting it during SSR throws `window is not defined`. Use the recipe in [Installation](/docs/2.x/installation). The code below works without further configuration in client-rendered apps such as Vite.
 
 </Step>
 
@@ -39,7 +39,7 @@ On Next.js, Nuxt, Remix, or other SSR frameworks the editor must render client-s
 
 ### Load, edit, save
 
-The whole flow in one file. A file input feeds the editor, the editor handles editing (typing, formatting, undo, tables), and a button serializes the current state back to a `.docx` download.
+This example puts load, edit, and save in one file. A file input supplies bytes to the editor, the editor supports editing (typing, formatting, undo, tables), and a button serializes the current state back to a `.docx` download.
 
 <FrameworkTabs>
 <Framework value="react">
@@ -157,12 +157,12 @@ async function download() {
 </Framework>
 </FrameworkTabs>
 
-Four things to know about this code:
+Notes for this example:
 
 - `document` takes a `Uint8Array`, an `ArrayBuffer`, a `DocumentHandle`, or `'blank'` for an empty document. Omitting it means no document at all. The editor shows its loading screen, and every control stays disabled until you supply bytes.
 - `mode` is `'edit'` (default), `'view'`, or `'suggesting'`, and is read at mount. Remount to change it.
-- `save()` on the ref returns `Promise<ArrayBuffer | null>`: a complete `.docx`, or `null` when there is no document. Parsing and serialization both happen in the browser; the document never touches a server.
-- The editor fills its parent, so give it a box with a real height. The stylesheet import is required once per app.
+- `save()` on the ref returns `Promise<ArrayBuffer | null>`: a complete `.docx`, or `null` when there is no document. Parsing and serialization both happen in the browser; the document stays in the browser; no server upload occurs.
+- The editor fills its parent, so give the parent a non-zero CSS height. The stylesheet import is required once per app.
 
 </Step>
 
@@ -190,12 +190,12 @@ const { document: bytes, isLoading } = useDocxSource('/template.docx');
 // <DocxEditor :document="bytes" />
 ```
 
-`useDocxSource()` does the fetch and tracks its state for you.
+`useDocxSource()` fetches the resource and exposes loading state.
 
 </Framework>
 </FrameworkTabs>
 
-To react to the built-in Save action (Cmd+S, or File → Save) instead of adding your own button, handle the save event. It replaces the packaged behavior, so read the bytes off the ref:
+To react to the built-in Save action (Cmd+S, or File → Save) instead of adding your own button, handle the save event. It replaces the packaged behavior, so read the bytes from the ref:
 
 <FrameworkTabs>
 <Framework value="react">
@@ -234,11 +234,11 @@ async function onSave() {
 
 <Step>
 
-### Open a real .docx from your machine
+### Open a local .docx file
 
-Run your dev server, click the file input, and pick a `.docx`: a contract, a CV, or a report with tables and headers. The editor parses it client-side and the download button writes the current state back. Check the result in Microsoft Word. If something renders or saves incorrectly, [file an issue](https://github.com/eigenpal/docx-editor/issues) with the document.
+Run your dev server, click the file input, and pick a `.docx`, for example a document that includes tables and headers. The editor parses it client-side and the download button writes the current state back. Check the result in Microsoft Word. If something renders or saves incorrectly, [file an issue](https://github.com/eigenpal/docx-editor/issues) with the document.
 
-No file handy? Try the [live demo](https://docx-editor.dev/editor) first.
+If you do not have a local file, try the [live demo](https://docx-editor.dev/editor) first.
 
 </Step>
 
@@ -248,5 +248,5 @@ No file handy? Try the [live demo](https://docx-editor.dev/editor) first.
 
 - [Installation](/docs/2.x/installation) for Next.js, Nuxt, Remix, and Astro specifics
 - [React composition](/docs/2.x/react/composition) or [Vue composition](/docs/2.x/vue/composition) to replace the packaged chrome with your own
-- [Word fidelity](/docs/2.x/word-fidelity) if you're evaluating feature support and round-trip behavior
-- [React props](/docs/2.x/react/props) and [Vue props](/docs/2.x/vue/props) for everything the packaged editor can do
+- [Word fidelity](/docs/2.x/word-fidelity) if you evaluate feature support and round-trip behavior
+- [React props](/docs/2.x/react/props) and [Vue props](/docs/2.x/vue/props) for the full packaged-editor prop surface

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -12,8 +12,8 @@ The packaged toolbar uses the hooks and primitives on this page.
 Your controls can use the same command and state APIs.
 
 <Callout>
-  🧊 The [Igloo customization example](https://igloo.docx-editor.dev/) implements these patterns
-  with custom markup. Open it to use the result, or read the
+  The [Igloo customization example](https://igloo.docx-editor.dev/) implements these patterns with
+  custom markup. Open the demo, or read the
   [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo) and run it with `bun
   run dev:igloo`.
 </Callout>
@@ -36,7 +36,7 @@ export function Editor({ bytes }: { bytes: Uint8Array }) {
 }
 ```
 
-- `Root` owns the editor instance and provides it through context.
+- `Root` holds the editor instance and provides it through context.
   It does not render a DOM element.
   It accepts document-level props such as `document`, `mode`, `author`,
   `fonts`, `locale`, `modules`, `onReady`, and `onChange`.
@@ -74,7 +74,7 @@ These changes preserve edits, caret position, and undo history.
 
 For exact signatures, see the [React API reference](/docs/2.x/api/react).
 
-## Customization ladder
+## Customization options
 
 Use the first option that meets your requirements:
 
@@ -309,7 +309,7 @@ You can add a host menu or replace the **Help** menu:
 
 Navigation parts are compound statics.
 Add a class to each part instead of targeting internal classes.
-The headings part continues to read the engine outline:
+The headings part continues to use the engine outline:
 
 ```tsx
 <DocxEditor.Navigation className="my-nav" toggle={{ className: 'my-nav__toggle' }}>
@@ -346,7 +346,8 @@ This example replaces the packaged loading content:
 Pass `overlay` to position the loading screen over its nearest positioned
 ancestor.
 The opaque overlay covers the previous document while the next document opens.
-A short delay prevents flashes during fast loads.
+A brief delay hides the overlay on loads that finish quickly, to avoid a visible
+flash.
 `<DocxEditor />` mounts this overlay by default.
 
 ```tsx
@@ -653,11 +654,11 @@ export function Workspace({ bytes }: { bytes: Uint8Array }) {
 }
 ```
 
-Composition gives you direct control of each part.
+Composition lets you mount each part explicitly.
 Omitted parts do not render an interface.
-The packaged `<DocxEditor>` mounts its default set for you.
+The packaged `<DocxEditor>` mounts the default part set.
 
-## Layout pitfalls
+## Layout constraints
 
 The navigation pane requires a positioning context.
 Place it beside the viewport in a row with `position: relative`.
@@ -685,7 +686,7 @@ Apply the same behavior to custom chrome.
 
 ## Next steps
 
-- [Igloo customization example](https://igloo.docx-editor.dev/) 🧊, and its
+- [Igloo customization example](https://igloo.docx-editor.dev/), and its
   [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo)
 - [Custom nodes example](https://github.com/eigenpal/docx-editor/tree/main/examples/custom-nodes)
 - [React hooks](/docs/2.x/react/hooks)

--- a/docs/site/content/react/hooks.mdx
+++ b/docs/site/content/react/hooks.mdx
@@ -200,8 +200,8 @@ function OrientationToggle() {
 ## `useParagraphFormat`
 
 Use `useParagraphFormat` to read and change the paragraph at the selection.
-`apply` sends every field as one command, so a dialog's worth of changes is
-one undo step:
+`apply` sends the supplied fields as one command, so one call creates one undo
+step:
 
 ```tsx
 import { useParagraphFormat } from '@docx-editor.dev/react';
@@ -221,13 +221,12 @@ function DoubleSpaceButton() {
 }
 ```
 
-A field reads `null` when the selected paragraphs disagree about it. A checkbox
-shows that as indeterminate. A number field has no such state: it opens on a
-default rather than on either value in play, and stays there until you change it.
-Nothing is written for a field you don't touch, so the paragraphs keep disagreeing. Omit a field to leave it as
-authored. The spacing, line-spacing and indent fields also take `null`, which
-removes the setting so the style supplies it again. That isn't the same as
-writing a zero, which blocks the style.
+A field is `null` when selected paragraphs have different values. A checkbox
+shows an indeterminate state. A number field has no indeterminate state. It shows
+a default until you change it. Omitted fields are not written, so existing values
+stay. Spacing, line-spacing, and indent fields also accept `null`. That value
+clears the local setting so the style supplies it. Writing `0` sets an explicit
+value instead.
 
 For the whole form, `DocxEditor.ParagraphDialog` is the Paragraph dialog
 over this hook.

--- a/docs/site/content/react/index.mdx
+++ b/docs/site/content/react/index.mdx
@@ -162,6 +162,6 @@ For object model details, see the
 - [React hooks](/docs/2.x/react/hooks)
 - [React props](/docs/2.x/react/props)
 - [React examples](/docs/2.x/react/examples)
-- [Igloo customization example](https://igloo.docx-editor.dev/) 🧊, and its
+- [Igloo customization example](https://igloo.docx-editor.dev/), and its
   [source](https://github.com/eigenpal/docx-editor/tree/main/examples/igloo)
 - [React API reference](/docs/2.x/api/react)

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -12,7 +12,7 @@ For all signatures, see the [React API reference](/docs/2.x/api/react).
 ## Document and mount state
 
 Use `document` for the document source.
-Use `fonts` to improve measurement fidelity.
+Use `fonts` to supply font metrics for measurement.
 
 | Prop       | Type                                                             | Description                                                                     |
 | ---------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -47,7 +47,7 @@ comments, and custom nodes.
 
 | Prop      | Type                      | Description                                                   |
 | --------- | ------------------------- | ------------------------------------------------------------- |
-| `modules` | `readonly EditorModule[]` | Capability modules that the editor reads during construction. |
+| `modules` | `readonly EditorModule[]` | Capability modules that the editor loads during construction. |
 
 Keep the array identity stable.
 A new array causes the editor to rebuild.
@@ -89,11 +89,11 @@ These props control the packaged frame around the document.
 
 ## Dark mode
 
-`colorMode` changes the editor chrome.
-The document canvas remains faithful to the DOCX file.
-The setting does not change saved or printed output.
+`colorMode` changes the editor chrome and applies a display transform to the document canvas.
+The setting does not change authored document colors or saved output.
+Printing uses a light page regardless of this setting.
 
-This example controls the chrome theme:
+This example controls the editor color mode:
 
 ```tsx
 const [colorMode, setColorMode] = useState<'light' | 'dark'>('light');
@@ -109,7 +109,7 @@ For theme behavior, see the [Dark mode guide](/docs/2.x/guides/dark-mode).
 ## Fonts
 
 `fonts` supplies font bytes for text measurement.
-Accurate metrics improve line wraps and page breaks.
+Matching metrics produce line wraps and page breaks that match Word more closely.
 The editor loads supported embedded fonts without extra configuration.
 The font picker combines declared document fonts with configured fonts.
 Use `useFontFamily()` to read that list.

--- a/docs/site/content/vue/composables.mdx
+++ b/docs/site/content/vue/composables.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Composables'
-description: 'The Vue API the packaged chrome is built on: subscribe to editor state, run commands, read the document outline, search, and drive page setup.'
+description: 'Vue composables used by the packaged chrome: subscribe to editor state, run commands, read the document outline, search, and drive page setup.'
 category: 'Vue'
 order: 38
 ---
@@ -9,8 +9,8 @@ Call each composable during `setup()` inside `DocxEditor.Root`. The packaged
 `<DocxEditor>` also renders this root.
 
 These composables return a ref, or a plain object that holds refs. A template
-unwraps a ref only when the ref is a top-level binding. A ref that sits on a
-returned object stays a ref, so read it with `.value` in the template and in
+unwraps a ref only when the ref is a top-level binding. A ref that is a property
+of a returned object stays a ref, so read it with `.value` in the template and in
 script code.
 
 ## useEditorCommand
@@ -142,7 +142,8 @@ their `at` value.
 
 ## useEditorSnapshot
 
-Returns a revision ref for an editor. Use it for custom external-store wiring.
+Returns a revision ref for an editor. Use it for a custom external-store
+subscription.
 
 ## useZoom
 
@@ -172,7 +173,7 @@ const font = useFontFamily();
 </template>
 ```
 
-The current family sits on the `value` member, and that member is a computed
+The current family is on the `value` member, and that member is a computed
 ref. Read it as `font.value.value`.
 
 `useParagraphStyle` provides the same pattern for paragraph styles.
@@ -210,8 +211,8 @@ use twips. Set `scope` to `'section'` or `'document'`.
 ## useParagraphFormat
 
 Use `useParagraphFormat` to read and change the paragraph at the selection.
-`apply` sends every field as one command, so a dialog's worth of changes is one
-undo step. Read the returned refs with `.value`:
+`apply` sends the supplied fields as one command, so one call creates one undo
+step. Read the returned refs with `.value`:
 
 ```vue
 <script setup lang="ts">
@@ -233,13 +234,12 @@ function toggle() {
 </template>
 ```
 
-A field reads `null` when the selected paragraphs disagree about it. A checkbox
-shows that as indeterminate. A number field has no such state: it opens on a
-default rather than on either value in play, and stays there until you change it.
-Nothing is written for a field you don't touch, so the paragraphs keep disagreeing. Omit a field to leave it as
-authored. The spacing, line-spacing and indent fields also take `null`, which
-removes the setting so the style supplies it again. That isn't the same as
-writing a zero, which blocks the style.
+A field is `null` when selected paragraphs have different values. A checkbox
+shows an indeterminate state. A number field has no indeterminate state. It shows
+a default until you change it. Omitted fields are not written, so existing values
+stay. Spacing, line-spacing, and indent fields also accept `null`. That value
+clears the local setting so the style supplies it. Writing `0` sets an explicit
+value instead.
 
 For the whole form, `DocxEditorParagraphDialog` is the Paragraph dialog over
 this composable.
@@ -326,7 +326,7 @@ Returns the horizontal page offset caused by the open navigation pane.
 ## useReviewGutter
 
 Returns the inline reservations for the active review rail.
-The full card column changes to balanced marker strips on narrow viewports.
+The full card column changes to compact marker strips on narrow viewports.
 
 ## useDocxSource
 

--- a/docs/site/content/vue/composition.mdx
+++ b/docs/site/content/vue/composition.mdx
@@ -26,7 +26,7 @@ import { DocxEditorContent, DocxEditorRoot, DocxEditorViewport } from '@docx-edi
 </template>
 ```
 
-- `DocxEditorRoot` owns the editor and provides it to descendants.
+- `DocxEditorRoot` holds the editor and provides it to descendants.
 - `DocxEditorViewport` supplies the scroll and page-layout container.
 - `DocxEditorContent` mounts the painted, editable document surface.
 
@@ -52,7 +52,7 @@ For full prop types, see the
 
 ## `provideDocxEditor()`
 
-Call `provideDocxEditor()` when a parent layout owns the editor. The helper
+Call `provideDocxEditor()` when a parent layout holds the editor. The helper
 provides one editor instance to the returned root and its descendants.
 
 ```vue
@@ -75,9 +75,9 @@ const { DocxEditorRoot, rootProps, rootListeners, editorRef } = provideDocxEdito
 `editorRef` tracks the same instance that `useDocxEditor()` returns in
 descendants.
 
-## Customization ladder
+## Customization options
 
-Use the first option that meets your needs:
+Use the first option that meets your requirements:
 
 1. Set a class or a `--doc-*` color token.
 2. Replace a part's `icon` prop.
@@ -135,8 +135,8 @@ state and disabled reasons from the editor.
 
 ### Add a host toolbar action
 
-Use `DocxEditorToolbar.Action` for an action without a registry slot. Ask
-`useEditorCommand()` whether the command can run.
+Use `DocxEditorToolbar.Action` for an action without a registry slot. Call
+`useEditorCommand()` to read whether the command can run.
 
 ```vue
 <script setup lang="ts">
@@ -239,8 +239,8 @@ the menus that your product changes.
 </DocxEditorMenu>
 ```
 
-Use `open-handler` and `save-handler` for composed Vue menu actions. The sugar
-host exposes these actions as `@open` and `@save`.
+Use `open-handler` and `save-handler` for composed Vue menu actions.
+`<DocxEditor>` exposes these actions as `@open` and `@save`.
 
 ## Custom navigation pane
 
@@ -258,7 +258,7 @@ Each navigation part accepts its own class.
 </DocxEditorNavigation>
 ```
 
-The headings list reads the document outline from the editor.
+The headings list uses the document outline from the editor.
 
 ## Custom loading screen
 
@@ -375,7 +375,7 @@ See [Tracked changes](/docs/2.x/pro/tracked-changes) for author colors.
 
 ## Custom labels
 
-Chrome reads labels from the active locale catalog. Pass a translator only when
+Chrome resolves labels from the active locale catalog. Pass a translator only when
 you need label overrides.
 
 ```vue
@@ -553,7 +553,7 @@ import {
 
 An omitted part has no interface.
 
-## Layout pitfalls
+## Layout constraints
 
 Place the navigation pane and viewport in a row with `position: relative`. The
 pane uses that row as its positioning context.

--- a/docs/site/content/vue/examples.mdx
+++ b/docs/site/content/vue/examples.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Vue examples'
-description: 'Concrete patterns for the current Vue root surface: mount bytes, save through the ref, compose custom chrome, and automate an open editor.'
+description: 'Patterns for the Vue root surface: mount bytes, save through the ref, compose custom chrome, and automate an open editor.'
 category: 'Vue'
 order: 39
 ---
@@ -55,7 +55,7 @@ async function save() {
 
 ## Compose custom chrome
 
-Create a button that reads the editor context:
+Create a button that uses the editor context:
 
 ```vue
 <script setup lang="ts">

--- a/docs/site/content/vue/index.mdx
+++ b/docs/site/content/vue/index.mdx
@@ -14,8 +14,8 @@ seoTitle: 'DOCX editor for Vue 3'
 npm install @docx-editor.dev/vue @docx-editor.dev/core vue
 ```
 
-`@docx-editor.dev/core` and Vue 3 are peer dependencies. Install both beside the
-adapter. The adapter includes `@docx-editor.dev/i18n`.
+`@docx-editor.dev/core` and Vue 3 are peer dependencies of the adapter. Install
+both with the adapter. The adapter includes `@docx-editor.dev/i18n`.
 
 Add [`@docx-editor.dev/pro`](/docs/2.x/pro) for tracked changes and comments.
 Add [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) to automate the open
@@ -42,7 +42,7 @@ import { DocxEditor } from '@docx-editor.dev/vue';
 </template>
 ```
 
-`<DocxEditor>` is the full packaged editor. It includes the title bar, menu,
+`<DocxEditor>` is the packaged editor. It includes the title bar, menu,
 toolbar, navigation pane, hyperlink popover, context menu, and editable
 document.
 
@@ -95,7 +95,7 @@ import { DocxEditor } from '@docx-editor.dev/vue';
 ```
 
 Keep `DocxEditor.Content` inside `DocxEditor.Viewport`. Place navigation and
-overlay chrome beside the content.
+overlay chrome next to the content in the viewport.
 
 ## Toolbar
 

--- a/docs/site/content/vue/props.mdx
+++ b/docs/site/content/vue/props.mdx
@@ -12,14 +12,14 @@ use. See the [Vue API reference](/docs/2.x/api/vue) for generated signatures.
 
 Use `document` for the document source.
 
-| Prop       | Type                               | Description                                        |
-| ---------- | ---------------------------------- | -------------------------------------------------- |
-| `document` | `DocumentSource`                   | DOCX bytes, `'blank'`, or a `DocumentHandle`.      |
-| `author`   | `string`                           | Author for comments and review commands.           |
-| `locale`   | `string`                           | Locale passed to the editor.                       |
-| `mode`     | `'edit' \| 'view' \| 'suggesting'` | Opening mode. The sugar host defaults to `'edit'`. |
-| `zoom`     | `number`                           | Numeric display scale.                             |
-| `zoomMode` | `ZoomMode \| 'auto'`               | Zoom source. `'auto'` fits the page width.         |
+| Prop       | Type                               | Description                                                     |
+| ---------- | ---------------------------------- | --------------------------------------------------------------- |
+| `document` | `DocumentSource`                   | DOCX bytes, `'blank'`, or a `DocumentHandle`.                   |
+| `author`   | `string`                           | Author for comments and review commands.                        |
+| `locale`   | `string`                           | Locale passed to the editor.                                    |
+| `mode`     | `'edit' \| 'view' \| 'suggesting'` | Opening mode. The packaged `<DocxEditor>` defaults to `'edit'`. |
+| `zoom`     | `number`                           | Numeric display scale.                                          |
+| `zoomMode` | `ZoomMode \| 'auto'`               | Zoom source. `'auto'` fits the page width.                      |
 
 `DocumentSource` accepts `Uint8Array`, `ArrayBuffer`, `'blank'`, or an existing
 `DocumentHandle`. Resolve URLs and paths with
@@ -35,8 +35,8 @@ import { DocxEditor } from '@docx-editor.dev/vue';
 </template>
 ```
 
-The sugar host rebuilds for a new `document` identity. It applies later `zoom`
-and `zoomMode` changes through the editor facade.
+`<DocxEditor>` rebuilds when the `document` identity changes. It applies later
+`zoom` and `zoomMode` changes through the editor facade.
 
 ## Modules
 
@@ -61,8 +61,8 @@ const modules = [reviewModule()];
 </template>
 ```
 
-The review module makes tracked changes and comments actionable. The Vue Pro
-entry also exports custom-node chip and context-menu chrome.
+The review module lets you show and manage tracked changes and comments. The Vue
+Pro entry also exports custom-node chip and context-menu chrome.
 
 ## Chrome and layout
 
@@ -79,19 +79,20 @@ These props control the packaged frame:
 | `t`              | `(key, params?) => string`              | Resolves packaged chrome labels.          |
 | `i18n`           | `Translations`                          | Supplies a locale catalog to this editor. |
 
-Set `chrome` to `false` for the bare document surface. You can then build the
-frame from the [composition primitives](/docs/2.x/vue/composition).
+Set `chrome` to `false` for the document surface without packaged chrome. You can
+then build the frame from the [composition primitives](/docs/2.x/vue/composition).
 
 ## Appearance
 
-Vue calls the appearance prop `colorMode`.
+The appearance prop name is `colorMode`.
 
-| Prop        | Type                            | Default   | Description            |
-| ----------- | ------------------------------- | --------- | ---------------------- |
-| `colorMode` | `'light' \| 'dark' \| 'system'` | `'light'` | Sets the chrome theme. |
+| Prop        | Type                            | Default   | Description                              |
+| ----------- | ------------------------------- | --------- | ---------------------------------------- |
+| `colorMode` | `'light' \| 'dark' \| 'system'` | `'light'` | Sets the chrome and document color mode. |
 
-The document canvas remains faithful to the DOCX file. The setting does not
-change saved or printed output.
+`colorMode` applies a display transform to the document canvas. The setting does
+not change authored document colors or saved output. Printing uses a light page
+regardless of this setting.
 
 ```vue
 <script setup lang="ts">
@@ -188,7 +189,7 @@ The title becomes editable when you listen for `@title-change`.
 
 ## Emits
 
-The sugar host emits these six events:
+`<DocxEditor>` emits these six events:
 
 | Emit            | Payload                  | Description                             |
 | --------------- | ------------------------ | --------------------------------------- |
@@ -216,7 +217,7 @@ saved bytes.
 ```
 
 `DocxEditorRoot` emits `ready`, `change`, and `font-error`. File and title
-events belong to the sugar host.
+events belong to `<DocxEditor>`.
 
 ## Ref methods
 

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -10,8 +10,8 @@ seoTitle: 'Word feature support and fidelity'
 ## Overview
 
 - **Browser editor use is client-side.** Parsing, rendering, editing, and serialization run in the browser for normal `<DocxEditor>` usage. The server-side editing API runs wherever you host it.
-- **`.docx` in, `.docx` out.** The editor reads OOXML and writes OOXML. Untouched content, unsupported markup, and package payloads survive editing and save.
-- **Apache 2.0** for every published package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`. Those two ship under the EigenPal Pro Evaluation License 1.0: evaluate freely, and use a commercial agreement for production. Versions follow **SemVer**, and CI tracks the public API with generated snapshots.
+- **The editor reads OOXML and writes OOXML.** Untouched content, unsupported markup, and package payloads survive editing and save.
+- **Apache 2.0** for every published package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`. Those two use the EigenPal Pro Evaluation License 1.0. Internal, non-production evaluation is free. Production use requires a commercial agreement. Versions follow **SemVer**, and CI tracks the public API with generated snapshots.
 - **Commercial support**: [docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com).
 
 ## Feature matrix
@@ -22,12 +22,12 @@ Every feature is tracked on three axes:
 - **Rendering**: does it display the way Microsoft Word renders it?
 - **Round-trip**: does it survive open, edit, save, and reopen without loss?
 
-A construct the editor doesn't model is retained as inert content and written
-back with structural fidelity; that's the "Preserved" status below.
+A construct the editor does not model is retained as inert content and written
+back with structural fidelity; that is the "Preserved" status below.
 
 <FeatureSummary />
 
-**Legend**: Full = works like Word · Partial = works with noted limits ·
+**Legend**: Full = matches Word behavior for this feature · Partial = works with noted limits ·
 Render only = displays correctly, not editable · Preserved = carried inertly
 through editing and save · Planned = on the roadmap · No = not supported.
 
@@ -73,7 +73,7 @@ through editing and save · Planned = on the roadmap · No = not supported.
 
 ## Rendering fidelity
 
-The editor does not let the browser lay out the document. A DOM-free layout
+The editor does not use browser layout for the document. A DOM-free layout
 pass positions every line and every page break from Word's own metrics: twips,
 the document's fonts and themes, and its section and margin geometry. The
 editor then paints the visible pages from that result. The layout pass decides
@@ -81,17 +81,17 @@ where a line or a page breaks, never the browser. The output is plain DOM text,
 not a canvas bitmap.
 
 How the pipeline achieves this is in
-[Architecture](/docs/2.x/core/architecture). To judge fidelity yourself, open
+[Architecture](/docs/2.x/core/architecture). To compare fidelity, open
 one of your own documents in the [live demo](https://docx-editor.dev/editor)
 next to Word.
 
 ## Drawings, shapes and legacy images
 
-These rows in the "Images & drawings" matrix are not Full yet, but their
+These rows in the "Images & drawings" matrix are not Full, but their
 authored markup and payloads survive editing and save.
 
 - **Text boxes**: story content renders read-only inside the authored extent;
-  editing, linked chains, autofit, and rotation are not built yet.
+  editing, linked chains, autofit, and rotation are not implemented.
 - **Drawing shapes**: unsupported geometry reserves its extent with a
   placeholder; the original markup is preserved.
 - **WMF / EMF**: rasterized where supported, otherwise shown as a placeholder;
@@ -99,22 +99,22 @@ authored markup and payloads survive editing and save.
 
 ## Round-trip behavior
 
-A `.docx` file is a ZIP of XML parts, and Word writes a lot of XML the
-editor has no reason to model: bookmarks, custom XML parts, mail-merge fields,
+A `.docx` file is a ZIP of XML parts, and Word writes XML constructs the
+editor does not model: bookmarks, custom XML parts, mail-merge fields,
 compatibility settings, VBA projects.
 
 This editor's pipeline is parse → document model → edit → serialize. On save,
 the canonical tree preserves the structure and semantics of every parsed XML
-part, while package payloads pass through untouched. Concretely:
+part, while package payloads pass through untouched. In detail:
 
 - Unmodeled XML elements and attributes are kept as generic nodes and
   re-emitted in place, including legacy VML, custom XML, and add-in markup.
 - Non-XML payloads such as media, VBA projects, embedded fonts, and OLE
   binaries are copied through the ZIP untouched.
 - References stay intact. The editor does not rename or renumber a relationship ID, bookmark name, field code, style ID, or numbering definition.
-- Output is canonical OOXML, not only valid. Tracked changes are real `w:ins` and `w:del` revisions that Word's review pane understands, theme colors stay theme references, and numbering keeps its definitions.
+- Output is canonical OOXML, not only valid. Tracked changes are real `w:ins` and `w:del` revisions that appear in Word's review pane, theme colors stay theme references, and numbering keeps its definitions.
 
-How it's tested: CI round-trips a corpus of real documents through two oracles,
+Test coverage: CI round-trips a corpus of real documents through two oracles,
 a canonical fingerprint over the tree and a save-and-reopen semantic digest.
 Serializer tests assert that specific constructs survive, such as revisions,
 fields, hyperlinks, and content controls. Browser end-to-end tests drive the
@@ -129,21 +129,21 @@ bug. Attach it to a
 
 - **Normal editor use is browser-only.** The editor package does not upload documents or call a conversion API.
 - **No macro execution.** VBA macros and embedded code are not evaluated.
-- **The editing API is host-controlled.** [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) ships no network transport and no model integration. The browser entry drives an editor already in the page, so the DOCX never leaves it. The server entry runs wherever you host it. Your own code decides what reaches a model.
+- **The editing API is host-controlled.** [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) ships no network transport and no LLM or external AI integration. The browser entry drives an editor already in the page, so the DOCX never leaves it. The server entry runs wherever you host it. Your own code decides what reaches an external service or model.
 
 ## Bundle and performance
 
 - `-core` ships subpath exports that tree-shake independently.
 - The engine is a peer dependency of the adapters, so one copy resolves for the whole tree.
 - Lazy-load the editor (`next/dynamic`, `React.lazy`) to keep it out of the initial bundle.
-- The layout engine caches per-block measurements; an edit doesn't re-measure the document.
+- The layout engine caches per-block measurements; an edit does not re-measure unchanged blocks.
 
 No published benchmarks; test with your own documents in the
 [live demo](https://docx-editor.dev/editor).
 
 ## Stability, license and support
 
-- **Apache 2.0** for every package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`. Those two ship under the EigenPal Pro Evaluation License 1.0: free to evaluate internally, and production use needs a written agreement from [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
+- **Apache 2.0** for every package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`. Those two ship under the EigenPal Pro Evaluation License 1.0: internal evaluation is free, and production use needs a written agreement from [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
 - **SemVer** via changesets; all packages share one version number.
 - The public API is tracked by [API Extractor snapshots](https://github.com/eigenpal/docx-editor/tree/main/docs/api); CI fails on drift.
 - Contributions need a one-time [CLA](https://github.com/eigenpal/docx-editor/blob/main/CLA.md).
@@ -154,6 +154,6 @@ for priority features and support contracts.
 
 ## Next steps
 
-- [Quickstart](/docs/2.x/quickstart): the load, edit, save loop
+- [Quickstart](/docs/2.x/quickstart): the load, edit, and save workflow
 - [Architecture](/docs/2.x/core/architecture): the pipeline in depth
-- [Tracked changes](/docs/2.x/pro/tracked-changes): the review model in practice
+- [Tracked changes](/docs/2.x/pro/tracked-changes): tracked-change and comment behavior


### PR DESCRIPTION
## Summary
- Replace colloquial, vague, and anthropomorphic wording across 36 documentation pages.
- Use precise engineering terms while preserving product behavior and technical claims.

## Test plan
- [x] `bun run format`
- [x] `bun run check:docs-mdx`
- [x] `bun run check:docs-vue-refs`
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790170958&installation_model_id=422592&pr_number=405&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F405&signature=3a74d8e4e2d26241393a8bba4519b83b5b7a2b43ccdddea264f5925d7325d978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->