### PR TITLE
fix: make API snapshot member order deterministic

### DIFF
--- a/.changeset/api-snapshot-canonical-order.md
+++ b/.changeset/api-snapshot-canonical-order.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+API report snapshots now use a canonical member order, so `api:check` no longer fails across machines; no runtime changes.

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -70,11 +70,11 @@ export type AutomationContentControlValue = {
     readonly kind: 'listItem';
     readonly value: string;
 } | {
-    readonly kind: 'checkbox';
     readonly checked: boolean;
+    readonly kind: 'checkbox';
 } | {
-    readonly kind: 'date';
     readonly iso: string;
+    readonly kind: 'date';
 };
 
 // @public
@@ -219,14 +219,14 @@ export type AutomationOperation =
 */
 | {
     readonly op: 'getText';
-    readonly target: AutomationHandle;
     readonly projection?: AutomationTextProjection;
+    readonly target: AutomationHandle;
 }
 /** Text between two endpoints, with a carriage return at every paragraph mark crossed. */
 | {
     readonly op: 'getSpanText';
-    readonly span: AutomationSpanRef;
     readonly projection?: AutomationTextProjection;
+    readonly span: AutomationSpanRef;
 }
 /**
 * A paragraph's own identity as the DOCUMENT writes it (`w14:paraId`).
@@ -247,9 +247,9 @@ export type AutomationOperation =
 */
 | {
     readonly op: 'search';
+    readonly options?: AutomationSearchOptions;
     readonly scope: AutomationSpanRef;
     readonly text: string;
-    readonly options?: AutomationSearchOptions;
 }
 /**
 * Insert text at a position. Answers the span the inserted text occupies.
@@ -295,19 +295,19 @@ export type AutomationOperation =
 * Resolved after the commit, because the paragraph it names does not exist until then.
 */
 | {
-    readonly op: 'insertParagraph';
     readonly anchor: AutomationParagraphRef;
-    readonly where: 'before' | 'after';
+    readonly op: 'insertParagraph';
     readonly text: string;
+    readonly where: 'before' | 'after';
 }
 /**
 * Split a paragraph at every occurrence of any delimiter. Answers a span per resulting
 * paragraph, in reading order, including the one that keeps the original identity.
 */
 | {
+    readonly delimiters: readonly string[];
     readonly op: 'splitParagraph';
     readonly paragraph: AutomationHandle;
-    readonly delimiters: readonly string[];
     readonly trimDelimiters?: boolean;
     readonly trimSpacing?: boolean;
 }
