### PR TITLE
fix: replace smart-substitution targets in place and keep the caret

### DIFF
--- a/.changeset/double-space-period-caret.md
+++ b/.changeset/double-space-period-caret.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Smart text substitutions (macOS double-space period, autocorrect) now replace the text they target instead of inserting beside it, and the browser's selection fix-up around them no longer highlights a stale range or moves the caret.

--- a/packages/core/src/editor/__tests__/replacement-text-input.test.ts
+++ b/packages/core/src/editor/__tests__/replacement-text-input.test.ts
@@ -1,0 +1,290 @@
+// Smart substitutions (`insertReplacementText`): macOS double-space period, autocorrect,
+// dictation. The browser replaces text it targeted itself, so two things must hold:
+//
+// 1. The substitution REPLACES the targeted characters in the model — matched by their
+//    TEXT against the characters before the caret, never by DOM coordinates, which address
+//    a paint that can be a commit behind during a typing burst. Double space becomes
+//    "word. ", not "word . ".
+// 2. The browser's own selection fix-up around the prevented default — it parks its
+//    selection over the text it wanted to replace, with no gesture behind it — is
+//    re-asserted away, never adopted. Adopting it highlighted a stale range and every
+//    keystroke after typed there.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { paragraphTextOf } from '@docx-editor.dev/core/store';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { docx } from './paginated-surface-fixtures.ts';
+
+// The selection belongs to the DOCUMENT, which every suite in this process shares.
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+});
+
+/** Attached to the document: the selection sync only writes into a connected tree. */
+function mounted(body: string): { surface: PaginatedSurface; container: HTMLElement } {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(body), { scale: 1 });
+  if (!opened.ok) throw new Error(opened.reason);
+  return { surface: opened.surface, container };
+}
+
+function putCaret(surface: PaginatedSurface, offset: number): string {
+  const paragraphId = surface.session.paragraphIds()[0]!;
+  surface.setSelection({
+    anchor: { paragraphId, offset },
+    head: { paragraphId, offset },
+  });
+  return paragraphId;
+}
+
+function rangeOver(node: Node, start: number, end: number): unknown {
+  return { startContainer: node, startOffset: start, endContainer: node, endOffset: end };
+}
+
+function dispatchReplacementRanges(
+  container: HTMLElement,
+  replacement: string,
+  ranges: readonly unknown[]
+): void {
+  const event = new InputEvent('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+    inputType: 'insertReplacementText',
+    data: replacement,
+  });
+  Object.defineProperty(event, 'getTargetRanges', { value: () => ranges });
+  container.querySelector('.docx-pages')!.dispatchEvent(event);
+}
+
+/**
+ * Dispatch `insertReplacementText` the way a browser does: replacement text on the event,
+ * the replaced text named by a target range. The range here covers a bare text node — the
+ * handler matches range TEXT, never coordinates, so a detached node is the honest shape of
+ * what a stale paint gives it.
+ */
+function dispatchReplacement(
+  container: HTMLElement,
+  replacement: string,
+  replaced: string | null
+): void {
+  const ranges =
+    replaced === null ? [] : [rangeOver(document.createTextNode(replaced), 0, replaced.length)];
+  dispatchReplacementRanges(container, replacement, ranges);
+}
+
+function keystroke(container: HTMLElement, data: string): void {
+  container.querySelector('.docx-pages')!.dispatchEvent(
+    new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      inputType: 'insertText',
+      data,
+    })
+  );
+}
+
+const WORD_SPACE = '<w:p><w:r><w:t xml:space="preserve">word </w:t></w:r></w:p>';
+
+describe('insertReplacementText replaces what the browser targeted', () => {
+  test('double-space period replaces the preceding space, not inserts beside it', () => {
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      dispatchReplacement(container, '. ', ' ');
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word. ');
+      expect(surface.state().selection.head).toEqual({ paragraphId: id, offset: 6 });
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('a substitution mid-burst lands the buffered keys first, then replaces', async () => {
+    const { surface, container } = mounted('<w:p/>');
+    try {
+      const id = putCaret(surface, 0);
+      for (const key of ['w', 'o', 'r', 'd', ' ']) keystroke(container, key);
+      // Still buffered — the substitution arrives before the zero-delay flush task.
+      dispatchReplacement(container, '. ', ' ');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word. ');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('an autocorrected word is replaced in place', () => {
+    const { surface, container } = mounted(
+      '<w:p><w:r><w:t xml:space="preserve">fix teh</w:t></w:r></w:p>'
+    );
+    try {
+      const id = putCaret(surface, 7);
+      dispatchReplacement(container, 'the', 'teh');
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('fix the');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('a target the model does not show falls back to inserting at the caret', () => {
+    // The one wrong thing would be editing text the browser never targeted. When the range
+    // text and the model characters before the caret disagree — a paint far enough behind
+    // that the browser reasoned about other text — the replacement still lands, at the caret.
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      dispatchReplacement(container, 'the', 'xyz');
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word the');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('an event with no target ranges inserts at the caret', () => {
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      dispatchReplacement(container, 'dictated', null);
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word dictated');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('an armed caret format keeps the caret-insert lane and is not retired', () => {
+    // The range selection the match takes would retire the armed format
+    // (`reconcilePendingWith`); the armed case must ride `type()` like a plain keystroke.
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      surface.toggleRunProperty('b');
+      expect(surface.state().pendingFormat).not.toBeNull();
+      dispatchReplacement(container, '. ', ' ');
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word . ');
+      // Consumed by the insert, not dropped by a selection move.
+      expect(surface.state().pendingFormat).toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('more than one target range falls back to inserting at the caret', () => {
+    // Concatenating ranges would let 'ab' + 'cd' pass the model match as 'abcd'.
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      dispatchReplacementRanges(container, '. ', [
+        rangeOver(document.createTextNode('wor'), 0, 3),
+        rangeOver(document.createTextNode('d '), 0, 2),
+      ]);
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word . ');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test("a connected target in ANOTHER paragraph never matches the caret's", () => {
+    // Same characters in the caret's paragraph would be a coincidence, not the target.
+    const { surface, container } = mounted(WORD_SPACE + WORD_SPACE);
+    try {
+      const ids = surface.session.paragraphIds();
+      const id = putCaret(surface, 5);
+      const otherSpan = container.querySelector<HTMLElement>(
+        `span[data-paragraph-id="${ids[1]}"]`
+      )!;
+      dispatchReplacementRanges(container, '. ', [rangeOver(otherSpan.firstChild!, 4, 5)]);
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word . ');
+      expect(paragraphTextOf(surface.session.part(), ids[1]!)).toBe('word ');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test("a connected target in the caret's own paragraph still replaces", () => {
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      const span = container.querySelector<HTMLElement>(`span[data-paragraph-id="${id}"]`)!;
+      dispatchReplacementRanges(container, '. ', [rangeOver(span.firstChild!, 4, 5)]);
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word. ');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});
+
+describe("the browser's selection fix-up around a substitution is not a gesture", () => {
+  test('a rangeless selection the browser parks after a substitution is re-asserted, not adopted', async () => {
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      dispatchReplacement(container, '. ', ' ');
+      expect(surface.state().selection.head).toEqual({ paragraphId: id, offset: 6 });
+      // Let the mirror's own `selectionchange` echo guard retire (it clears on a microtask).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The fix-up: the browser selects the text IT wanted to replace — over whatever paint
+      // it was reasoning about — with no pointerdown and no selectstart behind it.
+      const span = container.querySelector<HTMLElement>(`span[data-paragraph-id="${id}"]`)!;
+      const textNode = span.firstChild!;
+      const selection = document.getSelection()!;
+      selection.removeAllRanges();
+      const range = document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 1);
+      selection.addRange(range);
+      document.dispatchEvent(new Event('selectionchange'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The model caret stays where the substitution put it, and the next keystroke
+      // lands there — not inside the range the browser invented.
+      expect(surface.state().selection.head).toEqual({ paragraphId: id, offset: 6 });
+      keystroke(container, '!');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(paragraphTextOf(surface.session.part(), id)).toBe('word. !');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('a real gesture after a substitution still wins', async () => {
+    const { surface, container } = mounted(WORD_SPACE);
+    try {
+      const id = putCaret(surface, 5);
+      dispatchReplacement(container, '. ', ' ');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Same DOM selection, but with pointer provenance: the user clicked.
+      const pages = container.querySelector<HTMLElement>('.docx-pages')!;
+      pages.dispatchEvent(new Event('selectstart', { bubbles: true }));
+      const span = container.querySelector<HTMLElement>(`span[data-paragraph-id="${id}"]`)!;
+      const textNode = span.firstChild!;
+      const selection = document.getSelection()!;
+      selection.removeAllRanges();
+      const range = document.createRange();
+      range.setStart(textNode, 1);
+      range.collapse(true);
+      selection.addRange(range);
+      document.dispatchEvent(new Event('selectionchange'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(surface.state().selection.head).toEqual({ paragraphId: id, offset: 1 });
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -5480,6 +5480,13 @@ export function mountPaginatedSurface(
   const dispatchBeforeInput = createBeforeInputHandler(surface, {
     isComposing: () => selectionSync.isComposing(),
     insertPlainText,
+    // The browser parked its own selection over the text a substitution replaced. Rewrite
+    // the DOM selection now for a park that already happened, and flag the queued echo for
+    // one that has not.
+    onBrowserSelectionFixup: () => {
+      selectionSync.mirrorToDom();
+      selectionSync.noteBrowserSelectionFixup();
+    },
   });
   const onBeforeInput = (event: InputEvent): void => {
     selectionSync.adoptBeforeInput();

--- a/packages/core/src/editor/surface-input.ts
+++ b/packages/core/src/editor/surface-input.ts
@@ -8,9 +8,12 @@
 
 import type { TreeDocxSessionView } from '@docx-editor.dev/core/binding';
 import type { NavigationCommand } from '@docx-editor.dev/core/layout';
+import { paragraphTextOf } from '@docx-editor.dev/core/store';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
 import { plainTextFromTransfer } from './clipboard-plain-text.ts';
-import { spanSearchRoots } from './dom-selection.ts';
+import { selectionsEqual, spanSearchRoots } from './dom-selection.ts';
+import { partOfNodeId } from './surface-scope.ts';
+import { collapsedAt } from './surface-selection-ops.ts';
 import { paintedTextIn } from './surface-composition-readback.ts';
 
 const NAVIGATION: Record<string, NavigationCommand> = {
@@ -336,6 +339,13 @@ export function createBeforeInputHandler(
   hooks: {
     readonly isComposing: () => boolean;
     readonly insertPlainText: (text: string) => void;
+    /**
+     * An applied `insertReplacementText` was prevented, but the browser still parks its own
+     * selection over the text it meant to replace — before or after this dispatch, over a
+     * paint that can be a commit behind the model. The selection mirror re-asserts the model
+     * selection and treats the queued echo as the browser's, not the user's.
+     */
+    readonly onBrowserSelectionFixup?: () => void;
   }
 ): (event: InputEvent) => void {
   return (event: InputEvent): void => {
@@ -370,7 +380,9 @@ export function createBeforeInputHandler(
       // The replacement text is on the event; applying it is how a correction survives
       // instead of being silently dropped.
       const replacement = event.data ?? dataTransferText(event);
-      if (replacement) surface.type(replacement);
+      if (!replacement) return;
+      applyReplacementText(surface, replacementTarget(event), replacement);
+      hooks.onBrowserSelectionFixup?.();
       return;
     }
     if (event.inputType === 'deleteContentBackward') {
@@ -405,6 +417,101 @@ export function createBeforeInputHandler(
       surface.splitParagraph();
     }
   };
+}
+
+/** The text one static range covers, or null when it cannot be read. */
+function staticRangeText(range: StaticRange): string | null {
+  const { startContainer, endContainer } = range;
+  if (startContainer === endContainer && startContainer.nodeType === Node.TEXT_NODE) {
+    return (startContainer.textContent ?? '').slice(range.startOffset, range.endOffset);
+  }
+  const doc = startContainer.ownerDocument;
+  if (!doc) return null;
+  try {
+    const live = doc.createRange();
+    live.setStart(startContainer, range.startOffset);
+    live.setEnd(endContainer, range.endOffset);
+    return live.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** What one `insertReplacementText` event targeted: its text, and its paragraph if known. */
+interface ReplacementTarget {
+  readonly text: string;
+  /** The `data-paragraph-id` a CONNECTED target sits in; null for a detached (stale) node. */
+  readonly paragraphId: string | null;
+}
+
+/** The target of a replacement event, or null when it names none the model could act on. */
+function replacementTarget(event: InputEvent): ReplacementTarget | null {
+  if (typeof event.getTargetRanges !== 'function') return null;
+  const ranges = event.getTargetRanges();
+  // ONE range only. A real substitution targets one contiguous run of text, and
+  // concatenating several would let 'ab' + 'cd' pass the model match as 'abcd'.
+  if (ranges.length !== 1) return null;
+  const range = ranges[0]!;
+  const text = staticRangeText(range);
+  if (!text) return null;
+  return { text, paragraphId: targetParagraphId(range) };
+}
+
+/** The paragraph a connected target range sits in, or null when it cannot say. */
+function targetParagraphId(range: StaticRange): string | null {
+  const node = range.startContainer;
+  if (!node.isConnected) return null;
+  const element =
+    node.nodeType === Node.ELEMENT_NODE ? (node as Element) : (node.parentElement ?? null);
+  return element?.closest('[data-paragraph-id]')?.getAttribute('data-paragraph-id') ?? null;
+}
+
+/**
+ * Apply a browser text substitution — autocorrect, dictation, macOS double-space period.
+ *
+ * The event's target range says WHAT the browser replaced, but its coordinates address the
+ * painted DOM, which sits a paint behind the model during a typing burst — mapping them would
+ * edit characters the substitution never meant. Its TEXT is matched instead, against the model
+ * characters before the caret once the buffered burst has landed: on agreement the substitution
+ * replaces them (double space becomes "word. ", not "word . "); on anything else the
+ * replacement inserts at the caret, which never edits text the browser did not target. A
+ * connected target that names ANOTHER paragraph is never matched — same characters in the
+ * caret's paragraph would be a coincidence, not the browser's target.
+ */
+function applyReplacementText(
+  surface: PaginatedSurface,
+  target: ReplacementTarget | null,
+  replacement: string
+): void {
+  if (target !== null) {
+    // The model text and caret are read below, so the buffered burst sits ABOVE this read.
+    // The targetless path skips the flush: `type()` head-flushes on its own.
+    surface.flushPendingInput();
+    const state = surface.state();
+    const caret = state.selection.head;
+    const replaced = target.text;
+    if (
+      selectionsEqual(state.selection, collapsedAt(caret)) &&
+      caret.offset >= replaced.length &&
+      (target.paragraphId === null || target.paragraphId === caret.paragraphId) &&
+      // An armed caret format must ride the `type()` below exactly as it rides a plain
+      // keystroke, and the range selection would retire it. The armed case keeps the
+      // caret-insert lane; arming a format and substituting in the SAME keystroke gap
+      // is rare enough that the un-replaced space costs less than the lost format.
+      state.pendingFormat === null
+    ) {
+      // A pure ancestry read: `partOfNodeId`, never the story-store opener.
+      const part = partOfNodeId(surface.session, caret.paragraphId) ?? surface.session.part();
+      const text = paragraphTextOf(part, caret.paragraphId);
+      if (text !== null && text.slice(caret.offset - replaced.length, caret.offset) === replaced) {
+        surface.setSelection({
+          anchor: { paragraphId: caret.paragraphId, offset: caret.offset - replaced.length },
+          head: caret,
+        });
+      }
+    }
+  }
+  surface.type(replacement);
 }
 
 /**

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -173,6 +173,18 @@ export interface SurfaceSelectionSync {
   adoptBeforeInput(): void;
   /** Whether an IME is composing, which suspends repainting. */
   isComposing(): boolean;
+  /**
+   * Record that the browser may park its own selection as the FIX-UP of a prevented input.
+   *
+   * A smart substitution (`insertReplacementText`: macOS double-space period, autocorrect)
+   * moves the native selection over the text the browser wanted to replace, even though the
+   * surface prevented the default and applied the edit in the model. That write has no
+   * gesture behind it and can land before or after the event dispatch, over a paint that is
+   * a commit behind — adopting it highlighted a stale range and moved the caret there. The
+   * next in-pages `selectionchange` without gesture provenance re-asserts the model
+   * selection instead of adopting.
+   */
+  noteBrowserSelectionFixup(): void;
   readonly onSelectionChange: () => void;
   readonly onCompositionStart: () => void;
   readonly onCompositionEnd: (event?: CompositionEvent) => void;
@@ -440,6 +452,55 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
     userSelectionGesture = true;
   }
 
+  /**
+   * Whether the next in-pages `selectionchange` may be the browser's own fix-up of a
+   * prevented replacement rather than a user selection. One-shot: spent by the first
+   * `selectionchange` that touches the pages. See `noteBrowserSelectionFixup`.
+   */
+  let browserSelectionFixup = false;
+
+  function mirrorToDom(claim = false): void {
+    // Ahead of the ownership guard: the caret is this engine's own, painted whether or not
+    // the browser's selection lives here.
+    deps.updateCaret();
+    // Only when this surface owns the selection. A render runs on mount and on every commit
+    // — including one from another editor sharing the store — and writing unconditionally
+    // yanked the caret out of whatever the user was actually typing in. A CLAIMED write is
+    // the exception: someone asked for this range on purpose.
+    if (!claim && !ownsSelection()) return;
+    applyingSelection = true;
+    const began = deps.now();
+    const next = deps.domSelection?.() ?? deps.selection();
+    // This write is the new baseline. Matching DOM carets after it are echoes until the
+    // user starts another selection gesture.
+    userSelectionGesture = false;
+    const native = document.getSelection();
+    const preferredPageIndex = preferredSelectionPage(native);
+    const wrote = applySelectionToDom(
+      pagesLayer,
+      next,
+      native,
+      preferredPageIndex !== undefined ? { preferredPageIndex } : undefined
+    );
+    if (wrote) rememberSelectionPage(native);
+    // A REFUSED write is not a baseline. `applySelectionToDom` answers false when either
+    // endpoint has no painted place to land — a caret in a paragraph that painted no spans,
+    // an offset no span covers, a page that is not built — and the browser then keeps
+    // showing the PREVIOUS selection. Recording it anyway told `isStaleMirroredCaret` that
+    // the DOM had been given this value, so the disagreement it exists to catch read as a
+    // fresh gesture, and the stale caret won the next echo. The model is still the newer of
+    // the two here, which is exactly what `modelMoved` says.
+    lastMirroredSelection = wrote ? next : null;
+    if (!wrote) modelMoved = true;
+    deps.recordSelectionMs(deps.now() - began);
+    // Cleared on a LATER task, because `selectionchange` is queued rather than dispatched
+    // synchronously. Clearing it here would defeat the guard in every real browser while
+    // still appearing to work under a synchronous test DOM.
+    queueMicrotask(() => {
+      applyingSelection = false;
+    });
+  }
+
   // Native pointer mode binds no engine handlers; touch bypasses them even in engine mode.
   // Capture here so a caret that lands on the last mirrored offset is still a gesture.
   pagesLayer.addEventListener('pointerdown', noteUserSelectionGesture, true);
@@ -502,51 +563,15 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       modelMoved = false;
     },
 
-    mirrorToDom(claim = false) {
-      // Ahead of the ownership guard: the caret is this engine's own, painted whether or not
-      // the browser's selection lives here.
-      deps.updateCaret();
-      // Only when this surface owns the selection. A render runs on mount and on every commit
-      // — including one from another editor sharing the store — and writing unconditionally
-      // yanked the caret out of whatever the user was actually typing in. A CLAIMED write is
-      // the exception: someone asked for this range on purpose.
-      if (!claim && !ownsSelection()) return;
-      applyingSelection = true;
-      const began = deps.now();
-      const next = deps.domSelection?.() ?? deps.selection();
-      // This write is the new baseline. Matching DOM carets after it are echoes until the
-      // user starts another selection gesture.
-      userSelectionGesture = false;
-      const native = document.getSelection();
-      const preferredPageIndex = preferredSelectionPage(native);
-      const wrote = applySelectionToDom(
-        pagesLayer,
-        next,
-        native,
-        preferredPageIndex !== undefined ? { preferredPageIndex } : undefined
-      );
-      if (wrote) rememberSelectionPage(native);
-      // A REFUSED write is not a baseline. `applySelectionToDom` answers false when either
-      // endpoint has no painted place to land — a caret in a paragraph that painted no spans,
-      // an offset no span covers, a page that is not built — and the browser then keeps
-      // showing the PREVIOUS selection. Recording it anyway told `isStaleMirroredCaret` that
-      // the DOM had been given this value, so the disagreement it exists to catch read as a
-      // fresh gesture, and the stale caret won the next echo. The model is still the newer of
-      // the two here, which is exactly what `modelMoved` says.
-      lastMirroredSelection = wrote ? next : null;
-      if (!wrote) modelMoved = true;
-      deps.recordSelectionMs(deps.now() - began);
-      // Cleared on a LATER task, because `selectionchange` is queued rather than dispatched
-      // synchronously. Clearing it here would defeat the guard in every real browser while
-      // still appearing to work under a synchronous test DOM.
-      queueMicrotask(() => {
-        applyingSelection = false;
-      });
-    },
+    mirrorToDom,
 
     adoptBeforeInput: adoptPendingUserSelection,
 
     isComposing: () => composing,
+
+    noteBrowserSelectionFixup() {
+      browserSelectionFixup = true;
+    },
 
     onSelectionChange: (): void => {
       // Ignore the echo of our own write, and anything happening outside the pages. The flag
@@ -558,6 +583,24 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
       if (composing) return;
       if (deps.isGesturing?.()) return;
       if (deps.holdsCellSelection?.()) return;
+      // A prevented `insertReplacementText` leaves the browser's own selection parked over
+      // the text IT wanted to replace — a fix-up with no gesture behind it, written over a
+      // paint that can be a commit behind the model. Adopting it highlighted a stale range
+      // and every keystroke after typed there. Re-assert the model's selection instead; a
+      // real gesture spends the flag too but keeps its provenance and wins. An echo that
+      // already MATCHES the model does not spend the one-shot: it is this surface's own
+      // mirror reporting back, and spending on it would leave a park that lands on a later
+      // task unguarded.
+      if (browserSelectionFixup && domSelectionTouchesPages(pagesLayer, document.getSelection())) {
+        const reported = semanticSelectionFromDom(pagesLayer, document.getSelection());
+        if (reported === null || !selectionsEqual(reported, deps.selection())) {
+          browserSelectionFixup = false;
+          if (!userSelectionGesture) {
+            mirrorToDom();
+            return;
+          }
+        }
+      }
       // A deferred paint leaves the DOM caret at its PRE-edit offset while the model already
       // holds the post-edit one. A late echo from an earlier mirror must not make that stale
       // DOM caret authoritative again; the pending paint will mirror the newer model value.


### PR DESCRIPTION
macOS double-space period and autocorrect arrive as `insertReplacementText`. The handler inserted the replacement at the caret and ignored the text the browser targeted, so a double space produced "word . " instead of "word. ". The browser also parks its own selection over the targeted text even though the default is prevented; under a typing burst that range addresses a stale paint, the selection sync adopted it as a user gesture, and later keystrokes typed at the highlighted range.

The handler now reads the target range's text and matches it against the model characters before the caret; on agreement the substitution replaces them in one commit. A connected target in another paragraph, more than one range, a mismatch, or an armed caret format falls back to inserting at the caret, so the edit never touches text the browser did not target. The selection sync re-asserts the model selection after a handled substitution and treats the queued gesture-less `selectionchange` as the browser's fix-up, not a user selection.

Verified with the unit suite and against Chromium: a burst-typed double space now lands as "word. ", the caret stays in place, and typing continues there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255523&installation_model_id=422592&pr_number=469&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F469&signature=713967d72e3c59090a8d5818bea086c73a82b718aab18f881df730f149e07c41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->