### PR TITLE
fix: make core a peer dependency of editor-api

### DIFF
--- a/.changeset/editor-api-core-peer-dependency.md
+++ b/.changeset/editor-api-core-peer-dependency.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/editor-api': minor
 ---
 
-`@docx-editor.dev/core` is now a peer dependency of `@docx-editor.dev/editor-api` instead of a regular dependency, so install it alongside; this guarantees your project resolves one copy of the engine, shared with any editor adapter.
+`@docx-editor.dev/core` is now a peer dependency of `@docx-editor.dev/editor-api` instead of a regular dependency, so your project resolves one copy of the engine, shared with any editor adapter. Hosts whose package manager does not auto-install peers (for example Yarn) must add `@docx-editor.dev/core` explicitly.

--- a/.changeset/editor-api-core-peer-dependency.md
+++ b/.changeset/editor-api-core-peer-dependency.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': minor
+---
+
+`@docx-editor.dev/core` is now a peer dependency of `@docx-editor.dev/editor-api` instead of a regular dependency, so install it alongside; this guarantees your project resolves one copy of the engine, shared with any editor adapter.

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
     "examples/automation": {
       "name": "automation-example",
       "dependencies": {
+        "@docx-editor.dev/core": "workspace:*",
         "@docx-editor.dev/editor-api": "workspace:*",
       },
     },
@@ -280,9 +281,9 @@
     },
     "packages/core": {
       "name": "@docx-editor.dev/core",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.7.0",
+        "@docx-editor.dev/i18n": "^2.8.0",
         "bidi-js": "1.0.3",
         "emf-converter": "2.0.2",
         "fast-xml-parser": "^5.10.1",
@@ -313,19 +314,20 @@
     },
     "packages/editor-api": {
       "name": "@docx-editor.dev/editor-api",
-      "version": "2.7.0",
-      "dependencies": {
-        "@docx-editor.dev/core": "^2.7.0",
-      },
+      "version": "2.8.0",
       "devDependencies": {
+        "@docx-editor.dev/core": "workspace:*",
         "@microsoft/api-extractor": "^7.50.0",
         "fflate": "^0.8.2",
         "license-check-and-add": "^4.0.5",
       },
+      "peerDependencies": {
+        "@docx-editor.dev/core": "^2.8.0",
+      },
     },
     "packages/fonts": {
       "name": "@docx-editor.dev/fonts",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "typescript": "^5.3.3",
@@ -333,7 +335,7 @@
     },
     "packages/i18n": {
       "name": "@docx-editor.dev/i18n",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "devDependencies": {
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
@@ -341,7 +343,7 @@
     },
     "packages/nuxt": {
       "name": "@docx-editor.dev/nuxt",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dependencies": {
         "@docx-editor.dev/vue": "^0.0.1",
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
@@ -367,7 +369,7 @@
     },
     "packages/pro": {
       "name": "@docx-editor.dev/pro",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "@docx-editor.dev/i18n": "workspace:*",
@@ -401,9 +403,9 @@
     },
     "packages/react": {
       "name": "@docx-editor.dev/react",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.7.0",
+        "@docx-editor.dev/i18n": "^2.8.0",
         "@radix-ui/react-select": "^2.3.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -424,9 +426,9 @@
     },
     "packages/vue": {
       "name": "@docx-editor.dev/vue",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.7.0",
+        "@docx-editor.dev/i18n": "^2.8.0",
       },
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -13,8 +13,11 @@ seoTitle: 'Office.js-compatible DOCX editing API'
 You describe work against objects (paragraphs, ranges, comments, revisions, content controls) and one `sync()` sends it as a single ordered batch that either applies whole or not at all. The same code runs in two places: on a server over DOCX bytes, or in a page against a document a reader already has open.
 
 ```bash
-npm install @docx-editor.dev/editor-api
+npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 ```
+
+`@docx-editor.dev/core` is a peer dependency: the engine holds identity-keyed state, so your
+project must resolve exactly one copy of it, shared with any editor adapter you install.
 
 ## On a server
 

--- a/docs/site/content/index.mdx
+++ b/docs/site/content/index.mdx
@@ -55,7 +55,7 @@ npm install @docx-editor.dev/react @docx-editor.dev/core @docx-editor.dev/pro
 **Server-side editing without a user interface.** `-editor-api` opens DOCX data, applies edits through its object model, and saves the result.
 
 ```bash
-npm install @docx-editor.dev/editor-api
+npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 ```
 
 **Browser automation for an active editor.** Install `-editor-api` with `-react` and use the `/browser` entry. This entry controls the editor instance that the adapter created.

--- a/docs/site/content/installation.mdx
+++ b/docs/site/content/installation.mdx
@@ -42,7 +42,7 @@ npm install @docx-editor.dev/pro
 
 # Office.js-compatible editing API, on a server or with an active editor instance
 # Commercially licensed: same terms
-npm install @docx-editor.dev/editor-api
+npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 
 # Metric-compatible substitutes for Word's default fonts (optional)
 npm install @docx-editor.dev/fonts

--- a/examples/automation/package.json
+++ b/examples/automation/package.json
@@ -6,6 +6,7 @@
     "fill": "bun run fill-template.ts ../remix/public/sample.docx filled.docx"
   },
   "dependencies": {
+    "@docx-editor.dev/core": "workspace:*",
     "@docx-editor.dev/editor-api": "workspace:*"
   }
 }

