### PR TITLE
docs: restructure capability-heavy guides

### DIFF
--- a/docs/site/content/core/architecture.mdx
+++ b/docs/site/content/core/architecture.mdx
@@ -12,6 +12,22 @@ bytes → bounded OPC/XML read → canonical OOXML tree → layout → painted p
 
 What you see painted and what an edit mutates are the same tree, so there is no separate view model to synchronize.
 
+## Architecture boundaries
+
+| Boundary          | Owns                                                                    | Must not own                     |
+| ----------------- | ----------------------------------------------------------------------- | -------------------------------- |
+| `contracts`       | Public engine types and interfaces                                      | Runtime implementation or state  |
+| `store`           | Canonical trees, package reads and writes, indexes, and transactions    | DOM or ProseMirror state         |
+| `layout`          | DOM-free pagination and interaction geometry                            | Browser layout or authored state |
+| `output`          | Painted pages from layout records                                       | Document mutation                |
+| `binding`         | The ProseMirror projection and conversion of edits into tree operations | Canonical document authority     |
+| `automation`      | Transport-neutral host operations for browser and server automation     | DOM or editor chrome             |
+| `editor`          | The public editor facade, surface input, caret, and chrome registry     | A second document model          |
+| `react` and `vue` | Providers, hooks or composables, and framework chrome                   | Editing state                    |
+
+The package boundary keeps one copy of `@docx-editor.dev/core` in an
+application. Both adapters use it as a peer dependency.
+
 ## The canonical tree
 
 Reading a `.docx` produces one tree per XML part, up to a bounded part count. Non-XML parts stay as bytes and are never parsed. Nodes are **typed** where layout needs them (the paragraph, run, and table vocabulary) and **generic** everywhere else, preserving the element verbatim.
@@ -41,7 +57,14 @@ The painted pages are `contenteditable`, but the DOM is a non-authoritative rend
 
 The editor also paints its own caret, from layout geometry rather than from the DOM, which is why an empty paragraph gets a caret. On failure it falls back: range selection, IME composition, or a position it cannot place all restore the native caret instead of showing no caret.
 
-Selection maps through paragraph identity and offsets, never through DOM traversal. Page furniture (headers, footers, page numbers) is marked non-editable and excluded from selection.
+Selection maps through paragraph identity and offsets. It does not use DOM
+traversal.
+
+| Page furniture                   | Layout behavior                       | Interaction behavior                      |
+| -------------------------------- | ------------------------------------- | ----------------------------------------- |
+| Headers and footers              | Lay out by section and page variant   | Use scoped editing controls               |
+| Page numbers and other furniture | Attach to each painted page           | Stay non-editable and outside selection   |
+| Body content                     | Flows around reserved furniture bands | Uses the normal caret and selection model |
 
 ## Saving
 
@@ -51,7 +74,11 @@ That is what "structural fidelity" means here: unsupported XML and package paylo
 
 ## Adapters
 
-`@docx-editor.dev/core` contains everything above and no framework code. An adapter supplies DOM and paints the engine's positioned display list; it holds no editing state of its own. `@docx-editor.dev/react` provides React providers, hooks, and chrome over the engine contract. Every control it includes is a consumer of the same public contract that custom controls use.
+`@docx-editor.dev/core` contains the engine and no framework code. An adapter
+mounts the engine and provides framework-specific state access and chrome.
+`@docx-editor.dev/react` and `@docx-editor.dev/vue` hold no editing state.
+
+Packaged and custom controls consume the same public engine contract.
 
 ## Next steps
 

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -19,6 +19,33 @@ npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 `@docx-editor.dev/core` is a peer dependency: the engine holds identity-keyed state, so your
 project must resolve exactly one copy of it, shared with any editor adapter you install.
 
+## Choose a host
+
+| Capability                 | Server runtime | Browser runtime |
+| -------------------------- | -------------- | --------------- |
+| Read and edit a DOCX       | Yes            | Yes             |
+| Own document bytes         | Yes            | No              |
+| Return bytes with `save()` | Yes            | No              |
+| Read or set selection      | No             | Yes             |
+| Scroll to content          | No             | Yes             |
+| Use layout geometry        | No             | Yes             |
+
+`runtime.capabilities` reports these values. The values remain fixed for the
+runtime's lifetime.
+
+Use these prerequisites:
+
+| Task                          | Prerequisite                                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------------ |
+| Create a server runtime       | DOCX bytes and one resolved copy of `@docx-editor.dev/core`                                      |
+| Create a browser runtime      | An attached editor from `@docx-editor.dev/react`, `@docx-editor.dev/vue`, or the core editor API |
+| Write a comment or reply      | A non-empty `author`                                                                             |
+| Write browser review data     | The Pro review module, an editable mode, and a host that accepts the write                       |
+| Use the package in production | A written commercial agreement                                                                   |
+
+Dynamic document state can change after runtime creation. A refusal from
+`sync()` is therefore authoritative.
+
 ## On a server
 
 The server runtime is headless. It accepts bytes and returns bytes.
