### PR TITLE
fix: widen the notePropertiesState cache key

### DIFF
--- a/.changeset/note-properties-shared-header-section.md
+++ b/.changeset/note-properties-shared-header-section.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+The note-properties state now refreshes when a shared header or footer is re-entered from a different section, instead of reporting the previously opened section's numbering.

--- a/packages/core/src/editor/__tests__/note-properties-section.test.ts
+++ b/packages/core/src/editor/__tests__/note-properties-section.test.ts
@@ -195,3 +195,55 @@ describe('note properties follow the caret’s own section', () => {
     expect(first?.footnote.resolved.numFmt).toBe('decimal');
   });
 });
+
+describe('the notePropertiesState memo tracks every input of the computation', () => {
+  test('re-entering a shared header from another section refreshes the answer', () => {
+    const editor = mount();
+    const surface = editor.surface!;
+    // Section 0 declares `rId10`; section 1 inherits the same part. Entering is UI state:
+    // it moves no revision and lands the caret on the SAME header paragraph both times, so
+    // a key of revision + paragraph id alone pins the first section's answer forever.
+    expect(surface.enterHeaderFooter({ rId: HEADER_R_ID, sectionIndex: 0 })).toBe(true);
+    expect(surface.notePropertiesState()?.sectionIndex).toBe(0);
+    expect(surface.notePropertiesState()?.footnote.resolved.numFmt).toBe('decimal');
+
+    surface.exitHeaderFooter();
+    expect(surface.enterHeaderFooter({ rId: HEADER_R_ID, sectionIndex: 1 })).toBe(true);
+    expect(surface.headerFooterState()?.sectionIndex).toBe(1);
+    const reentered = surface.notePropertiesState();
+    expect(reentered?.sectionIndex).toBe(1);
+    expect(reentered?.footnote.resolved.numFmt).toBe('lowerRoman');
+  });
+
+  test('a note-properties write invalidates the memo at a standing caret', () => {
+    const editor = mount();
+    const surface = editor.surface!;
+    expect(surface.notePropertiesState()?.footnote.resolved.numFmt).toBe('decimal');
+    // The write moves the package revision while the caret stands still.
+    expect(
+      surface.setNoteProperties({
+        scope: 'section',
+        sectionIndex: 0,
+        footnote: { numFmt: 'upperLetter' },
+      })
+    ).toBe(true);
+    expect(surface.notePropertiesState()?.footnote.resolved.numFmt).toBe('upperLetter');
+  });
+
+  test('an unmoved caret returns the identical snapshot, offset moves included', () => {
+    const editor = mount();
+    const surface = editor.surface!;
+    const first = surface.notePropertiesState();
+    expect(first).not.toBeNull();
+    expect(surface.notePropertiesState()).toBe(first!);
+    // The computation reads only the head PARAGRAPH; section membership cannot change
+    // within one paragraph, so an offset move must not recompute. This pins the invariant
+    // that keeps the selection offset out of the memo key.
+    const paragraphId = surface.state().selection.head.paragraphId;
+    surface.setSelection({
+      anchor: { paragraphId, offset: 3 },
+      head: { paragraphId, offset: 3 },
+    });
+    expect(surface.notePropertiesState()).toBe(first!);
+  });
+});

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -173,6 +173,9 @@ import { createImageOps } from './surface-image-ops.ts';
 import { createHeaderFooterScopeController } from './surface-hf-editing.ts';
 import { createNoteOps } from './surface-note-ops.ts';
 import { notePropertiesStateOf, notePreviewTextOf } from './surface-note-state.ts';
