### PR TITLE
chore(core): machine-enforce cache, lane, and API invariants

### DIFF
--- a/.changeset/snapshot-review-content-equality.md
+++ b/.changeset/snapshot-review-content-equality.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+The editor snapshot now notifies subscribers when `hasReviewContent` changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,13 @@ jobs:
   # are legitimately consumed, and the release PR (changeset-release/*) deletes them by
   # design. No `bun install` — git and node are the whole setup, same as shipped-advisories.
   api-changeset:
+    # The changeset-release skip requires the SAME repo: head_ref is author-controlled, so
+    # a fork branch named changeset-release/x must not buy its way past the gate.
     if: >-
       github.event_name == 'pull_request' &&
       github.actor != 'dependabot[bot]' &&
-      !startsWith(github.head_ref, 'changeset-release/')
+      !(startsWith(github.head_ref, 'changeset-release/') &&
+        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Lane boundary compile check
+        # The only compile-level proof that store/layout/automation stay DOM-free:
+        # each lane compiles against a lib with no `dom`. The import-edge half of
+        # the lane DAG is a test (core-lane-imports.test.ts) and runs under `test`.
+        run: bun run check:lane-boundaries
+
       - name: tsconfig lib floor check
         # Several packages map core to `../core/src`, so they type-check core's
         # sources and core's `lib` is their floor. Below it, `build:packages`
@@ -124,6 +130,25 @@ jobs:
         with:
           sarif_file: shipped-advisories.sarif
           category: shipped-advisories
+
+  # A PR that changes the public API surface (docs/api/*.api.md) must carry a changeset,
+  # or a removed export ships as an unversioned change. PRs only: on a push the changesets
+  # are legitimately consumed, and the release PR (changeset-release/*) deletes them by
+  # design. No `bun install` — git and node are the whole setup, same as shipped-advisories.
+  api-changeset:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.actor != 'dependabot[bot]' &&
+      !startsWith(github.head_ref, 'changeset-release/')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Require a changeset when docs/api changed
+        run: node scripts/check-api-changeset.mjs --base "origin/${{ github.base_ref }}"
 
   build:
     if: github.actor != 'dependabot[bot]'

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,18 +8,16 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-# Parity gate — DISABLED while @docx-editor.dev/vue is WIP and unpublished. It blocks
-# drift between the React and Vue adapter exports, which shouldn't gate commits on an
-# adapter that doesn't ship. Still runnable by hand: `bun run check:parity`.
-# Re-enable the commented block below when the Vue package drops `private: true`.
+# Parity gate — blocks drift between the React and Vue adapter exports. The Vue package
+# ships, so the drift is a consumer-facing break, and CI runs the same check; failing here
+# saves the round-trip.
 # Spec: openspec/changes/vue-editor-robust-implementation/specs/vue-react-parity/spec.md
-#
-# echo "Running parity gates..."
-# bun run check:parity
-# if [ $? -ne 0 ]; then
-#   echo "Parity gates failed. Fix the drift or document it in notes/intentional-export-divergence.md."
-#   exit 1
-# fi
+echo "Running parity gates..."
+bun run check:parity
+if [ $? -ne 0 ]; then
+  echo "Parity gates failed. Fix the drift or document it in notes/intentional-export-divergence.md."
+  exit 1
+fi
 
 # The license-header checks used to ride along inside `check:parity`. They have
 # nothing to do with React/Vue parity, so they stay wired up on their own.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,10 @@ One engine. Thin chrome on top.
 | `editor-api`  | `DocxEditor` automation object model, headless/server                                                                                                                                          | published, Pro license         |
 | `pro`         | Review module (comments, tracked changes) + custom nodes, as `EditorModule`s                                                                                                                   | published, Pro license         |
 | `fonts`       | Metric-compatible substitutes for Word's defaults                                                                                                                                              | published                      |
-| `vue`, `nuxt` | WIP, not shipping                                                                                                                                                                              | private                        |
+| `vue`         | The Vue 3 adapter twin, parity-gated against `react`                                                                                                                                           | published                      |
+| `nuxt`        | Nuxt module over the Vue adapter                                                                                                                                                               | WIP, private                   |
 
-React is the only real adapter today. Parity rules below are the target, not the
-state.
+React and Vue both ship; the parity gates below keep them from drifting.
 
 **The engine must resolve to ONE copy.** It holds module-level state — the
 HarfBuzz shaper and its cache budget, the grapheme boundary strategy, layout
@@ -160,8 +160,8 @@ bun run i18n:validate
 openspec validate typed-ooxml-paragraph-editor --strict
 ```
 
-- `bun run lint`'s errors are the `max-lines` caps (1000 lines for most files, up to 3250 for
-  the handful already past it) and the `no-restricted-syntax` bans (HTML-from-strings sinks
+- `bun run lint`'s errors are the `max-lines` caps (1000 lines for most files, per-file caps up
+  to 3500 for the handful already past it) and the `no-restricted-syntax` bans (HTML-from-strings sinks
   everywhere, varargs array spread in `core/src/{store,layout}`). Nothing else catches the caps,
   so adding to a large file passes typecheck and the whole suite and fails CI. Extract; do not
   raise the cap — `scripts/check-eslint-max-lines-globs.mjs` also fails a cap that drifts more

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,13 @@ bun run i18n:validate
 openspec validate typed-ooxml-paragraph-editor --strict
 ```
 
-- `bun run lint`'s only errors are the `max-lines` caps: 1000 lines for most files, 2900 for the
-  handful already past it. Nothing else catches them, so adding to a large file passes typecheck
-  and the whole suite and fails CI. Extract; do not raise the cap. It covers `examples/*/src` as
-  well as `packages/*/src` — the demos hit the same cap.
+- `bun run lint`'s errors are the `max-lines` caps (1000 lines for most files, up to 3250 for
+  the handful already past it) and the `no-restricted-syntax` bans (HTML-from-strings sinks
+  everywhere, varargs array spread in `core/src/{store,layout}`). Nothing else catches the caps,
+  so adding to a large file passes typecheck and the whole suite and fails CI. Extract; do not
+  raise the cap — `scripts/check-eslint-max-lines-globs.mjs` also fails a cap that drifts more
+  than 100 lines above its file. Lint covers `examples/*/src` as well as `packages/*/src` — the
+  demos hit the same cap.
 - `bun run test` shards the suite one process per file across a worker pool
   (`scripts/test/run-parallel.mjs`, `--jobs N` to pin the width). That is also
   what CI runs. `bun test` still works and is the one to reach for when you want
@@ -243,9 +246,10 @@ clipboard or print:
 grep -rnE "innerHTML|outerHTML|insertAdjacentHTML|v-html|document\\.write|window\\.open\\(|\\.href\\s*=|font-family:.*\\$\\{" packages --include="*.ts" --include="*.tsx" --include="*.vue" | grep -viE "test|\\.spec\\."
 ```
 
-Fix sibling sinks when you fix one. `openPrintWindow` still builds its popup via
-`document.write` with an unescaped `title`/`content` — a known sink to harden,
-not a reference.
+Fix sibling sinks when you fix one. The HTML sinks in that grep are also lint
+errors (`SECURITY_SINK_SELECTORS` in `eslint.config.js`), so a new one fails
+`bun run lint`; the grep still covers what the AST selectors cannot (`v-html`,
+raw `href` assignment, CSS interpolation).
 
 ## i18n
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,11 @@ openspec validate typed-ooxml-paragraph-editor --strict
 
 - `bun run lint`'s errors are the `max-lines` caps (1000 lines for most files, per-file caps up
   to 3500 for the handful already past it) and the `no-restricted-syntax` bans (HTML-from-strings sinks
-  everywhere, varargs array spread in `core/src/{store,layout}`). Nothing else catches the caps,
-  so adding to a large file passes typecheck and the whole suite and fails CI. Extract; do not
-  raise the cap — `scripts/check-eslint-max-lines-globs.mjs` also fails a cap that drifts more
-  than 100 lines above its file. Lint covers `examples/*/src` as well as `packages/*/src` — the
-  demos hit the same cap.
+  in `packages/*/src` non-test code, varargs array spread in `core/src/{store,layout}`). Nothing
+  else catches the caps, so adding to a large file passes typecheck and the whole suite and fails
+  CI. Extract; do not raise the cap — `scripts/check-eslint-max-lines-globs.mjs` also fails a cap
+  that drifts more than 150 lines above its file. Lint covers `examples/*/src` as well as
+  `packages/*/src` — the demos hit the same line caps.
 - `bun run test` shards the suite one process per file across a worker pool
   (`scripts/test/run-parallel.mjs`, `--jobs N` to pin the width). That is also
   what CI runs. `bun test` still works and is the one to reach for when you want

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -2742,10 +2742,10 @@ export const DocxEditorRoot: vue.DefineComponent<vue.ExtractPropTypes<{
     author: string;
     mode: "suggesting" | "edit" | "view";
     imageDecodePort: ImageDecodePort;
+    zoomMode: "auto" | ZoomMode;
     translate: ((key: string, params?: Record<string, string | number>) => string) | undefined;
     modules: readonly EditorModule[];
     tableInteractionLabel: ((key: "table.insertRowBelow" | "table.insertColumnRight") => string) | undefined;
-    zoomMode: "auto" | ZoomMode;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -220,6 +220,15 @@ export default [
             'push/splice/Math.* sites are grandfathered — audit that the collection is ' +
             'bounded before adding one.',
         },
+        // Constructor varargs grow the same stack: `new Foo(...arr)` is not a
+        // CallExpression, so it needs its own selector.
+        {
+          selector: 'NewExpression > SpreadElement',
+          message:
+            'Spreading an array into a constructor grows the argument stack with the ' +
+            'document and throws on attacker-sized input. Pass the array itself ' +
+            '(new Set(items), not new Set(...items)).',
+        },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,12 +48,47 @@ const restrictStatic = (banned, message) => ({
   'no-restricted-imports': ['error', { patterns: [{ group: banned, message }] }],
 });
 
+// Security sinks (CLAUDE.md, "No HTML from strings"): every value from a DOCX, pasted HTML
+// or embedded part is attacker-controlled, so file-derived strings must never reach an HTML
+// parser. Use createElement(NS) + setAttribute/textContent instead. These selectors ride in
+// EVERY `no-restricted-syntax` value this config emits, because in flat config a later
+// block's value REPLACES an earlier one's — a block that redefines the rule without
+// spreading SECURITY_SINK_SELECTORS silently drops the sink ban for its files.
+const NO_HTML_SINK_MSG =
+  'No HTML from strings: file-derived values must not reach an HTML parser. ' +
+  'Use createElement(NS) + setAttribute/textContent. See CLAUDE.md "Security".';
+const SECURITY_SINK_SELECTORS = [
+  {
+    selector: "AssignmentExpression[left.property.name='innerHTML']",
+    message: NO_HTML_SINK_MSG,
+  },
+  {
+    selector: "AssignmentExpression[left.property.name='outerHTML']",
+    message: NO_HTML_SINK_MSG,
+  },
+  {
+    selector: "CallExpression[callee.property.name='insertAdjacentHTML']",
+    message: NO_HTML_SINK_MSG,
+  },
+  {
+    selector: "CallExpression[callee.object.name='document'][callee.property.name='write']",
+    message: NO_HTML_SINK_MSG,
+  },
+  // `someWindow.document.write(...)` — the popup variant.
+  {
+    selector:
+      "CallExpression[callee.object.property.name='document'][callee.property.name='write']",
+    message: NO_HTML_SINK_MSG,
+  },
+];
+
 // ESLint's `no-restricted-imports` skips `await import(...)` (it's an
 // `ImportExpression` AST node, not `ImportDeclaration`). Use
 // `no-restricted-syntax` to match dynamic imports by literal source value.
 const restrictDynamic = (specifiers, message) => ({
   'no-restricted-syntax': [
     'error',
+    ...SECURITY_SINK_SELECTORS,
     ...specifiers.map((s) => ({
       selector: `ImportExpression[source.value=${JSON.stringify(s)}]`,
       message,
@@ -146,6 +181,49 @@ export default [
     settings: { react: { version: 'detect' } },
   },
 
+  // Every published package's source bans the HTML-from-strings sinks. Adapter and
+  // editor-api blocks below re-state the same selectors through restrictDynamic when they
+  // take over `no-restricted-syntax` for their files. Tests are exempt — the ban guards
+  // the render path from file-derived strings, and test fixtures/cleanup (`innerHTML = ''`)
+  // never see one; the CLAUDE.md audit grep draws the same line.
+  {
+    files: ['packages/*/src/**/*.{ts,tsx,vue}'],
+    ignores: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx'],
+    rules: { 'no-restricted-syntax': ['error', ...SECURITY_SINK_SELECTORS] },
+  },
+
+  // The DOM-free engine lanes additionally ban spreading an array into a call. A
+  // file-controlled collection spread into varargs (`push(...arr)`) grows the argument
+  // stack with the document and throws on attacker-sized input — a rule repeated in
+  // source comments across both lanes (table-widths.ts, drawing-projection.ts,
+  // tree-op-revisions.ts, ...). `push`/`splice`/`Math.*` call shapes are grandfathered
+  // as human judgment (72 audited sites, all bounded); every OTHER varargs spread is new
+  // and gets stopped here.
+  {
+    files: ['packages/core/src/store/**/*.ts', 'packages/core/src/layout/**/*.ts'],
+    // Tests spread bounded literal fixtures; the rule guards the engine paths that see
+    // attacker-sized collections.
+    ignores: ['**/__tests__/**'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        ...SECURITY_SINK_SELECTORS,
+        {
+          selector:
+            "CallExpression:not([callee.object.name='Math'])" +
+            ":not([callee.property.name='push'])" +
+            ":not([callee.property.name='splice'])" +
+            ' > SpreadElement',
+          message:
+            'Spreading an array into a call grows the argument stack with the document ' +
+            'and throws on attacker-sized input. Iterate, or pass the array itself. ' +
+            'push/splice/Math.* sites are grandfathered — audit that the collection is ' +
+            'bounded before adding one.',
+        },
+      ],
+    },
+  },
+
   // Vue adapter: no React imports, and none of React's hook rules.
   //
   // `react-hooks/rules-of-hooks` keys off the `use` PREFIX, so it reads a Vue composable
