### PR TITLE
test: measure input delay in the huge-document benches

### DIFF
--- a/scripts/bench/settle-bench.ts
+++ b/scripts/bench/settle-bench.ts
@@ -16,6 +16,18 @@
 //   bun scripts/bench/settle-bench.ts --json > /tmp/settle-before.json
 //   bun scripts/bench/settle-bench.ts --compare /tmp/settle-before.json
 //   bun scripts/bench/settle-bench.ts --key enter   # structural keystrokes (splitParagraph)
+//   bun scripts/bench/settle-bench.ts --burst 40    # buffered typing under input pressure
+//
+// Beyond the per-keystroke medians, the report carries `taskGap`: the longest stretches the
+// main thread stayed occupied during the measured window, sampled by a setTimeout(0)
+// heartbeat. Settle medians say how long the pipeline takes; task gaps say how long a NEW
+// keystroke would have waited — the headless proxy for browser input delay. Wall-clock,
+// reported and compared, never pinned.
+//
+// `--burst N` additionally runs N characters through `enqueueType` while a stubbed
+// `navigator.scheduling.isInputPending` answers true, which is the only way the surface's
+// input-pressure lanes engage under happy-dom. The burst section reports total time,
+// observed flush count (published revisions), and the task gaps inside the burst.
 
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
@@ -36,11 +48,26 @@ interface Args {
   compare?: string;
   /** 'enter' sends a structural keystroke (splitParagraph) instead of typing 'x'. */
   key: 'x' | 'enter';
+  /** When positive, also run this many buffered characters under stubbed input pressure. */
+  burst: number;
 }
 
 interface TimingSummary {
   medianMs: number;
   p95Ms: number;
+}
+
+interface TaskGapSummary {
+  p95Ms: number;
+  maxMs: number;
+}
+
+interface BurstReport {
+  keys: number;
+  totalMs: number;
+  /** Published layout revisions observed during the burst — how often the buffer flushed. */
+  flushes: number;
+  taskGap: TaskGapSummary;
 }
 
 interface SettleReport {
@@ -54,6 +81,9 @@ interface SettleReport {
   settle: TimingSummary;
   layout: TimingSummary;
   paint: TimingSummary;
+  /** Main-thread occupancy during the measured keystrokes; absent in baselines that predate it. */
+  taskGap?: TaskGapSummary;
+  burst?: BurstReport;
   work: {
     placed: number;
     total: number;
@@ -71,6 +101,7 @@ function parseArgs(argv: string[]): Args {
     warmup: 3,
     json: false,
     key: 'x',
+    burst: 0,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index]!;
@@ -83,7 +114,8 @@ function parseArgs(argv: string[]): Args {
       if (key !== 'x' && key !== 'enter')
         throw new Error(`--key must be 'x' or 'enter', got ${key}`);
       args.key = key;
-    } else if (!value.startsWith('--')) args.fixture = resolve(value);
+    } else if (value === '--burst') args.burst = Number(argv[++index]);
+    else if (!value.startsWith('--')) args.fixture = resolve(value);
     else throw new Error(`unknown option ${value}`);
   }
   if (!Number.isInteger(args.keystrokes) || args.keystrokes < 1) {
@@ -92,10 +124,114 @@ function parseArgs(argv: string[]): Args {
   if (!Number.isInteger(args.warmup) || args.warmup < 0) {
     throw new Error('--warmup must be a non-negative integer');
   }
+  if (!Number.isInteger(args.burst) || args.burst < 0) {
+    throw new Error('--burst must be a non-negative integer');
+  }
   return args;
 }
 
+/**
+ * A setTimeout(0) heartbeat: the gap between consecutive fires is how long the main thread
+ * stayed occupied — the time a keystroke arriving in that window would have waited. The
+ * settle loop pumps the same timer queue, so the heartbeat interleaves with it and a long
+ * flush task shows up as one long gap.
+ */
+function startTaskGapSampler(): { stop: () => void; gaps: number[] } {
+  const gaps: number[] = [];
+  let last = performance.now();
+  let stopped = false;
+  let handle: ReturnType<typeof setTimeout>;
+  const beat = (): void => {
+    if (stopped) return;
+    const nowMs = performance.now();
+    gaps.push(nowMs - last);
+    last = nowMs;
+    handle = setTimeout(beat, 0);
+  };
+  handle = setTimeout(beat, 0);
+  return {
+    stop: () => {
+      stopped = true;
+      clearTimeout(handle);
+    },
+    gaps,
+  };
+}
+
+function taskGapSummary(gaps: readonly number[]): TaskGapSummary {
+  if (gaps.length === 0) return { p95Ms: 0, maxMs: 0 };
+  let max = 0;
+  for (const gap of gaps) if (gap > max) max = gap;
+  return { p95Ms: p95(gaps), maxMs: max };
+}
+
 const tick = (): Promise<void> => new Promise((done) => setTimeout(done, 0));
+
+/**
+ * Buffered typing under asserted input pressure: `enqueueType` one character per task while
+ * a stubbed `navigator.scheduling.isInputPending` answers true, release the pressure, then
+ * settle. This is the scenario where the surface's pressure-aware lanes (deferred paint,
+ * and any future flush split) actually engage under happy-dom.
+ */
+async function runBurst(surface: PaginatedSurface, keys: number): Promise<BurstReport> {
+  let pressure = true;
+  const nav = globalThis.navigator as Navigator & {
+    scheduling?: { isInputPending?: (options?: { includeContinuous?: boolean }) => boolean };
+  };
+  const hadScheduling = Object.prototype.hasOwnProperty.call(nav, 'scheduling');
+  const previous = nav.scheduling;
+  Object.defineProperty(nav, 'scheduling', {
+    value: { isInputPending: () => pressure },
+    configurable: true,
+  });
+
+  try {
+    const sampler = startTaskGapSampler();
+    let revision = surface.state().revision;
+    let flushes = 0;
+    const startedAt = performance.now();
+    for (let index = 0; index < keys; index += 1) {
+      surface.enqueueType('x');
+      await tick();
+      const next = surface.state().revision;
+      if (next !== revision) {
+        revision = next;
+        flushes += 1;
+      }
+    }
+    pressure = false;
+    // Settle inline so every flush (revision move) in the tail is counted, not just one.
+    let quietTicks = 0;
+    let lastChangeAt = performance.now();
+    while (quietTicks < 25) {
+      if (performance.now() - startedAt > 120_000) throw new Error('burst settle timeout');
+      await tick();
+      const next = surface.state().revision;
+      if (next !== revision) {
+        revision = next;
+        flushes += 1;
+        lastChangeAt = performance.now();
+        quietTicks = 0;
+      } else {
+        quietTicks += 1;
+      }
+    }
+    const settledAt = lastChangeAt;
+    sampler.stop();
+    return {
+      keys,
+      totalMs: settledAt - startedAt,
+      flushes,
+      taskGap: taskGapSummary(sampler.gaps),
+    };
+  } finally {
+    if (hadScheduling) {
+      Object.defineProperty(nav, 'scheduling', { value: previous, configurable: true });
+    } else {
+      delete (nav as { scheduling?: unknown }).scheduling;
+    }
+  }
+}
 
 /**
  * Wait until the surface state stops changing for `quiet` consecutive macrotasks, and
@@ -182,6 +318,7 @@ async function run(args: Args): Promise<SettleReport> {
     const settleMs: number[] = [];
     const layoutMs: number[] = [];
     const paintMs: number[] = [];
+    const sampler = startTaskGapSampler();
     for (let index = 0; index < args.keystrokes; index += 1) {
       const typedAt = performance.now();
       press();
@@ -191,6 +328,9 @@ async function run(args: Args): Promise<SettleReport> {
       layoutMs.push(perf.layoutMs);
       paintMs.push(perf.paintMs);
     }
+    sampler.stop();
+
+    const burst = args.burst > 0 ? await runBurst(surface, args.burst) : undefined;
 
     const state = surface.state();
     return {
@@ -204,6 +344,8 @@ async function run(args: Args): Promise<SettleReport> {
       settle: { medianMs: median(settleMs), p95Ms: p95(settleMs) },
       layout: { medianMs: median(layoutMs), p95Ms: p95(layoutMs) },
       paint: { medianMs: median(paintMs), p95Ms: p95(paintMs) },
+      taskGap: taskGapSummary(sampler.gaps),
+      ...(burst ? { burst } : {}),
       work: {
         placed: state.perf.placed,
         total: state.perf.total,
@@ -230,6 +372,18 @@ function printHuman(report: SettleReport): void {
   console.log(line('settle', report.settle));
   console.log(line('layout', report.layout));
   console.log(line('paint ', report.paint));
+  if (report.taskGap) {
+    console.log(
+      `  task gap p95 ${report.taskGap.p95Ms.toFixed(1)} ms, max ${report.taskGap.maxMs.toFixed(1)} ms`
+    );
+  }
+  if (report.burst) {
+    console.log(
+      `  burst ${report.burst.keys} keys in ${report.burst.totalMs.toFixed(1)} ms, ` +
+        `${report.burst.flushes} flushes, task gap p95 ${report.burst.taskGap.p95Ms.toFixed(1)} ms, ` +
+        `max ${report.burst.taskGap.maxMs.toFixed(1)} ms`
+    );
+  }
   const work = report.work;
   console.log(
     `  work  placed ${work.placed}/${work.total}, reused ${work.reusedPages} pages, ` +
@@ -247,6 +401,10 @@ function printComparison(baseline: SettleReport, current: SettleReport): void {
   console.log(`  settle ${delta(baseline.settle.medianMs, current.settle.medianMs)}`);
   console.log(`  layout ${delta(baseline.layout.medianMs, current.layout.medianMs)}`);
   console.log(`  paint  ${delta(baseline.paint.medianMs, current.paint.medianMs)}`);
+  // Baselines taken before the sampler existed have no taskGap; compare only when both do.
+  if (baseline.taskGap && current.taskGap && baseline.taskGap.p95Ms > 0) {
+    console.log(`  task gap p95 ${delta(baseline.taskGap.p95Ms, current.taskGap.p95Ms)}`);
+  }
   const before = baseline.work;
   const after = current.work;
   console.log(

--- a/scripts/bench/settle-bench.ts
+++ b/scripts/bench/settle-bench.ts
@@ -229,35 +229,14 @@ async function runBurst(surface: PaginatedSurface, keys: number): Promise<BurstR
       }
     }
     pressure = false;
-    // Settle inline, watching BOTH clocks: the commit revision (flush count) and the
-    // published paint timing — under pressure the render defers to a later task that never
-    // moves the revision, and totalMs must include that deferred paint.
-    let lastPaintMs = surface.state().perf.paintMs;
-    let quietTicks = 0;
-    let lastChangeAt = performance.now();
-    while (quietTicks < 25) {
-      if (performance.now() - startedAt > 120_000) throw new Error('burst settle timeout');
-      await tick();
-      const state = surface.state();
-      const next = state.revision;
-      let moved = false;
-      if (next > revision) {
-        flushes += next - revision;
-        revision = next;
-        moved = true;
-      }
-      if (state.perf.paintMs !== lastPaintMs) {
-        lastPaintMs = state.perf.paintMs;
-        moved = true;
-      }
-      if (moved) {
-        lastChangeAt = performance.now();
-        quietTicks = 0;
-      } else {
-        quietTicks += 1;
-      }
-    }
-    const settledAt = lastChangeAt;
+    // The shared settle, watching the paint clock too: under pressure the render defers to
+    // a task that never moves the commit revision, and totalMs must include that paint.
+    const settledAt = await settle(surface, {
+      watchPaint: true,
+      onRevisionAdvance: (delta) => {
+        flushes += delta;
+      },
+    });
     if (pressureChecks === 0) {
       throw new Error(
         'the isInputPending stub was never consulted; the pressure lanes did not engage'
@@ -280,22 +259,46 @@ async function runBurst(surface: PaginatedSurface, keys: number): Promise<BurstR
   }
 }
 
+interface SettleOptions {
+  quiet?: number;
+  maxMs?: number;
+  /** Count each commit-revision advance; the delta catches commits between observations. */
+  onRevisionAdvance?: (delta: number) => void;
+  /** Also treat a published paint (perf.paintMs move) as a change: under input pressure the
+   * render defers to a task that never bumps the commit revision, and a caller timing the
+   * whole pipeline must include it. */
+  watchPaint?: boolean;
+}
+
 /**
  * Wait until the surface state stops changing for `quiet` consecutive macrotasks, and
  * return the timestamp of the LAST observed change — the moment the keystroke settled.
  * The quiet tail itself is idle waiting, not latency, so it is excluded from the sample.
+ * Every settle in a report goes through this ONE definition of "stopped changing".
  */
-async function settle(surface: PaginatedSurface, quiet = 25, maxMs = 120_000): Promise<number> {
+async function settle(surface: PaginatedSurface, options: SettleOptions = {}): Promise<number> {
+  const quiet = options.quiet ?? 25;
+  const maxMs = options.maxMs ?? 120_000;
   const start = performance.now();
   let lastRevision = surface.state().revision;
+  let lastPaintMs = surface.state().perf.paintMs;
   let lastChangeAt = performance.now();
   let quietTicks = 0;
   while (quietTicks < quiet) {
     if (performance.now() - start > maxMs) throw new Error('settle timeout');
     await tick();
-    const revision = surface.state().revision;
-    if (revision !== lastRevision) {
-      lastRevision = revision;
+    const state = surface.state();
+    let moved = false;
+    if (state.revision !== lastRevision) {
+      if (state.revision > lastRevision) options.onRevisionAdvance?.(state.revision - lastRevision);
+      lastRevision = state.revision;
+      moved = true;
+    }
+    if (options.watchPaint && state.perf.paintMs !== lastPaintMs) {
+      lastPaintMs = state.perf.paintMs;
+      moved = true;
+    }
+    if (moved) {
       lastChangeAt = performance.now();
       quietTicks = 0;
     } else {
@@ -366,16 +369,20 @@ async function run(args: Args): Promise<SettleReport> {
     const layoutMs: number[] = [];
     const paintMs: number[] = [];
     const sampler = startTaskGapSampler();
-    for (let index = 0; index < args.keystrokes; index += 1) {
-      const typedAt = performance.now();
-      press();
-      const settledAt = await settle(surface);
-      settleMs.push(settledAt - typedAt);
-      const perf = surface.state().perf;
-      layoutMs.push(perf.layoutMs);
-      paintMs.push(perf.paintMs);
+    try {
+      for (let index = 0; index < args.keystrokes; index += 1) {
+        const typedAt = performance.now();
+        press();
+        const settledAt = await settle(surface);
+        settleMs.push(settledAt - typedAt);
+        const perf = surface.state().perf;
+        layoutMs.push(perf.layoutMs);
+        paintMs.push(perf.paintMs);
+      }
+    } finally {
+      // A settle timeout must not leave the self-rescheduling heartbeat firing during unwind.
+      sampler.stop();
     }
-    sampler.stop();
 
     // Snapshot BEFORE the burst: `work` and `pages` are the measured keystrokes' evidence,
     // and a burst-run baseline must stay comparable to a burst-free one.
@@ -445,15 +452,32 @@ function printComparison(baseline: SettleReport, current: SettleReport): void {
   if (baseline.fixtureSha256 !== current.fixtureSha256) {
     throw new Error('the baseline was taken from different document bytes; refusing to compare');
   }
+  // Optional-field presence handles additive growth WITHIN a schema; a schema move means a
+  // field was renamed or re-scoped, and diffing across it would print numbers from
+  // mismatched shapes.
+  if (baseline.schema !== current.schema) {
+    throw new Error(
+      `the baseline is schema ${baseline.schema} and this run is schema ${current.schema}; refusing to compare`
+    );
+  }
   const delta = (before: number, after: number): string =>
     `${(((after - before) / before) * 100).toFixed(1)}%`;
   console.log('comparison (negative is faster):');
   console.log(`  settle ${delta(baseline.settle.medianMs, current.settle.medianMs)}`);
   console.log(`  layout ${delta(baseline.layout.medianMs, current.layout.medianMs)}`);
   console.log(`  paint  ${delta(baseline.paint.medianMs, current.paint.medianMs)}`);
-  // Baselines taken before the sampler existed have no taskGap; compare only when both do.
-  if (baseline.taskGap && current.taskGap && baseline.taskGap.p95Ms > 0) {
-    console.log(`  task gap p95 ${delta(baseline.taskGap.p95Ms, current.taskGap.p95Ms)}`);
+  if (baseline.taskGap && current.taskGap) {
+    // A zero baseline p95 means no occupancy stall crossed the floor there; a percentage
+    // against zero is meaningless, so print the absolute values instead of a ratio.
+    if (baseline.taskGap.p95Ms > 0) {
+      console.log(`  task gap p95 ${delta(baseline.taskGap.p95Ms, current.taskGap.p95Ms)}`);
+    } else {
+      console.log(
+        `  task gap p95 ${baseline.taskGap.p95Ms.toFixed(1)} -> ${current.taskGap.p95Ms.toFixed(1)} ms (baseline had no stalls; no ratio)`
+      );
+    }
+  } else {
+    console.log('  task gap    (baseline predates the sampler; no comparison)');
   }
   const before = baseline.work;
   const after = current.work;

--- a/scripts/bench/settle-bench.ts
+++ b/scripts/bench/settle-bench.ts
@@ -65,8 +65,10 @@ interface TaskGapSummary {
 interface BurstReport {
   keys: number;
   totalMs: number;
-  /** Published layout revisions observed during the burst — how often the buffer flushed. */
+  /** Commit-revision advances during the burst — how often the buffer flushed. */
   flushes: number;
+  /** How often the surface consulted the stubbed isInputPending; zero fails the run. */
+  pressureChecks: number;
   taskGap: TaskGapSummary;
 }
 
@@ -131,6 +133,14 @@ function parseArgs(argv: string[]): Args {
 }
 
 /**
+ * Gaps below this are heartbeat cadence, not occupancy: the settle loops add ~25 idle
+ * sub-millisecond ticks per keystroke, which would put every real stall above the 95th
+ * percentile and make `p95Ms` a number about the timer queue. Only occupancy gaps are
+ * recorded, so the summary quantifies stalls — and an empty list means none happened.
+ */
+const OCCUPANCY_GAP_FLOOR_MS = 5;
+
+/**
  * A setTimeout(0) heartbeat: the gap between consecutive fires is how long the main thread
  * stayed occupied — the time a keystroke arriving in that window would have waited. The
  * settle loop pumps the same timer queue, so the heartbeat interleaves with it and a long
@@ -144,7 +154,8 @@ function startTaskGapSampler(): { stop: () => void; gaps: number[] } {
   const beat = (): void => {
     if (stopped) return;
     const nowMs = performance.now();
-    gaps.push(nowMs - last);
+    const gap = nowMs - last;
+    if (gap >= OCCUPANCY_GAP_FLOOR_MS) gaps.push(gap);
     last = nowMs;
     handle = setTimeout(beat, 0);
   };
@@ -167,49 +178,79 @@ function taskGapSummary(gaps: readonly number[]): TaskGapSummary {
 
 const tick = (): Promise<void> => new Promise((done) => setTimeout(done, 0));
 
+/** Keys enqueued per macrotask during a burst. The type-flush timer and this loop's own
+ * tick share the timer queue, and the flush timer is armed first — one key per task would
+ * therefore flush every key alone and never exercise the multi-character buffer. Several
+ * keys per task is also what hardware key repeat produces when a flush holds the thread. */
+const BURST_KEYS_PER_TASK = 3;
+
 /**
- * Buffered typing under asserted input pressure: `enqueueType` one character per task while
- * a stubbed `navigator.scheduling.isInputPending` answers true, release the pressure, then
- * settle. This is the scenario where the surface's pressure-aware lanes (deferred paint,
- * and any future flush split) actually engage under happy-dom.
+ * Buffered typing under asserted input pressure: `enqueueType` several characters per task
+ * while a stubbed `navigator.scheduling.isInputPending` answers true, release the pressure,
+ * then settle. This is the scenario where the surface's pressure-aware lanes (deferred
+ * paint, and any future flush split) actually engage under happy-dom.
  */
 async function runBurst(surface: PaginatedSurface, keys: number): Promise<BurstReport> {
   let pressure = true;
+  let pressureChecks = 0;
   const nav = globalThis.navigator as Navigator & {
     scheduling?: { isInputPending?: (options?: { includeContinuous?: boolean }) => boolean };
   };
   const hadScheduling = Object.prototype.hasOwnProperty.call(nav, 'scheduling');
   const previous = nav.scheduling;
   Object.defineProperty(nav, 'scheduling', {
-    value: { isInputPending: () => pressure },
+    value: {
+      isInputPending: () => {
+        pressureChecks += 1;
+        return pressure;
+      },
+    },
     configurable: true,
   });
 
+  const sampler = startTaskGapSampler();
   try {
-    const sampler = startTaskGapSampler();
+    // The revision is the commit clock (one flush commits once), so counting by DELTA
+    // catches two flushes landing between two observations. Deferred paint never moves it,
+    // which is why the settle tail below also watches the published paint timing.
     let revision = surface.state().revision;
     let flushes = 0;
+    let enqueued = 0;
     const startedAt = performance.now();
-    for (let index = 0; index < keys; index += 1) {
-      surface.enqueueType('x');
+    while (enqueued < keys) {
+      const chunk = Math.min(BURST_KEYS_PER_TASK, keys - enqueued);
+      for (let key = 0; key < chunk; key += 1) surface.enqueueType('x');
+      enqueued += chunk;
       await tick();
       const next = surface.state().revision;
-      if (next !== revision) {
+      if (next > revision) {
+        flushes += next - revision;
         revision = next;
-        flushes += 1;
       }
     }
     pressure = false;
-    // Settle inline so every flush (revision move) in the tail is counted, not just one.
+    // Settle inline, watching BOTH clocks: the commit revision (flush count) and the
+    // published paint timing — under pressure the render defers to a later task that never
+    // moves the revision, and totalMs must include that deferred paint.
+    let lastPaintMs = surface.state().perf.paintMs;
     let quietTicks = 0;
     let lastChangeAt = performance.now();
     while (quietTicks < 25) {
       if (performance.now() - startedAt > 120_000) throw new Error('burst settle timeout');
       await tick();
-      const next = surface.state().revision;
-      if (next !== revision) {
+      const state = surface.state();
+      const next = state.revision;
+      let moved = false;
+      if (next > revision) {
+        flushes += next - revision;
         revision = next;
-        flushes += 1;
+        moved = true;
+      }
+      if (state.perf.paintMs !== lastPaintMs) {
+        lastPaintMs = state.perf.paintMs;
+        moved = true;
+      }
+      if (moved) {
         lastChangeAt = performance.now();
         quietTicks = 0;
       } else {
@@ -217,14 +258,20 @@ async function runBurst(surface: PaginatedSurface, keys: number): Promise<BurstR
       }
     }
     const settledAt = lastChangeAt;
-    sampler.stop();
+    if (pressureChecks === 0) {
+      throw new Error(
+        'the isInputPending stub was never consulted; the pressure lanes did not engage'
+      );
+    }
     return {
       keys,
       totalMs: settledAt - startedAt,
       flushes,
+      pressureChecks,
       taskGap: taskGapSummary(sampler.gaps),
     };
   } finally {
+    sampler.stop();
     if (hadScheduling) {
       Object.defineProperty(nav, 'scheduling', { value: previous, configurable: true });
     } else {
@@ -330,9 +377,11 @@ async function run(args: Args): Promise<SettleReport> {
     }
     sampler.stop();
 
-    const burst = args.burst > 0 ? await runBurst(surface, args.burst) : undefined;
-
+    // Snapshot BEFORE the burst: `work` and `pages` are the measured keystrokes' evidence,
+    // and a burst-run baseline must stay comparable to a burst-free one.
     const state = surface.state();
+
+    const burst = args.burst > 0 ? await runBurst(surface, args.burst) : undefined;
     return {
       schema: 1,
       fixture: args.fixture,
@@ -380,7 +429,8 @@ function printHuman(report: SettleReport): void {
   if (report.burst) {
     console.log(
       `  burst ${report.burst.keys} keys in ${report.burst.totalMs.toFixed(1)} ms, ` +
-        `${report.burst.flushes} flushes, task gap p95 ${report.burst.taskGap.p95Ms.toFixed(1)} ms, ` +
+        `${report.burst.flushes} flushes, ${report.burst.pressureChecks} pressure checks, ` +
+        `task gap p95 ${report.burst.taskGap.p95Ms.toFixed(1)} ms, ` +
         `max ${report.burst.taskGap.maxMs.toFixed(1)} ms`
     );
   }

--- a/scripts/bench/typing-url-audit-lib.mjs
+++ b/scripts/bench/typing-url-audit-lib.mjs
@@ -52,7 +52,9 @@ export function requireRemainingMs(deadlineAt, { label = 'operation', globalDead
   const remaining = deadlineAt - Date.now();
   if (remaining <= 0) {
     const suffix =
-      globalDeadlineMs !== undefined ? `global deadline of ${globalDeadlineMs}ms exceeded` : 'global deadline exceeded';
+      globalDeadlineMs !== undefined
+        ? `global deadline of ${globalDeadlineMs}ms exceeded`
+        : 'global deadline exceeded';
     throw new Error(`${label}: ${suffix}`);
   }
   return Math.max(1, remaining);
@@ -277,6 +279,42 @@ export function hasConsoleErrors(consoleEvents) {
 }
 
 /**
+ * Aggregate the responsiveness probe: slow Event Timing entries (the API only reports
+ * interactions past its 16 ms floor, so every entry here already crossed one frame) and
+ * long tasks. Null when neither observer captured anything — either genuinely responsive
+ * or the APIs are unsupported, and the report omits the section rather than printing zeros
+ * it cannot distinguish.
+ *
+ * Callers filter both lists to the typing window first (`startTimeMs` on each entry):
+ * buffered observers also capture the document open, whose long task would otherwise
+ * dominate every typing report.
+ *
+ * @param {readonly { name: string; inputDelayMs: number; durationMs: number }[]} slowInputEvents
+ * @param {readonly number[]} longTaskDurations
+ * @returns {{ slowInputCount: number; worstInputDelayMs: number; worstEventDurationMs: number; longTaskCount: number; worstLongTaskMs: number } | null}
+ */
+export function summarizeResponsiveness(slowInputEvents, longTaskDurations) {
+  if (slowInputEvents.length === 0 && longTaskDurations.length === 0) return null;
+  let worstInputDelayMs = 0;
+  let worstEventDurationMs = 0;
+  for (const event of slowInputEvents) {
+    if (event.inputDelayMs > worstInputDelayMs) worstInputDelayMs = event.inputDelayMs;
+    if (event.durationMs > worstEventDurationMs) worstEventDurationMs = event.durationMs;
+  }
+  let worstLongTaskMs = 0;
+  for (const duration of longTaskDurations) {
+    if (duration > worstLongTaskMs) worstLongTaskMs = duration;
+  }
+  return {
+    slowInputCount: slowInputEvents.length,
+    worstInputDelayMs,
+    worstEventDurationMs,
+    longTaskCount: longTaskDurations.length,
+    worstLongTaskMs,
+  };
+}
+
+/**
  * @param {readonly { type: string; text: string }[]} consoleEvents
  * @param {readonly string[]} pageErrors
  */
@@ -321,9 +359,48 @@ export function validateTypingProbeSamples(samples, keys) {
  * after a layout revision mutation finishes it.
  */
 export function installTypingAuditProbeInPage() {
-  /** @type {{ trustedBeforeInputs: number; pendingSample: TypingAuditPendingSample | null; samples: TypingAuditProbeSample[] }} */
-  const probe = { trustedBeforeInputs: 0, pendingSample: null, samples: [] };
+  /** @type {{ trustedBeforeInputs: number; pendingSample: TypingAuditPendingSample | null; samples: TypingAuditProbeSample[]; slowInputEvents: { name: string; inputDelayMs: number; durationMs: number; startTimeMs: number }[]; longTasks: { durationMs: number; startTimeMs: number }[] }} */
+  const probe = {
+    trustedBeforeInputs: 0,
+    pendingSample: null,
+    samples: [],
+    slowInputEvents: [],
+    longTasks: [],
+  };
   globalThis.__typingAuditProbe = probe;
+
+  // Event Timing only reports interactions whose total duration crosses the threshold
+  // (16 ms is the API floor), so these are the SLOW events by construction: an empty list
+  // means no interaction crossed one frame. `inputDelayMs` is processingStart - startTime —
+  // the time the event waited for the main thread, the browser-truth queueing signal.
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        const timed =
+          /** @type {{ name: string; startTime: number; duration: number; processingStart?: number }} */ (
+            entry
+          );
+        if (typeof timed.processingStart !== 'number') continue;
+        probe.slowInputEvents.push({
+          name: timed.name,
+          inputDelayMs: timed.processingStart - timed.startTime,
+          durationMs: timed.duration,
+          startTimeMs: timed.startTime,
+        });
+      }
+    }).observe({ type: 'event', durationThreshold: 16, buffered: true });
+  } catch {
+    // Event Timing is unsupported here; the report simply omits the section.
+  }
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        probe.longTasks.push({ durationMs: entry.duration, startTimeMs: entry.startTime });
+      }
+    }).observe({ type: 'longtask', buffered: true });
+  } catch {
+    // Long Tasks is unsupported here; the report simply omits the section.
+  }
 
   const readRevision = () => {
     const pages = document.querySelector('.docx-pages');
@@ -600,20 +677,16 @@ export function evaluateTypingRun(input) {
     typeof input.modelTextAfter === 'string' &&
     modelGrowth === input.keys;
   const perKeyGrowthEvidence =
-    input.perKeyGrowth?.length === input.keys &&
-    input.perKeyGrowth.every((growth) => growth === 1);
+    input.perKeyGrowth?.length === input.keys && input.perKeyGrowth.every((growth) => growth === 1);
   const paintedTextEvidence =
     typeof input.paintedTextBefore === 'string' &&
     typeof input.paintedTextAfter === 'string' &&
     paintedInsertionOffset !== null &&
-    input.paintedTextAfter.slice(
-      paintedInsertionOffset,
-      paintedInsertionOffset + input.keys
-    ) === 'x'.repeat(input.keys) &&
+    input.paintedTextAfter.slice(paintedInsertionOffset, paintedInsertionOffset + input.keys) ===
+      'x'.repeat(input.keys) &&
     input.paintedTextAfter.length === input.paintedTextBefore.length + input.keys;
   const trustedInputEvidence =
-    input.trustedBeforeInputCount !== undefined &&
-    input.trustedBeforeInputCount === input.keys;
+    input.trustedBeforeInputCount !== undefined && input.trustedBeforeInputCount === input.keys;
   const perKeyRevisionEvidence =
     input.perKeyRevisionAdvance?.length === input.keys &&
     input.perKeyRevisionAdvance.every(Boolean);
@@ -691,6 +764,7 @@ export function evaluateTypingRun(input) {
  *   pageErrors: readonly string[];
  *   requestFailures?: readonly { url: string; failure: string }[];
  *   profileLines?: readonly string[];
+ *   responsiveness?: { slowInputCount: number; worstInputDelayMs: number; worstEventDurationMs: number; longTaskCount: number; worstLongTaskMs: number } | null;
  *   trustedBeforeInputCount?: number;
  *   caretOffsetBefore?: { paragraphId: string; offset: number } | null;
  *   caretOffsetAfter?: { paragraphId: string; offset: number } | null;
@@ -734,9 +808,7 @@ export function formatTypingAuditReport(verdict, args, report) {
     `edited paragraph painted length ${report.beforeLength} -> ${report.afterLength} (${verdict.paragraphGrowth} of ${args.keys} keys landed)`
   );
   if (report.beforeModelLength !== undefined && report.afterModelLength !== undefined) {
-    lines.push(
-      `canonical model length ${report.beforeModelLength} -> ${report.afterModelLength}`
-    );
+    lines.push(`canonical model length ${report.beforeModelLength} -> ${report.afterModelLength}`);
   }
   if (report.trustedBeforeInputCount !== undefined) {
     lines.push(`trusted beforeinput events: ${report.trustedBeforeInputCount} of ${args.keys}`);
@@ -752,7 +824,18 @@ export function formatTypingAuditReport(verdict, args, report) {
       `min ${report.sortedSamples[0].toFixed(1)} ms   ` +
       `max ${report.sortedSamples[report.sortedSamples.length - 1].toFixed(1)} ms`
   );
-  lines.push('budget: 16.7 ms median, 33.4 ms p95 (latency mode only; profile output is not budgeted)');
+  if (report.responsiveness) {
+    const r = report.responsiveness;
+    lines.push(
+      `slow input events (>=16 ms duration): ${r.slowInputCount}, worst input delay ${r.worstInputDelayMs.toFixed(1)} ms, worst duration ${r.worstEventDurationMs.toFixed(1)} ms`
+    );
+    lines.push(`long tasks: ${r.longTaskCount}, worst ${r.worstLongTaskMs.toFixed(1)} ms`);
+  } else if (report.responsiveness === null) {
+    lines.push('no input event crossed 16 ms and no long task was observed');
+  }
+  lines.push(
+    'budget: 16.7 ms median, 33.4 ms p95 (latency mode only; profile output is not budgeted)'
+  );
   if (report.profileLines?.length) {
     lines.push(...report.profileLines);
   }
@@ -962,7 +1045,9 @@ export function formatProfileLines(profile, keys, top) {
   const active = ranked.reduce((sum, [, micros]) => sum + micros, 0);
   /** @type {string[]} */
   const lines = [];
-  lines.push(`\nCPU profile (input-to-sample windows only): ${(active / 1000 / keys).toFixed(1)} ms/key active`);
+  lines.push(
+    `\nCPU profile (input-to-sample windows only): ${(active / 1000 / keys).toFixed(1)} ms/key active`
+  );
   lines.push(`${'ms/key'.padStart(8)}  ${'%'.padStart(5)}  function (file:line)`);
   for (const [key, micros] of ranked.slice(0, top)) {
     const [name, where] = key.split('|');

--- a/scripts/bench/typing-url-audit-lib.mjs
+++ b/scripts/bench/typing-url-audit-lib.mjs
@@ -290,7 +290,7 @@ export function hasConsoleErrors(consoleEvents) {
  * flags and pass nothing through when neither observer installed — an empty list is an
  * all-clear only when its API was actually watching.
  *
- * @param {readonly { name: string; inputDelayMs: number; durationMs: number }[]} slowInputEvents
+ * @param {readonly { inputDelayMs: number; durationMs: number }[]} slowInputEvents
  * @param {readonly number[]} longTaskDurations
  * @returns {{ slowInputCount: number; worstInputDelayMs: number; worstEventDurationMs: number; longTaskCount: number; worstLongTaskMs: number } | null}
  */
@@ -360,7 +360,11 @@ export function validateTypingProbeSamples(samples, keys) {
  * after a layout revision mutation finishes it.
  */
 export function installTypingAuditProbeInPage() {
-  /** @type {{ trustedBeforeInputs: number; pendingSample: TypingAuditPendingSample | null; samples: TypingAuditProbeSample[]; slowInputEvents: { name: string; inputDelayMs: number; durationMs: number; startTimeMs: number }[]; longTasks: { durationMs: number; startTimeMs: number }[]; observerSupport: { eventTiming: boolean; longTask: boolean } }} */
+  // Bounds the per-run CDP transfer: entries past the cap add nothing the summary reads
+  // (counts saturate, worst values are almost surely already inside), and an unbounded
+  // array on a long janky run serializes thousands of objects to reduce them to 5 numbers.
+  const MAX_PROBE_ENTRIES = 5000;
+  /** @type {{ trustedBeforeInputs: number; pendingSample: TypingAuditPendingSample | null; samples: TypingAuditProbeSample[]; slowInputEvents: { inputDelayMs: number; durationMs: number; startTimeMs: number }[]; longTasks: { durationMs: number; startTimeMs: number }[]; observerSupport: { eventTiming: boolean; longTask: boolean } }} */
   const probe = {
     trustedBeforeInputs: 0,
     pendingSample: null,
@@ -385,8 +389,8 @@ export function installTypingAuditProbeInPage() {
             entry
           );
         if (typeof timed.processingStart !== 'number') continue;
+        if (probe.slowInputEvents.length >= MAX_PROBE_ENTRIES) continue;
         probe.slowInputEvents.push({
-          name: timed.name,
           inputDelayMs: timed.processingStart - timed.startTime,
           durationMs: timed.duration,
           startTimeMs: timed.startTime,
@@ -400,6 +404,7 @@ export function installTypingAuditProbeInPage() {
   try {
     new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
+        if (probe.longTasks.length >= MAX_PROBE_ENTRIES) break;
         probe.longTasks.push({ durationMs: entry.duration, startTimeMs: entry.startTime });
       }
     }).observe({ type: 'longtask', buffered: true });

--- a/scripts/bench/typing-url-audit-lib.mjs
+++ b/scripts/bench/typing-url-audit-lib.mjs
@@ -281,13 +281,14 @@ export function hasConsoleErrors(consoleEvents) {
 /**
  * Aggregate the responsiveness probe: slow Event Timing entries (the API only reports
  * interactions past its 16 ms floor, so every entry here already crossed one frame) and
- * long tasks. Null when neither observer captured anything — either genuinely responsive
- * or the APIs are unsupported, and the report omits the section rather than printing zeros
- * it cannot distinguish.
+ * long tasks. Null when neither list has an entry, which the report prints as the
+ * all-clear line.
  *
  * Callers filter both lists to the typing window first (`startTimeMs` on each entry):
  * buffered observers also capture the document open, whose long task would otherwise
- * dominate every typing report.
+ * dominate every typing report. Callers must also gate on the probe's `observerSupport`
+ * flags and pass nothing through when neither observer installed — an empty list is an
+ * all-clear only when its API was actually watching.
  *
  * @param {readonly { name: string; inputDelayMs: number; durationMs: number }[]} slowInputEvents
  * @param {readonly number[]} longTaskDurations
@@ -359,13 +360,16 @@ export function validateTypingProbeSamples(samples, keys) {
  * after a layout revision mutation finishes it.
  */
 export function installTypingAuditProbeInPage() {
-  /** @type {{ trustedBeforeInputs: number; pendingSample: TypingAuditPendingSample | null; samples: TypingAuditProbeSample[]; slowInputEvents: { name: string; inputDelayMs: number; durationMs: number; startTimeMs: number }[]; longTasks: { durationMs: number; startTimeMs: number }[] }} */
+  /** @type {{ trustedBeforeInputs: number; pendingSample: TypingAuditPendingSample | null; samples: TypingAuditProbeSample[]; slowInputEvents: { name: string; inputDelayMs: number; durationMs: number; startTimeMs: number }[]; longTasks: { durationMs: number; startTimeMs: number }[]; observerSupport: { eventTiming: boolean; longTask: boolean } }} */
   const probe = {
     trustedBeforeInputs: 0,
     pendingSample: null,
     samples: [],
     slowInputEvents: [],
     longTasks: [],
+    // Distinguishes "quiet run" from "the API is unsupported here": an empty list is an
+    // all-clear ONLY when its observer actually installed.
+    observerSupport: { eventTiming: false, longTask: false },
   };
   globalThis.__typingAuditProbe = probe;
 
@@ -389,8 +393,9 @@ export function installTypingAuditProbeInPage() {
         });
       }
     }).observe({ type: 'event', durationThreshold: 16, buffered: true });
+    probe.observerSupport.eventTiming = true;
   } catch {
-    // Event Timing is unsupported here; the report simply omits the section.
+    // Event Timing is unsupported here; the report omits the section instead of claiming quiet.
   }
   try {
     new PerformanceObserver((list) => {
@@ -398,8 +403,9 @@ export function installTypingAuditProbeInPage() {
         probe.longTasks.push({ durationMs: entry.duration, startTimeMs: entry.startTime });
       }
     }).observe({ type: 'longtask', buffered: true });
+    probe.observerSupport.longTask = true;
   } catch {
-    // Long Tasks is unsupported here; the report simply omits the section.
+    // Long Tasks is unsupported here; the report omits the section instead of claiming quiet.
   }
 
   const readRevision = () => {

--- a/scripts/bench/typing-url-audit-lib.test.mjs
+++ b/scripts/bench/typing-url-audit-lib.test.mjs
@@ -395,8 +395,8 @@ describe('summarizeResponsiveness', () => {
   test('aggregates counts and worst values across both observers', () => {
     const summary = summarizeResponsiveness(
       [
-        { name: 'keydown', inputDelayMs: 4.2, durationMs: 24 },
-        { name: 'keypress', inputDelayMs: 86.4, durationMs: 117.2 },
+        { inputDelayMs: 4.2, durationMs: 24 },
+        { inputDelayMs: 86.4, durationMs: 117.2 },
       ],
       [55.5, 211.9]
     );

--- a/scripts/bench/typing-url-audit-lib.test.mjs
+++ b/scripts/bench/typing-url-audit-lib.test.mjs
@@ -19,6 +19,7 @@ import {
   parseTypingUrlAuditArgs,
   quantile,
   requireRemainingMs,
+  summarizeResponsiveness,
   validateAuditUrl,
   validateHttpUrlPolicy,
   validateProfileWindow,
@@ -44,9 +45,9 @@ describe('parseTypingUrlAuditArgs', () => {
   });
 
   test('rejects non-loopback URLs unless --allow-remote is set', () => {
-    expect(() =>
-      validateAuditUrl('https://example.com/?fixture=typing-perf-521pp.docx')
-    ).toThrow('loopback');
+    expect(() => validateAuditUrl('https://example.com/?fixture=typing-perf-521pp.docx')).toThrow(
+      'loopback'
+    );
     expect(
       validateAuditUrl('https://example.com/?fixture=typing-perf-521pp.docx', {
         allowRemote: true,
@@ -56,7 +57,9 @@ describe('parseTypingUrlAuditArgs', () => {
   });
 
   test('rejects non-finite numeric flags before browser launch', () => {
-    expect(() => parseTypingUrlAuditArgs(['--keys', 'NaN'])).toThrow('--keys must be a finite number');
+    expect(() => parseTypingUrlAuditArgs(['--keys', 'NaN'])).toThrow(
+      '--keys must be a finite number'
+    );
     expect(() => parseTypingUrlAuditArgs(['--min-pages', 'Infinity'])).toThrow(
       '--min-pages must be a finite number'
     );
@@ -285,13 +288,28 @@ describe('evaluateTypingRun', () => {
 
   test('validates probe timing samples', () => {
     expect(
-      validateTypingProbeSample({ ms: 12.5, revisionBefore: 3, revisionAfter: 4, validationRecordedAtMs: null })
+      validateTypingProbeSample({
+        ms: 12.5,
+        revisionBefore: 3,
+        revisionAfter: 4,
+        validationRecordedAtMs: null,
+      })
     ).toBe(true);
     expect(
-      validateTypingProbeSample({ ms: -1, revisionBefore: 3, revisionAfter: 4, validationRecordedAtMs: null })
+      validateTypingProbeSample({
+        ms: -1,
+        revisionBefore: 3,
+        revisionAfter: 4,
+        validationRecordedAtMs: null,
+      })
     ).toBe(false);
     expect(
-      validateTypingProbeSample({ ms: 12.5, revisionBefore: 4, revisionAfter: 4, validationRecordedAtMs: null })
+      validateTypingProbeSample({
+        ms: 12.5,
+        revisionBefore: 4,
+        revisionAfter: 4,
+        validationRecordedAtMs: null,
+      })
     ).toBe(false);
     expect(
       validateTypingProbeSamples(
@@ -331,6 +349,71 @@ describe('formatTypingAuditReport', () => {
     expect(text).toContain('INVALID');
     expect(text).not.toContain('2nd animation frame');
   });
+
+  test('prints the responsiveness section when the probe observed slow events', () => {
+    const verdict = { valid: true, reasons: [], paragraphGrowth: 2 };
+    const base = {
+      url: 'http://localhost:5173/',
+      opened: { pages: 521, paragraphs: 12820 },
+      beforeLength: 10,
+      afterLength: 12,
+      sortedSamples: [10, 20],
+      consoleErrors: [],
+      pageErrors: [],
+    };
+    const withEvents = formatTypingAuditReport(verdict, parseTypingUrlAuditArgs([]), {
+      ...base,
+      responsiveness: {
+        slowInputCount: 3,
+        worstInputDelayMs: 86.4,
+        worstEventDurationMs: 117.2,
+        longTaskCount: 2,
+        worstLongTaskMs: 211.9,
+      },
+    });
+    expect(withEvents).toContain('slow input events (>=16 ms duration): 3');
+    expect(withEvents).toContain('worst input delay 86.4 ms');
+    expect(withEvents).toContain('long tasks: 2, worst 211.9 ms');
+
+    const quiet = formatTypingAuditReport(verdict, parseTypingUrlAuditArgs([]), {
+      ...base,
+      responsiveness: null,
+    });
+    expect(quiet).toContain('no input event crossed 16 ms');
+
+    const absent = formatTypingAuditReport(verdict, parseTypingUrlAuditArgs([]), base);
+    expect(absent).not.toContain('slow input events');
+    expect(absent).not.toContain('no input event crossed');
+  });
+});
+
+describe('summarizeResponsiveness', () => {
+  test('null when neither observer captured anything', () => {
+    expect(summarizeResponsiveness([], [])).toBeNull();
+  });
+
+  test('aggregates counts and worst values across both observers', () => {
+    const summary = summarizeResponsiveness(
+      [
+        { name: 'keydown', inputDelayMs: 4.2, durationMs: 24 },
+        { name: 'keypress', inputDelayMs: 86.4, durationMs: 117.2 },
+      ],
+      [55.5, 211.9]
+    );
+    expect(summary).toEqual({
+      slowInputCount: 2,
+      worstInputDelayMs: 86.4,
+      worstEventDurationMs: 117.2,
+      longTaskCount: 2,
+      worstLongTaskMs: 211.9,
+    });
+  });
+
+  test('long tasks alone still produce a summary', () => {
+    const summary = summarizeResponsiveness([], [30]);
+    expect(summary?.slowInputCount).toBe(0);
+    expect(summary?.worstLongTaskMs).toBe(30);
+  });
 });
 
 describe('formatStructuredInvalid', () => {
@@ -339,7 +422,9 @@ describe('formatStructuredInvalid', () => {
       valid: false,
       reasons: ['opened 1 pages, expected exactly 521'],
       detail: 'navigation failed',
-      consoleErrors: [{ type: 'error', text: 'very long console payload that must not be truncated' }],
+      consoleErrors: [
+        { type: 'error', text: 'very long console payload that must not be truncated' },
+      ],
       pageErrors: ['ReferenceError: full page stack must remain intact'],
     });
     expect(text).toContain('very long console payload that must not be truncated');
@@ -359,12 +444,12 @@ describe('requireRemainingMs', () => {
 
 describe('validateHttpUrlPolicy', () => {
   test('blocks non-loopback http(s) unless allowRemote is set', () => {
-    expect(
-      validateHttpUrlPolicy('https://example.com/doc', { allowRemote: false }).allowed
-    ).toBe(false);
-    expect(
-      validateHttpUrlPolicy('https://example.com/doc', { allowRemote: true }).allowed
-    ).toBe(true);
+    expect(validateHttpUrlPolicy('https://example.com/doc', { allowRemote: false }).allowed).toBe(
+      false
+    );
+    expect(validateHttpUrlPolicy('https://example.com/doc', { allowRemote: true }).allowed).toBe(
+      true
+    );
     expect(validateHttpUrlPolicy('ws://localhost/socket').allowed).toBe(true);
   });
 });

--- a/scripts/bench/typing-url-audit.mjs
+++ b/scripts/bench/typing-url-audit.mjs
@@ -22,6 +22,7 @@ import {
   quantile,
   requireRemainingMs,
   resolveTargetParagraphId,
+  summarizeResponsiveness,
   typingUrlAuditHelpText,
   validateAuditUrl,
   validateHttpUrlPolicy,
@@ -184,8 +185,9 @@ try {
   if (args.paragraphIndex !== null) {
     targetParagraphId = await page.evaluate((index) => {
       return (
-        document.querySelectorAll('[data-paragraph-id]')[index]?.getAttribute('data-paragraph-id') ??
-        null
+        document
+          .querySelectorAll('[data-paragraph-id]')
+          [index]?.getAttribute('data-paragraph-id') ?? null
       );
     }, args.paragraphIndex);
   } else {
@@ -304,6 +306,10 @@ try {
   /** @type {import('playwright-core').Protocol.Profiler.Profile[]} */
   const profileWindows = [];
 
+  // The buffered responsiveness observers also capture the document open; everything
+  // before this stamp is load work, not typing.
+  const typingStartedAtMs = await page.evaluate(() => performance.now());
+
   for (let index = 0; index < args.keys; index += 1) {
     requireRemainingMs(deadlineAt, {
       label: `keystroke ${index + 1}`,
@@ -367,6 +373,16 @@ try {
   const trustedBeforeInputCount = await page.evaluate(
     () => globalThis.__typingAuditProbe?.trustedBeforeInputs ?? 0
   );
+  const responsivenessRaw = await page.evaluate(() => ({
+    slowInputEvents: globalThis.__typingAuditProbe?.slowInputEvents ?? [],
+    longTasks: globalThis.__typingAuditProbe?.longTasks ?? [],
+  }));
+  const responsiveness = summarizeResponsiveness(
+    responsivenessRaw.slowInputEvents.filter((event) => event.startTimeMs >= typingStartedAtMs),
+    responsivenessRaw.longTasks
+      .filter((task) => task.startTimeMs >= typingStartedAtMs)
+      .map((task) => task.durationMs)
+  );
 
   const caretInPagesLayer = await page.evaluate(() => {
     const pages = document.querySelector('.docx-pages');
@@ -422,6 +438,7 @@ try {
       pageErrors,
       requestFailures,
       profileLines: profileReport?.lines,
+      responsiveness,
       trustedBeforeInputCount,
       caretOffsetBefore,
       caretOffsetAfter,

--- a/scripts/bench/typing-url-audit.mjs
+++ b/scripts/bench/typing-url-audit.mjs
@@ -376,13 +376,24 @@ try {
   const responsivenessRaw = await page.evaluate(() => ({
     slowInputEvents: globalThis.__typingAuditProbe?.slowInputEvents ?? [],
     longTasks: globalThis.__typingAuditProbe?.longTasks ?? [],
+    observerSupport: globalThis.__typingAuditProbe?.observerSupport ?? {
+      eventTiming: false,
+      longTask: false,
+    },
   }));
-  const responsiveness = summarizeResponsiveness(
-    responsivenessRaw.slowInputEvents.filter((event) => event.startTimeMs >= typingStartedAtMs),
-    responsivenessRaw.longTasks
-      .filter((task) => task.startTimeMs >= typingStartedAtMs)
-      .map((task) => task.durationMs)
-  );
+  // Empty lists are an all-clear only when an observer actually installed; with neither
+  // API supported the section is omitted rather than claiming the run was jank-free.
+  const responsiveness =
+    responsivenessRaw.observerSupport.eventTiming || responsivenessRaw.observerSupport.longTask
+      ? summarizeResponsiveness(
+          responsivenessRaw.slowInputEvents.filter(
+            (event) => event.startTimeMs >= typingStartedAtMs
+          ),
+          responsivenessRaw.longTasks
+            .filter((task) => task.startTimeMs >= typingStartedAtMs)
+            .map((task) => task.durationMs)
+        )
+      : undefined;
 
   const caretInPagesLayer = await page.evaluate(() => {
     const pages = document.querySelector('.docx-pages');


### PR DESCRIPTION
Settle medians say how long the keystroke pipeline takes; nothing measured how long a NEW keystroke waits while the pipeline holds the main thread. This adds that measurement to both halves of the huge-document section, ahead of the scheduling changes that will need it.

- `settle-bench.ts`: a `taskGap` report section (p95/max gaps of a `setTimeout(0)` heartbeat during the measured keystrokes — the headless proxy for input delay) and a `--burst N` mode that runs N characters through `enqueueType` while a stubbed `navigator.scheduling.isInputPending` asserts pressure, reporting total time, observed flush count, and the gaps inside the burst. On the pinned fixture today a burst flushes once per key at roughly 390 ms per flush — the queueing pathology, now a number.
- `typing-url-audit.mjs`: the page probe observes Event Timing (16 ms floor) and Long Tasks, filtered to the typing window, and the report adds the slow-input-event count, worst input delay, and worst long task.

Wall-clock additions are reported and compared, never pinned. The exact-match `work` gate object is untouched and `settle-bench-gates` passes unchanged. Bench-only change, no changeset.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790236950&installation_model_id=422592&pr_number=445&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F445&signature=e292f1daa71c4729451449aa56989cf42966f7c3314cf86c25a27e52e688ab0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->