### PR TITLE
fix(core): restart disconnected ordered lists

### DIFF
--- a/.changeset/ordered-list-new-paragraph-numbering.md
+++ b/.changeset/ordered-list-new-paragraph-numbering.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+New ordered lists now start at one instead of continuing an earlier disconnected list.

--- a/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
+++ b/packages/core/src/editor/__tests__/word-keymap-indent.test.ts
@@ -129,6 +129,17 @@ const markerOf = (surface: PaginatedSurface) => {
   return undefined;
 };
 
+const markerFor = (surface: PaginatedSurface, paragraphId: string) => {
+  for (const page of surface.layout().pages) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind === 'paragraph' && fragment.paragraphId === paragraphId) {
+        return fragment.marker;
+      }
+    }
+  }
+  return undefined;
+};
+
 describe('Increase/Decrease Indent', () => {
   test('a list item changes LEVEL, and its marker changes with it', () => {
     const surface = mount(listItem('alpha'), true);
@@ -378,7 +389,7 @@ describe('Bullets and Numbering', () => {
     expect(markerOf(surface)?.text).toBe('1.');
   });
 
-  test('a document that already has numbering reuses its definition', () => {
+  test('a document that already has numbering reuses its template', () => {
     const surface = mount(listItem('alpha') + '<w:p><w:r><w:t>beta</w:t></w:r></w:p>', true);
     const before = JSON.stringify(surface.session.part().root);
     surface.selectAll();
@@ -388,6 +399,43 @@ describe('Bullets and Numbering', () => {
     const reopened = mountBytes(numbering);
     expect(markerOf(reopened)).toMatchObject({ text: '•' });
     expect(before).toContain('numPr');
+  });
+
+  test('a new ordered list after earlier items starts at one', () => {
+    const decimalNumbering =
+      '<w:abstractNum w:abstractNumId="7">' +
+      '<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>' +
+      '<w:lvlText w:val="%1."/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>' +
+      '</w:abstractNum><w:num w:numId="7"><w:abstractNumId w:val="7"/></w:num>';
+    const orderedItem = (text: string) =>
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="7"/>' +
+      `</w:numPr></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+    const earlier = Array.from({ length: 39 }, (_, index) => orderedItem(`item ${index + 1}`)).join(
+      ''
+    );
+    const surface = mount(
+      earlier +
+        '<w:p><w:r><w:t>ordinary paragraph</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>new list</w:t></w:r></w:p>',
+      true,
+      { numberingXml: decimalNumbering }
+    );
+    const target = surface.session.paragraphIds().at(-1)!;
+    surface.setSelection({
+      anchor: { paragraphId: target, offset: 0 },
+      head: { paragraphId: target, offset: 0 },
+    });
+
+    expect(surface.toggleList('ordered')).toBe(true);
+    expect(markerFor(surface, target)?.text).toBe('1.');
+
+    surface.setSelection({
+      anchor: { paragraphId: target, offset: 'new list'.length },
+      head: { paragraphId: target, offset: 'new list'.length },
+    });
+    createKeyDownHandler(surface)(key({ key: 'Enter' }));
+    const next = surface.session.paragraphIds().at(-1)!;
+    expect(markerFor(surface, next)?.text).toBe('2.');
   });
 
   test('the toggle keeps the rest of w:pPr', () => {

--- a/packages/core/src/store/__tests__/numbering-part-schema.test.ts
+++ b/packages/core/src/store/__tests__/numbering-part-schema.test.ts
@@ -259,14 +259,20 @@ describe('A2 — new abstractNum/num land at their CT_Numbering (17.9.16) positi
     expect(names).toEqual(['numPicBullet', 'abstractNum', 'num', 'numIdMacAtCleanup']);
   });
 
-  test('the existing definition is reused rather than duplicated', () => {
+  test('the existing template is reused with a fresh counter instance', () => {
     const first = ensured(load({ numbering: BUSY_NUMBERING }), 'bullet');
-    expect(first.numId).toBe('7');
+    expect(first.numId).toBe('8');
     expect(childNames(numberingRoot(first.pkg))).toEqual([
       'numPicBullet',
       'abstractNum',
       'num',
+      'num',
       'numIdMacAtCleanup',
+    ]);
+    const nums = named(numberingRoot(first.pkg), 'num');
+    expect(nums.map((num) => attribute(named(num, 'abstractNumId')[0]!, 'val'))).toEqual([
+      '4',
+      '4',
     ]);
   });
 });
@@ -398,11 +404,12 @@ describe('the saved package reopens with the list intact', () => {
     }
   });
 
-  test('a second toggle in the same package reuses the definition it just made', () => {
+  test('a second disconnected list reuses the template with a fresh counter', () => {
     const first = ensured(load(), 'bullet');
     const second = ensured(first.pkg, 'bullet');
-    expect(second.numId).toBe(first.numId);
+    expect(second.numId).not.toBe(first.numId);
     expect(named(numberingRoot(second.pkg), 'abstractNum')).toHaveLength(1);
+    expect(named(numberingRoot(second.pkg), 'num')).toHaveLength(2);
   });
 
   test('bullet then ordered gives two definitions, still in sequence order', () => {

--- a/packages/core/src/store/package/numbering-part.ts
+++ b/packages/core/src/store/package/numbering-part.ts
@@ -233,9 +233,9 @@ export interface EnsuredListDefinition {
 /**
  * Find or create a list definition of `kind`, returning the package that holds it.
  *
- * An existing definition of the same kind is REUSED rather than duplicated: Word does the
- * same, and a document that gains one `w:abstractNum` per toggled paragraph becomes
- * unreadable. Returns null only when the part cannot be built at all.
+ * An existing abstract definition of the same kind is reused, but every disconnected list
+ * gets a fresh `w:num` instance. Counters belong to `w:num`, so reusing that instance would
+ * continue an earlier list. Returns null only when the part cannot be built at all.
  */
 export function ensureListDefinition(
   pkg: OoxmlPackage,
@@ -249,57 +249,65 @@ export function ensureListDefinition(
   const abstractNums = childrenNamed(root, 'abstractNum');
   const nums = childrenNamed(root, 'num');
 
-  // Reuse: the first `w:num` whose abstract definition already formats this kind.
+  // Reuse the first matching TEMPLATE, not its counter instance. Two disconnected lists
+  // can share one `w:abstractNum`, but each needs its own `w:num` to start at the authored
+  // level baseline. Reusing the earlier `w:num` made a new list after 39 items begin at 40.
   const wantedFormat = kind === 'bullet' ? 'bullet' : 'decimal';
-  for (const num of nums) {
-    const numId = attribute(num, 'numId');
-    const abstractRef = childrenNamed(num, 'abstractNumId')[0];
-    const abstractId = abstractRef ? attribute(abstractRef, 'val') : undefined;
-    if (!numId || !abstractId) continue;
-    const abstract = abstractNums.find((node) => attribute(node, 'abstractNumId') === abstractId);
-    if (!abstract) continue;
+  const matchingAbstract = abstractNums.find((abstract) => {
+    const abstractId = attribute(abstract, 'abstractNumId');
+    if (!abstractId || !/^\d{1,9}$/.test(abstractId)) return false;
     const firstLevel = childrenNamed(abstract, 'lvl').find(
       (level) => attribute(level, 'ilvl') === '0' || attribute(level, 'ilvl') === undefined
     );
     const format = firstLevel ? childrenNamed(firstLevel, 'numFmt')[0] : undefined;
-    if (format && attribute(format, 'val') === wantedFormat) return { pkg, numId };
-  }
+    return format !== undefined && attribute(format, 'val') === wantedFormat;
+  });
 
-  const abstractNumId = nextFreeId(abstractNums, 'abstractNumId');
+  const matchingAbstractId = matchingAbstract
+    ? Number(attribute(matchingAbstract, 'abstractNumId'))
+    : null;
+  const abstractNumId = matchingAbstractId ?? nextFreeId(abstractNums, 'abstractNumId');
   const numId = nextFreeId(nums, 'numId');
-  // The new definitions are authored as their own document, shape-verified, then GRAFTED
-  // under fresh ids. `w:abstractNum` must precede every `w:num` (17.9.1), and Word's
-  // reader is strict about it, so the two groups are inserted at their own boundaries
-  // rather than appended.
+  // New elements are authored as their own document, shape-verified, then GRAFTED under
+  // fresh node ids. A matching template needs only a new counter instance.
+  const createsAbstract = matchingAbstract === undefined;
   const authored = authoredElements(
-    abstractNumXml(kind, abstractNumId) +
+    (createsAbstract ? abstractNumXml(kind, abstractNumId) : '') +
       `<w:num w:numId="${numId}"><w:abstractNumId w:val="${abstractNumId}"/></w:num>`,
-    [
-      {
-        localName: 'abstractNum',
-        attribute: { localName: 'abstractNumId', value: String(abstractNumId) },
-      },
-      { localName: 'num', attribute: { localName: 'numId', value: String(numId) } },
-    ]
+    createsAbstract
+      ? [
+          {
+            localName: 'abstractNum',
+            attribute: { localName: 'abstractNumId', value: String(abstractNumId) },
+          },
+          { localName: 'num', attribute: { localName: 'numId', value: String(numId) } },
+        ]
+      : [{ localName: 'num', attribute: { localName: 'numId', value: String(numId) } }]
   );
   if (!authored) return null;
   const nextId = createNodeIdAllocator(numbering);
-  const [newAbstract, newNum] = authored.map((node) => withFreshIds(node, nextId));
-  if (!newAbstract || !newNum) return null;
+  const fresh = authored.map((node) => withFreshIds(node, nextId));
+  const newAbstract = createsAbstract ? fresh[0] : undefined;
+  const newNum = fresh[createsAbstract ? 1 : 0];
+  if ((createsAbstract && !newAbstract) || !newNum) return null;
 
-  // Each lands at its CT_NUMBERING_SEQUENCE slot — see `sequenceInsertIndex`. `w:num` is
-  // positioned against the children the `w:abstractNum` insert produced, so the two agree.
-  const withAbstract = insertChildren(
-    numbering,
-    root.id,
-    sequenceInsertIndex(root.children, CT_NUMBERING_SEQUENCE, 'abstractNum'),
-    [newAbstract]
-  );
-  if (!withAbstract.ok) return null;
+  // A new `w:abstractNum` must precede every `w:num` (17.9.1). Each element lands at its
+  // CT_NUMBERING_SEQUENCE slot, while a reused template leaves existing children untouched.
+  let partWithAbstract = numbering;
+  if (newAbstract) {
+    const inserted = insertChildren(
+      numbering,
+      root.id,
+      sequenceInsertIndex(root.children, CT_NUMBERING_SEQUENCE, 'abstractNum'),
+      [newAbstract]
+    );
+    if (!inserted.ok) return null;
+    partWithAbstract = inserted.part;
+  }
   const withNum = insertChildren(
-    withAbstract.part,
+    partWithAbstract,
     root.id,
-    sequenceInsertIndex(withAbstract.part.root.children, CT_NUMBERING_SEQUENCE, 'num'),
+    sequenceInsertIndex(partWithAbstract.root.children, CT_NUMBERING_SEQUENCE, 'num'),
     [newNum]
   );
   if (!withNum.ok) return null;


### PR DESCRIPTION
## Summary
- Start disconnected ordered lists at one with a fresh `w:num` instance.
- Reuse the existing `w:abstractNum` template and preserve adjacent list continuation.

## Test plan
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `openspec validate typed-ooxml-paragraph-editor --strict`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790173043&installation_model_id=422592&pr_number=406&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F406&signature=850777b3b004f8f1f1340df29dedd3954472c348e7e5c6ccef92dabf5e76b2f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->