### PR TITLE
perf: stop per-keystroke whole-part sweeps and slice note-reserve context keys per section

### DIFF
--- a/.changeset/spicy-pugs-happen.md
+++ b/.changeset/spicy-pugs-happen.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Speed up typing and document open on large multi-section documents: per-keystroke layout no longer re-derives whole-document indexes (section enumeration, content-control tokens and boundaries, footnote reference maps), and the footnote reserve reflow no longer forces a second full pagination pass at open.
+Speed up typing and document open on large multi-section documents: each keystroke now pays for the edit instead of the document, and documents with footnotes open with one pagination pass instead of two.

--- a/.changeset/spicy-pugs-happen.md
+++ b/.changeset/spicy-pugs-happen.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Speed up typing and document open on large multi-section documents: per-keystroke layout no longer re-derives whole-document indexes (section enumeration, content-control tokens and boundaries, footnote reference maps), and the footnote reserve reflow no longer forces a second full pagination pass at open.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1283,7 +1283,7 @@ export interface LayoutSession {
     prepass: unknown;
     // @internal
     previous: SemanticLayout | null;
-    producer: string;
+    producer?: string;
     startLineCounter: number;
     startPageParity: number;
     // (undocumented)

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1283,6 +1283,7 @@ export interface LayoutSession {
     prepass: unknown;
     // @internal
     previous: SemanticLayout | null;
+    producer: string;
     startLineCounter: number;
     startPageParity: number;
     // (undocumented)

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3478,9 +3478,9 @@ export interface ReviewModelInput {
     readonly commentsExtendedPart?: OoxmlPart | undefined;
     readonly commentsPart?: OoxmlPart | undefined;
     readonly customNodePayloads?: ReadonlyMap<string, {
-        readonly nodeId: string;
-        readonly label: string;
         readonly data: string;
+        readonly label: string;
+        readonly nodeId: string;
     }> | undefined;
     readonly customNodes?: readonly unknown[] | undefined;
     readonly furnitureParts?: readonly OoxmlPart[] | undefined;

--- a/e2e/edit-browser-bench-gates.ts
+++ b/e2e/edit-browser-bench-gates.ts
@@ -37,11 +37,18 @@ export const TRACKED_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = 
  * Pinned per scenario for the 521-page reported reproduction (typing-perf-521pp.docx).
  * Bootstrapped from a local Chromium run; a change means the engine performs different
  * work on the huge document, which is exactly what these exist to catch.
+ *
+ * `fullPasses` counts the passes the OPEN performs; typing must add none. The open's
+ * note-reserve reflow used to force a second full pass because the document-wide reserve
+ * map was folded into every section's context key; the key now folds only the reserve
+ * slots a section's own pass can read, so the reflow's second body pass reuses every
+ * section and only the first pass is full — the same deliberate 2 -> 1 move as the
+ * settle-bench gate.
  */
 export const PINNED_HUGE_EXPECTED_LAYOUT_WORK: Record<string, ExpectedLayoutWork> = {
-  '521pp-editing-character': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 2 },
-  '521pp-editing-wrap': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 2 },
-  '521pp-suggesting-character': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 2 },
+  '521pp-editing-character': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 1 },
+  '521pp-editing-wrap': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 1 },
+  '521pp-suggesting-character': { placed: 11, total: 6540, reusedPages: 517, fullPasses: 1 },
 };
 
 /** Pinned for the ~1,000-page stress fixture (synthetic-huge-tracked.docx). */

--- a/packages/core/src/layout/__tests__/content-control-context-token.test.ts
+++ b/packages/core/src/layout/__tests__/content-control-context-token.test.ts
@@ -1,0 +1,203 @@
+// Differential for the content-control context-token memo.
+//
+// The randomized layout oracles cover WeakMap-on-node memos through their structuredClone
+// differential, but neither oracle fixture carries content controls — so this memo gets its
+// own: every token read through the memoized path must equal a memo-cold recompute over a
+// structurally identical tree (structuredClone shares no node identities, so no memo entry
+// can serve it). Edits are built as transaction-shaped path copies: the changed node and its
+// ancestors are fresh objects, every other node is the SAME object — which is exactly the
+// sharing the memo exploits.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { contentControlContextToken } from '../semantic-layout.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const sdt = (pr: string, content: string) =>
+  `<w:sdt><w:sdtPr>${pr}</w:sdtPr><w:sdtContent>${content}</w:sdtContent></w:sdt>`;
+
+/** The memo-cold answer: identical structure, no shared node identities. */
+function uncachedToken(part: OoxmlPart): string {
+  return contentControlContextToken(structuredClone(part));
+}
+
+function bodyOf(part: OoxmlPart): OoxmlElement {
+  const findBody = (node: OoxmlNode): OoxmlElement | undefined => {
+    if (node.kind === 'textValue') return undefined;
+    if (node.kind === 'body' || node.localName === 'body') return node;
+    for (const child of node.children) {
+      const found = findBody(child);
+      if (found) return found;
+    }
+    return undefined;
+  };
+  const body = findBody(part.root);
+  if (!body) throw new Error('no body');
+  return body;
+}
+
+/** Transaction-shaped path copy: a fresh body children array under fresh body/root shells. */
+function withBodyChildren(
+  part: OoxmlPart,
+  edit: (children: readonly OoxmlNode[]) => readonly OoxmlNode[]
+): OoxmlPart {
+  const rebuild = (node: OoxmlNode): OoxmlNode => {
+    if (node.kind === 'textValue') return node;
+    if (node.kind === 'body' || node.localName === 'body') {
+      return { ...node, children: edit(node.children) };
+    }
+    return { ...node, children: node.children.map(rebuild) };
+  };
+  return { ...part, root: rebuild(part.root) as OoxmlPart['root'] };
+}
+
+function isSdt(node: OoxmlNode): node is OoxmlElement {
+  return node.kind !== 'textValue' && node.localName === 'sdt';
+}
+
+/** Fresh twin of one sdt with its `w:sdtPr` replaced, content children SHARED by identity. */
+function withSdtPr(control: OoxmlElement, pr: string): OoxmlElement {
+  const donor = load(sdt(pr, p('x')));
+  const donorSdt = bodyOf(donor).children.find(isSdt)!;
+  const donorPr = donorSdt.children.find(
+    (child) => child.kind !== 'textValue' && child.localName === 'sdtPr'
+  )!;
+  return {
+    ...control,
+    children: control.children.map((child) =>
+      child.kind !== 'textValue' && child.localName === 'sdtPr' ? donorPr : child
+    ),
+  };
+}
+
+const FIXTURE =
+  p('before') +
+  sdt(
+    '<w:alias w:val="Outer"/><w:tag w:val="outer-tag"/>',
+    p('inside one') + sdt('<w:alias w:val="Inner"/>', p('nested')) + p('inside two')
+  ) +
+  p('after');
+
+describe('content-control context token memo differential', () => {
+  test('warm token equals the memo-cold recompute', () => {
+    const part = load(FIXTURE);
+    const first = contentControlContextToken(part);
+    // Second read is fully memoized; both must equal the clone recompute.
+    expect(contentControlContextToken(part)).toBe(first);
+    expect(uncachedToken(part)).toBe(first);
+    expect(first).not.toBe('');
+  });
+
+  test('control add: shared siblings keep their memos, token matches cold recompute', () => {
+    const part = load(FIXTURE);
+    contentControlContextToken(part);
+    const added = load(sdt('<w:alias w:val="Added"/>', p('new control')));
+    const addedSdt = bodyOf(added).children.find(isSdt)!;
+    const edited = withBodyChildren(part, (children) => [...children, addedSdt]);
+    const token = contentControlContextToken(edited);
+    expect(token).toBe(uncachedToken(edited));
+    expect(token).not.toBe(contentControlContextToken(part));
+  });
+
+  test('retitle (alias/tag) changes the token and matches cold recompute', () => {
+    const part = load(FIXTURE);
+    const before = contentControlContextToken(part);
+    const edited = withBodyChildren(part, (children) =>
+      children.map((child) =>
+        isSdt(child)
+          ? withSdtPr(child, '<w:alias w:val="Renamed"/><w:tag w:val="outer-tag"/>')
+          : child
+      )
+    );
+    const token = contentControlContextToken(edited);
+    expect(token).toBe(uncachedToken(edited));
+    expect(token).not.toBe(before);
+  });
+
+  test('lock change reaches the token and matches cold recompute', () => {
+    const part = load(FIXTURE);
+    const before = contentControlContextToken(part);
+    const edited = withBodyChildren(part, (children) =>
+      children.map((child) =>
+        isSdt(child)
+          ? withSdtPr(
+              child,
+              '<w:alias w:val="Outer"/><w:tag w:val="outer-tag"/><w:lock w:val="sdtContentLocked"/>'
+            )
+          : child
+      )
+    );
+    const token = contentControlContextToken(edited);
+    expect(token).toBe(uncachedToken(edited));
+    expect(token).not.toBe(before);
+  });
+
+  test('text edit inside a control keeps the token (content is not chrome)', () => {
+    const part = load(FIXTURE);
+    const before = contentControlContextToken(part);
+    const donor = load(p('inside one EDITED'));
+    const donorParagraph = bodyOf(donor).children.find((child) => child.kind === 'paragraph')!;
+    const edited = withBodyChildren(part, (children) =>
+      children.map((child) => {
+        if (!isSdt(child)) return child;
+        return {
+          ...child,
+          children: child.children.map((inner) => {
+            if (inner.kind === 'textValue' || inner.localName !== 'sdtContent') return inner;
+            const content = inner.children.map((block, index) =>
+              index === 0 ? donorParagraph : block
+            );
+            return { ...inner, children: content };
+          }),
+        };
+      })
+    );
+    const token = contentControlContextToken(edited);
+    expect(token).toBe(uncachedToken(edited));
+    expect(token).toBe(before);
+  });
+
+  test('a node reused at a DIFFERENT nesting depth is not served its old-depth token', () => {
+    // A chain deep enough that the nesting cap clips its tail. Wrapping the SAME chain node
+    // one level deeper moves the clipping point, so a depth-blind memo replaying the old
+    // answer would keep one level the cold recompute clips.
+    const chain = Array.from({ length: 33 }, (_, i) => i).reduceRight(
+      (inner, i) => sdt(`<w:alias w:val="L${i}"/>`, inner),
+      p('deepest')
+    );
+    const part = load(chain);
+    const shallowToken = contentControlContextToken(part);
+    expect(shallowToken).toBe(uncachedToken(part));
+
+    // Wrap the existing chain (same object identity) in one more control.
+    const wrapper = load(sdt('<w:alias w:val="Wrapper"/>', p('placeholder')));
+    const wrapperSdt = bodyOf(wrapper).children.find(isSdt)!;
+    const chainSdt = bodyOf(part).children.find(isSdt)!;
+    const edited = withBodyChildren(part, (children) =>
+      children.map((child) => {
+        if (!isSdt(child)) return child;
+        return {
+          ...wrapperSdt,
+          children: wrapperSdt.children.map((inner) => {
+            if (inner.kind === 'textValue' || inner.localName !== 'sdtContent') return inner;
+            return { ...inner, children: [chainSdt] };
+          }),
+        };
+      })
+    );
+    const deeperToken = contentControlContextToken(edited);
+    expect(deeperToken).toBe(uncachedToken(edited));
+    expect(deeperToken).not.toBe(shallowToken);
+  });
+});

--- a/packages/core/src/layout/__tests__/content-control-context-token.test.ts
+++ b/packages/core/src/layout/__tests__/content-control-context-token.test.ts
@@ -9,16 +9,21 @@
 // sharing the memo exploits.
 
 import { describe, expect, test } from 'bun:test';
-import { readOoxmlPart, type OoxmlElement, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
 import { contentControlContextToken } from '../semantic-layout.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
 function load(body: string): OoxmlPart {
-  const result = readOoxmlPart(
-    `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`,
-    { name: '/word/document.xml', contentType: 'app/xml' }
-  );
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
   if (!result.ok) throw new Error(result.reason);
   return result.part;
 }

--- a/packages/core/src/layout/__tests__/footnote-reserves.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserves.test.ts
@@ -689,3 +689,157 @@ describe('incremental notes layout (reserve persistence)', () => {
     expect(sessionEdit.stats.fullPasses).toBe(beforeEditFull);
   });
 });