@@ -179,20 +257,6 @@ export default [
   // React adapter: no Vue imports.
   { files: ['packages/react/src/**/*.{ts,tsx}'], rules: restrictVue },
 
-  // The DocxEditor entry components (React and Vue twins) have a relaxed
-  // 2000-line cap while the extraction effort (tracked in MEMORY.md)
-  // continues. The cap still enforces a ceiling so the files can't grow
-  // unbounded; the rest of the repo stays at 1000.
-  {
-    files: [
-      'packages/react/src/components/DocxEditor.tsx',
-      'packages/vue/src/components/DocxEditor.tsx',
-    ],
-    rules: {
-      'max-lines': ['error', { max: 2000, skipBlankLines: false, skipComments: false }],
-    },
-  },
-
   // word-features.ts is the feature-support matrix — a flat data table with one
   // entry per Word feature and no logic. It grows by a dozen lines every time a
   // feature ships, which is the file working as intended, not a file that wants
@@ -203,25 +267,6 @@ export default [
     files: ['docs/site/data/word-features.ts'],
     rules: {
       'max-lines': ['error', { max: 1400, skipBlankLines: false, skipComments: false }],
-    },
-  },
-
-  // semantic-layout.ts is the story loop: section flow, paragraph fragmentation
-  // and table-row pagination advance ONE cursor, and a paragraph that spans a
-  // page boundary is decided by all three at once. Splitting them into modules
-  // would mean passing that cursor across a boundary and re-deriving the same
-  // state on the other side. semantic-table-layout.ts is the same argument for
-  // row-split pagination, which has to stay with cell flow and finalize because
-  // a row's real height is only known after its cells have laid out. Both were
-  // carrying a blanket `eslint-disable max-lines`, which removes the ceiling
-  // instead of raising it; these keep the ceiling, with headroom.
-  {
-    files: [
-      'packages/core/src/layout/semantic-layout.ts',
-      'packages/core/src/layout/semantic-table-layout.ts',
-    ],
-    rules: {
-      'max-lines': ['error', { max: 1500, skipBlankLines: false, skipComments: false }],
     },
   },
 
@@ -297,18 +342,26 @@ export default [
   {
     files: [
       'packages/core/src/layout/drawing-layout.ts',
-      'packages/core/src/layout/semantic-hit-test.ts',
       'packages/core/src/store/__tests__/image-resources.test.ts',
-      'packages/core/src/store/package/image-resources.ts',
-      'packages/react/test/toolbar-composition.test.tsx',
     ],
     rules: {
-      'max-lines': ['error', { max: 1500, skipBlankLines: false, skipComments: false }],
+      'max-lines': ['error', { max: 1400, skipBlankLines: false, skipComments: false }],
     },
   },
 
   {
-    files: ['packages/core/src/store/__tests__/table-column-ops.test.ts'],
+    files: [
+      'packages/core/src/layout/semantic-hit-test.ts',
+      'packages/core/src/store/__tests__/table-column-ops.test.ts',
+      'packages/core/src/store/package/image-resources.ts',
+    ],
+    rules: {
+      'max-lines': ['error', { max: 1450, skipBlankLines: false, skipComments: false }],
+    },
+  },
+
+  {
+    files: ['packages/react/test/toolbar-composition.test.tsx'],
     rules: {
       'max-lines': ['error', { max: 1500, skipBlankLines: false, skipComments: false }],
     },
@@ -327,11 +380,19 @@ export default [
 
   {
     files: [
+      'packages/core/src/store/store/tree-op-drawings.ts',
+      'packages/core/src/store/store/tree-op-table-cell-properties.ts',
+    ],
+    rules: {
+      'max-lines': ['error', { max: 1650, skipBlankLines: false, skipComments: false }],
+    },
+  },
+
+  {
+    files: [
       'packages/core/src/binding/tree-session.ts',
       'packages/core/src/contracts/editor.ts',
       'packages/core/src/layout/paragraph-flow.ts',
-      'packages/core/src/store/store/tree-op-drawings.ts',
-      'packages/core/src/store/store/tree-op-table-cell-properties.ts',
       'packages/pro/src/__tests__/review-facade.test.ts',
     ],
     rules: {
@@ -348,8 +409,21 @@ export default [
 
   {
     files: [
-      'packages/core/src/layout/semantic-table-layout.ts',
       'packages/core/src/store/store/tree-op-content-controls.ts',
+      'packages/core/src/store/package/drawing-projection.ts',
+    ],
+    rules: {
+      'max-lines': ['error', { max: 1850, skipBlankLines: false, skipComments: false }],
+    },
+  },
+
+  // semantic-table-layout.ts holds row-split pagination, which has to stay with cell flow
+  // and finalize because a row's real height is only known after its cells have laid out.
+  // It carried a blanket `eslint-disable max-lines` once, which removes the ceiling instead
+  // of raising it; this keeps the ceiling, with headroom.
+  {
+    files: [
+      'packages/core/src/layout/semantic-table-layout.ts',
       'packages/core/src/store/store/tree-op-tables.ts',
     ],
     rules: {
@@ -358,17 +432,14 @@ export default [
   },
 
   {
-    files: ['packages/core/src/store/package/drawing-projection.ts'],
+    files: ['packages/core/src/store/package/ooxml-tree.ts'],
     rules: {
-      'max-lines': ['error', { max: 2000, skipBlankLines: false, skipComments: false }],
+      'max-lines': ['error', { max: 2050, skipBlankLines: false, skipComments: false }],
     },
   },
 
   {
-    files: [
-      'packages/core/src/store/package/ooxml-tree.ts',
-      'packages/pro/src/react/DocxEditorReview.tsx',
-    ],
+    files: ['packages/pro/src/react/DocxEditorReview.tsx'],
     rules: {
       'max-lines': ['error', { max: 2100, skipBlankLines: false, skipComments: false }],
     },
@@ -384,7 +455,7 @@ export default [
   {
     files: ['packages/core/src/store/__tests__/ooxml-tree.test.ts'],
     rules: {
-      'max-lines': ['error', { max: 2400, skipBlankLines: false, skipComments: false }],
+      'max-lines': ['error', { max: 2350, skipBlankLines: false, skipComments: false }],
     },
   },
 
@@ -395,10 +466,15 @@ export default [
     },
   },
 
+  // semantic-layout.ts is the story loop: section flow, paragraph fragmentation and
+  // table-row pagination advance ONE cursor, and a paragraph that spans a page boundary is
+  // decided by all three at once. Splitting them into modules would mean passing that
+  // cursor across a boundary and re-deriving the same state on the other side. The cap is
+  // a ceiling with headroom, not a blanket disable.
   {
     files: ['packages/core/src/layout/semantic-layout.ts'],
     rules: {
-      'max-lines': ['error', { max: 3500, skipBlankLines: false, skipComments: false }],
+      'max-lines': ['error', { max: 3250, skipBlankLines: false, skipComments: false }],
     },
   },
 

--- a/packages/core/src/__tests__/core-lane-imports.test.ts
+++ b/packages/core/src/__tests__/core-lane-imports.test.ts
@@ -97,16 +97,47 @@ function* sourceFiles(directory: string): Generator<string> {
 // One statement at a time, so `import type` classifies the whole statement. A mixed
 // `import { value, type T }` counts as a VALUE import, which is the conservative reading.
 //
-// The clause between the keyword and `from` excludes `;` and quotes rather than being
-// length-capped. Both restrictions are load-bearing: a char budget silently DROPPED any
-// import whose specifier list outgrew it (a 39-line layout import already had), and a
-// clause that could cross a `;` let a from-less `export type X = ...;` statement pair
-// with the NEXT statement's `from`, recording a VALUE import as type-only — which would
-// let it hide under a pinned type grandfather.
-const STATIC_IMPORT =
-  /(?:^|\n)[ \t]*(import|export)\s+(type\s+)?([^;'"`]*?)from\s*['"]([^'"]+)['"]/g;
+// The scan is two-stage: find each `import`/`export` keyword at a line start, then match
+// the clause up to `from '...'` with `;`, quotes and backticks EXCLUDED — after stripping
+// comments from that bounded window. Each piece is load-bearing:
+//  - a char budget here once silently DROPPED any import whose specifier list outgrew it
+//    (a 39-line layout import already had);
+//  - a clause that could cross a `;` let a from-less `export type X = ...;` pair with the
+//    NEXT statement's `from`, recording a VALUE import as type-only — hiding it under a
+//    pinned type grandfather;
+//  - an unstripped comment inside the clause (`// don't ...`) carries a quote or backtick
+//    and killed the match, silently dropping the statement (two real cases existed in
+//    layout/index.ts).
+// The synthetic-source suite at the bottom pins all three failure modes.
+const IMPORT_KEYWORD = /(?:^|\n)[ \t]*(import|export)\s+(type\s+)?/g;
+const CLAUSE_TO_FROM = /^[^;'"`]*?from\s*['"]([^'"]+)['"]/;
 const BARE_IMPORT = /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g;
+// Also matches type-position `import('x').T`, which is erased at compile time. That
+// over-reports type coupling as a VALUE edge — fail-closed, so it stays.
 const DYNAMIC_IMPORT = /\bimport\(\s*['"]([^'"]+)['"]/g;
+
+/**
+ * Strip comments from one statement window. Safe HERE and only here: between an import
+ * keyword and its `from`, `//` and `/*` always begin comments (no strings or regexes can
+ * appear). Never applied to whole files, where that assumption would corrupt strings.
+ */
+function stripClauseComments(window: string): string {
+  return window.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, '');
+}
+
+/** Every static `... from '...'` statement in `source`: specifier + type-only flag. */
+function staticImportsOf(
+  source: string
+): readonly { readonly specifier: string; readonly typeOnly: boolean }[] {
+  const found: { specifier: string; typeOnly: boolean }[] = [];
+  for (const keyword of source.matchAll(IMPORT_KEYWORD)) {
+    const clauseStart = keyword.index! + keyword[0].length;
+    const window = stripClauseComments(source.slice(clauseStart, clauseStart + 8000));
+    const clause = CLAUSE_TO_FROM.exec(window);
+    if (clause) found.push({ specifier: clause[1]!, typeOnly: keyword[2] !== undefined });
+  }
+  return found;
+}
 
 function edgesOf(file: string): ImportEdge[] {
   const relativePath = relative(SRC, file).split(sep).join('/');
@@ -120,7 +151,7 @@ function edgesOf(file: string): ImportEdge[] {
       edges.push({ file: relativePath, to: target, typeOnly, specifier });
     }
   };
-  for (const match of source.matchAll(STATIC_IMPORT)) record(match[4]!, match[2] !== undefined);
+  for (const found of staticImportsOf(source)) record(found.specifier, found.typeOnly);
   for (const match of source.matchAll(BARE_IMPORT)) record(match[1]!, false);
   for (const match of source.matchAll(DYNAMIC_IMPORT)) record(match[1]!, false);
   return edges;
@@ -160,5 +191,39 @@ describe('every lane import obeys the DAG (core-lane-graph.ts)', () => {
     // Exact equality, both directions: a NEW off-DAG type edge fails until pinned with a
     // justification, and a pin whose edge was cleaned up fails until removed — the ratchet.
     expect(actual).toEqual(pinned);
+  });
+});
+
+describe('the scanner itself, against the statement shapes that broke it', () => {
+  test('a clause comment carrying quotes, backticks and semicolons does not drop the import', () => {
+    const source = [
+      'export {',
+      '  buildStyleCascadeTable,',
+      "  // Referenced by `SemanticTableCell`: don't remove; it is load-bearing.",
+      '  caretAt,',
+      "} from './style-cascade.ts';",
+    ].join('\n');
+    expect(staticImportsOf(source)).toEqual([{ specifier: './style-cascade.ts', typeOnly: false }]);
+  });
+
+  test('a from-less export type cannot bridge to the next statement and launder it', () => {
+    const source = [
+      'export type CommandGate = (command: string) => boolean;',
+      "import { tableContextAt } from '../layout/table-context.ts';",
+    ].join('\n');
+    expect(staticImportsOf(source)).toEqual([
+      { specifier: '../layout/table-context.ts', typeOnly: false },
+    ]);
+  });
+
+  test('a very long specifier list is still scanned — no length budget', () => {
+    const names = Array.from({ length: 120 }, (_, index) => `  someLongExportedName${index},`);
+    const source = `import {\n${names.join('\n')}\n} from '../layout/index.ts';`;
+    expect(staticImportsOf(source)).toEqual([{ specifier: '../layout/index.ts', typeOnly: false }]);
+  });
+
+  test('import type classifies the whole statement as type-only', () => {
+    expect(staticImportsOf("import type { ReviewItem } from '../layout/review-support.ts';")) //
+      .toEqual([{ specifier: '../layout/review-support.ts', typeOnly: true }]);
   });
 });

--- a/packages/core/src/__tests__/core-lane-imports.test.ts
+++ b/packages/core/src/__tests__/core-lane-imports.test.ts
@@ -1,0 +1,157 @@
+// The lane DAG, enforced against the real import statements.
+//
+// `CORE_LANES` declares which lane may import which (`core-lane-graph.ts`). After the lanes
+// moved into `packages/core`, the declaration-level check in `core-lane-graph.test.ts`
+// short-circuits for every moved lane, and `check:lane-boundaries` only catches an illegal
+// edge incidentally, when the imported lane happens to need a DOM lib. So this walks every
+// source file of every lane and asserts each import statement's target lane is one the DAG
+// allows.
+//
+// VALUE imports must obey the DAG, no exceptions. TYPE-ONLY imports (`import type` /
+// `export type ... from`) are erased at compile time and cannot move code between
+// environments, but they are still coupling — so a cross-lane type edge outside the DAG is
+// permitted only when pinned in GRANDFATHERED_TYPE_EDGES below, and the pin RATCHETS: an
+// entry that stops matching fails, so the list can only shrink or be consciously edited.
+
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CORE_LANES, type LaneName } from './core-lane-graph';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+const LANES = Object.keys(CORE_LANES) as LaneName[];
+
+/**
+ * Type-only cross-lane edges the DAG does not allow, pinned file by file.
+ *
+ * Adding an entry needs the same justification a DAG edit does: say WHY the type cannot
+ * live in a lane both sides may import (usually `contracts` or `store`). The known bulk is
+ * the contracts lane describing editor-facing shapes that reference store and layout types
+ * — coupling that predates the lane move and is compile-time only.
+ */
+const GRANDFATHERED_TYPE_EDGES: readonly { readonly file: string; readonly to: LaneName }[] = [
+  { file: 'binding/tree-session.ts', to: 'layout' },
+  { file: 'contracts/editor.ts', to: 'layout' },
+  { file: 'contracts/editor.ts', to: 'store' },
+  { file: 'contracts/modules.ts', to: 'layout' },
+  { file: 'contracts/modules.ts', to: 'store' },
+  { file: 'layout/table-interaction-targets.ts', to: 'contracts' },
+  { file: 'store/store/tree-op-types.ts', to: 'contracts' },
+];
+
+/**
+ * VALUE edges the DAG does not allow, pinned until their code moves lane.
+ *
+ * These are live coupling, not just compile-time — each one is a debt with a tracked
+ * issue, and the pin ratchets exactly like the type list. Today's single entry:
+ * `review-patch.ts` calls `reviewItemKey`/`reviewItemPositionRank`, pure helpers over the
+ * `ReviewItem` vocabulary that lives in `layout/review-support.ts`; the fix is moving the
+ * review vocabulary to a lane binding may import, which is a refactor of its own.
+ */
+const GRANDFATHERED_VALUE_EDGES: readonly { readonly file: string; readonly to: LaneName }[] = [
+  { file: 'binding/review-patch.ts', to: 'layout' },
+];
+
+interface ImportEdge {
+  readonly file: string; // relative to src/, posix separators
+  readonly to: LaneName;
+  readonly typeOnly: boolean;
+  readonly specifier: string;
+}
+
+function laneOfFile(relativePath: string): LaneName | null {
+  const first = relativePath.split('/')[0]!;
+  return (LANES as string[]).includes(first) ? (first as LaneName) : null;
+}
+
+/** The lane a specifier lands in, or null for anything external to the lanes. */
+function laneOfSpecifier(specifier: string, fromFile: string): LaneName | null {
+  if (specifier.startsWith('.')) {
+    const absolute = resolve(join(SRC, dirname(fromFile)), specifier);
+    return laneOfFile(relative(SRC, absolute).split(sep).join('/'));
+  }
+  const CORE = '@docx-editor.dev/core';
+  if (specifier !== CORE && !specifier.startsWith(`${CORE}/`)) return null;
+  const subpath = specifier === CORE ? '.' : `./${specifier.slice(CORE.length + 1)}`;
+  for (const lane of LANES) {
+    const declared = CORE_LANES[lane];
+    if (declared.subpath === subpath) return lane;
+    if (declared.subpathPrefix && subpath.startsWith(declared.subpathPrefix)) return lane;
+  }
+  return null;
+}
+
+function* sourceFiles(directory: string): Generator<string> {
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      yield* sourceFiles(path);
+    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      yield path;
+    }
+  }
+}
+
+// One statement at a time, so `import type` classifies the whole statement. A mixed
+// `import { value, type T }` counts as a VALUE import, which is the conservative reading.
+const STATIC_IMPORT =
+  /(?:^|\n)\s*(import|export)\s+(type\s+)?[\s\S]{0,600}?from\s*['"]([^'"]+)['"]/g;
+const BARE_IMPORT = /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g;
+const DYNAMIC_IMPORT = /\bimport\(\s*['"]([^'"]+)['"]/g;
+
+function edgesOf(file: string): ImportEdge[] {
+  const relativePath = relative(SRC, file).split(sep).join('/');
+  const ownLane = laneOfFile(relativePath);
+  if (!ownLane) return [];
+  const source = readFileSync(file, 'utf8');
+  const edges: ImportEdge[] = [];
+  const record = (specifier: string, typeOnly: boolean) => {
+    const target = laneOfSpecifier(specifier, relativePath);
+    if (target && target !== ownLane) {
+      edges.push({ file: relativePath, to: target, typeOnly, specifier });
+    }
+  };
+  for (const match of source.matchAll(STATIC_IMPORT)) record(match[3]!, match[2] !== undefined);
+  for (const match of source.matchAll(BARE_IMPORT)) record(match[1]!, false);
+  for (const match of source.matchAll(DYNAMIC_IMPORT)) record(match[1]!, false);
+  return edges;
+}
+
+const allEdges: ImportEdge[] = [];
+for (const lane of LANES) {
+  for (const file of sourceFiles(join(SRC, lane))) allEdges.push(...edgesOf(file));
+}
+
+describe('every lane import obeys the DAG (core-lane-graph.ts)', () => {
+  test('the walk is not vacuous: it sees the editor lane import the others', () => {
+    const fromEditor = allEdges.filter((edge) => edge.file.startsWith('editor/'));
+    expect(fromEditor.some((edge) => edge.to === 'layout')).toBe(true);
+    expect(fromEditor.some((edge) => edge.to === 'store')).toBe(true);
+  });
+
+  test('no VALUE import crosses an edge the DAG forbids, beyond the pinned debt', () => {
+    const offDag = allEdges.filter((edge) => {
+      if (edge.typeOnly) return false;
+      const from = laneOfFile(edge.file)!;
+      return !CORE_LANES[from].mayImport.includes(edge.to);
+    });
+    const actual = [...new Set(offDag.map((edge) => `${edge.file} → ${edge.to}`))].sort();
+    const pinned = GRANDFATHERED_VALUE_EDGES.map((edge) => `${edge.file} → ${edge.to}`).sort();
+    expect(actual).toEqual(pinned);
+  });
+
+  test('every off-DAG TYPE edge is pinned, and every pin is still real', () => {
+    const offDag = allEdges.filter((edge) => {
+      if (!edge.typeOnly) return false;
+      const from = laneOfFile(edge.file)!;
+      return !CORE_LANES[from].mayImport.includes(edge.to);
+    });
+    const actual = [...new Set(offDag.map((edge) => `${edge.file} → ${edge.to}`))].sort();
+    const pinned = GRANDFATHERED_TYPE_EDGES.map((edge) => `${edge.file} → ${edge.to}`).sort();
+    // Exact equality, both directions: a NEW off-DAG type edge fails until pinned with a
+    // justification, and a pin whose edge was cleaned up fails until removed — the ratchet.
+    expect(actual).toEqual(pinned);
+  });
+});

--- a/packages/core/src/__tests__/core-lane-imports.test.ts
+++ b/packages/core/src/__tests__/core-lane-imports.test.ts
@@ -96,8 +96,15 @@ function* sourceFiles(directory: string): Generator<string> {
 
 // One statement at a time, so `import type` classifies the whole statement. A mixed
 // `import { value, type T }` counts as a VALUE import, which is the conservative reading.
+//
+// The clause between the keyword and `from` excludes `;` and quotes rather than being
+// length-capped. Both restrictions are load-bearing: a char budget silently DROPPED any
+// import whose specifier list outgrew it (a 39-line layout import already had), and a
+// clause that could cross a `;` let a from-less `export type X = ...;` statement pair
+// with the NEXT statement's `from`, recording a VALUE import as type-only — which would
+// let it hide under a pinned type grandfather.
 const STATIC_IMPORT =
-  /(?:^|\n)\s*(import|export)\s+(type\s+)?[\s\S]{0,600}?from\s*['"]([^'"]+)['"]/g;
+  /(?:^|\n)[ \t]*(import|export)\s+(type\s+)?([^;'"`]*?)from\s*['"]([^'"]+)['"]/g;
 const BARE_IMPORT = /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g;
 const DYNAMIC_IMPORT = /\bimport\(\s*['"]([^'"]+)['"]/g;
 
@@ -113,7 +120,7 @@ function edgesOf(file: string): ImportEdge[] {
       edges.push({ file: relativePath, to: target, typeOnly, specifier });
     }
   };
-  for (const match of source.matchAll(STATIC_IMPORT)) record(match[3]!, match[2] !== undefined);
+  for (const match of source.matchAll(STATIC_IMPORT)) record(match[4]!, match[2] !== undefined);
   for (const match of source.matchAll(BARE_IMPORT)) record(match[1]!, false);
   for (const match of source.matchAll(DYNAMIC_IMPORT)) record(match[1]!, false);
   return edges;

--- a/packages/core/src/__tests__/part-for-call-sites.test.ts
+++ b/packages/core/src/__tests__/part-for-call-sites.test.ts
@@ -1,0 +1,68 @@
+// `partFor` call sites are pinned, because a partFor read is a write in disguise.
+//
+// `partFor(partName)` opens a story store and PERMANENTLY retains its slot — the store
+// caps editable story parts (`DEFAULT_MAX_EDITABLE_STORY_PARTS`, 64), and a slot once
+// opened is never returned. `editor/surface-scope.ts` documents the failure in full:
+// sixty-four such "reads" and no further header, footer or note could be opened for the
+// rest of the session, silently. A pure read routes through `partOfNodeId`
+// (`editor/surface-scope.ts`) or another store read API instead.
+//
+// So every `partFor(` in non-test source is pinned here, in the manner of
+// `prosemirror-isolation.test.ts`. Add a new site only for a WRITE that needs the open
+// store, then update this list; a removed site fails too, so the list ratchets down.
+
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** file (relative to src/) → number of `partFor(` occurrences, definitions included. */
+const PINNED_CALL_SITES: Readonly<Record<string, number>> = {
+  'automation/server-host.ts': 1,
+  'binding/tree-session.ts': 7, // includes the TreeEditingSession facade definition
+  'editor/doc-target-resolution.ts': 2,
+  'editor/docx-editor-derive.ts': 1,
+  'editor/docx-editor-images.ts': 1,
+  'editor/paginated-surface.ts': 10,
+  'editor/surface-equations.ts': 1,
+  'editor/surface-format.ts': 1,
+  'editor/surface-hf-editing.ts': 1,
+  'editor/surface-hyperlinks.ts': 1,
+  'editor/surface-scope.ts': 2, // storyScopeOfNodeId — documented as a known debt in-file
+  'editor/surface-structure.ts': 1,
+  'store/store/tree-package-store.ts': 1, // the definition itself
+};
+
+function* sourceFiles(directory: string): Generator<string> {
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      yield* sourceFiles(path);
+    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      yield path;
+    }
+  }
+}
+
+describe('partFor stays a write-path API', () => {
+  test('the call-site census matches the pinned list exactly', () => {
+    const census: Record<string, number> = {};
+    for (const file of sourceFiles(SRC)) {
+      const count = (readFileSync(file, 'utf8').match(/\bpartFor\(/g) ?? []).length;
+      if (count > 0) census[relative(SRC, file).split(sep).join('/')] = count;
+    }
+    const sorted = Object.fromEntries(Object.entries(census).sort(([a], [b]) => (a < b ? -1 : 1)));
+    // A NEW site: partFor opens and permanently retains a story store (cap 64). If this
+    // is a pure read, use partOfNodeId (editor/surface-scope.ts) or a store read API and
+    // leave this list alone. If it is a write that needs the open store, add the entry.
+    // A REMOVED site: delete its entry — the list only ratchets down.
+    expect(sorted).toEqual(PINNED_CALL_SITES);
+  });
+
+  test('the census is not vacuous: it sees the definition', () => {
+    expect(PINNED_CALL_SITES['store/store/tree-package-store.ts']).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/__tests__/part-for-call-sites.test.ts
+++ b/packages/core/src/__tests__/part-for-call-sites.test.ts
@@ -7,32 +7,40 @@
 // rest of the session, silently. A pure read routes through `partOfNodeId`
 // (`editor/surface-scope.ts`) or another store read API instead.
 //
-// So every `partFor(` in non-test source is pinned here, in the manner of
-// `prosemirror-isolation.test.ts`. Add a new site only for a WRITE that needs the open
-// store, then update this list; a removed site fails too, so the list ratchets down.
+// So every `partFor(` in non-test source is pinned here — across every package that can
+// reach a session, not just core — in the manner of `prosemirror-isolation.test.ts`. Add
+// a new site only for a WRITE that needs the open store, then update this list; a removed
+// site fails too, so the list ratchets down. Occurrences count comment MENTIONS as well
+// as calls, deliberately: the census stays a dumb grep so it cannot be argued with.
 
 import { describe, expect, test } from 'bun:test';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGES = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
-/** file (relative to src/) → number of `partFor(` occurrences, definitions included. */
+/** Every published package's src root that could hold a call site. */
+const SCANNED_ROOTS = ['core/src', 'pro/src', 'editor-api/src', 'react/src', 'vue/src'];
+
+/** file (relative to packages/) → number of `partFor(` occurrences, definitions included. */
 const PINNED_CALL_SITES: Readonly<Record<string, number>> = {
-  'automation/server-host.ts': 1,
-  'binding/tree-session.ts': 7, // includes the TreeEditingSession facade definition
-  'editor/doc-target-resolution.ts': 2,
-  'editor/docx-editor-derive.ts': 1,
-  'editor/docx-editor-images.ts': 1,
-  'editor/paginated-surface.ts': 10,
-  'editor/surface-equations.ts': 1,
-  'editor/surface-format.ts': 1,
-  'editor/surface-hf-editing.ts': 1,
-  'editor/surface-hyperlinks.ts': 1,
-  'editor/surface-scope.ts': 2, // storyScopeOfNodeId — documented as a known debt in-file
-  'editor/surface-structure.ts': 1,
-  'store/store/tree-package-store.ts': 1, // the definition itself
+  'core/src/automation/server-host.ts': 1,
+  'core/src/binding/tree-session.ts': 7, // includes the TreeEditingSession facade definition
+  'core/src/editor/doc-target-resolution.ts': 2,
+  'core/src/editor/docx-editor-derive.ts': 1,
+  'core/src/editor/docx-editor-images.ts': 1,
+  'core/src/editor/paginated-surface.ts': 10,
+  'core/src/editor/surface-equations.ts': 1,
+  'core/src/editor/surface-format.ts': 1,
+  'core/src/editor/surface-hf-editing.ts': 1,
+  'core/src/editor/surface-hyperlinks.ts': 1,
+  'core/src/editor/surface-scope.ts': 2, // storyScopeOfNodeId — documented as a known debt in-file
+  'core/src/editor/surface-structure.ts': 1,
+  'core/src/store/store/tree-package-store.ts': 1, // the definition itself
+  // Custom-node payload writes genuinely need the open store (they mutate the part).
+  'pro/src/custom-nodes/insert-custom-node.ts': 1,
+  'pro/src/custom-nodes/update-custom-node.ts': 3,
 };
 
 function* sourceFiles(directory: string): Generator<string> {
@@ -50,9 +58,13 @@ function* sourceFiles(directory: string): Generator<string> {
 describe('partFor stays a write-path API', () => {
   test('the call-site census matches the pinned list exactly', () => {
     const census: Record<string, number> = {};
-    for (const file of sourceFiles(SRC)) {
-      const count = (readFileSync(file, 'utf8').match(/\bpartFor\(/g) ?? []).length;
-      if (count > 0) census[relative(SRC, file).split(sep).join('/')] = count;
+    for (const root of SCANNED_ROOTS) {
+      const absolute = join(PACKAGES, root);
+      if (!existsSync(absolute)) throw new Error(`census root missing: ${root}`);
+      for (const file of sourceFiles(absolute)) {
+        const count = (readFileSync(file, 'utf8').match(/\bpartFor\(/g) ?? []).length;
+        if (count > 0) census[relative(PACKAGES, file).split(sep).join('/')] = count;
+      }
     }
     const sorted = Object.fromEntries(Object.entries(census).sort(([a], [b]) => (a < b ? -1 : 1)));
     // A NEW site: partFor opens and permanently retains a story store (cap 64). If this
@@ -63,6 +75,6 @@ describe('partFor stays a write-path API', () => {
   });
 
   test('the census is not vacuous: it sees the definition', () => {
-    expect(PINNED_CALL_SITES['store/store/tree-package-store.ts']).toBeGreaterThan(0);
+    expect(PINNED_CALL_SITES['core/src/store/store/tree-package-store.ts']).toBeGreaterThan(0);
   });
 });

--- a/packages/core/src/binding/review-patch.ts
+++ b/packages/core/src/binding/review-patch.ts
@@ -7,15 +7,22 @@
 // the full derivation, which is always correct. A patch that keeps a stale card, or drops
 // a live one, is worse than a slower keystroke.
 
+// `reviewItemKey`/`reviewItemPositionRank` and the ReviewItem vocabulary live in the layout
+// lane — a binding→layout edge the DAG does not allow, pinned in core-lane-imports.test.ts
+// until the review vocabulary moves to a lane both sides may import.
 import {
-  linkRevisionReplies,
   reviewItemKey,
   reviewItemPositionRank,
   type ReviewCommentItem,
   type ReviewItem,
   type ReviewRevisionItem,
 } from '../layout/review-support.ts';
-import { findNode, type OoxmlPart, type TreeModelChange } from '@docx-editor.dev/core/store';
+import {
+  findNode,
+  linkRevisionReplies,
+  type OoxmlPart,
+  type TreeModelChange,
+} from '@docx-editor.dev/core/store';
 
 /** What the queue cache carries that the fast-path decision has to compare against. */
 export interface LocalReviewPatchCache {

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -13,7 +13,8 @@
 
 import { projectedText, storyCarriesCommentAnchor } from './story-text-reads.ts';
 import type { Node as PMNode } from 'prosemirror-model';
-import { paragraphOrderOfPart, type ReviewItem } from '../layout/review-support.ts';
+import { paragraphOrderOfPart } from '@docx-editor.dev/core/store';
+import type { ReviewItem } from '../layout/review-support.ts';
 import {
   canApplyLocalReviewPatch,
   localReviewPatchParagraphId,

--- a/packages/core/src/editor/__tests__/docx-editor-equality.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor-equality.test.ts
@@ -1,0 +1,87 @@
+// `snapshotsEqual` honesty (editor lane).
+//
+// The snapshot cache hands back the PREVIOUS snapshot object whenever `snapshotsEqual`
+// says nothing moved. A field the comparator misses is therefore a field that can never
+// wake a `useSyncExternalStore` subscriber. `hasReviewContent` was missing from the
+// hand-written list; a package-revision backstop hid it. The compile-time map in
+// docx-editor-equality.ts now makes omission a type error, and this suite makes it a
+// runtime failure: flip any single field and the snapshots must compare unequal.
+
+import { describe, expect, test } from 'bun:test';
+import type { EditorSnapshot } from '@docx-editor.dev/core/contracts/editor';
+import { snapshotsEqual } from '../docx-editor-equality.ts';
+
+const BASELINE: EditorSnapshot = {
+  scope: { kind: 'body' },
+  isLoading: false,
+  isOpening: false,
+  parseError: null,
+  editable: true,
+  zoom: 1,
+  zoomMode: { type: 'fixed' },
+  selection: null,
+  selectionCollapsed: true,
+  formatting: null,
+  table: null,
+  tocContext: null,
+  image: null,
+  page: { current: 1, total: 3 },
+  canUndo: false,
+  canRedo: false,
+  pageSetup: null,
+  reviewPaneOpen: false,
+  hasReviewContent: false,
+  editingMode: 'editing',
+  lastRejection: null,
+  fontSubstitutions: [],
+};
+
+/**
+ * One changed value per snapshot field. `snapshotsEqual` compares by `===` after
+ * sub-object reuse, so a fresh object or a flipped primitive is enough to count as a
+ * move. The `satisfies` clause keeps this table exhaustive: a new `EditorSnapshot`
+ * field fails typecheck here until it gets a mutation, the same ratchet the source map
+ * carries.
+ */
+const MUTATIONS = {
+  scope: { kind: 'headerFooter', rId: 'rId9' },
+  isLoading: true,
+  isOpening: true,
+  parseError: 'boom',
+  editable: false,
+  zoom: 2,
+  zoomMode: { type: 'fixed' },
+  selection: { from: { paraId: 'p1' }, to: { paraId: 'p1' } },
+  selectionCollapsed: false,
+  formatting: { bold: true },
+  table: { rows: 1, columns: 1 },
+  tocContext: { id: 'toc-1' },
+  image: { id: 'img-1' },
+  page: { current: 2, total: 3 },
+  canUndo: true,
+  canRedo: true,
+  pageSetup: { pageWidthTwips: 1 },
+  reviewPaneOpen: true,
+  hasReviewContent: true,
+  editingMode: 'viewing',
+  lastRejection: 'refused',
+  fontSubstitutions: ['Calibri'],
+} satisfies Record<keyof EditorSnapshot, unknown>;
+
+describe('snapshotsEqual compares every EditorSnapshot field', () => {
+  test('identical snapshots are equal', () => {
+    expect(snapshotsEqual(BASELINE, { ...BASELINE })).toBe(true);
+  });
+
+  test('the regression: a hasReviewContent flip is a change', () => {
+    const flipped: EditorSnapshot = { ...BASELINE, hasReviewContent: true };
+    expect(snapshotsEqual(BASELINE, flipped)).toBe(false);
+  });
+
+  for (const key of Object.keys(MUTATIONS) as (keyof EditorSnapshot)[]) {
+    test(`a lone ${key} change is a change`, () => {
+      const mutated = { ...BASELINE, [key]: MUTATIONS[key] } as EditorSnapshot;
+      expect(snapshotsEqual(BASELINE, mutated)).toBe(false);
+    });
+  }
+});

--- a/packages/core/src/editor/docx-editor-equality.ts
+++ b/packages/core/src/editor/docx-editor-equality.ts
@@ -195,38 +195,51 @@ export function createTocContextCache(): (id: string | null) => { readonly id: s
 }
 
 /**
+ * Every member the snapshot carries has to be compared in {@link snapshotsEqual} or it
+ * cannot move a subscriber: the comments button stayed pressed after the pane closed
+ * because the old hand-written list did not know the pane existed, and `hasReviewContent`
+ * was missing from it entirely. The `satisfies` clause makes a new `EditorSnapshot` field
+ * a compile error here until it is classified, in the manner of
+ * `COMPARED_FORMATTING_KEYS` above and `PAGE_REUSE_GUARDS` in the layout lane.
+ *
+ * Every field is `'compared'` today: after sub-object reuse, each one is a primitive or a
+ * reference-stable object, so `===` is the whole comparison.
+ */
+const SNAPSHOT_FIELDS = {
+  scope: 'compared',
+  isLoading: 'compared',
+  isOpening: 'compared',
+  parseError: 'compared',
+  editable: 'compared',
+  zoom: 'compared',
+  zoomMode: 'compared',
+  selection: 'compared',
+  // Load-bearing: `selection` is a paraId range with no offsets, so collapsing a range
+  // INSIDE one paragraph leaves it identical. Without this compare, a control gated on
+  // the caret/range distinction would never see the moment it changed.
+  selectionCollapsed: 'compared',
+  formatting: 'compared',
+  table: 'compared',
+  tocContext: 'compared',
+  image: 'compared',
+  page: 'compared',
+  canUndo: 'compared',
+  canRedo: 'compared',
+  pageSetup: 'compared',
+  reviewPaneOpen: 'compared',
+  hasReviewContent: 'compared',
+  editingMode: 'compared',
+  lastRejection: 'compared',
+  fontSubstitutions: 'compared',
+} as const satisfies Record<keyof EditorSnapshot, 'compared'>;
+
+const SNAPSHOT_KEYS = Object.keys(SNAPSHOT_FIELDS) as readonly (keyof EditorSnapshot)[];
+
+/**
  * Whether two snapshots are value-equal AFTER sub-object reuse — i.e. every field can be
  * compared by reference or primitive. When true, the previous snapshot object itself is
  * kept, so `snapshot()` returns the same reference across ticks that changed nothing.
  */
 export function snapshotsEqual(a: EditorSnapshot, b: EditorSnapshot): boolean {
-  return (
-    a.scope === b.scope &&
-    a.isLoading === b.isLoading &&
-    a.isOpening === b.isOpening &&
-    a.parseError === b.parseError &&
-    a.editable === b.editable &&
-    a.zoom === b.zoom &&
-    a.selection === b.selection &&
-    // Load-bearing: `selection` is a paraId range with no offsets, so collapsing a range
-    // INSIDE one paragraph leaves it identical. Without this compare, a control gated on
-    // the caret/range distinction would never see the moment it changed.
-    a.selectionCollapsed === b.selectionCollapsed &&
-    a.formatting === b.formatting &&
-    a.table === b.table &&
-    a.tocContext === b.tocContext &&
-    a.image === b.image &&
-    a.fontSubstitutions === b.fontSubstitutions &&
-    a.page === b.page &&
-    a.canUndo === b.canUndo &&
-    a.canRedo === b.canRedo &&
-    a.pageSetup === b.pageSetup &&
-    a.zoomMode === b.zoomMode &&
-    // Every member the snapshot carries has to be compared here or it cannot move a
-    // subscriber: the comments button stayed pressed after the pane closed because this
-    // list did not know the pane existed.
-    a.reviewPaneOpen === b.reviewPaneOpen &&
-    a.editingMode === b.editingMode &&
-    a.lastRejection === b.lastRejection
-  );
+  return SNAPSHOT_KEYS.every((key) => a[key] === b[key]);
 }

--- a/packages/core/src/layout/__tests__/flow-checkpoint-guard.test.ts
+++ b/packages/core/src/layout/__tests__/flow-checkpoint-guard.test.ts
@@ -1,0 +1,91 @@
+// The flow-checkpoint guard map stays true (companion to flow-checkpoint-guards.ts).
+//
+// The map's `satisfies` clause catches a `FlowCheckpoint` field that was never classified.
+// These tests catch the two failures the compiler cannot see:
+//  - a checkpoint BUILT with a field the interface never declared (runtime walk), and
+//  - the convergence comparison in semantic-layout.ts silently dropping a `'compared'`
+//    field, or quietly starting to compare a `'restore-only'` one (source scan).
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+  type PageGeometry,
+} from '../index.ts';
+import {
+  FLOW_CHECKPOINT_GUARDS,
+  unguardedCheckpointFields,
+  type FlowCheckpointGuard,
+} from '../flow-checkpoint-guards.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const measurer = createFixedMeasurer(6, 14);
+const GEOMETRY: PageGeometry = {
+  width: 300,
+  height: 120,
+  margin: { top: 10, right: 10, bottom: 10, left: 10 },
+};
+
+const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const DOCUMENT = Array.from({ length: 24 }, (_, index) =>
+  paragraph(`paragraph ${index} ${'word '.repeat(6)}`)
+).join('');
+
+describe('every checkpoint field is classified', () => {
+  test('a real multi-page pass records checkpoints with no unguarded field', () => {
+    const session = createLayoutSession();
+    layoutSemanticDocument(load(DOCUMENT), 1, { measurer, geometry: GEOMETRY, session });
+    expect(session.checkpoints.length).toBeGreaterThan(0);
+    for (const checkpoint of session.checkpoints) {
+      expect(unguardedCheckpointFields(checkpoint)).toEqual([]);
+    }
+  });
+});
+
+describe('the convergence comparison agrees with the map', () => {
+  // The comparison lives in semantic-layout.ts as a hand-written `mark && ...` condition.
+  // Slice the region from where the previous checkpoint is fetched to where the shift
+  // verdict is taken; every field's fate is decided inside it.
+  const source = readFileSync(
+    fileURLToPath(new URL('../semantic-layout.ts', import.meta.url)),
+    'utf8'
+  );
+  const start = source.indexOf('const mark = session.checkpoints[');
+  // The CALL, not the name: a comment inside the region mentions the function too.
+  const end = source.indexOf('convergenceTailShiftAllowed({', start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  const region = source.slice(start, end);
+
+  const fields = Object.entries(FLOW_CHECKPOINT_GUARDS) as [string, FlowCheckpointGuard][];
+
+  for (const [field, guard] of fields) {
+    if (guard === 'restore-only') {
+      test(`'${field}' is restore-only and the convergence region never reads it`, () => {
+        // If convergence starts comparing it, the map (and its documented argument for
+        // never comparing it) is stale — reclassify it, do not just silence this.
+        expect(region.includes(`mark.${field}`)).toBe(false);
+      });
+    } else {
+      test(`'${field}' (${guard}) is read by the convergence region`, () => {
+        // A 'compared' field that vanished from the condition converges a mismatched
+        // flow: the exact silent failure deferredAnchoredDrawings shipped once.
+        expect(region.includes(`mark.${field}`)).toBe(true);
+      });
+    }
+  }
+});

--- a/packages/core/src/layout/__tests__/flow-checkpoint-guard.test.ts
+++ b/packages/core/src/layout/__tests__/flow-checkpoint-guard.test.ts
@@ -74,17 +74,22 @@ describe('the convergence comparison agrees with the map', () => {
   const fields = Object.entries(FLOW_CHECKPOINT_GUARDS) as [string, FlowCheckpointGuard][];
 
   for (const [field, guard] of fields) {
+    // Word boundary, not substring: a future `mark.pageFragmentsExtra` must not satisfy
+    // the `pageFragments` gate.
+    const reads = new RegExp(`\\bmark\\.${field}\\b`);
     if (guard === 'restore-only') {
       test(`'${field}' is restore-only and the convergence region never reads it`, () => {
         // If convergence starts comparing it, the map (and its documented argument for
-        // never comparing it) is stale — reclassify it, do not just silence this.
-        expect(region.includes(`mark.${field}`)).toBe(false);
+        // never comparing it) is stale — reclassify it, do not just silence this. The
+        // region deliberately ends BEFORE convergenceTailShiftAllowed: the shift-delta
+        // arithmetic after the condition may read any field it likes.
+        expect(reads.test(region)).toBe(false);
       });
     } else {
       test(`'${field}' (${guard}) is read by the convergence region`, () => {
         // A 'compared' field that vanished from the condition converges a mismatched
         // flow: the exact silent failure deferredAnchoredDrawings shipped once.
-        expect(region.includes(`mark.${field}`)).toBe(true);
+        expect(reads.test(region)).toBe(true);
       });
     }
   }

--- a/packages/core/src/layout/__tests__/layout-cache.test.ts
+++ b/packages/core/src/layout/__tests__/layout-cache.test.ts
@@ -15,6 +15,7 @@ import {
   paragraphLayoutKey,
   type PageGeometry,
 } from '../index.ts';
+import { PARAGRAPH_KEY_INPUT_ROLES } from '../layout-cache.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -343,6 +344,38 @@ describe('key memoization over immutable nodes', () => {
       drawingToken: 'd1',
     });
     expect(withDrawing).not.toEqual(base);
+  });
+
+  test('every declared memo input misses the memo when it alone changes', () => {
+    // Table-driven over PARAGRAPH_KEY_INPUT_ROLES, the same map whose `satisfies` clause
+    // forces a new ParagraphKeyInputs field to be classified. The memo hit test is the
+    // trap this covers: an input folded into the joined key but missing from the memo
+    // comparison is silently inert, because the memo answers before the join runs.
+    const part = load(paragraph('memoized paragraph content'));
+    const node = firstParagraphOf(part);
+    const base: Parameters<typeof paragraphLayoutKey>[0] = {
+      paragraph: node,
+      properties: [],
+      width: 100,
+      producer: 'p',
+      drawingToken: 'd0',
+      exclusionToken: 'x0',
+    };
+    const changed: Record<
+      Exclude<keyof typeof PARAGRAPH_KEY_INPUT_ROLES, 'paragraph'>,
+      Partial<typeof base>
+    > = {
+      properties: { properties: [{ localName: 'jc', attributes: { 'w:val': 'center' } }] },
+      width: { width: 200 },
+      producer: { producer: 'q' },
+      drawingToken: { drawingToken: 'd1' },
+      exclusionToken: { exclusionToken: 'x1' },
+    };
+    for (const [field, override] of Object.entries(changed)) {
+      const warm = paragraphLayoutKey(base);
+      const moved = paragraphLayoutKey({ ...base, ...override });
+      expect(`${field}:${String(moved !== warm)}`).toBe(`${field}:true`);
+    }
   });
 
   test('a REPLACED paragraph node with identical content keys to the same value', () => {

--- a/packages/core/src/layout/__tests__/pagination-keeps.test.ts
+++ b/packages/core/src/layout/__tests__/pagination-keeps.test.ts
@@ -12,11 +12,14 @@ import { createParagraphLayoutCache } from '../layout-cache.ts';
 import {
   adjustedBreakIndex,
   borderGroupFlowKeys,
+  composeFlowKeys,
   contextualSpacingFlowKeys,
   keepNextFlowKeys,
+  listMarkerFlowKeys,
   tocFieldFlowKeys,
   paragraphKeeps,
   DEFAULT_PARAGRAPH_KEEPS,
+  type FlowKeyFoldInputs,
 } from '../pagination-keeps.ts';
 import type { PageGeometry, PageRecord } from '../semantic-records.ts';
 import { paragraphIndent } from '../paragraph-flow.ts';
@@ -534,5 +537,58 @@ describe('keepNextFlowKeys folds over the other folds', () => {
     const folded = tocFieldFlowKeys(['h', 'p'], (index) => (index === 1 ? '110' : ''));
     const flow = keepNextFlowKeys(folded, (index) => index === 0);
     expect(flow[0]).toBe('h~kn~p~toc~110');
+  });
+});
+
+describe('composeFlowKeys — the one composition, and its load-bearing order', () => {
+  const none: FlowKeyFoldInputs = {
+    contextualSpacingAt: () => false,
+    styleIdAt: () => null,
+    borderGroupKeyAt: () => '',
+    tocVerdicts: [],
+    markerTextAt: () => undefined,
+    keepsNextAt: () => false,
+  };
+
+  test('nothing folding returns the SAME array, not a copy', () => {
+    // Identity is the contract: the prepass memo and the unchanged-document exit both
+    // lean on flow keys not churning when no block reads across a boundary.
+    const keys = ['a', 'b', 'c'];
+    expect(composeFlowKeys(keys, none)).toBe(keys);
+  });
+
+  test('a keep-next chain head carries its successor POST-fold — every other fold first', () => {
+    // Block 0 keeps with block 1; block 1 carries a marker, a contextual verdict and a
+    // border-group verdict. The head must splice block 1's FINISHED key: run keepNext
+    // before any other fold and the head carries 'b' bare — a head that never re-places
+    // when a member's marker, contextual or border verdict moves.
+    const composed = composeFlowKeys(['a', 'b'], {
+      contextualSpacingAt: (index) => index === 1,
+      styleIdAt: () => 'Tight',
+      borderGroupKeyAt: (index) => (index === 1 ? 'box' : ''),
+      tocVerdicts: ['', '110'],
+      markerTextAt: (index) => (index === 1 ? 'M1' : undefined),
+      keepsNextAt: (index) => index === 0,
+    });
+    const successor = composed[1]!;
+    expect(successor).toContain('~cs~');
+    expect(successor).toContain('~bg~');
+    expect(successor).toContain('~toc~110');
+    expect(successor).toContain('~mk~M1');
+    // The whole finished successor key, spliced verbatim — the order test proper.
+    expect(composed[0]).toBe(`a~kn~${successor}`);
+  });
+
+  test('the composition equals the folds applied by hand with keepNext LAST', () => {
+    const keys = ['a', 'b', 'c'];
+    const markerAt = (index: number) => (index === 2 ? 'M2' : undefined);
+    const keepsAt = (index: number) => index === 1;
+    const byHand = keepNextFlowKeys(listMarkerFlowKeys(keys, markerAt), keepsAt);
+    const composed = composeFlowKeys(keys, {
+      ...none,
+      markerTextAt: markerAt,
+      keepsNextAt: keepsAt,
+    });
+    expect(composed).toEqual(byHand);
   });
 });

--- a/packages/core/src/layout/__tests__/randomized-incremental-layout.test.ts
+++ b/packages/core/src/layout/__tests__/randomized-incremental-layout.test.ts
@@ -11,6 +11,12 @@
 // Determinism: fixed seeds, and a pure inline PRNG (mulberry32) — no wall clock, no
 // Math.random, no dependency. A failure prints the seed and the accumulated edit script,
 // which replays the exact sequence.
+//
+// Scope: every step re-parses the document, so this exercises the STRING-KEYED half of
+// incrementality — flow keys, checkpoints, convergence, section spans. The identity-keyed
+// half (prepared-block memos, the paragraph key memo hit test, prepass `bodies` identity)
+// needs a store-driven variant that mutates one retained tree; that is tracked follow-up
+// work, not covered here.
 
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
@@ -212,10 +218,14 @@ describe('incremental layout equals from-scratch layout on random edit sequences
       const first = lay(load(renderDoc(doc)), 1, session);
       expect(first.pages.length).toBeGreaterThan(1);
 
+      let reusedSteps = 0;
+      let partialSteps = 0;
       for (let step = 0; step < STEPS; step += 1) {
         log.push(randomEdit(doc, rand, step));
         const part = load(renderDoc(doc));
         const incremental = publishedShapeOf(lay(part, step + 2, session));
+        if (session.stats.reusedPages > 0) reusedSteps += 1;
+        if (session.stats.placed < session.stats.total) partialSteps += 1;
         const fresh = publishedShapeOf(lay(part, step + 2));
         if (incremental !== fresh) {
           throw new Error(
@@ -225,6 +235,11 @@ describe('incremental layout equals from-scratch layout on random edit sequences
           );
         }
       }
+      // Anti-vacuity: an oracle comparing full pass against full pass proves nothing. If
+      // resume ever breaks outright, equality above still holds — these counters are what
+      // fail. Floors sit well under the measured behavior (17+ reuse steps per seed).
+      expect(reusedSteps).toBeGreaterThanOrEqual(8);
+      expect(partialSteps).toBeGreaterThanOrEqual(8);
     });
   }
 });

--- a/packages/core/src/layout/__tests__/randomized-incremental-layout.test.ts
+++ b/packages/core/src/layout/__tests__/randomized-incremental-layout.test.ts
@@ -1,0 +1,230 @@
+// The freshness oracle: incremental layout equals a from-scratch layout, under RANDOM edits.
+//
+// Every cache gate in this repo (scope-waste, settle-bench, edit-bench, the warm-derivation
+// gate) protects WARMTH: it fails when a cache misses too much. Nothing failed when a cache
+// key was too NARROW — a stale-render bug passed every gate, and the hand-enumerated
+// differential suite (incremental-semantic-layout.test.ts) only covers the edit shapes
+// someone thought to write. This test closes that side: a seeded generator drives random
+// edit sequences over a multi-section document with a table, and after EVERY step the
+// incremental pass must publish byte-identical pages to a clean pass over the same input.
+//
+// Determinism: fixed seeds, and a pure inline PRNG (mulberry32) — no wall clock, no
+// Math.random, no dependency. A failure prints the seed and the accumulated edit script,
+// which replays the exact sequence.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+  type LayoutSession,
+  type SemanticLayout,
+} from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const measurer = createFixedMeasurer(6, 14);
+
+const lay = (part: OoxmlPart, revision: number, session?: LayoutSession): SemanticLayout =>
+  layoutSemanticDocument(part, revision, { measurer, ...(session ? { session } : {}) });
+
+/** Every published field of every page, so a stale value anywhere fails the comparison. */
+const publishedShapeOf = (layout: SemanticLayout): string => JSON.stringify(layout.pages);
+
+/** Deterministic PRNG. Same seed, same sequence, every run, every machine. */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Document model ─────────────────────────────────────────────────────────────
+// Two sections; the LAST paragraph of section 0 carries the mid-body w:sectPr and is
+// never deleted or joined away. Section 1 holds a constant table between its paragraphs,
+// so table flow participates in every pass without being edited itself.
+
+interface Para {
+  text: string;
+  keepNext: boolean;
+  contextualSpacing: boolean;
+}
+
+interface Doc {
+  sections: [Para[], Para[]];
+  /** Section 0 closes with two columns when set — the section-affecting edit. */
+  twoColumns: boolean;
+}
+
+const para = (text: string): Para => ({ text, keepNext: false, contextualSpacing: false });
+
+function initialDoc(): Doc {
+  return {
+    sections: [
+      Array.from({ length: 10 }, (_, i) => para(`s0p${i} ${'word '.repeat(8)}`)),
+      Array.from({ length: 10 }, (_, i) => para(`s1p${i} ${'word '.repeat(8)}`)),
+    ],
+    twoColumns: false,
+  };
+}
+
+const TABLE =
+  `<w:tbl><w:tblPr><w:tblW w:w="4000" w:type="dxa"/></w:tblPr>` +
+  `<w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/></w:tblGrid>` +
+  `<w:tr><w:tc><w:p><w:r><w:t>cell a</w:t></w:r></w:p></w:tc>` +
+  `<w:tc><w:p><w:r><w:t>cell b</w:t></w:r></w:p></w:tc></w:tr>` +
+  `<w:tr><w:tc><w:p><w:r><w:t>cell c</w:t></w:r></w:p></w:tc>` +
+  `<w:tc><w:p><w:r><w:t>cell d</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`;
+
+function renderPara(block: Para, sectPrXml = ''): string {
+  const props =
+    (block.keepNext ? '<w:keepNext/>' : '') +
+    (block.contextualSpacing ? '<w:contextualSpacing/>' : '') +
+    sectPrXml;
+  return `<w:p>${props ? `<w:pPr>${props}</w:pPr>` : ''}<w:r><w:t xml:space="preserve">${block.text}</w:t></w:r></w:p>`;
+}
+
+const PAGE =
+  `<w:pgSz w:w="6000" w:h="2400"/>` +
+  `<w:pgMar w:top="200" w:right="200" w:bottom="200" w:left="200" w:header="100" w:footer="100"/>`;
+
+function renderDoc(doc: Doc): string {
+  const [s0, s1] = doc.sections;
+  const cols = doc.twoColumns ? `<w:cols w:num="2" w:space="200"/>` : '';
+  const section0 = s0
+    .map((block, index) =>
+      renderPara(block, index === s0.length - 1 ? `<w:sectPr>${cols}${PAGE}</w:sectPr>` : '')
+    )
+    .join('');
+  // The constant table sits after section 1's second paragraph (or first, when short).
+  const tableAt = Math.min(2, s1.length);
+  const section1 =
+    s1
+      .slice(0, tableAt)
+      .map((block) => renderPara(block))
+      .join('') +
+    TABLE +
+    s1
+      .slice(tableAt)
+      .map((block) => renderPara(block))
+      .join('');
+  return `${section0}${section1}<w:sectPr>${PAGE}</w:sectPr>`;
+}
+
+// ── Edit vocabulary ────────────────────────────────────────────────────────────
+
+type Edit = readonly [kind: string, section: number, index: number];
+
+/** Applies one random edit and returns its replayable description. */
+function randomEdit(doc: Doc, rand: () => number, step: number): Edit {
+  const pick = <T>(items: readonly T[]): T => items[Math.floor(rand() * items.length)]!;
+  const section = rand() < 0.5 ? 0 : 1;
+  const paras = doc.sections[section]!;
+  const carrier = section === 0 ? paras.length - 1 : -1;
+  const index = Math.floor(rand() * paras.length);
+  const kind = pick([
+    'insert-text',
+    'delete-text',
+    'split',
+    'join',
+    'insert-para',
+    'delete-para',
+    'toggle-keep-next',
+    'toggle-contextual',
+    'toggle-columns',
+  ] as const);
+
+  switch (kind) {
+    case 'insert-text':
+      paras[index]!.text += ` step${step} extra words`;
+      break;
+    case 'delete-text': {
+      const words = paras[index]!.text.split(' ');
+      paras[index]!.text = words.slice(0, Math.max(1, Math.floor(words.length / 2))).join(' ');
+      break;
+    }
+    case 'split': {
+      if (index === carrier) return ['skip', section, index];
+      const words = paras[index]!.text.split(' ');
+      const at = Math.max(1, Math.floor(words.length / 2));
+      const tail = { ...paras[index]!, text: words.slice(at).join(' ') || 'tail' };
+      paras[index]!.text = words.slice(0, at).join(' ');
+      paras.splice(index + 1, 0, tail);
+      break;
+    }
+    case 'join': {
+      if (index >= paras.length - 1 || index + 1 === carrier || index === carrier) {
+        return ['skip', section, index];
+      }
+      paras[index]!.text += ` ${paras[index + 1]!.text}`;
+      paras.splice(index + 1, 1);
+      break;
+    }
+    case 'insert-para':
+      paras.splice(Math.min(index, carrier === -1 ? paras.length : carrier), 0, {
+        ...para(`inserted at step ${step} ${'word '.repeat(4)}`),
+      });
+      break;
+    case 'delete-para':
+      if (paras.length <= 2 || index === carrier) return ['skip', section, index];
+      paras.splice(index, 1);
+      break;
+    case 'toggle-keep-next':
+      paras[index]!.keepNext = !paras[index]!.keepNext;
+      break;
+    case 'toggle-contextual':
+      paras[index]!.contextualSpacing = !paras[index]!.contextualSpacing;
+      break;
+    case 'toggle-columns':
+      doc.twoColumns = !doc.twoColumns;
+      break;
+  }
+  return [kind, section, index];
+}
+
+// ── The oracle ─────────────────────────────────────────────────────────────────
+
+const SEEDS = [0xc0ffee, 42, 20260824, 7];
+const STEPS = 30;
+
+describe('incremental layout equals from-scratch layout on random edit sequences', () => {
+  for (const seed of SEEDS) {
+    test(`seed ${seed}: ${STEPS} random edits, differential at every step`, () => {
+      const rand = mulberry32(seed);
+      const doc = initialDoc();
+      const session = createLayoutSession();
+      const log: Edit[] = [];
+
+      const first = lay(load(renderDoc(doc)), 1, session);
+      expect(first.pages.length).toBeGreaterThan(1);
+
+      for (let step = 0; step < STEPS; step += 1) {
+        log.push(randomEdit(doc, rand, step));
+        const part = load(renderDoc(doc));
+        const incremental = publishedShapeOf(lay(part, step + 2, session));
+        const fresh = publishedShapeOf(lay(part, step + 2));
+        if (incremental !== fresh) {
+          throw new Error(
+            `Incremental layout diverged from a clean pass.\n` +
+              `seed: ${seed}, step: ${step}\n` +
+              `replay script (kind, section, index):\n${JSON.stringify(log)}`
+          );
+        }
+      }
+    });
+  }
+});

--- a/packages/core/src/layout/__tests__/section-prepass-guard.test.ts
+++ b/packages/core/src/layout/__tests__/section-prepass-guard.test.ts
@@ -1,0 +1,41 @@
+// The section-prepass guard map stays true (companion to section-prepass-guards.ts).
+//
+// The map's `satisfies` clause catches a `SectionPrepass` field that was never classified.
+// This test catches the drift the compiler cannot see: the hand-written `prepassValid`
+// expression in semantic-layout.ts silently dropping a `'validity-checked'` clause — the
+// exact omission that serves a stale prepass — or quietly comparing a `'derived-covered'`
+// field, which would mean the map's proof for that field is stale.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { SECTION_PREPASS_GUARDS, type SectionPrepassGuard } from '../section-prepass-guards.ts';
+
+describe('the prepassValid expression agrees with the map', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../semantic-layout.ts', import.meta.url)),
+    'utf8'
+  );
+  const start = source.indexOf('const prepassValid =');
+  expect(start).toBeGreaterThan(-1);
+  // The validity expression ends where the memo is consumed.
+  const end = source.indexOf('const prepass: SectionPrepass', start);
+  expect(end).toBeGreaterThan(start);
+  const region = source.slice(start, end);
+
+  const fields = Object.entries(SECTION_PREPASS_GUARDS) as [string, SectionPrepassGuard][];
+
+  for (const [field, guard] of fields) {
+    if (guard === 'validity-checked') {
+      test(`'${field}' has a prepassValid clause`, () => {
+        expect(region.includes(`prepassMemo.${field}`)).toBe(true);
+      });
+    } else {
+      test(`'${field}' is derived-covered and prepassValid never reads it`, () => {
+        // If the expression starts comparing it, the field is no longer a pure derivation
+        // of the checked inputs — reclassify it, do not just silence this.
+        expect(region.includes(`prepassMemo.${field}`)).toBe(false);
+      });
+    }
+  }
+});

--- a/packages/core/src/layout/__tests__/section-prepass-guard.test.ts
+++ b/packages/core/src/layout/__tests__/section-prepass-guard.test.ts
@@ -26,15 +26,18 @@ describe('the prepassValid expression agrees with the map', () => {
   const fields = Object.entries(SECTION_PREPASS_GUARDS) as [string, SectionPrepassGuard][];
 
   for (const [field, guard] of fields) {
+    // Word boundary, not substring: a future `prepassMemo.keysExtra` must not satisfy
+    // the `keys` gate.
+    const reads = new RegExp(`\\bprepassMemo\\.${field}\\b`);
     if (guard === 'validity-checked') {
       test(`'${field}' has a prepassValid clause`, () => {
-        expect(region.includes(`prepassMemo.${field}`)).toBe(true);
+        expect(reads.test(region)).toBe(true);
       });
     } else {
       test(`'${field}' is derived-covered and prepassValid never reads it`, () => {
         // If the expression starts comparing it, the field is no longer a pure derivation
         // of the checked inputs — reclassify it, do not just silence this.
-        expect(region.includes(`prepassMemo.${field}`)).toBe(false);
+        expect(reads.test(region)).toBe(false);
       });
     }
   }

--- a/packages/core/src/layout/flow-checkpoint-guards.ts
+++ b/packages/core/src/layout/flow-checkpoint-guards.ts
@@ -1,0 +1,56 @@
+// What convergence does with each field of a FLOW CHECKPOINT.
+//
+// A resumed pass converges when the in-page flow returns to exactly the state the previous
+// pass recorded at the same paragraph (`semantic-layout.ts`, the `mark &&` block). That
+// comparison is hand-written: a field captured by `checkpointNow` and restored on resume but
+// missing from the comparison converges a MISMATCHED flow, and ships the silent failure this
+// lane has been bitten by before — `deferredAnchoredDrawings` was exactly that field once
+// (see the comment on it in `layout-session.ts`).
+//
+// This is `PAGE_REUSE_GUARDS` for the checkpoint: the set, written down and type-checked. A
+// new `FlowCheckpoint` field is a type error here until somebody says what convergence does
+// with it, and the companion test asserts the comparison in the source agrees with the map.
+
+import type { FlowCheckpoint } from './layout-session.ts';
+
+/** What convergence does with a checkpoint field. */
+export type FlowCheckpointGuard =
+  /** Compared at every paragraph of the unchanged tail; a mismatch keeps laying out. */
+  | 'compared'
+  /**
+   * Not an equality: convergence computes the whole-sheet shift from it (`pages.length -
+   * mark.pageCount`), and `convergenceTailShiftAllowed` decides whether that shift is
+   * reusable.
+   */
+  | 'delta'
+  /**
+   * Restored on resume, deliberately NEVER compared by convergence. Only `lineCounter`
+   * holds this role: line ids are paragraph-local, so a changed line count before the join
+   * cannot invalidate the tail — the terminal count is still carried forward so a
+   * multi-section orchestrator receives the correct number for the revision. Promoting a
+   * field to this role needs that same argument, written where the field is declared.
+   */
+  | 'restore-only';
+
+export const FLOW_CHECKPOINT_GUARDS = {
+  pageCount: 'delta',
+  pageFragments: 'compared', // sameFragments — structural, via the fragment signature
+  pendingAnchoredDrawings: 'compared', // sameAnchoredDrawings — reference per record
+  // A flow that still owes the next page a drawing is not one that owes it nothing.
+  deferredAnchoredDrawings: 'compared', // sameAnchoredDrawings
+  anchorPageDeferCounts: 'compared', // sameDeferCounts
+  cursorY: 'compared',
+  lineCounter: 'restore-only',
+  previousSpaceAfter: 'compared',
+  flowColumnIndex: 'compared',
+} as const satisfies Record<keyof FlowCheckpoint, FlowCheckpointGuard>;
+
+/**
+ * Fields a checkpoint actually carries that the table above does not classify.
+ *
+ * The `satisfies` clause catches a field added to the INTERFACE. This catches the other
+ * direction — a checkpoint built by `checkpointNow` with a key the interface never declared.
+ */
+export function unguardedCheckpointFields(checkpoint: FlowCheckpoint): readonly string[] {
+  return Object.keys(checkpoint).filter((key) => !(key in FLOW_CHECKPOINT_GUARDS));
+}

--- a/packages/core/src/layout/font-resource.ts
+++ b/packages/core/src/layout/font-resource.ts
@@ -311,90 +311,11 @@ export const assertValidatedResolvedFont: (font: unknown) => asserts font is Res
   }
 };
 
-const SHA256_INITIAL = new Uint32Array([
-  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
-]);
-
-const SHA256_CONSTANTS = new Uint32Array([
-  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
-]);
-
-const rotateRight = (value: number, count: number): number =>
-  (value >>> count) | (value << (32 - count));
-
-/** Synchronous platform-neutral SHA-256 used before font bytes cross into a shaping implementation. */
-export const sha256FontBytes = (bytes: Uint8Array): string => {
-  const paddedLength = Math.ceil((bytes.byteLength + 9) / 64) * 64;
-  const padded = new Uint8Array(paddedLength);
-  padded.set(bytes);
-  padded[bytes.byteLength] = 0x80;
-  const bitLength = BigInt(bytes.byteLength) * 8n;
-  for (let index = 0; index < 8; index += 1) {
-    padded[paddedLength - 1 - index] = Number((bitLength >> BigInt(index * 8)) & 0xffn);
-  }
-
-  const hash = SHA256_INITIAL.slice();
-  const words = new Uint32Array(64);
-  for (let offset = 0; offset < padded.length; offset += 64) {
-    for (let index = 0; index < 16; index += 1) {
-      const start = offset + index * 4;
-      words[index] =
-        ((padded[start]! << 24) |
-          (padded[start + 1]! << 16) |
-          (padded[start + 2]! << 8) |
-          padded[start + 3]!) >>>
-        0;
-    }
-    for (let index = 16; index < 64; index += 1) {
-      const left = words[index - 15]!;
-      const right = words[index - 2]!;
-      const sigma0 = rotateRight(left, 7) ^ rotateRight(left, 18) ^ (left >>> 3);
-      const sigma1 = rotateRight(right, 17) ^ rotateRight(right, 19) ^ (right >>> 10);
-      words[index] = (words[index - 16]! + sigma0 + words[index - 7]! + sigma1) >>> 0;
-    }
-
-    let a = hash[0]!;
-    let b = hash[1]!;
-    let c = hash[2]!;
-    let d = hash[3]!;
-    let e = hash[4]!;
-    let f = hash[5]!;
-    let g = hash[6]!;
-    let h = hash[7]!;
-    for (let index = 0; index < 64; index += 1) {
-      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
-      const choice = (e & f) ^ (~e & g);
-      const temp1 = (h + sum1 + choice + SHA256_CONSTANTS[index]! + words[index]!) >>> 0;
-      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
-      const majority = (a & b) ^ (a & c) ^ (b & c);
-      const temp2 = (sum0 + majority) >>> 0;
-      h = g;
-      g = f;
-      f = e;
-      e = (d + temp1) >>> 0;
-      d = c;
-      c = b;
-      b = a;
-      a = (temp1 + temp2) >>> 0;
-    }
-    hash[0] = (hash[0]! + a) >>> 0;
-    hash[1] = (hash[1]! + b) >>> 0;
-    hash[2] = (hash[2]! + c) >>> 0;
-    hash[3] = (hash[3]! + d) >>> 0;
-    hash[4] = (hash[4]! + e) >>> 0;
-    hash[5] = (hash[5]! + f) >>> 0;
-    hash[6] = (hash[6]! + g) >>> 0;
-    hash[7] = (hash[7]! + h) >>> 0;
-  }
-  return `sha256:${Array.from(hash, (word) => word.toString(16).padStart(8, '0')).join('')}`;
-};
+// The implementation lives in the store lane (`store/package/sha256.ts`), where both
+// byte-fingerprinting trust boundaries sit; this import + re-export keeps the layout entry
+// point and every shaping consumer unchanged. layout → store is a lane-legal edge.
+import { sha256FontBytes } from '../store/package/sha256.ts';
+export { sha256FontBytes };
 
 const readUint16 = (bytes: Uint8Array, offset: number): number =>
   (bytes[offset]! << 8) | bytes[offset + 1]!;

--- a/packages/core/src/layout/layout-cache.ts
+++ b/packages/core/src/layout/layout-cache.ts
@@ -163,6 +163,30 @@ export interface ParagraphKeyInputs {
   readonly exclusionToken?: string;
 }
 
+/**
+ * How each {@link ParagraphKeyInputs} field reaches the memo hit test in
+ * {@link paragraphLayoutKey}. The `satisfies` clause makes a new input field a compile
+ * error here until it is classified — the trap this map exists for is the memo: an input
+ * folded into the joined key but missing from the memo comparison is SILENTLY INERT,
+ * because the memo returns the previous key before the join ever runs.
+ *
+ * - `'memo-identity'`: the WeakMap key itself; its content reaches the key via `nodeToken`.
+ * - `'memo-compared'`: compared verbatim (after normalization) in the memo hit test AND
+ *   folded into the key.
+ * - `'memo-derived'`: compared through a derived token (`propertiesToken`).
+ */
+export const PARAGRAPH_KEY_INPUT_ROLES = {
+  paragraph: 'memo-identity',
+  properties: 'memo-derived',
+  width: 'memo-compared',
+  producer: 'memo-compared',
+  drawingToken: 'memo-compared',
+  exclusionToken: 'memo-compared',
+} as const satisfies Record<
+  keyof ParagraphKeyInputs,
+  'memo-identity' | 'memo-compared' | 'memo-derived'
+>;
+
 interface ParagraphKeyMemo {
   readonly producer: string;
   readonly width: number;

--- a/packages/core/src/layout/pagination-keeps.ts
+++ b/packages/core/src/layout/pagination-keeps.ts
@@ -383,3 +383,45 @@ export function keepNextFlowKeys(keys: string[], keepsNext: (index: number) => b
   }
   return flow;
 }
+
+/** The per-block answers {@link composeFlowKeys} folds over the break-cache keys. */
+export interface FlowKeyFoldInputs {
+  readonly contextualSpacingAt: (index: number) => boolean;
+  /** `null` for a block that can never match a neighbour — a table, or an unstyled paragraph. */
+  readonly styleIdAt: (index: number) => string | null;
+  /** `''` for a block outside every border group. */
+  readonly borderGroupKeyAt: (index: number) => string;
+  /** Empty when the part has no TOC; the fold is then skipped outright. */
+  readonly tocVerdicts: readonly string[];
+  readonly markerTextAt: (index: number) => string | undefined;
+  readonly keepsNextAt: (index: number) => boolean;
+}
+
+/**
+ * The one composition of the flow-key folds — what incremental resume compares.
+ *
+ * `keys` stays what the break cache is stored under; the CROSS-BLOCK properties make the
+ * two differ: `w:contextualSpacing` (§17.3.1.9), paragraph border groups (§17.3.1.24), the
+ * TOC field verdicts, the list marker, and `w:keepNext` (§17.3.1.15) — each of which makes
+ * a block's placement depend on a block it does not contain.
+ *
+ * Each fold returns its input BY IDENTITY when nothing folds, so a document that reads
+ * across no boundary at all reaches the end holding the array it started with.
+ *
+ * `keepNextFlowKeys` runs LAST, and the order is load-bearing. It is the only fold that
+ * splices a NEIGHBOUR'S WHOLE KEY into a block's own, so whatever it reads has to be
+ * finished: run it first and a chain head carries its members' pre-fold keys, which is a
+ * head that never re-places when a member's marker, contextual or border verdict moves.
+ * That is latent rather than live today only because `keepNextGroupHeight` prices AUTHORED
+ * spacing; folding last makes the composition correct whatever that lookahead grows into.
+ * The composition lives HERE, next to the folds, so the order is testable — see
+ * `pagination-keeps.test.ts`.
+ */
+export function composeFlowKeys(keys: string[], at: FlowKeyFoldInputs): string[] {
+  let flow = contextualSpacingFlowKeys(keys, at.contextualSpacingAt, at.styleIdAt);
+  flow = borderGroupFlowKeys(flow, at.borderGroupKeyAt);
+  if (at.tocVerdicts.length > 0) flow = tocFieldFlowKeys(flow, (index) => at.tocVerdicts[index]!);
+  flow = listMarkerFlowKeys(flow, at.markerTextAt);
+  flow = keepNextFlowKeys(flow, at.keepsNextAt); // LAST — see the doc comment above.
+  return flow;
+}

--- a/packages/core/src/layout/resolved-cache.ts
+++ b/packages/core/src/layout/resolved-cache.ts
@@ -16,6 +16,38 @@ export interface OperationSnapshot {
 }
 
 /**
+ * How each {@link OperationSnapshot} field gates reuse. Every comparison and eviction list
+ * in this file derives from this one map, and the `satisfies` clause makes a new snapshot
+ * field a compile error until it is classified — a field in the interface but in no list
+ * would typecheck and silently never invalidate anything.
+ *
+ * `'coarse-gate'`: compared wholesale in {@link firstMismatch}, {@link guardOperationSnapshot}
+ * and {@link ResolvedCache.evictEpoch}; any change restarts or evicts.
+ *
+ * `'resource-scoped'` (only `resourceEpoch`): deliberately NOT a coarse reuse gate. Resource
+ * changes are compared per-dependency through `CacheProvenance.resourceDependencies` (see
+ * {@link ResolvedCache.evictResources}), so one font update does not evict entries that
+ * consumed a different, unchanged font.
+ */
+const OPERATION_SNAPSHOT_ROLES = {
+  resourceEpoch: 'resource-scoped',
+  configEpoch: 'coarse-gate',
+  extensionFingerprint: 'coarse-gate',
+  shapingHash: 'coarse-gate',
+  producerVersion: 'coarse-gate',
+} as const satisfies Record<keyof OperationSnapshot, 'coarse-gate' | 'resource-scoped'>;
+
+/** Every snapshot field, in declaration order (`configEpoch` first among the coarse gates,
+ * which keeps the first-mismatch reporting order stable). */
+const ALL_SNAPSHOT_FIELDS = Object.keys(
+  OPERATION_SNAPSHOT_ROLES
+) as readonly (keyof OperationSnapshot)[];
+
+const COARSE_GATE_FIELDS = ALL_SNAPSHOT_FIELDS.filter(
+  (field) => OPERATION_SNAPSHOT_ROLES[field] === 'coarse-gate'
+);
+
+/**
  * One resource a cached entry consumed, and the fingerprint it had at the time.
  *
  * Per-dependency rather than one global epoch, so updating one font does not evict entries that
@@ -87,13 +119,29 @@ const assertFingerprint = (value: string, name: string): void => {
   if (value.trim().length === 0) throw new TypeError(`${name} must not be blank`);
 };
 
+/** Per-field validation, exhaustive by construction like the roles map above: a new
+ * snapshot field fails typecheck here until it declares its validator. */
+const SNAPSHOT_FIELD_VALIDATORS: {
+  readonly [K in keyof OperationSnapshot]: (value: OperationSnapshot[K], name: string) => void;
+} = {
+  resourceEpoch: assertNonNegativeEpoch,
+  configEpoch: assertNonNegativeEpoch,
+  extensionFingerprint: assertFingerprint,
+  shapingHash: assertFingerprint,
+  producerVersion: assertNonNegativeEpoch,
+};
+
+const validateSnapshotField = <K extends keyof OperationSnapshot>(
+  source: OperationSnapshot,
+  field: K
+): void => {
+  SNAPSHOT_FIELD_VALIDATORS[field](source[field], field);
+};
+
 /** Capture, validate, and freeze the environment used throughout one derived operation. */
 export const captureOperationSnapshot = (source: OperationSnapshot): OperationSnapshot => {
-  assertNonNegativeEpoch(source.resourceEpoch, 'resourceEpoch');
-  assertNonNegativeEpoch(source.configEpoch, 'configEpoch');
-  assertNonNegativeEpoch(source.producerVersion, 'producerVersion');
-  assertFingerprint(source.extensionFingerprint, 'extensionFingerprint');
-  assertFingerprint(source.shapingHash, 'shapingHash');
+  for (const field of ALL_SNAPSHOT_FIELDS) validateSnapshotField(source, field);
+  // The literal is a second ratchet: a new interface field is a compile error here too.
   return Object.freeze({
     resourceEpoch: source.resourceEpoch,
     configEpoch: source.configEpoch,
@@ -112,14 +160,9 @@ export const guardOperationSnapshot = (
 ): OperationSnapshotGuard => {
   const expected = captureOperationSnapshot(captured);
   const actual = captureOperationSnapshot(current);
-  const fields: readonly OperationSnapshotField[] = [
-    'resourceEpoch',
-    'configEpoch',
-    'extensionFingerprint',
-    'shapingHash',
-    'producerVersion',
-  ];
-  const changed = fields.filter((field) => expected[field] !== actual[field]);
+  // An in-flight operation restarts on ANY environment move, resources included — the
+  // per-dependency comparison only softens cache eviction, never a live pass.
+  const changed = ALL_SNAPSHOT_FIELDS.filter((field) => expected[field] !== actual[field]);
   return changed.length === 0
     ? Object.freeze({ status: 'current' })
     : Object.freeze({ status: 'restart', changed: Object.freeze(changed) });
@@ -185,14 +228,8 @@ function firstMismatch(a: CacheProvenance, b: Omit<CacheProvenance, 'revision'>)
   if (a.inputFingerprint !== b.inputFingerprint) return { hit: false, reason: 'input-changed' };
   const resources = resourceMismatch(a.resourceDependencies, b.resourceDependencies);
   if (resources) return resources;
-  const epochs: (keyof OperationSnapshot)[] = [
-    'configEpoch',
-    'extensionFingerprint',
-    'shapingHash',
-    'producerVersion',
-  ];
-  for (const e of epochs)
-    if (a[e] !== b[e]) return { hit: false, reason: 'epoch-changed', epoch: e };
+  for (const field of COARSE_GATE_FIELDS)
+    if (a[field] !== b[field]) return { hit: false, reason: 'epoch-changed', epoch: field };
   return null;
 }
 
@@ -229,12 +266,7 @@ export class ResolvedCache<V> {
     let evicted = 0;
     for (const [key, entry] of this.entries) {
       const p = entry.provenance;
-      if (
-        p.configEpoch !== operation.configEpoch ||
-        p.extensionFingerprint !== operation.extensionFingerprint ||
-        p.shapingHash !== operation.shapingHash ||
-        p.producerVersion !== operation.producerVersion
-      ) {
+      if (COARSE_GATE_FIELDS.some((field) => p[field] !== operation[field])) {
         this.entries.delete(key);
         evicted += 1;
       }

--- a/packages/core/src/layout/section-prepass-guards.ts
+++ b/packages/core/src/layout/section-prepass-guards.ts
@@ -1,0 +1,43 @@
+// What keeps each field of a REUSED section prepass current.
+//
+// The prepass memo (`semantic-layout.ts`, `const prepassValid =`) reuses the whole record
+// verbatim while every input it derives from is unchanged. The validity expression is
+// hand-written: a field added to `SectionPrepass` and to `buildSectionPrepass`'s return but
+// to no `prepassValid` clause typechecks — and is then served stale across every change
+// that moved it. This is the widest silent-staleness surface the memo chain has, which is
+// why it gets the `PAGE_REUSE_GUARDS` treatment: the set, written down and type-checked,
+// with a companion test asserting the source expression agrees with the map.
+
+import type { SectionPrepass } from './semantic-layout.ts';
+
+/** How a prepass field stays current across a pass that reuses the record. */
+export type SectionPrepassGuard =
+  /** Named in the `prepassValid` expression; a change rebuilds the whole prepass. */
+  | 'validity-checked'
+  /**
+   * Rebuilt by `buildSectionPrepass` as a pure function of the `validity-checked` inputs,
+   * so it can only be stale if one of THEM escaped its clause. The same role
+   * `semantic-fragment-signature.ts` calls `covered`: only a field with that proof gets
+   * this, not a field whose mechanism is merely unclear.
+   */
+  | 'derived-covered';
+
+export const SECTION_PREPASS_GUARDS = {
+  // The block list itself — compared element-wise by identity, which is what makes a
+  // typing pass in a many-section document reuse every section but the edited one.
+  bodies: 'validity-checked',
+  producer: 'validity-checked',
+  contentWidth: 'validity-checked',
+  styleCascade: 'validity-checked',
+  listItems: 'validity-checked',
+  // Stands in for the per-block drawing tokens; a caller that threads per-paragraph
+  // tokens WITHOUT an epoch keeps the recompute path (`drawingEpoch !== null`).
+  drawingEpoch: 'validity-checked',
+  tocToken: 'validity-checked',
+  prepared: 'derived-covered',
+  keys: 'derived-covered',
+  paragraphDocumentOrder: 'derived-covered',
+  keepsNext: 'derived-covered',
+  markerTexts: 'derived-covered',
+  flowKeys: 'derived-covered',
+} as const satisfies Record<keyof SectionPrepass, SectionPrepassGuard>;

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -60,11 +60,7 @@ import {
 import { resolveParagraphBorders } from './paragraph-border-resolve.ts';
 import {
   adjustedBreakIndex,
-  borderGroupFlowKeys,
-  keepNextFlowKeys,
-  listMarkerFlowKeys,
-  contextualSpacingFlowKeys,
-  tocFieldFlowKeys,
+  composeFlowKeys,
   keepNextGroupHeight,
   paragraphKeeps,
   MAX_KEEP_NEXT_CHAIN,
@@ -514,7 +510,7 @@ function tocIdsToken(ids: TocIdSets): string {
  * order — kept on the section's {@link LayoutSession} and reused verbatim while every
  * input it derives from is unchanged. Stored through the session's opaque `prepass` slot.
  */
-interface SectionPrepass {
+export interface SectionPrepass {
   readonly bodies: readonly OoxmlElement[];
   readonly producer: string;
   readonly contentWidth: number;
@@ -1164,29 +1160,17 @@ function layoutBlocksPass(
             entry.kind === 'paragraph' ? tocVerdictFor(entry.paragraph.id, tocIds) : ''
           );
 
-    // FLOW keys — what incremental resume compares. `keys` stays what the break cache is
-    // stored under; the CROSS-BLOCK properties make the two differ: `w:keepNext`
-    // (§17.3.1.15), the list marker, `w:contextualSpacing` (§17.3.1.9), paragraph border
-    // groups (§17.3.1.24) and the TOC field verdicts — each of which makes a block's
-    // placement depend on a block it does not contain.
-    //
-    // Each fold returns its input BY IDENTITY when nothing folds, so a document that reads
-    // across no boundary at all reaches the end holding the array it started with.
-    let flow = contextualSpacingFlowKeys(
-      keys,
-      (index) => contextualSpacings[index]!,
-      (index) => styleIds[index] ?? null
-    );
-    flow = borderGroupFlowKeys(flow, (index) => borderGroupKeys[index]!);
-    if (tocVerdicts.length > 0) flow = tocFieldFlowKeys(flow, (index) => tocVerdicts[index]!);
-    flow = listMarkerFlowKeys(flow, (index) => markerTexts[index]);
-    // LAST, and the order is load-bearing. `keepNextFlowKeys` is the only fold that splices
-    // a NEIGHBOUR'S WHOLE KEY into a block's own, so whatever it reads has to be finished:
-    // run it first and a chain head carries its members' pre-fold keys, which is a head that
-    // never re-places when a member's marker, contextual or border verdict moves. That is
-    // latent rather than live today only because `keepNextGroupHeight` prices AUTHORED
-    // spacing; folding last makes the composition correct whatever that lookahead grows into.
-    flow = keepNextFlowKeys(flow, (index) => keepsNext[index]!);
+    // FLOW keys — what incremental resume compares. The composition, its fold order and
+    // the argument for that order live with the folds in `pagination-keeps.ts`, where the
+    // order is testable.
+    const flow = composeFlowKeys(keys, {
+      contextualSpacingAt: (index) => contextualSpacings[index]!,
+      styleIdAt: (index) => styleIds[index] ?? null,
+      borderGroupKeyAt: (index) => borderGroupKeys[index]!,
+      tocVerdicts,
+      markerTextAt: (index) => markerTexts[index],
+      keepsNextAt: (index) => keepsNext[index]!,
+    });
 
     return {
       bodies,

--- a/packages/core/src/output/revision-presentation.ts
+++ b/packages/core/src/output/revision-presentation.ts
@@ -116,19 +116,31 @@ export interface ReviewAuthorInfo {
   readonly style?: RevisionAuthorStyle;
 }
 
-const STYLE_KEYS = ['color', 'background', 'spanClassName', 'avatarUrl'] as const;
-
 /**
- * The subset of {@link STYLE_KEYS} that reaches PAINTED DOM, and so the only fields the
- * paint-reuse key may hash.
+ * Where each {@link RevisionAuthorStyle} field lands, and so whether the paint-reuse key
+ * hashes it. The `satisfies` clause makes a new style field a compile error here until it
+ * is classified — a `'painted'` field the key misses keeps stale pages on screen, and a
+ * `'card-only'` field the key hashes drops every retained page for a change that alters
+ * no painted pixel.
  *
- * `avatarUrl` is deliberately absent. It is read by the review card and by nothing the
- * painter emits, so hashing it made an avatar arriving late — a host resolving its team
- * roster over the network, then redeclaring — move the context key and drop every retained
- * page. Measured at 228ms and 0 of 41 pages retained for a change that alters no painted
- * pixel; an identical redeclaration kept all 41 at 0.1ms.
+ * `avatarUrl` is deliberately `'card-only'`. It is read by the review card and by nothing
+ * the painter emits, so hashing it made an avatar arriving late — a host resolving its
+ * team roster over the network, then redeclaring — move the context key and drop every
+ * retained page. Measured at 228ms and 0 of 41 pages retained for a change that alters no
+ * painted pixel; an identical redeclaration kept all 41 at 0.1ms.
  */
-const PAINTED_STYLE_KEYS = ['color', 'background', 'spanClassName'] as const;
+const STYLE_KEY_REACH = {
+  color: 'painted',
+  background: 'painted',
+  spanClassName: 'painted',
+  avatarUrl: 'card-only',
+} as const satisfies Record<keyof Required<RevisionAuthorStyle>, 'painted' | 'card-only'>;
+
+const STYLE_KEYS = Object.keys(STYLE_KEY_REACH) as readonly (keyof RevisionAuthorStyle)[];
+
+/** The `'painted'` subset, in declaration order — the hash fold at the context key relies
+ * on that order staying stable. */
+const PAINTED_STYLE_KEYS = STYLE_KEYS.filter((key) => STYLE_KEY_REACH[key] === 'painted');
 
 /**
  * Schemes an avatar may load over. An allowlist, matching the package's `sanitizeHref`

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -3,7 +3,7 @@
 // Content type is a claim; signature sniffing, structural header validation, and
 // the decode port are authoritative. Validated bytes never enter public state.
 
-import { sha256FontBytes } from '../../layout/font-resource.ts';
+import { sha256FontBytes } from './sha256.ts';
 import {
   createValidatedImageBytesRegistry,
   type ValidatedImageBytesHandle,

--- a/packages/core/src/store/package/sha256.ts
+++ b/packages/core/src/store/package/sha256.ts
@@ -1,0 +1,91 @@
+// Synchronous platform-neutral SHA-256 over raw bytes.
+//
+// Lives in the store lane because both trust boundaries that fingerprint bytes sit here:
+// media parts (image resources) and embedded fonts hash their payloads before anything
+// downstream consumes them. The layout lane re-exports `sha256FontBytes` from
+// `font-resource.ts`, which is the direction the lane DAG allows (layout → store).
+
+const SHA256_INITIAL = new Uint32Array([
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+]);
+
+const SHA256_CONSTANTS = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+const rotateRight = (value: number, count: number): number =>
+  (value >>> count) | (value << (32 - count));
+
+/** Synchronous platform-neutral SHA-256 used before font bytes cross into a shaping implementation. */
+export const sha256FontBytes = (bytes: Uint8Array): string => {
+  const paddedLength = Math.ceil((bytes.byteLength + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.byteLength] = 0x80;
+  const bitLength = BigInt(bytes.byteLength) * 8n;
+  for (let index = 0; index < 8; index += 1) {
+    padded[paddedLength - 1 - index] = Number((bitLength >> BigInt(index * 8)) & 0xffn);
+  }
+
+  const hash = SHA256_INITIAL.slice();
+  const words = new Uint32Array(64);
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      const start = offset + index * 4;
+      words[index] =
+        ((padded[start]! << 24) |
+          (padded[start + 1]! << 16) |
+          (padded[start + 2]! << 8) |
+          padded[start + 3]!) >>>
+        0;
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const left = words[index - 15]!;
+      const right = words[index - 2]!;
+      const sigma0 = rotateRight(left, 7) ^ rotateRight(left, 18) ^ (left >>> 3);
+      const sigma1 = rotateRight(right, 17) ^ rotateRight(right, 19) ^ (right >>> 10);
+      words[index] = (words[index - 16]! + sigma0 + words[index - 7]! + sigma1) >>> 0;
+    }
+
+    let a = hash[0]!;
+    let b = hash[1]!;
+    let c = hash[2]!;
+    let d = hash[3]!;
+    let e = hash[4]!;
+    let f = hash[5]!;
+    let g = hash[6]!;
+    let h = hash[7]!;
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choice = (e & f) ^ (~e & g);
+      const temp1 = (h + sum1 + choice + SHA256_CONSTANTS[index]! + words[index]!) >>> 0;
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (sum0 + majority) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+    hash[0] = (hash[0]! + a) >>> 0;
+    hash[1] = (hash[1]! + b) >>> 0;
+    hash[2] = (hash[2]! + c) >>> 0;
+    hash[3] = (hash[3]! + d) >>> 0;
+    hash[4] = (hash[4]! + e) >>> 0;
+    hash[5] = (hash[5]! + f) >>> 0;
+    hash[6] = (hash[6]! + g) >>> 0;
+    hash[7] = (hash[7]! + h) >>> 0;
+  }
+  return `sha256:${Array.from(hash, (word) => word.toString(16).padStart(8, '0')).join('')}`;
+};

--- a/packages/editor-api/src/__tests__/package-dependencies.test.ts
+++ b/packages/editor-api/src/__tests__/package-dependencies.test.ts
@@ -48,7 +48,8 @@ describe('how this package asks for the engine', () => {
     // A caret range that fell behind the engine's major would make installs resolve a
     // SECOND, older engine next to the host's — the exact two-copies failure above.
     const range = manifest.dependencies!['@docx-editor.dev/core']!;
-    const match = /^\^(\d+)\.(\d+)\.\d+$/.exec(range);
+    // The optional suffix admits changesets pre-release mode (^3.0.0-next.0).
+    const match = /^\^(\d+)\.(\d+)\.\d+(?:-[0-9A-Za-z.-]+)?$/.exec(range);
     expect(match).not.toBeNull();
     const [rangeMajor, rangeMinor] = [Number(match![1]), Number(match![2])];
     const [coreMajor, coreMinor] = core.version.split('.').map(Number);

--- a/packages/editor-api/src/__tests__/package-dependencies.test.ts
+++ b/packages/editor-api/src/__tests__/package-dependencies.test.ts
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+
+// How this package asks for the engine — pinned, with the risk written down.
+//
+// The engine carries module-level state: the HarfBuzz shaper and its cache budget, the
+// grapheme boundary strategy, and layout caches keyed by object identity. Two copies in one
+// tree do not crash; they load the shaper twice and miss every identity-keyed cache,
+// quietly. That is why `@docx-editor.dev/core` is a PEER of the react and pro packages
+// (`packages/react/test/package-dependencies.test.ts`).
+//
+// This package currently declares the engine as a REGULAR dependency. That is safe for the
+// headless `server` entry, which constructs its own document from bytes. It is NOT the
+// right end state for the `browser` entry: `runtime/browser.ts` attaches to a
+// `DocxEditorInstance` the HOST constructed with the host's copy of core, so a package
+// manager nesting a second copy under this package puts the automation host and the editor
+// on different engines — brand checks and identity-keyed caches miss across the boundary.
+// Moving the engine to a peer dependency is a consumer-facing change with its own changeset
+// and release notes, tracked as a follow-up; until then this test pins the shape so it can
+// only change deliberately.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (path: string) =>
+  JSON.parse(readFileSync(path, 'utf8')) as {
+    version: string;
+    dependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  };
+
+const manifest = read(join(import.meta.dir, '..', '..', 'package.json'));
+const core = read(join(import.meta.dir, '..', '..', '..', 'core', 'package.json'));
+
+describe('how this package asks for the engine', () => {
+  test('the engine dependency shape is the pinned one', () => {
+    // A move to peerDependencies is the intended end state — but it changes what a
+    // consumer must install, so it lands as its own PR with a changeset, not as drift.
+    expect(manifest.dependencies?.['@docx-editor.dev/core']).toBeDefined();
+    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBeUndefined();
+  });
+
+  test('the declared range admits the workspace engine it is built against', () => {
+    // A caret range that fell behind the engine's major would make installs resolve a
+    // SECOND, older engine next to the host's — the exact two-copies failure above.
+    const range = manifest.dependencies!['@docx-editor.dev/core']!;
+    const match = /^\^(\d+)\.(\d+)\.\d+$/.exec(range);
+    expect(match).not.toBeNull();
+    const [rangeMajor, rangeMinor] = [Number(match![1]), Number(match![2])];
+    const [coreMajor, coreMinor] = core.version.split('.').map(Number);
+    expect(rangeMajor).toBe(coreMajor);
+    expect(rangeMinor).toBeLessThanOrEqual(coreMinor!);
+  });
+});

--- a/scripts/check-api-changeset.mjs
+++ b/scripts/check-api-changeset.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * A PR that changes the public API surface must carry a changeset.
+ *
+ * `docs/api/*.api.md` are the API Extractor snapshots: a diff there means a `@public`
+ * symbol moved. The snapshots themselves gate nothing about VERSIONING — regenerating and
+ * committing them is green — so without this check a PR can delete a public export and
+ * ship it as an unversioned change. CLAUDE.md's rule is "every code PR gets a changeset";
+ * an API-surface change is never a test/docs/CI-only PR, so here the rule is enforceable.
+ *
+ * Usage: node scripts/check-api-changeset.mjs --base origin/main
+ * Runs on pull_request only (the workflow guards merge commits and the
+ * changeset-release/* branches, where consumed changesets legitimately disappear).
+ */
+import { execFileSync } from 'node:child_process';
+
+const baseIndex = process.argv.indexOf('--base');
+const base = baseIndex > -1 ? process.argv[baseIndex + 1] : null;
+if (!base) {
+  console.error('usage: check-api-changeset.mjs --base <ref>');
+  process.exit(2);
+}
+
+const diff = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+  encoding: 'utf8',
+})
+  .split('\n')
+  .filter(Boolean);
+
+const apiChanges = diff.filter((path) => path.startsWith('docs/api/'));
+if (apiChanges.length === 0) {
+  console.log('api-changeset: no docs/api change in this PR — nothing to require.');
+  process.exit(0);
+}
+
+const changesets = diff.filter(
+  (path) => /^\.changeset\/[^/]+\.md$/.test(path) && path !== '.changeset/README.md'
+);
+if (changesets.length > 0) {
+  console.log(
+    `api-changeset: ${apiChanges.length} docs/api change(s) covered by ${changesets.length} changeset(s).`
+  );
+  process.exit(0);
+}
+
+console.error('This PR changes the public API surface without a changeset:');
+for (const path of apiChanges.slice(0, 20)) console.error(`  - ${path}`);
+if (apiChanges.length > 20) console.error(`  … and ${apiChanges.length - 20} more`);
+console.error('');
+console.error(
+  'Run `bun changeset` (or hand-write .changeset/<name>.md) so the release pipeline versions this change.'
+);
+process.exit(1);

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -1,29 +1,65 @@
 #!/usr/bin/env node
 /**
- * Every file-specific max-lines glob in eslint.config.js must match a real file.
+ * The per-file max-lines caps in eslint.config.js stay honest.
+ *
+ * Two checks over the imported config (imported, not regex-parsed, so a config the linter
+ * would reject fails here too):
+ *
+ * 1. Every non-glob `files` path exists — a cap for a deleted file is dead weight.
+ * 2. Every per-file cap is a RATCHET, not a permanent ceiling: the cap must sit within
+ *    SLACK lines of the file's current length. Without this, a file that shrinks by 800
+ *    lines keeps its inflated ceiling forever and the "nothing here can grow" claim in the
+ *    config is only true at the moment a cap is written. A file that comes down: lower its
+ *    cap (or delete the block once it fits the global 1000).
  */
-import { readFileSync, existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SLACK = 100;
+
+/** Paths allowed to hold headroom beyond SLACK, each with its reason. */
+const SLACK_EXEMPT = new Map([
+  [
+    'docs/site/data/word-features.ts',
+    'the feature matrix grows by design; its cap buys headroom so shipping a feature never negotiates with the linter',
+  ],
+]);
 
 const root = join(import.meta.dirname, '..');
-const configPath = join(root, 'eslint.config.js');
-const text = readFileSync(configPath, 'utf8');
-const filesBlocks = [...text.matchAll(/files:\s*\[([^\]]+)\]/g)];
-const paths = new Set();
+const configs = (await import(pathToFileURL(join(root, 'eslint.config.js')).href)).default;
 
-for (const block of filesBlocks) {
-  for (const match of block[1].matchAll(/'([^']+)'|"([^"]+)"/g)) {
-    const path = match[1] ?? match[2];
+const failures = [];
+let checked = 0;
+
+for (const block of configs) {
+  const cap = block.rules?.['max-lines']?.[1]?.max;
+  if (cap === undefined || !Array.isArray(block.files)) continue;
+  for (const path of block.files) {
     if (path.includes('*')) continue;
-    paths.add(path);
+    const absolute = join(root, path);
+    if (!existsSync(absolute)) {
+      failures.push(`missing file: ${path} (cap ${cap})`);
+      continue;
+    }
+    checked += 1;
+    const lines = readFileSync(absolute, 'utf8').split('\n').length - 1;
+    if (lines > cap) {
+      // eslint reports this too; repeating it keeps this script self-contained.
+      failures.push(`over cap: ${path} is ${lines} lines, cap ${cap}`);
+    } else if (cap - lines > SLACK && !SLACK_EXEMPT.has(path)) {
+      failures.push(
+        `stale cap: ${path} is ${lines} lines but capped at ${cap} — ` +
+          `lower the cap to within ${SLACK} lines (or delete the block once it fits the global cap)`
+      );
+    }
   }
 }
 
-const missing = [...paths].filter((path) => !existsSync(join(root, path)));
-if (missing.length > 0) {
-  console.error('eslint.config.js max-lines globs reference missing files:');
-  for (const path of missing) console.error(`  - ${path}`);
+if (failures.length > 0) {
+  console.error('eslint.config.js max-lines caps are stale or broken:');
+  for (const failure of failures) console.error(`  - ${failure}`);
   process.exit(1);
 }
 
-console.log(`eslint max-lines globs: ${paths.size} file-specific paths, all present`);
+console.log(`eslint max-lines caps: ${checked} file-specific paths present and within ${SLACK} lines of their cap`);

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -16,7 +16,10 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const SLACK = 100;
+// 150, not 100: with caps set ~100 over their file, a tighter slack made ONE deleted line
+// in a capped file a lint failure until the config moved too. 150 keeps the ratchet and
+// gives cleanup PRs a real margin.
+const SLACK = 150;
 
 /** Paths allowed to hold headroom beyond SLACK, each with its reason. */
 const SLACK_EXEMPT = new Map([

--- a/scripts/check-parity-contract.mjs
+++ b/scripts/check-parity-contract.mjs
@@ -43,11 +43,21 @@ function extractVueDocxEditorForms(source) {
 }
 
 /**
- * Pull field names out of an `export interface FooProps { ... }` block.
- * Lines beginning with whitespace + identifier + optional `?` + colon
- * are field declarations; nested object lines (deeper indent) are ignored.
+ * Normalize one member line for cross-adapter TYPE comparison: drop `readonly`
+ * (an adapter-idiom difference, not an API difference) and collapse whitespace.
+ * The name stays in the string — paired members share it by definition.
  */
-function extractInterfaceFields(snapshotText, interfaceName) {
+function normalizeMemberLine(line) {
+  return line.trim().replace(/^readonly\s+/, '').replace(/\s+/g, ' ');
+}
+
+/**
+ * Pull members out of an `export interface FooProps { ... }` block as a
+ * Map(name → normalized member line). Lines beginning with whitespace +
+ * identifier + optional `?` + colon are field declarations; nested object
+ * lines (deeper indent) are ignored.
+ */
+function scanInterfaceMembers(snapshotText, interfaceName) {
   const lines = snapshotText.split('\n');
   const startMarker = `export interface ${interfaceName} `;
   const startIdx = lines.findIndex(
@@ -60,7 +70,7 @@ function extractInterfaceFields(snapshotText, interfaceName) {
   // interface is closed. Inside the block, only lines at exactly 4-space
   // indent (top-level field declarations) are picked up — nested object
   // literals at deeper indent are skipped by the regex.
-  const fields = new Set();
+  const members = new Map();
   let depth = 0;
   let inBlockComment = false;
   for (let i = startIdx; i < lines.length; i++) {
@@ -83,9 +93,14 @@ function extractInterfaceFields(snapshotText, interfaceName) {
     // as `getEditor(): Editor | null` invisible to the gate, so a ref method
     // could be added or dropped on one adapter without the check noticing.
     const match = /^ {4}(?:readonly\s+)?(\w+)\??[(:]/.exec(line);
-    if (match) fields.add(match[1]);
+    if (match) members.set(match[1], normalizeMemberLine(line));
   }
-  return fields;
+  return members;
+}
+
+function extractInterfaceFields(snapshotText, interfaceName) {
+  const members = scanInterfaceMembers(snapshotText, interfaceName);
+  return members ? new Set(members.keys()) : null;
 }
 
 /**
@@ -108,25 +123,30 @@ function extractRefMembers(snapshotText) {
  * directly — the same shape React uses. That is BETTER parity, not worse, so
  * the checker accepts it instead of failing to find the alias.
  */
-function extractVueRefMembers(snapshotText) {
+function scanVueRefMembers(snapshotText) {
   const lines = snapshotText.split('\n');
   const startIdx = lines.findIndex((l) => l.startsWith('export type DocxEditorRef '));
   if (startIdx === -1) {
     // No alias — fall back to the interface form and report null only if that
     // is missing too, so a genuinely absent DocxEditorRef still fails loudly.
-    const asInterface = extractInterfaceFields(snapshotText, 'DocxEditorRef');
-    return asInterface.size > 0 ? asInterface : null;
+    const asInterface = scanInterfaceMembers(snapshotText, 'DocxEditorRef');
+    return asInterface && asInterface.size > 0 ? asInterface : null;
   }
-  const fields = new Set();
+  const members = new Map();
   let inBlock = false;
   for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i];
     if (line.includes('{')) inBlock = true;
     if (inBlock && line.startsWith('};')) break;
     const match = /^ {4}(\w+)[\?\(:]/.exec(line);
-    if (match) fields.add(match[1]);
+    if (match) members.set(match[1], normalizeMemberLine(line));
   }
-  return fields;
+  return members;
+}
+
+function extractVueRefMembers(snapshotText) {
+  const members = scanVueRefMembers(snapshotText);
+  return members ? new Set(members.keys()) : null;
 }
 
 function diffSets(name, contractList, actualSet) {
@@ -260,9 +280,18 @@ function main() {
   const vueOnly = Object.keys(contract.props.vueExclusive);
   const reactFormProps = [...callbackEmits, ...renderSlots, ...classFallthrough];
 
+  const reactPropTypes = scanInterfaceMembers(reactSnapshot, 'DocxEditorProps');
+  const vuePropTypes = scanInterfaceMembers(vueSnapshot, 'DocxEditorProps');
   for (const k of paired) {
     if (!reactProps.has(k)) issues.push(`PROP paired '${k}' missing from React`);
     if (!vueProps.has(k)) issues.push(`PROP paired '${k}' missing from Vue`);
+    // Paired means the SAME member, not two members with one name: compare the
+    // snapshot member text (normalized), so a type that drifts on one adapter fails.
+    const reactType = reactPropTypes?.get(k);
+    const vueType = vuePropTypes?.get(k);
+    if (reactType !== undefined && vueType !== undefined && reactType !== vueType) {
+      issues.push(`PROP paired '${k}' type drift — React: \`${reactType}\` Vue: \`${vueType}\``);
+    }
   }
   for (const k of deferred) {
     if (!reactProps.has(k)) issues.push(`PROP deferred '${k}' missing from React (contract stale)`);
@@ -339,9 +368,16 @@ function main() {
   const refInherited = Object.keys(contract.ref.pairedViaInheritance || {});
   const refVueOnly = Object.keys(contract.ref.vueExclusive);
 
+  const reactRefTypes = scanInterfaceMembers(reactSnapshot, 'DocxEditorRef');
+  const vueRefTypes = scanVueRefMembers(vueSnapshot);
   for (const k of refPaired) {
     if (!reactRef.has(k)) issues.push(`REF paired '${k}' missing from React`);
     if (!vueRef.has(k)) issues.push(`REF paired '${k}' missing from Vue`);
+    const reactType = reactRefTypes?.get(k);
+    const vueType = vueRefTypes?.get(k);
+    if (reactType !== undefined && vueType !== undefined && reactType !== vueType) {
+      issues.push(`REF paired '${k}' type drift — React: \`${reactType}\` Vue: \`${vueType}\``);
+    }
   }
   for (const k of refInherited) {
     if (!reactRef.has(k))


### PR DESCRIPTION
Converts the invariants behind the incremental-layout caches, the core lane DAG, and the public API surface from prose into compile errors, tests, lint rules, and CI gates.

## What this adds

- Exhaustiveness maps in the `satisfies Record<keyof T, …>` idiom for `EditorSnapshot` equality, `OperationSnapshot`, `ParagraphKeyInputs`, `RevisionAuthorStyle`, `FlowCheckpoint`, and `SectionPrepass`. A new field on any of these is a compile error until it is classified, and companion tests assert the source comparisons agree with each map.
- A seeded randomized differential layout test: 4 seeds x 30 random edits over a multi-section document, asserting incremental output equals a from-scratch pass at every step, with anti-vacuity floors on page reuse. Every existing bench gate protects cache warmth; this is the first gate that protects freshness.
- Lane-DAG enforcement against real import statements, with ratcheting pinned lists for the grandfathered edges. Two runtime violations are fixed (`paragraphOrderOfPart` now imports from the store lane; `sha256FontBytes` moves to `store/package/sha256.ts` with a lane-legal re-export).
- A pinned census of every `partFor(` call site across packages, because a `partFor` read permanently retains one of 64 story-store slots.
- ESLint bans for HTML-from-strings sinks in package source and varargs array spread in the store and layout lanes.
- CI: `check:lane-boundaries` now runs in the lint job, and a new `api-changeset` job requires a changeset when a PR changes `docs/api/**`. The pre-commit parity gate is re-enabled. The max-lines checker now fails caps that drift more than 150 lines above their file, and stale caps are retightened.
- The parity contract now compares paired prop and ref member types, not just names.

## Behavior fix

`snapshotsEqual` compared 21 of 22 snapshot fields; `hasReviewContent` was missing, so a flip could never wake a subscriber on its own. The exhaustiveness map found it; the changeset covers it.

## Verification

Full suite (8736 tests), typecheck, lint, `check:parity`, `check:lane-boundaries`, i18n, and license headers pass locally. Each new gate was verified to fail on a sabotaged input. Three review rounds ran; all findings are fixed. `api:check` was verified against a fresh build; the one residual local diff is the known machine-dependent member-order flip in the Vue snapshot, which this branch does not touch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790178274&installation_model_id=422592&pr_number=411&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F411&signature=3f9e51cec015535386e848806e2da8293245e777b5dd5f7cb2e29b8dba70e40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->