### PR TITLE
fix: descend into text-box stories in the furniture drawing-resource token

### DIFF
--- a/.changeset/header-textbox-picture-settles.md
+++ b/.changeset/header-textbox-picture-settles.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Repaint a header or footer once a picture inside one of its text boxes finishes decoding, so the picture no longer stays a loading placeholder. Fixes #442

--- a/packages/core/src/editor/__tests__/header-footer-drawing-resource.test.ts
+++ b/packages/core/src/editor/__tests__/header-footer-drawing-resource.test.ts
@@ -14,41 +14,25 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
-import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
-import { validateRasterHeader, type ImageDecodePort } from '../../store/package/image-resources.ts';
-import { resolveImageResourceLimits } from '../../store/runtime/limits.ts';
 import type { HeaderFooterStoryRecord } from '../../layout/semantic-records.ts';
+import {
+  CT_NS,
+  DRAWING_NS,
+  IMG_REL,
+  OD_REL,
+  PNG_1X1,
+  REL_NS,
+  blockDrawingKinds,
+  deferredDecodePort,
+  inlinePicture,
+  mountWithImages,
+  picture,
+  settle,
+  textboxWithPicture,
+} from './image-decode-harness.ts';
 
-const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
-const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
-const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
-const IMG = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
 const HDR = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
 const FTR = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
