### PR TITLE
fix: name clip-dropped text-box pictures in the furniture resource token (fixes #467)

### DIFF
--- a/.changeset/clipped-textbox-picture-invalidates.md
+++ b/.changeset/clipped-textbox-picture-invalidates.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Refresh header and footer pages when a picture that a text box clips out of the baseline layout finishes decoding, so a page-specific projection of the box no longer keeps a loading placeholder. Fixes #467

--- a/packages/core/src/editor/__tests__/header-footer-drawing-resource.test.ts
+++ b/packages/core/src/editor/__tests__/header-footer-drawing-resource.test.ts
@@ -28,6 +28,7 @@ import {
   mountWithImages,
   picture,
   settle,
+  textboxWithClippedPicture,
   textboxWithPicture,
 } from './image-decode-harness.ts';
 
@@ -149,6 +150,37 @@ describe('header/footer picture resources reach the page', () => {
     await settle();
     expect(textboxStoryDrawingKinds(surface.layout().pages[0]!.header)).toEqual(['ready']);
     expect(container.querySelectorAll('.docx-drawing-placeholder')).toHaveLength(0);
+    surface.destroy();
+    container.remove();
+  });
+
+  // The regression for #467: the furniture context tokenizes the BASELINE story, and the
+  // text-box height clip drops the picture's fragment from it — while a `withPageContext`
+  // projection can wrap differently and keep the picture. The token must name clipped
+  // resources too, or the settle moves nothing and the unchanged-pass early exit returns
+  // the previous pages by identity.
+  test('a picture the baseline text-box clip drops still invalidates the reused pages', async () => {
+    const { port, release } = deferredDecodePort();
+    const { surface, container } = await mountWithImages(
+      docx({ headerBody: textboxWithClippedPicture(), footerBody: '<w:r><w:t>f</w:t></w:r>' }),
+      port
+    );
+    const clippedTokenOf = (): string => {
+      const header = surface.layout().pages[0]!.header;
+      const box = (header?.anchoredDrawings ?? []).find((drawing) => drawing.textboxStory);
+      return box?.textboxStory?.clippedResourceToken ?? '';
+    };
+    // The clip drops the picture's fragment, so no laid-out record carries it...
+    expect(textboxStoryDrawingKinds(surface.layout().pages[0]!.header)).toEqual([]);
+    // ...but the clipped-resource token still names its pending resource.
+    expect(clippedTokenOf()).toContain('pending:');
+    const before = surface.layout().pages[0]!;
+    release();
+    await settle();
+    // The settle rebuilt the pages: the clipped token moved the furniture context, so the
+    // unchanged-pass early exit could not return `before` by identity.
+    expect(surface.layout().pages[0]!).not.toBe(before);
+    expect(clippedTokenOf()).toContain('ready:');
     surface.destroy();
     container.remove();
   });

--- a/packages/core/src/editor/__tests__/image-decode-harness.ts
+++ b/packages/core/src/editor/__tests__/image-decode-harness.ts
@@ -55,8 +55,8 @@ export function inlinePicture(id: number): string {
   );
 }
 
