### PR TITLE
fix: land tracked replacements after the last struck paragraph

### DIFF
--- a/.changeset/tracked-replace-lands-after-selection.md
+++ b/.changeset/tracked-replace-lands-after-selection.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fix tracked-changes replacement of a multi-paragraph selection: typed or pasted text now lands after the last struck paragraph in typing order, and the caret follows it instead of resting inside the struck words.
+Fix replacements over a selection in tracked-changes mode: typing, paste, Enter, tab, breaks, and page fields now land after the struck words with the caret following, instead of reversed or in front of the strike. Multi-line paste now splits its paragraphs inside the tracked insertion, and typing over your own pending Enter merges it instead of doing nothing.

--- a/.changeset/tracked-replace-lands-after-selection.md
+++ b/.changeset/tracked-replace-lands-after-selection.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix tracked-changes replacement of a multi-paragraph selection: typed or pasted text now lands after the last struck paragraph in typing order, and the caret follows it instead of resting inside the struck words.

--- a/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
@@ -53,6 +53,9 @@ const listItem = (text: string) =>
 const styledParagraph = (text: string) =>
   `<w:p><w:pPr><w:ind w:left="720"/></w:pPr><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
 
+const plainParagraph = (text: string) =>
+  `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
 function withSurface(body: string, run: (surface: PaginatedSurface) => void): void {
   const container = document.createElement('div');
   document.body.append(container);
@@ -104,6 +107,20 @@ function selectIn(surface: PaginatedSurface, index: number, start: number, end: 
   surface.setSelection({
     anchor: { paragraphId, offset: start },
     head: { paragraphId, offset: end },
+  });
+}
+
+function selectAcross(
+  surface: PaginatedSurface,
+  fromIndex: number,
+  fromOffset: number,
+  toIndex: number,
+  toOffset: number
+): void {
+  const ids = surface.session.paragraphIds();
+  surface.setSelection({
+    anchor: { paragraphId: ids[fromIndex]!, offset: fromOffset },
+    head: { paragraphId: ids[toIndex]!, offset: toOffset },
   });
 }
 
@@ -232,5 +249,80 @@ describe('Enter then Backspace, in suggesting mode', () => {
         expect(xml).toMatch(/<w:del[^>]*w:author="Ada Lovelace"/);
       }
     );
+  });
+});
+
+// REPLACING A SELECTION THAT SPANS PARAGRAPH MARKS.
+//
+// A suggesting-mode deletion keeps the characters it strikes, and the marks between the
+// paragraphs become merge proposals — every paragraph survives. So the replacement belongs
+// after the struck head of the LAST paragraph. Landing it at the range start instead put it
+// on the front edge of the fresh `w:del`, where the store relocates it past the deletion;
+// the caret math never heard about the relocation, so the caret came to rest INSIDE the
+// struck words, and each next keystroke relocated to the same spot — BEFORE the one already
+// typed. A typed replacement came out reversed, parked after the first struck paragraph.
+describe('replacing a selection that spans paragraphs, in suggesting mode', () => {
+  test('the replacement lands after the LAST struck paragraph, in typing order', () => {
+    withSurface(
+      plainParagraph('Alpha one') + plainParagraph('Beta two') + plainParagraph('Gamma three'),
+      (surface) => {
+        selectAcross(surface, 0, 0, 2, 'Gamma three'.length);
+        typeEach(surface, 'New');
+        expect(surface.state().lastRejection).toBeNull();
+        expect(paragraphTexts(surface)).toEqual(['Alpha one', 'Beta two', 'Gamma threeNew']);
+        const xml = serializeOoxmlPart(surface.session.part());
+        // The struck original stays, and the replacement is ONE ordered insertion after it.
+        expect(xml).toMatch(
+          /<w:delText[^>]*>Gamma three<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t[^>]*>New<\/w:t>/
+        );
+        // The caret follows the typing, so the NEXT character extends the replacement
+        // rather than landing in front of it.
+        expect(surface.state().selection.head).toEqual({
+          paragraphId: surface.session.paragraphIds()[2]!,
+          offset: 'Gamma threeNew'.length,
+        });
+      }
+    );
+  });
+
+  test('a paste over the selection lands in the same place', () => {
+    withSurface(plainParagraph('Alpha one') + plainParagraph('Beta two'), (surface) => {
+      selectAcross(surface, 0, 0, 1, 'Beta two'.length);
+      surface.insertPlainText('Replacement');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Alpha one', 'Beta twoReplacement']);
+      expect(surface.state().selection.head).toEqual({
+        paragraphId: surface.session.paragraphIds()[1]!,
+        offset: 'Beta twoReplacement'.length,
+      });
+    });
+  });
+
+  test('this author’s own insertion at the head of the last paragraph retracts', () => {
+    withSurface(plainParagraph('Alpha') + plainParagraph('Beta'), (surface) => {
+      caretTo(surface, 1, 0);
+      typeEach(surface, 'XY');
+      // The range covers "pha", the pending "XY" and the struck-to-be "Be": the struck
+      // halves stay, the author's own insertion leaves, and the replacement sits after
+      // what remains of the last paragraph's struck head.
+      selectAcross(surface, 0, 2, 1, 4);
+      surface.type('Z');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Alpha', 'BeZta']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).not.toMatch(/XY/);
+    });
+  });
+
+  test('typing with the caret resting INSIDE struck words lands past the deletion', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      selectIn(surface, 0, 0, 'Alpha'.length);
+      surface.deleteBackward();
+      caretTo(surface, 0, 2);
+      typeEach(surface, 'ab');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Alphaab one']);
+      expect(surface.state().selection.head.offset).toBe('Alphaab'.length);
+    });
   });
 });

