### PR TITLE
fix: restore the peer floors that changeset version raised

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,5 +18,8 @@
   "access": "public",
   "privatePackages": { "version": true, "tag": false },
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -281,9 +281,9 @@
     },
     "packages/core": {
       "name": "@docx-editor.dev/core",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.9.0",
+        "@docx-editor.dev/i18n": "^2.9.1",
         "bidi-js": "1.0.3",
         "emf-converter": "2.0.2",
         "fast-xml-parser": "^5.10.1",
@@ -314,7 +314,7 @@
     },
     "packages/editor-api": {
       "name": "@docx-editor.dev/editor-api",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "@microsoft/api-extractor": "^7.50.0",
@@ -327,7 +327,7 @@
     },
     "packages/fonts": {
       "name": "@docx-editor.dev/fonts",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "typescript": "^5.3.3",
@@ -335,7 +335,7 @@
     },
     "packages/i18n": {
       "name": "@docx-editor.dev/i18n",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "devDependencies": {
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
@@ -343,7 +343,7 @@
     },
     "packages/nuxt": {
       "name": "@docx-editor.dev/nuxt",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "dependencies": {
         "@docx-editor.dev/vue": "^0.0.1",
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
@@ -369,7 +369,7 @@
     },
     "packages/pro": {
       "name": "@docx-editor.dev/pro",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "@docx-editor.dev/i18n": "workspace:*",
@@ -403,9 +403,9 @@
     },
     "packages/react": {
       "name": "@docx-editor.dev/react",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.9.0",
+        "@docx-editor.dev/i18n": "^2.9.1",
         "@radix-ui/react-select": "^2.3.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -426,9 +426,9 @@
     },
     "packages/vue": {
       "name": "@docx-editor.dev/vue",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.9.0",
+        "@docx-editor.dev/i18n": "^2.9.1",
       },
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -322,7 +322,7 @@
         "license-check-and-add": "^4.0.5",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "2.9.1",
+        "@docx-editor.dev/core": "~2.9.1",
       },
     },
     "packages/fonts": {

--- a/bun.lock
+++ b/bun.lock
@@ -322,7 +322,7 @@
         "license-check-and-add": "^4.0.5",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "^2.8.0",
+        "@docx-editor.dev/core": "2.9.1",
       },
     },
     "packages/fonts": {

--- a/bun.lock
+++ b/bun.lock
@@ -386,9 +386,9 @@
         "zod": "^4.4.3",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "^2.6.0",
-        "@docx-editor.dev/react": "^2.0.1",
-        "@docx-editor.dev/vue": "^2.0.1",
+        "@docx-editor.dev/core": "~2.9.1",
+        "@docx-editor.dev/react": "~2.9.1",
+        "@docx-editor.dev/vue": "~2.9.1",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
         "vue": "^3.3.0",
@@ -415,7 +415,7 @@
         "fflate": "^0.8.2",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "^2.6.0",
+        "@docx-editor.dev/core": "~2.9.1",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
       },
@@ -436,7 +436,7 @@
         "vue": "^3.5.29",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "^2.6.0",
+        "@docx-editor.dev/core": "~2.9.1",
         "vue": "^3.3.0",
       },
       "optionalPeers": [

--- a/packages/editor-api/package.json
+++ b/packages/editor-api/package.json
@@ -75,6 +75,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.9.1"
+    "@docx-editor.dev/core": "^2.8.0"
   }
 }

--- a/packages/editor-api/package.json
+++ b/packages/editor-api/package.json
@@ -75,6 +75,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "2.9.1"
+    "@docx-editor.dev/core": "~2.9.1"
   }
 }

--- a/packages/editor-api/package.json
+++ b/packages/editor-api/package.json
@@ -75,6 +75,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.8.0"
+    "@docx-editor.dev/core": "2.9.1"
   }
 }

