### PR TITLE
fix: track tabs and breaks in suggesting mode and keep armed formats across relocation

### DIFF
--- a/.changeset/tracked-tab-break-insertions.md
+++ b/.changeset/tracked-tab-break-insertions.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Suggesting mode now records inserted tabs, line breaks, and page breaks as tracked insertions, and an armed typing format is no longer dropped when the insert relocates past struck text. Fixes #458

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3478,9 +3478,9 @@ export interface ReviewModelInput {
     readonly commentsExtendedPart?: OoxmlPart | undefined;
     readonly commentsPart?: OoxmlPart | undefined;
     readonly customNodePayloads?: ReadonlyMap<string, {
-        readonly nodeId: string;
-        readonly label: string;
         readonly data: string;
+        readonly label: string;
+        readonly nodeId: string;
     }> | undefined;
     readonly customNodes?: readonly unknown[] | undefined;
     readonly furnitureParts?: readonly OoxmlPart[] | undefined;
@@ -3986,14 +3986,17 @@ export type TreeDocOp = {
     readonly offset: number;
     readonly op: 'insertTab';
     readonly paragraphId: string;
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly offset: number;
     readonly op: 'insertHardBreak';
     readonly paragraphId: string;
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly offset: number;
     readonly op: 'insertPageBreak';
     readonly paragraphId: string;
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly field: 'PAGE' | 'NUMPAGES' | 'SECTIONPAGES' | 'PAGE_X_OF_Y';
     readonly offset: number;

--- a/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
@@ -381,16 +381,76 @@ describe('replacing a selection that spans paragraphs, in suggesting mode', () =
     });
   });
 