@@ -104,11 +131,8 @@ await runtime.run(async (context) => {
 The `/browser` entry includes integration with the painted engine. Import the root entry on servers
 to keep that browser code out of the bundle.
 
-The optional `author` has the same meaning as it does for `createServer`: it is the identity written
-into a comment reply. Omit it and `Comment.reply()` refuses with `NotSupported` before anything is
-queued. An author is not a capability flag—browser comment writes also require the Pro review module,
-an editable mode, and a host that accepts the write. Those conditions are dynamic, so the typed
-refusal at `sync()` remains authoritative.
+The optional `author` has the same meaning as it does for `createServer`.
+It supplies the identity for comment writes.
 
 ## Delete comments and Undo
 
@@ -125,8 +149,7 @@ for (const comment of comments.items.slice(0, 2)) comment.delete();
 await context.sync(); // one transaction; editor Undo restores both threads
 ```
 
-Browser deletion requires the Pro review module and a writable, attached editor. The server runtime
-supports the same object-model calls without a browser module. This section covers deletion only.
+The server runtime supports the same object-model calls without a browser module.
 
 ## Programming model
 
@@ -142,13 +165,6 @@ supports the same object-model calls without a browser module. This section cove
 For content-control writes, load `isBound` with the other properties and skip controls where it is
 true. That boolean is safe preflight metadata, not a write guarantee: `sync()` always checks the
 current document again and atomically refuses the batch if a control is bound by then.
-
-## Capabilities
-
-`runtime.capabilities` reports host differences. `save` is false in the browser; `selection`,
-`scrolling` and `layout` are false on a server. Branch on these values because they remain frozen
-for the life of the runtime. Comment writes intentionally have no static capability flag because
-module registration, editing mode, and document state can change.
 
 ## Entries
 
@@ -244,18 +260,17 @@ For a complete tool catalog, see the
 
 ### Choose one revision text projection
 
-The runtime uses the `allMarkup` text projection by default. This projection includes ordinary
-text, pending deletions, pending insertions, and both sides of a pending replacement.
+The runtime uses the `allMarkup` text projection by default. Select one
+projection when you create the runtime:
 
-Use the `original` projection when an agent must read the document before pending changes are
-accepted. This projection matches Word's **Original** review view. It has these rules:
+| Content             | `allMarkup`            | `original`                      |
+| ------------------- | ---------------------- | ------------------------------- |
+| Ordinary text       | Visible and searchable | Visible and searchable          |
+| Pending deletion    | Visible and searchable | Visible and searchable          |
+| Pending insertion   | Visible and searchable | Hidden and not searchable       |
+| Pending replacement | Shows both sides       | Shows the deleted original only |
 
-- Ordinary text remains unchanged.
-- A pending deletion remains visible and searchable.
-- A pending insertion is hidden and is not searchable.
-- A pending replacement shows its deleted original and hides its inserted replacement.
-
-Choose the projection when you create the runtime:
+`original` matches Word's **Original** review view.
 
 ```ts
 const runtime = DocxEditor.createBrowser(editor, {

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -21,17 +21,20 @@ project must resolve exactly one copy of it, shared with any editor adapter you 
 
 ## Choose a host
 
-| Capability                 | Server runtime | Browser runtime |
-| -------------------------- | -------------- | --------------- |
-| Read and edit a DOCX       | Yes            | Yes             |
-| Own document bytes         | Yes            | No              |
-| Return bytes with `save()` | Yes            | No              |
-| Read or set selection      | No             | Yes             |
-| Scroll to content          | No             | Yes             |
-| Use layout geometry        | No             | Yes             |
+| `DocumentCapabilities` field | Server runtime | Browser runtime |
+| ---------------------------- | -------------- | --------------- |
+| `document`                   | Yes            | Yes             |
+| `save`                       | Yes            | No              |
+| `events`                     | Yes            | Yes             |
+| `selection`                  | No             | Yes             |
+| `scrolling`                  | No             | Yes             |
+| `layout`                     | No             | Yes             |
 
 `runtime.capabilities` reports these values. The values remain fixed for the
 runtime's lifetime.
+
+The current mode and document state can still refuse writes. These dynamic
+permissions are not capability fields.
 
 Use these prerequisites:
 
@@ -43,8 +46,7 @@ Use these prerequisites:
 | Write browser review data     | The Pro review module, an editable mode, and a host that accepts the write                       |
 | Use the package in production | A written commercial agreement                                                                   |
 
-Dynamic document state can change after runtime creation. A refusal from
-`sync()` is therefore authoritative.
+A refusal from `sync()` is authoritative.
 
 ## On a server
 

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -14,21 +14,9 @@ The editor parses controls into the canonical tree, keeps them editable, renders
   variables; the two systems can coexist in one document.
 </Callout>
 
-## Support summary
-
-| Control or feature | Read and preserve | Fill                  | Create in editor   |
-| ------------------ | ----------------- | --------------------- | ------------------ |
-| Rich text          | Yes               | Yes                   | Yes                |
-| Plain text         | Yes               | Yes                   | Yes                |
-| Dropdown           | Yes               | Yes                   | Yes, without items |
-| Combo box          | Yes               | Yes                   | Yes, without items |
-| Checkbox           | Yes               | Yes                   | No                 |
-| Date picker        | Yes               | Yes                   | Yes                |
-| Picture            | Yes               | No                    | No                 |
-| Repeating section  | Yes               | No live behavior      | No                 |
-| `w:dataBinding`    | Yes               | Direct writes refused | No                 |
-
-Creating, filling, and removing controls do not create tracked changes.
+For cross-feature support levels, see the authoritative
+[Word fidelity matrix](/docs/2.x/word-fidelity). This guide covers content
+control tasks and operational refusals.
 
 ## Filling a template from a server
 
@@ -257,15 +245,16 @@ the reason.
 
 In the editor, typed controls get an interactive trigger at the top-right of their box: it toggles the checkbox, opens the dropdown's item menu, or opens a date picker, each as a normal undoable edit. These controls work without host event handlers.
 
-## Current limits
+## Operational limits
 
-| Area               | Limit                                                                              |
-| ------------------ | ---------------------------------------------------------------------------------- |
-| Tables             | A control around a whole cell or row is unsupported. Controls inside a cell work.  |
-| Hyperlinks         | The editor does not surface a control inside a hyperlink.                          |
-| Data binding       | `w:dataBinding` round-trips without bound-value resolution.                        |
-| Repeating sections | Repeating sections round-trip without automatic expansion.                         |
-| Review             | Control creation, filling, and removal do not create revisions in suggesting mode. |
+- The editor does not support a control around a whole table cell or row.
+  Controls inside a cell work.
+- The editor does not surface a control inside a hyperlink.
+- `w:dataBinding` round-trips without bound-value resolution.
+- Repeating-section markup round-trips without item add, item remove, or
+  section configuration edits.
+- Control creation, filling, and removal do not create revisions in suggesting
+  mode.
 
 ## Next steps
 

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -14,6 +14,22 @@ The editor parses controls into the canonical tree, keeps them editable, renders
   variables; the two systems can coexist in one document.
 </Callout>
 
+## Support summary
+
+| Control or feature | Read and preserve | Fill                  | Create in editor   |
+| ------------------ | ----------------- | --------------------- | ------------------ |
+| Rich text          | Yes               | Yes                   | Yes                |
+| Plain text         | Yes               | Yes                   | Yes                |
+| Dropdown           | Yes               | Yes                   | Yes, without items |
+| Combo box          | Yes               | Yes                   | Yes, without items |
+| Checkbox           | Yes               | Yes                   | No                 |
+| Date picker        | Yes               | Yes                   | Yes                |
+| Picture            | Yes               | No                    | No                 |
+| Repeating section  | Yes               | No live behavior      | No                 |
+| `w:dataBinding`    | Yes               | Direct writes refused | No                 |
+
+Creating, filling, and removing controls do not create tracked changes.
+
 ## Filling a template from a server
 
 [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) is the headless path, and its object model is Office.js-compatible. Reads are batched, then one `sync()` sends the writes as a single ordered batch:
@@ -219,19 +235,23 @@ editor.exec({
 });
 ```
 
-You can author `richText`, `plainText`, `dropdown` (also spelled `dropDownList`, as OOXML
-spells it), `comboBox`, and `date` controls. Checkbox, picture, and repeating-section controls
-carry content an insertion would have to invent, so they are not authored here. A dropdown or
-combo box starts with no items: add them in Word, or design the template there and fill it
-from code.
+You can author `richText`, `plainText`, `dropdown`, `comboBox`, and `date`
+controls. OOXML also spells `dropdown` as `dropDownList`.
+
+A new dropdown or combo box has no items. Add its items in Word, or fill a
+control from an existing template.
 
 `editor.can()` answers the same refusal `exec` would, so a button can disable itself and show
-the reason. The command rejects the operation when:
+the reason.
 
-- The selection crosses two paragraphs. A control over several paragraphs is a block wrapper,
-  which is a different element.
-- The position sits inside a hyperlink, a field, or another inline control. A control is a
-  sibling of the text around it, so those positions have no place to put one.
+| Operation    | Refusal condition                                            | Reason                                        |
+| ------------ | ------------------------------------------------------------ | --------------------------------------------- |
+| Fill or edit | The control or an ancestor locks its content                 | `locked`                                      |
+| Remove       | The control or an ancestor locks its wrapper                 | `locked`                                      |
+| Fill         | The control declares `w:dataBinding`                         | `bound`                                       |
+| Fill         | The value does not match the control type                    | `typeMismatch`                                |
+| Create       | The selection crosses paragraphs                             | Inline controls cannot wrap block content     |
+| Create       | The position is inside a hyperlink, field, or inline control | The new control has no valid sibling position |
 
 ## Typed control chrome
 
@@ -239,10 +259,13 @@ In the editor, typed controls get an interactive trigger at the top-right of the
 
 ## Current limits
 
-- A control that _wraps_ a whole table cell or row is not supported (controls _inside_ a cell are).
-- A control inside a hyperlink is not surfaced.
-- `dataBinding` and repeating sections round-trip but have no live behavior: no bound-value resolution, no automatic repeat expansion.
-- Creating, filling, and removing a control are not recorded as tracked changes, even in suggesting mode. A reviewer sees the result, not a revision to accept or reject.
+| Area               | Limit                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| Tables             | A control around a whole cell or row is unsupported. Controls inside a cell work.  |
+| Hyperlinks         | The editor does not surface a control inside a hyperlink.                          |
+| Data binding       | `w:dataBinding` round-trips without bound-value resolution.                        |
+| Repeating sections | Repeating sections round-trip without automatic expansion.                         |
+| Review             | Control creation, filling, and removal do not create revisions in suggesting mode. |
 
 ## Next steps
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -65,7 +65,29 @@ editor.getSelectedImage(); // same SelectedImageState shape
 editor.snapshot().image; // reference-stable until selection or image fields move
 ```
 
-`SelectedImageState.wrap` reports all nine Word menu targets (`inline`, `square`, `squareLeft`, `squareRight`, `tight`, `through`, `topAndBottom`, `behind`, `inFront`). `behind` and `inFront` are both `wrapNone` with different `@behindDoc`.
+`SelectedImageState.wrap` reports one of these Word menu targets:
+
+| Value          | Text behavior                                   | OOXML mapping                |
+| -------------- | ----------------------------------------------- | ---------------------------- |
+| `inline`       | Places the picture in the text line             | `wp:inline`                  |
+| `square`       | Wraps on both sides of a square boundary        | `wrapSquare`, `bothSides`    |
+| `squareLeft`   | Wraps on the left                               | `wrapSquare`, `left`         |
+| `squareRight`  | Wraps on the right                              | `wrapSquare`, `right`        |
+| `tight`        | Wraps around the authored polygon               | `wrapTight`                  |
+| `through`      | Wraps through the authored polygon              | `wrapThrough`                |
+| `topAndBottom` | Keeps text above and below                      | `wrapTopAndBottom`           |
+| `behind`       | Places the picture behind document content      | `wrapNone`, `@behindDoc="1"` |
+| `inFront`      | Places the picture in front of document content | `wrapNone`, `@behindDoc="0"` |
+
+The `resourceStatus` field reports image availability:
+
+| Status         | Meaning                                                                     |
+| -------------- | --------------------------------------------------------------------------- |
+| `pending`      | Validation or decoding is in progress                                       |
+| `ready`        | Validated image bytes are ready to paint                                    |
+| `unrenderable` | Validation, decoding, conversion, or format support failed                  |
+| `external`     | The relationship points outside the package and is not loaded automatically |
+| `missing`      | The relationship target is missing                                          |
 
 ## Authoring surface
 
@@ -139,22 +161,16 @@ Alt text uses `@descr`, then `@title`; `@name` is never announced. A picture wit
 
 ## Current limits
 
-Partially rendered:
-
-- Charts, SmartArt, groups, canvases: extent + labeled placeholder
-- Anchored text boxes render their story read-only, clipped to the extent (page-number
-  fields inside header/footer text boxes evaluate per page); inline text boxes, linked
-  chains, autofit, and rotation stay placeholders
-
-Preserved inertly:
-
-- VML (`w:pict`); watermark rendering and editing are not supported
-- `w:object` / `w:altChunk`: generic preservation with diagnostics
-- Tracked-change accept/reject on drawings
-
-Not rendered and not guaranteed to round-trip:
-
-- Artistic effects (`a:effectLst`)
+| Drawing content                                         | Status                                                 |
+| ------------------------------------------------------- | ------------------------------------------------------ |
+| Charts, SmartArt, groups, and canvases                  | Preserve the extent and show a labeled placeholder     |
+| Anchored text boxes                                     | Render the story read-only and clip it to the extent   |
+| Page fields in anchored header or footer text boxes     | Evaluate per page                                      |
+| Inline text boxes, linked chains, autofit, and rotation | Show a placeholder                                     |
+| VML (`w:pict`)                                          | Preserve inertly; do not render or edit watermarks     |
+| `w:object` and `w:altChunk`                             | Preserve as generic content with diagnostics           |
+| Tracked-change decisions on drawings                    | Preserve the markup without accept or reject actions   |
+| Artistic effects (`a:effectLst`)                        | Do not render and do not guarantee round-trip fidelity |
 
 ## Next steps
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -161,16 +161,16 @@ Alt text uses `@descr`, then `@title`; `@name` is never announced. A picture wit
 
 ## Current limits
 
-| Drawing content                                         | Status                                                 |
-| ------------------------------------------------------- | ------------------------------------------------------ |
-| Charts, SmartArt, groups, and canvases                  | Preserve the extent and show a labeled placeholder     |
-| Anchored text boxes                                     | Render the story read-only and clip it to the extent   |
-| Page fields in anchored header or footer text boxes     | Evaluate per page                                      |
-| Inline text boxes, linked chains, autofit, and rotation | Show a placeholder                                     |
-| VML (`w:pict`)                                          | Preserve inertly; do not render or edit watermarks     |
-| `w:object` and `w:altChunk`                             | Preserve as generic content with diagnostics           |
-| Tracked-change decisions on drawings                    | Preserve the markup without accept or reject actions   |
-| Artistic effects (`a:effectLst`)                        | Do not render and do not guarantee round-trip fidelity |
+| Drawing content                                         | Status                                               |
+| ------------------------------------------------------- | ---------------------------------------------------- |
+| Charts, SmartArt, groups, and canvases                  | Preserve the extent and show a labeled placeholder   |
+| Anchored text boxes                                     | Render the story read-only and clip it to the extent |
+| Page fields in anchored header or footer text boxes     | Evaluate per page                                    |
+| Inline text boxes, linked chains, autofit, and rotation | Show a placeholder                                   |
+| VML (`w:pict`)                                          | Preserve inertly; do not render or edit watermarks   |
+| `w:object` and `w:altChunk`                             | Preserve as generic content with diagnostics         |
+| Tracked-change decisions on drawings                    | Preserve the markup without accept or reject actions |
+| Artistic effects (`a:effectLst`)                        | Do not render; authored markup round-trips           |
 
 ## Next steps
 

--- a/docs/site/content/pro/comments.mdx
+++ b/docs/site/content/pro/comments.mdx
@@ -15,67 +15,21 @@ Comments share one sidebar, hook, and card layout with [tracked changes](/docs/2
 
 Comments require the review module from [`@docx-editor.dev/pro`](/docs/2.x/pro).
 
-## Setup
+## Prerequisites
 
-This example registers the review module and the rail:
+| Task                                  | Requirement                                                                      |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| Read comments                         | A loaded document                                                                |
+| Show the review rail                  | `reviewModule()` and `DocxEditorReview`                                          |
+| Create or reply in a browser          | A non-empty `author`, `reviewModule()`, an editable mode, and an attached editor |
+| Resolve, reopen, or delete in browser | `reviewModule()`, an editable mode, and an attached editor                       |
+| Create or reply on a server           | A non-empty `author` and a server runtime                                        |
 
-<FrameworkTabs>
-<Framework value="react">
+OOXML requires `w:author` for each comment and reply. The engine refuses a
+write without an author.
 
-```tsx
-import { DocxEditor } from '@docx-editor.dev/react';
-import { reviewModule, DocxEditorReview } from '@docx-editor.dev/pro/react';
-
-const MODULES = [reviewModule()];
-
-export function Commentable({ bytes }: { bytes: Uint8Array }) {
-  return (
-    <DocxEditor.Root document={bytes} modules={MODULES} author="Jess Lin">
-      <DocxEditor.Toolbar />
-      <DocxEditor.Viewport>
-        <DocxEditor.Content />
-        <DocxEditorReview />
-      </DocxEditor.Viewport>
-    </DocxEditor.Root>
-  );
-}
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import {
-  DocxEditorContent,
-  DocxEditorRoot,
-  DocxEditorToolbar,
-  DocxEditorViewport,
-} from '@docx-editor.dev/vue';
-import { DocxEditorReview, reviewModule } from '@docx-editor.dev/pro/vue';
-
-defineProps<{ bytes: Uint8Array }>();
-
-const modules = [reviewModule()];
-</script>
-
-<template>
-  <DocxEditorRoot :document="bytes" :modules="modules" author="Jess Lin">
-    <DocxEditorToolbar />
-    <DocxEditorViewport>
-      <DocxEditorContent />
-      <DocxEditorReview />
-    </DocxEditorViewport>
-  </DocxEditorRoot>
-</template>
-```
-
-</Framework>
-</FrameworkTabs>
-
-`author` supplies `w:author` for each comment and reply. OOXML requires this value.
-
-The engine refuses a write without an author.
+For module registration and licensing, see the
+[Pro package documentation](/docs/2.x/pro).
 
 ## Write a comment
 
@@ -168,8 +122,6 @@ await context.sync();
 ```
 
 Create the runtime with `{ author: 'Jess Lin' }`.
-
-Browser creation also requires the review module and a writable, attached editor. Server creation uses the licensed server host.
 
 The write uses one package transaction and one browser **Undo** unit. Collapsed ranges create insertion-point comments.
 
@@ -290,13 +242,18 @@ Render comment text with interpolation. The text comes from the file.
 </Framework>
 </FrameworkTabs>
 
-Comment items add `resolved` and `parentId` to the shared fields.
+Comment items include these fields:
 
-`resolved` reports whether `w15:commentsEx` marks the thread as complete. `parentId` is absent at the thread root.
-
-Shared fields include `key`, `id`, `author`, `initials`, `date`, `text`, and `replyIds`.
-
-They also include `anchorY`, `pageIndex`, and `isActive`.
+| Field                        | Meaning                                            |
+| ---------------------------- | -------------------------------------------------- |
+| `key`, `id`                  | Stable review and OOXML identifiers                |
+| `author`, `initials`, `date` | Comment author metadata                            |
+| `text`                       | File-derived comment text                          |
+| `replyIds`                   | Reply identifiers in the thread                    |
+| `resolved`                   | Whether `w15:commentsEx` marks the thread complete |
+| `parentId`                   | Parent comment identifier; absent on a thread root |
+| `anchorY`, `pageIndex`       | Document placement                                 |
+| `isActive`                   | Whether the caret is in the item                   |
 
 The editor reads `initials` from `w:initials` when available. Otherwise, it derives initials from the author name.
 
@@ -306,6 +263,19 @@ For a document-level read without the review module, `editor.getComments()` retu
 
 The packaged card renders `<DocxEditorReview.Resolve />` on an open comment and
 `<DocxEditorReview.Reopen />` on a resolved one. Custom cards use the matching hook actions:
+
+| Action                       | Result                                               | Refusal behavior                            |
+| ---------------------------- | ---------------------------------------------------- | ------------------------------------------- |
+| `comment(text, author?)`     | Adds a thread to the selection                       | Returns `false`; the caller keeps its draft |
+| `reply(item, text, author?)` | Adds a reply, or comments on a revision range        | Returns `false`                             |
+| `resolve(item)`              | Marks an open thread complete                        | Repeating it succeeds without a write       |
+| `reopen(item)`               | Reopens a complete thread                            | Repeating it succeeds without a write       |
+| `remove(item)`               | Deletes a comment thread or rejects a tracked change | Returns `false` when refused                |
+
+The hook does not own the caller's draft state.
+
+`commentResolutionDisabledReason` explains why Resolve and Reopen are
+unavailable.
 
 This example selects the correct action for the comment state:
 

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -11,6 +11,20 @@ Use the same components to build custom chrome.
 The packaged toolbar uses the hooks and primitives on this page.
 Your controls can use the same command and state APIs.
 
+## Composition requirements
+
+| Requirement              | When required                    | Purpose                                                          |
+| ------------------------ | -------------------------------- | ---------------------------------------------------------------- |
+| `DocxEditor.Root`        | Every composed editor            | Owns and provides the editor instance                            |
+| `DocxEditor.Viewport`    | Every composed editor            | Supplies the scroll container and page-layout classes            |
+| `DocxEditor.Content`     | Every composed editor            | Mounts the painted document surface                              |
+| Stable `modules` array   | When you register modules        | Prevents unintended module changes during construction           |
+| Positioned workspace row | When you use the navigation pane | Anchors the navigation pane                                      |
+| Pro review module        | When you use Pro review chrome   | Enables comments, tracked changes, and custom-node review chrome |
+
+If you use Pro review chrome, register its modules once on `Root`. For setup,
+see the [Pro package documentation](/docs/2.x/pro).
+
 <Callout>
   The [Igloo customization example](https://igloo.docx-editor.dev/) implements these patterns with
   custom markup. Open the demo, or read the
@@ -36,13 +50,8 @@ export function Editor({ bytes }: { bytes: Uint8Array }) {
 }
 ```
 
-- `Root` holds the editor instance and provides it through context.
-  It does not render a DOM element.
-  It accepts document-level props such as `document`, `mode`, `author`,
-  `fonts`, `locale`, `modules`, `onReady`, and `onChange`.
-- `Viewport` provides the scroll container and required page-layout classes.
-- `Content` provides the mount point for pages.
-  The rendered pages form the editable surface.
+`Root` does not render a DOM element. The rendered pages in `Content` form the
+editable surface.
 
 You can place optional chrome anywhere inside `Root`.
 Optional chrome includes the toolbar, menu, rulers, navigation pane,
@@ -428,18 +437,20 @@ For locks, data bindings, and fill-only mode, see the
 
 ## Page furniture
 
-Mount these parts only when you need their interface:
+Mount a part only when your layout needs its interface:
 
-- `DocxEditor.PageNumber` shows the current and total page count while you
-  scroll.
-- `DocxEditor.AuthorStyle` assigns a style to one review author.
-- `DocxEditor.ColorByChangeType` colors tracked changes by change type.
-  For details, see [Tracked changes](/docs/2.x/pro/tracked-changes).
-- `DocxEditor.FontNotice` lists substituted document fonts.
-- `DocxEditor.DocumentOutline` shows headings outside the navigation pane.
-  Selecting a heading moves the caret and scrolls it into view.
-- `DocxEditor.HeaderFooterChrome` provides header and footer editing controls.
-- `DocxEditor.NotesChrome` provides footnote and endnote controls.
+| Part                            | Interface                                     |
+| ------------------------------- | --------------------------------------------- |
+| `DocxEditor.PageNumber`         | Current and total page count during scrolling |
+| `DocxEditor.AuthorStyle`        | Review style for one author                   |
+| `DocxEditor.ColorByChangeType`  | Tracked-change colors by change type          |
+| `DocxEditor.FontNotice`         | List of substituted document fonts            |
+| `DocxEditor.DocumentOutline`    | Standalone heading list with caret navigation |
+| `DocxEditor.HeaderFooterChrome` | Header and footer editing controls            |
+| `DocxEditor.NotesChrome`        | Footnote and endnote controls                 |
+
+For review colors, see
+[Tracked changes](/docs/2.x/pro/tracked-changes).
 
 ## Custom labels
 
@@ -621,7 +632,6 @@ The node also includes `nodeId` and `text` when available.
 Use `useCustomNodeDefinitions()` to read registered definitions.
 
 Register the required module on `Root` before you use either compound.
-For module setup, see the [Pro package documentation](/docs/2.x/pro).
 
 ## A full composition
 

--- a/docs/site/content/vue/composition.mdx
+++ b/docs/site/content/vue/composition.mdx
@@ -8,6 +8,21 @@ order: 37
 `<DocxEditor>` supplies one arrangement of public parts. Use the parts when you
 need a different interface.
 
+## Composition requirements
+
+| Requirement              | When required                    | Purpose                                                          |
+| ------------------------ | -------------------------------- | ---------------------------------------------------------------- |
+| `DocxEditorRoot`         | Every composed editor            | Owns and provides the editor instance                            |
+| `DocxEditorViewport`     | Every composed editor            | Supplies the scroll container and page-layout classes            |
+| `DocxEditorContent`      | Every composed editor            | Mounts the painted document surface                              |
+| Stable `modules` array   | When you register modules        | Prevents unintended module changes during construction           |
+| Positioned workspace row | When you use the navigation pane | Anchors the navigation pane                                      |
+| Pro review module        | When you use Pro review chrome   | Enables comments, tracked changes, and custom-node review chrome |
+
+If you use Pro review chrome, register its modules once on
+`DocxEditorRoot`. For setup, see the
+[Pro package documentation](/docs/2.x/pro).
+
 ## Primitives
 
 Every editor needs these three components in this order:
@@ -25,10 +40,6 @@ import { DocxEditorContent, DocxEditorRoot, DocxEditorViewport } from '@docx-edi
   </DocxEditorRoot>
 </template>
 ```
-
-- `DocxEditorRoot` holds the editor and provides it to descendants.
-- `DocxEditorViewport` supplies the scroll and page-layout container.
-- `DocxEditorContent` mounts the painted, editable document surface.
 
 You can place all optional chrome inside `DocxEditorRoot`.
 
@@ -361,17 +372,20 @@ control behavior, see
 
 ## Page furniture
 
-Mount only the furniture that your layout needs:
+Mount a part only when your layout needs its interface:
 
-- `DocxEditorPageNumber` shows the page count while the document scrolls.
-- `DocxEditorAuthorStyle` assigns a tracked-change style to one author.
-- `DocxEditorColorByChangeType` colors changes by type.
-- `DocxEditorFontNotice` lists substituted fonts.
-- `DocxEditorDocumentOutline` renders a standalone headings list.
-- `DocxEditorHeaderFooterChrome` supplies header and footer controls.
-- `DocxEditorNotesChrome` supplies footnote and endnote controls.
+| Part                           | Interface                                     |
+| ------------------------------ | --------------------------------------------- |
+| `DocxEditorPageNumber`         | Current and total page count during scrolling |
+| `DocxEditorAuthorStyle`        | Review style for one author                   |
+| `DocxEditorColorByChangeType`  | Tracked-change colors by change type          |
+| `DocxEditorFontNotice`         | List of substituted document fonts            |
+| `DocxEditorDocumentOutline`    | Standalone heading list with caret navigation |
+| `DocxEditorHeaderFooterChrome` | Header and footer editing controls            |
+| `DocxEditorNotesChrome`        | Footnote and endnote controls                 |
 
-See [Tracked changes](/docs/2.x/pro/tracked-changes) for author colors.
+For review colors, see
+[Tracked changes](/docs/2.x/pro/tracked-changes).
 
 ## Custom labels
 
@@ -413,8 +427,7 @@ canvas must show the document's saved colors.
 
 ## Custom tracked changes and comments
 
-Vue review chrome comes from `@docx-editor.dev/pro/vue`. Register `reviewModule`
-on the root.
+Vue review chrome comes from `@docx-editor.dev/pro/vue`.
 
 ```vue
 <script setup lang="ts">

--- a/docs/site/data/word-features.test.ts
+++ b/docs/site/data/word-features.test.ts
@@ -8,13 +8,13 @@ function feature(id: string) {
 }
 
 describe('word-features — images lane honesty', () => {
-  test('inline and anchored editing is partial with React-only note until Vue follow-up', () => {
+  test('inline and anchored editing is partial in both adapters', () => {
     for (const id of ['images.inline', 'images.anchored'] as const) {
       const row = feature(id);
       expect(row.editing).toBe('partial');
       expect(row.rendering).toBe('full');
       expect(row.roundTrip).toBe('full');
-      expect(row.notes?.toLowerCase()).toContain('vue');
+      expect(row.notes?.toLowerCase()).toContain('both');
     }
   });
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -904,12 +904,12 @@ export const wordFeatures: WordFeature[] = [
     id: 'structure.repeating-sections',
     name: 'Repeating section controls',
     category: 'structure',
-    editing: 'partial',
+    editing: 'none',
     rendering: 'full',
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Add and remove items in the editor. The section configuration itself is read-only. The document object model does not type a repeating section as a content control, so a script reaches the controls inside it instead.',
+      'Repeating-section markup is preserved and rendered. Item add and remove operations and section configuration edits are unsupported.',
     docsLink: '/docs/2.x/guides/content-controls',
   },
   {


### PR DESCRIPTION
## Summary

- Add scannable tables for host capabilities, prerequisites, limits, and review actions.
- Keep React and Vue composition guidance aligned.
- Remove repeated setup and caveat prose from seven documentation pages.

## Test plan

- [x] `bun run check:docs-mdx`
- [x] `bun run check:public-docs-surface`
- [x] `git diff --check`
- [x] Repository pre-commit checks

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790238421&installation_model_id=422592&pr_number=446&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F446&signature=7054d93b79a1af1b6b552f846c8accb5d411b36f3de373674e0c80df5819f11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->