### PR TITLE
fix(core): close spacing between list items

### DIFF
--- a/.changeset/list-item-contextual-spacing.md
+++ b/.changeset/list-item-contextual-spacing.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Lists now suppress paragraph spacing between consecutive items when converted documents omit the built-in contextual spacing rule.

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -253,17 +253,9 @@ export interface TreeDocxSessionView {
    * empty paragraph — a declaration with no glyph behind it.
    */
   rendersText(): boolean;
-  /**
-   * The `w:style` definitions of the styles part, validated and projected for a style
-   * picker. Memoized once: the styles part is immutable for the session's lifetime.
-   * A document without a styles part answers `[]`.
-   */
+  /** Validated style-picker projection. A document without styles answers `[]`. */
   documentStyles(): readonly DocumentStyleEntry[];
-  /**
-   * Root of the styles part tree, for layout's style cascade. Memoized once; `null` when
-   * the package has no styles part. Styles editing is a later slice, so this is immutable
-   * for the session.
-   */
+  /** Current styles root for layout, or `null` when the package has no styles part. */
   stylesRoot(): OoxmlElement | null;
   /**
    * The theme part's Latin typefaces, for resolving `w:rFonts` theme references in layout.
@@ -709,18 +701,14 @@ export function openTreeSession(
     return headerFooterBySection;
   };
 
-  // The styles / numbering parts, resolved once through the main part's relationships
-  // (the same resolution discipline `resolveHeaderFooterParts` uses), with conventional
-  // part names as fallbacks. Both are immutable in-session (editing is a later slice).
+  // Resolve styles and numbering through relationships, with conventional-name fallbacks.
+  // Their memoized roots are cleared after the narrow package edits this session supports.
   const STYLES_REL_TYPE =
     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
   const NUMBERING_REL_TYPE =
     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
-  let stylesRootResolved = false;
   let stylesRoot: OoxmlElement | null = null;
   const resolveStylesRoot = (): OoxmlElement | null => {
-    if (stylesRootResolved) return stylesRoot;
-    stylesRootResolved = true;
     const live = currentPackage();
     const record = (live.relationships.get(live.mainDocumentPart) ?? []).find(
       (rel) => rel.type === STYLES_REL_TYPE
@@ -733,7 +721,12 @@ export function openTreeSession(
       }
     }
     part ??= live.parts.get('/word/styles.xml');
-    stylesRoot = part?.root ?? null;
+    const next = part?.root ?? null;
+    if (next !== stylesRoot) {
+      stylesRoot = next;
+      stylesCache = null;
+      runDefaultsResolver = null;
+    }
     return stylesRoot;
   };
 
@@ -870,16 +863,8 @@ export function openTreeSession(
   let themeColorsCache: readonly DocumentThemeColorEntry[] | null = null;
   let themeFontsCache: DocumentThemeFonts | null = null;
   /**
-   * The trees the document-wide catalogs read: the live body, the styles part, and every
-   * other story — each distinct header and footer across sections, and both note parts.
-   *
-   * NOTES ARE STORIES TOO. The list enumerated them explicitly and stopped one short, so a
-   * family declared only in a footnote was invisible: the host was never told to load it, so
-   * the note measured and painted with a fallback face, and the font picker did not offer it.
-   *
-   * Shared so `documentFonts` and `rendersText` can never disagree about what "the document"
-   * covers. Not memoized — both callers cache their own answer per package revision, and this
-   * only gathers already-resolved roots.
+   * Live body, styles, headers, footers, and notes used by both document-wide catalogs.
+   * Including notes ensures their fonts load. Callers memoize each answer by package revision.
    */
   const catalogRoots = (): OoxmlElement[] => {
     const roots: OoxmlElement[] = [bodyStore().part.root];
@@ -897,8 +882,7 @@ export function openTreeSession(
   let runDefaultsResolver:
     | ((styleId: string | null, runProperties?: readonly RunPropertyLike[]) => StyleRunDefaults)
     | null = null;
-  // Paragraph -> pStyle, per revision: an edit can change a paragraph's style, but the
-  // styles and theme parts cannot change in-session.
+  // Paragraph -> pStyle, per revision. Style-part repair clears this cache explicitly.
   let pStyleCache: { readonly revision: number; readonly byId: Map<string, string | null> } | null =
     null;
   let outlineCache: {

--- a/packages/core/src/editor/__tests__/blank-document-styles.test.ts
+++ b/packages/core/src/editor/__tests__/blank-document-styles.test.ts
@@ -90,6 +90,11 @@ async function savedDocument(editor: DocxEditorInstance): Promise<string> {
   return strFromU8(files['word/document.xml']!);
 }
 
+async function savedStyles(editor: DocxEditorInstance): Promise<string> {
+  const files = unzipSync(new Uint8Array(await editor.save()));
+  return strFromU8(files['word/styles.xml']!);
+}
+
 describe("the blank template's style gallery", () => {
   test("it defines Word's built-in styles, in Word's gallery order", () => {
     const { editor } = mount(blankDocumentBytes());
@@ -195,6 +200,35 @@ describe('toggleList applies List Paragraph, as Word does', () => {
     expect(saved).not.toContain('<w:pStyle w:val="Normal"/>');
     const [first, second] = blockHeights(surface);
     expect(second! - first!).toBe(8);
+  });
+
+  test('a converted List Paragraph style gains contextual spacing before use', async () => {
+    const { editor, surface } = mount(
+      docx(
+        '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>' +
+          '<w:style w:type="paragraph" w:styleId="ListParagraph">' +
+          '<w:name w:val="List Paragraph"/><w:basedOn w:val="Normal"/></w:style>',
+        '<w:p><w:pPr><w:spacing w:before="120" w:after="120"/></w:pPr><w:r><w:t>one</w:t></w:r></w:p>' +
+          '<w:p><w:pPr><w:spacing w:before="120" w:after="120"/></w:pPr><w:r><w:t>two</w:t></w:r></w:p>' +
+          '<w:p><w:r><w:t>after</w:t></w:r></w:p>'
+      )
+    );
+    selectParagraphs(surface, 0, 1);
+    expect(surface.toggleList('bullet')).toBe(true);
+
+    const styles = await savedStyles(editor);
+    expect(styles).toMatch(
+      /<w:style [^>]*w:styleId="ListParagraph"[^>]*>.*<w:pPr><w:contextualSpacing\/><\/w:pPr><\/w:style>/
+    );
+    const [first, second] = surface
+      .layout()
+      .pages[0]!.fragments.filter((fragment) => fragment.kind === 'paragraph');
+    if (first?.kind !== 'paragraph' || second?.kind !== 'paragraph') {
+      throw new Error('expected list paragraphs');
+    }
+    expect(first.spacing.after).toBe(0);
+    expect(second.spacing.before).toBe(0);
+    expect(second.spacing.after).toBe(6);
   });
 
   test('pressing Bullets FIRST and then typing closes the items up too', () => {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -579,8 +579,7 @@ export function mountPaginatedSurface(
   let lastPaintMs = 0;
   let lastSelectionMs = 0;
 
-  // Styles/numbering are immutable in-session; cascade + index are built once and shared
-  // by body layout and header/footer stories.
+  // Style and numbering indexes are identity-memoized and shared by every story.
   const { styleCascade, numberingIndex, defaultTabStopPt } = createSurfaceStyleDeps(session);
   let onDrawingResourcesChanged: (() => void) | null = null;
   const decodePort =
@@ -737,7 +736,7 @@ export function mountPaginatedSurface(
     selectionMark: () => selectionMark(),
     textOf: (paragraphId) => textOf(paragraphId),
     selectedCells: () => cellSelection?.cellIds,
-    defaultParagraphStyleId: () => styleCascade?.defaultParagraphStyleId ?? null,
+    defaultParagraphStyleId: () => styleCascade()?.defaultParagraphStyleId ?? null,
     defaultFontFamily: () => options.defaultFontFamily ?? null,
     pendingFormats: () => pendingAtCaret(),
     setPendingFormats: (next) => {
@@ -795,7 +794,7 @@ export function mountPaginatedSurface(
     // `setListLevel` was refused where layout would have rendered the marker fine.
     numberingLevelExists: (numId, level) =>
       resolveNumberingLevel(
-        withNumberingStyleLinks(numberingIndex(), styleCascade),
+        withNumberingStyleLinks(numberingIndex(), styleCascade()),
         numId,
         level
       ) !== null,
@@ -925,7 +924,7 @@ export function mountPaginatedSurface(
       cache: layoutCache,
       session: layoutSession,
       producer,
-      styleCascade,
+      styleCascade: styleCascade(),
       defaultTabStopPt,
       numberingIndex: numberingIndex(),
       sectionFurniture: furnitureSource.sectionFurniture(),

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -58,7 +58,7 @@ export function createFurnitureSource(env: {
   readonly measurer: TextMeasurer;
   readonly producer: string;
   readonly cache: Parameters<typeof layoutHeaderFooterStory>[4];
-  readonly styleCascade?: Parameters<typeof layoutHeaderFooterStory>[5];
+  readonly styleCascade?: () => Parameters<typeof layoutHeaderFooterStory>[5];
   /**
    * `numbering.xml`, so a `w:numPr` paragraph in a header or footer resolves a marker.
    *
@@ -132,6 +132,7 @@ export function createFurnitureSource(env: {
       producer: string;
       drawingLayoutToken: string;
       numberingIndex: import('../layout/numbering-index.ts').NumberingIndex | undefined;
+      styleCascade: Parameters<typeof layoutHeaderFooterStory>[5];
       story: ReturnType<typeof layoutHeaderFooterStory>;
     }
   >();
@@ -160,6 +161,7 @@ export function createFurnitureSource(env: {
     const marginLeft = sectionGeometry?.margin.left ?? 0;
     const marginRight = sectionGeometry?.margin.right ?? 0;
     const numbering = numberingIndex?.();
+    const styles = styleCascade?.();
     const memo = hfStoryMemo.get(part);
     if (
       memo &&
@@ -171,7 +173,8 @@ export function createFurnitureSource(env: {
       memo.marginRight === marginRight &&
       memo.producer === producer &&
       memo.drawingLayoutToken === partDrawingToken &&
-      memo.numberingIndex === numbering
+      memo.numberingIndex === numbering &&
+      memo.styleCascade === styles
     ) {
       return memo.story;
     }
@@ -182,7 +185,7 @@ export function createFurnitureSource(env: {
       measurer,
       producer,
       cache,
-      styleCascade,
+      styles,
       undefined,
       undefined,
       defaultTabStopPt,
@@ -218,6 +221,7 @@ export function createFurnitureSource(env: {
       producer,
       drawingLayoutToken: partDrawingToken,
       numberingIndex: numbering,
+      styleCascade: styles,
       story,
     });
     return story;
@@ -300,36 +304,42 @@ function stampStoryRId(
   };
 }
 
-/** Immutable-in-session style + numbering projections shared by body and furniture layout. */
+/** Style and numbering projections shared by body and furniture layout. */
 export function createSurfaceStyleDeps(session: TreeDocxSessionView): {
-  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly styleCascade: () => StyleCascadeTable | undefined;
   /**
    * `w:settings/w:defaultTabStop` in points. Read once: the settings part is immutable
-   * in-session, like the styles part.
+   * in-session.
    */
   readonly defaultTabStopPt: number;
   /**
    * Read per layout pass, not captured once.
    *
-   * The styles part is immutable in-session, but the numbering part is NOT: turning on
-   * bullets creates a definition, and a captured index would keep reporting the document
-   * as unnumbered. `session.numberingRoot()` is memoized until that happens, so re-reading
-   * costs a map lookup on every other pass.
+   * The numbering part is mutable: turning on bullets can create a definition.
    */
   numberingIndex(): NumberingIndex;
 } {
-  let root: OoxmlElement | null | undefined;
-  let index: NumberingIndex | undefined;
+  let numberingRoot: OoxmlElement | null | undefined;
+  let numbering: NumberingIndex | undefined;
+  let stylesRoot: OoxmlElement | null | undefined;
+  let styles: StyleCascadeTable | undefined;
   return {
-    styleCascade: buildStyleCascadeTable(session.stylesRoot(), session.documentThemeFonts()),
+    styleCascade() {
+      const current = session.stylesRoot();
+      if (styles === undefined || current !== stylesRoot) {
+        stylesRoot = current;
+        styles = buildStyleCascadeTable(current, session.documentThemeFonts());
+      }
+      return styles;
+    },
     defaultTabStopPt: defaultTabIntervalFromSettings(session.settingsRoot()),
     numberingIndex() {
       const current = session.numberingRoot();
-      if (index === undefined || current !== root) {
-        root = current;
-        index = buildNumberingIndex(current);
+      if (numbering === undefined || current !== numberingRoot) {
+        numberingRoot = current;
+        numbering = buildNumberingIndex(current);
       }
-      return index;
+      return numbering;
     },
   };
 }
@@ -494,7 +504,7 @@ export function createNotesLayoutInput(env: {
   readonly measurer: TextMeasurer;
   readonly producer: string;
   readonly cache: Parameters<typeof layoutHeaderFooterStory>[4];
-  readonly styleCascade?: StyleCascadeTable;
+  readonly styleCascade?: () => StyleCascadeTable | undefined;
   /** `numbering.xml`, so a `w:numPr` paragraph inside a note resolves a marker. */
   readonly numberingIndex?: () => import('../layout/numbering-index.ts').NumberingIndex;
   readonly defaultTabStopPt?: number;
@@ -572,7 +582,7 @@ export function createNotesLayoutInput(env: {
     measurer: env.measurer,
     producer: env.producer,
     cache: env.cache,
-    styleCascade: env.styleCascade,
+    styleCascade: env.styleCascade?.(),
     numberingIndex: env.numberingIndex?.(),
     defaultTabStopPt: env.defaultTabStopPt,
     ...(drawingsForPart ? { drawingsForPart } : {}),

--- a/packages/core/src/store/package/list-style-part.ts
+++ b/packages/core/src/store/package/list-style-part.ts
@@ -1,0 +1,177 @@
+// Repairing the built-in List Paragraph style for a list gesture.
+//
+// Word puts `w:contextualSpacing` on List Paragraph. Some converters keep the built-in
+// name and id but omit that property. Applying such a style preserves each paragraph's
+// direct before/after spacing between consecutive items, which makes the new list look
+// unlike the list Word creates.
+
+import { createNodeIdAllocator, insertChildren, replaceNode } from './ooxml-edit.ts';
+import { stylesPartOf } from './ooxml-indexes.ts';
+import type { OoxmlElement, OoxmlNode, OoxmlPart } from './ooxml-tree.ts';
+import { readOoxmlPart } from './ooxml-tree.ts';
+import type { OoxmlPackage } from './ooxml-package.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const STYLES_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml';
+
+function childNamed(node: OoxmlElement, localName: string): OoxmlElement | null {
+  for (const child of node.children) {
+    if (child.kind !== 'textValue' && child.namespaceUri === W && child.localName === localName) {
+      return child;
+    }
+  }
+  return null;
+}
+
+function attribute(node: OoxmlElement, localName: string): string | undefined {
+  return node.attributes.find((entry) => entry.namespaceUri === W && entry.localName === localName)
+    ?.value;
+}
+
+function enabled(node: OoxmlElement): boolean {
+  const value = attribute(node, 'val');
+  return value === undefined || value === '1' || value === 'true' || value === 'on';
+}
+
+function withFreshIds(node: OoxmlNode, nextId: () => string): OoxmlNode {
+  if (node.kind === 'textValue') return Object.freeze({ ...node, id: nextId() });
+  return Object.freeze({
+    ...node,
+    id: nextId(),
+    children: node.children.map((child) => withFreshIds(child, nextId)),
+  }) as OoxmlElement;
+}
+
+function authoredParagraphProperties(part: OoxmlPart): OoxmlElement | null {
+  const read = readOoxmlPart(
+    `<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="ListParagraph">` +
+      '<w:pPr><w:contextualSpacing/></w:pPr></w:style></w:styles>',
+    { name: part.name, contentType: STYLES_CONTENT_TYPE }
+  );
+  if (!read.ok) return null;
+  const style = childNamed(read.part.root, 'style');
+  const pPr = style ? childNamed(style, 'pPr') : null;
+  return pPr ? (withFreshIds(pPr, createNodeIdAllocator(part)) as OoxmlElement) : null;
+}
+
+// CT_PPrBase order through the slot used here. Later children remain after the insertion.
+const PPR_SEQUENCE = [
+  'pStyle',
+  'keepNext',
+  'keepLines',
+  'pageBreakBefore',
+  'framePr',
+  'widowControl',
+  'numPr',
+  'suppressLineNumbers',
+  'pBdr',
+  'shd',
+  'tabs',
+  'suppressAutoHyphens',
+  'kinsoku',
+  'wordWrap',
+  'overflowPunct',
+  'topLinePunct',
+  'autoSpaceDE',
+  'autoSpaceDN',
+  'bidi',
+  'adjustRightInd',
+  'snapToGrid',
+  'spacing',
+  'ind',
+  'contextualSpacing',
+  'mirrorIndents',
+  'suppressOverlap',
+  'jc',
+  'textDirection',
+  'textAlignment',
+  'textboxTightWrap',
+  'outlineLvl',
+  'divId',
+  'cnfStyle',
+  'rPr',
+  'sectPr',
+  'pPrChange',
+] as const;
+
+function sequenceInsertIndex(children: readonly OoxmlNode[], localName: string): number {
+  const rank = PPR_SEQUENCE.indexOf(localName as (typeof PPR_SEQUENCE)[number]);
+  let at = 0;
+  children.forEach((child, index) => {
+    if (child.kind === 'textValue') return;
+    const childRank = PPR_SEQUENCE.indexOf(child.localName as (typeof PPR_SEQUENCE)[number]);
+    if (childRank !== -1 && childRank <= rank) at = index + 1;
+  });
+  return at;
+}
+
+/**
+ * Ensure one paragraph style carries Word's contextual-spacing rule.
+ *
+ * Returns the unchanged package when the rule is already on. Returns null when the named
+ * paragraph style or a valid authored replacement cannot be found.
+ */
+export function ensureListParagraphContextualSpacing(
+  pkg: OoxmlPackage,
+  styleId: string
+): OoxmlPackage | null {
+  const part = stylesPartOf(pkg);
+  if (!part) return null;
+  let style: OoxmlElement | null = null;
+  for (const node of part.root.children) {
+    if (node.kind === 'textValue') continue;
+    if (
+      node.namespaceUri === W &&
+      node.localName === 'style' &&
+      attribute(node, 'type') === 'paragraph' &&
+      attribute(node, 'styleId') === styleId
+    ) {
+      style = node;
+      break;
+    }
+  }
+  if (!style) return null;
+  const name = childNamed(style, 'name');
+  if (
+    name &&
+    attribute(name, 'val')?.trim().toLowerCase() !== 'list paragraph' &&
+    styleId !== 'ListParagraph'
+  ) {
+    return null;
+  }
+
+  const authored = authoredParagraphProperties(part);
+  if (!authored) return null;
+  const authoredContextual = childNamed(authored, 'contextualSpacing');
+  if (!authoredContextual) return null;
+
+  const pPr = childNamed(style, 'pPr');
+  let edited;
+  if (!pPr) {
+    const firstLater = style.children.findIndex(
+      (child) =>
+        child.kind !== 'textValue' &&
+        ['rPr', 'tblPr', 'tcPr', 'tblStylePr'].includes(child.localName)
+    );
+    edited = insertChildren(
+      part,
+      style.id,
+      firstLater === -1 ? style.children.length : firstLater,
+      [authored]
+    );
+  } else {
+    const existing = childNamed(pPr, 'contextualSpacing');
+    if (existing && enabled(existing)) return pkg;
+    edited = existing
+      ? replaceNode(part, existing.id, authoredContextual)
+      : insertChildren(part, pPr.id, sequenceInsertIndex(pPr.children, 'contextualSpacing'), [
+          authoredContextual,
+        ]);
+  }
+  if (!edited.ok) return null;
+  return Object.freeze({
+    ...pkg,
+    parts: new Map([...pkg.parts, [part.name, edited.part]]),
+  });
+}

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -18,6 +18,7 @@ import type { OoxmlPart } from '../package/ooxml-tree.ts';
 import { normalizeParagraphIdentity } from '../package/para-id.ts';
 import { openStoryPartsOf, openStoryTokenOf } from './open-story-parts.ts';
 import { settingsPartOf } from '../package/note-properties.ts';
+import { ensureListParagraphContextualSpacing } from '../package/list-style-part.ts';
 import { withPart, type OoxmlExternalTarget, type OoxmlPackage } from '../package/ooxml-package.ts';
 import { resolveRelationship, type RelationshipRecord } from '../package/relationships.ts';
 import {
@@ -392,6 +393,8 @@ export class TreePackageStore {
     // a before/after diff, so it needs the same "was it even possible" gate.
     let mayEmptyComments = false;
     const commentTargets = new Set<string>();
+    let turnsListOn = false;
+    let listStyleId: string | undefined;
     const result = store.transact(
       (ctx) => {
         build({
@@ -400,6 +403,11 @@ export class TreePackageStore {
           // same unit as the story, and rebuilding the object dropped them.
           ...ctx,
           apply: (op) => {
+            if (op.op === 'setListNumbering' && op.numId !== null) turnsListOn = true;
+            if (op.op === 'setParagraphProperties') {
+              listStyleId ??= op.properties.find((property) => property.localName === 'pStyle')
+                ?.attributes?.val;
+            }
             if (!mayDeleteNoteAtoms) {
               if (
                 op.op === 'deleteText' &&
@@ -463,6 +471,10 @@ export class TreePackageStore {
     }
 
     this.syncPackageFromStore(store);
+    if (turnsListOn && listStyleId) {
+      const repaired = ensureListParagraphContextualSpacing(this.pkg, listStyleId);
+      if (repaired) this.replacePackageShell(repaired);
+    }
 
     // Cascade note-body deletion when a reference atom was removed by text or block delete.
     // Body mutation + cascade share one package history unit; local story history is


### PR DESCRIPTION
## Summary
- Repair converted `ListParagraph` styles that omit `w:contextualSpacing`.
- Refresh style cascades after the repair so list items close immediately.

## Test plan
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run api:check`
- [x] `openspec validate typed-ooxml-paragraph-editor --strict`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790175826&installation_model_id=422592&pr_number=407&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F407&signature=d1b49a3a969c7d269bec7a86d20cf8fc8bf340af6b7c5981a0d76e7bd560c94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->