### PR TITLE
fix(core): keep review author colors stable

### DIFF
--- a/.changeset/stable-review-author-colors.md
+++ b/.changeset/stable-review-author-colors.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Review author colours now remain stable while you edit, remove, and undo comments or tracked changes in an attached document.

--- a/openspec/changes/typed-revisions-and-comments/specs/review-surface/spec.md
+++ b/openspec/changes/typed-revisions-and-comments/specs/review-surface/spec.md
@@ -47,6 +47,31 @@ The adapter SHALL present comment threads and revisions in a sidebar, each ancho
 - **WHEN** card positions are computed
 - **THEN** they derive from semantic layout records, not from measuring painted DOM
 
+### Requirement: Author colours remain stable during an attached document session
+
+The review surface SHALL assign each author one colour slot for the lifetime of an attached
+document session. Tracked text, comment cards, revision cards, markers, and highlight hooks SHALL
+consume that same assignment. Removing an author's last visible item SHALL reserve their slot, so
+undo restores the item without recolouring that author or another reviewer. Attaching another
+document SHALL start a new assignment from that document's author order.
+
+#### Scenario: A commenter adds an earlier tracked change
+
+- **WHEN** a comment-only author has a card and then adds a tracked change before existing revisions
+- **THEN** the existing comment card keeps its colour slot
+- **AND** the new tracked text and revision card use that same slot
+
+#### Scenario: Removal and undo preserve the assignment
+
+- **WHEN** an author's last tracked change is removed and then restored by undo
+- **THEN** the restored change uses its previous slot
+- **AND** no other author's slot changes
+
+#### Scenario: Another document starts a new assignment
+
+- **WHEN** a different document attaches to the editor
+- **THEN** its author slots are seeded from that document rather than the previous session
+
 #### Scenario: Selecting a card selects its range
 
 - **WHEN** the user selects a comment card

--- a/openspec/changes/typed-revisions-and-comments/specs/review-surface/spec.md
+++ b/openspec/changes/typed-revisions-and-comments/specs/review-surface/spec.md
@@ -72,6 +72,11 @@ document SHALL start a new assignment from that document's author order.
 - **WHEN** a different document attaches to the editor
 - **THEN** its author slots are seeded from that document rather than the previous session
 
+#### Scenario: An internal remount keeps the assignment
+
+- **WHEN** font resolution or another internal operation remounts the same attached document
+- **THEN** every author keeps the slot assigned before the remount
+
 #### Scenario: Selecting a card selects its range
 
 - **WHEN** the user selects a comment card

--- a/openspec/changes/typed-revisions-and-comments/tasks.md
+++ b/openspec/changes/typed-revisions-and-comments/tasks.md
@@ -151,6 +151,7 @@ Counts are measured per part; see the fixture-evidence tables in `proposal.md`. 
 - [x] 6.50 The replacement text is inserted AFTER the struck words. A tracked deletion keeps its characters, so inserting at the selection start put the replacement before them: mid-sentence replacements showed as two unrelated cards and a reviewer could accept one half
 - [x] 6.51 A paragraph-mark revision anchors at the paragraph's END, where the pilcrow is. Collapsed to offset 0, a tracked Enter's card never opened at the break that made it, activating it threw the caret to the paragraph start, and its zero-width range painted no band
 - [x] 6.52 `w:instrText` becomes `w:delInstrText` inside a deletion (§17.16.23) — the reject path already renamed it back, so the write path could never produce what that code exists to undo. Extending your own `w:ins` is bounded to the same editing moment, matching the deletion path. A stale refusal is cleared when the mode changes
+- [x] 6.53 Author colour slots remain stable for one attached document session. A comment-only author who later adds an earlier tracked change keeps the card colour already assigned to them, tracked text consumes the same map, deleted slots stay reserved for undo, and another attachment reseeds the assignment
 
 ## 9. Verification and honest scope
 
@@ -193,73 +194,73 @@ inferred. None is a merge artefact alone — the merge made several of them reac
 none blocks the slice, so they land on their own branch rather than growing this one.
 
 - [x] 12.1 **The offset model is forked — closed by delegation, not by patching.**
-  `paragraphOffsetIndex` (`store/tree-op-segments.ts`) records every node's `[start, end)`
-  from `segmentsOf`'s OWN walk, at no cost to `segmentsOf` itself, and the three private
-  walkers are gone: `tree-op-tracked.ts` `lengthOf`, `comment-anchors.ts`
-  `textLengthOfRunChild`, and `review-model.ts` `runLength`. Was: none descends into
-  `w:hyperlink`; none gives a note reference or an atomic field its length of 1; one counted a
-  field's `w:instrText` as visible characters
+      `paragraphOffsetIndex` (`store/tree-op-segments.ts`) records every node's `[start, end)`
+      from `segmentsOf`'s OWN walk, at no cost to `segmentsOf` itself, and the three private
+      walkers are gone: `tree-op-tracked.ts` `lengthOf`, `comment-anchors.ts`
+      `textLengthOfRunChild`, and `review-model.ts` `runLength`. Was: none descends into
+      `w:hyperlink`; none gives a note reference or an atomic field its length of 1; one counted a
+      field's `w:instrText` as visible characters
 - [x] 12.2 Comment anchors delegate. A comment after a hyperlink anchors past it, and markers