--- a/packages/editor-api/README.md
+++ b/packages/editor-api/README.md
@@ -23,7 +23,7 @@ applies whole or not at all. The same code drives bytes on a server and a docume
 already has open in a page.
 
 ```bash
-npm install @docx-editor.dev/editor-api
+npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 ```
 
 ## On a server

--- a/packages/editor-api/package.json
+++ b/packages/editor-api/package.json
@@ -27,6 +27,7 @@
     }
   },
   "devDependencies": {
+    "@docx-editor.dev/core": "workspace:*",
     "@microsoft/api-extractor": "^7.50.0",
     "fflate": "^0.8.2",
     "license-check-and-add": "^4.0.5"
@@ -73,7 +74,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@docx-editor.dev/core": "^2.8.0"
   }
 }

--- a/packages/editor-api/scripts/pack-smoke.mjs
+++ b/packages/editor-api/scripts/pack-smoke.mjs
@@ -10,12 +10,12 @@
 //   - a bundle that resolves at build time and throws on `import` in a plain Node process;
 //   - `require()` of the CJS output returning something a consumer cannot use;
 //   - the font shaper, the editor lane or a Node builtin leaking into the SERVER bundle;
-//   - a bare import other than the declared core dependency, or core being inlined and creating
+//   - a bare import other than the declared core peer, or core being inlined and creating
 //     a second engine in a page that already has one through an adapter.
 //
 // So this packs the package with `npm pack`, unpacks it into a temporary directory, and drives the
 // unpacked files with a plain `node`. No registry and no network: the unpacked package is linked to
