### PR TITLE
fix: show selected empty lines

### DIFF
--- a/.changeset/visible-empty-line-selection.md
+++ b/.changeset/visible-empty-line-selection.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Show selected paragraph marks and empty lines with a small selection block.

--- a/packages/core/src/editor/__tests__/retained-selection.test.ts
+++ b/packages/core/src/editor/__tests__/retained-selection.test.ts
@@ -93,6 +93,18 @@ describe('a retained selection stays lit while focus is elsewhere', () => {
     expect(retainedRects(mounted)).toBe(0);
   });
 
+  test('an active paragraph-mark selection paints the part the browser cannot show', () => {
+    const mounted = mount();
+    mounted.surface.setSelection({
+      anchor: { paragraphId: P(0), offset: 'Visit example today'.length },
+      head: { paragraphId: P(1), offset: 0 },
+    });
+    const marks = mounted.container.querySelectorAll<HTMLElement>('.docx-selection-mark-rect');
+    expect(marks).toHaveLength(1);
+    expect(parseFloat(marks[0]!.style.width)).toBeGreaterThan(0);
+    expect(retainedRects(mounted)).toBe(0);
+  });
+
   test('retaining pins the range and paints it', () => {
     const mounted = mount();
     select(mounted, 0, 6, 13);

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -70,6 +70,7 @@ import {
 import { attachListResolveChangeEvidence } from '../layout/list-resolve.ts';
 import { DEFAULT_REVISION_DISPLAY_MODE } from '../layout/revision-projection.ts';
 import { mergedPredecessorsOf } from '../layout/line-segments.ts';
+import { selectionMarkRects } from '../layout/selection-rects.ts';
 import { paintSelectionOverlay, type OverlayRect } from '@docx-editor.dev/core/output';
 // By module path, like the roster walk below: dropping a retained paint is an engine
 // internal for the IME lane, not something the output barrel should offer consumers.
@@ -3515,23 +3516,30 @@ export function mountPaginatedSurface(
     commentHighlightAuthors = roster.resolved;
   }
 
-  /** Draw the selected cells, or clear the layer when nothing is selected that way. */
+  /** Draw selected cells, retained text, or paragraph marks native selection cannot show. */
   function renderOverlay(): void {
+    const rects = cellSelection
+      ? cellSelectionRects(currentLayout, cellSelection.cellIds)
+      : retainedSelection
+        ? selectionRects(currentLayout, retainedSelection, paragraphOrder())
+        : selectionMarkRects(currentLayout, selection, paragraphOrder());
     paintSelectionOverlay(
       overlayLayer,
       currentLayout,
-      cellSelection
-        ? cellSelectionRects(currentLayout, cellSelection.cellIds)
-        : retainedSelection
-          ? selectionRects(currentLayout, retainedSelection, paragraphOrder())
-          : [],
+      rects,
       // Pages of differing width are centred individually, so the overlay has to carry the
       // same per-page offset the painter applied or a highlight in a landscape section would
       // sit beside the cells it describes.
       {
         scale,
         pageOffsetX: materializedExtent?.pageOffsetX,
-        ...(cellSelection ? {} : { className: 'docx-retained-selection-rect' }),
+        ...(cellSelection
+          ? {}
+          : {
+              className: retainedSelection
+                ? 'docx-retained-selection-rect'
+                : 'docx-selection-mark-rect',
+            }),
       }
     );
   }

--- a/packages/core/src/layout/__tests__/semantic-interaction.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-interaction.test.ts
@@ -41,6 +41,7 @@ const lay = (part: OoxmlPart, geometry?: PageGeometry) =>
 
 const P0 = '/word/document.xml#0.0.0';
 const P1 = '/word/document.xml#0.0.1';
+const P2 = '/word/document.xml#0.0.2';
 const at = (paragraphId: string, offset: number): SemanticPosition => ({ paragraphId, offset });
 
 const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
@@ -202,6 +203,42 @@ describe('selection geometry', () => {
       documentOrder(layout)
     );
     expect(rects).toHaveLength(2);
+  });
+
+  test('a selected paragraph mark paints a small block after the line', () => {
+    const layout = lay(load(paragraph('abcd') + paragraph('efgh')));
+    const rects = selectionRects(
+      layout,
+      { anchor: at(P0, 4), head: at(P1, 0) },
+      documentOrder(layout)
+    );
+    expect(rects).toHaveLength(1);
+    expect(rects[0]!.x).toBe(24);
+    expect(rects[0]!.width).toBeGreaterThan(0);
+    expect(rects[0]!.width).toBeLessThan(6);
+  });
+
+  test('a selection crossing an empty paragraph shows its selected line', () => {
+    const layout = lay(load(paragraph('a') + '<w:p/>' + paragraph('b')));
+    const rects = selectionRects(
+      layout,
+      { anchor: at(P0, 1), head: at(P2, 0) },
+      documentOrder(layout)
+    );
+    expect(rects).toHaveLength(2);
+    expect(rects.every((rect) => rect.width > 0)).toBe(true);
+    expect(rects[1]!.x).toBe(0);
+  });
+
+  test('selected authored whitespace keeps its measured width', () => {
+    const layout = lay(load('<w:p><w:r><w:t xml:space="preserve">a  b</w:t></w:r></w:p>'));
+    const rects = selectionRects(
+      layout,
+      { anchor: at(P0, 1), head: at(P0, 3) },
+      documentOrder(layout)
+    );
+    expect(rects).toHaveLength(1);
+    expect(rects[0]!.width).toBe(12);
   });
 
   test('an empty selection covers nothing', () => {

--- a/packages/core/src/layout/selection-rects.ts
+++ b/packages/core/src/layout/selection-rects.ts
@@ -37,22 +37,127 @@ export function selectionRects(
    */
   order: readonly string[]
 ): SelectionRect[] {
+  return rangeRects(layout, selection, order, true);
+}
+
+/**
+ * Rectangles for selected paragraph marks only.
+ *
+ * Native DOM selection paints characters, but it cannot paint the paragraph mark after a
+ * filled line or the only position on an empty line. The active surface draws these small
+ * semantic rectangles beside the native highlight.
+ */
+export function selectionMarkRects(
+  layout: SemanticLayout,
+  selection: SemanticSelection,
+  order: readonly string[]
+): SelectionRect[] {
+  return rangeRects(layout, selection, order, false);
+}
+
+interface ParagraphTerminal {
+  end: number;
+  start: number;
+}
+
+const paragraphTerminalsCache = new WeakMap<
+  SemanticLayout,
+  ReadonlyMap<string, ParagraphTerminal>
+>();
+const orderIndexCache = new WeakMap<readonly string[], ReadonlyMap<string, number>>();
+
+/** Last visual segment range for each paragraph, including repeated visual occurrences. */
+function paragraphTerminals(layout: SemanticLayout): ReadonlyMap<string, ParagraphTerminal> {
+  const cached = paragraphTerminalsCache.get(layout);
+  if (cached) return cached;
+  const terminals = new Map<string, ParagraphTerminal>();
+  for (const page of layout.pages)
+    for (const fragment of paragraphFragmentsOf(page))
+      for (const line of fragment.lines)
+        for (const segment of lineSegments(line)) {
+          const previous = terminals.get(segment.paragraphId);
+          if (
+            !previous ||
+            segment.end > previous.end ||
+            (segment.end === previous.end && segment.start > previous.start)
+          ) {
+            terminals.set(segment.paragraphId, { end: segment.end, start: segment.start });
+          }
+        }
+  paragraphTerminalsCache.set(layout, terminals);
+  return terminals;
+}
+
+function indexesOf(order: readonly string[]): ReadonlyMap<string, number> {
+  const cached = orderIndexCache.get(order);
+  if (cached) return cached;
+  const index = new Map(order.map((paragraphId, at) => [paragraphId, at]));
+  orderIndexCache.set(order, index);
+  return index;
+}
+
+/** A compact Word-like block for a selected paragraph mark, in layout points. */
+function paragraphMarkWidth(lineHeight: number): number {
+  return Math.max(3, Math.min(8, lineHeight * 0.25));
+}
+
+function rangeRects(
+  layout: SemanticLayout,
+  selection: SemanticSelection,
+  order: readonly string[],
+  includeText: boolean
+): SelectionRect[] {
   const ordered = orderPositions(selection, order);
   if (!ordered) return [];
+  const orderIndex = indexesOf(order);
+  const fromIndex = orderIndex.get(ordered.from.paragraphId);
+  const toIndex = orderIndex.get(ordered.to.paragraphId);
+  const terminals = paragraphTerminals(layout);
   const rects: SelectionRect[] = [];
   for (const page of layout.pages) {
     for (const fragment of paragraphFragmentsOf(page)) {
       for (const line of fragment.lines) {
-        for (const segment of lineSegments(line)) {
+        const segments = lineSegments(line);
+        for (const [segmentIndex, segment] of segments.entries()) {
           const overlap = segmentOverlap(layout, segment, ordered.from, ordered.to);
-          if (!overlap) continue;
-          const startX = xWithinLine(line, overlap.start, undefined, segment);
-          const endX = xWithinLine(line, overlap.end, undefined, segment);
+          const paragraphIndex = orderIndex.get(segment.paragraphId);
+          const terminal = terminals.get(segment.paragraphId);
+          // A paragraph mark is the boundary AFTER this paragraph. The range selects it only
+          // when its head reaches a later paragraph; the head paragraph's own mark stays out.
+          const markSelected =
+            fromIndex !== undefined &&
+            toIndex !== undefined &&
+            paragraphIndex !== undefined &&
+            paragraphIndex >= fromIndex &&
+            paragraphIndex < toIndex &&
+            terminal?.end === segment.end &&
+            terminal.start === segment.start &&
+            segmentIndex === segments.length - 1;
+          if ((!includeText || !overlap) && !markSelected) continue;
+          const textStartX =
+            includeText && overlap ? xWithinLine(line, overlap.start, undefined, segment) : null;
+          const textEndX =
+            includeText && overlap ? xWithinLine(line, overlap.end, undefined, segment) : null;
+          const markStartX = markSelected
+            ? xWithinLine(line, segment.end, undefined, segment)
+            : null;
+          const markEndX =
+            markStartX !== null
+              ? markStartX +
+                paragraphMarkWidth(
+                  Math.max(0, line.box.height - line.leading - (line.trailingSpacing ?? 0))
+                )
+              : null;
+          const edges = [textStartX, textEndX, markStartX, markEndX].filter(
+            (edge): edge is number => edge !== null
+          );
+          const startX = Math.min(...edges);
+          const endX = Math.max(...edges);
           rects.push({
             pageIndex: page.index,
-            x: Math.min(startX, endX),
+            x: startX,
             y: line.box.y,
-            width: Math.abs(endX - startX),
+            width: endX - startX,
             height: line.box.height,
           });
         }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3402,6 +3402,11 @@ a.docx-hyperlink:focus-visible {
   background-color: var(--doc-selection);
 }
 
+/* A native range has no glyph box for a paragraph mark or an empty line. */
+.docx-paginated-surface .docx-selection-mark-rect {
+  background-color: var(--doc-selection);
+}
+
 /* ========================================================================
  * COMPOUND TOOLBAR (`docx-toolbar` family) — the composition API's default
  * chrome bar, the chrome spec's visual recipe:


### PR DESCRIPTION
## Summary
- Show selected paragraph marks and empty lines with a small selection block.
- Keep native text selection and retained-selection behavior unchanged.

## Test plan
- [x] Run `bun run test`.
- [x] Run `bun run typecheck`, `bun run lint`, `bun run check:parity`, `bun run api:check`, and `bun run i18n:validate`.
- [x] Verify an empty-line selection in Chromium.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790192915&installation_model_id=422592&pr_number=435&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F435&signature=37e71b71ce678bd0de52a25df654b8bbba5ab15b9b9fbe07d300bdf7d191d9e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->