-  written INSIDE a `w:hyperlink` — what Word writes when you comment on link text — yield an
-  anchor instead of reporting the comment `orphaned`
+      written INSIDE a `w:hyperlink` — what Word writes when you comment on link text — yield an
+      anchor instead of reporting the comment `orphaned`
 - [x] 12.3 Threading: two comments over two ADJACENT hyperlinks anchor over their own links.
-  Coincidence is additionally refused on a ZERO-WIDTH range, which is evidence of nothing —
-  two remarks covering no characters sit at the same offset for any number of reasons
+      Coincidence is additionally refused on a ZERO-WIDTH range, which is evidence of nothing —
+      two remarks covering no characters sit at the same offset for any number of reasons
 - [x] 12.4 Suggesting mode delegates. In a paragraph carrying a footnote, endnote or field a
-  tracked insert lands where asked, an insert at the true paragraph end is accepted, and a
-  delete strikes exactly the selected units
+      tracked insert lands where asked, an insert at the true paragraph end is accepted, and a
+      delete strikes exactly the selected units
 - [x] 12.4a **Beyond the finding, and found by the losslessness sweep it made possible.** An
-  ATOM is one addressable unit spread over several nodes, and the tracked writer now respects
-  that grouping: striking a complex field strikes all of it (`w:instrText` becoming
-  `w:delInstrText`) rather than leaving a `w:del` around the `begin` with the `end` outside it,
-  which accepting then turned into an orphaned field; typing at a field's model end lands
-  after the field instead of between its chrome runs, where the words were invisible and
-  stayed invisible. A `w:fldSimple` is struck from INSIDE, because `CT_RunTrackChange` takes
-  `EG_ContentRunContent` and that has no `fldSimple` in it — which also widened the tree
-  invariant, since the same shape in a file Word wrote was demoting the field on READ. An
-  insertion whose offset falls INSIDE another author's deletion is placed after it rather than
-  refused `offset-out-of-range`; a `w:fldSimple` or `w:hyperlink` the resolution empties is
-  dropped, matching what the untracked delete does. Gated by
-  `store/__tests__/tracked-edit-losslessness.test.ts`: over every insert position, delete
-  range and replacement range of nine paragraph shapes, reject-all returns the D9 semantic
-  digest through a save and reopen, and accept-all equals the untracked edit
+      ATOM is one addressable unit spread over several nodes, and the tracked writer now respects
+      that grouping: striking a complex field strikes all of it (`w:instrText` becoming
+      `w:delInstrText`) rather than leaving a `w:del` around the `begin` with the `end` outside it,
+      which accepting then turned into an orphaned field; typing at a field's model end lands
+      after the field instead of between its chrome runs, where the words were invisible and
+      stayed invisible. A `w:fldSimple` is struck from INSIDE, because `CT_RunTrackChange` takes
+      `EG_ContentRunContent` and that has no `fldSimple` in it — which also widened the tree
+      invariant, since the same shape in a file Word wrote was demoting the field on READ. An
+      insertion whose offset falls INSIDE another author's deletion is placed after it rather than
+      refused `offset-out-of-range`; a `w:fldSimple` or `w:hyperlink` the resolution empties is
+      dropped, matching what the untracked delete does. Gated by
+      `store/__tests__/tracked-edit-losslessness.test.ts`: over every insert position, delete
+      range and replacement range of nine paragraph shapes, reject-all returns the D9 semantic
+      digest through a save and reopen, and accept-all equals the untracked edit
 - [x] 12.5 **Section addressing desyncs from the filtered block list.** `enumerateDocumentSections`
-  takes the display mode and passes it to `storyBlocks`, so the indices it hands out belong to
-  the list `semantic-layout.ts` slices. Was: body text landed under the wrong section's page
-  geometry. The comment above `revisionRemovesParagraph` predicted exactly this
+      takes the display mode and passes it to `storyBlocks`, so the indices it hands out belong to
+      the list `semantic-layout.ts` slices. Was: body text landed under the wrong section's page
+      geometry. The comment above `revisionRemovesParagraph` predicted exactly this
 - [x] 12.6 `MAX_INLINE_DEPTH` is now `MAX_REVISION_DEPTH`, taken from the layout walk rather
-  than restated. At a local 8 against layout's 32, a paragraph nested past 8 was called empty
-  while layout still emitted its spans, so file-controlled nesting dropped visible text
+      than restated. At a local 8 against layout's 32, a paragraph nested past 8 was called empty
+      while layout still emitted its spans, so file-controlled nesting dropped visible text
 - [x] 12.7 A comment reply grafts the coordinator's package into the story store before the
-  write (`graftPackage`, the narrow documented lane, referenced again), so publishing the
-  result no longer discards a `numbering.xml` graft or a minted hyperlink relationship — the
-  dangling `w:numPr` / `r:id` on save
+      write (`graftPackage`, the narrow documented lane, referenced again), so publishing the
+      result no longer discards a `numbering.xml` graft or a minted hyperlink relationship — the
+      dangling `w:numPr` / `r:id` on save
 - [x] 12.8 A comments relationship is honoured only when the target's declared CONTENT TYPE
