### PR TITLE
ci: rename the changesets action inputs for v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,12 +224,12 @@ jobs:
         id: changesets
         uses: changesets/action@v2.1.0
         with:
-          version: bun run version-packages
-          publish: bunx changeset publish
-          title: 'chore: release'
-          commit: 'chore: release'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version-script: bun run version-packages
+          publish-script: bunx changeset publish
+          pr-title: 'chore: release'
+          commit-message: 'chore: release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 
       # changesets/action creates per-package tags (e.g. `@docx-editor.dev/react@1.0.1`);
@@ -241,7 +241,7 @@ jobs:
       - name: Create umbrella version tag (vX.Y.Z)
         if: ${{ steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/main' }}
         env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: |
           version=$(jq -r '.[0].version' <<<"$PUBLISHED_PACKAGES")
           git tag -a "v$version" -m "Release v$version"
@@ -275,7 +275,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.pal-token.outputs.token }}
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: |
           version=$(jq -r '.[0].version' <<<"$PUBLISHED_PACKAGES")
           # `|| true`: the default shell is `bash -eo pipefail`, so a grep
@@ -305,7 +305,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.pal-token.outputs.token }}
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: |
           version=$(jq -r '.[0].version' <<<"$PUBLISHED_PACKAGES")
           gh api "repos/${{ github.repository_owner }}/docx-editor.dev/dispatches" \
@@ -316,12 +316,12 @@ jobs:
         if: ${{ steps.changesets.outputs.published == 'true' && env.SLACK_WEBHOOK_URL != '' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
           ACTOR: ${{ github.actor }}
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # publishedPackages is JSON like:
+          # published-packages is JSON like:
           # [{"name":"@docx-editor.dev/react","version":"1.0.0"}, ...]
           version=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[0].version')
           packages_md=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "• <https://www.npmjs.com/package/\(.name)/v/\(.version)|\(.name)@\(.version)>"')


### PR DESCRIPTION
The `changesets/action` v2 bump (#430) landed without the v2 rename migration, so every Release run now fails at the **Release PR or Publish** step before the action does any work.

This updates `release.yml` to the v2 names:

- Inputs: `version` → `version-script`, `publish` → `publish-script`, `title` → `pr-title`, `commit` → `commit-message`.
- Output: `publishedPackages` → `published-packages` in the umbrella-tag, PR-comment, dispatch, and Slack steps.
- Token: v2 reads the `github-token` input instead of the `GITHUB_TOKEN` env, so the token moves from `env` to `with`.

v2 also pushes the release commit through the GitHub API by default (`push-with-git-cli: false`), which should stop the earlier `workflows`-permission rejection when a merge to main edits a workflow file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790228706&installation_model_id=422592&pr_number=438&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F438&signature=95f0756b0b039ed7e306a1b68bef81b03c30e3dc42ba9be26aea77f579c96d08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->