-  test('a Tab over a selection lands after the struck words', () => {
+  test('a Tab over a selection lands after the struck words, as a proposal', () => {
     withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
       selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
       surface.insertTab();
       expect(surface.state().lastRejection).toBeNull();
       const xml = serializeOoxmlPart(surface.session.part());
-      // The strike then the tab, adjacent. (The tab itself is still written untracked in
-      // suggesting mode — a separate attribution gap; this pins only where it lands.)
-      expect(xml).toMatch(/<w:delText[^>]*>Beta<\/w:delText><\/w:r><\/w:del><w:r><w:tab\/>/);
+      // The strike then the tab, adjacent — and the tab is itself a tracked insertion, so
+      // Accept/Reject can act on it rather than the file recording an unattributed edit.
+      expect(xml).toMatch(
+        /<w:delText[^>]*>Beta<\/w:delText><\/w:r><\/w:del><w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:tab\/>/
+      );
       expect(surface.state().selection.head.offset).toBe('Alpha Beta'.length + 1);
+    });
+  });
+
+  test('a line break and a page break are proposals too', () => {
+    withSurface(plainParagraph('Alpha one') + plainParagraph('Beta two'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      surface.insertLineBreak();
+      caretTo(surface, 1, 'Beta'.length);
+      surface.insertPageBreak();
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:br\/><\/w:r><\/w:ins>/);
+      expect(xml).toMatch(
+        /<w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:br w:type="page"\/><\/w:r><\/w:ins>/
+      );
+    });
+  });
+
+  test('rejecting the proposal removes the tab', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      surface.insertTab();
+      expect(surface.state().lastRejection).toBeNull();
+      expect(serializeOoxmlPart(surface.session.part())).toMatch(/<w:tab\/>/);
+      const result = surface.session.applyTreeOps([{ op: 'rejectAllRevisions' }]);
+      expect(result.committed).toBe(true);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).not.toMatch(/<w:tab\/>/);
+      expect(xml).not.toMatch(/<w:ins/);
+    });
+  });
+
+  test('a Tab inside your own pending insertion extends it instead of nesting', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      caretTo(surface, 0, 0);
+      typeEach(surface, 'ab');
+      caretTo(surface, 0, 1);
+      surface.insertTab();
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // ONE insertion: the tab joins the run the author is already proposing.
+      expect(xml).toMatch(/<w:ins[^>]*><w:r><w:t[^>]*>a<\/w:t><w:tab\/><w:t[^>]*>b<\/w:t>/);
+      expect(xml.match(/<w:ins /g)).toHaveLength(1);
+    });
+  });
+
+  test('a format armed at a caret INSIDE struck words survives the relocation', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      selectIn(surface, 0, 0, 'Alpha'.length);
+      surface.deleteBackward();
+      caretTo(surface, 0, 2);
+      surface.toggleRunProperty('b');
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['AlphaX one']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      // The insert relocated past the deletion, and the armed bold rode along with it.
+      expect(xml).toMatch(/<w:ins[^>]*><w:r><w:rPr><w:b\/><\/w:rPr><w:t[^>]*>X<\/w:t>/);
     });
   });
 

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -521,7 +521,13 @@ export function mountPaginatedSurface(
   ): TreeDocOp[] {
     const armed = armedAtCaret();
     if (!armed || length === 0) return [];
-    const at = pendingFormats!.position;
+    // The insert this format rides RELOCATES past a deletion the caret rests in — the rule
+    // `rangeDeletionPlan` applies through `positionPastDeletion`. The armed anchor must
+    // follow the same relocation, or the two positions disagree by construction and the
+    // armed ops silently vanish: bold armed inside a `w:del`, then a character typed there,
+    // landed correctly and unbold. Identity everywhere else, so the exact-position check
+    // still guards a consumer that aims somewhere the caret never was.
+    const at = positionPastDeletion(currentLayout, pendingFormats!.position);
     if (at.paragraphId !== paragraphId || at.offset !== offset) return [];
     return [
       {
@@ -2685,13 +2691,46 @@ export function mountPaginatedSurface(
   }
 
   /** Ops that create or extend a reviewable proposal. */
+  /**
+   * The ops that carry per-op revision attribution, spelled ONCE.
+   *
+   * `attributeTrackedOps` stamps exactly these and `isTrackedEdit` reports exactly these, so
+   * a new revision-capable op added to one list but not the other would either write
+   * untracked in suggesting mode — the #458 failure — or stop `onTrackedChange` firing.
+   * Tabs and breaks are members because they are insertions too: passed through
+   * unattributed, they serialized as a plain run beside the strike — an edit the review
+   * pane could neither accept nor reject, in a document whose author believed everything
+   * they did was a proposal.
+   */
+  type RevisionCapableOp = Extract<
+    TreeDocOp,
+    {
+      op:
+        | 'insertText'
+        | 'deleteText'
+        | 'insertTab'
+        | 'insertHardBreak'
+        | 'insertPageBreak'
+        | 'insertTableRow'
+        | 'deleteTableRow';
+    }
+  >;
+  const REVISION_CAPABLE_OPS: ReadonlySet<TreeDocOp['op']> = new Set<RevisionCapableOp['op']>([
+    'insertText',
+    'deleteText',
+    'insertTab',
+    'insertHardBreak',
+    'insertPageBreak',
+    'insertTableRow',
+    'deleteTableRow',
+  ]);
+  function isRevisionCapable(op: TreeDocOp): op is RevisionCapableOp {
+    return REVISION_CAPABLE_OPS.has(op.op);
+  }
+
   function isTrackedEdit(op: TreeDocOp): boolean {
+    if (isRevisionCapable(op)) return op.revision !== undefined;
     switch (op.op) {
-      case 'insertText':
-      case 'deleteText':
-      case 'insertTableRow':
-      case 'deleteTableRow':
-        return op.revision !== undefined;
       case 'setParagraphMarkRevision':
       case 'proposeParagraphMerge':
         return true;
@@ -2709,22 +2748,9 @@ export function mountPaginatedSurface(
     revision: import('../store/store/tree-op-types.ts').RevisionAttributionInput
   ): TreeDocOp[] {
     return ops.flatMap((op): TreeDocOp[] => {
-      if (
-        (op.op === 'insertText' ||
-          op.op === 'deleteText' ||
-          op.op === 'insertTableRow' ||
-          op.op === 'deleteTableRow') &&
-        op.revision !== undefined
-      ) {
-        return [op];
-      }
-      if (
-        op.op === 'insertText' ||
-        op.op === 'deleteText' ||
-        op.op === 'insertTableRow' ||
-        op.op === 'deleteTableRow'
-      ) {
-        return [{ ...op, revision }];
+      // Already-attributed ops pass through untouched — a caller that named an author keeps it.
+      if (isRevisionCapable(op)) {
+        return [op.revision !== undefined ? op : { ...op, revision }];
       }
       // A SPLIT becomes a real split plus a proposed mark on the first paragraph: the text
       // is already in two paragraphs, and what is being proposed is the break between them.

--- a/packages/core/src/store/__tests__/review-reads.test.ts
+++ b/packages/core/src/store/__tests__/review-reads.test.ts
@@ -287,6 +287,35 @@ describe('a document with no tracked changes', () => {
     expect(items[0]!.text).toBe('MORE');
     expect(items[0]!.ranges[0]!.start.paragraphId).toBe(paragraphId);
   });
+
+  // A tab or a break has no `w:t`, so its card read as EMPTY — the reviewer was asked to
+  // accept content they were never shown. The card projects the same character the offset
+  // model counts for the element.
+  test('a tracked tab derives a card with the tab character, not empty text', () => {
+    const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+        `<w:p><w:r><w:t>plain words only</w:t></w:r></w:p>` +
+        `</w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    const store = new TreeDocumentStore(result.part);
+    const paragraphId = [...deepParagraphOrderOfPart(store.part).keys()][0]!;
+    const applied = store.transact((tx) => {
+      tx.apply({
+        op: 'insertTab',
+        paragraphId,
+        offset: 5,
+        revision: { author: 'QA Reviewer', date: '2026-01-01T00:00:00Z' },
+      });
+    });
+    expect(applied.ok).toBe(true);
+    const items = revisionItemsOf(store.part);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.revisionKind).toBe('insert');
+    expect(items[0]!.text).toBe('\t');
+  });
 });
 
 describe('the revision-card memo is keyed on the part, not just its root', () => {

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -15,6 +15,7 @@
 
 import { WML_NAMESPACE_URI } from '../package/ooxml-tree.ts';
 import type { OoxmlElement, OoxmlNode, OoxmlPart } from '../package/ooxml-tree.ts';
+import { hardBreakText } from '../package/hard-break.ts';
 import { collectRevisionSites } from './tree-op-revisions.ts';
 import type { RevisionAddress } from './tree-op-types.ts';
 import {
@@ -86,6 +87,12 @@ function wmlAttribute(node: OoxmlElement, localName: string): string | undefined
 /** Text under a node, counting `w:t` and `w:delText` alike. */
 function textUnder(node: OoxmlNode): string {
   if (node.kind === 'textValue') return node.value;
+  // A tab or a break carries no text value, so a card derived from a tracked one read as
+  // EMPTY — the reviewer was asked to accept content they were never shown, and a tab
+  // replacing a word presented as a pure deletion. Project the same characters the offset
+  // model counts for them.
+  if (node.kind === 'tab') return '\t';
+  if (node.kind === 'hardBreak') return hardBreakText(node);
   let text = '';
   for (const child of node.children) text += textUnder(child);
   return text;

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -33,6 +33,7 @@ import { applyInsertCommentMarker } from './tree-op-comments.ts';
 import {
   applyDeleteTracked,
   applyInsertTracked,
+  applyInsertTrackedElement,
   applyParagraphMarkRevision,
   applyProposeParagraphMerge,
   retractsOwnParagraphMark,
@@ -174,6 +175,15 @@ function simpleElement(
     children: [],
   } as unknown as OoxmlNode;
 }
+
+/** The one run-level element each insert op places, shared by its tracked and untracked arms. */
+const RUN_ELEMENT_INSERTS: Readonly<
+  Record<'insertTab' | 'insertHardBreak' | 'insertPageBreak', (nextId: () => string) => OoxmlNode>
+> = {
+  insertTab: (nextId) => simpleElement(nextId, 'tab'),
+  insertHardBreak: (nextId) => simpleElement(nextId, 'br', 'line'),
+  insertPageBreak: (nextId) => simpleElement(nextId, 'br', 'page'),
+};
 
 /**
  * Where the caller's characters go once a prompt has been emptied.
@@ -383,21 +393,16 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
         op.bias
       );
     case 'insertTab':
-      return applyInsertContent(
-        part,
-        paragraph,
-        op.offset,
-        [(mint) => simpleElement(mint, 'tab')],
-        options
-      );
     case 'insertHardBreak':
-      return applyInsertContent(
-        part,
-        paragraph,
-        op.offset,
-        [(mint) => simpleElement(mint, 'br', 'line')],
-        options
-      );
+    case 'insertPageBreak': {
+      // ONE builder per op, shared by the tracked and untracked arms — two lambdas per op
+      // would let suggesting mode insert a different element than edit mode for the same key.
+      const element = RUN_ELEMENT_INSERTS[op.op];
+      if (op.revision) {
+        return applyInsertTrackedElement(part, paragraph, op.offset, element, op.revision, options);
+      }
+      return applyInsertContent(part, paragraph, op.offset, [element], options);
+    }
     case 'setListLevel':
       return applySetListLevel(part, paragraph, op.level, options, nextId);
     case 'setParagraphMarkProperties':
@@ -412,14 +417,6 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
         op.inForcePositionsTwips,
         options,
         nextId
-      );
-    case 'insertPageBreak':
-      return applyInsertContent(
-        part,
-        paragraph,
-        op.offset,
-        [(mint) => simpleElement(mint, 'br', 'page')],
-        options
       );
     case 'insertPageField':
       return applyInsertContent(

--- a/packages/core/src/store/store/tree-op-revision-ids.ts
+++ b/packages/core/src/store/store/tree-op-revision-ids.ts
@@ -1,0 +1,101 @@
+// Minting `@w:id` values for NEW revisions — the id space the tracked-edit appliers draw on.
+//
+// Split from `tree-op-tracked.ts`, which owns the wrappers and placement rules; this module
+// owns only the question "which id is free in this part".
+
+import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlPart } from '../package/ooxml-tree.ts';
+
+/**
+ * The next free `@w:id` for a revision in this part.
+ *
+ * `ST_DecimalNumber`, and only ever compared for equality — Word writes them densely from
+ * zero and nothing reads them as an order. Taking one past the highest in use keeps a new
+ * revision from joining an existing one by accident, which is what an id collision means.
+ */
+export function nextRevisionId(part: OoxmlPart): () => string {
+  let highest = -1;
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    // REVISION ids only. `@w:id` is also carried by bookmarks, comments and permissions,
+    // and those are separate id spaces — a `w:bookmarkStart` id is attacker-controlled and
+    // unbounded (`ST_DecimalNumber` is xsd:integer), so scanning them all let a 23-digit
+    // bookmark id produce `w:id="1e+22"`: not an integer, and a file Word calls unreadable.
+    if (REVISION_ID_BEARING.has(node.localName) && node.namespaceUri === WML_NAMESPACE_URI) {
+      for (const attribute of node.attributes) {
+        if (attribute.namespaceUri !== WML_NAMESPACE_URI || attribute.localName !== 'id') continue;
+        // Strictly parsed and clamped: Word reads a revision id as a 32-bit signed integer,
+        // so a larger value is not something to count past — it is something to ignore.
+        if (!/^\d{1,10}$/.test(attribute.value)) continue;
+        const value = Number(attribute.value);
+        if (value <= MAX_REVISION_ID && value > highest) highest = value;
+      }
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(part.root);
+  let next = highest + 1;
+  return () => {
+    // Past the ceiling there is no "one higher" left, and clamping to it would hand back an
+    // id the file already uses — turning every edit the user makes into a member of somebody
+    // else's revision, which a crafted `@w:id` could force deliberately. Wrap and take the
+    // lowest id nobody is using instead.
+    if (next > MAX_REVISION_ID) {
+      const used = usedRevisionIds(part);
+      for (let candidate = 0; candidate <= MAX_REVISION_ID; candidate += 1) {
+        if (!used.has(String(candidate))) return String(candidate);
+      }
+      // Two billion revisions in one part is not a document; refuse to invent a collision.
+      throw new TypeError('no free revision id');
+    }
+    return String(next++);
+  };
+}
+
+/** Every revision id in use, for the wrap-around case. */
+function usedRevisionIds(part: OoxmlPart): Set<string> {
+  const used = new Set<string>();
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (REVISION_ID_BEARING.has(node.localName) && node.namespaceUri === WML_NAMESPACE_URI) {
+      for (const attribute of node.attributes) {
+        if (attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id') {
+          used.add(attribute.value);
+        }
+      }
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(part.root);
+  return used;
+}
+
+/**
+ * The elements whose `@w:id` is a REVISION id. Every other `@w:id` is a different space.
+ *
+ * Matched on LOCAL NAME, not on the typed kind: only the four content wrappers get a kind of
+ * their own, and `w:cellIns`, `w:trPr/w:ins`, `w:rPrChange` and the rest read as `generic`.
+ * Keying on kind missed them, so a document whose only revisions were a tracked row
+ * insertion minted an id already in use — and the new edit then shared an address with a
+ * structural revision the engine refuses, which marked the user's own insertion read-only.
+ */
+const REVISION_ID_BEARING: ReadonlySet<string> = new Set([
+  'ins',
+  'del',
+  'moveFrom',
+  'moveTo',
+  'cellIns',
+  'cellDel',
+  'cellMerge',
+  'rPrChange',
+  'pPrChange',
+  'tblPrChange',
+  'tblPrExChange',
+  'tcPrChange',
+  'trPrChange',
+  'sectPrChange',
+  'tblGridChange',
+  'numberingChange',
+]);
+
+/** `ST_DecimalNumber` is unbounded; Word's reader is not. */
+const MAX_REVISION_ID = 2147483647;

--- a/packages/core/src/store/store/tree-op-tables.ts
+++ b/packages/core/src/store/store/tree-op-tables.ts
@@ -53,7 +53,7 @@ import { paragraphIdsWithin } from './tree-op-blocks.ts';
 import { fromEdit, TEXT_DEPS } from './tree-op-nodes.ts';
 import { isWmlElement, wmlAttributeValue, wmlChildNamed } from './tree-op-table-shared.ts';
 import { readEditableTableTopology, type EditableTableTopology } from './tree-op-table-topology.ts';
-import { nextRevisionId } from './tree-op-tracked.ts';
+import { nextRevisionId } from './tree-op-revision-ids.ts';
 import type {
   RevisionAttributionInput,
   TreeOpEffect,

--- a/packages/core/src/store/store/tree-op-tracked.ts
+++ b/packages/core/src/store/store/tree-op-tracked.ts
@@ -39,6 +39,7 @@ import {
   replaceChildren,
 } from '../package/ooxml-edit.ts';
 import { equivalentNodes } from './ooxml-node-equality.ts';
+import { nextRevisionId } from './tree-op-revision-ids.ts';
 import { TEXT_DEPS, fromEdit } from './tree-op-nodes.ts';
 import { paragraphOffsetIndex, type ParagraphOffsetIndex } from './tree-op-segments.ts';
 import { insertionAuthor, insideDeletion } from './tree-op-retraction.ts';
@@ -73,101 +74,6 @@ function build(
   } as OoxmlElement;
 }
 
-/**
- * The next free `@w:id` for a revision in this part.
- *
- * `ST_DecimalNumber`, and only ever compared for equality — Word writes them densely from
- * zero and nothing reads them as an order. Taking one past the highest in use keeps a new
- * revision from joining an existing one by accident, which is what an id collision means.
- */
-export function nextRevisionId(part: OoxmlPart): () => string {
-  let highest = -1;
-  const visit = (node: OoxmlNode): void => {
-    if (node.kind === 'textValue') return;
-    // REVISION ids only. `@w:id` is also carried by bookmarks, comments and permissions,
-    // and those are separate id spaces — a `w:bookmarkStart` id is attacker-controlled and
-    // unbounded (`ST_DecimalNumber` is xsd:integer), so scanning them all let a 23-digit
-    // bookmark id produce `w:id="1e+22"`: not an integer, and a file Word calls unreadable.
-    if (REVISION_ID_BEARING.has(node.localName) && node.namespaceUri === WML_NAMESPACE_URI) {
-      for (const attribute of node.attributes) {
-        if (attribute.namespaceUri !== WML_NAMESPACE_URI || attribute.localName !== 'id') continue;
-        // Strictly parsed and clamped: Word reads a revision id as a 32-bit signed integer,
-        // so a larger value is not something to count past — it is something to ignore.
-        if (!/^\d{1,10}$/.test(attribute.value)) continue;
-        const value = Number(attribute.value);
-        if (value <= MAX_REVISION_ID && value > highest) highest = value;
-      }
-    }
-    for (const child of node.children) visit(child);
-  };
-  visit(part.root);
-  let next = highest + 1;
-  return () => {
-    // Past the ceiling there is no "one higher" left, and clamping to it would hand back an
-    // id the file already uses — turning every edit the user makes into a member of somebody
-    // else's revision, which a crafted `@w:id` could force deliberately. Wrap and take the
-    // lowest id nobody is using instead.
-    if (next > MAX_REVISION_ID) {
-      const used = usedRevisionIds(part);
-      for (let candidate = 0; candidate <= MAX_REVISION_ID; candidate += 1) {
-        if (!used.has(String(candidate))) return String(candidate);
-      }
-      // Two billion revisions in one part is not a document; refuse to invent a collision.
-      throw new TypeError('no free revision id');
-    }
-    return String(next++);
-  };
-}
-
-/** Every revision id in use, for the wrap-around case. */
-function usedRevisionIds(part: OoxmlPart): Set<string> {
-  const used = new Set<string>();
-  const visit = (node: OoxmlNode): void => {
-    if (node.kind === 'textValue') return;
-    if (REVISION_ID_BEARING.has(node.localName) && node.namespaceUri === WML_NAMESPACE_URI) {
-      for (const attribute of node.attributes) {
-        if (attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id') {
-          used.add(attribute.value);
-        }
-      }
-    }
-    for (const child of node.children) visit(child);
-  };
-  visit(part.root);
-  return used;
-}
-
-/**
- * The elements whose `@w:id` is a REVISION id. Every other `@w:id` is a different space.
- *
- * Matched on LOCAL NAME, not on the typed kind: only the four content wrappers get a kind of
- * their own, and `w:cellIns`, `w:trPr/w:ins`, `w:rPrChange` and the rest read as `generic`.
- * Keying on kind missed them, so a document whose only revisions were a tracked row
- * insertion minted an id already in use — and the new edit then shared an address with a
- * structural revision the engine refuses, which marked the user's own insertion read-only.
- */
-const REVISION_ID_BEARING: ReadonlySet<string> = new Set([
-  'ins',
-  'del',
-  'moveFrom',
-  'moveTo',
-  'cellIns',
-  'cellDel',
-  'cellMerge',
-  'rPrChange',
-  'pPrChange',
-  'tblPrChange',
-  'tblPrExChange',
-  'tcPrChange',
-  'trPrChange',
-  'sectPrChange',
-  'tblGridChange',
-  'numberingChange',
-]);
-
-/** `ST_DecimalNumber` is unbounded; Word's reader is not. */
-const MAX_REVISION_ID = 2147483647;
-
 function revisionAttributes(id: string, revision: RevisionAttributionInput) {
   return [
     attr('id', id),
@@ -188,14 +94,9 @@ function textNode(mint: () => string, value: string, deleted: boolean): OoxmlNod
   );
 }
 
-/** A run carrying `properties` (its `w:rPr`, kept) and one text node. */
-function runWith(
-  mint: () => string,
-  properties: readonly OoxmlNode[],
-  value: string,
-  deleted: boolean
-): OoxmlNode {
-  return build(mint(), 'run', 'r', [], [...properties, textNode(mint, value, deleted)]);
+/** A `w:r` over its children — the ONE spelling of the run shape this module writes. */
+function runOf(mint: () => string, children: readonly OoxmlNode[]): OoxmlNode {
+  return build(mint(), 'run', 'r', [], children);
 }
 
 function isRunProperties(node: OoxmlNode): boolean {
@@ -301,6 +202,18 @@ function holdsAtomBegin(node: OoxmlNode, atoms: AtomNodes): boolean {
 }
 
 /**
+ * What a tracked insertion places: run text, or one run-level element (a tab or a break).
+ *
+ * `length` is the payload's size in MODEL units, on `segmentsOf`'s terms — `text.length`
+ * for characters, one for a tab or a break — so the extend-own-insertion path can step the
+ * cursor past what it just placed without re-measuring the rebuilt run.
+ */
+interface TrackedInsertionPayload {
+  readonly length: number;
+  readonly nodes: (mint: () => string) => readonly OoxmlNode[];
+}
+
+/**
  * Insert `text` at `offset` as a tracked insertion.
  *
  * Returns the paragraph's new children, or null when the offset was never reached — which
@@ -315,8 +228,51 @@ export function applyInsertTracked(
   revision: RevisionAttributionInput,
   options?: { readonly deferValidation?: boolean }
 ): TreeOpResult {
+  return applyTrackedInsertion(
+    part,
+    paragraph,
+    offset,
+    { length: text.length, nodes: (mint) => [textNode(mint, text, false)] },
+    revision,
+    options
+  );
+}
+
+/**
+ * Insert ONE run-level element — a tab or a break — at `offset` as a tracked insertion.
+ *
+ * The element builder comes from the caller because the element vocabulary lives with the
+ * untracked appliers; this module owns only the wrapper and the placement rules, which are
+ * the same ones typed text follows. A tab or break inserted in suggesting mode used to pass
+ * through unwrapped, so the file recorded an unattributed edit Accept/Reject could not act on.
+ */
+export function applyInsertTrackedElement(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  offset: number,
+  element: (mint: () => string) => OoxmlNode,
+  revision: RevisionAttributionInput,
+  options?: { readonly deferValidation?: boolean }
+): TreeOpResult {
+  return applyTrackedInsertion(
+    part,
+    paragraph,
+    offset,
+    { length: 1, nodes: (mint) => [element(mint)] },
+    revision,
+    options
+  );
+}
+
+function applyTrackedInsertion(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  offset: number,
+  payload: TrackedInsertionPayload,
+  revision: RevisionAttributionInput,
+  options?: { readonly deferValidation?: boolean }
+): TreeOpResult {
   const mint = createNodeIdAllocator(part);
-  const mintRevision = nextRevisionId(part);
   const offsets = paragraphOffsetIndex(paragraph);
   const effect: TreeOpEffect = {
     dirty: [paragraph.id],
@@ -347,11 +303,13 @@ export function applyInsertTracked(
   const attribution: RevisionAttributionInput = replaced
     ? { author: revision.author, ...(replaced.date === undefined ? {} : { date: replaced.date }) }
     : revision;
-  const insertionId = replaced?.id ?? mintRevision();
+  // Minted LAZILY: `nextRevisionId` walks the whole part, and an insertion that adopts the
+  // adjacent deletion's id — every replace-typing keystroke — would pay that walk for nothing.
+  const insertionId = replaced?.id ?? nextRevisionId(part)();
 
   const wrap = (properties: readonly OoxmlNode[]): OoxmlNode =>
     build(mint(), 'revisionInsert', 'ins', revisionAttributes(insertionId, attribution), [
-      runWith(mint, properties, text, false),
+      runOf(mint, [...properties, ...payload.nodes(mint)]),
     ]);
 
   const rebuild = (nodes: readonly OoxmlNode[], stack: readonly OoxmlNode[]): OoxmlNode[] => {
@@ -477,9 +435,9 @@ export function applyInsertTracked(
         // Inside our OWN pending insertion: extend it. A second `w:ins` nested in the first
         // says two people proposed the same words, which is not what happened.
         if (own === revision.author) {
-          out.push(splitRunAndInsert(mint, offsets, node, offset - start, text, false));
+          out.push(splitRunAndInsert(mint, offsets, node, offset - start, payload.nodes(mint)));
           placed = true;
-          cursor.offset = end + text.length;
+          cursor.offset = end + payload.length;
           continue;
         }
         const properties = childrenOf(node)
@@ -541,30 +499,29 @@ function splitRun(
     seen += length;
   }
   return [
-    build(mint(), 'run', 'r', [], [...properties.map((child) => copy(mint, child)), ...head]),
-    build(mint(), 'run', 'r', [], [...properties.map((child) => copy(mint, child)), ...tail]),
+    runOf(mint, [...properties.map((child) => copy(mint, child)), ...head]),
+    runOf(mint, [...properties.map((child) => copy(mint, child)), ...tail]),
   ];
 }
 
-/** Put `text` into an existing run at a local offset — the extend-my-own-insertion path. */
+/** Put new content into an existing run at a local offset — the extend-my-own-insertion path. */
 function splitRunAndInsert(
   mint: () => string,
   offsets: ParagraphOffsetIndex,
   run: OoxmlNode,
   local: number,
-  text: string,
-  deleted: boolean
+  nodes: readonly OoxmlNode[]
 ): OoxmlNode {
   const [head, tail] = splitRun(mint, offsets, run, local);
   const content = [
     ...childrenOf(head).filter((child) => !isRunProperties(child)),
-    textNode(mint, text, deleted),
+    ...nodes,
     ...childrenOf(tail).filter((child) => !isRunProperties(child)),
   ];
   const properties = childrenOf(run)
     .filter(isRunProperties)
     .map((child) => copy(mint, child));
-  return build(mint(), 'run', 'r', [], [...properties, ...coalesced(mint, content)]);
+  return runOf(mint, [...properties, ...coalesced(mint, content)]);
 }
 
 /**

--- a/packages/core/src/store/store/tree-op-types.ts
+++ b/packages/core/src/store/store/tree-op-types.ts
@@ -315,9 +315,27 @@ export type TreeDocOp =
       /** Internal shared-notes scope. When present, this must be the canonical id of a note root. */
       readonly scopeRootId?: string;
     }
-  | { readonly op: 'insertTab'; readonly paragraphId: string; readonly offset: number }
-  | { readonly op: 'insertHardBreak'; readonly paragraphId: string; readonly offset: number }
-  | { readonly op: 'insertPageBreak'; readonly paragraphId: string; readonly offset: number }
+  | {
+      readonly op: 'insertTab';
+      readonly paragraphId: string;
+      readonly offset: number;
+      /** Write this as a TRACKED insertion, on the same terms as `insertText`. */
+      readonly revision?: RevisionAttributionInput;
+    }
+  | {
+      readonly op: 'insertHardBreak';
+      readonly paragraphId: string;
+      readonly offset: number;
+      /** Write this as a TRACKED insertion, on the same terms as `insertText`. */
+      readonly revision?: RevisionAttributionInput;
+    }
+  | {
+      readonly op: 'insertPageBreak';
+      readonly paragraphId: string;
+      readonly offset: number;
+      /** Write this as a TRACKED insertion, on the same terms as `insertText`. */
+      readonly revision?: RevisionAttributionInput;
+    }
   | {
       /**
        * Insert an allowlisted page-number complex field at a UTF-16 offset.

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -642,6 +642,14 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
       if (!Number.isInteger(op.offset) || op.offset < 0 || op.offset > length) {
         return 'offset-out-of-range';
       }
+      // `CT_TrackChange` makes `@w:author` required, so a tracked variant with an empty one
+      // would serialize a proposal no reader can attribute or resolve.
+      if (
+        op.revision !== undefined &&
+        (typeof op.revision.author !== 'string' || op.revision.author.length === 0)
+      ) {
+        return 'invalid-property-value';
+      }
       if (splitsSurrogate(paragraph, op.offset)) return 'splits-surrogate-pair';
       return rejectContentEdit(part, paragraph, op.offset, op.offset);
     }


### PR DESCRIPTION
In suggesting mode, a tab, line break, or page break now writes a `w:ins`-wrapped tracked insertion instead of a plain run, so the review pane can accept or reject it. The tracked-insertion core in `packages/core/src/store/store/tree-op-tracked.ts` is generalized to place one run-level element on the same terms as text, including extending the author's own pending insertion. Review cards project the tab or break character instead of empty text.

A typing format armed at a caret inside struck text now follows the same relocation the insert follows (`positionPastDeletion`), so the armed properties apply instead of silently vanishing.

The revision id is minted lazily when an insertion adopts an adjacent deletion's id, and an empty `revision.author` on the new op fields is refused. The remaining untracked insert lanes (page field, hyperlink, note) and the IME landing-rule divergence are tracked in #463.

Fixes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790249320&installation_model_id=422592&pr_number=464&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F464&signature=cd67ad796d0919d14c147d40af131247095045f05dce3db300bcf15a32f1885f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->