+import { settingsPartOf } from '../store/package/note-properties.ts';
+import { resolveNotesPart } from '../store/package/note-references.ts';
+import type { OoxmlPart } from '../store/package/ooxml-tree.ts';
 
 export type {
   ContentControlOps,
@@ -538,8 +541,36 @@ export function mountPaginatedSurface(
   /** Filled once selection sync exists; enter/exit need its noteModelMoved/mirror helpers. */
   let hfScope: ReturnType<typeof createHeaderFooterScopeController> | null = null;
   let noteOps: ReturnType<typeof createNoteOps> | null = null;
-  let cachedNoteProperties: ReturnType<typeof notePropertiesStateOf> = null;
-  let cachedNotePropertiesKey = '';
+  /**
+   * Memo for `notePropertiesState`, keyed on the COMPLETE read set of
+   * {@link notePropertiesStateOf}. `packageRevision` covers every publishing
+   * mutation (story transact, lifecycle ops, undo/redo, `publishStoryWrite`
+   * all bump it), but two kinds of input move without one. The open
+   * header/footer occurrence is UI state: inheritance lets one part serve
+   * several sections, so re-entering it from another section changes the
+   * answer while the revision and the caret paragraph both stand still. And
+   * shell installs (`replacePackageShell`, `installPackageSnapshot`) can swap
+   * parts without a bump, so the parts the computation walks — body for
+   * `w:sectPr` and note references, settings for `w:footnotePr`/`w:endnotePr`,
+   * the notes parts for a note caret's citing paragraph — join by object
+   * identity, for the same reason `currentPackage()` keys on identity rather
+   * than revision. The selection OFFSET is deliberately absent: the
+   * computation reads only the head paragraph id, and section membership
+   * cannot change within one paragraph (pinned in
+   * `__tests__/note-properties-section.test.ts`).
+   */
+  let notePropertiesCache: {
+    readonly packageRevision: number;
+    readonly paragraphId: string;
+    readonly bodyPart: OoxmlPart;
+    readonly settingsPart: OoxmlPart | null;
+    readonly footnotesPart: OoxmlPart | null;
+    readonly endnotesPart: OoxmlPart | null;
+    readonly headerFooterOpen: boolean;
+    readonly headerFooterRId: string | null;
+    readonly headerFooterSectionIndex: number | null;
+    readonly result: ReturnType<typeof notePropertiesStateOf>;
+  } | null = null;
   const storyScope = () =>
     storyScopeOf(hfScope?.getActive() ?? null, noteOps?.activeNoteScope() ?? null);
   const noteScopeId = () => noteOps?.activeNoteScope()?.id ?? null;
@@ -4721,13 +4752,47 @@ export function mountPaginatedSurface(
       return noteOps!.exitNote();
     },
     notePropertiesState: () => {
+      // See notePropertiesCache for why each field is in the key.
       const paragraphId = surface.state().selection.head.paragraphId;
-      const key = `${session.packageRevision()}:${paragraphId}`;
-      if (key === cachedNotePropertiesKey) return cachedNoteProperties;
-      const fresh = notePropertiesStateOf(surface);
-      cachedNoteProperties = fresh;
-      cachedNotePropertiesKey = key;
-      return fresh;
+      const packageRevision = session.packageRevision();
+      const pkg = session.currentPackage();
+      const bodyPart = session.part();
+      const settingsPart = settingsPartOf(pkg);
+      const footnotesPart = resolveNotesPart(pkg, 'footnote');
+      const endnotesPart = resolveNotesPart(pkg, 'endnote');
+      const headerFooterOpen = surface.activeScope().kind === 'headerFooter';
+      const hfState = surface.headerFooterState();
+      const headerFooterRId = hfState?.rId ?? null;
+      const headerFooterSectionIndex = hfState?.sectionIndex ?? null;
+      const cached = notePropertiesCache;
+      if (
+        cached &&
+        cached.packageRevision === packageRevision &&
+        cached.paragraphId === paragraphId &&
+        cached.bodyPart === bodyPart &&
+        cached.settingsPart === settingsPart &&
+        cached.footnotesPart === footnotesPart &&
+        cached.endnotesPart === endnotesPart &&
+        cached.headerFooterOpen === headerFooterOpen &&
+        cached.headerFooterRId === headerFooterRId &&
+        cached.headerFooterSectionIndex === headerFooterSectionIndex
+      ) {
+        return cached.result;
+      }
+      const result = notePropertiesStateOf(surface);
+      notePropertiesCache = {
+        packageRevision,
+        paragraphId,
+        bodyPart,
+        settingsPart,
+        footnotesPart,
+        endnotesPart,
+        headerFooterOpen,
+        headerFooterRId,
+        headerFooterSectionIndex,
+        result,
+      };
+      return result;
     },
     notePreviewText: (scopeId) => notePreviewTextOf(session, scopeId),
     applyTableCommandPlan(plan: TableCommandPlan): ExecResult {


### PR DESCRIPTION
The `notePropertiesState` memo keyed on package revision and caret paragraph id, but the computation also reads the open header/footer occurrence, which moves without a revision bump. Re-entering a header shared through section inheritance from a different section returned the previous section's note numbering. The key now covers the computation's full read set, with the consulted parts compared by object identity, and the selection offset stays out of the key because the computation reads only the head paragraph.

Fixes #418

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790180779&installation_model_id=422592&pr_number=424&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F424&signature=54d09d78a629d44385d93a0514c82c1d60db0bd5dd38c09ac3ba182047931979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->