### PR TITLE
feat: add document loading scaffold

### DIFF
--- a/.changeset/document-loading-page.md
+++ b/.changeset/document-loading-page.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Show a responsive document-page scaffold while a document loads.

--- a/.changeset/document-loading-page.md
+++ b/.changeset/document-loading-page.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/react': patch
 ---
 
-Show a responsive document-page scaffold while a document loads.
+Show a responsive document page with loading status while a document opens.

--- a/docs/site/content/quickstart.mdx
+++ b/docs/site/content/quickstart.mdx
@@ -41,7 +41,7 @@ On Next.js, Nuxt, Remix, or other SSR frameworks the editor must render client-s
 
 This example puts load, edit, and save in one file. A file input supplies bytes to the editor, the editor supports editing (typing, formatting, undo, tables), and a button serializes the current state back to a `.docx` download.
 
-The packaged `<DocxEditor>` shows the page scaffold while a document opens.
+The packaged `<DocxEditor>` shows a document page with loading status while a document opens.
 
 <FrameworkTabs>
 <Framework value="react">

--- a/docs/site/content/quickstart.mdx
+++ b/docs/site/content/quickstart.mdx
@@ -41,6 +41,8 @@ On Next.js, Nuxt, Remix, or other SSR frameworks the editor must render client-s
 
 This example puts load, edit, and save in one file. A file input supplies bytes to the editor, the editor supports editing (typing, formatting, undo, tables), and a button serializes the current state back to a `.docx` download.
 
+The packaged `<DocxEditor>` shows the page scaffold while a document opens.
+
 <FrameworkTabs>
 <Framework value="react">
 

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -706,10 +706,7 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
                 big file behind one painted frame and reports `isOpening`, so picking a
                 large document through Open DOCX shows this screen instead of freezing
                 on the old one. It renders nothing while the document is on screen. */}
-            <DocxEditor.Loading overlay>
-              <DocxEditor.Loading.Spinner />
-              <span>Loading document…</span>
-            </DocxEditor.Loading>
+            <DocxEditor.Loading overlay />
             {/* Floating diagnostics chrome, above the overlay panels. */}
             <PerfHud />
             <CitationPopover
@@ -730,12 +727,9 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
         </div>
       ) : (
         // The library's loading surface rather than a hand-rolled div: rendered outside
-        // a `Root` it always shows, which is exactly this branch's condition. Children
-        // replace the packaged screen, so the spinner is composed back in by name.
-        <DocxEditor.Loading className="demo-loading">
-          <DocxEditor.Loading.Spinner />
-          <span>Loading document…</span>
-        </DocxEditor.Loading>
+        // a `Root` it always shows, which is exactly this branch's condition. Its default
+        // page scaffold uses the active locale and the same paper tokens as the editor.
+        <DocxEditor.Loading className="demo-loading" />
       )}
     </div>
   );

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -728,7 +728,7 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
       ) : (
         // The library's loading surface rather than a hand-rolled div: rendered outside
         // a `Root` it always shows, which is exactly this branch's condition. Its default
-        // page scaffold uses the active locale and the same paper tokens as the editor.
+        // loading page uses the active locale and the same paper tokens as the editor.
         <DocxEditor.Loading className="demo-loading" />
       )}
     </div>

--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -618,12 +618,18 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
       className={`docx-editor demo-app${colorMode === 'dark' ? ' dark' : ''}`}
       data-testid="composed-mount"
     >
-      {bytes ? (
+      {loadError ? (
+        // A failed fetch is NOT a loading state: it is terminal, and routing it through
+        // the polite live region would announce it as progress. Its own assertive region.
+        <div className="demo-loading" role="alert">
+          {`Could not load the document: ${loadError.message}`}
+        </div>
+      ) : (
         // Authoring is ambient: comments and tracked changes take their `@w:author` from
         // `author`, the way the Office JS API sources it from context. A real app supplies
         // the signed-in user; a demo supplies a name so replies can be written at all.
         <DocxEditor.Root
-          document={bytes}
+          {...(bytes ? { document: bytes } : {})}
           author="Demo Reviewer"
           // The demo always opens ready to type: without an explicit mode, a document
           // carrying `w:trackRevisions` opens in suggesting (the Root follows the file).
@@ -719,17 +725,6 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
             ) : null}
           </div>
         </DocxEditor.Root>
-      ) : loadError ? (
-        // A failed fetch is NOT a loading state: it is terminal, and routing it through
-        // the polite live region would announce it as progress. Its own assertive region.
-        <div className="demo-loading" role="alert">
-          {`Could not load the document: ${loadError.message}`}
-        </div>
-      ) : (
-        // The library's loading surface rather than a hand-rolled div: rendered outside
-        // a `Root` it always shows, which is exactly this branch's condition. Its default
-        // loading page uses the active locale and the same paper tokens as the editor.
-        <DocxEditor.Loading className="demo-loading" />
       )}
     </div>
   );

--- a/packages/core/src/editor/__tests__/deferred-open.test.ts
+++ b/packages/core/src/editor/__tests__/deferred-open.test.ts
@@ -14,6 +14,7 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { createDocxEditor } from '../docx-editor.ts';
+import { stubReviewModule } from './review-test-module.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -158,6 +159,25 @@ describe('deferred open of a large document', () => {
 
     await until(() => container.textContent?.includes('large document body') === true);
     expect(editor.snapshot().isOpening).toBe(false);
+    editor.destroy();
+  });
+
+  test('load() closes the previous comments pane before it shows the overlay', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      document: SMALL,
+      modules: [stubReviewModule()],
+    });
+    editor.exec({ type: 'toggleReviewPane' });
+    expect(editor.isReviewPaneOpen()).toBe(true);
+
+    editor.load(LARGE);
+
+    expect(editor.snapshot().isOpening).toBe(true);
+    expect(editor.isReviewPaneOpen()).toBe(false);
+    await until(() => editor.surface?.session.bodyText().includes('large document body') === true);
+    expect(editor.isReviewPaneOpen()).toBe(false);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -599,7 +599,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     surface = result.surface;
     // Keep the loading page centred and its comments control inactive until the review
     // model exists. Once open completes, show the pane only when the model found content.
-    reviewPaneOpen = reviewEnabled && surface.session.hasReviewContent();
+    reviewPaneOpen = reviewEnabled && surface.session.reviewItems().length > 0;
     adoptDocumentTracking();
     sweepCustomNodePayloadsOnOpen(surface, modules);
     mountGeneration += 1;

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -431,6 +431,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   /** Monotonic mount generation for async image mutation preconditions. */
   let mountGeneration = 0;
   let cachedVersion = -1;
+  /** Closed until a mounted review model confirms that the document has review content. */
+  let reviewPaneOpen = false;
 
   /** Called at every place observable state can move. Derivation stays lazy. */
   function bump(): void {
@@ -595,6 +597,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     }
     parseError = null;
     surface = result.surface;
+    // Keep the loading page centred and its comments control inactive until the review
+    // model exists. Once open completes, show the pane only when the model found content.
+    reviewPaneOpen = reviewEnabled && surface.session.hasReviewContent();
     adoptDocumentTracking();
     sweepCustomNodePayloadsOnOpen(surface, modules);
     mountGeneration += 1;
@@ -1332,9 +1337,6 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
 
   /** Word writes `@w:date` to the second; milliseconds group with nothing. */
   const secondsPrecisionNow = (): string => `${new Date().toISOString().slice(0, 19)}Z`;
