### PR TITLE
refactor(core): brand twips/points and unify the converters

### DIFF
--- a/.changeset/branded-twips-points-units.md
+++ b/.changeset/branded-twips-points-units.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Internal unit-type hardening: twips and points values now carry branded types and share one conversion module, with no behavior change.

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3076,6 +3076,17 @@ export function planTocEntries(part: OoxmlPart, outline: readonly TocOutlineHead
 };
 
 // @public
+export type Points = number & {
+    readonly [POINTS]: true;
+};
+
+// @public
+export const points: (value: number) => Points;
+
+// @public
+export const pointsToTwips: (value: Points) => Twips;
+
+// @public
 export class PortRegistry {
     availablePorts(): string[];
     // (undocumented)
@@ -3810,7 +3821,7 @@ export interface TextOccurrences {
 export function threadStateOfPart(part: OoxmlPart): Map<string, CommentThreadState>;
 
 // @public
-export const TOC_LEVEL_INDENT_TWIPS = 240;
+export const TOC_LEVEL_INDENT_TWIPS: Twips;
 
 // @public
 export const TOC_MAX_BOOKMARKS_PER_REFRESH = 512;
@@ -3858,7 +3869,7 @@ export interface TocInstruction {
 }
 
 // @public
-export function tocLeftIndentTwips(level: number): number;
+export function tocLeftIndentTwips(level: number): Twips;
 
 // @public
 export interface TocOutlineHeading {
@@ -4589,6 +4600,20 @@ export type TreeTransactResult = {
     readonly reason: TreeOpRejection;
     readonly detail?: string;
 };
+
+// @public
+export type Twips = number & {
+    readonly [TWIPS]: true;
+};
+
+// @public
+export const twips: (value: number) => Twips;
+
+// @public
+export const TWIPS_PER_POINT = 20;
+
+// @public
+export const twipsToPoints: (value: Twips) => Points;
 
 // @public
 export function usedParaIds(root: OoxmlElement): ReadonlySet<string>;

--- a/packages/core/src/automation/formatting.ts
+++ b/packages/core/src/automation/formatting.ts
@@ -40,9 +40,8 @@ import {
 } from '../store/store/tree-op-nodes.ts';
 import { paragraphStyleName, styleIdFor, type AutomationStyleIndex } from './styles.ts';
 import type { OoxmlProperty } from '../store/store/tree-ops.ts';
+import { points, pointsToTwips, twips, twipsToPoints } from '../store/units.ts';
 
-/** Twips per point (ECMA-376 measures most lengths in twentieths of a point). */
-const TWIPS_PER_POINT = 20;
 /** Widest value `w:ind`/`w:spacing` will be authored with, in twips — 22 inches of slack. */
 const MAX_TWIPS = 31680;
 /** Half-points, so 1..999 points. `w:sz` is a half-point measure (17.3.2.38). */
@@ -186,7 +185,7 @@ function pointsFromTwips(value: string | null): number | null {
   if (value === null) return null;
   const parsed = Number(value.trim());
   if (!Number.isFinite(parsed)) return null;
-  return parsed / TWIPS_PER_POINT;
+  return twipsToPoints(twips(parsed));
 }
 
 /** One value if every voice agrees on it, else null. An empty set of voices agrees on nothing. */
@@ -312,12 +311,12 @@ function firstLineIndentOf(indent: OoxmlElement | undefined): number | null {
   return hanging === null ? null : -hanging;
 }
 
-function twipsFor(points: number, field: string): FormattingPlan<number> {
-  if (typeof points !== 'number' || !Number.isFinite(points))
+function twipsFor(value: number, field: string): FormattingPlan<number> {
+  if (typeof value !== 'number' || !Number.isFinite(value))
     return { ok: false, detail: `${field}: not a measurement` };
-  const twips = Math.round(points * TWIPS_PER_POINT);
-  if (Math.abs(twips) > MAX_TWIPS) return { ok: false, detail: `${field}: out of range` };
-  return { ok: true, value: twips };
+  const authored = pointsToTwips(points(value));
+  if (Math.abs(authored) > MAX_TWIPS) return { ok: false, detail: `${field}: out of range` };
+  return { ok: true, value: authored };
 }
 
 /**

--- a/packages/core/src/automation/sections.ts
+++ b/packages/core/src/automation/sections.ts
@@ -23,9 +23,13 @@ import { collectSectionPropertyNodes } from '../store/package/hf-references.ts';
 import type { OoxmlPackage } from '../store/package/ooxml-package.ts';
 import type { OoxmlNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
 import { metricsOfSection } from '../store/store/tree-op-section-address.ts';
-
-/** Twips in one point. Word's own ratio, and the only place this lane spells it. */
-const TWIPS_PER_POINT = 20;
+import {
+  points as asPoints,
+  pointsToTwips,
+  twips as asTwips,
+  twipsToPoints,
+  type Twips,
+} from '../store/units.ts';
 
 /** The largest page or margin this lane will write, in twips — `w:pgSz`'s own ceiling. */
 const MAX_TWIPS = 63360;
@@ -81,8 +85,8 @@ export interface AutomationSectionRead {
 }
 
 /** Points from twips, rounded to the hundredth so a read is stable and legible. */
-function points(twips: number): number {
-  return Math.round((twips / TWIPS_PER_POINT) * 100) / 100;
+function points(value: number): number {
+  return Math.round(twipsToPoints(asTwips(value)) * 100) / 100;
 }
 
 /**
@@ -92,13 +96,13 @@ function points(twips: number): number {
  * ceiling is refused rather than clamped: clamping would report a page set to a size it was not
  * set to, and the caller has no way to notice.
  */
-export function twipsFromPoints(value: unknown, allowZero: boolean): number | null {
+export function twipsFromPoints(value: unknown, allowZero: boolean): Twips | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) return null;
-  const twips = Math.round(value * TWIPS_PER_POINT);
-  if (twips > MAX_TWIPS) return null;
-  if (twips < 0) return null;
-  if (twips === 0 && !allowZero) return null;
-  return twips;
+  const authored = pointsToTwips(asPoints(value));
+  if (authored > MAX_TWIPS) return null;
+  if (authored < 0) return null;
+  if (authored === 0 && !allowZero) return null;
+  return authored;
 }
 
 /** The `setSectionProperties` fields a page-setup write turns into. */

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -7,9 +7,12 @@
 
 import {
   PAGE_BREAK_CHAR,
+  twips,
+  twipsToPoints,
   type DocumentProperties,
   type OoxmlNode,
   type OoxmlProperty,
+  type Twips,
 } from '@docx-editor.dev/core/store';
 import {
   piecesOfParagraph,
@@ -465,16 +468,16 @@ export function frozenLine(line: PendingLine): PendingLine {
  */
 export const MAX_PARAGRAPH_INDENT_TWIPS = 31_680;
 
-export function indentTwips(raw: string | undefined): number | null {
+export function indentTwips(raw: string | undefined): Twips | null {
   // Up to 9 digits so an oversized authored value reaches the clamp rather than being read
   // as a measurement; a longer digit string is garbage, and `Number` turns enough of them
   // into `Infinity`, which then poisons every width derived from it.
   if (raw === undefined || !/^-?\d{1,9}$/.test(raw)) return null;
-  const twips = Number(raw);
-  if (!Number.isFinite(twips)) return null;
-  if (twips > MAX_PARAGRAPH_INDENT_TWIPS) return MAX_PARAGRAPH_INDENT_TWIPS;
-  if (twips < -MAX_PARAGRAPH_INDENT_TWIPS) return -MAX_PARAGRAPH_INDENT_TWIPS;
-  return twips;
+  const authored = Number(raw);
+  if (!Number.isFinite(authored)) return null;
+  if (authored > MAX_PARAGRAPH_INDENT_TWIPS) return twips(MAX_PARAGRAPH_INDENT_TWIPS);
+  if (authored < -MAX_PARAGRAPH_INDENT_TWIPS) return twips(-MAX_PARAGRAPH_INDENT_TWIPS);
+  return twips(authored);
 }
 
 export function paragraphIndent(props: readonly OoxmlProperty[]): {
@@ -491,8 +494,8 @@ export function paragraphIndent(props: readonly OoxmlProperty[]): {
     const rawRight = property.attributes?.right ?? property.attributes?.end;
     const twipsLeft = indentTwips(rawLeft);
     const twipsRight = indentTwips(rawRight);
-    if (twipsLeft !== null) left = twipsLeft / 20;
-    if (twipsRight !== null) right = twipsRight / 20;
+    if (twipsLeft !== null) left = twipsToPoints(twipsLeft);
+    if (twipsRight !== null) right = twipsToPoints(twipsRight);
   }
   return { left, right };
 }

--- a/packages/core/src/layout/paragraph-style.ts
+++ b/packages/core/src/layout/paragraph-style.ts
@@ -4,7 +4,13 @@
 // only draws them. Unrecognised or hostile values are dropped or clamped rather than
 // guessed — a wrong before-spacing moves every subsequent page break.
 
-import type { OoxmlElement, OoxmlNode, OoxmlProperty } from '@docx-editor.dev/core/store';
+import {
+  twips,
+  twipsToPoints,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlProperty,
+} from '@docx-editor.dev/core/store';
 import { borderStrokeWidthPt } from './border-metrics.ts';
 
 /**
@@ -193,10 +199,11 @@ function clampNonNegative(value: number, max: number): number {
   return value > max ? max : value;
 }
 
-function twipsToPoints(raw: string | undefined): number {
-  const twips = integer(raw, true);
-  if (twips === null) return 0;
-  return clampNonNegative(twips / 20, MAX_PARAGRAPH_SPACING_PT);
+/** Authored twips attribute to clamped spacing points, through the one conversion pair. */
+function spacingPoints(raw: string | undefined): number {
+  const authored = integer(raw, true);
+  if (authored === null) return 0;
+  return clampNonNegative(twipsToPoints(twips(authored)), MAX_PARAGRAPH_SPACING_PT);
 }
 
 /** `ST_OnOff` carried as an attribute value: anything but an explicit off is on (§17.17.4). */
@@ -275,8 +282,8 @@ export function paragraphSpacing(
     // that `w:docDefaults` set, which is exactly the shape Word's own Heading styles have.
     const authoredBefore = property.attributes?.before;
     const authoredAfter = property.attributes?.after;
-    if (authoredBefore !== undefined) before = twipsToPoints(authoredBefore);
-    if (authoredAfter !== undefined) after = twipsToPoints(authoredAfter);
+    if (authoredBefore !== undefined) before = spacingPoints(authoredBefore);
+    if (authoredAfter !== undefined) after = spacingPoints(authoredAfter);
     // The autospacing flags merge per attribute too, and independently of the measurement
     // beside them: a style may turn auto spacing OFF while leaving the `@before` it inherited
     // in place, and that paragraph must then use the measurement, not 0.

--- a/packages/core/src/layout/section-columns.ts
+++ b/packages/core/src/layout/section-columns.ts
@@ -1,3 +1,4 @@
+import { twips, twipsToPoints } from '@docx-editor.dev/core/store';
 import type { SectionColumns } from './section-properties.ts';
 
 export interface ResolvedSectionColumns {
@@ -8,7 +9,6 @@ export interface ResolvedSectionColumns {
   readonly separator: boolean;
 }
 
-const TWIPS_PER_POINT = 20;
 const MIN_COLUMN_WIDTH_PT = 1;
 
 /**
@@ -33,11 +33,11 @@ export function resolveSectionColumns(
   let gaps: number[];
   if (completeUnequal) {
     widths = definitions.map((definition) =>
-      Math.max(MIN_COLUMN_WIDTH_PT, definition.widthTwips / TWIPS_PER_POINT)
+      Math.max(MIN_COLUMN_WIDTH_PT, twipsToPoints(twips(definition.widthTwips)))
     );
     gaps = definitions
       .slice(0, -1)
-      .map((definition) => Math.max(0, definition.gapTwips / TWIPS_PER_POINT));
+      .map((definition) => Math.max(0, twipsToPoints(twips(definition.gapTwips))));
     const gapTotal = gaps.reduce((sum, gap) => sum + gap, 0);
     const availableForWidths = Math.max(count * MIN_COLUMN_WIDTH_PT, width - gapTotal);
     const statedWidth = widths.reduce((sum, columnWidth) => sum + columnWidth, 0);
@@ -46,7 +46,7 @@ export function resolveSectionColumns(
       widths = widths.map((columnWidth) => Math.max(MIN_COLUMN_WIDTH_PT, columnWidth * scale));
     }
   } else {
-    const requestedGap = Math.max(0, columns.gapTwips / TWIPS_PER_POINT);
+    const requestedGap = Math.max(0, twipsToPoints(twips(columns.gapTwips)));
     const gap = Math.min(
       requestedGap,
       Math.max(0, (width - count * MIN_COLUMN_WIDTH_PT) / (count - 1 || 1))

--- a/packages/core/src/layout/section-properties.ts
+++ b/packages/core/src/layout/section-properties.ts
@@ -17,6 +17,9 @@
 
 import {
   readOnOffChild,
+  // Aliased: this file's own `twips` is the bounded attribute parser below.
+  twips as asTwips,
+  twipsToPoints,
   type OoxmlElement,
   type OoxmlNode,
   type OoxmlPart,
@@ -133,8 +136,6 @@ export interface DocumentSection {
   readonly blockStart: number;
   readonly blockEndExclusive: number;
 }
-
-const TWIPS_PER_POINT = 20;
 
 /** US Letter, portrait, one-inch margins: Word's own default when a section says nothing. */
 export const DEFAULT_SECTION_PROPERTIES: SectionProperties = Object.freeze({
@@ -566,12 +567,12 @@ function enumerateSectionsUncached(
  * edge, and folding it into the content width instead would silently narrow every line.
  */
 export function geometryOfSection(section: SectionProperties): PageGeometry {
-  const width = section.pageSize.widthTwips / TWIPS_PER_POINT;
-  const height = section.pageSize.heightTwips / TWIPS_PER_POINT;
-  const left = (section.margins.leftTwips + section.margins.gutterTwips) / TWIPS_PER_POINT;
-  const right = section.margins.rightTwips / TWIPS_PER_POINT;
-  const top = section.margins.topTwips / TWIPS_PER_POINT;
-  const bottom = section.margins.bottomTwips / TWIPS_PER_POINT;
+  const width = twipsToPoints(asTwips(section.pageSize.widthTwips));
+  const height = twipsToPoints(asTwips(section.pageSize.heightTwips));
+  const left = twipsToPoints(asTwips(section.margins.leftTwips + section.margins.gutterTwips));
+  const right = twipsToPoints(asTwips(section.margins.rightTwips));
+  const top = twipsToPoints(asTwips(section.margins.topTwips));
+  const bottom = twipsToPoints(asTwips(section.margins.bottomTwips));
 
   // A page whose margins exceed it has no content area at all, and paginating into a
   // zero-height column never terminates. Fall back rather than hang.
@@ -580,7 +581,7 @@ export function geometryOfSection(section: SectionProperties): PageGeometry {
     width,
     height,
     margin: { top, right, bottom, left },
-    headerDistance: Math.max(0, section.margins.headerTwips) / TWIPS_PER_POINT,
-    footerDistance: Math.max(0, section.margins.footerTwips) / TWIPS_PER_POINT,
+    headerDistance: twipsToPoints(asTwips(Math.max(0, section.margins.headerTwips))),
+    footerDistance: twipsToPoints(asTwips(Math.max(0, section.margins.footerTwips))),
   };
 }

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -13,7 +13,12 @@
 // full styles material — layout embeds it in every paragraph key, so an unbounded string
 // would be quadratic in memory.
 
-import type { OoxmlElement, OoxmlNode, OoxmlProperty } from '@docx-editor.dev/core/store';
+import {
+  twipsToPoints,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlProperty,
+} from '@docx-editor.dev/core/store';
 import { stableHash } from '../store/comparators/canonical.ts';
 import { isDangerousKey } from '../store/package/safe-record.ts';
 import {
@@ -745,12 +750,12 @@ export function resolveParagraphLayoutInputs(
         property.attributes?.firstLine !== undefined
       ) {
         // `w:hanging` is `ST_TwipsMeasure`, unsigned: a negative one is not a measurement.
-        hanging = h !== null ? Math.max(0, h) / 20 : 0;
+        hanging = h !== null ? Math.max(0, twipsToPoints(h)) : 0;
         // `w:firstLine` is DECLARED unsigned, but Word's model keeps one SIGNED first-line
         // indent and the numbering reader already reads it that way (`numbering-index.ts`).
         // Flattening a negative to zero here rendered a body paragraph flush where Word
         // renders a hanging, and made the two readers disagree about the same attribute.
-        firstLine = f !== null ? f / 20 : 0;
+        firstLine = f !== null ? twipsToPoints(f) : 0;
       }
     }
   }

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -39,3 +39,14 @@ export * from './package/index.ts';
 export * from './store/index.ts';
 
 export { TABLE_BORDER_STYLES, type TableBorderStyle } from './table-border-style.ts';
+
+// Branded length units and the one twips/points conversion pair.
+export {
+  TWIPS_PER_POINT,
+  points,
+  pointsToTwips,
+  twips,
+  twipsToPoints,
+  type Points,
+  type Twips,
+} from './units.ts';

--- a/packages/core/src/store/package/toc-build.ts
+++ b/packages/core/src/store/package/toc-build.ts
@@ -3,6 +3,7 @@
 import { WML_NAMESPACE_URI, XML_NAMESPACE_URI } from './ooxml-shared.ts';
 import type { OoxmlNode, OoxmlPart } from './ooxml-tree.ts';
 import { buildBookmarkIndex } from './bookmarks.ts';
+import { twips, type Twips } from '../units.ts';
 /** Outline heading shape consumed by TOC planning (mirrors DocumentOutlineEntry). */
 export interface TocOutlineHeading {
   readonly text: string;
@@ -13,13 +14,13 @@ import type { TocInstruction } from './toc-instruction.ts';
 import { TOC_MAX_BOOKMARKS_PER_REFRESH, TOC_MAX_ENTRIES } from './toc-instruction.ts';
 
 /** Left-indent step between TOC levels, in twips (matches `scripts/demo-doc/toc-block.xml`). */
-export const TOC_LEVEL_INDENT_TWIPS = 240;
+export const TOC_LEVEL_INDENT_TWIPS: Twips = twips(240);
 
 /** Bounded left-indent twips for a TOC entry level (0-based heading depth). */
-export function tocLeftIndentTwips(level: number): number {
-  if (!Number.isFinite(level)) return 0;
+export function tocLeftIndentTwips(level: number): Twips {
+  if (!Number.isFinite(level)) return twips(0);
   const bounded = Math.max(0, Math.min(8, Math.trunc(level)));
-  return bounded * TOC_LEVEL_INDENT_TWIPS;
+  return twips(bounded * TOC_LEVEL_INDENT_TWIPS);
 }
 
 /** One planned TOC entry: its level, its text, and the heading it points at. */

--- a/packages/core/src/store/units.ts
+++ b/packages/core/src/store/units.ts
@@ -1,0 +1,74 @@
+// Branded length units: twips and points, and the ONE conversion pair between them.
+//
+// The engine's rule is "points everywhere; twips convert at property-read boundaries", but a
+// rule over raw `number`s is convention only — nothing stops a twips value from reaching an
+// arithmetic expression that assumes points. The brands make the unit part of the type, so a
+// declared `Twips` parameter refuses a raw or points-valued number at compile time.
+//
+// This lives in the store lane deliberately: it is the one lane every consumer of the
+// conversion may import (`layout`, `automation` and `editor` all reach `store` in the lane
+// DAG; none of them may reach `contracts`). See
+// `packages/core/src/__tests__/core-lane-graph.ts`.
+
+declare const TWIPS: unique symbol;
+declare const POINTS: unique symbol;
+
+/**
+ * A length in twentieths of a point — OOXML's `ST_TwipsMeasure` / `ST_SignedTwipsMeasure`.
+ *
+ * The brand is intersection-typed onto `number`, so a `Twips` value still decays to `number`
+ * wherever arithmetic consumes it; only the reverse direction — passing a raw number where
+ * `Twips` is declared — is refused.
+ *
+ * @public
+ */
+export type Twips = number & { readonly [TWIPS]: true };
+
+/**
+ * A length in typographic points, the unit layout and paint compute in.
+ *
+ * @public
+ */
+export type Points = number & { readonly [POINTS]: true };
+
+/**
+ * Twentieths of a point per point.
+ *
+ * @public
+ */
+export const TWIPS_PER_POINT = 20;
+
+/**
+ * Assert that a number is a twips measurement.
+ *
+ * A compile-time cast, not a validator: bounds, integrality and finiteness stay at the parse
+ * boundary that produced the number, exactly where they are enforced today. The cast is the
+ * caller's claim about the UNIT, nothing more.
+ *
+ * @public
+ */
+export const twips = (value: number): Twips => value as Twips;
+
+/**
+ * Assert that a number is a points measurement. A compile-time cast; see {@link twips}.
+ *
+ * @public
+ */
+export const points = (value: number): Points => value as Points;
+
+/**
+ * The one twips-to-points conversion. Exact division; twips are the finer unit.
+ *
+ * @public
+ */
+export const twipsToPoints = (value: Twips): Points => (value / TWIPS_PER_POINT) as Points;
+
+/**
+ * The one points-to-twips conversion.
+ *
+ * Rounds to the nearest twip: every OOXML twips measurement is integral, and emitting a
+ * fractional twip would write a value no consumer of the file can represent.
+ *
+ * @public
+ */
+export const pointsToTwips = (value: Points): Twips => Math.round(value * TWIPS_PER_POINT) as Twips;


### PR DESCRIPTION
Stage 1 of #419: adds branded `Twips` and `Points` types with one conversion pair in `packages/core/src/store/units.ts`, the one lane every consumer of the conversion can reach, and collapses the duplicated converters in the layout, automation, and store lanes onto it. The brands stop at the conversion-boundary signatures: values decay to `number` where arithmetic consumes them, `snapTwips` keeps its unbranded public signature, and the remaining raw `/ 20` sites are follow-up work. Stage 2 covers node addresses.

Part of #419

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790182482&installation_model_id=422592&pr_number=425&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F425&signature=5482533adf55c572a4b000466bfcff165ccdc041379c45571ab97e05816ed050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->