-  agrees, or when the package does not hold that part yet — so a crafted package cannot
-  redirect a comment write into `settings.xml`. The READ side resolves the same way the write
-  side does instead of hardcoding `/word/comments.xml`
+      agrees, or when the package does not hold that part yet — so a crafted package cannot
+      redirect a comment write into `settings.xml`. The READ side resolves the same way the write
+      side does instead of hardcoding `/word/comments.xml`
 - [ ] 12.9 A reply to a reply is unreachable: the rail filters every `parentId` from the top
-  level and renders exactly one level of replies
+      level and renders exactly one level of replies
 - [ ] 12.10 A multi-site revision (a tracked row insertion) yields two cards with identical
-  ids — the grouping key includes `localName`, the card id does not
+      ids — the grouping key includes `localName`, the card id does not
 - [x] 12.11 `w:rPrChange` anchors over the RUN it decorates: `locateSites` places a run's own
-  `w:rPr` subtree at the run's range. It stopped at the run, so the card sorted to the end of
-  the rail, had no geometry, painted no band, and the caret in tracked-formatted text
-  activated nothing while accept/reject stayed offered
+      `w:rPr` subtree at the run's range. It stopped at the run, so the card sorted to the end of
+      the rail, had no geometry, painted no band, and the caret in tracked-formatted text
+      activated nothing while accept/reject stayed offered
 - [ ] 12.12 `pairReplacements` is deletions x insertions and the thread walk is per-comment
-  ancestor chains: ~128ms at 2000 revisions, ~255ms at 4000 comments, both on file-controlled
-  input and both re-run per paint
+      ancestor chains: ~128ms at 2000 revisions, ~255ms at 4000 comments, both on file-controlled
+      input and both re-run per paint
 - [ ] 12.13 Accept/reject render live in Viewing and fail silently — the rail ignores editing
-  mode, `useReview.accept/reject` discard the `ExecResult`, and the facade replaces the
-  engine's refusal with an invented string
+      mode, `useReview.accept/reject` discard the `ExecResult`, and the facade replaces the
+      engine's refusal with an invented string
 - [ ] 12.14 `nextCommentId` returns `highest + 1` unguarded where `nextRevisionId` clamps to
-  signed 32-bit and wraps
+      signed 32-bit and wraps
 - [ ] 12.15 Headers, footers, notes and comment anchors call `storyBlocks` unfiltered, so they
-  resolve revisions in a different mode than the body on the same page
+      resolve revisions in a different mode than the body on the same page
 - [ ] 12.16 `revisionRemovesParagraph` defaults to `'proposed'` while every call site defaults
-  to `'all-markup'`; its unit tests call it bare and assert behaviour no production path reaches
+      to `'all-markup'`; its unit tests call it bare and assert behaviour no production path reaches
 - [ ] 12.17 The projection drops a mark-deleted paragraph only when it renders empty; it never
-  performs the join when content survives, so `proposed` still differs from accept-all on a
-  case the fixture does not contain
+      performs the join when content survives, so `proposed` still differs from accept-all on a
+      case the fixture does not contain
 - [ ] 12.18 `RevisionDisplayMode` is plumbed through all of layout with no editor facade — no
-  read, no command, no snapshot field — so the mode is permanently `all-markup` to any host
+      read, no command, no snapshot field — so the mode is permanently `all-markup` to any host

--- a/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
+++ b/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
@@ -22,6 +22,7 @@ import { sha256FontBytes } from '../../layout/index.ts';
 import { deobfuscateFont } from '../../store/package/embedded-fonts.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
 import { embeddedFontSources } from '../embedded-font-sources.ts';
