### PR TITLE
fix: re-project page-field furniture on reused sheets when the page count moves

### DIFF
--- a/.changeset/reused-page-field-refinalize.md
+++ b/.changeset/reused-page-field-refinalize.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+PAGE and NUMPAGES footers on reused pages now update when an edit changes the page count in a single-section document. Fixes #441

--- a/packages/core/src/layout/__tests__/finalize-page-field-memo.test.ts
+++ b/packages/core/src/layout/__tests__/finalize-page-field-memo.test.ts
@@ -26,7 +26,10 @@ import {
   type PageRecord,
   type SemanticLayout,
 } from '../index.ts';
-import { finalizePageFieldProjection } from '../field-projection.ts';
+import {
+  carryStrippedPageFieldProjection,
+  finalizePageFieldProjection,
+} from '../field-projection.ts';
 import { layoutHeaderFooterStory, type HeaderFooterStoryLayout } from '../hf-layout.ts';
 import type { HeaderFooterStoryRecord } from '../semantic-records.ts';
 
@@ -197,7 +200,7 @@ describe('finalizePageFieldProjection memo', () => {
     // Two sections, because that is the path where reused sheets still carry projectors at
     // finalize time: the multi-section publish re-finalizes every pass, so a memo entry taken
     // under the old total is what would serve the stale value here. (A single-section resume
-    // reuses already-finalized records, so it never re-projects furniture either way.)
+    // reuses already-finalized records, whose retained projectors the next describe covers.)
     const furniture: PageFurniture = {
       titlePage: false,
       evenAndOddHeaders: false,
@@ -232,5 +235,85 @@ describe('finalizePageFieldProjection memo', () => {
     expect(third.pages.length).toBe(second.pages.length);
     third.pages.forEach((page, index) => expect(page).toBe(second.pages[index]!));
     expect(footerText(third, 0)).toBe(`Page 1 of ${third.pages.length}`);
+  });
+});
+
+describe('single-section incremental reuse re-projects furniture page fields (#441)', () => {
+  test('a reused sheet updates NUMPAGES when the page count moves, and holds identity when it does not', () => {
+    // Single section, one session. The first pass finalizes and STRIPS every footer's
+    // projector; a later pass reuses the finished sheets whole. Without the retained
+    // projector, the reused footer kept the first pass's `of Y` text forever.
+    const furniture: PageFurniture = {
+      titlePage: false,
+      evenAndOddHeaders: false,
+      headers: new Map(),
+      footers: new Map([
+        ['default', layoutHeaderFooterStory(footerPart(), CONTENT_WIDTH, measurer, 'test')],
+      ]),
+    };
+    const session = createLayoutSession();
+    const build = (count: number) => partOf(filler(count) + tightSectPr);
+    const options = { measurer, producer: 'test', session, furniture };
+
+    const first = layoutSemanticDocument(build(18), 1, options);
+    const firstTotal = first.pages.length;
+    expect(firstTotal).toBeGreaterThan(2);
+    expect(footerText(first, 0)).toBe(`Page 1 of ${firstTotal}`);
+
+    // Grow the tail: page 1's flow is untouched, so the resume path carries its finished
+    // sheet over by reference — the reuse under suspicion.
+    const second = layoutSemanticDocument(build(40), 2, options);
+    const secondTotal = second.pages.length;
+    expect(secondTotal).toBeGreaterThan(firstTotal);
+    expect(session.stats.reusedPages).toBeGreaterThan(0);
+    expect(footerText(second, 0)).toBe(`Page 1 of ${secondTotal}`);
+    expect(footerText(second, secondTotal - 1)).toBe(`Page ${secondTotal} of ${secondTotal}`);
+
+    // A no-change pass keeps every sheet by identity: the retained projection context still
+    // holds, so re-finalize must not mint fresh footers.
+    const third = layoutSemanticDocument(build(40), 3, options);
+    expect(third.pages.length).toBe(secondTotal);
+    third.pages.forEach((page, index) => expect(page).toBe(second.pages[index]!));
+
+    // Shrink back: the same reused sheets re-project down as well.
+    const fourth = layoutSemanticDocument(build(18), 4, options);
+    expect(fourth.pages.length).toBe(firstTotal);
+    expect(footerText(fourth, 0)).toBe(`Page 1 of ${firstTotal}`);
+  });
+
+  test('a carried (remap-shifted) published story re-projects at its shifted origin', () => {
+    const base = lay(partOf(filler(20) + tightSectPr), 1);
+    const total = base.pages.length;
+    const unfinalized = unfinalizedLayoutOf(base, fieldFooterRecord(footerPart()));
+    const first = finalizePageFieldProjection(unfinalized);
+    const published = first.pages[1]!.footer!;
+
+    // What `remapPage` does to a reused published sheet: mint a Y-shifted furniture twin and
+    // carry the retained projection onto it, `dy` sheets of stack away.
+    const dy = 120;
+    const shifted: typeof published = {
+      ...published,
+      box: { ...published.box, y: published.box.y + dy },
+    };
+    carryStrippedPageFieldProjection(published, shifted, dy);
+    const withShifted = {
+      revision: 2,
+      pages: first.pages.map((page, index) => (index === 1 ? { ...page, footer: shifted } : page)),
+    };
+
+    // Unmoved context: the carried entry keeps the shifted record by identity.
+    const held = finalizePageFieldProjection(withShifted);
+    expect(held.pages[1]!.footer).toBe(shifted);
+
+    // Moved page count: the carried projector re-projects the text AND lands the box at the
+    // SHIFTED origin, not the minting pass's pre-shift one.
+    const extra: PageRecord = {
+      ...unfinalized.pages[total - 1]!,
+      index: total,
+      pageFieldSource: { pageNumber: total + 1, sectionPageCount: total + 1 },
+    };
+    const grown = finalizePageFieldProjection({ revision: 3, pages: [...held.pages, extra] });
+    expect(footerText(grown, 1)).toBe(`Page 2 of ${total + 1}`);
+    expect(grown.pages[1]!.footer!.box.y).toBe(published.box.y + dy);
   });
 });

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -42,6 +42,9 @@ export const PAGE_FIELD_PLACEHOLDER = '0';
  * `pageNumber` is the displayed PAGE value after section `w:pgNumType/@w:start` (1-based).
  * `pageCount` is document NUMPAGES. `sectionPageCount` is SECTIONPAGES for the attached
  * section. `format` is the authored `w:pgNumType/@w:fmt` applied only to PAGE.
+ *
+ * A new field here must also join `sameFieldPageContext` below, or finalize compares two
+ * contexts that differ in it as equal and keeps a reused story's stale text.
  */
 export interface FieldPageContext {
   readonly pageNumber: number;
@@ -292,6 +295,81 @@ export function substituteBodyPageFields(
   return next ?? blocks;
 }
 
+/** Story projector retained past finalize, with the context its published text was projected under. */
+interface RetainedStoryProjection {
+  readonly context: FieldPageContext;
+  readonly projector: (context: FieldPageContext) => HeaderFooterStoryRecord;
+  /**
+   * Cumulative sheet-stack Y offset between where the projector places the story and where
+   * the published record sits. A NUMBER, not a composed closure: a sheet that survives many
+   * tail shifts folds each shift into this one value, so re-projection stays one projector
+   * call plus one translation however long the reuse lineage gets.
+   */
+  readonly dy: number;
+}
+
+/**
+ * Projectors of PUBLISHED story records, keyed on the stripped record finalize minted.
+ *
+ * Finalize strips `pageFieldProjector` from what it publishes, but incremental layout reuses
+ * published sheets whole: a later pass that changes the page count hands those stripped
+ * records straight back to finalize, which then has nothing to re-project NUMPAGES through —
+ * the reused footer kept the old `of Y` text. Retaining the projector on the side (with the
+ * context it last ran under) lets finalize keep an unchanged-context story by identity and
+ * re-project it when the pagination moved underneath it. Weak on the story record, so a story
+ * that falls out of the layout takes its projector with it. The retained closure keeps its
+ * minting pass's scope alive for as long as the sheet is reused — the same retention profile
+ * the multi-section span cache already has for LIVE projectors on `previousRemapped` pages.
+ *
+ * INVARIANT: anything that CLONES a published field-bearing story record must carry this
+ * entry onto the clone ({@link carryStrippedPageFieldProjection}) — a published story leaves
+ * no data trace of its field needs, so an orphaned clone silently keeps stale text.
+ * `remapPage` is the one cloner today.
+ */
+const strippedStoryProjections = new WeakMap<HeaderFooterStoryRecord, RetainedStoryProjection>();
+
+/**
+ * True when two projection contexts substitute identical values for every page field.
+ *
+ * Compares EVERY dimension of {@link FieldPageContext}, so it must grow in lockstep with
+ * that interface: a context field this misses compares as "same context" and finalize keeps
+ * a reused story's stale text. Needs-blind on purpose — finalize does not know which fields
+ * a published story reads, so it re-projects on any moved dimension; the story layout's own
+ * per-token cache absorbs the re-layout when the story's text did not actually change.
+ */
+function sameFieldPageContext(a: FieldPageContext, b: FieldPageContext): boolean {
+  return (
+    a.pageNumber === b.pageNumber &&
+    a.pageCount === b.pageCount &&
+    (a.sectionPageCount ?? a.pageCount) === (b.sectionPageCount ?? b.pageCount) &&
+    a.format === b.format
+  );
+}
+
+/**
+ * Carry a published story's retained projection onto its Y-shifted twin, `dy` points away.
+ *
+ * `remapPage` moves a reused sheet's furniture by minting a shifted record, which would
+ * orphan the retained projector — the shifted footer could never re-project at a new page
+ * count. The shift folds into the retained OFFSET rather than wrapping the projector in
+ * another closure, so repeated shifts cannot accumulate a call chain. The retained context
+ * is the source's: the shifted text is still the text projected under it, and the first
+ * finalize whose context differs re-projects.
+ */
+export function carryStrippedPageFieldProjection(
+  source: HeaderFooterStoryRecord,
+  shifted: HeaderFooterStoryRecord,
+  dy: number
+): void {
+  const retained = strippedStoryProjections.get(source);
+  if (!retained) return;
+  strippedStoryProjections.set(shifted, {
+    context: retained.context,
+    projector: retained.projector,
+    dy: retained.dy + dy,
+  });
+}
+
 /**
  * Finalized projection of one page under one total page count, memoized on the immutable
  * page record.
@@ -336,13 +414,32 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
     const project = (
       story: HeaderFooterStoryRecord | undefined
     ): HeaderFooterStoryRecord | undefined => {
-      if (!story?.pageFieldProjector) return story;
+      if (!story) return story;
+      let projector = story.pageFieldProjector;
+      let dy = 0;
+      if (!projector) {
+        const retained = strippedStoryProjections.get(story);
+        // Already-published story: keep it by identity while the context it was projected
+        // under still holds; re-project through the retained projector when the pagination
+        // moved under the reused sheet. No retained entry means the story never carried a
+        // page field.
+        if (!retained || sameFieldPageContext(retained.context, context)) return story;
+        projector = retained.projector;
+        dy = retained.dy;
+      }
       changed = true;
-      const projected = story.pageFieldProjector(context);
-      // Strip the projector from the published record.
-      const { pageFieldProjector: _drop, ...rest } = projected;
+      const projected = projector(context);
+      // Strip the projector from the published record; retain it on the side so a reused
+      // sheet can still re-finalize when the page count moves. The retained offset applies
+      // here — the projector places at its minting pass's sheet Y.
+      const { pageFieldProjector: _drop, box, ...rest } = projected;
       void _drop;
-      return rest;
+      const placed: HeaderFooterStoryRecord = {
+        ...rest,
+        box: dy === 0 ? box : { ...box, y: box.y + dy },
+      };
+      strippedStoryProjections.set(placed, { context, projector, dy });
+      return placed;
     };
     const header = project(page.header);
     const footer = project(page.footer);
@@ -356,7 +453,8 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
     // Reachable only for pages with NO live projector and NO body substitution: `project`
     // always mints a fresh record for a projector-bearing story (the rest-spread above), so
     // this identity entry can never publish — or memoize as final — a record that still
-    // carries a `pageFieldProjector`.
+    // carries a `pageFieldProjector`. A story kept by identity because its RETAINED
+    // projection context still holds is already published text under this exact context.
     if (header === page.header && footer === page.footer && fragments === page.fragments) {
       finalizedPageMemos.set(page, { pageCount, result: page });
       return page;

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -55,6 +55,7 @@ import {
   type StoryPageFieldNeeds,
 } from './field-instruction.ts';
 import {
+  carryStrippedPageFieldProjection,
   fieldPageContextToken,
   finalizePageFieldProjection,
   formatPageNumber,
@@ -132,6 +133,7 @@ export {
   type StoryPageFieldNeeds,
 };
 export {
+  carryStrippedPageFieldProjection,
   fieldPageContextToken,
   finalizePageFieldProjection,
   formatPageNumber,

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -20,6 +20,7 @@ import type { OoxmlPart } from '@docx-editor.dev/core/store';
 import { stableHash } from '../store/comparators/canonical.ts';
 import { canonicalOoxmlFingerprint } from '../store/package/ooxml-tree.ts';
 import {
+  carryStrippedPageFieldProjection,
   detectStoryPageFields,
   fieldPageContextToken,
   storyNeedsPageFields,
@@ -441,7 +442,12 @@ export function remapPage(page: PageRecord, globalIndex: number, sheetY: number)
       box: shiftBox(story.box),
       ...(story.anchoredDrawings ? { anchoredDrawings: story.anchoredDrawings } : {}),
     };
-    if (!story.pageFieldProjector) return shifted;
+    if (!story.pageFieldProjector) {
+      // A published (already-finalized) story keeps its projector on the side; carry it onto
+      // the shifted twin so a moved reused sheet can still re-project at a new page count.
+      carryStrippedPageFieldProjection(story, shifted, dy);
+      return shifted;
+    }
     const project = story.pageFieldProjector;
     return {
       ...shifted,

--- a/packages/core/src/layout/page-reuse-guards.ts
+++ b/packages/core/src/layout/page-reuse-guards.ts
@@ -61,7 +61,10 @@ export const PAGE_REUSE_GUARDS = {
   // variant's flow height, so that half is `context`.
   anchoredDrawings: 'flow',
   // `furnitureContext` folds each variant's flow height, content key and drawing-resource
-  // token, which is what a header or footer edit moves.
+  // token, which is what a header or footer edit moves. The PAGE/NUMPAGES/SECTIONPAGES text
+  // inside the furniture is the one part a reused sheet can hold stale: finalize strips the
+  // story's projector, so `finalizePageFieldProjection` retains it on the side and
+  // re-projects a reused story whose page context moved (#441).
   header: 'context',
   footer: 'context',
   // `attachNotesToLayout` rebuilds the note areas over the assembled pages every pass, and

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -600,7 +600,13 @@ export interface HeaderFooterStoryRecord {
   readonly anchoredDrawings?: readonly AnchoredDrawingRecord[];
   /**
    * Transient projector used between furniture attach and document-level page-field
-   * finalize. Absent on published layout records after finalize.
+   * finalize. Absent on published layout records after finalize — but not dead: finalize
+   * retains it (with the context it last ran under) in a side table keyed on the published
+   * record (`strippedStoryProjections` in `field-page-furniture.ts`), so a reused sheet can
+   * re-project when the page count moves (#441). The retained closure keeps its minting
+   * pass's scope alive for as long as the sheet is reused, and anything that clones a
+   * published field-bearing story must carry the entry onto the clone
+   * (`carryStrippedPageFieldProjection`).
    */
   readonly pageFieldProjector?: (context: {
     readonly pageNumber: number;


### PR DESCRIPTION
Fixes #441.

In a single-section document, `finalizePageFieldProjection` strips `pageFieldProjector` from the story records it publishes. Incremental layout reuses those finished sheets whole, so a later edit that changes the page count hands the stripped records back to finalize, which has nothing to re-project NUMPAGES through — a reused footer keeps the old `of Y` text.

Finalize now retains each stripped projector, with the context it last ran under, in a WeakMap keyed on the published story record. A reused story stays identity-stable while its projected context still holds and re-projects when the pagination moves under it. `remapPage` carries the retained entry onto a shifted furniture record, folding the shift into one cumulative offset so repeated tail shifts never accumulate a closure chain. The multi-section publish path is unchanged: it already re-finalizes projector-carrying sheets each pass.

The regression test drives one layout session through a grow, a no-change pass (asserting page identity holds), and a shrink, and covers the carry path directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790256915&installation_model_id=422592&pr_number=472&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F472&signature=0b770339ecef6f0aa723dfbc65665b2b0becc61e92b53279a2625d1aa8dade39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->