### PR TITLE
perf: unify note-reference scans on the budgeted subtree memo

### DIFF
--- a/.changeset/note-scan-memo-unification.md
+++ b/.changeset/note-scan-memo-unification.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Reduce per-keystroke scan work and memory use on documents with footnotes or endnotes.

--- a/packages/core/src/store/__tests__/note-scan-boundary.test.ts
+++ b/packages/core/src/store/__tests__/note-scan-boundary.test.ts
@@ -21,6 +21,7 @@ import {
   type OoxmlParagraphNode,
   type OoxmlPart,
 } from '../package/index.ts';
+import { budgetedNoteScanMemoStats } from '../package/note-references.ts';
 import { segmentsOf } from '../store/tree-op-segments.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -403,6 +404,147 @@ describe('diagnoseNoteReferences truncation signal', () => {
   });
 });
 
+function loadDocumentPart(bodyInner: string): OoxmlPart {
+  const read = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body>${bodyInner}<w:sectPr/></w:body></w:document>`,
+    {
+      name: '/word/document.xml',
+      contentType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+    }
+  );
+  if (!read.ok) throw new Error(read.reason);
+  return read.part;
+}
+
+describe('budget-free scans share the budgeted walk', () => {
+  function refParagraph(id: number): string {
+    return `<w:p><w:r><w:footnoteReference w:id="${id}"/></w:r></w:p>`;
+  }
+
+  test('finite maxHits without a budget returns the document-order prefix', () => {
+    const part = loadDocumentPart(refParagraph(1) + refParagraph(2) + refParagraph(3));
+    const all = collectNoteReferences(part);
+    expect(all.map((hit) => hit.noteId)).toEqual([1, 2, 3]);
+    const clipped = collectNoteReferences(structuredClone(part), { maxHits: 2 });
+    expect(JSON.stringify(clipped)).toBe(JSON.stringify(all.slice(0, 2)));
+  });
+
+  test('an unchanged part answers warm budget-free scans by identity', () => {
+    const part = loadDocumentPart(refParagraph(1) + refParagraph(2));
+    collectNoteReferences(part); // cold walk memoizes the root
+    const warm = collectNoteReferences(part);
+    expect(warm.map((hit) => hit.noteId)).toEqual([1, 2]);
+    expect(collectNoteReferences(part)).toBe(warm);
+    expect(Object.isFrozen(warm)).toBe(true);
+    // A clip below the cached hit count serves a warm slice with the same prefix.
+    const clippedWarm = collectNoteReferences(part, { maxHits: 1 });
+    expect(JSON.stringify(clippedWarm)).toBe(JSON.stringify(warm.slice(0, 1)));
+  });
+
+  test('depth past 64 prunes budget-free scans but fails budgeted scans closed', () => {
+    // A >64-deep generic chain between two shallow references. Budget-free (layout)
+    // scans prune the deep subtree and keep the trailing reference; budgeted (mutation)
+    // scans mark the shared budget truncated and stop, so callers refuse atomically.
+    const deepChain = '<w:x>'.repeat(70) + '</w:x>'.repeat(70);
+    const part = loadDocumentPart(refParagraph(1) + deepChain + refParagraph(2));
+
+    // A truncated budgeted scan first must not poison the later budget-free walk.
+    const preBudget = createNoteReferenceScanBudget(
+      Number.POSITIVE_INFINITY,
+      Number.POSITIVE_INFINITY
+    );
+    collectNoteReferences(part, { budget: preBudget, maxHits: Number.POSITIVE_INFINITY });
+    expect(preBudget.truncated).toBe(true);
+
+    const budgetFree = collectNoteReferences(part);
+    expect(budgetFree.map((hit) => hit.noteId)).toEqual([1, 2]);
+
+    // The pruned scan warmed the memos on this exact part; the budgeted walk over the
+    // SAME nodes must still fail closed — no entry may stand in for the pruned region.
+    const budget = createNoteReferenceScanBudget(
+      Number.POSITIVE_INFINITY,
+      Number.POSITIVE_INFINITY
+    );
+    const budgeted = collectNoteReferences(part, { budget, maxHits: Number.POSITIVE_INFINITY });
+    expect(budget.truncated).toBe(true);
+    expect(budgeted.map((hit) => hit.noteId)).toEqual([1]);
+
+    const coldBudget = createNoteReferenceScanBudget(
+      Number.POSITIVE_INFINITY,
+      Number.POSITIVE_INFINITY
+    );
+    const coldBudgeted = collectNoteReferences(structuredClone(part), {
+      budget: coldBudget,
+      maxHits: Number.POSITIVE_INFINITY,
+    });
+    expect(JSON.stringify(budgeted)).toBe(JSON.stringify(coldBudgeted));
+    expect(budget.visited).toBe(coldBudget.visited);
+
+    // Warm budget-free scans agree with the cold pruned walk.
+    expect(JSON.stringify(collectNoteReferences(part))).toBe(
+      JSON.stringify(collectNoteReferences(structuredClone(part)))
+    );
+  });
+
+  test('a paragraph re-parented deeper still serves its memo with budgeted parity', () => {
+    const flat = loadDocumentPart(refParagraph(1) + refParagraph(2));
+    collectNoteReferences(flat); // memoize the paragraph entries at their flat depth
+    const flatBody = flat.root.children.find((child) => child.kind === 'body')!;
+    const shared = flatBody.children.filter((child) => child.kind === 'paragraph');
+    expect(shared).toHaveLength(2);
+
+    // Rebuild a second part holding the SAME paragraph node objects six generic
+    // wrapper levels deeper. Spreads keep realistic node shapes; the memo keys on
+    // object identity, and paragraph answers must be depth-invariant.
+    const shell = loadDocumentPart('<w:x>'.repeat(6) + '</w:x>'.repeat(6));
+    const shellBody = shell.root.children.find((child) => child.kind === 'body')!;
+    const chain: OoxmlNode[] = [];
+    let cursor = shellBody.children.find(
+      (child) => child.kind !== 'textValue' && child.localName === 'x'
+    );
+    while (cursor && cursor.kind !== 'textValue') {
+      chain.push(cursor);
+      cursor = cursor.children.find(
+        (child) => child.kind !== 'textValue' && child.localName === 'x'
+      );
+    }
+    expect(chain).toHaveLength(6);
+    let rebuilt = { ...chain[5]!, children: shared } as OoxmlNode;
+    for (let level = 4; level >= 0; level -= 1) {
+      rebuilt = { ...chain[level]!, children: [rebuilt] } as OoxmlNode;
+    }
+    const deepBody = {
+      ...shellBody,
+      children: shellBody.children.map((child) => (child === chain[0] ? rebuilt : child)),
+    } as typeof shellBody;
+    const deepRoot = {
+      ...shell.root,
+      children: shell.root.children.map((child) => (child === shellBody ? deepBody : child)),
+    } as typeof shell.root;
+    const deepPart: OoxmlPart = { ...shell, root: deepRoot };
+
+    const reusesBefore = budgetedNoteScanMemoStats.reuses;
+    const warmBudget = createNoteReferenceScanBudget(1_000_000);
+    const warmHits = collectNoteReferences(deepPart, {
+      budget: warmBudget,
+      maxHits: Number.POSITIVE_INFINITY,
+    });
+    const coldBudget = createNoteReferenceScanBudget(1_000_000);
+    const coldHits = collectNoteReferences(structuredClone(deepPart), {
+      budget: coldBudget,
+      maxHits: Number.POSITIVE_INFINITY,
+    });
+    expect(warmHits.map((hit) => hit.noteId)).toEqual([1, 2]);
+    expect(JSON.stringify(warmHits)).toBe(JSON.stringify(coldHits));
+    expect(warmBudget.visited).toBe(coldBudget.visited);
+    expect(warmBudget.truncated).toBe(false);
+    expect(coldBudget.truncated).toBe(false);
+    // Anti-vacuity: both flat-depth paragraph entries served at the deeper depth.
+    expect(budgetedNoteScanMemoStats.reuses - reusesBefore).toBeGreaterThanOrEqual(2);
+  });
+});
+
 describe('collectNoteReferences atomOffset matches segmentsOf', () => {
   function findParagraph(node: OoxmlNode): OoxmlParagraphNode | null {
     if (node.kind === 'paragraph') return node;
@@ -418,18 +560,10 @@ describe('collectNoteReferences atomOffset matches segmentsOf', () => {
     readonly part: OoxmlPart;
     readonly paragraph: OoxmlParagraphNode;
   } {
-    const read = readOoxmlPart(
-      `<w:document xmlns:w="${W}"><w:body>${bodyInner}<w:sectPr/></w:body></w:document>`,
-      {
-        name: '/word/document.xml',
-        contentType:
-          'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
-      }
-    );
-    if (!read.ok) throw new Error(read.reason);
-    const paragraph = findParagraph(read.part.root);
+    const part = loadDocumentPart(bodyInner);
+    const paragraph = findParagraph(part.root);
     if (!paragraph) throw new Error('missing paragraph');
-    return { part: read.part, paragraph };
+    return { part, paragraph };
   }
 
   function assertHitsMatchSegments(part: OoxmlPart, paragraph: OoxmlParagraphNode): void {

--- a/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
+++ b/packages/core/src/store/__tests__/note-scan-memo-freshness.test.ts
@@ -9,13 +9,15 @@
 // data properties, so the clone carries the ORIGINAL ids and hits compare by value.
 //
 // Three probes per applied op:
-// 1. Full budget: hits AND the final `budget.visited` / `budget.truncated` must be
+// 1. The budget-free path FIRST (while the edited spine is still unmemoized), which
+//    runs the same walk over the same memo under an unbounded internal budget — so the
+//    two entry points cannot drift apart — then again warm through the root fast path.
+// 2. Full budget: hits AND the final `budget.visited` / `budget.truncated` must be
 //    byte-identical to the cold walk — downstream parts sharing one budget must truncate
 //    at exactly the same point.
-// 2. A budget small enough to truncate mid-tree: hits and accounting must STILL match
+// 3. A budget small enough to truncate mid-tree: hits and accounting must STILL match
 //    the cold walk byte-for-byte, because an overrunning memo falls through to the
 //    plain descent (pre-truncation prefixes feed diagnoseNoteReferences).
-// 3. The budget-free memoized path, so the two memo systems cannot drift apart.
 //
 // Determinism and the random-edit machinery live in `random-edit-test-support.ts`,
 // shared with `derivation-memo-freshness.test.ts`.
@@ -72,6 +74,22 @@ function assertBudgetedScanFresh(
   step: number,
   log: unknown[]
 ): void {
+  // Budget-free first, before anything re-memoizes the edited spine: the root entry is
+  // stale after an edit, so this exercises the warm budget-free WALK (in-walk bulk
+  // reuse and prune bookkeeping), not just the root fast path. It must agree with its
+  // own cold walk, so the two entry points into the shared memo cannot drift apart.
+  const plainJson = JSON.stringify(collectNoteReferences(part));
+  const plainColdJson = JSON.stringify(collectNoteReferences(structuredClone(part)));
+  if (plainJson !== plainColdJson) {
+    fail('budget-free hits', seed, step, `memoized: ${plainJson}\nfresh: ${plainColdJson}`, log);
+  }
+  // That walk completed, so a second budget-free scan serves from the root fast path
+  // and must return the same answer.
+  const plainWarmJson = JSON.stringify(collectNoteReferences(part));
+  if (plainWarmJson !== plainJson) {
+    fail('budget-free root reuse', seed, step, `warm: ${plainWarmJson}\nwalk: ${plainJson}`, log);
+  }
+
   // Full budget: hits and accounting byte-identical to the cold walk.
   const memoBudget = createNoteReferenceScanBudget(FULL_BUDGET);
   const memoHits = collectNoteReferences(part, {
@@ -101,14 +119,6 @@ function assertBudgetedScanFresh(
   }
   if (memoBudget.truncated) {
     fail('full budget', seed, step, 'full budget unexpectedly truncated', log);
-  }
-
-  // Budget-free memoized path must agree with its own cold walk too, so the two memo
-  // systems cannot drift apart.
-  const plainJson = JSON.stringify(collectNoteReferences(part));
-  const plainColdJson = JSON.stringify(collectNoteReferences(structuredClone(part)));
-  if (plainJson !== plainColdJson) {
-    fail('budget-free hits', seed, step, `memoized: ${plainJson}\nfresh: ${plainColdJson}`, log);
   }
 
   // A budget that truncates mid-tree: a warm memo whose bulk charge would overrun the
@@ -163,6 +173,8 @@ describe('budgeted note-reference scan memos stay fresh across random op sequenc
       assertBudgetedScanFresh(store.part, seed, -1, []);
 
       const reusesBefore = budgetedNoteScanMemoStats.reuses;
+      const budgetFreeReusesBefore = budgetedNoteScanMemoStats.budgetFreeReuses;
+      const rootReusesBefore = budgetedNoteScanMemoStats.budgetFreeRootReuses;
       const { applied, splitsApplied } = driveRandomEdits(store, {
         rand: mulberry32(seed),
         steps: STEPS,
@@ -172,11 +184,20 @@ describe('budgeted note-reference scan memos stay fresh across random op sequenc
 
       // Anti-vacuity: enough ops applied, and enough splits that fresh spines were
       // rescanned against — and read back through — the memoized subtrees. The reuse
-      // floor proves memos actually served (equivalence alone would also pass for a
+      // floors prove memos actually served (equivalence alone would also pass for a
       // memo that never hits, which delivers correctness but none of the latency win).
+      // The counters are per serve site, so a budgeted-walk regression cannot hide
+      // behind budget-free reuses, an in-walk regression cannot hide behind the root
+      // fast path, or the reverse.
       expect(applied).toBeGreaterThanOrEqual(12);
       expect(splitsApplied).toBeGreaterThanOrEqual(2);
       expect(budgetedNoteScanMemoStats.reuses - reusesBefore).toBeGreaterThanOrEqual(applied);
+      expect(
+        budgetedNoteScanMemoStats.budgetFreeReuses - budgetFreeReusesBefore
+      ).toBeGreaterThanOrEqual(applied);
+      expect(
+        budgetedNoteScanMemoStats.budgetFreeRootReuses - rootReusesBefore
+      ).toBeGreaterThanOrEqual(applied);
     });
   }
 });

--- a/packages/core/src/store/package/note-references.ts
+++ b/packages/core/src/store/package/note-references.ts
@@ -127,8 +127,7 @@ function customMarkFollowsOf(node: OoxmlNode): boolean {
   return !(raw === '0' || raw === 'false' || raw === 'off');
 }
 
-function charge(budget: NoteReferenceScanBudget | undefined): boolean {
-  if (!budget) return true;
+function charge(budget: NoteReferenceScanBudget): boolean {
   if (budget.visited >= budget.maxVisited) {
     budget.truncated = true;
     return false;
@@ -204,110 +203,51 @@ function pushReferenceHit(
 function collectParagraphNoteReferences(
   paragraph: OoxmlParagraphNode,
   hits: NoteReferenceHit[],
-  budget: NoteReferenceScanBudget | undefined,
+  budget: NoteReferenceScanBudget,
   maxHits: number,
   partName: string
 ): void {
-  if (hits.length >= maxHits || (budget && budget.truncated)) return;
-
+  // The caller (walk) already returned on a truncated budget; only charge() can truncate
+  // here, and it reports that by returning false.
   for (const segment of segmentsOf(paragraph)) {
-    if (hits.length >= maxHits || (budget && budget.truncated)) return;
+    if (hits.length >= maxHits) return;
     if (!charge(budget)) return;
     if (segment.node.kind !== 'noteReference') continue;
     pushReferenceHit(hits, segment.node, paragraph.id, segment.start, partName, maxHits);
   }
 }
 
-/**
- * Per-paragraph note-reference memo, keyed on the immutable paragraph node.
- *
- * The budget-free scan uses it (layout runs one per published pass over a part whose
- * paragraphs are all shared but the edited one); budgeted scans use
- * {@link budgetedNoteScanMemos} instead, which also records exact visited accounting.
- * Hits carry a baked-in `partName`, so the entry records the name it was computed under
- * and a paragraph reached under a second part name recomputes.
- */
-const paragraphNoteHitMemos = new WeakMap<
-  OoxmlNode,
-  { readonly partName: string; readonly hits: readonly NoteReferenceHit[] }
->();
-
-function paragraphNoteHitsOf(
-  paragraph: OoxmlParagraphNode,
-  partName: string
-): readonly NoteReferenceHit[] {
-  const cached = paragraphNoteHitMemos.get(paragraph);
-  if (cached && cached.partName === partName) return cached.hits;
-  const hits: NoteReferenceHit[] = [];
-  collectParagraphNoteReferences(paragraph, hits, undefined, MAX_NOTE_REFERENCE_SCAN, partName);
-  paragraphNoteHitMemos.set(paragraph, { partName, hits });
-  return hits;
-}
-
 const NO_NOTE_HITS: readonly NoteReferenceHit[] = Object.freeze([]);
-
-/**
- * Note-reference hits under one immutable container.
- *
- * A text edit replaces one paragraph and its ancestors. Unchanged sibling containers keep
- * their identity, so their complete answer remains reusable across part revisions.
- *
- * The entry records the depth and part name it was computed under, like
- * {@link budgetedNoteScanMemos}: the 64-level cap makes the answer depth-dependent (a
- * subtree first reached past the cap caches empty), and hits carry a baked-in
- * `partName`. A mismatch on either recomputes instead of replaying the stale answer.
- */
-const containerNoteHitMemos = new WeakMap<
-  OoxmlNode,
-  { readonly depth: number; readonly partName: string; readonly hits: readonly NoteReferenceHit[] }
->();
-
-function subtreeNoteHitsOf(
-  node: OoxmlNode,
-  partName: string,
-  depth: number
-): readonly NoteReferenceHit[] {
-  if (node.kind === 'textValue' || depth > 64) return NO_NOTE_HITS;
-  if (node.kind === 'paragraph') return paragraphNoteHitsOf(node, partName);
-  const cached = containerNoteHitMemos.get(node);
-  if (cached && cached.depth === depth && cached.partName === partName) return cached.hits;
-
-  let hits: NoteReferenceHit[] | null = null;
-  for (const child of node.children) {
-    const childHits = subtreeNoteHitsOf(child, partName, depth + 1);
-    if (childHits.length === 0) continue;
-    hits ??= [];
-    const remaining = MAX_NOTE_REFERENCE_SCAN - hits.length;
-    if (remaining <= 0) break;
-    hits.push(...childHits.slice(0, remaining));
-  }
-  const result: readonly NoteReferenceHit[] = hits ? Object.freeze(hits) : NO_NOTE_HITS;
-  containerNoteHitMemos.set(node, { depth, partName, hits: result });
-  return result;
-}
 
 /**
  * Budgeted subtree memo: the hits under one immutable node plus the exact visited-node
  * count the plain budgeted walk charges for that subtree (including the subtree root's
  * own charge).
  *
- * Mutation paths always carry a budget, and before this memo they re-walked the whole
- * package on every transaction. A budgeted walk that reaches a memoized subtree
- * bulk-charges the cached count and reuses the hits without descending — but only when
- * the cached count fits the remaining budget AND appending the cached hits stays under
- * `maxHits`. Otherwise the walk falls through to the plain descent, which stops at
- * exactly the node the unmemoized walk would stop at. Every budgeted scan is therefore
- * byte-identical to the unmemoized walk — hits, `visited` and `truncated` alike — warm
- * or cold, truncated or not, so downstream parts sharing one budget behave identically
- * and pre-truncation hit prefixes (which `diagnoseNoteReferences` reports) survive.
+ * Every scan runs the one walk — budget-free entry points (layout's per-publish scans)
+ * run it under a fresh effectively-unbounded budget — so this is the ONE memo for both.
+ * A walk that reaches a memoized subtree bulk-charges the cached count and reuses the
+ * hits without descending — but only when the cached count fits the remaining budget AND
+ * appending the cached hits stays under `maxHits`. Otherwise the walk falls through to
+ * the plain descent, which stops at exactly the node the unmemoized walk would stop at.
+ * Every budgeted scan is therefore byte-identical to the unmemoized walk — hits,
+ * `visited` and `truncated` alike — warm or cold, truncated or not, so downstream parts
+ * sharing one budget behave identically and pre-truncation hit prefixes (which
+ * `diagnoseNoteReferences` reports) survive.
+ *
+ * An entry is only ever written for a subtree the walk covered COMPLETELY — no budget
+ * truncation, no maxHits clip, no deep-nesting prune anywhere inside it — so both modes
+ * (fail-closed budgeted, prune-and-continue budget-free) can share entries: a complete
+ * answer is the same answer under either mode.
  *
  * The entry records the depth and part name it was computed under. The 64-level cap
- * makes results depth-dependent, so a shared subtree republished at a different depth
- * recomputes instead of serving an answer computed under the old cap (same fix as
- * `subtreeDeepParagraphIdsCache` in `review-reads.ts`). The part name makes the
- * one-part-per-node assumption self-enforcing: hits carry a baked-in `partName`, so a
- * node reached under a second part name must recompute rather than replay the first
- * part's hits.
+ * makes container results depth-dependent, so a shared subtree republished at a
+ * different depth recomputes instead of serving an answer computed under the old cap
+ * (same fix as `subtreeDeepParagraphIdsCache` in `review-reads.ts`). Paragraph answers
+ * come from `segmentsOf` alone and never descend, so they are depth-invariant and reused
+ * across depths. The part name makes the one-part-per-node assumption self-enforcing:
+ * hits carry a baked-in `partName`, so a node reached under a second part name must
+ * recompute rather than replay the first part's hits.
  */
 interface BudgetedNoteScanEntry {
   readonly hits: readonly NoteReferenceHit[];
@@ -323,18 +263,32 @@ const budgetedNoteScanMemos = new WeakMap<OoxmlNode, BudgetedNoteScanEntry>();
  * a hit. Their nearest memoized ancestor answers for them on an unchanged spine, and a
  * rebuilt spine re-walks them for less than an entry is worth — this keeps the memo from
  * retaining one entry per element of every non-story part. Paragraphs always get an
- * entry: they are the reuse unit when an edit rebuilds the story spine above them.
+ * entry: they are the reuse unit when an edit rebuilds the story spine above them. The
+ * part root (depth 0) always gets one too: a root entry is what serves the budget-free
+ * warm path, and one entry per part is cheap even for a tiny hitless part.
  */
 const MEMO_MIN_SUBTREE_VISITED = 64;
 
-/** Test-only observability: bulk memo reuses. Asserted by the freshness differential. */
-export const budgetedNoteScanMemoStats = { reuses: 0 };
+/**
+ * Test-only observability: bulk memo reuses, counted per serve site so the freshness
+ * differential can floor each on its own — a budgeted-walk regression must not hide
+ * behind budget-free reuses, an in-walk regression must not hide behind the root fast
+ * path, or the reverse.
+ */
+export const budgetedNoteScanMemoStats = {
+  reuses: 0,
+  budgetFreeReuses: 0,
+  budgetFreeRootReuses: 0,
+};
 
 /**
- * Walk a part for addressable typed note references. Bounded by visited nodes; skips deep
- * hostile nesting by marking the shared budget truncated. When `budget` is supplied it is
- * shared and mutated in place. Hits are segment-aligned (`segmentsOf`); demoted wrappers
- * never invent atomOffsets.
+ * Walk a part for addressable typed note references. Budgeted scans are bounded by
+ * visited nodes and fail closed on deep hostile nesting (the shared budget is marked
+ * truncated and the walk stops, so mutation callers refuse); budget-free scans are
+ * bounded by the 64-level depth cap and `maxHits` alone and fail open (a too-deep
+ * subtree is pruned and siblings still scan, so layout keeps every reachable citation).
+ * When `budget` is supplied it is shared and mutated in place. Hits are segment-aligned
+ * (`segmentsOf`); demoted wrappers never invent atomOffsets.
  */
 export function collectNoteReferences(
   part: OoxmlPart,
@@ -344,37 +298,45 @@ export function collectNoteReferences(
   }
 ): readonly NoteReferenceHit[] {
   // Hit count is a soft collector bound for diagnostics only. Mutation paths pass an
-  // unbounded maxHits and rely on the visited-node budget (+ truncation) instead.
-  const maxHits = options?.maxHits ?? MAX_NOTE_REFERENCE_SCAN;
-  const budget = options?.budget;
+  // unbounded maxHits and rely on the visited-node budget (+ truncation) instead. A
+  // fractional cap would make warm and cold scans disagree (slice truncates, `>=` does
+  // not), and NaN fails every comparison, which would disable the cap entirely — floor
+  // once here and reject NaN like a non-positive cap.
+  const rawMaxHits = options?.maxHits ?? MAX_NOTE_REFERENCE_SCAN;
+  const maxHits = Number.isNaN(rawMaxHits) ? 0 : Math.floor(rawMaxHits);
   if (maxHits <= 0) return NO_NOTE_HITS;
-  if (budget === undefined && maxHits <= MAX_NOTE_REFERENCE_SCAN) {
-    const all = subtreeNoteHitsOf(part.root, part.name, 0);
-    return all.length > maxHits ? all.slice(0, maxHits) : all;
-  }
-  const hits: NoteReferenceHit[] = [];
+  const external = options?.budget;
 
-  if (budget === undefined) {
-    // No accounting to keep exact: per-paragraph memos only (maxHits above the cap the
-    // subtree memo path at the top of this function serves).
-    const walkUnbudgeted = (node: OoxmlNode, depth: number): void => {
-      if (hits.length >= maxHits || depth > 64 || node.kind === 'textValue') return;
-      if (node.kind === 'paragraph') {
-        for (const hit of paragraphNoteHitsOf(node, part.name)) {
-          if (hits.length >= maxHits) return;
-          hits.push(hit);
-        }
-        return;
-      }
-      for (const child of node.children) walkUnbudgeted(child, depth + 1);
-    };
-    walkUnbudgeted(part.root, 0);
-    return hits;
+  // Budget-free warm path: a root entry is a complete document-order answer, so a part
+  // whose last walk completed returns the same frozen array by identity, publish after
+  // publish (sliced only when `maxHits` binds below the cached hit count).
+  if (external === undefined) {
+    const cached = budgetedNoteScanMemos.get(part.root);
+    if (cached !== undefined && cached.depth === 0 && cached.partName === part.name) {
+      budgetedNoteScanMemoStats.budgetFreeRootReuses += 1;
+      return cached.hits.length > maxHits ? cached.hits.slice(0, maxHits) : cached.hits;
+    }
   }
+
+  // Budget-free callers run the same walk under a fresh effectively-unbounded budget.
+  // `charge` accounting does not depend on the cap, so the memo entries this walk
+  // writes are exactly the ones a budgeted walk writes and both paths share ONE memo.
+  const budget =
+    external ?? createNoteReferenceScanBudget(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
+  const pruneDeep = external === undefined;
+  const hits: NoteReferenceHit[] = [];
+  // Deep-nesting prunes inside the current call, budget-free mode only. Any subtree a
+  // prune happened under is incomplete and must not be memoized: a budgeted walk
+  // reusing it would report hits and accounting the plain fail-closed walk never would.
+  let prunes = 0;
 
   const walk = (node: OoxmlNode, depth: number): void => {
     if (hits.length >= maxHits || budget.truncated) return;
     if (depth > 64) {
+      if (pruneDeep) {
+        prunes += 1;
+        return;
+      }
       budget.truncated = true;
       return;
     }
@@ -383,23 +345,27 @@ export function collectNoteReferences(
     // fits the remaining budget and the cached hits stay strictly under maxHits (at the
     // clip the plain walk stops charging mid-subtree, which the bulk charge cannot
     // reproduce). Anything else falls through to the plain descent below, which stops
-    // at exactly the node the unmemoized walk stops at.
+    // at exactly the node the unmemoized walk stops at. Paragraph answers never depend
+    // on depth (segmentsOf only, and depth ≤ 64 held to get here), so a paragraph
+    // re-parented deeper by a structural edit still reuses its entry.
     const cached = budgetedNoteScanMemos.get(node);
     if (
       cached !== undefined &&
-      cached.depth === depth &&
+      (cached.depth === depth || node.kind === 'paragraph') &&
       cached.partName === part.name &&
       cached.visited <= budget.maxVisited - budget.visited &&
       hits.length + cached.hits.length < maxHits
     ) {
       budget.visited += cached.visited;
       for (const hit of cached.hits) hits.push(hit);
-      budgetedNoteScanMemoStats.reuses += 1;
+      if (pruneDeep) budgetedNoteScanMemoStats.budgetFreeReuses += 1;
+      else budgetedNoteScanMemoStats.reuses += 1;
       return;
     }
 
     const startVisited = budget.visited;
     const startHits = hits.length;
+    const startPrunes = prunes;
     if (!charge(budget)) return;
     if (node.kind === 'textValue') return;
 
@@ -409,15 +375,17 @@ export function collectNoteReferences(
       for (const child of node.children) walk(child, depth + 1);
     }
 
-    // Memoize only subtrees the walk covered completely: a budget truncation or a
-    // maxHits clip inside the subtree leaves nodes uncharged and hits unrecorded, and
-    // caching that partial answer would replay it as a complete one. (`>= maxHits` is
-    // ambiguous — the clip may have bound on the subtree's last hit — so it never
-    // caches.)
-    if (budget.truncated || hits.length >= maxHits) return;
+    // Memoize only subtrees the walk covered completely: a budget truncation, a maxHits
+    // clip or a deep-nesting prune inside the subtree leaves nodes uncharged and hits
+    // unrecorded, and caching that partial answer would replay it as a complete one.
+    // (`>= maxHits` is ambiguous — the clip may have bound on the subtree's last hit —
+    // so it never caches.)
+    if (budget.truncated || hits.length >= maxHits || prunes > startPrunes) return;
     const visited = budget.visited - startVisited;
     const gotHits = hits.length > startHits;
-    if (node.kind !== 'paragraph' && !gotHits && visited < MEMO_MIN_SUBTREE_VISITED) return;
+    if (depth > 0 && node.kind !== 'paragraph' && !gotHits && visited < MEMO_MIN_SUBTREE_VISITED) {
+      return;
+    }
     budgetedNoteScanMemos.set(node, {
       hits: gotHits ? Object.freeze(hits.slice(startHits)) : NO_NOTE_HITS,
       visited,


### PR DESCRIPTION
Budget-free note-reference scans (layout's per-publish passes) previously kept their own per-paragraph and per-container memos next to the budgeted subtree memo that mutation scans use. Both systems answered the same question over the same immutable nodes, so every published revision was walked cold twice and the same hits were retained twice.

This change makes the budget-free entry point run the one budgeted walk under an unbounded internal budget, and deletes the parallel memo system. Observable behavior is unchanged:

- Budget-free scans still prune a subtree past the 64-level depth cap and keep scanning siblings; budgeted scans still fail closed by marking the shared budget truncated.
- A memo entry is only written for a completely covered subtree (no truncation, no `maxHits` clip, no prune inside it), so the two modes can share entries without poisoning each other. Both directions are pinned in `note-scan-boundary.test.ts`.
- A part whose last walk completed answers warm budget-free scans from its root entry by identity.
- Warm and cold budgeted scans stay byte-identical on hits, `visited`, and `truncated`; the freshness differential now floors memo reuse per serve site.

`bun run bench:huge --compare` reports byte-identical work counters (placed +0, reused +0, full passes +0).

Fixes #455

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255711&installation_model_id=422592&pr_number=470&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F470&signature=34db4fe0ae37d995f4e59667c624be894e0ece4c9f21363db415d8652690040c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->