+
+describe('multi-section reserve locality', () => {
+  /**
+   * Section 0 spans three pages and carries the one citation on its LAST page (reserve page
+   * slot 2). Sections 1 and 2 are one page each, so slot 2 sits past every reserve slot
+   * their passes can read — a reserve there must not enter their context keys.
+   */
+  function multiSectionFootnoteDoc(noteWords: number): Uint8Array {
+    const sectPr =
+      '<w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/>';
+    const section0 = Array.from({ length: 80 }, (_, i) => {
+      const text = `S0 line ${i} ${'word '.repeat(18)}`;
+      if (i === 75) {
+        return `<w:p><w:r><w:t>${text}</w:t><w:footnoteReference w:id="1"/></w:r></w:p>`;
+      }
+      return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+    }).join('');
+    const shortSection = (label: string): string =>
+      Array.from(
+        { length: 4 },
+        (_, i) => `<w:p><w:r><w:t>${label} line ${i} ${'word '.repeat(10)}</w:t></w:r></w:p>`
+      ).join('');
+    const sectionBreak = `<w:p><w:pPr><w:sectPr>${sectPr}</w:sectPr></w:pPr></w:p>`;
+    return zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}">` +
+          '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+          '</Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/_rels/document.xml.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+      ),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>` +
+          section0 +
+          sectionBreak +
+          shortSection('S1') +
+          sectionBreak +
+          shortSection('S2') +
+          `<w:sectPr>${sectPr}</w:sectPr>` +
+          '</w:body></w:document>'
+      ),
+      'word/footnotes.xml': strToU8(
+        `<w:footnotes xmlns:w="${W}">` +
+          `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+          `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+          `<w:footnote w:id="1"><w:p><w:r><w:t>Note ${'note '.repeat(noteWords)}</w:t></w:r></w:p></w:footnote>` +
+          '</w:footnotes>'
+      ),
+    });
+  }
+
+  const layoutShape = (layout: SemanticLayout): string =>
+    JSON.stringify(
+      layout.pages.map((page) => ({
+        index: page.index,
+        box: page.box,
+        contentBox: page.contentBox,
+        fragments: page.fragments.map((f) => ({
+          kind: f.kind,
+          id: f.id,
+          box: f.box,
+          ...(f.kind === 'paragraph'
+            ? { paragraphId: f.paragraphId, range: f.range, lines: f.lines.length }
+            : {}),
+        })),
+        footnoteHeight: page.footnotes?.box.height ?? 0,
+      }))
+    );
+
+  function notesFor(bytes: Uint8Array): ReturnType<typeof loadNotesDoc> {
+    const { part, notes } = loadNotesDoc(bytes);
+    const props = notes.footnotePropsBySection[0]!;
+    const enProps = notes.endnotePropsBySection[0]!;
+    return {
+      part,
+      notes: {
+        ...notes,
+        footnotePropsBySection: [props, props, props],
+        endnotePropsBySection: [enProps, enProps, enProps],
+      },
+    };
+  }
+
+  test('a reserve change on section 0 relayouts only section 0; the result matches a clean pass', () => {
+    const { part, notes } = notesFor(multiSectionFootnoteDoc(20));
+    const session = createLayoutSession();
+    const first = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      session,
+      producer: 'notes-section-locality',
+    });
+    // The reserve sits on section 0's last page (slot 2); sections 1 and 2 hold one page each.
+    expect(first.pages.length).toBe(5);
+    expect(session.notePageBottomReserves).not.toBeNull();
+    expect([...session.notePageBottomReserves!.keys()]).toEqual([2]);
+    const firstReserve = session.notePageBottomReserves!.get(2)!;
+    const sectionOnePage = first.pages[3]!;
+    const sectionTwoPage = first.pages[4]!;
+
+    // The edit grows the note, so section 0's reserve height changes ({2: h} -> {2: h'}).
+    const { part: editedPart, notes: editedNotes } = notesFor(multiSectionFootnoteDoc(60));
+    const incremental = layoutSemanticDocument(editedPart, 2, {
+      measurer: editedNotes.measurer,
+      notes: editedNotes,
+      session,
+      producer: 'notes-section-locality',
+    });
+    expect([...session.notePageBottomReserves!.keys()]).toEqual([2]);
+    expect(session.notePageBottomReserves!.get(2)!).toBeGreaterThan(firstReserve);
+
+    // Locality: the reserve change stayed inside section 0 — the other sections' pages come
+    // back as the SAME records, not rebuilt twins.
+    expect(incremental.pages[3]).toBe(sectionOnePage);
+    expect(incremental.pages[4]).toBe(sectionTwoPage);
+
+    // Equivalence: the sliced context key changes nothing about the layout itself.
+    const clean = layoutSemanticDocument(editedPart, 2, {
+      measurer: editedNotes.measurer,
+      notes: editedNotes,
+      producer: 'notes-section-locality',
+    });
+    expect(layoutShape(incremental)).toBe(layoutShape(clean));
+  });
+
+  test('open pays one full pass; the reserved reflow pass reuses every section', () => {
+    const { part, notes } = notesFor(multiSectionFootnoteDoc(20));
+    const session = createLayoutSession();
+    const first = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      session,
+      producer: 'notes-section-open',
+    });
+    expect(first.pages.length).toBe(5);
+    expect(session.notePageBottomReserves!.size).toBe(1);
+    // The reflow's second body pass re-places only the reserved section, so the open
+    // performs exactly one FULL pass. Before the per-section reserve slice it performed two.
+    expect(session.stats.fullPasses).toBe(1);
+    // And the second pass really applied the reserve: the citation page keeps room for the
+    // note above the page bottom.
+    const host = first.pages.find((page) =>
+      (page.footnotes?.notes ?? []).some((n) => n.noteId === 1 && !n.continuation)
+    );
+    expect(host).toBeTruthy();
+    expect(host!.index).toBe(2);
+  });
+});

--- a/packages/core/src/layout/__tests__/footnote-reserves.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserves.test.ts
@@ -834,6 +834,15 @@ describe('multi-section reserve locality', () => {
     // The reflow's second body pass re-places only the reserved section, so the open
     // performs exactly one FULL pass. Before the per-section reserve slice it performed two.
     expect(session.stats.fullPasses).toBe(1);
+    // `fullPasses` alone is a weak gate: it increments only when NOTHING is reused, so a
+    // regression that re-places two of three sections would still read 1. Pin the reflow
+    // pass's actual work — it re-placed exactly the reserved section's blocks and took the
+    // other two sections' pages back by reuse.
+    const sections = enumerateDocumentSections(part);
+    expect(sections.length).toBe(3);
+    const sectionZeroBlocks = sections[0]!.blockEndExclusive - sections[0]!.blockStart;
+    expect(session.stats.placed).toBe(sectionZeroBlocks);
+    expect(session.stats.reusedPages).toBe(2);
     // And the second pass really applied the reserve: the citation page keeps room for the
     // note above the page bottom.
     const host = first.pages.find((page) =>

--- a/packages/core/src/layout/content-control-boundary-layout.ts
+++ b/packages/core/src/layout/content-control-boundary-layout.ts
@@ -52,16 +52,28 @@ export function contentControlContextToken(part: OoxmlPart): string {
 }
 
 const contentControlContextTokens = new WeakMap<OoxmlPart, string>();
-const contentControlSubtreeTokens = new WeakMap<OoxmlElement, string>();
+/**
+ * Subtree tokens memoized per immutable node, remembering the DEPTH they were computed at:
+ * the walk clips content controls at {@link MAX_SDT_NESTING}, so a subtree's token is a pure
+ * function of the node only at a fixed nesting depth. Typing keeps every unchanged subtree at
+ * its old depth, which is the case the memo exists for.
+ */
+const contentControlSubtreeTokens = new WeakMap<
+  OoxmlElement,
+  { readonly depth: number; readonly token: string }
+>();
 
 function computeContentControlContextToken(part: OoxmlPart): string {
   const tokenOf = (node: OoxmlNode, depth: number): string => {
     if (node.kind === 'textValue') return '';
-    // Paragraph/table nodes are immutable and structurally shared across text edits. Cache
-    // their complete depth-zero result so a new part revision does not re-walk every run.
-    if (depth === 0 && (node.kind === 'paragraph' || node.kind === 'table')) {
+    // Paragraph, table and control wrappers are immutable and structurally shared across
+    // text edits. Caching only at depth zero left every paragraph INSIDE a block control
+    // (a TOC wrapped in `w:sdt` is the common shape) re-walked per part revision.
+    const memoizable =
+      node.kind === 'paragraph' || node.kind === 'table' || isContentControl(node);
+    if (memoizable) {
       const cached = contentControlSubtreeTokens.get(node);
-      if (cached !== undefined) return cached;
+      if (cached !== undefined && cached.depth === depth) return cached.token;
     }
     let token: string;
     if (isContentControl(node)) {
@@ -86,8 +98,8 @@ function computeContentControlContextToken(part: OoxmlPart): string {
         .filter((entry) => entry.length > 0)
         .join('|');
     }
-    if (depth === 0 && (node.kind === 'paragraph' || node.kind === 'table')) {
-      contentControlSubtreeTokens.set(node, token);
+    if (memoizable) {
+      contentControlSubtreeTokens.set(node as OoxmlElement, { depth, token });
     }
     return token;
   };

--- a/packages/core/src/layout/content-control-boundary-layout.ts
+++ b/packages/core/src/layout/content-control-boundary-layout.ts
@@ -34,77 +34,9 @@ import {
   type SemanticLayout,
 } from './semantic-records.ts';
 
-/**
- * Fingerprint of every control wrapper's chrome metadata — not its content.
- *
- * Changing alias/tag/lock/type/placeholder/binding without touching nested paragraphs still
- * changes this token, which is folded into the layout producer.
- */
-export function contentControlContextToken(part: OoxmlPart): string {
-  // Parts are immutable (edits publish a new part object), so the token is a pure function
-  // of the part reference. Without the memo this whole-tree walk ran on EVERY layout pass —
-  // including no-change passes that reuse every page.
-  const cached = contentControlContextTokens.get(part);
-  if (cached !== undefined) return cached;
-  const token = computeContentControlContextToken(part);
-  contentControlContextTokens.set(part, token);
-  return token;
-}
+import { contentControlContextToken } from './content-control-context-token.ts';
 
-const contentControlContextTokens = new WeakMap<OoxmlPart, string>();
-/**
- * Subtree tokens memoized per immutable node, remembering the DEPTH they were computed at:
- * the walk clips content controls at {@link MAX_SDT_NESTING}, so a subtree's token is a pure
- * function of the node only at a fixed nesting depth. Typing keeps every unchanged subtree at
- * its old depth, which is the case the memo exists for.
- */
-const contentControlSubtreeTokens = new WeakMap<
-  OoxmlElement,
-  { readonly depth: number; readonly token: string }
->();
-
-function computeContentControlContextToken(part: OoxmlPart): string {
-  const tokenOf = (node: OoxmlNode, depth: number): string => {
-    if (node.kind === 'textValue') return '';
-    // Paragraph, table and control wrappers are immutable and structurally shared across
-    // text edits. Caching only at depth zero left every paragraph INSIDE a block control
-    // (a TOC wrapped in `w:sdt` is the common shape) re-walked per part revision.
-    const memoizable =
-      node.kind === 'paragraph' || node.kind === 'table' || isContentControl(node);
-    if (memoizable) {
-      const cached = contentControlSubtreeTokens.get(node);
-      if (cached !== undefined && cached.depth === depth) return cached.token;
-    }
-    let token: string;
-    if (isContentControl(node)) {
-      if (depth >= MAX_SDT_NESTING) return '';
-      const properties = contentControlPropertiesOf(node);
-      const own = [
-        node.id,
-        propertyVal(properties, 'alias') ?? '',
-        propertyVal(properties, 'tag') ?? '',
-        parseContentControlLock(propertyVal(properties, 'lock')),
-        mapContentControlType(properties),
-        propertyChild(properties, 'showingPlcHdr') ? '1' : '0',
-        propertyChild(properties, 'dataBinding') ? '1' : '0',
-      ].join(':');
-      const nested = contentControlContentChildren(node)
-        .map((inner) => tokenOf(inner, depth + 1))
-        .filter((entry) => entry.length > 0);
-      token = [own, ...nested].join('|');
-    } else {
-      token = node.children
-        .map((child) => tokenOf(child, depth))
-        .filter((entry) => entry.length > 0)
-        .join('|');
-    }
-    if (memoizable) {
-      contentControlSubtreeTokens.set(node as OoxmlElement, { depth, token });
-    }
-    return token;
-  };
-  return tokenOf(part.root, 0);
-}
+export { contentControlContextToken };
 
 /** Addressable UTF-16 length of an inline node — mirrors the store / layout offset model. */
 function addressableInlineLength(node: OoxmlNode): number {
@@ -144,10 +76,42 @@ export interface CollectedControlIndex {
 
 const collectedControlIndexes = new WeakMap<OoxmlPart, CollectedControlIndex>();
 
+/**
+ * The one retained previous index, content-validated: the index is a pure function of the
+ * per-top-level-block control lists, and a keystroke outside any control leaves every one of
+ * those lists identical (the edited block's list is the shared empty constant). Rebuilding
+ * the sets and the sorted needed-token for a control-heavy document on every fresh part cost
+ * more than the walk the per-block memo already saves. One strong slot, bounded.
+ */
+let lastCollectedIndexSlot: {
+  readonly lists: readonly (readonly CollectedControl[])[];
+  readonly index: CollectedControlIndex;
+} | null = null;
+
+function sameControlLists(
+  left: readonly (readonly CollectedControl[])[],
+  right: readonly (readonly CollectedControl[])[]
+): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
 export function collectedControlIndexOf(part: OoxmlPart): CollectedControlIndex {
   const cached = collectedControlIndexes.get(part);
   if (cached !== undefined) return cached;
-  const controls = collectControls(part);
+  const lists = collectControlLists(part);
+  const slot = lastCollectedIndexSlot;
+  if (slot && sameControlLists(slot.lists, lists)) {
+    collectedControlIndexes.set(part, slot.index);
+    return slot.index;
+  }
+  const controls: CollectedControl[] = [];
+  for (const list of lists) {
+    for (const control of list) controls.push(control);
+  }
   const neededBlockIds = new Set<string>();
   const neededParagraphIds = new Set<string>();
   for (const control of controls) {
@@ -160,11 +124,14 @@ export function collectedControlIndexOf(part: OoxmlPart): CollectedControlIndex 
     neededParagraphIds,
     neededToken: `${[...neededBlockIds].sort().join(',')};${[...neededParagraphIds].sort().join(',')}`,
   };
+  lastCollectedIndexSlot = { lists, index };
   collectedControlIndexes.set(part, index);
   return index;
 }
 
-function collectControls(part: OoxmlPart): CollectedControl[] {
+const EMPTY_CONTROLS: readonly CollectedControl[] = Object.freeze([]);
+
+function collectControlLists(part: OoxmlPart): readonly (readonly CollectedControl[])[] {
   const out: CollectedControl[] = [];
 
   const collectBlocks = (nodes: readonly OoxmlNode[], into: string[]): void => {
@@ -283,26 +250,31 @@ function collectControls(part: OoxmlPart): CollectedControl[] {
   // Per top-level block, memoized on the immutable node: at body level the depth is 0 and
   // the lock stack is empty, so a block's entries are a pure function of its subtree. A
   // keystroke publishes a new part whose body children are all shared but one — without
-  // this the whole document re-walked per pass.
+  // this the whole document re-walked per pass. An empty answer is the SHARED constant, so
+  // the retained-index slot can identity-compare a replaced control-free block.
   // EVERY story the part holds, not a `w:body` child. A header's root is `w:hdr` and a note
   // part's stories hang off `w:footnote` elements, so looking for `body` collected nothing
   // from either — which is why a content control in a header had no record at all, and the
   // caret's geometry then matched whichever BODY control sat at the same page coordinates.
+  const lists: (readonly CollectedControl[])[] = [];
   for (const story of storyRootsOf(part)) {
     if (story.root.kind === 'textValue') continue;
     for (const child of story.root.children) {
       if (child.kind === 'textValue') continue;
       const cached = topLevelBlockControls.get(child);
       if (cached !== undefined) {
-        for (const entry of cached) out.push(entry);
+        lists.push(cached);
         continue;
       }
       const before = out.length;
       walkBlocks([child], 0, []);
-      topLevelBlockControls.set(child, Object.freeze(out.slice(before)));
+      const collected =
+        out.length === before ? EMPTY_CONTROLS : Object.freeze(out.slice(before));
+      topLevelBlockControls.set(child, collected);
+      lists.push(collected);
     }
   }
-  return out;
+  return lists;
 }
 
 const topLevelBlockControls = new WeakMap<OoxmlNode, readonly CollectedControl[]>();
@@ -632,14 +604,44 @@ function fragmentsForInlineControl(
     });
 }
 
+/**
+ * Wrapper chrome (alias/tag/type/placeholder/binding), memoized per immutable control node:
+ * one settle builds a record per control per pass, and re-reading `w:sdtPr` for hundreds of
+ * unchanged controls was a measurable share of the boundary attach.
+ */
+interface ControlChromeMetadata {
+  readonly alias?: string;
+  readonly tag?: string;
+  readonly controlType: ContentControlBoundaryRecord['controlType'];
+  readonly placeholder: boolean;
+  readonly bound: boolean;
+}
+
+const controlChromeMemos = new WeakMap<OoxmlElement, ControlChromeMetadata>();
+
+function controlChromeOf(control: OoxmlElement): ControlChromeMetadata {
+  const cached = controlChromeMemos.get(control);
+  if (cached !== undefined) return cached;
+  const properties = contentControlPropertiesOf(control);
+  const alias = propertyVal(properties, 'alias');
+  const tag = propertyVal(properties, 'tag');
+  const chrome: ControlChromeMetadata = {
+    ...(alias !== undefined ? { alias } : {}),
+    ...(tag !== undefined ? { tag } : {}),
+    controlType: mapContentControlType(properties),
+    placeholder: propertyChild(properties, 'showingPlcHdr') !== undefined,
+    bound: propertyChild(properties, 'dataBinding') !== undefined,
+  };
+  controlChromeMemos.set(control, chrome);
+  return chrome;
+}
+
 function boundaryRecordOf(
   collected: CollectedControl,
   geometry: PlacedGeometryIndex,
   work?: ContentControlBoundaryWork
 ): ContentControlBoundaryRecord {
-  const properties = contentControlPropertiesOf(collected.control);
-  const alias = propertyVal(properties, 'alias');
-  const tag = propertyVal(properties, 'tag');
+  const chrome = controlChromeOf(collected.control);
   const lock = collected.lockStack[collected.lockStack.length - 1] ?? 'unlocked';
   const fragments =
     collected.level === 'inline' && collected.paragraphId && collected.range
@@ -647,13 +649,13 @@ function boundaryRecordOf(
       : fragmentsForBlockControl(collected.blockIds, geometry, work);
   return {
     id: collected.control.id,
-    ...(alias !== undefined ? { alias } : {}),
-    ...(tag !== undefined ? { tag } : {}),
-    controlType: mapContentControlType(properties),
+    ...(chrome.alias !== undefined ? { alias: chrome.alias } : {}),
+    ...(chrome.tag !== undefined ? { tag: chrome.tag } : {}),
+    controlType: chrome.controlType,
     lock,
     effectiveLock: effectiveContentControlLock(collected.lockStack),
-    placeholder: propertyChild(properties, 'showingPlcHdr') !== undefined,
-    bound: propertyChild(properties, 'dataBinding') !== undefined,
+    placeholder: chrome.placeholder,
+    bound: chrome.bound,
     nestingDepth: collected.nestingDepth,
     level: collected.level,
     fragments,
@@ -934,18 +936,16 @@ export function contentControlHoldingParagraph(
 }
 
 function recordWithoutGeometry(collected: CollectedControl): ContentControlBoundaryRecord {
-  const properties = contentControlPropertiesOf(collected.control);
-  const alias = propertyVal(properties, 'alias');
-  const tag = propertyVal(properties, 'tag');
+  const chrome = controlChromeOf(collected.control);
   return {
     id: collected.control.id,
-    ...(alias !== undefined ? { alias } : {}),
-    ...(tag !== undefined ? { tag } : {}),
-    controlType: mapContentControlType(properties),
+    ...(chrome.alias !== undefined ? { alias: chrome.alias } : {}),
+    ...(chrome.tag !== undefined ? { tag: chrome.tag } : {}),
+    controlType: chrome.controlType,
     lock: collected.lockStack[collected.lockStack.length - 1] ?? 'unlocked',
     effectiveLock: effectiveContentControlLock(collected.lockStack),
-    placeholder: propertyChild(properties, 'showingPlcHdr') !== undefined,
-    bound: propertyChild(properties, 'dataBinding') !== undefined,
+    placeholder: chrome.placeholder,
+    bound: chrome.bound,
     nestingDepth: collected.nestingDepth,
     level: collected.level,
     fragments: [],

--- a/packages/core/src/layout/content-control-boundary-layout.ts
+++ b/packages/core/src/layout/content-control-boundary-layout.ts
@@ -76,22 +76,8 @@ export interface CollectedControlIndex {
 
 const collectedControlIndexes = new WeakMap<OoxmlPart, CollectedControlIndex>();
 
-/**
- * The one retained previous index, content-validated: the index is a pure function of the
- * per-top-level-block control lists, and a keystroke outside any control leaves every one of
- * those lists identical (the edited block's list is the shared empty constant). Rebuilding
- * the sets and the sorted needed-token for a control-heavy document on every fresh part cost
- * more than the walk the per-block memo already saves. One strong slot, bounded.
- */
-let lastCollectedIndexSlot: {
-  readonly lists: readonly (readonly CollectedControl[])[];
-  readonly index: CollectedControlIndex;
-} | null = null;
-
-function sameControlLists(
-  left: readonly (readonly CollectedControl[])[],
-  right: readonly (readonly CollectedControl[])[]
-): boolean {
+/** Same references, same order — the identity comparison every retained memo here uses. */
+export function sameRefs<T>(left: readonly T[], right: readonly T[]): boolean {
   if (left.length !== right.length) return false;
   for (let index = 0; index < left.length; index += 1) {
     if (left[index] !== right[index]) return false;
@@ -99,12 +85,44 @@ function sameControlLists(
   return true;
 }
 
+/**
+ * The retained previous index, content-validated: the index is a pure function of the
+ * per-top-level-block control lists, and a keystroke outside any control leaves every one of
+ * those lists identical (the edited block's list is the shared empty constant). Rebuilding
+ * the sets and the sorted needed-token for a control-heavy document on every fresh part cost
+ * more than the walk the per-block memo already saves.
+ *
+ * Keyed weakly on the story's FIRST block node rather than held in a module slot, so a
+ * closed document's index dies with its tree instead of staying pinned until some other
+ * document lays out, and two live editors do not thrash one slot (the `list-resolve.ts`
+ * anchor idiom). An edit to the first block itself only misses once, never mixes — the
+ * lists are still compared reference-for-reference.
+ */
+const collectedIndexByAnchor = new WeakMap<
+  OoxmlNode,
+  {
+    readonly lists: readonly (readonly CollectedControl[])[];
+    readonly index: CollectedControlIndex;
+  }
+>();
+
+function firstStoryChildOf(part: OoxmlPart): OoxmlNode | null {
+  for (const story of storyRootsOf(part)) {
+    if (story.root.kind === 'textValue') continue;
+    for (const child of story.root.children) {
+      if (child.kind !== 'textValue') return child;
+    }
+  }
+  return null;
+}
+
 export function collectedControlIndexOf(part: OoxmlPart): CollectedControlIndex {
   const cached = collectedControlIndexes.get(part);
   if (cached !== undefined) return cached;
   const lists = collectControlLists(part);
-  const slot = lastCollectedIndexSlot;
-  if (slot && sameControlLists(slot.lists, lists)) {
+  const anchor = firstStoryChildOf(part);
+  const slot = anchor ? collectedIndexByAnchor.get(anchor) : undefined;
+  if (slot && sameRefs(slot.lists, lists)) {
     collectedControlIndexes.set(part, slot.index);
     return slot.index;
   }
@@ -124,7 +142,7 @@ export function collectedControlIndexOf(part: OoxmlPart): CollectedControlIndex 
     neededParagraphIds,
     neededToken: `${[...neededBlockIds].sort().join(',')};${[...neededParagraphIds].sort().join(',')}`,
   };
-  lastCollectedIndexSlot = { lists, index };
+  if (anchor) collectedIndexByAnchor.set(anchor, { lists, index });
   collectedControlIndexes.set(part, index);
   return index;
 }
@@ -640,25 +658,13 @@ function boundaryRecordOf(
   geometry: PlacedGeometryIndex,
   work?: ContentControlBoundaryWork
 ): ContentControlBoundaryRecord {
-  const chrome = controlChromeOf(collected.control);
-  const lock = collected.lockStack[collected.lockStack.length - 1] ?? 'unlocked';
   const fragments =
     collected.level === 'inline' && collected.paragraphId && collected.range
       ? fragmentsForInlineControl(collected.paragraphId, collected.range, geometry, work)
       : fragmentsForBlockControl(collected.blockIds, geometry, work);
-  return {
-    id: collected.control.id,
-    ...(chrome.alias !== undefined ? { alias: chrome.alias } : {}),
-    ...(chrome.tag !== undefined ? { tag: chrome.tag } : {}),
-    controlType: chrome.controlType,
-    lock,
-    effectiveLock: effectiveContentControlLock(collected.lockStack),
-    placeholder: chrome.placeholder,
-    bound: chrome.bound,
-    nestingDepth: collected.nestingDepth,
-    level: collected.level,
-    fragments,
-  };
+  // One source for the chrome fields: a field added to the record has one place to be
+  // forgotten, not two, and the no-geometry path can never drift from this one.
+  return { ...recordWithoutGeometry(collected), fragments };
 }
 
 function sameGeometryFragments(

--- a/packages/core/src/layout/content-control-boundary-layout.ts
+++ b/packages/core/src/layout/content-control-boundary-layout.ts
@@ -268,8 +268,7 @@ function collectControlLists(part: OoxmlPart): readonly (readonly CollectedContr
       }
       const before = out.length;
       walkBlocks([child], 0, []);
-      const collected =
-        out.length === before ? EMPTY_CONTROLS : Object.freeze(out.slice(before));
+      const collected = out.length === before ? EMPTY_CONTROLS : Object.freeze(out.slice(before));
       topLevelBlockControls.set(child, collected);
       lists.push(collected);
     }

--- a/packages/core/src/layout/content-control-boundary-parts.ts
+++ b/packages/core/src/layout/content-control-boundary-parts.ts
@@ -59,23 +59,44 @@ const mergedControlIndexes = new WeakMap<
   { readonly parts: readonly OoxmlPart[]; readonly index: CollectedControlIndex }
 >();
 
+/**
+ * The one retained previous merge, guarded by the per-part INDEX identities. A keystroke
+ * mints a new body part, so the part-keyed memo above misses by design — but the body's own
+ * index comes back by identity when its controls are unchanged, and an identical index tuple
+ * proves the merge cannot differ. One strong slot, bounded.
+ */
+let lastMergedIndexSlot: {
+  readonly indexes: readonly CollectedControlIndex[];
+  readonly index: CollectedControlIndex;
+} | null = null;
+
+function sameIndexes(
+  left: readonly CollectedControlIndex[],
+  right: readonly CollectedControlIndex[]
+): boolean {
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i += 1) if (left[i] !== right[i]) return false;
+  return true;
+}
+
 export function collectedControlIndexOverParts(parts: readonly OoxmlPart[]): CollectedControlIndex {
   if (parts.length === 1) return collectedControlIndexOf(parts[0]!);
   // Memoized on the BODY part, guarded by the exact part list. Each part's own index is
   // already memoized, but the merge was not, and one layout pass makes several passes over it.
-  //
-  // Not a per-keystroke saving: an edit mints a new body part, so the key misses by design and
-  // the merge runs again at the new revision. What this removes is the repeat within one
-  // revision, which is where a control-heavy template paid the set unions and the
-  // `sort().join()` more than once for the same answer.
   const cached = mergedControlIndexes.get(parts[0]!);
   if (cached && sameParts(cached.parts, parts)) return cached.index;
+
+  const indexes = parts.map((storyPart) => collectedControlIndexOf(storyPart));
+  const slot = lastMergedIndexSlot;
+  if (slot && sameIndexes(slot.indexes, indexes)) {
+    mergedControlIndexes.set(parts[0]!, { parts, index: slot.index });
+    return slot.index;
+  }
 
   const controls: CollectedControl[] = [];
   const neededBlockIds = new Set<string>();
   const neededParagraphIds = new Set<string>();
-  for (const storyPart of parts) {
-    const index = collectedControlIndexOf(storyPart);
+  for (const index of indexes) {
     // A LOOP, not a spread: the control count comes from a file, and spreading an unbounded
     // array into `push` throws `RangeError` once it is large enough.
     for (const control of index.controls) controls.push(control);
@@ -94,6 +115,7 @@ export function collectedControlIndexOverParts(parts: readonly OoxmlPart[]): Col
     neededParagraphIds,
     neededToken,
   };
+  lastMergedIndexSlot = { indexes, index };
   mergedControlIndexes.set(parts[0]!, { parts, index });
   return index;
 }

--- a/packages/core/src/layout/content-control-boundary-parts.ts
+++ b/packages/core/src/layout/content-control-boundary-parts.ts
@@ -11,6 +11,7 @@ import type { OoxmlPart } from '../store/package/ooxml-tree.ts';
 import type { SemanticLayout } from './semantic-records.ts';
 import {
   collectedControlIndexOf,
+  sameRefs,
   type CollectedControl,
   type CollectedControlIndex,
 } from './content-control-boundary-layout.ts';
@@ -60,35 +61,31 @@ const mergedControlIndexes = new WeakMap<
 >();
 
 /**
- * The one retained previous merge, guarded by the per-part INDEX identities. A keystroke
- * mints a new body part, so the part-keyed memo above misses by design — but the body's own
- * index comes back by identity when its controls are unchanged, and an identical index tuple
- * proves the merge cannot differ. One strong slot, bounded.
+ * The retained previous merge, guarded by the per-part INDEX identities. A keystroke mints a
+ * new body part, so the part-keyed memo above misses by design — but the body's own index
+ * comes back by identity when its controls are unchanged, and an identical index tuple
+ * proves the merge cannot differ. Keyed weakly on the body's index, so a closed document's
+ * merge dies with its index instead of staying pinned in a module slot.
  */
-let lastMergedIndexSlot: {
-  readonly indexes: readonly CollectedControlIndex[];
-  readonly index: CollectedControlIndex;
-} | null = null;
-
-function sameIndexes(
-  left: readonly CollectedControlIndex[],
-  right: readonly CollectedControlIndex[]
-): boolean {
-  if (left.length !== right.length) return false;
-  for (let i = 0; i < left.length; i += 1) if (left[i] !== right[i]) return false;
-  return true;
-}
+const mergedIndexByBodyIndex = new WeakMap<
+  CollectedControlIndex,
+  {
+    readonly indexes: readonly CollectedControlIndex[];
+    readonly index: CollectedControlIndex;
+  }
+>();
 
 export function collectedControlIndexOverParts(parts: readonly OoxmlPart[]): CollectedControlIndex {
   if (parts.length === 1) return collectedControlIndexOf(parts[0]!);
   // Memoized on the BODY part, guarded by the exact part list. Each part's own index is
   // already memoized, but the merge was not, and one layout pass makes several passes over it.
+  // Part objects are immutable, so identity is the whole comparison.
   const cached = mergedControlIndexes.get(parts[0]!);
-  if (cached && sameParts(cached.parts, parts)) return cached.index;
+  if (cached && sameRefs(cached.parts, parts)) return cached.index;
 
   const indexes = parts.map((storyPart) => collectedControlIndexOf(storyPart));
-  const slot = lastMergedIndexSlot;
-  if (slot && sameIndexes(slot.indexes, indexes)) {
+  const slot = mergedIndexByBodyIndex.get(indexes[0]!);
+  if (slot && sameRefs(slot.indexes, indexes)) {
     mergedControlIndexes.set(parts[0]!, { parts, index: slot.index });
     return slot.index;
   }
@@ -115,14 +112,7 @@ export function collectedControlIndexOverParts(parts: readonly OoxmlPart[]): Col
     neededParagraphIds,
     neededToken,
   };
-  lastMergedIndexSlot = { indexes, index };
+  mergedIndexByBodyIndex.set(indexes[0]!, { indexes, index });
   mergedControlIndexes.set(parts[0]!, { parts, index });
   return index;
-}
-
-/** Same parts, same order. Part objects are immutable, so identity is the whole comparison. */
-function sameParts(left: readonly OoxmlPart[], right: readonly OoxmlPart[]): boolean {
-  if (left.length !== right.length) return false;
-  for (let i = 0; i < left.length; i += 1) if (left[i] !== right[i]) return false;
-  return true;
 }

--- a/packages/core/src/layout/content-control-context-token.ts
+++ b/packages/core/src/layout/content-control-context-token.ts
@@ -64,8 +64,7 @@ function computeContentControlContextToken(part: OoxmlPart): string {
     // Paragraph, table and control wrappers are immutable and structurally shared across
     // text edits. Caching only at depth zero left every paragraph INSIDE a block control
     // (a TOC wrapped in `w:sdt` is the common shape) re-walked per part revision.
-    const memoizable =
-      node.kind === 'paragraph' || node.kind === 'table' || isContentControl(node);
+    const memoizable = node.kind === 'paragraph' || node.kind === 'table' || isContentControl(node);
     if (memoizable) {
       const cached = contentControlSubtreeTokens.get(node);
       if (cached !== undefined && cached.depth === depth) return cached.token;

--- a/packages/core/src/layout/content-control-context-token.ts
+++ b/packages/core/src/layout/content-control-context-token.ts
@@ -1,0 +1,102 @@
+// The content-control context token: a fingerprint of every control wrapper's chrome.
+//
+// Extracted from `content-control-boundary-layout.ts` to keep it under the line cap. Pure
+// functions over immutable parts; the memos are the point — the token is folded into the
+// layout producer, so it is asked for on every pass over every fresh part revision.
+
+import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  MAX_CONTENT_CONTROL_NESTING as MAX_SDT_NESTING,
+  contentControlContentChildren,
+  isContentControl,
+} from '../store/package/content-control-walk.ts';
+import {
+  contentControlPropertiesOf,
+  mapContentControlType,
+  parseContentControlLock,
+  propertyChild,
+  propertyVal,
+} from './content-control-properties.ts';
+
+/**
+ * Fingerprint of every control wrapper's chrome metadata — not its content.
+ *
+ * Changing alias/tag/lock/type/placeholder/binding without touching nested paragraphs still
+ * changes this token, which is folded into the layout producer.
+ */
+export function contentControlContextToken(part: OoxmlPart): string {
+  // Parts are immutable (edits publish a new part object), so the token is a pure function
+  // of the part reference. Without the memo this whole-tree walk ran on EVERY layout pass —
+  // including no-change passes that reuse every page.
+  const cached = contentControlContextTokens.get(part);
+  if (cached !== undefined) return cached;
+  let token = computeContentControlContextToken(part);
+  // Hand back the PREVIOUS string object when the content is unchanged (one compare per
+  // fresh part). A control-heavy document's token runs to kilobytes, and it is embedded in
+  // the layout producer — identity-stable tokens keep every downstream string comparison a
+  // pointer check instead of a memcmp per section per pass.
+  if (lastContextTokenObject !== null && lastContextTokenObject === token) {
+    token = lastContextTokenObject;
+  } else {
+    lastContextTokenObject = token;
+  }
+  contentControlContextTokens.set(part, token);
+  return token;
+}
+
+let lastContextTokenObject: string | null = null;
+
+const contentControlContextTokens = new WeakMap<OoxmlPart, string>();
+/**
+ * Subtree tokens memoized per immutable node, remembering the DEPTH they were computed at:
+ * the walk clips content controls at {@link MAX_SDT_NESTING}, so a subtree's token is a pure
+ * function of the node only at a fixed nesting depth. Typing keeps every unchanged subtree at
+ * its old depth, which is the case the memo exists for.
+ */
+const contentControlSubtreeTokens = new WeakMap<
+  OoxmlElement,
+  { readonly depth: number; readonly token: string }
+>();
+
+function computeContentControlContextToken(part: OoxmlPart): string {
+  const tokenOf = (node: OoxmlNode, depth: number): string => {
+    if (node.kind === 'textValue') return '';
+    // Paragraph, table and control wrappers are immutable and structurally shared across
+    // text edits. Caching only at depth zero left every paragraph INSIDE a block control
+    // (a TOC wrapped in `w:sdt` is the common shape) re-walked per part revision.
+    const memoizable =
+      node.kind === 'paragraph' || node.kind === 'table' || isContentControl(node);
+    if (memoizable) {
+      const cached = contentControlSubtreeTokens.get(node);
+      if (cached !== undefined && cached.depth === depth) return cached.token;
+    }
+    let token: string;
+    if (isContentControl(node)) {
+      if (depth >= MAX_SDT_NESTING) return '';
+      const properties = contentControlPropertiesOf(node);
+      const own = [
+        node.id,
+        propertyVal(properties, 'alias') ?? '',
+        propertyVal(properties, 'tag') ?? '',
+        parseContentControlLock(propertyVal(properties, 'lock')),
+        mapContentControlType(properties),
+        propertyChild(properties, 'showingPlcHdr') ? '1' : '0',
+        propertyChild(properties, 'dataBinding') ? '1' : '0',
+      ].join(':');
+      const nested = contentControlContentChildren(node)
+        .map((inner) => tokenOf(inner, depth + 1))
+        .filter((entry) => entry.length > 0);
+      token = [own, ...nested].join('|');
+    } else {
+      token = node.children
+        .map((child) => tokenOf(child, depth))
+        .filter((entry) => entry.length > 0)
+        .join('|');
+    }
+    if (memoizable) {
+      contentControlSubtreeTokens.set(node as OoxmlElement, { depth, token });
+    }
+    return token;
+  };
+  return tokenOf(part.root, 0);
+}

--- a/packages/core/src/layout/drawing-exclusion.ts
+++ b/packages/core/src/layout/drawing-exclusion.ts
@@ -861,8 +861,10 @@ export function collectExclusionZonesByPageMemoized(
   /** Projection epoch of the owning part — the context object keeps identity across it. */
   drawingLayoutEpoch: string | undefined,
   contentWidth: number,
+  // The source-order LOOKUP is derived here from the keyed map, never passed in: a caller-
+  // supplied closure could disagree with the map the memo keys on, and the key could not see
+  // it — warm passes would then serve zones computed under a different drawing order.
   drawingSourceOrder: ReadonlyMap<string, number> | undefined,
-  sourceOrderOf: ((drawingNodeId: string) => number | undefined) | undefined,
   columnLayout?: ExclusionColumnLayout
 ): ReadonlyMap<number, readonly ExclusionZone[]> {
   const columnToken = columnLayoutToken(columnLayout);
@@ -881,7 +883,9 @@ export function collectExclusionZonesByPageMemoized(
     pages,
     drawingLayout,
     contentWidth,
-    sourceOrderOf,
+    drawingSourceOrder
+      ? (drawingNodeId: string) => drawingSourceOrder.get(drawingNodeId)
+      : undefined,
     columnLayout
   );
   exclusionZonesByPageMemos.set(pages, {

--- a/packages/core/src/layout/drawing-exclusion.ts
+++ b/packages/core/src/layout/drawing-exclusion.ts
@@ -828,6 +828,73 @@ export function collectExclusionZonesByPage(
   return out;
 }
 
+/**
+ * Zone maps memoized on the pages array plus every input that can move a zone.
+ *
+ * The wrap-exclusion wrapper collects zones from each section's PREVIOUS pages before every
+ * pass, and a multi-section document runs that wrapper once per section per keystroke — for
+ * unchanged sections the pages array comes back by identity, so the collection is a replay.
+ * The column layout is a fresh object per call, so it keys by content, not identity.
+ */
+interface ExclusionZonesMemoEntry {
+  readonly drawingLayout: import('./drawing-layout.ts').InlineDrawingLayoutContext;
+  readonly drawingLayoutEpoch: string | undefined;
+  readonly contentWidth: number;
+  readonly drawingSourceOrder: ReadonlyMap<string, number> | undefined;
+  readonly columnToken: string;
+  readonly zones: ReadonlyMap<number, readonly ExclusionZone[]>;
+}
+
+const exclusionZonesByPageMemos = new WeakMap<
+  readonly import('./semantic-records.ts').PageRecord[],
+  ExclusionZonesMemoEntry
+>();
+
+function columnLayoutToken(layout: ExclusionColumnLayout | undefined): string {
+  if (!layout) return '';
+  return `${layout.columnCount};${layout.columnGapPt};${layout.contentWidth};${(layout.columnLefts ?? []).join(',')};${(layout.columnWidths ?? []).join(',')}`;
+}
+
+export function collectExclusionZonesByPageMemoized(
+  pages: readonly import('./semantic-records.ts').PageRecord[],
+  drawingLayout: import('./drawing-layout.ts').InlineDrawingLayoutContext,
+  /** Projection epoch of the owning part — the context object keeps identity across it. */
+  drawingLayoutEpoch: string | undefined,
+  contentWidth: number,
+  drawingSourceOrder: ReadonlyMap<string, number> | undefined,
+  sourceOrderOf: ((drawingNodeId: string) => number | undefined) | undefined,
+  columnLayout?: ExclusionColumnLayout
+): ReadonlyMap<number, readonly ExclusionZone[]> {
+  const columnToken = columnLayoutToken(columnLayout);
+  const cached = exclusionZonesByPageMemos.get(pages);
+  if (
+    cached &&
+    cached.drawingLayout === drawingLayout &&
+    cached.drawingLayoutEpoch === drawingLayoutEpoch &&
+    cached.contentWidth === contentWidth &&
+    cached.drawingSourceOrder === drawingSourceOrder &&
+    cached.columnToken === columnToken
+  ) {
+    return cached.zones;
+  }
+  const zones = collectExclusionZonesByPage(
+    pages,
+    drawingLayout,
+    contentWidth,
+    sourceOrderOf,
+    columnLayout
+  );
+  exclusionZonesByPageMemos.set(pages, {
+    drawingLayout,
+    drawingLayoutEpoch,
+    contentWidth,
+    drawingSourceOrder,
+    columnToken,
+    zones,
+  });
+  return zones;
+}
+
 export function exclusionMapsEqual(
   left: ReadonlyMap<number, readonly ExclusionZone[]>,
   right: ReadonlyMap<number, readonly ExclusionZone[]>

--- a/packages/core/src/layout/layout-session.ts
+++ b/packages/core/src/layout/layout-session.ts
@@ -90,8 +90,11 @@ export interface LayoutSession {
    * control-heavy document, and embedding it copied that token into every section's context
    * string on every pass. Identity-stable when unchanged, so the comparison is a pointer
    * check.
+   *
+   * Optional so a session literal built before this field existed still type-checks; an
+   * absent producer never matches and forces a conservative full pass.
    */
-  producer: string;
+  producer?: string;
   /**
    * Whether the previous pass read page PARITY: even/odd header variants, or an anchored
    * drawing positioned against an inside/outside frame or alignment.

--- a/packages/core/src/layout/layout-session.ts
+++ b/packages/core/src/layout/layout-session.ts
@@ -82,8 +82,16 @@ export interface LayoutSession {
   previous: SemanticLayout | null;
   checkpoints: FlowCheckpoint[];
   keys: string[];
-  /** Geometry and producer of the previous pass; a change to either forces a full pass. */
+  /** Geometry and flow context of the previous pass; a change forces a full pass. */
   context: string;
+  /**
+   * Producer of the previous pass, compared beside {@link context} rather than embedded in
+   * it: the producer carries the content-control token, which runs to kilobytes on a
+   * control-heavy document, and embedding it copied that token into every section's context
+   * string on every pass. Identity-stable when unchanged, so the comparison is a pointer
+   * check.
+   */
+  producer: string;
   /**
    * Whether the previous pass read page PARITY: even/odd header variants, or an anchored
    * drawing positioned against an inside/outside frame or alignment.
@@ -161,6 +169,7 @@ export function createLayoutSession(): LayoutSession {
     checkpoints: [],
     keys: [],
     context: '',
+    producer: '',
     parityDependent: false,
     startPageParity: 0,
     prepass: null,

--- a/packages/core/src/layout/multi-section-layout.ts
+++ b/packages/core/src/layout/multi-section-layout.ts
@@ -255,6 +255,7 @@ function adoptMultiSectionResult(
   session.keys = [];
   session.checkpoints = [];
   session.context = '';
+  session.producer = '';
 }
 
 /**

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -2260,6 +2260,33 @@ function tableParagraphIdsOf(table: OoxmlNode): readonly string[] {
   return ids;
 }
 
+/**
+ * The note-reserve slice of one section's layout context key.
+ *
+ * `pageBound` is EXCLUSIVE and names the highest page slot the pass can read plus one — the
+ * pass reads reserves at consecutive local page slots as it opens pages, so every entry at or
+ * past the bound is unreadable by it and must stay OUT of the key. Folding the whole
+ * document-wide map in (the previous behaviour) meant a reserve on one section's pages
+ * changed every other section's context, and the open's second reflow pass re-placed every
+ * section instead of only the reserved ones.
+ *
+ * Entries are sorted by page slot so two content-equal maps render one canonical key
+ * regardless of insertion order. `Infinity` folds the whole map (a pass with no prior page
+ * count cannot bound its reads).
+ */
+export function notesReserveContextKey(
+  reserves: ReadonlyMap<number, number> | undefined,
+  pageBound: number
+): string {
+  if (!reserves) return '';
+  const entries: [number, number][] = [];
+  for (const [pageSlot, height] of reserves) {
+    if (pageSlot < pageBound) entries.push([pageSlot, height]);
+  }
+  entries.sort((a, b) => a[0] - b[0]);
+  return `|nr:${entries.map(([pageSlot, height]) => `${pageSlot}=${height}`).join(',')}`;
+}
+
 /** Drop non-positive heights so missing and zero compare equal. */
 function compactFootnoteReserves(reserves: ReadonlyMap<number, number>): Map<number, number> {
   const next = new Map<number, number>();

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -406,13 +406,6 @@ export function buildPageRefIndex(allRefs: readonly PageRefHit[]): PageRefIndex 
 }
 
 /**
- * Collect note references that appear in laid-out body fragments on a page.
- * Matches {@link ParagraphFragmentRecord.range} ownership (half-open + boundary affinity).
- *
- * Pass {@link buildPageRefIndex} result as `refIndex` for O(fragments + matching refs)
- * instead of scanning every document ref against every page fragment.
- */
-/**
  * Per-page answers, memoized on the page's fragments array: a page an incremental pass
  * carried over keeps its fragments by identity, and one settle walks every page THREE times
  * (mark sites, reserve compute, attach). Keyed on the index too — a changed hit set publishes
@@ -423,6 +416,13 @@ const pageRefFilterMemos = new WeakMap<
   { readonly refIndex: PageRefIndex; readonly result: readonly PageRefHit[] }
 >();
 
+/**
+ * Collect note references that appear in laid-out body fragments on a page.
+ * Matches {@link ParagraphFragmentRecord.range} ownership (half-open + boundary affinity).
+ *
+ * Pass {@link buildPageRefIndex} result as `refIndex` for O(fragments + matching refs)
+ * instead of scanning every document ref against every page fragment.
+ */
 export function filterRefsOnPage(
   page: PageRecord,
   allRefs: readonly PageRefHit[],

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -2235,18 +2235,25 @@ function collectBodyNoteReferences(part: OoxmlPart): readonly {
 }
 
 /**
- * The one retained previous answer, content-validated. The map is a pure function of the
- * section bounds plus each block's paragraph-id list, and a keystroke changes NEITHER — it
- * replaces one block with a twin carrying the same ids. Rebuilding 10k+ map entries per
- * keystroke cost more than the lookups the map serves, so the previous answer is kept
- * (one strong slot, bounded) and revalidated by identity-diffing the block lists: blocks
- * that changed identity must still contribute the same ids, or the map rebuilds.
+ * The retained previous answer per SESSION, content-validated. The map is a pure function of
+ * the section bounds plus each block's paragraph-id list, and a keystroke changes NEITHER —
+ * it replaces one block with a twin carrying the same ids. Rebuilding 10k+ map entries per
+ * keystroke cost more than the lookups the map serves, so the previous answer is kept and
+ * revalidated by identity-diffing the block lists: blocks that changed identity must still
+ * contribute the same ids, or the map rebuilds.
+ *
+ * Keyed weakly on the caller's session object — NOT a module slot — so a disposed editor's
+ * block list and id map die with its session instead of staying pinned until some other
+ * document lays out, and two live editors do not thrash one slot. A call without a session
+ * has no incremental pass to serve and builds fresh.
  */
-let paragraphSectionIndexMemo: {
+interface ParagraphSectionIndexMemo {
   blocks: readonly OoxmlElement[];
   boundsFingerprint: string;
   map: ReadonlyMap<string, number>;
-} | null = null;
+}
+
+const paragraphSectionIndexMemos = new WeakMap<object, ParagraphSectionIndexMemo>();
 
 function sectionBoundsFingerprint(
   sections: readonly DocumentSection[],
@@ -2271,7 +2278,9 @@ function blockParagraphIdsEqual(next: OoxmlElement, previous: OoxmlElement): boo
 function paragraphSectionIndexOf(
   part: OoxmlPart,
   sections: readonly DocumentSection[],
-  displayMode: RevisionDisplayMode
+  displayMode: RevisionDisplayMode,
+  /** The caller's layout session, as the memo's weak key; absent means no reuse. */
+  memoHost?: object
 ): ReadonlyMap<string, number> {
   // IN THE SAME MODE the section bounds were counted in. `blockStart`/`blockEndExclusive`
   // index a mode-filtered block list, and a resolved view has fewer blocks — a paragraph a
@@ -2280,7 +2289,7 @@ function paragraphSectionIndexOf(
   // edited.
   const blocks = storyBlocks(part, displayMode);
   const boundsFingerprint = sectionBoundsFingerprint(sections, displayMode);
-  const memo = paragraphSectionIndexMemo;
+  const memo = memoHost ? paragraphSectionIndexMemos.get(memoHost) : undefined;
   if (
     memo &&
     memo.boundsFingerprint === boundsFingerprint &&
@@ -2317,7 +2326,7 @@ function paragraphSectionIndexOf(
       for (const id of tableParagraphIdsOf(block)) map.set(id, sectionIndex);
     }
   }
-  paragraphSectionIndexMemo = { blocks, boundsFingerprint, map };
+  if (memoHost) paragraphSectionIndexMemos.set(memoHost, { blocks, boundsFingerprint, map });
   return map;
 }
 
@@ -2345,11 +2354,19 @@ function tableParagraphIdsOf(table: OoxmlNode): readonly string[] {
  * The note-reserve slice of one section's layout context key.
  *
  * `pageBound` is EXCLUSIVE and names the highest page slot the pass can read plus one — the
- * pass reads reserves at consecutive local page slots as it opens pages, so every entry at or
- * past the bound is unreadable by it and must stay OUT of the key. Folding the whole
- * document-wide map in (the previous behaviour) meant a reserve on one section's pages
- * changed every other section's context, and the open's second reflow pass re-placed every
- * section instead of only the reserved ones.
+ * pass reads reserves at consecutive PASS-LOCAL page slots as it opens pages
+ * (`pageBottomReserves?.get(pages.length)`), so every entry at or past the bound is
+ * unreadable by it and must stay OUT of the key. Folding the whole document-wide map in
+ * (the previous behaviour) meant a reserve on one section's pages changed every other
+ * section's context, and the open's second reflow pass re-placed every section instead of
+ * only the reserved ones.
+ *
+ * KNOWN MISALIGNMENT, tracked as issue #460: {@link computeFootnoteReserves} keys the map by
+ * DOCUMENT page index while the pass reads pass-local slots, so in a multi-section document
+ * the two spaces disagree for every section after the first. This slice deliberately matches
+ * what the pass READS, not what the computer meant — soundness of the memo requires exactly
+ * that, and fixing the read side is a layout-output change that belongs to #460, not to a
+ * key refactor whose contract is byte-identical output.
  *
  * Entries are sorted by page slot so two content-equal maps render one canonical key
  * regardless of insertion order. `Infinity` folds the whole map (a pass with no prior page
@@ -2459,7 +2476,8 @@ export function layoutSemanticDocumentWithNotes<
     part,
     sections,
     (optionsWithLists as { displayMode?: RevisionDisplayMode }).displayMode ??
-      DEFAULT_REVISION_DISPLAY_MODE
+      DEFAULT_REVISION_DISPLAY_MODE,
+    optionsWithLists.session
   );
   const builtHits = buildPageRefHits(packageRefs, paragraphSectionIndex);
   // The session memo hands back the PREVIOUS pass's hit array and provisional marks by

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -7,7 +7,7 @@
 // layout-owned note records. Endnotes reserve nothing on reference pages — they collect at
 // sectEnd / docEnd. Hostile counts and oscillation fail closed with named reasons.
 
-import type { OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
+import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
 import { fragmentOwnsPosition, fragmentParagraphs } from './line-segments.ts';
 import { collectNoteReferences } from '../store/package/note-references.ts';
 import type { DocumentSection } from './section-properties.ts';
@@ -384,14 +384,24 @@ function paragraphFragmentsOfBlocks(
 /** Paragraph-id → refs index for linear {@link filterRefsOnPage} over a layout pass. */
 export type PageRefIndex = ReadonlyMap<string, readonly PageRefHit[]>;
 
+/**
+ * Memoized on the hit array's identity: the session memo hands the previous pass's hit array
+ * back by identity when its content is unchanged, so the reserve compute and the attach pass
+ * of every keystroke rebuilt an identical index.
+ */
+const pageRefIndexMemos = new WeakMap<readonly PageRefHit[], PageRefIndex>();
+
 /** Build a reusable paragraph-id index (document order preserved per paragraph). */
 export function buildPageRefIndex(allRefs: readonly PageRefHit[]): PageRefIndex {
+  const cached = pageRefIndexMemos.get(allRefs);
+  if (cached) return cached;
   const map = new Map<string, PageRefHit[]>();
   for (const ref of allRefs) {
     const list = map.get(ref.paragraphId);
     if (list) list.push(ref);
     else map.set(ref.paragraphId, [ref]);
   }
+  pageRefIndexMemos.set(allRefs, map);
   return map;
 }
 
@@ -402,6 +412,17 @@ export function buildPageRefIndex(allRefs: readonly PageRefHit[]): PageRefIndex 
  * Pass {@link buildPageRefIndex} result as `refIndex` for O(fragments + matching refs)
  * instead of scanning every document ref against every page fragment.
  */
+/**
+ * Per-page answers, memoized on the page's fragments array: a page an incremental pass
+ * carried over keeps its fragments by identity, and one settle walks every page THREE times
+ * (mark sites, reserve compute, attach). Keyed on the index too — a changed hit set publishes
+ * a new index object, which invalidates every entry at once.
+ */
+const pageRefFilterMemos = new WeakMap<
+  readonly BlockFragmentRecord[],
+  { readonly refIndex: PageRefIndex; readonly result: readonly PageRefHit[] }
+>();
+
 export function filterRefsOnPage(
   page: PageRecord,
   allRefs: readonly PageRefHit[],
@@ -413,6 +434,8 @@ export function filterRefsOnPage(
       fragments.some((fragment) => fragmentOwnsPosition(fragment, ref.paragraphId, ref.atomOffset))
     );
   }
+  const cached = pageRefFilterMemos.get(page.fragments);
+  if (cached && cached.refIndex === refIndex) return cached.result;
   const out: PageRefHit[] = [];
   const claimed = new Set<PageRefHit>();
   for (const fragment of fragments) {
@@ -430,6 +453,7 @@ export function filterRefsOnPage(
       }
     }
   }
+  pageRefFilterMemos.set(page.fragments, { refIndex, result: out });
   return out;
 }
 
@@ -2210,19 +2234,75 @@ function collectBodyNoteReferences(part: OoxmlPart): readonly {
   }));
 }
 
+/**
+ * The one retained previous answer, content-validated. The map is a pure function of the
+ * section bounds plus each block's paragraph-id list, and a keystroke changes NEITHER — it
+ * replaces one block with a twin carrying the same ids. Rebuilding 10k+ map entries per
+ * keystroke cost more than the lookups the map serves, so the previous answer is kept
+ * (one strong slot, bounded) and revalidated by identity-diffing the block lists: blocks
+ * that changed identity must still contribute the same ids, or the map rebuilds.
+ */
+let paragraphSectionIndexMemo: {
+  blocks: readonly OoxmlElement[];
+  boundsFingerprint: string;
+  map: ReadonlyMap<string, number>;
+} | null = null;
+
+function sectionBoundsFingerprint(
+  sections: readonly DocumentSection[],
+  displayMode: RevisionDisplayMode
+): string {
+  return `${displayMode};${sections.map((section) => `${section.blockStart}-${section.blockEndExclusive}`).join(',')}`;
+}
+
+function blockParagraphIdsEqual(next: OoxmlElement, previous: OoxmlElement): boolean {
+  if (next.kind !== previous.kind) return false;
+  if (next.kind === 'paragraph') return next.id === previous.id;
+  const nextIds = tableParagraphIdsOf(next);
+  const previousIds = tableParagraphIdsOf(previous);
+  if (nextIds.length !== previousIds.length) return false;
+  for (let index = 0; index < nextIds.length; index += 1) {
+    if (nextIds[index] !== previousIds[index]) return false;
+  }
+  return true;
+}
+
 /** Map paragraph id → section index for note numbering / position resolution. */
 function paragraphSectionIndexOf(
   part: OoxmlPart,
   sections: readonly DocumentSection[],
   displayMode: RevisionDisplayMode
 ): ReadonlyMap<string, number> {
-  const map = new Map<string, number>();
   // IN THE SAME MODE the section bounds were counted in. `blockStart`/`blockEndExclusive`
   // index a mode-filtered block list, and a resolved view has fewer blocks — a paragraph a
   // tracked mark merged away is gone from it. Indexing an All Markup list with those bounds
   // put paragraphs in the wrong section, which renumbers a footnote in a section nobody
   // edited.
   const blocks = storyBlocks(part, displayMode);
+  const boundsFingerprint = sectionBoundsFingerprint(sections, displayMode);
+  const memo = paragraphSectionIndexMemo;
+  if (
+    memo &&
+    memo.boundsFingerprint === boundsFingerprint &&
+    memo.blocks.length === blocks.length
+  ) {
+    let reusable = true;
+    for (let index = 0; index < blocks.length; index += 1) {
+      const block = blocks[index]!;
+      const previous = memo.blocks[index]!;
+      if (block === previous) continue;
+      if (!blockParagraphIdsEqual(block, previous)) {
+        reusable = false;
+        break;
+      }
+    }
+    if (reusable) {
+      // Re-anchor on the fresh list so the next keystroke diffs against it, not a stale one.
+      memo.blocks = blocks;
+      return memo.map;
+    }
+  }
+  const map = new Map<string, number>();
   for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex += 1) {
     const section = sections[sectionIndex]!;
     for (let i = section.blockStart; i < section.blockEndExclusive; i += 1) {
@@ -2237,6 +2317,7 @@ function paragraphSectionIndexOf(
       for (const id of tableParagraphIdsOf(block)) map.set(id, sectionIndex);
     }
   }
+  paragraphSectionIndexMemo = { blocks, boundsFingerprint, map };
   return map;
 }
 

--- a/packages/core/src/layout/pass-producer.ts
+++ b/packages/core/src/layout/pass-producer.ts
@@ -7,14 +7,8 @@
 // per pass. Both helpers keep one retained slot (bounded); the inputs are identity-stable
 // when unchanged, so a hit is a handful of pointer compares.
 
-import {
-  noteMarksCacheToken,
-  type NoteMarkContext,
-} from './note-projection.ts';
-import {
-  DEFAULT_REVISION_DISPLAY_MODE,
-  type RevisionDisplayMode,
-} from './revision-projection.ts';
+import { noteMarksCacheToken, type NoteMarkContext } from './note-projection.ts';
+import { DEFAULT_REVISION_DISPLAY_MODE, type RevisionDisplayMode } from './revision-projection.ts';
 import type { StyleCascadeTable } from './style-cascade.ts';
 
 let controlProducerSlot: {

--- a/packages/core/src/layout/pass-producer.ts
+++ b/packages/core/src/layout/pass-producer.ts
@@ -1,0 +1,76 @@
+// Identity-stable producer strings for layout passes.
+//
+// The producer folds the content-control token in, and that token runs to kilobytes on a
+// control-heavy document. It reaches every section's prepass memo, break-cache key prefix
+// and session comparison — so the string OBJECT must stay stable while its content does,
+// or every one of those `===` checks degrades from a pointer check to a memcmp per section
+// per pass. Both helpers keep one retained slot (bounded); the inputs are identity-stable
+// when unchanged, so a hit is a handful of pointer compares.
+
+import {
+  noteMarksCacheToken,
+  type NoteMarkContext,
+} from './note-projection.ts';
+import {
+  DEFAULT_REVISION_DISPLAY_MODE,
+  type RevisionDisplayMode,
+} from './revision-projection.ts';
+import type { StyleCascadeTable } from './style-cascade.ts';
+
+let controlProducerSlot: {
+  readonly base: string | undefined;
+  readonly token: string;
+  readonly producer: string;
+} | null = null;
+
+/** The document producer with the control token folded in, identity-stable across passes. */
+export function producerWithControlContext(base: string | undefined, token: string): string {
+  const slot = controlProducerSlot;
+  if (slot && slot.base === base && slot.token === token) return slot.producer;
+  const producer = `${base ?? 'unversioned-measurer'}|cc:${token}`;
+  controlProducerSlot = { base, token, producer };
+  return producer;
+}
+
+let passProducerSlot: {
+  readonly base: string | undefined;
+  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly noteMarks: NoteMarkContext | undefined;
+  readonly defaultTabStopPt: number | undefined;
+  readonly displayMode: RevisionDisplayMode;
+  readonly producer: string;
+} | null = null;
+
+/**
+ * The per-pass producer: base plus cascade, note-mark, default-tab and display-mode tokens.
+ *
+ * A multi-section pass derives this once per SECTION, and every input is identity-stable
+ * when unchanged, so one retained slot serves the whole pass — and the next one.
+ */
+export function passProducerOf(
+  base: string | undefined,
+  styleCascade: StyleCascadeTable | undefined,
+  noteMarks: NoteMarkContext | undefined,
+  defaultTabStopPt: number | undefined,
+  displayMode: RevisionDisplayMode
+): string {
+  const slot = passProducerSlot;
+  if (
+    slot &&
+    slot.base === base &&
+    slot.styleCascade === styleCascade &&
+    slot.noteMarks === noteMarks &&
+    slot.defaultTabStopPt === defaultTabStopPt &&
+    slot.displayMode === displayMode
+  ) {
+    return slot.producer;
+  }
+  const producer =
+    (base ?? 'unversioned-measurer') +
+    (styleCascade ? `|sc:${styleCascade.cacheToken}` : '') +
+    (noteMarks ? `|nm:${noteMarksCacheToken(noteMarks)}` : '') +
+    (defaultTabStopPt !== undefined ? `|dts:${defaultTabStopPt}` : '') +
+    (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`);
+  passProducerSlot = { base, styleCascade, noteMarks, defaultTabStopPt, displayMode, producer };
+  return producer;
+}