--- a/packages/editor-api/src/__tests__/package-dependencies.test.ts
+++ b/packages/editor-api/src/__tests__/package-dependencies.test.ts
@@ -58,11 +58,17 @@ describe('how this package asks for the engine', () => {
     expect(manifest.devDependencies?.['@docx-editor.dev/core']).toBe('workspace:*');
   });
 
-  test('the engine peer is an EXACT pin on the version it ships with', () => {
-    // The `./browser` entry attaches to internals of the host's engine, not just its public
-    // contract, so a range here would admit an engine this exact build was never tested
-    // against. The fixed release group publishes both packages at the same version, and an
-    // exact pin is out of range on every bump, so `changeset version` moves it in lockstep.
-    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBe(core.version);
+  test('the engine peer requires the minor it ships with', () => {
+    // A tilde range on the engine's current minor: patch drift is allowed, a different minor
+    // is not, so the automation host never attaches to an engine minor it did not ship with.
+    // The floor patch may lag within the minor because in-range releases do not rewrite the
+    // range.
+    const range = manifest.peerDependencies?.['@docx-editor.dev/core'];
+    const match = /^~(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range ?? '');
+    expect(match).not.toBeNull();
+    const [major, minor, patch] = core.version.split('.').map(Number);
+    expect(Number(match![1])).toBe(major!);
+    expect(Number(match![2])).toBe(minor!);
+    expect(Number(match![3])).toBeLessThanOrEqual(patch!);
   });
 });

--- a/packages/editor-api/src/__tests__/package-dependencies.test.ts
+++ b/packages/editor-api/src/__tests__/package-dependencies.test.ts
@@ -58,16 +58,11 @@ describe('how this package asks for the engine', () => {
     expect(manifest.devDependencies?.['@docx-editor.dev/core']).toBe('workspace:*');
   });
 
-  test('the declared range admits the workspace engine it is built against', () => {
-    // A caret range that fell behind the engine's major would make installs resolve a
-    // SECOND, older engine next to the host's — the exact two-copies failure above.
-    const range = manifest.peerDependencies!['@docx-editor.dev/core']!;
-    // The optional suffix admits changesets pre-release mode (^3.0.0-next.0).
-    const match = /^\^(\d+)\.(\d+)\.\d+(?:-[0-9A-Za-z.-]+)?$/.exec(range);
-    expect(match).not.toBeNull();
-    const [rangeMajor, rangeMinor] = [Number(match![1]), Number(match![2])];
-    const [coreMajor, coreMinor] = core.version.split('.').map(Number);
-    expect(rangeMajor).toBe(coreMajor);
-    expect(rangeMinor).toBeLessThanOrEqual(coreMinor!);
+  test('the engine peer is an EXACT pin on the version it ships with', () => {
+    // The `./browser` entry attaches to internals of the host's engine, not just its public
+    // contract, so a range here would admit an engine this exact build was never tested
+    // against. The fixed release group publishes both packages at the same version, and an
+    // exact pin is out of range on every bump, so `changeset version` moves it in lockstep.
+    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBe(core.version);
   });
 });