-// the workspace's built core, exactly the one declared runtime dependency a real install provides.
+// the workspace's built core, exactly the one declared peer dependency a real install resolves.
 
 import { spawnSync } from 'node:child_process';
 import {
@@ -217,8 +217,8 @@ try {
     'dist/index.mjs imports a Node builtin, so it no longer runs in a worker'
   );
   check(
-    manifest.dependencies?.['@docx-editor.dev/core'],
-    'the package does not declare the external core engine as a dependency'
+    manifest.peerDependencies?.['@docx-editor.dev/core'],
+    'the package does not declare the external core engine as a peer dependency'
   );
   check(
     serverBundle.includes('@docx-editor.dev/core/automation'),
@@ -233,7 +233,7 @@ try {
     'dist/browser.mjs does not reach the editor lane'
   );
 
-  // Core is the only bare runtime dependency. Keeping it external is the one-core invariant:
+  // Core is the only bare specifier, declared as a peer. Keeping it external is the one-core invariant:
   // browser adapters and automation must resolve the same engine copy. Any other bare import is an
   // undeclared bundle leak, including the font shaper deliberately externalized for resolution.
   for (const name of ['dist/index.mjs', 'dist/index.js', 'dist/browser.mjs', 'dist/browser.js']) {

--- a/packages/editor-api/src/__tests__/package-dependencies.test.ts
+++ b/packages/editor-api/src/__tests__/package-dependencies.test.ts
@@ -3,24 +3,25 @@ Copyright (c) 2026 EigenPal, Inc. All rights reserved.
 Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
 Production use requires a commercial agreement: licensing@eigenpal.com
 */
-
-// How this package asks for the engine — pinned, with the risk written down.
+// How this package asks for the engine, which decides whether a page ends up with one of it.
 //
-// The engine carries module-level state: the HarfBuzz shaper and its cache budget, the
-// grapheme boundary strategy, and layout caches keyed by object identity. Two copies in one
-// tree do not crash; they load the shaper twice and miss every identity-keyed cache,
-// quietly. That is why `@docx-editor.dev/core` is a PEER of the react and pro packages
-// (`packages/react/test/package-dependencies.test.ts`).
+// The engine carries module-level state: the HarfBuzz shaper and its cache budget, the grapheme
+// boundary strategy, and layout caches keyed by object identity. Two copies in one tree do not
+// crash. They load the shaper twice, read a boundary configured on the other copy, and miss every
+// identity-keyed cache — wrong and expensive, quietly.
 //
-// This package currently declares the engine as a REGULAR dependency. That is safe for the
-// headless `server` entry, which constructs its own document from bytes. It is NOT the
-// right end state for the `browser` entry: `runtime/browser.ts` attaches to a
-// `DocxEditorInstance` the HOST constructed with the host's copy of core, so a package
-// manager nesting a second copy under this package puts the automation host and the editor
-// on different engines — brand checks and identity-keyed caches miss across the boundary.
-// Moving the engine to a peer dependency is a consumer-facing change with its own changeset
-// and release notes, tracked as a follow-up; until then this test pins the shape so it can
-// only change deliberately.
+// The headless `index` entry constructs its own document from bytes, so a nested engine copy
+// would merely be slow there. The `./browser` entry is the one a second copy breaks: it attaches
+// to a `DocxEditorInstance` the HOST constructed with the host's copy of core, so a package
+// manager nesting a second copy under this package puts the automation host and the editor on
+// different engines — brand checks fail and identity-keyed caches miss across the boundary. A
+// regular dependency lets a package manager nest that second copy the moment the ranges diverge;
+// a peer makes the manager resolve one, and say so at install when it cannot.
+//
+// `packages/react/test/package-dependencies.test.ts` and
+// `packages/pro/src/__tests__/package-dependencies.test.ts` assert the same shape for the same
+// reason. Neither file is decoration: moving the engine back to a regular dependency is the
+// failure all of them were written to catch.
 
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
@@ -31,23 +32,36 @@ const read = (path: string) =>
     version: string;
     dependencies?: Record<string, string>;
     peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+    devDependencies?: Record<string, string>;
   };
 
 const manifest = read(join(import.meta.dir, '..', '..', 'package.json'));
 const core = read(join(import.meta.dir, '..', '..', '..', 'core', 'package.json'));
 
 describe('how this package asks for the engine', () => {
-  test('the engine dependency shape is the pinned one', () => {
-    // A move to peerDependencies is the intended end state — but it changes what a
-    // consumer must install, so it lands as its own PR with a changeset, not as drift.
-    expect(manifest.dependencies?.['@docx-editor.dev/core']).toBeDefined();
-    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBeUndefined();
+  test('the engine is a peer, so the consumer resolves one copy of it', () => {
+    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBeDefined();
+    expect(manifest.dependencies?.['@docx-editor.dev/core']).toBeUndefined();
+  });
+
+  test('the engine peer is REQUIRED, not optional', () => {
+    // An optional peer is a suggestion: the manager installs nothing and stays silent, which is
+    // the opposite of the point. There is no consumer of this package without the engine — the
+    // server entry parses with it and the browser entry attaches to an editor built from it.
+    expect(manifest.peerDependenciesMeta?.['@docx-editor.dev/core']?.optional).toBeUndefined();
+  });
+
+  test('it is still installed here, so this workspace builds and tests against it', () => {
+    // A peer is what a CONSUMER resolves. It is not an install for this package's own build, so
+    // the dev dependency is what makes `bun run build` and these tests see the engine at all.
+    expect(manifest.devDependencies?.['@docx-editor.dev/core']).toBe('workspace:*');
   });
 
   test('the declared range admits the workspace engine it is built against', () => {
     // A caret range that fell behind the engine's major would make installs resolve a
     // SECOND, older engine next to the host's — the exact two-copies failure above.
-    const range = manifest.dependencies!['@docx-editor.dev/core']!;
+    const range = manifest.peerDependencies!['@docx-editor.dev/core']!;
     // The optional suffix admits changesets pre-release mode (^3.0.0-next.0).
     const match = /^\^(\d+)\.(\d+)\.\d+(?:-[0-9A-Za-z.-]+)?$/.exec(range);
     expect(match).not.toBeNull();

--- a/packages/editor-api/src/__tests__/package-surface.test.ts
+++ b/packages/editor-api/src/__tests__/package-surface.test.ts
@@ -115,30 +115,30 @@ describe('what the package depends on', () => {
     expect(declared.filter((name) => forbidden.includes(name))).toEqual([]);
   });
 
-  test('the engine is a runtime dependency, resolved rather than carried', () => {
+  test('the engine is a peer dependency, resolved rather than carried', () => {
     // `@docx-editor.dev/core` is a published package and stays external in both outputs, so a
     // consumer resolves one copy of the engine. Inlining it would put a second engine in this
     // tarball, and a page running this next to the adapter would hold two instances.
     // A plain range, never `workspace:*`: that protocol survives `changeset version` and
     // `npm publish` untouched, so it would reach the tarball and fail the consumer's
     // install. `scripts/__tests__/published-manifests.test.ts` holds the rule for every
-    // package; this asserts the range still points at the engine.
-    expect(manifest.dependencies?.['@docx-editor.dev/core']).toMatch(/^\^\d+\.\d+\.\d+/);
-    expect(Object.keys(manifest.devDependencies ?? {})).not.toContain('@docx-editor.dev/core');
+    // package; this asserts the range still points at the engine. Why the engine is a PEER
+    // rather than a regular dependency is `package-dependencies.test.ts`, next to this file.
+    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toMatch(/^\^\d+\.\d+\.\d+/);
   });
 
-  test('there are no peer dependencies left to be optional about', () => {
-    expect(manifest.peerDependencies).toBeUndefined();
+  test('the engine is the only peer dependency, and it is required', () => {
+    expect(Object.keys(manifest.peerDependencies ?? {})).toEqual(['@docx-editor.dev/core']);
     expect(manifest.peerDependenciesMeta).toBeUndefined();
   });
 
-  test('the engine is the only runtime dependency', () => {
+  test('there are no runtime dependencies left to nest', () => {
     // Everything else either bundles or is external for a build reason rather than a consumer
     // one. `harfbuzzjs` is listed as external in the tsup config only so the build can skip
     // RESOLVING the shaper the layout pass loads dynamically — the emitted bundles do not
     // mention it, which `scripts/pack-smoke.mjs` asserts against the tarball itself. A
     // dependency declared here that no output imports would be install weight for nothing.
-    expect(Object.keys(manifest.dependencies ?? {})).toEqual(['@docx-editor.dev/core']);
+    expect(Object.keys(manifest.dependencies ?? {})).toEqual([]);
   });
 });
 

--- a/packages/editor-api/tsup.config.ts
+++ b/packages/editor-api/tsup.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   // redistributes on its own account.
   metafile: true,
   // `@docx-editor.dev/core` stays external by tsup's workspace-package behavior. It is a published
-  // package and a declared dependency, so the consumer resolves one copy of the engine. Inlining
+  // package and a declared peer, so the consumer resolves one copy of the engine. Inlining
   // it here would give a page running this alongside an adapter two engines.
   // `harfbuzzjs` is external to get the build to RESOLVE, not because the output needs it.
   //
@@ -43,6 +43,6 @@ export default defineConfig({
   //
   // Nothing then mentions `harfbuzzjs`: `createBrowserAutomationHost` takes an editor the host
   // already created, so this package needs the host adapter and not the text-measurement pass.
-  // `scripts/pack-smoke.mjs` allows only the declared core dependency to remain bare.
+  // `scripts/pack-smoke.mjs` allows only the declared core peer to remain bare.
   external: ['harfbuzzjs'],
 });


### PR DESCRIPTION
The `./browser` entry attaches to an editor the host constructed with the host's copy of the engine, so a nested second engine copy misses every identity-keyed cache and fails brand checks across the boundary. Declaring `@docx-editor.dev/core` as a peer dependency makes the package manager resolve one copy, the same shape `react` and `pro` already use, and `package-dependencies.test.ts` now enforces it.

Fixes #412

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790180667&installation_model_id=422592&pr_number=422&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F422&signature=098fe59114d16728f5895b3c8a744349c829461a3cebc0d6abd0326bc4fde435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->