-const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
-const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
-const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
-const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
-
-const PNG_1X1 = Uint8Array.from(
-  atob(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
-  ),
-  (c) => c.charCodeAt(0)
-);
-
-const NS = `xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"`;
-
-function picture(): string {
-  return (
-    `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
-    '<pic:nvPicPr><pic:cNvPr id="1" name="pic"/><pic:cNvPicPr/></pic:nvPicPr>' +
-    '<pic:blipFill><a:blip r:embed="rIdImg"/><a:srcRect/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
-    '<pic:spPr><a:xfrm><a:ext cx="457200" cy="457200"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
-    '</pic:pic></a:graphicData></a:graphic>'
-  );
-}
 
 /** Anchored the way a letterhead is: `wrapNone`, offset out past the text column. */
 function anchoredDrawing(): string {
@@ -60,26 +44,18 @@ function anchoredDrawing(): string {
     '<wp:positionH relativeFrom="column"><wp:posOffset>5000000</wp:posOffset></wp:positionH>' +
     '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
     '<wp:extent cx="457200" cy="457200"/><wp:wrapNone/><wp:docPr id="1" name="pic"/>' +
-    `${picture()}</wp:anchor></w:drawing></w:r>`
-  );
-}
-
-function inlineDrawing(): string {
-  return (
-    '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
-    '<wp:extent cx="457200" cy="457200"/><wp:docPr id="2" name="pic"/>' +
-    `${picture()}</wp:inline></w:drawing></w:r>`
+    `${picture(1)}</wp:anchor></w:drawing></w:r>`
   );
 }
 
 function docx(options: { readonly headerBody: string; readonly footerBody: string }): Uint8Array {
   const rels = (target: string) =>
     strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${IMG}" Target="${target}"/></Relationships>`
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rIdImg" Type="${IMG_REL}" Target="${target}"/></Relationships>`
     );
   return zipSync({
     '[Content_Types].xml': strToU8(
-      `<Types xmlns="${CT}">` +
+      `<Types xmlns="${CT_NS}">` +
         '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
         '<Default Extension="png" ContentType="image/png"/>' +
         '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
@@ -88,10 +64,10 @@ function docx(options: { readonly headerBody: string; readonly footerBody: strin
         '</Types>'
     ),
     '_rels/.rels': strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}" Target="word/document.xml"/></Relationships>`
     ),
     'word/document.xml': strToU8(
-      `<w:document ${NS}><w:body>` +
+      `<w:document ${DRAWING_NS}><w:body>` +
         '<w:p><w:r><w:t>body</w:t></w:r></w:p>' +
         '<w:sectPr>' +
         '<w:headerReference r:id="rIdHdr" w:type="default"/>' +
@@ -101,67 +77,41 @@ function docx(options: { readonly headerBody: string; readonly footerBody: strin
         '</w:sectPr></w:body></w:document>'
     ),
     'word/_rels/document.xml.rels': strToU8(
-      `<Relationships xmlns="${REL}">` +
+      `<Relationships xmlns="${REL_NS}">` +
         `<Relationship Id="rIdHdr" Type="${HDR}" Target="header1.xml"/>` +
         `<Relationship Id="rIdFtr" Type="${FTR}" Target="footer1.xml"/>` +
         '</Relationships>'
     ),
-    'word/header1.xml': strToU8(`<w:hdr ${NS}><w:p>${options.headerBody}</w:p></w:hdr>`),
-    'word/footer1.xml': strToU8(`<w:ftr ${NS}><w:p>${options.footerBody}</w:p></w:ftr>`),
+    'word/header1.xml': strToU8(`<w:hdr ${DRAWING_NS}><w:p>${options.headerBody}</w:p></w:hdr>`),
+    'word/footer1.xml': strToU8(`<w:ftr ${DRAWING_NS}><w:p>${options.footerBody}</w:p></w:ftr>`),
     'word/_rels/header1.xml.rels': rels('media/image1.png'),
     'word/_rels/footer1.xml.rels': rels('media/image1.png'),
     'word/media/image1.png': PNG_1X1,
   });
 }
 
-/** Validates the real bytes, like the browser port does, but without a browser. */
-function decodePort(): ImageDecodePort {
-  return Object.freeze({
-    async decode(bytes, mime) {
-      const header = validateRasterHeader(bytes, mime);
-      if (!header) throw new Error('invalid raster');
-      const limits = resolveImageResourceLimits();
-      if (header.pixelWidth * header.pixelHeight > limits.maxPixels) throw new Error('too large');
-      return Object.freeze({ ...header, dpiX: 96, dpiY: 96 });
-    },
-  });
-}
-
-/** Resource resolution and the relayout it triggers are both asynchronous. */
-async function settle(): Promise<void> {
-  for (let turn = 0; turn < 10; turn += 1) await new Promise((resolve) => setTimeout(resolve, 5));
-}
-
 function storyDrawingKinds(story: HeaderFooterStoryRecord | undefined): string[] {
   if (!story) return [];
   const kinds = (story.anchoredDrawings ?? []).map((drawing) => drawing.resource.kind);
-  for (const fragment of story.fragments) {
-    if (fragment.kind === 'table') continue;
-    for (const line of fragment.lines) {
-      for (const drawing of line.drawings ?? []) kinds.push(drawing.resource.kind);
-    }
+  for (const kind of blockDrawingKinds(story.fragments)) kinds.push(kind);
+  return kinds;
+}
+
+/** Resource kinds of the pictures inside the story's anchored text-box stories. */
+function textboxStoryDrawingKinds(story: HeaderFooterStoryRecord | undefined): string[] {
+  if (!story) return [];
+  const kinds: string[] = [];
+  for (const drawing of story.anchoredDrawings ?? []) {
+    const inner = drawing.textboxStory;
+    if (!inner) continue;
+    for (const kind of blockDrawingKinds(inner.fragments)) kinds.push(kind);
   }
   return kinds;
 }
 
-async function mount(bytes: Uint8Array): Promise<{
-  surface: PaginatedSurface;
-  container: HTMLElement;
-}> {
-  const container = document.createElement('div');
-  document.body.append(container);
-  const opened = mountPaginatedSurface(container, bytes, {
-    scale: 1,
-    imageDecodePort: decodePort(),
-  });
-  if (!opened.ok) throw new Error(opened.reason);
-  await settle();
-  return { surface: opened.surface, container };
-}
-
 describe('header/footer picture resources reach the page', () => {
   test('an anchored header picture stops being pending once it decodes', async () => {
-    const { surface, container } = await mount(
+    const { surface, container } = await mountWithImages(
       docx({ headerBody: anchoredDrawing(), footerBody: '<w:r><w:t>f</w:t></w:r>' })
     );
     const page = surface.layout().pages[0]!;
@@ -174,8 +124,8 @@ describe('header/footer picture resources reach the page', () => {
   });
 
   test('an inline footer picture does too', async () => {
-    const { surface, container } = await mount(
-      docx({ headerBody: '<w:r><w:t>h</w:t></w:r>', footerBody: inlineDrawing() })
+    const { surface, container } = await mountWithImages(
+      docx({ headerBody: '<w:r><w:t>h</w:t></w:r>', footerBody: inlinePicture(2) })
     );
     const page = surface.layout().pages[0]!;
     expect(storyDrawingKinds(page.footer)).toEqual(['ready']);
@@ -184,9 +134,28 @@ describe('header/footer picture resources reach the page', () => {
     container.remove();
   });
 
+  // The regression for a picture nested one story deeper: `storyDrawingResourceToken` has to
+  // descend into each anchored drawing's text-box story, or the furniture context is identical
+  // before and after the decode and the unchanged-pass early exit returns the previous pages
+  // by identity — the picture stays a placeholder with nothing left to invalidate it.
+  test('a picture inside a header text box stops being pending once it decodes', async () => {
+    const { port, release } = deferredDecodePort();
+    const { surface, container } = await mountWithImages(
+      docx({ headerBody: textboxWithPicture(), footerBody: '<w:r><w:t>f</w:t></w:r>' }),
+      port
+    );
+    expect(textboxStoryDrawingKinds(surface.layout().pages[0]!.header)).toEqual(['pending']);
+    release();
+    await settle();
+    expect(textboxStoryDrawingKinds(surface.layout().pages[0]!.header)).toEqual(['ready']);
+    expect(container.querySelectorAll('.docx-drawing-placeholder')).toHaveLength(0);
+    surface.destroy();
+    container.remove();
+  });
+
   test('every page carries the resolved picture, not just the first', async () => {
-    const { surface, container } = await mount(
-      docx({ headerBody: anchoredDrawing(), footerBody: inlineDrawing() })
+    const { surface, container } = await mountWithImages(
+      docx({ headerBody: anchoredDrawing(), footerBody: inlinePicture(2) })
     );
     for (const page of surface.layout().pages) {
       expect(storyDrawingKinds(page.header)).toEqual(['ready']);

--- a/packages/core/src/editor/__tests__/image-decode-harness.ts
+++ b/packages/core/src/editor/__tests__/image-decode-harness.ts
@@ -1,0 +1,160 @@
+// Decode ports, drawing fixture snippets and record walks shared by the image-resource
+// suites (header/footer, footnote/endnote and text-box stories).
+//
+// Image resources resolve ASYNCHRONOUSLY: the first pass publishes `pending`, the decode
+// settles, and a later pass must pick the ready record up. Suites that assert on that
+// window need the SAME gate-and-release port and the same settle cadence, or a fix to one
+// copy leaves the other silently asserting post-decode — a test that passes with the
+// invalidation deleted. Nothing here touches the DOM at module scope.
+
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { validateRasterHeader, type ImageDecodePort } from '../../store/package/image-resources.ts';
+import { resolveImageResourceLimits } from '../../store/runtime/limits.ts';
+import type { BlockFragmentRecord } from '../../layout/semantic-records.ts';
+
+export const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+export const CT_NS = 'http://schemas.openxmlformats.org/package/2006/content-types';
+export const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+export const OD_REL =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+export const IMG_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
+const WP_NS = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC_NS = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+export const WPS_NS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+/** Root-element namespace declarations covering every snippet below. */
+export const DRAWING_NS =
+  `xmlns:w="${W_NS}" xmlns:wp="${WP_NS}" xmlns:a="${A_NS}" ` +
+  `xmlns:pic="${PIC_NS}" xmlns:r="${R_NS}" xmlns:wps="${WPS_NS}"`;
+
+export const PNG_1X1 = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  ),
+  (c) => c.charCodeAt(0)
+);
+
+/** A `pic:pic` graphic referencing the part's `rIdImg` image relationship. */
+export function picture(id: number): string {
+  return (
+    `<a:graphic><a:graphicData uri="${PIC_NS}"><pic:pic>` +
+    `<pic:nvPicPr><pic:cNvPr id="${id}" name="pic"/><pic:cNvPicPr/></pic:nvPicPr>` +
+    '<pic:blipFill><a:blip r:embed="rIdImg"/><a:srcRect/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+    '<pic:spPr><a:xfrm><a:ext cx="457200" cy="457200"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
+    '</pic:pic></a:graphicData></a:graphic>'
+  );
+}
+
+export function inlinePicture(id: number): string {
+  return (
+    '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    `<wp:extent cx="457200" cy="457200"/><wp:docPr id="${id}" name="pic"/>` +
+    `${picture(id)}</wp:inline></w:drawing></w:r>`
+  );
+}
+
+/** An anchored text box whose story holds one inline picture. */
+export function textboxWithPicture(): string {
+  return (
+    '<w:r><w:drawing>' +
+    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" ' +
+    'layoutInCell="1" allowOverlap="1" relativeHeight="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="2743200" cy="1828800"/><wp:wrapNone/><wp:docPr id="10" name="box"/>' +
+    `<a:graphic><a:graphicData uri="${WPS_NS}">` +
+    '<wps:wsp><wps:cNvSpPr txBox="1"/>' +
+    '<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2743200" cy="1828800"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"/></wps:spPr>' +
+    '<wps:txbx><w:txbxContent>' +
+    `<w:p><w:r><w:t>in the box</w:t></w:r>${inlinePicture(11)}</w:p>` +
+    '</w:txbxContent></wps:txbx>' +
+    '<wps:bodyPr/></wps:wsp>' +
+    '</a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
+  );
+}
+
+export function decodeBytes(
+  bytes: Uint8Array,
+  mime: string
+): { pixelWidth: number; pixelHeight: number } {
+  const header = validateRasterHeader(bytes, mime);
+  if (!header) throw new Error('invalid raster');
+  const limits = resolveImageResourceLimits();
+  if (header.pixelWidth * header.pixelHeight > limits.maxPixels) throw new Error('too large');
+  return header;
+}
+
+/** Validates the real bytes, like the browser port does, but without a browser. */
+export function decodePort(): ImageDecodePort {
+  return Object.freeze({
+    async decode(bytes, mime) {
+      return Object.freeze({ ...decodeBytes(bytes, mime), dpiX: 96, dpiY: 96 });
+    },
+  });
+}
+
+/**
+ * A decode port that does not settle until told to.
+ *
+ * The invalidation half of a resource fix is only observable if a layout is READ while the
+ * picture is still pending. A port that resolves on its own microtask makes every assertion
+ * a post-decode one, and a test written that way passes with the invalidation removed
+ * entirely.
+ */
+export function deferredDecodePort(): { port: ImageDecodePort; release: () => void } {
+  let release = (): void => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    port: Object.freeze({
+      async decode(bytes, mime) {
+        await gate;
+        return Object.freeze({ ...decodeBytes(bytes, mime), dpiX: 96, dpiY: 96 });
+      },
+    }),
+    release: () => release(),
+  };
+}
+
+/** Resource resolution and the relayout it triggers are both asynchronous. */
+export async function settle(): Promise<void> {
+  for (let turn = 0; turn < 10; turn += 1) await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+/** Resource kinds of the line drawings in a block list, table interiors included. */
+export function blockDrawingKinds(blocks: readonly BlockFragmentRecord[]): string[] {
+  const kinds: string[] = [];
+  const visit = (block: BlockFragmentRecord): void => {
+    if (block.kind === 'table') {
+      for (const row of block.rows) {
+        for (const cell of row.cells) for (const inner of cell.blocks) visit(inner);
+      }
+      return;
+    }
+    for (const line of block.lines) {
+      for (const drawing of line.drawings ?? []) kinds.push(drawing.resource.kind);
+    }
+  };
+  for (const block of blocks) visit(block);
+  return kinds;
+}
+
+export async function mountWithImages(
+  bytes: Uint8Array,
+  port: ImageDecodePort = decodePort()
+): Promise<{ surface: PaginatedSurface; container: HTMLElement }> {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, bytes, {
+    scale: 1,
+    imageDecodePort: port,
+  });
+  if (!opened.ok) throw new Error(opened.reason);
+  await settle();
+  return { surface: opened.surface, container };
+}

--- a/packages/core/src/editor/__tests__/story-drawing-resource.test.ts
+++ b/packages/core/src/editor/__tests__/story-drawing-resource.test.ts
@@ -12,72 +12,25 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
-import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
-import { validateRasterHeader, type ImageDecodePort } from '../../store/package/image-resources.ts';
-import { resolveImageResourceLimits } from '../../store/runtime/limits.ts';
-import type { BlockFragmentRecord, PageRecord } from '../../layout/semantic-records.ts';
+import type { PageRecord } from '../../layout/semantic-records.ts';
+import {
+  CT_NS,
+  DRAWING_NS,
+  IMG_REL,
+  OD_REL,
+  PNG_1X1,
+  REL_NS,
+  WPS_NS,
+  blockDrawingKinds,
+  deferredDecodePort,
+  inlinePicture,
+  mountWithImages,
+  settle,
+  textboxWithPicture,
+} from './image-decode-harness.ts';
 
-const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
-const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
-const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
-const IMG = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
 const FOOTNOTES = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes';
 const ENDNOTES = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes';
-const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
-const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
-const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
-const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
-const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
-
-const PNG_1X1 = Uint8Array.from(
-  atob(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
-  ),
-  (c) => c.charCodeAt(0)
-);
-
-const NS = `xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}" xmlns:wps="${WPS}"`;
-
-function picture(id: number): string {
-  return (
-    `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
-    `<pic:nvPicPr><pic:cNvPr id="${id}" name="pic"/><pic:cNvPicPr/></pic:nvPicPr>` +
-    '<pic:blipFill><a:blip r:embed="rIdImg"/><a:srcRect/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
-    '<pic:spPr><a:xfrm><a:ext cx="457200" cy="457200"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
-    '</pic:pic></a:graphicData></a:graphic>'
-  );
-}
-
-function inlinePicture(id: number): string {
-  return (
-    '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
-    `<wp:extent cx="457200" cy="457200"/><wp:docPr id="${id}" name="pic"/>` +
-    `${picture(id)}</wp:inline></w:drawing></w:r>`
-  );
-}
-
-/** An anchored text box whose story holds one inline picture. */
-function textboxWithPicture(): string {
-  return (
-    '<w:r><w:drawing>' +
-    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" ' +
-    'layoutInCell="1" allowOverlap="1" relativeHeight="1">' +
-    '<wp:simplePos x="0" y="0"/>' +
-    '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
-    '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
-    '<wp:extent cx="2743200" cy="1828800"/><wp:wrapNone/><wp:docPr id="10" name="box"/>' +
-    `<a:graphic><a:graphicData uri="${WPS}">` +
-    '<wps:wsp><wps:cNvSpPr txBox="1"/>' +
-    '<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2743200" cy="1828800"/></a:xfrm>' +
-    '<a:prstGeom prst="rect"/></wps:spPr>' +
-    '<wps:txbx><w:txbxContent>' +
-    `<w:p><w:r><w:t>in the box</w:t></w:r>${inlinePicture(11)}</w:p>` +
-    '</w:txbxContent></wps:txbx>' +
-    '<wps:bodyPr/></wps:wsp>' +
-    '</a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
-  );
-}
 
 /** A drawing that never types, carrying the story element's NAME in a position it cannot open one. */
 function strayStoryNameDrawing(): string {
@@ -89,7 +42,7 @@ function strayStoryNameDrawing(): string {
     '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
     '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
     '<wp:extent cx="2743200" cy="1828800"/><wp:wrapNone/><wp:docPr id="20" name="stray"/>' +
-    `<a:graphic><a:graphicData uri="${WPS}">` +
+    `<a:graphic><a:graphicData uri="${WPS_NS}">` +
     '<wps:wsp><wps:cNvSpPr txBox="1"/>' +
     // `w:txbxContent` under the shape properties rather than under `wps:txbx`.
     `<wps:spPr><w:txbxContent><w:p>${inlinePicture(21)}</w:p></w:txbxContent></wps:spPr>` +
@@ -104,11 +57,11 @@ function docx(options: {
   readonly endnoteRuns?: string;
 }): Uint8Array {
   const imageRels = strToU8(
-    `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/></Relationships>`
+    `<Relationships xmlns="${REL_NS}"><Relationship Id="rIdImg" Type="${IMG_REL}" Target="media/image1.png"/></Relationships>`
   );
   return zipSync({
     '[Content_Types].xml': strToU8(
-      `<Types xmlns="${CT}">` +
+      `<Types xmlns="${CT_NS}">` +
         '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
         '<Default Extension="png" ContentType="image/png"/>' +
         '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
@@ -117,10 +70,10 @@ function docx(options: {
         '</Types>'
     ),
     '_rels/.rels': strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}" Target="word/document.xml"/></Relationships>`
     ),
     'word/document.xml': strToU8(
-      `<w:document ${NS}><w:body>` +
+      `<w:document ${DRAWING_NS}><w:body>` +
         `<w:p><w:r><w:t>body</w:t></w:r>${options.bodyRuns}</w:p>` +
         '<w:sectPr>' +
         '<w:pgSz w:w="11906" w:h="16838"/>' +
@@ -128,21 +81,21 @@ function docx(options: {
         '</w:sectPr></w:body></w:document>'
     ),
     'word/_rels/document.xml.rels': strToU8(
-      `<Relationships xmlns="${REL}">` +
+      `<Relationships xmlns="${REL_NS}">` +
         `<Relationship Id="rIdFn" Type="${FOOTNOTES}" Target="footnotes.xml"/>` +
         `<Relationship Id="rIdEn" Type="${ENDNOTES}" Target="endnotes.xml"/>` +
-        `<Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/>` +
+        `<Relationship Id="rIdImg" Type="${IMG_REL}" Target="media/image1.png"/>` +
         '</Relationships>'
     ),
     'word/footnotes.xml': strToU8(
-      `<w:footnotes ${NS}>` +
+      `<w:footnotes ${DRAWING_NS}>` +
         '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
         '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>' +
         `<w:footnote w:id="1"><w:p><w:r><w:footnoteRef/></w:r><w:r><w:t>note </w:t></w:r>${options.footnoteRuns}</w:p></w:footnote>` +
         '</w:footnotes>'
     ),
     'word/endnotes.xml': strToU8(
-      `<w:endnotes ${NS}>` +
+      `<w:endnotes ${DRAWING_NS}>` +
         '<w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>' +
         '<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>' +
         `<w:endnote w:id="1"><w:p><w:r><w:endnoteRef/></w:r><w:r><w:t>note </w:t></w:r>${options.endnoteRuns ?? '<w:r><w:t>plain</w:t></w:r>'}</w:p></w:endnote>` +
@@ -157,73 +110,10 @@ function docx(options: {
 const FOOTNOTE_REFERENCE = '<w:r><w:footnoteReference w:id="1"/></w:r>';
 const ENDNOTE_REFERENCE = '<w:r><w:endnoteReference w:id="1"/></w:r>';
 
-function decodeBytes(bytes: Uint8Array, mime: string): { pixelWidth: number; pixelHeight: number } {
-  const header = validateRasterHeader(bytes, mime);
-  if (!header) throw new Error('invalid raster');
-  const limits = resolveImageResourceLimits();
-  if (header.pixelWidth * header.pixelHeight > limits.maxPixels) throw new Error('too large');
-  return header;
-}
-
-/** Validates the real bytes, like the browser port does, but without a browser. */
-function decodePort(): ImageDecodePort {
-  return Object.freeze({
-    async decode(bytes, mime) {
-      return Object.freeze({ ...decodeBytes(bytes, mime), dpiX: 96, dpiY: 96 });
-    },
-  });
-}
-
-/**
- * A decode port that does not settle until told to.
- *
- * The whole asynchronous half of this fix — the resource identity in the break key — is only
- * observable if a layout is READ while the picture is still pending. A port that resolves on
- * its own microtask makes every assertion a post-decode one, and a test written that way
- * passes with the invalidation removed entirely.
- */
-function deferredDecodePort(): { port: ImageDecodePort; release: () => void } {
-  let release = (): void => {};
-  const gate = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return {
-    port: Object.freeze({
-      async decode(bytes, mime) {
-        await gate;
-        return Object.freeze({ ...decodeBytes(bytes, mime), dpiX: 96, dpiY: 96 });
-      },
-    }),
-    release: () => release(),
-  };
-}
-
-/** Resource resolution and the relayout it triggers are both asynchronous. */
-async function settle(): Promise<void> {
-  for (let turn = 0; turn < 10; turn += 1) await new Promise((resolve) => setTimeout(resolve, 5));
-}
-
-function blockDrawingKinds(blocks: readonly BlockFragmentRecord[]): string[] {
-  const kinds: string[] = [];
-  const visit = (block: BlockFragmentRecord): void => {
-    if (block.kind === 'table') {
-      for (const row of block.rows) {
-        for (const cell of row.cells) for (const inner of cell.blocks) visit(inner);
-      }
-      return;
-    }
-    for (const line of block.lines) {
-      for (const drawing of line.drawings ?? []) kinds.push(drawing.resource.kind);
-    }
-  };
-  for (const block of blocks) visit(block);
-  return kinds;
-}
-
 function footnoteDrawingKinds(page: PageRecord): string[] {
   const kinds: string[] = [];
   for (const note of page.footnotes?.notes ?? []) {
-    kinds.push(...blockDrawingKinds(note.fragments));
+    for (const kind of blockDrawingKinds(note.fragments)) kinds.push(kind);
   }
   return kinds;
 }
@@ -231,7 +121,7 @@ function footnoteDrawingKinds(page: PageRecord): string[] {
 function endnoteDrawingKinds(page: PageRecord): string[] {
   const kinds: string[] = [];
   for (const note of page.endnotes?.notes ?? []) {
-    kinds.push(...blockDrawingKinds(note.fragments));
+    for (const kind of blockDrawingKinds(note.fragments)) kinds.push(kind);
   }
   return kinds;
 }
@@ -241,27 +131,9 @@ function textboxDrawingKinds(page: PageRecord): string[] {
   for (const drawing of page.anchoredDrawings ?? []) {
     const story = drawing.textboxStory;
     if (!story) continue;
-    kinds.push(...blockDrawingKinds(story.fragments));
+    for (const kind of blockDrawingKinds(story.fragments)) kinds.push(kind);
   }
   return kinds;
-}
-
-async function mount(
-  bytes: Uint8Array,
-  port: ImageDecodePort = decodePort()
-): Promise<{
-  surface: PaginatedSurface;
-  container: HTMLElement;
-}> {
-  const container = document.createElement('div');
-  document.body.append(container);
-  const opened = mountPaginatedSurface(container, bytes, {
-    scale: 1,
-    imageDecodePort: port,
-  });
-  if (!opened.ok) throw new Error(opened.reason);
-  await settle();
-  return { surface: opened.surface, container };
 }
 
 /** `<img>` elements painted inside a page's note areas. */
@@ -271,7 +143,7 @@ function paintedNoteImages(container: HTMLElement): HTMLImageElement[] {
 
 describe('pictures in stories outside the body flow', () => {
   test('a footnote picture lays out, resolves, and paints', async () => {
-    const { surface, container } = await mount(
+    const { surface, container } = await mountWithImages(
       docx({ bodyRuns: FOOTNOTE_REFERENCE, footnoteRuns: inlinePicture(2) })
     );
     const page = surface.layout().pages[0]!;
@@ -283,7 +155,7 @@ describe('pictures in stories outside the body flow', () => {
   });
 
   test('an endnote picture does too', async () => {
-    const { surface, container } = await mount(
+    const { surface, container } = await mountWithImages(
       docx({
         bodyRuns: ENDNOTE_REFERENCE,
         footnoteRuns: '<w:r><w:t>plain</w:t></w:r>',
@@ -302,7 +174,7 @@ describe('pictures in stories outside the body flow', () => {
   // stripped out of the break key entirely.
   test('a footnote picture pending at first paint reaches the page when it decodes', async () => {
     const { port, release } = deferredDecodePort();
-    const { surface, container } = await mount(
+    const { surface, container } = await mountWithImages(
       docx({ bodyRuns: FOOTNOTE_REFERENCE, footnoteRuns: inlinePicture(2) }),
       port
     );
@@ -317,7 +189,7 @@ describe('pictures in stories outside the body flow', () => {
 
   test('a text-box picture pending at first paint reaches the page when it decodes', async () => {
     const { port, release } = deferredDecodePort();
-    const { surface, container } = await mount(
+    const { surface, container } = await mountWithImages(
       docx({ bodyRuns: textboxWithPicture(), footnoteRuns: '<w:r><w:t>plain</w:t></w:r>' }),
       port
     );
@@ -330,7 +202,7 @@ describe('pictures in stories outside the body flow', () => {
   });
 
   test('a picture inside a text box lays out and resolves', async () => {
-    const { surface, container } = await mount(
+    const { surface, container } = await mountWithImages(
       docx({ bodyRuns: textboxWithPicture(), footnoteRuns: '<w:r><w:t>plain</w:t></w:r>' })
     );
     const page = surface.layout().pages[0]!;
@@ -343,7 +215,7 @@ describe('pictures in stories outside the body flow', () => {
   // directly under a `wps:txbx` opens one. A file that plants the name elsewhere inside a
   // failed drawing subtree must not get typed drawings preserved there.
   test('a stray txbxContent outside a text box opens no story', async () => {
-    const { surface, container } = await mount(
+    const { surface, container } = await mountWithImages(
       docx({ bodyRuns: strayStoryNameDrawing(), footnoteRuns: '<w:r><w:t>plain</w:t></w:r>' })
     );
     const page = surface.layout().pages[0]!;

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -41,6 +41,7 @@ import {
   type ExclusionZone,
 } from './drawing-exclusion.ts';
 import { flowBlocksInBox } from './semantic-table-layout.ts';
+import { forEachStoryDrawing } from './semantic-record-queries.ts';
 import { withResolvedListItems, type ResolvedListItem } from './list-resolve.ts';
 import type { NumberingIndex } from './numbering-index.ts';
 import { layoutTextboxStory } from './textbox-story-layout.ts';
@@ -481,6 +482,9 @@ export function remapPage(page: PageRecord, globalIndex: number, sheetY: number)
   };
 }
 
+/** Memoized per story object, exactly like {@link storyDrawingResourceTokens}. */
+const storyListMarkerTokens = new WeakMap<HeaderFooterStoryLayout, string>();
+
 /**
  * Marker identity of every list item a header/footer story paints.
  *
@@ -494,8 +498,16 @@ export function remapPage(page: PageRecord, globalIndex: number, sheetY: number)
  * Measured before this existed: a body edit that also changed the numbering left six reused
  * pages showing the old header marker and the one rebuilt page showing the new one — two
  * different numbers for the same header in one section.
+ *
+ * Unlike {@link storyDrawingResourceToken} this walk stops at the story's own fragments: a
+ * text-box story never resolves list items today (`layoutTextboxStory` receives no
+ * `listItems`, so a `w:numPr` paragraph in a box carries no marker record). If text-box
+ * stories ever grow markers, this token must descend with them or a `numbering.xml` edit
+ * leaves a reused page showing the old number inside the box.
  */
 export function storyListMarkerToken(story: HeaderFooterStoryLayout): string {
+  const cached = storyListMarkerTokens.get(story);
+  if (cached !== undefined) return cached;
   const tokens: string[] = [];
   const visitBlock = (block: BlockFragmentRecord): void => {
     if (block.kind === 'table') {
@@ -508,8 +520,17 @@ export function storyListMarkerToken(story: HeaderFooterStoryLayout): string {
     if (marker) tokens.push(`${block.paragraphId}=${marker.text}@${marker.numFmt}:${marker.level}`);
   };
   for (const block of story.fragments) visitBlock(block);
-  return tokens.length === 0 ? '' : `|list:${tokens.join(',')}`;
+  const token = tokens.length === 0 ? '' : `|list:${tokens.join(',')}`;
+  storyListMarkerTokens.set(story, token);
+  return token;
 }
+
+/**
+ * Memoized per story object: a story layout is immutable, and `hfStoryMemo` keeps the
+ * object identity stable across passes, so the walk would otherwise repeat per section per
+ * layout pass on the keystroke path.
+ */
+const storyDrawingResourceTokens = new WeakMap<HeaderFooterStoryLayout, string>();
 
 /**
  * Resource identity of every image a header/footer story paints.
@@ -521,29 +542,23 @@ export function storyListMarkerToken(story: HeaderFooterStoryLayout): string {
  * returns the previous pages BY IDENTITY, furniture included, so a header or footer image
  * stays a "loading" placeholder for the rest of the session — nothing will invalidate it
  * again. Body drawings have no such gap; they ride the per-paragraph flow keys.
+ *
+ * Walks with {@link forEachStoryDrawing}, which descends into each anchored drawing's
+ * text-box story: a picture inside a `wps:txbx` in a header settles on the same
+ * asynchronous clock as a direct one, so its resource has to move this token too.
  */
 export function storyDrawingResourceToken(story: HeaderFooterStoryLayout): string {
+  const cached = storyDrawingResourceTokens.get(story);
+  if (cached !== undefined) return cached;
   const tokens: string[] = [];
-  const visitBlock = (block: BlockFragmentRecord): void => {
-    if (block.kind === 'table') {
-      for (const row of block.rows) {
-        for (const cell of row.cells) for (const inner of cell.blocks) visitBlock(inner);
-      }
-      return;
-    }
-    for (const line of block.lines) {
-      for (const drawing of line.drawings ?? []) {
-        tokens.push(drawingResourceLayoutToken(drawing.resource));
-      }
-    }
-  };
-  for (const drawing of story.anchoredDrawings ?? []) {
+  forEachStoryDrawing(story, (drawing) => {
     tokens.push(drawingResourceLayoutToken(drawing.resource));
-  }
-  for (const fragment of story.fragments) visitBlock(fragment);
+  });
   // Empty for the overwhelmingly common story with no pictures, so the context string for a
   // plain header is byte-for-byte what it was.
-  return tokens.length === 0 ? '' : `!${tokens.join('!')}`;
+  const token = tokens.length === 0 ? '' : `!${tokens.join('!')}`;
+  storyDrawingResourceTokens.set(story, token);
+  return token;
 }
 
 /**

--- a/packages/core/src/layout/semantic-record-queries.ts
+++ b/packages/core/src/layout/semantic-record-queries.ts
@@ -10,6 +10,7 @@ import type {
   BlockFragmentRecord,
   ContentControlBoundaryRecord,
   ContentControlLock,
+  InlineDrawingRecord,
   LayoutBox,
   LineRecord,
   PageRecord,
@@ -88,6 +89,58 @@ export function linesOf(layout: SemanticLayout): LineRecord[] {
 /** Anchored drawings on one body page (page-content coordinates). */
 export function anchoredDrawingsOf(page: PageRecord): readonly AnchoredDrawingRecord[] {
   return page.anchoredDrawings ?? [];
+}
+
+/** The fragment-plus-anchored-drawings shape every laid-out story shares. */
+export interface StoryDrawingHost {
+  readonly fragments: readonly BlockFragmentRecord[];
+  readonly anchoredDrawings?: readonly AnchoredDrawingRecord[];
+}
+
+/**
+ * Text-box stories descended per {@link forEachStoryDrawing} walk before it stops.
+ *
+ * Sits ABOVE layout's construction ceiling (`MAX_TEXTBOX_STORY_NESTING`, 4) on purpose:
+ * records deeper than the ceiling cannot be built, so the bound is defensive, not policy.
+ * Layout builds these records and a cycle should be impossible — which is the reason to
+ * bound the walk rather than to trust it, since the cost of the bound is nothing.
+ */
+const MAX_STORY_DRAWING_WALK_DEPTH = 16;
+
+/**
+ * Visit every drawing record one story paints — line drawings, anchored drawings, and the
+ * drawings inside each anchored drawing's text-box story, recursively.
+ *
+ * The ONE walk shared by the two consumers that must agree by construction: the furniture
+ * invalidation token (a drawing this walk misses leaves a settled picture a permanent
+ * placeholder) and paint's page reconcile (a drawing it misses gets a live resource
+ * revoked). Table interiors flatten through rows and cells.
+ */
+export function forEachStoryDrawing(
+  story: StoryDrawingHost,
+  visit: (drawing: InlineDrawingRecord | AnchoredDrawingRecord) => void
+): void {
+  const visitBlock = (block: BlockFragmentRecord): void => {
+    if (block.kind === 'table') {
+      for (const row of block.rows) {
+        for (const cell of row.cells) for (const inner of cell.blocks) visitBlock(inner);
+      }
+      return;
+    }
+    for (const line of block.lines) {
+      for (const drawing of line.drawings ?? []) visit(drawing);
+    }
+  };
+  const visitStory = (inner: StoryDrawingHost, depth: number): void => {
+    if (depth > MAX_STORY_DRAWING_WALK_DEPTH) return;
+    for (const drawing of inner.anchoredDrawings ?? []) {
+      visit(drawing);
+      // A text box is a story of its own, nested in the drawing that anchors it.
+      if (drawing.textboxStory) visitStory(drawing.textboxStory, depth + 1);
+    }
+    for (const fragment of inner.fragments) visitBlock(fragment);
+  };
+  visitStory(story, 0);
 }
 
 /** Every fragment belonging to one paragraph, in order, across page boundaries. */

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -856,6 +856,7 @@ export {
   anchoredDrawingsOf,
   contentControlsOfLayout,
   effectiveContentControlLock,
+  forEachStoryDrawing,
   fragmentsOfParagraph,
   lineAtPosition,
   linesOf,
@@ -863,3 +864,4 @@ export {
   paragraphFragmentsOfBlocks,
   unionLayoutBoxes,
 } from './semantic-record-queries.ts';
+export type { StoryDrawingHost } from './semantic-record-queries.ts';

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -17,6 +17,7 @@ import type {
   ParagraphFragmentRecord,
   TableFragmentRecord,
 } from '../layout/semantic-records.ts';
+import { forEachStoryDrawing } from '../layout/semantic-record-queries.ts';
 import type { SemanticLayout } from '@docx-editor.dev/core/layout';
 import { paintLayerOf } from '../layout/drawing-exclusion.ts';
 
@@ -704,9 +705,6 @@ export function paintAnchoredDrawingsLayer(
   return Object.freeze(painted);
 }
 
-/** Nesting bound for text-box stories inside text-box stories. */
-const MAX_TEXTBOX_STORY_DEPTH = 16;
-
 /**
  * Every drawing one page paints, whatever story it is in.
  *
@@ -715,55 +713,30 @@ const MAX_TEXTBOX_STORY_DEPTH = 16;
  * body and the furniture stories meant the reconcile pass never saw those keys and treated them
  * as unused — so every repaint revoked the note image's resource and stripped its `src`. Typing
  * one character in the body blanked a picture in a footnote.
+ *
+ * Each story walks with {@link forEachStoryDrawing} — the SAME bounded walk the furniture
+ * invalidation token uses, so what layout invalidates and what paint keeps alive cannot
+ * drift apart.
  */
 function forEachPageDrawing(
   page: PageRecord,
   visitDrawing: (drawing: InlineDrawingRecord | AnchoredDrawingRecord) => void
 ): void {
-  const visitBlock = (block: ParagraphFragmentRecord | TableFragmentRecord): void => {
-    if (block.kind === 'table') {
-      for (const row of block.rows) {
-        for (const cell of row.cells) {
-          for (const inner of cell.blocks) visitBlock(inner);
-        }
-      }
-      return;
-    }
-    for (const line of block.lines) {
-      for (const drawing of line.drawings ?? []) visitDrawing(drawing);
-    }
-  };
-  const visitStory = (
-    story: {
-      readonly fragments: readonly (ParagraphFragmentRecord | TableFragmentRecord)[];
-      readonly anchoredDrawings?: readonly AnchoredDrawingRecord[];
+  forEachStoryDrawing(
+    {
+      fragments: page.fragments,
+      ...(page.anchoredDrawings ? { anchoredDrawings: page.anchoredDrawings } : {}),
     },
-    depth = 0
-  ): void => {
-    // Capped like every other walk over file-derived structure here. Layout builds these
-    // records, so a cycle should be impossible — which is the reason to bound it rather than
-    // to trust it, since the cost of the bound is nothing.
-    if (depth > MAX_TEXTBOX_STORY_DEPTH) return;
-    for (const drawing of story.anchoredDrawings ?? []) {
-      visitDrawing(drawing);
-      // A text box is a story of its own, nested in the drawing that anchors it.
-      if (drawing.textboxStory) visitStory(drawing.textboxStory, depth + 1);
-    }
-    for (const fragment of story.fragments) visitBlock(fragment);
-  };
-
-  visitStory({
-    fragments: page.fragments,
-    ...(page.anchoredDrawings ? { anchoredDrawings: page.anchoredDrawings } : {}),
-  });
+    visitDrawing
+  );
   for (const story of [page.header, page.footer]) {
-    if (story) visitStory(story);
+    if (story) forEachStoryDrawing(story, visitDrawing);
   }
   for (const area of [page.footnotes, page.endnotes]) {
     if (!area) continue;
     // The separator is an authored story too, and `paintPageNoteAreas` paints it.
-    if (area.separator) visitStory(area.separator);
-    for (const note of area.notes) visitStory(note);
+    if (area.separator) forEachStoryDrawing(area.separator, visitDrawing);
+    for (const note of area.notes) forEachStoryDrawing(note, visitDrawing);
   }
 }
 


### PR DESCRIPTION
A picture inside a `wps:txbx` in a header or footer settles asynchronously like a direct one, but `storyDrawingResourceToken` stopped at the story's own lines and anchored drawings. The furniture context was identical before and after the decode, so the unchanged-pass early exit returned the previous pages by identity and the picture stayed a placeholder until an unrelated edit forced a repaint.

The walk now lives in `forEachStoryDrawing` and is shared with paint's page reconcile, so the invalidation token and the resource keep-alive set cannot drift. Both furniture tokens memoize per story object, because story layouts are identity-stable across passes. The image-resource suites share one decode-port harness so the pending-window assertions cannot rot apart.

Follow-ups filed from review: #466 (text-box stories resolve no list markers) and #467 (the furniture context tokenizes the baseline story, not page-context projections).

Fixes #442

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255216&installation_model_id=422592&pr_number=468&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F468&signature=70a262167cf38b3a2b6fd000185d6f6db4cb533766df7ef103849b0130c22958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->