-
-  /** Open by default: a document with comments should show them without being asked. */
-  let reviewPaneOpen = true;
 
   /** Paragraph id to document position, memoized per layout. */
   const paragraphOrderCache = new WeakMap<SemanticLayout, Map<string, number>>();

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -662,6 +662,9 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   function loadBytes(bytes: Uint8Array): void {
     // A load supersedes any open still waiting on its frame: drop the superseded bytes.
     openScheduler.cancel();
+    // The previous document can leave its comments pane open. Close it before a deferred
+    // open publishes `isOpening`, so the loading page uses the full centred workspace.
+    reviewPaneOpen = false;
     loadSeq += 1;
     shapedMeasurer = undefined;
     shapedProducer = undefined;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3662,8 +3662,10 @@ a.docx-hyperlink:focus-visible {
   user-select: none;
 }
 
-.docx-toolbar__picker[aria-disabled='true'] {
+.docx-toolbar__picker[aria-disabled='true'],
+.docx-toolbar__picker:disabled {
   opacity: 0.5;
+  cursor: default;
 }
 
 .docx-toolbar__picker-caret {

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3423,6 +3423,9 @@ a.docx-hyperlink:focus-visible {
 .docx-toolbar {
   display: flex;
   align-items: center;
+  min-inline-size: 0;
+  margin: 0;
+  border: 0;
   /* NOT overflow-scroll like the chrome spec's pill: this toolbar hosts LIVE popups
    * (font menu, swatch grids) positioned absolutely inside their parts, and any
    * overflow clipping on the bar would cut them off. A bar that does not measure
@@ -4698,7 +4701,6 @@ a.docx-hyperlink:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
   transform: translateY(-50%);
 }
 

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4635,6 +4635,7 @@ a.docx-hyperlink:focus-visible {
   width: 100%;
   height: 100%;
   min-height: 0;
+  container-type: size;
   color: var(--doc-text-muted);
   font-size: 14px;
 }
@@ -4668,11 +4669,88 @@ a.docx-hyperlink:focus-visible {
   }
 }
 
-/* The default screen when the host supplies no children.
-   `display` and `box-sizing` are explicit rather than inherited from Tailwind's
-   preflight: the part emits its own `docx-editor`, so it can be composed somewhere the
-   preflight does not reach, and an inline span would otherwise measure 42px and only
-   size at all by accident of being a flex item. */
+/* The default screen resembles the first page before its contents arrive. It uses the
+   same US Letter proportions and shadow as the painted surface. Container units let the
+   page respond to both axes, including narrow or short overlay viewports. */
+.docx-editor__loading-page {
+  position: relative;
+  box-sizing: border-box;
+  flex: none;
+  width: min(816px, calc(100cqw - 32px), calc((100cqh - 32px) * 0.772727));
+  aspect-ratio: 8.5 / 11;
+  overflow: hidden;
+  padding: clamp(28px, 9.09%, 96px) clamp(24px, 11.76%, 96px);
+  background: var(--doc-page-bg-rendered);
+  border: 1px solid var(--doc-border-light);
+  box-shadow: 0 1px 3px var(--doc-shadow);
+}
+
+.docx-editor__loading-page-status {
+  position: absolute;
+  inset: 30% 12% auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--doc-text-muted);
+  font-size: 14px;
+}
+
+/* Restrained paragraph shapes make the page read as a document, not a generic card.
+   The whole scaffold breathes together instead of sending separate waves through it. */
+.docx-editor__loading-lines {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(7px, 1.25cqw, 12px);
+  animation: docx-editor-loading-pulse 1.8s ease-in-out infinite;
+}
+
+.docx-editor__loading-lines > span {
+  display: block;
+  width: 100%;
+  height: clamp(5px, 0.74cqw, 8px);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--doc-text-muted) 14%, var(--doc-page-bg-rendered));
+}
+
+.docx-editor__loading-lines > span:nth-child(1) {
+  width: 48%;
+  height: clamp(8px, 1.1cqw, 12px);
+  margin-bottom: clamp(7px, 1.25cqw, 12px);
+}
+
+.docx-editor__loading-lines > span:nth-child(3),
+.docx-editor__loading-lines > span:nth-child(8) {
+  width: 91%;
+}
+
+.docx-editor__loading-lines > span:nth-child(4) {
+  width: 73%;
+  margin-bottom: clamp(32px, 7cqw, 64px);
+}
+
+.docx-editor__loading-lines > span:nth-child(6),
+.docx-editor__loading-lines > span:nth-child(10) {
+  width: 84%;
+}
+
+.docx-editor__loading-lines > span:nth-child(11) {
+  width: 62%;
+}
+
+@keyframes docx-editor-loading-pulse {
+  0%,
+  100% {
+    opacity: 0.42;
+  }
+
+  50% {
+    opacity: 0.82;
+  }
+}
+
+/* `display` and `box-sizing` are explicit rather than inherited from Tailwind's
+   preflight. The loading part can sit outside the host's utility scope. */
 .docx-editor__loading-spinner {
   display: block;
   box-sizing: border-box;
@@ -4687,6 +4765,12 @@ a.docx-hyperlink:focus-visible {
   animation: docx-editor-loading-spin 0.8s linear infinite;
 }
 
+.docx-editor__loading-page-status .docx-editor__loading-spinner {
+  width: 18px;
+  height: 18px;
+  border-width: 2px;
+}
+
 @keyframes docx-editor-loading-spin {
   to {
     transform: rotate(360deg);
@@ -4695,7 +4779,8 @@ a.docx-hyperlink:focus-visible {
 
 /* Respect a reduced-motion preference: keep the indicator, drop the rotation. */
 @media (prefers-reduced-motion: reduce) {
-  .docx-editor__loading-spinner {
+  .docx-editor__loading-spinner,
+  .docx-editor__loading-lines {
     animation: none;
   }
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4636,23 +4636,15 @@ a.docx-hyperlink:focus-visible {
    Loading surface (`DocxEditor.Loading`)
    --------------------------------------------------------------------------- */
 
-/* Fills whatever box the host places it in, so the same declaration works as a
-   full-page screen and as an in-viewport overlay. */
+/* Fills whatever box the host places it in. The default child uses the real paginated
+   surface and page classes, so its position and paper styling match a loaded document. */
 .docx-editor__loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 16px;
+  display: block;
   box-sizing: border-box;
   width: 100%;
   height: 100%;
   min-height: 0;
-  padding: 32px 0;
-  padding-inline-start: var(--docx-loading-inline-start, 0px);
-  padding-right: var(--docx-loading-right, 0px);
   overflow: auto;
-  container-type: size;
   color: var(--doc-text-muted);
   font-size: 14px;
 }
@@ -4686,25 +4678,28 @@ a.docx-hyperlink:focus-visible {
   }
 }
 
-/* The default screen resembles the first page before its contents arrive. It uses the
-   same full-size US Letter proportions and shadow as the painted surface. Only the
-   available width can reduce it; short viewports scroll as the painted surface does. */
-.docx-editor__loading-page {
+/* The loading sheet uses the same surface tree as a painted document:
+   `.docx-paginated-surface > .docx-pages > .docx-page`. React and Vue apply the layout
+   page size and zoom to the surface. The shared surface margin and page rule then control
+   centring, paper colour, and shadow without a second approximation. */
+.docx-editor__loading-surface > .docx-pages {
   position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.docx-editor__loading-page {
+  position: absolute;
+  inset: 0;
   box-sizing: border-box;
-  flex: none;
-  width: min(816px, calc(100cqw - 32px));
-  aspect-ratio: 8.5 / 11;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
-  padding: clamp(28px, 9.09%, 96px) clamp(24px, 11.76%, 96px);
-  background: var(--doc-page-bg-rendered);
-  border: 1px solid var(--doc-border-light);
-  box-shadow: 0 1px 3px var(--doc-shadow);
 }
 
 .docx-editor__loading-page-status {
   position: absolute;
-  top: min(50%, calc(50cqh - 32px));
+  top: 50%;
   right: 0;
   left: 0;
   display: flex;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4630,11 +4630,14 @@ a.docx-hyperlink:focus-visible {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 16px;
+  box-sizing: border-box;
   width: 100%;
   height: 100%;
   min-height: 0;
+  padding: 32px 0;
+  overflow: auto;
   container-type: size;
   color: var(--doc-text-muted);
   font-size: 14px;
@@ -4670,30 +4673,19 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* The default screen resembles the first page before its contents arrive. It uses the
-   same US Letter proportions and shadow as the painted surface. Container units let the
-   page respond to both axes, including narrow or short overlay viewports. */
+   same full-size US Letter proportions and shadow as the painted surface. Only the
+   available width can reduce it; short viewports scroll as the painted surface does. */
 .docx-editor__loading-page {
   position: relative;
   box-sizing: border-box;
   flex: none;
-  width: min(816px, calc(100cqw - 32px), calc((100cqh - 32px) * 0.772727));
+  width: min(816px, calc(100cqw - 32px));
   aspect-ratio: 8.5 / 11;
   overflow: hidden;
   padding: clamp(28px, 9.09%, 96px) clamp(24px, 11.76%, 96px);
   background: var(--doc-page-bg-rendered);
   border: 1px solid var(--doc-border-light);
   box-shadow: 0 1px 3px var(--doc-shadow);
-}
-
-.docx-editor__loading-page-status {
-  position: absolute;
-  inset: 30% 12% auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  color: var(--doc-text-muted);
-  font-size: 14px;
 }
 
 /* Restrained paragraph shapes make the page read as a document, not a generic card.
@@ -4765,19 +4757,13 @@ a.docx-hyperlink:focus-visible {
   animation: docx-editor-loading-spin 0.8s linear infinite;
 }
 
-.docx-editor__loading-page-status .docx-editor__loading-spinner {
-  width: 18px;
-  height: 18px;
-  border-width: 2px;
-}
-
 @keyframes docx-editor-loading-spin {
   to {
     transform: rotate(360deg);
   }
 }
 
-/* Respect a reduced-motion preference: keep the indicator, drop the rotation. */
+/* Respect a reduced-motion preference by keeping both indicators still. */
 @media (prefers-reduced-motion: reduce) {
   .docx-editor__loading-spinner,
   .docx-editor__loading-lines {

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4690,57 +4690,16 @@ a.docx-hyperlink:focus-visible {
   box-shadow: 0 1px 3px var(--doc-shadow);
 }
 
-/* Restrained paragraph shapes make the page read as a document, not a generic card.
-   The whole scaffold breathes together instead of sending separate waves through it. */
-.docx-editor__loading-lines {
+.docx-editor__loading-page-status {
+  position: absolute;
+  top: min(50%, calc(50cqh - 32px));
+  right: 0;
+  left: 0;
   display: flex;
-  flex-direction: column;
-  gap: clamp(7px, 1.25cqw, 12px);
-  animation: docx-editor-loading-pulse 1.8s ease-in-out infinite;
-}
-
-.docx-editor__loading-lines > span {
-  display: block;
-  width: 100%;
-  height: clamp(5px, 0.74cqw, 8px);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--doc-text-muted) 14%, var(--doc-page-bg-rendered));
-}
-
-.docx-editor__loading-lines > span:nth-child(1) {
-  width: 48%;
-  height: clamp(8px, 1.1cqw, 12px);
-  margin-bottom: clamp(7px, 1.25cqw, 12px);
-}
-
-.docx-editor__loading-lines > span:nth-child(3),
-.docx-editor__loading-lines > span:nth-child(8) {
-  width: 91%;
-}
-
-.docx-editor__loading-lines > span:nth-child(4) {
-  width: 73%;
-  margin-bottom: clamp(32px, 7cqw, 64px);
-}
-
-.docx-editor__loading-lines > span:nth-child(6),
-.docx-editor__loading-lines > span:nth-child(10) {
-  width: 84%;
-}
-
-.docx-editor__loading-lines > span:nth-child(11) {
-  width: 62%;
-}
-
-@keyframes docx-editor-loading-pulse {
-  0%,
-  100% {
-    opacity: 0.42;
-  }
-
-  50% {
-    opacity: 0.82;
-  }
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  transform: translateY(-50%);
 }
 
 /* `display` and `box-sizing` are explicit rather than inherited from Tailwind's
@@ -4765,10 +4724,9 @@ a.docx-hyperlink:focus-visible {
   }
 }
 
-/* Respect a reduced-motion preference by keeping both indicators still. */
+/* Respect a reduced-motion preference by keeping the indicator still. */
 @media (prefers-reduced-motion: reduce) {
-  .docx-editor__loading-spinner,
-  .docx-editor__loading-lines {
+  .docx-editor__loading-spinner {
     animation: none;
   }
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -4637,6 +4637,8 @@ a.docx-hyperlink:focus-visible {
   height: 100%;
   min-height: 0;
   padding: 32px 0;
+  padding-inline-start: var(--docx-loading-inline-start, 0px);
+  padding-right: var(--docx-loading-right, 0px);
   overflow: auto;
   container-type: size;
   color: var(--doc-text-muted);

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -2703,6 +2703,13 @@ a.docx-hyperlink:focus-visible {
   transition: padding-inline-start 0.2s ease;
 }
 
+/* A deferred open gives the loading overlay one frame before parsing. The parse blocks
+   layout transitions, so snap both ruler reservations before that frame or the right edge
+   moves while the start edge remains frozen, leaving the ruler half a strip off the page. */
+.docx-ruler-frame--opening {
+  transition: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .docx-ruler-frame {
     transition: none;

--- a/packages/pro/src/__tests__/review-composition.test.tsx
+++ b/packages/pro/src/__tests__/review-composition.test.tsx
@@ -174,8 +174,15 @@ describe('review compound composition', () => {
   });
 
   test('uses a List Empty override and preserves legacy root render children', () => {
+    let emptyEditor: DocxEditorInstance | null = null;
     const empty = render(
-      <DocxEditorRoot document={PLAIN} modules={[reviewModule()]}>
+      <DocxEditorRoot
+        document={PLAIN}
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          emptyEditor = editor as DocxEditorInstance;
+        }}
+      >
         <DocxEditorViewport>
           <DocxEditorContent />
           <DocxEditorReview>
@@ -186,6 +193,9 @@ describe('review compound composition', () => {
         </DocxEditorViewport>
       </DocxEditorRoot>
     );
+    act(() => {
+      emptyEditor!.exec({ type: 'toggleReviewPane' });
+    });
     expect(empty.getByTestId('review-empty').textContent).toBe('All clear');
     empty.unmount();
 

--- a/packages/pro/src/__tests__/review-facade.test.ts
+++ b/packages/pro/src/__tests__/review-facade.test.ts
@@ -1106,9 +1106,8 @@ describe('the review pane', () => {
 
   test('reopens when suggesting commits another tracked change', () => {
     const editor = mount({ body: '<w:p><w:r><w:t>plain text</w:t></w:r></w:p>' });
-    editor.setEditingMode('suggesting');
-    editor.exec({ type: 'toggleReviewPane' });
     expect(editor.isReviewPaneOpen()).toBe(false);
+    editor.setEditingMode('suggesting');
 
     editor.surface!.type('X');
 

--- a/packages/pro/src/__tests__/review-sidebar-vue.test.ts
+++ b/packages/pro/src/__tests__/review-sidebar-vue.test.ts
@@ -193,7 +193,6 @@ describe('DocxEditorReview (Vue)', () => {
       await waitFor(() => mounted.container.querySelector('.docx-page') !== null);
       const editor = mounted.editor();
       editor.surface!.selectAll();
-      editor.exec({ type: 'toggleReviewPane' });
       expect(editor.isReviewPaneOpen()).toBe(false);
       await flush();
       await waitFor(

--- a/packages/pro/src/__tests__/review-sidebar.test.tsx
+++ b/packages/pro/src/__tests__/review-sidebar.test.tsx
@@ -117,7 +117,6 @@ describe('the review sidebar', () => {
     const editor = instance!;
     await act(async () => {
       editor.surface!.selectAll();
-      editor.exec({ type: 'toggleReviewPane' });
     });
     expect(editor.isReviewPaneOpen()).toBe(false);
 
@@ -204,7 +203,6 @@ describe('the review sidebar', () => {
     const editor = instance!;
     await act(async () => {
       editor.surface!.selectAll();
-      editor.exec({ type: 'toggleReviewPane' });
     });
     expect(editor.isReviewPaneOpen()).toBe(false);
 
@@ -834,8 +832,8 @@ describe('DocxEditor.Review while the document is loading', () => {
     });
 
     expect(view.getByTestId('review-rail')).toBeDefined();
-    expect(view.getByTestId('review-empty')).toBeDefined();
-    expect(view.getByTestId('host-furniture')).toBeDefined();
+    expect(view.queryByTestId('review-empty')).toBeNull();
+    expect(view.queryByTestId('host-furniture')).toBeNull();
 
     // A parse failure clears `isLoading` (so a host can put its error screen up) while
     // still leaving no document. The rail must read that as "nothing to review", not as

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -32,6 +32,8 @@ import type { ReactNode } from 'react';
 import type { CSSProperties } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
+import { useNavigationShift } from './navigation/navigation-layout';
+import { useReviewGutter } from './review-gutter';
 import { useEditorState } from './useEditorState';
 
 /**
@@ -107,14 +109,21 @@ function DocxEditorLoadingImpl({
   children,
 }: DocxEditorLoadingProps) {
   const showLoading = useEditorState(selectShowLoading);
+  const navigationShift = useNavigationShift();
+  const reviewGutter = useReviewGutter();
   const { t } = useTranslation();
   if (!when && !showLoading) return null;
 
   const classes = `docx-editor docx-editor__loading${
     overlay ? ' docx-editor__loading--overlay' : ''
   }${className ? ` ${className}` : ''}`;
+  const loadingStyle = {
+    ['--docx-loading-inline-start' as string]: `${navigationShift + reviewGutter.inlineStart}px`,
+    ['--docx-loading-right' as string]: `${reviewGutter.inlineEnd}px`,
+    ...style,
+  } as CSSProperties;
   return (
-    <div className={classes} style={style} role="status" aria-live="polite">
+    <div className={classes} style={loadingStyle} role="status" aria-live="polite">
       {children ?? (
         <div className="docx-editor__loading-page">
           <span className="docx-editor-sr-only">{t('loading.label')}</span>

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -32,7 +32,6 @@ import type { ReactNode } from 'react';
 import type { CSSProperties } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
-import { useNavigationShift } from './navigation/navigation-layout';
 import { useEditorState } from './useEditorState';
 
 /**
@@ -108,7 +107,6 @@ function DocxEditorLoadingImpl({
   children,
 }: DocxEditorLoadingProps) {
   const showLoading = useEditorState(selectShowLoading);
-  const navigationShift = useNavigationShift();
   const { t } = useTranslation();
   if (!when && !showLoading) return null;
 
@@ -116,7 +114,7 @@ function DocxEditorLoadingImpl({
     overlay ? ' docx-editor__loading--overlay' : ''
   }${className ? ` ${className}` : ''}`;
   const loadingStyle = {
-    ['--docx-loading-inline-start' as string]: `${navigationShift}px`,
+    ['--docx-loading-inline-start' as string]: '0px',
     ['--docx-loading-right' as string]: '0px',
     ...style,
   } as CSSProperties;

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -33,7 +33,6 @@ import type { CSSProperties } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
 import { useNavigationShift } from './navigation/navigation-layout';
-import { useReviewGutter } from './review-gutter';
 import { useEditorState } from './useEditorState';
 
 /**
@@ -110,7 +109,6 @@ function DocxEditorLoadingImpl({
 }: DocxEditorLoadingProps) {
   const showLoading = useEditorState(selectShowLoading);
   const navigationShift = useNavigationShift();
-  const reviewGutter = useReviewGutter();
   const { t } = useTranslation();
   if (!when && !showLoading) return null;
 
@@ -118,8 +116,8 @@ function DocxEditorLoadingImpl({
     overlay ? ' docx-editor__loading--overlay' : ''
   }${className ? ` ${className}` : ''}`;
   const loadingStyle = {
-    ['--docx-loading-inline-start' as string]: `${navigationShift + reviewGutter.inlineStart}px`,
-    ['--docx-loading-right' as string]: `${reviewGutter.inlineEnd}px`,
+    ['--docx-loading-inline-start' as string]: `${navigationShift}px`,
+    ['--docx-loading-right' as string]: '0px',
     ...style,
   } as CSSProperties;
   return (

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -69,9 +69,9 @@ export interface DocxEditorLoadingProps {
   /** Inline styles for the loading container, as on `DocxEditor.Viewport`. */
   style?: CSSProperties;
   /**
-   * The loading screen. Omitted, a document-page scaffold rendered from the `--doc-*`
-   * tokens is used. Compose your own around `DocxEditor.Loading.Spinner` to keep the
-   * packaged indicator beside your own copy.
+   * The loading screen. Omitted, a full-size document page with the packaged indicator
+   * and localized status is used. Compose your own around `DocxEditor.Loading.Spinner`
+   * to keep the packaged indicator beside your own copy.
    */
   children?: DocxEditorChildren;
 }
@@ -126,19 +126,9 @@ function DocxEditorLoadingImpl({
     <div className={classes} style={loadingStyle} role="status" aria-live="polite">
       {children ?? (
         <div className="docx-editor__loading-page">
-          <span className="docx-editor-sr-only">{t('loading.label')}</span>
-          <div className="docx-editor__loading-lines" aria-hidden="true">
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
+          <div className="docx-editor__loading-page-status">
+            <DocxEditorLoadingSpinner />
+            <span>{t('loading.label')}…</span>
           </div>
         </div>
       )}

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -67,9 +67,9 @@ export interface DocxEditorLoadingProps {
   /** Inline styles for the loading container, as on `DocxEditor.Viewport`. */
   style?: CSSProperties;
   /**
-   * The loading screen. Omitted, a neutral spinner rendered from the `--doc-*` tokens is
-   * used, so the batteries-included path has something to show. Compose your own around
-   * `DocxEditor.Loading.Spinner` to keep the packaged indicator beside your own copy.
+   * The loading screen. Omitted, a document-page scaffold rendered from the `--doc-*`
+   * tokens is used. Compose your own around `DocxEditor.Loading.Spinner` to keep the
+   * packaged indicator beside your own copy.
    */
   children?: DocxEditorChildren;
 }
@@ -116,12 +116,25 @@ function DocxEditorLoadingImpl({
   return (
     <div className={classes} style={style} role="status" aria-live="polite">
       {children ?? (
-        <>
-          <DocxEditorLoadingSpinner />
-          {/* The spinner is decorative, so the live region would otherwise announce an
-              empty string — worse than having no region at all. */}
-          <span className="docx-editor-sr-only">{t('loading.label')}</span>
-        </>
+        <div className="docx-editor__loading-page">
+          <div className="docx-editor__loading-page-status">
+            <DocxEditorLoadingSpinner />
+            <span>{t('loading.label')}…</span>
+          </div>
+          <div className="docx-editor__loading-lines" aria-hidden="true">
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+          </div>
+        </div>
       )}
     </div>
   );

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -128,7 +128,7 @@ function DocxEditorLoadingImpl({
         <div className="docx-editor__loading-page">
           <div className="docx-editor__loading-page-status">
             <DocxEditorLoadingSpinner />
-            <span>{t('loading.label')}…</span>
+            <span className="docx-editor-sr-only">{t('loading.label')}</span>
           </div>
         </div>
       )}

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -32,6 +32,7 @@ import type { ReactNode } from 'react';
 import type { CSSProperties } from 'react';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
+import { twipsToPixels } from '../lib/units';
 import { useEditorState } from './useEditorState';
 
 /**
@@ -41,6 +42,19 @@ import { useEditorState } from './useEditorState';
  */
 const selectShowLoading = (snapshot: EditorSnapshot) =>
   snapshot.isLoading || snapshot.isOpening === true;
+
+interface LoadingPageSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+const selectLoadingPageSize = (snapshot: EditorSnapshot): LoadingPageSize => ({
+  width: twipsToPixels(snapshot.pageSetup?.pageWidthTwips ?? 12_240) * snapshot.zoom,
+  height: twipsToPixels(snapshot.pageSetup?.pageHeightTwips ?? 15_840) * snapshot.zoom,
+});
+
+const sameLoadingPageSize = (a: LoadingPageSize, b: LoadingPageSize) =>
+  a.width === b.width && a.height === b.height;
 
 /** Props for `DocxEditor.Loading`. @public */
 export interface DocxEditorLoadingProps {
@@ -107,24 +121,27 @@ function DocxEditorLoadingImpl({
   children,
 }: DocxEditorLoadingProps) {
   const showLoading = useEditorState(selectShowLoading);
+  const pageSize = useEditorState(selectLoadingPageSize, sameLoadingPageSize);
   const { t } = useTranslation();
   if (!when && !showLoading) return null;
 
   const classes = `docx-editor docx-editor__loading${
     overlay ? ' docx-editor__loading--overlay' : ''
   }${className ? ` ${className}` : ''}`;
-  const loadingStyle = {
-    ['--docx-loading-inline-start' as string]: '0px',
-    ['--docx-loading-right' as string]: '0px',
-    ...style,
-  } as CSSProperties;
   return (
-    <div className={classes} style={loadingStyle} role="status" aria-live="polite">
+    <div className={classes} style={style} role="status" aria-live="polite">
       {children ?? (
-        <div className="docx-editor__loading-page">
-          <div className="docx-editor__loading-page-status">
-            <DocxEditorLoadingSpinner />
-            <span className="docx-editor-sr-only">{t('loading.label')}</span>
+        <div
+          className="docx-paginated-surface docx-editor__loading-surface"
+          style={{ width: pageSize.width, height: pageSize.height }}
+        >
+          <div className="docx-pages">
+            <div className="docx-page docx-editor__loading-page">
+              <div className="docx-editor__loading-page-status">
+                <DocxEditorLoadingSpinner />
+                <span className="docx-editor-sr-only">{t('loading.label')}</span>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/packages/react/src/editor/DocxEditorLoading.tsx
+++ b/packages/react/src/editor/DocxEditorLoading.tsx
@@ -117,10 +117,7 @@ function DocxEditorLoadingImpl({
     <div className={classes} style={style} role="status" aria-live="polite">
       {children ?? (
         <div className="docx-editor__loading-page">
-          <div className="docx-editor__loading-page-status">
-            <DocxEditorLoadingSpinner />
-            <span>{t('loading.label')}…</span>
-          </div>
+          <span className="docx-editor-sr-only">{t('loading.label')}</span>
           <div className="docx-editor__loading-lines" aria-hidden="true">
             <span />
             <span />

--- a/packages/react/src/editor/DocxEditorRulers.tsx
+++ b/packages/react/src/editor/DocxEditorRulers.tsx
@@ -33,6 +33,7 @@ import { useNavigationShift, useNavigationViewportElement } from './navigation/n
 import { useReviewGutter, useViewportClientWidth } from './review-gutter';
 
 const selectZoom = (snapshot: EditorSnapshot): number => snapshot.zoom;
+const selectOpening = (snapshot: EditorSnapshot): boolean => snapshot.isOpening === true;
 
 /** Props for the context-fed ruler parts. @public */
 export interface DocxEditorRulerProps {
@@ -190,6 +191,7 @@ function useViewportScrollLeft(): number {
  */
 export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactElement | null {
   const documentAbsent = useEditorState(selectDocumentAbsent);
+  const opening = useEditorState(selectOpening);
   const { pageSetup, isEnabled } = usePageSetup();
   const zoom = useEditorState(selectZoom);
   const { pending, preview, commit } = useMarginDrag();
@@ -210,7 +212,7 @@ export function DocxEditorHorizontalRuler(props: DocxEditorRulerProps): ReactEle
     // the viewport's own padding moves the centred page by. The class carries the glide
     // (and its reduced-motion opt-out) so the ruler moves with the page rather than snaps.
     <div
-      className="docx-ruler-frame"
+      className={`docx-ruler-frame${opening ? ' docx-ruler-frame--opening' : ''}`}
       style={{
         // The review gutter's inline-start half composes with the navigation shift, the
         // same way the scroll container adds the two into one `padding-inline-start`.

--- a/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
+++ b/packages/react/src/editor/toolbar/DocxEditorToolbar.tsx
@@ -219,6 +219,8 @@ function buildDefaultGroups(image: EditorSnapshot['image']): readonly DefaultGro
 }
 
 const selectToolbarImage = (snapshot: EditorSnapshot) => snapshot.image;
+const selectToolbarDisabled = (snapshot: EditorSnapshot) =>
+  snapshot.isLoading || snapshot.isOpening === true;
 
 /** Slots whose panel row is the CONTROL itself, because it shows a value. */
 function isValueSlot(slot: ArrangementKey): boolean {
@@ -292,6 +294,7 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
   // use. It runs above `ToolbarContext.Provider`, so it takes the host `t` directly.
   const label = useToolbarLabelFor(t);
   const image = useEditorState(selectToolbarImage);
+  const toolbarDisabled = useEditorState(selectToolbarDisabled);
   const defaultGroups = useMemo(() => buildDefaultGroups(image), [image]);
   const defaultSlots = useMemo(
     () => new Set(defaultGroups.flatMap((group) => group.entries.map((entry) => entry.slot))),
@@ -396,8 +399,9 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
           decide what collapses into the overflow panel, and a dialog counted among them
           fed that measurement — the panel re-measured, the dialog re-rendered, forever. */}
       <ParagraphDialogHost>
-        <div
+        <fieldset
           ref={attach}
+          disabled={toolbarDisabled}
           role="toolbar"
           data-testid="docx-toolbar"
           // `docx-editor` self-emitted: chrome CSS and --doc-* tokens are scoped under it, and
@@ -418,7 +422,7 @@ function DocxEditorToolbarRoot(props: DocxEditorToolbarProps) {
           ) : (
             content
           )}
-        </div>
+        </fieldset>
       </ParagraphDialogHost>
     </ToolbarContext.Provider>
   );

--- a/packages/react/src/editor/toolbar/EditingMode.tsx
+++ b/packages/react/src/editor/toolbar/EditingMode.tsx
@@ -21,6 +21,8 @@ import { chromeControlForSlot, guardToolbarMousedown } from './ToolbarButton';
 
 const selectMode = (snapshot: EditorSnapshot): DocumentEditingMode =>
   snapshot.editingMode ?? 'editing';
+const selectLoading = (snapshot: EditorSnapshot) =>
+  snapshot.isLoading || snapshot.isOpening === true;
 
 interface ModeOption {
   readonly mode: DocumentEditingMode;
@@ -70,6 +72,7 @@ export interface ToolbarEditingModeProps {
 export function ToolbarEditingMode({ className, hidden }: ToolbarEditingModeProps) {
   const editor = useDocxEditor();
   const mode = useEditorState(selectMode);
+  const loading = useEditorState(selectLoading);
   const label = useToolbarLabel();
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -167,7 +170,7 @@ export function ToolbarEditingMode({ className, hidden }: ToolbarEditingModeProp
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={label(control?.labelKey ?? 'editingMode.label')}
-        disabled={!state.enabled}
+        disabled={loading || !state.enabled}
         {...(disabledReason ? { title: disabledReason } : {})}
         onMouseDown={guardToolbarMousedown}
         onClick={() => setOpen((previous) => !previous)}

--- a/packages/react/src/editor/toolbar/useToolbarOverflow.ts
+++ b/packages/react/src/editor/toolbar/useToolbarOverflow.ts
@@ -41,7 +41,7 @@ const NONE: ReadonlySet<string> = new Set<string>();
 
 export interface UseToolbarOverflowResult {
   /** Attach to the bar element. */
-  readonly attach: (element: HTMLDivElement | null) => void;
+  readonly attach: (element: HTMLFieldSetElement | null) => void;
   /** Group ids that must render in the "⋯" menu instead of the bar. */
   readonly overflow: ReadonlySet<string>;
 }
@@ -57,7 +57,7 @@ export function useToolbarOverflow(
   groups: readonly string[],
   order: readonly string[]
 ): UseToolbarOverflowResult {
-  const barRef = useRef<HTMLDivElement | null>(null);
+  const barRef = useRef<HTMLFieldSetElement | null>(null);
   // Widths SURVIVE a group leaving the bar. A group in the overflow menu renders nothing to
   // measure, and forgetting its width would mean never knowing whether it could come back.
   const widths = useRef(new Map<string, number>());
@@ -129,7 +129,7 @@ export function useToolbarOverflow(
     }
   }, [enabled]);
 
-  const attach = useCallback((element: HTMLDivElement | null) => {
+  const attach = useCallback((element: HTMLFieldSetElement | null) => {
     barRef.current = element;
   }, []);
 

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -323,10 +323,12 @@ describe('DocxEditor.Loading', () => {
     );
   });
 
-  test('renders the packaged spinner when the host supplies no children', () => {
+  test('renders one packaged document scaffold when the host supplies no children', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
 
+    expect(el.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
+    expect(el.querySelectorAll('.docx-editor__loading-lines > span')).toHaveLength(11);
     expect(el.querySelector(SPINNER)).not.toBeNull();
     // Announced as a live status, and the decorative spinner is hidden from it.
     expect(el.getAttribute('role')).toBe('status');
@@ -334,14 +336,14 @@ describe('DocxEditor.Loading', () => {
     expect(el.querySelector(SPINNER)!.getAttribute('aria-hidden')).toBe('true');
   });
 
-  test('the default screen has something to announce, not an empty live region', () => {
-    // The spinner is aria-hidden, so without a text node `role="status"` would announce
-    // "" — worse than having no live region at all.
+  test('the default screen shows localized text inside the document page', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
+    const page = el.querySelector('.docx-editor__loading-page')!;
+    const lines = el.querySelector('.docx-editor__loading-lines')!;
 
-    expect(el.textContent!.trim().length).toBeGreaterThan(0);
-    expect(el.querySelector('.docx-editor-sr-only')).not.toBeNull();
+    expect(page.textContent).toContain('Loading…');
+    expect(lines.getAttribute('aria-hidden')).toBe('true');
   });
 
   test('carries its own token scope, so it is styled wherever it is composed', () => {

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -19,11 +19,13 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { renderToString } from 'react-dom/server';
 import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
+import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
 import { DocxEditor } from '../src/components/DocxEditor.tsx';
 import { DocxEditorLoading } from '../src/editor/DocxEditorLoading.tsx';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorHorizontalRuler } from '../src/editor/DocxEditorRulers.tsx';
 import { useEditorState } from '../src/editor/useEditorState.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -287,6 +289,37 @@ describe('DocxEditor.Loading', () => {
     await waitFor(() => {
       expect(view.container.querySelector(LOADING)).toBeNull();
     });
+  });
+
+  test('a ruler snaps to the centred loading page before a deferred replacement', async () => {
+    let editor: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={SOURCE}
+        onReady={(ready) => {
+          editor = ready as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorHorizontalRuler />
+        <DocxEditorLoading />
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    await waitFor(() => expect(editor).not.toBeNull());
+
+    act(() => {
+      editor!.load(LARGE_SOURCE);
+    });
+    expect(editor!.snapshot().isOpening).toBe(true);
+    await act(async () => {});
+
+    expect(view.container.querySelector('.docx-ruler-frame--opening')).not.toBeNull();
+    await waitFor(() => {
+      expect(view.container.textContent).toContain('large body');
+    });
+    expect(view.container.querySelector('.docx-ruler-frame--opening')).toBeNull();
   });
 
   test('onReady waits for a LARGE document to mount, so it can scroll a real document', async () => {

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -323,26 +323,25 @@ describe('DocxEditor.Loading', () => {
     );
   });
 
-  test('renders one packaged document scaffold when the host supplies no children', () => {
+  test('renders one packaged loading page when the host supplies no children', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
 
     expect(el.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
-    expect(el.querySelectorAll('.docx-editor__loading-lines > span')).toHaveLength(11);
-    expect(el.querySelector(SPINNER)).toBeNull();
+    expect(el.querySelector('.docx-editor__loading-lines')).toBeNull();
+    expect(el.querySelector(SPINNER)).not.toBeNull();
     expect(el.getAttribute('role')).toBe('status');
     expect(el.getAttribute('aria-live')).toBe('polite');
   });
 
-  test('the default screen announces localized text without showing a label', () => {
+  test('the default screen shows localized loading text inside the document page', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
     const page = el.querySelector('.docx-editor__loading-page')!;
-    const lines = el.querySelector('.docx-editor__loading-lines')!;
 
-    expect(page.textContent).toContain('Loading');
-    expect(page.querySelector('.docx-editor-sr-only')).not.toBeNull();
-    expect(lines.getAttribute('aria-hidden')).toBe('true');
+    expect(page.textContent).toContain('Loading…');
+    expect(page.querySelector('.docx-editor__loading-page-status')).not.toBeNull();
+    expect(el.querySelector(SPINNER)!.getAttribute('aria-hidden')).toBe('true');
   });
 
   test('carries its own token scope, so it is styled wherever it is composed', () => {
@@ -415,7 +414,7 @@ describe('DocxEditor.Loading', () => {
 });
 
 describe('packaged DocxEditor loading screen', () => {
-  test('mounts the default page scaffold while no document is available', () => {
+  test('mounts the default loading page while no document is available', () => {
     const view = render(<DocxEditor />);
     const loading = view.container.querySelector('.docx-editor__loading--overlay');
 
@@ -423,7 +422,7 @@ describe('packaged DocxEditor loading screen', () => {
     expect(loading!.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
   });
 
-  test('keeps the default page scaffold up while a large document opens', async () => {
+  test('keeps the default loading page up while a large document opens', async () => {
     const view = render(<DocxEditor document={LARGE_SOURCE} />);
 
     await act(async () => {});

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -329,20 +329,19 @@ describe('DocxEditor.Loading', () => {
 
     expect(el.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
     expect(el.querySelectorAll('.docx-editor__loading-lines > span')).toHaveLength(11);
-    expect(el.querySelector(SPINNER)).not.toBeNull();
-    // Announced as a live status, and the decorative spinner is hidden from it.
+    expect(el.querySelector(SPINNER)).toBeNull();
     expect(el.getAttribute('role')).toBe('status');
     expect(el.getAttribute('aria-live')).toBe('polite');
-    expect(el.querySelector(SPINNER)!.getAttribute('aria-hidden')).toBe('true');
   });
 
-  test('the default screen shows localized text inside the document page', () => {
+  test('the default screen announces localized text without showing a label', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
     const page = el.querySelector('.docx-editor__loading-page')!;
     const lines = el.querySelector('.docx-editor__loading-lines')!;
 
-    expect(page.textContent).toContain('Loading…');
+    expect(page.textContent).toContain('Loading');
+    expect(page.querySelector('.docx-editor-sr-only')).not.toBeNull();
     expect(lines.getAttribute('aria-hidden')).toBe('true');
   });
 

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -359,8 +359,12 @@ describe('DocxEditor.Loading', () => {
   test('renders one packaged loading page when the host supplies no children', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
+    const surface = el.querySelector('.docx-paginated-surface') as HTMLElement;
 
     expect(el.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
+    expect(surface.querySelector(':scope > .docx-pages > .docx-page')).not.toBeNull();
+    expect(surface.style.width).toBe('816px');
+    expect(surface.style.height).toBe('1056px');
     expect(el.querySelector('.docx-editor__loading-lines')).toBeNull();
     expect(el.querySelector(SPINNER)).not.toBeNull();
     expect(el.getAttribute('role')).toBe('status');

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -423,6 +423,10 @@ describe('packaged DocxEditor loading screen', () => {
     expect(
       (view.container.querySelector('[data-testid="docx-toolbar"]') as HTMLFieldSetElement).disabled
     ).toBe(true);
+    expect(
+      (view.container.querySelector('[data-testid="editing-mode-trigger"]') as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
   });
 
   test('keeps the default loading page up while a large document opens', async () => {

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -334,12 +334,12 @@ describe('DocxEditor.Loading', () => {
     expect(el.getAttribute('aria-live')).toBe('polite');
   });
 
-  test('the default screen shows localized loading text inside the document page', () => {
+  test('the default screen announces loading without a visible label', () => {
     const view = render(<DocxEditorLoading when />);
     const el = view.container.querySelector(LOADING)!;
     const page = el.querySelector('.docx-editor__loading-page')!;
 
-    expect(page.textContent).toContain('Loading…');
+    expect(page.querySelector('.docx-editor-sr-only')?.textContent).toBe('Loading');
     expect(page.querySelector('.docx-editor__loading-page-status')).not.toBeNull();
     expect(el.querySelector(SPINNER)!.getAttribute('aria-hidden')).toBe('true');
   });
@@ -420,6 +420,9 @@ describe('packaged DocxEditor loading screen', () => {
 
     expect(loading).not.toBeNull();
     expect(loading!.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
+    expect(
+      (view.container.querySelector('[data-testid="docx-toolbar"]') as HTMLFieldSetElement).disabled
+    ).toBe(true);
   });
 
   test('keeps the default loading page up while a large document opens', async () => {
@@ -433,5 +436,8 @@ describe('packaged DocxEditor loading screen', () => {
       expect(view.container.textContent).toContain('large body');
     });
     expect(view.container.querySelector('.docx-editor__loading')).toBeNull();
+    expect(
+      (view.container.querySelector('[data-testid="docx-toolbar"]') as HTMLFieldSetElement).disabled
+    ).toBe(false);
   });
 });

--- a/packages/react/test/loading-part.test.tsx
+++ b/packages/react/test/loading-part.test.tsx
@@ -414,3 +414,26 @@ describe('DocxEditor.Loading', () => {
     expect(DocxEditor.Loading).toBe(DocxEditorLoading);
   });
 });
+
+describe('packaged DocxEditor loading screen', () => {
+  test('mounts the default page scaffold while no document is available', () => {
+    const view = render(<DocxEditor />);
+    const loading = view.container.querySelector('.docx-editor__loading--overlay');
+
+    expect(loading).not.toBeNull();
+    expect(loading!.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
+  });
+
+  test('keeps the default page scaffold up while a large document opens', async () => {
+    const view = render(<DocxEditor document={LARGE_SOURCE} />);
+
+    await act(async () => {});
+    expect(view.container.querySelector('.docx-editor__loading-page')).not.toBeNull();
+    expect(view.container.textContent).not.toContain('large body');
+
+    await waitFor(() => {
+      expect(view.container.textContent).toContain('large body');
+    });
+    expect(view.container.querySelector('.docx-editor__loading')).toBeNull();
+  });
+});

--- a/packages/react/test/review-gutter-integration.test.tsx
+++ b/packages/react/test/review-gutter-integration.test.tsx
@@ -17,6 +17,7 @@ import { zipSync, strToU8 } from 'fflate';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { DocxEditorLoading } from '../src/editor/DocxEditorLoading.tsx';
 import { ReviewRailContext } from '../src/editor/context.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -119,6 +120,7 @@ describe('the viewport’s review gutter', () => {
           <DocxEditorContent />
         </DocxEditorViewport>
         <RailStub />
+        <DocxEditorLoading when overlay />
       </DocxEditorRoot>
     );
     await settle();
@@ -126,6 +128,9 @@ describe('the viewport’s review gutter', () => {
     expect(scroller.getAttribute('data-review-pane')).toBe('open');
     expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('44px');
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('44px');
+    const loading = container.querySelector('.docx-editor__loading') as HTMLElement;
+    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('44px');
+    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('44px');
   });
 
   test('a rail on a wide viewport keeps the full column, with nothing at the start', async () => {
@@ -136,6 +141,7 @@ describe('the viewport’s review gutter', () => {
           <DocxEditorContent />
         </DocxEditorViewport>
         <RailStub />
+        <DocxEditorLoading when overlay />
       </DocxEditorRoot>
     );
     await settle();
@@ -143,5 +149,8 @@ describe('the viewport’s review gutter', () => {
     expect(scroller.getAttribute('data-review-pane')).toBe('open');
     expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('316px');
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('0px');
+    const loading = container.querySelector('.docx-editor__loading') as HTMLElement;
+    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
+    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('316px');
   });
 });

--- a/packages/react/test/review-gutter-integration.test.tsx
+++ b/packages/react/test/review-gutter-integration.test.tsx
@@ -157,8 +157,9 @@ describe('the viewport’s review gutter', () => {
     expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('44px');
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('44px');
     const loading = container.querySelector('.docx-editor__loading') as HTMLElement;
-    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
-    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
+    expect(
+      loading.querySelector('.docx-paginated-surface > .docx-pages > .docx-page')
+    ).not.toBeNull();
   });
 
   test('a rail on a wide viewport keeps the full column, with nothing at the start', async () => {
@@ -189,7 +190,8 @@ describe('the viewport’s review gutter', () => {
     expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('316px');
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('0px');
     const loading = container.querySelector('.docx-editor__loading') as HTMLElement;
-    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
-    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
+    expect(
+      loading.querySelector('.docx-paginated-surface > .docx-pages > .docx-page')
+    ).not.toBeNull();
   });
 });

--- a/packages/react/test/review-gutter-integration.test.tsx
+++ b/packages/react/test/review-gutter-integration.test.tsx
@@ -20,6 +20,7 @@ import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
 import { DocxEditorLoading } from '../src/editor/DocxEditorLoading.tsx';
 import { ReviewRailContext } from '../src/editor/context.ts';
+import { useNavigationLayoutStore } from '../src/editor/navigation/navigation-layout.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -57,6 +58,12 @@ const REVIEW_MODULE: EditorModule = {
 function RailStub() {
   const registry = useContext(ReviewRailContext);
   useEffect(() => registry?.register(), [registry]);
+  return null;
+}
+
+function ShiftWriter() {
+  const store = useNavigationLayoutStore();
+  useEffect(() => store?.setShift(128), [store]);
   return null;
 }
 
@@ -136,6 +143,7 @@ describe('the viewport’s review gutter', () => {
           <DocxEditorContent />
         </DocxEditorViewport>
         <RailStub />
+        <ShiftWriter />
         <DocxEditorLoading when overlay />
       </DocxEditorRoot>
     );

--- a/packages/react/test/review-gutter-integration.test.tsx
+++ b/packages/react/test/review-gutter-integration.test.tsx
@@ -14,6 +14,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test
 import { useContext, useEffect } from 'react';
 import { act, cleanup, render } from '@testing-library/react';
 import { zipSync, strToU8 } from 'fflate';
+import type { DocxEditorInstance, EditorModule } from '@docx-editor.dev/core/editor';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
@@ -43,6 +44,14 @@ function docx(body: string): Uint8Array {
 }
 
 const SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
+const REVIEW_MODULE: EditorModule = {
+  id: 'review',
+  review: {
+    displayModes: ['all-markup', 'proposed', 'original'],
+    collectReviewItems: () => [],
+    revisionItemsOfParagraph: () => [],
+  },
+};
 
 /** A rail with no UI: claims the gutter exactly the way `DocxEditor.Review` does. */
 function RailStub() {
@@ -114,8 +123,15 @@ describe('the viewport’s review gutter', () => {
     // Letter page (816px at 100%) in a 1000px scroller: 184px leftover against the 364
     // the column and the clearance need together, so the strip mirrors onto both edges.
     scrollerWidth = 1000;
+    let editor: DocxEditorInstance | null = null;
     const { container } = render(
-      <DocxEditorRoot document={SOURCE}>
+      <DocxEditorRoot
+        document={SOURCE}
+        modules={[REVIEW_MODULE]}
+        onReady={(ready) => {
+          editor = ready as DocxEditorInstance;
+        }}
+      >
         <DocxEditorViewport>
           <DocxEditorContent />
         </DocxEditorViewport>
@@ -124,19 +140,30 @@ describe('the viewport’s review gutter', () => {
       </DocxEditorRoot>
     );
     await settle();
+    act(() => {
+      editor!.exec({ type: 'toggleReviewPane' });
+    });
+    await settle();
     const scroller = container.querySelector('.docx-editor__scroll-container') as HTMLElement;
     expect(scroller.getAttribute('data-review-pane')).toBe('open');
     expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('44px');
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('44px');
     const loading = container.querySelector('.docx-editor__loading') as HTMLElement;
-    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('44px');
-    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('44px');
+    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
+    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
   });
 
   test('a rail on a wide viewport keeps the full column, with nothing at the start', async () => {
     scrollerWidth = 1728;
+    let editor: DocxEditorInstance | null = null;
     const { container } = render(
-      <DocxEditorRoot document={SOURCE}>
+      <DocxEditorRoot
+        document={SOURCE}
+        modules={[REVIEW_MODULE]}
+        onReady={(ready) => {
+          editor = ready as DocxEditorInstance;
+        }}
+      >
         <DocxEditorViewport>
           <DocxEditorContent />
         </DocxEditorViewport>
@@ -144,6 +171,10 @@ describe('the viewport’s review gutter', () => {
         <DocxEditorLoading when overlay />
       </DocxEditorRoot>
     );
+    await settle();
+    act(() => {
+      editor!.exec({ type: 'toggleReviewPane' });
+    });
     await settle();
     const scroller = container.querySelector('.docx-editor__scroll-container') as HTMLElement;
     expect(scroller.getAttribute('data-review-pane')).toBe('open');
@@ -151,6 +182,6 @@ describe('the viewport’s review gutter', () => {
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('0px');
     const loading = container.querySelector('.docx-editor__loading') as HTMLElement;
     expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
-    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('316px');
+    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
   });
 });

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -2,6 +2,8 @@ import { defineComponent, h, type CSSProperties, type PropType, type VNode } fro
 import type { DocxEditorChildren } from '../docx-editor-children';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
+import { useNavigationShift } from './navigation/navigation-layout';
+import { useReviewGutter } from './review-gutter';
 import { useEditorState } from './useEditorState';
 
 const selectShowLoading = (snapshot: EditorSnapshot) =>
@@ -46,6 +48,8 @@ const DocxEditorLoadingImpl = defineComponent({
   },
   setup(props, { slots }) {
     const showLoading = useEditorState(selectShowLoading);
+    const navigationShift = useNavigationShift();
+    const reviewGutter = useReviewGutter();
     const { t } = useTranslation();
 
     return () => {
@@ -53,9 +57,16 @@ const DocxEditorLoadingImpl = defineComponent({
       const classes = `docx-editor docx-editor__loading${
         props.overlay ? ' docx-editor__loading--overlay' : ''
       }${props.className ? ` ${props.className}` : ''}`;
+      const loadingStyle: CSSProperties = {
+        '--docx-loading-inline-start': `${
+          navigationShift.value + reviewGutter.value.inlineStart
+        }px`,
+        '--docx-loading-right': `${reviewGutter.value.inlineEnd}px`,
+        ...props.style,
+      };
       return h(
         'div',
-        { class: classes, style: props.style, role: 'status', ariaLive: 'polite' },
+        { class: classes, style: loadingStyle, role: 'status', ariaLive: 'polite' },
         slots.default?.() ??
           h('div', { class: 'docx-editor__loading-page' }, [
             h('span', { class: 'docx-editor-sr-only' }, t('loading.label')),

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -2,7 +2,6 @@ import { defineComponent, h, type CSSProperties, type PropType, type VNode } fro
 import type { DocxEditorChildren } from '../docx-editor-children';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
-import { useNavigationShift } from './navigation/navigation-layout';
 import { useEditorState } from './useEditorState';
 
 const selectShowLoading = (snapshot: EditorSnapshot) =>
@@ -47,7 +46,6 @@ const DocxEditorLoadingImpl = defineComponent({
   },
   setup(props, { slots }) {
     const showLoading = useEditorState(selectShowLoading);
-    const navigationShift = useNavigationShift();
     const { t } = useTranslation();
 
     return () => {
@@ -56,7 +54,7 @@ const DocxEditorLoadingImpl = defineComponent({
         props.overlay ? ' docx-editor__loading--overlay' : ''
       }${props.className ? ` ${props.className}` : ''}`;
       const loadingStyle: CSSProperties = {
-        '--docx-loading-inline-start': `${navigationShift.value}px`,
+        '--docx-loading-inline-start': '0px',
         '--docx-loading-right': '0px',
         ...props.style,
       };

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -2,10 +2,15 @@ import { defineComponent, h, type CSSProperties, type PropType, type VNode } fro
 import type { DocxEditorChildren } from '../docx-editor-children';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
+import { twipsToPixels } from '../lib/units';
 import { useEditorState } from './useEditorState';
 
 const selectShowLoading = (snapshot: EditorSnapshot) =>
   snapshot.isLoading || snapshot.isOpening === true;
+const selectLoadingPageSize = (snapshot: EditorSnapshot) => ({
+  width: twipsToPixels(snapshot.pageSetup?.pageWidthTwips ?? 12_240) * snapshot.zoom,
+  height: twipsToPixels(snapshot.pageSetup?.pageHeightTwips ?? 15_840) * snapshot.zoom,
+});
 
 /** Props for `DocxEditor.Loading`. @public */
 export interface DocxEditorLoadingProps {
@@ -46,6 +51,7 @@ const DocxEditorLoadingImpl = defineComponent({
   },
   setup(props, { slots }) {
     const showLoading = useEditorState(selectShowLoading);
+    const pageSize = useEditorState(selectLoadingPageSize);
     const { t } = useTranslation();
 
     return () => {
@@ -53,21 +59,30 @@ const DocxEditorLoadingImpl = defineComponent({
       const classes = `docx-editor docx-editor__loading${
         props.overlay ? ' docx-editor__loading--overlay' : ''
       }${props.className ? ` ${props.className}` : ''}`;
-      const loadingStyle: CSSProperties = {
-        '--docx-loading-inline-start': '0px',
-        '--docx-loading-right': '0px',
-        ...props.style,
-      };
       return h(
         'div',
-        { class: classes, style: loadingStyle, role: 'status', ariaLive: 'polite' },
+        { class: classes, style: props.style, role: 'status', ariaLive: 'polite' },
         slots.default?.() ??
-          h('div', { class: 'docx-editor__loading-page' }, [
-            h('div', { class: 'docx-editor__loading-page-status' }, [
-              h(DocxEditorLoadingSpinner),
-              h('span', { class: 'docx-editor-sr-only' }, t('loading.label')),
-            ]),
-          ])
+          h(
+            'div',
+            {
+              class: 'docx-paginated-surface docx-editor__loading-surface',
+              style: {
+                width: `${pageSize.value.width}px`,
+                height: `${pageSize.value.height}px`,
+              },
+            },
+            [
+              h('div', { class: 'docx-pages' }, [
+                h('div', { class: 'docx-page docx-editor__loading-page' }, [
+                  h('div', { class: 'docx-editor__loading-page-status' }, [
+                    h(DocxEditorLoadingSpinner),
+                    h('span', { class: 'docx-editor-sr-only' }, t('loading.label')),
+                  ]),
+                ]),
+              ]),
+            ]
+          )
       );
     };
   },

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -71,7 +71,7 @@ const DocxEditorLoadingImpl = defineComponent({
           h('div', { class: 'docx-editor__loading-page' }, [
             h('div', { class: 'docx-editor__loading-page-status' }, [
               h(DocxEditorLoadingSpinner),
-              h('span', `${t('loading.label')}…`),
+              h('span', { class: 'docx-editor-sr-only' }, t('loading.label')),
             ]),
           ])
       );

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -56,10 +56,18 @@ const DocxEditorLoadingImpl = defineComponent({
       return h(
         'div',
         { class: classes, style: props.style, role: 'status', ariaLive: 'polite' },
-        slots.default?.() ?? [
-          h(DocxEditorLoadingSpinner),
-          h('span', { class: 'docx-editor-sr-only' }, t('loading.label')),
-        ]
+        slots.default?.() ??
+          h('div', { class: 'docx-editor__loading-page' }, [
+            h('div', { class: 'docx-editor__loading-page-status' }, [
+              h(DocxEditorLoadingSpinner),
+              h('span', `${t('loading.label')}…`),
+            ]),
+            h(
+              'div',
+              { class: 'docx-editor__loading-lines', ariaHidden: 'true' },
+              Array.from({ length: 11 }, () => h('span'))
+            ),
+          ])
       );
     };
   },

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -58,10 +58,7 @@ const DocxEditorLoadingImpl = defineComponent({
         { class: classes, style: props.style, role: 'status', ariaLive: 'polite' },
         slots.default?.() ??
           h('div', { class: 'docx-editor__loading-page' }, [
-            h('div', { class: 'docx-editor__loading-page-status' }, [
-              h(DocxEditorLoadingSpinner),
-              h('span', `${t('loading.label')}…`),
-            ]),
+            h('span', { class: 'docx-editor-sr-only' }, t('loading.label')),
             h(
               'div',
               { class: 'docx-editor__loading-lines', ariaHidden: 'true' },

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -3,7 +3,6 @@ import type { DocxEditorChildren } from '../docx-editor-children';
 import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
 import { useTranslation } from '../i18n';
 import { useNavigationShift } from './navigation/navigation-layout';
-import { useReviewGutter } from './review-gutter';
 import { useEditorState } from './useEditorState';
 
 const selectShowLoading = (snapshot: EditorSnapshot) =>
@@ -49,7 +48,6 @@ const DocxEditorLoadingImpl = defineComponent({
   setup(props, { slots }) {
     const showLoading = useEditorState(selectShowLoading);
     const navigationShift = useNavigationShift();
-    const reviewGutter = useReviewGutter();
     const { t } = useTranslation();
 
     return () => {
@@ -58,10 +56,8 @@ const DocxEditorLoadingImpl = defineComponent({
         props.overlay ? ' docx-editor__loading--overlay' : ''
       }${props.className ? ` ${props.className}` : ''}`;
       const loadingStyle: CSSProperties = {
-        '--docx-loading-inline-start': `${
-          navigationShift.value + reviewGutter.value.inlineStart
-        }px`,
-        '--docx-loading-right': `${reviewGutter.value.inlineEnd}px`,
+        '--docx-loading-inline-start': `${navigationShift.value}px`,
+        '--docx-loading-right': '0px',
         ...props.style,
       };
       return h(

--- a/packages/vue/src/editor/DocxEditorLoading.ts
+++ b/packages/vue/src/editor/DocxEditorLoading.ts
@@ -69,12 +69,10 @@ const DocxEditorLoadingImpl = defineComponent({
         { class: classes, style: loadingStyle, role: 'status', ariaLive: 'polite' },
         slots.default?.() ??
           h('div', { class: 'docx-editor__loading-page' }, [
-            h('span', { class: 'docx-editor-sr-only' }, t('loading.label')),
-            h(
-              'div',
-              { class: 'docx-editor__loading-lines', ariaHidden: 'true' },
-              Array.from({ length: 11 }, () => h('span'))
-            ),
+            h('div', { class: 'docx-editor__loading-page-status' }, [
+              h(DocxEditorLoadingSpinner),
+              h('span', `${t('loading.label')}…`),
+            ]),
           ])
       );
     };

--- a/packages/vue/src/editor/DocxEditorRulers.tsx
+++ b/packages/vue/src/editor/DocxEditorRulers.tsx
@@ -21,6 +21,7 @@ import { useReviewGutter, useViewportClientWidth } from './review-gutter';
 import { formatPx, twipsToPixels } from '../lib/units';
 
 const selectZoom = (snapshot: EditorSnapshot): number => snapshot.zoom;
+const selectOpening = (snapshot: EditorSnapshot): boolean => snapshot.isOpening === true;
 
 /** @public */
 export interface DocxEditorRulerProps {
@@ -120,6 +121,7 @@ export const DocxEditorHorizontalRuler = defineComponent({
   },
   setup(props) {
     const documentAbsent = useEditorState(selectDocumentAbsent);
+    const opening = useEditorState(selectOpening);
     const { pageSetup, isEnabled } = usePageSetup();
     const zoom = useEditorState(selectZoom);
     const marginDrag = useMarginDrag();
@@ -149,7 +151,7 @@ export const DocxEditorHorizontalRuler = defineComponent({
       if (documentAbsent.value) return null;
       return (
         <div
-          class="docx-ruler-frame"
+          class={`docx-ruler-frame${opening.value ? ' docx-ruler-frame--opening' : ''}`}
           style={{
             paddingInlineStart: formatPx(shift.value + reserved.value.inlineStart),
             paddingRight: formatPx(reserved.value.inlineEnd),

--- a/packages/vue/src/editor/toolbar/DocxEditorToolbar.tsx
+++ b/packages/vue/src/editor/toolbar/DocxEditorToolbar.tsx
@@ -176,6 +176,8 @@ function buildDefaultGroups(image: EditorSnapshot['image']): readonly DefaultGro
 }
 
 const selectToolbarImage = (snapshot: EditorSnapshot) => snapshot.image;
+const selectToolbarDisabled = (snapshot: EditorSnapshot) =>
+  snapshot.isLoading || snapshot.isOpening === true;
 
 function isValueSlot(slot: ArrangementKey): boolean {
   return slot === 'alignment' || slot in SHAPED_PARTS;
@@ -289,6 +291,7 @@ const DocxEditorToolbarRoot = defineComponent({
     );
     const label = useToolbarLabel();
     const image = useEditorState(selectToolbarImage);
+    const toolbarDisabled = useEditorState(selectToolbarDisabled);
     const defaultGroups = computed(() => buildDefaultGroups(image.value));
     const defaultSlots = computed(
       () =>
@@ -389,9 +392,10 @@ const DocxEditorToolbarRoot = defineComponent({
       // host wrapping the element would make this component's root a fragment, and Vue
       // then drops every fallthrough attribute the host passes — `class`, `style`, `id`.
       return h(
-        'div',
+        'fieldset',
         {
-          ref: (el: unknown) => attach(el as HTMLDivElement | null),
+          ref: (el: unknown) => attach(el as HTMLFieldSetElement | null),
+          disabled: toolbarDisabled.value,
           role: 'toolbar',
           'data-testid': 'docx-toolbar',
           class: `${scopeClassName}docx-toolbar${props.className ? ` ${props.className}` : ''}`,

--- a/packages/vue/src/editor/toolbar/EditingMode.tsx
+++ b/packages/vue/src/editor/toolbar/EditingMode.tsx
@@ -11,6 +11,8 @@ import type { ToolbarSlotPartComponent } from './parts';
 
 const selectMode = (snapshot: EditorSnapshot): DocumentEditingMode =>
   snapshot.editingMode ?? 'editing';
+const selectLoading = (snapshot: EditorSnapshot) =>
+  snapshot.isLoading || snapshot.isOpening === true;
 
 interface ModeOption {
   readonly mode: DocumentEditingMode;
@@ -69,6 +71,7 @@ export const ToolbarEditingMode = defineComponent({
   setup(props) {
     const editorRef = useDocxEditor();
     const mode = useEditorState(selectMode);
+    const loading = useEditorState(selectLoading);
     const label = useToolbarLabel();
     const { t } = useTranslation();
     const open = ref(false);
@@ -150,7 +153,7 @@ export const ToolbarEditingMode = defineComponent({
             aria-haspopup="menu"
             aria-expanded={open.value}
             aria-label={label(control?.labelKey ?? 'editingMode.label')}
-            disabled={!state.enabled}
+            disabled={loading.value || !state.enabled}
             {...(disabledReason ? { title: disabledReason } : {})}
             onMousedown={guardToolbarMousedown}
             onClick={() => {

--- a/packages/vue/src/editor/toolbar/useToolbarOverflow.ts
+++ b/packages/vue/src/editor/toolbar/useToolbarOverflow.ts
@@ -22,7 +22,7 @@ const ASSUMED_MORE_WIDTH = 34;
 const NONE: ReadonlySet<string> = new Set<string>();
 
 export interface UseToolbarOverflowResult {
-  readonly attach: (element: HTMLDivElement | null) => void;
+  readonly attach: (element: HTMLFieldSetElement | null) => void;
   readonly overflow: Ref<ReadonlySet<string>>;
 }
 
@@ -31,7 +31,7 @@ export function useToolbarOverflow(
   groups: Ref<readonly string[]> | (() => readonly string[]),
   order: Ref<readonly string[]> | (() => readonly string[])
 ): UseToolbarOverflowResult {
-  const barRef = shallowRef<HTMLDivElement | null>(null);
+  const barRef = shallowRef<HTMLFieldSetElement | null>(null);
   const widths = shallowRef(new Map<string, number>());
   const moreWidth = shallowRef(ASSUMED_MORE_WIDTH);
   const overflow = ref<ReadonlySet<string>>(NONE);
@@ -95,7 +95,7 @@ export function useToolbarOverflow(
     }
   };
 
-  const attach = (element: HTMLDivElement | null) => {
+  const attach = (element: HTMLFieldSetElement | null) => {
     barRef.value = element;
   };
 

--- a/packages/vue/test/helpers/fixtures.ts
+++ b/packages/vue/test/helpers/fixtures.ts
@@ -25,6 +25,35 @@ export function docx(body: string): Uint8Array {
 
 export const SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
 
+function compressibleText(length: number): Uint8Array {
+  const lines: string[] = [];
+  let total = 0;
+  for (let line = 1; total < length; line += 1) {
+    const text = `filler line ${line} carrying a little ordinary sentence text.\n`;
+    lines.push(text);
+    total += text.length;
+  }
+  return strToU8(lines.join('').slice(0, length));
+}
+
+/** DOCX bytes above the deferred-open threshold, for loading-overlay tests. */
+export const LARGE_SOURCE = zipSync({
+  '[Content_Types].xml': strToU8(
+    `<Types xmlns="${CT}">` +
+      '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+      '<Default Extension="bin" ContentType="application/octet-stream"/>' +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+      '</Types>'
+  ),
+  '_rels/.rels': strToU8(
+    `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+  ),
+  'word/document.xml': strToU8(
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>large body</w:t></w:r></w:p></w:body></w:document>`
+  ),
+  'word/media/filler.bin': compressibleText(1024 * 1024),
+});
+
 /** Flush Vue updates and engine paint ticks. */
 export async function flush(): Promise<void> {
   const { nextTick } = await import('vue');

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -284,6 +284,9 @@ describe('DocxEditorLoading composition', () => {
     app.mount(container);
     await nextTick();
     expect(container.querySelector('.docx-editor__loading')).not.toBeNull();
+    expect(container.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
+    expect(container.querySelectorAll('.docx-editor__loading-lines > span')).toHaveLength(11);
+    expect(container.textContent).toContain('Loading…');
     app.unmount();
     container.remove();
   });

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -11,7 +11,7 @@ import { DocxEditorNavigation } from '../src/editor/navigation';
 import { DocxEditorLoading } from '../src/editor/DocxEditorLoading';
 import { LocaleProvider } from '../src/i18n';
 import { flush, mountComponent, mountEditorTree, mountSugarAsync, SOURCE } from './helpers/mount';
-import { docx } from './helpers/fixtures';
+import { docx, LARGE_SOURCE } from './helpers/fixtures';
 
 const label = createT(en);
 
@@ -20,6 +20,26 @@ afterEach(() => {
 });
 
 describe('DocxEditor sugar host', () => {
+  test('mounts the default page scaffold while no document is available', async () => {
+    const view = await mountSugarAsync({ document: undefined });
+    await nextTick();
+    const loading = view.container.querySelector('.docx-editor__loading--overlay');
+    expect(loading).not.toBeNull();
+    expect(loading?.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
+    view.unmount();
+  });
+
+  test('keeps the default page scaffold up while a large document opens', async () => {
+    const view = await mountSugarAsync({ document: LARGE_SOURCE });
+    await nextTick();
+    expect(view.container.querySelector('.docx-editor__loading-page')).not.toBeNull();
+
+    await view.flush();
+    expect(view.container.querySelector('.docx-editor__loading')).toBeNull();
+    expect(view.container.textContent).toContain('large body');
+    view.unmount();
+  });
+
   test('clamps rulers with the page on narrow viewports', async () => {
     const widthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
     Object.defineProperty(HTMLElement.prototype, 'clientWidth', {

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -29,6 +29,10 @@ describe('DocxEditor sugar host', () => {
     expect(
       (view.container.querySelector('[data-testid="docx-toolbar"]') as HTMLFieldSetElement).disabled
     ).toBe(true);
+    expect(
+      (view.container.querySelector('[data-testid="editing-mode-trigger"]') as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
     view.unmount();
   });
 

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -26,6 +26,9 @@ describe('DocxEditor sugar host', () => {
     const loading = view.container.querySelector('.docx-editor__loading--overlay');
     expect(loading).not.toBeNull();
     expect(loading?.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
+    expect(
+      (view.container.querySelector('[data-testid="docx-toolbar"]') as HTMLFieldSetElement).disabled
+    ).toBe(true);
     view.unmount();
   });
 
@@ -37,6 +40,9 @@ describe('DocxEditor sugar host', () => {
     await view.flush();
     expect(view.container.querySelector('.docx-editor__loading')).toBeNull();
     expect(view.container.textContent).toContain('large body');
+    expect(
+      (view.container.querySelector('[data-testid="docx-toolbar"]') as HTMLFieldSetElement).disabled
+    ).toBe(false);
     view.unmount();
   });
 
@@ -307,9 +313,7 @@ describe('DocxEditorLoading composition', () => {
     expect(container.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
     expect(container.querySelector('.docx-editor__loading-lines')).toBeNull();
     expect(container.querySelector('.docx-editor__loading-spinner')).not.toBeNull();
-    expect(container.querySelector('.docx-editor__loading-page-status')?.textContent).toContain(
-      'Loading…'
-    );
+    expect(container.querySelector('.docx-editor-sr-only')?.textContent).toBe('Loading');
     app.unmount();
     container.remove();
   });

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 });
 
 describe('DocxEditor sugar host', () => {
-  test('mounts the default page scaffold while no document is available', async () => {
+  test('mounts the default loading page while no document is available', async () => {
     const view = await mountSugarAsync({ document: undefined });
     await nextTick();
     const loading = view.container.querySelector('.docx-editor__loading--overlay');
@@ -29,7 +29,7 @@ describe('DocxEditor sugar host', () => {
     view.unmount();
   });
 
-  test('keeps the default page scaffold up while a large document opens', async () => {
+  test('keeps the default loading page up while a large document opens', async () => {
     const view = await mountSugarAsync({ document: LARGE_SOURCE });
     await nextTick();
     expect(view.container.querySelector('.docx-editor__loading-page')).not.toBeNull();
@@ -305,9 +305,11 @@ describe('DocxEditorLoading composition', () => {
     await nextTick();
     expect(container.querySelector('.docx-editor__loading')).not.toBeNull();
     expect(container.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
-    expect(container.querySelectorAll('.docx-editor__loading-lines > span')).toHaveLength(11);
-    expect(container.querySelector('.docx-editor__loading-spinner')).toBeNull();
-    expect(container.querySelector('.docx-editor-sr-only')?.textContent).toBe('Loading');
+    expect(container.querySelector('.docx-editor__loading-lines')).toBeNull();
+    expect(container.querySelector('.docx-editor__loading-spinner')).not.toBeNull();
+    expect(container.querySelector('.docx-editor__loading-page-status')?.textContent).toContain(
+      'Loading…'
+    );
     app.unmount();
     container.remove();
   });

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -306,7 +306,8 @@ describe('DocxEditorLoading composition', () => {
     expect(container.querySelector('.docx-editor__loading')).not.toBeNull();
     expect(container.querySelectorAll('.docx-editor__loading-page')).toHaveLength(1);
     expect(container.querySelectorAll('.docx-editor__loading-lines > span')).toHaveLength(11);
-    expect(container.textContent).toContain('Loading…');
+    expect(container.querySelector('.docx-editor__loading-spinner')).toBeNull();
+    expect(container.querySelector('.docx-editor-sr-only')?.textContent).toBe('Loading');
     app.unmount();
     container.remove();
   });

--- a/packages/vue/test/viewport-rail.test.ts
+++ b/packages/vue/test/viewport-rail.test.ts
@@ -115,13 +115,19 @@ describe('DocxEditorViewport review rail', () => {
     view.unmount();
   });
 
-  test('applies nav shift from the layout store outside render', async () => {
-    const view = mountEditorTree(() => h(ShiftWriter));
+  test('applies nav shift to the viewport but keeps the loading page centred', async () => {
+    const view = mountEditorTree(() => [
+      h(ShiftWriter),
+      h(DocxEditorLoading, { when: true, overlay: true }),
+    ]);
     await flush();
     const scroller = view.container.querySelector(
       '[data-testid="docx-editor-scroll"]'
     ) as HTMLElement;
     expect(scroller.style.getPropertyValue('--docx-nav-shift')).toBe('128px');
+    const loading = view.container.querySelector('.docx-editor__loading') as HTMLElement;
+    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
+    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
     view.unmount();
   });
 });

--- a/packages/vue/test/viewport-rail.test.ts
+++ b/packages/vue/test/viewport-rail.test.ts
@@ -3,15 +3,26 @@ import './dom-setup.ts';
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { defineComponent, h, onMounted, onUnmounted } from 'vue';
+import type { EditorModule } from '@docx-editor.dev/core/editor';
 import { DocxEditorNavigation } from '../src/editor/navigation';
 import { DocxEditorLoading } from '../src/editor/DocxEditorLoading';
 import { useReviewRailRegistry } from '../src/editor/context';
 import { useNavigationLayoutStore } from '../src/editor/navigation/navigation-layout';
+import { SOURCE } from './helpers/fixtures';
 import { flush, mountEditorTree } from './helpers/mount';
 
 afterEach(() => {
   document.body.innerHTML = '';
 });
+
+const REVIEW_MODULE: EditorModule = {
+  id: 'review',
+  review: {
+    displayModes: ['all-markup', 'proposed', 'original'],
+    collectReviewItems: () => [],
+    revisionItemsOfParagraph: () => [],
+  },
+};
 
 const RailRegistrar = defineComponent({
   setup() {
@@ -62,11 +73,18 @@ describe('DocxEditorViewport review rail', () => {
   });
 
   test('sets data-review-pane and nav shift when a rail mounts', async () => {
-    const view = mountEditorTree(() => [
-      h(RailRegistrar),
-      h(DocxEditorNavigation, { t: (key: string) => key }),
-      h(DocxEditorLoading, { when: true, overlay: true }),
-    ]);
+    const view = mountEditorTree(
+      () => [
+        h(RailRegistrar),
+        h(DocxEditorNavigation, { t: (key: string) => key }),
+        h(DocxEditorLoading, { when: true, overlay: true }),
+      ],
+      SOURCE,
+      () => [],
+      [REVIEW_MODULE]
+    );
+    await flush();
+    view.editor().exec({ type: 'toggleReviewPane' });
     await flush();
     const scroller = view.container.querySelector(
       '[data-testid="docx-editor-scroll"]'
@@ -80,7 +98,7 @@ describe('DocxEditorViewport review rail', () => {
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('0px');
     const loading = view.container.querySelector('.docx-editor__loading') as HTMLElement;
     expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
-    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('316px');
+    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
     view.unmount();
   });
 

--- a/packages/vue/test/viewport-rail.test.ts
+++ b/packages/vue/test/viewport-rail.test.ts
@@ -4,6 +4,7 @@ import './dom-setup.ts';
 import { afterEach, describe, expect, test } from 'bun:test';
 import { defineComponent, h, onMounted, onUnmounted } from 'vue';
 import { DocxEditorNavigation } from '../src/editor/navigation';
+import { DocxEditorLoading } from '../src/editor/DocxEditorLoading';
 import { useReviewRailRegistry } from '../src/editor/context';
 import { useNavigationLayoutStore } from '../src/editor/navigation/navigation-layout';
 import { flush, mountEditorTree } from './helpers/mount';
@@ -64,6 +65,7 @@ describe('DocxEditorViewport review rail', () => {
     const view = mountEditorTree(() => [
       h(RailRegistrar),
       h(DocxEditorNavigation, { t: (key: string) => key }),
+      h(DocxEditorLoading, { when: true, overlay: true }),
     ]);
     await flush();
     const scroller = view.container.querySelector(
@@ -76,6 +78,9 @@ describe('DocxEditorViewport review rail', () => {
     expect(Number.parseFloat(shift)).toBeGreaterThanOrEqual(0);
     expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('316px');
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('0px');
+    const loading = view.container.querySelector('.docx-editor__loading') as HTMLElement;
+    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
+    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('316px');
     view.unmount();
   });
 

--- a/packages/vue/test/viewport-rail.test.ts
+++ b/packages/vue/test/viewport-rail.test.ts
@@ -2,13 +2,14 @@
 import './dom-setup.ts';
 
 import { afterEach, describe, expect, test } from 'bun:test';
-import { defineComponent, h, onMounted, onUnmounted } from 'vue';
+import { defineComponent, h, nextTick, onMounted, onUnmounted } from 'vue';
 import type { EditorModule } from '@docx-editor.dev/core/editor';
 import { DocxEditorNavigation } from '../src/editor/navigation';
 import { DocxEditorLoading } from '../src/editor/DocxEditorLoading';
+import { DocxEditorHorizontalRuler } from '../src/editor/DocxEditorRulers';
 import { useReviewRailRegistry } from '../src/editor/context';
 import { useNavigationLayoutStore } from '../src/editor/navigation/navigation-layout';
-import { SOURCE } from './helpers/fixtures';
+import { LARGE_SOURCE, SOURCE } from './helpers/fixtures';
 import { flush, mountEditorTree } from './helpers/mount';
 
 afterEach(() => {
@@ -128,6 +129,24 @@ describe('DocxEditorViewport review rail', () => {
     const loading = view.container.querySelector('.docx-editor__loading') as HTMLElement;
     expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
     expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
+    view.unmount();
+  });
+
+  test('snaps the ruler reservation while a replacement document opens', async () => {
+    const view = mountEditorTree(() => [
+      h(DocxEditorHorizontalRuler),
+      h(DocxEditorLoading, { overlay: true }),
+    ]);
+    await flush();
+
+    view.editor().load(LARGE_SOURCE);
+    expect(view.editor().snapshot().isOpening).toBe(true);
+    await nextTick();
+    await nextTick();
+
+    expect(view.container.querySelector('.docx-ruler-frame--opening')).not.toBeNull();
+    await flush();
+    expect(view.container.querySelector('.docx-ruler-frame--opening')).toBeNull();
     view.unmount();
   });
 });

--- a/packages/vue/test/viewport-rail.test.ts
+++ b/packages/vue/test/viewport-rail.test.ts
@@ -98,8 +98,9 @@ describe('DocxEditorViewport review rail', () => {
     expect(scroller.style.getPropertyValue('--docx-review-gutter')).toBe('316px');
     expect(scroller.style.getPropertyValue('--docx-review-gutter-start')).toBe('0px');
     const loading = view.container.querySelector('.docx-editor__loading') as HTMLElement;
-    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
-    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
+    expect(
+      loading.querySelector('.docx-paginated-surface > .docx-pages > .docx-page')
+    ).not.toBeNull();
     view.unmount();
   });
 
@@ -127,8 +128,9 @@ describe('DocxEditorViewport review rail', () => {
     ) as HTMLElement;
     expect(scroller.style.getPropertyValue('--docx-nav-shift')).toBe('128px');
     const loading = view.container.querySelector('.docx-editor__loading') as HTMLElement;
-    expect(loading.style.getPropertyValue('--docx-loading-inline-start')).toBe('0px');
-    expect(loading.style.getPropertyValue('--docx-loading-right')).toBe('0px');
+    expect(
+      loading.querySelector('.docx-paginated-surface > .docx-pages > .docx-page')
+    ).not.toBeNull();
     view.unmount();
   });
 


### PR DESCRIPTION
## Summary
- Show a pulsing document-page scaffold while documents load.
- Use the scaffold by default in React and Vue packaged editors.
- Document the automatic loading state in the quickstart.

## Test plan
- [x] Run focused React and Vue tests.
- [x] Run type checks, lint, formatting, parity, API, and MDX checks.
- [x] Review the branch with Bugbot.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790176040&installation_model_id=422592&pr_number=408&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F408&signature=ef9557f09f70a21655c6f8938c824b99dab6c2367e9314f4e5021ce804aac02d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->