### PR TITLE
perf: split the keystroke flush at the transact/layout seam under input pressure

### DIFF
--- a/.changeset/input-pressure-flush-split.md
+++ b/.changeset/input-pressure-flush-split.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Reduce input delay while typing into very large documents: when the browser reports queued input behind an expensive layout pass, a keystroke commits in its own task and layout and paint follow in separate tasks, instead of one blocking flush.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"acbc784c-e79a-4180-b429-d1b50ab4de73","pid":27591,"procStart":"Mon May  4 06:29:32 2026","acquiredAt":1777910360228}
+{"sessionId":"04befb1b-2999-4a82-8755-8e08db52c541","pid":52523,"procStart":"Tue Aug 25 08:57:11 2026","acquiredAt":1787650912974}

--- a/packages/core/src/editor/__tests__/input-pressure-flush.test.ts
+++ b/packages/core/src/editor/__tests__/input-pressure-flush.test.ts
@@ -203,6 +203,50 @@ describe('commit-tail layout deferral under input pressure', () => {
   });
 });
 
+describe('refusals and pressure', () => {
+  test('a REFUSED commit under pressure still flushes in-task and reports its refusal', async () => {
+    const restorePressure = stubInputPending();
+    const restoreClock = stubClock(10);
+    const container = document.createElement('div');
+    document.body.append(container);
+    let changes = 0;
+    const { mountPaginatedSurface } = await import('../paginated-surface.ts');
+    const { docx } = await import('./paginated-surface-fixtures.ts');
+    const opened = mountPaginatedSurface(container, docx(paragraph('tail')), {
+      scale: 1,
+      onChange: () => {
+        changes += 1;
+      },
+    });
+    if (!opened.ok) throw new Error(opened.reason);
+    const surface = opened.surface;
+    try {
+      putCaret(surface, 0);
+      surface.type('a'); // leaves a deferred pass pending in the shared accumulator
+      const revisionBefore = surface.publishedLayout().revision;
+      const changesBefore = changes;
+
+      // A staged-ops build that returns null is a refusal that commits nothing. The
+      // shared accumulator still holds the typed commit's pass, so without the rejected
+      // gate the tail deferred — and the render that reports `lastRejection` with it.
+      surface.applyAutomationOps(() => null);
+
+      expect(surface.state().lastRejection).not.toBeNull();
+      // The refusal's synchronous flush landed the earlier deferred pass in-task; only
+      // the paint may still ride the pre-existing paint deferral one task.
+      expect(surface.publishedLayout().revision).toBeGreaterThan(revisionBefore);
+      await tick();
+      expect(changes).toBeGreaterThan(changesBefore);
+      expect(surface.state().lastRejection).not.toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+      restoreClock();
+      restorePressure();
+    }
+  });
+});
+
 describe('the deferral lane stays off outside its two conditions', () => {
   test('without navigator.scheduling an expensive commit stays fully synchronous', () => {
     const restoreClock = stubClock(10);

--- a/packages/core/src/editor/__tests__/input-pressure-flush.test.ts
+++ b/packages/core/src/editor/__tests__/input-pressure-flush.test.ts
@@ -1,0 +1,243 @@
+// The keystroke flush split at the transact/layout seam under input pressure.
+//
+// A commit used to be one unyielding task: transact, synchronous layout, paint. When the
+// browser reports queued input (`navigator.scheduling.isInputPending`) AND the previous
+// layout pass was expensive, the commit tail now leaves layout to the scheduler's own
+// `setTimeout(0)` backstop, and `renderPublishedLayout` may defer paint to a third task.
+// These tests pin three things: the deferral engages only under both conditions, every
+// synchronous reader still sees fresh geometry at its own seam, and the IME lane flushes
+// all the way to PAINT before it hands the DOM to a composition.
+//
+// The pressure stub follows selection-integrity.test.ts; the "expensive layout" half is a
+// monotonic `performance.now` stub, so every measured pass reads as 10 ms — above the 8 ms
+// deferral floor — without depending on real machine speed.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { PaginatedSurface } from '../paginated-surface.ts';
+import { mount, paragraph, putCaret } from './paginated-surface-fixtures.ts';
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+});
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Queued browser input, for as long as the returned restore has not run. */
+function stubInputPending(): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(window.navigator, 'scheduling');
+  Object.defineProperty(window.navigator, 'scheduling', {
+    configurable: true,
+    value: { isInputPending: () => true },
+  });
+  return () => {
+    if (descriptor) Object.defineProperty(window.navigator, 'scheduling', descriptor);
+    else delete (window.navigator as Navigator & { scheduling?: unknown }).scheduling;
+  };
+}
+
+/**
+ * Every measured span reads as `stepMs`: the surface computes `now() - began`, and this
+ * clock advances one step per call. `0` makes every pass read as free, which pins the
+ * synchronous path even under pressure.
+ */
+function stubClock(stepMs: number): () => void {
+  const original = performance.now;
+  let tickCount = 0;
+  performance.now = () => {
+    tickCount += 1;
+    return tickCount * stepMs;
+  };
+  return () => {
+    performance.now = original;
+  };
+}
+
+function paintedText(container: HTMLElement): string {
+  return container.querySelector('.docx-pages')?.textContent ?? '';
+}
+
+/** The IME rewriting a paragraph's painted spans, the way a browser does mid-composition. */
+function repaintParagraphAs(container: HTMLElement, paragraphId: string, text: string): void {
+  const spans = [...container.querySelectorAll('[data-paragraph-id][data-start]')].filter(
+    (element) => (element as HTMLElement).dataset.paragraphId === paragraphId
+  ) as HTMLElement[];
+  if (spans.length === 0) throw new Error(`no painted span for ${paragraphId}`);
+  spans[0]!.textContent = text;
+  for (const extra of spans.slice(1)) extra.textContent = '';
+}
+
+function keystroke(container: HTMLElement, data: string): void {
+  container.querySelector('.docx-pages')!.dispatchEvent(
+    new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      inputType: 'insertText',
+      data,
+    })
+  );
+}
+
+function withPressureAndExpensiveLayout(
+  run: (surface: PaginatedSurface, container: HTMLElement) => void | Promise<void>
+): Promise<void> {
+  const restorePressure = stubInputPending();
+  const restoreClock = stubClock(10);
+  const { surface, container } = mount(paragraph('tail'));
+  document.body.append(container);
+  return Promise.resolve(run(surface, container)).finally(() => {
+    surface.destroy();
+    container.remove();
+    restoreClock();
+    restorePressure();
+  });
+}
+
+describe('commit-tail layout deferral under input pressure', () => {
+  test('an expensive commit under pressure defers layout to its own task, then paints', async () => {
+    await withPressureAndExpensiveLayout(async (surface, container) => {
+      putCaret(surface, 0);
+      const revisionBefore = surface.publishedLayout().revision;
+
+      surface.type('a');
+
+      // The model moved; the published layout did not — the flush task ended at the transact.
+      expect(surface.session.bodyText()).toBe('atail');
+      expect(surface.publishedLayout().revision).toBe(revisionBefore);
+
+      // The scheduler's setTimeout(0) backstop runs layout+publish as its own task.
+      await tick();
+      expect(surface.publishedLayout().revision).toBeGreaterThan(revisionBefore);
+
+      // Paint may defer to a third task under sustained pressure, but it lands.
+      await tick();
+      expect(paintedText(container)).toContain('atail');
+      expect(surface.state().perf.staleDiscards).toBe(0);
+    });
+  });
+
+  test('a beforeinput burst under pressure lands in order with a fresh final paint', async () => {
+    await withPressureAndExpensiveLayout(async (surface, container) => {
+      putCaret(surface, 0);
+      for (const digit of '123') keystroke(container, digit);
+      await tick(); // type-buffer flush → one transact, layout deferred
+      await tick(); // scheduler backstop → publish
+      await tick(); // deferred paint
+      expect(surface.session.bodyText()).toBe('123tail');
+      expect(surface.state().selection.head.offset).toBe(3);
+      expect(paintedText(container)).toContain('123tail');
+      expect(surface.state().perf.staleDiscards).toBe(0);
+    });
+  });
+
+  test('geometry readers flush the deferred pass at their own seam', async () => {
+    await withPressureAndExpensiveLayout((surface) => {
+      putCaret(surface, 0);
+      const revisionBefore = surface.publishedLayout().revision;
+      surface.type('a');
+      expect(surface.publishedLayout().revision).toBe(revisionBefore);
+
+      // `layout()` is the contract's geometry read: it must return the committed revision.
+      expect(surface.layout().revision).toBeGreaterThan(revisionBefore);
+    });
+  });
+
+  test('flushPendingInput lands buffered text AND the deferred layout pass', async () => {
+    await withPressureAndExpensiveLayout((surface, container) => {
+      putCaret(surface, 0);
+      const revisionBefore = surface.publishedLayout().revision;
+      keystroke(container, 'z');
+      surface.flushPendingInput();
+      expect(surface.session.bodyText()).toBe('ztail');
+      expect(surface.publishedLayout().revision).toBeGreaterThan(revisionBefore);
+    });
+  });
+
+  test('navigate reads the layout that includes the deferred edit', async () => {
+    await withPressureAndExpensiveLayout((surface) => {
+      putCaret(surface, 0);
+      surface.type('a'); // caret at offset 1, layout deferred
+      surface.navigate('right');
+      expect(surface.state().selection.head.offset).toBe(2);
+    });
+  });
+
+  test('undo after a deferred commit rewinds the document cleanly', async () => {
+    await withPressureAndExpensiveLayout(async (surface, container) => {
+      putCaret(surface, 0);
+      surface.type('a');
+      surface.undo();
+      expect(surface.session.bodyText()).toBe('tail');
+      await tick();
+      await tick();
+      expect(paintedText(container)).toContain('tail');
+      expect(paintedText(container)).not.toContain('atail');
+      expect(surface.state().perf.staleDiscards).toBe(0);
+    });
+  });
+
+  test('compositionstart flushes to PAINT, so the readback diffs against the committed text', async () => {
+    await withPressureAndExpensiveLayout((surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      putCaret(surface, 0);
+      surface.type('X'); // deferred: the painted DOM still reads 'tail'
+      expect(paintedText(container)).not.toContain('Xtail');
+
+      const pages = container.querySelector('.docx-pages')!;
+      pages.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      // The handover flushed buffer, layout and paint: the IME composes over 'Xtail'.
+      expect(paintedText(container)).toContain('Xtail');
+
+      // The IME writes at the caret (after 'X') and only then says it is finished.
+      repaintParagraphAs(container, id, 'X中tail');
+      pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+
+      // The diff is exactly the composed character — not the deferred 'X' read back twice.
+      expect(surface.session.bodyText()).toBe('X中tail');
+      expect(surface.state().perf.staleDiscards).toBe(0);
+    });
+  });
+});
+
+describe('the deferral lane stays off outside its two conditions', () => {
+  test('without navigator.scheduling an expensive commit stays fully synchronous', () => {
+    const restoreClock = stubClock(10);
+    const { surface, container } = mount(paragraph('tail'));
+    document.body.append(container);
+    try {
+      putCaret(surface, 0);
+      const revisionBefore = surface.publishedLayout().revision;
+      surface.type('a');
+      // No scheduling API (happy-dom, servers): layout and paint land inside the commit.
+      expect(surface.publishedLayout().revision).toBeGreaterThan(revisionBefore);
+      expect(paintedText(container)).toContain('atail');
+    } finally {
+      surface.destroy();
+      container.remove();
+      restoreClock();
+    }
+  });
+
+  test('under pressure a CHEAP layout still flushes synchronously', () => {
+    const restorePressure = stubInputPending();
+    const restoreClock = stubClock(0);
+    const { surface, container } = mount(paragraph('tail'));
+    document.body.append(container);
+    try {
+      putCaret(surface, 0);
+      const revisionBefore = surface.publishedLayout().revision;
+      surface.type('a');
+      // Below the deferral floor the task split costs more than the pass: keep today's chain.
+      expect(surface.publishedLayout().revision).toBeGreaterThan(revisionBefore);
+    } finally {
+      surface.destroy();
+      container.remove();
+      restoreClock();
+      restorePressure();
+    }
+  });
+});

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -425,7 +425,13 @@ export interface PaginatedSurface {
    * keep calling it directly.
    */
   enqueueType(text: string): void;
-  /** Land any queued typed text now, as its own transaction. No-op when empty. */
+  /**
+   * Land any queued typed text now, as its own transaction, AND publish any layout pass a
+   * commit deferred under input pressure — so the caller reads current text and current
+   * geometry at one seam. Both halves are no-ops when nothing is pending, which is the
+   * common case: an isolated commit lays out synchronously in its own tail, and deferral
+   * only happens when the browser reports queued input behind an expensive pass.
+   */
   flushPendingInput(): void;
   /**
    * Insert text whose newlines are PARAGRAPH BOUNDARIES, in one commit.

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1031,10 +1031,9 @@ export function mountPaginatedSurface(
       armDerivationPrewarmOnce();
       return;
     }
-    // Layout stays synchronous so the next edit reads current geometry, but paint and DOM
-    // selection do not need to run once per event already waiting in the browser's input
-    // queue. One task catches the view up to the newest published layout; ordinary isolated
-    // edits still render synchronously through the branch above.
+    // Paint and DOM selection do not need to run once per event already waiting in the
+    // browser's input queue. One task catches the view up to the newest published layout;
+    // ordinary isolated edits still render synchronously through the branch above.
     if (deferredPublishRender !== null) return;
     deferredPublishRender = setTimeout(() => {
       deferredPublishRender = null;
@@ -1250,6 +1249,70 @@ export function mountPaginatedSurface(
     // Nothing pending means nothing committed since the last pass, so the layout in hand is
     // already current and re-running it would be pure waste.
     return scheduler.pending() ? scheduler.flush() : false;
+  }
+
+  /**
+   * Above this, a commit that finds queued browser input hands layout to the scheduler's
+   * own task instead of flushing synchronously. Below it, deferral buys nothing: the pass
+   * is cheaper than the task split, and an isolated keystroke must keep today's fully
+   * synchronous commit → layout → paint chain.
+   */
+  const INPUT_PRESSURE_LAYOUT_DEFER_MS = 8;
+
+  /**
+   * The commit tail: publish this commit's layout, synchronously on the common path.
+   *
+   * Under input pressure the flush used to be one unyielding task — transact, layout and
+   * paint — so a keystroke arriving mid-flush waited for all three. When the browser already
+   * holds queued input AND the previous pass was expensive, layout is left to the scheduler's
+   * `setTimeout(0)` backstop (armed by the commit's own `notify`), which runs layout+publish
+   * as its own task; `renderPublishedLayout` may defer paint to a third. Every synchronous
+   * reader regains current geometry through `flushLayout` at its own seam, and the deferred
+   * pass reads the model as it is when it runs, so no pass is ever published stale.
+   *
+   * A REFUSED commit leaves the scheduler empty, so it takes the synchronous branch and the
+   * `render()` below refreshes the state it just changed, exactly as before.
+   */
+  function publishAfterCommit(): void {
+    if (
+      scheduler.pending() !== null &&
+      lastLayoutMs > INPUT_PRESSURE_LAYOUT_DEFER_MS &&
+      hasPendingBrowserInput()
+    ) {
+      return;
+    }
+    if (!flushLayout()) render();
+  }
+
+  /**
+   * Land queued typing AND any deferred layout pass, so the caller reads current geometry.
+   *
+   * The one seam every synchronous reader shares — selection reads, navigation, geometry,
+   * scope flips, the contract's `flushPendingInput`. Both halves are no-ops when nothing is
+   * pending, so the common case costs two cheap checks.
+   */
+  function flushPendingInputAndLayout(): void {
+    flushTypeBuffer();
+    flushLayout();
+  }
+
+  /**
+   * Land queued typing, any deferred layout pass AND any deferred paint.
+   *
+   * For lanes that are about to hand the painted DOM over or read it back — the IME: a
+   * composition writes into whatever is on screen, and the readback diffs the painted text
+   * against the model, so both must describe the committed revision before it starts.
+   */
+  function flushToPaint(): void {
+    flushTypeBuffer();
+    flushLayout();
+    // The flushes above render on their own synchronous paths; what can remain is only a
+    // paint deferred under input pressure, and that is exactly what must land now.
+    if (deferredPublishRender === null) return;
+    clearTimeout(deferredPublishRender);
+    deferredPublishRender = null;
+    render();
+    armDerivationPrewarmOnce();
   }
 
   /** TOC chrome is hover-projected; never sticky from caret/click. */
@@ -2415,9 +2478,11 @@ export function mountPaginatedSurface(
   function rematerialize(): void {
     // The scroll-driven repaint can adopt a pending DOM gesture (adoptBeforePaint),
     // which moves the selection without passing `setSelection`'s buffer guard;
-    // landing queued typing here first closes that window. Safe: this runs from
-    // a scheduled frame, never inside a render.
-    flushTypeBuffer();
+    // landing queued typing here first closes that window. The layout flush rides
+    // along so the page set is chosen against current geometry when a commit
+    // deferred its pass. Safe: this runs from a scheduled frame, never inside a
+    // render.
+    flushPendingInputAndLayout();
     const nextSet = visiblePages();
     const nextExtent = surfaceExtent(currentLayout, nextSet);
     if (
@@ -2819,8 +2884,10 @@ export function mountPaginatedSurface(
       }
     }
     // A committed edit repaints through the scheduler's publish; a REFUSED one commits
-    // nothing, so the surface still has to refresh the state it just changed.
-    if (!flushLayout()) render();
+    // nothing, so the surface still has to refresh the state it just changed. Under input
+    // pressure the publish may hand layout+paint to the scheduler's own task — see
+    // `publishAfterCommit`.
+    publishAfterCommit();
   }
 
   /**
@@ -2951,6 +3018,7 @@ export function mountPaginatedSurface(
       replacementOffset({ paragraphId, offset: from }, { paragraphId, offset: to }),
     render: () => render(),
     flushLayout: () => flushLayout(),
+    flushToPaint: () => flushToPaint(),
     updateCaret: () => {
       caret.update();
       syncActiveFieldShading(pagesLayer, collapsedCaretPosition());
@@ -3020,6 +3088,9 @@ export function mountPaginatedSurface(
     noteModelMoved: () => selectionSync.noteModelMoved(),
     render: () => render(),
     revealNote: (scopeId) => {
+      // The note just inserted only exists in the post-commit layout, which the commit
+      // may have deferred under input pressure.
+      flushLayout();
       for (const page of currentLayout.pages) {
         const note = [...(page.footnotes?.notes ?? []), ...(page.endnotes?.notes ?? [])].find(
           (candidate) => candidate.scopeId === scopeId
@@ -3874,14 +3945,12 @@ export function mountPaginatedSurface(
     // sharing the store — must not leave a caller reading geometry for a revision the model
     // has left behind. Nothing pending makes this a plain read.
     layout: () => {
-      flushTypeBuffer();
-      flushLayout();
+      flushPendingInputAndLayout();
       return currentLayout;
     },
     state: currentState,
     currentPage: (mode = 'caret') => {
-      flushTypeBuffer();
-      flushLayout();
+      flushPendingInputAndLayout();
       if (mode === 'viewport') {
         const page = viewportPage(container, currentLayout, scale);
         if (page !== null) return page;
@@ -3991,7 +4060,7 @@ export function mountPaginatedSurface(
     },
 
     enqueueType,
-    flushPendingInput: flushTypeBuffer,
+    flushPendingInput: flushPendingInputAndLayout,
 
     type(text) {
       // Insert at the selection's START, not at its head. Deleting a selection removes the
@@ -4191,7 +4260,7 @@ export function mountPaginatedSurface(
     navigate(command, extend = false) {
       // Arrow keys move from the caret AFTER the typed text, over the layout
       // that includes it.
-      flushTypeBuffer();
+      flushPendingInputAndLayout();
       if (
         !extend &&
         (command === 'left' || command === 'right') &&
@@ -4754,8 +4823,9 @@ export function mountPaginatedSurface(
     setActiveScope: (scope: ViewScope) => {
       // Buffered typing belongs to the story it was typed in: it must land
       // BEFORE the active scope flips. A flush after the flip commits the burst
-      // into the wrong story, or gets refused and silently drops it.
-      flushTypeBuffer();
+      // into the wrong story, or gets refused and silently drops it. Scope
+      // entry resolves geometry from the layout, so a deferred pass lands too.
+      flushPendingInputAndLayout();
       if (scope.kind === 'note') return noteOps!.enterNote(scope.id);
       // REFUSED BEFORE ANYTHING IS LEFT. A scope this surface does not open — `frame`, or
       // anything a later contract adds — used to fall through to the exit below and only
@@ -4766,7 +4836,7 @@ export function mountPaginatedSurface(
     },
     insertNote: (noteKind) => {
       // Inserting a note ENTERS its story; same scope-flip rule as setActiveScope.
-      flushTypeBuffer();
+      flushPendingInputAndLayout();
       return noteOps!.insertNote(noteKind);
     },
     deleteNote: (noteKind, noteId) => noteOps!.deleteNote(noteKind, noteId),
@@ -4774,11 +4844,11 @@ export function mountPaginatedSurface(
     convertAllNotes: (fromKind) => noteOps!.convertAllNotes(fromKind),
     setNoteProperties: (args) => noteOps!.setNoteProperties(args),
     enterNote: (scopeId, position) => {
-      flushTypeBuffer();
+      flushPendingInputAndLayout();
       return noteOps!.enterNote(scopeId, position);
     },
     exitNote: () => {
-      flushTypeBuffer();
+      flushPendingInputAndLayout();
       return noteOps!.exitNote();
     },
     notePropertiesState: () => {
@@ -4866,8 +4936,9 @@ export function mountPaginatedSurface(
     },
     enterHeaderFooter: (args) => {
       // Land buffered body typing in the BODY before the scope flips to a
-      // header/footer story (see setActiveScope).
-      flushTypeBuffer();
+      // header/footer story (see setActiveScope). The band scroll below reads
+      // the layout, so a deferred pass lands with it.
+      flushPendingInputAndLayout();
       const entered = hfScope!.enterHeaderFooter(args);
       if (!entered) return entered;
       // A PROGRAMMATIC enter (review card, automation) must bring the band into view —
@@ -4888,7 +4959,7 @@ export function mountPaginatedSurface(
     },
     exitHeaderFooter: () => {
       // Escape from a header lands buffered HEADER typing in the header first.
-      flushTypeBuffer();
+      flushPendingInputAndLayout();
       return hfScope!.exitHeaderFooter();
     },
     headerFooterState: () => hfScope!.headerFooterStateStable(session.packageRevision()),
@@ -5072,8 +5143,9 @@ export function mountPaginatedSurface(
   /** The selection in DOCUMENT order, whichever way the user dragged it. */
   function orderedRange(): { from: SemanticPosition; to: SemanticPosition } {
     // Queued typing lands first: every range consumer must see the selection
-    // and layout the typed text produced. (No-op mid-flush and when empty.)
-    flushTypeBuffer();
+    // and layout the typed text produced — including a layout pass a commit
+    // deferred under input pressure. (No-op mid-flush and when empty.)
+    flushPendingInputAndLayout();
     return orderedRangeOf(currentLayout, selection, paragraphOrder());
   }
 
@@ -5116,8 +5188,10 @@ export function mountPaginatedSurface(
   function deleteSelectionPlan(): RangeDeletionPlan {
     // Every edit op builds its plan from here first, so this is where queued
     // typing must land: a plan computed against the pre-buffer selection would
-    // edit beside text the user has already typed. (No-op mid-flush.)
-    flushTypeBuffer();
+    // edit beside text the user has already typed. The plan reads `currentLayout`
+    // as its text oracle, so a deferred layout pass lands with it. (No-op
+    // mid-flush.)
+    flushPendingInputAndLayout();
     // A RECTANGLE is not the range it stands in for. Rows one and two of column one, read as
     // a range, run through every cell between them — so deleting through the range empties
     // cells the drag never covered, which is the exact failure the rectangle exists to
@@ -5204,9 +5278,13 @@ export function mountPaginatedSurface(
   // surface-input.ts, the selection mirror and the IME lane in surface-selection-sync.ts.
   const { onSelectionChange, onCompositionEnd } = selectionSync;
   // The IME owns the DOM from compositionstart on; buffered plain typing must
-  // be in the document before that handover, not woven into the readback.
+  // be in the document before that handover, not woven into the readback. The
+  // handover is of the PAINTED DOM, so a layout pass or paint a commit deferred
+  // under input pressure must land too: the readback at compositionend diffs the
+  // painted text against the model, and a composition that began over a stale
+  // paint would read the missing edit back as the IME's own.
   const onCompositionStart: typeof selectionSync.onCompositionStart = (...args) => {
-    flushTypeBuffer();
+    flushToPaint();
     selectionSync.onCompositionStart(...args);
   };
 
@@ -5426,7 +5504,7 @@ export function mountPaginatedSurface(
         // lane goes through, not here where only the pointer would be covered.
         // The pointer lane flips story scope too: land buffered typing first
         // (see setActiveScope).
-        flushTypeBuffer();
+        flushPendingInputAndLayout();
         hfScope?.enterHeaderFooter({
           rId: info.rId,
           pageIndex: info.pageIndex,
@@ -5438,21 +5516,21 @@ export function mountPaginatedSurface(
         });
       },
       enterNote: (scopeId, position, pageIndex) => {
-        flushTypeBuffer();
+        flushPendingInputAndLayout();
         noteOps?.enterNote(scopeId, position, pageIndex);
       },
       exitNote: (restoreBody) => {
-        flushTypeBuffer();
+        flushPendingInputAndLayout();
         noteOps?.exitNote(restoreBody);
       },
       exitHeaderFooter: () => {
-        flushTypeBuffer();
+        flushPendingInputAndLayout();
         return hfScope?.exitHeaderFooter();
       },
       enterEmptyHeaderFooter: (kind, pageIndex) => {
         // Creating the part is a WRITE — viewing mode refuses it like every other lane.
         if (editingMode === 'view') return;
-        flushTypeBuffer();
+        flushPendingInputAndLayout();
         // Which section owns the page, from the multi-section spans; a single-section
         // document has no spans and every page belongs to section 0.
         const { sectionIndex, sectionStart } = sectionAtPage(pageIndex);

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1010,7 +1010,13 @@ export function mountPaginatedSurface(
     });
   }
 
-  function hasPendingBrowserInput(): boolean {
+  /**
+   * `includeContinuous` folds mousemove/wheel into the answer. Paint deferral wants that
+   * (any input beats a repaint); the commit-tail LAYOUT deferral must not — a moving
+   * pointer over a large document would otherwise defer every toolbar op, paste and
+   * programmatic write, so that gate asks for discrete input (keys, clicks) only.
+   */
+  function hasPendingBrowserInput(includeContinuous = true): boolean {
     const scheduling = (
       container.ownerDocument.defaultView?.navigator as
         | (Navigator & {
@@ -1020,13 +1026,12 @@ export function mountPaginatedSurface(
           })
         | undefined
     )?.scheduling;
-    return scheduling?.isInputPending?.({ includeContinuous: true }) ?? false;
+    return scheduling?.isInputPending?.({ includeContinuous }) ?? false;
   }
 
   function renderPublishedLayout(): void {
     if (!hasPendingBrowserInput()) {
-      if (deferredPublishRender !== null) clearTimeout(deferredPublishRender);
-      deferredPublishRender = null;
+      // `render()` retires any armed deferred publish render itself.
       render();
       armDerivationPrewarmOnce();
       return;
@@ -1037,6 +1042,11 @@ export function mountPaginatedSurface(
     if (deferredPublishRender !== null) return;
     deferredPublishRender = setTimeout(() => {
       deferredPublishRender = null;
+      // Superseded: a newer commit is already pending, so this layout is not the one the
+      // user will see — its own publish paints and reports. Painting here anyway spent one
+      // full render per flush batch on a frame one commit behind, and mirrored the newer
+      // model selection into the older spans.
+      if (scheduler.pending() !== null) return;
       render();
       armDerivationPrewarmOnce();
     }, 0);
@@ -1264,20 +1274,24 @@ export function mountPaginatedSurface(
    *
    * Under input pressure the flush used to be one unyielding task — transact, layout and
    * paint — so a keystroke arriving mid-flush waited for all three. When the browser already
-   * holds queued input AND the previous pass was expensive, layout is left to the scheduler's
-   * `setTimeout(0)` backstop (armed by the commit's own `notify`), which runs layout+publish
-   * as its own task; `renderPublishedLayout` may defer paint to a third. Every synchronous
-   * reader regains current geometry through `flushLayout` at its own seam, and the deferred
-   * pass reads the model as it is when it runs, so no pass is ever published stale.
+   * holds queued DISCRETE input (a key, a click — never a mere mousemove) AND the previous
+   * pass was expensive, layout is left to the scheduler's `setTimeout(0)` backstop (armed by
+   * the commit's own `notify`), which runs layout+publish as its own task;
+   * `renderPublishedLayout` may defer paint to a third. Every synchronous reader regains
+   * current geometry through `flushLayout` at its own seam, and the deferred pass reads the
+   * model as it is when it runs, so no pass is ever published stale.
    *
-   * A REFUSED commit leaves the scheduler empty, so it takes the synchronous branch and the
-   * `render()` below refreshes the state it just changed, exactly as before.
+   * A REFUSED commit never defers, whatever the scheduler holds: the accumulator is shared
+   * (a prior deferred commit, an external commit, a drawing-resource invalidation can all
+   * have filled it), and the `render()` below is the one report of the refusal the host
+   * gets — deferring it delayed `lastRejection`, or lost it to a later commit entirely.
    */
-  function publishAfterCommit(): void {
+  function publishAfterCommit(rejected: boolean): void {
     if (
+      !rejected &&
       scheduler.pending() !== null &&
       lastLayoutMs > INPUT_PRESSURE_LAYOUT_DEFER_MS &&
-      hasPendingBrowserInput()
+      hasPendingBrowserInput(false)
     ) {
       return;
     }
@@ -1297,22 +1311,27 @@ export function mountPaginatedSurface(
   }
 
   /**
-   * Land queued typing, any deferred layout pass AND any deferred paint.
+   * Land queued typing, any deferred layout pass AND any deferred paint. Returns whether a
+   * paint happened, so a caller that must ALWAYS leave a fresh paint (the IME readback's
+   * discarded-paint rebuild) can render once instead of twice.
    *
    * For lanes that are about to hand the painted DOM over or read it back — the IME: a
    * composition writes into whatever is on screen, and the readback diffs the painted text
    * against the model, so both must describe the committed revision before it starts.
    */
-  function flushToPaint(): void {
+  function flushToPaint(): boolean {
     flushTypeBuffer();
-    flushLayout();
+    const published = flushLayout();
     // The flushes above render on their own synchronous paths; what can remain is only a
     // paint deferred under input pressure, and that is exactly what must land now.
-    if (deferredPublishRender === null) return;
-    clearTimeout(deferredPublishRender);
-    deferredPublishRender = null;
-    render();
-    armDerivationPrewarmOnce();
+    // `render()` retires the deferred timer itself.
+    if (deferredPublishRender !== null) {
+      render();
+      armDerivationPrewarmOnce();
+      return true;
+    }
+    // Published with nothing deferred means `renderPublishedLayout` painted synchronously.
+    return published;
   }
 
   /** TOC chrome is hover-projected; never sticky from caret/click. */
@@ -2390,6 +2409,15 @@ export function mountPaginatedSurface(
   }
 
   function render(notifyChange = true): void {
+    // Any render catches the screen up to `currentLayout`, so a paint deferred under input
+    // pressure is performed BY this one rather than repeated a task later — a scroll repaint
+    // during a deferral used to paint the same layout twice. The deferred render was also
+    // the commit's only state report, so this render inherits its notify duty.
+    if (deferredPublishRender !== null) {
+      clearTimeout(deferredPublishRender);
+      deferredPublishRender = null;
+      notifyChange = true;
+    }
     // Reading the DOM selection BEFORE the paint replaces the nodes it lives in is what makes
     // a repaint carry a gesture the queued `selectionchange` has not delivered yet, rather
     // than erase it — see `adoptBeforePaint`.
@@ -2851,8 +2879,9 @@ export function mountPaginatedSurface(
     // rather than silently dropped: the view is repainted from what the model actually
     // holds, so the user never keeps looking at an edit that will not be saved.
     const result = run();
-    if (typeof result !== 'boolean' && result.rejected) {
-      lastRejection = String(result.reason ?? 'rejected');
+    const rejection = typeof result === 'boolean' || !result.rejected ? null : result;
+    if (rejection) {
+      lastRejection = String(rejection.reason ?? 'rejected');
     } else {
       lastRejection = null;
       // The post-edit selection is installed BEFORE the paint, so the single render below
@@ -2887,7 +2916,7 @@ export function mountPaginatedSurface(
     // nothing, so the surface still has to refresh the state it just changed. Under input
     // pressure the publish may hand layout+paint to the scheduler's own task — see
     // `publishAfterCommit`.
-    publishAfterCommit();
+    publishAfterCommit(rejection !== null);
   }
 
   /**
@@ -3086,7 +3115,12 @@ export function mountPaginatedSurface(
     setActiveScopeBodyOrHf: (scope) => hfScope!.setActiveScope(scope),
     setSelection: (next) => setSelection(next),
     noteModelMoved: () => selectionSync.noteModelMoved(),
-    render: () => render(),
+    // Flushed first: note ops render right after their own commit, whose pass may have
+    // deferred under input pressure — the render must show the note it just created. The
+    // publish paints on its own, so the explicit render only covers the nothing-pending case.
+    render: () => {
+      if (!flushLayout()) render();
+    },
     revealNote: (scopeId) => {
       // The note just inserted only exists in the post-commit layout, which the commit
       // may have deferred under input pressure.
@@ -4460,6 +4494,9 @@ export function mountPaginatedSurface(
     setSelection: (next) => setSelection(next),
 
     revealPage(pageIndex, options) {
+      // Flushed like its siblings below: a page the deferred pass creates is not findable
+      // in the superseded layout, and "false" must mean "no such page", not "not yet".
+      flushLayout();
       const page = currentLayout.pages.find((entry) => entry.index === pageIndex);
       return page ? scrollToContentY(page.box.y, page.box.height, options) : false;
     },
@@ -4556,6 +4593,9 @@ export function mountPaginatedSurface(
       // across what Accept or Reject removed. Clamping alone only fires when the paragraph
       // ends up shorter than the offset; a caret in the MIDDLE of a paragraph that shrank
       // silently re-points at different characters, and the next thing typed lands there.
+      // The baseline is read from the LAYOUT, so buffered typing and a deferred pass must
+      // land first or the diff runs against text the resolution never saw.
+      flushPendingInputAndLayout();
       const caretParagraph = selection.head.paragraphId;
       const beforeText = textOf(caretParagraph);
       return commit(
@@ -4670,8 +4710,9 @@ export function mountPaginatedSurface(
     editingMode: () => editingMode,
     setEditingMode: (mode) => {
       // Text typed under the OLD mode commits under it — a buffered edit must
-      // not silently become a suggestion (or a viewing-mode refusal).
-      flushTypeBuffer();
+      // not silently become a suggestion (or a viewing-mode refusal). The layout
+      // flush rides along so the mode repaint below is not one commit behind.
+      flushPendingInputAndLayout();
       // A host wiring a mode control re-sends the value it already has — a controlled prop
       // re-synced in an effect, a dropdown re-picking the current row. Repainting every
       // materialized page for a mode that did not move is the cost `setRevisionStyles`
@@ -4708,8 +4749,9 @@ export function mountPaginatedSurface(
       // BEFORE the repaint, as `rematerialize` does: `render` adopts a pending DOM gesture,
       // which moves the selection without passing `setSelection`'s buffer guard. A style
       // change can land mid-typing-burst — a colour picker is a live control — and buffered
-      // characters are still destined for the old selection.
-      flushTypeBuffer();
+      // characters are still destined for the old selection. The layout flush rides along
+      // so the repaint below shows the burst it just landed rather than the pre-burst pages.
+      flushPendingInputAndLayout();
       // Paint-level only: the reuse key moves with the resolved styles, so the pages
       // repaint in the new colours without a layout pass.
       render(false);
@@ -4999,8 +5041,11 @@ export function mountPaginatedSurface(
     },
     destroy() {
       // Typed-but-unflushed text lands before teardown, so a detach-then-save
-      // flow keeps the last keystrokes.
-      flushTypeBuffer();
+      // flow keeps the last keystrokes — all the way to a paint and its state
+      // report: the final commit's `onChange` used to come from the synchronous
+      // commit tail, and a deferral swallowed by `scheduler.cancel()` below
+      // would silence the last keystrokes for an onChange-driven host.
+      flushToPaint();
       document.removeEventListener('selectionchange', onSelectionChange);
       pagesLayer.removeEventListener('keydown', onKeyDown);
       pagesLayer.removeEventListener('beforeinput', onBeforeInput as EventListener);
@@ -5283,7 +5328,15 @@ export function mountPaginatedSurface(
   // under input pressure must land too: the readback at compositionend diffs the
   // painted text against the model, and a composition that began over a stale
   // paint would read the missing edit back as the IME's own.
+  //
+  // The pending USER selection is taken up FIRST, exactly as `onKeyDown` does.
+  // The flush's render mirrors the model selection into the DOM — over the
+  // user's still-unadopted range — and its `applyingSelection` echo guard is
+  // still up (it clears on a microtask) when `onCompositionStart` performs its
+  // own mandatory adoption, which would skip it: the #383 lane choice would
+  // again be made from a selection the user no longer has.
   const onCompositionStart: typeof selectionSync.onCompositionStart = (...args) => {
+    selectionSync.adoptBeforeInput();
     flushToPaint();
     selectionSync.onCompositionStart(...args);
   };
@@ -5481,7 +5534,15 @@ export function mountPaginatedSurface(
       // portrait ones is painted at an x its record does not carry. Without this the
       // transform reads every point on such a page shifted by that offset.
       pageOffsetX: (pageIndex) => materializedExtent?.pageOffsetX.get(pageIndex) ?? 0,
-      layout: () => currentLayout,
+      // Flushed: the pointer maps a client point to a MODEL offset, and a pass a commit
+      // deferred under input pressure would hand it the pre-edit offsets — a click during
+      // a burst then wrote a caret shifted by the inserted length. Only ever a real pass
+      // right after a deferring commit; every other call is a cheap no-op check. This is
+      // an event-handler-only dep — no render path reads it — so it cannot re-enter paint.
+      layout: () => {
+        flushLayout();
+        return currentLayout;
+      },
       measurer: () => measurer,
       selection: () => selection,
       setSelection: (next) => setSelection(next),
@@ -5563,6 +5624,9 @@ export function mountPaginatedSurface(
           });
           if (!created?.ok) return;
           rId = slotsOf(session.headerFooterResolutionBySection())?.get(variant)?.rId;
+          // The band only exists in the post-create layout, and the create's commit may
+          // have deferred its pass — the same reason `revealNote` flushes.
+          flushLayout();
         }
         if (!rId) return;
         hfScope?.enterHeaderFooter({ rId, pageIndex, sectionIndex, kind, variant });

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -61,11 +61,11 @@ export interface SurfaceSelectionSyncDeps {
   flushLayout(): boolean;
   /**
    * Land queued typing, any deferred layout pass and any deferred paint, so the painted
-   * DOM matches the committed model. The readback lane calls it after its own commit;
-   * without it, a layout or paint the commit deferred under input pressure would leave
-   * the screen behind the composition it just landed.
+   * DOM matches the committed model. Returns whether a paint happened, so the readback
+   * lane can render exactly once; without it, a layout or paint the commit deferred under
+   * input pressure would leave the screen behind the composition it just landed.
    */
-  flushToPaint?(): void;
+  flushToPaint(): boolean;
   /** The engine's painted caret, repainted with every mirror. */
   updateCaret(): void;
   /** The model text of one paragraph, for diffing what an IME wrote against it. */
@@ -632,10 +632,9 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // render below rebuilds from records.
       if (session.revisionFor(scope) === before) deps.discardPaint?.();
       // The readback's own commit may have deferred its layout or paint under input
-      // pressure; land both before the unconditional render below, so the screen leaves
-      // the composition current.
-      (deps.flushToPaint ?? deps.flushLayout)();
-      deps.render();
+      // pressure; land both, and render exactly ONCE — either the flush's own catch-up
+      // paint, or the explicit rebuild the discarded-paint case needs.
+      if (!deps.flushToPaint()) deps.render();
     },
 
     selectionPageIndex: () => lastSelectionPageIndex,

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -59,6 +59,13 @@ export interface SurfaceSelectionSyncDeps {
   ): TreeApplyResult;
   render(): void;
   flushLayout(): boolean;
+  /**
+   * Land queued typing, any deferred layout pass and any deferred paint, so the painted
+   * DOM matches the committed model. The readback lane calls it after its own commit;
+   * without it, a layout or paint the commit deferred under input pressure would leave
+   * the screen behind the composition it just landed.
+   */
+  flushToPaint?(): void;
   /** The engine's painted caret, repainted with every mirror. */
   updateCaret(): void;
   /** The model text of one paragraph, for diffing what an IME wrote against it. */
@@ -624,7 +631,10 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       // nobody can edit nothing would ever remove them. Forget the retained paint so the
       // render below rebuilds from records.
       if (session.revisionFor(scope) === before) deps.discardPaint?.();
-      deps.flushLayout();
+      // The readback's own commit may have deferred its layout or paint under input
+      // pressure; land both before the unconditional render below, so the screen leaves
+      // the composition current.
+      (deps.flushToPaint ?? deps.flushLayout)();
       deps.render();
     },
 


### PR DESCRIPTION
A keystroke flush was one unyielding task: transact, layout, and paint. When the browser reports queued discrete input and the previous layout pass took more than 8 ms, the commit tail now leaves layout to the layout scheduler's own task, and paint can defer to a third. Isolated keystrokes, refused commits, and environments without `navigator.scheduling` keep the fully synchronous chain.

Synchronous readers keep fresh geometry: `flushPendingInput` now lands both the type buffer and any deferred pass, and every geometry-reading seam (navigation, selection ranges, edit plans, scope entry, pointer hit-testing, reveal calls) flushes before it reads. The IME lane flushes to paint before a composition takes the DOM and after the readback commits, so the readback always diffs against the committed text.

Verified on the pinned 521-page fixture: the browser ordered-typing burst lands all keys in order, `staleDiscards` stays 0 in every scope-waste scenario, and the settle and edit bench work counters are unchanged.

Fixes #451

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790245195&installation_model_id=422592&pr_number=457&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F457&signature=77b1e3992c1250193ea176e09193cfedb1679dd5acb4ad99c68cb1c538512cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->