@@ -352,9 +352,9 @@ export type AutomationOperation =
 * read back — and would turn a caller's string into a new part.
 */
 | {
+    readonly name: string;
     readonly op: 'setStyle';
     readonly span: AutomationSpanRef;
-    readonly name: string;
 }
 /** One paragraph's own paragraph properties, in points. */
 | {
@@ -381,8 +381,8 @@ export type AutomationOperation =
 * is which.
 */
 | {
-    readonly op: 'getSections';
     readonly document: AutomationHandle;
+    readonly op: 'getSections';
 }
 /** One section's page geometry, in points. */
 | {
@@ -427,8 +427,8 @@ export type AutomationOperation =
 }
 /** One note's story, as a BODY. Two notes in one part are two stories. */
 | {
-    readonly op: 'getNoteBody';
     readonly note: AutomationHandle;
+    readonly op: 'getNoteBody';
 }
 /**
 * One note's story as plain text.
@@ -469,8 +469,8 @@ export type AutomationOperation =
 }
 /** A list's `w:numId`, as the number the file states. */
 | {
-    readonly op: 'getListId';
     readonly list: AutomationHandle;
+    readonly op: 'getListId';
 }
 /**
 * One story's list by the `w:numId` its paragraphs share, refused where none does.
@@ -490,9 +490,9 @@ export type AutomationOperation =
 * error: a list is free to skip a level.
 */
 | {
-    readonly op: 'getListParagraphs';
-    readonly list: AutomationHandle;
     readonly level?: number;
+    readonly list: AutomationHandle;
+    readonly op: 'getListParagraphs';
 }
 /**
 * The list a paragraph is in.
@@ -586,8 +586,8 @@ export type AutomationOperation =
 * that held them, and a stale range would point a caller at whatever moved into their place.
 */
 | {
-    readonly op: 'getBookmarkRange';
     readonly bookmark: AutomationHandle;
+    readonly op: 'getBookmarkRange';
 }
 /**
 * The comments anchored in a scope, in document order — the TOP-LEVEL ones.
@@ -601,23 +601,23 @@ export type AutomationOperation =
 }
 /** Replies to one comment, in document order. */
 | {
-    readonly op: 'getCommentReplies';
     readonly comment: AutomationHandle;
+    readonly op: 'getCommentReplies';
 }
 /** The `w:id` the comments part holds a comment under. */
 | {
-    readonly op: 'getCommentId';
     readonly comment: AutomationHandle;
+    readonly op: 'getCommentId';
 }
 /** Who wrote a comment. `CT_TrackChange` requires it, so a comment always has one. */
 | {
-    readonly op: 'getCommentAuthor';
     readonly comment: AutomationHandle;
+    readonly op: 'getCommentAuthor';
 }
 /** `@w:date` verbatim, or empty where the file wrote none. Never invented. */
 | {
-    readonly op: 'getCommentDate';
     readonly comment: AutomationHandle;
+    readonly op: 'getCommentDate';
 }
 /** A comment's body as plain text. */
 | {
@@ -739,17 +739,17 @@ export type AutomationOperation =
 * all-decision scoped to that exact canonical note root. Both forms agree for the main story.
 */
 | {
-    readonly op: 'acceptAllRevisions';
     readonly body: AutomationHandle;
-} | {
     readonly op: 'acceptAllRevisions';
-    readonly document: AutomationHandle;
 } | {
-    readonly op: 'rejectAllRevisions';
+    readonly document: AutomationHandle;
+    readonly op: 'acceptAllRevisions';
+} | {
     readonly body: AutomationHandle;
-} | {
     readonly op: 'rejectAllRevisions';
+} | {
     readonly document: AutomationHandle;
+    readonly op: 'rejectAllRevisions';
 }
 /**
 * Put the reader's selection on a span. Requires the `selection` capability, so a headless
@@ -767,9 +767,9 @@ export type AutomationOperation =
 * obtain an addressable range. Requires the `selection` capability, like `selectSpan`.
 */
 | {
-    readonly op: 'selectBookmark';
     readonly bookmark: AutomationHandle;
     readonly mode: AutomationSelectionMode;
+    readonly op: 'selectBookmark';
 }
 /**
 * The content controls a scope holds, outermost first and in document order.
@@ -813,8 +813,8 @@ export type AutomationOperation =
 }
 /** `w:alias` — what Word's UI calls the title. Empty where absent. */
 | {
-    readonly op: 'getContentControlTitle';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlTitle';
 }
 /**
 * `w:id` as a STRING, and empty where the file wrote none.
@@ -824,8 +824,8 @@ export type AutomationOperation =
 * not an identity however it is spelled.
 */
 | {
-    readonly op: 'getContentControlFileId';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlFileId';
 }
 /** The control's type: `richText`, `plainText`, `dropDownList`, `comboBox`, `date`, … */
 | {
@@ -865,8 +865,8 @@ export type AutomationOperation =
 }
 /** The paragraphs the control holds, in reading order. Empty for an inline control's own. */
 | {
-    readonly op: 'getContentControlParagraphs';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlParagraphs';
 }
 /**
 * The span the control's content covers, so a caller can read or format it.
@@ -901,9 +901,9 @@ export type AutomationOperation =
 }
 /** Remove the control. `keepContent` is Word's own "Remove content control". */
 | {
-    readonly op: 'deleteContentControl';
     readonly contentControl: AutomationHandle;
     readonly keepContent: boolean;
+    readonly op: 'deleteContentControl';
 }
 /**
 * Put text into the control, at `replace` (its value) or at one edge of its content.
@@ -913,10 +913,10 @@ export type AutomationOperation =
 * write would be two refusals instead of one.
 */
 | {
-    readonly op: 'insertContentControlText';
-    readonly contentControl: AutomationHandle;
-    readonly text: string;
     readonly at: 'replace' | 'start' | 'end';
+    readonly contentControl: AutomationHandle;
+    readonly op: 'insertContentControlText';
+    readonly text: string;
 }
 /** Wrap a span in a new control of the named type. */
 | {
@@ -943,14 +943,14 @@ export type AutomationOperation =
 * both would be an insertion the caller thinks is a wrap.
 */
 | {
-    readonly op: 'insertCustomNode';
     readonly at?: AutomationPoint;
+    readonly lock?: AutomationContentControlLock;
+    readonly op: 'insertCustomNode';
+    readonly payload?: AutomationCustomNodePayload;
     readonly span?: AutomationSpanRef;
     readonly tag: string;
     readonly text: string;
     readonly title?: string;
-    readonly lock?: AutomationContentControlLock;
-    readonly payload?: AutomationCustomNodePayload;
 };
 
 // @public
@@ -961,8 +961,8 @@ export type AutomationOperationResult = {
     readonly status: 'ok';
     readonly value: AutomationValue;
 } | {
-    readonly status: 'error';
     readonly error: AutomationError;
+    readonly status: 'error';
 } | {
     readonly status: 'skipped';
 };
@@ -1062,26 +1062,26 @@ export interface AutomationParagraphFormatWrite {
 export type AutomationParagraphRef = {
     readonly paragraph: AutomationHandle;
 } | {
-    readonly body: AutomationHandle;
     readonly at: 'first' | 'last';
+    readonly body: AutomationHandle;
 };
 
 // @public
 export type AutomationPoint = AutomationEndpoint | {
+    readonly at: 'start' | 'end';
     readonly paragraph: AutomationHandle;
-    readonly at: 'start' | 'end';
 } | {
-    readonly body: AutomationHandle;
     readonly at: 'start' | 'end';
+    readonly body: AutomationHandle;
 };
 
 // @public
 export type AutomationSaveResult = {
-    readonly ok: true;
     readonly bytes: Uint8Array;
+    readonly ok: true;
 } | {
-    readonly ok: false;
     readonly error: AutomationError;
+    readonly ok: false;
 };
 
 // @public
@@ -1110,8 +1110,8 @@ export interface AutomationSpan {
 
 // @public
 export type AutomationSpanRef = {
-    readonly start: AutomationPoint;
     readonly end: AutomationPoint;
+    readonly start: AutomationPoint;
 } | {
     readonly paragraph: AutomationHandle;
 } | {
@@ -1127,8 +1127,8 @@ export type AutomationStoryId = {
     readonly variant: HeaderFooterVariant;
 } | {
     readonly kind: 'note';
-    readonly noteKind: NoteKind;
     readonly noteId: number;
+    readonly noteKind: NoteKind;
 };
 
 // @public
@@ -1139,11 +1139,11 @@ export type AutomationUnsubscribe = () => void;
 
 // @public
 export type AutomationValue = {
-    readonly kind: 'handle';
     readonly handle: AutomationHandle;
+    readonly kind: 'handle';
 } | {
-    readonly kind: 'handles';
     readonly handles: readonly AutomationHandle[];
+    readonly kind: 'handles';
 } | {
     readonly kind: 'text';
     readonly text: string;
@@ -1162,11 +1162,11 @@ export type AutomationValue = {
 * declared before it can be sent. A record keyed by strings would let a host answer anything.
 */
 | {
-    readonly kind: 'font';
     readonly font: AutomationFontRead;
+    readonly kind: 'font';
 } | {
-    readonly kind: 'paragraphFormat';
     readonly format: AutomationParagraphFormatRead;
+    readonly kind: 'paragraphFormat';
 }
 /** One section's page geometry, in points. */
 | {
@@ -1226,12 +1226,12 @@ export type ServerAutomationHostRejection = OoxmlPackageRejection | 'no-main-doc
 
 // @public
 export type ServerAutomationHostResult = {
-    readonly ok: true;
     readonly host: AutomationHost;
+    readonly ok: true;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: ServerAutomationHostRejection;
-    readonly detail?: string;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -192,8 +192,8 @@ export type AutomationOperation =
 }
 /** The main story of a document. */
 | {
-    readonly op: 'getBody';
     readonly document: AutomationHandle;
+    readonly op: 'getBody';
 }
 /**
 * A story's paragraphs, in reading order.
@@ -203,8 +203,8 @@ export type AutomationOperation =
 * Word's own paragraph collection contains them. A story with no paragraphs answers none.
 */
 | {
-    readonly op: 'getParagraphs';
     readonly body: AutomationHandle;
+    readonly op: 'getParagraphs';
 }
 /** The paragraphs a span covers, in reading order. */
 | {
@@ -261,8 +261,8 @@ export type AutomationOperation =
 * order-independent.
 */
 | {
-    readonly op: 'insertText';
     readonly at: AutomationPoint;
+    readonly op: 'insertText';
     readonly text: string;
 }
 /**
@@ -285,8 +285,8 @@ export type AutomationOperation =
 * section marks, comments, and revisions. A body's final page-level section properties survive.
 */
 | {
-    readonly op: 'replaceStoryBlocks';
     readonly body: AutomationHandle;
+    readonly op: 'replaceStoryBlocks';
     readonly paragraphs: readonly string[];
 }
 /**
@@ -330,9 +330,9 @@ export type AutomationOperation =
 * so sizing a bulleted paragraph without it leaves the bullet at the old size.
 */
 | {
+    readonly font: AutomationFontWrite;
     readonly op: 'setFont';
     readonly span: AutomationSpanRef;
-    readonly font: AutomationFontWrite;
 }
 /**
 * The paragraph style NAME every paragraph a span covers agrees on.
@@ -363,9 +363,9 @@ export type AutomationOperation =
 }
 /** Author paragraph properties. Only the fields present are written. */
 | {
+    readonly format: AutomationParagraphFormatWrite;
     readonly op: 'setParagraphFormat';
     readonly paragraph: AutomationParagraphRef;
-    readonly format: AutomationParagraphFormatWrite;
 }
 /** Remove a paragraph and everything in it. */
 | {
@@ -409,9 +409,9 @@ export type AutomationOperation =
 * document did not have.
 */
 | {
+    readonly kind: 'header' | 'footer';
     readonly op: 'getFurniture';
     readonly section: AutomationHandle;
-    readonly kind: 'header' | 'footer';
     readonly variant: HeaderFooterVariant;
 }
 /**
@@ -421,9 +421,9 @@ export type AutomationOperation =
 * caller can reach: reporting them would say the document has two more footnotes than it has.
 */
 | {
-    readonly op: 'getNotes';
     readonly document: AutomationHandle;
     readonly noteKind: NoteKind;
+    readonly op: 'getNotes';
 }
 /** One note's story, as a BODY. Two notes in one part are two stories. */
 | {
@@ -437,14 +437,14 @@ export type AutomationOperation =
 * without requiring that intermediate handle: paragraphs joined by one `\r` paragraph mark.
 */
 | {
-    readonly op: 'getNoteText';
     readonly note: AutomationHandle;
+    readonly op: 'getNoteText';
     readonly projection?: AutomationTextProjection;
 }
 /** Whether a note is a footnote or an endnote. */
 | {
-    readonly op: 'getNoteKind';
     readonly note: AutomationHandle;
+    readonly op: 'getNoteKind';
 }
 /**
 * Delete a note: its body in the notes part and every reference that reached it.
@@ -453,8 +453,8 @@ export type AutomationOperation =
 * `AUTOMATION_SOLITARY_OPERATIONS`.
 */
 | {
-    readonly op: 'deleteNote';
     readonly note: AutomationHandle;
+    readonly op: 'deleteNote';
 }
 /**
 * Every list one story holds, in the order its numbers first appear.
@@ -464,8 +464,8 @@ export type AutomationOperation =
 * still two lists, because the paragraphs are not in the same story.
 */
 | {
-    readonly op: 'getLists';
     readonly body: AutomationHandle;
+    readonly op: 'getLists';
 }
 /** A list's `w:numId`, as the number the file states. */
 | {
@@ -479,9 +479,9 @@ export type AutomationOperation =
 * numbering DEFINITION, and a list handle for it would answer no paragraphs forever.
 */
 | {
-    readonly op: 'getListById';
     readonly body: AutomationHandle;
     readonly id: number;
+    readonly op: 'getListById';
 }
 /**
 * A list's paragraphs in reading order, or only the ones at one level.
@@ -517,9 +517,9 @@ export type AutomationOperation =
 * outside 0-8 is refused rather than clamped: nothing defines a format there.
 */
 | {
+    readonly level: number;
     readonly op: 'setListLevel';
     readonly paragraph: AutomationHandle;
-    readonly level: number;
 }
 /**
 * Add a paragraph to a list, at one of its edges. Answers the NEW paragraph.
@@ -529,10 +529,10 @@ export type AutomationOperation =
 * end of one and Enter is pressed.
 */
 | {
-    readonly op: 'insertListParagraph';
     readonly list: AutomationHandle;
-    readonly where: 'start' | 'end';
+    readonly op: 'insertListParagraph';
     readonly text: string;
+    readonly where: 'start' | 'end';
 }
 /**
 * Where a span points: an absolute URL, `#anchor`, or empty for text in no link.
@@ -576,8 +576,8 @@ export type AutomationOperation =
 }
 /** The name a bookmark is declared with. */
 | {
-    readonly op: 'getBookmarkName';
     readonly bookmark: AutomationHandle;
+    readonly op: 'getBookmarkName';
 }
 /**
 * The range a bookmark's two markers enclose.
@@ -621,18 +621,18 @@ export type AutomationOperation =
 }
 /** A comment's body as plain text. */
 | {
-    readonly op: 'getCommentText';
     readonly comment: AutomationHandle;
+    readonly op: 'getCommentText';
 }
 /** The words a comment is about. Refused for a comment the file gave no usable range. */
 | {
-    readonly op: 'getCommentRange';
     readonly comment: AutomationHandle;
+    readonly op: 'getCommentRange';
 }
 /** Whether the thread is resolved (`w15:commentEx/@w15:done`). */
 | {
-    readonly op: 'getCommentResolved';
     readonly comment: AutomationHandle;
+    readonly op: 'getCommentResolved';
 }
 /**
 * Create a top-level comment anchored to a span.
@@ -644,11 +644,11 @@ export type AutomationOperation =
 * Answers the NEW comment whose id is minted inside the package transaction.
 */
 | {
+    readonly author: string;
+    readonly date?: string;
     readonly op: 'insertComment';
     readonly span: AutomationSpanRef;
     readonly text: string;
-    readonly author: string;
-    readonly date?: string;
 }
 /**
 * Resolve a comment thread, or reopen it.
@@ -657,8 +657,8 @@ export type AutomationOperation =
 * the parent alone would leave a reply reading as open under a closed remark.
 */
 | {
-    readonly op: 'setCommentResolved';
     readonly comment: AutomationHandle;
+    readonly op: 'setCommentResolved';
     readonly resolved: boolean;
 }
 /**
@@ -672,11 +672,11 @@ export type AutomationOperation =
 * another writer may have changed in between.
 */
 | {
-    readonly op: 'replyToComment';
-    readonly comment: AutomationHandle;
-    readonly text: string;
     readonly author: string;
+    readonly comment: AutomationHandle;
     readonly date?: string;
+    readonly op: 'replyToComment';
+    readonly text: string;
 }
 /**
 * Delete one comment object.
@@ -686,8 +686,8 @@ export type AutomationOperation =
 * one package transaction and one undo unit, but they cannot share a batch with any other write.
 */
 | {
-    readonly op: 'deleteComment';
     readonly comment: AutomationHandle;
+    readonly op: 'deleteComment';
 }
 /**
 * The tracked changes of a story, in document order.
@@ -697,8 +697,8 @@ export type AutomationOperation =
 * such as a complete tracked row.
 */
 | {
-    readonly op: 'getRevisions';
     readonly body: AutomationHandle;
+    readonly op: 'getRevisions';
 }
 /** Word's name for the kind of change: `Insert`, `Delete`, `Replace`, `Property`, … */
 | {
@@ -756,9 +756,9 @@ export type AutomationOperation =
 * host refuses it rather than pretending to have a caret.
 */
 | {
+    readonly mode: AutomationSelectionMode;
     readonly op: 'selectSpan';
     readonly span: AutomationSpanRef;
-    readonly mode: AutomationSelectionMode;
 }
 /**
 * Put the reader's selection on the range a bookmark currently encloses.
@@ -790,9 +790,9 @@ export type AutomationOperation =
 * choosing document order is the choice a caller can predict.
 */
 | {
+    readonly id: number;
     readonly op: 'getContentControlById';
     readonly scope: AutomationContentControlScope;
-    readonly id: number;
 }
 /** Every control in a scope carrying a tag, in document order. */
 | {
@@ -808,8 +808,8 @@ export type AutomationOperation =
 }
 /** `w:tag`, or empty where the file wrote none. Never invented. */
 | {
-    readonly op: 'getContentControlTag';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlTag';
 }
 /** `w:alias` — what Word's UI calls the title. Empty where absent. */
 | {
@@ -829,13 +829,13 @@ export type AutomationOperation =
 }
 /** The control's type: `richText`, `plainText`, `dropDownList`, `comboBox`, `date`, … */
 | {
-    readonly op: 'getContentControlSubtype';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlSubtype';
 }
 /** The `ST_Lock` in force, INCLUDING what an enclosing control imposes. */
 | {
-    readonly op: 'getContentControlLock';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlLock';
 }
 /**
 * Whether the control declares `w:dataBinding`.
@@ -844,23 +844,23 @@ export type AutomationOperation =
 * protocol boundary, and the binding target is never resolved or fetched.
 */
 | {
-    readonly op: 'getContentControlIsBound';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlIsBound';
 }
 /** Whether the control is showing its placeholder rather than a value (`w:showingPlcHdr`). */
 | {
-    readonly op: 'getContentControlPlaceholderShown';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlPlaceholderShown';
 }
 /** Whether the control removes itself on the first edit (`w:temporary`). */
 | {
-    readonly op: 'getContentControlTemporary';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlTemporary';
 }
 /** The text the control encloses, as the document reads it. */
 | {
-    readonly op: 'getContentControlText';
     readonly contentControl: AutomationHandle;
+    readonly op: 'getContentControlText';
     readonly projection?: AutomationTextProjection;
 }
 /** The paragraphs the control holds, in reading order. Empty for an inline control's own. */
@@ -875,9 +875,9 @@ export type AutomationOperation =
 * answer those same edges because a control's boundary marks occupy no offset here.
 */
 | {
-    readonly op: 'getContentControlRange';
     readonly contentControl: AutomationHandle;
     readonly location?: AutomationContentControlRangeLocation;
+    readonly op: 'getContentControlRange';
 }
 /**
 * Write the control's value in the vocabulary its own type accepts.
@@ -887,17 +887,17 @@ export type AutomationOperation =
 * same reasons or a form is only as protected as the path a caller happened to take.
 */
 | {
-    readonly op: 'setContentControlValue';
     readonly contentControl: AutomationHandle;
+    readonly op: 'setContentControlValue';
     readonly value: AutomationContentControlValue;
 }
 /** Author tag, title or lock. An omitted member is left as it is; `null` removes it. */
 | {
-    readonly op: 'setContentControlProperties';
     readonly contentControl: AutomationHandle;
+    readonly lock?: AutomationContentControlLock;
+    readonly op: 'setContentControlProperties';
     readonly tag?: string | null;
     readonly title?: string | null;
-    readonly lock?: AutomationContentControlLock;
 }
 /** Remove the control. `keepContent` is Word's own "Remove content control". */
 | {

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -31,9 +31,9 @@ export type MapResult = {
     readonly ok: true;
     readonly ops: readonly TreeDocOp[];
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: TreeBindingRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -47,9 +47,9 @@ export type OpenTreeSessionResult = {
     readonly ok: true;
     readonly session: TreeDocxSession;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: TreeSessionRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -66,9 +66,9 @@ export const PROJECTION_ORIGIN: "dev.docx-editor.core.origin.projection";
 
 // @public
 export function reconcileDoc(previousDoc: Node_2, part: OoxmlPart, change: {
-    readonly dirty: readonly string[];
     readonly created: readonly string[];
     readonly deleted: readonly string[];
+    readonly dirty: readonly string[];
     readonly splitJoin: readonly unknown[];
 } | null): Node_2;
 
@@ -164,17 +164,17 @@ export interface TreeDocxSessionView {
     // (undocumented)
     redo(): SelectionMark | null;
     relationshipTarget(relationshipId: string, scope?: StoryScope): {
-        readonly target: string;
         readonly external: boolean;
+        readonly target: string;
     } | null;
     removeCustomNode(controlNodeId: string, scope?: StoryScope): CustomNodeWriteResult;
     rendersText(): boolean;
     replaceImage(scope: StoryScope, drawingNodeId: string, bytes: Uint8Array, mime: SupportedImageMime, decodePort: ImageDecodePort, options: ReplaceImageOptions): Promise<ImageIntentResult>;
     replyToComment(parentCommentId: string | null, anchor: {
-        paragraphId: string;
-        start: number;
         end: number;
         endParagraphId?: string;
+        paragraphId: string;
+        start: number;
     }, text: string, author: string,
     date?: string, scope?: StoryScope): string | null;
     reviewItems(): readonly ReviewItem[];

--- a/docs/api/docx-editor-core/contracts-document.api.md
+++ b/docs/api/docx-editor-core/contracts-document.api.md
@@ -20,9 +20,9 @@ export type ColorValue = {
     readonly value: string;
 } | {
     readonly kind: 'theme';
+    readonly shade?: number;
     readonly slot: string;
     readonly tint?: number;
-    readonly shade?: number;
 } | {
     readonly kind: 'auto';
 };
@@ -34,8 +34,8 @@ export type ContainerRef = {
     part: 'header' | 'footer';
     rId: string;
 } | {
-    part: 'footnote' | 'endnote';
     noteId: number;
+    part: 'footnote' | 'endnote';
 };
 
 // @public
@@ -135,28 +135,28 @@ export interface DocEdits {
     // (undocumented)
     acceptRevision: {
         id: number;
-        part?: 'body' | 'footnote' | 'endnote';
         noteId?: number;
+        part?: 'body' | 'footnote' | 'endnote';
     };
     // (undocumented)
     addComment: {
+        author: string;
         target: DocTarget;
         text: string;
-        author: string;
     };
     // (undocumented)
     addRepeatingSectionItem: {
-        target: DocTarget;
         index?: number;
+        target: DocTarget;
     };
     adjustIndent: {
-        target: DocTarget;
         direction: 'increase' | 'decrease';
+        target: DocTarget;
     };
     // (undocumented)
     applyFormatting: {
-        target: DocTarget;
         marks: RunFormatting;
+        target: DocTarget;
     };
     // (undocumented)
     applyVariables: {
@@ -168,32 +168,32 @@ export interface DocEdits {
     };
     // (undocumented)
     insertBreak: {
-        target: DocTarget;
         kind: 'page' | 'column' | 'line' | 'section';
+        target: DocTarget;
     };
     insertContentControl: {
-        target: DocTarget;
         subtype: InsertableContentControlType;
         tag?: string;
+        target: DocTarget;
         title?: string;
     };
     // (undocumented)
     insertHyperlink: {
-        target: DocTarget;
         href: string;
+        target: DocTarget;
         text?: string;
     };
     // (undocumented)
     insertImage: {
-        target: DocTarget;
         data: Uint8Array;
         extent?: Extent;
+        target: DocTarget;
     };
     // (undocumented)
     insertTable: {
-        target: DocTarget;
-        rows: number;
         cols: number;
+        rows: number;
+        target: DocTarget;
     };
     // (undocumented)
     insertText: {
@@ -206,27 +206,27 @@ export interface DocEdits {
     };
     // (undocumented)
     proposeDeletion: {
-        target: DocTarget;
         author: string;
+        target: DocTarget;
     };
     // (undocumented)
     proposeInsertion: {
+        author: string;
         target: DocTarget;
         text: string;
-        author: string;
     };
     proposeReplacement: {
-        target: DocTarget;
-        replaceWith: string;
         author: string;
+        replaceWith: string;
+        target: DocTarget;
     };
     // (undocumented)
     rejectAllRevisions: Record<never, never>;
     // (undocumented)
     rejectRevision: {
         id: number;
-        part?: 'body' | 'footnote' | 'endnote';
         noteId?: number;
+        part?: 'body' | 'footnote' | 'endnote';
     };
     // (undocumented)
     removeContentControl: {
@@ -238,8 +238,8 @@ export interface DocEdits {
     };
     // (undocumented)
     removeRepeatingSectionItem: {
-        target: DocTarget;
         index: number;
+        target: DocTarget;
     };
     // (undocumented)
     replaceText: {
@@ -248,9 +248,9 @@ export interface DocEdits {
     };
     // (undocumented)
     replyComment: {
+        author: string;
         commentId: string;
         text: string;
-        author: string;
     };
     // (undocumented)
     resolveComment: {
@@ -263,8 +263,8 @@ export interface DocEdits {
     };
     // (undocumented)
     setParagraphStyle: {
-        target: DocTarget;
         styleId: string;
+        target: DocTarget;
     };
     // (undocumented)
     setVariable: {
@@ -276,8 +276,8 @@ export interface DocEdits {
         target: DocTarget;
     };
     toggleList: {
-        target: DocTarget;
         kind: 'bullet' | 'ordered';
+        target: DocTarget;
     };
 }
 
@@ -302,8 +302,8 @@ export interface DocQueries {
     };
     // (undocumented)
     findText: {
-        text: string;
         container?: ContainerRef;
+        text: string;
     };
     // (undocumented)
     paragraphs: {
@@ -381,11 +381,11 @@ export type ExecErrorCode = 'notFound' | 'ambiguous' | 'locked' | 'bound' | 'typ
 
 // @public
 export type ExecResult = {
-    ok: true;
     changed: boolean;
+    ok: true;
 } | {
-    ok: false;
     code: ExecErrorCode;
+    ok: false;
     reason: string;
     target?: DocTarget;
 };
@@ -413,9 +413,9 @@ export interface IndentFormatting {
     readonly firstLine: number;
     readonly left: number;
     readonly mixed: {
+        readonly firstLine: boolean;
         readonly left: boolean;
         readonly right: boolean;
-        readonly firstLine: boolean;
     };
     readonly right: number;
 }
@@ -550,8 +550,8 @@ export interface SectionProperties {
     readonly margins: PageMargins;
     // (undocumented)
     readonly pageSize: {
-        widthTwips: number;
         heightTwips: number;
+        widthTwips: number;
     };
     readonly titlePage?: boolean;
 }

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -23,8 +23,8 @@ export type Block = Paragraph | Table | ContentControl;
 export type CanResult = {
     ok: true;
 } | {
-    ok: false;
     code: ExecErrorCode;
+    ok: false;
     reason: string;
 };
 
@@ -34,9 +34,9 @@ export type ColorValue = {
     readonly value: string;
 } | {
     readonly kind: 'theme';
+    readonly shade?: number;
     readonly slot: string;
     readonly tint?: number;
-    readonly shade?: number;
 } | {
     readonly kind: 'auto';
 };
@@ -63,8 +63,8 @@ export type ContainerRef = {
     part: 'header' | 'footer';
     rId: string;
 } | {
-    part: 'footnote' | 'endnote';
     noteId: number;
+    part: 'footnote' | 'endnote';
 };
 
 // @public
@@ -157,28 +157,28 @@ export interface DocEdits {
     // (undocumented)
     acceptRevision: {
         id: number;
-        part?: 'body' | 'footnote' | 'endnote';
         noteId?: number;
+        part?: 'body' | 'footnote' | 'endnote';
     };
     // (undocumented)
     addComment: {
+        author: string;
         target: DocTarget;
         text: string;
-        author: string;
     };
     // (undocumented)
     addRepeatingSectionItem: {
-        target: DocTarget;
         index?: number;
+        target: DocTarget;
     };
     adjustIndent: {
-        target: DocTarget;
         direction: 'increase' | 'decrease';
+        target: DocTarget;
     };
     // (undocumented)
     applyFormatting: {
-        target: DocTarget;
         marks: RunFormatting;
+        target: DocTarget;
     };
     // (undocumented)
     applyVariables: {
@@ -190,32 +190,32 @@ export interface DocEdits {
     };
     // (undocumented)
     insertBreak: {
-        target: DocTarget;
         kind: 'page' | 'column' | 'line' | 'section';
+        target: DocTarget;
     };
     insertContentControl: {
-        target: DocTarget;
         subtype: InsertableContentControlType;
         tag?: string;
+        target: DocTarget;
         title?: string;
     };
     // (undocumented)
     insertHyperlink: {
-        target: DocTarget;
         href: string;
+        target: DocTarget;
         text?: string;
     };
     // (undocumented)
     insertImage: {
-        target: DocTarget;
         data: Uint8Array;
         extent?: Extent;
+        target: DocTarget;
     };
     // (undocumented)
     insertTable: {
-        target: DocTarget;
-        rows: number;
         cols: number;
+        rows: number;
+        target: DocTarget;
     };
     // (undocumented)
     insertText: {
@@ -228,27 +228,27 @@ export interface DocEdits {
     };
     // (undocumented)
     proposeDeletion: {
-        target: DocTarget;
         author: string;
+        target: DocTarget;
     };
     // (undocumented)
     proposeInsertion: {
+        author: string;
         target: DocTarget;
         text: string;
-        author: string;
     };
     proposeReplacement: {
-        target: DocTarget;
-        replaceWith: string;
         author: string;
+        replaceWith: string;
+        target: DocTarget;
     };
     // (undocumented)
     rejectAllRevisions: Record<never, never>;
     // (undocumented)
     rejectRevision: {
         id: number;
-        part?: 'body' | 'footnote' | 'endnote';
         noteId?: number;
+        part?: 'body' | 'footnote' | 'endnote';
     };
     // (undocumented)
     removeContentControl: {
@@ -260,8 +260,8 @@ export interface DocEdits {
     };
     // (undocumented)
     removeRepeatingSectionItem: {
-        target: DocTarget;
         index: number;
+        target: DocTarget;
     };
     // (undocumented)
     replaceText: {
@@ -270,9 +270,9 @@ export interface DocEdits {
     };
     // (undocumented)
     replyComment: {
+        author: string;
         commentId: string;
         text: string;
-        author: string;
     };
     // (undocumented)
     resolveComment: {
@@ -285,8 +285,8 @@ export interface DocEdits {
     };
     // (undocumented)
     setParagraphStyle: {
-        target: DocTarget;
         styleId: string;
+        target: DocTarget;
     };
     // (undocumented)
     setVariable: {
@@ -298,8 +298,8 @@ export interface DocEdits {
         target: DocTarget;
     };
     toggleList: {
-        target: DocTarget;
         kind: 'bullet' | 'ordered';
+        target: DocTarget;
     };
 }
 
@@ -324,8 +324,8 @@ export interface DocQueries {
     };
     // (undocumented)
     findText: {
-        text: string;
         container?: ContainerRef;
+        text: string;
     };
     // (undocumented)
     paragraphs: {
@@ -485,42 +485,42 @@ export interface Editor {
     getAvailableFonts(): readonly string[];
     getComments(): readonly {
         readonly id: string;
-        readonly text: string;
         readonly resolved: boolean;
+        readonly text: string;
     }[];
     getCurrentPage(mode?: 'viewport' | 'caret'): number;
     getCustomNodeDefinitions(): readonly unknown[];
     getDocumentFonts(): readonly string[];
     getDocumentHandle(): DocumentHandle;
     getDocumentStyles(): readonly {
-        readonly styleId: string;
         readonly name: string;
-        readonly type: string;
         readonly preview: {
+            readonly bold: boolean;
+            readonly color: string | null;
             readonly fontFamily: string | null;
             readonly fontSizePt: number | null;
-            readonly bold: boolean;
             readonly italic: boolean;
-            readonly color: string | null;
         };
+        readonly styleId: string;
+        readonly type: string;
     }[];
     getDocumentThemeColors(): readonly {
-        readonly slot: string;
         readonly hex: string;
+        readonly slot: string;
     }[];
     getEditingMode(): DocumentEditingMode;
     getHeaderFooterState(): HeaderFooterState | null;
     getNotePreviewText(scopeId: string): string | null;
     getNotePropertiesState(): NotePropertiesState | null;
     getOutline(): readonly {
-        readonly text: string;
-        readonly level: number;
         readonly blockId: string;
+        readonly level: number;
+        readonly text: string;
     }[];
     getPageGeometry(): readonly {
-        index: number;
         box: Rect;
         contentBox: Rect;
+        index: number;
     }[];
     getPageSetup(): PageSetup | null;
     getRenderScale(): number;
@@ -529,20 +529,20 @@ export interface Editor {
     getSelectedImage(): SelectedImageState | null;
     getSelectedTable(): {
         readonly blockId: string;
-        readonly rowCount: number;
-        readonly columnCount: number;
         readonly cell: {
-            readonly row: number;
             readonly column: number;
+            readonly row: number;
         } | null;
+        readonly columnCount: number;
+        readonly rowCount: number;
     } | null;
     getSelectionFormatting(): {
-        readonly fontFamily?: string;
-        readonly fontSizeHalfPoints?: number;
-        readonly styleId?: string;
         readonly alignment?: string;
         readonly bold?: boolean;
+        readonly fontFamily?: string;
+        readonly fontSizeHalfPoints?: number;
         readonly italic?: boolean;
+        readonly styleId?: string;
         readonly underline?: boolean;
     } | null;
     getSelectionPlacement(): {
@@ -550,23 +550,23 @@ export interface Editor {
         readonly pageIndex: number;
     } | null;
     getTableCellSelection(): {
-        readonly tableId: string;
-        readonly rows: {
-            readonly from: number;
-            readonly to: number;
-        };
+        readonly cellIds: readonly string[];
         readonly columns: {
             readonly from: number;
             readonly to: number;
         };
-        readonly cellIds: readonly string[];
+        readonly rows: {
+            readonly from: number;
+            readonly to: number;
+        };
+        readonly tableId: string;
     } | null;
     // (undocumented)
     getTotalPages(): number;
     getTrackedChanges(): readonly {
+        readonly author?: string;
         readonly id: string;
         readonly kind: string;
-        readonly author?: string;
         readonly story?: 'body' | 'header' | 'footer' | 'footnote' | 'endnote';
     }[];
     getWatermark(): {
@@ -630,14 +630,14 @@ export type EditorCommand = {
 export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHeaderFooterCommands, EditorNoteCommands {
     clearFormatting: Record<never, never>;
     commitTableColumnDividerResize: {
-        target: TableColumnDividerResizeTarget;
         leftWidthTwips: number;
         rightWidthTwips: number;
+        target: TableColumnDividerResizeTarget;
     };
     commitTableRightEdgeResize: {
-        target: TableRightEdgeResizeTarget;
         columnWidthTwips: number;
         tableWidthTwips: number;
+        target: TableRightEdgeResizeTarget;
     };
     copy: Record<never, never>;
     cut: Record<never, never>;
@@ -657,23 +657,23 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     deleteTable: Record<never, never>;
     // (undocumented)
     insertColumn: {
-        where: 'left' | 'right';
         target?: TableColumnOccurrenceTarget;
+        where: 'left' | 'right';
     };
     insertImage: {
         data: Uint8Array;
-        mime: SupportedImageMime;
-        widthPoints: number;
-        heightPoints: number;
-        expectedPackageRevision?: number;
-        title?: string;
         description?: string;
+        expectedPackageRevision?: number;
+        heightPoints: number;
         hyperlink?: string;
+        mime: SupportedImageMime;
+        title?: string;
+        widthPoints: number;
     };
     // (undocumented)
     insertRow: {
-        where: 'above' | 'below';
         target?: TableRowOccurrenceTarget;
+        where: 'above' | 'below';
     };
     insertToc: Record<never, never>;
     // (undocumented)
@@ -685,23 +685,23 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     redo: Record<never, never>;
     // (undocumented)
     refreshToc: {
-        tocId?: string;
         mode?: 'entire' | 'pageNumbers';
+        tocId?: string;
     };
     removeTabMark: {
         positionTwips: number;
     };
     replaceAllMatches: {
+        matchCase?: boolean;
         query: string;
         text: string;
-        matchCase?: boolean;
         wholeWord?: boolean;
     };
     replaceImage: {
         data: Uint8Array;
-        mime?: SupportedImageMime;
         drawingNodeId?: string;
         expectedPackageRevision?: number;
+        mime?: SupportedImageMime;
     };
     replaceMatch: {
         match: TextMatch;
@@ -725,44 +725,44 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
         drawingNodeId?: string;
         expectedPackageRevision?: number;
         horizontalEmu?: number;
-        verticalEmu?: number;
         relativeToH?: string;
         relativeToV?: string;
+        verticalEmu?: number;
     };
     setImageProperties: {
+        alt?: string;
+        borderColor?: ColorValue;
+        borderWidthEmu?: number;
+        crop?: ImageCropPercent;
+        description?: string;
         drawingNodeId?: string;
         expectedPackageRevision?: number;
-        selectionParagraphId?: string;
-        selectionOffset?: number;
-        widthEmu?: number;
         heightEmu?: number;
-        alt?: string;
-        title?: string;
-        description?: string;
-        hyperlink?: string | null;
-        crop?: ImageCropPercent;
-        resetToNaturalSize?: boolean;
-        wrap?: ImageWrapTarget;
         horizontalEmu?: number;
-        verticalEmu?: number;
+        hyperlink?: string | null;
         relativeToH?: string;
         relativeToV?: string;
-        borderWidthEmu?: number;
-        borderColor?: ColorValue;
+        resetToNaturalSize?: boolean;
+        selectionOffset?: number;
+        selectionParagraphId?: string;
+        title?: string;
+        verticalEmu?: number;
+        widthEmu?: number;
+        wrap?: ImageWrapTarget;
     };
     setImageWrapType: {
         drawingNodeId?: string;
         expectedPackageRevision?: number;
-        target: 'inline' | 'square' | 'squareLeft' | 'squareRight' | 'tight' | 'through' | 'topAndBottom' | 'behind' | 'inFront';
         initialPositionEmu?: {
             horizontalEmu: number;
             verticalEmu: number;
         };
+        target: 'inline' | 'square' | 'squareLeft' | 'squareRight' | 'tight' | 'through' | 'topAndBottom' | 'behind' | 'inFront';
     };
     setIndent: {
+        firstLine?: number | null;
         left?: number | null;
         right?: number | null;
-        firstLine?: number | null;
     };
     setLineSpacing: {
         rule: 'multiple' | 'exact' | 'atLeast';
@@ -770,24 +770,24 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     };
     // (undocumented)
     setMarkAttr: {
-        mark: string;
         attr: string;
+        mark: string;
         value: unknown;
     };
     setPageSetup: {
-        pageWidth?: number;
-        pageHeight?: number;
-        marginTop?: number;
-        marginRight?: number;
         marginBottom?: number;
         marginLeft?: number;
+        marginRight?: number;
+        marginTop?: number;
         orientation?: 'portrait' | 'landscape';
+        pageHeight?: number;
+        pageWidth?: number;
         scope?: 'document' | 'section';
     };
     setParagraphFormat: ParagraphFormatCommand;
     setParagraphSpacing: {
-        beforePt?: number | null;
         afterPt?: number | null;
+        beforePt?: number | null;
     };
     setSelection: {
         anchor: DocAnchor;
@@ -805,9 +805,9 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
         alignment: TableCellVerticalAlignment;
     };
     setTableProperties: {
+        justification?: 'left' | 'center' | 'right' | null;
         width?: number | null;
         widthType?: string | null;
-        justification?: 'left' | 'center' | 'right' | null;
     };
     // (undocumented)
     setWatermark: {
@@ -815,8 +815,8 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     };
     // (undocumented)
     splitCell: {
-        rows: number;
         cols: number;
+        rows: number;
     };
     // (undocumented)
     toggleHeaderRow: Record<never, never>;
@@ -830,9 +830,9 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     };
     toggleReviewPane: Record<never, never>;
     transformImage: {
+        action: 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV';
         drawingNodeId?: string;
         expectedPackageRevision?: number;
-        action: 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV';
     };
     // (undocumented)
     undo: Record<never, never>;
@@ -868,9 +868,9 @@ export interface EditorEvents {
 // @public
 export class EditorFontError extends Error {
     constructor(code: EditorFontErrorCode, message: string, details?: {
-        readonly request?: FontFaceRequest;
-        readonly diagnostic?: string;
         readonly cause?: unknown;
+        readonly diagnostic?: string;
+        readonly request?: FontFaceRequest;
     });
     // (undocumented)
     readonly code: EditorFontErrorCode;
@@ -888,11 +888,11 @@ export type EditorFontErrorCode = 'initializationFailed' | 'wasmUnavailable' | '
 // @public
 export interface EditorHeaderFooterCommands {
     editHeaderFooter: {
-        position: 'header' | 'footer';
-        variant?: FurnitureVariant;
-        firstPage?: boolean;
         evenPage?: boolean;
+        firstPage?: boolean;
+        position: 'header' | 'footer';
         sectionIndex?: number;
+        variant?: FurnitureVariant;
     };
     exitHeaderFooter: Record<never, never>;
     insertPageField: {
@@ -901,11 +901,11 @@ export interface EditorHeaderFooterCommands {
     linkHeaderFooterToPrevious: HeaderFooterSlotArgs;
     removeHeaderFooter: HeaderFooterSlotArgs;
     setHeaderFooterOptions: {
+        evenAndOddHeaders?: boolean;
+        footerDistanceTwips?: number;
+        headerDistanceTwips?: number;
         sectionIndex?: number;
         titlePage?: boolean;
-        evenAndOddHeaders?: boolean;
-        headerDistanceTwips?: number;
-        footerDistanceTwips?: number;
     };
     unlinkHeaderFooterFromPrevious: HeaderFooterSlotArgs;
 }
@@ -920,27 +920,27 @@ export interface EditorNoteCommands {
         noteId: number;
     };
     deleteNote: {
-        noteKind: NoteKind;
         noteId: number;
+        noteKind: NoteKind;
     };
     insertNote: {
         noteKind: NoteKind;
     };
     setNoteProperties: {
-        scope?: 'document' | 'section';
-        sectionIndex?: number;
-        footnote?: {
-            numFmt?: string;
-            numRestart?: string;
-            position?: string;
-            numStart?: number;
-        };
         endnote?: {
             numFmt?: string;
             numRestart?: string;
-            position?: string;
             numStart?: number;
+            position?: string;
         };
+        footnote?: {
+            numFmt?: string;
+            numRestart?: string;
+            numStart?: number;
+            position?: string;
+        };
+        scope?: 'document' | 'section';
+        sectionIndex?: number;
     };
 }
 
@@ -955,8 +955,8 @@ export interface EditorQueries extends DocQueries {
     };
     // (undocumented)
     hyperlinkAt: {
-        pos?: number;
         fallbackHref?: string;
+        pos?: number;
     };
     // (undocumented)
     isInsideToc: {
@@ -1001,8 +1001,8 @@ export interface EditorQueryResults extends DocQueryResults {
     selectionFormatting: RunFormatting | null;
     // (undocumented)
     splitCellConfig: {
-        maxRows: number;
         maxCols: number;
+        maxRows: number;
     } | null;
     // (undocumented)
     tableContext: TableContext | null;
@@ -1027,13 +1027,13 @@ export type EditorScope = {
 * store package. Do not invent a parallel `{ noteKind, noteId }` scope arm.
 */
 | {
-    kind: 'note';
     id: string;
+    kind: 'note';
 }
 /** A text box or floating frame with its own content, addressed by id. */
 | {
-    kind: 'frame';
     id: string;
+    kind: 'frame';
 }
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | {
@@ -1091,11 +1091,11 @@ export type ExecErrorCode = 'notFound' | 'ambiguous' | 'locked' | 'bound' | 'typ
 
 // @public
 export type ExecResult = {
-    ok: true;
     changed: boolean;
+    ok: true;
 } | {
-    ok: false;
     code: ExecErrorCode;
+    ok: false;
     reason: string;
     target?: DocTarget;
 };
@@ -1237,20 +1237,20 @@ export interface ImageCropPercent {
 
 // @public
 export type ImageResourceState = {
-    readonly kind: 'ready';
-    readonly partName: string;
     readonly contentId: string;
-    readonly resourceKey: string;
-    readonly validatedHandle: ValidatedImageBytesHandle;
-    readonly mime: RenderableImageMime;
-    readonly pixelWidth: number;
-    readonly pixelHeight: number;
     readonly dpiX: number;
     readonly dpiY: number;
+    readonly kind: 'ready';
+    readonly mime: RenderableImageMime;
+    readonly partName: string;
+    readonly pixelHeight: number;
+    readonly pixelWidth: number;
+    readonly resourceKey: string;
+    readonly validatedHandle: ValidatedImageBytesHandle;
 } | {
     readonly kind: 'unrenderable';
-    readonly partName: string | null;
     readonly mime: RenderableImageMime | PreservedImageMime | 'unknown';
+    readonly partName: string | null;
     readonly reason: 'unsupported-format' | 'non-picture-graphic' | 'signature-mismatch' | 'decode-failed' | 'resource-limit';
 } | {
     readonly kind: 'external';
@@ -1272,9 +1272,9 @@ export interface IndentFormatting {
     readonly firstLine: number;
     readonly left: number;
     readonly mixed: {
+        readonly firstLine: boolean;
         readonly left: boolean;
         readonly right: boolean;
-        readonly firstLine: boolean;
     };
     readonly right: number;
 }
@@ -1290,8 +1290,8 @@ export type InteractionOutcome<T> = {
     readonly ok: true;
     readonly value: T;
 } | {
-    readonly ok: false;
     readonly code: InteractionOutcomeCode;
+    readonly ok: false;
     readonly reason: string;
 };
 
@@ -1345,10 +1345,10 @@ export interface PageSetup {
     readonly gutterTwips?: number;
     // (undocumented)
     readonly marginsTwips: {
-        readonly top: number;
-        readonly right: number;
         readonly bottom: number;
         readonly left: number;
+        readonly right: number;
+        readonly top: number;
     };
     // (undocumented)
     readonly orientation: 'portrait' | 'landscape';
@@ -1747,8 +1747,8 @@ export interface SectionProperties {
     readonly margins: PageMargins;
     // (undocumented)
     readonly pageSize: {
-        widthTwips: number;
         heightTwips: number;
+        widthTwips: number;
     };
     readonly titlePage?: boolean;
 }
@@ -1776,10 +1776,10 @@ export interface SelectedImageState {
     readonly id: string;
     // (undocumented)
     readonly intrinsic: Readonly<{
-        readonly pixelWidth: number;
-        readonly pixelHeight: number;
         readonly dpiX: number;
         readonly dpiY: number;
+        readonly pixelHeight: number;
+        readonly pixelWidth: number;
     }> | null;
     // (undocumented)
     readonly kind: DrawingKind;
@@ -1830,15 +1830,15 @@ export interface SemanticSelection {
 
 // @public
 export type SemanticTarget = {
+    readonly affinity: InteractionAffinity;
+    readonly graphemeOffset: number;
+    readonly identity: SemanticIdentity;
     readonly kind: 'text';
     readonly scope: ViewScope;
-    readonly identity: SemanticIdentity;
-    readonly graphemeOffset: number;
-    readonly affinity: InteractionAffinity;
 } | {
     readonly kind: 'atomic';
-    readonly scope: ViewScope;
     readonly objectId: string;
+    readonly scope: ViewScope;
 };
 
 // @public
@@ -2035,10 +2035,10 @@ export type ZoomFitTarget = 'pageWidth';
 export type ZoomMode = {
     readonly type: 'fixed';
 } | {
-    readonly type: 'fit';
     readonly fit: ZoomFitTarget;
-    readonly minZoom?: number;
     readonly maxZoom?: number;
+    readonly minZoom?: number;
+    readonly type: 'fit';
 };
 
 // (No @packageDocumentation comment for this package)

--- a/docs/api/docx-editor-core/contracts-interaction.api.md
+++ b/docs/api/docx-editor-core/contracts-interaction.api.md
@@ -19,13 +19,13 @@ export type EditorScope = {
 * store package. Do not invent a parallel `{ noteKind, noteId }` scope arm.
 */
 | {
-    kind: 'note';
     id: string;
+    kind: 'note';
 }
 /** A text box or floating frame with its own content, addressed by id. */
 | {
-    kind: 'frame';
     id: string;
+    kind: 'frame';
 }
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | {
@@ -40,8 +40,8 @@ export type InteractionOutcome<T> = {
     readonly ok: true;
     readonly value: T;
 } | {
-    readonly ok: false;
     readonly code: InteractionOutcomeCode;
+    readonly ok: false;
     readonly reason: string;
 };
 
@@ -58,15 +58,15 @@ export interface SemanticIdentity {
 
 // @public
 export type SemanticTarget = {
+    readonly affinity: InteractionAffinity;
+    readonly graphemeOffset: number;
+    readonly identity: SemanticIdentity;
     readonly kind: 'text';
     readonly scope: ViewScope;
-    readonly identity: SemanticIdentity;
-    readonly graphemeOffset: number;
-    readonly affinity: InteractionAffinity;
 } | {
     readonly kind: 'atomic';
-    readonly scope: ViewScope;
     readonly objectId: string;
+    readonly scope: ViewScope;
 };
 
 // @public

--- a/docs/api/docx-editor-core/contracts-modules.api.md
+++ b/docs/api/docx-editor-core/contracts-modules.api.md
@@ -100,9 +100,9 @@ export interface ReviewModelInput {
     readonly commentsPart?: OoxmlPart | undefined;
     // (undocumented)
     readonly customNodePayloads?: ReadonlyMap<string, {
-        readonly nodeId: string;
-        readonly label: string;
         readonly data: string;
+        readonly label: string;
+        readonly nodeId: string;
     }> | undefined;
     readonly customNodes?: readonly unknown[] | undefined;
     readonly furnitureParts?: readonly OoxmlPart[] | undefined;

--- a/docs/api/docx-editor-core/contracts-types.api.md
+++ b/docs/api/docx-editor-core/contracts-types.api.md
@@ -13,9 +13,9 @@ export type ColorValue = {
     readonly value: string;
 } | {
     readonly kind: 'theme';
+    readonly shade?: number;
     readonly slot: string;
     readonly tint?: number;
-    readonly shade?: number;
 } | {
     readonly kind: 'auto';
 };
@@ -27,8 +27,8 @@ export type ContainerRef = {
     part: 'header' | 'footer';
     rId: string;
 } | {
-    part: 'footnote' | 'endnote';
     noteId: number;
+    part: 'footnote' | 'endnote';
 };
 
 // @public
@@ -152,11 +152,11 @@ export type ExecErrorCode = 'notFound' | 'ambiguous' | 'locked' | 'bound' | 'typ
 
 // @public
 export type ExecResult = {
-    ok: true;
     changed: boolean;
+    ok: true;
 } | {
-    ok: false;
     code: ExecErrorCode;
+    ok: false;
     reason: string;
     target?: DocTarget;
 };
@@ -192,9 +192,9 @@ export interface IndentFormatting {
     readonly firstLine: number;
     readonly left: number;
     readonly mixed: {
+        readonly firstLine: boolean;
         readonly left: boolean;
         readonly right: boolean;
-        readonly firstLine: boolean;
     };
     readonly right: number;
 }
@@ -412,8 +412,8 @@ export interface SectionProperties {
     readonly margins: PageMargins;
     // (undocumented)
     readonly pageSize: {
-        widthTwips: number;
         heightTwips: number;
+        widthTwips: number;
     };
     readonly titlePage?: boolean;
 }

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -40,8 +40,6 @@ export function captureImageMutationPreconditions(editor: Pick<DocxEditorInstanc
 
 // @public
 export const CHROME_GROUPS: readonly [{
-    readonly id: "history";
-    readonly labelKey: "formattingBar.groups.history";
     readonly controls: readonly [{
         readonly id: "undo";
         readonly labelKey: "formattingBar.undoShortcut";
@@ -57,59 +55,59 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "history";
+    readonly labelKey: "formattingBar.groups.history";
 }, {
-    readonly id: "zoom";
-    readonly labelKey: "formattingBar.groups.zoom";
     readonly controls: readonly [{
         readonly id: "level";
-        readonly shape: "stepper";
-        readonly valueText: "100%";
         readonly labelKey: "formattingBar.groups.zoom";
         readonly paths: null;
-        readonly valueKey: "zoom.zoomLevel";
+        readonly shape: "stepper";
         readonly state: {
             readonly kind: "command";
         };
+        readonly valueKey: "zoom.zoomLevel";
+        readonly valueText: "100%";
     }];
+    readonly id: "zoom";
+    readonly labelKey: "formattingBar.groups.zoom";
 }, {
-    readonly id: "styles";
-    readonly labelKey: "formattingBar.groups.styles";
     readonly controls: readonly [{
         readonly id: "style";
-        readonly shape: "dropdown";
         readonly labelKey: "styles.selectAriaLabel";
         readonly paths: null;
-        readonly valueKey: "styles.normalText";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "styles.normalText";
     }];
+    readonly id: "styles";
+    readonly labelKey: "formattingBar.groups.styles";
 }, {
-    readonly id: "font";
-    readonly labelKey: "formattingBar.groups.font";
     readonly controls: readonly [{
         readonly id: "family";
-        readonly shape: "dropdown";
         readonly labelKey: "font.selectAriaLabel";
         readonly paths: null;
-        readonly valueKey: "font.sansSerif";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "font.sansSerif";
     }, {
         readonly id: "size";
-        readonly shape: "stepper";
-        readonly valueText: "11";
         readonly labelKey: "fontSize.listLabel";
         readonly paths: null;
-        readonly valueKey: "fontSize.label";
+        readonly shape: "stepper";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "fontSize.label";
+        readonly valueText: "11";
     }];
+    readonly id: "font";
+    readonly labelKey: "formattingBar.groups.font";
 }, {
-    readonly id: "text";
-    readonly labelKey: "formattingBar.groups.textFormatting";
     readonly controls: readonly [{
         readonly id: "bold";
         readonly labelKey: "formattingBar.boldShortcut";
@@ -140,22 +138,22 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "color";
-        readonly shape: "colorSplit";
-        readonly swatch: "#ff0000";
         readonly labelKey: "formattingBar.fontColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#ff0000";
     }, {
         readonly id: "highlight";
-        readonly shape: "colorSplit";
-        readonly swatch: "#ffff00";
         readonly labelKey: "formattingBar.highlightColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#ffff00";
     }, {
         readonly id: "link";
         readonly labelKey: "formattingBar.insertLinkShortcut";
@@ -164,9 +162,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "text";
+    readonly labelKey: "formattingBar.groups.textFormatting";
 }, {
-    readonly id: "script";
-    readonly labelKey: "formattingBar.groups.script";
     readonly controls: readonly [{
         readonly id: "super";
         readonly labelKey: "formattingBar.superscript";
@@ -182,9 +180,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "script";
+    readonly labelKey: "formattingBar.groups.script";
 }, {
-    readonly id: "alignment";
-    readonly labelKey: "formattingBar.groups.alignment";
     readonly controls: readonly [{
         readonly id: "left";
         readonly labelKey: "alignment.alignLeft";
@@ -214,9 +212,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "alignment";
+    readonly labelKey: "formattingBar.groups.alignment";
 }, {
-    readonly id: "list";
-    readonly labelKey: "formattingBar.groups.listFormatting";
     readonly controls: readonly [{
         readonly id: "bullet";
         readonly labelKey: "lists.bulletList";
@@ -247,16 +245,16 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "lineSpacing";
-        readonly shape: "dropdown";
         readonly labelKey: "lineSpacing.label";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "command";
         };
     }];
+    readonly id: "list";
+    readonly labelKey: "formattingBar.groups.listFormatting";
 }, {
-    readonly id: "format";
-    readonly labelKey: "formattingBar.clearFormatting";
     readonly controls: readonly [{
         readonly id: "clear";
         readonly labelKey: "formattingBar.clearFormatting";
@@ -265,30 +263,30 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "format";
+    readonly labelKey: "formattingBar.clearFormatting";
 }, {
-    readonly id: "review";
-    readonly labelKey: "formattingBar.commentsAndChanges";
     readonly controls: readonly [{
         readonly id: "comments";
-        readonly shape: "icon";
         readonly labelKey: "formattingBar.commentsAndChanges";
         readonly paths: readonly string[];
+        readonly shape: "icon";
         readonly state: {
             readonly kind: "command";
         };
     }, {
         readonly id: "editingMode";
-        readonly shape: "dropdown";
         readonly labelKey: "editingMode.label";
-        readonly valueKey: "editingMode.editing";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "command";
         };
+        readonly valueKey: "editingMode.editing";
     }];
+    readonly id: "review";
+    readonly labelKey: "formattingBar.commentsAndChanges";
 }, {
-    readonly id: "contentControl";
-    readonly labelKey: "contentControl.group";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "showAll";
@@ -319,9 +317,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "contentControl";
+    readonly labelKey: "contentControl.group";
 }, {
-    readonly id: "image";
-    readonly labelKey: "formattingBar.groups.image";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "insert";
@@ -339,26 +337,26 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "wrap";
-        readonly shape: "dropdown";
         readonly labelKey: "formattingBar.imageWrap";
         readonly paths: readonly string[];
-        readonly valueKey: "imageWrap.inline";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "imageWrap.inline";
     }, {
         readonly id: "altText";
-        readonly shape: "dropdown";
         readonly labelKey: "formattingBar.altText";
         readonly paths: null;
-        readonly valueKey: "imageProperties.altText";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "imageProperties.altText";
     }];
+    readonly id: "image";
+    readonly labelKey: "formattingBar.groups.image";
 }, {
-    readonly id: "table";
-    readonly labelKey: "formattingBar.groups.table";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "insert";
@@ -369,50 +367,50 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "borderTarget";
-        readonly shape: "dropdown";
         readonly labelKey: "table.borders.tooltip";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
     }, {
         readonly id: "borderColor";
-        readonly shape: "colorSplit";
-        readonly swatch: "#000000";
         readonly labelKey: "table.borderColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#000000";
     }, {
         readonly id: "borderStyle";
-        readonly shape: "dropdown";
         readonly labelKey: "table.borders.styleAriaLabel";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
     }, {
         readonly id: "borderWidth";
-        readonly shape: "dropdown";
         readonly labelKey: "table.borderWidth";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
     }, {
         readonly id: "cellFill";
-        readonly shape: "colorSplit";
-        readonly swatch: "#ffffff";
         readonly labelKey: "table.cellFillColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#ffffff";
     }];
+    readonly id: "table";
+    readonly labelKey: "formattingBar.groups.table";
 }, {
-    readonly id: "paragraph";
-    readonly labelKey: "dialogs.paragraph.title";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "dialog";
@@ -422,9 +420,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "paragraph";
+    readonly labelKey: "dialogs.paragraph.title";
 }, {
-    readonly id: "file";
-    readonly labelKey: "toolbar.file";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "open";
@@ -448,9 +446,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "file";
+    readonly labelKey: "toolbar.file";
 }, {
-    readonly id: "insert";
-    readonly labelKey: "toolbar.insert";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "footnote";
@@ -523,6 +521,8 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "insert";
+    readonly labelKey: "toolbar.insert";
 }];
 
 // @public
@@ -672,8 +672,8 @@ export type CollectReviewItems = (input: ReviewModelInput) => readonly ReviewIte
 
 // @public
 export type ColorLowerResult = {
-    readonly ok: true;
     readonly color: TreeDocColorValue;
+    readonly ok: true;
 } | ColorLowerRefusal;
 
 // @public
@@ -690,22 +690,22 @@ export function composeFontConfiguration(base: FontConfigurationBase, ...fragmen
 
 // @public
 export function computeImageResizeResult(options: {
-    readonly handle: ImageResizeHandle;
-    readonly startWidthEmu: number;
-    readonly startHeightEmu: number;
-    readonly startBounds: {
-        readonly x: number;
-        readonly y: number;
-        readonly width: number;
-        readonly height: number;
-    };
-    readonly startPosition: DrawingPositionInput | null;
     readonly anchorFrameOrigin?: AnchorFrameOrigin | null;
     readonly deltaXPt: number;
     readonly deltaYPt: number;
-    readonly transform: DrawingTransform;
-    readonly preserveAspect: boolean;
+    readonly handle: ImageResizeHandle;
     readonly kind: 'inline' | 'anchored';
+    readonly preserveAspect: boolean;
+    readonly startBounds: {
+        readonly height: number;
+        readonly width: number;
+        readonly x: number;
+        readonly y: number;
+    };
+    readonly startHeightEmu: number;
+    readonly startPosition: DrawingPositionInput | null;
+    readonly startWidthEmu: number;
+    readonly transform: DrawingTransform;
 }): ImageResizeResult;
 
 // @public
@@ -871,10 +871,10 @@ export interface EquationActivation {
     readonly equation: SurfaceEquation;
     // (undocumented)
     readonly rect: {
-        readonly left: number;
-        readonly top: number;
-        readonly right: number;
         readonly bottom: number;
+        readonly left: number;
+        readonly right: number;
+        readonly top: number;
     };
 }
 
@@ -918,13 +918,13 @@ export interface FinalizedImageOverlayInteraction extends ImageResizeResult {
 
 // @public
 export function finalizeImageOverlayInteraction(options: {
-    readonly session: ImageInteractionSession;
+    readonly accumulatedScrollPt: number;
+    readonly anchorFrameOrigin: AnchorFrameOrigin | null;
+    readonly aspectLocked: boolean;
     readonly deltaXPt: number;
     readonly deltaYPt: number;
-    readonly accumulatedScrollPt: number;
-    readonly aspectLocked: boolean;
+    readonly session: ImageInteractionSession;
     readonly shiftKey: boolean;
-    readonly anchorFrameOrigin: AnchorFrameOrigin | null;
 }): FinalizedImageOverlayInteraction;
 
 // @public
@@ -1015,10 +1015,10 @@ export interface HyperlinkActivation {
     // (undocumented)
     readonly link: SurfaceHyperlink;
     readonly rect: {
-        readonly left: number;
-        readonly top: number;
         readonly bottom: number;
+        readonly left: number;
         readonly right: number;
+        readonly top: number;
     };
 }
 
@@ -1031,10 +1031,10 @@ export interface HyperlinkChromeHandlers {
 // @public
 export interface HyperlinkOps {
     applyHyperlink(input: {
-        readonly url?: string;
         readonly anchor?: string;
         readonly text?: string;
         readonly tooltip?: string;
+        readonly url?: string;
     }): boolean;
     fieldLinkAtCaret(): SurfaceHyperlink | null;
     linkAtCaret(): SurfaceHyperlink | null;
@@ -1087,10 +1087,10 @@ export interface ImageDecodePort {
     }> | null>;
     // (undocumented)
     decode(bytes: Uint8Array, mime: SupportedImageMime, limits: ImageResourceLimits): Promise<Readonly<{
-        pixelWidth: number;
-        pixelHeight: number;
         dpiX: number;
         dpiY: number;
+        pixelHeight: number;
+        pixelWidth: number;
     }>>;
 }
 
@@ -1117,10 +1117,10 @@ export interface ImageInteractionSession {
     readonly preconditions: ImageMutationPreconditions;
     // (undocumented)
     readonly startBounds: {
+        readonly height: number;
+        readonly width: number;
         readonly x: number;
         readonly y: number;
-        readonly width: number;
-        readonly height: number;
     };
     // (undocumented)
     readonly startHeightEmu: number;
@@ -1148,10 +1148,10 @@ export interface ImageResizeResult {
     readonly position: DrawingPositionInput | null;
     // (undocumented)
     readonly previewBounds: {
+        readonly height: number;
+        readonly width: number;
         readonly x: number;
         readonly y: number;
-        readonly width: number;
-        readonly height: number;
     };
     // (undocumented)
     readonly widthEmu: number;
@@ -1228,9 +1228,9 @@ export type OpenPaginatedResult = {
     readonly ok: true;
     readonly surface: PaginatedSurface;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: string;
-    readonly detail?: string;
 };
 
 // @public
@@ -1249,10 +1249,10 @@ export interface OverlayFrameRect {
 
 // @public
 export function overlayFrameToSheetCssPixels(layout: SemanticLayout, frame: OverlayFrameRect, coordinates: SurfaceOverlayCoordinates): {
+    readonly height: number;
     readonly left: number;
     readonly top: number;
     readonly width: number;
-    readonly height: number;
 };
 
 // @public
@@ -1266,14 +1266,14 @@ export interface PaginatedSurface {
     // (undocumented)
     applyDrawingOps(ops: readonly DrawingTreeDocOp[]): TreeApplyResult;
     applyHeaderFooterLifecycle(op: {
+        readonly evenAndOddHeaders?: boolean;
+        readonly footerDistanceTwips?: number;
+        readonly headerDistanceTwips?: number;
+        readonly kind?: 'header' | 'footer';
         readonly op: 'createHeaderFooter' | 'deleteHeaderFooter' | 'linkToPrevious' | 'unlinkFromPrevious' | 'setSectionFurnitureOptions';
         readonly sectionIndex?: number;
-        readonly kind?: 'header' | 'footer';
-        readonly variant?: 'default' | 'first' | 'even';
         readonly titlePage?: boolean;
-        readonly evenAndOddHeaders?: boolean;
-        readonly headerDistanceTwips?: number;
-        readonly footerDistanceTwips?: number;
+        readonly variant?: 'default' | 'first' | 'even';
     }): {
         readonly ok: true;
     } | {
@@ -1315,17 +1315,17 @@ export interface PaginatedSurface {
     editingMode(): SurfaceEditingMode;
     enqueueType(text: string): void;
     enterHeaderFooter(args: {
-        readonly rId: string;
-        readonly pageIndex?: number;
-        readonly sectionIndex?: number;
         readonly kind?: 'header' | 'footer';
-        readonly variant?: 'default' | 'first' | 'even';
+        readonly pageIndex?: number;
         readonly position?: SemanticPosition;
+        readonly rId: string;
+        readonly sectionIndex?: number;
+        readonly variant?: 'default' | 'first' | 'even';
     }): boolean;
     // (undocumented)
     enterNote(scopeId: string, position?: {
-        paragraphId: string;
         offset: number;
+        paragraphId: string;
     }): boolean;
     // (undocumented)
     readonly equations: EquationOps;
@@ -1339,15 +1339,15 @@ export interface PaginatedSurface {
     formatting(): SurfaceFormatting;
     headerFooterState(): {
         readonly editing: 'header' | 'footer' | null;
-        readonly sectionIndex: number;
-        readonly variant?: 'default' | 'first' | 'even';
-        readonly rId?: string;
-        readonly partName?: string;
-        readonly inherited?: boolean;
-        readonly titlePage?: boolean;
         readonly evenAndOddHeaders?: boolean;
-        readonly headerDistanceTwips?: number;
         readonly footerDistanceTwips?: number;
+        readonly headerDistanceTwips?: number;
+        readonly inherited?: boolean;
+        readonly partName?: string;
+        readonly rId?: string;
+        readonly sectionIndex: number;
+        readonly titlePage?: boolean;
+        readonly variant?: 'default' | 'first' | 'even';
     } | null;
     readonly hyperlinks: HyperlinkOps;
     // (undocumented)
@@ -1371,8 +1371,8 @@ export interface PaginatedSurface {
     layoutSession(): {
         readonly stats: {
             readonly placed: number;
-            readonly total: number;
             readonly reusedPages: number;
+            readonly total: number;
         };
     };
     // (undocumented)
@@ -1390,8 +1390,8 @@ export interface PaginatedSurface {
     releaseSelection(pin: SelectionPin): void;
     // (undocumented)
     replaceImage(drawingNodeId: string, bytes: Uint8Array, mime: SupportedImageMime, options: {
-        readonly expectedPackageRevision: number;
         readonly commitGuard?: () => boolean;
+        readonly expectedPackageRevision: number;
     }): Promise<ImageIntentResult>;
     retainedSelection(): SemanticSelection | null;
     retainSelection(): SelectionPin;
@@ -1417,26 +1417,26 @@ export interface PaginatedSurface {
     // (undocumented)
     setEditingMode(mode: SurfaceEditingMode): void;
     setIndent(update: {
+        readonly firstLine?: number | null;
         readonly left?: number | null;
         readonly right?: number | null;
-        readonly firstLine?: number | null;
     }): boolean;
     // (undocumented)
     setNoteProperties(args: {
-        readonly scope: 'document' | 'section';
-        readonly sectionIndex?: number;
-        readonly footnote?: {
-            readonly numFmt?: string;
-            readonly numRestart?: string;
-            readonly position?: string;
-            readonly numStart?: number;
-        };
         readonly endnote?: {
             readonly numFmt?: string;
             readonly numRestart?: string;
-            readonly position?: string;
             readonly numStart?: number;
+            readonly position?: string;
         };
+        readonly footnote?: {
+            readonly numFmt?: string;
+            readonly numRestart?: string;
+            readonly numStart?: number;
+            readonly position?: string;
+        };
+        readonly scope: 'document' | 'section';
+        readonly sectionIndex?: number;
     }): boolean;
     setParagraphFormat(update: SurfaceParagraphFormat): boolean;
     setParagraphProperties(entries: readonly ParagraphPropertyEdit[]): void;
@@ -1447,14 +1447,14 @@ export interface PaginatedSurface {
     setRevisionStyles(colors: RevisionStyles | undefined): void;
     setRunProperty(localName: string, attributes?: Record<string, string>): void;
     setSectionProperties(update: {
-        readonly pageWidthTwips?: number;
-        readonly pageHeightTwips?: number;
-        readonly orientation?: 'portrait' | 'landscape';
-        readonly marginTopTwips?: number;
-        readonly marginRightTwips?: number;
+        readonly anchorParagraphId?: string;
         readonly marginBottomTwips?: number;
         readonly marginLeftTwips?: number;
-        readonly anchorParagraphId?: string;
+        readonly marginRightTwips?: number;
+        readonly marginTopTwips?: number;
+        readonly orientation?: 'portrait' | 'landscape';
+        readonly pageHeightTwips?: number;
+        readonly pageWidthTwips?: number;
     }): boolean;
     setSelection(next: SemanticSelection): void;
     setTableInteractionLabel(resolver: (key: 'table.insertRowBelow' | 'table.insertColumnRight') => string): void;
@@ -1564,9 +1564,9 @@ export function pointsToEmu(points: number): number;
 // @public
 export function positionInputFromPropertiesCommand(command: {
     readonly horizontalEmu?: number;
-    readonly verticalEmu?: number;
     readonly relativeToH?: string;
     readonly relativeToV?: string;
+    readonly verticalEmu?: number;
 }, selected: {
     readonly position?: DrawingPositionInput | null;
 } | null): DrawingPositionInput;
@@ -1577,9 +1577,9 @@ export function probeTableChromeCommand(slot: TableChromeSlotId, draft?: TableCh
 // @public
 export function propertiesCommandHasPositionFields(command: {
     readonly horizontalEmu?: number;
-    readonly verticalEmu?: number;
     readonly relativeToH?: string;
     readonly relativeToV?: string;
+    readonly verticalEmu?: number;
 }): boolean;
 
 // @public
@@ -1610,8 +1610,8 @@ export function resolveSvgIntrinsicSize(bytes: Uint8Array, limits: ImageResource
 export function resolveThemeColorHex(color: Extract<ColorValue, {
     kind: 'theme';
 }>, themeColors: readonly DocumentThemeColorEntry[]): {
-    ok: true;
     hex: string;
+    ok: true;
 } | {
     ok: false;
     reason: string;
@@ -1634,9 +1634,9 @@ export interface ReviewModelInput {
     readonly commentsPart?: OoxmlPart | undefined;
     // (undocumented)
     readonly customNodePayloads?: ReadonlyMap<string, {
-        readonly nodeId: string;
-        readonly label: string;
         readonly data: string;
+        readonly label: string;
+        readonly nodeId: string;
     }> | undefined;
     readonly customNodes?: readonly unknown[] | undefined;
     readonly furnitureParts?: readonly OoxmlPart[] | undefined;
@@ -1690,14 +1690,14 @@ export type RulerIndentHandle = 'firstLine' | 'hanging' | 'left' | 'right';
 
 // @public
 export function rulerPageBox(pages: readonly {
-    readonly index: number;
     readonly box: {
-        width: number;
         height: number;
+        width: number;
     };
+    readonly index: number;
 }[]): {
-    width: number;
     height: number;
+    width: number;
 } | null;
 
 // @public

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -1780,8 +1780,8 @@ export interface SectionProperties {
     readonly pageNumbering?: SectionPageNumbering;
     // (undocumented)
     readonly pageSize: {
-        readonly widthTwips: number;
         readonly heightTwips: number;
+        readonly widthTwips: number;
     };
     // (undocumented)
     readonly titlePage: boolean;
@@ -1849,10 +1849,10 @@ export interface SelectedImageState {
     readonly id: string;
     // (undocumented)
     readonly intrinsic: Readonly<{
-        readonly pixelWidth: number;
-        readonly pixelHeight: number;
         readonly dpiX: number;
         readonly dpiY: number;
+        readonly pixelHeight: number;
+        readonly pixelWidth: number;
     }> | null;
     // (undocumented)
     readonly kind: DrawingKind;
@@ -2002,8 +2002,8 @@ export interface SurfaceNavigation {
     destroy(): void;
     goToBookmark(name: string): boolean;
     goToPosition(position: {
-        paragraphId: string;
         offset: number;
+        paragraphId: string;
     }): boolean;
     openExternal(href: string | null): boolean;
 }
@@ -2137,8 +2137,8 @@ export type TableInteractionLabelKey = 'table.insertRowBelow' | 'table.insertCol
 // @public
 export interface TextMeasurer {
     lineMetrics(style: ResolvedRunStyle): {
-        height: number;
         baseline: number;
+        height: number;
     };
     measure(text: string, style: ResolvedRunStyle): number;
 }
@@ -2227,17 +2227,17 @@ export interface TreeDocxSessionView {
     // (undocumented)
     redo(): SelectionMark | null;
     relationshipTarget(relationshipId: string, scope?: StoryScope): {
-        readonly target: string;
         readonly external: boolean;
+        readonly target: string;
     } | null;
     removeCustomNode(controlNodeId: string, scope?: StoryScope): CustomNodeWriteResult;
     rendersText(): boolean;
     replaceImage(scope: StoryScope, drawingNodeId: string, bytes: Uint8Array, mime: SupportedImageMime, decodePort: ImageDecodePort, options: ReplaceImageOptions): Promise<ImageIntentResult>;
     replyToComment(parentCommentId: string | null, anchor: {
-        paragraphId: string;
-        start: number;
         end: number;
         endParagraphId?: string;
+        paragraphId: string;
+        start: number;
     }, text: string, author: string,
     date?: string, scope?: StoryScope): string | null;
     reviewItems(): readonly ReviewItem[];
@@ -2274,9 +2274,9 @@ export function validateRasterHeader(bytes: Uint8Array, mime: SupportedImageMime
 // @public
 export function validateSetImagePositionCommand(command: {
     readonly horizontalEmu?: number;
-    readonly verticalEmu?: number;
     readonly relativeToH?: string;
     readonly relativeToV?: string;
+    readonly verticalEmu?: number;
 }, mode: 'frame' | 'simple'): boolean;
 
 // @public

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -33,15 +33,13 @@ export type Block = Paragraph | Table | ContentControl;
 export type CanResult = {
     ok: true;
 } | {
-    ok: false;
     code: ExecErrorCode;
+    ok: false;
     reason: string;
 };
 
 // @public
 export const CHROME_GROUPS: readonly [{
-    readonly id: "history";
-    readonly labelKey: "formattingBar.groups.history";
     readonly controls: readonly [{
         readonly id: "undo";
         readonly labelKey: "formattingBar.undoShortcut";
@@ -57,59 +55,59 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "history";
+    readonly labelKey: "formattingBar.groups.history";
 }, {
-    readonly id: "zoom";
-    readonly labelKey: "formattingBar.groups.zoom";
     readonly controls: readonly [{
         readonly id: "level";
-        readonly shape: "stepper";
-        readonly valueText: "100%";
         readonly labelKey: "formattingBar.groups.zoom";
         readonly paths: null;
-        readonly valueKey: "zoom.zoomLevel";
+        readonly shape: "stepper";
         readonly state: {
             readonly kind: "command";
         };
+        readonly valueKey: "zoom.zoomLevel";
+        readonly valueText: "100%";
     }];
+    readonly id: "zoom";
+    readonly labelKey: "formattingBar.groups.zoom";
 }, {
-    readonly id: "styles";
-    readonly labelKey: "formattingBar.groups.styles";
     readonly controls: readonly [{
         readonly id: "style";
-        readonly shape: "dropdown";
         readonly labelKey: "styles.selectAriaLabel";
         readonly paths: null;
-        readonly valueKey: "styles.normalText";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "styles.normalText";
     }];
+    readonly id: "styles";
+    readonly labelKey: "formattingBar.groups.styles";
 }, {
-    readonly id: "font";
-    readonly labelKey: "formattingBar.groups.font";
     readonly controls: readonly [{
         readonly id: "family";
-        readonly shape: "dropdown";
         readonly labelKey: "font.selectAriaLabel";
         readonly paths: null;
-        readonly valueKey: "font.sansSerif";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "font.sansSerif";
     }, {
         readonly id: "size";
-        readonly shape: "stepper";
-        readonly valueText: "11";
         readonly labelKey: "fontSize.listLabel";
         readonly paths: null;
-        readonly valueKey: "fontSize.label";
+        readonly shape: "stepper";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "fontSize.label";
+        readonly valueText: "11";
     }];
+    readonly id: "font";
+    readonly labelKey: "formattingBar.groups.font";
 }, {
-    readonly id: "text";
-    readonly labelKey: "formattingBar.groups.textFormatting";
     readonly controls: readonly [{
         readonly id: "bold";
         readonly labelKey: "formattingBar.boldShortcut";
@@ -140,22 +138,22 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "color";
-        readonly shape: "colorSplit";
-        readonly swatch: "#ff0000";
         readonly labelKey: "formattingBar.fontColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#ff0000";
     }, {
         readonly id: "highlight";
-        readonly shape: "colorSplit";
-        readonly swatch: "#ffff00";
         readonly labelKey: "formattingBar.highlightColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#ffff00";
     }, {
         readonly id: "link";
         readonly labelKey: "formattingBar.insertLinkShortcut";
@@ -164,9 +162,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "text";
+    readonly labelKey: "formattingBar.groups.textFormatting";
 }, {
-    readonly id: "script";
-    readonly labelKey: "formattingBar.groups.script";
     readonly controls: readonly [{
         readonly id: "super";
         readonly labelKey: "formattingBar.superscript";
@@ -182,9 +180,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "script";
+    readonly labelKey: "formattingBar.groups.script";
 }, {
-    readonly id: "alignment";
-    readonly labelKey: "formattingBar.groups.alignment";
     readonly controls: readonly [{
         readonly id: "left";
         readonly labelKey: "alignment.alignLeft";
@@ -214,9 +212,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "alignment";
+    readonly labelKey: "formattingBar.groups.alignment";
 }, {
-    readonly id: "list";
-    readonly labelKey: "formattingBar.groups.listFormatting";
     readonly controls: readonly [{
         readonly id: "bullet";
         readonly labelKey: "lists.bulletList";
@@ -247,16 +245,16 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "lineSpacing";
-        readonly shape: "dropdown";
         readonly labelKey: "lineSpacing.label";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "command";
         };
     }];
+    readonly id: "list";
+    readonly labelKey: "formattingBar.groups.listFormatting";
 }, {
-    readonly id: "format";
-    readonly labelKey: "formattingBar.clearFormatting";
     readonly controls: readonly [{
         readonly id: "clear";
         readonly labelKey: "formattingBar.clearFormatting";
@@ -265,30 +263,30 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "format";
+    readonly labelKey: "formattingBar.clearFormatting";
 }, {
-    readonly id: "review";
-    readonly labelKey: "formattingBar.commentsAndChanges";
     readonly controls: readonly [{
         readonly id: "comments";
-        readonly shape: "icon";
         readonly labelKey: "formattingBar.commentsAndChanges";
         readonly paths: readonly string[];
+        readonly shape: "icon";
         readonly state: {
             readonly kind: "command";
         };
     }, {
         readonly id: "editingMode";
-        readonly shape: "dropdown";
         readonly labelKey: "editingMode.label";
-        readonly valueKey: "editingMode.editing";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "command";
         };
+        readonly valueKey: "editingMode.editing";
     }];
+    readonly id: "review";
+    readonly labelKey: "formattingBar.commentsAndChanges";
 }, {
-    readonly id: "contentControl";
-    readonly labelKey: "contentControl.group";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "showAll";
@@ -319,9 +317,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "contentControl";
+    readonly labelKey: "contentControl.group";
 }, {
-    readonly id: "image";
-    readonly labelKey: "formattingBar.groups.image";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "insert";
@@ -339,26 +337,26 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "wrap";
-        readonly shape: "dropdown";
         readonly labelKey: "formattingBar.imageWrap";
         readonly paths: readonly string[];
-        readonly valueKey: "imageWrap.inline";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "imageWrap.inline";
     }, {
         readonly id: "altText";
-        readonly shape: "dropdown";
         readonly labelKey: "formattingBar.altText";
         readonly paths: null;
-        readonly valueKey: "imageProperties.altText";
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
+        readonly valueKey: "imageProperties.altText";
     }];
+    readonly id: "image";
+    readonly labelKey: "formattingBar.groups.image";
 }, {
-    readonly id: "table";
-    readonly labelKey: "formattingBar.groups.table";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "insert";
@@ -369,50 +367,50 @@ export const CHROME_GROUPS: readonly [{
         };
     }, {
         readonly id: "borderTarget";
-        readonly shape: "dropdown";
         readonly labelKey: "table.borders.tooltip";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
     }, {
         readonly id: "borderColor";
-        readonly shape: "colorSplit";
-        readonly swatch: "#000000";
         readonly labelKey: "table.borderColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#000000";
     }, {
         readonly id: "borderStyle";
-        readonly shape: "dropdown";
         readonly labelKey: "table.borders.styleAriaLabel";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
     }, {
         readonly id: "borderWidth";
-        readonly shape: "dropdown";
         readonly labelKey: "table.borderWidth";
         readonly paths: readonly string[];
+        readonly shape: "dropdown";
         readonly state: {
             readonly kind: "value";
         };
     }, {
         readonly id: "cellFill";
-        readonly shape: "colorSplit";
-        readonly swatch: "#ffffff";
         readonly labelKey: "table.cellFillColor";
         readonly paths: readonly string[];
+        readonly shape: "colorSplit";
         readonly state: {
             readonly kind: "value";
         };
+        readonly swatch: "#ffffff";
     }];
+    readonly id: "table";
+    readonly labelKey: "formattingBar.groups.table";
 }, {
-    readonly id: "paragraph";
-    readonly labelKey: "dialogs.paragraph.title";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "dialog";
@@ -422,9 +420,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "paragraph";
+    readonly labelKey: "dialogs.paragraph.title";
 }, {
-    readonly id: "file";
-    readonly labelKey: "toolbar.file";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "open";
@@ -448,9 +446,9 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "file";
+    readonly labelKey: "toolbar.file";
 }, {
-    readonly id: "insert";
-    readonly labelKey: "toolbar.insert";
     readonly contextual: true;
     readonly controls: readonly [{
         readonly id: "footnote";
@@ -523,6 +521,8 @@ export const CHROME_GROUPS: readonly [{
             readonly kind: "command";
         };
     }];
+    readonly id: "insert";
+    readonly labelKey: "toolbar.insert";
 }];
 
 // @public
@@ -588,9 +588,9 @@ export type ColorValue = {
     readonly value: string;
 } | {
     readonly kind: 'theme';
+    readonly shade?: number;
     readonly slot: string;
     readonly tint?: number;
-    readonly shade?: number;
 } | {
     readonly kind: 'auto';
 };
@@ -626,8 +626,8 @@ export type ContainerRef = {
     part: 'header' | 'footer';
     rId: string;
 } | {
-    part: 'footnote' | 'endnote';
     noteId: number;
+    part: 'footnote' | 'endnote';
 };
 
 // @public
@@ -742,28 +742,28 @@ export interface DocEdits {
     // (undocumented)
     acceptRevision: {
         id: number;
-        part?: 'body' | 'footnote' | 'endnote';
         noteId?: number;
+        part?: 'body' | 'footnote' | 'endnote';
     };
     // (undocumented)
     addComment: {
+        author: string;
         target: DocTarget;
         text: string;
-        author: string;
     };
     // (undocumented)
     addRepeatingSectionItem: {
-        target: DocTarget;
         index?: number;
+        target: DocTarget;
     };
     adjustIndent: {
-        target: DocTarget;
         direction: 'increase' | 'decrease';
+        target: DocTarget;
     };
     // (undocumented)
     applyFormatting: {
-        target: DocTarget;
         marks: RunFormatting;
+        target: DocTarget;
     };
     // (undocumented)
     applyVariables: {
@@ -775,32 +775,32 @@ export interface DocEdits {
     };
     // (undocumented)
     insertBreak: {
-        target: DocTarget;
         kind: 'page' | 'column' | 'line' | 'section';
+        target: DocTarget;
     };
     insertContentControl: {
-        target: DocTarget;
         subtype: InsertableContentControlType;
         tag?: string;
+        target: DocTarget;
         title?: string;
     };
     // (undocumented)
     insertHyperlink: {
-        target: DocTarget;
         href: string;
+        target: DocTarget;
         text?: string;
     };
     // (undocumented)
     insertImage: {
-        target: DocTarget;
         data: Uint8Array;
         extent?: Extent;
+        target: DocTarget;
     };
     // (undocumented)
     insertTable: {
-        target: DocTarget;
-        rows: number;
         cols: number;
+        rows: number;
+        target: DocTarget;
     };
     // (undocumented)
     insertText: {
@@ -813,27 +813,27 @@ export interface DocEdits {
     };
     // (undocumented)
     proposeDeletion: {
-        target: DocTarget;
         author: string;
+        target: DocTarget;
     };
     // (undocumented)
     proposeInsertion: {
+        author: string;
         target: DocTarget;
         text: string;
-        author: string;
     };
     proposeReplacement: {
-        target: DocTarget;
-        replaceWith: string;
         author: string;
+        replaceWith: string;
+        target: DocTarget;
     };
     // (undocumented)
     rejectAllRevisions: Record<never, never>;
     // (undocumented)
     rejectRevision: {
         id: number;
-        part?: 'body' | 'footnote' | 'endnote';
         noteId?: number;
+        part?: 'body' | 'footnote' | 'endnote';
     };
     // (undocumented)
     removeContentControl: {
@@ -845,8 +845,8 @@ export interface DocEdits {
     };
     // (undocumented)
     removeRepeatingSectionItem: {
-        target: DocTarget;
         index: number;
+        target: DocTarget;
     };
     // (undocumented)
     replaceText: {
@@ -855,9 +855,9 @@ export interface DocEdits {
     };
     // (undocumented)
     replyComment: {
+        author: string;
         commentId: string;
         text: string;
-        author: string;
     };
     // (undocumented)
     resolveComment: {
@@ -870,8 +870,8 @@ export interface DocEdits {
     };
     // (undocumented)
     setParagraphStyle: {
-        target: DocTarget;
         styleId: string;
+        target: DocTarget;
     };
     // (undocumented)
     setVariable: {
@@ -883,8 +883,8 @@ export interface DocEdits {
         target: DocTarget;
     };
     toggleList: {
-        target: DocTarget;
         kind: 'bullet' | 'ordered';
+        target: DocTarget;
     };
 }
 
@@ -909,8 +909,8 @@ export interface DocQueries {
     };
     // (undocumented)
     findText: {
-        text: string;
         container?: ContainerRef;
+        text: string;
     };
     // (undocumented)
     paragraphs: {
@@ -1116,42 +1116,42 @@ export interface Editor {
     getAvailableFonts(): readonly string[];
     getComments(): readonly {
         readonly id: string;
-        readonly text: string;
         readonly resolved: boolean;
+        readonly text: string;
     }[];
     getCurrentPage(mode?: 'viewport' | 'caret'): number;
     getCustomNodeDefinitions(): readonly unknown[];
     getDocumentFonts(): readonly string[];
     getDocumentHandle(): DocumentHandle;
     getDocumentStyles(): readonly {
-        readonly styleId: string;
         readonly name: string;
-        readonly type: string;
         readonly preview: {
+            readonly bold: boolean;
+            readonly color: string | null;
             readonly fontFamily: string | null;
             readonly fontSizePt: number | null;
-            readonly bold: boolean;
             readonly italic: boolean;
-            readonly color: string | null;
         };
+        readonly styleId: string;
+        readonly type: string;
     }[];
     getDocumentThemeColors(): readonly {
-        readonly slot: string;
         readonly hex: string;
+        readonly slot: string;
     }[];
     getEditingMode(): DocumentEditingMode;
     getHeaderFooterState(): HeaderFooterState | null;
     getNotePreviewText(scopeId: string): string | null;
     getNotePropertiesState(): NotePropertiesState | null;
     getOutline(): readonly {
-        readonly text: string;
-        readonly level: number;
         readonly blockId: string;
+        readonly level: number;
+        readonly text: string;
     }[];
     getPageGeometry(): readonly {
-        index: number;
         box: Rect;
         contentBox: Rect;
+        index: number;
     }[];
     getPageSetup(): PageSetup | null;
     getRenderScale(): number;
@@ -1160,20 +1160,20 @@ export interface Editor {
     getSelectedImage(): SelectedImageState | null;
     getSelectedTable(): {
         readonly blockId: string;
-        readonly rowCount: number;
-        readonly columnCount: number;
         readonly cell: {
-            readonly row: number;
             readonly column: number;
+            readonly row: number;
         } | null;
+        readonly columnCount: number;
+        readonly rowCount: number;
     } | null;
     getSelectionFormatting(): {
-        readonly fontFamily?: string;
-        readonly fontSizeHalfPoints?: number;
-        readonly styleId?: string;
         readonly alignment?: string;
         readonly bold?: boolean;
+        readonly fontFamily?: string;
+        readonly fontSizeHalfPoints?: number;
         readonly italic?: boolean;
+        readonly styleId?: string;
         readonly underline?: boolean;
     } | null;
     getSelectionPlacement(): {
@@ -1181,23 +1181,23 @@ export interface Editor {
         readonly pageIndex: number;
     } | null;
     getTableCellSelection(): {
-        readonly tableId: string;
-        readonly rows: {
-            readonly from: number;
-            readonly to: number;
-        };
+        readonly cellIds: readonly string[];
         readonly columns: {
             readonly from: number;
             readonly to: number;
         };
-        readonly cellIds: readonly string[];
+        readonly rows: {
+            readonly from: number;
+            readonly to: number;
+        };
+        readonly tableId: string;
     } | null;
     // (undocumented)
     getTotalPages(): number;
     getTrackedChanges(): readonly {
+        readonly author?: string;
         readonly id: string;
         readonly kind: string;
-        readonly author?: string;
         readonly story?: 'body' | 'header' | 'footer' | 'footnote' | 'endnote';
     }[];
     getWatermark(): {
@@ -1261,14 +1261,14 @@ export type EditorCommand = {
 export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHeaderFooterCommands, EditorNoteCommands {
     clearFormatting: Record<never, never>;
     commitTableColumnDividerResize: {
-        target: TableColumnDividerResizeTarget;
         leftWidthTwips: number;
         rightWidthTwips: number;
+        target: TableColumnDividerResizeTarget;
     };
     commitTableRightEdgeResize: {
-        target: TableRightEdgeResizeTarget;
         columnWidthTwips: number;
         tableWidthTwips: number;
+        target: TableRightEdgeResizeTarget;
     };
     copy: Record<never, never>;
     cut: Record<never, never>;
@@ -1288,23 +1288,23 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     deleteTable: Record<never, never>;
     // (undocumented)
     insertColumn: {
-        where: 'left' | 'right';
         target?: TableColumnOccurrenceTarget;
+        where: 'left' | 'right';
     };
     insertImage: {
         data: Uint8Array;
-        mime: SupportedImageMime;
-        widthPoints: number;
-        heightPoints: number;
-        expectedPackageRevision?: number;
-        title?: string;
         description?: string;
+        expectedPackageRevision?: number;
+        heightPoints: number;
         hyperlink?: string;
+        mime: SupportedImageMime;
+        title?: string;
+        widthPoints: number;
     };
     // (undocumented)
     insertRow: {
-        where: 'above' | 'below';
         target?: TableRowOccurrenceTarget;
+        where: 'above' | 'below';
     };
     insertToc: Record<never, never>;
     // (undocumented)
@@ -1316,23 +1316,23 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     redo: Record<never, never>;
     // (undocumented)
     refreshToc: {
-        tocId?: string;
         mode?: 'entire' | 'pageNumbers';
+        tocId?: string;
     };
     removeTabMark: {
         positionTwips: number;
     };
     replaceAllMatches: {
+        matchCase?: boolean;
         query: string;
         text: string;
-        matchCase?: boolean;
         wholeWord?: boolean;
     };
     replaceImage: {
         data: Uint8Array;
-        mime?: SupportedImageMime;
         drawingNodeId?: string;
         expectedPackageRevision?: number;
+        mime?: SupportedImageMime;
     };
     replaceMatch: {
         match: TextMatch;
@@ -1356,44 +1356,44 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
         drawingNodeId?: string;
         expectedPackageRevision?: number;
         horizontalEmu?: number;
-        verticalEmu?: number;
         relativeToH?: string;
         relativeToV?: string;
+        verticalEmu?: number;
     };
     setImageProperties: {
+        alt?: string;
+        borderColor?: ColorValue;
+        borderWidthEmu?: number;
+        crop?: ImageCropPercent;
+        description?: string;
         drawingNodeId?: string;
         expectedPackageRevision?: number;
-        selectionParagraphId?: string;
-        selectionOffset?: number;
-        widthEmu?: number;
         heightEmu?: number;
-        alt?: string;
-        title?: string;
-        description?: string;
-        hyperlink?: string | null;
-        crop?: ImageCropPercent;
-        resetToNaturalSize?: boolean;
-        wrap?: ImageWrapTarget;
         horizontalEmu?: number;
-        verticalEmu?: number;
+        hyperlink?: string | null;
         relativeToH?: string;
         relativeToV?: string;
-        borderWidthEmu?: number;
-        borderColor?: ColorValue;
+        resetToNaturalSize?: boolean;
+        selectionOffset?: number;
+        selectionParagraphId?: string;
+        title?: string;
+        verticalEmu?: number;
+        widthEmu?: number;
+        wrap?: ImageWrapTarget;
     };
     setImageWrapType: {
         drawingNodeId?: string;
         expectedPackageRevision?: number;
-        target: 'inline' | 'square' | 'squareLeft' | 'squareRight' | 'tight' | 'through' | 'topAndBottom' | 'behind' | 'inFront';
         initialPositionEmu?: {
             horizontalEmu: number;
             verticalEmu: number;
         };
+        target: 'inline' | 'square' | 'squareLeft' | 'squareRight' | 'tight' | 'through' | 'topAndBottom' | 'behind' | 'inFront';
     };
     setIndent: {
+        firstLine?: number | null;
         left?: number | null;
         right?: number | null;
-        firstLine?: number | null;
     };
     setLineSpacing: {
         rule: 'multiple' | 'exact' | 'atLeast';
@@ -1401,24 +1401,24 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     };
     // (undocumented)
     setMarkAttr: {
-        mark: string;
         attr: string;
+        mark: string;
         value: unknown;
     };
     setPageSetup: {
-        pageWidth?: number;
-        pageHeight?: number;
-        marginTop?: number;
-        marginRight?: number;
         marginBottom?: number;
         marginLeft?: number;
+        marginRight?: number;
+        marginTop?: number;
         orientation?: 'portrait' | 'landscape';
+        pageHeight?: number;
+        pageWidth?: number;
         scope?: 'document' | 'section';
     };
     setParagraphFormat: ParagraphFormatCommand;
     setParagraphSpacing: {
-        beforePt?: number | null;
         afterPt?: number | null;
+        beforePt?: number | null;
     };
     setSelection: {
         anchor: DocAnchor;
@@ -1436,9 +1436,9 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
         alignment: TableCellVerticalAlignment;
     };
     setTableProperties: {
+        justification?: 'left' | 'center' | 'right' | null;
         width?: number | null;
         widthType?: string | null;
-        justification?: 'left' | 'center' | 'right' | null;
     };
     // (undocumented)
     setWatermark: {
@@ -1446,8 +1446,8 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     };
     // (undocumented)
     splitCell: {
-        rows: number;
         cols: number;
+        rows: number;
     };
     // (undocumented)
     toggleHeaderRow: Record<never, never>;
@@ -1461,9 +1461,9 @@ export interface EditorCommands extends EditorCommandShape<DocEdits>, EditorHead
     };
     toggleReviewPane: Record<never, never>;
     transformImage: {
+        action: 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV';
         drawingNodeId?: string;
         expectedPackageRevision?: number;
-        action: 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV';
     };
     // (undocumented)
     undo: Record<never, never>;
@@ -1499,9 +1499,9 @@ export interface EditorEvents {
 // @public
 export class EditorFontError extends Error {
     constructor(code: EditorFontErrorCode, message: string, details?: {
-        readonly request?: FontFaceRequest;
-        readonly diagnostic?: string;
         readonly cause?: unknown;
+        readonly diagnostic?: string;
+        readonly request?: FontFaceRequest;
     });
     // (undocumented)
     readonly code: EditorFontErrorCode;
@@ -1519,11 +1519,11 @@ export type EditorFontErrorCode = 'initializationFailed' | 'wasmUnavailable' | '
 // @public
 export interface EditorHeaderFooterCommands {
     editHeaderFooter: {
-        position: 'header' | 'footer';
-        variant?: FurnitureVariant;
-        firstPage?: boolean;
         evenPage?: boolean;
+        firstPage?: boolean;
+        position: 'header' | 'footer';
         sectionIndex?: number;
+        variant?: FurnitureVariant;
     };
     exitHeaderFooter: Record<never, never>;
     insertPageField: {
@@ -1532,11 +1532,11 @@ export interface EditorHeaderFooterCommands {
     linkHeaderFooterToPrevious: HeaderFooterSlotArgs;
     removeHeaderFooter: HeaderFooterSlotArgs;
     setHeaderFooterOptions: {
+        evenAndOddHeaders?: boolean;
+        footerDistanceTwips?: number;
+        headerDistanceTwips?: number;
         sectionIndex?: number;
         titlePage?: boolean;
-        evenAndOddHeaders?: boolean;
-        headerDistanceTwips?: number;
-        footerDistanceTwips?: number;
     };
     unlinkHeaderFooterFromPrevious: HeaderFooterSlotArgs;
 }
@@ -1560,27 +1560,27 @@ export interface EditorNoteCommands {
         noteId: number;
     };
     deleteNote: {
-        noteKind: NoteKind;
         noteId: number;
+        noteKind: NoteKind;
     };
     insertNote: {
         noteKind: NoteKind;
     };
     setNoteProperties: {
-        scope?: 'document' | 'section';
-        sectionIndex?: number;
-        footnote?: {
-            numFmt?: string;
-            numRestart?: string;
-            position?: string;
-            numStart?: number;
-        };
         endnote?: {
             numFmt?: string;
             numRestart?: string;
-            position?: string;
             numStart?: number;
+            position?: string;
         };
+        footnote?: {
+            numFmt?: string;
+            numRestart?: string;
+            numStart?: number;
+            position?: string;
+        };
+        scope?: 'document' | 'section';
+        sectionIndex?: number;
     };
 }
 
@@ -1595,8 +1595,8 @@ export interface EditorQueries extends DocQueries {
     };
     // (undocumented)
     hyperlinkAt: {
-        pos?: number;
         fallbackHref?: string;
+        pos?: number;
     };
     // (undocumented)
     isInsideToc: {
@@ -1641,8 +1641,8 @@ export interface EditorQueryResults extends DocQueryResults {
     selectionFormatting: RunFormatting | null;
     // (undocumented)
     splitCellConfig: {
-        maxRows: number;
         maxCols: number;
+        maxRows: number;
     } | null;
     // (undocumented)
     tableContext: TableContext | null;
@@ -1667,13 +1667,13 @@ export type EditorScope = {
 * store package. Do not invent a parallel `{ noteKind, noteId }` scope arm.
 */
 | {
-    kind: 'note';
     id: string;
+    kind: 'note';
 }
 /** A text box or floating frame with its own content, addressed by id. */
 | {
-    kind: 'frame';
     id: string;
+    kind: 'frame';
 }
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | {
@@ -1731,11 +1731,11 @@ export type ExecErrorCode = 'notFound' | 'ambiguous' | 'locked' | 'bound' | 'typ
 
 // @public
 export type ExecResult = {
-    ok: true;
     changed: boolean;
+    ok: true;
 } | {
-    ok: false;
     code: ExecErrorCode;
+    ok: false;
     reason: string;
     target?: DocTarget;
 };
@@ -1927,10 +1927,10 @@ export interface HyperlinkActivation {
     // (undocumented)
     readonly link: SurfaceHyperlink;
     readonly rect: {
-        readonly left: number;
-        readonly top: number;
         readonly bottom: number;
+        readonly left: number;
         readonly right: number;
+        readonly top: number;
     };
 }
 
@@ -1966,20 +1966,20 @@ export interface ImageCropPercent {
 
 // @public
 export type ImageResourceState = {
-    readonly kind: 'ready';
-    readonly partName: string;
     readonly contentId: string;
-    readonly resourceKey: string;
-    readonly validatedHandle: ValidatedImageBytesHandle;
-    readonly mime: RenderableImageMime;
-    readonly pixelWidth: number;
-    readonly pixelHeight: number;
     readonly dpiX: number;
     readonly dpiY: number;
+    readonly kind: 'ready';
+    readonly mime: RenderableImageMime;
+    readonly partName: string;
+    readonly pixelHeight: number;
+    readonly pixelWidth: number;
+    readonly resourceKey: string;
+    readonly validatedHandle: ValidatedImageBytesHandle;
 } | {
     readonly kind: 'unrenderable';
-    readonly partName: string | null;
     readonly mime: RenderableImageMime | PreservedImageMime | 'unknown';
+    readonly partName: string | null;
     readonly reason: 'unsupported-format' | 'non-picture-graphic' | 'signature-mismatch' | 'decode-failed' | 'resource-limit';
 } | {
     readonly kind: 'external';
@@ -2001,9 +2001,9 @@ export interface IndentFormatting {
     readonly firstLine: number;
     readonly left: number;
     readonly mixed: {
+        readonly firstLine: boolean;
         readonly left: boolean;
         readonly right: boolean;
-        readonly firstLine: boolean;
     };
     readonly right: number;
 }
@@ -2019,8 +2019,8 @@ export type InteractionOutcome<T> = {
     readonly ok: true;
     readonly value: T;
 } | {
-    readonly ok: false;
     readonly code: InteractionOutcomeCode;
+    readonly ok: false;
     readonly reason: string;
 };
 
@@ -2094,10 +2094,10 @@ export interface PageSetup {
     readonly gutterTwips?: number;
     // (undocumented)
     readonly marginsTwips: {
-        readonly top: number;
-        readonly right: number;
         readonly bottom: number;
         readonly left: number;
+        readonly right: number;
+        readonly top: number;
     };
     // (undocumented)
     readonly orientation: 'portrait' | 'landscape';
@@ -2335,9 +2335,9 @@ export interface ReviewModelInput {
     readonly commentsPart?: OoxmlPart | undefined;
     // (undocumented)
     readonly customNodePayloads?: ReadonlyMap<string, {
-        readonly nodeId: string;
-        readonly label: string;
         readonly data: string;
+        readonly label: string;
+        readonly nodeId: string;
     }> | undefined;
     readonly customNodes?: readonly unknown[] | undefined;
     readonly furnitureParts?: readonly OoxmlPart[] | undefined;
@@ -2526,8 +2526,8 @@ export interface SectionProperties {
     readonly margins: PageMargins;
     // (undocumented)
     readonly pageSize: {
-        widthTwips: number;
         heightTwips: number;
+        widthTwips: number;
     };
     readonly titlePage?: boolean;
 }
@@ -2555,10 +2555,10 @@ export interface SelectedImageState {
     readonly id: string;
     // (undocumented)
     readonly intrinsic: Readonly<{
-        readonly pixelWidth: number;
-        readonly pixelHeight: number;
         readonly dpiX: number;
         readonly dpiY: number;
+        readonly pixelHeight: number;
+        readonly pixelWidth: number;
     }> | null;
     // (undocumented)
     readonly kind: DrawingKind;
@@ -2609,15 +2609,15 @@ export interface SemanticSelection {
 
 // @public
 export type SemanticTarget = {
+    readonly affinity: InteractionAffinity;
+    readonly graphemeOffset: number;
+    readonly identity: SemanticIdentity;
     readonly kind: 'text';
     readonly scope: ViewScope;
-    readonly identity: SemanticIdentity;
-    readonly graphemeOffset: number;
-    readonly affinity: InteractionAffinity;
 } | {
     readonly kind: 'atomic';
-    readonly scope: ViewScope;
     readonly objectId: string;
+    readonly scope: ViewScope;
 };
 
 // @public
@@ -2851,10 +2851,10 @@ export type ZoomFitTarget = 'pageWidth';
 export type ZoomMode = {
     readonly type: 'fixed';
 } | {
-    readonly type: 'fit';
     readonly fit: ZoomFitTarget;
-    readonly minZoom?: number;
     readonly maxZoom?: number;
+    readonly minZoom?: number;
+    readonly type: 'fit';
 };
 
 // (No @packageDocumentation comment for this package)

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -25,15 +25,15 @@ export function appliedSpaceBefore(before: number, previousAfter: number, atTopO
 
 // @public
 export function applyLineSpacing(spacing: ParagraphLineSpacing, naturalHeight: number, naturalBaseline: number): {
-    height: number;
     baseline: number;
+    height: number;
 };
 
 // @public
 export function attachNotesToLayout(layout: SemanticLayout, allRefs: readonly PageRefHit[], input: NotesLayoutInput, options?: {
     readonly fallbackReasons?: readonly NotePaginationFallbackReason[];
-    readonly paragraphSectionIndex?: ReadonlyMap<string, number>;
     readonly memo?: unknown;
+    readonly paragraphSectionIndex?: ReadonlyMap<string, number>;
 }): NotesAttachResult;
 
 // @public
@@ -51,9 +51,9 @@ export interface BidiEmbeddingLevels {
     readonly levels: Uint8Array;
     // (undocumented)
     readonly paragraphs: readonly {
-        readonly start: number;
         readonly end: number;
         readonly level: number;
+        readonly start: number;
     }[];
 }
 
@@ -66,13 +66,13 @@ export function borderExtentPt(edge: ResolvedTableBorderEdge | TableBorderSide |
 // @public
 export interface BorderGridGeometry {
     readonly cellBoxes: readonly (readonly {
-        readonly width: number;
         readonly height: number;
+        readonly width: number;
     }[])[];
     readonly columnWidthsPt: readonly number[];
     readonly rowBands: readonly {
-        readonly y: number;
         readonly height: number;
+        readonly y: number;
     }[];
 }
 
@@ -100,8 +100,8 @@ export function buildStyleCascadeTable(stylesRoot: OoxmlElement | null, themeFon
 // @public
 export type CacheLookup<V> = {
     readonly hit: true;
-    readonly value: V;
     readonly provenance: CacheProvenance;
+    readonly value: V;
 } | CacheMiss;
 
 // @public
@@ -119,9 +119,9 @@ export type CacheMiss = {
     readonly reason: 'resource-changed';
     readonly resourceKey: string;
 } | {
+    readonly epoch: keyof OperationSnapshot;
     readonly hit: false;
     readonly reason: 'epoch-changed';
-    readonly epoch: keyof OperationSnapshot;
 };
 
 // @public
@@ -176,12 +176,12 @@ export interface CaretAtOptions {
 
 // @public
 export function caretBoxOnLine(line: LineRecord, offset: number, measurer: TextMeasurer | undefined, segment?: {
-    readonly spans: readonly StyleSpanRecord[];
     readonly drawings: readonly InlineDrawingRecord[];
+    readonly spans: readonly StyleSpanRecord[];
 } | null): {
+    height: number;
     x: number;
     y: number;
-    height: number;
 };
 
 // @public
@@ -279,11 +279,11 @@ export function cellSelectionBetween(layout: SemanticLayout, anchor: TableCellAd
 
 // @public
 export function cellSelectionRects(layout: SemanticLayout, cellIds: readonly string[]): readonly {
+    height: number;
     pageIndex: number;
+    width: number;
     x: number;
     y: number;
-    width: number;
-    height: number;
 }[];
 
 // @public
@@ -376,9 +376,9 @@ export function computeDoubleBorderMetricsPt(widthPt: number): CompoundBorderMet
 // @public
 export function computeFootnoteReserves(layout: SemanticLayout, allRefs: readonly PageRefHit[], input: NotesLayoutInput, noteMarks: NoteMarkContext,
 passMemo?: unknown): {
+    readonly reasons: readonly NotePaginationFallbackReason[];
     readonly reserves: ReadonlyMap<number, number>;
     readonly stable: boolean;
-    readonly reasons: readonly NotePaginationFallbackReason[];
 };
 
 // @public
@@ -386,9 +386,9 @@ export function contentControlAtPoint(layout: SemanticLayout, pageIndex: number,
 
 // @public
 export function contentControlAtSemantic(layout: SemanticLayout, point: {
+    readonly pageIndex?: number;
     readonly x: number;
     readonly y: number;
-    readonly pageIndex?: number;
 }): ContentControlBoundaryRecord | null;
 
 // @public
@@ -769,11 +769,11 @@ export const fontRequestKey: (request: FontRequest) => string;
 // @public
 export class FontResolutionError extends Error {
     constructor(code: FontResolutionErrorCode, request: FontRequest, details?: {
-        readonly limit?: number;
         readonly actual?: number;
+        readonly actualHash?: string;
         readonly diagnostic?: string;
         readonly expectedHash?: string;
-        readonly actualHash?: string;
+        readonly limit?: number;
     });
     // (undocumented)
     readonly actual?: number;
@@ -862,8 +862,8 @@ export interface FontSubstitution {
 export type FontValidationResult = {
     readonly valid: true;
 } | {
-    readonly valid: false;
     readonly diagnostic: string;
+    readonly valid: false;
 };
 
 // @public
@@ -886,8 +886,8 @@ export function formatPageNumber(value: number, format: string | undefined): str
 
 // @public
 export function formatRevisionOf(properties: readonly {
-    readonly localName: string;
     readonly attributes?: Readonly<Record<string, string>>;
+    readonly localName: string;
 }[]): RevisionAttribution | null;
 
 // @public
@@ -997,10 +997,10 @@ export interface HarfBuzzShapeCacheEvent {
 // @public
 export class HarfBuzzShapingError extends Error {
     constructor(code: HarfBuzzShapingErrorCode, details?: {
-        readonly limit?: number;
         readonly actual?: number;
-        readonly diagnostic?: string;
         readonly cause?: unknown;
+        readonly diagnostic?: string;
+        readonly limit?: number;
     });
     // (undocumented)
     readonly actual?: number;
@@ -1077,10 +1077,10 @@ export interface HeaderFooterStoryRecord {
     // (undocumented)
     readonly kind: 'header' | 'footer';
     readonly pageFieldProjector?: (context: {
-        readonly pageNumber: number;
-        readonly pageCount: number;
-        readonly sectionPageCount?: number;
         readonly format?: string;
+        readonly pageCount: number;
+        readonly pageNumber: number;
+        readonly sectionPageCount?: number;
     }) => HeaderFooterStoryRecord;
     readonly part?: OoxmlPart;
     // (undocumented)
@@ -1112,9 +1112,9 @@ export function hitTestPage(layout: SemanticLayout, pageIndex: number, point: Hi
 
 // @public
 export function hitTestSemantic(layout: SemanticLayout, point: {
+    readonly pageIndex?: number;
     readonly x: number;
     readonly y: number;
-    readonly pageIndex?: number;
 }): CaretGeometry | null;
 
 // @public
@@ -1307,14 +1307,14 @@ export interface LayoutShapingOptions {
     };
     // (undocumented)
     readonly environment: {
-        readonly variationAxes: Readonly<Record<string, number>>;
-        readonly shapingLibrary: VersionedShapingLibrary;
-        readonly unicodeDataVersion: string;
-        readonly normalization: NormalizationPolicy;
-        readonly language: string;
         readonly features: Readonly<Record<string, number>>;
         readonly fixedPointScale: number;
+        readonly language: string;
+        readonly normalization: NormalizationPolicy;
         readonly roundingMode: FixedPointRoundingMode;
+        readonly shapingLibrary: VersionedShapingLibrary;
+        readonly unicodeDataVersion: string;
+        readonly variationAxes: Readonly<Record<string, number>>;
     };
     // (undocumented)
     readonly fonts: FontResourceSnapshot;
@@ -1387,10 +1387,10 @@ export type ListMarkerAlign = 'left' | 'center' | 'right';
 
 // @public
 export function listMarkerBox(item: ResolvedListItem, markerWidth: number, lineY: number, lineHeight: number): {
+    height: number;
+    width: number;
     x: number;
     y: number;
-    width: number;
-    height: number;
 } | null;
 
 // @public
@@ -1498,8 +1498,8 @@ export function mergeListIndent(levelIndent: NumberingLevelIndent, inherited: re
 
 // @public
 export function moveCaret(layout: SemanticLayout, position: SemanticPosition, command: NavigationCommand, desiredX?: number | null, options?: MoveCaretOptions): {
-    position: SemanticPosition;
     desiredX: number | null;
+    position: SemanticPosition;
 } | null;
 
 // @public
@@ -1691,9 +1691,9 @@ export interface NumberingLevelIndent {
     // (undocumented)
     readonly right: number;
     readonly stated?: {
+        readonly firstLineOffset: boolean;
         readonly left: boolean;
         readonly right: boolean;
-        readonly firstLineOffset: boolean;
     };
 }
 
@@ -1728,8 +1728,8 @@ export type OperationSnapshotField = keyof OperationSnapshot;
 export type OperationSnapshotGuard = {
     readonly status: 'current';
 } | {
-    readonly status: 'restart';
     readonly changed: readonly OperationSnapshotField[];
+    readonly status: 'restart';
 };
 
 // @public
@@ -1755,10 +1755,10 @@ export interface PageGeometry {
     readonly height: number;
     // (undocumented)
     readonly margin: {
-        readonly top: number;
-        readonly right: number;
         readonly bottom: number;
         readonly left: number;
+        readonly right: number;
+        readonly top: number;
     };
     // (undocumented)
     readonly width: number;
@@ -1785,9 +1785,9 @@ export interface PageRecord {
     readonly index: number;
     readonly noteStream?: PageNoteStream;
     readonly pageFieldSource?: {
+        readonly format?: string;
         readonly pageNumber: number;
         readonly sectionPageCount: number;
-        readonly format?: string;
     };
 }
 
@@ -1962,10 +1962,10 @@ export interface ParagraphLayoutInputs {
     readonly contextualSpacing: boolean;
     // (undocumented)
     readonly indent: {
+        firstLine: number;
+        hanging: number;
         left: number;
         right: number;
-        hanging: number;
-        firstLine: number;
     };
     // (undocumented)
     readonly inheritedRunProperties: readonly OoxmlProperty[];
@@ -2089,8 +2089,8 @@ export function readCellBorders(tcPr: OoxmlElement | undefined): CellBorderBox;
 
 // @public
 export function readNumPr(paragraphPropertyNodes: readonly OoxmlNode[]): {
-    numId: string;
     ilvl: number;
+    numId: string;
 } | null;
 
 // @public
@@ -2296,31 +2296,31 @@ export interface ResourceDependencyProvenance {
 
 // @public
 export function reviewAnchorIndex<TPage extends {
-    readonly index: number;
     readonly contentBox: {
         readonly y: number;
     };
+    readonly index: number;
 }>(layout: {
     readonly pages: readonly TPage[];
 }, paragraphFragments: (page: TPage) => readonly {
-    readonly paragraphId: string;
     readonly box: {
         readonly y: number;
     };
     readonly lines?: readonly {
-        readonly range: {
-            readonly end: number;
-        };
         readonly box: {
             readonly y: number;
         };
+        readonly range: {
+            readonly end: number;
+        };
         readonly spans?: readonly {
             readonly range: {
-                readonly paragraphId: string;
                 readonly end: number;
+                readonly paragraphId: string;
             };
         }[];
     }[];
+    readonly paragraphId: string;
 }[]): Map<string, ReviewParagraphAnchor>;
 
 // @public
@@ -2386,9 +2386,9 @@ export interface ReviewModelInput {
     readonly commentsPart?: OoxmlPart | undefined;
     // (undocumented)
     readonly customNodePayloads?: ReadonlyMap<string, {
-        readonly nodeId: string;
-        readonly label: string;
         readonly data: string;
+        readonly label: string;
+        readonly nodeId: string;
     }> | undefined;
     readonly customNodes?: readonly unknown[] | undefined;
     readonly furnitureParts?: readonly OoxmlPart[] | undefined;
@@ -2402,16 +2402,16 @@ export interface ReviewParagraphAnchor {
     readonly fragmentY: number;
     // (undocumented)
     readonly lines?: readonly {
-        readonly range: {
-            readonly end: number;
-        };
         readonly box: {
             readonly y: number;
         };
+        readonly range: {
+            readonly end: number;
+        };
         readonly spans?: readonly {
             readonly range: {
-                readonly paragraphId: string;
                 readonly end: number;
+                readonly paragraphId: string;
             };
         }[];
     }[];
@@ -2591,8 +2591,8 @@ export interface SectionProperties {
     readonly pageNumbering?: SectionPageNumbering;
     // (undocumented)
     readonly pageSize: {
-        readonly widthTwips: number;
         readonly heightTwips: number;
+        readonly widthTwips: number;
     };
     // (undocumented)
     readonly titlePage: boolean;
@@ -2867,10 +2867,10 @@ export interface ShapedRunComparatorInputs {
     readonly direction: TextDirection;
     // (undocumented)
     readonly fontSpans: readonly {
-        readonly glyphStart: number;
-        readonly glyphEnd: number;
         readonly fallbackIndex: number | null;
         readonly font: FontFingerprintInputs;
+        readonly glyphEnd: number;
+        readonly glyphStart: number;
     }[];
     // (undocumented)
     readonly glyphs: readonly ShapedGlyph[];
@@ -3056,8 +3056,8 @@ export interface StyleSpanRecord {
     readonly fieldAtom?: FieldAtomMarker;
     readonly link?: SpanLinkRecord;
     readonly noteNav?: {
-        readonly scopeId: string;
         readonly direction: 'to-note' | 'to-body';
+        readonly scopeId: string;
     };
     readonly projected?: boolean;
     readonly props: readonly OoxmlProperty[];
@@ -3121,9 +3121,9 @@ export type TableBorderSide = {
 } | {
     readonly state: 'none';
 } | {
+    readonly color: string | null;
     readonly state: 'edge';
     readonly style: TableBorderStyle;
-    readonly color: string | null;
     readonly widthPt: number;
 };
 
@@ -3280,8 +3280,8 @@ export type TextDirection = 'ltr' | 'rtl';
 // @public
 export interface TextMeasurer {
     lineMetrics(style: ResolvedRunStyle): {
-        height: number;
         baseline: number;
+        height: number;
     };
     measure(text: string, style: ResolvedRunStyle): number;
 }
@@ -3347,13 +3347,13 @@ export function withNumberingStyleLinks(index: NumberingIndex, styleCascade: Sty
 
 // @public
 export function withResolvedListItems<T extends {
-    readonly numberingIndex?: NumberingIndex;
-    readonly listItems?: ReadonlyMap<string, ResolvedListItem>;
-    readonly styleCascade?: StyleCascadeTable;
     readonly isFontAvailable?: (family: string) => boolean;
-}>(options: T, blocks: readonly OoxmlElement[]): T & {
-    readonly numberingIndex: NumberingIndex;
     readonly listItems?: ReadonlyMap<string, ResolvedListItem>;
+    readonly numberingIndex?: NumberingIndex;
+    readonly styleCascade?: StyleCascadeTable;
+}>(options: T, blocks: readonly OoxmlElement[]): T & {
+    readonly listItems?: ReadonlyMap<string, ResolvedListItem>;
+    readonly numberingIndex: NumberingIndex;
 };
 
 // @public

--- a/docs/api/docx-editor-core/output.api.md
+++ b/docs/api/docx-editor-core/output.api.md
@@ -32,14 +32,14 @@ export interface PaintOptions {
     readonly activeHeaderFooterRId?: string;
     readonly ariaHidden?: boolean;
     readonly contentControlChrome?: {
-        readonly showAll?: boolean;
         readonly activeIds?: ReadonlySet<string>;
-        readonly hoverIds?: ReadonlySet<string>;
-        readonly suppressedIds?: ReadonlySet<string>;
-        readonly checkedIds?: ReadonlySet<string>;
         readonly additionalBoundaries?: readonly ContentControlBoundaryRecord[];
-        readonly tocControlIds?: ReadonlySet<string>;
+        readonly checkedIds?: ReadonlySet<string>;
+        readonly hoverIds?: ReadonlySet<string>;
         readonly readOnly?: boolean;
+        readonly showAll?: boolean;
+        readonly suppressedIds?: ReadonlySet<string>;
+        readonly tocControlIds?: ReadonlySet<string>;
     };
     readonly defaultFontFamily?: string;
     // (undocumented)

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4480,13 +4480,13 @@ export type TreeOpRejection = 'unknown-op' | 'unknown-paragraph' | 'not-a-paragr
 
 // @public
 export type TreeOpResult = {
+    readonly effect: TreeOpEffect;
     readonly ok: true;
     readonly part: OoxmlPart;
-    readonly effect: TreeOpEffect;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: TreeOpRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -4558,8 +4558,8 @@ export type TreeStoryRef = {
     readonly rId: string;
 } | {
     readonly kind: 'notesPart';
-    readonly partName: string;
     readonly noteKind: 'footnote' | 'endnote';
+    readonly partName: string;
 };
 
 // @public
@@ -4582,12 +4582,12 @@ export interface TreeTransactOptions {
 
 // @public
 export type TreeTransactResult = {
-    readonly ok: true;
     readonly change: TreeModelChange | null;
+    readonly ok: true;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: TreeOpRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -4673,11 +4673,11 @@ export function withEmbeddedImage(pkg: OoxmlPackage, ownerPartName: string, inpu
     bytes: Uint8Array;
     mime: SupportedImageMime;
 }>): Readonly<{
-    ok: true;
-    pkg: OoxmlPackage;
-    partName: string;
-    relationshipId: string;
     docPrId: number;
+    ok: true;
+    partName: string;
+    pkg: OoxmlPackage;
+    relationshipId: string;
 }> | Readonly<{
     ok: false;
     reason: 'invalidArgs' | 'invalid-image';
@@ -4709,9 +4709,9 @@ export function withPart(pkg: OoxmlPackage, part: OoxmlPart): OoxmlPackage;
 
 // @public
 export function withRelationship(pkg: OoxmlPackage, ownerPart: string, type: string, rawTarget: string): {
+    readonly ok: boolean;
     readonly pkg: OoxmlPackage;
     readonly relationshipId: string;
-    readonly ok: boolean;
 };
 
 // @public
@@ -4743,10 +4743,10 @@ export interface XmlLimits {
 
 // @public
 export type XmlNode = {
-    readonly type: 'element';
-    readonly name: string;
     readonly attributes: Readonly<Record<string, string>>;
     readonly children: readonly XmlNode[];
+    readonly name: string;
+    readonly type: 'element';
 } | {
     readonly type: 'text';
     readonly value: string;
@@ -4760,8 +4760,8 @@ export type XmlRejection = 'too-large' | 'dtd-forbidden' | 'entity-forbidden' | 
 
 // @public
 export type XmlResult = {
-    readonly ok: true;
     readonly nodes: readonly XmlNode[];
+    readonly ok: true;
 } | {
     readonly ok: false;
     readonly reason: XmlRejection;
@@ -4777,12 +4777,12 @@ export interface ZipLimits {
 
 // @public
 export type ZipReadResult = {
-    readonly ok: true;
     readonly entries: ReadonlyMap<string, Uint8Array>;
+    readonly ok: true;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: ZipRejection;
-    readonly detail?: string;
 };
 
 // @public

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -28,9 +28,9 @@ export interface AddCommentRequest {
 
 // @public
 export type AddCommentResult = {
-    readonly ok: true;
-    readonly commentId: string;
     readonly change: TreeModelChange | null;
+    readonly commentId: string;
+    readonly ok: true;
 } | {
     readonly ok: false;
     readonly reason: TreeOpRejection | 'invalid-author';
@@ -97,8 +97,8 @@ export interface AtomicFieldSpan {
 
 // @public
 export function atomicFieldSpansOf(paragraph: OoxmlParagraphNode, options?: {
-    readonly maxNesting?: number;
     readonly maxInstructionChars?: number;
+    readonly maxNesting?: number;
 }): readonly AtomicFieldSpan[];
 
 // @public
@@ -120,8 +120,8 @@ export function atomicNoteSpansOf(paragraph: OoxmlParagraphNode): readonly Atomi
 export interface AuditPort {
     // (undocumented)
     record(entry: {
-        readonly kind: string;
         readonly at: number;
+        readonly kind: string;
         readonly meta?: Record<string, unknown>;
     }): void;
 }
@@ -187,8 +187,8 @@ export type BookmarkIndex = ReadonlyMap<string, BookmarkAnchor>;
 
 // @public
 export function bookmarkPairNodes(mint: () => string, name: string, id: string): {
-    readonly start: OoxmlNode;
     readonly end: OoxmlNode;
+    readonly start: OoxmlNode;
 };
 
 // @public
@@ -350,8 +350,8 @@ export function collectNodeIds(part: OoxmlPart): Set<string>;
 
 // @public (undocumented)
 export function collectNoteReferences(part: OoxmlPart, options?: {
-    readonly maxHits?: number;
     readonly budget?: NoteReferenceScanBudget;
+    readonly maxHits?: number;
 }): readonly NoteReferenceHit[];
 
 // @public
@@ -414,10 +414,10 @@ export function commentInitials(comment: CommentRecord): string;
 // @public
 export function commentItemsOf(comments: readonly CommentRecord[], anchors: readonly {
     commentId: string;
-    partName: string;
-    start: ReviewPosition;
     end: ReviewPosition;
     orphaned: boolean;
+    partName: string;
+    start: ReviewPosition;
 }[], threadState: ReadonlyMap<string, CommentThreadState>): ReviewCommentItem[];
 
 // @public
@@ -478,65 +478,65 @@ export type ComparatorName = keyof typeof COMPARATORS;
 
 // @public
 export const COMPARATORS: {
-    readonly authoredState: {
-        readonly id: "dev.docx-editor.core.comparator.authored-state";
-        readonly mode: "canonical-exact";
-        readonly ephemera: readonly ["revision", "provenance", "producedAt", "commitId"];
-        readonly note: "canonical normalized authored records; ephemera excluded";
-    };
     readonly anchor: {
+        readonly ephemera: readonly [];
         readonly id: "dev.docx-editor.core.comparator.anchor";
         readonly mode: "exact";
-        readonly ephemera: readonly [];
         readonly note: "internal anchor identity/affinity compares exactly";
     };
-    readonly yjsStateVector: {
-        readonly id: "dev.docx-editor.core.comparator.yjs-state-vector";
+    readonly authoredState: {
+        readonly ephemera: readonly ["revision", "provenance", "producedAt", "commitId"];
+        readonly id: "dev.docx-editor.core.comparator.authored-state";
+        readonly mode: "canonical-exact";
+        readonly note: "canonical normalized authored records; ephemera excluded";
+    };
+    readonly benchmarkEvidence: {
+        readonly ephemera: readonly [];
+        readonly id: "dev.docx-editor.core.comparator.benchmark-evidence";
         readonly mode: "sync-optimization-only";
-        readonly ephemera: readonly [];
-        readonly note: "exchange optimization only; never proves update or delete-set coverage";
-    };
-    readonly shapedRun: {
-        readonly id: "dev.docx-editor.core.comparator.shaped-run";
-        readonly mode: "exact";
-        readonly ephemera: readonly [];
-        readonly note: "glyph ids, clusters, and fixed-point advances compare exactly";
-    };
-    readonly paginationFingerprint: {
-        readonly id: "dev.docx-editor.core.comparator.pagination-fingerprint";
-        readonly mode: "exact";
-        readonly ephemera: readonly [];
-        readonly note: "page/column boundaries, break causes, fixed-point geometry compare exactly";
-    };
-    readonly semanticTree: {
-        readonly id: "dev.docx-editor.core.comparator.semantic-tree";
-        readonly mode: "exact";
-        readonly ephemera: readonly [];
-        readonly note: "reading order, roles, headings, alt text compare exactly";
+        readonly note: "diagnostic evidence, not an equivalence basis";
     };
     readonly hitTest: {
+        readonly ephemera: readonly [];
         readonly id: "dev.docx-editor.core.comparator.hit-test";
         readonly mode: "exact";
-        readonly ephemera: readonly [];
         readonly note: "resolved hit target and cluster affinity compare exactly";
     };
+    readonly paginationFingerprint: {
+        readonly ephemera: readonly [];
+        readonly id: "dev.docx-editor.core.comparator.pagination-fingerprint";
+        readonly mode: "exact";
+        readonly note: "page/column boundaries, break causes, fixed-point geometry compare exactly";
+    };
     readonly pdfSemantics: {
+        readonly ephemera: readonly ["objectNumber", "producer", "creationDate", "modDate", "subsetTag"];
         readonly id: "dev.docx-editor.core.comparator.pdf-semantics";
         readonly mode: "canonical-exact";
-        readonly ephemera: readonly ["objectNumber", "producer", "creationDate", "modDate", "subsetTag"];
         readonly note: "canonical semantic PDF objects; container ephemera excluded";
     };
     readonly rasterCheckpoint: {
+        readonly ephemera: readonly [];
         readonly id: "dev.docx-editor.core.comparator.raster-checkpoint";
         readonly mode: "tolerance";
-        readonly ephemera: readonly [];
         readonly note: "documented unavoidable raster comparison; explicit tolerance only";
     };
-    readonly benchmarkEvidence: {
-        readonly id: "dev.docx-editor.core.comparator.benchmark-evidence";
-        readonly mode: "sync-optimization-only";
+    readonly semanticTree: {
         readonly ephemera: readonly [];
-        readonly note: "diagnostic evidence, not an equivalence basis";
+        readonly id: "dev.docx-editor.core.comparator.semantic-tree";
+        readonly mode: "exact";
+        readonly note: "reading order, roles, headings, alt text compare exactly";
+    };
+    readonly shapedRun: {
+        readonly ephemera: readonly [];
+        readonly id: "dev.docx-editor.core.comparator.shaped-run";
+        readonly mode: "exact";
+        readonly note: "glyph ids, clusters, and fixed-point advances compare exactly";
+    };
+    readonly yjsStateVector: {
+        readonly ephemera: readonly [];
+        readonly id: "dev.docx-editor.core.comparator.yjs-state-vector";
+        readonly mode: "sync-optimization-only";
+        readonly note: "exchange optimization only; never proves update or delete-set coverage";
     };
 };
 
@@ -704,8 +704,8 @@ export function contentControlPropertiesOf(control: OoxmlNode): ContentControlPr
 
 // @public
 export function contentControlsIn(root: OoxmlNode, options?: {
-    readonly maxDepth?: number;
     readonly limit?: number;
+    readonly maxDepth?: number;
 }): readonly ContentControlEntry[];
 
 // @public
@@ -753,8 +753,8 @@ export interface ContentTypeRecords {
 
 // @public
 export function contentTypesPartBytes(pkg: OoxmlPackage): {
-    readonly storageKey: string;
     readonly bytes: Uint8Array;
+    readonly storageKey: string;
 } | null;
 
 // @public
@@ -767,9 +767,9 @@ export interface Contribution {
     readonly payload?: unknown;
     readonly replaceable?: ReplacementPolicy;
     readonly replaces?: {
+        readonly priority?: number;
         readonly targetId: string;
         readonly targetRange: string;
-        readonly priority?: number;
     };
     // (undocumented)
     readonly version: string;
@@ -834,8 +834,8 @@ export interface CustomNodeExportRequest {
 export type CustomNodeExportResult = {
     readonly ok: true;
     readonly pkg: OoxmlPackage;
-    readonly unwrapped: number;
     readonly removed: number;
+    readonly unwrapped: number;
 } | {
     readonly ok: false;
     readonly reason: string;
@@ -854,8 +854,8 @@ dataOwnerPartName?: string): ReadonlyMap<string, CustomNodePayloadRead>;
 
 // @public
 export function customNodePayloadsOf(pkg: OoxmlPackage, storyPartName: string, namespaceUri: string): ReadonlyMap<string, {
-    readonly label: string;
     readonly data: string;
+    readonly label: string;
 }>;
 
 // @public
@@ -897,13 +897,13 @@ export type CustomNodeWriteRejection = TreeOpRejection
 
 // @public (undocumented)
 export type CustomNodeWriteResult = {
-    readonly ok: true;
     readonly change: TreeModelChange | null;
     readonly nodeId?: string;
+    readonly ok: true;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: CustomNodeWriteRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -1011,17 +1011,17 @@ export function deobfuscateFont(bytes: Uint8Array, fontKey: string): Uint8Array 
 
 // @public
 export const DEPENDENCY_KEY_IDS: {
-    readonly style: "dev.docx-editor.core.dep.style";
+    readonly annotation: "dev.docx-editor.core.dep.annotation";
+    readonly field: "dev.docx-editor.core.dep.field";
+    readonly font: "dev.docx-editor.core.dep.font";
+    readonly headerFooter: "dev.docx-editor.core.dep.header-footer";
+    readonly image: "dev.docx-editor.core.dep.image";
+    readonly note: "dev.docx-editor.core.dep.note";
     readonly numbering: "dev.docx-editor.core.dep.numbering";
     readonly section: "dev.docx-editor.core.dep.section";
     readonly story: "dev.docx-editor.core.dep.story";
-    readonly font: "dev.docx-editor.core.dep.font";
-    readonly image: "dev.docx-editor.core.dep.image";
+    readonly style: "dev.docx-editor.core.dep.style";
     readonly table: "dev.docx-editor.core.dep.table";
-    readonly field: "dev.docx-editor.core.dep.field";
-    readonly note: "dev.docx-editor.core.dep.note";
-    readonly headerFooter: "dev.docx-editor.core.dep.header-footer";
-    readonly annotation: "dev.docx-editor.core.dep.annotation";
 };
 
 // @public
@@ -1086,9 +1086,9 @@ export function diffSemanticDigests(before: SemanticDigest, after: SemanticDiges
 
 // @public
 export type DigestDifference = {
-    readonly path: string;
-    readonly before: string;
     readonly after: string;
+    readonly before: string;
+    readonly path: string;
 };
 
 // @public
@@ -1158,8 +1158,8 @@ export interface DrawingPositionInput {
 
 // @public
 export type DrawingPropertyIdResult = {
-    readonly ok: true;
     readonly id: number;
+    readonly ok: true;
 } | {
     readonly ok: false;
     readonly reason: 'invalidArgs';
@@ -1228,29 +1228,29 @@ export function ensureNumberingLevel(pkg: OoxmlPackage, numId: string, level: nu
 
 // @public (undocumented)
 export type EquationExpression = {
-    readonly kind: 'row';
     readonly items: readonly EquationExpression[];
+    readonly kind: 'row';
 } | {
     readonly kind: 'text';
     readonly value: string;
 } | {
+    readonly denominator: EquationExpression;
     readonly kind: 'fraction';
     readonly numerator: EquationExpression;
-    readonly denominator: EquationExpression;
 } | {
+    readonly degree?: EquationExpression;
     readonly kind: 'radical';
     readonly radicand: EquationExpression;
-    readonly degree?: EquationExpression;
 } | {
-    readonly kind: 'script';
     readonly base: EquationExpression;
+    readonly kind: 'script';
     readonly subscript?: EquationExpression;
     readonly superscript?: EquationExpression;
 } | {
-    readonly kind: 'nary';
-    readonly operator: string;
     readonly body: EquationExpression;
+    readonly kind: 'nary';
     readonly lowerLimit?: EquationExpression;
+    readonly operator: string;
     readonly upperLimit?: EquationExpression;
 } | {
     readonly kind: 'fallback';
@@ -1350,9 +1350,9 @@ export type FixtureOutcome = 'applied' | 'aborted' | 'validation' | 'conflict' |
 export type FixtureSource = {
     readonly kind: 'create';
 } | {
+    readonly bytesRef: string;
     readonly kind: 'docx';
     readonly sha256: string;
-    readonly bytesRef: string;
 };
 
 // @public
@@ -1445,34 +1445,34 @@ export type HeaderFooterLifecycleImpact = 'flow-structural' | 'global';
 
 // @public
 export type HeaderFooterLifecycleOp = {
+    readonly evenAndOddHeaders?: boolean;
+    readonly kind: HeaderFooterKind;
     readonly op: 'createHeaderFooter';
     readonly sectionIndex: number;
-    readonly kind: HeaderFooterKind;
-    readonly variant: HeaderFooterVariant;
     readonly titlePage?: boolean;
-    readonly evenAndOddHeaders?: boolean;
+    readonly variant: HeaderFooterVariant;
 } | {
+    readonly kind: HeaderFooterKind;
     readonly op: 'deleteHeaderFooter';
     readonly sectionIndex: number;
-    readonly kind: HeaderFooterKind;
     readonly variant: HeaderFooterVariant;
 } | {
+    readonly kind: HeaderFooterKind;
     readonly op: 'linkToPrevious';
     readonly sectionIndex: number;
-    readonly kind: HeaderFooterKind;
     readonly variant: HeaderFooterVariant;
 } | {
+    readonly kind: HeaderFooterKind;
     readonly op: 'unlinkFromPrevious';
     readonly sectionIndex: number;
-    readonly kind: HeaderFooterKind;
     readonly variant: HeaderFooterVariant;
 } | {
+    readonly evenAndOddHeaders?: boolean;
+    readonly footerDistanceTwips?: number;
+    readonly headerDistanceTwips?: number;
     readonly op: 'setSectionFurnitureOptions';
     readonly sectionIndex?: number;
     readonly titlePage?: boolean;
-    readonly evenAndOddHeaders?: boolean;
-    readonly headerDistanceTwips?: number;
-    readonly footerDistanceTwips?: number;
 };
 
 // @public
@@ -1480,15 +1480,15 @@ export type HeaderFooterLifecycleRejection = 'invalidArgs' | 'tree-invariant';
 
 // @public
 export type HeaderFooterLifecycleResult = {
+    readonly createdPartName?: string;
+    readonly createdRId?: string;
+    readonly impact: HeaderFooterLifecycleImpact;
     readonly ok: true;
     readonly package: OoxmlPackage;
-    readonly impact: HeaderFooterLifecycleImpact;
-    readonly createdRId?: string;
-    readonly createdPartName?: string;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: HeaderFooterLifecycleRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -1530,11 +1530,11 @@ export type HeaderFooterVariant = 'default' | 'first' | 'even';
 
 // @public
 export type HrefProjection = {
-    readonly ok: true;
     readonly href: string;
+    readonly ok: true;
 } | {
-    readonly ok: false;
     readonly inert: true;
+    readonly ok: false;
 };
 
 // @public
@@ -1603,10 +1603,10 @@ export interface ImageDecodePort {
     }> | null>;
     // (undocumented)
     decode(bytes: Uint8Array, mime: SupportedImageMime, limits: ImageResourceLimits): Promise<Readonly<{
-        pixelWidth: number;
-        pixelHeight: number;
         dpiX: number;
         dpiY: number;
+        pixelHeight: number;
+        pixelWidth: number;
     }>>;
 }
 
@@ -1623,8 +1623,8 @@ export type ImageRelationshipResolution = {
     readonly raw: string;
 } | {
     readonly mode: 'external';
-    readonly sinkSafe: boolean;
     readonly raw: string;
+    readonly sinkSafe: boolean;
 } | {
     readonly mode: 'missing';
 };
@@ -1664,20 +1664,20 @@ export function imageResourceLookupFor(pkg: OoxmlPackage, options: CreateImageRe
 
 // @public
 export type ImageResourceState = {
-    readonly kind: 'ready';
-    readonly partName: string;
     readonly contentId: string;
-    readonly resourceKey: string;
-    readonly validatedHandle: ValidatedImageBytesHandle;
-    readonly mime: RenderableImageMime;
-    readonly pixelWidth: number;
-    readonly pixelHeight: number;
     readonly dpiX: number;
     readonly dpiY: number;
+    readonly kind: 'ready';
+    readonly mime: RenderableImageMime;
+    readonly partName: string;
+    readonly pixelHeight: number;
+    readonly pixelWidth: number;
+    readonly resourceKey: string;
+    readonly validatedHandle: ValidatedImageBytesHandle;
 } | {
     readonly kind: 'unrenderable';
-    readonly partName: string | null;
     readonly mime: RenderableImageMime | PreservedImageMime | 'unknown';
+    readonly partName: string | null;
     readonly reason: 'unsupported-format' | 'non-picture-graphic' | 'signature-mismatch' | 'decode-failed' | 'resource-limit';
 } | {
     readonly kind: 'external';
@@ -1699,11 +1699,11 @@ export type ImpactClass = 'text-local' | 'paragraph-local' | 'flow-structural' |
 
 // @public
 export type IndexResult = {
-    readonly ok: true;
     readonly index: ContentTypeIndex;
+    readonly ok: true;
 } | {
-    readonly ok: false;
     readonly error: ContentTypeError;
+    readonly ok: false;
 };
 
 // @public
@@ -1930,9 +1930,9 @@ export type LimitUnit = 'bytes' | 'count' | 'depth' | 'ratio' | 'passes';
 
 // @public (undocumented)
 export type LinearMathOmmlResult = {
-    readonly ok: true;
-    readonly expression: EquationExpression;
     readonly equation: OoxmlGenericElementNode;
+    readonly expression: EquationExpression;
+    readonly ok: true;
 } | {
     readonly ok: false;
     readonly reason: LinearMathRejection;
@@ -1940,8 +1940,8 @@ export type LinearMathOmmlResult = {
 
 // @public (undocumented)
 export type LinearMathParseResult = {
-    readonly ok: true;
     readonly expression: EquationExpression;
+    readonly ok: true;
 } | {
     readonly ok: false;
     readonly reason: LinearMathRejection;
@@ -2102,8 +2102,8 @@ export function noteAtomText(): typeof NOTE_ATOM_CHAR;
 // @public
 export type NoteDiagnostic = {
     readonly code: 'dangling-note-reference';
-    readonly noteKind: NoteKind;
     readonly noteId: number;
+    readonly noteKind: NoteKind;
     readonly sourceNodeId?: string;
 } | {
     readonly code: 'note-reference-scan-truncated';
@@ -2126,37 +2126,37 @@ export type NoteLifecycleImpact = 'flow-structural' | 'global';
 
 // @public
 export type NoteLifecycleOp = {
-    readonly op: 'insertNote';
     readonly noteKind: NoteKind;
-    readonly paragraphId: string;
     readonly offset: number;
+    readonly op: 'insertNote';
+    readonly paragraphId: string;
 } | {
-    readonly op: 'deleteNote';
+    readonly noteId: number;
     readonly noteKind: NoteKind;
-    readonly noteId: number;
+    readonly op: 'deleteNote';
 } | {
+    readonly fromKind: NoteKind;
+    readonly noteId: number;
     readonly op: 'convertNote';
-    readonly fromKind: NoteKind;
-    readonly noteId: number;
 } | {
+    readonly fromKind: NoteKind;
     readonly op: 'convertAllNotes';
-    readonly fromKind: NoteKind;
 } | {
-    readonly op: 'setNoteProperties';
-    readonly scope: 'document' | 'section';
-    readonly sectionIndex?: number;
-    readonly footnote?: {
-        readonly numFmt?: string;
-        readonly numRestart?: string;
-        readonly position?: string;
-        readonly numStart?: number;
-    };
     readonly endnote?: {
         readonly numFmt?: string;
         readonly numRestart?: string;
-        readonly position?: string;
         readonly numStart?: number;
+        readonly position?: string;
     };
+    readonly footnote?: {
+        readonly numFmt?: string;
+        readonly numRestart?: string;
+        readonly numStart?: number;
+        readonly position?: string;
+    };
+    readonly op: 'setNoteProperties';
+    readonly scope: 'document' | 'section';
+    readonly sectionIndex?: number;
 };
 
 // @public
@@ -2169,16 +2169,16 @@ export type NoteLifecycleRejection = 'invalidArgs' | 'tree-invariant';
 
 // @public
 export type NoteLifecycleResult = {
-    readonly ok: true;
-    readonly package: OoxmlPackage;
+    readonly createdPartName?: string;
     readonly impact: NoteLifecycleImpact;
     readonly noteId?: number;
     readonly noteKind?: NoteKind;
-    readonly createdPartName?: string;
+    readonly ok: true;
+    readonly package: OoxmlPackage;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: NoteLifecycleRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -2513,8 +2513,8 @@ export type OoxmlEditResult = {
     readonly ok: true;
     readonly part: OoxmlPart;
 } | {
-    readonly ok: false;
     readonly issues: readonly OoxmlInvariantIssue[];
+    readonly ok: false;
 };
 
 // @public
@@ -2643,8 +2643,8 @@ export type OoxmlInvariantIssueCode = 'invalid-id' | 'duplicate-id' | 'invalid-n
 export type OoxmlInvariantResult = {
     readonly ok: true;
 } | {
-    readonly ok: false;
     readonly issues: readonly OoxmlInvariantIssue[];
+    readonly ok: false;
 };
 
 // @public
@@ -2736,9 +2736,9 @@ export type OoxmlPackageResult = {
     readonly ok: true;
     readonly package: OoxmlPackage;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: OoxmlPackageRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -2930,16 +2930,16 @@ export function orderedContentControlProperties(children: readonly OoxmlNode[]):
 
 // @public
 export const ORIGIN_IDS: {
-    readonly mutationHuman: "dev.docx-editor.core.origin.mutation.human";
+    readonly awareness: "dev.docx-editor.core.origin.awareness";
     readonly mutationAgent: "dev.docx-editor.core.origin.mutation.agent";
-    readonly mutationRemote: "dev.docx-editor.core.origin.mutation.remote";
-    readonly mutationUndo: "dev.docx-editor.core.origin.mutation.undo";
-    readonly mutationRedo: "dev.docx-editor.core.origin.mutation.redo";
+    readonly mutationHuman: "dev.docx-editor.core.origin.mutation.human";
     readonly mutationMigration: "dev.docx-editor.core.origin.mutation.migration";
+    readonly mutationRedo: "dev.docx-editor.core.origin.mutation.redo";
+    readonly mutationRemote: "dev.docx-editor.core.origin.mutation.remote";
     readonly mutationRepair: "dev.docx-editor.core.origin.mutation.repair";
     readonly mutationServer: "dev.docx-editor.core.origin.mutation.server";
+    readonly mutationUndo: "dev.docx-editor.core.origin.mutation.undo";
     readonly projection: "dev.docx-editor.core.origin.projection";
-    readonly awareness: "dev.docx-editor.core.origin.awareness";
 };
 
 // @public
@@ -2973,18 +2973,18 @@ export interface PackageInvariantIssue {
 export type PackageInvariantResult = {
     readonly ok: true;
 } | {
-    readonly ok: false;
     readonly issues: readonly PackageInvariantIssue[];
+    readonly ok: false;
 };
 
 // @public
 export type PackageTransactResult = {
-    readonly ok: true;
     readonly change: TreeModelChange | null;
+    readonly ok: true;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: StoryTargetRejection | TreeOpRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -2994,8 +2994,8 @@ export const PAGE_BREAK_CHAR = "\f";
 export interface ParagraphDigest {
     readonly genericStructure: readonly string[];
     readonly ordinal: number;
-    readonly paragraphProperties: readonly string[];
     readonly paraId: string | null;
+    readonly paragraphProperties: readonly string[];
     readonly path: string;
     readonly runProperties: readonly (readonly string[])[];
     readonly text: string;
@@ -3047,8 +3047,8 @@ export function parseNoteId(raw: string | undefined): number | null;
 
 // @public
 export function parseNoteScopeId(id: string): {
-    readonly noteKind: NoteKind;
     readonly noteId: number;
+    readonly noteKind: NoteKind;
 } | null;
 
 // @public
@@ -3068,11 +3068,11 @@ export interface PersistencePort {
 
 // @public
 export function planTocEntries(part: OoxmlPart, outline: readonly TocOutlineHeading[], instruction: TocInstruction, pageNumberByParagraphId: ReadonlyMap<string, string>, excludeParagraphIds: ReadonlySet<string>): {
-    readonly entries: readonly TocEntryPlan[];
     readonly bookmarksToCreate: readonly {
-        paragraphId: string;
         name: string;
+        paragraphId: string;
     }[];
+    readonly entries: readonly TocEntryPlan[];
 };
 
 // @public
@@ -3113,11 +3113,11 @@ export type PreservedImageMime = 'image/tiff' | 'image/x-emf' | 'image/x-wmf';
 
 // @public
 export function projectDrawing(drawing: OoxmlDrawingNode, context: Readonly<{
-    ownerPartName: string;
-    supportedMcRequires: ReadonlySet<string>;
     limits: DrawingProjectionLimits;
     namespaceScope?: ReadonlyMap<string, string>;
+    ownerPartName: string;
     resolveRelationship?: RelationshipTargetResolver;
+    supportedMcRequires: ReadonlySet<string>;
 }>): DrawingProjection | null;
 
 // @public
@@ -3174,8 +3174,8 @@ export type RegistryErrorCode = 'invalid-id' | 'invalid-version' | 'duplicate-ex
 // @public
 export type RelationshipError = {
     readonly code: 'duplicate-id';
-    readonly ownerPart: string;
     readonly id: string;
+    readonly ownerPart: string;
 };
 
 // @public
@@ -3196,11 +3196,11 @@ export interface RelationshipRecord {
 
 // @public
 export type RelationshipSetResult = {
-    readonly ok: true;
     readonly byOwner: ReadonlyMap<string, readonly RelationshipRecord[]>;
+    readonly ok: true;
 } | {
-    readonly ok: false;
     readonly error: RelationshipError;
+    readonly ok: false;
 };
 
 // @public
@@ -3208,16 +3208,16 @@ export function relationshipsOf(pkg: OoxmlPackage, ownerPart: string): readonly 
 
 // @public
 export function relationshipTargetIn(pkg: OoxmlPackage, ownerPart: string, relationshipId: string): {
-    readonly target: string;
     readonly external: boolean;
     readonly sinkSafe?: boolean;
+    readonly target: string;
 } | null;
 
 // @public
 export type RelationshipTargetResolver = (relationshipId: string) => {
-    readonly target: string;
     readonly external: boolean;
     readonly sinkSafe?: boolean;
+    readonly target: string;
 } | null;
 
 // @public
@@ -3329,12 +3329,12 @@ export interface ResolvedRegistry {
 // @public
 export type ResolvedRelationship = {
     readonly mode: 'Internal';
-    readonly target: NameResult;
     readonly raw: string;
+    readonly target: NameResult;
 } | {
     readonly mode: 'External';
-    readonly sinkSafe: NameResult;
     readonly raw: string;
+    readonly sinkSafe: NameResult;
 };
 
 // @public
@@ -3377,8 +3377,8 @@ export function resolveRelationship(rec: RelationshipRecord): ResolvedRelationsh
 
 // @public
 export type ResolveResult = {
-    readonly ok: true;
     readonly contentType: string;
+    readonly ok: true;
     readonly source: 'override' | 'default';
 } | {
     readonly ok: false;
@@ -3409,12 +3409,12 @@ export interface ResourceLimits {
 
 // @public
 export const RESULT_IDS: {
+    readonly aborted: "dev.docx-editor.core.result.aborted";
     readonly applied: "dev.docx-editor.core.result.applied";
-    readonly validation: "dev.docx-editor.core.result.validation";
+    readonly authorization: "dev.docx-editor.core.result.authorization";
     readonly conflict: "dev.docx-editor.core.result.conflict";
     readonly resource: "dev.docx-editor.core.result.resource";
-    readonly authorization: "dev.docx-editor.core.result.authorization";
-    readonly aborted: "dev.docx-editor.core.result.aborted";
+    readonly validation: "dev.docx-editor.core.result.validation";
 };
 
 // @public
@@ -3527,8 +3527,8 @@ export function revisionItemsOf(part: OoxmlPart): readonly ReviewRevisionItem[];
 export function runAddressRanges(paragraph: Extract<OoxmlNode, {
     kind: 'paragraph';
 }>): Map<string, {
-    start: number;
     end: number;
+    start: number;
 }>;
 
 // @public
@@ -3550,19 +3550,19 @@ export function runsCovering(part: OoxmlPart, paragraphId: string, start: number
 
 // @public
 export const RUNTIME_PORT_IDS: {
-    readonly fonts: "dev.docx-editor.core.port.fonts";
-    readonly shaping: "dev.docx-editor.core.port.shaping";
-    readonly images: "dev.docx-editor.core.port.images";
-    readonly clock: "dev.docx-editor.core.port.clock";
-    readonly identity: "dev.docx-editor.core.port.identity";
-    readonly persistence: "dev.docx-editor.core.port.persistence";
-    readonly transport: "dev.docx-editor.core.port.transport";
-    readonly scheduling: "dev.docx-editor.core.port.scheduling";
     readonly audit: "dev.docx-editor.core.port.audit";
     readonly authorization: "dev.docx-editor.core.port.authorization";
-    readonly resourceAccounting: "dev.docx-editor.core.port.resource-accounting";
     readonly cancellation: "dev.docx-editor.core.port.cancellation";
+    readonly clock: "dev.docx-editor.core.port.clock";
     readonly externalResourceConsent: "dev.docx-editor.core.port.external-resource-consent";
+    readonly fonts: "dev.docx-editor.core.port.fonts";
+    readonly identity: "dev.docx-editor.core.port.identity";
+    readonly images: "dev.docx-editor.core.port.images";
+    readonly persistence: "dev.docx-editor.core.port.persistence";
+    readonly resourceAccounting: "dev.docx-editor.core.port.resource-accounting";
+    readonly scheduling: "dev.docx-editor.core.port.scheduling";
+    readonly shaping: "dev.docx-editor.core.port.shaping";
+    readonly transport: "dev.docx-editor.core.port.transport";
 };
 
 // @public
@@ -3656,9 +3656,9 @@ export function setCommentResolved(store: TreeDocumentStore, commentId: string, 
 
 // @public
 export type SetCommentResolvedResult = {
-    readonly ok: true;
-    readonly changed: boolean;
     readonly change: TreeModelChange | null;
+    readonly changed: boolean;
+    readonly ok: true;
 } | {
     readonly ok: false;
     readonly reason: TreeOpRejection | 'unknown-comment';
@@ -3714,12 +3714,12 @@ export function storyParagraphs(root: OoxmlNode): readonly OoxmlNode[];
 // @public
 export type StoryResolveResult = {
     readonly ok: true;
-    readonly story: TreeStoryRef;
     readonly store: TreeDocumentStore;
+    readonly story: TreeStoryRef;
 } | {
+    readonly detail?: string;
     readonly ok: false;
     readonly reason: StoryTargetRejection;
-    readonly detail?: string;
 };
 
 // @public
@@ -3885,61 +3885,61 @@ export const TREE_DOC_OP_KINDS: readonly ["replaceStoryBlocks", "insertText", "d
 // @public
 export type TreeDocOp = {
     readonly op: 'replaceStoryBlocks';
-    readonly storyRootId: string;
     readonly paragraphs: readonly string[];
+    readonly storyRootId: string;
 } | {
-    readonly op: 'insertToc';
-    readonly beforeParagraphId: string;
-    readonly instruction: string;
     readonly alias: string;
-    readonly entries: readonly {
-        readonly level: number;
-        readonly text: string;
-        readonly headingParagraphId: string;
-        readonly bookmarkName: string;
-        readonly pageNumberText: string;
-    }[];
+    readonly beforeParagraphId: string;
     readonly bookmarksToCreate: readonly {
-        readonly paragraphId: string;
         readonly name: string;
+        readonly paragraphId: string;
     }[];
+    readonly entries: readonly {
+        readonly bookmarkName: string;
+        readonly headingParagraphId: string;
+        readonly level: number;
+        readonly pageNumberText: string;
+        readonly text: string;
+    }[];
+    readonly instruction: string;
+    readonly op: 'insertToc';
 } | {
+    readonly bias?: 'left' | 'right';
+    readonly inside?: string;
+    readonly offset: number;
     readonly op: 'insertText';
     readonly paragraphId: string;
-    readonly offset: number;
-    readonly text: string;
     readonly revision?: RevisionAttributionInput;
-    readonly inside?: string;
-    readonly bias?: 'left' | 'right';
+    readonly text: string;
 } | {
+    readonly end: number;
     readonly op: 'deleteText';
     readonly paragraphId: string;
-    readonly start: number;
-    readonly end: number;
     readonly revision?: RevisionAttributionInput;
+    readonly start: number;
 } | {
+    readonly kind: 'ins' | 'del';
     readonly op: 'setParagraphMarkRevision';
     readonly paragraphId: string;
-    readonly kind: 'ins' | 'del';
     readonly revision: RevisionAttributionInput;
 } | {
     readonly op: 'proposeParagraphMerge';
     readonly paragraphId: string;
     readonly revision: RevisionAttributionInput;
 } | {
-    readonly op: 'insertCommentMarker';
-    readonly paragraphId: string;
-    readonly offset: number;
     readonly commentId: string;
     readonly marker: 'start' | 'end' | 'reference';
+    readonly offset: number;
+    readonly op: 'insertCommentMarker';
+    readonly paragraphId: string;
 } | {
+    readonly localName?: string;
     readonly op: 'acceptRevision';
     readonly revision: RevisionAddress;
-    readonly localName?: string;
 } | {
+    readonly localName?: string;
     readonly op: 'rejectRevision';
     readonly revision: RevisionAddress;
-    readonly localName?: string;
 } | {
     readonly op: 'acceptAllRevisions';
     readonly scopeRootId?: string;
@@ -3947,348 +3947,348 @@ export type TreeDocOp = {
     readonly op: 'rejectAllRevisions';
     readonly scopeRootId?: string;
 } | {
+    readonly offset: number;
     readonly op: 'insertTab';
     readonly paragraphId: string;
-    readonly offset: number;
 } | {
+    readonly offset: number;
     readonly op: 'insertHardBreak';
     readonly paragraphId: string;
-    readonly offset: number;
 } | {
+    readonly offset: number;
     readonly op: 'insertPageBreak';
     readonly paragraphId: string;
-    readonly offset: number;
 } | {
+    readonly field: 'PAGE' | 'NUMPAGES' | 'SECTIONPAGES' | 'PAGE_X_OF_Y';
+    readonly offset: number;
     readonly op: 'insertPageField';
     readonly paragraphId: string;
-    readonly offset: number;
-    readonly field: 'PAGE' | 'NUMPAGES' | 'SECTIONPAGES' | 'PAGE_X_OF_Y';
 } | {
+    readonly level: number;
     readonly op: 'setListLevel';
     readonly paragraphId: string;
-    readonly level: number;
 } | {
     readonly op: 'setParagraphMarkProperties';
     readonly paragraphId: string;
     readonly properties: readonly OoxmlProperty[];
 } | {
+    readonly level?: number;
+    readonly numId: string | null;
     readonly op: 'setListNumbering';
     readonly paragraphId: string;
-    readonly numId: string | null;
-    readonly level?: number;
 } | {
+    readonly inForcePositionsTwips?: readonly number[];
     readonly op: 'setParagraphTabStops';
     readonly paragraphId: string;
     readonly stops: readonly TabStopWrite[];
-    readonly inForcePositionsTwips?: readonly number[];
 } | {
+    readonly offset: number;
     readonly op: 'splitParagraph';
     readonly paragraphId: string;
-    readonly offset: number;
 } | {
+    readonly offsets: readonly number[];
     readonly op: 'splitParagraphMany';
     readonly paragraphId: string;
-    readonly offsets: readonly number[];
     readonly revision?: RevisionAttributionInput;
 } | {
-    readonly op: 'joinParagraphs';
     readonly firstId: string;
+    readonly op: 'joinParagraphs';
     readonly secondId: string;
 } | {
+    readonly end: number;
     readonly op: 'setRunProperties';
     readonly paragraphId: string;
-    readonly start: number;
-    readonly end: number;
     readonly properties: readonly OoxmlProperty[];
+    readonly start: number;
     readonly targetRunIds?: readonly string[];
 } | {
     readonly op: 'setParagraphProperties';
     readonly paragraphId: string;
     readonly properties: readonly OoxmlProperty[];
 } | {
-    readonly op: 'setSectionProperties';
-    readonly pageWidthTwips?: number;
-    readonly pageHeightTwips?: number;
-    readonly orientation?: 'portrait' | 'landscape';
-    readonly marginTopTwips?: number;
-    readonly marginRightTwips?: number;
+    readonly anchorParagraphId?: string;
     readonly marginBottomTwips?: number;
     readonly marginLeftTwips?: number;
-    readonly anchorParagraphId?: string;
+    readonly marginRightTwips?: number;
+    readonly marginTopTwips?: number;
+    readonly op: 'setSectionProperties';
+    readonly orientation?: 'portrait' | 'landscape';
+    readonly pageHeightTwips?: number;
+    readonly pageWidthTwips?: number;
 } | {
     readonly op: 'setSectionMark';
     readonly paragraphId: string;
 } | {
+    readonly anchor?: string;
+    readonly end: number;
     readonly op: 'insertHyperlink';
     readonly paragraphId: string;
+    readonly relationshipId?: string;
     readonly start: number;
-    readonly end: number;
-    readonly relationshipId?: string;
-    readonly anchor?: string;
-    readonly tooltip?: string;
     readonly styleId?: string;
-} | {
-    readonly op: 'setHyperlinkTarget';
-    readonly linkId: string;
-    readonly relationshipId?: string;
-    readonly anchor?: string;
     readonly tooltip?: string;
 } | {
-    readonly op: 'removeHyperlink';
+    readonly anchor?: string;
     readonly linkId: string;
+    readonly op: 'setHyperlinkTarget';
+    readonly relationshipId?: string;
+    readonly tooltip?: string;
 } | {
-    readonly op: 'setMathEquation';
+    readonly linkId: string;
+    readonly op: 'removeHyperlink';
+} | {
     readonly equationId: string;
     readonly linear: string;
+    readonly op: 'setMathEquation';
 } | {
-    readonly op: 'removeMathEquation';
     readonly equationId: string;
+    readonly op: 'removeMathEquation';
 } | {
-    readonly op: 'insertInlineContentControl';
-    readonly paragraphId: string;
-    readonly offset: number;
-    readonly tag: string;
-    readonly text: string;
     readonly alias?: string;
-    readonly lock?: 'sdtLocked' | 'sdtContentLocked' | 'contentLocked';
     readonly dataBinding?: {
         readonly prefixMappings: string;
-        readonly xpath: string;
         readonly storeItemId: string;
+        readonly xpath: string;
     };
+    readonly lock?: 'sdtLocked' | 'sdtContentLocked' | 'contentLocked';
+    readonly offset: number;
+    readonly op: 'insertInlineContentControl';
+    readonly paragraphId: string;
+    readonly tag: string;
+    readonly text: string;
 } | {
-    readonly op: 'addRepeatingSectionItem';
     readonly controlId: string;
     readonly index?: number;
+    readonly op: 'addRepeatingSectionItem';
 } | {
-    readonly op: 'removeRepeatingSectionItem';
     readonly controlId: string;
     readonly index: number;
+    readonly op: 'removeRepeatingSectionItem';
 } | {
-    readonly op: 'deleteBlock';
     readonly blockId: string;
+    readonly op: 'deleteBlock';
 } | {
-    readonly op: 'insertTable';
     readonly beforeParagraphId: string;
-    readonly rows: number;
     readonly cols: number;
     readonly columnWidthTwips: number;
+    readonly op: 'insertTable';
+    readonly rows: number;
 } | {
     readonly op: 'insertTableRow';
-    readonly tableId: string;
-    readonly rowId: string;
-    readonly where: 'above' | 'below';
     readonly revision?: RevisionAttributionInput;
+    readonly rowId: string;
+    readonly tableId: string;
+    readonly where: 'above' | 'below';
 } | {
     readonly op: 'deleteTableRow';
-    readonly tableId: string;
-    readonly rowId: string;
     readonly referenceCellId?: string;
     readonly revision?: RevisionAttributionInput;
-} | {
-    readonly op: 'insertTableColumn';
+    readonly rowId: string;
     readonly tableId: string;
-    readonly where: 'left' | 'right';
+} | {
     readonly gridColumnId: string;
-} | {
     readonly op: 'insertTableColumn';
     readonly tableId: string;
     readonly where: 'left' | 'right';
-    readonly referenceCellId: string;
 } | {
+    readonly op: 'insertTableColumn';
+    readonly referenceCellId: string;
+    readonly tableId: string;
+    readonly where: 'left' | 'right';
+} | {
+    readonly gridColumnId: string;
     readonly op: 'deleteTableColumn';
     readonly tableId: string;
-    readonly gridColumnId: string;
 } | {
-    readonly op: 'setTableColumnWidths';
-    readonly tableId: string;
     readonly leftGridColumnId: string;
-    readonly rightGridColumnId: string;
     readonly leftWidthTwips: number;
+    readonly op: 'setTableColumnWidths';
+    readonly rightGridColumnId: string;
     readonly rightWidthTwips: number;
+    readonly tableId: string;
 } | {
+    readonly columnWidthTwips: number;
+    readonly gridColumnId: string;
     readonly op: 'setTableRightEdgeWidth';
     readonly tableId: string;
-    readonly gridColumnId: string;
-    readonly columnWidthTwips: number;
     readonly tableWidthTwips: number;
 } | {
-    readonly op: 'setTableRowHeight';
-    readonly tableId: string;
-    readonly rowId: string;
     readonly heightTwips: number;
-} | {
-    readonly op: 'setTableCellBorders';
+    readonly op: 'setTableRowHeight';
+    readonly rowId: string;
     readonly tableId: string;
+} | {
     readonly cellIds: readonly string[];
+    readonly op: 'setTableCellBorders';
     readonly scope: 'none';
+    readonly tableId: string;
     readonly target: TableBorderEdgeTarget;
 } | {
-    readonly op: 'setTableCellBorders';
-    readonly tableId: string;
     readonly cellIds: readonly string[];
+    readonly op: 'setTableCellBorders';
     readonly scope: TableBorderEdgeTarget;
     readonly spec: TableBorderSpecInput;
-} | {
-    readonly op: 'setTableCellFill';
     readonly tableId: string;
+} | {
     readonly cellIds: readonly string[];
     readonly color: TreeDocColorValue | null;
+    readonly op: 'setTableCellFill';
+    readonly tableId: string;
 } | {
+    readonly alignment: 'top' | 'center' | 'bottom';
+    readonly cellIds: readonly string[];
     readonly op: 'setTableCellVerticalAlignment';
     readonly tableId: string;
-    readonly cellIds: readonly string[];
-    readonly alignment: 'top' | 'center' | 'bottom';
 } | {
+    readonly evenAndOddHeaders?: boolean;
+    readonly kind: 'header' | 'footer';
     readonly op: 'createHeaderFooter';
     readonly sectionIndex: number;
-    readonly kind: 'header' | 'footer';
-    readonly variant: 'default' | 'first' | 'even';
     readonly titlePage?: boolean;
-    readonly evenAndOddHeaders?: boolean;
+    readonly variant: 'default' | 'first' | 'even';
 } | {
+    readonly kind: 'header' | 'footer';
     readonly op: 'deleteHeaderFooter';
     readonly sectionIndex: number;
-    readonly kind: 'header' | 'footer';
     readonly variant: 'default' | 'first' | 'even';
 } | {
+    readonly kind: 'header' | 'footer';
     readonly op: 'linkToPrevious';
     readonly sectionIndex: number;
-    readonly kind: 'header' | 'footer';
     readonly variant: 'default' | 'first' | 'even';
 } | {
+    readonly kind: 'header' | 'footer';
     readonly op: 'unlinkFromPrevious';
     readonly sectionIndex: number;
-    readonly kind: 'header' | 'footer';
     readonly variant: 'default' | 'first' | 'even';
 } | {
+    readonly evenAndOddHeaders?: boolean;
+    readonly footerDistanceTwips?: number;
+    readonly headerDistanceTwips?: number;
     readonly op: 'setSectionFurnitureOptions';
     readonly sectionIndex?: number;
     readonly titlePage?: boolean;
-    readonly evenAndOddHeaders?: boolean;
-    readonly headerDistanceTwips?: number;
-    readonly footerDistanceTwips?: number;
 } | {
-    readonly op: 'insertNote';
     readonly noteKind: 'footnote' | 'endnote';
-    readonly paragraphId: string;
     readonly offset: number;
+    readonly op: 'insertNote';
+    readonly paragraphId: string;
 } | {
-    readonly op: 'deleteNote';
+    readonly noteId: number;
     readonly noteKind: 'footnote' | 'endnote';
-    readonly noteId: number;
+    readonly op: 'deleteNote';
 } | {
+    readonly fromKind: 'footnote' | 'endnote';
+    readonly noteId: number;
     readonly op: 'convertNote';
-    readonly fromKind: 'footnote' | 'endnote';
-    readonly noteId: number;
 } | {
+    readonly fromKind: 'footnote' | 'endnote';
     readonly op: 'convertAllNotes';
-    readonly fromKind: 'footnote' | 'endnote';
 } | {
-    readonly op: 'setContentControlValue';
     readonly controlId: string;
+    readonly op: 'setContentControlValue';
     readonly value: string | ContentControlValueInput;
 } | {
-    readonly op: 'setContentControlProperties';
-    readonly controlId: string;
-    readonly tag?: string | null;
     readonly alias?: string | null;
+    readonly controlId: string;
     readonly lock?: ContentControlLock;
+    readonly op: 'setContentControlProperties';
+    readonly tag?: string | null;
 } | {
-    readonly op: 'removeContentControl';
     readonly controlId: string;
     readonly keepContent?: boolean;
+    readonly op: 'removeContentControl';
 } | {
+    readonly alias?: string;
+    readonly end: number;
+    readonly lock?: ContentControlLock;
     readonly op: 'insertContentControl';
     readonly paragraphId: string;
     readonly start: number;
-    readonly end: number;
-    readonly type: InsertableContentControlKind;
     readonly tag?: string;
-    readonly alias?: string;
-    readonly lock?: ContentControlLock;
+    readonly type: InsertableContentControlKind;
 } | {
-    readonly op: 'setNoteProperties';
-    readonly scope: 'document' | 'section';
-    readonly sectionIndex?: number;
-    readonly footnote?: {
-        readonly numFmt?: string;
-        readonly numRestart?: string;
-        readonly position?: string;
-        readonly numStart?: number;
-    };
     readonly endnote?: {
         readonly numFmt?: string;
         readonly numRestart?: string;
-        readonly position?: string;
         readonly numStart?: number;
+        readonly position?: string;
     };
+    readonly footnote?: {
+        readonly numFmt?: string;
+        readonly numRestart?: string;
+        readonly numStart?: number;
+        readonly position?: string;
+    };
+    readonly op: 'setNoteProperties';
+    readonly scope: 'document' | 'section';
+    readonly sectionIndex?: number;
 } | {
+    readonly drawing: OoxmlDrawingNode;
+    readonly offset: number;
     readonly op: 'insertDrawing';
     readonly paragraphId: string;
-    readonly offset: number;
-    readonly drawing: OoxmlDrawingNode;
 } | {
-    readonly op: 'replaceDrawingResource';
     readonly drawingNodeId: string;
+    readonly op: 'replaceDrawingResource';
     readonly relationshipId: string;
 } | {
-    readonly op: 'deleteDrawing';
     readonly drawingNodeId: string;
+    readonly op: 'deleteDrawing';
     readonly revision?: RevisionAttributionInput;
 } | {
-    readonly op: 'resizeDrawing';
     readonly drawingNodeId: string;
     readonly extentEmu: {
         readonly cx: number;
         readonly cy: number;
     };
+    readonly op: 'resizeDrawing';
 } | {
-    readonly op: 'cropDrawing';
-    readonly drawingNodeId: string;
     readonly crop: SourceCrop;
-} | {
-    readonly op: 'positionDrawing';
     readonly drawingNodeId: string;
+    readonly op: 'cropDrawing';
+} | {
+    readonly drawingNodeId: string;
+    readonly op: 'positionDrawing';
     readonly position: DrawingPositionInput;
 } | {
-    readonly op: 'setDrawingWrap';
     readonly drawingNodeId: string;
+    readonly op: 'setDrawingWrap';
     readonly wrap: ImageWrapTarget;
 } | {
-    readonly op: 'setDrawingMetadata';
-    readonly drawingNodeId: string;
-    readonly title: string;
     readonly description: string;
+    readonly drawingNodeId: string;
     readonly hyperlink?: string | null;
+    readonly op: 'setDrawingMetadata';
+    readonly title: string;
 } | {
-    readonly op: 'setDrawingLocks';
     readonly drawingNodeId: string;
     readonly locks: DrawingLocksInput;
+    readonly op: 'setDrawingLocks';
 } | {
-    readonly op: 'transformDrawing';
-    readonly drawingNodeId: string;
     readonly action: 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV';
+    readonly drawingNodeId: string;
+    readonly op: 'transformDrawing';
 } | {
+    readonly bookmarksToCreate: readonly {
+        readonly name: string;
+        readonly paragraphId: string;
+    }[];
+    readonly entries: readonly {
+        readonly bookmarkName: string;
+        readonly headingParagraphId: string;
+        readonly level: number;
+        readonly pageNumberText: string;
+        readonly text: string;
+    }[];
     readonly op: 'replaceTocResult';
     readonly tocId: string;
-    readonly entries: readonly {
-        readonly level: number;
-        readonly text: string;
-        readonly headingParagraphId: string;
-        readonly bookmarkName: string;
-        readonly pageNumberText: string;
-    }[];
-    readonly bookmarksToCreate: readonly {
-        readonly paragraphId: string;
-        readonly name: string;
-    }[];
 } | {
     readonly op: 'rewriteTocPageNumbers';
     readonly tocId: string;
     readonly updates: readonly {
-        readonly paragraphId: string;
         readonly pageNumberText: string;
+        readonly paragraphId: string;
     }[];
 };
 

--- a/docs/api/docx-editor-editor-api/browser.api.md
+++ b/docs/api/docx-editor-editor-api/browser.api.md
@@ -112,8 +112,8 @@ export abstract class ClientObject implements RuntimeManagedObject {
 export class ClientResult<T> {
     // @internal
     static create<T>(target: string): {
-        result: ClientResult<T>;
         fill: (value: T) => void;
+        result: ClientResult<T>;
     };
     get isLoaded(): boolean;
     get value(): T;
@@ -236,13 +236,13 @@ export type ContentControlValue = {
     readonly kind: 'listItem';
     readonly value: string;
 } | {
-    readonly kind: 'checkbox';
     readonly checked: boolean;
+    readonly kind: 'checkbox';
 }
 /** `YYYY-MM-DD`, or a full ISO-8601 instant. */
 | {
-    readonly kind: 'date';
     readonly iso: string;
+    readonly kind: 'date';
 };
 
 // @public

--- a/docs/api/docx-editor-editor-api/browser.api.md
+++ b/docs/api/docx-editor-editor-api/browser.api.md
@@ -660,8 +660,8 @@ export class RequestContext {
     get [INTERNALS](): ContextInternals;
     // @internal
     static begin(session: RuntimeSession): {
-        context: RequestContext;
         adopt: (objects: readonly ClientObject[]) => void;
+        context: RequestContext;
         finish: () => void;
     };
     get capabilities(): DocumentCapabilities;

--- a/docs/api/docx-editor-editor-api/index.api.md
+++ b/docs/api/docx-editor-editor-api/index.api.md
@@ -652,8 +652,8 @@ export class RequestContext {
     get [INTERNALS](): ContextInternals;
     // @internal
     static begin(session: RuntimeSession): {
-        context: RequestContext;
         adopt: (objects: readonly ClientObject[]) => void;
+        context: RequestContext;
         finish: () => void;
     };
     get capabilities(): DocumentCapabilities;

--- a/docs/api/docx-editor-editor-api/index.api.md
+++ b/docs/api/docx-editor-editor-api/index.api.md
@@ -111,8 +111,8 @@ export abstract class ClientObject implements RuntimeManagedObject {
 export class ClientResult<T> {
     // @internal
     static create<T>(target: string): {
-        result: ClientResult<T>;
         fill: (value: T) => void;
+        result: ClientResult<T>;
     };
     get isLoaded(): boolean;
     get value(): T;
@@ -235,13 +235,13 @@ export type ContentControlValue = {
     readonly kind: 'listItem';
     readonly value: string;
 } | {
-    readonly kind: 'checkbox';
     readonly checked: boolean;
+    readonly kind: 'checkbox';
 }
 /** `YYYY-MM-DD`, or a full ISO-8601 instant. */
 | {
-    readonly kind: 'date';
     readonly iso: string;
+    readonly kind: 'date';
 };
 
 // @public

--- a/docs/api/docx-editor-fonts/google.api.md
+++ b/docs/api/docx-editor-fonts/google.api.md
@@ -38,8 +38,8 @@ export interface GoogleFontLoadFailure {
 
 // @public
 export function googleFonts(options?: GoogleFontsOptions): (request: {
-    readonly families: readonly string[];
     readonly defaultFamily: string;
+    readonly families: readonly string[];
 }) => Promise<GoogleFontsFragment>;
 
 // @public

--- a/docs/api/docx-editor-pro/index.api.md
+++ b/docs/api/docx-editor-pro/index.api.md
@@ -27,8 +27,8 @@ export const CUSTOM_NODE_STORE_ROOT = "docxEditor";
 // @public
 export interface CustomNode<Schema extends StandardSchemaV1 | undefined = any> extends CustomNodeDefinition<Schema> {
     readonly dataOf: (node: {
-        readonly name?: string;
         readonly data?: unknown;
+        readonly name?: string;
     } | null | undefined) => InferSchemaOutput<Schema> | undefined;
 }
 
@@ -40,9 +40,9 @@ export type CustomNodeDataResult<Output> = {
     readonly ok: true;
     readonly value: Output;
 } | {
+    readonly issues: readonly string[];
     readonly ok: false;
     readonly reason: CustomNodeDataRejection;
-    readonly issues: readonly string[];
 };
 
 // @public
@@ -52,8 +52,8 @@ export interface CustomNodeDefinition<Schema extends StandardSchemaV1 | undefine
     };
     readonly fromDocx?: (input: {
         readonly attrs: Readonly<Record<string, string>>;
-        readonly text: string;
         readonly data?: InferSchemaOutput<Schema>;
+        readonly text: string;
     }) => Readonly<Record<string, string>> | null;
     readonly label?: string;
     readonly name: string;
@@ -64,12 +64,12 @@ export interface CustomNodeDefinition<Schema extends StandardSchemaV1 | undefine
     readonly preserveOnExport?: boolean | 'text';
     readonly reviewCard?: (node: {
         readonly attrs: Readonly<Record<string, string>>;
-        readonly text: string;
         readonly data?: InferSchemaOutput<Schema>;
+        readonly text: string;
     }) => {
-        readonly title: string;
         readonly detail?: string;
         readonly icon?: string;
+        readonly title: string;
     } | null;
     readonly schema?: Schema;
     readonly tagAttrs?: (data: InferSchemaOutput<Schema>) => Readonly<Record<string, string>>;
@@ -89,8 +89,8 @@ export interface CustomNodeDiagnostic {
 export interface CustomNodeInput<Schema extends StandardSchemaV1 | undefined = any> {
     readonly alias?: string;
     readonly at?: {
-        readonly paragraphId: string;
         readonly offset: number;
+        readonly paragraphId: string;
     };
     readonly attrs?: Readonly<Record<string, string>>;
     readonly data?: InferSchemaInput<Schema>;
@@ -170,19 +170,19 @@ export interface CustomNodeXmlOptions<Schema extends StandardSchemaV1 | undefine
 // @public
 export type CustomNodeXmlResult = {
     readonly ok: true;
-    readonly xml: string;
     readonly store?: CustomNodeXmlStore;
+    readonly xml: string;
 } | {
-    readonly ok: false;
     readonly code: 'invalidArgs';
+    readonly ok: false;
     readonly reason: string;
 };
 
 // @public
 export interface CustomNodeXmlStore {
     readonly contentTypeOverride: {
-        readonly partName: string;
         readonly contentType: string;
+        readonly partName: string;
     };
     readonly itemPartName: string;
     // (undocumented)
@@ -192,8 +192,8 @@ export interface CustomNodeXmlStore {
     readonly propsXml: string;
     readonly relationships: readonly {
         readonly from: string;
-        readonly type: string;
         readonly target: string;
+        readonly type: string;
     }[];
     readonly storeItemId: string;
 }
@@ -221,10 +221,10 @@ export interface DocumentExportOptions {
 
 // @public
 export type DocumentExportResult = {
-    readonly ok: true;
     readonly bytes: Uint8Array;
-    readonly unwrapped: number;
+    readonly ok: true;
     readonly removed: number;
+    readonly unwrapped: number;
 } | {
     readonly ok: false;
     readonly reason: string;
@@ -238,9 +238,9 @@ export type EncodeTagResult = {
     readonly ok: true;
     readonly tag: string;
 } | {
+    readonly length: number;
     readonly ok: false;
     readonly reason: 'tag-overflow';
-    readonly length: number;
 };
 
 // @public
@@ -324,8 +324,8 @@ export interface StandardSchemaIssue {
 
 // @public
 export type StandardSchemaResult<Output> = {
-    readonly value: Output;
     readonly issues?: undefined;
+    readonly value: Output;
 } | {
     readonly issues: readonly StandardSchemaIssue[];
 };
@@ -334,13 +334,13 @@ export type StandardSchemaResult<Output> = {
 export interface StandardSchemaV1<Input = unknown, Output = Input> {
     // (undocumented)
     readonly '~standard': {
-        readonly version: 1;
-        readonly vendor: string;
-        readonly validate: (value: unknown) => StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>;
         readonly types?: {
             readonly input: Input;
             readonly output: Output;
         } | undefined;
+        readonly validate: (value: unknown) => StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>;
+        readonly vendor: string;
+        readonly version: 1;
     };
 }
 

--- a/docs/api/docx-editor-pro/react.api.md
+++ b/docs/api/docx-editor-pro/react.api.md
@@ -121,8 +121,8 @@ export interface ReviewMarkersProps {
     // (undocumented)
     scale?: number;
     window?: {
-        top: number;
         bottom: number;
+        top: number;
     } | null;
 }
 
@@ -195,12 +195,12 @@ export interface UseReviewReturn {
 
 // @public
 export function useStackedReviewPositions(items: readonly {
-    readonly key: string;
     readonly anchorY: number | null;
+    readonly key: string;
 }[], heights: ReadonlyMap<string, number>, options?: {
+    readonly defaultHeight?: number;
     readonly gap?: number;
     readonly scale?: number;
-    readonly defaultHeight?: number;
 }): ReadonlyMap<string, number>;
 
 // (No @packageDocumentation comment for this package)

--- a/docs/api/docx-editor-pro/vue.api.md
+++ b/docs/api/docx-editor-pro/vue.api.md
@@ -50,469 +50,545 @@ export interface CustomNodeContextMenuProps {
 // @public (undocumented)
 export const DocxEditorReview: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
         asChild: BooleanConstructor;
-        hidden: BooleanConstructor;
-        t: {
-            type: PropType<(key: string, params?: Record<string, string | number>) => string>;
-            default: undefined;
-        };
         card: {
+            default: undefined;
             type: PropType<{
                 className?: string;
             }>;
-            default: undefined;
         };
-        furniture: {
-            type: PropType<VNode | VNode[]>;
-            default: undefined;
-        };
-        preset: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
-        stack: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
-        gap: {
-            type: NumberConstructor;
-            default: number;
-        };
+        className: StringConstructor;
         filter: {
-            type: PropType<(item: ReviewItemView) => boolean>;
             default: undefined;
-        };
-        structural: {
-            type: BooleanConstructor;
-            default: boolean;
+            type: PropType<(item: ReviewItemView) => boolean>;
         };
         formatting: {
-            type: BooleanConstructor;
             default: boolean;
+            type: BooleanConstructor;
+        };
+        furniture: {
+            default: undefined;
+            type: PropType<VNode | VNode[]>;
+        };
+        gap: {
+            default: number;
+            type: NumberConstructor;
+        };
+        hidden: BooleanConstructor;
+        preset: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        stack: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        structural: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        t: {
+            default: undefined;
+            type: PropType<(key: string, params?: Record<string, string | number>) => string>;
         };
     }>> & Readonly<{}>, () => VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        asChild: boolean;
+        card: {
+            className?: string;
+        };
         filter: (item: ReviewItemView) => boolean;
-        hidden: boolean;
-        t: (key: string, params?: Record<string, string | number>) => string;
-        structural: boolean;
+        formatting: boolean;
         furniture: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }> | VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>[];
-        formatting: boolean;
-        asChild: boolean;
         gap: number;
+        hidden: boolean;
         preset: boolean;
-        card: {
-            className?: string;
-        };
         stack: boolean;
+        structural: boolean;
+        t: (key: string, params?: Record<string, string | number>) => string;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
         asChild: BooleanConstructor;
-        hidden: BooleanConstructor;
-        t: {
-            type: PropType<(key: string, params?: Record<string, string | number>) => string>;
-            default: undefined;
-        };
         card: {
+            default: undefined;
             type: PropType<{
                 className?: string;
             }>;
-            default: undefined;
         };
-        furniture: {
-            type: PropType<VNode | VNode[]>;
-            default: undefined;
-        };
-        preset: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
-        stack: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
-        gap: {
-            type: NumberConstructor;
-            default: number;
-        };
+        className: StringConstructor;
         filter: {
-            type: PropType<(item: ReviewItemView) => boolean>;
             default: undefined;
-        };
-        structural: {
-            type: BooleanConstructor;
-            default: boolean;
+            type: PropType<(item: ReviewItemView) => boolean>;
         };
         formatting: {
-            type: BooleanConstructor;
             default: boolean;
+            type: BooleanConstructor;
+        };
+        furniture: {
+            default: undefined;
+            type: PropType<VNode | VNode[]>;
+        };
+        gap: {
+            default: number;
+            type: NumberConstructor;
+        };
+        hidden: BooleanConstructor;
+        preset: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        stack: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        structural: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        t: {
+            default: undefined;
+            type: PropType<(key: string, params?: Record<string, string | number>) => string>;
         };
     }>> & Readonly<{}>, () => VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }> | null, {}, {}, {}, {
+        asChild: boolean;
+        card: {
+            className?: string;
+        };
         filter: (item: ReviewItemView) => boolean;
-        hidden: boolean;
-        t: (key: string, params?: Record<string, string | number>) => string;
-        structural: boolean;
+        formatting: boolean;
         furniture: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }> | VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>[];
-        formatting: boolean;
-        asChild: boolean;
         gap: number;
+        hidden: boolean;
         preset: boolean;
-        card: {
-            className?: string;
-        };
         stack: boolean;
+        structural: boolean;
+        t: (key: string, params?: Record<string, string | number>) => string;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    className: StringConstructor;
     asChild: BooleanConstructor;
-    hidden: BooleanConstructor;
-    t: {
-        type: PropType<(key: string, params?: Record<string, string | number>) => string>;
-        default: undefined;
-    };
     card: {
+        default: undefined;
         type: PropType<{
             className?: string;
         }>;
-        default: undefined;
     };
-    furniture: {
-        type: PropType<VNode | VNode[]>;
-        default: undefined;
-    };
-    preset: {
-        type: BooleanConstructor;
-        default: boolean;
-    };
-    stack: {
-        type: BooleanConstructor;
-        default: boolean;
-    };
-    gap: {
-        type: NumberConstructor;
-        default: number;
-    };
+    className: StringConstructor;
     filter: {
-        type: PropType<(item: ReviewItemView) => boolean>;
         default: undefined;
-    };
-    structural: {
-        type: BooleanConstructor;
-        default: boolean;
+        type: PropType<(item: ReviewItemView) => boolean>;
     };
     formatting: {
-        type: BooleanConstructor;
         default: boolean;
+        type: BooleanConstructor;
+    };
+    furniture: {
+        default: undefined;
+        type: PropType<VNode | VNode[]>;
+    };
+    gap: {
+        default: number;
+        type: NumberConstructor;
+    };
+    hidden: BooleanConstructor;
+    preset: {
+        default: boolean;
+        type: BooleanConstructor;
+    };
+    stack: {
+        default: boolean;
+        type: BooleanConstructor;
+    };
+    structural: {
+        default: boolean;
+        type: BooleanConstructor;
+    };
+    t: {
+        default: undefined;
+        type: PropType<(key: string, params?: Record<string, string | number>) => string>;
     };
 }>> & Readonly<{}>, () => VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    asChild: boolean;
+    card: {
+        className?: string;
+    };
     filter: (item: ReviewItemView) => boolean;
-    hidden: boolean;
-    t: (key: string, params?: Record<string, string | number>) => string;
-    structural: boolean;
+    formatting: boolean;
     furniture: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }> | VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>[];
-    formatting: boolean;
-    asChild: boolean;
     gap: number;
+    hidden: boolean;
     preset: boolean;
-    card: {
-        className?: string;
-    };
     stack: boolean;
+    structural: boolean;
+    t: (key: string, params?: Record<string, string | number>) => string;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
-    List: vue.DefineComponent<vue.ExtractPropTypes<{
-        stack: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
-        positions: {
-            type: PropType<ReadonlyMap<string, number>>;
-            default: undefined;
-        };
-        collapsed: {
-            type: PropType<ReadonlySet<string>>;
-            default: undefined;
-        };
-        scale: {
-            type: NumberConstructor;
-            default: number;
-        };
-        offset: {
-            type: NumberConstructor;
-            default: number;
-        };
-        window: {
-            type: PropType<{
-                top: number;
-                bottom: number;
-            } | null>;
-            default: null;
-        };
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
-        [key: string]: any;
-    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        stack: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
-        positions: {
-            type: PropType<ReadonlyMap<string, number>>;
-            default: undefined;
-        };
-        collapsed: {
-            type: PropType<ReadonlySet<string>>;
-            default: undefined;
-        };
-        scale: {
-            type: NumberConstructor;
-            default: number;
-        };
-        offset: {
-            type: NumberConstructor;
-            default: number;
-        };
-        window: {
-            type: PropType<{
-                top: number;
-                bottom: number;
-            } | null>;
-            default: null;
-        };
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-    }>> & Readonly<{}>, {
-        hidden: boolean;
-        offset: number;
-        window: {
-            top: number;
-            bottom: number;
-        } | null;
-        scale: number;
-        collapsed: ReadonlySet<string>;
-        stack: boolean;
-        positions: ReadonlyMap<string, number>;
-    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Empty: vue.DefineComponent<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        hidden: BooleanConstructor;
+    Accept: vue.DefineComponent<vue.ExtractPropTypes<{
         asChild: BooleanConstructor;
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | string>;
+        };
     }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | string>;
+        };
     }>> & Readonly<{}>, {
-        hidden: boolean;
         asChild: boolean;
+        hidden: boolean;
+        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
+            [key: string]: any;
+        }>;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Card: vue.DefineComponent<vue.ExtractPropTypes<{
+    AddComment: vue.DefineComponent<vue.ExtractPropTypes<{
         className: StringConstructor;
+        drafting: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
         hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
+        top: {
+            default: null;
+            type: PropType<number | null>;
+        };
     }>, () => VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
         className: StringConstructor;
+        drafting: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
         hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
+        top: {
+            default: null;
+            type: PropType<number | null>;
+        };
     }>> & Readonly<{}>, {
+        drafting: boolean;
         hidden: boolean;
-        asChild: boolean;
-    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Avatar: vue.DefineComponent<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
-    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
-    }>> & Readonly<{}>, {
-        hidden: boolean;
-        asChild: boolean;
+        top: number | null;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
     Author: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
     }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
     }>> & Readonly<{}>, {
-        hidden: boolean;
         asChild: boolean;
+        hidden: boolean;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Time: vue.DefineComponent<vue.ExtractPropTypes<{
+    Avatar: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
     }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
     }>> & Readonly<{}>, {
-        hidden: boolean;
         asChild: boolean;
-    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Summary: vue.DefineComponent<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
-    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-        asChild: BooleanConstructor;
-    }>> & Readonly<{}>, {
         hidden: boolean;
-        asChild: boolean;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Accept: vue.DefineComponent<vue.ExtractPropTypes<{
+    Balloon: vue.DefineComponent<vue.ExtractPropTypes<{
         className: StringConstructor;
-        asChild: BooleanConstructor;
         hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
-    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        asChild: BooleanConstructor;
-        hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
-    }>> & Readonly<{}>, {
-        hidden: boolean;
-        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
-            [key: string]: any;
-        }>;
-        asChild: boolean;
-    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Reject: vue.DefineComponent<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        asChild: BooleanConstructor;
-        hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
-    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        asChild: BooleanConstructor;
-        hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
-    }>> & Readonly<{}>, {
-        hidden: boolean;
-        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
-            [key: string]: any;
-        }>;
-        asChild: boolean;
-    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Resolve: vue.DefineComponent<vue.ExtractPropTypes<{
-        className: StringConstructor;
-        asChild: BooleanConstructor;
-        hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
     }>, () => VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
         className: StringConstructor;
-        asChild: BooleanConstructor;
         hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
     }>> & Readonly<{}>, {
         hidden: boolean;
-        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
-            [key: string]: any;
-        }>;
-        asChild: boolean;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Reopen: vue.DefineComponent<vue.ExtractPropTypes<{
-        className: StringConstructor;
+    Card: vue.DefineComponent<vue.ExtractPropTypes<{
         asChild: BooleanConstructor;
+        className: StringConstructor;
         hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
     }>, () => VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
         asChild: BooleanConstructor;
+        className: StringConstructor;
         hidden: BooleanConstructor;
-        icon: {
-            type: PropType<VNode | string>;
-            default: undefined;
-        };
     }>> & Readonly<{}>, {
-        hidden: boolean;
-        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
-            [key: string]: any;
-        }>;
         asChild: boolean;
+        hidden: boolean;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
     Delete: vue.DefineComponent<vue.ExtractPropTypes<{
-        className: StringConstructor;
         asChild: BooleanConstructor;
+        className: StringConstructor;
         hidden: BooleanConstructor;
         icon: {
-            type: PropType<VNode | string>;
             default: undefined;
+            type: PropType<VNode | string>;
         };
     }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        className: StringConstructor;
         asChild: BooleanConstructor;
+        className: StringConstructor;
         hidden: BooleanConstructor;
         icon: {
-            type: PropType<VNode | string>;
             default: undefined;
+            type: PropType<VNode | string>;
         };
     }>> & Readonly<{}>, {
+        asChild: boolean;
         hidden: boolean;
         icon: string | VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
+    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+    Draft: vue.DefineComponent<vue.ExtractPropTypes<{
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        left: {
+            default: null;
+            type: PropType<number | null>;
+        };
+        top: {
+            default: number;
+            type: NumberConstructor;
+        };
+    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
+        [key: string]: any;
+    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        left: {
+            default: null;
+            type: PropType<number | null>;
+        };
+        top: {
+            default: number;
+            type: NumberConstructor;
+        };
+    }>> & Readonly<{}>, {
+        hidden: boolean;
+        left: number | null;
+        top: number;
+    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+    Empty: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+    }>> & Readonly<{}>, {
         asChild: boolean;
+        hidden: boolean;
+    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+    List: vue.DefineComponent<vue.ExtractPropTypes<{
+        className: StringConstructor;
+        collapsed: {
+            default: undefined;
+            type: PropType<ReadonlySet<string>>;
+        };
+        hidden: BooleanConstructor;
+        offset: {
+            default: number;
+            type: NumberConstructor;
+        };
+        positions: {
+            default: undefined;
+            type: PropType<ReadonlyMap<string, number>>;
+        };
+        scale: {
+            default: number;
+            type: NumberConstructor;
+        };
+        stack: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        window: {
+            default: null;
+            type: PropType<{
+                bottom: number;
+                top: number;
+            } | null>;
+        };
+    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
+        [key: string]: any;
+    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        className: StringConstructor;
+        collapsed: {
+            default: undefined;
+            type: PropType<ReadonlySet<string>>;
+        };
+        hidden: BooleanConstructor;
+        offset: {
+            default: number;
+            type: NumberConstructor;
+        };
+        positions: {
+            default: undefined;
+            type: PropType<ReadonlyMap<string, number>>;
+        };
+        scale: {
+            default: number;
+            type: NumberConstructor;
+        };
+        stack: {
+            default: boolean;
+            type: BooleanConstructor;
+        };
+        window: {
+            default: null;
+            type: PropType<{
+                bottom: number;
+                top: number;
+            } | null>;
+        };
+    }>> & Readonly<{}>, {
+        collapsed: ReadonlySet<string>;
+        hidden: boolean;
+        offset: number;
+        positions: ReadonlyMap<string, number>;
+        scale: number;
+        stack: boolean;
+        window: {
+            bottom: number;
+            top: number;
+        } | null;
+    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+    Markers: vue.DefineComponent<vue.ExtractPropTypes<{
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | ((item: ReviewItemView) => VNode | null | undefined)>;
+        };
+        offset: {
+            default: number;
+            type: NumberConstructor;
+        };
+        scale: {
+            default: number;
+            type: NumberConstructor;
+        };
+        window: {
+            default: null;
+            type: PropType<{
+                bottom: number;
+                top: number;
+            } | null>;
+        };
+    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | ((item: ReviewItemView) => VNode | null | undefined)>;
+        };
+        offset: {
+            default: number;
+            type: NumberConstructor;
+        };
+        scale: {
+            default: number;
+            type: NumberConstructor;
+        };
+        window: {
+            default: null;
+            type: PropType<{
+                bottom: number;
+                top: number;
+            } | null>;
+        };
+    }>> & Readonly<{}>, {
+        hidden: boolean;
+        icon: VNode<vue.RendererNode, vue.RendererElement, {
+            [key: string]: any;
+        }> | ((item: ReviewItemView) => VNode | null | undefined);
+        offset: number;
+        scale: number;
+        window: {
+            bottom: number;
+            top: number;
+        } | null;
+    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+    Reject: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | string>;
+        };
+    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | string>;
+        };
+    }>> & Readonly<{}>, {
+        asChild: boolean;
+        hidden: boolean;
+        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
+            [key: string]: any;
+        }>;
+    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+    Reopen: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | string>;
+        };
+    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
+        [key: string]: any;
+    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
+        className: StringConstructor;
+        hidden: BooleanConstructor;
+        icon: {
+            default: undefined;
+            type: PropType<VNode | string>;
+        };
+    }>> & Readonly<{}>, {
+        asChild: boolean;
+        hidden: boolean;
+        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
+            [key: string]: any;
+        }>;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
     Replies: vue.DefineComponent<vue.ExtractPropTypes<{
         className: StringConstructor;
@@ -534,129 +610,53 @@ export const DocxEditorReview: {
     }>> & Readonly<{}>, {
         hidden: boolean;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Markers: vue.DefineComponent<vue.ExtractPropTypes<{
-        scale: {
-            type: NumberConstructor;
-            default: number;
-        };
-        offset: {
-            type: NumberConstructor;
-            default: number;
-        };
-        window: {
-            type: PropType<{
-                top: number;
-                bottom: number;
-            } | null>;
-            default: null;
-        };
+    Resolve: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
         icon: {
-            type: PropType<VNode | ((item: ReviewItemView) => VNode | null | undefined)>;
             default: undefined;
+            type: PropType<VNode | string>;
         };
-    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        scale: {
-            type: NumberConstructor;
-            default: number;
-        };
-        offset: {
-            type: NumberConstructor;
-            default: number;
-        };
-        window: {
-            type: PropType<{
-                top: number;
-                bottom: number;
-            } | null>;
-            default: null;
-        };
+    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
+        [key: string]: any;
+    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
         icon: {
-            type: PropType<VNode | ((item: ReviewItemView) => VNode | null | undefined)>;
             default: undefined;
+            type: PropType<VNode | string>;
         };
     }>> & Readonly<{}>, {
+        asChild: boolean;
         hidden: boolean;
-        offset: number;
-        window: {
-            top: number;
-            bottom: number;
-        } | null;
-        scale: number;
-        icon: VNode<vue.RendererNode, vue.RendererElement, {
+        icon: string | VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
-        }> | ((item: ReviewItemView) => VNode | null | undefined);
+        }>;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    AddComment: vue.DefineComponent<vue.ExtractPropTypes<{
-        top: {
-            type: PropType<number | null>;
-            default: null;
-        };
-        drafting: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
+    Summary: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
-    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
-        [key: string]: any;
-    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        top: {
-            type: PropType<number | null>;
-            default: null;
-        };
-        drafting: {
-            type: BooleanConstructor;
-            default: boolean;
-        };
+    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
     }>> & Readonly<{}>, {
-        top: number | null;
-        hidden: boolean;
-        drafting: boolean;
-    }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Draft: vue.DefineComponent<vue.ExtractPropTypes<{
-        top: {
-            type: NumberConstructor;
-            default: number;
-        };
-        left: {
-            type: PropType<number | null>;
-            default: null;
-        };
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
-        [key: string]: any;
-    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-        top: {
-            type: NumberConstructor;
-            default: number;
-        };
-        left: {
-            type: PropType<number | null>;
-            default: null;
-        };
-        className: StringConstructor;
-        hidden: BooleanConstructor;
-    }>> & Readonly<{}>, {
-        left: number | null;
-        top: number;
+        asChild: boolean;
         hidden: boolean;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
-    Balloon: vue.DefineComponent<vue.ExtractPropTypes<{
+    Time: vue.DefineComponent<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
-    }>, () => VNode<vue.RendererNode, vue.RendererElement, {
-        [key: string]: any;
-    }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+    }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
+        asChild: BooleanConstructor;
         className: StringConstructor;
         hidden: BooleanConstructor;
     }>> & Readonly<{}>, {
+        asChild: boolean;
         hidden: boolean;
     }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 };
@@ -706,8 +706,8 @@ export interface ReviewMarkersProps extends ReviewPartProps {
     scale?: number;
     // (undocumented)
     window?: {
-        top: number;
         bottom: number;
+        top: number;
     } | null;
 }
 
@@ -808,12 +808,12 @@ export interface UseReviewReturn {
 
 // @public (undocumented)
 export function useStackedReviewPositions(items: MaybeRefOrGetter_2<readonly {
-    readonly key: string;
     readonly anchorY: number | null;
+    readonly key: string;
 }[]>, heights: MaybeRefOrGetter_2<ReadonlyMap<string, number>>, options?: MaybeRefOrGetter_2<{
+    readonly defaultHeight?: number;
     readonly gap?: number;
     readonly scale?: number;
-    readonly defaultHeight?: number;
 }>): ComputedRef<ReadonlyMap<string, number>>;
 
 // (No @packageDocumentation comment for this package)

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -125,10 +125,10 @@ export { composeFontConfiguration }
 
 // @public
 export const CONTENT_CONTROL_SLOTS: {
-    readonly showAll: "contentControl.showAll";
     readonly formFill: "contentControl.formFill";
     readonly inspector: "contentControl.inspector";
     readonly remove: "contentControl.remove";
+    readonly showAll: "contentControl.showAll";
 };
 
 // @public
@@ -784,39 +784,39 @@ export interface DocxEditorRulerProps {
 
 // @public @deprecated (undocumented)
 export function DocxEditorShell(input: {
-    i18n: React.ComponentProps<typeof LocaleProvider>['i18n'];
-    isDark?: boolean;
-    onEditorError: (error: Error) => void;
-    containerRef: React.Ref<HTMLDivElement>;
-    scrollContainerRef: React.Ref<HTMLDivElement>;
-    editorContentRef: React.Ref<HTMLDivElement>;
     className: string | undefined;
+    containerRef: React.Ref<HTMLDivElement>;
     containerStyle: CSSProperties;
-    mainContentStyle: CSSProperties;
+    dialogs: ReactNode;
     editorContainerStyle: CSSProperties;
-    showRuler: boolean;
-    readOnlyProp: boolean | undefined;
-    showOutline: boolean;
-    showOutlineButton: boolean;
-    sidebarOpen: boolean;
-    minLayoutWidth: number;
-    toolbarHeight: number;
+    editorContentRef: React.Ref<HTMLDivElement>;
     editorScrollLeft: number;
     expandedSidebarItem: string | null;
-    trackedChanges: readonly TrackedChangeSummary[];
-    onScrollContainerMouseDown: (e: React.MouseEvent) => void;
+    fileInputs: ReactNode;
+    horizontalRulerProps: HorizontalRulerProps_2;
+    i18n: React.ComponentProps<typeof LocaleProvider>['i18n'];
+    isDark?: boolean;
+    mainContentStyle: CSSProperties;
+    minLayoutWidth: number;
     onEditorBgMouseDown: (e: React.MouseEvent) => void;
     onEditorContextMenu: (e: React.MouseEvent) => void;
-    horizontalRulerProps: HorizontalRulerProps_2;
-    verticalRulerProps: VerticalRulerProps$1;
-    outlineProps: OutlineProps;
+    onEditorError: (error: Error) => void;
+    onScrollContainerMouseDown: (e: React.MouseEvent) => void;
     onToggleOutline: () => void;
-    scrollPageInfo: ScrollPageInfo;
-    toolbar: ReactNode;
-    pagedArea: ReactNode;
+    outlineProps: OutlineProps;
     overlays: ReactNode;
-    dialogs: ReactNode;
-    fileInputs: ReactNode;
+    pagedArea: ReactNode;
+    readOnlyProp: boolean | undefined;
+    scrollContainerRef: React.Ref<HTMLDivElement>;
+    scrollPageInfo: ScrollPageInfo;
+    showOutline: boolean;
+    showOutlineButton: boolean;
+    showRuler: boolean;
+    sidebarOpen: boolean;
+    toolbar: ReactNode;
+    toolbarHeight: number;
+    trackedChanges: readonly TrackedChangeSummary[];
+    verticalRulerProps: VerticalRulerProps$1;
 }): react.JSX.Element;
 
 // @public
@@ -1416,11 +1416,11 @@ export function NavigationToggle(input: NavigationPartProps): ReactElement;
 
 // @public (undocumented)
 export type NormalizedImagePayload = {
-    readonly ok: true;
     readonly bytes: Uint8Array;
-    readonly mime: SupportedImageMime;
-    readonly widthPoints: number;
     readonly heightPoints: number;
+    readonly mime: SupportedImageMime;
+    readonly ok: true;
+    readonly widthPoints: number;
 } | {
     readonly ok: false;
     readonly reasonKey: string;
@@ -1579,13 +1579,13 @@ export interface ParagraphFormatRead {
     readonly contextualSpacing: ParagraphFlagState;
     readonly disagrees: {
         readonly alignment: boolean;
-        readonly spaceBeforePt: boolean;
-        readonly spaceAfterPt: boolean;
-        readonly lineSpacing: boolean;
-        readonly tabStops: boolean;
+        readonly indentFirstLine: boolean;
         readonly indentLeft: boolean;
         readonly indentRight: boolean;
-        readonly indentFirstLine: boolean;
+        readonly lineSpacing: boolean;
+        readonly spaceAfterPt: boolean;
+        readonly spaceBeforePt: boolean;
+        readonly tabStops: boolean;
     };
     readonly indentFirstLineTwips: number | null;
     // (undocumented)
@@ -1669,11 +1669,11 @@ export interface ParagraphStyleOption {
     // (undocumented)
     readonly name: string;
     readonly preview: {
+        readonly bold: boolean;
+        readonly color: string | null;
         readonly fontFamily: string | null;
         readonly fontSizePt: number | null;
-        readonly bold: boolean;
         readonly italic: boolean;
-        readonly color: string | null;
     };
     // (undocumented)
     readonly styleId: string;
@@ -1814,43 +1814,43 @@ export interface SlotProps extends HTMLAttributes<HTMLElement> {
 // @public
 export interface TableBorderColorNamespace extends TableChromePartComponent {
     readonly Content: (props: TableChromePartProps) => DocxEditorChildren;
-    readonly docxSlot: 'table.borderColor';
     readonly Item: (props: TableChromeItemProps) => DocxEditorChildren;
     readonly Main: (props: TableChromePartProps) => DocxEditorChildren;
     readonly Trigger: (props: TableChromePartProps) => DocxEditorChildren;
+    readonly docxSlot: 'table.borderColor';
 }
 
 // @public
 export interface TableBorderStyleNamespace extends TableChromePartComponent {
     readonly Content: (props: TableChromePartProps) => DocxEditorChildren;
-    readonly docxSlot: 'table.borderStyle';
     readonly Item: (props: TableChromeItemProps) => DocxEditorChildren;
     readonly Trigger: (props: TableChromePartProps) => DocxEditorChildren;
+    readonly docxSlot: 'table.borderStyle';
 }
 
 // @public
 export interface TableBorderTargetNamespace extends TableChromePartComponent {
     readonly Content: (props: TableChromePartProps) => DocxEditorChildren;
-    readonly docxSlot: 'table.borderTarget';
     readonly Item: (props: TableChromeItemProps) => DocxEditorChildren;
     readonly Trigger: (props: TableChromePartProps) => DocxEditorChildren;
+    readonly docxSlot: 'table.borderTarget';
 }
 
 // @public
 export interface TableBorderWidthNamespace extends TableChromePartComponent {
     readonly Content: (props: TableChromePartProps) => DocxEditorChildren;
-    readonly docxSlot: 'table.borderWidth';
     readonly Item: (props: TableChromeItemProps) => DocxEditorChildren;
     readonly Trigger: (props: TableChromePartProps) => DocxEditorChildren;
+    readonly docxSlot: 'table.borderWidth';
 }
 
 // @public
 export interface TableCellFillNamespace extends TableChromePartComponent {
     readonly Content: (props: TableChromePartProps) => DocxEditorChildren;
-    readonly docxSlot: 'table.cellFill';
     readonly Item: (props: TableChromeItemProps) => DocxEditorChildren;
     readonly Main: (props: TableChromePartProps) => DocxEditorChildren;
     readonly Trigger: (props: TableChromePartProps) => DocxEditorChildren;
+    readonly docxSlot: 'table.cellFill';
 }
 
 // @public
@@ -1861,9 +1861,9 @@ export interface TableChromeItemProps extends TableChromePartProps {
 // @public
 export interface TableChromePartComponent extends ToolbarSlotPartComponent {
     readonly Content: (props: TableChromePartProps) => DocxEditorChildren;
-    readonly docxSlot: TableChromeSlotId;
     readonly Item: (props: TableChromeItemProps) => DocxEditorChildren;
     readonly Trigger: (props: TableChromePartProps) => DocxEditorChildren;
+    readonly docxSlot: TableChromeSlotId;
 }
 
 // @public
@@ -1970,9 +1970,9 @@ export interface ToolbarProps {
     enableShortcuts?: boolean;
     fontFamilies?: ReadonlyArray<string | FontOption>;
     imageContext?: {
-        wrapType: string;
-        displayMode: string;
         cssFloat: string | null;
+        displayMode: string;
+        wrapType: string;
     } | null;
     inline?: boolean;
     onFormat?: (action: FormattingAction) => void;
@@ -1983,16 +1983,16 @@ export interface ToolbarProps {
     onInsertSectionBreakContinuous?: () => void;
     onInsertSectionBreakNextPage?: () => void;
     onInsertShape?: (data: {
-        shapeType: string;
-        width: number;
-        height: number;
         fillColor?: string;
         fillType?: string;
-        outlineWidth?: number;
+        height: number;
         outlineColor?: string;
+        outlineWidth?: number;
+        shapeType: string;
+        width: number;
     }) => void;
-    onInsertTable?: (rows: number, columns: number) => void;
     onInsertTOC?: () => void;
+    onInsertTable?: (rows: number, columns: number) => void;
     onOpen?: () => void;
     onOpenImageProperties?: () => void;
     onPageSetup?: () => void;
@@ -2017,13 +2017,13 @@ export interface ToolbarProps {
     showZoomControl?: boolean;
     style?: CSSProperties;
     tableContext?: {
+        canSplitCell?: boolean;
+        cellBackgroundColor?: string;
+        cellBorderColor?: ColorValue;
+        columnCount?: number;
+        hasMultiCellSelection?: boolean;
         isInTable: boolean;
         rowCount?: number;
-        columnCount?: number;
-        canSplitCell?: boolean;
-        hasMultiCellSelection?: boolean;
-        cellBorderColor?: ColorValue;
-        cellBackgroundColor?: string;
     } | null;
     theme?: Theme | null;
     zoom?: number;
@@ -2331,8 +2331,8 @@ export function useToolbarLabelFor(t: ToolbarTranslate | undefined): (key: strin
 
 // @public (undocumented)
 export function useTranslation(): {
-    t: TFunction;
     catalogue: LocaleStrings;
+    t: TFunction;
 };
 
 // @public

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -129,10 +129,10 @@ export { composeFontConfiguration }
 
 // @public (undocumented)
 export const CONTENT_CONTROL_SLOTS: {
-    readonly showAll: "contentControl.showAll";
     readonly formFill: "contentControl.formFill";
     readonly inspector: "contentControl.inspector";
     readonly remove: "contentControl.remove";
+    readonly showAll: "contentControl.showAll";
 };
 
 // @public
@@ -197,13 +197,13 @@ export interface ContextMenuAnchor {
 // @public (undocumented)
 export const ContextMenuCellVerticalAlignment: vue.DefineComponent<vue.ExtractPropTypes<{
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
     };
 }>> & Readonly<{}>, {
     hidden: boolean;
@@ -242,103 +242,103 @@ export interface ContextMenuContextValue {
 // @public (undocumented)
 export const ContextMenuCopy: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    shortcutKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    shortcutKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
     shortcutKey: string;
-    className: string;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -346,103 +346,103 @@ export const ContextMenuCopy: {
 // @public (undocumented)
 export const ContextMenuCut: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    shortcutKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    shortcutKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
     shortcutKey: string;
-    className: string;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -450,103 +450,103 @@ export const ContextMenuCut: {
 // @public (undocumented)
 export const ContextMenuDelete: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    shortcutKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    shortcutKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
     shortcutKey: string;
-    className: string;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -554,103 +554,103 @@ export const ContextMenuDelete: {
 // @public (undocumented)
 export const ContextMenuDeleteTable: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    hidden: {
-        type: BooleanConstructor;
-        default: undefined;
     };
     destructive: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    hidden: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
+    destructive: boolean;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
-    destructive: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -658,103 +658,103 @@ export const ContextMenuDeleteTable: {
 // @public (undocumented)
 export const ContextMenuDeleteTableColumn: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    hidden: {
-        type: BooleanConstructor;
-        default: undefined;
     };
     destructive: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    hidden: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
+    destructive: boolean;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
-    destructive: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -762,103 +762,103 @@ export const ContextMenuDeleteTableColumn: {
 // @public (undocumented)
 export const ContextMenuDeleteTableRow: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    hidden: {
-        type: BooleanConstructor;
-        default: undefined;
     };
     destructive: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    hidden: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
+    destructive: boolean;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
-    destructive: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -866,103 +866,103 @@ export const ContextMenuDeleteTableRow: {
 // @public (undocumented)
 export const ContextMenuInsertColumnLeft: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    hidden: {
-        type: BooleanConstructor;
-        default: undefined;
     };
     destructive: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    hidden: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
+    destructive: boolean;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
-    destructive: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -970,103 +970,103 @@ export const ContextMenuInsertColumnLeft: {
 // @public (undocumented)
 export const ContextMenuInsertColumnRight: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    hidden: {
-        type: BooleanConstructor;
-        default: undefined;
     };
     destructive: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    hidden: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
+    destructive: boolean;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
-    destructive: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -1074,103 +1074,103 @@ export const ContextMenuInsertColumnRight: {
 // @public (undocumented)
 export const ContextMenuInsertRowAbove: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    hidden: {
-        type: BooleanConstructor;
-        default: undefined;
     };
     destructive: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    hidden: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
+    destructive: boolean;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
-    destructive: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -1178,184 +1178,184 @@ export const ContextMenuInsertRowAbove: {
 // @public (undocumented)
 export const ContextMenuInsertRowBelow: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
+            default: undefined;
             type: StringConstructor;
-            default: undefined;
-        };
-        hidden: {
-            type: BooleanConstructor;
-            default: undefined;
         };
         destructive: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        hidden: {
+            default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
+        destructive: boolean;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
-        destructive: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    hidden: {
-        type: BooleanConstructor;
-        default: undefined;
     };
     destructive: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    hidden: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
+    destructive: boolean;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
-    destructive: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
 
 // @public (undocumented)
 export const ContextMenuItem: vue.DefineComponent<vue.ExtractPropTypes<{
-    label: {
-        type: StringConstructor;
-        required: true;
-    };
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    shortcut: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    disabled: {
-        type: BooleanConstructor;
-        default: undefined;
-    };
-    disabledReason: {
-        type: StringConstructor;
-        default: undefined;
-    };
     active: {
+        default: undefined;
         type: BooleanConstructor;
-        default: undefined;
-    };
-    onSelect: {
-        type: PropType<() => void>;
-        default: undefined;
     };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
+    };
+    disabled: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    disabledReason: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    label: {
+        required: true;
+        type: StringConstructor;
+    };
+    onSelect: {
+        default: undefined;
+        type: PropType<() => void>;
+    };
+    shortcut: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>, () => VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    label: {
-        type: StringConstructor;
-        required: true;
-    };
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    shortcut: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    disabled: {
-        type: BooleanConstructor;
-        default: undefined;
-    };
-    disabledReason: {
-        type: StringConstructor;
-        default: undefined;
-    };
     active: {
+        default: undefined;
         type: BooleanConstructor;
-        default: undefined;
-    };
-    onSelect: {
-        type: PropType<() => void>;
-        default: undefined;
     };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
+    };
+    disabled: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    disabledReason: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    label: {
+        required: true;
+        type: StringConstructor;
+    };
+    onSelect: {
+        default: undefined;
+        type: PropType<() => void>;
+    };
+    shortcut: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
-    disabledReason: string;
     active: boolean;
+    className: string;
+    disabled: boolean;
+    disabledReason: string;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
-    disabled: boolean;
-    className: string;
     onSelect: () => void;
     shortcut: string;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
@@ -1382,142 +1382,142 @@ export interface ContextMenuItemProps {
 
 // @public (undocumented)
 export const ContextMenuPaste: vue.DefineComponent<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    shortcutKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    shortcutKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    shortcutKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    shortcutKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
+    className: string;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
     shortcutKey: string;
-    className: string;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export const ContextMenuRefreshToc: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -1525,88 +1525,88 @@ export const ContextMenuRefreshToc: {
 // @public (undocumented)
 export const ContextMenuRefreshTocPageNumbers: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
-        className: string;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
-    className: string;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -1614,103 +1614,103 @@ export const ContextMenuRefreshTocPageNumbers: {
 // @public (undocumented)
 export const ContextMenuSelectAll: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        icon: {
-            type: PropType<VNode>;
-            default: undefined;
-        };
-        labelKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
-        shortcutKey: {
-            type: StringConstructor;
-            default: undefined;
-        };
         className: {
-            type: StringConstructor;
             default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
+            type: BooleanConstructor;
+        };
+        icon: {
+            default: undefined;
+            type: PropType<VNode>;
+        };
+        labelKey: {
+            default: undefined;
+            type: StringConstructor;
+        };
+        shortcutKey: {
+            default: undefined;
+            type: StringConstructor;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
+        className: string;
         hidden: boolean;
         icon: VNode<vue.RendererNode, vue.RendererElement, {
             [key: string]: any;
         }>;
         labelKey: string;
         shortcutKey: string;
-        className: string;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    icon: {
-        type: PropType<VNode>;
-        default: undefined;
-    };
-    labelKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    shortcutKey: {
-        type: StringConstructor;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
+    };
+    icon: {
+        default: undefined;
+        type: PropType<VNode>;
+    };
+    labelKey: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    shortcutKey: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
+    className: string;
     hidden: boolean;
     icon: VNode<vue.RendererNode, vue.RendererElement, {
         [key: string]: any;
     }>;
     labelKey: string;
     shortcutKey: string;
-    className: string;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxRow: string;
 };
@@ -1725,87 +1725,87 @@ export { createFontSource }
 
 // @public @deprecated (undocumented)
 export const DocumentName: vue.DefineComponent<vue.ExtractPropTypes<{
-    value: {
-        type: StringConstructor;
-        default: string;
-    };
     onChange: {
-        type: PropType<(value: string) => void>;
         default: undefined;
+        type: PropType<(value: string) => void>;
+    };
+    value: {
+        default: string;
+        type: StringConstructor;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    value: {
-        type: StringConstructor;
-        default: string;
-    };
     onChange: {
-        type: PropType<(value: string) => void>;
         default: undefined;
+        type: PropType<(value: string) => void>;
+    };
+    value: {
+        default: string;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
-    value: string;
     onChange: (value: string) => void;
+    value: string;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export const DocumentOutline: vue.DefineComponent<vue.ExtractPropTypes<{
     headings: {
+        required: true;
         type: PropType<readonly OutlineHeading_2[]>;
-        required: true;
-    };
-    onHeadingClick: {
-        type: PropType<(blockId: string) => void>;
-        required: true;
-    };
-    onClose: {
-        type: PropType<() => void>;
-        required: true;
-    };
-    topOffset: {
-        type: NumberConstructor;
-        default: number;
-    };
-    scrollLeft: {
-        type: NumberConstructor;
-        default: number;
     };
     leftOffset: {
-        type: NumberConstructor;
         default: number;
+        type: NumberConstructor;
+    };
+    onClose: {
+        required: true;
+        type: PropType<() => void>;
+    };
+    onHeadingClick: {
+        required: true;
+        type: PropType<(blockId: string) => void>;
+    };
+    scrollLeft: {
+        default: number;
+        type: NumberConstructor;
+    };
+    topOffset: {
+        default: number;
+        type: NumberConstructor;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     headings: {
+        required: true;
         type: PropType<readonly OutlineHeading_2[]>;
-        required: true;
-    };
-    onHeadingClick: {
-        type: PropType<(blockId: string) => void>;
-        required: true;
-    };
-    onClose: {
-        type: PropType<() => void>;
-        required: true;
-    };
-    topOffset: {
-        type: NumberConstructor;
-        default: number;
-    };
-    scrollLeft: {
-        type: NumberConstructor;
-        default: number;
     };
     leftOffset: {
-        type: NumberConstructor;
         default: number;
+        type: NumberConstructor;
+    };
+    onClose: {
+        required: true;
+        type: PropType<() => void>;
+    };
+    onHeadingClick: {
+        required: true;
+        type: PropType<(blockId: string) => void>;
+    };
+    scrollLeft: {
+        default: number;
+        type: NumberConstructor;
+    };
+    topOffset: {
+        default: number;
+        type: NumberConstructor;
     };
 }>> & Readonly<{}>, {
-    topOffset: number;
-    scrollLeft: number;
     leftOffset: number;
+    scrollLeft: number;
+    topOffset: number;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 export { DocxDocument }
@@ -1835,23 +1835,23 @@ export const DocxEditorColorByChangeType: vue.DefineComponent<{}, () => null, {}
 // @public (undocumented)
 export const DocxEditorContent: vue.DefineComponent<vue.ExtractPropTypes<{
     class: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     class: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
     class: string;
@@ -1886,54 +1886,54 @@ export interface DocxEditorContentProps {
 // @public (undocumented)
 export const DocxEditorContextMenu: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    t: {
-        type: PropType<ToolbarTranslate>;
-        default: undefined;
-    };
-    preset: {
-        type: BooleanConstructor;
-        default: boolean;
     };
     disabled: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
     };
     onOpenChange: {
-        type: PropType<(open: boolean) => void>;
         default: undefined;
+        type: PropType<(open: boolean) => void>;
+    };
+    preset: {
+        default: boolean;
+        type: BooleanConstructor;
+    };
+    t: {
+        default: undefined;
+        type: PropType<ToolbarTranslate>;
     };
 }>, () => VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    t: {
-        type: PropType<ToolbarTranslate>;
-        default: undefined;
-    };
-    preset: {
-        type: BooleanConstructor;
-        default: boolean;
     };
     disabled: {
-        type: BooleanConstructor;
         default: undefined;
+        type: BooleanConstructor;
     };
     onOpenChange: {
-        type: PropType<(open: boolean) => void>;
         default: undefined;
+        type: PropType<(open: boolean) => void>;
+    };
+    preset: {
+        default: boolean;
+        type: BooleanConstructor;
+    };
+    t: {
+        default: undefined;
+        type: PropType<ToolbarTranslate>;
     };
 }>> & Readonly<{}>, {
-    t: ToolbarTranslate;
-    disabled: boolean;
     className: string;
-    preset: boolean;
+    disabled: boolean;
     onOpenChange: (open: boolean) => void;
+    preset: boolean;
+    t: ToolbarTranslate;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -2002,37 +2002,37 @@ export interface DocxEditorContextMenuProps {
 
 // @public (undocumented)
 export const DocxEditorDocumentOutline: vue.DefineComponent<vue.ExtractPropTypes<{
-    onClose: {
-        type: PropType<() => void>;
+    leftOffset: {
         default: undefined;
+        type: NumberConstructor;
+    };
+    onClose: {
+        default: undefined;
+        type: PropType<() => void>;
     };
     topOffset: {
-        type: NumberConstructor;
         default: number;
-    };
-    leftOffset: {
         type: NumberConstructor;
-        default: undefined;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    onClose: {
-        type: PropType<() => void>;
+    leftOffset: {
         default: undefined;
+        type: NumberConstructor;
+    };
+    onClose: {
+        default: undefined;
+        type: PropType<() => void>;
     };
     topOffset: {
-        type: NumberConstructor;
         default: number;
-    };
-    leftOffset: {
         type: NumberConstructor;
-        default: undefined;
     };
 }>> & Readonly<{}>, {
+    leftOffset: number;
     onClose: () => void;
     topOffset: number;
-    leftOffset: number;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
@@ -2053,36 +2053,36 @@ export const DocxEditorEquation: vue.DefineComponent<{}, () => vue.VNode<vue.Ren
 // @public (undocumented)
 export const DocxEditorFontNotice: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
     t: {
-        type: PropType<TFunction>;
         default: undefined;
+        type: PropType<TFunction>;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
     t: {
-        type: PropType<TFunction>;
         default: undefined;
+        type: PropType<TFunction>;
     };
 }>> & Readonly<{}>, {
-    t: TFunction;
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
+    t: TFunction;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
@@ -2098,15 +2098,15 @@ export interface DocxEditorFontNoticeProps {
 // @public
 export const DocxEditorHeaderFooterChrome: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
     className: string;
@@ -2120,34 +2120,34 @@ export interface DocxEditorHeaderFooterChromeProps {
 
 // @public (undocumented)
 export const DocxEditorHorizontalRuler: vue.DefineComponent<vue.ExtractPropTypes<{
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    unit: {
+        default: undefined;
+        type: PropType<"inch" | "cm">;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    unit: {
+        default: undefined;
+        type: PropType<"inch" | "cm">;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
     unit: "cm" | "inch";
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
@@ -2178,38 +2178,38 @@ export interface DocxEditorHyperLinkNamespace {
 
 // @public
 export const DocxEditorImagePropertiesDialog: vue.DefineComponent<vue.ExtractPropTypes<{
-    open: {
-        type: BooleanConstructor;
-        required: true;
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     onClose: {
-        type: PropType<() => void>;
         required: true;
+        type: PropType<() => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: undefined;
+    open: {
+        required: true;
+        type: BooleanConstructor;
     };
     triggerRef: {
-        type: PropType<RefObject<HTMLElement | null>>;
         default: undefined;
+        type: PropType<RefObject<HTMLElement | null>>;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    open: {
-        type: BooleanConstructor;
-        required: true;
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     onClose: {
-        type: PropType<() => void>;
         required: true;
+        type: PropType<() => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: undefined;
+    open: {
+        required: true;
+        type: BooleanConstructor;
     };
     triggerRef: {
-        type: PropType<RefObject<HTMLElement | null>>;
         default: undefined;
+        type: PropType<RefObject<HTMLElement | null>>;
     };
 }>> & Readonly<{}>, {
     className: string;
@@ -2256,15 +2256,15 @@ export interface DocxEditorLoadingProps {
 // @public (undocumented)
 export const DocxEditorLoadingSpinner: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>, () => VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
     className: string;
@@ -2433,15 +2433,15 @@ export interface DocxEditorNavigationProps extends UseNavigationPaneOptions {
 // @public (undocumented)
 export const DocxEditorNotesChrome: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
     className: string;
@@ -2456,27 +2456,27 @@ export interface DocxEditorNotesChromeProps {
 // @public (undocumented)
 export const DocxEditorPageNumber: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }> | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
@@ -2489,30 +2489,30 @@ export interface DocxEditorPageNumberProps {
 
 // @public (undocumented)
 export const DocxEditorPageSetupDialog: vue.DefineComponent<vue.ExtractPropTypes<{
-    open: {
-        type: BooleanConstructor;
-        required: true;
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     onClose: {
-        type: PropType<() => void>;
         required: true;
+        type: PropType<() => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: undefined;
+    open: {
+        required: true;
+        type: BooleanConstructor;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    open: {
-        type: BooleanConstructor;
-        required: true;
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     onClose: {
-        type: PropType<() => void>;
         required: true;
+        type: PropType<() => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: undefined;
+    open: {
+        required: true;
+        type: BooleanConstructor;
     };
 }>> & Readonly<{}>, {
     className: string;
@@ -2530,30 +2530,30 @@ export interface DocxEditorPageSetupDialogProps {
 
 // @public
 export const DocxEditorParagraphDialog: vue.DefineComponent<vue.ExtractPropTypes<{
-    open: {
-        type: BooleanConstructor;
-        required: true;
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     onClose: {
-        type: PropType<() => void>;
         required: true;
+        type: PropType<() => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: undefined;
+    open: {
+        required: true;
+        type: BooleanConstructor;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    open: {
-        type: BooleanConstructor;
-        required: true;
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     onClose: {
-        type: PropType<() => void>;
         required: true;
+        type: PropType<() => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: undefined;
+    open: {
+        required: true;
+        type: BooleanConstructor;
     };
 }>> & Readonly<{}>, {
     className: string;
@@ -2635,117 +2635,117 @@ export interface DocxEditorRef {
 
 // @public (undocumented)
 export const DocxEditorRoot: vue.DefineComponent<vue.ExtractPropTypes<{
-    document: {
-        type: PropType<DocumentSource>;
+    author: {
         default: undefined;
+        type: StringConstructor;
+    };
+    document: {
+        default: undefined;
+        type: PropType<DocumentSource>;
     };
     fonts: {
+        default: undefined;
         type: PropType<DocxEditorRootProps["fonts"]>;
-        default: undefined;
-    };
-    author: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    locale: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    translate: {
-        type: PropType<DocxEditorRootProps["translate"]>;
-        default: undefined;
-    };
-    modules: {
-        type: PropType<readonly EditorModule[]>;
-        default: undefined;
-    };
-    mode: {
-        type: PropType<"edit" | "view" | "suggesting">;
-        default: undefined;
-    };
-    zoom: {
-        type: NumberConstructor;
-        default: undefined;
-    };
-    zoomMode: {
-        type: PropType<ZoomMode | "auto">;
-        default: undefined;
-    };
-    tableInteractionLabel: {
-        type: PropType<DocxEditorRootProps["tableInteractionLabel"]>;
-        default: undefined;
     };
     imageDecodePort: {
-        type: PropType<ImageDecodePort>;
         default: undefined;
+        type: PropType<ImageDecodePort>;
+    };
+    locale: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    mode: {
+        default: undefined;
+        type: PropType<"edit" | "view" | "suggesting">;
+    };
+    modules: {
+        default: undefined;
+        type: PropType<readonly EditorModule[]>;
+    };
+    tableInteractionLabel: {
+        default: undefined;
+        type: PropType<DocxEditorRootProps["tableInteractionLabel"]>;
+    };
+    translate: {
+        default: undefined;
+        type: PropType<DocxEditorRootProps["translate"]>;
+    };
+    zoom: {
+        default: undefined;
+        type: NumberConstructor;
+    };
+    zoomMode: {
+        default: undefined;
+        type: PropType<ZoomMode | "auto">;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {
-    ready: (_editor: Editor) => true;
     change: (_change: DocumentChange) => true;
     fontError: (_error: unknown) => true;
+    ready: (_editor: Editor) => true;
 }, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    document: {
-        type: PropType<DocumentSource>;
+    author: {
         default: undefined;
+        type: StringConstructor;
+    };
+    document: {
+        default: undefined;
+        type: PropType<DocumentSource>;
     };
     fonts: {
+        default: undefined;
         type: PropType<DocxEditorRootProps["fonts"]>;
-        default: undefined;
-    };
-    author: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    locale: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    translate: {
-        type: PropType<DocxEditorRootProps["translate"]>;
-        default: undefined;
-    };
-    modules: {
-        type: PropType<readonly EditorModule[]>;
-        default: undefined;
-    };
-    mode: {
-        type: PropType<"edit" | "view" | "suggesting">;
-        default: undefined;
-    };
-    zoom: {
-        type: NumberConstructor;
-        default: undefined;
-    };
-    zoomMode: {
-        type: PropType<ZoomMode | "auto">;
-        default: undefined;
-    };
-    tableInteractionLabel: {
-        type: PropType<DocxEditorRootProps["tableInteractionLabel"]>;
-        default: undefined;
     };
     imageDecodePort: {
-        type: PropType<ImageDecodePort>;
         default: undefined;
+        type: PropType<ImageDecodePort>;
+    };
+    locale: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    mode: {
+        default: undefined;
+        type: PropType<"edit" | "view" | "suggesting">;
+    };
+    modules: {
+        default: undefined;
+        type: PropType<readonly EditorModule[]>;
+    };
+    tableInteractionLabel: {
+        default: undefined;
+        type: PropType<DocxEditorRootProps["tableInteractionLabel"]>;
+    };
+    translate: {
+        default: undefined;
+        type: PropType<DocxEditorRootProps["translate"]>;
+    };
+    zoom: {
+        default: undefined;
+        type: NumberConstructor;
+    };
+    zoomMode: {
+        default: undefined;
+        type: PropType<ZoomMode | "auto">;
     };
 }>> & Readonly<{
     onChange?: ((_change: DocumentChange) => any) | undefined;
-    onReady?: ((_editor: Editor) => any) | undefined;
     onFontError?: ((_error: unknown) => any) | undefined;
+    onReady?: ((_editor: Editor) => any) | undefined;
 }>, {
-    document: DocumentSource;
-    locale: string;
-    zoom: number;
-    fonts: _docx_editor_dev_core.FontConfiguration | _docx_editor_dev_core.FontConfigurationFragment | _docx_editor_dev_core.FontResolver | undefined;
     author: string;
-    mode: "suggesting" | "edit" | "view";
+    document: DocumentSource;
+    fonts: _docx_editor_dev_core.FontConfiguration | _docx_editor_dev_core.FontConfigurationFragment | _docx_editor_dev_core.FontResolver | undefined;
     imageDecodePort: ImageDecodePort;
-    zoomMode: "auto" | ZoomMode;
-    translate: ((key: string, params?: Record<string, string | number>) => string) | undefined;
+    locale: string;
+    mode: "suggesting" | "edit" | "view";
     modules: readonly EditorModule[];
     tableInteractionLabel: ((key: "table.insertRowBelow" | "table.insertColumnRight") => string) | undefined;
+    translate: ((key: string, params?: Record<string, string | number>) => string) | undefined;
+    zoom: number;
+    zoomMode: "auto" | ZoomMode;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
@@ -2924,70 +2924,70 @@ export interface DocxEditorToolbarProps {
 
 // @public (undocumented)
 export const DocxEditorVerticalRuler: vue.DefineComponent<vue.ExtractPropTypes<{
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    unit: {
+        default: undefined;
+        type: PropType<"inch" | "cm">;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    unit: {
+        default: undefined;
+        type: PropType<"inch" | "cm">;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
     unit: "cm" | "inch";
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export const DocxEditorViewport: vue.DefineComponent<vue.ExtractPropTypes<{
     class: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     class: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     class: string;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -3133,152 +3133,152 @@ export type HeaderFooterState = Exclude<ReturnType<Editor['getHeaderFooterState'
 
 // @public (undocumented)
 export const HorizontalRuler: vue.DefineComponent<vue.ExtractPropTypes<{
-    pageSetup: {
-        type: PropType<RulerPageSetup | null>;
-        default: null;
-    };
-    zoom: {
-        type: NumberConstructor;
-        default: number;
+    className: {
+        default: string;
+        type: StringConstructor;
     };
     editable: {
-        type: BooleanConstructor;
         default: boolean;
-    };
-    onLeftMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
-        default: undefined;
-    };
-    onRightMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
-        default: undefined;
-    };
-    onMarginDragEnd: {
-        type: PropType<() => void>;
-        default: undefined;
-    };
-    showIndentHandles: {
         type: BooleanConstructor;
-        default: boolean;
     };
     indent: {
-        type: PropType<RulerIndent | null>;
         default: null;
+        type: PropType<RulerIndent | null>;
     };
     indentEditable: {
-        type: BooleanConstructor;
         default: boolean;
+        type: BooleanConstructor;
     };
     onIndentChange: {
-        type: PropType<(indent: RulerIndent) => void>;
         default: undefined;
+        type: PropType<(indent: RulerIndent) => void>;
     };
     onIndentDragEnd: {
+        default: undefined;
         type: PropType<() => void>;
+    };
+    onLeftMarginChange: {
         default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: string;
-    };
-    className: {
-        type: StringConstructor;
-        default: string;
-    };
-    style: {
-        type: PropType<CSSProperties>;
+    onMarginDragEnd: {
         default: undefined;
+        type: PropType<() => void>;
     };
-    tabMarks: {
-        type: PropType<RulerTabStop[] | null>;
-        default: null;
+    onRightMarginChange: {
+        default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
     onTabMarkRemove: {
-        type: PropType<(positionTwips: number) => void>;
         default: undefined;
+        type: PropType<(positionTwips: number) => void>;
+    };
+    pageSetup: {
+        default: null;
+        type: PropType<RulerPageSetup | null>;
+    };
+    showIndentHandles: {
+        default: boolean;
+        type: BooleanConstructor;
+    };
+    style: {
+        default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    tabMarks: {
+        default: null;
+        type: PropType<RulerTabStop[] | null>;
+    };
+    unit: {
+        default: string;
+        type: PropType<"inch" | "cm">;
+    };
+    zoom: {
+        default: number;
+        type: NumberConstructor;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    pageSetup: {
-        type: PropType<RulerPageSetup | null>;
-        default: null;
-    };
-    zoom: {
-        type: NumberConstructor;
-        default: number;
+    className: {
+        default: string;
+        type: StringConstructor;
     };
     editable: {
-        type: BooleanConstructor;
         default: boolean;
-    };
-    onLeftMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
-        default: undefined;
-    };
-    onRightMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
-        default: undefined;
-    };
-    onMarginDragEnd: {
-        type: PropType<() => void>;
-        default: undefined;
-    };
-    showIndentHandles: {
         type: BooleanConstructor;
-        default: boolean;
     };
     indent: {
-        type: PropType<RulerIndent | null>;
         default: null;
+        type: PropType<RulerIndent | null>;
     };
     indentEditable: {
-        type: BooleanConstructor;
         default: boolean;
+        type: BooleanConstructor;
     };
     onIndentChange: {
-        type: PropType<(indent: RulerIndent) => void>;
         default: undefined;
+        type: PropType<(indent: RulerIndent) => void>;
     };
     onIndentDragEnd: {
+        default: undefined;
         type: PropType<() => void>;
+    };
+    onLeftMarginChange: {
         default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: string;
-    };
-    className: {
-        type: StringConstructor;
-        default: string;
-    };
-    style: {
-        type: PropType<CSSProperties>;
+    onMarginDragEnd: {
         default: undefined;
+        type: PropType<() => void>;
     };
-    tabMarks: {
-        type: PropType<RulerTabStop[] | null>;
-        default: null;
+    onRightMarginChange: {
+        default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
     onTabMarkRemove: {
-        type: PropType<(positionTwips: number) => void>;
         default: undefined;
+        type: PropType<(positionTwips: number) => void>;
+    };
+    pageSetup: {
+        default: null;
+        type: PropType<RulerPageSetup | null>;
+    };
+    showIndentHandles: {
+        default: boolean;
+        type: BooleanConstructor;
+    };
+    style: {
+        default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    tabMarks: {
+        default: null;
+        type: PropType<RulerTabStop[] | null>;
+    };
+    unit: {
+        default: string;
+        type: PropType<"inch" | "cm">;
+    };
+    zoom: {
+        default: number;
+        type: NumberConstructor;
     };
 }>> & Readonly<{}>, {
-    zoom: number;
-    pageSetup: _docx_editor_dev_core.PageSetup | null;
-    style: CSSProperties;
-    indent: RulerIndent | null;
-    editable: boolean;
     className: string;
-    onLeftMarginChange: (marginTwips: number) => void;
-    onRightMarginChange: (marginTwips: number) => void;
-    onMarginDragEnd: () => void;
-    showIndentHandles: boolean;
+    editable: boolean;
+    indent: RulerIndent | null;
     indentEditable: boolean;
     onIndentChange: (indent: RulerIndent) => void;
     onIndentDragEnd: () => void;
-    unit: "cm" | "inch";
-    tabMarks: RulerTabStop[] | null;
+    onLeftMarginChange: (marginTwips: number) => void;
+    onMarginDragEnd: () => void;
+    onRightMarginChange: (marginTwips: number) => void;
     onTabMarkRemove: (positionTwips: number) => void;
+    pageSetup: _docx_editor_dev_core.PageSetup | null;
+    showIndentHandles: boolean;
+    style: CSSProperties;
+    tabMarks: RulerTabStop[] | null;
+    unit: "cm" | "inch";
+    zoom: number;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -3367,35 +3367,35 @@ export interface HyperLinkProps extends HyperLinkPartProps {
 
 // @public (undocumented)
 export const ImageAltText: vue.DefineComponent<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>> & Readonly<{}>, {
-    hidden: boolean;
-    className: string;
     asChild: boolean;
+    className: string;
+    hidden: boolean;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -3405,68 +3405,68 @@ export const ImageInsertProvider: vue.DefineComponent<{}, () => vue.VNode<vue.Re
 
 // @public (undocumented)
 export const ImageInsertTrigger: vue.DefineComponent<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>> & Readonly<{}>, {
-    hidden: boolean;
-    className: string;
     asChild: boolean;
+    className: string;
+    hidden: boolean;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
 export const ImagePropertiesTrigger: vue.DefineComponent<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>> & Readonly<{}>, {
-    hidden: boolean;
-    className: string;
     asChild: boolean;
+    className: string;
+    hidden: boolean;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
@@ -3483,35 +3483,35 @@ export interface ImagePropertiesTriggerProps {
 
 // @public (undocumented)
 export const ImageWrap: vue.DefineComponent<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>> & Readonly<{}>, {
-    hidden: boolean;
-    className: string;
     asChild: boolean;
+    className: string;
+    hidden: boolean;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 export { ImageWrapTarget }
@@ -3540,15 +3540,15 @@ export { LOADING_SNAPSHOT }
 // @public (undocumented)
 export const LocaleProvider: vue.DefineComponent<vue.ExtractPropTypes<{
     i18n: {
-        type: PropType<Translations>;
         default: undefined;
+        type: PropType<Translations>;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>[] | undefined, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     i18n: {
-        type: PropType<Translations>;
         default: undefined;
+        type: PropType<Translations>;
     };
 }>> & Readonly<{}>, {
     i18n: _docx_editor_dev_i18n.PartialLocaleStrings;
@@ -3694,97 +3694,97 @@ export const NAVIGATION_PANE_WIDTH = 280;
 // @public (undocumented)
 export const NavigationClose: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export const NavigationFind: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export const NavigationHeader: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export const NavigationHeadings: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
@@ -3815,34 +3815,34 @@ export interface NavigationShiftInput {
 
 // @public (undocumented)
 export const NavigationTab: vue.DefineComponent<vue.ExtractPropTypes<{
-    value: {
-        type: PropType<NavigationTabValue>;
-        required: true;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    value: {
+        required: true;
+        type: PropType<NavigationTabValue>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    value: {
-        type: PropType<NavigationTabValue>;
-        required: true;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    value: {
+        required: true;
+        type: PropType<NavigationTabValue>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -3854,25 +3854,25 @@ export interface NavigationTabProps extends NavigationPartProps {
 // @public (undocumented)
 export const NavigationTabs: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -3881,58 +3881,58 @@ export type NavigationTabValue = 'headings' | 'find';
 // @public (undocumented)
 export const NavigationTitle: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export const NavigationToggle: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
     };
 }>> & Readonly<{}>, {
-    style: CSSProperties;
     className: string;
+    style: CSSProperties;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
 export type NormalizedImagePayload = {
-    readonly ok: true;
     readonly bytes: Uint8Array;
-    readonly mime: SupportedImageMime;
-    readonly widthPoints: number;
     readonly heightPoints: number;
+    readonly mime: SupportedImageMime;
+    readonly ok: true;
+    readonly widthPoints: number;
 } | {
     readonly ok: false;
     readonly reasonKey: string;
@@ -3973,31 +3973,31 @@ export interface OutlineHeadingItem {
 // @public (undocumented)
 export const PageIndicator: vue.DefineComponent<vue.ExtractPropTypes<{
     currentPage: {
-        type: NumberConstructor;
         required: true;
+        type: NumberConstructor;
     };
     totalPages: {
-        type: NumberConstructor;
         required: true;
+        type: NumberConstructor;
     };
     visible: {
-        type: BooleanConstructor;
         required: true;
+        type: BooleanConstructor;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     currentPage: {
-        type: NumberConstructor;
         required: true;
+        type: NumberConstructor;
     };
     totalPages: {
-        type: NumberConstructor;
         required: true;
+        type: NumberConstructor;
     };
     visible: {
-        type: BooleanConstructor;
         required: true;
+        type: BooleanConstructor;
     };
 }>> & Readonly<{}>, {}, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
@@ -4038,70 +4038,70 @@ export interface PageSetupUpdate {
 
 // @public (undocumented)
 export const PaginatedDocxEditor: vue.DefineComponent<vue.ExtractPropTypes<{
-    source: {
-        type: PropType<Uint8Array>;
-        required: true;
-    };
-    scale: {
-        type: NumberConstructor;
-        default: undefined;
-    };
-    measurer: {
-        type: PropType<TextMeasurer>;
-        default: undefined;
-    };
-    onStateChange: {
-        type: PropType<(state: PaginatedSurfaceState) => void>;
-        default: undefined;
-    };
-    onError: {
-        type: PropType<(reason: string, detail?: string) => void>;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     documentFontFamily: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
+    };
+    measurer: {
+        default: undefined;
+        type: PropType<TextMeasurer>;
+    };
+    onError: {
+        default: undefined;
+        type: PropType<(reason: string, detail?: string) => void>;
+    };
+    onStateChange: {
+        default: undefined;
+        type: PropType<(state: PaginatedSurfaceState) => void>;
+    };
+    scale: {
+        default: undefined;
+        type: NumberConstructor;
+    };
+    source: {
+        required: true;
+        type: PropType<Uint8Array>;
     };
 }>, () => VNode, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    source: {
-        type: PropType<Uint8Array>;
-        required: true;
-    };
-    scale: {
-        type: NumberConstructor;
-        default: undefined;
-    };
-    measurer: {
-        type: PropType<TextMeasurer>;
-        default: undefined;
-    };
-    onStateChange: {
-        type: PropType<(state: PaginatedSurfaceState) => void>;
-        default: undefined;
-    };
-    onError: {
-        type: PropType<(reason: string, detail?: string) => void>;
-        default: undefined;
-    };
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
     documentFontFamily: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
+    };
+    measurer: {
+        default: undefined;
+        type: PropType<TextMeasurer>;
+    };
+    onError: {
+        default: undefined;
+        type: PropType<(reason: string, detail?: string) => void>;
+    };
+    onStateChange: {
+        default: undefined;
+        type: PropType<(state: PaginatedSurfaceState) => void>;
+    };
+    scale: {
+        default: undefined;
+        type: NumberConstructor;
+    };
+    source: {
+        required: true;
+        type: PropType<Uint8Array>;
     };
 }>> & Readonly<{}>, {
-    measurer: TextMeasurer;
-    scale: number;
     className: string;
+    documentFontFamily: string;
+    measurer: TextMeasurer;
     onError: (reason: string, detail?: string) => void;
     onStateChange: (state: PaginatedSurfaceState) => void;
-    documentFontFamily: string;
+    scale: number;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public
@@ -4158,108 +4158,108 @@ export interface PaginatedDocxEditorProps {
 
 // @public @deprecated (undocumented)
 export const PaginatedDocxEditorShell: vue.DefineComponent<vue.ExtractPropTypes<{
-    source: {
-        type: PropType<Uint8Array>;
-        required: true;
-    };
-    documentName: {
+    className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    scale: {
-        type: NumberConstructor;
-        default: undefined;
-    };
-    measurer: {
-        type: PropType<TextMeasurer>;
-        default: undefined;
-    };
-    onStateChange: {
-        type: PropType<(state: PaginatedSurfaceState) => void>;
-        default: undefined;
-    };
-    onError: {
-        type: PropType<(reason: string, detail?: string) => void>;
-        default: undefined;
-    };
-    onSave: {
-        type: PropType<(bytes: Uint8Array) => void>;
-        default: undefined;
     };
     colorMode: {
+        default: undefined;
         type: PropType<"light" | "dark">;
-        default: undefined;
-    };
-    onZoomChange: {
-        type: PropType<(zoom: number) => void>;
-        default: undefined;
     };
     documentFontFamily: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
-    className: {
-        type: StringConstructor;
+    documentName: {
         default: undefined;
+        type: StringConstructor;
+    };
+    measurer: {
+        default: undefined;
+        type: PropType<TextMeasurer>;
+    };
+    onError: {
+        default: undefined;
+        type: PropType<(reason: string, detail?: string) => void>;
+    };
+    onSave: {
+        default: undefined;
+        type: PropType<(bytes: Uint8Array) => void>;
+    };
+    onStateChange: {
+        default: undefined;
+        type: PropType<(state: PaginatedSurfaceState) => void>;
+    };
+    onZoomChange: {
+        default: undefined;
+        type: PropType<(zoom: number) => void>;
+    };
+    scale: {
+        default: undefined;
+        type: NumberConstructor;
+    };
+    source: {
+        required: true;
+        type: PropType<Uint8Array>;
     };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    source: {
-        type: PropType<Uint8Array>;
-        required: true;
-    };
-    documentName: {
+    className: {
+        default: undefined;
         type: StringConstructor;
-        default: undefined;
-    };
-    scale: {
-        type: NumberConstructor;
-        default: undefined;
-    };
-    measurer: {
-        type: PropType<TextMeasurer>;
-        default: undefined;
-    };
-    onStateChange: {
-        type: PropType<(state: PaginatedSurfaceState) => void>;
-        default: undefined;
-    };
-    onError: {
-        type: PropType<(reason: string, detail?: string) => void>;
-        default: undefined;
-    };
-    onSave: {
-        type: PropType<(bytes: Uint8Array) => void>;
-        default: undefined;
     };
     colorMode: {
+        default: undefined;
         type: PropType<"light" | "dark">;
-        default: undefined;
-    };
-    onZoomChange: {
-        type: PropType<(zoom: number) => void>;
-        default: undefined;
     };
     documentFontFamily: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
-    className: {
-        type: StringConstructor;
+    documentName: {
         default: undefined;
+        type: StringConstructor;
+    };
+    measurer: {
+        default: undefined;
+        type: PropType<TextMeasurer>;
+    };
+    onError: {
+        default: undefined;
+        type: PropType<(reason: string, detail?: string) => void>;
+    };
+    onSave: {
+        default: undefined;
+        type: PropType<(bytes: Uint8Array) => void>;
+    };
+    onStateChange: {
+        default: undefined;
+        type: PropType<(state: PaginatedSurfaceState) => void>;
+    };
+    onZoomChange: {
+        default: undefined;
+        type: PropType<(zoom: number) => void>;
+    };
+    scale: {
+        default: undefined;
+        type: NumberConstructor;
+    };
+    source: {
+        required: true;
+        type: PropType<Uint8Array>;
     };
 }>> & Readonly<{}>, {
-    measurer: TextMeasurer;
-    scale: number;
     className: string;
-    onError: (reason: string, detail?: string) => void;
-    onSave: (bytes: Uint8Array) => void;
     colorMode: "light" | "dark";
-    onStateChange: (state: PaginatedSurfaceState) => void;
     documentFontFamily: string;
     documentName: string;
+    measurer: TextMeasurer;
+    onError: (reason: string, detail?: string) => void;
+    onSave: (bytes: Uint8Array) => void;
+    onStateChange: (state: PaginatedSurfaceState) => void;
     onZoomChange: (zoom: number) => void;
+    scale: number;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -4304,13 +4304,13 @@ export interface ParagraphFormatRead {
     readonly contextualSpacing: ParagraphFlagState;
     readonly disagrees: {
         readonly alignment: boolean;
-        readonly spaceBeforePt: boolean;
-        readonly spaceAfterPt: boolean;
-        readonly lineSpacing: boolean;
-        readonly tabStops: boolean;
+        readonly indentFirstLine: boolean;
         readonly indentLeft: boolean;
         readonly indentRight: boolean;
-        readonly indentFirstLine: boolean;
+        readonly lineSpacing: boolean;
+        readonly spaceAfterPt: boolean;
+        readonly spaceBeforePt: boolean;
+        readonly tabStops: boolean;
     };
     readonly indentFirstLineTwips: number | null;
     // (undocumented)
@@ -4396,11 +4396,11 @@ export interface ParagraphStyleOption {
     readonly name: string;
     // (undocumented)
     readonly preview: {
+        readonly bold: boolean;
+        readonly color: string | null;
         readonly fontFamily: string | null;
         readonly fontSizePt: number | null;
-        readonly bold: boolean;
         readonly italic: boolean;
-        readonly color: string | null;
     };
     // (undocumented)
     readonly styleId: string;
@@ -4656,15 +4656,15 @@ export const TitleBarRight: vue.DefineComponent<{}, () => vue.VNode<vue.Renderer
 // @public @deprecated (undocumented)
 export const Toolbar: vue.DefineComponent<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>, () => VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     className: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{}>, {
     className: string;
@@ -4703,56 +4703,56 @@ export interface ToolbarAlignmentComponent {
 // @public @deprecated (undocumented)
 export const ToolbarButton: vue.DefineComponent<vue.ExtractPropTypes<{
     active: {
+        default: undefined;
         type: BooleanConstructor;
-        default: undefined;
-    };
-    disabled: {
-        type: BooleanConstructor;
-        default: undefined;
-    };
-    title: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    className: {
-        type: StringConstructor;
-        default: undefined;
     };
     ariaLabel: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    disabled: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    title: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>, () => VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, "click"[], "click", vue.PublicProps, Readonly<vue.ExtractPropTypes<{
     active: {
+        default: undefined;
         type: BooleanConstructor;
-        default: undefined;
-    };
-    disabled: {
-        type: BooleanConstructor;
-        default: undefined;
-    };
-    title: {
-        type: StringConstructor;
-        default: undefined;
-    };
-    className: {
-        type: StringConstructor;
-        default: undefined;
     };
     ariaLabel: {
-        type: StringConstructor;
         default: undefined;
+        type: StringConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
+    };
+    disabled: {
+        default: undefined;
+        type: BooleanConstructor;
+    };
+    title: {
+        default: undefined;
+        type: StringConstructor;
     };
 }>> & Readonly<{
     onClick?: ((...args: any[]) => any) | undefined;
 }>, {
-    ariaLabel: string;
-    title: string;
     active: boolean;
-    disabled: boolean;
+    ariaLabel: string;
     className: string;
+    disabled: boolean;
+    title: string;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -4796,67 +4796,67 @@ export const ToolbarGroup: vue.DefineComponent<{}, () => VNode<vue.RendererNode,
 // @public (undocumented)
 export const ToolbarImageProperties: {
     new (...args: any[]): vue.CreateComponentPublicInstanceWithMixins<Readonly<vue.ExtractPropTypes<{
-        className: {
-            type: StringConstructor;
+        asChild: {
             default: undefined;
+            type: BooleanConstructor;
+        };
+        className: {
+            default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
-        };
-        asChild: {
             type: BooleanConstructor;
-            default: undefined;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, vue.PublicProps, {
-        hidden: boolean;
-        className: string;
         asChild: boolean;
+        className: string;
+        hidden: boolean;
     }, true, {}, {}, vue.GlobalComponents, vue.GlobalDirectives, string, {}, any, vue.ComponentProvideOptions, {
-        P: {};
         B: {};
-        D: {};
         C: {};
-        M: {};
+        D: {};
         Defaults: {};
+        M: {};
+        P: {};
     }, Readonly<vue.ExtractPropTypes<{
-        className: {
-            type: StringConstructor;
+        asChild: {
             default: undefined;
+            type: BooleanConstructor;
+        };
+        className: {
+            default: undefined;
+            type: StringConstructor;
         };
         hidden: {
-            type: BooleanConstructor;
             default: undefined;
-        };
-        asChild: {
             type: BooleanConstructor;
-            default: undefined;
         };
     }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, {
-        hidden: boolean;
-        className: string;
         asChild: boolean;
+        className: string;
+        hidden: boolean;
     }>;
     __isFragment?: never;
     __isTeleport?: never;
     __isSuspense?: never;
 } & vue.ComponentOptionsBase<Readonly<vue.ExtractPropTypes<{
-    className: {
-        type: StringConstructor;
+    asChild: {
         default: undefined;
+        type: BooleanConstructor;
+    };
+    className: {
+        default: undefined;
+        type: StringConstructor;
     };
     hidden: {
-        type: BooleanConstructor;
         default: undefined;
-    };
-    asChild: {
         type: BooleanConstructor;
-        default: undefined;
     };
 }>> & Readonly<{}>, () => vue_jsx_runtime.JSX.Element | null, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, {
-    hidden: boolean;
-    className: string;
     asChild: boolean;
+    className: string;
+    hidden: boolean;
 }, {}, string, {}, vue.GlobalComponents, vue.GlobalDirectives, string, vue.ComponentProvideOptions> & vue.VNodeProps & vue.AllowedComponentProps & vue.ComponentCustomProps & {
     docxSlot: "image.properties";
 };
@@ -4896,9 +4896,9 @@ export interface ToolbarProps {
     fontFamilies?: ReadonlyArray<string | FontOption>;
     // (undocumented)
     imageContext?: {
-        wrapType: string;
-        displayMode: string;
         cssFloat: string | null;
+        displayMode: string;
+        wrapType: string;
     } | null;
     // (undocumented)
     inline?: boolean;
@@ -4918,13 +4918,13 @@ export interface ToolbarProps {
     onInsertSectionBreakNextPage?: () => void;
     // (undocumented)
     onInsertShape?: (data: {
-        shapeType: string;
-        width: number;
-        height: number;
         fillColor?: string;
         fillType?: string;
-        outlineWidth?: number;
+        height: number;
         outlineColor?: string;
+        outlineWidth?: number;
+        shapeType: string;
+        width: number;
     }) => void;
     // (undocumented)
     onInsertTable?: (rows: number, columns: number) => void;
@@ -4978,13 +4978,13 @@ export interface ToolbarProps {
     style?: CSSProperties;
     // (undocumented)
     tableContext?: {
+        canSplitCell?: boolean;
+        cellBackgroundColor?: string;
+        cellBorderColor?: ColorValue;
+        columnCount?: number;
+        hasMultiCellSelection?: boolean;
         isInTable: boolean;
         rowCount?: number;
-        columnCount?: number;
-        canSplitCell?: boolean;
-        hasMultiCellSelection?: boolean;
-        cellBorderColor?: ColorValue;
-        cellBackgroundColor?: string;
     } | null;
     // (undocumented)
     theme?: Theme | null;
@@ -5355,8 +5355,8 @@ export function useToolbarLabelFor(t: ToolbarTranslate | undefined): (key: strin
 
 // @public (undocumented)
 export function useTranslation(): {
-    t: TFunction;
     catalogue: ShallowRef<LocaleStrings>;
+    t: TFunction;
 };
 
 // @public (undocumented)
@@ -5397,89 +5397,89 @@ export const VERSION: string;
 
 // @public (undocumented)
 export const VerticalRuler: vue.DefineComponent<vue.ExtractPropTypes<{
-    pageSetup: {
-        type: PropType<RulerPageSetup | null>;
-        default: null;
-    };
-    zoom: {
-        type: NumberConstructor;
-        default: number;
+    className: {
+        default: string;
+        type: StringConstructor;
     };
     editable: {
-        type: BooleanConstructor;
         default: boolean;
-    };
-    onTopMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
-        default: undefined;
+        type: BooleanConstructor;
     };
     onBottomMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
         default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
     onMarginDragEnd: {
-        type: PropType<() => void>;
         default: undefined;
+        type: PropType<() => void>;
     };
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: string;
+    onTopMarginChange: {
+        default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: string;
+    pageSetup: {
+        default: null;
+        type: PropType<RulerPageSetup | null>;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    unit: {
+        default: string;
+        type: PropType<"inch" | "cm">;
+    };
+    zoom: {
+        default: number;
+        type: NumberConstructor;
     };
 }>, () => vue_jsx_runtime.JSX.Element, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, {}, string, vue.PublicProps, Readonly<vue.ExtractPropTypes<{
-    pageSetup: {
-        type: PropType<RulerPageSetup | null>;
-        default: null;
-    };
-    zoom: {
-        type: NumberConstructor;
-        default: number;
+    className: {
+        default: string;
+        type: StringConstructor;
     };
     editable: {
-        type: BooleanConstructor;
         default: boolean;
-    };
-    onTopMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
-        default: undefined;
+        type: BooleanConstructor;
     };
     onBottomMarginChange: {
-        type: PropType<(marginTwips: number) => void>;
         default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
     onMarginDragEnd: {
-        type: PropType<() => void>;
         default: undefined;
+        type: PropType<() => void>;
     };
-    unit: {
-        type: PropType<"inch" | "cm">;
-        default: string;
+    onTopMarginChange: {
+        default: undefined;
+        type: PropType<(marginTwips: number) => void>;
     };
-    className: {
-        type: StringConstructor;
-        default: string;
+    pageSetup: {
+        default: null;
+        type: PropType<RulerPageSetup | null>;
     };
     style: {
-        type: PropType<CSSProperties>;
         default: undefined;
+        type: PropType<CSSProperties>;
+    };
+    unit: {
+        default: string;
+        type: PropType<"inch" | "cm">;
+    };
+    zoom: {
+        default: number;
+        type: NumberConstructor;
     };
 }>> & Readonly<{}>, {
-    zoom: number;
+    className: string;
+    editable: boolean;
+    onBottomMarginChange: (marginTwips: number) => void;
+    onMarginDragEnd: () => void;
+    onTopMarginChange: (marginTwips: number) => void;
     pageSetup: _docx_editor_dev_core.PageSetup | null;
     style: CSSProperties;
-    editable: boolean;
-    className: string;
-    onMarginDragEnd: () => void;
     unit: "cm" | "inch";
-    onTopMarginChange: (marginTwips: number) => void;
-    onBottomMarginChange: (marginTwips: number) => void;
+    zoom: number;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)

--- a/scripts/__tests__/api-snapshot-canonicalize.test.ts
+++ b/scripts/__tests__/api-snapshot-canonicalize.test.ts
@@ -138,6 +138,52 @@ describe('canonicalizeApiReport', () => {
     );
   });
 
+  test('an odd apostrophe in a block comment does not stop sorting', () => {
+    const input = report(
+      [
+        "/** it's a thing */",
+        'export type Z = {',
+        '    d: 1;',
+        '    c: 2;',
+        '};',
+      ].join('\n')
+    );
+    expect(canonicalizeApiReport(input)).toBe(
+      report(
+        [
+          "/** it's a thing */",
+          'export type Z = {',
+          '    c: 2;',
+          '    d: 1;',
+          '};',
+        ].join('\n')
+      )
+    );
+  });
+
+  test('sorts function-typed property values correctly', () => {
+    const input = report(
+      [
+        'export const x: {',
+        '    onFoo?: (e: X) => void;',
+        '    bar: string;',
+        '    onBaz: (a: string, b: { z: 1; y: 2; }) => Promise<void>;',
+        '};',
+      ].join('\n')
+    );
+    expect(canonicalizeApiReport(input)).toBe(
+      report(
+        [
+          'export const x: {',
+          '    bar: string;',
+          '    onBaz: (a: string, b: { y: 2; z: 1; }) => Promise<void>;',
+          '    onFoo?: (e: X) => void;',
+          '};',
+        ].join('\n')
+      )
+    );
+  });
+
   test('leaves markdown outside the ts fence untouched', () => {
     const input = ['# Title {not: code; other: thing;}', '', '```ts', 'export const a: 1;', '```', ''].join(
       '\n'

--- a/scripts/__tests__/api-snapshot-canonicalize.test.ts
+++ b/scripts/__tests__/api-snapshot-canonicalize.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test';
+import { canonicalizeApiReport } from '../lib/api-snapshot-canonicalize.mjs';
+
+function report(body: string): string {
+  return ['## API Report File', '', '```ts', body, '```', ''].join('\n');
+}
+
+describe('canonicalizeApiReport', () => {
+  test('two reports differing only in inferred member order canonicalize identically', () => {
+    const orderA = report(
+      [
+        'export const DocxEditorRoot: vue.DefineComponent<vue.ExtractPropTypes<{',
+        '    zoomMode: {',
+        '        type: PropType<ZoomMode | "auto">;',
+        '        default: undefined;',
+        '    };',
+        '    tableInteractionLabel: {',
+        '        type: PropType<DocxEditorRootProps["tableInteractionLabel"]>;',
+        '        default: undefined;',
+        '    };',
+        '    imageDecodePort: {',
+        '        type: PropType<ImageDecodePort>;',
+        '        default: undefined;',
+        '    };',
+        '}>>;',
+      ].join('\n')
+    );
+    const orderB = report(
+      [
+        'export const DocxEditorRoot: vue.DefineComponent<vue.ExtractPropTypes<{',
+        '    tableInteractionLabel: {',
+        '        type: PropType<DocxEditorRootProps["tableInteractionLabel"]>;',
+        '        default: undefined;',
+        '    };',
+        '    imageDecodePort: {',
+        '        type: PropType<ImageDecodePort>;',
+        '        default: undefined;',
+        '    };',
+        '    zoomMode: {',
+        '        type: PropType<ZoomMode | "auto">;',
+        '        default: undefined;',
+        '    };',
+        '}>>;',
+      ].join('\n')
+    );
+    expect(orderA).not.toBe(orderB);
+    expect(canonicalizeApiReport(orderA)).toBe(canonicalizeApiReport(orderB));
+  });
+
+  test('sorts property signatures alphabetically and recursively', () => {
+    const input = report(
+      ['export const x: {', '    b: {', '        d: 1;', '        c: 2;', '    };', '    a: 3;', '};'].join(
+        '\n'
+      )
+    );
+    expect(canonicalizeApiReport(input)).toBe(
+      report(
+        ['export const x: {', '    a: 3;', '    b: {', '        c: 2;', '        d: 1;', '    };', '};'].join(
+          '\n'
+        )
+      )
+    );
+  });
+
+  test('is idempotent', () => {
+    const input = report(
+      ['export const x: {', '    b: string;', '    a: number;', '};'].join('\n')
+    );
+    const once = canonicalizeApiReport(input);
+    expect(canonicalizeApiReport(once)).toBe(once);
+  });
+
+  test('leaves declaration bodies with report comments untouched', () => {
+    const input = report(
+      [
+        'export interface Props {',
+        '    // (undocumented)',
+        '    zoom?: number;',
+        '    // (undocumented)',
+        '    author?: string;',
+        '}',
+      ].join('\n')
+    );
+    expect(canonicalizeApiReport(input)).toBe(input);
+  });
+
+  test('leaves call signatures, methods, and index signatures untouched', () => {
+    const overloads = report(
+      [
+        'export const x: {',
+        '    (a: string): number;',
+        '    (a: number): string;',
+        '};',
+      ].join('\n')
+    );
+    expect(canonicalizeApiReport(overloads)).toBe(overloads);
+
+    const methods = report(
+      ['export const x: {', '    save(): void;', '    load(): void;', '};'].join('\n')
+    );
+    expect(canonicalizeApiReport(methods)).toBe(methods);
+
+    const indexed = report(
+      ['export const x: {', '    [key: string]: any;', '    a: 1;', '};'].join('\n')
+    );
+    expect(canonicalizeApiReport(indexed)).toBe(indexed);
+  });
+
+  test('does not reorder unions, tuples, or parameter lists', () => {
+    const input = report(
+      [
+        "export type U = 'b' | 'a';",
+        'export type T = [b: string, a: number];',
+        'export function f(b: string, a: number): void;',
+      ].join('\n')
+    );
+    expect(canonicalizeApiReport(input)).toBe(input);
+  });
+
+  test('handles quoted member names and braces inside string literals', () => {
+    const input = report(
+      [
+        'export const x: {',
+        "    'z-key': string;",
+        '    "a.key": \'{\';',
+        '};',
+      ].join('\n')
+    );
+    expect(canonicalizeApiReport(input)).toBe(
+      report(
+        [
+          'export const x: {',
+          '    "a.key": \'{\';',
+          "    'z-key': string;",
+          '};',
+        ].join('\n')
+      )
+    );
+  });
+
+  test('leaves markdown outside the ts fence untouched', () => {
+    const input = ['# Title {not: code; other: thing;}', '', '```ts', 'export const a: 1;', '```', ''].join(
+      '\n'
+    );
+    expect(canonicalizeApiReport(input)).toBe(input);
+  });
+});

--- a/scripts/lib/api-extractor-runner.mjs
+++ b/scripts/lib/api-extractor-runner.mjs
@@ -11,6 +11,7 @@ import { CompilerState, Extractor, ExtractorConfig } from '@microsoft/api-extrac
 import fs from 'node:fs';
 import path from 'node:path';
 import { evaluateForgottenExportPolicy } from './api-extractor-forgotten-exports.mjs';
+import { canonicalizeApiReport } from './api-snapshot-canonicalize.mjs';
 import { collectNamedExports } from './named-exports.mjs';
 
 function slugForKey(key) {
@@ -217,8 +218,33 @@ export function runApiExtractor(options) {
     totalErrors += result.errorCount;
     totalWarnings += result.warningCount;
 
-    if (!isLocal && result.apiReportChanged) {
-      driftedEntries.push(target);
+    // The dts emit order of inferred object types (Vue's ExtractPropTypes
+    // blocks) is machine-dependent, so the raw report text is not comparable
+    // across machines. Canonicalize the committed snapshot (sorted property
+    // signatures inside anonymous object types) and compare/write through the
+    // same canonical form.
+    const reportPath = path.join(reportDir, `${target.slug}.api.md`);
+    const tempReportPath = path.join(tempDir, `${target.slug}.api.md`);
+    if (isLocal) {
+      // In local mode Extractor already copied its raw report over
+      // `reportPath`; rewrite it in canonical form.
+      const raw = fs.readFileSync(reportPath, 'utf8');
+      const canonical = canonicalizeApiReport(raw);
+      if (canonical !== raw) fs.writeFileSync(reportPath, canonical);
+    } else if (result.apiReportChanged) {
+      // Raw texts differ. Only call it drift when the canonical forms differ
+      // too — a pure emit-order difference is not drift.
+      const committed = fs.existsSync(reportPath) ? fs.readFileSync(reportPath, 'utf8') : null;
+      const generated = fs.existsSync(tempReportPath)
+        ? fs.readFileSync(tempReportPath, 'utf8')
+        : null;
+      if (
+        committed === null ||
+        generated === null ||
+        canonicalizeApiReport(committed) !== canonicalizeApiReport(generated)
+      ) {
+        driftedEntries.push(target);
+      }
     }
   }
 

--- a/scripts/lib/api-snapshot-canonicalize.mjs
+++ b/scripts/lib/api-snapshot-canonicalize.mjs
@@ -40,6 +40,23 @@ function skipLineComment(text, i) {
   return nl === -1 ? text.length : nl;
 }
 
+/**
+ * Skip a comment starting at `i`: a `//` comment to end of line, or a
+ * block comment to its closing delimiter.
+ * Returns the index just past the comment, or `i` when there is none.
+ * Block comments matter: an apostrophe inside a TSDoc comment must not be
+ * mistaken for the start of a string literal.
+ */
+function skipComment(text, i) {
+  if (text[i] !== '/') return i;
+  if (text[i + 1] === '/') return skipLineComment(text, i);
+  if (text[i + 1] === '*') {
+    const end = text.indexOf('*/', i + 2);
+    return end === -1 ? text.length : end + 2;
+  }
+  return i;
+}
+
 /** Index of the `}` matching the `{` at `open`, or -1. */
 function matchingBrace(text, open) {
   let depth = 0;
@@ -47,8 +64,9 @@ function matchingBrace(text, open) {
     const c = text[i];
     if (c === "'" || c === '"' || c === '`') {
       i = skipString(text, i) - 1;
-    } else if (c === '/' && text[i + 1] === '/') {
-      i = skipLineComment(text, i) - 1;
+    } else if (c === '/') {
+      const next = skipComment(text, i);
+      if (next !== i) i = next - 1;
     } else if (c === '{') {
       depth++;
     } else if (c === '}') {
@@ -71,8 +89,9 @@ function splitTopLevelMembers(body) {
     const c = body[i];
     if (c === "'" || c === '"' || c === '`') {
       i = skipString(body, i) - 1;
-    } else if (c === '/' && body[i + 1] === '/') {
-      i = skipLineComment(body, i) - 1;
+    } else if (c === '/') {
+      const next = skipComment(body, i);
+      if (next !== i) i = next - 1;
     } else if (c === '{' || c === '(' || c === '[') {
       depth++;
     } else if (c === '}' || c === ')' || c === ']') {
@@ -120,8 +139,8 @@ function canonicalizeTypeText(text) {
       const end = skipString(text, i);
       out += text.slice(i, end);
       i = end;
-    } else if (c === '/' && text[i + 1] === '/') {
-      const end = skipLineComment(text, i);
+    } else if (c === '/' && (text[i + 1] === '/' || text[i + 1] === '*')) {
+      const end = skipComment(text, i);
       out += text.slice(i, end);
       i = end;
     } else if (c === '{') {

--- a/scripts/lib/api-snapshot-canonicalize.mjs
+++ b/scripts/lib/api-snapshot-canonicalize.mjs
@@ -1,0 +1,171 @@
+// Canonicalizes API Extractor markdown snapshots so the committed files are
+// machine-independent.
+//
+// Why: the Vue dts rollup emits the members of inferred object types (the
+// `ExtractPropTypes<{ ... }>` blocks inside `DefineComponent`) in an order
+// that is stable per machine but differs between machines. API Extractor
+// preserves that order in the report, so `api:check` fails on some machines
+// with a pure-reordering diff. Declared interface members are already
+// alphabetized by API Extractor itself; anonymous object TYPE literals are
+// not.
+//
+// What we sort: only object type literals whose every top-level member is a
+// plain property signature (`name: Type;`, optionally `readonly`/`?`, quoted
+// names allowed). Property order in an object type is semantically
+// meaningless in TypeScript, so alphabetizing is safe. Anything else —
+// call/construct signatures (overload order matters), index signatures,
+// method signatures, blocks containing report comments (declaration bodies) —
+// is left exactly as emitted.
+
+const PROPERTY_NAME =
+  /^(?:readonly\s+)?([A-Za-z_$][\w$]*|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")\??:(?!:)\s/;
+
+/** Skip a quoted string starting at `i`; returns the index just past it. */
+function skipString(text, i) {
+  const quote = text[i];
+  for (let j = i + 1; j < text.length; j++) {
+    const c = text[j];
+    if (c === '\\') {
+      j++;
+    } else if (c === quote) {
+      return j + 1;
+    }
+  }
+  return text.length;
+}
+
+/** Skip a `//` line comment starting at `i`; returns the index of the newline. */
+function skipLineComment(text, i) {
+  const nl = text.indexOf('\n', i);
+  return nl === -1 ? text.length : nl;
+}
+
+/** Index of the `}` matching the `{` at `open`, or -1. */
+function matchingBrace(text, open) {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (c === "'" || c === '"' || c === '`') {
+      i = skipString(text, i) - 1;
+    } else if (c === '/' && text[i + 1] === '/') {
+      i = skipLineComment(text, i) - 1;
+    } else if (c === '{') {
+      depth++;
+    } else if (c === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Split `body` on `;` at brace/paren/bracket depth zero. The final element is
+ * the trailing text after the last `;` (whitespace before the closing brace).
+ */
+function splitTopLevelMembers(body) {
+  const parts = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (c === "'" || c === '"' || c === '`') {
+      i = skipString(body, i) - 1;
+    } else if (c === '/' && body[i + 1] === '/') {
+      i = skipLineComment(body, i) - 1;
+    } else if (c === '{' || c === '(' || c === '[') {
+      depth++;
+    } else if (c === '}' || c === ')' || c === ']') {
+      depth--;
+    } else if (c === ';' && depth === 0) {
+      parts.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(body.slice(start));
+  return parts;
+}
+
+function memberName(member) {
+  const match = PROPERTY_NAME.exec(member.trim());
+  return match ? match[1] : null;
+}
+
+/**
+ * Sort the members of one object type body alphabetically, if every member is
+ * a plain property signature. Returns the body unchanged otherwise.
+ */
+function sortMembersIfEligible(body) {
+  const parts = splitTopLevelMembers(body);
+  if (parts.length < 3) return body; // fewer than two members: nothing to sort
+  const tail = parts[parts.length - 1];
+  if (tail.trim() !== '') return body; // last member missing its `;`: not a member list
+  const members = parts.slice(0, -1);
+  const named = members.map((member) => ({ member, name: memberName(member) }));
+  if (named.some((entry) => entry.name === null)) return body;
+  named.sort((a, b) => {
+    if (a.name !== b.name) return a.name < b.name ? -1 : 1;
+    return a.member < b.member ? -1 : a.member > b.member ? 1 : 0;
+  });
+  return [...named.map((entry) => entry.member), tail].join(';');
+}
+
+/** Recursively canonicalize every `{ ... }` block in a stretch of type text. */
+function canonicalizeTypeText(text) {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === "'" || c === '"' || c === '`') {
+      const end = skipString(text, i);
+      out += text.slice(i, end);
+      i = end;
+    } else if (c === '/' && text[i + 1] === '/') {
+      const end = skipLineComment(text, i);
+      out += text.slice(i, end);
+      i = end;
+    } else if (c === '{') {
+      const close = matchingBrace(text, i);
+      if (close === -1) {
+        out += text.slice(i);
+        break;
+      }
+      const inner = canonicalizeTypeText(text.slice(i + 1, close));
+      out += `{${sortMembersIfEligible(inner)}}`;
+      i = close + 1;
+    } else {
+      out += c;
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Canonicalize an API Extractor `.api.md` report so its content does not
+ * depend on the machine that emitted the dts rollup. Only the fenced ```ts
+ * block is touched; the markdown around it passes through verbatim.
+ */
+export function canonicalizeApiReport(reportText) {
+  const lines = reportText.split('\n');
+  const out = [];
+  let fence = [];
+  let inFence = false;
+  for (const line of lines) {
+    if (!inFence && line.trim() === '```ts') {
+      inFence = true;
+      out.push(line);
+    } else if (inFence && line.trim() === '```') {
+      inFence = false;
+      out.push(canonicalizeTypeText(fence.join('\n')));
+      fence = [];
+      out.push(line);
+    } else if (inFence) {
+      fence.push(line);
+    } else {
+      out.push(line);
+    }
+  }
+  if (fence.length > 0) out.push(...fence); // unterminated fence: pass through
+  return out.join('\n');
+}


### PR DESCRIPTION
The Vue dts rollup emits inferred object-type members in a machine-dependent order, which turns `api:check` red on some machines with a pure-reordering diff. `api:extract` now sorts property signatures inside anonymous object types before writing each report, and `api:check` compares through the same canonical form. The committed snapshots are regenerated in canonical form.

Fixes #416

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790180449&installation_model_id=422592&pr_number=421&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F421&signature=2604109cc1cc73d78020f3fe4fa9bd0334ce60436c2a659d84bcc15d1bf795c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->