### PR TITLE
fix: thin the caret to 1.5px and soften its contrast ring

### DIFF
--- a/.changeset/thinner-caret-softer-ring.md
+++ b/.changeset/thinner-caret-softer-ring.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Draw a thinner insertion caret with a translucent contrast ring, so the caret no longer shows a hard outline over highlighted or shaded text.

--- a/packages/core/src/editor/__tests__/editor-css-tokens.test.ts
+++ b/packages/core/src/editor/__tests__/editor-css-tokens.test.ts
@@ -132,8 +132,9 @@ describe('editor stylesheet custom properties', () => {
     const rule = /\.docx-editor-one-surface__caret\s*\{([^}]*)\}/.exec(withoutComments);
     expect(rule).not.toBeNull();
     expect(rule![1]).toMatch(/background:\s*var\(--doc-caret/);
-    // 2px, not 1: a hairline caret is a single device pixel on a high-DPI screen and
-    // reads as a rendering artefact rather than a cursor.
-    expect(rule![1]).toMatch(/width:\s*2px/);
+    // 1.5px, not 1: a hairline caret is a single device pixel on a high-DPI screen and
+    // reads as a rendering artefact rather than a cursor. Not 2: with the contrast
+    // ring the caret read as a slab that overlapped neighbouring glyphs.
+    expect(rule![1]).toMatch(/width:\s*1\.5px/);
   });
 });

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -2304,10 +2304,11 @@ a.docx-hyperlink:focus-visible {
 
 .docx-editor-one-surface__caret {
   position: absolute;
-  /* 2px, not 1: a hairline caret disappears against body text at 100% zoom on a
+  /* 1.5px, not 1: a hairline caret disappears against body text at 100% zoom on a
    * high-DPI screen, and reads as a rendering artefact rather than a cursor.
-   * Every desktop word processor draws a two-pixel insertion point. */
-  width: 2px;
+   * Not 2 either: with the contrast ring below, a 2px core read as a 4px slab that
+   * overlapped the neighbouring glyphs — Word's insertion bar is thinner. */
+  width: 1.5px;
   background: var(--doc-caret);
   /* A CONTRASTING 1px ring, because a caret position is not always beside text: the offset
    * before an inline image puts the insertion point exactly on the picture's leading edge,
@@ -2316,7 +2317,10 @@ a.docx-hyperlink:focus-visible {
    *
    * The ring and the core are a complementary pair, so whichever one the backdrop hides,
    * the other reads. On an ordinary white page the ring is white on white and the caret
-   * looks exactly as it did before.
+   * looks exactly as it did before. The ring is TRANSLUCENT: at full strength it drew a
+   * hard outline on mid-tone backdrops (highlights, table shading) where both colours are
+   * visible at once, and the caret read as a boxed slab instead of a bar. Half strength
+   * still lifts the bar off a dark photo without outlining it on a pink highlight.
    *
    * NOT `mix-blend-mode: difference`, which is the textbook XOR caret and is wrong here:
    * blending resolves against the nearest ISOLATED GROUP, and this stylesheet puts two of
@@ -2325,7 +2329,7 @@ a.docx-hyperlink:focus-visible {
    * editing. Inside either, the backdrop is transparent rather than the sheet's paper, so
    * the caret would blend to white and the dark page's inversion would then paint it black
    * on black: the very bug this ring exists to fix. The pair needs no backdrop at all. */
-  box-shadow: 0 0 0 1px var(--doc-caret-contrast);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--doc-caret-contrast) 50%, transparent);
   animation: docx-editor-caret-blink 1.06s steps(1) infinite;
 }
 


### PR DESCRIPTION
The 2px caret core and its full-strength 1px contrast ring rendered as a 4px slab that overlapped adjacent glyphs on mid-tone backdrops, such as highlights and table shading. The caret core is now 1.5px and the ring is 50% translucent, so the ring still keeps the caret visible over dark images without outlining it elsewhere. Word draws a comparably thin insertion bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790246868&installation_model_id=422592&pr_number=461&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F461&signature=0b079db63345a71df8d8633a8e967e6f9ee80ed6c48401af163e8bcf0c7022c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->