+import { stubReviewModule } from './review-test-module.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -103,6 +104,10 @@ function docxWithEmbeds(body: string, embeds: readonly EmbedEntry[]): Uint8Array
 
 const p = (text: string, family = 'DejaVu Sans') =>
   `<w:p><w:r><w:rPr><w:rFonts w:ascii="${family}" w:hAnsi="${family}"/></w:rPr><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+const insertion = (id: number, author: string, text: string) =>
+  `<w:ins w:id="${id}" w:author="${author}" w:date="2026-01-01T00:00:00Z">` +
+  `<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:ins>`;
 
 /** Controllable proportional browser metrics, deliberately unlike the fixed 6pt grid. */
 function mockCanvasContext(): CanvasRenderingContext2D {
@@ -224,6 +229,66 @@ describe('embedded fonts auto-wire into shaped measurement', () => {
     // Settled: no further remount happens once shaped layout is in place.
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(editor.surface).toBe(surfaceAfterResolve);
+    editor.destroy();
+  });
+
+  test('a same-document remount keeps author slots, while a true load resets them', async () => {
+    const container = document.createElement('div');
+    const trackedBody =
+      '<w:p><w:r><w:rPr><w:rFonts w:ascii="DejaVu Sans" w:hAnsi="DejaVu Sans"/></w:rPr>' +
+      '<w:t xml:space="preserve">base </w:t></w:r>' +
+      insertion(1, 'Ada', 'one ') +
+      insertion(2, 'Bea', 'two ') +
+      insertion(3, 'Cora', 'three') +
+      '</w:p>';
+    const editor = createDocxEditor({
+      container,
+      document: docxWithEmbeds(trackedBody, EMBED_BOTH),
+      author: 'Grace',
+      modules: [stubReviewModule()],
+    });
+    await mounted(editor);
+    expect(
+      new Map(editor.getReviewAuthors().map((author) => [author.author, author.slot]))
+    ).toEqual(
+      new Map([
+        ['Ada', 0],
+        ['Bea', 1],
+        ['Cora', 2],
+      ])
+    );
+
+    editor.setEditingMode('suggesting');
+    const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+    editor.surface!.setSelection({
+      anchor: { paragraphId, offset: 0 },
+      head: { paragraphId, offset: 0 },
+    });
+    editor.surface!.type('X');
+    const slotsBeforeRemount = new Map(
+      editor.getReviewAuthors().map((author) => [author.author, author.slot])
+    );
+    expect(slotsBeforeRemount.get('Grace')).toBe(3);
+    const surfaceBeforeResolve = editor.surface;
+
+    // Detach/attach and font resolution both rebuild through `mountBytes` for the SAME load.
+    // This path is deterministic even when the font promise settles before the test can
+    // observe its own remount under a loaded parallel run.
+    editor.detach();
+    editor.attach(container);
+    await mounted(editor);
+    await fontsSettled(editor);
+
+    expect(editor.surface).not.toBe(surfaceBeforeResolve);
+    expect(
+      new Map(editor.getReviewAuthors().map((author) => [author.author, author.slot]))
+    ).toEqual(slotsBeforeRemount);
+
+    editor.load(docxWithEmbeds(`<w:p>${insertion(1, 'Grace', 'new document')}</w:p>`, []));
+    expect(editor.surface!.session.bodyText()).toBe('new document');
+    expect(editor.getReviewAuthors()).toEqual([
+      { author: 'Grace', slot: 0, color: 'var(--doc-review-author-0)' },
+    ]);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -48,6 +48,10 @@ import {
   type SemanticLayout,
   type SemanticPosition,
 } from '../layout/index.ts';
+import {
+  createStableReviewAuthorSlots,
+  type StableReviewAuthorSlots,
+} from '../output/revision-presentation.ts';
 import type {
   DocumentEditingMode,
   ReviewActivationOptions,
@@ -273,6 +277,13 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   let reviewActivationExclusions: readonly ReviewRevisionKind[] | null = null;
   // How tracked changes are coloured, replaceable live; a reload mounts with the latest.
   const revisionStyleState = createRevisionStyleState(config.revisionStyles);
+  /**
+   * Author colours belong to the loaded DOCUMENT, not to one surface instance.
+   *
+   * Font resolution and attach rebuild the surface from the same bytes. They reuse this
+   * assignment. `loadBytes` replaces it before a true document load mounts.
+   */
+  let reviewAuthorSlots: StableReviewAuthorSlots = createStableReviewAuthorSlots();
   /**
    * True once the reader has moved the mode themselves.
    *
@@ -506,6 +517,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       ...(revisionStyleState.current() !== undefined
         ? { revisionStyles: revisionStyleState.current() }
         : {}),
+      reviewAuthorSlots,
       editingMode:
         editingMode === 'suggesting' ? 'suggest' : editingMode === 'viewing' ? 'view' : 'edit',
       // The free engine renders the FINAL-STATE projection (Word's "No Markup"):
@@ -657,6 +669,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // A load supersedes any open still waiting on its frame: drop the superseded bytes.
     openScheduler.cancel();
     loadSeq += 1;
+    reviewAuthorSlots = createStableReviewAuthorSlots();
     shapedMeasurer = undefined;
     shapedProducer = undefined;
     // An on-demand answer describes the document that asked for it. Carrying it into the

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -84,6 +84,7 @@ import {
   createStableReviewAuthorSlots,
   reviewAuthorsOf,
   type ReviewAuthorInfo,
+  type StableReviewAuthorSlots,
 } from '../output/revision-presentation.ts';
 import {
   DEFAULT_DRAWING_PAINT_STRINGS,
@@ -219,6 +220,7 @@ export function mountPaginatedSurface(
 ): OpenPaginatedResult {
   const runtimeOptions = options as PaginatedSurfaceOptions & {
     readonly onTrackedChange?: () => void;
+    readonly reviewAuthorSlots?: StableReviewAuthorSlots;
   };
   const opened = openTreeSession(
     bytes,
@@ -712,9 +714,9 @@ export function mountPaginatedSurface(
   // because a colour change must never cost the reader their undo history to a remount.
   // Declared before the first paint can run — `render` reads it.
   let revisionStyles = options.revisionStyles;
-  // One allocator per ATTACHED surface. Reattaching creates another surface and reseeds from
-  // that document, while edits, deletions and undo inside this surface keep every issued slot.
-  const stableAuthorSlots = createStableReviewAuthorSlots();
+  // The facade owns this across internal remounts of the SAME attached document. A direct
+  // surface mount has no facade session, so it correctly starts a fresh assignment here.
+  const stableAuthorSlots = runtimeOptions.reviewAuthorSlots ?? createStableReviewAuthorSlots();
   // One roster per layout instance, so `revisionAuthors()` is cheap to poll and callers can
   // key their own caches on the returned map's identity. Keyed on the review queue too: a
   // COMMENT-ONLY author is in the roster and in no layout record, so a queue that moved

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -70,20 +70,19 @@ import {
 import { attachListResolveChangeEvidence } from '../layout/list-resolve.ts';
 import { DEFAULT_REVISION_DISPLAY_MODE } from '../layout/revision-projection.ts';
 import { mergedPredecessorsOf } from '../layout/line-segments.ts';
-import {
-  paintSelectionOverlay,
-  paintSemanticLayout,
-  type OverlayRect,
-} from '@docx-editor.dev/core/output';
+import { paintSelectionOverlay, type OverlayRect } from '@docx-editor.dev/core/output';
 // By module path, like the roster walk below: dropping a retained paint is an engine
 // internal for the IME lane, not something the output barrel should offer consumers.
-import { discardRetainedPaint } from '../output/semantic-paint.ts';
+import {
+  discardRetainedPaint,
+  paintSemanticLayoutWithAuthorSlots,
+} from '../output/semantic-paint.ts';
 // By module path: the roster walk is an engine internal, not part of the output barrel's
 // public surface. See the note there.
 import {
   authorSlotsOf,
+  createStableReviewAuthorSlots,
   reviewAuthorsOf,
-  reviewAuthorSlotsOf,
   type ReviewAuthorInfo,
 } from '../output/revision-presentation.ts';
 import {
@@ -713,6 +712,9 @@ export function mountPaginatedSurface(
   // because a colour change must never cost the reader their undo history to a remount.
   // Declared before the first paint can run — `render` reads it.
   let revisionStyles = options.revisionStyles;
+  // One allocator per ATTACHED surface. Reattaching creates another surface and reseeds from
+  // that document, while edits, deletions and undo inside this surface keep every issued slot.
+  const stableAuthorSlots = createStableReviewAuthorSlots();
   // One roster per layout instance, so `revisionAuthors()` is cheap to poll and callers can
   // key their own caches on the returned map's identity. Keyed on the review queue too: a
   // COMMENT-ONLY author is in the roster and in no layout record, so a queue that moved
@@ -2222,27 +2224,32 @@ export function mountPaginatedSurface(
     const activeHf = hfScope?.getActive() ?? null;
     const contentControlChrome = contentControlChromeOptions();
     const emptyTocIds = emptyTocPlaceholderParagraphIds(session.part());
-    paintSemanticLayout(pagesLayer, currentLayout, {
-      scale,
-      readOnlyParagraphIds: tocParagraphIds(),
-      ...(emptyTocIds.size > 0 ? { emptyTocPlaceholderIds: emptyTocIds } : {}),
-      ...(options.fontAlias ? { fontAlias: options.fontAlias } : {}),
-      ...(options.defaultFontFamily ? { defaultFontFamily: options.defaultFontFamily } : {}),
-      materialize: materializedSet,
-      ariaHidden: false,
-      drawingStrings,
-      ...(options.fieldShading ? { fieldShading: options.fieldShading } : {}),
-      ...(revisionStyles !== undefined ? { revisionStyles } : {}),
-      shadeFormFields: shadeFormFields(),
-      ...(paintImageUrlPort ? { imageUrlPort: paintImageUrlPort } : {}),
-      ...(activeHf
-        ? {
-            activeHeaderFooterRId: activeHf.scope.rId,
-            activeHeaderFooterPageIndex: activeHf.pageIndex,
-          }
-        : {}),
-      ...(contentControlChrome ? { contentControlChrome } : {}),
-    });
+    paintSemanticLayoutWithAuthorSlots(
+      pagesLayer,
+      currentLayout,
+      {
+        scale,
+        readOnlyParagraphIds: tocParagraphIds(),
+        ...(emptyTocIds.size > 0 ? { emptyTocPlaceholderIds: emptyTocIds } : {}),
+        ...(options.fontAlias ? { fontAlias: options.fontAlias } : {}),
+        ...(options.defaultFontFamily ? { defaultFontFamily: options.defaultFontFamily } : {}),
+        materialize: materializedSet,
+        ariaHidden: false,
+        drawingStrings,
+        ...(options.fieldShading ? { fieldShading: options.fieldShading } : {}),
+        ...(revisionStyles !== undefined ? { revisionStyles } : {}),
+        shadeFormFields: shadeFormFields(),
+        ...(paintImageUrlPort ? { imageUrlPort: paintImageUrlPort } : {}),
+        ...(activeHf
+          ? {
+              activeHeaderFooterRId: activeHf.scope.rId,
+              activeHeaderFooterPageIndex: activeHf.pageIndex,
+            }
+          : {}),
+        ...(contentControlChrome ? { contentControlChrome } : {}),
+      },
+      reviewAuthorState().value
+    );
     // Paint just rebuilt every span, so the caret's field lost its mark with the old DOM.
     syncActiveFieldShading(pagesLayer, collapsedCaretPosition(), { domReplaced: true });
     setHeaderFooterEditingChrome(container, pagesLayer, activeHf != null);
@@ -3281,7 +3288,7 @@ export function mountPaginatedSurface(
     if (prior !== null && prior.layout === currentLayout && prior.items === items) {
       if (prior.styles === revisionStyles) return prior;
     }
-    const next = reviewAuthorSlotsOf(
+    const next = stableAuthorSlots.resolve(
       authorSlotsOf(currentLayout),
       (function* authors() {
         for (const item of items) yield reviewItemAuthor(item);

--- a/packages/core/src/output/__tests__/review-author-slots.test.ts
+++ b/packages/core/src/output/__tests__/review-author-slots.test.ts
@@ -1,0 +1,65 @@
+// Author colours are session state, not a fresh ranking after every edit.
+//
+// A commenter starts outside the layout author scan. If that person later types a tracked
+// change before existing revisions, a cold scan ranks them first. The attached editor must
+// retain the colour its review cards already taught the reader.
+
+import { describe, expect, test } from 'bun:test';
+import type { SemanticLayout } from '../../layout/semantic-records.ts';
+import { createStableReviewAuthorSlots, revisionStyleContextOf } from '../revision-presentation.ts';
+
+const REVISION_AUTHORS = new Map([
+  ['Ada', 0],
+  ['Bea', 1],
+  ['Cora', 2],
+]);
+
+describe('stable review author slots', () => {
+  test('keeps a commenter’s slot when they become the first revision author', () => {
+    const session = createStableReviewAuthorSlots();
+    const before = session.resolve(REVISION_AUTHORS, ['Demo Reviewer']);
+    expect(before.get('Demo Reviewer')).toBe(3);
+
+    const after = session.resolve(
+      new Map([
+        ['Demo Reviewer', 0],
+        ['Ada', 1],
+        ['Bea', 2],
+        ['Cora', 3],
+      ]),
+      ['Demo Reviewer']
+    );
+    expect(after).toEqual(before);
+  });
+
+  test('reserves a deleted author’s slot for undo and resets with another session', () => {
+    const session = createStableReviewAuthorSlots();
+    session.resolve(REVISION_AUTHORS, ['Demo Reviewer']);
+
+    const deleted = session.resolve(REVISION_AUTHORS, []);
+    expect(deleted.has('Demo Reviewer')).toBe(false);
+
+    const restored = session.resolve(
+      new Map([
+        ['Demo Reviewer', 0],
+        ['Ada', 1],
+        ['Bea', 2],
+        ['Cora', 3],
+      ]),
+      ['Demo Reviewer']
+    );
+    expect(restored.get('Demo Reviewer')).toBe(3);
+
+    const otherDocument = createStableReviewAuthorSlots().resolve(
+      new Map([['Demo Reviewer', 0]]),
+      []
+    );
+    expect(otherDocument.get('Demo Reviewer')).toBe(0);
+  });
+
+  test('hands the stable assignment to tracked-text presentation', () => {
+    const slots = createStableReviewAuthorSlots().resolve(REVISION_AUTHORS, ['Demo Reviewer']);
+    const layout = { pages: [] } as unknown as SemanticLayout;
+    expect(revisionStyleContextOf('author', layout, slots)?.authorSlots).toBe(slots);
+  });
+});

--- a/packages/core/src/output/revision-presentation.ts
+++ b/packages/core/src/output/revision-presentation.ts
@@ -71,10 +71,10 @@ export interface RevisionAuthorAssignments {
  * How painted tracked changes are coloured.
  *
  * - `'author'` (the DEFAULT) — every change takes its author's colour from the
- *   `--doc-review-author-N` ramp, assigned by order of first appearance in the document.
- *   Word's own default, and the reason it is this engine's: a paragraph three people
- *   edited has to read as three people. Restyle a slot under `.docx-editor` to change the
- *   ramp.
+ *   `--doc-review-author-N` ramp. An attached document seeds slots by order of first
+ *   appearance, then keeps those assignments stable for that session. Word's own default,
+ *   and the reason it is this engine's: a paragraph three people edited has to read as three
+ *   people. Restyle a slot under `.docx-editor` to change the ramp.
  * - `'kind'` — insertions and deletions take the two kind colours
  *   (`--doc-revision-insertion` / `--doc-revision-deletion`), so "added" and "removed" are
  *   what a reader tells apart at a glance, whoever proposed them.
@@ -96,7 +96,7 @@ export interface ReviewAuthorInfo {
   /** The `w:author` string, exactly as the file carries it. */
   readonly author: string;
   /**
-   * Rank by order of first appearance — an UNBOUNDED index, not a ramp slot.
+   * Stable session rank, seeded by order of first appearance — an UNBOUNDED index.
    *
    * The ramp defines {@link REVIEW_AUTHOR_SLOTS} colours and every DOM hook wraps into it,
    * so the ninth author ranks 8 here and carries `data-review-author-slot="0"`. Building a
@@ -318,19 +318,31 @@ export function revisionStyleContextKey(context: RevisionStyleContext | null): s
  */
 const contextCache = new WeakMap<
   SemanticLayout,
-  { option: RevisionStyles | undefined; context: RevisionStyleContext | null }
+  {
+    option: RevisionStyles | undefined;
+    authorSlots: ReadonlyMap<string, number> | undefined;
+    context: RevisionStyleContext | null;
+  }
 >();
 
-/** Resolve the public option against a layout, or `null` for the default kind colouring. */
+/**
+ * Resolve the public option against a layout, or `null` for the default kind colouring.
+ *
+ * `authorSlots` is the attached surface's stable assignment when one exists. A standalone
+ * painter has no session and keeps deriving the assignment from the layout.
+ */
 export function revisionStyleContextOf(
   option: RevisionStyles | undefined,
-  layout: SemanticLayout
+  layout: SemanticLayout,
+  authorSlots?: ReadonlyMap<string, number>
 ): RevisionStyleContext | null {
   // OMITTED MEANS BY AUTHOR. Word's default, and the one this engine takes: colour answers
   // who proposed the change, decoration answers what it was. `'kind'` is the opt-out.
   if (option === 'kind') return null;
   const cached = contextCache.get(layout);
-  if (cached && cached.option === option) return cached.context;
+  if (cached && cached.option === option && cached.authorSlots === authorSlots) {
+    return cached.context;
+  }
   const styles = revisionAuthorStylesOf(option);
   const others =
     option === undefined || option === 'author' ? 'author' : (option.others ?? 'author');
@@ -338,10 +350,10 @@ export function revisionStyleContextOf(
   // Returning a context for it would cost a full walk per paint and mark every tracked span
   // with a slot hook, for no visible difference.
   if (styles.size === 0 && others === 'kind') {
-    contextCache.set(layout, { option, context: null });
+    contextCache.set(layout, { option, authorSlots, context: null });
     return null;
   }
-  const authorSlots = authorSlotsOf(layout);
+  const resolvedAuthorSlots = authorSlots ?? authorSlotsOf(layout);
   const classTokens = new Map<string, readonly string[]>();
   for (const [author, style] of styles) {
     if (!style.spanClassName) continue;
@@ -349,13 +361,13 @@ export function revisionStyleContextOf(
     if (tokens.length > 0) classTokens.set(author, tokens);
   }
   const context: RevisionStyleContext = {
-    authorSlots,
+    authorSlots: resolvedAuthorSlots,
     styles,
     classTokens,
     others,
-    key: computeContextKey(authorSlots, styles, others),
+    key: computeContextKey(resolvedAuthorSlots, styles, others),
   };
-  contextCache.set(layout, { option, context });
+  contextCache.set(layout, { option, authorSlots, context });
   return context;
 }
 
@@ -528,6 +540,40 @@ export function reviewAuthorSlotsOf(
     if (!combined.has(author)) combined.set(author, combined.size);
   }
   return combined ?? documentSlots;
+}
+
+/**
+ * One attached document's author-slot allocator.
+ *
+ * The first resolve seeds the assignment in document order. Later resolves keep every slot
+ * already issued, including slots whose author is temporarily absent. New authors append after
+ * the reserved range, so deleting and undoing a decision cannot recolour another reviewer.
+ */
+export interface StableReviewAuthorSlots {
+  resolve(
+    documentSlots: ReadonlyMap<string, number>,
+    reviewAuthors: Iterable<string>
+  ): ReadonlyMap<string, number>;
+}
+
+export function createStableReviewAuthorSlots(): StableReviewAuthorSlots {
+  const reserved = new Map<string, number>();
+  let nextSlot = 0;
+  return {
+    resolve(documentSlots, reviewAuthors) {
+      const current = reviewAuthorSlotsOf(documentSlots, reviewAuthors);
+      for (const author of current.keys()) {
+        if (reserved.has(author)) continue;
+        reserved.set(author, nextSlot);
+        nextSlot += 1;
+      }
+      return new Map(
+        [...current.keys()]
+          .map((author) => [author, reserved.get(author)!] as const)
+          .sort((left, right) => left[1] - right[1])
+      );
+    },
+  };
 }
 
 /**

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -2828,6 +2828,22 @@ export function paintSemanticLayout(
   layout: SemanticLayout,
   options: PaintOptions = {}
 ): void {
+  paintSemanticLayoutWithAuthorSlots(container, layout, options);
+}
+
+/**
+ * Paint with the attached surface's stable author-slot assignment.
+ *
+ * Internal editor-to-output seam. Standalone consumers use {@link paintSemanticLayout}.
+ *
+ * @internal
+ */
+export function paintSemanticLayoutWithAuthorSlots(
+  container: HTMLElement,
+  layout: SemanticLayout,
+  options: PaintOptions,
+  authorSlots?: ReadonlyMap<string, number>
+): void {
   const chrome = options.contentControlChrome;
   // `hoverIds` is absent ON PURPOSE — see its doc comment. Including it made a pointer
   // entering a TOC rebuild every page, which detached the node the gesture started on.
@@ -2859,7 +2875,7 @@ export function paintSemanticLayout(
   const tocKey = chrome?.tocControlIds ? [...chrome.tocControlIds].sort().join(',') : '';
   // Once per paint, from the WHOLE layout, so every page shares one author→slot map and an
   // incremental repaint cannot disagree with a full one.
-  const revisionStyles = revisionStyleContextOf(options.revisionStyles, layout);
+  const revisionStyles = revisionStyleContextOf(options.revisionStyles, layout, authorSlots);
   const resolved = {
     scale: options.scale ?? 96 / 72,
     ariaHidden: options.ariaHidden ?? true,
@@ -2903,8 +2919,8 @@ export function paintSemanticLayout(
     `ro:${readOnlyKey}|tocEmpty:${emptyTocKey}|` +
     `${options.imageUrlPort ? 'url' : ''}|` +
     `${drawingPaintStringsCacheToken(drawingStrings)}|` +
-    // The slot map derives from the whole layout: an edit elsewhere can renumber an author,
-    // recolouring pages whose own records did not change. The key must move with the map.
+    // The slot map belongs to this paint. A standalone paint derives it from the layout; an
+    // attached surface supplies its stable session map. The key must move when that map moves.
     `rev:${revisionStyleContextKey(revisionStyles)}`;
   const previous = retainedPaints.get(container);
   const parametersUnchanged = previous?.parameters === parameters;

--- a/packages/pro/src/__tests__/review-author-band.test.tsx
+++ b/packages/pro/src/__tests__/review-author-band.test.tsx
@@ -159,6 +159,69 @@ describe('the comment band carries its author', () => {
     expect(cardSlot(view, 'Grace Hopper')).toBe('1');
   });
 
+  test('a comment card keeps its colour when its author adds an earlier tracked change', async () => {
+    const { view, editor } = await mount();
+    const comment = view.container.querySelector<HTMLElement>(
+      '.docx-review__card[data-kind="comment"][data-review-author="Grace Hopper"]'
+    )!;
+    expect(comment.dataset.reviewAuthorSlot).toBe('1');
+    expect(comment.style.getPropertyValue('--doc-review-author-current')).toBe(
+      'var(--doc-review-author-1)'
+    );
+
+    await act(async () => {
+      editor.setEditingMode('suggesting');
+      const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+      editor.surface!.setSelection({
+        anchor: { paragraphId, offset: 0 },
+        head: { paragraphId, offset: 0 },
+      });
+      editor.surface!.type('X');
+    });
+
+    const cards = [
+      ...view.container.querySelectorAll<HTMLElement>(
+        '.docx-review__card[data-review-author="Grace Hopper"]'
+      ),
+    ];
+    expect(cards).toHaveLength(2);
+    expect(cards.every((card) => card.dataset.reviewAuthorSlot === '1')).toBe(true);
+    expect(
+      cards.every(
+        (card) =>
+          card.style.getPropertyValue('--doc-review-author-current') ===
+          'var(--doc-review-author-1)'
+      )
+    ).toBe(true);
+    expect(
+      view.container.querySelector<HTMLElement>('.docx-revision[data-review-author="Grace Hopper"]')
+        ?.dataset.reviewAuthorSlot
+    ).toBe('1');
+    expect(
+      view.container.querySelector<HTMLElement>('.docx-revision[data-review-author="Grace Hopper"]')
+        ?.style.color
+    ).toBe('var(--doc-review-author-1)');
+    expect(comment.isConnected).toBe(true);
+    expect(comment.dataset.kind).toBe('comment');
+
+    const revision = editor
+      .getReviewItems()
+      .find((item) => item.kind === 'revision' && item.author === 'Grace Hopper')!;
+    await act(async () => {
+      expect(editor.rejectReviewItem(revision.key).ok).toBe(true);
+    });
+    expect(comment.dataset.reviewAuthorSlot).toBe('1');
+
+    await act(async () => {
+      expect(editor.exec({ type: 'undo' }).ok).toBe(true);
+    });
+    expect(comment.dataset.reviewAuthorSlot).toBe('1');
+    expect(
+      view.container.querySelector<HTMLElement>('.docx-revision[data-review-author="Grace Hopper"]')
+        ?.dataset.reviewAuthorSlot
+    ).toBe('1');
+  });
+
   test('the band stays Word’s yellow: the author is a handle, not a default', async () => {
     const { view } = await mount();
     const band = view.container.querySelector<HTMLElement>(

--- a/packages/react/src/editor/useReviewAuthors.ts
+++ b/packages/react/src/editor/useReviewAuthors.ts
@@ -19,6 +19,7 @@ const NOOP_UNSUBSCRIBE = () => {};
  *
  * Both halves of review: authors of tracked changes first, numbered by where their first
  * change appears, then authors who only commented. One person is one colour across the two.
+ * Once assigned, a slot stays with that author for the attached document session.
  *
  * A read of the rendered projection, not of the package: a resolved view hides the
  * revisions it has resolved away, so an author whose only change is hidden there is listed


### PR DESCRIPTION
## Summary
- Keep review author color slots stable during edits, undo, and internal remounts.
- Share one slot assignment between review cards and tracked text.
- Reset the assignment when another document loads.

## Test plan
- [x] Run focused core and Pro review-color tests.
- [x] Run repository type checks.
- [x] Run formatting, lint, API, parity, package build, and strict OpenSpec checks.
- [x] Run Bugbot and fix its remount finding.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790176048&installation_model_id=422592&pr_number=409&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F409&signature=e2ca47e97fe6f13279b115d660ce333adf589ab377908337850e58387cfdde0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->