### PR TITLE
fix(core): keep overflow submenus visible on small screens

### DIFF
--- a/.changeset/mobile-format-submenus.md
+++ b/.changeset/mobile-format-submenus.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep font, spacing, and alignment menus visible in the responsive toolbar overflow panel.

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3540,6 +3540,22 @@ a.docx-hyperlink:focus-visible {
   overflow-y: visible;
 }
 
+/* Right-edge controls open toward the panel instead of beyond the viewport. */
+.docx-toolbar__more-panel .docx-toolbar__font-size-menu {
+  right: 0;
+  left: auto;
+}
+
+/* The lower controls have no room below them in a small scrollport. Their compact menus
+ * open upward and toward the panel, while the panel keeps its scroll position and bounds. */
+.docx-toolbar__more-panel .docx-toolbar__alignment-popup,
+.docx-toolbar__more-panel .docx-toolbar__line-spacing-menu {
+  top: auto;
+  right: 0;
+  bottom: 100%;
+  left: auto;
+}
+
 .docx-toolbar__more-section + .docx-toolbar__more-section {
   margin-top: 4px;
   padding-top: 4px;

--- a/packages/react/test/toolbar-overflow-react.test.tsx
+++ b/packages/react/test/toolbar-overflow-react.test.tsx
@@ -424,16 +424,31 @@ describe('toolbar overflow integration', () => {
     expect(rule).toContain('max-height: min(72vh, 560px)');
   });
 
-  test('More and its nested Zoom picker are not clipped by overflow containers', () => {
+  test('More keeps every nested picker visible on small screens', () => {
     const coreCss = readFileSync(
       new URL('../../core/src/styles/editor.css', import.meta.url),
       'utf8'
     );
-    const nestedMenuRule =
+    const zoomRule =
       coreCss.match(
         /\.docx-toolbar__more-panel:has\(\.docx-toolbar__zoom-menu\)\s*\{[^}]+\}/
       )?.[0] ?? '';
-    expect(nestedMenuRule).toContain('overflow-y: visible');
+    expect(zoomRule).toContain('overflow-y: visible');
+
+    const fontSizeRule =
+      coreCss.match(/\.docx-toolbar__more-panel \.docx-toolbar__font-size-menu\s*\{[^}]+\}/)?.[0] ??
+      '';
+    expect(fontSizeRule).toContain('right: 0');
+    expect(fontSizeRule).toContain('left: auto');
+
+    const lowerMenuRule =
+      coreCss.match(
+        /\.docx-toolbar__more-panel \.docx-toolbar__alignment-popup,\s*\.docx-toolbar__more-panel \.docx-toolbar__line-spacing-menu\s*\{[^}]+\}/
+      )?.[0] ?? '';
+    expect(lowerMenuRule).toContain('top: auto');
+    expect(lowerMenuRule).toContain('right: 0');
+    expect(lowerMenuRule).toContain('bottom: 100%');
+    expect(lowerMenuRule).toContain('left: auto');
 
     const demoCss = readFileSync(
       new URL('../../../examples/vite/src/styles.css', import.meta.url),


### PR DESCRIPTION
## Summary
- Keep font-size, alignment, and line-spacing menus inside the responsive viewport.
- Preserve the overflow panel scroll position while lower menus open upward.

## Test plan
- [x] Run the responsive toolbar test.
- [x] Run type checks, formatting, lint, and adapter CSS checks.
- [x] Verify the menus in a small browser viewport.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790176835&installation_model_id=422592&pr_number=410&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F410&signature=dc5c845e56e9905a940673f2f499438f760432f27fdf028978f515245aa3c103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->