### PR TITLE
perf: compose budgeted note-reference scans from per-subtree memos

### DIFF
--- a/.changeset/budgeted-note-scan-memos.md
+++ b/.changeset/budgeted-note-scan-memos.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Reduce per-keystroke latency on documents with footnotes or endnotes: mutation-path note-reference scans reuse per-subtree results instead of re-walking the whole package.

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -348,7 +348,7 @@ export function collectFlowBlocks(children: readonly OoxmlNode[], depth?: number
 // @public
 export function collectNodeIds(part: OoxmlPart): Set<string>;
 
-// @public (undocumented)
+// @public
 export function collectNoteReferences(part: OoxmlPart, options?: {
     readonly budget?: NoteReferenceScanBudget;
     readonly maxHits?: number;

--- a/packages/core/src/store/__tests__/derivation-memo-freshness.test.ts
+++ b/packages/core/src/store/__tests__/derivation-memo-freshness.test.ts
@@ -15,43 +15,26 @@
 // `w:ins`/`w:del` plus tracked insertions in the op vocabulary, where the read must keep
 // answering the full card list.
 //
-// Determinism: fixed seeds and a pure inline PRNG (mulberry32). A failure prints the seed
-// and the accumulated op script, which replays the exact sequence.
+// Determinism and the random-edit machinery live in `random-edit-test-support.ts`,
+// shared with `note-scan-memo-freshness.test.ts`.
 
 import { describe, expect, test } from 'bun:test';
 import {
   deepParagraphOrderOfPart,
-  paragraphTextOf,
-  readOoxmlPart,
   revisionItemsOf,
   TreeDocumentStore,
   usedParaIds,
-  type OoxmlElement,
-  type OoxmlNode,
   type OoxmlPart,
-  type TreeDocOp,
 } from '../index.ts';
-
-const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
-
-function loadPart(xml: string): OoxmlPart {
-  const result = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
-  if (!result.ok) throw new Error(result.reason);
-  return result.part;
-}
-
-/** Deterministic PRNG. Same seed, same sequence, every run, every machine. */
-function mulberry32(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = (state + 0x6d2b79f5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+import {
+  driveRandomEdits,
+  loadPart,
+  mulberry32,
+  PLAIN_RANDOM_OPS,
+  TRACKED_RANDOM_OPS,
+  W,
+  W14,
+} from './random-edit-test-support.ts';
 
 // ── Fixtures ───────────────────────────────────────────────────────────────────
 // Every paragraph carries authored identity and the root binds w14, so every applied
@@ -79,105 +62,6 @@ function fixturePart(tracked: boolean): OoxmlPart {
   return loadPart(
     `<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body>${body}</w:body></w:document>`
   );
-}
-
-// ── Reading the retained tree ──────────────────────────────────────────────────
-
-function* walk(node: OoxmlNode): Generator<OoxmlNode> {
-  yield node;
-  if (node.kind === 'textValue') return;
-  for (const child of node.children ?? []) yield* walk(child);
-}
-
-function paragraphSitesOf(part: OoxmlPart): { id: string; length: number }[] {
-  const sites: { id: string; length: number }[] = [];
-  for (const node of walk(part.root)) {
-    if (node.kind !== 'paragraph') continue;
-    sites.push({ id: node.id, length: paragraphTextOf(part, node.id)?.length ?? 0 });
-  }
-  return sites;
-}
-
-/** Adjacent (first, second) paragraph pairs among the body's direct children. */
-function adjacentBodyParagraphPairs(part: OoxmlPart): [string, string][] {
-  const body = part.root.children.find(
-    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
-  );
-  const pairs: [string, string][] = [];
-  const children = body?.children ?? [];
-  for (let index = 0; index + 1 < children.length; index += 1) {
-    const first = children[index]!;
-    const second = children[index + 1]!;
-    if (first.kind === 'paragraph' && second.kind === 'paragraph') {
-      pairs.push([first.id, second.id]);
-    }
-  }
-  return pairs;
-}
-
-// ── Op vocabulary ──────────────────────────────────────────────────────────────
-// Generated against the CURRENT tree, so ids and offsets are usually valid; the store may
-// still refuse (a delete crossing tracked content, a join it will not perform). A refusal
-// is logged and skipped, and the applied-op floor below keeps the test from passing by
-// refusing everything.
-
-type OpKind = 'insert-text' | 'delete-text' | 'split' | 'join' | 'tracked-insert';
-
-const PLAIN_OPS: readonly OpKind[] = [
-  'insert-text',
-  'insert-text',
-  'delete-text',
-  'split',
-  'split',
-  'join',
-];
-const TRACKED_OPS: readonly OpKind[] = [...PLAIN_OPS, 'tracked-insert', 'tracked-insert'];
-
-function randomOp(
-  part: OoxmlPart,
-  rand: () => number,
-  step: number,
-  tracked: boolean
-): TreeDocOp | null {
-  const pick = <T>(items: readonly T[]): T => items[Math.floor(rand() * items.length)]!;
-  const sites = paragraphSitesOf(part);
-  if (sites.length === 0) return null;
-  const site = pick(sites);
-  switch (pick(tracked ? TRACKED_OPS : PLAIN_OPS)) {
-    case 'insert-text':
-      return {
-        op: 'insertText',
-        paragraphId: site.id,
-        offset: Math.floor(rand() * (site.length + 1)),
-        text: ` step${step} extra`,
-      };
-    case 'tracked-insert':
-      return {
-        op: 'insertText',
-        paragraphId: site.id,
-        offset: Math.floor(rand() * (site.length + 1)),
-        text: ` step${step} proposal`,
-        revision: { author: 'QA Reviewer', date: '2026-01-03T00:00:00Z' },
-      };
-    case 'delete-text': {
-      if (site.length < 2) return null;
-      const start = Math.floor(rand() * (site.length - 1));
-      const end = start + 1 + Math.floor(rand() * (site.length - start - 1));
-      return { op: 'deleteText', paragraphId: site.id, start, end };
-    }
-    case 'split':
-      return {
-        op: 'splitParagraph',
-        paragraphId: site.id,
-        offset: Math.floor(rand() * (site.length + 1)),
-      };
-    case 'join': {
-      const pairs = adjacentBodyParagraphPairs(part);
-      if (pairs.length === 0) return null;
-      const [firstId, secondId] = pick(pairs);
-      return { op: 'joinParagraphs', firstId, secondId };
-    }
-  }
 }
 
 // ── The oracle ─────────────────────────────────────────────────────────────────
@@ -219,9 +103,7 @@ describe('per-subtree derivation memos stay fresh across random op sequences', (
   for (const tracked of [false, true]) {
     for (const seed of SEEDS) {
       test(`${tracked ? 'tracked' : 'untracked'} fixture, seed ${seed}: ${STEPS} random ops`, () => {
-        const rand = mulberry32(seed);
         const store = new TreeDocumentStore(fixturePart(tracked));
-        const log: unknown[] = [];
 
         // The fixture's authored identity must have parsed, or splits mint nothing and
         // the id half of the oracle measures a constant.
@@ -229,26 +111,12 @@ describe('per-subtree derivation memos stay fresh across random op sequences', (
         if (tracked) expect(revisionItemsOf(store.part).length).toBeGreaterThanOrEqual(2);
         else expect(revisionItemsOf(store.part)).toEqual([]);
 
-        let applied = 0;
-        let splitsApplied = 0;
-        for (let step = 0; step < STEPS; step += 1) {
-          const op = randomOp(store.part, rand, step, tracked);
-          if (op === null) {
-            log.push(['skip', step]);
-            continue;
-          }
-          const result = store.transact((tx) => {
-            tx.apply(op);
-          });
-          if (!result.ok) {
-            log.push(['refused', step, result.reason, op]);
-            continue;
-          }
-          log.push([step, op]);
-          applied += 1;
-          if (op.op === 'splitParagraph') splitsApplied += 1;
-          assertFreshDerivations(store, seed, step, log);
-        }
+        const { applied, splitsApplied } = driveRandomEdits(store, {
+          rand: mulberry32(seed),
+          steps: STEPS,
+          ops: tracked ? TRACKED_RANDOM_OPS : PLAIN_RANDOM_OPS,
+          onApplied: (step, _op, log) => assertFreshDerivations(store, seed, step, log),
+        });
 
         // Anti-vacuity: enough ops applied, and enough splits that fresh paraIds were
         // minted against — and then read back through — the memoized set.

--- a/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
+++ b/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
@@ -12,9 +12,9 @@
 // 1. Full budget: hits AND the final `budget.visited` / `budget.truncated` must be
 //    byte-identical to the cold walk — downstream parts sharing one budget must truncate
 //    at exactly the same point.
-// 2. A budget small enough to truncate mid-tree: the terminal accounting must match the
-//    cold walk. Hits under truncation are immaterial (callers treat `truncated` as
-//    atomic failure), so they are not compared.
+// 2. A budget small enough to truncate mid-tree: hits and accounting must STILL match
+//    the cold walk byte-for-byte, because an overrunning memo falls through to the
+//    plain descent (pre-truncation prefixes feed diagnoseNoteReferences).
 // 3. The budget-free memoized path, so the two memo systems cannot drift apart.
 //
 // Determinism: fixed seeds and a pure inline PRNG (mulberry32). A failure prints the
@@ -34,6 +34,7 @@ import {
   createNoteReferenceScanBudget,
   readOoxmlPart,
 } from '../package/index.ts';
+import { budgetedNoteScanMemoStats } from '../package/note-references.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -209,14 +210,18 @@ function assertBudgetedScanFresh(
     fail('budget-free hits', seed, step, `memoized: ${plainJson}\nfresh: ${plainColdJson}`, log);
   }
 
-  // A budget that truncates mid-tree: warm memos (populated by the scan above) may
-  // bulk-charge past the stop point, but the terminal accounting must match the cold
-  // walk. Hits under truncation are immaterial: callers treat it as atomic failure.
+  // A budget that truncates mid-tree: a warm memo whose bulk charge would overrun the
+  // remaining budget must fall through to the plain descent, so hits AND accounting
+  // stay byte-identical to the cold walk — pre-truncation hit prefixes (which
+  // diagnoseNoteReferences reports) survive warm memos.
   const cap = Math.max(1, Math.floor(coldBudget.visited / 2));
   const memoSmall = createNoteReferenceScanBudget(cap);
-  collectNoteReferences(part, { budget: memoSmall, maxHits: Number.POSITIVE_INFINITY });
+  const memoSmallHits = collectNoteReferences(part, {
+    budget: memoSmall,
+    maxHits: Number.POSITIVE_INFINITY,
+  });
   const coldSmall = createNoteReferenceScanBudget(cap);
-  collectNoteReferences(structuredClone(part), {
+  const coldSmallHits = collectNoteReferences(structuredClone(part), {
     budget: coldSmall,
     maxHits: Number.POSITIVE_INFINITY,
   });
@@ -227,6 +232,17 @@ function assertBudgetedScanFresh(
       step,
       `cap: ${cap}\nmemoized: visited ${memoSmall.visited}, truncated ${memoSmall.truncated}\n` +
         `fresh: visited ${coldSmall.visited}, truncated ${coldSmall.truncated}`,
+      log
+    );
+  }
+  const memoSmallJson = JSON.stringify(memoSmallHits);
+  const coldSmallJson = JSON.stringify(coldSmallHits);
+  if (memoSmallJson !== coldSmallJson) {
+    fail(
+      'truncated hit prefix',
+      seed,
+      step,
+      `cap: ${cap}\nmemoized: ${memoSmallJson}\nfresh: ${coldSmallJson}`,
       log
     );
   }
@@ -249,6 +265,7 @@ describe('budgeted note-reference scan memos stay fresh across random op sequenc
 
       let applied = 0;
       let splitsApplied = 0;
+      const reusesBefore = budgetedNoteScanMemoStats.reuses;
       for (let step = 0; step < STEPS; step += 1) {
         const op = randomOp(store.part, rand, step);
         if (op === null) {
@@ -269,9 +286,12 @@ describe('budgeted note-reference scan memos stay fresh across random op sequenc
       }
 
       // Anti-vacuity: enough ops applied, and enough splits that fresh spines were
-      // rescanned against — and read back through — the memoized subtrees.
+      // rescanned against — and read back through — the memoized subtrees. The reuse
+      // floor proves memos actually served (equivalence alone would also pass for a
+      // memo that never hits, which delivers correctness but none of the latency win).
       expect(applied).toBeGreaterThanOrEqual(12);
       expect(splitsApplied).toBeGreaterThanOrEqual(2);
+      expect(budgetedNoteScanMemoStats.reuses - reusesBefore).toBeGreaterThanOrEqual(applied);
     });
   }
 });
@@ -287,10 +307,9 @@ describe('memo reuse under a finite maxHits clip', () => {
     });
     expect(all.length).toBeGreaterThanOrEqual(6);
 
-    // Diagnostics-style clip over the warmed tree. Memo hits append in document order,
-    // so the clipped prefix is identical to the cold walk; only the visited count may
-    // run ahead (bulk-charged subtrees), which diagnose already reports as truncated
-    // coverage via the full hit buffer.
+    // Diagnostics-style clip over the warmed tree. A memo whose hits would reach the
+    // clip must fall through to the plain descent, so hits, visited and truncated all
+    // stay byte-identical to the cold walk even where the clip binds mid-subtree.
     const maxHits = 2;
     const memoBudget = createNoteReferenceScanBudget(FULL_BUDGET);
     const memoClipped = collectNoteReferences(store.part, { budget: memoBudget, maxHits });
@@ -301,6 +320,7 @@ describe('memo reuse under a finite maxHits clip', () => {
     });
     expect(memoClipped).toHaveLength(maxHits);
     expect(JSON.stringify(memoClipped)).toBe(JSON.stringify(coldClipped));
+    expect(memoBudget.visited).toBe(coldBudget.visited);
     expect(memoBudget.truncated).toBe(false);
     expect(coldBudget.truncated).toBe(false);
   });

--- a/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
+++ b/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
@@ -1,0 +1,307 @@
+// Budgeted note-reference scans compose from per-subtree memos in a module-level WeakMap
+// keyed on node OBJECTS, and a store edit shares every untouched subtree by reference
+// across revisions — so a stale entry (wrong hits, wrong visited count, wrong depth)
+// would be read back by every later scan, including the one that checks it.
+//
+// The clean side of the differential therefore scans a structuredClone of the part: same
+// content, all-new node objects, so nothing identity-keyed can be shared with the
+// memoized side and the clone's first walk IS the unmemoized walk. Node ids are plain
+// data properties, so the clone carries the ORIGINAL ids and hits compare by value.
+//
+// Three probes per applied op:
+// 1. Full budget: hits AND the final `budget.visited` / `budget.truncated` must be
+//    byte-identical to the cold walk — downstream parts sharing one budget must truncate
+//    at exactly the same point.
+// 2. A budget small enough to truncate mid-tree: the terminal accounting must match the
+//    cold walk. Hits under truncation are immaterial (callers treat `truncated` as
+//    atomic failure), so they are not compared.
+// 3. The budget-free memoized path, so the two memo systems cannot drift apart.
+//
+// Determinism: fixed seeds and a pure inline PRNG (mulberry32). A failure prints the
+// seed and the accumulated op script, which replays the exact sequence.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  paragraphTextOf,
+  TreeDocumentStore,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+  type TreeDocOp,
+} from '../index.ts';
+import {
+  collectNoteReferences,
+  createNoteReferenceScanBudget,
+  readOoxmlPart,
+} from '../package/index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function loadPart(xml: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/** Deterministic PRNG. Same seed, same sequence, every run, every machine. */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Fixture ────────────────────────────────────────────────────────────────────
+// Note references sit in every third paragraph, inside hyperlinks in some, so edits hit
+// both ref-bearing and plain subtrees and splits/joins move refs between spines.
+
+function fixturePart(): OoxmlPart {
+  const words = 'word '.repeat(6);
+  const paragraphs = Array.from({ length: 12 }, (_, i) => {
+    const ref =
+      i % 3 === 0
+        ? `<w:r><w:footnoteReference w:id="${i + 1}"/></w:r>`
+        : i % 3 === 1
+          ? `<w:hyperlink w:anchor="a${i}"><w:r><w:endnoteReference w:id="${i + 100}"/></w:r></w:hyperlink>`
+          : '';
+    return `<w:p><w:r><w:t xml:space="preserve">p${i} ${words}</w:t></w:r>${ref}</w:p>`;
+  }).join('');
+  return loadPart(
+    `<w:document xmlns:w="${W}"><w:body>${paragraphs}<w:sectPr/></w:body></w:document>`
+  );
+}
+
+// ── Reading the retained tree ──────────────────────────────────────────────────
+
+function* walk(node: OoxmlNode): Generator<OoxmlNode> {
+  yield node;
+  if (node.kind === 'textValue') return;
+  for (const child of node.children ?? []) yield* walk(child);
+}
+
+function paragraphSitesOf(part: OoxmlPart): { id: string; length: number }[] {
+  const sites: { id: string; length: number }[] = [];
+  for (const node of walk(part.root)) {
+    if (node.kind !== 'paragraph') continue;
+    sites.push({ id: node.id, length: paragraphTextOf(part, node.id)?.length ?? 0 });
+  }
+  return sites;
+}
+
+/** Adjacent (first, second) paragraph pairs among the body's direct children. */
+function adjacentBodyParagraphPairs(part: OoxmlPart): [string, string][] {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  );
+  const pairs: [string, string][] = [];
+  const children = body?.children ?? [];
+  for (let index = 0; index + 1 < children.length; index += 1) {
+    const first = children[index]!;
+    const second = children[index + 1]!;
+    if (first.kind === 'paragraph' && second.kind === 'paragraph') {
+      pairs.push([first.id, second.id]);
+    }
+  }
+  return pairs;
+}
+
+// ── Op vocabulary ──────────────────────────────────────────────────────────────
+// Generated against the CURRENT tree, so ids and offsets are usually valid; the store
+// may still refuse. A refusal is logged and skipped, and the applied-op floor below
+// keeps the test from passing by refusing everything.
+
+type OpKind = 'insert-text' | 'delete-text' | 'split' | 'join';
+
+const OPS: readonly OpKind[] = ['insert-text', 'insert-text', 'delete-text', 'split', 'join'];
+
+function randomOp(part: OoxmlPart, rand: () => number, step: number): TreeDocOp | null {
+  const pick = <T>(items: readonly T[]): T => items[Math.floor(rand() * items.length)]!;
+  const sites = paragraphSitesOf(part);
+  if (sites.length === 0) return null;
+  const site = pick(sites);
+  switch (pick(OPS)) {
+    case 'insert-text':
+      return {
+        op: 'insertText',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+        text: ` step${step} extra`,
+      };
+    case 'delete-text': {
+      if (site.length < 2) return null;
+      const start = Math.floor(rand() * (site.length - 1));
+      const end = start + 1 + Math.floor(rand() * (site.length - start - 1));
+      return { op: 'deleteText', paragraphId: site.id, start, end };
+    }
+    case 'split':
+      return {
+        op: 'splitParagraph',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+      };
+    case 'join': {
+      const pairs = adjacentBodyParagraphPairs(part);
+      if (pairs.length === 0) return null;
+      const [firstId, secondId] = pick(pairs);
+      return { op: 'joinParagraphs', firstId, secondId };
+    }
+  }
+}
+
+// ── The oracle ─────────────────────────────────────────────────────────────────
+
+const FULL_BUDGET = 1_000_000;
+
+function fail(name: string, seed: number, step: number, detail: string, log: unknown[]): never {
+  throw new Error(
+    `${name} over the retained tree diverged from the clone walk.\n` +
+      `seed: ${seed}, step: ${step}\n${detail}\nreplay script:\n${JSON.stringify(log)}`
+  );
+}
+
+/** Memoized budgeted scans over the retained part vs cold walks over structuredClones. */
+function assertBudgetedScanFresh(
+  part: OoxmlPart,
+  seed: number,
+  step: number,
+  log: unknown[]
+): void {
+  // Full budget: hits and accounting byte-identical to the cold walk.
+  const memoBudget = createNoteReferenceScanBudget(FULL_BUDGET);
+  const memoHits = collectNoteReferences(part, {
+    budget: memoBudget,
+    maxHits: Number.POSITIVE_INFINITY,
+  });
+  const coldClone = structuredClone(part);
+  const coldBudget = createNoteReferenceScanBudget(FULL_BUDGET);
+  const coldHits = collectNoteReferences(coldClone, {
+    budget: coldBudget,
+    maxHits: Number.POSITIVE_INFINITY,
+  });
+  const memoJson = JSON.stringify(memoHits);
+  const coldJson = JSON.stringify(coldHits);
+  if (memoJson !== coldJson) {
+    fail('budgeted hits', seed, step, `memoized: ${memoJson}\nfresh: ${coldJson}`, log);
+  }
+  if (memoBudget.visited !== coldBudget.visited || memoBudget.truncated !== coldBudget.truncated) {
+    fail(
+      'budget accounting',
+      seed,
+      step,
+      `memoized: visited ${memoBudget.visited}, truncated ${memoBudget.truncated}\n` +
+        `fresh: visited ${coldBudget.visited}, truncated ${coldBudget.truncated}`,
+      log
+    );
+  }
+  if (memoBudget.truncated) {
+    fail('full budget', seed, step, 'full budget unexpectedly truncated', log);
+  }
+
+  // Budget-free memoized path must agree with its own cold walk too, so the two memo
+  // systems cannot drift apart.
+  const plainJson = JSON.stringify(collectNoteReferences(part));
+  const plainColdJson = JSON.stringify(collectNoteReferences(structuredClone(part)));
+  if (plainJson !== plainColdJson) {
+    fail('budget-free hits', seed, step, `memoized: ${plainJson}\nfresh: ${plainColdJson}`, log);
+  }
+
+  // A budget that truncates mid-tree: warm memos (populated by the scan above) may
+  // bulk-charge past the stop point, but the terminal accounting must match the cold
+  // walk. Hits under truncation are immaterial: callers treat it as atomic failure.
+  const cap = Math.max(1, Math.floor(coldBudget.visited / 2));
+  const memoSmall = createNoteReferenceScanBudget(cap);
+  collectNoteReferences(part, { budget: memoSmall, maxHits: Number.POSITIVE_INFINITY });
+  const coldSmall = createNoteReferenceScanBudget(cap);
+  collectNoteReferences(structuredClone(part), {
+    budget: coldSmall,
+    maxHits: Number.POSITIVE_INFINITY,
+  });
+  if (memoSmall.visited !== coldSmall.visited || memoSmall.truncated !== coldSmall.truncated) {
+    fail(
+      'truncating budget accounting',
+      seed,
+      step,
+      `cap: ${cap}\nmemoized: visited ${memoSmall.visited}, truncated ${memoSmall.truncated}\n` +
+        `fresh: visited ${coldSmall.visited}, truncated ${coldSmall.truncated}`,
+      log
+    );
+  }
+}
+
+const SEEDS = [0xc0ffee, 42, 20260825];
+const STEPS = 30;
+
+describe('budgeted note-reference scan memos stay fresh across random op sequences', () => {
+  for (const seed of SEEDS) {
+    test(`seed ${seed}: ${STEPS} random ops`, () => {
+      const rand = mulberry32(seed);
+      const store = new TreeDocumentStore(fixturePart());
+      const log: unknown[] = [];
+
+      // The fixture's typed references must have parsed, or the oracle compares empty
+      // hit lists at every step.
+      expect(collectNoteReferences(store.part).length).toBeGreaterThanOrEqual(6);
+      assertBudgetedScanFresh(store.part, seed, -1, log);
+
+      let applied = 0;
+      let splitsApplied = 0;
+      for (let step = 0; step < STEPS; step += 1) {
+        const op = randomOp(store.part, rand, step);
+        if (op === null) {
+          log.push(['skip', step]);
+          continue;
+        }
+        const result = store.transact((tx) => {
+          tx.apply(op);
+        });
+        if (!result.ok) {
+          log.push(['refused', step, result.reason, op]);
+          continue;
+        }
+        log.push([step, op]);
+        applied += 1;
+        if (op.op === 'splitParagraph') splitsApplied += 1;
+        assertBudgetedScanFresh(store.part, seed, step, log);
+      }
+
+      // Anti-vacuity: enough ops applied, and enough splits that fresh spines were
+      // rescanned against — and read back through — the memoized subtrees.
+      expect(applied).toBeGreaterThanOrEqual(12);
+      expect(splitsApplied).toBeGreaterThanOrEqual(2);
+    });
+  }
+});
+
+describe('memo reuse under a finite maxHits clip', () => {
+  test('clipped hit prefix matches the cold walk; full buffer reads as truncated coverage', () => {
+    const store = new TreeDocumentStore(fixturePart());
+    // Warm the memos with an unclipped mutation-style scan.
+    const warm = createNoteReferenceScanBudget(FULL_BUDGET);
+    const all = collectNoteReferences(store.part, {
+      budget: warm,
+      maxHits: Number.POSITIVE_INFINITY,
+    });
+    expect(all.length).toBeGreaterThanOrEqual(6);
+
+    // Diagnostics-style clip over the warmed tree. Memo hits append in document order,
+    // so the clipped prefix is identical to the cold walk; only the visited count may
+    // run ahead (bulk-charged subtrees), which diagnose already reports as truncated
+    // coverage via the full hit buffer.
+    const maxHits = 2;
+    const memoBudget = createNoteReferenceScanBudget(FULL_BUDGET);
+    const memoClipped = collectNoteReferences(store.part, { budget: memoBudget, maxHits });
+    const coldBudget = createNoteReferenceScanBudget(FULL_BUDGET);
+    const coldClipped = collectNoteReferences(structuredClone(store.part), {
+      budget: coldBudget,
+      maxHits,
+    });
+    expect(memoClipped).toHaveLength(maxHits);
+    expect(JSON.stringify(memoClipped)).toBe(JSON.stringify(coldClipped));
+    expect(memoBudget.truncated).toBe(false);
+    expect(coldBudget.truncated).toBe(false);
+  });
+});

--- a/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
+++ b/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
@@ -17,44 +17,20 @@
 //    plain descent (pre-truncation prefixes feed diagnoseNoteReferences).
 // 3. The budget-free memoized path, so the two memo systems cannot drift apart.
 //
-// Determinism: fixed seeds and a pure inline PRNG (mulberry32). A failure prints the
-// seed and the accumulated op script, which replays the exact sequence.
+// Determinism and the random-edit machinery live in `random-edit-test-support.ts`,
+// shared with `derivation-memo-freshness.test.ts`.
 
 import { describe, expect, test } from 'bun:test';
-import {
-  paragraphTextOf,
-  TreeDocumentStore,
-  type OoxmlElement,
-  type OoxmlNode,
-  type OoxmlPart,
-  type TreeDocOp,
-} from '../index.ts';
-import {
-  collectNoteReferences,
-  createNoteReferenceScanBudget,
-  readOoxmlPart,
-} from '../package/index.ts';
+import { TreeDocumentStore, type OoxmlPart } from '../index.ts';
+import { collectNoteReferences, createNoteReferenceScanBudget } from '../package/index.ts';
 import { budgetedNoteScanMemoStats } from '../package/note-references.ts';
-
-const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-
-function loadPart(xml: string): OoxmlPart {
-  const result = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
-  if (!result.ok) throw new Error(result.reason);
-  return result.part;
-}
-
-/** Deterministic PRNG. Same seed, same sequence, every run, every machine. */
-function mulberry32(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = (state + 0x6d2b79f5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+import {
+  driveRandomEdits,
+  loadPart,
+  mulberry32,
+  W,
+  type RandomOpKind,
+} from './random-edit-test-support.ts';
 
 // ── Fixture ────────────────────────────────────────────────────────────────────
 // Note references sit in every third paragraph, inside hyperlinks in some, so edits hit
@@ -76,82 +52,7 @@ function fixturePart(): OoxmlPart {
   );
 }
 
-// ── Reading the retained tree ──────────────────────────────────────────────────
-
-function* walk(node: OoxmlNode): Generator<OoxmlNode> {
-  yield node;
-  if (node.kind === 'textValue') return;
-  for (const child of node.children ?? []) yield* walk(child);
-}
-
-function paragraphSitesOf(part: OoxmlPart): { id: string; length: number }[] {
-  const sites: { id: string; length: number }[] = [];
-  for (const node of walk(part.root)) {
-    if (node.kind !== 'paragraph') continue;
-    sites.push({ id: node.id, length: paragraphTextOf(part, node.id)?.length ?? 0 });
-  }
-  return sites;
-}
-
-/** Adjacent (first, second) paragraph pairs among the body's direct children. */
-function adjacentBodyParagraphPairs(part: OoxmlPart): [string, string][] {
-  const body = part.root.children.find(
-    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
-  );
-  const pairs: [string, string][] = [];
-  const children = body?.children ?? [];
-  for (let index = 0; index + 1 < children.length; index += 1) {
-    const first = children[index]!;
-    const second = children[index + 1]!;
-    if (first.kind === 'paragraph' && second.kind === 'paragraph') {
-      pairs.push([first.id, second.id]);
-    }
-  }
-  return pairs;
-}
-
-// ── Op vocabulary ──────────────────────────────────────────────────────────────
-// Generated against the CURRENT tree, so ids and offsets are usually valid; the store
-// may still refuse. A refusal is logged and skipped, and the applied-op floor below
-// keeps the test from passing by refusing everything.
-
-type OpKind = 'insert-text' | 'delete-text' | 'split' | 'join';
-
-const OPS: readonly OpKind[] = ['insert-text', 'insert-text', 'delete-text', 'split', 'join'];
-
-function randomOp(part: OoxmlPart, rand: () => number, step: number): TreeDocOp | null {
-  const pick = <T>(items: readonly T[]): T => items[Math.floor(rand() * items.length)]!;
-  const sites = paragraphSitesOf(part);
-  if (sites.length === 0) return null;
-  const site = pick(sites);
-  switch (pick(OPS)) {
-    case 'insert-text':
-      return {
-        op: 'insertText',
-        paragraphId: site.id,
-        offset: Math.floor(rand() * (site.length + 1)),
-        text: ` step${step} extra`,
-      };
-    case 'delete-text': {
-      if (site.length < 2) return null;
-      const start = Math.floor(rand() * (site.length - 1));
-      const end = start + 1 + Math.floor(rand() * (site.length - start - 1));
-      return { op: 'deleteText', paragraphId: site.id, start, end };
-    }
-    case 'split':
-      return {
-        op: 'splitParagraph',
-        paragraphId: site.id,
-        offset: Math.floor(rand() * (site.length + 1)),
-      };
-    case 'join': {
-      const pairs = adjacentBodyParagraphPairs(part);
-      if (pairs.length === 0) return null;
-      const [firstId, secondId] = pick(pairs);
-      return { op: 'joinParagraphs', firstId, secondId };
-    }
-  }
-}
+const OPS: readonly RandomOpKind[] = ['insert-text', 'insert-text', 'delete-text', 'split', 'join'];
 
 // ── The oracle ─────────────────────────────────────────────────────────────────
 
@@ -254,36 +155,20 @@ const STEPS = 30;
 describe('budgeted note-reference scan memos stay fresh across random op sequences', () => {
   for (const seed of SEEDS) {
     test(`seed ${seed}: ${STEPS} random ops`, () => {
-      const rand = mulberry32(seed);
       const store = new TreeDocumentStore(fixturePart());
-      const log: unknown[] = [];
 
       // The fixture's typed references must have parsed, or the oracle compares empty
       // hit lists at every step.
       expect(collectNoteReferences(store.part).length).toBeGreaterThanOrEqual(6);
-      assertBudgetedScanFresh(store.part, seed, -1, log);
+      assertBudgetedScanFresh(store.part, seed, -1, []);
 
-      let applied = 0;
-      let splitsApplied = 0;
       const reusesBefore = budgetedNoteScanMemoStats.reuses;
-      for (let step = 0; step < STEPS; step += 1) {
-        const op = randomOp(store.part, rand, step);
-        if (op === null) {
-          log.push(['skip', step]);
-          continue;
-        }
-        const result = store.transact((tx) => {
-          tx.apply(op);
-        });
-        if (!result.ok) {
-          log.push(['refused', step, result.reason, op]);
-          continue;
-        }
-        log.push([step, op]);
-        applied += 1;
-        if (op.op === 'splitParagraph') splitsApplied += 1;
-        assertBudgetedScanFresh(store.part, seed, step, log);
-      }
+      const { applied, splitsApplied } = driveRandomEdits(store, {
+        rand: mulberry32(seed),
+        steps: STEPS,
+        ops: OPS,
+        onApplied: (step, _op, log) => assertBudgetedScanFresh(store.part, seed, step, log),
+      });
 
       // Anti-vacuity: enough ops applied, and enough splits that fresh spines were
       // rescanned against — and read back through — the memoized subtrees. The reuse

--- a/packages/core/src/store/__tests__/random-edit-test-support.ts
+++ b/packages/core/src/store/__tests__/random-edit-test-support.ts
@@ -1,0 +1,189 @@
+// Shared random-edit harness for the memo-freshness differentials
+// (`derivation-memo-freshness.test.ts`, `note-scan-memo-freshness.test.ts`).
+//
+// Each suite supplies its own fixture, oracle and op distribution; this module owns the
+// deterministic machinery they must not let drift apart: the PRNG, the op generator that
+// reads the CURRENT tree, and the transact/log/replay driver. A failure in either suite
+// prints the seed and the accumulated op script, which replays the exact sequence.
+
+import {
+  paragraphTextOf,
+  TreeDocumentStore,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+  type TreeDocOp,
+} from '../index.ts';
+import { readOoxmlPart } from '../package/index.ts';
+
+export const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+export const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+
+export function loadPart(xml: string): OoxmlPart {
+  const result = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/** Deterministic PRNG. Same seed, same sequence, every run, every machine. */
+export function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Reading the retained tree ──────────────────────────────────────────────────
+
+function* walk(node: OoxmlNode): Generator<OoxmlNode> {
+  yield node;
+  if (node.kind === 'textValue') return;
+  for (const child of node.children ?? []) yield* walk(child);
+}
+
+function paragraphSitesOf(part: OoxmlPart): { id: string; length: number }[] {
+  const sites: { id: string; length: number }[] = [];
+  for (const node of walk(part.root)) {
+    if (node.kind !== 'paragraph') continue;
+    sites.push({ id: node.id, length: paragraphTextOf(part, node.id)?.length ?? 0 });
+  }
+  return sites;
+}
+
+/** Adjacent (first, second) paragraph pairs among the body's direct children. */
+function adjacentBodyParagraphPairs(part: OoxmlPart): [string, string][] {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  );
+  const pairs: [string, string][] = [];
+  const children = body?.children ?? [];
+  for (let index = 0; index + 1 < children.length; index += 1) {
+    const first = children[index]!;
+    const second = children[index + 1]!;
+    if (first.kind === 'paragraph' && second.kind === 'paragraph') {
+      pairs.push([first.id, second.id]);
+    }
+  }
+  return pairs;
+}
+
+// ── Op vocabulary ──────────────────────────────────────────────────────────────
+// Generated against the CURRENT tree, so ids and offsets are usually valid; the store
+// may still refuse (a delete crossing tracked content, a join it will not perform). A
+// refusal is logged and skipped, and each suite's applied-op floor keeps its test from
+// passing by refusing everything.
+
+export type RandomOpKind = 'insert-text' | 'delete-text' | 'split' | 'join' | 'tracked-insert';
+
+export const PLAIN_RANDOM_OPS: readonly RandomOpKind[] = [
+  'insert-text',
+  'insert-text',
+  'delete-text',
+  'split',
+  'split',
+  'join',
+];
+export const TRACKED_RANDOM_OPS: readonly RandomOpKind[] = [
+  ...PLAIN_RANDOM_OPS,
+  'tracked-insert',
+  'tracked-insert',
+];
+
+export function randomOp(
+  part: OoxmlPart,
+  rand: () => number,
+  step: number,
+  ops: readonly RandomOpKind[]
+): TreeDocOp | null {
+  const pick = <T>(items: readonly T[]): T => items[Math.floor(rand() * items.length)]!;
+  const sites = paragraphSitesOf(part);
+  if (sites.length === 0) return null;
+  const site = pick(sites);
+  switch (pick(ops)) {
+    case 'insert-text':
+      return {
+        op: 'insertText',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+        text: ` step${step} extra`,
+      };
+    case 'tracked-insert':
+      return {
+        op: 'insertText',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+        text: ` step${step} proposal`,
+        revision: { author: 'QA Reviewer', date: '2026-01-03T00:00:00Z' },
+      };
+    case 'delete-text': {
+      if (site.length < 2) return null;
+      const start = Math.floor(rand() * (site.length - 1));
+      const end = start + 1 + Math.floor(rand() * (site.length - start - 1));
+      return { op: 'deleteText', paragraphId: site.id, start, end };
+    }
+    case 'split':
+      return {
+        op: 'splitParagraph',
+        paragraphId: site.id,
+        offset: Math.floor(rand() * (site.length + 1)),
+      };
+    case 'join': {
+      const pairs = adjacentBodyParagraphPairs(part);
+      if (pairs.length === 0) return null;
+      const [firstId, secondId] = pick(pairs);
+      return { op: 'joinParagraphs', firstId, secondId };
+    }
+  }
+}
+
+// ── The driver ─────────────────────────────────────────────────────────────────
+
+export interface RandomEditDriveResult {
+  /** Ops the store accepted. Suites assert a floor so refusals cannot vacuously pass. */
+  readonly applied: number;
+  /** Applied splitParagraph ops, for suites whose oracle needs fresh spines minted. */
+  readonly splitsApplied: number;
+  /** The replayable op script (also handed to `onApplied` for failure messages). */
+  readonly log: unknown[];
+}
+
+/**
+ * Drive `steps` random ops through the store, logging skips and refusals, and call
+ * `onApplied` after every accepted op — that is where each suite runs its differential.
+ */
+export function driveRandomEdits(
+  store: TreeDocumentStore,
+  options: {
+    readonly rand: () => number;
+    readonly steps: number;
+    readonly ops: readonly RandomOpKind[];
+    readonly onApplied: (step: number, op: TreeDocOp, log: unknown[]) => void;
+  }
+): RandomEditDriveResult {
+  const log: unknown[] = [];
+  let applied = 0;
+  let splitsApplied = 0;
+  for (let step = 0; step < options.steps; step += 1) {
+    const op = randomOp(store.part, options.rand, step, options.ops);
+    if (op === null) {
+      log.push(['skip', step]);
+      continue;
+    }
+    const result = store.transact((tx) => {
+      tx.apply(op);
+    });
+    if (!result.ok) {
+      log.push(['refused', step, result.reason, op]);
+      continue;
+    }
+    log.push([step, op]);
+    applied += 1;
+    if (op.op === 'splitParagraph') splitsApplied += 1;
+    options.onApplied(step, op, log);
+  }
+  return { applied, splitsApplied, log };
+}

--- a/packages/core/src/store/__tests__/tree-ops.test.ts
+++ b/packages/core/src/store/__tests__/tree-ops.test.ts
@@ -515,7 +515,7 @@ describe('rejections leave everything unchanged (task 5.3)', () => {
     },
     {
       name: 'text containing a character XML cannot represent',
-      op: { op: 'insertText', paragraphId: id!, offset: 0, text: ' ' },
+      op: { op: 'insertText', paragraphId: id!, offset: 0, text: '\u0000' },
       reason: 'invalid-text',
     },
   ];

--- a/packages/core/src/store/package/note-references.ts
+++ b/packages/core/src/store/package/note-references.ts
@@ -224,18 +224,23 @@ function collectParagraphNoteReferences(
  * The budget-free scan uses it (layout runs one per published pass over a part whose
  * paragraphs are all shared but the edited one); budgeted scans use
  * {@link budgetedNoteScanMemos} instead, which also records exact visited accounting.
+ * Hits carry a baked-in `partName`, so the entry records the name it was computed under
+ * and a paragraph reached under a second part name recomputes.
  */
-const paragraphNoteHitMemos = new WeakMap<OoxmlNode, readonly NoteReferenceHit[]>();
+const paragraphNoteHitMemos = new WeakMap<
+  OoxmlNode,
+  { readonly partName: string; readonly hits: readonly NoteReferenceHit[] }
+>();
 
 function paragraphNoteHitsOf(
   paragraph: OoxmlParagraphNode,
   partName: string
 ): readonly NoteReferenceHit[] {
   const cached = paragraphNoteHitMemos.get(paragraph);
-  if (cached) return cached;
+  if (cached && cached.partName === partName) return cached.hits;
   const hits: NoteReferenceHit[] = [];
   collectParagraphNoteReferences(paragraph, hits, undefined, MAX_NOTE_REFERENCE_SCAN, partName);
-  paragraphNoteHitMemos.set(paragraph, hits);
+  paragraphNoteHitMemos.set(paragraph, { partName, hits });
   return hits;
 }
 
@@ -246,8 +251,16 @@ const NO_NOTE_HITS: readonly NoteReferenceHit[] = Object.freeze([]);
  *
  * A text edit replaces one paragraph and its ancestors. Unchanged sibling containers keep
  * their identity, so their complete answer remains reusable across part revisions.
+ *
+ * The entry records the depth and part name it was computed under, like
+ * {@link budgetedNoteScanMemos}: the 64-level cap makes the answer depth-dependent (a
+ * subtree first reached past the cap caches empty), and hits carry a baked-in
+ * `partName`. A mismatch on either recomputes instead of replaying the stale answer.
  */
-const containerNoteHitMemos = new WeakMap<OoxmlNode, readonly NoteReferenceHit[]>();
+const containerNoteHitMemos = new WeakMap<
+  OoxmlNode,
+  { readonly depth: number; readonly partName: string; readonly hits: readonly NoteReferenceHit[] }
+>();
 
 function subtreeNoteHitsOf(
   node: OoxmlNode,
@@ -257,7 +270,7 @@ function subtreeNoteHitsOf(
   if (node.kind === 'textValue' || depth > 64) return NO_NOTE_HITS;
   if (node.kind === 'paragraph') return paragraphNoteHitsOf(node, partName);
   const cached = containerNoteHitMemos.get(node);
-  if (cached) return cached;
+  if (cached && cached.depth === depth && cached.partName === partName) return cached.hits;
 
   let hits: NoteReferenceHit[] | null = null;
   for (const child of node.children) {
@@ -269,7 +282,7 @@ function subtreeNoteHitsOf(
     hits.push(...childHits.slice(0, remaining));
   }
   const result: readonly NoteReferenceHit[] = hits ? Object.freeze(hits) : NO_NOTE_HITS;
-  containerNoteHitMemos.set(node, result);
+  containerNoteHitMemos.set(node, { depth, partName, hits: result });
   return result;
 }
 
@@ -280,33 +293,42 @@ function subtreeNoteHitsOf(
  *
  * Mutation paths always carry a budget, and before this memo they re-walked the whole
  * package on every transaction. A budgeted walk that reaches a memoized subtree
- * bulk-charges the cached count and reuses the hits without descending, so on every
- * non-truncated scan the shared budget's `visited` stays byte-identical to the
- * unmemoized walk — downstream parts sharing the budget behave identically.
+ * bulk-charges the cached count and reuses the hits without descending — but only when
+ * the cached count fits the remaining budget AND appending the cached hits stays under
+ * `maxHits`. Otherwise the walk falls through to the plain descent, which stops at
+ * exactly the node the unmemoized walk would stop at. Every budgeted scan is therefore
+ * byte-identical to the unmemoized walk — hits, `visited` and `truncated` alike — warm
+ * or cold, truncated or not, so downstream parts sharing one budget behave identically
+ * and pre-truncation hit prefixes (which `diagnoseNoteReferences` reports) survive.
  *
- * Divergences are confined to outcomes callers already treat as failed coverage:
- * - When a bulk charge overruns the remaining budget the walk lands on the plain walk's
- *   terminal state (`visited === maxVisited`, `truncated === true`) without descending.
- *   Callers treat `budget.truncated` as atomic failure (see header), so the exact
- *   stop-point prefix of hits is immaterial.
- * - A finite `maxHits` clip stops the plain walk from charging nodes past the clip,
- *   while a memo reuse has already bulk-charged its whole subtree, so `visited` can run
- *   ahead under a clip. The clipped hit prefix itself is identical (memo hits append in
- *   document order). `diagnoseNoteReferences` — the only finite-`maxHits` budgeted
- *   caller — reports a full hit buffer as truncated coverage either way.
- *
- * The entry records the depth it was computed at, because the 64-level cap makes results
- * depth-dependent: a shared subtree republished at a different depth recomputes instead
- * of serving an answer computed under the old cap (same fix as
- * `subtreeDeepParagraphIdsCache` in `review-reads.ts`).
+ * The entry records the depth and part name it was computed under. The 64-level cap
+ * makes results depth-dependent, so a shared subtree republished at a different depth
+ * recomputes instead of serving an answer computed under the old cap (same fix as
+ * `subtreeDeepParagraphIdsCache` in `review-reads.ts`). The part name makes the
+ * one-part-per-node assumption self-enforcing: hits carry a baked-in `partName`, so a
+ * node reached under a second part name must recompute rather than replay the first
+ * part's hits.
  */
 interface BudgetedNoteScanEntry {
   readonly hits: readonly NoteReferenceHit[];
   readonly visited: number;
   readonly depth: number;
+  readonly partName: string;
 }
 
 const budgetedNoteScanMemos = new WeakMap<OoxmlNode, BudgetedNoteScanEntry>();
+
+/**
+ * Non-paragraph subtrees below this plain-walk cost carry no memo entry unless they hold
+ * a hit. Their nearest memoized ancestor answers for them on an unchanged spine, and a
+ * rebuilt spine re-walks them for less than an entry is worth — this keeps the memo from
+ * retaining one entry per element of every non-story part. Paragraphs always get an
+ * entry: they are the reuse unit when an edit rebuilds the story spine above them.
+ */
+const MEMO_MIN_SUBTREE_VISITED = 64;
+
+/** Test-only observability: bulk memo reuses. Asserted by the freshness differential. */
+export const budgetedNoteScanMemoStats = { reuses: 0 };
 
 /**
  * Walk a part for addressable typed note references. Bounded by visited nodes; skips deep
@@ -332,45 +354,56 @@ export function collectNoteReferences(
   }
   const hits: NoteReferenceHit[] = [];
 
-  const walk = (node: OoxmlNode, depth: number): void => {
-    if (hits.length >= maxHits || (budget && budget.truncated)) return;
-    if (depth > 64) {
-      if (budget) budget.truncated = true;
-      return;
-    }
-
-    if (budget) {
-      const cached = budgetedNoteScanMemos.get(node);
-      if (cached !== undefined && cached.depth === depth) {
-        if (cached.visited > budget.maxVisited - budget.visited) {
-          // The plain walk runs out of budget inside this subtree; land on the same
-          // terminal state without descending.
-          budget.visited = budget.maxVisited;
-          budget.truncated = true;
-          return;
-        }
-        budget.visited += cached.visited;
-        for (const hit of cached.hits) {
-          if (hits.length >= maxHits) return;
-          hits.push(hit);
-        }
-        return;
-      }
-    }
-
-    const startVisited = budget ? budget.visited : 0;
-    const startHits = hits.length;
-    if (!charge(budget)) return;
-    if (node.kind === 'textValue') return;
-
-    if (node.kind === 'paragraph') {
-      if (budget === undefined) {
+  if (budget === undefined) {
+    // No accounting to keep exact: per-paragraph memos only (maxHits above the cap the
+    // subtree memo path at the top of this function serves).
+    const walkUnbudgeted = (node: OoxmlNode, depth: number): void => {
+      if (hits.length >= maxHits || depth > 64 || node.kind === 'textValue') return;
+      if (node.kind === 'paragraph') {
         for (const hit of paragraphNoteHitsOf(node, part.name)) {
           if (hits.length >= maxHits) return;
           hits.push(hit);
         }
         return;
       }
+      for (const child of node.children) walkUnbudgeted(child, depth + 1);
+    };
+    walkUnbudgeted(part.root, 0);
+    return hits;
+  }
+
+  const walk = (node: OoxmlNode, depth: number): void => {
+    if (hits.length >= maxHits || budget.truncated) return;
+    if (depth > 64) {
+      budget.truncated = true;
+      return;
+    }
+
+    // Bulk reuse only when the outcome is provably the plain walk's: the cached charge
+    // fits the remaining budget and the cached hits stay strictly under maxHits (at the
+    // clip the plain walk stops charging mid-subtree, which the bulk charge cannot
+    // reproduce). Anything else falls through to the plain descent below, which stops
+    // at exactly the node the unmemoized walk stops at.
+    const cached = budgetedNoteScanMemos.get(node);
+    if (
+      cached !== undefined &&
+      cached.depth === depth &&
+      cached.partName === part.name &&
+      cached.visited <= budget.maxVisited - budget.visited &&
+      hits.length + cached.hits.length < maxHits
+    ) {
+      budget.visited += cached.visited;
+      for (const hit of cached.hits) hits.push(hit);
+      budgetedNoteScanMemoStats.reuses += 1;
+      return;
+    }
+
+    const startVisited = budget.visited;
+    const startHits = hits.length;
+    if (!charge(budget)) return;
+    if (node.kind === 'textValue') return;
+
+    if (node.kind === 'paragraph') {
       collectParagraphNoteReferences(node, hits, budget, maxHits, part.name);
     } else {
       for (const child of node.children) walk(child, depth + 1);
@@ -378,14 +411,19 @@ export function collectNoteReferences(
 
     // Memoize only subtrees the walk covered completely: a budget truncation or a
     // maxHits clip inside the subtree leaves nodes uncharged and hits unrecorded, and
-    // caching that partial answer would replay it as a complete one.
-    if (budget && !budget.truncated && hits.length < maxHits) {
-      budgetedNoteScanMemos.set(node, {
-        hits: hits.length > startHits ? Object.freeze(hits.slice(startHits)) : NO_NOTE_HITS,
-        visited: budget.visited - startVisited,
-        depth,
-      });
-    }
+    // caching that partial answer would replay it as a complete one. (`>= maxHits` is
+    // ambiguous — the clip may have bound on the subtree's last hit — so it never
+    // caches.)
+    if (budget.truncated || hits.length >= maxHits) return;
+    const visited = budget.visited - startVisited;
+    const gotHits = hits.length > startHits;
+    if (node.kind !== 'paragraph' && !gotHits && visited < MEMO_MIN_SUBTREE_VISITED) return;
+    budgetedNoteScanMemos.set(node, {
+      hits: gotHits ? Object.freeze(hits.slice(startHits)) : NO_NOTE_HITS,
+      visited,
+      depth,
+      partName: part.name,
+    });
   };
 
   walk(part.root, 0);

--- a/packages/core/src/store/package/note-references.ts
+++ b/packages/core/src/store/package/note-references.ts
@@ -219,17 +219,11 @@ function collectParagraphNoteReferences(
 }
 
 /**
- * Walk a part for addressable typed note references. Bounded by visited nodes; skips deep
- * hostile nesting by marking the shared budget truncated. When `budget` is supplied it is
- * shared and mutated in place. Hits are segment-aligned (`segmentsOf`); demoted wrappers
- * never invent atomOffsets.
- */
-/**
  * Per-paragraph note-reference memo, keyed on the immutable paragraph node.
  *
- * Only the budget-free scan uses it (layout runs one per published pass over a part whose
- * paragraphs are all shared but the edited one); budgeted mutation scans keep the plain
- * walk so their visited accounting stays exact.
+ * The budget-free scan uses it (layout runs one per published pass over a part whose
+ * paragraphs are all shared but the edited one); budgeted scans use
+ * {@link budgetedNoteScanMemos} instead, which also records exact visited accounting.
  */
 const paragraphNoteHitMemos = new WeakMap<OoxmlNode, readonly NoteReferenceHit[]>();
 
@@ -279,6 +273,47 @@ function subtreeNoteHitsOf(
   return result;
 }
 
+/**
+ * Budgeted subtree memo: the hits under one immutable node plus the exact visited-node
+ * count the plain budgeted walk charges for that subtree (including the subtree root's
+ * own charge).
+ *
+ * Mutation paths always carry a budget, and before this memo they re-walked the whole
+ * package on every transaction. A budgeted walk that reaches a memoized subtree
+ * bulk-charges the cached count and reuses the hits without descending, so on every
+ * non-truncated scan the shared budget's `visited` stays byte-identical to the
+ * unmemoized walk — downstream parts sharing the budget behave identically.
+ *
+ * Divergences are confined to outcomes callers already treat as failed coverage:
+ * - When a bulk charge overruns the remaining budget the walk lands on the plain walk's
+ *   terminal state (`visited === maxVisited`, `truncated === true`) without descending.
+ *   Callers treat `budget.truncated` as atomic failure (see header), so the exact
+ *   stop-point prefix of hits is immaterial.
+ * - A finite `maxHits` clip stops the plain walk from charging nodes past the clip,
+ *   while a memo reuse has already bulk-charged its whole subtree, so `visited` can run
+ *   ahead under a clip. The clipped hit prefix itself is identical (memo hits append in
+ *   document order). `diagnoseNoteReferences` — the only finite-`maxHits` budgeted
+ *   caller — reports a full hit buffer as truncated coverage either way.
+ *
+ * The entry records the depth it was computed at, because the 64-level cap makes results
+ * depth-dependent: a shared subtree republished at a different depth recomputes instead
+ * of serving an answer computed under the old cap (same fix as
+ * `subtreeDeepParagraphIdsCache` in `review-reads.ts`).
+ */
+interface BudgetedNoteScanEntry {
+  readonly hits: readonly NoteReferenceHit[];
+  readonly visited: number;
+  readonly depth: number;
+}
+
+const budgetedNoteScanMemos = new WeakMap<OoxmlNode, BudgetedNoteScanEntry>();
+
+/**
+ * Walk a part for addressable typed note references. Bounded by visited nodes; skips deep
+ * hostile nesting by marking the shared budget truncated. When `budget` is supplied it is
+ * shared and mutated in place. Hits are segment-aligned (`segmentsOf`); demoted wrappers
+ * never invent atomOffsets.
+ */
 export function collectNoteReferences(
   part: OoxmlPart,
   options?: {
@@ -295,7 +330,6 @@ export function collectNoteReferences(
     const all = subtreeNoteHitsOf(part.root, part.name, 0);
     return all.length > maxHits ? all.slice(0, maxHits) : all;
   }
-  const memoized = budget === undefined;
   const hits: NoteReferenceHit[] = [];
 
   const walk = (node: OoxmlNode, depth: number): void => {
@@ -304,11 +338,33 @@ export function collectNoteReferences(
       if (budget) budget.truncated = true;
       return;
     }
+
+    if (budget) {
+      const cached = budgetedNoteScanMemos.get(node);
+      if (cached !== undefined && cached.depth === depth) {
+        if (cached.visited > budget.maxVisited - budget.visited) {
+          // The plain walk runs out of budget inside this subtree; land on the same
+          // terminal state without descending.
+          budget.visited = budget.maxVisited;
+          budget.truncated = true;
+          return;
+        }
+        budget.visited += cached.visited;
+        for (const hit of cached.hits) {
+          if (hits.length >= maxHits) return;
+          hits.push(hit);
+        }
+        return;
+      }
+    }
+
+    const startVisited = budget ? budget.visited : 0;
+    const startHits = hits.length;
     if (!charge(budget)) return;
     if (node.kind === 'textValue') return;
 
     if (node.kind === 'paragraph') {
-      if (memoized) {
+      if (budget === undefined) {
         for (const hit of paragraphNoteHitsOf(node, part.name)) {
           if (hits.length >= maxHits) return;
           hits.push(hit);
@@ -316,10 +372,20 @@ export function collectNoteReferences(
         return;
       }
       collectParagraphNoteReferences(node, hits, budget, maxHits, part.name);
-      return;
+    } else {
+      for (const child of node.children) walk(child, depth + 1);
     }
 
-    for (const child of node.children) walk(child, depth + 1);
+    // Memoize only subtrees the walk covered completely: a budget truncation or a
+    // maxHits clip inside the subtree leaves nodes uncharged and hits unrecorded, and
+    // caching that partial answer would replay it as a complete one.
+    if (budget && !budget.truncated && hits.length < maxHits) {
+      budgetedNoteScanMemos.set(node, {
+        hits: hits.length > startHits ? Object.freeze(hits.slice(startHits)) : NO_NOTE_HITS,
+        visited: budget.visited - startVisited,
+        depth,
+      });
+    }
   };
 
   walk(part.root, 0);

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -334,7 +334,7 @@ function pairReplacements(
   for (const insertion of pairable) {
     if (insertion.revisionKind !== 'insert') continue;
     const start = insertion.ranges[0]!.start;
-    const key = `${start.paragraphId} ${start.offset}`;
+    const key = `${start.paragraphId}\u0000${start.offset}`;
     const bucket = insertionsByStart.get(key);
     if (bucket) bucket.push(insertion);
     else insertionsByStart.set(key, [insertion]);
@@ -345,7 +345,7 @@ function pairReplacements(
     // The deletion's LAST range end: the end that actually meets the insertion's first
     // start when the halves span more than one range each.
     const end = deletion.ranges[deletion.ranges.length - 1]!.end;
-    const bucket = insertionsByStart.get(`${end.paragraphId} ${end.offset}`) ?? [];
+    const bucket = insertionsByStart.get(`${end.paragraphId}\u0000${end.offset}`) ?? [];
     // A ZERO-WIDTH insertion is not the replacement, even when it starts exactly here.
     // Several legal shapes cover no characters: an empty run carrying only run properties,
     // a comment reference, a bookmark pair. Taking the first candidate in the bucket paired
@@ -423,7 +423,7 @@ function mergeAdjacentSameKindEdits(
   if (mergeable.length < 2) return items;
 
   const keyOf = (item: ReviewRevisionItem, position: ReviewPosition): string =>
-    `${item.revisionKind} ${item.author} ${position.paragraphId} ${position.offset}`;
+    `${item.revisionKind}\u0000${item.author}\u0000${position.paragraphId}\u0000${position.offset}`;
   const byStart = new Map<string, ReviewRevisionItem>();
   const endKeys = new Set<string>();
   for (const item of mergeable) {
@@ -723,7 +723,7 @@ export interface LinkableReviewItem {
 /** A range as a comparable key, so "exactly these characters" is one lookup. */
 function rangeKey(range: ReviewRange): string {
   return (
-    `${range.partName} ${range.start.paragraphId}:${range.start.offset}` +
+    `${range.partName}\u0000${range.start.paragraphId}:${range.start.offset}` +
     `|${range.end.paragraphId}:${range.end.offset}`
   );
 }


### PR DESCRIPTION
Fixes #448.

Budgeted note-reference scans took the unmemoized walk, and mutation paths always carry a budget, so `collectPackageNoteReferences` re-walked the whole package on every transaction. Budgeted walks now reuse a per-subtree memo of hits plus the exact visited count the plain walk charges, so only the rebuilt spine recomputes.

A memo is reused only when its charge fits the remaining budget and its hits stay under `maxHits`; otherwise the walk falls through to the plain descent. Every budgeted scan therefore returns the same hits, `visited`, and `truncated` as the unmemoized walk, warm or cold, so parts sharing one budget truncate at the same point and `diagnoseNoteReferences` keeps its pre-truncation prefix. Entries record the depth and part name they were computed under and recompute on mismatch; the pre-existing budget-free memos gain the same keys. Zero-hit non-paragraph subtrees below a re-walk-cost threshold carry no entry, which bounds memo growth on large packages.

A randomized differential drives a store through random edits and asserts hits and budget accounting against cold walks over a `structuredClone` of the part after every edit, including a budget that truncates mid-tree, plus a reuse-counter floor so a memo that never serves fails the suite.

On the 521-page fixture, a package-wide mutation scan drops from ~38 ms to ~0.02 ms warm and ~0.9 ms after an edit; the delete-path cascade pair drops from ~74 ms to ~0.2 ms. Settle-bench work counters stay byte-identical.

A separate commit escapes two literal NUL bytes in string literals that made grep classify their files as binary and hide every match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790243110&installation_model_id=422592&pr_number=454&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F454&signature=70cddc5f5557486eeb2c3a260fbb171af54f4a7bc0c941aaf978870e685b6920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->