### PR TITLE
docs: narrow site index SEO title

### DIFF
--- a/docs/site/content/index.mdx
+++ b/docs/site/content/index.mdx
@@ -3,7 +3,7 @@ title: 'Introduction'
 description: 'Browser-based WYSIWYG DOCX editor for React and Vue 3, with tracked changes, comments, content controls, and custom nodes.'
 category: 'Getting Started'
 order: 1
-seoTitle: 'DOCX editor for React and Vue'
+seoTitle: 'Documentation and API reference'
 ---
 
 `docx-editor` is an open-source, what-you-see-is-what-you-get (WYSIWYG) DOCX editor for React and Vue 3. It parses Office Open XML (OOXML) and renders paginated document pages. It then serializes the document state to a `.docx` file. Standard browser editing does not require an upload service or conversion backend.


### PR DESCRIPTION
## Summary
- change the docs index `seoTitle` to target documentation and API reference intent
- keep the synced frontmatter authoritative for the docx-editor.dev renderer
- complement [docx-editor.dev#67](https://github.com/eigenpal/docx-editor.dev/pull/67), which removes the site-only override

## Test plan
- [x] `bun run check:docs-mdx`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790184738&installation_model_id=422592&pr_number=426&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F426&signature=315dd1ae2ca6ddd2fd6a214891c054fb28b6d9e34006104ffabed3aef35e3235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->