### PR TITLE
fix: gate pro react/vue surface parity

### DIFF
--- a/scripts/check-adapter-mirror.mjs
+++ b/scripts/check-adapter-mirror.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 /**
- * Every Vue adapter source file must have a React twin at the same relative path.
- * Framework-neutral twins listed below must also stay byte-identical.
- * Deprecated shell-only paths under `components/Toolbar`, `components/TitleBar`, and
- * `managers/` are excluded on both sides.
+ * Mirrors the Vue side of each React/Vue pair against its React twin:
+ * every Vue source file must have a React twin at the same relative path,
+ * unless it is skipped (deprecated shell paths) or listed as an acknowledged
+ * Vue-only module. Framework-neutral twins listed per pair must also stay
+ * byte-identical.
+ *
+ * Pairs:
+ *  - the adapters: `packages/react/src` vs `packages/vue/src`
+ *  - the pro entries: `packages/pro/src/react` vs `packages/pro/src/vue`
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
@@ -11,52 +16,72 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const REACT_SRC = join(ROOT, 'packages/react/src');
-const VUE_SRC = join(ROOT, 'packages/vue/src');
 
-const SKIP_PREFIXES = [
-  'components/Toolbar',
-  'components/TitleBar',
-  'components/EditorToolbar',
-  'components/PaginatedDocxEditorShell',
-  'components/DocxEditor/DocxEditorShell',
-  'managers/',
-  'hooks/',
+const PAIRS = [
+  {
+    label: 'adapter',
+    reactSrc: join(ROOT, 'packages/react/src'),
+    vueSrc: join(ROOT, 'packages/vue/src'),
+    // Deprecated shell-only paths, excluded on both sides.
+    skipPrefixes: [
+      'components/Toolbar',
+      'components/TitleBar',
+      'components/EditorToolbar',
+      'components/PaginatedDocxEditorShell',
+      'components/DocxEditor/DocxEditorShell',
+      'managers/',
+      'hooks/',
+    ],
+    vueOnlyAllowed: [],
+    byteIdentical: [
+      'docx-editor-ref-callback.ts',
+      'editor/contextmenu/contextmenu-icons.ts',
+      'editor/deferred-notifier.ts',
+      'editor/document-presence.ts',
+      'editor/editor-scope.ts',
+      'editor/header-footer-units.ts',
+      'editor/images/normalizeImageFile.ts',
+      'editor/loading-snapshot.ts',
+      'editor/menu/download.ts',
+      'editor/menu/menu-keyboard.ts',
+      'editor/paragraph-dialog-fields.ts',
+      'editor/scroller-geometry.ts',
+      'editor/toolbar/toolbar-measure.ts',
+      'editor/toolbar/toolbar-overflow.ts',
+      'editor/zoom-levels.ts',
+      'lib/colorMode.ts',
+      'lib/colorResolver.ts',
+      'lib/fontOptions.ts',
+      'lib/highlightColors.ts',
+      'lib/listState.ts',
+      'lib/reportIssue.ts',
+      'lib/sidebarConstants.ts',
+      'lib/stylePreview.ts',
+      'lib/units.ts',
+      'rulerTicks.ts',
+      'styles/zIndex.ts',
+      'version.ts',
+    ],
+  },
+  {
+    label: 'pro',
+    reactSrc: join(ROOT, 'packages/pro/src/react'),
+    vueSrc: join(ROOT, 'packages/pro/src/vue'),
+    skipPrefixes: [],
+    // Vue-internal decomposition with no React twin. Every entry must still
+    // exist and stay React-twin-less, or the list is stale and the check fails.
+    vueOnlyAllowed: [
+      'review-card-parts.tsx',
+      'review-context.ts',
+      'review-rail-parts.tsx',
+      'review-shared.ts',
+      'review-types.ts',
+      'stable-id.ts',
+      'useEditorRenderRevision.ts',
+    ],
+    byteIdentical: ['review-labels.ts'],
+  },
 ];
-
-const BYTE_IDENTICAL_PATHS = [
-  'docx-editor-ref-callback.ts',
-  'editor/contextmenu/contextmenu-icons.ts',
-  'editor/deferred-notifier.ts',
-  'editor/document-presence.ts',
-  'editor/editor-scope.ts',
-  'editor/header-footer-units.ts',
-  'editor/images/normalizeImageFile.ts',
-  'editor/loading-snapshot.ts',
-  'editor/menu/download.ts',
-  'editor/menu/menu-keyboard.ts',
-  'editor/paragraph-dialog-fields.ts',
-  'editor/scroller-geometry.ts',
-  'editor/toolbar/toolbar-measure.ts',
-  'editor/toolbar/toolbar-overflow.ts',
-  'editor/zoom-levels.ts',
-  'lib/colorMode.ts',
-  'lib/colorResolver.ts',
-  'lib/fontOptions.ts',
-  'lib/highlightColors.ts',
-  'lib/listState.ts',
-  'lib/reportIssue.ts',
-  'lib/sidebarConstants.ts',
-  'lib/stylePreview.ts',
-  'lib/units.ts',
-  'rulerTicks.ts',
-  'styles/zIndex.ts',
-  'version.ts',
-];
-
-function shouldSkip(rel) {
-  return SKIP_PREFIXES.some((prefix) => rel.startsWith(prefix));
-}
 
 function walk(dir, base = dir) {
   const out = [];
@@ -68,44 +93,69 @@ function walk(dir, base = dir) {
       continue;
     }
     if (!/\.(ts|tsx)$/.test(name)) continue;
-    if (shouldSkip(rel)) continue;
     out.push(rel);
   }
   return out;
 }
 
-function reactTwin(vueRel) {
+function reactTwin(reactSrc, vueRel) {
   const base = vueRel.replace(/\.tsx?$/, '');
   for (const ext of ['.tsx', '.ts']) {
-    const candidate = join(REACT_SRC, `${base}${ext}`);
+    const candidate = join(reactSrc, `${base}${ext}`);
     if (existsSync(candidate)) return candidate;
   }
   return null;
 }
 
-const vueFiles = walk(VUE_SRC);
-const missing = vueFiles.filter((rel) => !reactTwin(rel));
+let failed = false;
 
-if (missing.length) {
-  console.error(`Adapter mirror drift: ${missing.length} Vue file(s) without a React twin`);
-  for (const rel of missing.slice(0, 40)) console.error(`  vue-only path: ${rel}`);
-  if (missing.length > 40) console.error(`  … and ${missing.length - 40} more`);
-  process.exit(1);
-}
-
-const contentDrift = BYTE_IDENTICAL_PATHS.filter((rel) => {
-  const react = join(REACT_SRC, rel);
-  const vue = join(VUE_SRC, rel);
-  return !existsSync(react) || !existsSync(vue) || !readFileSync(react).equals(readFileSync(vue));
-});
-if (contentDrift.length) {
-  console.error(
-    `Adapter mirror drift: ${contentDrift.length} shared pure module(s) are no longer byte-identical`
+for (const pair of PAIRS) {
+  const vueFiles = walk(pair.vueSrc).filter(
+    (rel) => !pair.skipPrefixes.some((prefix) => rel.startsWith(prefix))
   );
-  for (const rel of contentDrift) console.error(`  content drift: ${rel}`);
-  process.exit(1);
+
+  const vueOnlyAllowed = new Set(pair.vueOnlyAllowed);
+  const missing = vueFiles.filter(
+    (rel) => !vueOnlyAllowed.has(rel) && !reactTwin(pair.reactSrc, rel)
+  );
+  if (missing.length) {
+    failed = true;
+    console.error(
+      `Adapter mirror drift (${pair.label}): ${missing.length} Vue file(s) without a React twin`
+    );
+    for (const rel of missing.slice(0, 40)) console.error(`  vue-only path: ${rel}`);
+    if (missing.length > 40) console.error(`  … and ${missing.length - 40} more`);
+  }
+
+  const staleAllowed = pair.vueOnlyAllowed.filter(
+    (rel) => !existsSync(join(pair.vueSrc, rel)) || reactTwin(pair.reactSrc, rel)
+  );
+  if (staleAllowed.length) {
+    failed = true;
+    console.error(
+      `Adapter mirror drift (${pair.label}): ${staleAllowed.length} stale vueOnlyAllowed entr${staleAllowed.length === 1 ? 'y' : 'ies'} — remove from the list or drop the React twin`
+    );
+    for (const rel of staleAllowed) console.error(`  stale allowlist entry: ${rel}`);
+  }
+
+  const contentDrift = pair.byteIdentical.filter((rel) => {
+    const react = join(pair.reactSrc, rel);
+    const vue = join(pair.vueSrc, rel);
+    return !existsSync(react) || !existsSync(vue) || !readFileSync(react).equals(readFileSync(vue));
+  });
+  if (contentDrift.length) {
+    failed = true;
+    console.error(
+      `Adapter mirror drift (${pair.label}): ${contentDrift.length} shared pure module(s) are no longer byte-identical`
+    );
+    for (const rel of contentDrift) console.error(`  content drift: ${rel}`);
+  }
+
+  if (!missing.length && !staleAllowed.length && !contentDrift.length) {
+    console.log(
+      `✓ adapter mirror (${pair.label}): ${vueFiles.length} Vue paths matched (${vueOnlyAllowed.size} acknowledged Vue-only); ${pair.byteIdentical.length} shared pure modules matched byte-for-byte`
+    );
+  }
 }
 
-console.log(
-  `✓ adapter mirror: ${vueFiles.length} Vue paths matched; ${BYTE_IDENTICAL_PATHS.length} shared pure modules matched byte-for-byte`
-);
+if (failed) process.exit(1);

--- a/scripts/check-parity-contract.mjs
+++ b/scripts/check-parity-contract.mjs
@@ -4,6 +4,11 @@
 // (`docs/api/<adapter-slug>/index.api.md`), extracts the `DocxEditorProps`
 // and `DocxEditorRef` field names, and applies `scripts/parity/parity.contract.json`.
 //
+// The contract's `pro` section extends the same bucket semantics to the pro
+// package's paired entries (`docs/api/docx-editor-pro/{react,vue}.api.md`):
+// top-level export names, the DocxEditorReview compound part names, and the
+// extends-resolved member names of interfaces exported by both entries.
+//
 // Fails non-zero on any drift the contract does not acknowledge:
 // - A prop/method exists in one adapter but the contract didn't classify it.
 // - A "paired" entry is missing on one side.
@@ -28,6 +33,8 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const REACT_SNAPSHOT = path.join(repoRoot, 'docs/api/docx-editor-react/index.api.md');
 const VUE_SNAPSHOT = path.join(repoRoot, 'docs/api/docx-editor-vue/index.api.md');
+const PRO_REACT_SNAPSHOT = path.join(repoRoot, 'docs/api/docx-editor-pro/react.api.md');
+const PRO_VUE_SNAPSHOT = path.join(repoRoot, 'docs/api/docx-editor-pro/vue.api.md');
 const CONTRACT_PATH = path.join(repoRoot, 'scripts/parity/parity.contract.json');
 const VUE_DOCX_EDITOR_SOURCE = path.join(repoRoot, 'packages/vue/src/components/DocxEditor.tsx');
 
@@ -129,6 +136,271 @@ function extractVueRefMembers(snapshotText) {
   return fields;
 }
 
+// ── Pro entry parity (docs/api/docx-editor-pro/{react,vue}.api.md) ──────────
+// The pro package publishes one React and one Vue entry from the same package.
+// The contract's `pro` section classifies:
+//  - `exports`: every top-level export name of each snapshot
+//  - `reviewParts`: the DocxEditorReview compound part names
+//  - `interfaceMemberExceptions`: acknowledged per-member divergence on
+//    interfaces both entries export (member names compare extends-resolved)
+
+/** Top-level export names of an API Extractor snapshot. */
+function extractTopLevelExportNames(snapshotText) {
+  const names = new Set();
+  for (const line of snapshotText.split('\n')) {
+    const match =
+      /^export (?:declare )?(?:abstract )?(?:function|const|let|var|interface|type|namespace|class|enum) (\w+)/.exec(
+        line
+      );
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+/**
+ * Vue's DocxEditorReview snapshot is one `export const DocxEditorReview: { ... };`
+ * whose trailing intersection enumerates each compound part as
+ * `    PartName: vue.DefineComponent<...>`. Pull those part names out.
+ */
+function extractVueReviewParts(snapshotText) {
+  const lines = snapshotText.split('\n');
+  const startIdx = lines.findIndex((l) => l.startsWith('export const DocxEditorReview'));
+  if (startIdx === -1) return null;
+  const parts = new Set();
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('};') || line.startsWith('export ')) break;
+    const match = /^ {4}(\w+): vue\.DefineComponent</.exec(line);
+    if (match) parts.add(match[1]);
+  }
+  return parts;
+}
+
+/** Map of interface name → extends clause (or null) for a snapshot. */
+function extractInterfaceDecls(snapshotText) {
+  const decls = new Map();
+  for (const line of snapshotText.split('\n')) {
+    const match = /^export interface (\w+)(?: extends (.+?))? \{/.exec(line);
+    if (match) decls.set(match[1], match[2] ?? null);
+  }
+  return decls;
+}
+
+/** Parse `Base` / `Omit<Base, 'a' | 'b'>` terms from an extends clause. */
+function parseExtendsClause(clause) {
+  const bases = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i <= clause.length; i++) {
+    const c = clause[i];
+    if (c === '<' || c === '(') depth++;
+    else if (c === '>' || c === ')') depth--;
+    if ((c === ',' && depth === 0) || i === clause.length) {
+      const part = clause.slice(start, i).trim();
+      start = i + 1;
+      if (!part) continue;
+      const omit = /^Omit<(\w+),\s*(.+)>$/.exec(part);
+      if (omit) {
+        const omitted = new Set([...omit[2].matchAll(/'([^']+)'/g)].map((m) => m[1]));
+        bases.push({ base: omit[1], omitted });
+      } else if (/^\w+$/.test(part)) {
+        bases.push({ base: part, omitted: new Set() });
+      }
+      // Anything else (generic bases from other packages) cannot be resolved
+      // from the snapshot alone and is skipped.
+    }
+  }
+  return bases;
+}
+
+/** Member names of an interface with same-snapshot `extends` chains folded in. */
+function effectiveInterfaceFields(snapshotText, decls, name, seen = new Set()) {
+  if (seen.has(name)) return new Set();
+  seen.add(name);
+  const fields = new Set(extractInterfaceFields(snapshotText, name) ?? []);
+  const extendsClause = decls.get(name);
+  if (!extendsClause) return fields;
+  for (const { base, omitted } of parseExtendsClause(extendsClause)) {
+    if (!decls.has(base)) continue;
+    for (const field of effectiveInterfaceFields(snapshotText, decls, base, seen)) {
+      if (!omitted.has(field)) fields.add(field);
+    }
+  }
+  return fields;
+}
+
+/** Apply the paired / deferredInVue / vueExclusive buckets to one name set pair. */
+function applyProBuckets(kind, section, reactSet, vueSet, issues) {
+  const paired = section.paired;
+  const deferred = Object.keys(section.deferredInVue);
+  const vueOnly = Object.keys(section.vueExclusive);
+  for (const k of paired) {
+    if (!reactSet.has(k)) issues.push(`${kind} paired '${k}' missing from React`);
+    if (!vueSet.has(k)) issues.push(`${kind} paired '${k}' missing from Vue`);
+  }
+  for (const k of deferred) {
+    if (!reactSet.has(k)) issues.push(`${kind} deferred '${k}' missing from React (contract stale)`);
+    if (vueSet.has(k)) issues.push(`${kind} '${k}' has shipped in Vue — move from deferredInVue to paired`);
+  }
+  for (const k of vueOnly) {
+    if (!vueSet.has(k)) issues.push(`${kind} vueExclusive '${k}' missing from Vue (contract stale)`);
+    if (reactSet.has(k)) issues.push(`${kind} '${k}' has shipped in React — move from vueExclusive to paired`);
+  }
+  for (const k of reactSet) {
+    if (!paired.includes(k) && !deferred.includes(k) && !vueOnly.includes(k)) {
+      issues.push(`${kind} '${k}' in React is not declared in the parity contract`);
+    }
+  }
+  for (const k of vueSet) {
+    if (!paired.includes(k) && !deferred.includes(k) && !vueOnly.includes(k)) {
+      issues.push(`${kind} '${k}' in Vue is not declared in the parity contract`);
+    }
+  }
+}
+
+const PRO_BUCKET_SCHEMA = { paired: 'array', deferredInVue: 'object', vueExclusive: 'object' };
+
+function validateProShape(pro) {
+  const errors = [];
+  if (!pro || typeof pro !== 'object') {
+    errors.push('Missing or invalid top-level key: pro');
+    return errors;
+  }
+  for (const sub of ['exports', 'reviewParts']) {
+    const section = pro[sub];
+    if (!section || typeof section !== 'object') {
+      errors.push(`contract.pro.${sub} is required`);
+      continue;
+    }
+    const seen = new Set();
+    for (const [bucket, type] of Object.entries(PRO_BUCKET_SCHEMA)) {
+      const value = section[bucket];
+      if (value === undefined) {
+        errors.push(`contract.pro.${sub}.${bucket} is required`);
+        continue;
+      }
+      const ok = type === 'array' ? Array.isArray(value) : typeof value === 'object' && !Array.isArray(value);
+      if (!ok) {
+        errors.push(`contract.pro.${sub}.${bucket} must be ${type === 'array' ? 'an array' : 'an object'}`);
+        continue;
+      }
+      for (const k of Array.isArray(value) ? value : Object.keys(value)) {
+        if (seen.has(k)) errors.push(`contract.pro.${sub}: '${k}' appears in multiple buckets — must be in exactly one`);
+        seen.add(k);
+      }
+    }
+  }
+  const exceptions = pro.interfaceMemberExceptions ?? {};
+  if (typeof exceptions !== 'object' || Array.isArray(exceptions)) {
+    errors.push('contract.pro.interfaceMemberExceptions must be an object');
+    return errors;
+  }
+  for (const [name, entry] of Object.entries(exceptions)) {
+    if (!entry || typeof entry !== 'object' || typeof entry.reason !== 'string') {
+      errors.push(`contract.pro.interfaceMemberExceptions.${name} needs a string 'reason'`);
+      continue;
+    }
+    for (const side of ['reactOnly', 'vueOnly']) {
+      if (entry[side] !== undefined && !Array.isArray(entry[side])) {
+        errors.push(`contract.pro.interfaceMemberExceptions.${name}.${side} must be an array`);
+      }
+    }
+    if (!entry.reactOnly?.length && !entry.vueOnly?.length) {
+      errors.push(`contract.pro.interfaceMemberExceptions.${name} declares no members — remove it`);
+    }
+  }
+  return errors;
+}
+
+function checkProParity(contract, reactSnapshot, vueSnapshot, issues) {
+  const reactExports = extractTopLevelExportNames(reactSnapshot);
+  const vueExports = extractTopLevelExportNames(vueSnapshot);
+  const reactParts = extractInterfaceFields(reactSnapshot, 'DocxEditorReviewNamespace');
+  const vueParts = extractVueReviewParts(vueSnapshot);
+
+  // Freshness oracle: a parse regression must fail loudly, never pass vacuously.
+  const MIN_EXPORTS = 20;
+  const MIN_PARTS = 15;
+  if (reactExports.size < MIN_EXPORTS || vueExports.size < MIN_EXPORTS) {
+    console.error(
+      `Pro parity gate misconfigured: expected at least ${MIN_EXPORTS} exports per snapshot, got React ${reactExports.size} / Vue ${vueExports.size}.`
+    );
+    process.exit(1);
+  }
+  if (!reactParts || reactParts.size < MIN_PARTS) {
+    console.error(
+      `Pro parity gate misconfigured: could not parse DocxEditorReviewNamespace parts from ${PRO_REACT_SNAPSHOT} (got ${reactParts?.size ?? 0}).`
+    );
+    process.exit(1);
+  }
+  if (!vueParts || vueParts.size < MIN_PARTS) {
+    console.error(
+      `Pro parity gate misconfigured: could not parse DocxEditorReview parts from ${PRO_VUE_SNAPSHOT} (got ${vueParts?.size ?? 0}).`
+    );
+    process.exit(1);
+  }
+
+  applyProBuckets('PRO EXPORT', contract.pro.exports, reactExports, vueExports, issues);
+  applyProBuckets('PRO REVIEW PART', contract.pro.reviewParts, reactParts, vueParts, issues);
+
+  // Member-name parity for every interface both entries export.
+  const reactDecls = extractInterfaceDecls(reactSnapshot);
+  const vueDecls = extractInterfaceDecls(vueSnapshot);
+  const shared = [...reactDecls.keys()].filter((n) => vueDecls.has(n)).sort();
+  const exceptions = contract.pro.interfaceMemberExceptions ?? {};
+
+  const MIN_SHARED_INTERFACES = 8;
+  if (shared.length < MIN_SHARED_INTERFACES) {
+    console.error(
+      `Pro parity gate misconfigured: expected at least ${MIN_SHARED_INTERFACES} shared interfaces, got ${shared.length}.`
+    );
+    process.exit(1);
+  }
+
+  let memberChecks = 0;
+  for (const name of shared) {
+    const reactFields = effectiveInterfaceFields(reactSnapshot, reactDecls, name);
+    const vueFields = effectiveInterfaceFields(vueSnapshot, vueDecls, name);
+    const exception = exceptions[name];
+    const reactAllowed = new Set(exception?.reactOnly ?? []);
+    const vueAllowed = new Set(exception?.vueOnly ?? []);
+    for (const k of reactAllowed) {
+      if (!reactFields.has(k) || vueFields.has(k)) {
+        issues.push(`PRO INTERFACE '${name}': stale reactOnly exception '${k}' — remove it from the contract`);
+      }
+    }
+    for (const k of vueAllowed) {
+      if (!vueFields.has(k) || reactFields.has(k)) {
+        issues.push(`PRO INTERFACE '${name}': stale vueOnly exception '${k}' — remove it from the contract`);
+      }
+    }
+    for (const k of reactFields) {
+      memberChecks++;
+      if (!vueFields.has(k) && !reactAllowed.has(k)) {
+        issues.push(`PRO INTERFACE '${name}': member '${k}' missing from Vue`);
+      }
+    }
+    for (const k of vueFields) {
+      if (!reactFields.has(k) && !vueAllowed.has(k)) {
+        issues.push(`PRO INTERFACE '${name}': member '${k}' missing from React`);
+      }
+    }
+  }
+  for (const name of Object.keys(exceptions)) {
+    if (!shared.includes(name)) {
+      issues.push(`PRO INTERFACE exception '${name}' does not match a shared interface — remove it`);
+    }
+  }
+
+  return {
+    reactExports: reactExports.size,
+    vueExports: vueExports.size,
+    reviewParts: reactParts.size,
+    sharedInterfaces: shared.length,
+    memberChecks,
+  };
+}
+
 function diffSets(name, contractList, actualSet) {
   const missing = contractList.filter((k) => !actualSet.has(k));
   const extra = [...actualSet].filter((k) => !contractList.includes(k));
@@ -206,7 +478,14 @@ function validateContractShape(contract) {
 }
 
 function main() {
-  for (const f of [REACT_SNAPSHOT, VUE_SNAPSHOT, CONTRACT_PATH, VUE_DOCX_EDITOR_SOURCE]) {
+  for (const f of [
+    REACT_SNAPSHOT,
+    VUE_SNAPSHOT,
+    PRO_REACT_SNAPSHOT,
+    PRO_VUE_SNAPSHOT,
+    CONTRACT_PATH,
+    VUE_DOCX_EDITOR_SOURCE,
+  ]) {
     if (!fs.existsSync(f)) {
       console.error(`Missing required file: ${f}`);
       console.error('Run `bun run api:extract` first.');
@@ -219,7 +498,7 @@ function main() {
   const vueForms = extractVueDocxEditorForms(fs.readFileSync(VUE_DOCX_EDITOR_SOURCE, 'utf8'));
   const contract = readJson(CONTRACT_PATH);
 
-  const shapeErrors = validateContractShape(contract);
+  const shapeErrors = [...validateContractShape(contract), ...validateProShape(contract.pro)];
   if (shapeErrors.length > 0) {
     console.error('Parity contract has structural errors:');
     for (const e of shapeErrors) console.error(`  - ${e}`);
@@ -370,6 +649,11 @@ function main() {
     }
   }
 
+  // ── Pro entries ──────────────────────────────────────────────────────────
+  const proReactSnapshot = normalizeSnapshotText(fs.readFileSync(PRO_REACT_SNAPSHOT, 'utf8'));
+  const proVueSnapshot = normalizeSnapshotText(fs.readFileSync(PRO_VUE_SNAPSHOT, 'utf8'));
+  const proStats = checkProParity(contract, proReactSnapshot, proVueSnapshot, issues);
+
   // ── Report ───────────────────────────────────────────────────────────────
   const reactPropsCount = reactProps.size;
   const vuePropsCount = vueProps.size;
@@ -389,6 +673,11 @@ function main() {
   console.log(`  Paired ref members:    ${refPaired.length}`);
   console.log(`  Inherited via EditorRefLike: ${refInherited.length}`);
   console.log(`  Vue-exclusive refs:    ${refVueOnly.length}`);
+  console.log(`  Pro exports:           React ${proStats.reactExports} / Vue ${proStats.vueExports}`);
+  console.log(`  Pro review parts:      ${proStats.reviewParts}`);
+  console.log(
+    `  Pro shared interfaces: ${proStats.sharedInterfaces} (${proStats.memberChecks} member checks)`
+  );
 
   if (issues.length > 0) {
     console.error(`\nParity drift: ${issues.length} issue${issues.length === 1 ? '' : 's'}`);

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -57,5 +57,69 @@
     "paired": ["exec", "focus", "getDocumentHandle", "getEditor", "load", "save", "snapshot"],
     "pairedViaInheritance": {},
     "vueExclusive": {}
+  },
+  "pro": {
+    "comment": "Pro review surface across docs/api/docx-editor-pro/{react,vue}.api.md: top-level exports, DocxEditorReview compound part names, and extends-resolved member names of interfaces exported by both entries.",
+    "exports": {
+      "paired": [
+        "CustomNodeChrome",
+        "CustomNodeChromeProps",
+        "CustomNodeContextMenu",
+        "CustomNodeContextMenuProps",
+        "DocxEditorReview",
+        "DocxEditorReviewNamespace",
+        "ProLicenseOptions",
+        "ResolvedCustomNodeActivation",
+        "ReviewActionProps",
+        "ReviewActivationOptions",
+        "ReviewItemView",
+        "ReviewMarkersProps",
+        "ReviewModuleOptions",
+        "ReviewPartProps",
+        "ReviewProps",
+        "UseReviewReturn",
+        "activatedCustomNodeOf",
+        "resolveCustomNodeActivation",
+        "reviewModule",
+        "useCustomNodeDefinitions",
+        "useReview",
+        "useReviewAuthor",
+        "useReviewItem",
+        "useReviewOf",
+        "useStackedReviewPositions"
+      ],
+      "deferredInVue": {},
+      "vueExclusive": {}
+    },
+    "reviewParts": {
+      "paired": [
+        "Accept",
+        "AddComment",
+        "Author",
+        "Avatar",
+        "Balloon",
+        "Card",
+        "Delete",
+        "Draft",
+        "Empty",
+        "List",
+        "Markers",
+        "Reject",
+        "Reopen",
+        "Replies",
+        "Reply",
+        "Resolve",
+        "Summary",
+        "Time"
+      ],
+      "deferredInVue": {},
+      "vueExclusive": {}
+    },
+    "interfaceMemberExceptions": {
+      "ReviewMarkersProps": {
+        "vueOnly": ["asChild", "children"],
+        "reason": "Vue declares ReviewMarkersProps as extending ReviewPartProps, so asChild and children appear in the type although the markers part does not wire them. React declares only the wired members."
+      }
+    }
   }
 }


### PR DESCRIPTION
The parity contract gains a `pro` section that `check:parity-contract` applies to the pro entry snapshots: top-level export names, the `DocxEditorReview` compound part names, and extends-resolved member names of interfaces both entries export, each classified as `paired`, `deferredInVue`, or `vueExclusive`. The adapter mirror check now also mirrors `packages/pro/src/vue` against `packages/pro/src/react`, with the existing Vue-only decomposition modules on an allowlist that fails when stale.

The current surfaces are fully paired except one acknowledged divergence: Vue's `ReviewMarkersProps` extends `ReviewPartProps`, so its type declares `asChild` and `children` that the markers part does not wire and React does not declare.

Fixes #417

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790180719&installation_model_id=422592&pr_number=423&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F423&signature=3c8872f5b5eb031fc7fbd369983621241ca10fbbca6a755b9c9f5be664a7e51a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->