--- a/packages/core/src/layout/pass-producer.ts
+++ b/packages/core/src/layout/pass-producer.ts
@@ -4,13 +4,18 @@
 // control-heavy document. It reaches every section's prepass memo, break-cache key prefix
 // and session comparison — so the string OBJECT must stay stable while its content does,
 // or every one of those `===` checks degrades from a pointer check to a memcmp per section
-// per pass. Both helpers keep one retained slot (bounded); the inputs are identity-stable
-// when unchanged, so a hit is a handful of pointer compares.
+// per pass. The inputs are identity-stable when unchanged, so a hit is a handful of
+// pointer compares.
 
 import { noteMarksCacheToken, type NoteMarkContext } from './note-projection.ts';
 import { DEFAULT_REVISION_DISPLAY_MODE, type RevisionDisplayMode } from './revision-projection.ts';
 import type { StyleCascadeTable } from './style-cascade.ts';
 
+/**
+ * One retained slot. Strings only — the slot pins a few kilobytes of the last document's
+ * token, never its tree — so a module slot is a bounded trade; two live editors merely
+ * alternate one concat per pass instead of sharing the hit.
+ */
 let controlProducerSlot: {
   readonly base: string | undefined;
   readonly token: string;
@@ -26,20 +31,45 @@ export function producerWithControlContext(base: string | undefined, token: stri
   return producer;
 }
 
-let passProducerSlot: {
+interface PassProducerEntry {
   readonly base: string | undefined;
-  readonly styleCascade: StyleCascadeTable | undefined;
   readonly noteMarks: NoteMarkContext | undefined;
   readonly defaultTabStopPt: number | undefined;
   readonly displayMode: RevisionDisplayMode;
   readonly producer: string;
-} | null = null;
+}
+
+/**
+ * Keyed weakly on the style cascade — the one heavy object among the inputs — so a closed
+ * document's cascade, mark context and producer die with it instead of staying pinned in a
+ * module slot, and two live editors keep separate entries. A cascade-less caller (bare
+ * tests, furniture-only passes) falls back to one strings-and-marks slot, which retains no
+ * document tree.
+ */
+const passProducersByCascade = new WeakMap<StyleCascadeTable, PassProducerEntry>();
+let cascadeFreeProducerSlot: PassProducerEntry | null = null;
+
+function passProducerEntryMatches(
+  entry: PassProducerEntry | null | undefined,
+  base: string | undefined,
+  noteMarks: NoteMarkContext | undefined,
+  defaultTabStopPt: number | undefined,
+  displayMode: RevisionDisplayMode
+): entry is PassProducerEntry {
+  return (
+    entry != null &&
+    entry.base === base &&
+    entry.noteMarks === noteMarks &&
+    entry.defaultTabStopPt === defaultTabStopPt &&
+    entry.displayMode === displayMode
+  );
+}
 
 /**
  * The per-pass producer: base plus cascade, note-mark, default-tab and display-mode tokens.
  *
- * A multi-section pass derives this once per SECTION, and every input is identity-stable
- * when unchanged, so one retained slot serves the whole pass — and the next one.
+ * A multi-section pass derives this once per SECTION; rebuilding a content-equal
+ * multi-kilobyte string per section made every downstream `===` a memcmp.
  */
 export function passProducerOf(
   base: string | undefined,
@@ -48,16 +78,9 @@ export function passProducerOf(
   defaultTabStopPt: number | undefined,
   displayMode: RevisionDisplayMode
 ): string {
-  const slot = passProducerSlot;
-  if (
-    slot &&
-    slot.base === base &&
-    slot.styleCascade === styleCascade &&
-    slot.noteMarks === noteMarks &&
-    slot.defaultTabStopPt === defaultTabStopPt &&
-    slot.displayMode === displayMode
-  ) {
-    return slot.producer;
+  const entry = styleCascade ? passProducersByCascade.get(styleCascade) : cascadeFreeProducerSlot;
+  if (passProducerEntryMatches(entry, base, noteMarks, defaultTabStopPt, displayMode)) {
+    return entry.producer;
   }
   const producer =
     (base ?? 'unversioned-measurer') +
@@ -65,6 +88,8 @@ export function passProducerOf(
     (noteMarks ? `|nm:${noteMarksCacheToken(noteMarks)}` : '') +
     (defaultTabStopPt !== undefined ? `|dts:${defaultTabStopPt}` : '') +
     (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`);
-  passProducerSlot = { base, styleCascade, noteMarks, defaultTabStopPt, displayMode, producer };
+  const fresh: PassProducerEntry = { base, noteMarks, defaultTabStopPt, displayMode, producer };
+  if (styleCascade) passProducersByCascade.set(styleCascade, fresh);
+  else cascadeFreeProducerSlot = fresh;
   return producer;
 }

--- a/packages/core/src/layout/section-properties.ts
+++ b/packages/core/src/layout/section-properties.ts
@@ -312,10 +312,24 @@ export function parsePageNumbering(sectPr: OoxmlNode): SectionPageNumbering | un
   return numbering;
 }
 
+/**
+ * Memoized on the immutable `w:sectPr` node. Every layout pass re-enumerates sections over
+ * the fresh part, and re-parsing each unchanged sectPr allocated a new properties object per
+ * pass — which also broke identity-keyed memos downstream (geometry, structure keys).
+ */
+const parsedSectionProperties = new WeakMap<object, SectionProperties>();
+
 /** Parse one `w:sectPr` into geometry/break properties (null reads as Word's defaults). */
 export function parseSectionProperties(sectPr: OoxmlNode | null | undefined): SectionProperties {
   if (!sectPr) return DEFAULT_SECTION_PROPERTIES;
+  const cached = parsedSectionProperties.get(sectPr);
+  if (cached !== undefined) return cached;
+  const parsed = parseSectionPropertiesUncached(sectPr);
+  parsedSectionProperties.set(sectPr, parsed);
+  return parsed;
+}
 
+function parseSectionPropertiesUncached(sectPr: OoxmlNode): SectionProperties {
   const pgSz = childNamed(sectPr, 'pgSz');
   const pgMar = childNamed(sectPr, 'pgMar');
   const cols = childNamed(sectPr, 'cols');
@@ -396,12 +410,22 @@ export function bodySectionNode(part: OoxmlPart): OoxmlNode | undefined {
   return find(part.root);
 }
 
+/**
+ * Memoized on the immutable paragraph: an edit replaces the paragraph object, so the answer
+ * holds for as long as the node does. Section enumeration asks this of EVERY body paragraph
+ * on every fresh part, which made the per-keystroke scan O(document).
+ */
+const paragraphSectionNodes = new WeakMap<OoxmlElement, OoxmlElement | null>();
+
 /** `w:sectPr` nested under a paragraph's `w:pPr`, if present. */
 export function paragraphSectionNode(paragraph: OoxmlElement): OoxmlElement | undefined {
+  const cached = paragraphSectionNodes.get(paragraph);
+  if (cached !== undefined) return cached ?? undefined;
   const pPr = paragraph.children.find((child) => child.kind === 'paragraphProperties');
-  if (!pPr) return undefined;
-  const sectPr = childNamed(pPr, 'sectPr');
-  return sectPr && sectPr.kind !== 'textValue' ? (sectPr as OoxmlElement) : undefined;
+  const sectPr = pPr ? childNamed(pPr, 'sectPr') : undefined;
+  const result = sectPr && sectPr.kind !== 'textValue' ? (sectPr as OoxmlElement) : undefined;
+  paragraphSectionNodes.set(paragraph, result ?? null);
+  return result;
 }
 
 /**

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -152,7 +152,11 @@ import {
   type SectionColumns,
 } from './section-properties.ts';
 import { resolveSectionColumns, type ResolvedSectionColumns } from './section-columns.ts';
-import { inheritNotesLayoutInput, layoutSemanticDocumentWithNotes } from './note-pagination.ts';
+import {
+  inheritNotesLayoutInput,
+  layoutSemanticDocumentWithNotes,
+  notesReserveContextKey,
+} from './note-pagination.ts';
 import { noteMarksCacheToken } from './note-projection.ts';
 import {
   DEFAULT_PAGE_GEOMETRY,
@@ -939,9 +943,12 @@ function layoutBlocksPass(
   // Where this section's first sheet lands in the DOCUMENT. Even/odd header selection
   // alternates by page number, so it is not a section-local question.
   const pageIndexStart = options.pageIndexStart ?? 0;
-  const notesReserveKey = pageBottomReserves
-    ? `|nr:${[...pageBottomReserves].map(([i, h]) => `${i}=${h}`).join(',')}`
-    : '';
+  // Only the reserve entries THIS pass can read belong in its context key. The pass reads
+  // reserves at consecutive page slots as it opens pages, so a bound of "the page count the
+  // previous pass produced, plus one" covers every slot an input-identical replay can touch —
+  // and keeps a reserve on another section's pages from invalidating this one. A fresh
+  // session has no such bound and folds the whole map (conservative, one full pass).
+  const reserveKeyBound = session?.previous ? session.previous.pages.length + 1 : Infinity;
   const columnRegionBottom = options.columnRegionBottom;
   const columnsContext = `|cols:${columns.widths.join(',')};${columns.gaps.join(',')};${columns.separator ? 1 : 0}${columnRegionBottom !== undefined ? `;bal:${columnRegionBottom}` : ''}`;
   // Body line ids are paragraph-local, so a changed line count in an earlier section does
@@ -949,7 +956,9 @@ function layoutBlocksPass(
   // is deliberately NOT here — numbers re-project at finalize and shells renumber at remap;
   // keying on it re-laid every section below an Enter that added one page. The one real
   // dependence, page PARITY, is checked by `comparable` through the session parity fields.
-  const context = `${producer}|${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}|fs:${flowStartY},${spaceBeforeCarry}${furnitureContext}${notesReserveKey}${columnsContext}`;
+  const contextFor = (notesReserveKey: string): string =>
+    `${producer}|${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}|fs:${flowStartY},${spaceBeforeCarry}${furnitureContext}${notesReserveKey}${columnsContext}`;
+  const context = contextFor(notesReserveContextKey(pageBottomReserves, reserveKeyBound));
   const startPageParity = pageIndexStart & 1;
   /** Set when this pass places an anchored drawing whose geometry reads page parity. */
   let usedPageParity = false;
@@ -2997,7 +3006,11 @@ function layoutBlocksPass(
         ]
       : checkpoints;
     session.keys = flowKeys;
-    session.context = context;
+    // Re-sliced with the page count THIS pass produced: a pass that grew past the start-time
+    // bound read reserve slots the start-time key never folded, and the next comparison must
+    // see them. An input-identical replay produces the same count, so its start-time bound
+    // (previous count + 1) rebuilds this exact string.
+    session.context = contextFor(notesReserveContextKey(pageBottomReserves, pages.length + 1));
     // Sticky whenever any part of the previous layout was reused: a resumed pass never
     // re-places the prefix and a converged pass never re-places the tail, so their
     // parity-reading anchors could not fire `onPageParityRead` this pass. Only a pass that

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -115,6 +115,7 @@ import {
 } from './drawing-layout.ts';
 import {
   collectExclusionZonesByPage,
+  collectExclusionZonesByPageMemoized,
   DrawingExclusionConvergenceError,
   exclusionLayoutToken,
   exclusionMapsEqual,
@@ -157,7 +158,7 @@ import {
   layoutSemanticDocumentWithNotes,
   notesReserveContextKey,
 } from './note-pagination.ts';
-import { noteMarksCacheToken } from './note-projection.ts';
+import { passProducerOf, producerWithControlContext } from './pass-producer.ts';
 import {
   DEFAULT_PAGE_GEOMETRY,
   type BlockFragmentRecord,
@@ -574,7 +575,7 @@ export function layoutSemanticDocument(
   const controlToken = contentControlContextToken(part);
   const optionsWithControlContext: SemanticLayoutOptions = {
     ...options,
-    producer: `${options.producer ?? 'unversioned-measurer'}|cc:${controlToken}`,
+    producer: producerWithControlContext(options.producer, controlToken),
     tocFieldChromeParagraphIds:
       options.tocFieldChromeParagraphIds ?? tocFieldChromeParagraphIds(part),
     emptyTocPlaceholderParagraphIds:
@@ -767,10 +768,12 @@ function layoutBlocksPass(
     const seenZoneTokens = new Set<string>();
     const previousPages = options.session?.previous?.pages;
     if (previousPages) {
-      zonesByPage = collectExclusionZonesByPage(
+      zonesByPage = collectExclusionZonesByPageMemoized(
         previousPages,
         options.inlineDrawingLayout,
+        options.drawingLayoutEpoch,
         contentWidthForReflow,
+        options.drawingSourceOrder,
         sourceOrderOf,
         exclusionColumnLayout
       );
@@ -779,10 +782,17 @@ function layoutBlocksPass(
         drawingExclusionPass: 0,
         drawingExclusionZonesByPage: zonesByPage,
       });
-      const nextZones = collectExclusionZonesByPage(
+      // A pass that hands the previous pages back BY IDENTITY was laid under `zonesByPage`
+      // and re-collecting from the same page records under the same inputs reproduces the
+      // same zones — the equality below is true by construction. Every no-change section of
+      // a multi-section document takes this path on every keystroke.
+      if (result.pages === previousPages) return result;
+      const nextZones = collectExclusionZonesByPageMemoized(
         result.pages,
         options.inlineDrawingLayout,
+        options.drawingLayoutEpoch,
         contentWidthForReflow,
+        options.drawingSourceOrder,
         sourceOrderOf,
         exclusionColumnLayout
       );
@@ -890,22 +900,23 @@ function layoutBlocksPass(
   };
   /** `''` for a part with no TOC, which skips the per-block verdict scan entirely. */
   const tocToken = tocIdsToken(tocIds);
-  const producer =
-    (options.producer ?? 'unversioned-measurer') +
-    (styleCascade ? `|sc:${styleCascade.cacheToken}` : '') +
-    // In `producer`, not beside it in the section context: a note mark is measured INTO the
-    // broken lines, so the break cache holds the citation's width under a key built from
-    // this. Keying only the section left a warm cache serving `1`-wide slots to roman marks.
-    (options.noteMarks ? `|nm:${noteMarksCacheToken(options.noteMarks)}` : '') +
-    // NOT THE NUMBER OF LIST ITEMS. `producer` is in the session context, in every paragraph's
-    // break-cache key and in the prepared-block memo, so folding a COUNT in meant one Enter in
-    // a list re-measured every paragraph in the document and rebuilt every page — while two
-    // different numbering states with the same count still hashed the same. What a numbering
-    // change actually affects is each list paragraph, and each one carries its own
-    // `listItem.cacheToken` in its key and in the memo above.
-
-    (defaultTabStopPt !== undefined ? `|dts:${defaultTabStopPt}` : '') +
-    (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`);
+  // In `producer`, not beside it in the section context: a note mark is measured INTO the
+  // broken lines, so the break cache holds the citation's width under a key built from
+  // this. Keying only the section left a warm cache serving `1`-wide slots to roman marks.
+  //
+  // NOT THE NUMBER OF LIST ITEMS. `producer` is in the session context, in every paragraph's
+  // break-cache key and in the prepared-block memo, so folding a COUNT in meant one Enter in
+  // a list re-measured every paragraph in the document and rebuilt every page — while two
+  // different numbering states with the same count still hashed the same. What a numbering
+  // change actually affects is each list paragraph, and each one carries its own
+  // `listItem.cacheToken` in its key and in the memo above.
+  const producer = passProducerOf(
+    options.producer,
+    styleCascade,
+    options.noteMarks,
+    defaultTabStopPt,
+    displayMode
+  );
 
   // Prepass and incremental keys use the first region. Placement re-prepares a block when it
   // enters an unequal-width later column; multi-column passes conservatively skip resume.
@@ -956,8 +967,12 @@ function layoutBlocksPass(
   // is deliberately NOT here — numbers re-project at finalize and shells renumber at remap;
   // keying on it re-laid every section below an Enter that added one page. The one real
   // dependence, page PARITY, is checked by `comparable` through the session parity fields.
+  //
+  // The producer is compared BESIDE the context (`session.producer`), not embedded in it:
+  // it carries the control token, which runs to kilobytes on a control-heavy document, and
+  // embedding it copied that token into every section's context string on every pass.
   const contextFor = (notesReserveKey: string): string =>
-    `${producer}|${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}|fs:${flowStartY},${spaceBeforeCarry}${furnitureContext}${notesReserveKey}${columnsContext}`;
+    `${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}|fs:${flowStartY},${spaceBeforeCarry}${furnitureContext}${notesReserveKey}${columnsContext}`;
   const context = contextFor(notesReserveContextKey(pageBottomReserves, reserveKeyBound));
   const startPageParity = pageIndexStart & 1;
   /** Set when this pass places an anchored drawing whose geometry reads page parity. */
@@ -1232,6 +1247,7 @@ function layoutBlocksPass(
     previous !== null &&
     session !== undefined &&
     session.context === context &&
+    session.producer === producer &&
     (!session.parityDependent || session.startPageParity === startPageParity);
   const resumable = columns.count === 1 && comparable;
 
@@ -3011,6 +3027,7 @@ function layoutBlocksPass(
     // see them. An input-identical replay produces the same count, so its start-time bound
     // (previous count + 1) rebuilds this exact string.
     session.context = contextFor(notesReserveContextKey(pageBottomReserves, pages.length + 1));
+    session.producer = producer;
     // Sticky whenever any part of the previous layout was reused: a resumed pass never
     // re-places the prefix and a converged pass never re-places the tail, so their
     // parity-reading anchors could not fire `onPageParityRead` this pass. Only a pass that

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -774,7 +774,6 @@ function layoutBlocksPass(
         options.drawingLayoutEpoch,
         contentWidthForReflow,
         options.drawingSourceOrder,
-        sourceOrderOf,
         exclusionColumnLayout
       );
       result = layoutBlocksWithGeometry(bodies, revision, {
@@ -793,7 +792,6 @@ function layoutBlocksPass(
         options.drawingLayoutEpoch,
         contentWidthForReflow,
         options.drawingSourceOrder,
-        sourceOrderOf,
         exclusionColumnLayout
       );
       if (exclusionMapsEqual(zonesByPage, nextZones)) return result;
@@ -3025,8 +3023,13 @@ function layoutBlocksPass(
     // Re-sliced with the page count THIS pass produced: a pass that grew past the start-time
     // bound read reserve slots the start-time key never folded, and the next comparison must
     // see them. An input-identical replay produces the same count, so its start-time bound
-    // (previous count + 1) rebuilds this exact string.
-    session.context = contextFor(notesReserveContextKey(pageBottomReserves, pages.length + 1));
+    // (previous count + 1) rebuilds this exact string. When the counts agree the start-time
+    // string IS that string — reuse it by identity so the next pass's context check is a
+    // pointer compare, not a rebuild plus memcmp.
+    session.context =
+      pages.length + 1 === reserveKeyBound
+        ? context
+        : contextFor(notesReserveContextKey(pageBottomReserves, pages.length + 1));
     session.producer = producer;
     // Sticky whenever any part of the previous layout was reused: a resumed pass never
     // re-places the prefix and a converged pass never re-places the tail, so their

--- a/scripts/bench/settle-bench-gates.test.ts
+++ b/scripts/bench/settle-bench-gates.test.ts
@@ -51,12 +51,15 @@ test('a keystroke on the huge document performs the pinned amount of work', () =
   expect(report.paragraphs).toBe(12820);
   expect(report.work).toEqual({
     // The last pass of a one-character keystroke: a handful of re-placed paragraphs against
-    // the document's total, everything else reused. `fullPasses` counts the two passes the
-    // OPEN performs; typing must add none.
+    // the document's total, everything else reused. `fullPasses` counts the passes the OPEN
+    // performs; typing must add none. The open's note-reserve reflow used to force a second
+    // full pass because the document-wide reserve map was folded into every section's
+    // context key; the key now folds only the reserve slots a section's own pass can read,
+    // so the reflow's second body pass reuses every section and only the first pass is full.
     placed: 7,
     total: 6540,
     reusedPages: 555,
-    fullPasses: 2,
+    fullPasses: 1,
     staleDiscards: 0,
     cancelledRuns: 0,
   });


### PR DESCRIPTION
Fixes #449. Fixes #450.

Each lever is one commit, so a regression bisects.

## What changes

For #450, a section's layout context key now folds only the note-reserve slots its own pass can read, bounded by the previous pass's page count plus one. The stored context re-slices with the count the pass actually produced, so a pass that grows past its start-time bound cannot be resumed against a key that never folded the slots it read. The open's reserve reflow pass then reuses every unreserved section, so the settle-bench gate pins `fullPasses` at 1 instead of 2. No other counter moves.

For #449, each per-keystroke sweep applies the established per-immutable-node memo idiom: sectPr parses and per-paragraph sectPr lookups, content-control subtree tokens at any depth, the note wrap's section index and per-page ref filters, the collected control index with per-control chrome, and the wrap-exclusion zone collection. The pass producer and the control token stay identity-stable across passes, and the session compares the producer beside the context string instead of embedding a multi-kilobyte token into it per section.

## Measurements

Pinned 521-page fixture, same machine, quiet load, headless `bench:huge`:

- Keystroke layout median: 33.5 ms to 16.8 ms. Enter variant: 59.3 ms to 50.7 ms.
- Open: about 2.8 s to about 2.3 to 2.6 s (the reflow's second body pass reuses every section).
- Work counters are byte-identical except the deliberate `fullPasses` 2 to 1. `bench:edit` counters on `synthetic-massive-multisection.docx` match main exactly.

## Tests

- Multi-section reserve locality: a reserve change on section 0 relayouts only section 0, other sections' pages return by reference, and the result matches a clean pass. The open test pins the reflow pass's placed and reused counts.
- The content-control token memo gets its own differential (control add, retitle, lock change, in-control edits, depth shifts) against a memo-cold structuredClone recompute, because neither randomized-oracle fixture carries content controls.
- Both randomized layout oracles, the full suite, typecheck, lint, parity, i18n, and `api:check` pass.

## Known limitation

Reserve maps are computed at document page indexes but read at pass-local slots, so multi-section reserves misalign for sections after the first. That is pre-existing behavior; the new key slice is deliberately bug-compatible with it, and the fix is tracked as #460 because it changes layout output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790246958&installation_model_id=422592&pr_number=462&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F462&signature=8b0d4e3f8bcced9518ee91286827038efa5b1c16fc7612bdab628c7630a15808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->