### PR TITLE
perf: stop re-deriving whole-document indexes on structural keystrokes

### DIFF
--- a/.changeset/lazy-derivation-memos.md
+++ b/.changeset/lazy-derivation-memos.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Reduce per-keystroke latency on very large documents: structural edits no longer re-derive whole-document indexes, and page-field projection reuses unchanged pages.

--- a/packages/core/src/editor/__tests__/derivation-prewarm.test.ts
+++ b/packages/core/src/editor/__tests__/derivation-prewarm.test.ts
@@ -1,0 +1,176 @@
+// The idle pre-warm exists to move the first structural edit's memo population off the
+// keystroke, so what matters is its scheduling contract: one step per task, input outranks
+// warming, an edit or view mode stops it, cancel stops it, and a failing step forfeits the
+// head start instead of throwing into the timer.
+
+import { describe, expect, test } from 'bun:test';
+import { createDerivationPrewarmSteps, scheduleDerivationPrewarm } from '../derivation-prewarm.ts';
+import { readOoxmlPart, usedParaIds, type OoxmlPart } from '../../store/index.ts';
+
+/** Manual scheduler: tasks run only when the test pumps, so ordering is explicit. */
+function manualScheduler(): {
+  schedule: (run: () => void, delayMs: number) => () => void;
+  pump: () => boolean;
+  pending: () => number;
+  delays: number[];
+} {
+  const queue: (() => void)[] = [];
+  const delays: number[] = [];
+  return {
+    schedule(run, delayMs) {
+      queue.push(run);
+      delays.push(delayMs);
+      return () => {
+        const at = queue.indexOf(run);
+        if (at >= 0) queue.splice(at, 1);
+      };
+    },
+    pump() {
+      const next = queue.shift();
+      if (!next) return false;
+      next();
+      return true;
+    },
+    pending: () => queue.length,
+    delays,
+  };
+}
+
+describe('scheduleDerivationPrewarm', () => {
+  test('runs every step, one per scheduled task', () => {
+    const timer = manualScheduler();
+    const ran: number[] = [];
+    scheduleDerivationPrewarm({
+      steps: [() => ran.push(0), () => ran.push(1), () => ran.push(2)],
+      shouldRun: () => true,
+      hasPendingInput: () => false,
+      schedule: timer.schedule,
+    });
+    expect(ran).toEqual([]);
+    while (timer.pump()) {
+      // At most one new step lands per pumped task.
+    }
+    expect(ran).toEqual([0, 1, 2]);
+    expect(timer.pending()).toBe(0);
+  });
+
+  test('stops between steps the moment shouldRun answers no', () => {
+    const timer = manualScheduler();
+    const ran: number[] = [];
+    let allowed = true;
+    scheduleDerivationPrewarm({
+      steps: [() => ran.push(0), () => ran.push(1)],
+      shouldRun: () => allowed,
+      hasPendingInput: () => false,
+      schedule: timer.schedule,
+    });
+    timer.pump();
+    expect(ran).toEqual([0]);
+    allowed = false;
+    while (timer.pump()) {
+      // The re-check happens inside the task, so the queue drains without running step 1.
+    }
+    expect(ran).toEqual([0]);
+  });
+
+  test('pending input defers the step and the deferral waits a frame, not zero', () => {
+    const timer = manualScheduler();
+    const ran: number[] = [];
+    let busy = true;
+    scheduleDerivationPrewarm({
+      steps: [() => ran.push(0)],
+      shouldRun: () => true,
+      hasPendingInput: () => busy,
+      schedule: timer.schedule,
+    });
+    timer.pump();
+    expect(ran).toEqual([]);
+    expect(timer.delays.at(-1)).toBeGreaterThan(0);
+    busy = false;
+    timer.pump();
+    expect(ran).toEqual([0]);
+  });
+
+  test('gives up after sustained input pressure instead of spinning forever', () => {
+    const timer = manualScheduler();
+    const ran: number[] = [];
+    scheduleDerivationPrewarm({
+      steps: [() => ran.push(0)],
+      shouldRun: () => true,
+      hasPendingInput: () => true,
+      schedule: timer.schedule,
+    });
+    let pumps = 0;
+    while (timer.pump()) {
+      pumps += 1;
+      if (pumps > 200) throw new Error('the warm must stop re-arming under constant input');
+    }
+    expect(ran).toEqual([]);
+  });
+
+  test('cancel stops the chain', () => {
+    const timer = manualScheduler();
+    const ran: number[] = [];
+    const cancel = scheduleDerivationPrewarm({
+      steps: [() => ran.push(0), () => ran.push(1)],
+      shouldRun: () => true,
+      hasPendingInput: () => false,
+      schedule: timer.schedule,
+    });
+    timer.pump();
+    cancel();
+    while (timer.pump()) {
+      // Nothing scheduled after cancel may run a step.
+    }
+    expect(ran).toEqual([0]);
+  });
+
+  test('a throwing step ends the warm without throwing into the scheduler', () => {
+    const timer = manualScheduler();
+    const ran: number[] = [];
+    scheduleDerivationPrewarm({
+      steps: [
+        () => {
+          throw new Error('derivation failed');
+        },
+        () => ran.push(1),
+      ],
+      shouldRun: () => true,
+      hasPendingInput: () => false,
+      schedule: timer.schedule,
+    });
+    expect(() => {
+      while (timer.pump()) {
+        // The failure must stay inside the task.
+      }
+    }).not.toThrow();
+    expect(ran).toEqual([]);
+  });
+});
+
+describe('createDerivationPrewarmSteps', () => {
+  const XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+  <w:body>
+    <w:p w14:paraId="1A2B3C4D"><w:r><w:t>alpha</w:t></w:r></w:p>
+    <w:p w14:paraId="2B3C4D5E"><w:r><w:t>beta</w:t></w:r></w:p>
+  </w:body>
+</w:document>`;
+
+  function loadPart(): OoxmlPart {
+    const result = readOoxmlPart(XML, { name: '/word/document.xml', contentType: 'app/xml' });
+    if (!result.ok) throw new Error(result.reason);
+    return result.part;
+  }
+
+  test('the steps run the real derivations and warm the same memo a mint reads', () => {
+    const part = loadPart();
+    const steps = createDerivationPrewarmSteps(() => part);
+    expect(steps.length).toBeGreaterThanOrEqual(3);
+    for (const step of steps) step();
+    // Warmed means: the set the first split will mint against is already derived, and a
+    // repeat read hands back the identical object instead of re-walking.
+    expect(usedParaIds(part.root)).toBe(usedParaIds(part.root));
+    expect([...usedParaIds(part.root)].sort()).toEqual(['1A2B3C4D', '2B3C4D5E']);
+  });
+});

--- a/packages/core/src/editor/__tests__/table-command-plan.test.ts
+++ b/packages/core/src/editor/__tests__/table-command-plan.test.ts
@@ -267,6 +267,40 @@ describe('table command planner and editor parity', () => {
     expect(editor.exec(cmd)).toEqual(can);
   });
 
+  test('caret in plain body text answers null table context, and flips with the caret', () => {
+    // The snapshot derive gates `tableContextAt` on the store's parent index: a caret whose
+    // paragraph provably has no tableCell ancestor must answer null WITHOUT building the
+    // layout's table index — and the gate must not change any answer. The document contains
+    // a table so the null is the gate's, not an empty document's.
+    const editor = mount(p('plain lead') + TABLE_2X2);
+    const surface = editor.surface!;
+    caret(surface, paragraphByText('plain lead', surface));
+    expect(editor.getSelectedTable()).toBeNull();
+    expect(editor.query({ type: 'tableContext' })).toBeNull();
+    expect(editor.snapshot().table).toBeNull();
+
+    // Into a cell: the full path answers with the exact table.
+    caret(surface, paragraphByText('B1', surface));
+    expect(editor.getSelectedTable()).toEqual({
+      blockId: expect.any(String),
+      rowCount: 2,
+      columnCount: 2,
+      cell: { row: 0, column: 1 },
+    });
+    expect(editor.query({ type: 'tableContext' })).toEqual({
+      rows: 2,
+      columns: 2,
+      rowIndex: 0,
+      columnIndex: 1,
+    });
+
+    // Back out: the gate answers null again for the same snapshot surface.
+    caret(surface, paragraphByText('plain lead', surface));
+    expect(editor.getSelectedTable()).toBeNull();
+    expect(editor.query({ type: 'tableContext' })).toBeNull();
+    expect(editor.snapshot().table).toBeNull();
+  });
+
   test('getSelectedTable and tableContext query return real values in a cell', () => {
     const editor = mount(TABLE_2X2);
     const surface = editor.surface!;

--- a/packages/core/src/editor/derivation-prewarm.ts
+++ b/packages/core/src/editor/derivation-prewarm.ts
@@ -1,0 +1,86 @@
+// Idle pre-warm of the store derivations a structural edit reads.
+//
+// The first Enter or Backspace after a document opens pays a one-time population of the
+// per-subtree memos behind `usedParaIds`, the deep paragraph order and the revision-site
+// walk — on a very large document that is a visible hitch on exactly the first structural
+// keystroke. Every one of those derivations is a pure function of the opened tree, so
+// running them once in an idle task after first paint moves the population off the
+// keystroke without changing any answer: the memos are keyed on immutable nodes, so a
+// pre-warmed entry can never be stale — an edit publishes new nodes and misses naturally.
+
+import { usedParaIds } from '../store/package/para-id.ts';
+import { deepParagraphOrderOfPart } from '../store/store/review-reads.ts';
+import { collectRevisionSites } from '../store/store/tree-op-revisions.ts';
+import type { OoxmlPart } from '../store/package/ooxml-tree.ts';
+
+/** One derivation per idle task, so no single warm chunk exceeds the largest derivation. */
+export function createDerivationPrewarmSteps(part: () => OoxmlPart): readonly (() => void)[] {
+  return [
+    () => void usedParaIds(part().root),
+    () => void deepParagraphOrderOfPart(part()),
+    () => void collectRevisionSites(part()),
+  ];
+}
+
+export interface DerivationPrewarmOptions {
+  readonly steps: readonly (() => void)[];
+  /** Re-checked before every step: view mode, a destroyed surface or an edit stops the warm. */
+  readonly shouldRun: () => boolean;
+  /** Real input outranks warming: a pending-input answer defers the step, never runs it. */
+  readonly hasPendingInput: () => boolean;
+  /** Injectable timer for tests; returns a cancel. Defaults to `setTimeout`. */
+  readonly schedule?: (run: () => void, delayMs: number) => () => void;
+}
+
+/** How often a step yields to pending input before the warm gives up entirely. A user who
+ * types continuously from the first frame pays the population on their first structural
+ * edit, exactly as before the warm existed — giving up is the pre-existing behavior. */
+const MAX_INPUT_DEFERRALS = 50;
+const INPUT_DEFERRAL_DELAY_MS = 16;
+
+/**
+ * Run the steps one per macrotask, yielding to pending input, and stop the moment
+ * `shouldRun` says no. Returns a cancel for teardown. Never throws into the scheduler: a
+ * failing derivation would fail identically — but user-visibly — on the first structural
+ * edit, so the warm only forfeits its head start.
+ */
+export function scheduleDerivationPrewarm(options: DerivationPrewarmOptions): () => void {
+  const schedule =
+    options.schedule ??
+    ((run: () => void, delayMs: number): (() => void) => {
+      const handle = setTimeout(run, delayMs);
+      return () => clearTimeout(handle);
+    });
+
+  let cancelled = false;
+  let cancelPending: (() => void) | null = null;
+  let deferrals = 0;
+  let index = 0;
+
+  const arm = (delayMs: number): void => {
+    cancelPending = schedule(() => {
+      cancelPending = null;
+      if (cancelled || index >= options.steps.length || !options.shouldRun()) return;
+      if (options.hasPendingInput()) {
+        deferrals += 1;
+        if (deferrals > MAX_INPUT_DEFERRALS) return;
+        arm(INPUT_DEFERRAL_DELAY_MS);
+        return;
+      }
+      try {
+        options.steps[index]!();
+      } catch {
+        return;
+      }
+      index += 1;
+      if (index < options.steps.length) arm(0);
+    }, delayMs);
+  };
+
+  arm(0);
+  return () => {
+    cancelled = true;
+    if (cancelPending) cancelPending();
+    cancelPending = null;
+  };
+}

--- a/packages/core/src/editor/docx-editor-derive.ts
+++ b/packages/core/src/editor/docx-editor-derive.ts
@@ -32,7 +32,7 @@ import {
   type TableCommandPlan,
   type TableCommandPlannerInput,
 } from './table-command-plan.ts';
-import { paragraphTextOf } from '@docx-editor.dev/core/store';
+import { findNode, paragraphTextOf, parentNodeOf } from '@docx-editor.dev/core/store';
 import { allParagraphs } from '../binding/tree-binding.ts';
 import { paragraphStyleId } from '../binding/document-outline.ts';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
@@ -484,6 +484,32 @@ export function gateCommand(
   return { ok: true };
 }
 
+/**
+ * Whether the caret's paragraph can possibly sit in a table — answered from the tree's
+ * O(1) node index, so the snapshot derive does not build the layout's whole table index
+ * (a walk over every placed cell of every page) just to learn the caret is in plain body
+ * text. Answers TRUE on any doubt — an unknown part, an unknown node, a demoted generic
+ * cell — so the full `tableContextAt` path keeps the final word.
+ */
+function caretMaybeInTableCell(surface: PaginatedSurface, paragraphId: string): boolean {
+  const part = surface.session.part();
+  // Only the body story's ids resolve against the body part; a header, footer or note
+  // paragraph falls through to the full path.
+  if (!paragraphId.startsWith(`${part.name}#`)) return true;
+  if (!findNode(part, paragraphId)) return true;
+  let current = parentNodeOf(part, paragraphId);
+  let hops = 0;
+  while (current) {
+    if (current.kind === 'tableCell') return true;
+    // A demoted table's cell is a generic `w:tc`; the layout will not index it as a
+    // table, but stay conservative and let the full path answer.
+    if (current.kind === 'generic' && current.localName === 'tc') return true;
+    if ((hops += 1) > 64) return true;
+    current = parentNodeOf(part, current.id);
+  }
+  return false;
+}
+
 export function selectedTableOf(surface: PaginatedSurface | null): {
   readonly blockId: string;
   readonly rowCount: number;
@@ -493,6 +519,7 @@ export function selectedTableOf(surface: PaginatedSurface | null): {
   if (!surface) return null;
   const state = surface.state();
   const cells = state.cellSelection;
+  if (!cells && !caretMaybeInTableCell(surface, state.selection.head.paragraphId)) return null;
   const context = tableContextAt(surface.layout(), state.selection.head.paragraphId);
   if (!context) return null;
   return {
@@ -519,6 +546,7 @@ export function tableContextOf(surface: PaginatedSurface | null): TableContext |
   const cells = state.cellSelection;
   // `selection` is a rectangle's own text range when one is live, so its head is inside the
   // table either way and one lookup serves both.
+  if (!cells && !caretMaybeInTableCell(surface, state.selection.head.paragraphId)) return null;
   const context = tableContextAt(surface.layout(), state.selection.head.paragraphId);
   if (!context) return null;
   return {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -174,6 +174,7 @@ import { createImageOps } from './surface-image-ops.ts';
 import { createHeaderFooterScopeController } from './surface-hf-editing.ts';
 import { createNoteOps } from './surface-note-ops.ts';
 import { notePropertiesStateOf, notePreviewTextOf } from './surface-note-state.ts';
+import { createDerivationPrewarmSteps, scheduleDerivationPrewarm } from './derivation-prewarm.ts';
 import { settingsPartOf } from '../store/package/note-properties.ts';
 import { resolveNotesPart } from '../store/package/note-references.ts';
 import type { OoxmlPart } from '../store/package/ooxml-tree.ts';
@@ -990,6 +991,25 @@ export function mountPaginatedSurface(
 
   let deferredPublishRender: ReturnType<typeof setTimeout> | null = null;
 
+  // Armed once, after the first published render: the derivations a structural edit reads
+  // populate their per-node memos in idle tasks instead of inside the first Enter. An edit
+  // before the warm finishes stops it (the edit's own reads populate the new root), and
+  // view mode never warms (nothing structural can be typed there).
+  let cancelDerivationPrewarm: (() => void) | null = null;
+  let derivationPrewarmArmed = false;
+
+  function armDerivationPrewarmOnce(): void {
+    if (derivationPrewarmArmed) return;
+    derivationPrewarmArmed = true;
+    const revisionAtArm = session.packageRevision();
+    cancelDerivationPrewarm = scheduleDerivationPrewarm({
+      steps: createDerivationPrewarmSteps(() => session.part()),
+      shouldRun: () =>
+        editingMode !== 'view' && session.editable && session.packageRevision() === revisionAtArm,
+      hasPendingInput: hasPendingBrowserInput,
+    });
+  }
+
   function hasPendingBrowserInput(): boolean {
     const scheduling = (
       container.ownerDocument.defaultView?.navigator as
@@ -1008,6 +1028,7 @@ export function mountPaginatedSurface(
       if (deferredPublishRender !== null) clearTimeout(deferredPublishRender);
       deferredPublishRender = null;
       render();
+      armDerivationPrewarmOnce();
       return;
     }
     // Layout stays synchronous so the next edit reads current geometry, but paint and DOM
@@ -1018,6 +1039,7 @@ export function mountPaginatedSurface(
     deferredPublishRender = setTimeout(() => {
       deferredPublishRender = null;
       render();
+      armDerivationPrewarmOnce();
     }, 0);
   }
 
@@ -4934,6 +4956,8 @@ export function mountPaginatedSurface(
       scheduler.cancel();
       if (deferredPublishRender !== null) clearTimeout(deferredPublishRender);
       deferredPublishRender = null;
+      if (cancelDerivationPrewarm) cancelDerivationPrewarm();
+      cancelDerivationPrewarm = null;
       drawingBundle.dispose();
       detachDrawingUrlRegistry(pagesLayer);
       caret.destroy();

--- a/packages/core/src/layout/__tests__/finalize-page-field-memo.test.ts
+++ b/packages/core/src/layout/__tests__/finalize-page-field-memo.test.ts
@@ -1,0 +1,236 @@
+// `finalizePageFieldProjection` is memoized per (immutable page record, page count).
+//
+// Contract under test:
+//   1. A memo hit returns the identical finalized record — two finalize passes over the SAME
+//      page records may not mint fresh projections (that is the incremental-pass cost the memo
+//      removes), and finalize over its own output is identity per page.
+//   2. A memo hit returns exactly what a recompute would — a finalize of structurally identical
+//      records that share nothing by identity deep-equals the memoized result.
+//   3. The page count is part of the key: the same page records under a different total must
+//      re-project, and flipping back must re-project again (one overwritten memo entry cannot
+//      keep answering for the other count).
+//
+// Pages with a live `pageFieldProjector` are pre-finalize records, which `layoutSemanticDocument`
+// never publishes — so the first three tests assemble them the way furniture attach does: a body
+// layout's pages plus a footer story record whose projector re-lays the story per context. The
+// last test drives the same memo through the public pipeline: one session, a field-bearing
+// footer, and an edit that changes the page count.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+  type PageFurniture,
+  type PageRecord,
+  type SemanticLayout,
+} from '../index.ts';
+import { finalizePageFieldProjection } from '../field-projection.ts';
+import { layoutHeaderFooterStory, type HeaderFooterStoryLayout } from '../hf-layout.ts';
+import type { HeaderFooterStoryRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+/** Section content width in points: 6000 − 200 − 200 twips. */
+const CONTENT_WIDTH = 280;
+
+/** Tight page geometry so a handful of one-line paragraphs already spills across pages. */
+const tightSectPr =
+  `<w:sectPr><w:pgSz w:w="6000" w:h="2400"/>` +
+  `<w:pgMar w:top="200" w:right="200" w:bottom="200" w:left="200" w:header="100" w:footer="100"/>` +
+  `</w:sectPr>`;
+
+function partOf(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const filler = (count: number, tag = 'f') =>
+  Array.from({ length: count }, (_, i) => `<w:p><w:r><w:t>${tag} ${i}</w:t></w:r></w:p>`).join('');
+
+/** Footer part carrying both PAGE and NUMPAGES so every finalize pass has real work. */
+function footerPart(): OoxmlPart {
+  const field = (instr: string) =>
+    `<w:r><w:fldChar w:fldCharType="begin"/><w:instrText>${instr}</w:instrText>` +
+    `<w:fldChar w:fldCharType="separate"/><w:t>0</w:t><w:fldChar w:fldCharType="end"/></w:r>`;
+  const result = readOoxmlPart(
+    `<w:ftr xmlns:w="${W}"><w:p><w:r><w:t xml:space="preserve">Page </w:t></w:r>${field('PAGE')}` +
+      `<w:r><w:t xml:space="preserve"> of </w:t></w:r>${field('NUMPAGES')}</w:p></w:ftr>`,
+    { name: '/word/footer1.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/**
+ * A pre-finalize footer record: fragments from the baseline story plus the projector furniture
+ * attach would install (the same shape `furnitureFor` in `semantic-layout.ts` builds).
+ */
+function fieldFooterRecord(part: OoxmlPart): HeaderFooterStoryRecord {
+  const story = layoutHeaderFooterStory(part, CONTENT_WIDTH, measurer, 'test');
+  const place = (laid: HeaderFooterStoryLayout): HeaderFooterStoryRecord => ({
+    kind: 'footer',
+    variant: 'default',
+    partName: laid.partName,
+    box: { x: 10, y: 100, width: CONTENT_WIDTH, height: laid.flowHeight },
+    fragments: laid.fragments,
+  });
+  return {
+    ...place(story),
+    pageFieldProjector: (context) => place(story.withPageContext(context)),
+  };
+}
+
+function footerText(layout: SemanticLayout, pageIndex: number): string {
+  const story = layout.pages[pageIndex]!.footer;
+  if (!story) return '';
+  return story.fragments
+    .flatMap((fragment) =>
+      fragment.kind === 'paragraph'
+        ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+        : []
+    )
+    .join('');
+}
+
+const lay = (part: OoxmlPart, revision: number, session?: ReturnType<typeof createLayoutSession>) =>
+  layoutSemanticDocument(part, revision, {
+    measurer,
+    producer: 'test',
+    ...(session ? { session } : {}),
+  });
+
+/** Multi-page body pages wearing one pre-finalize field footer each — the finalize input. */
+function unfinalizedLayoutOf(
+  base: SemanticLayout,
+  footer: HeaderFooterStoryRecord
+): SemanticLayout {
+  return { revision: base.revision, pages: base.pages.map((page) => ({ ...page, footer })) };
+}
+
+describe('finalizePageFieldProjection memo', () => {
+  test('a second finalize over the same page records returns the identical pages', () => {
+    const base = lay(partOf(filler(20) + tightSectPr), 1);
+    const total = base.pages.length;
+    expect(total).toBeGreaterThan(2);
+    const unfinalized = unfinalizedLayoutOf(base, fieldFooterRecord(footerPart()));
+
+    const first = finalizePageFieldProjection(unfinalized);
+    // The projection really ran: every sheet shows its own PAGE and the shared NUMPAGES.
+    expect(footerText(first, 0)).toBe(`Page 1 of ${total}`);
+    expect(footerText(first, total - 1)).toBe(`Page ${total} of ${total}`);
+    // Projected records lost their projector; the inputs still carry theirs.
+    expect(first.pages[0]!.footer?.pageFieldProjector).toBeUndefined();
+    expect(unfinalized.pages[0]!.footer?.pageFieldProjector).toBeDefined();
+
+    // The memo hit: without it every projector-bearing page mints a fresh record per pass.
+    const second = finalizePageFieldProjection(unfinalized);
+    first.pages.forEach((page, index) => expect(second.pages[index]).toBe(page));
+
+    // Finalize over its own output is identity per page (already-final records memo to
+    // themselves), which is what lets an incremental pass keep reused sheets stable.
+    const third = finalizePageFieldProjection(first);
+    first.pages.forEach((page, index) => expect(third.pages[index]).toBe(page));
+  });
+
+  test('a memo hit deep-equals a finalize of structurally identical fresh records', () => {
+    const bodyXml = filler(20) + tightSectPr;
+    const part = partOf(bodyXml);
+    const footer = footerPart();
+    const unfinalized = unfinalizedLayoutOf(lay(part, 1), fieldFooterRecord(footer));
+
+    const memoized = finalizePageFieldProjection(unfinalized);
+    // Warm the memo, then read through it a second time — THIS is the result under suspicion.
+    const throughMemo = finalizePageFieldProjection(unfinalized);
+    memoized.pages.forEach((page, index) => expect(throughMemo.pages[index]).toBe(page));
+
+    // The clean pass: structuredClone keeps every id and value but shares no object identity,
+    // so nothing the WeakMap memoized can leak into it (same discipline as the randomized
+    // store-driven oracle).
+    const fresh = finalizePageFieldProjection(
+      unfinalizedLayoutOf(lay(structuredClone(part), 1), fieldFooterRecord(structuredClone(footer)))
+    );
+    expect(fresh.pages.length).toBe(throughMemo.pages.length);
+    fresh.pages.forEach((page, index) => expect(page).not.toBe(throughMemo.pages[index]));
+    expect(JSON.stringify(throughMemo.pages)).toBe(JSON.stringify(fresh.pages));
+  });
+
+  test('the same page records under a different page count re-project, both ways', () => {
+    const base = lay(partOf(filler(20) + tightSectPr), 1);
+    const total = base.pages.length;
+    const unfinalized = unfinalizedLayoutOf(base, fieldFooterRecord(footerPart()));
+
+    // Memoize every page under `total`.
+    const first = finalizePageFieldProjection(unfinalized);
+    expect(footerText(first, 0)).toBe(`Page 1 of ${total}`);
+
+    // The SAME page records plus one extra sheet: sharing records across layouts of different
+    // lengths is constructible directly, so this is the strongest form of the invalidation
+    // assertion — a memo keyed on the record alone would keep answering `total`. The clone
+    // carries its own field source; finalize reads PAGE from it, not from `index`.
+    const extra: PageRecord = {
+      ...unfinalized.pages[total - 1]!,
+      index: total,
+      pageFieldSource: { pageNumber: total + 1, sectionPageCount: total + 1 },
+    };
+    const grown = finalizePageFieldProjection({
+      revision: 2,
+      pages: [...unfinalized.pages, extra],
+    });
+    expect(footerText(grown, 0)).toBe(`Page 1 of ${total + 1}`);
+    expect(footerText(grown, total)).toBe(`Page ${total + 1} of ${total + 1}`);
+    expect(grown.pages[0]).not.toBe(first.pages[0]);
+
+    // Back to the original length: the memo now holds `total + 1` for these records, so it
+    // must re-validate and re-project rather than serve the overwritten entry.
+    const shrunk = finalizePageFieldProjection(unfinalized);
+    expect(footerText(shrunk, 0)).toBe(`Page 1 of ${total}`);
+    expect(footerText(shrunk, total - 1)).toBe(`Page ${total} of ${total}`);
+  });
+
+  test('through the pipeline: a page-count edit updates NUMPAGES on an unchanged sheet', () => {
+    // Two sections, because that is the path where reused sheets still carry projectors at
+    // finalize time: the multi-section publish re-finalizes every pass, so a memo entry taken
+    // under the old total is what would serve the stale value here. (A single-section resume
+    // reuses already-finalized records, so it never re-projects furniture either way.)
+    const furniture: PageFurniture = {
+      titlePage: false,
+      evenAndOddHeaders: false,
+      headers: new Map(),
+      footers: new Map([
+        ['default', layoutHeaderFooterStory(footerPart(), CONTENT_WIDTH, measurer, 'test')],
+      ]),
+    };
+    const session = createLayoutSession();
+    const build = (tail: number) =>
+      partOf(
+        filler(12, 's0') +
+          `<w:p><w:pPr>${tightSectPr}</w:pPr><w:r><w:t>s0 end</w:t></w:r></w:p>` +
+          filler(tail, 's1') +
+          tightSectPr
+      );
+    const options = { measurer, session, sectionFurniture: [furniture, furniture] };
+
+    const first = layoutSemanticDocument(build(6), 1, options);
+    const firstTotal = first.pages.length;
+    expect(firstTotal).toBeGreaterThan(2);
+    expect(footerText(first, 0)).toBe(`Page 1 of ${firstTotal}`);
+
+    // Grow section 1: section 0's sheets are untouched, so a memo that ignored the page count
+    // would keep serving the stale total on them.
+    const second = layoutSemanticDocument(build(26), 2, options);
+    expect(second.pages.length).toBeGreaterThan(firstTotal);
+    expect(footerText(second, 0)).toBe(`Page 1 of ${second.pages.length}`);
+
+    // A count-stable pass returns the previous pages by identity — the memo hit path.
+    const third = layoutSemanticDocument(build(26), 3, options);
+    expect(third.pages.length).toBe(second.pages.length);
+    third.pages.forEach((page, index) => expect(page).toBe(second.pages[index]!));
+    expect(footerText(third, 0)).toBe(`Page 1 of ${third.pages.length}`);
+  });
+});

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -3,11 +3,14 @@ import {
   readOoxmlPackage,
   readOoxmlPart,
   type ImageResourceLookup,
+  type OoxmlNode,
 } from '@docx-editor.dev/core/store';
 import { zipSync, strToU8 } from 'fflate';
 import {
   createInlineDrawingLayoutBundle,
   drawingAtomIdentities,
+  drawingTokenForTableBlock,
+  drawingTokenForTableBlockMemo,
 } from '../inline-drawing-source.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -96,4 +99,109 @@ test('a slot hit resolves no package; a substrate change through sync still does
   bundle.sync(session);
   // Compatibility after a package move stays resetPackage's job — sync must still read.
   expect(packageReads).toBeGreaterThan(afterFirst);
+});
+
+// ── drawingTokenForTableBlockMemo ─────────────────────────────────────────────────────────
+// The table token exists to VALIDATE the table's prepared-block memo, so it used to be
+// recomputed (a full row/cell walk) before every hit. The memo keys on (immutable table
+// node, drawingLayoutEpoch); an undefined epoch means the caller cannot see resource moves,
+// so that path must stay a recompute.
+
+/** A table whose first cell paragraph carries an inline drawing; the second is plain text. */
+function tableWithDrawing(): OoxmlNode {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}" xmlns:wp="${WP}"><w:body><w:tbl>` +
+      '<w:tblGrid><w:gridCol w:w="2400"/><w:gridCol w:w="2400"/></w:tblGrid>' +
+      '<w:tr><w:tc><w:p><w:r><w:drawing>' +
+      '<wp:inline><wp:extent cx="914400" cy="914400"/></wp:inline></w:drawing></w:r></w:p></w:tc>' +
+      '<w:tc><w:p><w:r><w:t>plain</w:t></w:r></w:p></w:tc></w:tr>' +
+      '</w:tbl></w:body></w:document>',
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  const body = result.part.root.children.find(
+    (node) => node.kind !== 'textValue' && node.localName === 'body'
+  );
+  if (!body || body.kind === 'textValue') throw new Error('no body');
+  const table = body.children.find((node) => node.kind === 'table');
+  if (!table) throw new Error('no table');
+  return table;
+}
+
+/** Whether a paragraph subtree contains a `w:drawing` — the shape a real token fn keys on. */
+function paragraphHasDrawing(paragraph: OoxmlNode): boolean {
+  if (paragraph.kind === 'textValue') return false;
+  if (paragraph.localName === 'drawing') return true;
+  return paragraph.children.some((child) => paragraphHasDrawing(child));
+}
+
+function countedTokenFn(): { fn: (paragraph: OoxmlNode) => string; calls: () => number } {
+  let calls = 0;
+  return {
+    fn: (paragraph) => {
+      calls += 1;
+      return paragraphHasDrawing(paragraph) ? `drawing@${paragraph.id}` : '';
+    },
+    calls: () => calls,
+  };
+}
+
+test('memoized table drawing token equals a direct recompute under a fixed epoch', () => {
+  const table = tableWithDrawing();
+  const memoSide = countedTokenFn();
+  const directSide = countedTokenFn();
+
+  const memoized = drawingTokenForTableBlockMemo(table, 'epoch-1', memoSide.fn);
+  const direct = drawingTokenForTableBlock(table, directSide.fn);
+  expect(memoized).toBe(direct);
+  expect(memoized).toContain('drawing@');
+  // Both sides walked every paragraph of the subtree exactly once.
+  expect(memoSide.calls()).toBe(directSide.calls());
+});
+
+test('same node and same epoch answers from the cache without re-walking', () => {
+  const table = tableWithDrawing();
+  const counted = countedTokenFn();
+
+  const first = drawingTokenForTableBlockMemo(table, 'epoch-1', counted.fn);
+  const walkCost = counted.calls();
+  expect(walkCost).toBeGreaterThan(0);
+
+  const second = drawingTokenForTableBlockMemo(table, 'epoch-1', counted.fn);
+  expect(second).toBe(first);
+  expect(counted.calls()).toBe(walkCost);
+});
+
+test('an epoch change recomputes', () => {
+  const table = tableWithDrawing();
+  const counted = countedTokenFn();
+
+  const first = drawingTokenForTableBlockMemo(table, 'epoch-1', counted.fn);
+  const walkCost = counted.calls();
+
+  const second = drawingTokenForTableBlockMemo(table, 'epoch-2', counted.fn);
+  expect(second).toBe(first);
+  expect(counted.calls()).toBe(walkCost * 2);
+
+  // The recompute re-armed the cache under the new epoch.
+  drawingTokenForTableBlockMemo(table, 'epoch-2', counted.fn);
+  expect(counted.calls()).toBe(walkCost * 2);
+});
+
+test('an undefined epoch always recomputes and never reads or arms the cache', () => {
+  const table = tableWithDrawing();
+  const counted = countedTokenFn();
+
+  drawingTokenForTableBlockMemo(table, undefined, counted.fn);
+  const walkCost = counted.calls();
+  drawingTokenForTableBlockMemo(table, undefined, counted.fn);
+  expect(counted.calls()).toBe(walkCost * 2);
+
+  // Nothing was armed: the first epoch-carrying call still pays a walk.
+  drawingTokenForTableBlockMemo(table, 'epoch-1', counted.fn);
+  expect(counted.calls()).toBe(walkCost * 3);
+
+  // A warm epoch entry does not leak into the epoch-free path either.
+  drawingTokenForTableBlockMemo(table, undefined, counted.fn);
+  expect(counted.calls()).toBe(walkCost * 4);
 });

--- a/packages/core/src/layout/__tests__/randomized-store-driven-layout.test.ts
+++ b/packages/core/src/layout/__tests__/randomized-store-driven-layout.test.ts
@@ -49,8 +49,10 @@ import {
   layoutSemanticDocument,
   type LayoutSession,
   type NumberingIndex,
+  type PageFurniture,
   type SemanticLayout,
 } from '../index.ts';
+import { layoutHeaderFooterStory } from '../hf-layout.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -99,6 +101,52 @@ const TABLE =
   `<w:tc><w:p><w:r><w:t>cell b</w:t></w:r></w:p></w:tc></w:tr>` +
   `<w:tr><w:tc><w:p><w:r><w:t>cell c</w:t></w:r></w:p></w:tc>` +
   `<w:tc><w:p><w:r><w:t>cell d</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`;
+
+// A STATIC default header carrying PAGE and NUMPAGES rides every page of both sections. The
+// random edits never target it — it exists so the per-page field finalize (and its memo on
+// reused page records) sits inside the differential: page-count moves must re-project the
+// header on every reused sheet, and `publishedShapeOf` serializes the furniture too.
+const HEADER_PART_XML = (() => {
+  const field = (instr: string) =>
+    `<w:r><w:fldChar w:fldCharType="begin"/><w:instrText>${instr}</w:instrText>` +
+    `<w:fldChar w:fldCharType="separate"/><w:t>0</w:t><w:fldChar w:fldCharType="end"/></w:r>`;
+  return (
+    `<w:hdr xmlns:w="${W}"><w:p><w:r><w:t xml:space="preserve">Page </w:t></w:r>${field('PAGE')}` +
+    `<w:r><w:t xml:space="preserve"> of </w:t></w:r>${field('NUMPAGES')}</w:p></w:hdr>`
+  );
+})();
+
+/** Section content width in points: 6000 − 200 − 200 twips. */
+const HEADER_CONTENT_WIDTH = 280;
+
+/**
+ * Fresh furniture from a header part. The incremental pass retains ONE furniture object (as a
+ * live session would); each clean pass builds its own from a `structuredClone` of the same part
+ * — same ids and content, all-new objects — so no story-keyed cache can be shared either.
+ */
+function headerFurnitureOf(headerPart: OoxmlPart): PageFurniture {
+  return {
+    titlePage: false,
+    evenAndOddHeaders: false,
+    headers: new Map([
+      ['default', layoutHeaderFooterStory(headerPart, HEADER_CONTENT_WIDTH, measurer, 'test')],
+    ]),
+    footers: new Map(),
+  };
+}
+
+/** The projected header text of one page, for the anti-vacuity check below. */
+function headerTextOf(layout: SemanticLayout, pageIndex: number): string {
+  const story = layout.pages[pageIndex]?.header;
+  if (!story) return '';
+  return story.fragments
+    .flatMap((fragment) =>
+      fragment.kind === 'paragraph'
+        ? fragment.lines.flatMap((line) => line.spans.map((span) => span.text))
+        : []
+    )
+    .join('');
+}
 
 function initialDocumentPart(): OoxmlPart {
   const words = 'word '.repeat(8);
@@ -318,10 +366,18 @@ const STEPS = 30;
 
 const NUMBERING = numberingIndexForTest();
 
-const lay = (part: OoxmlPart, revision: number, session?: LayoutSession): SemanticLayout =>
+const lay = (
+  part: OoxmlPart,
+  revision: number,
+  furniture: PageFurniture,
+  session?: LayoutSession
+): SemanticLayout =>
   layoutSemanticDocument(part, revision, {
     measurer,
     numberingIndex: NUMBERING,
+    // Both sections wear the same default header; the section count is pinned at two (the
+    // section carrier is never joined or deleted), so the array stays index-aligned.
+    sectionFurniture: [furniture, furniture],
     ...(session ? { session } : {}),
   });
 
@@ -333,9 +389,17 @@ describe('store-driven incremental layout equals from-scratch layout on random o
       const session = createLayoutSession();
       const log: unknown[] = [];
 
+      const headerPart = loadPart(HEADER_PART_XML, '/word/header1.xml');
+      const retainedFurniture = headerFurnitureOf(headerPart);
+
       let revision = 1;
-      const first = lay(store.part, revision, session);
+      const first = lay(store.part, revision, retainedFurniture, session);
       expect(first.pages.length).toBeGreaterThan(1);
+      // The header really carries live page fields, or the finalize memo is invisible here.
+      expect(headerTextOf(first, 0)).toBe(`Page 1 of ${first.pages.length}`);
+      expect(headerTextOf(first, first.pages.length - 1)).toBe(
+        `Page ${first.pages.length} of ${first.pages.length}`
+      );
       // The observation contract: the prepass shape must be visible from step 0, or every
       // identity floor below would be measuring nothing.
       let previousPrepasses = sectionSessionsOf(session).map((s) => s.prepass);
@@ -364,7 +428,7 @@ describe('store-driven incremental layout equals from-scratch layout on random o
         applied += 1;
         revision += 1;
 
-        const incremental = publishedShapeOf(lay(store.part, revision, session));
+        const incremental = publishedShapeOf(lay(store.part, revision, retainedFurniture, session));
         if (session.stats.reusedPages > 0) reusedSteps += 1;
         if (session.stats.placed < session.stats.total) partialSteps += 1;
 
@@ -388,8 +452,12 @@ describe('store-driven incremental layout equals from-scratch layout on random o
         previousEntries = new Set(entries);
 
         // The clean pass: same ids, same content, all-new node objects — nothing
-        // identity-keyed can be shared with the incremental pass.
-        const fresh = publishedShapeOf(lay(structuredClone(store.part), revision));
+        // identity-keyed can be shared with the incremental pass. Furniture too: a fresh
+        // story from a cloned header part, so the finalize memo (keyed on the incremental
+        // pass's page records) cannot answer for any clean page.
+        const fresh = publishedShapeOf(
+          lay(structuredClone(store.part), revision, headerFurnitureOf(structuredClone(headerPart)))
+        );
         if (incremental !== fresh) {
           throw new Error(
             `Store-driven incremental layout diverged from a clean pass.\n` +

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -353,6 +353,10 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
       page.hasBodyPageFields === false
         ? page.fragments
         : substituteBodyPageFields(page.fragments, context);
+    // Reachable only for pages with NO live projector and NO body substitution: `project`
+    // always mints a fresh record for a projector-bearing story (the rest-spread above), so
+    // this identity entry can never publish — or memoize as final — a record that still
+    // carries a `pageFieldProjector`.
     if (header === page.header && footer === page.footer && fragments === page.fragments) {
       finalizedPageMemos.set(page, { pageCount, result: page });
       return page;

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -293,6 +293,20 @@ export function substituteBodyPageFields(
 }
 
 /**
+ * Finalized projection of one page under one total page count, memoized on the immutable
+ * page record.
+ *
+ * The whole per-page finalize is a pure function of the page record and `pageCount`: the
+ * field context reads `pageFieldSource` and `index` off the record, and the story
+ * projectors are deterministic closures the story layout minted. Without this memo an
+ * incremental pass that reused 555 of 561 pages by identity still re-projected all 561 —
+ * including a header/footer story RE-LAYOUT for every sheet whose furniture carries a PAGE
+ * field — and then threw 555 of those fresh records away when the previous finalized
+ * identities were restored. Same idiom as `publishedPageMemos` in `multi-section-layout.ts`.
+ */
+const finalizedPageMemos = new WeakMap<PageRecord, { pageCount: number; result: PageRecord }>();
+
+/**
  * Project allowlisted PAGE/NUMPAGES/SECTIONPAGES once the document page count is known.
  *
  * Header/footer furniture substitutes through each story's transient projector. Body flow (and
@@ -307,6 +321,11 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
 
   let changed = false;
   const pages = layout.pages.map((page) => {
+    const memo = finalizedPageMemos.get(page);
+    if (memo && memo.pageCount === pageCount) {
+      if (memo.result !== page) changed = true;
+      return memo.result;
+    }
     const source = page.pageFieldSource;
     const context: FieldPageContext = {
       pageNumber: source?.pageNumber ?? page.index + 1,
@@ -335,15 +354,18 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
         ? page.fragments
         : substituteBodyPageFields(page.fragments, context);
     if (header === page.header && footer === page.footer && fragments === page.fragments) {
+      finalizedPageMemos.set(page, { pageCount, result: page });
       return page;
     }
     if (fragments !== page.fragments) changed = true;
-    return {
+    const result: PageRecord = {
       ...page,
       ...(header !== undefined ? { header } : {}),
       ...(footer !== undefined ? { footer } : {}),
       ...(fragments !== page.fragments ? { fragments } : {}),
     };
+    finalizedPageMemos.set(page, { pageCount, result });
+    return result;
   });
 
   return changed ? { revision: layout.revision, pages } : layout;

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -675,6 +675,36 @@ export function paragraphDrawingLayoutTokenFromContext(
     .join(';');
 }
 
+/**
+ * `drawingTokenForTableBlock` memoized per (immutable table node, drawing epoch).
+ *
+ * The table token exists to VALIDATE the prepass memo, so it is recomputed before every
+ * memo hit — which walked every row and cell of every table on every layout pass. The
+ * token is a pure function of the table subtree (node identity) and the part's drawing
+ * projection/resource state, and `drawingLayoutEpoch` already stands in for the latter
+ * (it moves whenever any projection or resource in the part does). No epoch means the
+ * caller cannot see resource moves, so the recompute path is kept — the same rule the
+ * section prepass memo follows.
+ */
+export function drawingTokenForTableBlockMemo(
+  table: OoxmlNode,
+  epoch: string | undefined,
+  drawingTokenForParagraph: (paragraph: OoxmlNode) => string
+): string {
+  if (epoch === undefined) return drawingTokenForTableBlock(table, drawingTokenForParagraph);
+  const cached = tableDrawingTokenCache.get(table);
+  if (cached && cached.epoch === epoch) return cached.token;
+  const token = drawingTokenForTableBlock(table, drawingTokenForParagraph);
+  tableDrawingTokenCache.set(table, { epoch, token });
+  return token;
+}
+
+/** Aggregated drawing token per immutable table node, valid for one drawing epoch. */
+const tableDrawingTokenCache = new WeakMap<
+  OoxmlNode,
+  { readonly epoch: string; readonly token: string }
+>();
+
 /** Aggregate per-paragraph drawing tokens for a table subtree (cache + incremental keys). */
 export function drawingTokenForTableBlock(
   table: OoxmlNode,

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -496,6 +496,19 @@ function createPartDrawingContextSlot(options: {
   };
 }
 
+/**
+ * Monotonic PROCESS-WIDE slot mint, folded into `cacheTokenForPart`: a slot's own epoch
+ * counters restart at zero when a reset recreates it, so `part|0|0|N` would recur and an
+ * epoch-keyed consumer (the section prepass memo, {@link tableDrawingTokenCache}) could
+ * validate against a stale token. A fresh mint per created slot makes every recreation
+ * observably different, which fails safe — one extra rebuild, never a stale reuse.
+ *
+ * Process-wide, not per-bundle: {@link tableDrawingTokenCache} is module-level, so two
+ * bundles that see the same node objects must never emit the same epoch string for
+ * different resource states.
+ */
+let slotMintCounter = 0;
+
 export function createInlineDrawingLayoutBundle(
   options: CreateInlineDrawingLayoutBundleOptions
 ): InlineDrawingLayoutBundle {
@@ -508,12 +521,6 @@ export function createInlineDrawingLayoutBundle(
     });
   const slots = new Map<string, PartDrawingContextSlot>();
   const partByName = new Map<string, OoxmlPart>();
-  // Monotonic per-bundle slot mint, folded into `cacheTokenForPart`: a slot's own epoch
-  // counters restart at zero when a reset recreates it, so `part|0|0|N` would recur and an
-  // epoch-keyed consumer (the section prepass memo) could validate against a stale token.
-  // A fresh mint per created slot makes every recreation observably different, which fails
-  // safe — one extra rebuild, never a stale reuse.
-  let slotMints = 0;
   const slotMintBySlot = new WeakMap<PartDrawingContextSlot, number>();
   const handlesByKey = new Map<string, ValidatedImageBytesHandle>();
   const releaseTokensByKey = new Map<string, ValidatedImageBytesReleaseToken>();
@@ -561,8 +568,8 @@ export function createInlineDrawingLayoutBundle(
       forgetReadyHandle,
     });
     slots.set(ownerPartName, slot);
-    slotMints += 1;
-    slotMintBySlot.set(slot, slotMints);
+    slotMintCounter += 1;
+    slotMintBySlot.set(slot, slotMintCounter);
     return slot;
   };
 

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -130,7 +130,7 @@ import {
   MAX_DRAWING_EXCLUSION_REFLOW_PASSES,
 } from './drawing-exclusion.ts';
 import { drawingModelOffsetsInParagraph } from './drawing-layout.ts';
-import { drawingTokenForTableBlock } from './inline-drawing-source.ts';
+import { drawingTokenForTableBlockMemo } from './inline-drawing-source.ts';
 import { projectDrawingsInPart } from '../store/package/drawing-projection.ts';
 import {
   emptyTocPlaceholderParagraphIds,
@@ -987,7 +987,11 @@ function layoutBlocksPass(
       block.kind === 'paragraph'
         ? (options.drawingTokenForParagraph?.(block) ?? options.drawingLayoutToken ?? '')
         : block.kind === 'table' && options.drawingTokenForParagraph
-          ? drawingTokenForTableBlock(block, options.drawingTokenForParagraph)
+          ? drawingTokenForTableBlockMemo(
+              block,
+              options.drawingLayoutEpoch,
+              options.drawingTokenForParagraph
+            )
           : '';
     // A TABLE'S LIST STATE IS ITS CELLS'. `listItems` is keyed by PARAGRAPH, and a numbered
     // list that continues inside a table cell has its markers there — so reading the table's

--- a/packages/core/src/store/__tests__/derivation-memo-freshness.test.ts
+++ b/packages/core/src/store/__tests__/derivation-memo-freshness.test.ts
@@ -1,0 +1,260 @@
+// Derivation freshness under structural edits: `usedParaIds`, `deepParagraphOrderOfPart`
+// and `revisionItemsOf` compose from per-subtree memos in module-level WeakMaps keyed on
+// node OBJECTS, and a store edit shares every untouched subtree by reference across
+// revisions — so a stale entry would be read back by any pass over the same nodes,
+// including the one that checks it.
+//
+// The clean side of the differential therefore derives over a structuredClone of the part:
+// same content, all-new node objects, so nothing identity-keyed can be shared with the
+// memoized side. Node ids are plain data properties (minted as `${partName}#${path}` at
+// parse, and by the transaction's id counter afterwards), so the clone carries the
+// ORIGINAL ids and both the paragraph-order map and the revision items compare by value.
+//
+// Two fixtures: an untracked one, where the revision read must answer [] at every step
+// (the empty early return in front of the site index), and a tracked one seeded with
+// `w:ins`/`w:del` plus tracked insertions in the op vocabulary, where the read must keep
+// answering the full card list.
+//
+// Determinism: fixed seeds and a pure inline PRNG (mulberry32). A failure prints the seed
+// and the accumulated op script, which replays the exact sequence.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  deepParagraphOrderOfPart,
+  paragraphTextOf,
+  readOoxmlPart,
+  revisionItemsOf,
+  TreeDocumentStore,
+  usedParaIds,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+  type TreeDocOp,
+} from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+
+function loadPart(xml: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/** Deterministic PRNG. Same seed, same sequence, every run, every machine. */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+// Every paragraph carries authored identity and the root binds w14, so every applied
+// split MINTS a fresh paraId against the memoized set — without identity the id half of
+// the oracle would never move.
+
+const paraIdFor = (index: number): string => (0x4c0a0001 + index).toString(16).toUpperCase();
+
+const para = (index: number, text: string, extra = ''): string =>
+  `<w:p w14:paraId="${paraIdFor(index)}" w14:textId="${paraIdFor(index)}">` +
+  `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>${extra}</w:p>`;
+
+const INS =
+  `<w:ins w:id="101" w:author="QA Reviewer" w:date="2026-01-01T00:00:00Z">` +
+  `<w:r><w:t xml:space="preserve"> added words</w:t></w:r></w:ins>`;
+const DEL =
+  `<w:del w:id="102" w:author="QA Reviewer" w:date="2026-01-02T00:00:00Z">` +
+  `<w:r><w:delText xml:space="preserve"> removed words</w:delText></w:r></w:del>`;
+
+function fixturePart(tracked: boolean): OoxmlPart {
+  const words = 'word '.repeat(6);
+  const body = Array.from({ length: 10 }, (_, i) =>
+    para(i, `p${i} ${words}`, tracked && i === 2 ? INS : tracked && i === 5 ? DEL : '')
+  ).join('');
+  return loadPart(
+    `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>${body}</w:body></w:document>`
+  );
+}
+
+// ── Reading the retained tree ──────────────────────────────────────────────────
+
+function* walk(node: OoxmlNode): Generator<OoxmlNode> {
+  yield node;
+  if (node.kind === 'textValue') return;
+  for (const child of node.children ?? []) yield* walk(child);
+}
+
+function paragraphSitesOf(part: OoxmlPart): { id: string; length: number }[] {
+  const sites: { id: string; length: number }[] = [];
+  for (const node of walk(part.root)) {
+    if (node.kind !== 'paragraph') continue;
+    sites.push({ id: node.id, length: paragraphTextOf(part, node.id)?.length ?? 0 });
+  }
+  return sites;
+}
+
+/** Adjacent (first, second) paragraph pairs among the body's direct children. */
+function adjacentBodyParagraphPairs(part: OoxmlPart): [string, string][] {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  );
+  const pairs: [string, string][] = [];
+  const children = body?.children ?? [];
+  for (let index = 0; index + 1 < children.length; index += 1) {
+    const first = children[index]!;
+    const second = children[index + 1]!;
+    if (first.kind === 'paragraph' && second.kind === 'paragraph') {
+      pairs.push([first.id, second.id]);
+    }
+  }
+  return pairs;
+}
+
+// ── Op vocabulary ──────────────────────────────────────────────────────────────
+// Generated against the CURRENT tree, so ids and offsets are usually valid; the store may
+// still refuse (a delete crossing tracked content, a join it will not perform). A refusal
+// is logged and skipped, and the applied-op floor below keeps the test from passing by
+// refusing everything.
+
+type OpKind = 'insert-text' | 'delete-text' | 'split' | 'join' | 'tracked-insert';
+
+const PLAIN_OPS: readonly OpKind[] = [
+  'insert-text',
+  'insert-text',
+  'delete-text',
+  'split',
+  'split',
+  'join',
+];
+const TRACKED_OPS: readonly OpKind[] = [...PLAIN_OPS, 'tracked-insert', 'tracked-insert'];
+
+function randomOp(
+  part: OoxmlPart,
+  rand: () => number,
+  step: number,
+  tracked: boolean
+): TreeDocOp | null {
+  const pick = <T>(items: readonly T[]): T => items[Math.floor(rand() * items.length)]!;
+  const sites = paragraphSitesOf(part);
+  if (sites.length === 0) return null;
+  const site = pick(sites);
+  switch (pick(tracked ? TRACKED_OPS : PLAIN_OPS)) {
+    case 'insert-text':
+      return {
+        op: 'insertText',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+        text: ` step${step} extra`,
+      };
+    case 'tracked-insert':
+      return {
+        op: 'insertText',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+        text: ` step${step} proposal`,
+        revision: { author: 'QA Reviewer', date: '2026-01-03T00:00:00Z' },
+      };
+    case 'delete-text': {
+      if (site.length < 2) return null;
+      const start = Math.floor(rand() * (site.length - 1));
+      const end = start + 1 + Math.floor(rand() * (site.length - start - 1));
+      return { op: 'deleteText', paragraphId: site.id, start, end };
+    }
+    case 'split':
+      return {
+        op: 'splitParagraph',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+      };
+    case 'join': {
+      const pairs = adjacentBodyParagraphPairs(part);
+      if (pairs.length === 0) return null;
+      const [firstId, secondId] = pick(pairs);
+      return { op: 'joinParagraphs', firstId, secondId };
+    }
+  }
+}
+
+// ── The oracle ─────────────────────────────────────────────────────────────────
+
+/** Memoized derivations over the retained part vs the same derivations over a clone. */
+function assertFreshDerivations(
+  store: TreeDocumentStore,
+  seed: number,
+  step: number,
+  log: unknown[]
+): void {
+  const clone = structuredClone(store.part);
+  const comparisons: [string, unknown, unknown][] = [
+    ['usedParaIds', [...usedParaIds(store.part.root)].sort(), [...usedParaIds(clone.root)].sort()],
+    [
+      'deepParagraphOrderOfPart',
+      [...deepParagraphOrderOfPart(store.part).entries()],
+      [...deepParagraphOrderOfPart(clone).entries()],
+    ],
+    ['revisionItemsOf', revisionItemsOf(store.part), revisionItemsOf(clone)],
+  ];
+  for (const [name, memoized, fresh] of comparisons) {
+    const memoizedJson = JSON.stringify(memoized);
+    const freshJson = JSON.stringify(fresh);
+    if (memoizedJson !== freshJson) {
+      throw new Error(
+        `${name} over the retained tree diverged from the clone derivation.\n` +
+          `seed: ${seed}, step: ${step}\nmemoized: ${memoizedJson}\nfresh: ${freshJson}\n` +
+          `replay script:\n${JSON.stringify(log)}`
+      );
+    }
+  }
+}
+
+const SEEDS = [0xc0ffee, 42, 20260825];
+const STEPS = 30;
+
+describe('per-subtree derivation memos stay fresh across random op sequences', () => {
+  for (const tracked of [false, true]) {
+    for (const seed of SEEDS) {
+      test(`${tracked ? 'tracked' : 'untracked'} fixture, seed ${seed}: ${STEPS} random ops`, () => {
+        const rand = mulberry32(seed);
+        const store = new TreeDocumentStore(fixturePart(tracked));
+        const log: unknown[] = [];
+
+        // The fixture's authored identity must have parsed, or splits mint nothing and
+        // the id half of the oracle measures a constant.
+        expect(usedParaIds(store.part.root).size).toBe(10);
+        if (tracked) expect(revisionItemsOf(store.part).length).toBeGreaterThanOrEqual(2);
+        else expect(revisionItemsOf(store.part)).toEqual([]);
+
+        let applied = 0;
+        let splitsApplied = 0;
+        for (let step = 0; step < STEPS; step += 1) {
+          const op = randomOp(store.part, rand, step, tracked);
+          if (op === null) {
+            log.push(['skip', step]);
+            continue;
+          }
+          const result = store.transact((tx) => {
+            tx.apply(op);
+          });
+          if (!result.ok) {
+            log.push(['refused', step, result.reason, op]);
+            continue;
+          }
+          log.push([step, op]);
+          applied += 1;
+          if (op.op === 'splitParagraph') splitsApplied += 1;
+          assertFreshDerivations(store, seed, step, log);
+        }
+
+        // Anti-vacuity: enough ops applied, and enough splits that fresh paraIds were
+        // minted against — and then read back through — the memoized set.
+        expect(applied).toBeGreaterThanOrEqual(15);
+        expect(splitsApplied).toBeGreaterThanOrEqual(2);
+      });
+    }
+  }
+});

--- a/packages/core/src/store/__tests__/para-id.test.ts
+++ b/packages/core/src/store/__tests__/para-id.test.ts
@@ -15,6 +15,7 @@ import {
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
 import { readOoxmlPackage } from '../package/ooxml-package.ts';
+import { TreeDocumentStore } from '../store/tree-store.ts';
 import {
   isValidParaId,
   mintParaId,
@@ -263,5 +264,44 @@ describe('normalizeParagraphIdentity', () => {
     const reopened = loadDocument(serializeOoxmlPart(normalized));
     expect(canonicalOoxmlFingerprint(reopened)).toBe(canonicalOoxmlFingerprint(normalized));
     expect(usedParaIds(reopened.root)).toEqual(usedParaIds(normalized.root));
+  });
+});
+
+describe('usedParaIds', () => {
+  test('after a store split, the memoized set over the new root equals a full walk', () => {
+    // `usedParaIds` composes from per-subtree memos, and a split shares the untouched
+    // sibling paragraph by reference — so a stale entry would surface exactly here, as a
+    // set that misses the id the split just minted against it.
+    const part = loadDocument(
+      `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>` +
+        '<w:p w14:paraId="4C000001" w14:textId="4C000001"><w:r><w:t>alphaomega</w:t></w:r></w:p>' +
+        '<w:p w14:paraId="4C000002" w14:textId="4C000002"><w:r><w:t>second</w:t></w:r></w:p>' +
+        '</w:body></w:document>'
+    );
+    const store = new TreeDocumentStore(part);
+    // Warm the memo on the pre-split root, so the post-split read cannot pass by
+    // recomputing from scratch.
+    expect(usedParaIds(store.part.root)).toEqual(new Set(['4C000001', '4C000002']));
+    const firstParagraphId = wmlParagraphs(store.part)[0]!.id;
+    const result = store.transact((tx) => {
+      tx.apply({ op: 'splitParagraph', paragraphId: firstParagraphId, offset: 5 });
+    });
+    expect(result.ok).toBe(true);
+
+    // The oracle: an unmemoized full walk of the new root.
+    const walked = new Set<string>();
+    const visit = (node: OoxmlNode): void => {
+      if (node.kind === 'textValue') return;
+      const value = paraIdOf(node);
+      if (value !== null && isValidParaId(value)) walked.add(value.toUpperCase());
+      for (const child of node.children) visit(child);
+    };
+    visit(store.part.root);
+
+    expect(usedParaIds(store.part.root)).toEqual(walked);
+    expect(walked.size).toBe(3);
+    const minted = [...walked].filter((id) => id !== '4C000001' && id !== '4C000002');
+    expect(minted).toHaveLength(1);
+    expect(isValidParaId(minted[0]!)).toBe(true);
   });
 });

--- a/packages/core/src/store/__tests__/review-reads.test.ts
+++ b/packages/core/src/store/__tests__/review-reads.test.ts
@@ -253,6 +253,42 @@ describe('a card id names the part it lives in', () => {
   });
 });
 
+describe('a document with no tracked changes', () => {
+  // The read answers [] without building the site-location index — so the guard here is
+  // that the shortcut is taken only when there is truly nothing, and a tracked insertion
+  // written afterwards still surfaces.
+  test('reads an empty array, and a tracked insertion then surfaces', () => {
+    const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+        `<w:p><w:r><w:t>plain words only</w:t></w:r></w:p>` +
+        `</w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    const store = new TreeDocumentStore(result.part);
+    expect(revisionItemsOf(store.part)).toEqual([]);
+
+    const paragraphId = [...deepParagraphOrderOfPart(store.part).keys()][0]!;
+    const applied = store.transact((tx) => {
+      tx.apply({
+        op: 'insertText',
+        paragraphId,
+        offset: 5,
+        text: 'MORE',
+        revision: { author: 'QA Reviewer', date: '2026-01-01T00:00:00Z' },
+      });
+    });
+    expect(applied.ok).toBe(true);
+
+    const items = revisionItemsOf(store.part);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.revisionKind).toBe('insert');
+    expect(items[0]!.text).toBe('MORE');
+    expect(items[0]!.ranges[0]!.start.paragraphId).toBe(paragraphId);
+  });
+});
+
 describe('the revision-card memo is keyed on the part, not just its root', () => {
   test('two parts sharing one root under different names each get their own part name', () => {
     const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';

--- a/packages/core/src/store/package/para-id.ts
+++ b/packages/core/src/store/package/para-id.ts
@@ -80,18 +80,44 @@ export function mintParaId(seed: string, used: ReadonlySet<string>): string {
 
 const usedParaIdCache = new WeakMap<OoxmlElement, ReadonlySet<string>>();
 
+/** One shared empty list for the (vast) majority of subtrees that carry no paraId. */
+const EMPTY_PARA_IDS: readonly string[] = Object.freeze([]);
+
+/**
+ * Valid paraIds under one immutable node, in document pre-order, uppercased.
+ *
+ * Per-NODE memo: an edit shares every untouched subtree by reference, so recomputing the
+ * root set after a split touches only the rebuilt spine and reuses every sibling block's
+ * cached list. The full walk this composes replaced was O(document) per fresh root, which
+ * every structural keystroke paid inside `applyOps` (a split mints its new id against this
+ * set). Subtrees with no id share one frozen empty list, so the memo costs nothing where
+ * there is nothing to remember.
+ */
+const subtreeParaIdsCache = new WeakMap<OoxmlNode, readonly string[]>();
+
+function subtreeParaIds(node: OoxmlNode): readonly string[] {
+  if (node.kind === 'textValue') return EMPTY_PARA_IDS;
+  const cached = subtreeParaIdsCache.get(node);
+  if (cached) return cached;
+  let found: string[] | null = null;
+  const value = paraIdOf(node);
+  if (value !== null && isValidParaId(value)) (found ??= []).push(value.toUpperCase());
+  for (const child of node.children) {
+    const ids = subtreeParaIds(child);
+    if (ids.length === 0) continue;
+    found ??= [];
+    for (const id of ids) found.push(id);
+  }
+  const result: readonly string[] = found ?? EMPTY_PARA_IDS;
+  subtreeParaIdsCache.set(node, result);
+  return result;
+}
+
 /** Every valid `w14:paraId` in the tree, uppercased. Memoized per root object. */
 export function usedParaIds(root: OoxmlElement): ReadonlySet<string> {
   const cached = usedParaIdCache.get(root);
   if (cached) return cached;
-  const used = new Set<string>();
-  const visit = (node: OoxmlNode): void => {
-    if (node.kind === 'textValue') return;
-    const value = paraIdOf(node);
-    if (value !== null && isValidParaId(value)) used.add(value.toUpperCase());
-    for (const child of node.children) visit(child);
-  };
-  visit(root);
+  const used = new Set<string>(subtreeParaIds(root));
   usedParaIdCache.set(root, used);
   return used;
 }

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -913,16 +913,23 @@ const EMPTY_DEEP_PARAGRAPH_IDS: readonly string[] = Object.freeze([]);
  *
  * The deep order re-derives per fresh root, and a structural keystroke re-walked every
  * node of the document — every run of every paragraph — to relist ids that did not move.
- * Composing from per-subtree memos re-walks only the rebuilt spine. Like the revision
- * site walk's memo, depth restarts at the subtree a cache entry is keyed on, so the cap
- * bounds hostile nesting per subtree rather than from the root.
+ * Composing from per-subtree memos re-walks only the rebuilt spine.
+ *
+ * The entry remembers the depth it was computed at, because the 64-level cap makes the
+ * list depth-dependent: an op can republish a shared subtree at a different depth (an
+ * unwrap rebuilds only the spine ABOVE it), and serving a list computed under the old
+ * cap would diverge from a cold walk on hostile >64-deep nesting. A depth mismatch just
+ * recomputes, so the memo stays exactly the cold walk's answer.
  */
-const subtreeDeepParagraphIdsCache = new WeakMap<OoxmlNode, readonly string[]>();
+const subtreeDeepParagraphIdsCache = new WeakMap<
+  OoxmlNode,
+  { readonly depth: number; readonly ids: readonly string[] }
+>();
 
 function subtreeDeepParagraphIds(node: OoxmlNode, depth: number): readonly string[] {
   if (node.kind === 'textValue' || depth > 64) return EMPTY_DEEP_PARAGRAPH_IDS;
   const cached = subtreeDeepParagraphIdsCache.get(node);
-  if (cached) return cached;
+  if (cached && cached.depth === depth) return cached.ids;
   let found: string[] | null = null;
   if (node.kind === 'paragraph') (found ??= []).push(node.id);
   for (const child of node.children) {
@@ -932,7 +939,7 @@ function subtreeDeepParagraphIds(node: OoxmlNode, depth: number): readonly strin
     for (const id of ids) found.push(id);
   }
   const result: readonly string[] = found ?? EMPTY_DEEP_PARAGRAPH_IDS;
-  subtreeDeepParagraphIdsCache.set(node, result);
+  subtreeDeepParagraphIdsCache.set(node, { depth, ids: result });
   return result;
 }
 

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -138,6 +138,12 @@ const revisionItemsCache = createRecentRootCache<{
 }>(8);
 
 function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
+  // Sites FIRST, and the site index only when there is at least one. `locateSites` merges
+  // an O(document) index per fresh root, and a structural keystroke on an untracked
+  // document paid that merge for a list this function was about to answer "empty" over.
+  // The site walk itself is per-subtree memoized, so it is the cheap half.
+  const sites = collectRevisionSites(part);
+  if (sites.length === 0) return [];
   const located = locateSites(part);
   const byAddress = new Map<
     string,
@@ -157,7 +163,7 @@ function computeRevisionItemsOf(part: OoxmlPart): ReviewRevisionItem[] {
     }
   >();
 
-  for (const site of collectRevisionSites(part)) {
+  for (const site of sites) {
     const id = wmlAttribute(site.node, 'id');
     if (id === undefined) continue;
     // `@w:author` is REQUIRED by `CT_TrackChange`, and files from other generators omit it
@@ -892,14 +898,42 @@ export function deepParagraphOrderOfPart(part: OoxmlPart): ReadonlyMap<string, n
   const cached = deepParagraphOrderCache.get(part.root);
   if (cached) return cached;
   const order = new Map<string, number>();
-  const walk = (node: OoxmlNode, depth: number): void => {
-    if (node.kind === 'textValue' || depth > 64) return;
-    if (node.kind === 'paragraph' && !order.has(node.id)) order.set(node.id, order.size);
-    for (const child of node.children) walk(child, depth + 1);
-  };
-  walk(part.root, 0);
+  for (const id of subtreeDeepParagraphIds(part.root, 0)) {
+    if (!order.has(id)) order.set(id, order.size);
+  }
   deepParagraphOrderCache.set(part.root, order);
   return order;
+}
+
+/** One shared empty list for the subtrees that hold no paragraph. */
+const EMPTY_DEEP_PARAGRAPH_IDS: readonly string[] = Object.freeze([]);
+
+/**
+ * Deep paragraph ids under one immutable node, in document order, memoized per node.
+ *
+ * The deep order re-derives per fresh root, and a structural keystroke re-walked every
+ * node of the document — every run of every paragraph — to relist ids that did not move.
+ * Composing from per-subtree memos re-walks only the rebuilt spine. Like the revision
+ * site walk's memo, depth restarts at the subtree a cache entry is keyed on, so the cap
+ * bounds hostile nesting per subtree rather than from the root.
+ */
+const subtreeDeepParagraphIdsCache = new WeakMap<OoxmlNode, readonly string[]>();
+
+function subtreeDeepParagraphIds(node: OoxmlNode, depth: number): readonly string[] {
+  if (node.kind === 'textValue' || depth > 64) return EMPTY_DEEP_PARAGRAPH_IDS;
+  const cached = subtreeDeepParagraphIdsCache.get(node);
+  if (cached) return cached;
+  let found: string[] | null = null;
+  if (node.kind === 'paragraph') (found ??= []).push(node.id);
+  for (const child of node.children) {
+    const ids = subtreeDeepParagraphIds(child, depth + 1);
+    if (ids.length === 0) continue;
+    found ??= [];
+    for (const id of ids) found.push(id);
+  }
+  const result: readonly string[] = found ?? EMPTY_DEEP_PARAGRAPH_IDS;
+  subtreeDeepParagraphIdsCache.set(node, result);
+  return result;
 }
 
 /** The deep paragraph order per part root, bounded like the shallow one above. */

--- a/scripts/bench/settle-bench.ts
+++ b/scripts/bench/settle-bench.ts
@@ -15,6 +15,7 @@
 //   bun scripts/bench/settle-bench.ts [fixture] [--keystrokes 25] [--warmup 3] [--json]
 //   bun scripts/bench/settle-bench.ts --json > /tmp/settle-before.json
 //   bun scripts/bench/settle-bench.ts --compare /tmp/settle-before.json
+//   bun scripts/bench/settle-bench.ts --key enter   # structural keystrokes (splitParagraph)
 
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
@@ -33,6 +34,8 @@ interface Args {
   warmup: number;
   json: boolean;
   compare?: string;
+  /** 'enter' sends a structural keystroke (splitParagraph) instead of typing 'x'. */
+  key: 'x' | 'enter';
 }
 
 interface TimingSummary {
@@ -67,6 +70,7 @@ function parseArgs(argv: string[]): Args {
     keystrokes: 25,
     warmup: 3,
     json: false,
+    key: 'x',
   };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index]!;
@@ -74,6 +78,11 @@ function parseArgs(argv: string[]): Args {
     else if (value === '--keystrokes') args.keystrokes = Number(argv[++index]);
     else if (value === '--warmup') args.warmup = Number(argv[++index]);
     else if (value === '--compare') args.compare = argv[++index]!;
+    else if (value === '--key') {
+      const key = argv[++index];
+      if (key !== 'x' && key !== 'enter') throw new Error(`--key must be 'x' or 'enter', got ${key}`);
+      args.key = key;
+    }
     else if (!value.startsWith('--')) args.fixture = resolve(value);
     else throw new Error(`unknown option ${value}`);
   }
@@ -159,8 +168,14 @@ async function run(args: Args): Promise<SettleReport> {
     });
     await settle(surface);
 
+    const press = (): void => {
+      // The same call the surface keymap makes for an unmodified Enter.
+      if (args.key === 'enter') surface.splitParagraph();
+      else surface.type('x');
+    };
+
     for (let index = 0; index < args.warmup; index += 1) {
-      surface.type('w');
+      press();
       await settle(surface);
     }
 
@@ -169,7 +184,7 @@ async function run(args: Args): Promise<SettleReport> {
     const paintMs: number[] = [];
     for (let index = 0; index < args.keystrokes; index += 1) {
       const typedAt = performance.now();
-      surface.type('x');
+      press();
       const settledAt = await settle(surface);
       settleMs.push(settledAt - typedAt);
       const perf = surface.state().perf;

--- a/scripts/bench/settle-bench.ts
+++ b/scripts/bench/settle-bench.ts
@@ -80,10 +80,10 @@ function parseArgs(argv: string[]): Args {
     else if (value === '--compare') args.compare = argv[++index]!;
     else if (value === '--key') {
       const key = argv[++index];
-      if (key !== 'x' && key !== 'enter') throw new Error(`--key must be 'x' or 'enter', got ${key}`);
+      if (key !== 'x' && key !== 'enter')
+        throw new Error(`--key must be 'x' or 'enter', got ${key}`);
       args.key = key;
-    }
-    else if (!value.startsWith('--')) args.fixture = resolve(value);
+    } else if (!value.startsWith('--')) args.fixture = resolve(value);
     else throw new Error(`unknown option ${value}`);
   }
   if (!Number.isInteger(args.keystrokes) || args.keystrokes < 1) {


### PR DESCRIPTION
On very large documents, a structural keystroke (Enter, Backspace) re-derived several whole-document facts even though the edit touched one paragraph: the used paraId set, the deep paragraph order, the revision-site index, the layout's table index for the snapshot's table context, the per-table drawing token, and the finalized PAGE/NUMPAGES projection of every page. Each derivation now reuses per-immutable-node memos or skips work the caret position rules out, with the same results as before.

Measured on the pinned 521-page fixture (`e2e/fixtures/typing-perf-521pp.docx`, same machine):

- Headless (`bun run bench:huge`): layout median 42.4 ms to 30.7 ms (-27.6%); settle and paint unchanged; work counters identical (placed 5/6540, reused 555, full passes 2, stale discards 0).
- Chrome, warm document: per-Enter keydown task 176-272 ms to 109-155 ms. The first structural edit pays a one-time memo population.

A new randomized store-level differential (`derivation-memo-freshness.test.ts`) checks each derivation against a `structuredClone` of the part after every random edit, so an identity-keyed memo that survives an edit it should not fails with a replayable op script. The layout oracle's fixture now carries PAGE/NUMPAGES header furniture, which puts the finalize memo under its existing clone differential. The settle bench gains `--key enter` for structural keystrokes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790229905&installation_model_id=422592&pr_number=440&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F440&signature=1788bf6fa08e1c1522fc7724c0514fce8d7079ff89e2566d357798dbc77e9088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

The surface also pre-warms these derivations in idle tasks after the first published render, so the first structural edit no longer pays the one-time memo population (first Enter on the fixture: 477 ms to 414 ms headless). The warm yields to pending input and stops on an edit, view mode, or teardown.
