### PR TITLE
fix: read footnote reserves at document page indexes in every section (fixes #460)

### DIFF
--- a/.changeset/multisection-footnote-reserve-index.md
+++ b/.changeset/multisection-footnote-reserve-index.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix footnote placement in multi-section documents: a citation on a full page of a later section now reserves space on that page, so the note sits under its citation instead of draining onto the following pages. Fixes #460

--- a/packages/core/src/layout/__tests__/footnote-reserve-index-space.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserve-index-space.test.ts
@@ -1,0 +1,290 @@
+// Multi-section footnote reserves live in ONE index space (issue #460): the reserve map is
+// keyed by DOCUMENT page index, and every section's pass reads it through `pageIndexStart`.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import { resolveNotesPart } from '../../store/package/note-references.ts';
+import {
+  resolveEndnoteProperties,
+  resolveFootnoteProperties,
+} from '../../store/package/note-properties.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import { enumerateDocumentSections } from '../section-properties.ts';
+import { notesReserveContextKey, type NotesLayoutInput } from '../note-pagination.ts';
+import type { OoxmlPart } from '../../store/package/ooxml-package.ts';
+import type { PageRecord, ParagraphFragmentRecord } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const SECT_GEOMETRY =
+  '<w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/>';
+const sectionBreak = `<w:p><w:pPr><w:sectPr>${SECT_GEOMETRY}</w:sectPr></w:pPr></w:p>`;
+
+function bodyUsedHeight(page: PageRecord): number {
+  let bottom = 0;
+  for (const fragment of page.fragments) {
+    bottom = Math.max(bottom, fragment.box.y + fragment.box.height);
+  }
+  return bottom;
+}
+
+function paras(label: string, count: number, wordsPer: number, citationAt?: number): string {
+  return Array.from({ length: count }, (_, i) => {
+    const text = `${label} line ${i} ${'word '.repeat(wordsPer)}`;
+    if (i === citationAt) {
+      return `<w:p><w:r><w:t>${text}</w:t><w:footnoteReference w:id="1"/></w:r></w:p>`;
+    }
+    return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+  }).join('');
+}
+
+function zipFootnoteDoc(bodyXml: string, noteWords: number): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${bodyXml}</w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}">` +
+        `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+        `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+        `<w:footnote w:id="1"><w:p><w:r><w:t>Note ${'note '.repeat(noteWords)}</w:t></w:r></w:p></w:footnote>` +
+        '</w:footnotes>'
+    ),
+  });
+}
+
+function notesFor(
+  bytes: Uint8Array,
+  sectionCount: number
+): { part: OoxmlPart; notes: NotesLayoutInput } {
+  const loaded = readOoxmlPackage(bytes);
+  expect(loaded.ok).toBe(true);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+  const props = resolveFootnoteProperties(undefined, undefined);
+  const enProps = resolveEndnoteProperties(undefined, undefined);
+  return {
+    part,
+    notes: {
+      footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+      endnotesPart: null,
+      footnotePropsBySection: Array.from({ length: sectionCount }, () => props),
+      endnotePropsBySection: Array.from({ length: sectionCount }, () => enProps),
+      documentFootnoteProps: props,
+      documentEndnoteProps: enProps,
+      measurer: createFixedMeasurer(),
+      producer: 'footnote-reserve-index-space-test',
+    },
+  };
+}
+
+const sortedKeys = (map: ReadonlyMap<number, number>): number[] =>
+  [...map.keys()].sort((a, b) => a - b);
+
+describe('multi-section reserve index space (#460)', () => {
+  test('notesReserveContextKey folds document slots at section-local positions', () => {
+    const reserves = new Map<number, number>([
+      [3, 40],
+      [1, 20],
+    ]);
+    // A section starting at document page 1 with 3 readable local slots reads document
+    // slots 1..3 — entries land in the key at their LOCAL positions.
+    expect(notesReserveContextKey(reserves, 1, 3)).toBe('|nr:0=20,2=40');
+    // Entries before the section or past its bound stay out; a window with no entries keys
+    // exactly like no map at all (both mean every read returns zero).
+    expect(notesReserveContextKey(reserves, 2, 1)).toBe('');
+    // A section that moves while a reserve stays at its document page must invalidate.
+    expect(notesReserveContextKey(reserves, 0, 4)).not.toBe(notesReserveContextKey(reserves, 1, 4));
+    // No prior page count: every entry from the section start on folds in.
+    expect(notesReserveContextKey(reserves, 1, Infinity)).toBe('|nr:0=20,2=40');
+    expect(notesReserveContextKey(undefined, 1, 3)).toBe('');
+  });
+
+  test('a citation on a full page of a later section reserves space on that page', () => {
+    // Section 0 is one page; section 1 spans three, with the citation on its FULL middle
+    // page — document page 2, section-local slot 1. Reading the reserve at the local slot
+    // (the pre-#460 behaviour) misapplies it one sheet late: the citation page keeps its
+    // full body, and the note renders only as a continuation on the page after it.
+    const bytes = zipFootnoteDoc(
+      paras('S0', 4, 10) +
+        sectionBreak +
+        paras('S1', 80, 18, 40) +
+        `<w:sectPr>${SECT_GEOMETRY}</w:sectPr>`,
+      60
+    );
+    const { part, notes } = notesFor(bytes, 2);
+    const session = createLayoutSession();
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      session,
+      producer: 'notes-later-section-reserve',
+    });
+
+    // The reserve is keyed by DOCUMENT page index: section 1's full middle page.
+    expect(sortedKeys(session.notePageBottomReserves!)).toEqual([2]);
+
+    const host = layout.pages.find((page) =>
+      (page.footnotes?.notes ?? []).some((n) => n.noteId === 1 && !n.continuation)
+    );
+    expect(host).toBeTruthy();
+    expect(host!.index).toBe(2);
+    // No continuation chain: the whole note sits under its citation.
+    for (const page of layout.pages) {
+      expect((page.footnotes?.notes ?? []).filter((n) => n.continuation)).toEqual([]);
+    }
+    // The reserve applied: the body stops above the note area instead of filling the column.
+    const area = host!.footnotes!;
+    const used = bodyUsedHeight(host!);
+    expect(area.box.height).toBeGreaterThan(0);
+    expect(used).toBeLessThanOrEqual(area.box.y - host!.contentBox.y + 0.5);
+    expect(used + area.box.height).toBeLessThanOrEqual(host!.contentBox.height + 0.5);
+  });
+
+  test('an edit that grows an earlier section moves the reserve with the citation', () => {
+    // Warm session: section 0 grows from one page to two, so section 1 (the citation) and
+    // section 2 (reserve-free) both shift down one document page. The recomputed reserve
+    // must follow the citation to its NEW document page, and the warm re-layout must
+    // publish exactly what a cold pass publishes — the local-slot context key may reuse,
+    // never against different reads.
+    const docWith = (sectionZeroParas: number): Uint8Array =>
+      zipFootnoteDoc(
+        paras('S0', sectionZeroParas, 18) +
+          sectionBreak +
+          paras('S1', 80, 18, 40) +
+          sectionBreak +
+          paras('S2', 4, 10) +
+          `<w:sectPr>${SECT_GEOMETRY}</w:sectPr>`,
+        60
+      );
+    const { part, notes } = notesFor(docWith(4), 3);
+    const session = createLayoutSession();
+    layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      session,
+      producer: 'notes-reserve-shift',
+    });
+    expect(sortedKeys(session.notePageBottomReserves!)).toEqual([2]);
+
+    const { part: grownPart, notes: grownNotes } = notesFor(docWith(30), 3);
+    const incremental = layoutSemanticDocument(grownPart, 2, {
+      measurer: grownNotes.measurer,
+      notes: grownNotes,
+      session,
+      producer: 'notes-reserve-shift',
+    });
+    expect(sortedKeys(session.notePageBottomReserves!)).toEqual([3]);
+    const host = incremental.pages.find((page) =>
+      (page.footnotes?.notes ?? []).some((n) => n.noteId === 1 && !n.continuation)
+    );
+    expect(host).toBeTruthy();
+    expect(host!.index).toBe(3);
+    for (const page of incremental.pages) {
+      expect((page.footnotes?.notes ?? []).filter((n) => n.continuation)).toEqual([]);
+    }
+
+    // The reuse half of the local-slot key: section 2 holds no readable reserve entry at
+    // its old OR new position, so its key is '' in both and the shift must not re-lay it.
+    // (Sections 0 and 1 legitimately re-place — one changed, the other reads a changed
+    // reserve slice — so only section 2 pins the document-index-free key property.)
+    const sections = enumerateDocumentSections(grownPart);
+    expect(sections.length).toBe(3);
+    const reserveFreeSectionBlocks = sections[2]!.blockEndExclusive - sections[2]!.blockStart;
+    expect(reserveFreeSectionBlocks).toBeGreaterThan(0);
+    expect(session.stats.placed).toBe(session.stats.total - reserveFreeSectionBlocks);
+    expect(session.stats.reusedPages).toBeGreaterThanOrEqual(1);
+
+    const clean = layoutSemanticDocument(grownPart, 2, {
+      measurer: grownNotes.measurer,
+      notes: grownNotes,
+      producer: 'notes-reserve-shift',
+    });
+    expect(JSON.stringify(incremental)).toBe(JSON.stringify(clean));
+  });
+
+  test('a continuous section sharing the citation sheet honours the same reserve', () => {
+    // Section 0 ends half way down its last page with the citation there; section 1 is
+    // continuous and long enough to fill the rest of that sheet. Both passes read the
+    // reserve at the shared sheet's DOCUMENT page index, so the continued flow also stops
+    // above the note area rather than filling the band the note needs.
+    const bytes = zipFootnoteDoc(
+      paras('S0', 60, 18, 59) +
+        sectionBreak +
+        paras('S1', 40, 18) +
+        `<w:sectPr><w:type w:val="continuous"/>${SECT_GEOMETRY}</w:sectPr>`,
+      20
+    );
+    const { part, notes } = notesFor(bytes, 2);
+    const session = createLayoutSession();
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      session,
+      producer: 'notes-continuous-shared-sheet',
+    });
+
+    const host = layout.pages.find((page) =>
+      (page.footnotes?.notes ?? []).some((n) => n.noteId === 1 && !n.continuation)
+    );
+    expect(host).toBeTruthy();
+    expect(host!.index).toBe(2);
+    for (const page of layout.pages) {
+      expect((page.footnotes?.notes ?? []).filter((n) => n.continuation)).toEqual([]);
+    }
+
+    // The continued section really shares the sheet: a section-1 paragraph fragment sits on
+    // the host page. The fixture's blocks are all top-level paragraphs, so the section
+    // bounds index straight into the document-order paragraph list.
+    const sections = enumerateDocumentSections(part);
+    expect(sections.length).toBe(2);
+    const paragraphIds: string[] = [];
+    const collect = (node: { kind: string; id?: string; children?: readonly unknown[] }): void => {
+      if (node.kind === 'textValue') return;
+      if (node.kind === 'paragraph' && node.id) {
+        paragraphIds.push(node.id);
+        return;
+      }
+      for (const child of node.children ?? []) {
+        collect(child as { kind: string; id?: string; children?: readonly unknown[] });
+      }
+    };
+    collect(part.root as { kind: string; id?: string; children?: readonly unknown[] });
+    const sectionOneIds = new Set(
+      paragraphIds.slice(sections[1]!.blockStart, sections[1]!.blockEndExclusive)
+    );
+    expect(sectionOneIds.size).toBeGreaterThan(0);
+    const hostParagraphIds = host!.fragments
+      .filter((f) => f.kind === 'paragraph')
+      .map((f) => (f as ParagraphFragmentRecord).paragraphId);
+    expect(hostParagraphIds.some((id) => sectionOneIds.has(id))).toBe(true);
+
+    // BOTH flows on the sheet stop above the note area.
+    const area = host!.footnotes!;
+    const used = bodyUsedHeight(host!);
+    expect(area.box.height).toBeGreaterThan(0);
+    expect(used).toBeLessThanOrEqual(area.box.y - host!.contentBox.y + 0.5);
+    expect(used + area.box.height).toBeLessThanOrEqual(host!.contentBox.height + 0.5);
+  });
+});

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -2353,36 +2353,42 @@ function tableParagraphIdsOf(table: OoxmlNode): readonly string[] {
 /**
  * The note-reserve slice of one section's layout context key.
  *
- * `pageBound` is EXCLUSIVE and names the highest page slot the pass can read plus one — the
- * pass reads reserves at consecutive PASS-LOCAL page slots as it opens pages
- * (`pageBottomReserves?.get(pages.length)`), so every entry at or past the bound is
- * unreadable by it and must stay OUT of the key. Folding the whole document-wide map in
- * (the previous behaviour) meant a reserve on one section's pages changed every other
- * section's context, and the open's second reflow pass re-placed every section instead of
- * only the reserved ones.
+ * The reserve map is keyed by DOCUMENT page index ({@link computeFootnoteReserves}), while a
+ * section's pass reads it at `pageIndexStart + localSlot` as it opens pages. The key folds
+ * exactly the entries that pass can read — document slots in
+ * `[pageIndexStart, pageIndexStart + pageBound)` — so a reserve on another section's pages
+ * cannot invalidate this one. `pageBound` is EXCLUSIVE and section-LOCAL: the highest local
+ * page slot the pass can read, plus one.
  *
- * KNOWN MISALIGNMENT, tracked as issue #460: {@link computeFootnoteReserves} keys the map by
- * DOCUMENT page index while the pass reads pass-local slots, so in a multi-section document
- * the two spaces disagree for every section after the first. This slice deliberately matches
- * what the pass READS, not what the computer meant — soundness of the memo requires exactly
- * that, and fixing the read side is a layout-output change that belongs to #460, not to a
- * key refactor whose contract is byte-identical output.
+ * Entries are emitted at their LOCAL slot (`documentSlot - pageIndexStart`), not the document
+ * one. The document page index is deliberately absent from a section's context key (an Enter
+ * that adds a page above must not re-lay every section below), and the local slot is what the
+ * pass's reads actually depend on: two passes whose readable windows carry the same heights
+ * at the same local offsets read identically wherever the section sits, so a section whose
+ * reserves shift down a sheet with it reconverges to its stored key once the reflow loop has
+ * recomputed the map, while a reserve that stays at a fixed document page as the section
+ * moves lands on a different local slot and invalidates.
  *
- * Entries are sorted by page slot so two content-equal maps render one canonical key
- * regardless of insertion order. `Infinity` folds the whole map (a pass with no prior page
- * count cannot bound its reads).
+ * Entries are sorted by slot so two content-equal maps render one canonical key regardless
+ * of insertion order. `Infinity` folds every entry from `pageIndexStart` on (a pass with no
+ * prior page count cannot bound its reads). A window with no entries keys like no map at
+ * all: both mean every read returns zero, and two encodings of that would invalidate every
+ * untouched section when a document's last note disappears.
  */
 export function notesReserveContextKey(
   reserves: ReadonlyMap<number, number> | undefined,
+  pageIndexStart: number,
   pageBound: number
 ): string {
   if (!reserves) return '';
   const entries: [number, number][] = [];
   for (const [pageSlot, height] of reserves) {
-    if (pageSlot < pageBound) entries.push([pageSlot, height]);
+    const localSlot = pageSlot - pageIndexStart;
+    if (localSlot >= 0 && localSlot < pageBound) entries.push([localSlot, height]);
   }
+  if (entries.length === 0) return '';
   entries.sort((a, b) => a[0] - b[0]);
-  return `|nr:${entries.map(([pageSlot, height]) => `${pageSlot}=${height}`).join(',')}`;
+  return `|nr:${entries.map(([localSlot, height]) => `${localSlot}=${height}`).join(',')}`;
 }
 
 /** Drop non-positive heights so missing and zero compare equal. */

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -347,8 +347,9 @@ export interface SemanticLayoutOptions {
    */
   readonly notes?: import('./note-pagination.ts').NotesLayoutInput;
   /**
-   * Per-page bottom reserves (points) subtracted from content height before line placement.
-   * Produced by the note reflow loop; absent means full content column.
+   * Per-page bottom reserves (points) subtracted from content height before line placement,
+   * keyed by DOCUMENT page index. A section's pass reads its own slice through
+   * `pageIndexStart`. Produced by the note reflow loop; absent means full content column.
    */
   readonly pageBottomReserves?: ReadonlyMap<number, number>;
   /** Derived note marks for body/note projection (provisional or final). */
@@ -953,10 +954,11 @@ function layoutBlocksPass(
   // alternates by page number, so it is not a section-local question.
   const pageIndexStart = options.pageIndexStart ?? 0;
   // Only the reserve entries THIS pass can read belong in its context key. The pass reads
-  // reserves at consecutive page slots as it opens pages, so a bound of "the page count the
-  // previous pass produced, plus one" covers every slot an input-identical replay can touch —
-  // and keeps a reserve on another section's pages from invalidating this one. A fresh
-  // session has no such bound and folds the whole map (conservative, one full pass).
+  // reserves at `pageIndexStart` plus consecutive local page slots as it opens pages, so a
+  // bound of "the page count the previous pass produced, plus one" covers every slot an
+  // input-identical replay can touch — and keeps a reserve on another section's pages from
+  // invalidating this one. A fresh session has no such bound and folds every entry from
+  // `pageIndexStart` on (conservative, one full pass).
   const reserveKeyBound = session?.previous ? session.previous.pages.length + 1 : Infinity;
   const columnRegionBottom = options.columnRegionBottom;
   const columnsContext = `|cols:${columns.widths.join(',')};${columns.gaps.join(',')};${columns.separator ? 1 : 0}${columnRegionBottom !== undefined ? `;bal:${columnRegionBottom}` : ''}`;
@@ -971,7 +973,9 @@ function layoutBlocksPass(
   // embedding it copied that token into every section's context string on every pass.
   const contextFor = (notesReserveKey: string): string =>
     `${geometry.width}x${geometry.height}|${geometry.margin.top},${geometry.margin.right},${geometry.margin.bottom},${geometry.margin.left}|fs:${flowStartY},${spaceBeforeCarry}${furnitureContext}${notesReserveKey}${columnsContext}`;
-  const context = contextFor(notesReserveContextKey(pageBottomReserves, reserveKeyBound));
+  const context = contextFor(
+    notesReserveContextKey(pageBottomReserves, pageIndexStart, reserveKeyBound)
+  );
   const startPageParity = pageIndexStart & 1;
   /** Set when this pass places an anchored drawing whose geometry reads page parity. */
   let usedPageParity = false;
@@ -990,7 +994,14 @@ function layoutBlocksPass(
    * search reads "produced a second page" as "does not fit".
    */
   const contentHeight = (): number => {
-    const base = Math.max(1, baseContentHeight - (pageBottomReserves?.get(pages.length) ?? 0));
+    // Reserves are keyed by DOCUMENT page index (computeFootnoteReserves); this pass fills
+    // the document page at `pageIndexStart + pages.length`. A continuous section's local
+    // page 0 IS the previous section's last sheet: both passes read the same document slot,
+    // so every flow sharing the sheet stops above the same note area.
+    const base = Math.max(
+      1,
+      baseContentHeight - (pageBottomReserves?.get(pageIndexStart + pages.length) ?? 0)
+    );
     return columnRegionBottom !== undefined && pages.length === 0
       ? Math.max(1, Math.min(base, columnRegionBottom))
       : base;
@@ -3029,7 +3040,7 @@ function layoutBlocksPass(
     session.context =
       pages.length + 1 === reserveKeyBound
         ? context
-        : contextFor(notesReserveContextKey(pageBottomReserves, pages.length + 1));
+        : contextFor(notesReserveContextKey(pageBottomReserves, pageIndexStart, pages.length + 1));
     session.producer = producer;
     // Sticky whenever any part of the previous layout was reused: a resumed pass never
     // re-places the prefix and a converged pass never re-places the tail, so their


### PR DESCRIPTION
`computeFootnoteReserves` keys the reserve map by document page index, but each section's layout pass read it at pass-local page slots, so every section after the first missed or misapplied its reserves — a citation on a full page of a later section drained its note as a continuation chain instead of reserving space under the citation.

The pass now reads reserves at `pageIndexStart + pages.length`, and `notesReserveContextKey` folds only the document slots a pass can read, emitted at section-local positions so a section whose reserves shift with it can still reuse while a reserve that stays put invalidates. On a sheet shared by a continuous section, both flows read the same document slot and stop above the same note area. A readable window with no entries now keys like no map at all, so removing a document's last note does not invalidate untouched sections.

Settle-bench, edit-bench, and scope-waste pinned work counters are unchanged: the 521-page fixture's citation pages carry enough slack that applying the reserve moves no line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255768&installation_model_id=422592&pr_number=471&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F471&signature=186183ace485a65250d0bd16fa3aec90c0ba0ff04d71f032b37c5a6b7c9a7be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->