--- a/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
@@ -325,4 +325,90 @@ describe('replacing a selection that spans paragraphs, in suggesting mode', () =
       expect(surface.state().selection.head.offset).toBe('Alphaab'.length);
     });
   });
+
+  test('a MULTI-LINE paste splits inside the tracked insertion, not after it', () => {
+    // `splitParagraphMany` is the op paste emits, and `distributeInline` used to send a
+    // whole `w:ins` wrapper to the first piece — the lines stayed in one paragraph and the
+    // minted tails came out empty.
+    withSurface(plainParagraph('Alpha one') + plainParagraph('Beta two'), (surface) => {
+      selectAcross(surface, 0, 0, 1, 'Beta two'.length);
+      surface.insertPlainText('one\ntwo');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Alpha one', 'Beta twoone', 'two']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      // Each piece keeps the same tracked-insertion attribution.
+      expect(xml).toMatch(/<w:ins[^>]*><w:r><w:t[^>]*>one<\/w:t><\/w:r><\/w:ins>/);
+      expect(xml).toMatch(/<w:ins[^>]*><w:r><w:t[^>]*>two<\/w:t><\/w:r><\/w:ins>/);
+      expect(surface.state().selection.head.offset).toBe('two'.length);
+    });
+  });
+
+  test('typing over your OWN pending Enter split merges and lands after the strike', () => {
+    // The join that retracts this author's own paragraph mark REALLY joins, so the last
+    // paragraph of the range leaves the tree — an insert naming it vetoed the whole
+    // transaction and every keystroke did nothing.
+    withSurface(plainParagraph('Alpha Beta'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      surface.splitParagraph();
+      selectAcross(surface, 0, 2, 1, 3);
+      typeEach(surface, 'X');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Alpha BeXta']);
+      expect(surface.state().selection.head.offset).toBe('Alpha BeX'.length);
+    });
+  });
+
+  test('a range that ENDS inside a pre-existing deletion lands past it, in order', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      selectIn(surface, 0, 0, 'Alpha'.length);
+      surface.deleteBackward();
+      selectIn(surface, 0, 1, 3);
+      typeEach(surface, 'ab');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Alphaab one']);
+      expect(surface.state().selection.head.offset).toBe('Alphaab'.length);
+    });
+  });
+
+  test('Enter over a selection breaks AFTER the struck words', () => {
+    withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
+      surface.splitParagraph();
+      expect(surface.state().lastRejection).toBeNull();
+      // The struck word stays with the paragraph it came from; the tail carries the rest.
+      expect(paragraphTexts(surface)).toEqual(['Alpha Beta', ' Gamma']);
+      expect(surface.state().selection.head.offset).toBe(0);
+    });
+  });
+
+  test('a Tab over a selection lands after the struck words', () => {
+    withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
+      surface.insertTab();
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // The strike then the tab, adjacent. (The tab itself is still written untracked in
+      // suggesting mode — a separate attribution gap; this pins only where it lands.)
+      expect(xml).toMatch(/<w:delText[^>]*>Beta<\/w:delText><\/w:r><\/w:del><w:r><w:tab\/>/);
+      expect(surface.state().selection.head.offset).toBe('Alpha Beta'.length + 1);
+    });
+  });
+
+  test('a range that removes a table still lands after the last struck paragraph', () => {
+    const cell = (text: string) =>
+      `<w:tc><w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>${plainParagraph(text)}</w:tc>`;
+    const table =
+      '<w:tbl><w:tblPr><w:tblW w:w="8000" w:type="dxa"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>' +
+      `<w:tr>${cell('CellA')}${cell('CellB')}</w:tr></w:tbl>`;
+    withSurface(plainParagraph('Alpha one') + table + plainParagraph('Beta two'), (surface) => {
+      const last = surface.session.paragraphIds().length - 1;
+      selectAcross(surface, 0, 0, last, 'Beta two'.length);
+      typeEach(surface, 'New');
+      expect(surface.state().lastRejection).toBeNull();
+      // The fully covered table goes; the last paragraph survives and hosts the replacement.
+      expect(paragraphTexts(surface)).toEqual(['Alpha one', 'Beta twoNew']);
+      expect(surface.state().selection.head.offset).toBe('Beta twoNew'.length);
+    });
+  });
 });

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -3999,36 +3999,23 @@ export function mountPaginatedSurface(
       // puts the text where the removed characters used to be rather than where the user
       // was typing.
       const plan = deleteSelectionPlan();
-      const start = plan.collapseTo;
+      // In SUGGESTING the deletion keeps the characters it strikes, so the replacement goes
+      // after them — only then are the two halves adjacent, which is what lets the pane
+      // fold them into one `Replaced "x" with "y"` card. `replacementTarget` owns that rule
+      // for every replacing lane, including where the struck range spans paragraph marks.
+      const target = replacementTarget(plan);
       // Consume the stored caret format (armed only at a collapsed caret, so it cannot
       // coexist with the delete ops below): the typed range gets the caret run's own
       // properties plus the armed ones, in the SAME transaction — one undo step.
-      const pendingOps = consumePendingFormatOps(start.paragraphId, start.offset, text.length);
-      // In SUGGESTING the deletion keeps its characters, so the selection's start offset is
-      // still the start of the struck words — inserting there put the replacement BEFORE
-      // them. Word puts it after, and only then are the two halves adjacent, which is what
-      // lets the pane fold them into one `Replaced "x" with "y"` card. Mid-sentence
-      // replacements were showing as two unrelated decisions, and a reviewer could accept
-      // one half.
-      //
-      // It keeps only the characters it STRIKES. Whatever of the range is this author's own
-      // pending insertion is RETRACTED instead — those characters leave the paragraph — so
-      // the offset past the selection is past the end of what the insert will find there.
-      // Typing over your own suggestion was refused as `offset-out-of-range`, and since a
-      // refusal takes the whole transaction, the keystroke did nothing at all.
-      const struck = editingMode === 'suggest' ? orderedRange() : null;
-      const insertAt =
-        struck && struck.to.paragraphId === start.paragraphId
-          ? struck.to.offset - retractedByOwnInsertion(struck.from, struck.to)
-          : start.offset;
+      const pendingOps = consumePendingFormatOps(target.paragraphId, target.offset, text.length);
       const insertOps: TreeDocOp[] = [
         ...plan.ops,
-        { op: 'insertText', paragraphId: start.paragraphId, offset: insertAt, text },
+        { op: 'insertText', paragraphId: target.paragraphId, offset: target.offset, text },
       ];
       const redoMark = {
-        paragraphId: start.paragraphId,
-        start: insertAt + text.length,
-        end: insertAt + text.length,
+        paragraphId: target.paragraphId,
+        start: target.offset + text.length,
+        end: target.offset + text.length,
       };
       commit(
         () =>
@@ -4038,7 +4025,7 @@ export function mountPaginatedSurface(
             selectionMark(),
             redoMark
           ),
-        () => collapsedAt({ paragraphId: start.paragraphId, offset: insertAt + text.length })
+        () => collapsedAt({ paragraphId: target.paragraphId, offset: target.offset + text.length })
       );
     },
     proposeTextChange: (kind, text, author) => commitProposedTextChange(kind, text, author),