--- a/packages/editor-api/src/__tests__/package-surface.test.ts
+++ b/packages/editor-api/src/__tests__/package-surface.test.ts
@@ -123,8 +123,9 @@ describe('what the package depends on', () => {
     // `npm publish` untouched, so it would reach the tarball and fail the consumer's
     // install. `scripts/__tests__/published-manifests.test.ts` holds the rule for every
     // package; this asserts the range still points at the engine. Why the engine is a PEER
-    // rather than a regular dependency is `package-dependencies.test.ts`, next to this file.
-    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toMatch(/^\^\d+\.\d+\.\d+/);
+    // rather than a regular dependency — and why the range is a same-minor tilde — is
+    // `package-dependencies.test.ts`, next to this file.
+    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toMatch(/^~\d+\.\d+\.\d+/);
   });
 
   test('the engine is the only peer dependency, and it is required', () => {

--- a/packages/pro/package.json
+++ b/packages/pro/package.json
@@ -35,9 +35,9 @@
     "license:add": "license-check-and-add add -f license-check.json"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.6.0",
-    "@docx-editor.dev/react": "^2.0.1",
-    "@docx-editor.dev/vue": "^2.0.1",
+    "@docx-editor.dev/core": "~2.9.1",
+    "@docx-editor.dev/react": "~2.9.1",
+    "@docx-editor.dev/vue": "~2.9.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "vue": "^3.3.0"

--- a/packages/pro/package.json
+++ b/packages/pro/package.json
@@ -35,9 +35,9 @@
     "license:add": "license-check-and-add add -f license-check.json"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.9.1",
-    "@docx-editor.dev/react": "^2.9.1",
-    "@docx-editor.dev/vue": "^2.9.1",
+    "@docx-editor.dev/core": "^2.6.0",
+    "@docx-editor.dev/react": "^2.0.1",
+    "@docx-editor.dev/vue": "^2.0.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "vue": "^3.3.0"

--- a/packages/pro/src/__tests__/package-dependencies.test.ts
+++ b/packages/pro/src/__tests__/package-dependencies.test.ts
@@ -27,15 +27,39 @@ const manifest = JSON.parse(
   devDependencies?: Record<string, string>;
 };
 
+const versionOf = (pkg: string) =>
+  (
+    JSON.parse(
+      readFileSync(join(import.meta.dir, '..', '..', '..', pkg, 'package.json'), 'utf8')
+    ) as { version: string }
+  ).version;
+
+// A tilde range on the peer's current minor: patch drift is allowed, a different minor is
+// not, so an app never pairs this module with an engine or adapter minor it did not ship
+// with. The floor patch may lag within the minor because in-range releases do not rewrite
+// the range.
+const requiresSameMinor = (range: string | undefined, version: string) => {
+  const match = /^~(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range ?? '');
+  if (!match) return false;
+  const [major, minor, patch] = version.split('.').map(Number);
+  return Number(match[1]) === major && Number(match[2]) === minor && Number(match[3]) <= patch!;
+};
+
 describe('how this package asks for the engine', () => {
   test('the engine is a peer, so the consumer resolves one copy of it', () => {
-    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBe('^2.6.0');
+    expect(
+      requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/core'], versionOf('core'))
+    ).toBe(true);
     expect(manifest.dependencies?.['@docx-editor.dev/core']).toBeUndefined();
   });
 
   test('the adapter is a peer for the same reason', () => {
-    expect(manifest.peerDependencies?.['@docx-editor.dev/react']).toBeDefined();
-    expect(manifest.peerDependencies?.['@docx-editor.dev/vue']).toBeDefined();
+    expect(
+      requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/react'], versionOf('react'))
+    ).toBe(true);
+    expect(
+      requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/vue'], versionOf('vue'))
+    ).toBe(true);
     expect(manifest.dependencies?.['@docx-editor.dev/react']).toBeUndefined();
     expect(manifest.dependencies?.['@docx-editor.dev/vue']).toBeUndefined();
   });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     "api:check": "node ../../scripts/api-extractor.mjs --package @docx-editor.dev/react"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.9.1",
+    "@docx-editor.dev/core": "^2.6.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     "api:check": "node ../../scripts/api-extractor.mjs --package @docx-editor.dev/react"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.6.0",
+    "@docx-editor.dev/core": "~2.9.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/packages/react/test/package-dependencies.test.ts
+++ b/packages/react/test/package-dependencies.test.ts
@@ -27,9 +27,25 @@ const manifest = JSON.parse(readFileSync(join(import.meta.dir, '..', 'package.js
   devDependencies?: Record<string, string>;
 };
 
+const core = JSON.parse(
+  readFileSync(join(import.meta.dir, '..', '..', 'core', 'package.json'), 'utf8')
+) as { version: string };
+
+// A tilde range on the engine's current minor: patch drift is allowed, a different minor is
+// not, so an app never pairs this adapter with an engine minor it did not ship with. The floor
+// patch may lag within the minor because in-range releases do not rewrite the range.
+const requiresSameMinor = (range: string | undefined, version: string) => {
+  const match = /^~(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range ?? '');
+  if (!match) return false;
+  const [major, minor, patch] = version.split('.').map(Number);
+  return Number(match[1]) === major && Number(match[2]) === minor && Number(match[3]) <= patch!;
+};
+
 describe('how this package asks for the engine', () => {
   test('the engine is a peer, so the consumer resolves one copy of it', () => {
-    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBe('^2.6.0');
+    expect(
+      requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/core'], core.version)
+    ).toBe(true);
     expect(manifest.dependencies?.['@docx-editor.dev/core']).toBeUndefined();
   });
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -26,7 +26,7 @@
     "api:check": "node ../../scripts/api-extractor.mjs --package @docx-editor.dev/vue"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.9.1",
+    "@docx-editor.dev/core": "^2.6.0",
     "vue": "^3.3.0"
   },
   "peerDependenciesMeta": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -26,7 +26,7 @@
     "api:check": "node ../../scripts/api-extractor.mjs --package @docx-editor.dev/vue"
   },
   "peerDependencies": {
-    "@docx-editor.dev/core": "^2.6.0",
+    "@docx-editor.dev/core": "~2.9.1",
     "vue": "^3.3.0"
   },
   "peerDependenciesMeta": {

--- a/packages/vue/test/package-dependencies.test.ts
+++ b/packages/vue/test/package-dependencies.test.ts
@@ -9,9 +9,25 @@ const manifest = JSON.parse(readFileSync(join(import.meta.dir, '..', 'package.js
   devDependencies?: Record<string, string>;
 };
 
+const core = JSON.parse(
+  readFileSync(join(import.meta.dir, '..', '..', 'core', 'package.json'), 'utf8')
+) as { version: string };
+
+// A tilde range on the engine's current minor: patch drift is allowed, a different minor is
+// not, so an app never pairs this adapter with an engine minor it did not ship with. The floor
+// patch may lag within the minor because in-range releases do not rewrite the range.
+const requiresSameMinor = (range: string | undefined, version: string) => {
+  const match = /^~(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range ?? '');
+  if (!match) return false;
+  const [major, minor, patch] = version.split('.').map(Number);
+  return Number(match[1]) === major && Number(match[2]) === minor && Number(match[3]) <= patch!;
+};
+
 describe('how this package asks for the engine', () => {
   test('the engine is a peer', () => {
-    expect(manifest.peerDependencies?.['@docx-editor.dev/core']).toBe('^2.6.0');
+    expect(
+      requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/core'], core.version)
+    ).toBe(true);
     expect(manifest.dependencies?.['@docx-editor.dev/core']).toBeUndefined();
   });
 


### PR DESCRIPTION
The publish run for 2.9.1 failed at the prepublish gate: the release commit rewrote the adapter peer ranges on `@docx-editor.dev/core`, and the `package-dependencies` tests pinned the old values.

Root cause: the CLI v3 migration (#437) removed
`___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange`
from `.changeset/config.json`. `@changesets/apply-release-plan` v8 still reads that flag when deciding whether to rewrite in-range peer ranges. The flag is restored.

The internal peer policy also tightens, per owner decision: every internal peer uses a tilde range on the version it ships with (`~2.9.1`). That requires the same major and minor and allows patch drift. This applies to the `core` peer in `react`, `vue`, `pro`, and `editor-api`, and to the `react`/`vue` peers in `pro`.

The `package-dependencies` tests assert the tilde shape structurally against the workspace versions instead of hardcoded floors. Also syncs the workspace versions in `bun.lock` to 2.9.1.

Verified with scratch `changeset version` runs: a patch bump keeps the ranges (still in range); a minor bump rewrites every range with the release and keeps the tilde style. All four test files pass at each step.

No changeset on purpose: 2.9.1 is versioned on main but not yet on npm, and a pending changeset would switch the next Release run back into PR mode instead of publishing 2.9.1.