-/** An anchored text box whose story holds one inline picture. */
-export function textboxWithPicture(): string {
+/** An anchored `wps:txbx` text box with the given extent height and story content. */
+function anchoredTextbox(cyEmu: number, storyContent: string): string {
   return (
     '<w:r><w:drawing>' +
     '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" ' +
@@ -64,16 +64,36 @@ export function textboxWithPicture(): string {
     '<wp:simplePos x="0" y="0"/>' +
     '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
     '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
-    '<wp:extent cx="2743200" cy="1828800"/><wp:wrapNone/><wp:docPr id="10" name="box"/>' +
+    `<wp:extent cx="2743200" cy="${cyEmu}"/><wp:wrapNone/><wp:docPr id="10" name="box"/>` +
     `<a:graphic><a:graphicData uri="${WPS_NS}">` +
     '<wps:wsp><wps:cNvSpPr txBox="1"/>' +
-    '<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2743200" cy="1828800"/></a:xfrm>' +
+    `<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2743200" cy="${cyEmu}"/></a:xfrm>` +
     '<a:prstGeom prst="rect"/></wps:spPr>' +
-    '<wps:txbx><w:txbxContent>' +
-    `<w:p><w:r><w:t>in the box</w:t></w:r>${inlinePicture(11)}</w:p>` +
-    '</w:txbxContent></wps:txbx>' +
+    `<wps:txbx><w:txbxContent>${storyContent}</w:txbxContent></wps:txbx>` +
     '<wps:bodyPr/></wps:wsp>' +
     '</a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
+  );
+}
+
+/** An anchored text box whose story holds one inline picture. */
+export function textboxWithPicture(): string {
+  return anchoredTextbox(
+    1828800,
+    `<w:p><w:r><w:t>in the box</w:t></w:r>${inlinePicture(11)}</w:p>`
+  );
+}
+
+/**
+ * An anchored text box too short for its story, whose picture the height clip drops.
+ *
+ * The extent height (91440 EMU = 7.2pt) equals the default vertical insets, so the content
+ * height is zero and `layoutTextboxStory` drops every fragment — the picture flows, its
+ * decode is scheduled, but no laid-out record carries it (`textbox-height-clip`).
+ */
+export function textboxWithClippedPicture(): string {
+  return anchoredTextbox(
+    91440,
+    `<w:p><w:r><w:t>in the box</w:t></w:r></w:p><w:p>${inlinePicture(11)}</w:p>`
   );
 }
 

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -552,6 +552,13 @@ const storyDrawingResourceTokens = new WeakMap<HeaderFooterStoryLayout, string>(
  * Walks with {@link forEachStoryDrawing}, which descends into each anchored drawing's
  * text-box story: a picture inside a `wps:txbx` in a header settles on the same
  * asynchronous clock as a direct one, so its resource has to move this token too.
+ *
+ * CLIPPED drawings ride along (#467). This token is computed from the BASELINE story, and
+ * `layoutTextboxStory` drops fragments below the box's content height — while a
+ * `withPageContext` projection of the same story can wrap differently (PAGE digits) and
+ * paint a drawing the baseline clipped out. Painted plus clipped is the story's full source
+ * set, a superset of what any projection paints, so a settle always moves this token no
+ * matter which projection shows the picture.
  */
 export function storyDrawingResourceToken(story: HeaderFooterStoryLayout): string {
   const cached = storyDrawingResourceTokens.get(story);
@@ -559,6 +566,9 @@ export function storyDrawingResourceToken(story: HeaderFooterStoryLayout): strin
   const tokens: string[] = [];
   forEachStoryDrawing(story, (drawing) => {
     tokens.push(drawingResourceLayoutToken(drawing.resource));
+    if (drawing.kind === 'anchoredDrawing' && drawing.textboxStory?.clippedResourceToken) {
+      tokens.push(`clip:${drawing.textboxStory.clippedResourceToken}`);
+    }
   });
   // Empty for the overwhelmingly common story with no pictures, so the context string for a
   // plain header is byte-for-byte what it was.

--- a/packages/core/src/layout/textbox-story-layout.ts
+++ b/packages/core/src/layout/textbox-story-layout.ts
@@ -18,6 +18,8 @@
 import type { OoxmlElement } from '@docx-editor.dev/core/store';
 import type { DrawingProjection } from '../store/package/drawing-projection.ts';
 import { emuToPoints } from './drawing-layout.ts';
+import { drawingResourceLayoutToken } from './inline-drawing-source.ts';
+import { forEachStoryDrawing } from './semantic-record-queries.ts';
 import type { FieldPageContext } from './field-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
 import type { PendingLine } from './paragraph-flow.ts';
@@ -71,6 +73,18 @@ export interface TextboxStoryLayout {
   readonly strokeWidthPt: number;
   /** True when layout hit a named bound and returned a truncated / empty story. */
   readonly fallbackReason?: TextboxStoryFallbackReason;
+  /**
+   * Resource identities of the drawings the clip DROPPED, in flow order.
+   *
+   * The furniture invalidation token walks laid-out records, and a dropped fragment leaves
+   * none — while a `withPageContext` projection of the same story can wrap differently
+   * (PAGE digits) and keep the drawing. Without this a picture clipped out of the baseline
+   * but painted by a projection never reaches the session context, so its decode settling
+   * moves nothing and the unchanged-pass early exit reuses the placeholder pages forever
+   * (#467). Absent when the clip dropped no drawings, so the common story keys byte-for-byte
+   * as before.
+   */
+  readonly clippedResourceToken?: string;
 }
 
 export interface TextboxStoryLayoutOptions {
@@ -139,6 +153,9 @@ export function layoutTextboxStory(
 
   const depth = options.depth ?? 0;
   if (depth >= MAX_TEXTBOX_STORY_NESTING) {
+    // No clipped-resource token here: past the ceiling nothing is flowed, so no projection
+    // can paint these drawings either. If nested box rendering ever ships, this return must
+    // name the story's resources too, or the #467 pattern recurs one level down.
     return {
       fragments: [],
       flowHeight: 0,
@@ -173,8 +190,13 @@ export function layoutTextboxStory(
   let fragments = flow.blocks;
   let flowHeight = flow.bottom;
   let fallbackReason: TextboxStoryFallbackReason | undefined;
+  const clippedResourceTokens: string[] = [];
 
   if (fragments.length > MAX_TEXTBOX_STORY_FRAGMENTS) {
+    collectDrawingResourceTokens(
+      fragments.slice(MAX_TEXTBOX_STORY_FRAGMENTS),
+      clippedResourceTokens
+    );
     fragments = fragments.slice(0, MAX_TEXTBOX_STORY_FRAGMENTS);
     const last = fragments[fragments.length - 1];
     flowHeight = last ? last.box.y + last.box.height : 0;
@@ -186,6 +208,10 @@ export function layoutTextboxStory(
   if (flowHeight > contentHeight + 0.001) {
     const kept = fragments.filter((fragment) => fragment.box.y < contentHeight - 0.001);
     if (kept.length < fragments.length) {
+      collectDrawingResourceTokens(
+        fragments.filter((fragment) => fragment.box.y >= contentHeight - 0.001),
+        clippedResourceTokens
+      );
       fragments = kept;
       fallbackReason = fallbackReason ?? 'textbox-height-clip';
     }
@@ -203,5 +229,23 @@ export function layoutTextboxStory(
     contentOffset: { x: insetLeft, y: insetTop + anchorOffset },
     ...chrome,
     ...(fallbackReason ? { fallbackReason } : {}),
+    ...(clippedResourceTokens.length > 0
+      ? { clippedResourceToken: clippedResourceTokens.join('!') }
+      : {}),
   };
+}
+
+/**
+ * Resource tokens of the drawings in clip-dropped fragments.
+ *
+ * The SAME walk the furniture token uses over kept records, so a new drawing channel can
+ * never reach one side of the painted-plus-clipped invariant and not the other.
+ */
+function collectDrawingResourceTokens(
+  blocks: readonly BlockFragmentRecord[],
+  tokens: string[]
+): void {
+  forEachStoryDrawing({ fragments: blocks }, (drawing) => {
+    tokens.push(drawingResourceLayoutToken(drawing.resource));
+  });
 }


### PR DESCRIPTION
The furniture slice of the layout-session context tokenizes the baseline header/footer story. `layoutTextboxStory` drops fragments below the box's content height, so a picture in a dropped fragment leaves no laid-out record and its decode settling moves no token. The unchanged-pass early exit then returns the previous pages by identity, and a `withPageContext` projection that wraps differently (PAGE digits) keeps painting the placeholder.

`layoutTextboxStory` now records the resource identities of the drawings its clip drops, and `storyDrawingResourceToken` folds them in. Painted plus clipped is the story's full source drawing set — a superset of what any projection paints — so a settle always moves the furniture context. Paint's reconcile walk is unchanged, so clipped pictures still don't retain live resources.

Fixes #467

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790261710&installation_model_id=422592&pr_number=474&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F474&signature=e7746555f3014067e7797d6674d928aff7708663241041c25b749ed6226a1307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->