@@ -5179,6 +5166,42 @@ export function mountPaginatedSurface(
     return to.offset - retractedByOwnInsertion(from, to);
   }
 
+  /**
+   * Where a replacement for the current selection lands, as a full position.
+   *
+   * In editing mode the range simply goes and `collapseTo` is the spot. In suggesting the
+   * struck characters STAY, so the replacement belongs after them — past the range END,
+   * minus whatever of the range was this author's own pending insertion, which leaves. A
+   * range spanning paragraph marks keeps every paragraph (the marks become merge
+   * proposals), so the end lives in the LAST paragraph, after its struck head.
+   *
+   * Falling back to the range START for a spanning selection put the insert on the front
+   * edge of the fresh `w:del`, where the store relocates it past the deletion — but the
+   * caret math never heard about the relocation, so the caret came to rest INSIDE the
+   * struck words, and the next keystroke relocated to the same spot, landing BEFORE the
+   * previous one: a typed replacement came out reversed, parked after the first struck
+   * paragraph instead of the last.
+   */
+  function replacementTarget(plan: RangeDeletionPlan): SemanticPosition {
+    const start = plan.collapseTo;
+    if (editingMode !== 'suggest' || cellSelection) return start;
+    const { from, to } = orderedRange();
+    // Collapsed: `collapseTo` already sits past any deletion the caret rested in.
+    if (from.paragraphId === to.paragraphId && from.offset === to.offset) return start;
+    if (from.paragraphId === to.paragraphId) {
+      return { paragraphId: to.paragraphId, offset: replacementOffset(from, to) };
+    }
+    // A fully covered table is REMOVED, not struck, so the last paragraph may not survive
+    // the transaction — an insert naming it would veto the whole edit. The range start is
+    // the position `collapseTo` guarantees survives.
+    if (plan.ops.some((op) => op.op === 'deleteBlock')) return start;
+    const lastParagraphFrom = { paragraphId: to.paragraphId, offset: 0 };
+    return {
+      paragraphId: to.paragraphId,
+      offset: to.offset - retractedByOwnInsertion(lastParagraphFrom, to),
+    };
+  }
+
   function retractedByOwnInsertion(from: SemanticPosition, to: SemanticPosition): number {
     if (editingMode !== 'suggest') return 0;
     return retractedByInsertionAuthor(from, to, options.author);
@@ -5256,28 +5279,22 @@ export function mountPaginatedSurface(
     // paragraph at every newline offset in a single pass — one rebuild of the body's child
     // sequence, however many paragraphs the clipboard carried.
     const plan = deleteSelectionPlan();
-    const start = plan.collapseTo;
+    // WHERE THE REPLACEMENT GOES, the same question `type()` answers: in suggesting mode a
+    // deletion keeps the characters it strikes, so the replacement belongs AFTER them.
+    // Pasting at the range start put the new text in front of the struck words and left
+    // the caret inside it, so the next keystroke landed mid-word.
+    const target = replacementTarget(plan);
     const joined = lines.join('');
     const ops: TreeDocOp[] = [...plan.ops];
-    // WHERE THE REPLACEMENT GOES, the same question `type()` answers. In suggesting mode a
-    // deletion keeps the characters it strikes, so the replacement belongs AFTER them — and
-    // keeps only those, since whatever of the range was this author's own pending insertion
-    // is retracted and leaves. Pasting at the range start put the new text in front of the
-    // struck words and left the caret inside it, so the next keystroke landed mid-word.
-    const struck = editingMode === 'suggest' ? orderedRange() : null;
-    const insertAt =
-      struck && struck.to.paragraphId === start.paragraphId
-        ? struck.to.offset - retractedByOwnInsertion(struck.from, struck.to)
-        : start.offset;
     // Plain text pasted at a caret takes the armed typing format, like typed text — Word
     // formats a plain paste as if you had typed it. Written over the PRE-SPLIT offsets, so
     // the op runs before `splitParagraphMany` cuts the paragraph up.
-    const pendingOps = consumePendingFormatOps(start.paragraphId, insertAt, joined.length);
+    const pendingOps = consumePendingFormatOps(target.paragraphId, target.offset, joined.length);
     if (joined.length > 0) {
       ops.push({
         op: 'insertText',
-        paragraphId: start.paragraphId,
-        offset: insertAt,
+        paragraphId: target.paragraphId,
+        offset: target.offset,
         text: joined,
       });
       ops.push(...pendingOps);
@@ -5286,10 +5303,10 @@ export function mountPaginatedSurface(
     let consumed = 0;
     for (let index = 0; index < lines.length - 1; index += 1) {
       consumed += lines[index]!.length;
-      boundaries.push(insertAt + consumed);
+      boundaries.push(target.offset + consumed);
     }
     if (boundaries.length > 0) {
-      ops.push({ op: 'splitParagraphMany', paragraphId: start.paragraphId, offsets: boundaries });
+      ops.push({ op: 'splitParagraphMany', paragraphId: target.paragraphId, offsets: boundaries });
     }
     if (ops.length === 0) return;
 
@@ -5301,7 +5318,7 @@ export function mountPaginatedSurface(
     // the clamp, which is where this lane started.
     const redoMark =
       boundaries.length === 0
-        ? caretMark({ paragraphId: start.paragraphId, offset: insertAt + lastLine.length })
+        ? caretMark({ paragraphId: target.paragraphId, offset: target.offset + lastLine.length })
         : undefined;
     const withoutFormat = ops.filter((op) => !pendingOps.includes(op));
     commit(
@@ -5309,8 +5326,8 @@ export function mountPaginatedSurface(
       () => {
         if (boundaries.length === 0) {
           return collapsedAt({
-            paragraphId: start.paragraphId,
-            offset: insertAt + lastLine.length,
+            paragraphId: target.paragraphId,
+            offset: target.offset + lastLine.length,
           });
         }
         // The caret lands at the end of the pasted text: in the LAST minted paragraph, right

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -27,6 +27,7 @@ import {
   type TreeModelChange,
 } from '@docx-editor.dev/core/store';
 import { retractedLengthOf } from '../store/store/tree-op-retraction.ts';
+import { retractsOwnParagraphMark } from '../store/store/tree-op-tracked.ts';
 import { syncActiveFieldShading } from './surface-field-shading.ts';
 import {
   createLayoutScheduler,
@@ -4001,9 +4002,9 @@ export function mountPaginatedSurface(
       const plan = deleteSelectionPlan();
       // In SUGGESTING the deletion keeps the characters it strikes, so the replacement goes
       // after them — only then are the two halves adjacent, which is what lets the pane
-      // fold them into one `Replaced "x" with "y"` card. `replacementTarget` owns that rule
-      // for every replacing lane, including where the struck range spans paragraph marks.
-      const target = replacementTarget(plan);
+      // fold them into one `Replaced "x" with "y"` card. The plan's `replaceAt` owns that
+      // rule for every replacing lane, including where the range spans paragraph marks.
+      const target = plan.replaceAt ?? plan.collapseTo;
       // Consume the stored caret format (armed only at a collapsed caret, so it cannot
       // coexist with the delete ops below): the typed range gets the caret run's own
       // properties plus the armed ones, in the SAME transaction — one undo step.
@@ -4144,11 +4145,12 @@ export function mountPaginatedSurface(
     },
 
     splitParagraph() {
-      // Enter REPLACES a selection, like every other insertion, and splits at its START —
-      // splitting at the head left the selected text in place and cut the paragraph at
-      // whichever end the user happened to drag to.
+      // Enter REPLACES a selection, like every other insertion — splitting at the head left
+      // the selected text in place and cut the paragraph at whichever end the user happened
+      // to drag to. `replaceAt` puts the break AFTER the words a suggestion strikes, so the
+      // strike and the proposed break read as one decision instead of two.
       const plan = deleteSelectionPlan();
-      const position = plan.collapseTo;
+      const position = plan.replaceAt ?? plan.collapseTo;
       const before = new Set(session.paragraphIdsIn(storyScope()));
       // Word carries the typing format across Enter: bold armed before the split applies
       // to the first characters typed in the new paragraph.
@@ -5101,6 +5103,14 @@ export function mountPaginatedSurface(
    * deleted vetoes the whole transaction.
    */
   function deleteSelectionPlan(): RangeDeletionPlan {
+    // Every replacing lane reads `replaceAt` from the plan it already holds, so the landing
+    // rule cannot be skipped by a lane that never heard of it — that is how tabs, breaks and
+    // the PAGE field each kept landing in FRONT of the words a suggestion strikes.
+    const plan = rangeDeletionPlan();
+    return { ...plan, replaceAt: replacementTarget(plan) };
+  }
+
+  function rangeDeletionPlan(): RangeDeletionPlan {
     // Every edit op builds its plan from here first, so this is where queued
     // typing must land: a plan computed against the pre-buffer selection would
     // edit beside text the user has already typed. (No-op mid-flush.)
@@ -5163,7 +5173,12 @@ export function mountPaginatedSurface(
    */
   function replacementOffset(from: SemanticPosition, to: SemanticPosition): number {
     if (editingMode !== 'suggest' || from.paragraphId !== to.paragraphId) return from.offset;
-    return to.offset - retractedByOwnInsertion(from, to);
+    // A range end INSIDE a pre-existing deletion aims the insert at the interior of that
+    // `w:del`: the store relocates it past the deletion, the caret math does not hear about
+    // it, and the next keystroke lands before the previous one. Map past the old deletion
+    // FIRST; the retracted characters all sit before it, so the subtraction still holds.
+    const past = positionPastDeletion(currentLayout, to);
+    return past.offset - retractedByOwnInsertion(from, past);
   }
 
   /**
@@ -5191,15 +5206,68 @@ export function mountPaginatedSurface(
     if (from.paragraphId === to.paragraphId) {
       return { paragraphId: to.paragraphId, offset: replacementOffset(from, to) };
     }
-    // A fully covered table is REMOVED, not struck, so the last paragraph may not survive
-    // the transaction — an insert naming it would veto the whole edit. The range start is
-    // the position `collapseTo` guarantees survives.
-    if (plan.ops.some((op) => op.op === 'deleteBlock')) return start;
-    const lastParagraphFrom = { paragraphId: to.paragraphId, offset: 0 };
-    return {
-      paragraphId: to.paragraphId,
-      offset: to.offset - retractedByOwnInsertion(lastParagraphFrom, to),
+    // A fully covered table is REMOVED, not struck, so a last paragraph INSIDE one does not
+    // survive the transaction — an insert naming it would veto the whole edit. The range
+    // start is the position `collapseTo` guarantees survives. A removed block elsewhere in
+    // the range leaves the last paragraph standing, so only its own ancestry decides.
+    const removedBlocks = new Set(
+      plan.ops.flatMap((op) => (op.op === 'deleteBlock' ? [op.blockId] : []))
+    );
+    // A pure ancestry read: `partOfNodeId`, not `partFor`, which would retain a story store.
+    const part = partOfNodeId(session, to.paragraphId) ?? session.part();
+    if (removedBlocks.size > 0) {
+      for (
+        let node = parentNodeOf(part, to.paragraphId);
+        node;
+        node = parentNodeOf(part, node.id)
+      ) {
+        if (removedBlocks.has(node.id)) return start;
+      }
+    }
+    // A planned join whose mark is this author's OWN pending insertion REALLY joins — the
+    // break retracts and the second paragraph leaves the tree (`tree-op-apply.ts`), so an
+    // insert naming it would veto the whole transaction: typing over a selection spanning
+    // your own pending Enter did nothing at all. Walk back to the paragraph that survives
+    // as the merged host, and count each folded member's struck length into its offsets.
+    // The merged mark is always the SECOND paragraph's (`withSectionMarkOf`), so each
+    // member's ORIGINAL mark decides whether the member after it folds in.
+    const author = options.author?.trim();
+    if (!author) return start;
+    const joinedSecondIds = new Set(
+      plan.ops.flatMap((op) => (op.op === 'joinParagraphs' ? [op.secondId] : []))
+    );
+    const order = paragraphOrder();
+    const fromIndex = order.indexOf(from.paragraphId);
+    const toIndex = order.indexOf(to.paragraphId);
+    if (fromIndex === -1 || toIndex === -1) return start;
+    const markRetracts = (paragraphId: string): boolean => {
+      const node = findNode(part, paragraphId);
+      return node?.kind === 'paragraph' && retractsOwnParagraphMark(node, author);
     };
+    let hostIndex = toIndex;
+    while (
+      hostIndex > fromIndex &&
+      joinedSecondIds.has(order[hostIndex]!) &&
+      markRetracts(order[hostIndex - 1]!)
+    ) {
+      hostIndex -= 1;
+    }
+    let offset = 0;
+    for (let index = hostIndex; index <= toIndex; index += 1) {
+      const id = order[index]!;
+      const coveredFrom = {
+        paragraphId: id,
+        offset: id === from.paragraphId ? from.offset : 0,
+      };
+      const coveredTo =
+        id === to.paragraphId
+          ? positionPastDeletion(currentLayout, to)
+          : { paragraphId: id, offset: textOf(id).length };
+      if (index === hostIndex) offset += coveredFrom.offset;
+      offset +=
+        coveredTo.offset - coveredFrom.offset - retractedByOwnInsertion(coveredFrom, coveredTo);
+    }
+    return { paragraphId: order[hostIndex]!, offset };
   }
 
   function retractedByOwnInsertion(from: SemanticPosition, to: SemanticPosition): number {
@@ -5283,7 +5351,7 @@ export function mountPaginatedSurface(
     // deletion keeps the characters it strikes, so the replacement belongs AFTER them.
     // Pasting at the range start put the new text in front of the struck words and left
     // the caret inside it, so the next keystroke landed mid-word.
-    const target = replacementTarget(plan);
+    const target = plan.replaceAt ?? plan.collapseTo;
     const joined = lines.join('');
     const ops: TreeDocOp[] = [...plan.ops];
     // Plain text pasted at a caret takes the armed typing format, like typed text — Word

--- a/packages/core/src/editor/surface-hf-ops.ts
+++ b/packages/core/src/editor/surface-hf-ops.ts
@@ -29,6 +29,7 @@ export function createHeaderFooterOps(deps: {
   deleteSelectionPlan: () => {
     readonly ops: readonly TreeDocOp[];
     readonly collapseTo: { paragraphId: string; offset: number };
+    readonly replaceAt?: { paragraphId: string; offset: number };
   };
   orderedStart: () => { paragraphId: string; offset: number };
   selectionMark: () => { paragraphId: string; start: number; end: number } | null;
@@ -54,11 +55,12 @@ export function createHeaderFooterOps(deps: {
 
     insertPageField(field) {
       if (!deps.isHeaderFooterOpen()) return false;
-      // The plan's `collapseTo`, never the range start: a deletion that takes a block with it
-      // leaves no paragraph at the start to insert into, and one refused op vetoes the whole
-      // transaction — so the field did not appear AND the deletion did not happen.
+      // The plan's `replaceAt`, never the range start: in suggesting mode the struck words
+      // stay and the field belongs after them, and a deletion that takes a block with it
+      // leaves no paragraph at the start to insert into — one refused op vetoes the whole
+      // transaction, so the field did not appear AND the deletion did not happen.
       const plan = deps.deleteSelectionPlan();
-      const start = plan.collapseTo;
+      const start = plan.replaceAt ?? plan.collapseTo;
       deps.commit(
         () =>
           deps.applyOps(

--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -6,15 +6,13 @@
 // the little state it cannot own — so React, Vue and a plain page get identical behaviour
 // instead of three hand-written keymaps that drift.
 
-import type { TreeApplyResult, TreeDocxSessionView } from '@docx-editor.dev/core/binding';
-import type { NavigationCommand, SemanticSelection } from '@docx-editor.dev/core/layout';
-import type { StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
+import type { TreeDocxSessionView } from '@docx-editor.dev/core/binding';
+import type { NavigationCommand } from '@docx-editor.dev/core/layout';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 import { plainTextFromTransfer } from './clipboard-plain-text.ts';
 import { spanSearchRoots } from './dom-selection.ts';
 import { paintedTextIn } from './surface-composition-readback.ts';
 
-type SelectionMark = { paragraphId: string; start: number; end: number };
 const NAVIGATION: Record<string, NavigationCommand> = {
   ArrowLeft: 'left',
   ArrowRight: 'right',
@@ -478,66 +476,4 @@ export function paragraphReplacePlan(
   }
   if (ops.length === 0) return null;
   return { ops, caret: prefix + inserted.length };
-}
-
-/**
- * Plain-text insert used by clipboard paste and beforeinput insertText: one
- * commit that inserts joined lines then splits at every newline boundary.
- */
-export function createInsertPlainText(deps: {
-  orderedStart: () => { paragraphId: string; offset: number };
-  deleteSelectionOps: () => readonly TreeDocOp[];
-  selectionMark: () => SelectionMark | null;
-  storyScope: () => StoryScope;
-  session: TreeDocxSessionView;
-  commit: (
-    run: () => TreeApplyResult | boolean,
-    selectionAfter?: () => SemanticSelection | null
-  ) => void;
-  applyOps: (ops: readonly TreeDocOp[], mark: SelectionMark | null) => TreeApplyResult;
-  collapsedAt: (pos: { paragraphId: string; offset: number }) => SemanticSelection;
-}): (text: string) => void {
-  return (text: string): void => {
-    const lines = text.replace(/\r\n?/g, '\n').split('\n');
-    const start = deps.orderedStart();
-    const joined = lines.join('');
-    const ops: TreeDocOp[] = [...deps.deleteSelectionOps()];
-    if (joined.length > 0) {
-      ops.push({
-        op: 'insertText',
-        paragraphId: start.paragraphId,
-        offset: start.offset,
-        text: joined,
-      });
-    }
-    const boundaries: number[] = [];
-    let consumed = 0;
-    for (let index = 0; index < lines.length - 1; index += 1) {
-      consumed += lines[index]!.length;
-      boundaries.push(start.offset + consumed);
-    }
-    if (boundaries.length > 0) {
-      ops.push({ op: 'splitParagraphMany', paragraphId: start.paragraphId, offsets: boundaries });
-    }
-    if (ops.length === 0) return;
-
-    const before = new Set(deps.session.paragraphIdsIn(deps.storyScope()));
-    const lastLine = lines[lines.length - 1]!;
-    deps.commit(
-      () => deps.applyOps(ops, deps.selectionMark()),
-      () => {
-        if (boundaries.length === 0) {
-          return deps.collapsedAt({
-            paragraphId: start.paragraphId,
-            offset: start.offset + lastLine.length,
-          });
-        }
-        const minted = deps.session
-          .paragraphIdsIn(deps.storyScope())
-          .filter((id) => !before.has(id));
-        const landing = minted[minted.length - 1];
-        return landing ? deps.collapsedAt({ paragraphId: landing, offset: lastLine.length }) : null;
-      }
-    );
-  };
 }

--- a/packages/core/src/editor/surface-selection-ops.ts
+++ b/packages/core/src/editor/surface-selection-ops.ts
@@ -126,6 +126,15 @@ export function selectedTextIn(
 export interface RangeDeletionPlan {
   readonly ops: Parameters<TreeDocxSessionView['applyTreeOps']>[0];
   readonly collapseTo: SemanticPosition;
+  /**
+   * Where content REPLACING the range belongs, when it differs from `collapseTo`.
+   *
+   * In suggesting mode a deletion keeps the characters it strikes, so a replacement goes
+   * AFTER them — in the last surviving paragraph of the range, past its struck head. Set by
+   * the surface's plan wrapper, which owns the editing mode; `planRangeDeletion` itself
+   * never sets it. Replacing lanes read `replaceAt ?? collapseTo`.
+   */
+  readonly replaceAt?: SemanticPosition;
 }
 
 type TreeOp = Parameters<TreeDocxSessionView['applyTreeOps']>[0][number];

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -402,9 +402,12 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
   }
 
   return {
+    // The three inline units below REPLACE a selection, so they land at the plan's
+    // `replaceAt`: in suggesting mode a deletion keeps the characters it strikes, and an
+    // insert at the range start sat in FRONT of the struck words instead of after them.
     insertTab() {
       const plan = deleteSelectionPlan();
-      const start = plan.collapseTo;
+      const start = plan.replaceAt ?? plan.collapseTo;
       commit(
         () =>
           applyOps(
@@ -420,7 +423,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
 
     insertLineBreak() {
       const plan = deleteSelectionPlan();
-      const start = plan.collapseTo;
+      const start = plan.replaceAt ?? plan.collapseTo;
       commit(
         () =>
           applyOps(
@@ -436,7 +439,7 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
 
     insertPageBreak() {
       const plan = deleteSelectionPlan();
-      const start = plan.collapseTo;
+      const start = plan.replaceAt ?? plan.collapseTo;
       commit(
         () =>
           applyOps(

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -2603,7 +2603,16 @@ function distributeInline(
 ): OoxmlNode[][] {
   const byPiece: OoxmlNode[][] = Array.from({ length: pieceCount }, () => []);
 
-  if (child.kind === 'hyperlink') {
+  // A REVISION WRAPPER DISTRIBUTES LIKE A HYPERLINK, the same rule `divideInline` states:
+  // `w:ins` and `w:del` are containers of run content, not run content, so the "not a run,
+  // keep it whole" answer below put an entire tracked insertion into the FIRST piece however
+  // many boundaries ran through it — a multi-line paste in suggesting mode kept its lines in
+  // one paragraph and minted empty tails. Every piece keeps the same author, date and id,
+  // which is how a reader groups them back into one decision.
+  if (
+    child.kind === 'hyperlink' ||
+    (child.kind !== 'textValue' && isContentRevisionKind(child.kind))
+  ) {
     const innerByPiece: OoxmlNode[][] = Array.from({ length: pieceCount }, () => []);
     // Absolute paragraph offsets, seeded from the link's own start — see `divideInline`.
     // At zero, `pieceIndexOf` put every zero-length child of a link in the FIRST piece: a


### PR DESCRIPTION
Typing or pasting over a selection in suggesting mode inserts at the range start. The store relocates an insert aimed at the front edge of a `w:del` past the deletion, but the caret math doesn't learn about the relocation. The caret comes to rest inside the struck words, and each next keystroke lands before the previous one: the replacement comes out reversed, parked after the first struck paragraph.

The landing rule now lives on the deletion plan as `replaceAt`: in suggesting mode a replacement lands after the struck words, in the last surviving paragraph of the range, minus this author's retracted insertions. Every replacing lane reads it — typing, paste, IME readback, Enter, tab, line break, page break, and the PAGE field.

Related fixes in the same family:

- A join that retracts your own pending paragraph mark really joins, so the insert targets the surviving host paragraph instead of vetoing the transaction.
- A range that ends inside a pre-existing deletion maps past it, so the replacement stays in typing order.
- `distributeInline` spreads `w:ins`/`w:del` wrappers across split pieces, so a multi-line paste in suggesting mode splits inside the tracked insertion instead of leaving the lines joined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)