### PR TITLE
docs: make feature support easier to scan

### DIFF
--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -63,6 +63,7 @@ Use `loadFonts` for brand fonts or licensed Word fonts.
 
 ```ts
 import { composeFontConfiguration, loadFonts } from '@docx-editor.dev/core/editor';
+import { loadDefaultFonts } from '@docx-editor.dev/fonts';
 
 const brand = await loadFonts({
   sources: [
@@ -105,6 +106,8 @@ Use `createFontSource` when you already have bytes from a file input, IndexedDB,
 or a bundler.
 
 ```ts
+import { composeFontConfiguration, createFontSource } from '@docx-editor.dev/core/editor';
+
 const made = createFontSource(bytes, {
   family: 'Acme Sans',
   weight: 400,
@@ -170,6 +173,9 @@ googleFonts({
   substitute: { Georgia: 'Tinos' },
 });
 ```
+
+An arbitrary substitute can change line breaks and pagination. Use a
+metric-compatible substitute when layout must remain stable.
 
 | Resolver constraint        | Required behavior                                                     |
 | -------------------------- | --------------------------------------------------------------------- |

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -1,35 +1,33 @@
 ---
 title: 'Fonts and measurement'
-description: 'How the editor resolves fonts for Word-accurate line wrap and pagination: embedded DOCX fonts, metric-compatible substitutes, and app-supplied font URLs.'
+description: 'Resolve fonts for Word-accurate line wrapping and pagination with embedded fonts, metric-compatible substitutes, or app-supplied files.'
 category: 'Guides'
 seoTitle: 'Fonts and text measurement'
 ---
 
-The editor measures text with a real shaping engine (HarfBuzz) whenever it has font
-bytes to measure with. With no fonts, the editor still opens: layout falls back to a
-fixed-width estimate, but wrap and page-break points are then approximations rather
-than Word's. This guide covers the three ways fonts reach the editor, the two ways of
-timing them, and how they combine.
+The editor uses HarfBuzz when it has usable font bytes. Without them, it uses a
+fixed-width estimate.
 
-## Font sources
+The document still opens with fixed measurement. Line wraps and page breaks can
+differ from Word.
 
-**1. Fonts embedded in the document, automatic.** A `.docx` can carry the faces it was
-written in. When it does, the editor extracts them on load and measures with them. No
-configuration, no assets, no network: a document that brings its own fonts is
-Word-accurate without extra font configuration, in metrics and in pixels. The editor also registers the
-embedded bytes with the browser so the painted pages show the real glyphs, not a platform
-substitute.
+## Choose a font source
 
-Those faces register under an internal alias, never under the family name the document
-declares. A `.docx` controls its own font names, and the browser's font registry is
-page-wide, so registering a document's `Segoe UI` would repaint your application's own
-buttons and dialogs with glyphs from that file.
+| Source                     | Network on document open         | Measurement                        | Painted glyphs                          |
+| -------------------------- | -------------------------------- | ---------------------------------- | --------------------------------------- |
+| Fonts embedded in the DOCX | No                               | Uses the embedded bytes            | Registers an isolated browser alias     |
+| `@docx-editor.dev/fonts`   | Only when your code loads assets | Uses metric-compatible substitutes | Optional browser registration           |
+| `loadFonts` with your URLs | Only when your code calls it     | Uses admitted files                | Register faces separately when required |
+| Resolver function          | Depends on your resolver         | Uses matched files                 | Depends on returned sources             |
+| No usable source           | No                               | Fixed-width estimate               | Browser fallback                        |
 
-**2. Metric-compatible substitutes via `loadDefaultFonts`.** Most documents use Word's default
-fonts (Calibri, Cambria, Times New Roman, Arial, Courier New), which are proprietary
-and cannot be bundled. The optional `@docx-editor.dev/fonts` package provides open-licensed
-faces built to match their metrics: identical advance widths, so lines wrap where Word
-wraps them:
+Embedded fonts load automatically. The editor registers them under internal
+aliases. A document cannot replace a page-wide font family used by your
+application.
+
+## Load Word-compatible defaults
+
+The optional `@docx-editor.dev/fonts` package provides open-licensed substitutes.
 
 | Word font       | Substitute       | License |
 | --------------- | ---------------- | ------- |
@@ -39,105 +37,41 @@ wraps them:
 | Arial           | Liberation Sans  | SIL OFL |
 | Courier New     | Liberation Mono  | SIL OFL |
 
-<FrameworkTabs>
-<Framework value="react">
+These fonts match advance widths. Rare kerning differences can still change an
+edge case. Supply licensed font bytes when pixels must match the original face.
 
-```tsx
-import { useEffect, useState } from 'react';
-import { DocxEditor } from '@docx-editor.dev/react';
-import { loadDefaultFonts, installDefaultFontFaces } from '@docx-editor.dev/fonts';
-import type { FontConfigurationFragment } from '@docx-editor.dev/react';
-
-function Editor({ bytes }: { bytes: Uint8Array }) {
-  // `settled` gates the FIRST mount. `fonts` is sampled at mount and an identity change
-  // remounts, so mounting before fonts resolve costs a visible remount, and a remount
-  // resets the undo stack and the caret. Waiting once avoids both.
-  const [fonts, setFonts] = useState<{
-    settled: boolean;
-    value?: FontConfigurationFragment;
-  }>({ settled: false });
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const fragment = await loadDefaultFonts(); // or { families: ['Calibri'] }
-        // Optional: also register the substitutes with the browser under the Word family
-        // names, so painted glyphs match the metrics layout measured with.
-        void installDefaultFontFaces();
-        if (!cancelled) setFonts({ settled: true, value: fragment });
-      } catch {
-        // A load failure settles with no fonts: the editor opens on the fixed measurer,
-        // which is the documented degradation.
-        if (!cancelled) setFonts({ settled: true });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  if (!fonts.settled) return null;
-  return <DocxEditor.Root document={bytes} fonts={fonts.value} />;
-}
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { onMounted, shallowRef } from 'vue';
-import { DocxEditorRoot, type FontConfigurationFragment } from '@docx-editor.dev/vue';
-import { loadDefaultFonts, installDefaultFontFaces } from '@docx-editor.dev/fonts';
-
-defineProps<{ bytes: Uint8Array }>();
-
-// `settled` gates the FIRST mount. `fonts` is sampled at mount and an identity change
-// rebuilds the editor, so mounting before fonts resolve costs a visible rebuild, and a
-// rebuild resets the undo stack and the caret. Waiting once avoids both.
-const settled = shallowRef(false);
-const fonts = shallowRef<FontConfigurationFragment>();
-
-onMounted(async () => {
-  try {
-    fonts.value = await loadDefaultFonts(); // or { families: ['Calibri'] }
-    // Optional: also register the substitutes with the browser under the Word family
-    // names, so painted glyphs match the metrics layout measured with.
-    void installDefaultFontFaces();
-  } catch {
-    // A load failure settles with no fonts: the editor opens on the fixed measurer,
-    // which is the documented degradation.
-  } finally {
-    settled.value = true;
-  }
-});
-</script>
-
-<template>
-  <DocxEditorRoot v-if="settled" :document="bytes" :fonts="fonts" />
-</template>
-```
-
-</Framework>
-</FrameworkTabs>
-
-Font binaries load lazily as separate assets, only for the families you ask for.
-Importing the package fetches nothing.
-
-**3. Your own fonts, explicit URLs.** For brand fonts or licensed copies of the real
-faces, `loadFonts` fetches URLs you specify and caches them locally. When you pin a
-`sha256:` hash it rejects the bytes when the hash does not match. Pin it for any URL not under your sole
-control:
+Load fonts before the first editor mount. This avoids a visible remount and
+keeps the initial caret and undo history.
 
 ```ts
-// Also re-exported by both adapters: '@docx-editor.dev/react' and
-// '@docx-editor.dev/vue'.
-import { loadFonts, composeFontConfiguration } from '@docx-editor.dev/core/editor';
+import { defaultFonts } from '@docx-editor.dev/fonts';
+
+const fonts = await defaultFonts();
+```
+
+Pass `fonts` to `DocxEditor.Root` or `DocxEditorRoot`. You can limit the load:
+
+```ts
+const fonts = await defaultFonts({ families: ['Calibri'] });
+```
+
+Font binaries load as separate assets. Importing the package fetches nothing.
+
+## Load your own fonts
+
+Use `loadFonts` for brand fonts or licensed Word fonts.
+
+```ts
+import { composeFontConfiguration, loadFonts } from '@docx-editor.dev/core/editor';
 
 const brand = await loadFonts({
   sources: [
-    { url: '/fonts/AcmeSans-Regular.ttf', family: 'Acme Sans', weight: 400, style: 'normal' },
+    {
+      url: '/fonts/AcmeSans-Regular.ttf',
+      family: 'Acme Sans',
+      weight: 400,
+      style: 'normal',
+    },
     {
       url: '/fonts/AcmeSans-Bold.ttf',
       family: 'Acme Sans',
@@ -147,55 +81,59 @@ const brand = await loadFonts({
     },
   ],
 });
+
 const fonts = composeFontConfiguration(brand, await loadDefaultFonts());
 ```
 
-`loadFonts` never rejects for a single bad source: it returns the admitted sources plus
-a typed `failures` list, so the editor can open with partial coverage.
+| `loadFonts` behavior | Result                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| One source fails     | Returns admitted sources and a typed `failures` list.                  |
+| Hash matches         | Admits the source.                                                     |
+| Hash differs         | Rejects that source with `hashMismatch`.                               |
+| Hash omitted         | Computes one for the returned source.                                  |
+| Same request repeats | Uses the Cache API when available. Otherwise, each call fetches again. |
 
-You do not need to supply a hash. Pins are optional: omit `hash` for URLs on
-your own origin and `loadFonts` computes one. When you do want to pin a
-third-party URL, run it once without a pin and read the values back off the result:
+Pin every URL that you do not control. To create pins, load once without a hash
+and store the returned source hashes.
 
 ```ts
 const result = await loadFonts({ sources });
 console.log(result.sources.map((source) => `${source.id}: ${source.hash}`));
 ```
 
-Paste those into your source list (or generate the list at build time, which is how
-`@docx-editor.dev/fonts` bakes the hashes for its own assets).
-
-If you already have font bytes from a file input, IndexedDB, or a bundler import, `createFontSource`
-turns them into a source directly, with the hash computed. It returns a typed
-failure rather than throwing when the descriptor or the bytes are unusable:
+Use `createFontSource` when you already have bytes from a file input, IndexedDB,
+or a bundler.
 
 ```ts
-import { createFontSource, composeFontConfiguration } from '@docx-editor.dev/core/editor';
+const made = createFontSource(bytes, {
+  family: 'Acme Sans',
+  weight: 400,
+  style: 'normal',
+});
 
-const made = createFontSource(bytes, { family: 'Acme Sans', weight: 400, style: 'normal' });
 if ('source' in made) {
   const fonts = composeFontConfiguration({ sources: [made.source] });
 } else {
-  report(made.failure.reason); // 'malformed', 'overLimit', 'invalidRequest', …
+  report(made.failure.reason);
 }
 ```
 
-## Loading upfront or on demand
+This function returns a typed failure instead of throwing for invalid
+descriptors or bytes.
 
-Every path above resolves fonts before a document opens. You pick the faces, load the
-bytes, and hand the editor a value. Keep this as your default: it is the only path that
-makes no network request on open.
+## Load fonts on demand
 
-`fonts` also accepts a function. The editor calls it once per load, after parsing the
-file, with the families that file declares. A document then loads only the faces it uses,
-and one that names nothing you cover loads nothing:
+The `fonts` prop also accepts a resolver. The editor calls it once per document
+load after parsing. It receives the family names declared by that document.
+
+Use `useFonts` to keep the resolver identity stable across renders.
 
 <FrameworkTabs>
 <Framework value="react">
 
 ```tsx
-import { DocxEditor, useFonts } from '@docx-editor.dev/react';
 import { googleFonts } from '@docx-editor.dev/fonts/google';
+import { DocxEditor, useFonts } from '@docx-editor.dev/react';
 
 function Editor({ bytes }: { bytes: Uint8Array }) {
   const fonts = useFonts(googleFonts());
@@ -208,11 +146,10 @@ function Editor({ bytes }: { bytes: Uint8Array }) {
 
 ```vue
 <script setup lang="ts">
-import { DocxEditorRoot, useFonts } from '@docx-editor.dev/vue';
 import { googleFonts } from '@docx-editor.dev/fonts/google';
+import { DocxEditorRoot, useFonts } from '@docx-editor.dev/vue';
 
 defineProps<{ bytes: Uint8Array }>();
-
 const fonts = useFonts(googleFonts());
 </script>
 
@@ -224,183 +161,83 @@ const fonts = useFonts(googleFonts());
 </Framework>
 </FrameworkTabs>
 
-`googleFonts()` serves those families from a generated catalog. Every face is pinned to
-one `google/fonts` commit and carries a baked `sha256:` that the editor re-derives before
-it admits the bytes. Use `allow` to narrow what it may ever fetch, and `substitute` to map
-your own document family names onto catalog ones:
+`googleFonts()` uses a generated catalog. Each face is pinned to one
+`google/fonts` commit and includes a checked `sha256:` value.
 
 ```ts
-googleFonts({ allow: ['Tinos', 'Carlito'], substitute: { Georgia: 'Tinos' } });
-```
-
-Write your own resolver when the bytes are yours. It takes the declared families and
-returns the same fragment shape as everything else:
-
-```ts
-// A Map, not an object: the families are file-derived, and `'constructor' in {}` is true.
-const myBrandFaces = new Map([['Acme Sans', '/fonts/AcmeSans-Regular.ttf']]);
-
-const fonts = useFonts(async ({ families, defaultFamily }) => {
-  const wanted = [defaultFamily, ...families].filter((family) => myBrandFaces.has(family));
-  return { sources: await loadMyFaces(wanted) };
+googleFonts({
+  allow: ['Tinos', 'Carlito'],
+  substitute: { Georgia: 'Tinos' },
 });
 ```
 
-<Callout type="warn">
-  A resolver that fetches makes opening a document perform network requests, which the editor never
-  does on its own. The families come from the file, so treat them as lookup keys against a set you
-  shipped, and never build a URL out of one. Whoever serves the fonts also learns which families a
-  document uses. Stay on the upfront path if that matters. The editor caps how many families it
-  hands a resolver, and `googleFonts()` matches names only against its closed catalog.
-</Callout>
+| Resolver constraint        | Required behavior                                                     |
+| -------------------------- | --------------------------------------------------------------------- |
+| File-supplied family names | Match them against a closed `Map` or catalog.                         |
+| URL construction           | Never build a URL from a document family name.                        |
+| Privacy                    | A remote font host can learn which families the document uses.        |
+| Updates                    | Load another document or remount to apply changed resolver arguments. |
+| Composition                | `useFonts(googleFonts(), brandFragment)` combines sources.            |
 
-`useFonts` exists because the editor root rebuilds its instance when `fonts` changes
-identity. An inline resolver is a new function on every render, which rebuilds the
-editor on every render. `useFonts` returns one resolver for the component's life. It also merges
-origins, so on-demand and upfront faces compose:
+An inline resolver creates a new function on each render. That identity change
+can rebuild the editor. `useFonts` keeps one resolver for the component life.
 
-```ts
-const fonts = useFonts(googleFonts(), brandFragment);
-```
+The editor caps the family list passed to a resolver. `googleFonts()` matches
+only its closed catalog.
 
-Because the resolver keeps its identity, the editor re-reads its arguments per load rather
-than per render. Changing them mid-document resolves nothing new. Load a document or
-remount for new fonts to take effect.
+## Source precedence
 
-## How sources combine
+`composeFontConfiguration(base, ...fragments)` creates one immutable
+configuration.
 
-`composeFontConfiguration(base, ...fragments)` merges any number of fragments into the
-one immutable configuration the editor samples per mount. Precedence is simple:
+| Priority | Rule                                                                               |
+| -------- | ---------------------------------------------------------------------------------- |
+| 1        | An explicit source beats an embedded face with the same family, weight, and style. |
+| 2        | An embedded face beats a substitution.                                             |
+| 3        | The first fragment wins between equal sources.                                     |
+| 4        | Duplicate faces are removed.                                                       |
 
-1. **Explicit sources win.** A face you supply beats an embedded face with the same
-   family, weight, and style.
-2. **Embedded faces beat substitutions.** A document that embeds Calibri uses those
-   bytes; the Calibri→Carlito mapping applies only when no direct source exists.
-3. **First fragment wins** among equals, and duplicate faces are deduplicated rather
-   than erroring.
+## Handle failures
 
-## Fallback behavior
+Fonts never block a document from opening. Each failed face falls back
+independently.
 
-Fonts never block a document from opening. The document mounts immediately on the
-fixed measurer and swaps to shaped measurement in a single re-mount when fonts resolve.
-Edits made before fonts resolve survive that remount, but the undo stack and caret
-position do not, which is why the upfront sample above waits for fonts before the first
-mount. A resolver skips that step. It runs after the document is parsed, so you have
-nothing to gate the first mount on.
-Every failure (a corrupt embedded face, a 404, a hash mismatch) degrades exactly one
-face, reports a typed `EditorFontError` through `onFontError`, and leaves the rest
-measuring accurately.
+| Failure path       | Notification         |
+| ------------------ | -------------------- |
+| React root         | `onFontError`        |
+| Vue root           | `@font-error`        |
+| `createDocxEditor` | `onFontError` option |
 
-## Observing font state
+Each `EditorFontError` has a typed `code`. Known codes include `missing`,
+`malformed`, `overLimit`, `hashMismatch`, and `wasmUnavailable`.
 
-Font errors reach you as `onFontError` on the React root, as the `@font-error` emit on
-the Vue root, and as an option on `createDocxEditor`. Each error carries a typed `code`
-(`missing`, `malformed`, `overLimit`, `hashMismatch`, …) and, where known, the face
-`request` it concerns. To check whether measurement uses shaped fonts, read
-`fontMeasurement()` on the editor instance:
+Read `editor.fontMeasurement()` to inspect measurement:
 
-<FrameworkTabs>
-<Framework value="react">
+| Field       | Meaning                                     |
+| ----------- | ------------------------------------------- |
+| `measurer`  | `'shaped'` or `'fixed'`                     |
+| `resolving` | `true` while font resolution is in progress |
+| `producer`  | Optional source identifier                  |
 
-```tsx
-<DocxEditor.Root
-  document={bytes}
-  fonts={fragment}
-  onFontError={(error) => report(error.code, error.diagnostic ?? error.message)}
-/>;
+`{ measurer: 'fixed', resolving: false }` means no usable font source remains.
 
-// Inside the tree:
-const editor = useDocxEditor();
-editor?.fontMeasurement();
-// → { measurer: 'shaped' | 'fixed', resolving: boolean, producer?: string }
-```
+## Serve the HarfBuzz WASM asset
 
-</Framework>
-<Framework value="vue">
+Webpack, Turbopack, and Vite emit the bundled WebAssembly asset automatically.
+Some esbuild, Bun, and library builds do not emit
+`new URL(..., import.meta.url)` assets.
 
-```vue
-<script setup lang="ts">
-import { DocxEditorRoot } from '@docx-editor.dev/vue';
+Without `harfbuzz.wasm`, the editor reports `wasmUnavailable` and uses fixed
+measurement. Rendering continues, but line and page breaks can differ from
+Word.
 
-function reportFontError(error: { code: string; diagnostic?: string; message: string }) {
-  report(error.code, error.diagnostic ?? error.message);
-}
-</script>
+For affected builds:
 
-<template>
-  <DocxEditorRoot :document="bytes" :fonts="fragment" @font-error="reportFontError">
-    <!-- Viewport, content, and any component that reads the editor. -->
-  </DocxEditorRoot>
-</template>
-```
-
-```ts
-// In a DESCENDANT of DocxEditorRoot: useDocxEditor() reads the root's provide,
-// and the editor is null until the content mounts, so wrap the read in a
-// computed rather than calling it once during setup.
-const editor = useDocxEditor();
-const measurement = computed(() => editor.value?.fontMeasurement());
-// → { measurer: 'shaped' | 'fixed', resolving: boolean, producer?: string }
-```
-
-</Framework>
-</FrameworkTabs>
-
-`{ measurer: 'fixed', resolving: false }` is the steady state for a document with no
-usable font source; `resolving: true` means shaped resolution is still in flight.
-
-## Serving the shaper's WASM yourself
-
-The text shaper is a WASM binary included in `@docx-editor.dev/core` and
-loads lazily when fonts resolve. Webpack, Turbopack, and Vite emit it as an
-asset automatically, so those bundlers need no extra setup for this asset.
-
-Some bundlers do not emit `new URL(..., import.meta.url)` assets. esbuild and Bun
-are the common ones, and so is any build that inlines dynamic imports, such as a
-library bundle. Those builds succeed and then fail at runtime, reaching
-`onFontError` as an `EditorFontError` with code `wasmUnavailable`:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditor
-  onFontError={(error) => {
-    if (error.code === 'wasmUnavailable') showSetupError(error.diagnostic);
-  }}
-/>
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<DocxEditor
-  @font-error="(error) => error.code === 'wasmUnavailable' && showSetupError(error.diagnostic)"
-/>
-```
-
-</Framework>
-</FrameworkTabs>
-
-Without that binary the editor keeps rendering, but it measures text with
-fallback metrics, so line breaks and page breaks no longer match Word. The
-engine also logs the failure once, so you see it even with no handler attached.
-
-To fix it, copy `harfbuzz.wasm` into your served assets and point the shaper at
-it before you create an editor:
-
-```ts
-import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
-
-setHarfBuzzWasmUrl('/static/harfbuzz.wasm');
-```
-
-Copy it as a build step. Resolving the package subpath works under Yarn
-Plug'n'Play too, where there's no `node_modules` directory to read from:
+1. Copy `harfbuzz.wasm` from the installed core package into your served assets.
+2. Call `setHarfBuzzWasmUrl` before you create the first editor.
+3. Repeat the copy after each package upgrade.
 
 ```js
-// scripts/copy-shaper.mjs — run before your bundler
 import { copyFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
@@ -410,40 +247,30 @@ await copyFile(
 );
 ```
 
-Re-run that step on every upgrade. The shaper rejects a binary from a different
-version, so a stale copy fails the same way a missing one does.
+```ts
+import { setHarfBuzzWasmUrl } from '@docx-editor.dev/core/layout';
 
-Call `setHarfBuzzWasmUrl` before the first editor. The shaper reads the location
-once and caches it, so a later call warns and does nothing: move the call and
-reload the page. A Web Worker gets its own module instance, so a worker that
-runs layout needs its own call.
+setHarfBuzzWasmUrl('/static/harfbuzz.wasm');
+```
 
-Pass a URL your application controls. The file is fetched and instantiated as
-WebAssembly, so never build it from user input, a query parameter, or remote
-configuration. Serving it from another origin needs that origin in your
-`connect-src` directive, and WebAssembly needs `wasm-unsafe-eval` in `script-src`
-either way.
+The shaper reads this URL once per module instance. A later call warns and does
+nothing. A Web Worker has a separate module instance and needs its own call.
 
-Serve the copy from the installed package version. The shaper compares the
-HarfBuzz library version it loads against the one it was built for, and rejects a
-mismatch instead of measuring text with unverified metrics.
+Use a URL that your application controls. Do not build it from user input or
+remote configuration.
 
-Because the shaper is bundled into the package, an npm `overrides` entry for
-`harfbuzzjs` does not change the code that runs. Upgrade `@docx-editor.dev/core`
-instead.
+Cross-origin hosting needs that origin in `connect-src`. WebAssembly needs
+`wasm-unsafe-eval` in `script-src`.
 
-## Caveats
+The shaper rejects a missing, stale, or version-mismatched binary. An npm
+`overrides` entry for `harfbuzzjs` does not change bundled shaper code. Upgrade
+`@docx-editor.dev/core` instead.
 
-- **Metric-compatible is not identical.** Advance widths match, so wrap points match;
-  rare kerning-pair differences can still move an edge case. Documents that must
-  render the true faces should supply licensed bytes via `loadFonts`.
-- **The editor never fetches fonts on its own.** `loadFonts`, `loadDefaultFonts` and any
-  resolver you pass run because your code asked for them. Embedded fonts come from inside
-  the file. Opening a document makes no network request unless you passed a resolver that
-  fetches, which is the one case where a font request happens on open.
+For engine implementation details, see
+[Architecture](/docs/2.x/core/architecture).
 
 ## Next steps
 
-- [React props: Fonts](/docs/2.x/react/props#fonts) and [Vue props: Fonts](/docs/2.x/vue/props#fonts): `fonts` and font error reporting
-- [Word fidelity](/docs/2.x/word-fidelity): how measurement affects pagination
-- [Custom styles](/docs/2.x/guides/custom-styles): styles, themes, and the font picker
+- [React font props](/docs/2.x/react/props#fonts): Configure React roots.
+- [Vue font props](/docs/2.x/vue/props#fonts): Configure Vue roots.
+- [Word fidelity](/docs/2.x/word-fidelity): Review pagination support.

--- a/docs/site/content/index.mdx
+++ b/docs/site/content/index.mdx
@@ -6,86 +6,90 @@ order: 1
 seoTitle: 'Documentation and API reference'
 ---
 
-`docx-editor` is an open-source, what-you-see-is-what-you-get (WYSIWYG) DOCX editor for React and Vue 3. It parses Office Open XML (OOXML) and renders paginated document pages. It then serializes the document state to a `.docx` file. Standard browser editing does not require an upload service or conversion backend.
+`docx-editor` is a what-you-see-is-what-you-get (WYSIWYG) DOCX editor for React
+and Vue 3.
 
-During save, semantic round-trip processing preserves untouched content, unsupported OOXML elements, and package payloads.
+It parses Office Open XML (OOXML), renders paginated pages, and saves the edited
+state as a DOCX file. Browser editing needs no upload or conversion service.
 
 <Cards>
   <Card title="Install the editor" href="/docs/2.x/quickstart">
-    Install an adapter, import the stylesheet, load a `.docx` file, and save the edited document.
+    Install an adapter, load a DOCX file, and save the result.
   </Card>
   <Card title="Compose an editor interface" href="/docs/2.x/react/composition">
-    Use unstyled primitives and hooks to compose an interface through the public API.
+    Build an interface with public components and hooks.
   </Card>
   <Card title="Review document fidelity" href="/docs/2.x/word-fidelity">
-    Review feature support, round-trip behavior, the security model, API stability, and known
-    limits.
+    Check feature support, round-trip behavior, security, and limits.
   </Card>
 </Cards>
 
 ## Packages
 
-| Package                                               | Purpose                                                                                                           |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| [`@docx-editor.dev/react`](/docs/2.x/react)           | React adapter with the `<DocxEditor>` component, `DocxEditor.Root`, and composition hooks.                        |
-| [`@docx-editor.dev/core`](/docs/2.x/core)             | Framework-independent engine for OOXML read/write, document storage, layout, painting, and the `Editor` contract. |
-| [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) | Office.js-compatible batching API for server-side documents and active browser editors.                           |
-| [`@docx-editor.dev/pro`](/docs/2.x/pro)               | Modules for tracked changes, comments, and custom nodes.                                                          |
-| [`@docx-editor.dev/i18n`](/docs/2.x/i18n)             | Locale data for `en`, `de`, `fr`, `he`, `hi`, `id`, `pl`, `pt-BR`, `tr`, and `zh-CN`.                             |
-| [`@docx-editor.dev/fonts`](/docs/2.x/guides/fonts)    | Metric-compatible substitutes for Word default fonts when a document does not embed those fonts.                  |
+| Package                                               | Purpose                                                                        | License                             |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------- |
+| [`@docx-editor.dev/react`](/docs/2.x/react)           | React adapter and composition hooks                                            | Apache 2.0                          |
+| [`@docx-editor.dev/vue`](/docs/2.x/vue)               | Vue 3 adapter and composables                                                  | Apache 2.0                          |
+| [`@docx-editor.dev/core`](/docs/2.x/core)             | Framework-independent OOXML, document, layout, paint, and editor engine        | Apache 2.0                          |
+| [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) | Browser and server automation through a documented Office.js-compatible subset | EigenPal Pro Evaluation License 1.0 |
+| [`@docx-editor.dev/pro`](/docs/2.x/pro)               | Tracked changes, comments, and custom nodes                                    | EigenPal Pro Evaluation License 1.0 |
+| [`@docx-editor.dev/i18n`](/docs/2.x/i18n)             | Shared interface translations                                                  | Apache 2.0                          |
+| [`@docx-editor.dev/fonts`](/docs/2.x/guides/fonts)    | Metric-compatible substitutes for common Word fonts                            | Apache-2.0 AND OFL-1.1              |
 
-All packages use a fixed version group and release together. Most packages use the Apache 2.0 license.
-
-`@docx-editor.dev/editor-api` and `@docx-editor.dev/pro` use the EigenPal Pro Evaluation License 1.0. Internal, non-production evaluation is free. Production use requires a commercial agreement with [EigenPal](mailto:licensing@eigenpal.com).
+All packages use one fixed version group. Internal, non-production evaluation of
+Pro packages is free. Production use requires a
+[separate written commercial agreement signed by EigenPal, Inc.](mailto:licensing@eigenpal.com).
 
 ## Select packages
 
-**React applications.** Install the React adapter and the core engine. The React package includes the string catalog.
+| Goal                                                                   | Packages                                                       |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------- |
+| React editor                                                           | `@docx-editor.dev/react` and `@docx-editor.dev/core`           |
+| Vue editor                                                             | `@docx-editor.dev/vue` and `@docx-editor.dev/core`             |
+| Tracked changes, comments, or custom nodes                             | Add `@docx-editor.dev/pro`                                     |
+| Server-side editing through the documented Office.js-compatible subset | `@docx-editor.dev/editor-api` and `@docx-editor.dev/core`      |
+| Browser automation through the same subset                             | Add `@docx-editor.dev/editor-api` and use its `/browser` entry |
+
+Install the React editor:
 
 ```bash
 npm install @docx-editor.dev/react @docx-editor.dev/core
 ```
 
-**Tracked changes, comments, or custom nodes.** Install `-pro` and register its modules.
+For Vue, replace `@docx-editor.dev/react` with `@docx-editor.dev/vue`.
 
-```bash
-npm install @docx-editor.dev/react @docx-editor.dev/core @docx-editor.dev/pro
-```
+## Document capabilities
 
-**Server-side editing without a user interface.** `-editor-api` opens DOCX data, applies edits through its object model, and saves the result.
+| Area        | Examples                                                                |
+| ----------- | ----------------------------------------------------------------------- |
+| Text        | Formatting, fonts, theme colors, paragraph styles, and character styles |
+| Structure   | Tables, lists, numbering, footnotes, endnotes, and content controls     |
+| Page layout | Sections, columns, headers, footers, margins, and pagination            |
+| Content     | Images, hyperlinks, bookmarks, and fields                               |
+| Review      | Tracked changes and comments with `@docx-editor.dev/pro`                |
 
-```bash
-npm install @docx-editor.dev/editor-api @docx-editor.dev/core
-```
+Support differs by feature and operation. See
+[Word fidelity](/docs/2.x/word-fidelity) for editing, rendering, and round-trip
+status. Use the [live demo](https://docx-editor.dev/editor) to test a document.
 
-**Browser automation for an active editor.** Install `-editor-api` with `-react` and use the `/browser` entry. This entry controls the editor instance that the adapter created.
+## Round-trip behavior
 
-## Supported document features
+Saving preserves untouched package content and unsupported OOXML.
 
-The editor reads, renders, edits, and writes these Word features:
+| Content                                | Behavior                                  |
+| -------------------------------------- | ----------------------------------------- |
+| Modeled document structures            | Uses typed nodes for layout and editing.  |
+| Unsupported or misplaced XML           | Keeps generic nodes in the document tree. |
+| Media, fonts, macros, and VBA projects | Copies package payloads through save.     |
+| Custom XML and add-in markup           | Preserves structural content.             |
 
-- Text formatting, fonts, theme colors, paragraph and character styles
-- Tables (merged cells, page-spanning rows, repeated header rows), lists and numbering
-- Headers, footers, sections, columns, page layout
-- Images (inline and anchored), hyperlinks, bookmarks, fields
-- Footnotes, endnotes, content controls
-- Tracked changes and comments, with [`@docx-editor.dev/pro`](/docs/2.x/pro)
-
-See [Word fidelity](/docs/2.x/word-fidelity) for feature coverage and known limits. Use the [live demo](https://docx-editor.dev/editor) to test a document.
-
-## Lossless round-trip
-
-Saving after an edit preserves package content that the edit did not modify. Preserved content includes custom XML, embedded fonts, macros, media, VBA projects, Smart Tags, and unsupported add-in markup.
-
-During parsing, the canonical tree creates typed nodes only for structures that layout requires. It represents all other elements as generic nodes. During save, the serializer preserves tree structure and copies package payloads without modification. Package payloads include media, fonts, and VBA binaries.
-
-The parser also represents unsupported or structurally invalid elements as generic nodes. This representation preserves unrecognized markup without preventing document editing.
-
-Continuous integration (CI) validates this behavior with a corpus of documents. One comparison uses a canonical fingerprint to validate tree structure. Another comparison uses a semantic digest after save and reopen. CI fails if either comparison detects content loss.
+For the preservation contract and test method, see
+[Word fidelity](/docs/2.x/word-fidelity). For engine details, see
+[Architecture](/docs/2.x/core/architecture).
 
 ## Next steps
 
-- [Quickstart](/docs/2.x/quickstart): load, edit, and save a `.docx`
-- [Installation](/docs/2.x/installation): Next.js, Vite, Remix, Astro
-- [Composition](/docs/2.x/react/composition): compose an editor interface with primitives and hooks
-- [Word fidelity](/docs/2.x/word-fidelity): feature support and round-trip behavior
+- [Quickstart](/docs/2.x/quickstart): Load, edit, and save a DOCX file.
+- [Installation](/docs/2.x/installation): Configure supported frameworks.
+- [React composition](/docs/2.x/react/composition): Build a React interface.
+- [Vue composition](/docs/2.x/vue/composition): Build a Vue interface.

--- a/docs/site/content/pro/review-styling.mdx
+++ b/docs/site/content/pro/review-styling.mdx
@@ -1,35 +1,28 @@
 ---
 title: 'Review colors and styling'
-description: 'Color tracked changes and comments by author or by change type, map your own reviewer colors, add avatars, and restyle the review cards with CSS hooks.'
+description: 'Color tracked changes and comments by author or change type, map reviewer colors, add avatars, and style review chrome.'
 category: 'Pro'
 order: 62
 ---
 
-The editor assigns a color to each reviewer. It provides three ways to change
-that assignment: CSS tokens, declarative style components, and one imperative call. Every
-option is display-only. None of them changes the document file.
+Review styling changes presentation only. It does not change the document file.
 
-These styles apply to [tracked changes](/docs/2.x/pro/tracked-changes) and
-[comments](/docs/2.x/pro/comments) alike, so one reviewer keeps one color across
-both.
+The same author color applies to [tracked changes](/docs/2.x/pro/tracked-changes)
+and [comments](/docs/2.x/pro/comments).
 
-The editor assigns a color to each reviewer. A paragraph with changes from three reviewers shows three author colors.
+## Default behavior
 
-You do not need to configure this behavior. Color identifies the author.
+| Behavior                | Result                                                           |
+| ----------------------- | ---------------------------------------------------------------- |
+| Author assignment       | Authors receive slots in first-appearance order.                 |
+| Color ramp              | `--doc-review-author-0` through `--doc-review-author-7`          |
+| More than eight authors | The ramp repeats after eight authors.                            |
+| Change type             | Insertions stay underlined. Deletions stay struck through.       |
+| Review sidebar          | Cards use the author color for the leading edge and avatar disc. |
+| Comment highlights      | All authors use the same yellow highlight by default.            |
 
-Decoration identifies the change type. Insertions remain underlined, and deletions remain struck through.
-
-Each author receives a color from `--doc-review-author-0` through `--doc-review-author-7`.
-
-The editor assigns slots by each author's first appearance. The ramp repeats after eight authors.
-
-The review sidebar uses the same colors. Each card uses its author color on the leading edge and avatar disc.
-
-## Restyle the ramp
-
-Override the slots under `.docx-editor` to change the shared palette.
-
-This example changes two author colors for the painted document and review cards:
+Override ramp tokens under `.docx-editor`. Load your stylesheet after
+`editor.css`, or use a more specific selector.
 
 ```css
 .docx-editor {
@@ -38,20 +31,27 @@ This example changes two author colors for the painted document and review cards
 }
 ```
 
-One ramp supports both themes. Define the slots for a light page.
+The document filter handles dark mode. Review chrome adjusts separately.
 
-Dark mode applies an inverting filter to the document. The review cards adjust their colors separately.
+## Choose a styling API
 
-The packaged stylesheet declares the ramp on `.docx-editor`. Load your stylesheet after `editor.css`, or use a more specific selector.
+| API                             | Use                                                              |
+| ------------------------------- | ---------------------------------------------------------------- |
+| CSS tokens                      | Replace the shared eight-color ramp.                             |
+| `AuthorStyle` declaration       | Set one author's color, background, classes, or avatar.          |
+| `ColorByChangeType` declaration | Color unmatched insertions green and deletions red.              |
+| `setRevisionStyles`             | Control the same state from an editor instance or headless host. |
 
-## Use declarative styles
+Use declarations or `setRevisionStyles` as the source of style state. Calling
+`setRevisionStyles` replaces mounted declarations until a declaration changes.
 
-Mount style declarations for more control. React exposes them as `DocxEditor.AuthorStyle` and
-`DocxEditor.ColorByChangeType`. Vue exports `DocxEditorAuthorStyle` and
-`DocxEditorColorByChangeType` from `@docx-editor.dev/vue`.
+Declarations do not render Document Object Model (DOM) elements. Mounting,
+changing, or removing one repaints the editor without resetting selection,
+caret position, or undo history.
 
-This example assigns one author their own color and avatar, and colors every
-other author's changes by type:
+### Declare author styles
+
+Place declarations anywhere inside the editor root.
 
 <FrameworkTabs>
 <Framework value="react">
@@ -65,7 +65,6 @@ const MODULES = [reviewModule()];
 <DocxEditor.Root document={bytes} modules={MODULES} author="Jess Lin">
   <DocxEditor.AuthorStyle author="Jess Lin" color="#7c3aed" avatarUrl="/avatars/jess.png" />
   <DocxEditor.ColorByChangeType />
-
   <DocxEditor.Viewport>
     <DocxEditor.Content />
   </DocxEditor.Viewport>
@@ -87,7 +86,6 @@ import {
 import { reviewModule } from '@docx-editor.dev/pro/vue';
 
 defineProps<{ bytes: Uint8Array }>();
-
 const modules = [reviewModule()];
 </script>
 
@@ -105,347 +103,27 @@ const modules = [reviewModule()];
 </Framework>
 </FrameworkTabs>
 
-The author-style and change-type components do not render Document Object Model (DOM) elements.
-
-They declare presentation for the engine:
-
-- **Mount:** The engine applies the declaration. A declaration present during creation applies before the first paint.
-- **Prop change:** The engine reapplies the declaration and repaints pages without a remount. The caret, selection, and undo history remain.
-- **Unmount:** The engine removes the declaration. The author returns to the ramp color.
-
-You can render declarations conditionally, map them from configuration, or control them with a color picker.
-
-Place declarations anywhere inside `DocxEditor.Root`. They access the editor through context.
-
-Use either declarations or `setRevisionStyles` as the source of style state.
-
-Calling `setRevisionStyles` while declarations are mounted replaces their combined value. The declarations reapply after a mount, unmount, or prop change.
-
-The imperative value remains until one of these changes occurs. Control the declarations from state to prevent conflicting updates.
-
-The engine paints these styles on the page. These presentation settings do not change the document file.
-
-## Map your own authors to colors
-
-If you know the reviewers, map your configuration to declarations.
-
-This example creates declarations from an author-color map:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-const AUTHOR_COLORS: Record<string, string> = {
-  'Jess Lin': '#7c3aed',
-  'Sam Reyes': '#0e7490',
-  'AI Assistant': '#b91c1c',
-};
-
-<DocxEditor.Root document={bytes} modules={MODULES}>
-  {Object.entries(AUTHOR_COLORS).map(([author, color]) => (
-    <DocxEditor.AuthorStyle key={author} author={author} color={color} />
-  ))}
-  {/* Viewport and content. */}
-</DocxEditor.Root>;
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { DocxEditorAuthorStyle, DocxEditorRoot } from '@docx-editor.dev/vue';
-
-const AUTHOR_COLORS: Record<string, string> = {
-  'Jess Lin': '#7c3aed',
-  'Sam Reyes': '#0e7490',
-  'AI Assistant': '#b91c1c',
-};
-</script>
-
-<template>
-  <DocxEditorRoot :document="bytes" :modules="modules">
-    <DocxEditorAuthorStyle
-      v-for="(color, author) in AUTHOR_COLORS"
-      :key="author"
-      :author="author"
-      :color="color"
-    />
-    <!-- Viewport and content. -->
-  </DocxEditorRoot>
-</template>
-```
-
-</Framework>
-</FrameworkTabs>
-
-`author` must match the document's `w:author` string.
-
-A declaration for an absent author has no effect. You can use one shared configuration for multiple documents.
-
-Authors without declarations keep their ramp colors.
-
-Each declaration accepts more than a color. This example sets all supported presentation fields:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditor.AuthorStyle
-  author="Jess Lin"
-  color="#7c3aed" // ink and decoration in the document, and their card accent
-  background="rgb(124 58 237 / 8%)" // the wash behind their changes
-  spanClassName="jess-edit" // classes added to their painted changes
-  avatarUrl="https://example.com/avatars/jess.png" // their avatar in the review sidebar
-/>
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<DocxEditorAuthorStyle
-  author="Jess Lin"
-  color="#7c3aed"
-  background="rgb(124 58 237 / 8%)"
-  span-class-name="jess-edit"
-  avatar-url="https://example.com/avatars/jess.png"
-/>
-```
-
-`color` sets the ink and decoration in the document, and the card accent. `background` is the
-background tint behind their changes. `span-class-name` adds classes to their painted changes.
-`avatar-url` sets their avatar in the review sidebar.
-
-</Framework>
-</FrameworkTabs>
-
-Use `spanClassName` to apply per-author CSS to painted text.
-
-The declaration renders no wrapper. The engine adds the classes to the author's painted spans.
-
-Keep these rules metric-safe. You can use outlines, shadows, and background accents.
-
-Do not change font size, weight, or family. These changes make painted text differ from the measured layout.
-
-## Color by change type instead
-
-Mount the change-type declaration to color insertions green and deletions red:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditor.Root document={bytes} modules={MODULES}>
-  <DocxEditor.ColorByChangeType />
-  {/* … */}
-</DocxEditor.Root>
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<DocxEditorRoot :document="bytes" :modules="modules">
-  <DocxEditorColorByChangeType />
-  <!-- … -->
-</DocxEditorRoot>
-```
-
-</Framework>
-</FrameworkTabs>
-
-You can combine it with an author declaration.
-
-Named authors keep their declared colors. Other authors use the change-type colors:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditor.AuthorStyle author="AI Assistant" color="#b91c1c" />
-<DocxEditor.ColorByChangeType />
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<DocxEditorAuthorStyle author="AI Assistant" color="#b91c1c" />
-<DocxEditorColorByChangeType />
-```
-
-</Framework>
-</FrameworkTabs>
-
-## Discover the authors in a document
-
-Use the document's author list to build a legend.
-
-`useReviewAuthors()` returns each displayed review author in slot order. Each entry includes its resolved color and style.
-
-The list updates when a document loads or review styling changes.
-
-This example renders an author legend:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-import { useReviewAuthors } from '@docx-editor.dev/react';
-
-const SWATCH = { width: 10, height: 10, display: 'inline-block' };
-
-function ReviewerLegend() {
-  const authors = useReviewAuthors();
-
-  return (
-    <ul className="docx-editor">
-      {authors.map(({ author, color }) => (
-        <li key={author}>
-          <span aria-hidden="true" style={{ ...SWATCH, background: color }} />
-          {author}
-        </li>
-      ))}
-    </ul>
-  );
-}
-```
-
-React returns the author list directly.
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { useReviewAuthors } from '@docx-editor.dev/vue';
-
-const authors = useReviewAuthors();
-</script>
-
-<template>
-  <ul class="docx-editor">
-    <li v-for="entry in authors" :key="entry.author">
-      <span
-        aria-hidden="true"
-        :style="{ background: entry.color, display: 'inline-block', height: '10px', width: '10px' }"
-      />
-      {{ entry.author }}
-    </li>
-  </ul>
-</template>
-```
-
-Vue returns a shallow ref. Call `useReviewAuthors()` in a component under `DocxEditorRoot`.
-
-</Framework>
-</FrameworkTabs>
-
-The list covers tracked changes and comments.
-
-Authors of tracked changes appear first. Their order follows the first appearance of each change.
-
-Authors who only added comments follow. Each comment-only author receives a separate color.
-
-A resolved view hides resolved revisions. It omits authors whose only changes are hidden, unless those authors also commented.
-
-`color` is the author color used by review chrome.
-
-It uses a declaration when available. Otherwise, it uses the author's ramp slot.
-
-With `ColorByChangeType`, painted text uses insertion and deletion colors. Cards keep their author accents.
-
-Therefore, a legend from this list describes the sidebar colors, not the page colors.
-
-An unstyled author's `color` is a `var(--doc-review-author-N)` reference.
-
-The editor declares the ramp on `.docx-editor`. Add this class to the legend or an ancestor so the swatches resolve.
-
-Store selected colors in state and render them as declarations.
-
-This example combines the author list with color inputs:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-import { useState } from 'react';
-import { DocxEditor, useReviewAuthors } from '@docx-editor.dev/react';
-
-function ReviewerColors() {
-  const authors = useReviewAuthors();
-  const [picks, setPicks] = useState<Record<string, string>>({});
-
-  return (
-    <>
-      {Object.entries(picks).map(([author, color]) => (
-        <DocxEditor.AuthorStyle key={author} author={author} color={color} />
-      ))}
-      {authors.map(({ author, color }) => (
-        <input
-          key={author}
-          type="color"
-          aria-label={author}
-          value={picks[author] ?? (color.startsWith('var(') ? '#000000' : color)}
-          onChange={(event) =>
-            setPicks((previous) => ({ ...previous, [author]: event.target.value }))
-          }
-        />
-      ))}
-    </>
-  );
-}
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { reactive } from 'vue';
-import { DocxEditorAuthorStyle, useReviewAuthors } from '@docx-editor.dev/vue';
-
-const authors = useReviewAuthors();
-const picks = reactive<Record<string, string>>({});
-</script>
-
-<template>
-  <DocxEditorAuthorStyle
-    v-for="(color, author) in picks"
-    :key="author"
-    :author="author"
-    :color="color"
-  />
-  <input
-    v-for="entry in authors"
-    :key="entry.author"
-    type="color"
-    :aria-label="entry.author"
-    :value="picks[entry.author] ?? (entry.color.startsWith('var(') ? '#000000' : entry.color)"
-    @input="picks[entry.author] = ($event.target as HTMLInputElement).value"
-  />
-</template>
-```
-
-</Framework>
-</FrameworkTabs>
-
-`useReview().items` includes an `author` on every card. This list includes authors who only added comments.
-
-Call `getReviewAuthors()` on the editor instance to get the author list without an adapter.
-
-A headless host can pass `revisionStyles` during editor creation. It can call `setRevisionStyles` to update styles later.
-
-Vue and React hosts can also call this method when they do not mount declarations.
-
-Both APIs accept a `RevisionStyles` value. Use `'author'`, the default, `'kind'`, or an object with named author styles.
-
-This example uses change-type colors for other authors:
+`author` must match the document's `w:author` value. An absent author has no
+effect. Unmatched authors keep ramp colors unless `ColorByChangeType` is mounted.
+
+| Author style field                  | Effect                                            |
+| ----------------------------------- | ------------------------------------------------- |
+| `color`                             | Sets document ink, decorations, and card accents. |
+| `background`                        | Sets the background tint behind changes.          |
+| `spanClassName` / `span-class-name` | Adds classes to painted change spans.             |
+| `avatarUrl` / `avatar-url`          | Sets the review sidebar avatar.                   |
+
+Keep span CSS metric-safe. Do not change font size, weight, or family. Such
+changes make painted text differ from measured layout.
+
+### Set styles through the editor
+
+`setRevisionStyles` and the editor creation option accept a `RevisionStyles`
+value. Declarative components accept individual author or change-type props.
+Set `others` to `'author'`, the default, or `'kind'` in `RevisionStyles`.
 
 ```ts
 editor.setRevisionStyles({
-  // What authors you don't name take. Defaults to 'author', the ramp.
   others: 'kind',
   authors: {
     'Jess Lin': '#7c3aed',
@@ -454,164 +132,76 @@ editor.setRevisionStyles({
 });
 ```
 
-An author value can be a color string or the fields accepted by `AuthorStyle`.
+An author value can be a color string or an author style object. A headless host
+can also pass `revisionStyles` during editor creation.
 
-Setting `others` to `'kind'` matches mounting `ColorByChangeType` with your declarations.
+## Read document authors
 
-## Add custom avatars
+Use `useReviewAuthors()` to build legends and color controls. Use
+`getReviewAuthors()` without an adapter.
 
-A review card shows the author's initials in a colored disc.
+| Returned behavior   | Detail                                                                                   |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| Order               | Tracked-change authors appear first. Comment-only authors follow.                        |
+| Updates             | The list updates after document load or review style changes.                            |
+| `slot`              | This unbounded rank identifies first-appearance order.                                   |
+| `color`             | This is the resolved card color. An unmatched value can be `var(--doc-review-author-N)`. |
+| Resolved view       | Authors with only hidden revisions are omitted unless they also commented.               |
+| `ColorByChangeType` | Page colors show change types. Returned colors still describe card accents.              |
 
-Set the avatar URL to show an image in the disc:
+React returns the list directly. Vue returns a shallow ref. Call the composable
+under `DocxEditorRoot`.
 
-<FrameworkTabs>
-<Framework value="react">
+Add `.docx-editor` to a legend or its ancestor. This class resolves ramp token
+values used by swatches.
 
-```tsx
-<DocxEditor.AuthorStyle author="Jess Lin" avatarUrl="https://example.com/avatars/jess.png" />
-```
+## Add avatars
 
-</Framework>
-<Framework value="vue">
+Set `avatarUrl` to replace initials in a review card. Authors without an avatar
+keep their initials.
 
-```vue
-<DocxEditorAuthorStyle author="Jess Lin" avatar-url="https://example.com/avatars/jess.png" />
-```
+| Avatar behavior    | Result                                                       |
+| ------------------ | ------------------------------------------------------------ |
+| Loading or failure | The author color remains visible under the image.            |
+| Rejected URL       | The card uses initials. `useReviewAuthor` reports no avatar. |
+| Document page      | The avatar does not affect painted document content.         |
+| Request policy     | The packaged image uses `referrerPolicy="no-referrer"`.      |
 
-</Framework>
-</FrameworkTabs>
+Use a host you control. The editor accepts application-held `blob:` URLs and
+non-SVG `data:image/*` URLs. It rejects other `data:` URLs, SVG data images,
+script schemes, and protocol-relative hosts.
 
-The image covers the disc and uses its round shape. The author color remains under the image.
+The browser fetches an avatar when its card renders. The editor never loads an
+avatar address from the document.
 
-The color appears while the image loads or if loading fails. Authors without `avatarUrl` keep their initials.
+Document authors are untrusted strings. A sender can use a known name and
+receive its configured image. Do not use review styling as identity proof.
 
-An avatar does not change the painted document. Only `color` changes an author's document ink.
+## Use CSS hooks
 
-Use a host you control for `avatarUrl`. You can also use a `data:` or `blob:` URL that your application already holds.
+| Element                 | Author hooks                                         |
+| ----------------------- | ---------------------------------------------------- |
+| Tracked-change spans    | `data-review-author`; slot only with author coloring |
+| Paragraph-mark pilcrows | `data-review-author`, `data-review-author-slot`      |
+| Comment highlight bands | Both attributes and `--doc-review-author-current`    |
+| Review cards            | Both attributes and `--doc-review-author-current`    |
+| Hover balloons          | Both attributes and `--doc-review-author-current`    |
+| Gutter markers          | Both attributes and `--doc-review-author-current`    |
 
-The browser fetches the image when the card renders. The packaged card uses `referrerPolicy="no-referrer"`.
+`data-review-author` contains the exact document value.
+`data-review-author-slot` wraps to `0` through `7`. Calculate it as `slot % 8`
+when you build selectors from `useReviewAuthors()`.
 
-The editor does not load image addresses from the document. It rejects unsafe declaration URLs, including script schemes and protocol-relative hosts.
-
-The card uses initials after rejection. `useReviewAuthor` then reports no avatar.
-
-Declarations match the exact author name in the document. The document sender controls this value.
-
-A document can use a known author's name and receive that author's color and image. Do not use review styling as identity proof.
-
-Style the packaged class to resize or reshape the disc:
-
-```css
-.docx-editor .docx-review__avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 8px;
-}
-```
-
-In a custom card, read the avatar from `useReviewAuthor` and render your own image.
-
-For an example, see [Per-author card design](#per-author-card-design).
-
-## Per-author CSS hooks
-
-The editor adds author attributes to these elements:
-
-- Tracked-change spans
-- Paragraph-mark pilcrows
-- Comment highlight bands
-- Review cards
-- Hover balloons
-- Gutter markers
-
-Each element has these attributes:
-
-- `data-review-author`: The exact author name from the document.
-- `data-review-author-slot`: The author's ramp slot from `0` through `7`.
-
-Use the slot attribute when you do not know author names. The ramp repeats after eight authors.
-
-The `slot` value from the author list is an unbounded rank. The DOM attribute wraps that rank to the ramp.
-
-Build selectors from `useReviewAuthors()` with the same calculation: `` `[data-review-author-slot='${slot % 8}']` ``.
-
-One author uses the same wrapped slot across all elements. This CSS example styles an author by name or slot:
+Painted spans use an inline ink color. CSS cannot override that color or its text
+decoration. Use a declaration or ramp token for ink. Use `currentColor` for
+metric-safe span effects.
 
 ```css
-/* Their changes in the text and their cards in the sidebar, together. */
 .docx-editor [data-review-author='Jess Lin'] {
   outline: 1px dotted currentColor;
   outline-offset: 1px;
 }
 
-/* Or by slot, which survives whoever opens the document. */
-.docx-editor [data-review-author-slot='2'] {
-  text-shadow: 0 0 6px currentColor;
-}
-```
-
-Narrow the selector to style one review surface:
-
-```css
-/* Cards only. Their leading edge is already the author's color. */
-.docx-editor .docx-review__card[data-review-author='AI Assistant'] {
-  background: #fef2f2;
-  font-weight: 600;
-}
-```
-
-Cards, balloons, markers, and bands define `--doc-review-author-current`.
-
-This custom property contains the resolved author color. Use it to color these elements.
-
-Painted spans do not define this property. The engine writes the author color to their inline `color`.
-
-Use `currentColor` for painted spans, or read the slot's ramp token.
-
-CSS rules cannot override the inline ink color or text decoration on a painted span.
-
-Set ink color through a declaration or by changing the ramp. Keep span rules metric-safe because the engine measures painted text.
-
-Spans have `data-review-author-slot` only when the editor colors changes by author.
-
-`ColorByChangeType` without author declarations keeps the name attribute and removes the slot attribute.
-
-These rules also apply to comment authors. One author uses one color across comments and tracked changes.
-
-A comment-only author receives a slot. `useReviewAuthors()` lists comment-only authors after tracked-change authors.
-
-This declaration styles a comment-only author:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-// Sam only comments. Their cards still get this color and picture.
-<DocxEditor.AuthorStyle author="Sam Reyes" color="#0e7490" avatarUrl="/avatars/sam.png" />
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<!-- Sam only comments. Their cards still get this color and picture. -->
-<DocxEditorAuthorStyle author="Sam Reyes" color="#0e7490" avatar-url="/avatars/sam.png" />
-```
-
-</Framework>
-</FrameworkTabs>
-
-## Tint commented text by author
-
-Commented text has a highlight band. The band has `data-review-author`, `data-review-author-slot`, and `--doc-review-author-current`.
-
-By default, the band color does not change by author. Word uses the same yellow highlight for all comments.
-
-Add a CSS rule to use author colors:
-
-```css
-/* Every comment, in its author's color. The fallback keeps a band that has no author
-   (a custom node, or a comment the file left unattributed) visible. */
 .docx-editor .docx-comment-band {
   background: color-mix(
     in srgb,
@@ -619,123 +209,23 @@ Add a CSS rule to use author colors:
     transparent
   );
 }
-
-/* Or one reviewer only. */
-.docx-editor .docx-comment-band[data-review-author='Sam Reyes'] {
-  box-shadow: inset 0 -2px 0 var(--doc-review-author-current);
-}
 ```
 
-The band and card read the same variable. Their colors match without duplicate color values.
+`--doc-review-author-current` contains the light-theme value in both themes.
+Define a dark-theme rule when you tint comment bands by author.
 
-The band is chrome, not page content. The dark theme's page filter does not affect it.
+## Build custom review cards
 
-`--doc-review-author-current` contains the light-theme value in both themes. Define a dark-theme value when you tint bands by author:
+`useReviewAuthor` returns one author's resolved color, ramp slot, and declared
+style. React returns the value directly. The Vue composable accepts a ref or
+getter and returns a computed ref.
 
-```css
-.docx-editor.dark .docx-comment-band {
-  background: color-mix(in srgb, var(--doc-review-author-current) 34%, transparent);
-}
-```
-
-## Per-author card design
-
-Use composition to change card design.
-
-The packaged card uses the resolved author color for its leading edge and avatar disc. `avatarUrl` provides the avatar image.
-
-The collapsed gutter marker remains neutral. It includes author hooks for optional color styling.
-
-Use `data-review-author` hooks for more changes, or replace the card.
-
-The `List` render callback receives each item and its `author`.
-
-This example selects a card component by author:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditorReview>
-  <DocxEditorReview.List>
-    {(item) =>
-      item.author === 'AI Assistant' ? <AgentCard item={item} /> : <MyCard item={item} />
-    }
-  </DocxEditorReview.List>
-</DocxEditorReview>
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<DocxEditorReview>
-  <DocxEditorReview.List>
-    <template #item="{ item }">
-      <AgentCard v-if="item.author === 'AI Assistant'" :item="item" />
-      <MyCard v-else :item="item" />
-    </template>
-  </DocxEditorReview.List>
-</DocxEditorReview>
-```
-
-</Framework>
-</FrameworkTabs>
-
-Use `useReviewAuthor` to connect a custom card to author styling.
-
-It returns one author's resolved color, ramp slot, and declared style. These values match the painted text.
-
-The hook supports comment authors. A declaration change updates the card.
-
-This example renders a custom card with the resolved author style:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-import { DocxEditorReview, useReviewAuthor, type ReviewItemView } from '@docx-editor.dev/pro/react';
-
-function MyCard({ item }: { item: ReviewItemView }) {
-  const author = useReviewAuthor(item.author);
-  return (
-    <div className="my-card" style={{ borderLeft: `3px solid ${author?.color ?? 'transparent'}` }}>
-      {author?.style?.avatarUrl ? <img src={author.style.avatarUrl} alt="" /> : item.author}
-      {item.text}
-    </div>
-  );
-}
-
-<DocxEditorReview>
-  <DocxEditorReview.List>{(item) => <MyCard item={item} />}</DocxEditorReview.List>
-</DocxEditorReview>;
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { useReviewAuthor, type ReviewItemView } from '@docx-editor.dev/pro/vue';
-
-const props = defineProps<{ item: ReviewItemView }>();
-const author = useReviewAuthor(() => props.item.author);
-</script>
-
-<template>
-  <div class="my-card" :style="{ borderColor: author?.color }">
-    {{ item.author }}: {{ item.text }}
-  </div>
-</template>
-```
-
-The Vue composable accepts a ref or a getter and returns a computed ref.
-
-</Framework>
-</FrameworkTabs>
+The `DocxEditorReview.List` callback or Vue `#item` slot receives each item and
+its `author`. Use that value to select a custom card. For composition patterns,
+see [React composition](/docs/2.x/react/composition) or
+[Vue composition](/docs/2.x/vue/composition).
 
 ## Next steps
 
-- [Tracked changes](/docs/2.x/pro/tracked-changes): Record, render, and resolve revisions.
-- [Comments](/docs/2.x/pro/comments): Add discussion threads beside revisions.
-- [Vue composition](/docs/2.x/vue/composition) and [React composition](/docs/2.x/react/composition): Arrange the editor and review parts.
+- [Tracked changes](/docs/2.x/pro/tracked-changes): Record and resolve revisions.
+- [Comments](/docs/2.x/pro/comments): Add discussion threads.

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -1,42 +1,59 @@
 ---
 title: 'Tracked changes'
-description: 'Use suggesting mode to record Word revisions. Render, accept, or reject them with the packaged review sidebar or your own UI.'
+description: 'Use suggesting mode to record Word revisions. Render, accept, or reject them with the review sidebar or your own interface.'
 category: 'Pro'
 order: 61
 ---
 
-In suggesting mode, the editor records each edit as a revision. It underlines insertions and strikes through deletions.
+Suggesting mode records edits as Word revisions. The editor underlines
+insertions and strikes through deletions.
 
-Each revision includes its author and timestamp. The editor serializes revisions as Word `w:ins` and `w:del` markup.
+Each revision keeps its author and timestamp. Saved files use Word `w:ins` and
+`w:del` markup.
 
-You can review the saved document in this editor or Microsoft Word.
+This feature requires the review module from
+[`@docx-editor.dev/pro`](/docs/2.x/pro).
 
-This feature requires the review module from [`@docx-editor.dev/pro`](/docs/2.x/pro).
+## Choose an editing mode
 
-## Turn on suggesting
+| Root `mode` value | Engine state   | Behavior                              |
+| ----------------- | -------------- | ------------------------------------- |
+| `'edit'`          | `'editing'`    | Applies edits without revisions.      |
+| `'suggesting'`    | `'suggesting'` | Records supported edits as revisions. |
+| `'view'`          | `'viewing'`    | Keeps the document read-only.         |
 
-Editing mode is engine state. Use the `setEditingMode` command to change it after mount.
+Use the `setEditingMode` command to change the mode after mount. The packaged
+toolbar exposes the same command in `review.editingMode`.
 
-This example switches between editing and suggesting modes:
+If you omit `mode`, the root honors `w:trackRevisions` when a review module and
+an `author` are present. An explicit `mode` overrides this document setting.
+
+The `<DocxEditor>` convenience component defaults to `mode="edit"`. Enforced
+document protection can also restrict the available mode.
+
+This example switches between editing and suggesting:
 
 <FrameworkTabs>
 <Framework value="react">
 
 ```tsx
 import { DocxEditor, useEditorCommand, useEditorState } from '@docx-editor.dev/react';
-import { reviewModule, DocxEditorReview } from '@docx-editor.dev/pro/react';
+import { DocxEditorReview, reviewModule } from '@docx-editor.dev/pro/react';
 
 const MODULES = [reviewModule()];
 
 function SuggestToggle() {
-  const mode = useEditorState((s) => s.editingMode);
+  const mode = useEditorState((state) => state.editingMode);
   const suggest = useEditorCommand({ type: 'setEditingMode', mode: 'suggesting' });
   const edit = useEditorCommand({ type: 'setEditingMode', mode: 'editing' });
-  const on = mode === 'suggesting';
+  const active = mode === 'suggesting';
 
   return (
-    <button onMouseDown={(e) => e.preventDefault()} onClick={() => (on ? edit : suggest).execute()}>
-      {on ? 'Suggesting' : 'Editing'}
+    <button
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => (active ? edit : suggest).execute()}
+    >
+      {active ? 'Suggesting' : 'Editing'}
     </button>
   );
 }
@@ -59,554 +76,190 @@ export function Reviewer({ bytes }: { bytes: Uint8Array }) {
 
 ```vue
 <script setup lang="ts">
-import { useEditorCommand, useEditorState } from '@docx-editor.dev/vue';
+import {
+  DocxEditorContent,
+  DocxEditorRoot,
+  DocxEditorViewport,
+  useEditorCommand,
+  useEditorState,
+} from '@docx-editor.dev/vue';
+import { DocxEditorReview, reviewModule } from '@docx-editor.dev/pro/vue';
 
+defineProps<{ bytes: Uint8Array }>();
+
+const modules = [reviewModule()];
 const mode = useEditorState((state) => state.editingMode);
 const suggest = useEditorCommand({ type: 'setEditingMode', mode: 'suggesting' });
 const edit = useEditorCommand({ type: 'setEditingMode', mode: 'editing' });
 </script>
 
 <template>
-  <button type="button" @click="mode === 'suggesting' ? edit.execute() : suggest.execute()">
-    {{ mode === 'suggesting' ? 'Suggesting' : 'Editing' }}
-  </button>
+  <DocxEditorRoot :document="bytes" :modules="modules" author="Jess Lin">
+    <button type="button" @click="mode === 'suggesting' ? edit.execute() : suggest.execute()">
+      {{ mode === 'suggesting' ? 'Suggesting' : 'Editing' }}
+    </button>
+    <DocxEditorViewport>
+      <DocxEditorContent />
+      <DocxEditorReview />
+    </DocxEditorViewport>
+  </DocxEditorRoot>
 </template>
 ```
 
-Save this component as `SuggestToggle.vue`. Mount it as a child of `DocxEditorRoot`.
-
 </Framework>
 </FrameworkTabs>
 
-`DocumentEditingMode` is `'editing' | 'suggesting' | 'viewing'`.
+## Tracked content
 
-The packaged toolbar provides this control in the `review.editingMode` slot. `<DocxEditor.Toolbar />` adds the control without a custom toggle.
+| Change               | Support and display                                                          |
+| -------------------- | ---------------------------------------------------------------------------- |
+| Text                 | Tracks insertions, deletions, and replacements. A replacement uses one card. |
+| Paragraph structure  | Tracks inserted and deleted paragraph marks.                                 |
+| Paragraph properties | Tracks property changes in a separate card.                                  |
+| Tables               | Tracks row and cell insertion, deletion, and property changes.               |
+| Run formatting       | Tracks formatting changes in a separate card.                                |
 
-Import the Vue review rail and composables from `@docx-editor.dev/pro/vue`. Vue composables return computed refs.
+A changed paragraph mark shows a colored pilcrow and margin change bar. This
+display also works inside table cells.
 
-## Choose the opening mode
+One paragraph mark can contain two decisions. For example, one author can insert
+a break before another author suggests its removal.
 
-The `mode` prop sets the opening mode. Its values match the toolbar control: `'edit'`, `'suggesting'`, or `'view'`.
+Attribution appears only in **All Markup**. Resolved views omit review colors,
+pilcrows, and change bars. **No Markup** merges paragraphs when a revision
+deletes their paragraph mark.
 
-This example sets `mode` on the editor root:
+For author colors and avatars, see
+[Review colors and styling](/docs/2.x/pro/review-styling).
 
-<FrameworkTabs>
-<Framework value="react">
+## Add the review sidebar
 
-```tsx
-<DocxEditor.Root document={bytes} author="Jess Lin" mode="suggesting">
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<DocxEditorRoot :document="bytes" :modules="modules" author="Jess Lin" mode="suggesting">
-  <!-- Editor parts -->
-</DocxEditorRoot>
-```
-
-</Framework>
-</FrameworkTabs>
-
-Microsoft Word writes `w:trackRevisions` to `word/settings.xml` when an author turns on tracked changes.
-
-If you omit `mode`, the editor honors this setting and opens in suggesting mode. This behavior requires a review module and an `author`.
-
-An explicit `mode` overrides the document setting. The toolbar can switch between `'edit'` and `'suggesting'`.
-
-The `'view'` mode keeps the editor read-only. Enforced protection overrides this rule when the document permits only tracked changes.
-
-The `<DocxEditor>` component defaults `mode` to `'edit'`, so the packaged editor opens every document in editing mode.
-
-## What gets tracked
-
-The revision model covers these changes:
-
-- **Text:** The editor tracks insertions, deletions, and replacements. A replacement uses one card, as in Word.
-- **Paragraph structure:** The editor tracks inserted and deleted paragraph marks, plus paragraph property changes.
-- **Tables:** The editor tracks row and cell insertion or deletion. It also tracks row, cell, and table property changes.
-- **Formatting:** The editor gives run and paragraph property changes separate cards.
-
-A changed paragraph mark appears as a colored pilcrow with a margin change bar. This behavior also applies inside table cells.
-
-A paragraph mark can contain two decisions. For example, one author can insert a break before another author proposes its removal.
-
-The editor presents both decisions. It saves all supported changes as OOXML revisions.
-
-The editor shows attribution only in **All Markup**, consistent with Word.
-
-Resolved views show the result after all decisions. They omit review colors, pilcrows, and change bars.
-
-Resolved views also merge paragraphs when a revision deletes the paragraph mark. **No Markup** then matches the result of accepting that change.
-
-## Color review content by author
-
-The editor colors each reviewer's changes, and you can override the ramp, declare
-per-author colors and avatars, or color by change type instead.
-
-For details, see [Review colors and styling](/docs/2.x/pro/review-styling).
-
-## The review sidebar
-
-`<DocxEditorReview />` renders one card for each pending decision. It anchors each card beside its change.
-
+`<DocxEditorReview />` renders one card for each included pending decision.
 Place it inside the viewport so the rail scrolls with the document.
 
-You can compose each card from review parts.
-
-This example composes a review card from the rail parts:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditorReview>
-  <DocxEditorReview.List>
-    <DocxEditorReview.Card>
-      <DocxEditorReview.Avatar />
-      <DocxEditorReview.Author />
-      <DocxEditorReview.Time />
-      <DocxEditorReview.Summary />
-      <DocxEditorReview.Accept />
-      <DocxEditorReview.Reject />
-      <DocxEditorReview.Delete />
-      <DocxEditorReview.Replies />
-      <DocxEditorReview.Reply />
-    </DocxEditorReview.Card>
-  </DocxEditorReview.List>
-  <DocxEditorReview.Empty>Nothing to review</DocxEditorReview.Empty>
-</DocxEditorReview>
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { DocxEditorReview } from '@docx-editor.dev/pro/vue';
-</script>
-
-<template>
-  <DocxEditorReview>
-    <DocxEditorReview.List>
-      <DocxEditorReview.Card>
-        <DocxEditorReview.Avatar />
-        <DocxEditorReview.Author />
-        <DocxEditorReview.Time />
-        <DocxEditorReview.Summary />
-        <DocxEditorReview.Accept />
-        <DocxEditorReview.Reject />
-        <DocxEditorReview.Resolve />
-        <DocxEditorReview.Reopen />
-        <DocxEditorReview.Delete />
-        <DocxEditorReview.Replies />
-        <DocxEditorReview.Reply />
-      </DocxEditorReview.Card>
-      <DocxEditorReview.Empty>Nothing to review</DocxEditorReview.Empty>
-    </DocxEditorReview.List>
-    <DocxEditorReview.Markers />
-    <DocxEditorReview.AddComment />
-    <DocxEditorReview.Draft />
-    <DocxEditorReview.Balloon />
-  </DocxEditorReview>
-</template>
-```
-
-Use the `#item="{ item }"` slot on `DocxEditorReview.List` to render a custom Vue card.
-
-</Framework>
-</FrameworkTabs>
-
-`Markers` renders one gutter marker for each top-level item while the pane is closed.
-
-Selecting a marker opens the pane at that item. `Balloon` shows the decision popover for a formatting or structural change.
-
-`AddComment` and `Draft` provide comment authoring.
-
-Review rail parts support Vue and React.
-
-Both adapter entries export custom-node chip and context-menu chrome.
-
-Every part accepts `className`, `asChild`, and `hidden`.
-
-The `Accept`, `Reject`, `Delete`, and `Reply` action parts also accept `icon`.
-
-`Markers` accepts an `icon` function because one component draws all gutter markers.
-
-Return a node to replace an item's packaged glyph. Return `null` or `undefined` to keep the packaged glyph.
-
-The packaged glyph identifies the item kind. It uses a custom node's `reviewCard` icon when provided.
-
-This example selects marker icons by item kind:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditorReview>
-  <DocxEditorReview.Markers
-    icon={(item) => (item.kind === 'comment' ? <SpeechIcon /> : <EditIcon />)}
-  />
-</DocxEditorReview>
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { h } from 'vue';
-import { DocxEditorReview } from '@docx-editor.dev/pro/vue';
-import EditIcon from './EditIcon.vue';
-import SpeechIcon from './SpeechIcon.vue';
-</script>
-
-<template>
-  <DocxEditorReview>
-    <DocxEditorReview.Markers
-      :icon="(item) => h(item.kind === 'comment' ? SpeechIcon : EditIcon)"
-    />
-  </DocxEditorReview>
-</template>
-```
-
-The Vue `icon` prop takes a `VNode` or a function that returns one, so wrap a component in `h()`.
-
-</Framework>
-</FrameworkTabs>
-
-An override inherits the rail's scale, offset, and visible window. Pass only the props that you want to change.
-
-`Delete` removes content from both card types.
-
-On a comment card, it deletes the thread. On a tracked-change card, it discards the suggestion.
-
-`Replies` renders one Delete control for each reply. This control removes the reply without deleting its thread.
-
-Cards with nothing to discard do not show Delete.
-
-The stylesheet shows Delete when its target has hover or keyboard focus. This behavior reduces accidental deletion.
-
-You can style Delete like other parts. Set `visibility: visible` on `[data-testid='review-delete']` to keep it visible.
-
-## Choose sidebar content
-
-Use these `DocxEditorReview` props to control content and stacking:
-
-- `filter`, default none: Shows a subset. Use `(item) => item.kind === 'comment'` to separate comments and revisions.
-- `structural`, default `false`: Shows cards for document structure changes.
-- `formatting`, default `false`: Shows cards for text formatting changes.
-- `stack`, default `true`: Moves overlapping cards down to prevent collisions.
-- `gap`, default `8`: Sets the pixel gap between stacked cards. It is the only source of vertical spacing.
-- `furniture`, default none: Adds host content before cards, such as filters, a legend, or a summary.
-- `preset`, default `true`: Set `false` to mount only the rail and its context. You then position cards.
-
-`structural` and `formatting` default to `false`. A document with many revisions can create one card for each change location.
-
-These revisions remain marked on the page. Selecting one opens its balloon.
-
-This example shows only comments and adds custom furniture:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-<DocxEditorReview filter={(item) => item.kind === 'comment'} gap={12} furniture={<MyFilters />} />
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { h } from 'vue';
-import { DocxEditorReview } from '@docx-editor.dev/pro/vue';
-import MyFilters from './MyFilters.vue';
-</script>
-
-<template>
-  <DocxEditorReview
-    :filter="(item) => item.kind === 'comment'"
-    :gap="12"
-    :furniture="h(MyFilters)"
-  />
-</template>
-```
-
-`furniture` is a `VNode` prop in Vue, not a slot.
-
-</Framework>
-</FrameworkTabs>
-
-Setting `preset` to `false` keeps subscriptions and anchors while you render the cards.
-
-Use `useStackedReviewPositions(items, heights, { gap, scale })` for the packaged stacking calculation.
-
-Pass the editor render scale from `editor.getRenderScale()` as `scale`.
-
-Card heights use CSS pixels, while anchors use document points. The default scale of `1` makes spacing approximately one-third too large.
-
-## Host content inside a card
-
-`useReviewItem()` reads the parent card's item.
-
-This example adds a link only to revision cards:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-import { DocxEditorReview, useReviewItem } from '@docx-editor.dev/pro/react';
-
-function AuditLink() {
-  const item = useReviewItem();
-  if (item?.kind !== 'revision') return null;
-  return <a href={`/audit/${item.id}`}>History</a>;
-}
-
-<DocxEditorReview>
-  <AuditLink />
-</DocxEditorReview>;
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<!-- AuditLink.vue -->
-<script setup lang="ts">
-import { useReviewItem } from '@docx-editor.dev/pro/vue';
-
-const item = useReviewItem();
-</script>
-
-<template>
-  <a v-if="item?.kind === 'revision'" :href="`/audit/${item.id}`">History</a>
-</template>
-```
-
-</Framework>
-</FrameworkTabs>
-
-## useReview
-
-The review rail renders data from this composable or hook. Use it to build your own list or card layout.
-
-This example renders review items and revision actions:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-import { useReview } from '@docx-editor.dev/pro/react';
-
-function ChangeList() {
-  const { items, activeKey, setActive, accept, reject, ready } = useReview();
-  if (!ready) return null;
-
-  return (
-    <ul>
-      {items.map((item) => (
-        <li key={item.key} data-active={item.key === activeKey || undefined}>
-          {/* `text` is file-derived. Render it as text, never as markup. */}
-          <button onClick={() => setActive(item.key)}>{item.text}</button>
-          <span>{item.author}</span>
-          {!item.readOnly && (
-            <>
-              <button onClick={() => accept(item)}>Accept</button>
-              <button onClick={() => reject(item)}>Reject</button>
-            </>
-          )}
-        </li>
-      ))}
-    </ul>
-  );
-}
-```
-
-`text` is file-derived. Render it as text, never as markup.
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { useReview } from '@docx-editor.dev/pro/vue';
-
-const review = useReview();
-</script>
-
-<template>
-  <ul v-if="review.ready.value">
-    <li
-      v-for="item in review.items.value"
-      :key="item.key"
-      :data-active="item.key === review.activeKey.value || undefined"
-    >
-      <button type="button" @click="review.setActive(item.key)">
-        {{ item.text }}
-      </button>
-      <span>{{ item.author }}</span>
-      <button
-        v-if="item.kind === 'revision' && !item.readOnly"
-        type="button"
-        @click="review.accept(item)"
-      >
-        Accept
-      </button>
-      <button
-        v-if="item.kind === 'revision' && !item.readOnly"
-        type="button"
-        @click="review.reject(item)"
-      >
-        Reject
-      </button>
-    </li>
-  </ul>
-</template>
-```
-
-Render `item.text` with interpolation. The text comes from the file.
-
-</Framework>
-</FrameworkTabs>
-
-The review API provides these members:
-
-- `items`: Contains each pending decision selected by the query in reading order.
-- `activeKey` and `setActive`: Read or set the open item.
-- `accept(item)` and `reject(item)`: Resolve a revision and return whether the write succeeded.
-- `resolve(item)` and `reopen(item)`: Change comment thread state.
-- `commentResolutionDisabledReason`: Contains the engine refusal for comment-resolution actions, or `null`.
-- `reply(item, text, author?)`: Adds a reply and returns whether the write succeeded.
-- `remove(item)`: Deletes a comment thread or discards a suggestion. It returns whether the write succeeded.
-- `comment(text, author?)`: Comments on the current selection and returns whether the write succeeded.
-- `selectionAnchorY`: Contains the proposed comment position, or `null`.
-- `paneOpen` and `setPaneOpen`: Read or change the same state as the toolbar comments control.
-- `ready`: Is `false` while no document is loaded.
-
-`setActive` opens the requested item or the item that contains the caret.
-
-It puts the caret at the start of the item range and scrolls to it. It opens or closes header and footer stories as required.
-
-It does not select content. The open item renders its own highlight.
-
-Read `item.ranges` for revision ranges. Read `item.range` for a comment range.
-
-`setActive` returns whether it moved the caret. Check `activatable`, and pass `{ reveal }` to control scrolling.
-
-`accept` and `reject` return `false` for a `readOnly` item or a document in viewing mode.
-
-Repeating the current comment state through `resolve` or `reopen` succeeds without a write.
-
-Each item contains `key`, `id`, `author`, `initials`, `date`, `text`, `replyIds`, and `readOnly`.
-
-It also contains `activatable`, `anchorY`, `pageIndex`, and `isActive`.
-
-Revision items add `kind: 'revision'`, `revisionKind`, and `replacedText` for replacements. A card can use these fields to show _Replaced "x" with "y"_.
-
-Revision items also contain `replyIds`. OOXML gives `w:ins` and `w:del` no body.
-
-A reply to a tracked change creates a comment over the revision range. The comment uses `parentRevisionId` to identify the revision.
-
-Show that reply inside the revision card. A top-level list must omit comments with `parentId` or `parentRevisionId` to prevent duplicates.
-
-Use the hook's items and anchors instead of recalculating them.
-
-Items come from the document tree, not visible painted content. A visible-page queue would lose items during scrolling.
-
-Each `anchorY` comes from layout records, not measured DOM. DOM measurements can lag one paint behind and fail during pagination.
-
-`readOnly` identifies a decision that the engine cannot resolve structurally. Do not show **Accept** or **Reject** for these items.
-
-In viewing mode, packaged **Accept**, **Reject**, **Delete**, **Resolve**, and **Reopen** controls remain visible but disabled.
-
-Comment actions use the engine reason `the document is open for viewing`. Users can still inspect and activate the decision.
-
-`useReviewOf(editor, query)` applies the same behavior to an existing editor.
-
-This example passes an explicit editor and a query:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-import { useDocxEditor } from '@docx-editor.dev/react';
-import { useReviewOf } from '@docx-editor.dev/pro/react';
-
-function TextChangeCount() {
-  const editor = useDocxEditor();
-  const { items } = useReviewOf(editor, {
-    excludeRevisionKinds: ['format', 'structural'],
-  });
-
-  return <span>{items.length} text changes</span>;
-}
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { useDocxEditor } from '@docx-editor.dev/vue';
-import { useReviewOf } from '@docx-editor.dev/pro/vue';
-
-const editorRef = useDocxEditor();
-const review = useReviewOf(editorRef, () => ({
-  excludeRevisionKinds: ['format', 'structural'],
-}));
-</script>
-
-<template>
-  <span>{{ review.items.value.length }} text changes</span>
-</template>
-```
-
-Vue accepts an editor ref and a reactive query.
-
-</Framework>
-</FrameworkTabs>
-
-Filtering and activation use these rules:
-
-1. `excludeRevisionKinds` removes those revision kinds from `items`.
-2. `placement: false` keeps item metadata and sets `anchorY` and `pageIndex` to `null`.
-3. A query filters returned data. It does not limit caret-driven activation.
-4. A custom rail that hides revision kinds must call `editor.setReviewActivationExclusions([...])`.
-5. `DocxEditorReview` sets exclusions from `structural` and `formatting`. It clears them on unmount.
-6. Activation exclusions do not remove entries from an unfiltered queue. These entries remain in `items` with `activatable: false`.
-7. An item without a resolvable range also has `activatable: false`.
-8. `setActive` returns `false` without moving the caret when activation is excluded or no range exists.
-9. `setActive` can also return `false` when the item's story cannot open.
-
-### Scroll position after activation
-
-`setActive` centers an item when scrolling is required. It does not move an item that is already visible.
-
-Pass `reveal` to select another behavior:
-
-```ts
-setActive(item.key, { reveal: 'start' }); // near the top, the way a jump to a heading reads
-setActive(item.key, { reveal: 'nearest' }); // the minimum scroll, so it lands against an edge
-setActive(item.key, { reveal: false }); // open it, but leave the viewport alone
-```
-
-Use `reveal: false` when your list controls viewport scrolling.
-
-This option controls item scrolling. Activating a header, footer, or note change still opens that story and shows its band.
+The default sidebar excludes structural and formatting revisions. Its props can
+include those revisions or filter the queue further.
+
+| Prop         | Default | Behavior                                                        |
+| ------------ | ------- | --------------------------------------------------------------- |
+| `filter`     | None    | Returns a subset of items.                                      |
+| `structural` | `false` | Adds cards for structural revisions.                            |
+| `formatting` | `false` | Adds cards for formatting revisions.                            |
+| `stack`      | `true`  | Moves overlapping cards to prevent collisions.                  |
+| `gap`        | `8`     | Sets the CSS-pixel gap between stacked cards.                   |
+| `furniture`  | None    | Adds host content before cards.                                 |
+| `preset`     | `true`  | Set `false` to keep context and anchors without packaged cards. |
+
+Structural and formatting revisions remain marked when their cards are hidden.
+Selecting one opens its balloon.
+
+### Review parts
+
+| Part                                  | Purpose                                       |
+| ------------------------------------- | --------------------------------------------- |
+| `List`, `Card`, `Empty`               | Build the card collection.                    |
+| `Avatar`, `Author`, `Time`, `Summary` | Display item metadata.                        |
+| `Accept`, `Reject`                    | Resolve a revision.                           |
+| `Resolve`, `Reopen`                   | Change comment thread state.                  |
+| `Delete`                              | Delete a thread or discard a suggestion.      |
+| `Replies`, `Reply`                    | Display or add replies.                       |
+| `Markers`                             | Show gutter markers while the pane is closed. |
+| `Balloon`                             | Show formatting or structural decisions.      |
+| `AddComment`, `Draft`                 | Author comments.                              |
+
+Review parts support React and Vue. Every part accepts `className` and `hidden`.
+All parts except `Draft` and `Reply` accept `asChild`. `Accept`, `Reject`,
+`Delete`, and `Reply` also accept `icon`.
+
+`Markers` accepts an icon function because one component draws all markers. The
+packaged icon identifies the item kind.
+
+On a comment card, `Delete` removes the thread. On a tracked-change card, it
+discards the suggestion. Reply delete controls remove only their reply.
+
+The stylesheet shows delete controls on hover or keyboard focus. Cards without
+a deletable target omit the control.
+
+## Build a custom review interface
+
+`useReview()` returns the same data and actions as the packaged rail.
+
+React returns plain values from `useReview()`. Vue returns computed refs for
+`items`, `activeKey`, `ready`, `paneOpen`, `selectionAnchorY`, and
+`commentResolutionDisabledReason`. Vue templates unwrap these refs.
+
+| Member                            | Behavior                                 |
+| --------------------------------- | ---------------------------------------- |
+| `items`                           | Pending decisions in reading order       |
+| `activeKey`, `setActive`          | Read or open an item                     |
+| `accept`, `reject`                | Resolve a revision                       |
+| `resolve`, `reopen`               | Change comment thread state              |
+| `reply`                           | Add a reply                              |
+| `remove`                          | Delete a thread or discard a suggestion  |
+| `comment`                         | Comment on the current selection         |
+| `selectionAnchorY`                | Proposed comment position, or `null`     |
+| `paneOpen`, `setPaneOpen`         | Read or change pane state                |
+| `ready`                           | `false` before a document loads          |
+| `commentResolutionDisabledReason` | Engine refusal for comment state actions |
+
+Render `item.text` as text. The document controls this value. Do not render it
+as markup.
+
+| Item field group | Fields                                            |
+| ---------------- | ------------------------------------------------- |
+| Identity         | `key`, `id`, `kind`, `author`, `initials`, `date` |
+| Content          | `text`, `replyIds`                                |
+| Position         | `anchorY`, `pageIndex`                            |
+| State            | `readOnly`, `activatable`, `isActive`             |
+| Revision only    | `revisionKind`, `replacedText`                    |
+
+The nested `item` field holds engine review data. For an `entry`, revision
+ranges are in `entry.item.ranges`. Comment ranges are in `entry.item.range`.
+
+A reply to a revision creates a comment over its range. Its
+`parentRevisionId` links it to the revision. Omit comments with `parentId` or
+`parentRevisionId` from top-level lists.
+
+`readOnly` means the engine cannot resolve that item. Hide **Accept** and
+**Reject** in custom cards. Packaged actions remain visible but disabled in
+viewing mode.
+
+### Activate and reveal items
+
+`setActive` moves the caret to the item start and opens its story. It does not
+select content. The item renders its own highlight.
+
+| `reveal` value | Scroll behavior                                  |
+| -------------- | ------------------------------------------------ |
+| Omitted        | Centers an item only when scrolling is required. |
+| `'start'`      | Places the item near the viewport start.         |
+| `'nearest'`    | Uses the minimum scroll distance.                |
+| `false`        | Opens the item without scrolling.                |
+
+`setActive` returns `false` when activation is excluded, no range exists, or the
+story cannot open.
+
+Use `useReviewOf(editor, query)` with an existing editor. React accepts
+`Editor | null`. Vue requires `Ref<Editor | null>` and accepts a reactive query.
+
+| Query or exclusion              | Effect                                                         |
+| ------------------------------- | -------------------------------------------------------------- |
+| `excludeRevisionKinds`          | Removes those kinds from returned `items`.                     |
+| `placement: false`              | Keeps metadata and sets placement fields to `null`.            |
+| `setReviewActivationExclusions` | Prevents caret-driven activation for hidden kinds.             |
+| `DocxEditorReview`              | Sets activation exclusions from `structural` and `formatting`. |
+
+A query filters returned data. It does not limit caret-driven activation.
+
+If `preset={false}`, use
+`useStackedReviewPositions(items, heights, { gap, scale })`. Pass
+`editor.getRenderScale()` as `scale`. Card heights use CSS pixels. Anchors use
+document points.
 
 ## Accept or reject in bulk
 
-The API does not provide an accept-all command. Resolve the queue with the same per-item calls used by cards.
-
-Each call resolves every location with the revision's `(id, author, date)` tuple. It uses one transaction and one undo step.
-
-Therefore, a tracked row insertion cannot become partly resolved. This example accepts each actionable item:
-
-<FrameworkTabs>
-<Framework value="react">
+The review hook has no accept-all command. Call the per-item action for each
+actionable item.
 
 ```tsx
 function AcceptAll() {
@@ -621,70 +274,37 @@ function AcceptAll() {
 }
 ```
 
-</Framework>
-<Framework value="vue">
+Each call resolves every location with the revision's `(id, author, date)`
+tuple. The call uses one transaction and one undo step. A tracked row insertion
+cannot become partly resolved.
 
-```vue
-<script setup lang="ts">
-import { computed } from 'vue';
-import { useReview } from '@docx-editor.dev/pro/vue';
+The automation object model also provides revision collection bulk actions. See
+the [editor API](/docs/2.x/editor-api).
 
-const review = useReview();
-const actionable = computed(() => review.items.value.filter((item) => !item.readOnly));
-</script>
+## Detect review content without Pro
 
-<template>
-  <button
-    type="button"
-    :disabled="actionable.length === 0"
-    @click="actionable.forEach(review.accept)"
-  >
-    Accept all ({{ actionable.length }})
-  </button>
-</template>
-```
-
-</Framework>
-</FrameworkTabs>
-
-## Detecting review content without the module
-
-The snapshot's `hasReviewContent` reports whether a document contains revisions or comment anchors.
-
-It works without a registered review module. Use it to report review content before loading the Pro interface:
-
-<FrameworkTabs>
-<Framework value="react">
-
-```tsx
-const hasReview = useEditorState((s) => s.hasReviewContent ?? false);
-```
-
-</Framework>
-<Framework value="vue">
+The snapshot field `hasReviewContent` detects revisions or comment anchors
+without a registered review module.
 
 ```ts
-// A shallow ref: read it with `.value` in script code.
-const hasReview = useEditorState((s) => s.hasReviewContent ?? false);
+const hasReview = useEditorState((state) => state.hasReviewContent ?? false);
 ```
 
-</Framework>
-</FrameworkTabs>
+Without the module, the editor renders revisions in their final state. It keeps
+the original revision markup during save.
 
-Without a review module, the editor renders revisions in their final state and provides no review interface.
+## Word compatibility
 
-It still saves the revisions without changes.
-
-## Work with Word
-
-- Saving writes standard `w:ins` and `w:del`. Word shows the same author and date. Its **Accept** and **Reject** actions resolve them.
-- Opening a document with Word revisions renders them inline and in the sidebar. The editor does not flatten them during load.
-- The editor tracks and reviews header, footer, footnote, and endnote revisions in their own scopes.
+| Workflow                 | Behavior                                                          |
+| ------------------------ | ----------------------------------------------------------------- |
+| Save                     | Writes standard `w:ins` and `w:del` with author and date.         |
+| Open                     | Keeps Word revisions and shows them in the page and sidebar.      |
+| Accept or reject in Word | Resolves revisions saved by the editor.                           |
+| Other stories            | Tracks headers, footers, footnotes, and endnotes in their scopes. |
 
 ## Next steps
 
-- [Review colors and styling](/docs/2.x/pro/review-styling): Color changes by author or by change type.
-- [Comments](/docs/2.x/pro/comments): Add discussion threads beside revisions.
-- [Vue composition](/docs/2.x/vue/composition): Arrange Vue editor and review parts.
-- [React composition](/docs/2.x/react/composition): Arrange React editor and review parts.
-- [Custom nodes](/docs/2.x/pro/custom-nodes): Add custom-node chrome.
+- [Review colors and styling](/docs/2.x/pro/review-styling): Style review content.
+- [Comments](/docs/2.x/pro/comments): Add discussion threads.
+- [React composition](/docs/2.x/react/composition): Arrange React review parts.
+- [Vue composition](/docs/2.x/vue/composition): Arrange Vue review parts.

--- a/docs/site/content/pro/tracked-changes.mdx
+++ b/docs/site/content/pro/tracked-changes.mdx
@@ -8,8 +8,8 @@ order: 61
 Suggesting mode records edits as Word revisions. The editor underlines
 insertions and strikes through deletions.
 
-Each revision keeps its author and timestamp. Saved files use Word `w:ins` and
-`w:del` markup.
+Each revision keeps available author and timestamp metadata. OOXML timestamps
+are optional. Saved files use Word `w:ins` and `w:del` markup.
 
 This feature requires the review module from
 [`@docx-editor.dev/pro`](/docs/2.x/pro).
@@ -75,29 +75,40 @@ export function Reviewer({ bytes }: { bytes: Uint8Array }) {
 <Framework value="vue">
 
 ```vue
+<!-- SuggestToggle.vue -->
 <script setup lang="ts">
-import {
-  DocxEditorContent,
-  DocxEditorRoot,
-  DocxEditorViewport,
-  useEditorCommand,
-  useEditorState,
-} from '@docx-editor.dev/vue';
-import { DocxEditorReview, reviewModule } from '@docx-editor.dev/pro/vue';
+import { useEditorCommand, useEditorState } from '@docx-editor.dev/vue';
 
-defineProps<{ bytes: Uint8Array }>();
-
-const modules = [reviewModule()];
 const mode = useEditorState((state) => state.editingMode);
 const suggest = useEditorCommand({ type: 'setEditingMode', mode: 'suggesting' });
 const edit = useEditorCommand({ type: 'setEditingMode', mode: 'editing' });
 </script>
 
 <template>
+  <button
+    type="button"
+    @mousedown.prevent
+    @click="mode === 'suggesting' ? edit.execute() : suggest.execute()"
+  >
+    {{ mode === 'suggesting' ? 'Suggesting' : 'Editing' }}
+  </button>
+</template>
+```
+
+```vue
+<!-- Reviewer.vue -->
+<script setup lang="ts">
+import { DocxEditorContent, DocxEditorRoot, DocxEditorViewport } from '@docx-editor.dev/vue';
+import { DocxEditorReview, reviewModule } from '@docx-editor.dev/pro/vue';
+import SuggestToggle from './SuggestToggle.vue';
+
+defineProps<{ bytes: Uint8Array }>();
+const modules = [reviewModule()];
+</script>
+
+<template>
   <DocxEditorRoot :document="bytes" :modules="modules" author="Jess Lin">
-    <button type="button" @click="mode === 'suggesting' ? edit.execute() : suggest.execute()">
-      {{ mode === 'suggesting' ? 'Suggesting' : 'Editing' }}
-    </button>
+    <SuggestToggle />
     <DocxEditorViewport>
       <DocxEditorContent />
       <DocxEditorReview />
@@ -155,21 +166,24 @@ Selecting one opens its balloon.
 
 ### Review parts
 
-| Part                                  | Purpose                                       |
-| ------------------------------------- | --------------------------------------------- |
-| `List`, `Card`, `Empty`               | Build the card collection.                    |
-| `Avatar`, `Author`, `Time`, `Summary` | Display item metadata.                        |
-| `Accept`, `Reject`                    | Resolve a revision.                           |
-| `Resolve`, `Reopen`                   | Change comment thread state.                  |
-| `Delete`                              | Delete a thread or discard a suggestion.      |
-| `Replies`, `Reply`                    | Display or add replies.                       |
-| `Markers`                             | Show gutter markers while the pane is closed. |
-| `Balloon`                             | Show formatting or structural decisions.      |
-| `AddComment`, `Draft`                 | Author comments.                              |
+All listed parts accept `className` and `hidden`. The other supported props vary
+by part.
 
-Review parts support React and Vue. Every part accepts `className` and `hidden`.
-All parts except `Draft` and `Reply` accept `asChild`. `Accept`, `Reject`,
-`Delete`, and `Reply` also accept `icon`.
+| Parts                                 | Purpose                                    | `asChild` | `icon`           |
+| ------------------------------------- | ------------------------------------------ | --------- | ---------------- |
+| `List`                                | Builds the card collection.                | No        | No               |
+| `Card`                                | Wraps one review item.                     | Yes       | No               |
+| `Empty`                               | Shows the empty state.                     | No        | No               |
+| `Avatar`, `Author`, `Time`, `Summary` | Display item metadata.                     | Yes       | No               |
+| `Accept`, `Reject`                    | Resolve a revision.                        | Yes       | Yes              |
+| `Resolve`, `Reopen`                   | Change comment thread state.               | Yes       | Yes              |
+| `Delete`                              | Deletes a thread or discards a suggestion. | Yes       | Yes              |
+| `Replies`                             | Displays existing replies.                 | No        | No               |
+| `Reply`                               | Adds a reply.                              | No        | No               |
+| `Markers`                             | Shows markers while the pane is closed.    | No        | Function or node |
+| `Balloon`                             | Shows formatting or structural decisions.  | No        | No               |
+| `AddComment`                          | Starts a comment draft.                    | No        | No               |
+| `Draft`                               | Authors a new comment.                     | No        | No               |
 
 `Markers` accepts an icon function because one component draws all markers. The
 packaged icon identifies the item kind.
@@ -259,17 +273,39 @@ document points.
 ## Accept or reject in bulk
 
 The review hook has no accept-all command. Call the per-item action for each
-actionable item.
+actionable revision.
 
 ```tsx
+import { DocxEditor, useEditorState } from '@docx-editor.dev/react';
+import { DocxEditorReview, reviewModule, useReview } from '@docx-editor.dev/pro/react';
+
+const MODULES = [reviewModule()];
+
 function AcceptAll() {
   const { items, accept } = useReview();
-  const actionable = items.filter((item) => !item.readOnly);
+  const viewing = useEditorState((state) => state.editingMode === 'viewing');
+  const actionable = items.filter((item) => item.kind === 'revision' && !item.readOnly);
 
   return (
-    <button disabled={actionable.length === 0} onClick={() => actionable.forEach(accept)}>
+    <button
+      disabled={viewing || actionable.length === 0}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => actionable.forEach(accept)}
+    >
       Accept all ({actionable.length})
     </button>
+  );
+}
+
+export function BulkReviewer({ bytes }: { bytes: Uint8Array }) {
+  return (
+    <DocxEditor.Root document={bytes} modules={MODULES} author="Jess Lin">
+      <AcceptAll />
+      <DocxEditor.Viewport>
+        <DocxEditor.Content />
+        <DocxEditorReview />
+      </DocxEditor.Viewport>
+    </DocxEditor.Root>
   );
 }
 ```

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -1,45 +1,51 @@
 ---
 title: 'Word fidelity'
-description: 'Word feature support matrix for the DOCX editor: what renders, what edits, what round-trips with structural fidelity, plus the security model and API stability policy.'
+description: 'Word feature support for editing, rendering, and structural round-trip fidelity, plus security and API stability.'
 category: 'Getting Started'
 seoTitle: 'Word feature support and fidelity'
 ---
 
 <PackageStats name="@docx-editor.dev/react" />
 
-## Overview
+## Product behavior
 
-- **Browser editor use is client-side.** Parsing, rendering, editing, and serialization run in the browser for normal `<DocxEditor>` usage. The server-side editing API runs wherever you host it.
-- **The editor reads OOXML and writes OOXML.** Untouched content, unsupported markup, and package payloads survive editing and save.
-- **Apache 2.0** for every published package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`. Those two use the EigenPal Pro Evaluation License 1.0. Internal, non-production evaluation is free. Production use requires a commercial agreement. Versions follow **SemVer**, and CI tracks the public API with generated snapshots.
-- **Commercial support**: [docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com).
+| Area                | Behavior                                                                     |
+| ------------------- | ---------------------------------------------------------------------------- |
+| Browser editor      | Parses, renders, edits, and serializes DOCX data in the browser.             |
+| Server editing API  | Runs where you host it.                                                      |
+| File format         | Reads and writes Office Open XML (OOXML).                                    |
+| Unsupported content | Preserves unmodeled markup and package payloads when you edit other content. |
+| Support             | Contact [docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com).         |
 
 ## Feature matrix
 
-Every feature is tracked on three axes:
+The matrix reports three separate support axes.
 
-- **Editing**: can a user (or code driving the editor) change it in the editor?
-- **Rendering**: does it display the way Microsoft Word renders it?
-- **Round-trip**: does it survive open, edit, save, and reopen without loss?
+| Axis       | Question                                      |
+| ---------- | --------------------------------------------- |
+| Editing    | Can a user or API change the feature?         |
+| Rendering  | Does the feature display like Microsoft Word? |
+| Round-trip | Does it survive open, edit, save, and reopen? |
 
-A construct the editor does not model is retained as inert content and written
-back with structural fidelity; that is the "Preserved" status below.
+| Status      | Meaning                                            |
+| ----------- | -------------------------------------------------- |
+| Full        | Matches Word behavior for this feature.            |
+| Partial     | Works with the limits in its note.                 |
+| Render only | Displays correctly but is not editable.            |
+| Preserved   | Remains as inert content through editing and save. |
+| No          | Is not supported.                                  |
 
 <FeatureSummary />
 
-**Legend**: Full = matches Word behavior for this feature · Partial = works with noted limits ·
-Render only = displays correctly, not editable · Preserved = carried inertly
-through editing and save · Planned = on the roadmap · No = not supported.
-
-### Text & formatting
+### Text and formatting
 
 <FeatureMatrix category="text" />
 
-### Paragraphs & styles
+### Paragraphs and styles
 
 <FeatureMatrix category="paragraphs" />
 
-### Lists & numbering
+### Lists and numbering
 
 <FeatureMatrix category="lists" />
 
@@ -47,113 +53,122 @@ through editing and save · Planned = on the roadmap · No = not supported.
 
 <FeatureMatrix category="tables" />
 
-### Images & drawings
+### Images and drawings
 
 <FeatureMatrix category="images" />
 
-### Page layout, headers & footers
+### Page layout, headers, and footers
 
 <FeatureMatrix category="layout" />
 
-### Review: tracked changes, comments, notes
+### Tracked changes, comments, and notes
 
 <FeatureMatrix category="review" />
 
-### Fields, links & TOC
+### Fields, links, and table of contents
 
 <FeatureMatrix category="fields" />
 
-### Document structure & content controls
+### Document structure and content controls
 
 <FeatureMatrix category="structure" />
 
-### Collaboration, i18n & editing UX
+### Collaboration, languages, and editing
 
 <FeatureMatrix category="collaboration" />
 
-## Rendering fidelity
+## Important drawing limits
 
-The editor does not use browser layout for the document. A DOM-free layout
-pass positions every line and every page break from Word's own metrics: twips,
-the document's fonts and themes, and its section and margin geometry. The
-editor then paints the visible pages from that result. The layout pass decides
-where a line or a page breaks, never the browser. The output is plain DOM text,
-not a canvas bitmap.
+The matrix remains the source of truth for support status. These drawing limits
+often affect document evaluation.
 
-How the pipeline achieves this is in
-[Architecture](/docs/2.x/core/architecture). To compare fidelity, open
-one of your own documents in the [live demo](https://docx-editor.dev/editor)
-next to Word.
+| Feature             | Rendering                                                                                                              | Editing | Round-trip |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- | ---------- |
+| Anchored text boxes | Shows read-only content inside the authored extent. Linked chains, autofit, and rotation can clip or use placeholders. | No      | Preserved  |
+| Drawing shapes      | Reserves unsupported geometry with a placeholder.                                                                      | No      | Preserved  |
+| WMF and EMF         | Rasterizes supported files. Other files keep their extent with a placeholder.                                          | No      | Full       |
 
-## Drawings, shapes and legacy images
+## Rendering and pagination
 
-These rows in the "Images & drawings" matrix are not Full, but their
-authored markup and payloads survive editing and save.
+The editor calculates document layout without browser flow layout. It uses
+document fonts, themes, section geometry, margins, and Word units.
 
-- **Text boxes**: story content renders read-only inside the authored extent;
-  editing, linked chains, autofit, and rotation are not implemented.
-- **Drawing shapes**: unsupported geometry reserves its extent with a
-  placeholder; the original markup is preserved.
-- **WMF / EMF**: rasterized where supported, otherwise shown as a placeholder;
-  the original media bytes are preserved.
+The layout result controls line and page breaks. The editor paints that result
+as DOM text, not a canvas bitmap.
 
-## Round-trip behavior
+Usable font bytes are required for Word-accurate text measurement. See
+[Fonts and measurement](/docs/2.x/guides/fonts).
 
-A `.docx` file is a ZIP of XML parts, and Word writes XML constructs the
-editor does not model: bookmarks, custom XML parts, mail-merge fields,
-compatibility settings, VBA projects.
+For pipeline details, see [Architecture](/docs/2.x/core/architecture). Test your
+documents in the [live demo](https://docx-editor.dev/editor).
 
-This editor's pipeline is parse → document model → edit → serialize. On save,
-the canonical tree preserves the structure and semantics of every parsed XML
-part, while package payloads pass through untouched. In detail:
+## Round-trip contract
 
-- Unmodeled XML elements and attributes are kept as generic nodes and
-  re-emitted in place, including legacy VML, custom XML, and add-in markup.
-- Non-XML payloads such as media, VBA projects, embedded fonts, and OLE
-  binaries are copied through the ZIP untouched.
-- References stay intact. The editor does not rename or renumber a relationship ID, bookmark name, field code, style ID, or numbering definition.
-- Output is canonical OOXML, not only valid. Tracked changes are real `w:ins` and `w:del` revisions that appear in Word's review pane, theme colors stay theme references, and numbering keeps its definitions.
+A DOCX file is a ZIP package with XML parts and binary payloads.
 
-Test coverage: CI round-trips a corpus of real documents through two oracles,
-a canonical fingerprint over the tree and a save-and-reopen semantic digest.
-Serializer tests assert that specific constructs survive, such as revisions,
-fields, hyperlinks, and content controls. Browser end-to-end tests drive the
-painted editor.
+| Content                                                                | Save behavior                                                    |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Modeled OOXML                                                          | Serializes from typed document nodes.                            |
+| Unmodeled XML elements and attributes                                  | Re-emits generic nodes in place.                                 |
+| Legacy VML, custom XML, and add-in markup                              | Preserves structural content.                                    |
+| Media, VBA projects, embedded fonts, and OLE binaries                  | Copies package payloads without modification.                    |
+| Relationship IDs, bookmark names, style IDs, and numbering definitions | Keeps references intact.                                         |
+| Tracked changes                                                        | Writes Word `w:ins` and `w:del` revisions.                       |
+| Theme colors                                                           | Keeps theme references instead of flattening them to RGB values. |
 
-The preservation contract is semantic and structural: content you did not edit
-must not be lost or reinterpreted. A document that breaks this behavior is a
-bug. Attach it to a
-[GitHub issue](https://github.com/eigenpal/docx-editor/issues/new/choose).
+The contract protects semantic meaning and structure. It does not promise byte
+identity for rewritten XML parts.
 
-## Security
+Continuous integration checks real documents with a canonical tree fingerprint
+and a save-and-reopen semantic digest. Focused tests cover revisions, fields,
+hyperlinks, content controls, and browser editing.
 
-- **Normal editor use is browser-only.** The editor package does not upload documents or call a conversion API.
-- **No macro execution.** VBA macros and embedded code are not evaluated.
-- **The editing API is host-controlled.** [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) ships no network transport and no LLM or external AI integration. The browser entry drives an editor already in the page, so the DOCX never leaves it. The server entry runs wherever you host it. Your own code decides what reaches an external service or model.
+If untouched content is lost or reinterpreted, report a
+[round-trip issue](https://github.com/eigenpal/docx-editor/issues/new/choose)
+with the source document.
+
+## Security and data flow
+
+| Concern                          | Behavior                                                                   |
+| -------------------------------- | -------------------------------------------------------------------------- |
+| Browser uploads                  | The editor package does not upload documents or call a conversion service. |
+| Macros                           | The editor preserves VBA payloads but never executes them.                 |
+| OLE and field instructions       | The editor keeps them inert.                                               |
+| Server editing                   | Your host controls where DOCX data runs.                                   |
+| Browser automation               | Controls an editor already in the page.                                    |
+| External artificial intelligence | `@docx-editor.dev/editor-api` includes no model integration or transport.  |
+
+Your application controls any data sent to another service or model.
 
 ## Bundle and performance
 
-- `-core` ships subpath exports that tree-shake independently.
-- The engine is a peer dependency of the adapters, so one copy resolves for the whole tree.
-- Lazy-load the editor (`next/dynamic`, `React.lazy`) to keep it out of the initial bundle.
-- The layout engine caches per-block measurements; an edit does not re-measure unchanged blocks.
+| Area           | Behavior                                                               |
+| -------------- | ---------------------------------------------------------------------- |
+| Core exports   | Subpath exports can tree-shake independently.                          |
+| Engine copies  | Adapters use core as a peer dependency to resolve one engine copy.     |
+| Initial bundle | You can lazy-load the editor with your framework.                      |
+| Layout work    | Per-block caches avoid measuring unchanged blocks again.               |
+| Benchmarks     | No published benchmark represents every document. Test your own files. |
 
-No published benchmarks; test with your own documents in the
-[live demo](https://docx-editor.dev/editor).
+## License and API stability
 
-## Stability, license and support
+| Package or policy                                                                                      | Terms                                                                                                        |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `@docx-editor.dev/core`, `@docx-editor.dev/react`, `@docx-editor.dev/vue`, and `@docx-editor.dev/i18n` | Apache 2.0                                                                                                   |
+| `@docx-editor.dev/fonts`                                                                               | Apache-2.0 AND OFL-1.1                                                                                       |
+| `@docx-editor.dev/editor-api`                                                                          | EigenPal Pro Evaluation License 1.0                                                                          |
+| `@docx-editor.dev/pro`                                                                                 | EigenPal Pro Evaluation License 1.0                                                                          |
+| Pro evaluation                                                                                         | Free for internal, non-production evaluation                                                                 |
+| Pro production use                                                                                     | Requires a separate written commercial agreement signed by [EigenPal, Inc.](mailto:licensing@eigenpal.com)   |
+| Versions                                                                                               | Semantic Versioning with one fixed version group                                                             |
+| Public API                                                                                             | CI checks generated API Extractor snapshots                                                                  |
+| Contributions                                                                                          | Require a one-time [Contributor License Agreement](https://github.com/eigenpal/docx-editor/blob/main/CLA.md) |
 
-- **Apache 2.0** for every package except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`. Those two ship under the EigenPal Pro Evaluation License 1.0: internal evaluation is free, and production use needs a written agreement from [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
-- **SemVer** via changesets; all packages share one version number.
-- The public API is tracked by [API Extractor snapshots](https://github.com/eigenpal/docx-editor/tree/main/docs/api); CI fails on drift.
-- Contributions need a one-time [CLA](https://github.com/eigenpal/docx-editor/blob/main/CLA.md).
-
-If a feature you need is Partial or missing, [open an issue](https://github.com/eigenpal/docx-editor/issues/new/choose)
-with a sample `.docx`, or email [docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com)
-for priority features and support contracts.
+For priority features and support contracts, email
+[docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com).
 
 ## Next steps
 
-- [Quickstart](/docs/2.x/quickstart): the load, edit, and save workflow
-- [Architecture](/docs/2.x/core/architecture): the pipeline in depth
-- [Tracked changes](/docs/2.x/pro/tracked-changes): tracked-change and comment behavior
+- [Quickstart](/docs/2.x/quickstart): Load, edit, and save a DOCX file.
+- [Architecture](/docs/2.x/core/architecture): Review the engine pipeline.
+- [Tracked changes](/docs/2.x/pro/tracked-changes): Review revision behavior.

--- a/docs/site/data/word-features.test.ts
+++ b/docs/site/data/word-features.test.ts
@@ -8,13 +8,13 @@ function feature(id: string) {
 }
 
 describe('word-features — images lane honesty', () => {
-  test('inline and anchored editing is partial with React-only note until Vue follow-up', () => {
+  test('inline and anchored editing is partial in both adapters', () => {
     for (const id of ['images.inline', 'images.anchored'] as const) {
       const row = feature(id);
       expect(row.editing).toBe('partial');
       expect(row.rendering).toBe('full');
       expect(row.roundTrip).toBe('full');
-      expect(row.notes?.toLowerCase()).toContain('vue');
+      expect(row.notes?.toLowerCase()).toContain('both');
     }
   });
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -654,11 +654,11 @@ export const wordFeatures: WordFeature[] = [
     name: 'Watermarks (text & image)',
     category: 'layout',
     editing: 'none',
-    rendering: 'planned',
+    rendering: 'none',
     roundTrip: 'preserved',
     tier: 'community',
     notes:
-      'Watermarks live as VML or drawings inside header parts. Layout and editing are deferred to the drawings work, and Editor.getWatermark() is a stub. The markup can survive in the header part, but watermarks are not a supported feature yet.',
+      'Watermarks use VML or drawing markup in header parts. The editor does not render or edit them. It preserves the authored markup and package relationships through save.',
     docsLink: '/docs/2.x/guides/headers-footers',
   },
   {


### PR DESCRIPTION
## Summary

- Replace verbose feature-support prose with focused tables and procedures.
- Consolidate repeated Pro review, font loading, fidelity, and licensing constraints.
- Keep framework-specific review APIs and security limits explicit.

## Test plan

- [x] `bun run check:docs-mdx`
- [x] `bun run check:public-docs-surface`
- [x] `git diff --check`
- [x] Repository pre-commit checks

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790238897&installation_model_id=422592&pr_number=447&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F447&signature=57a738730f7cafbd17602b7016d09299c4a60d64e0f96cd13b1ae6e8167cf2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->