### PR TITLE
fix: make check:feature-parity a real gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,10 @@ jobs:
       - name: Parity gates
         run: bun run check:parity
 
-      - name: Feature parity report
+      # Fails when React/Vue adapter drift diverges from the pinned
+      # baseline in scripts/feature-parity-baseline.json, in either
+      # direction. Update the baseline with --update-baseline.
+      - name: Feature parity gate
         run: bun run check:feature-parity
 
       # Same generator the release runs, here as a gate rather than for its

--- a/scripts/check-feature-parity.mjs
+++ b/scripts/check-feature-parity.mjs
@@ -42,17 +42,15 @@ const RENDER_PATH_DIVERGENCE = path.join(
 // Files whose React-only-ness is documented as intentional in the
 // render-path divergence note. They share their behaviour with Vue
 // via the core package surface, so the parity counter should not
-// penalize them.
+// penalize them. Keys are adapter-relative paths without extension,
+// the same keys buildReport pairs components by.
 function loadIntentionalRenderPathSet() {
   if (!fs.existsSync(RENDER_PATH_DIVERGENCE)) return new Set();
   const md = fs.readFileSync(RENDER_PATH_DIVERGENCE, 'utf8');
   const out = new Set();
   for (const line of md.split('\n')) {
-    const m = line.match(/`(packages\/react\/src\/[^`]+)`/);
-    if (m) {
-      const base = path.basename(m[1]).replace(/\.(tsx?|ts)$/, '');
-      out.add(base);
-    }
+    const m = line.match(/`packages\/react\/src\/([^`]+)`/);
+    if (m) out.add(m[1].replace(/\.(tsx?|jsx?)$/, ''));
   }
   return out;
 }
@@ -71,7 +69,12 @@ const PATTERNS = {
 function walkFiles(rootDir, accept) {
   const out = [];
   if (!fs.existsSync(rootDir)) return out;
-  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+  // readdir order is filesystem-dependent; sort by code point so the
+  // walk (and everything derived from it) is identical on every host.
+  const entries = fs
+    .readdirSync(rootDir, { withFileTypes: true })
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  for (const entry of entries) {
     if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
     const full = path.join(rootDir, entry.name);
     if (entry.isDirectory()) {
@@ -100,11 +103,16 @@ function readSfcScript(src) {
   return src.slice(openEnd + 1, close);
 }
 
-function extractFromFile(absPath) {
+function extractFromFile(absPath, adapterRoot) {
   const src = fs.readFileSync(absPath, 'utf8');
   const body = absPath.endsWith('.vue') ? readSfcScript(src) : src;
+  // Key by adapter-relative path, not basename: both adapters hold
+  // several files with the same basename (`parts`, `index`, `types`),
+  // and a basename key would let all but one of them escape the gate.
   const componentName = path
-    .basename(absPath)
+    .relative(adapterRoot, absPath)
+    .split(path.sep)
+    .join('/')
     .replace(/\.(tsx?|vue|jsx?)$/, '');
 
   // Tag files that are pure core re-exports — they don't add surface
@@ -190,15 +198,22 @@ function diffSets(reactSet, vueSet) {
 
 function buildReport() {
   const reactFiles = walkFiles(REACT_ROOT, (n) => n.endsWith('.tsx') || n.endsWith('.ts'));
-  const vueFiles = walkFiles(VUE_ROOT, (n) => n.endsWith('.vue') || n.endsWith('.ts'));
+  // The Vue adapter ships .tsx files too (render-function components);
+  // leaving them out would hide their pairs from the gate entirely.
+  const vueFiles = walkFiles(
+    VUE_ROOT,
+    (n) => n.endsWith('.vue') || n.endsWith('.tsx') || n.endsWith('.ts')
+  );
   // Drop pure core re-exports, the surface lives in core, not in
   // the adapter, so they should not count as adapter-specific drift.
   // Also drop files documented as intentional render-path divergence
   // where Vue ships the same behaviour through the core package.
   const reactComponents = reactFiles
-    .map(extractFromFile)
+    .map((f) => extractFromFile(f, REACT_ROOT))
     .filter((f) => !f.isCoreReexport && !INTENTIONAL_RENDER_PATH.has(f.componentName));
-  const vueComponents = vueFiles.map(extractFromFile).filter((f) => !f.isCoreReexport);
+  const vueComponents = vueFiles
+    .map((f) => extractFromFile(f, VUE_ROOT))
+    .filter((f) => !f.isCoreReexport);
 
   const byName = new Map();
   for (const r of reactComponents) {
@@ -242,7 +257,9 @@ function buildReport() {
     }
     components.push(row);
   }
-  components.sort((a, b) => a.name.localeCompare(b.name));
+  // Code-point sort, not localeCompare: baseline output must not vary
+  // with the host's ICU locale.
+  components.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
   // Aggregate global category sets across the whole adapter.
   const aggregate = (xs, key) => {
@@ -368,7 +385,7 @@ function parityState(report) {
     reactOnlyComponents: names('react-only'),
     vueOnlyComponents: names('vue-only'),
     signatureDivergence: Object.fromEntries(
-      Object.entries(signatureDivergence).sort(([a], [b]) => a.localeCompare(b))
+      Object.entries(signatureDivergence).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     ),
     categoryDrift,
   };

--- a/scripts/check-feature-parity.mjs
+++ b/scripts/check-feature-parity.mjs
@@ -4,11 +4,21 @@
 // (commands, dialogs, sidebar kinds, plugin hooks, agent bridges) that
 // haven't crossed over to Vue yet.
 //
-// Designed to land alongside check-export-parity.mjs and
-// check-i18n-parity.mjs as a third parity tier — informational while
-// the Vue adapter is hardening, strict once the matrix flips.
+// This is a GATE, not just a report. The current drift state must match
+// scripts/feature-parity-baseline.json exactly, the same idiom as the
+// pinned lane DAG in packages/core/src/__tests__/core-lane-graph.test.ts:
 //
-// Run: node scripts/check-feature-parity.mjs
+// - New drift (a component, prop, emit, command, shortcut, sidebar kind
+//   or plugin hook that exists in one adapter but not the other, and is
+//   not in the baseline) fails with a diff.
+// - Drift that CLOSES also fails, with a prompt to tighten the baseline,
+//   so the pinned file never goes stale and the ratchet only moves down.
+//
+// To intentionally accept either kind of change, rerun with
+// --update-baseline and commit the rewritten baseline alongside the
+// adapter change that caused it.
+//
+// Run: node scripts/check-feature-parity.mjs [--update-baseline]
 // Output: structured Markdown report on stdout, JSON to
 //   openspec/changes/typed-ooxml-paragraph-editor/notes/feature-parity-report.json
 
@@ -23,6 +33,7 @@ const REPORT_PATH = path.join(
   ROOT,
   'openspec/changes/typed-ooxml-paragraph-editor/notes/feature-parity-report.json'
 );
+const BASELINE_PATH = path.join(ROOT, 'scripts/feature-parity-baseline.json');
 const RENDER_PATH_DIVERGENCE = path.join(
   ROOT,
   'openspec/changes/typed-ooxml-paragraph-editor/notes/intentional-render-path-divergence.md'
@@ -327,9 +338,139 @@ function formatMarkdown(report) {
   return out.join('\n');
 }
 
+// The deterministic slice of the report the baseline pins. Every list is
+// sorted and `generatedAt` is excluded, so two runs over the same tree
+// produce byte-identical state.
+function parityState(report) {
+  const names = (status) =>
+    report.components
+      .filter((r) => r.status === status)
+      .map((r) => r.name)
+      .sort();
+  const signatureDivergence = {};
+  for (const row of report.components) {
+    if (row.status !== 'signature-divergence') continue;
+    signatureDivergence[row.name] = {
+      propsAddedInReact: row.divergence.propsAddedInReact.map((p) => p.name).sort(),
+      propsAddedInVue: row.divergence.propsAddedInVue.map((p) => p.name).sort(),
+      emitsAddedInReact: [...row.divergence.emitsAddedInReact].sort(),
+      emitsAddedInVue: [...row.divergence.emitsAddedInVue].sort(),
+    };
+  }
+  const categoryDrift = {};
+  for (const cat of ['commands', 'shortcuts', 'sidebarKinds', 'pluginHooks']) {
+    categoryDrift[cat] = {
+      reactOnly: [...report[cat].reactOnly].sort(),
+      vueOnly: [...report[cat].vueOnly].sort(),
+    };
+  }
+  return {
+    reactOnlyComponents: names('react-only'),
+    vueOnlyComponents: names('vue-only'),
+    signatureDivergence: Object.fromEntries(
+      Object.entries(signatureDivergence).sort(([a], [b]) => a.localeCompare(b))
+    ),
+    categoryDrift,
+  };
+}
+
+// Compare two sorted string arrays. Entries only in `current` are new
+// drift (regressions); entries only in `baseline` are drift that closed
+// (the baseline is stale and must tighten).
+function diffList(label, baseline, current, regressions, improvements) {
+  const base = new Set(baseline);
+  const cur = new Set(current);
+  for (const x of current) if (!base.has(x)) regressions.push(`${label}: ${x}`);
+  for (const x of baseline) if (!cur.has(x)) improvements.push(`${label}: ${x}`);
+}
+
+function compareToBaseline(baseline, current) {
+  const regressions = [];
+  const improvements = [];
+  diffList(
+    'react-only component',
+    baseline.reactOnlyComponents ?? [],
+    current.reactOnlyComponents,
+    regressions,
+    improvements
+  );
+  diffList(
+    'vue-only component',
+    baseline.vueOnlyComponents ?? [],
+    current.vueOnlyComponents,
+    regressions,
+    improvements
+  );
+  const baseDiv = baseline.signatureDivergence ?? {};
+  const allDivergent = new Set([...Object.keys(baseDiv), ...Object.keys(current.signatureDivergence)]);
+  for (const name of [...allDivergent].sort()) {
+    const b = baseDiv[name];
+    const c = current.signatureDivergence[name];
+    if (!b) {
+      regressions.push(`signature divergence: ${name}`);
+      continue;
+    }
+    if (!c) {
+      improvements.push(`signature divergence: ${name}`);
+      continue;
+    }
+    for (const key of ['propsAddedInReact', 'propsAddedInVue', 'emitsAddedInReact', 'emitsAddedInVue']) {
+      diffList(`${name}.${key}`, b[key] ?? [], c[key], regressions, improvements);
+    }
+  }
+  for (const cat of ['commands', 'shortcuts', 'sidebarKinds', 'pluginHooks']) {
+    const b = (baseline.categoryDrift ?? {})[cat] ?? {};
+    const c = current.categoryDrift[cat];
+    diffList(`${cat} react-only`, b.reactOnly ?? [], c.reactOnly, regressions, improvements);
+    diffList(`${cat} vue-only`, b.vueOnly ?? [], c.vueOnly, regressions, improvements);
+  }
+  return { regressions, improvements };
+}
+
 const report = buildReport();
 process.stdout.write(formatMarkdown(report) + '\n');
 
 fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });
 fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2) + '\n');
 process.stderr.write(`\nJSON report written to ${path.relative(ROOT, REPORT_PATH)}\n`);
+
+const state = parityState(report);
+const baselineRel = path.relative(ROOT, BASELINE_PATH);
+
+if (process.argv.includes('--update-baseline')) {
+  fs.writeFileSync(BASELINE_PATH, JSON.stringify(state, null, 2) + '\n');
+  process.stderr.write(`Baseline written to ${baselineRel}\n`);
+  process.exit(0);
+}
+
+if (!fs.existsSync(BASELINE_PATH)) {
+  process.stderr.write(
+    `\nFeature parity gate FAILED: ${baselineRel} is missing.\n` +
+      `Generate it with: node scripts/check-feature-parity.mjs --update-baseline\n`
+  );
+  process.exit(1);
+}
+
+const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+const { regressions, improvements } = compareToBaseline(baseline, state);
+
+if (regressions.length) {
+  process.stderr.write(
+    `\nFeature parity gate FAILED: new React/Vue adapter drift not in ${baselineRel}:\n` +
+      regressions.map((r) => `  + ${r}`).join('\n') +
+      '\n\nClose the gap in the other adapter. If the drift is intentional,\n' +
+      'accept it with: node scripts/check-feature-parity.mjs --update-baseline\n' +
+      'and commit the rewritten baseline with an explanation.\n'
+  );
+}
+if (improvements.length) {
+  process.stderr.write(
+    `\nFeature parity gate FAILED: drift pinned in ${baselineRel} no longer exists:\n` +
+      improvements.map((r) => `  - ${r}`).join('\n') +
+      '\n\nThe parity gap narrowed — tighten the baseline so it cannot reopen:\n' +
+      'node scripts/check-feature-parity.mjs --update-baseline\n' +
+      'and commit the rewritten baseline.\n'
+  );
+}
+if (regressions.length || improvements.length) process.exit(1);
+process.stderr.write(`Feature parity gate passed: drift matches ${baselineRel}.\n`);

--- a/scripts/feature-parity-baseline.json
+++ b/scripts/feature-parity-baseline.json
@@ -1,83 +1,52 @@
 {
   "reactOnlyComponents": [
-    "AlignmentButtons",
-    "Button",
-    "ColorPicker",
-    "ColorSplit",
-    "ContentControlParts",
-    "DocxEditor",
-    "DocxEditorContentControl",
-    "DocxEditorContextMenu",
-    "DocxEditorEquation",
-    "DocxEditorHeaderFooter",
-    "DocxEditorHyperLink",
-    "DocxEditorMenu",
-    "DocxEditorNavigation",
-    "DocxEditorNotes",
-    "DocxEditorPageSetup",
-    "DocxEditorParagraphDialog",
-    "DocxEditorRulers",
-    "DocxEditorShell",
-    "DocxEditorToolbar",
-    "EditingMode",
-    "EditorToolbar",
-    "EditorToolbarContext",
-    "ErrorBoundary",
-    "ErrorManager",
-    "FontFamily",
-    "FontPicker",
-    "FontSizePicker",
-    "HorizontalRuler",
-    "IconGridDropdown",
-    "Icons",
-    "ImageAltText",
-    "ImageInsert",
-    "ImageProperties",
-    "ImageSelectionOverlay",
-    "ImageTransformDropdown",
-    "ImageWrap",
-    "ImageWrapDropdown",
-    "LineSpacing",
-    "LineSpacingPicker",
-    "ListButtons",
-    "MaterialSymbol",
-    "MenuDropdown",
-    "OutlineToggleButton",
-    "PageIndicator",
-    "PaginatedDocxEditor",
-    "PaginatedDocxEditorShell",
-    "ParagraphStyle",
-    "Select",
-    "StylePicker",
-    "Subscribable",
-    "TableBorderColorPicker",
-    "TableBorderPicker",
-    "TableBorderWidthPicker",
-    "TableCellFillPicker",
-    "TableControls",
-    "TableGridInline",
-    "TableMoreDropdown",
-    "TableToolbar",
-    "TitleBar",
-    "Tooltip",
-    "VerticalRuler",
-    "ZoomControl",
-    "constants",
-    "fontPickerValue",
-    "menu-flyouts",
-    "normalizeFontFamilies",
-    "operations",
-    "paragraph-dialog-host",
-    "steppers",
-    "table-chrome-shared",
-    "toolbarUtils",
-    "useFixedDropdown",
-    "useTableChrome",
-    "watermark"
+    "components/DocxEditor/OutlineToggleButton",
+    "components/DocxEditor/hooks/useDocxEditorRefApi",
+    "components/EditorToolbar",
+    "components/EditorToolbarContext",
+    "components/ErrorBoundary",
+    "components/reportIssue",
+    "components/sidebar/constants",
+    "components/toolbarUtils",
+    "components/ui/AlignmentButtons",
+    "components/ui/Button",
+    "components/ui/ColorPicker",
+    "components/ui/FontPicker",
+    "components/ui/FontSizePicker",
+    "components/ui/IconGridDropdown",
+    "components/ui/ImageTransformDropdown",
+    "components/ui/ImageWrapDropdown",
+    "components/ui/LineSpacingPicker",
+    "components/ui/ListButtons",
+    "components/ui/MaterialSymbol",
+    "components/ui/MenuDropdown",
+    "components/ui/Select",
+    "components/ui/StylePicker",
+    "components/ui/TableBorderColorPicker",
+    "components/ui/TableBorderPicker",
+    "components/ui/TableBorderWidthPicker",
+    "components/ui/TableCellFillPicker",
+    "components/ui/TableGridInline",
+    "components/ui/TableMoreDropdown",
+    "components/ui/TableToolbar",
+    "components/ui/TableToolbar/operations",
+    "components/ui/Tooltip",
+    "components/ui/ZoomControl",
+    "components/ui/fontPickerValue",
+    "components/ui/normalizeFontFamilies",
+    "hooks/useFixedDropdown",
+    "index",
+    "lib/watermark",
+    "managers/ErrorManager",
+    "managers/Subscribable",
+    "managers/types"
   ],
-  "vueOnlyComponents": [],
+  "vueOnlyComponents": [
+    "editor/images/index",
+    "types"
+  ],
   "signatureDivergence": {
-    "DocumentOutline": {
+    "components/DocumentOutline": {
       "propsAddedInReact": [
         "bottom",
         "display",
@@ -106,7 +75,156 @@
       ],
       "emitsAddedInVue": []
     },
-    "DocxEditorAuthorStyle": {
+    "components/DocxEditor/DocxEditorShell": {
+      "propsAddedInReact": [
+        "className",
+        "containerRef",
+        "containerStyle",
+        "dialogs",
+        "editable",
+        "editable",
+        "editorContainerStyle",
+        "editorContentRef",
+        "editorScrollLeft",
+        "expandedSidebarItem",
+        "fileInputs",
+        "headings",
+        "horizontalRulerProps",
+        "i18n",
+        "isDark",
+        "mainContentStyle",
+        "minLayoutWidth",
+        "onBottomMarginChange",
+        "onClose",
+        "onEditorBgMouseDown",
+        "onEditorContextMenu",
+        "onEditorError",
+        "onHeadingClick",
+        "onLeftMarginChange",
+        "onRightMarginChange",
+        "onScrollContainerMouseDown",
+        "onTabMarkRemove",
+        "onToggleOutline",
+        "onTopMarginChange",
+        "outlineProps",
+        "overlays",
+        "pageSetup",
+        "pageSetup",
+        "pagedArea",
+        "readOnlyProp",
+        "scrollContainerRef",
+        "scrollLeft",
+        "scrollPageInfo",
+        "showOutline",
+        "showOutlineButton",
+        "showRuler",
+        "sidebarOpen",
+        "tabMarks",
+        "toolbar",
+        "toolbarHeight",
+        "topOffset",
+        "trackedChanges",
+        "unit",
+        "unit",
+        "verticalRulerProps",
+        "zoom",
+        "zoom"
+      ],
+      "propsAddedInVue": [],
+      "emitsAddedInReact": [
+        "bottom-margin-change",
+        "close",
+        "editor-bg-mouse-down",
+        "editor-context-menu",
+        "editor-error",
+        "heading-click",
+        "left-margin-change",
+        "right-margin-change",
+        "scroll-container-mouse-down",
+        "tab-mark-remove",
+        "toggle-outline",
+        "top-margin-change"
+      ],
+      "emitsAddedInVue": []
+    },
+    "components/DocxEditor/PageIndicator": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props",
+        "role",
+        "style"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "components/PaginatedDocxEditorShell": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "className",
+        "colorMode",
+        "default",
+        "default",
+        "documentFontFamily",
+        "documentName",
+        "measurer",
+        "name",
+        "onError",
+        "onSave",
+        "onStateChange",
+        "onZoomChange",
+        "props",
+        "scale",
+        "source",
+        "type",
+        "type"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": [
+        "error",
+        "save",
+        "state-change",
+        "zoom-change"
+      ]
+    },
+    "components/TitleBar": {
+      "propsAddedInReact": [
+        "children",
+        "children",
+        "editable",
+        "onChange",
+        "placeholder",
+        "value"
+      ],
+      "propsAddedInVue": [],
+      "emitsAddedInReact": [
+        "change"
+      ],
+      "emitsAddedInVue": []
+    },
+    "components/ui/VerticalRuler": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "default",
+        "default",
+        "name",
+        "props",
+        "type",
+        "type"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "components/ui/icon-base": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/DocxEditorAuthorStyle": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "name"
@@ -114,7 +232,7 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "DocxEditorContent": {
+    "editor/DocxEditorContent": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "class",
@@ -126,7 +244,7 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "DocxEditorFontNotice": {
+    "editor/DocxEditorFontNotice": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "class",
@@ -137,7 +255,7 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "DocxEditorLoading": {
+    "editor/DocxEditorLoading": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "ariaHidden",
@@ -148,7 +266,7 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "DocxEditorOutline": {
+    "editor/DocxEditorOutline": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "name"
@@ -156,7 +274,7 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "DocxEditorPageNumber": {
+    "editor/DocxEditorPageNumber": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "name",
@@ -165,7 +283,37 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "DocxEditorRoot": {
+    "editor/DocxEditorPageSetup": {
+      "propsAddedInReact": [
+        "alignItems",
+        "backgroundColor",
+        "display",
+        "inset",
+        "justifyContent",
+        "position",
+        "zIndex"
+      ],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/DocxEditorParagraphDialog": {
+      "propsAddedInReact": [
+        "color",
+        "fontSize",
+        "marginRight"
+      ],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/DocxEditorRoot": {
       "propsAddedInReact": [
         "author",
         "children",
@@ -200,7 +348,7 @@
       ],
       "emitsAddedInVue": []
     },
-    "DocxEditorViewport": {
+    "editor/DocxEditorViewport": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "class",
@@ -211,7 +359,70 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "icon-base": {
+    "editor/images/ImageAltText": {
+      "propsAddedInReact": [
+        "children"
+      ],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/images/ImageInsert": {
+      "propsAddedInReact": [
+        "children",
+        "data",
+        "heightPoints",
+        "mime",
+        "type",
+        "widthPoints"
+      ],
+      "propsAddedInVue": [
+        "name"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/images/ImageSelectionOverlay": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "containerRef",
+        "portalRef",
+        "scrollPort"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/images/ImageWrap": {
+      "propsAddedInReact": [
+        "children"
+      ],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/menu/menu-flyouts": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "children",
+        "className",
+        "className",
+        "labelKey",
+        "labelKey",
+        "name",
+        "paths",
+        "paths",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/menu/parts": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "name",
@@ -220,7 +431,46 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "LocaleContext": {
+    "editor/navigation/DocxEditorNavigation": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "default",
+        "defaultOpen",
+        "defaultTab",
+        "name",
+        "onOpenChange",
+        "onTabChange",
+        "open",
+        "paneWidth",
+        "props",
+        "tab",
+        "type"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": [
+        "open-change",
+        "tab-change"
+      ]
+    },
+    "editor/navigation/parts": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props",
+        "value"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/toolbar/ColorSplit": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "className"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/toolbar/DocxEditorToolbar": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "name",
@@ -229,21 +479,48 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "parts": {
+    "editor/toolbar/EditingMode": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
-        "asChild",
-        "class",
-        "class",
-        "docxSlot",
-        "icon",
         "name",
         "props"
       ],
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "Slot": {
+    "editor/toolbar/FontFamily": {
+      "propsAddedInReact": [
+        "disabled",
+        "onClick",
+        "onMouseDown"
+      ],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [
+        "click",
+        "mouse-down"
+      ],
+      "emitsAddedInVue": []
+    },
+    "editor/toolbar/ParagraphStyle": {
+      "propsAddedInReact": [
+        "disabled",
+        "onClick",
+        "onMouseDown"
+      ],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [
+        "click",
+        "mouse-down"
+      ],
+      "emitsAddedInVue": []
+    },
+    "editor/toolbar/Slot": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "class",
@@ -253,7 +530,16 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "ToolbarAction": {
+    "editor/toolbar/TableControls": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/toolbar/ToolbarAction": {
       "propsAddedInReact": [
         "type"
       ],
@@ -267,7 +553,7 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "ToolbarButton": {
+    "editor/toolbar/ToolbarButton": {
       "propsAddedInReact": [
         "disabled",
         "onClick",
@@ -285,7 +571,7 @@
       ],
       "emitsAddedInVue": []
     },
-    "ToolbarOverflow": {
+    "editor/toolbar/ToolbarOverflow": {
       "propsAddedInReact": [
         "close"
       ],
@@ -293,33 +579,32 @@
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "types": {
+    "editor/toolbar/parts": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
-        "author",
-        "chrome",
+        "asChild",
         "class",
-        "colorMode",
-        "contextMenu",
-        "document",
-        "fonts",
-        "hyperlinkPopup",
-        "i18n",
-        "locale",
-        "menu",
-        "mode",
-        "modules",
-        "navigation",
-        "rulers",
-        "t",
-        "title",
-        "zoom",
-        "zoomMode"
+        "class",
+        "docxSlot",
+        "icon",
+        "name",
+        "props"
       ],
       "emitsAddedInReact": [],
       "emitsAddedInVue": []
     },
-    "useDocxEditorRoot": {
+    "editor/toolbar/useTableChrome": {
+      "propsAddedInReact": [
+        "editable",
+        "editingMode",
+        "editor",
+        "snapshot"
+      ],
+      "propsAddedInVue": [],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "editor/useDocxEditorRoot": {
       "propsAddedInReact": [],
       "propsAddedInVue": [
         "author",
@@ -351,6 +636,15 @@
         "font-error",
         "ready"
       ]
+    },
+    "i18n/LocaleContext": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
     }
   },
   "categoryDrift": {
@@ -371,11 +665,7 @@
     "sidebarKinds": {
       "reactOnly": [
         "auto",
-        "body",
-        "hex",
         "picture",
-        "row",
-        "separator",
         "text",
         "theme"
       ],

--- a/scripts/feature-parity-baseline.json
+++ b/scripts/feature-parity-baseline.json
@@ -1,0 +1,389 @@
+{
+  "reactOnlyComponents": [
+    "AlignmentButtons",
+    "Button",
+    "ColorPicker",
+    "ColorSplit",
+    "ContentControlParts",
+    "DocxEditor",
+    "DocxEditorContentControl",
+    "DocxEditorContextMenu",
+    "DocxEditorEquation",
+    "DocxEditorHeaderFooter",
+    "DocxEditorHyperLink",
+    "DocxEditorMenu",
+    "DocxEditorNavigation",
+    "DocxEditorNotes",
+    "DocxEditorPageSetup",
+    "DocxEditorParagraphDialog",
+    "DocxEditorRulers",
+    "DocxEditorShell",
+    "DocxEditorToolbar",
+    "EditingMode",
+    "EditorToolbar",
+    "EditorToolbarContext",
+    "ErrorBoundary",
+    "ErrorManager",
+    "FontFamily",
+    "FontPicker",
+    "FontSizePicker",
+    "HorizontalRuler",
+    "IconGridDropdown",
+    "Icons",
+    "ImageAltText",
+    "ImageInsert",
+    "ImageProperties",
+    "ImageSelectionOverlay",
+    "ImageTransformDropdown",
+    "ImageWrap",
+    "ImageWrapDropdown",
+    "LineSpacing",
+    "LineSpacingPicker",
+    "ListButtons",
+    "MaterialSymbol",
+    "MenuDropdown",
+    "OutlineToggleButton",
+    "PageIndicator",
+    "PaginatedDocxEditor",
+    "PaginatedDocxEditorShell",
+    "ParagraphStyle",
+    "Select",
+    "StylePicker",
+    "Subscribable",
+    "TableBorderColorPicker",
+    "TableBorderPicker",
+    "TableBorderWidthPicker",
+    "TableCellFillPicker",
+    "TableControls",
+    "TableGridInline",
+    "TableMoreDropdown",
+    "TableToolbar",
+    "TitleBar",
+    "Tooltip",
+    "VerticalRuler",
+    "ZoomControl",
+    "constants",
+    "fontPickerValue",
+    "menu-flyouts",
+    "normalizeFontFamilies",
+    "operations",
+    "paragraph-dialog-host",
+    "steppers",
+    "table-chrome-shared",
+    "toolbarUtils",
+    "useFixedDropdown",
+    "useTableChrome",
+    "watermark"
+  ],
+  "vueOnlyComponents": [],
+  "signatureDivergence": {
+    "DocumentOutline": {
+      "propsAddedInReact": [
+        "bottom",
+        "display",
+        "flexDirection",
+        "fontFamily",
+        "headings",
+        "left",
+        "leftOffset",
+        "onClose",
+        "onHeadingClick",
+        "overflow",
+        "paddingTop",
+        "position",
+        "scrollLeft",
+        "top",
+        "topOffset",
+        "transform",
+        "transition",
+        "width",
+        "zIndex"
+      ],
+      "propsAddedInVue": [],
+      "emitsAddedInReact": [
+        "close",
+        "heading-click"
+      ],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorAuthorStyle": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorContent": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "class",
+        "class",
+        "inheritAttrs",
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorFontNotice": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "class",
+        "name",
+        "props",
+        "role"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorLoading": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "ariaHidden",
+        "class",
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorOutline": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorPageNumber": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorRoot": {
+      "propsAddedInReact": [
+        "author",
+        "children",
+        "document",
+        "fonts",
+        "imageDecodePort",
+        "locale",
+        "mode",
+        "modules",
+        "onChange",
+        "onChange",
+        "onChange",
+        "onChange",
+        "onFontError",
+        "onFontError",
+        "onFontError",
+        "onFontError",
+        "onReady",
+        "onReady",
+        "onReady",
+        "onReady",
+        "tableInteractionLabel",
+        "translate",
+        "zoom",
+        "zoomMode"
+      ],
+      "propsAddedInVue": [],
+      "emitsAddedInReact": [
+        "change",
+        "font-error",
+        "ready"
+      ],
+      "emitsAddedInVue": []
+    },
+    "DocxEditorViewport": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "class",
+        "class",
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "icon-base": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "LocaleContext": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "parts": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "asChild",
+        "class",
+        "class",
+        "docxSlot",
+        "icon",
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "Slot": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "class",
+        "inheritAttrs",
+        "name"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "ToolbarAction": {
+      "propsAddedInReact": [
+        "type"
+      ],
+      "propsAddedInVue": [
+        "class",
+        "class",
+        "emits",
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "ToolbarButton": {
+      "propsAddedInReact": [
+        "disabled",
+        "onClick",
+        "onMouseDown"
+      ],
+      "propsAddedInVue": [
+        "class",
+        "class",
+        "name",
+        "props"
+      ],
+      "emitsAddedInReact": [
+        "click",
+        "mouse-down"
+      ],
+      "emitsAddedInVue": []
+    },
+    "ToolbarOverflow": {
+      "propsAddedInReact": [
+        "close"
+      ],
+      "propsAddedInVue": [],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "types": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "author",
+        "chrome",
+        "class",
+        "colorMode",
+        "contextMenu",
+        "document",
+        "fonts",
+        "hyperlinkPopup",
+        "i18n",
+        "locale",
+        "menu",
+        "mode",
+        "modules",
+        "navigation",
+        "rulers",
+        "t",
+        "title",
+        "zoom",
+        "zoomMode"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": []
+    },
+    "useDocxEditorRoot": {
+      "propsAddedInReact": [],
+      "propsAddedInVue": [
+        "author",
+        "change",
+        "children",
+        "document",
+        "editorRef",
+        "emit",
+        "fontError",
+        "fonts",
+        "imageDecodePort",
+        "locale",
+        "mode",
+        "modules",
+        "onChange",
+        "onFontError",
+        "onReady",
+        "props",
+        "ready",
+        "tableInteractionLabel",
+        "translate",
+        "translateResolver",
+        "zoom",
+        "zoomMode"
+      ],
+      "emitsAddedInReact": [],
+      "emitsAddedInVue": [
+        "change",
+        "font-error",
+        "ready"
+      ]
+    }
+  },
+  "categoryDrift": {
+    "commands": {
+      "reactOnly": [],
+      "vueOnly": []
+    },
+    "shortcuts": {
+      "reactOnly": [
+        "\"Ctrl+K\"",
+        "'Ctrl+E'",
+        "'Ctrl+J'",
+        "'Ctrl+L'",
+        "'Ctrl+R'"
+      ],
+      "vueOnly": []
+    },
+    "sidebarKinds": {
+      "reactOnly": [
+        "auto",
+        "body",
+        "hex",
+        "picture",
+        "row",
+        "separator",
+        "text",
+        "theme"
+      ],
+      "vueOnly": []
+    },
+    "pluginHooks": {
+      "reactOnly": [],
+      "vueOnly": []
+    }
+  }
+}


### PR DESCRIPTION
The \`check:feature-parity\` CI step always exited 0, so it read as a gate but measured nothing. The script now compares the current React/Vue adapter drift against a committed baseline (\`scripts/feature-parity-baseline.json\`) and fails on any mismatch: new drift fails with a diff, and drift that closes fails with a prompt to tighten the baseline. Update the baseline intentionally with \`node scripts/check-feature-parity.mjs --update-baseline\`.

Fixes #415

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790180310&installation_model_id=422592&pr_number=420&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F420&signature=bf0cbd51037cced0827259ca3ea982389cdf0c08c2672ef41009f4134dd875dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->