### PR TITLE
fix: paint list markers for numbered paragraphs inside text boxes

### DIFF
--- a/.changeset/textbox-list-markers.md
+++ b/.changeset/textbox-list-markers.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Render list markers for numbered paragraphs inside anchored text boxes, in the body and in headers and footers, and refresh reused pages when a numbering change moves a marker inside a box. Fixes #466

--- a/packages/core/src/layout/__tests__/textbox-story-layout.test.ts
+++ b/packages/core/src/layout/__tests__/textbox-story-layout.test.ts
@@ -17,7 +17,12 @@ import {
   type PageFurniture,
   type SemanticLayout,
 } from '../index.ts';
-import { layoutHeaderFooterStory, type HeaderFooterStoryLayout } from '../hf-layout.ts';
+import {
+  layoutHeaderFooterStory,
+  storyListMarkerToken,
+  type HeaderFooterStoryLayout,
+} from '../hf-layout.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
 import {
   layoutTextboxStory,
   MAX_TEXTBOX_STORY_NESTING,
@@ -26,6 +31,7 @@ import {
 import type { InlineDrawingLayoutContext } from '../drawing-layout.ts';
 import {
   readOoxmlPackage,
+  readOoxmlPart,
   resolveHeaderFooterPartsBySection,
   type OoxmlPackage,
   type OoxmlPart,
@@ -143,7 +149,11 @@ function drawingLayoutFor(part: OoxmlPart): InlineDrawingLayoutContext {
   };
 }
 
-function layoutFooterStory(part: OoxmlPart, geometry: ReturnType<typeof geometryOfSection>) {
+function layoutFooterStory(
+  part: OoxmlPart,
+  geometry: ReturnType<typeof geometryOfSection>,
+  numberingIndex?: ReturnType<typeof buildNumberingIndex>
+) {
   const width = geometry.width - geometry.margin.left - geometry.margin.right;
   return layoutHeaderFooterStory(
     part,
@@ -167,7 +177,9 @@ function layoutFooterStory(part: OoxmlPart, geometry: ReturnType<typeof geometry
       marginRight: geometry.margin.right,
       marginTop: geometry.margin.top,
       marginBottom: geometry.margin.bottom,
-    }
+    },
+    undefined,
+    numberingIndex ? { numberingIndex } : undefined
   );
 }
 
@@ -529,5 +541,169 @@ describe('incremental relayout with footer textboxes', () => {
     const first = lay(1);
     const second = lay(2);
     expect(shapeOf(second)).toBe(shapeOf(first));
+  });
+});
+
+describe('list markers inside textbox stories', () => {
+  const numberingIndexFor = (lvlText: string) => {
+    const num = readOoxmlPart(
+      `<w:numbering xmlns:w="${W}">` +
+        '<w:abstractNum w:abstractNumId="7">' +
+        '<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>' +
+        `<w:lvlText w:val="${lvlText}"/><w:lvlJc w:val="left"/>` +
+        '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>' +
+        '</w:abstractNum>' +
+        '<w:num w:numId="7"><w:abstractNumId w:val="7"/></w:num>' +
+        '</w:numbering>',
+      { name: '/word/numbering.xml', contentType: 'app/xml' }
+    );
+    if (!num.ok) throw new Error(num.reason);
+    return buildNumberingIndex(num.part.root);
+  };
+
+  const numberedParagraph = (text: string) =>
+    '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="7"/></w:numPr></w:pPr>' +
+    `<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+  function markerTexts(story: TextboxStoryLayout): string[] {
+    return story.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph' && fragment.marker ? [fragment.marker.text] : []
+    );
+  }
+
+  function footerStoryWithNumbering(lvlText: string): HeaderFooterStoryLayout {
+    const bytes = footerTextboxDoc(
+      textboxDrawing(numberedParagraph('alpha') + numberedParagraph('beta')),
+      5
+    );
+    const pkg = openPackage(bytes);
+    const main = pkg.parts.get(pkg.mainDocumentPart)!;
+    const geometry = geometryOfSection(enumerateDocumentSections(main)[0]!.properties);
+    const footerPart = [...resolveHeaderFooterPartsBySection(pkg)[0]!.footers.values()][0]!;
+    return layoutFooterStory(footerPart, geometry, numberingIndexFor(lvlText));
+  }
+
+  test('a numbered paragraph inside a footer text box paints a marker (fixes #466)', () => {
+    const story = footerStoryWithNumbering('%1.');
+    expect(markerTexts(storyOfRecord(story))).toEqual(['1.', '2.']);
+  });
+
+  test('storyListMarkerToken descends into the text-box story', () => {
+    const decimal = footerStoryWithNumbering('%1.');
+    const wrapped = footerStoryWithNumbering('(%1)');
+    const token = storyListMarkerToken(decimal);
+    expect(token).toContain('1.');
+    expect(token).toContain('2.');
+    expect(storyListMarkerToken(wrapped)).not.toBe(token);
+  });
+
+  const NS = `xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"`;
+
+  function bodyTextboxPart(): OoxmlPart {
+    const doc = readOoxmlPart(
+      `<w:document ${NS}><w:body>` +
+        `<w:p><w:r>${textboxDrawing(numberedParagraph('alpha') + numberedParagraph('beta'))}</w:r></w:p>` +
+        '<w:p><w:r><w:t>after the box</w:t></w:r></w:p>' +
+        '</w:body></w:document>',
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!doc.ok) throw new Error(doc.reason);
+    return doc.part;
+  }
+
+  test('a numbered paragraph inside a body text box paints a marker (fixes #466)', () => {
+    const part = bodyTextboxPart();
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      producer: 'test',
+      inlineDrawingLayout: drawingLayoutFor(part),
+      numberingIndex: numberingIndexFor('%1.'),
+    });
+    const record = layout.pages[0]!.anchoredDrawings?.[0];
+    if (!record?.textboxStory) throw new Error('no textbox story on record');
+    expect(markerTexts(record.textboxStory)).toEqual(['1.', '2.']);
+  });
+
+  test('a numbering change reaches a body text box through the flow keys', () => {
+    const part = bodyTextboxPart();
+    const session = createLayoutSession();
+    const drawingLayout = drawingLayoutFor(part);
+    const lay = (revision: number, lvlText: string): SemanticLayout =>
+      layoutSemanticDocument(part, revision, {
+        measurer,
+        producer: 'test',
+        inlineDrawingLayout: drawingLayout,
+        numberingIndex: numberingIndexFor(lvlText),
+        session,
+      });
+    const boxMarkers = (layout: SemanticLayout): string[] => {
+      const record = layout.pages[0]!.anchoredDrawings?.[0];
+      if (!record?.textboxStory) throw new Error('no textbox story on record');
+      return markerTexts(record.textboxStory);
+    };
+    expect(boxMarkers(lay(1, '%1.'))).toEqual(['1.', '2.']);
+    // The host paragraph carries no numbering of its own, so without the hosted-story token
+    // in its flow key the previous pages are reused by identity and keep the old markers.
+    expect(boxMarkers(lay(2, '(%1)'))).toEqual(['(1)', '(2)']);
+  });
+
+  test('a numbering change reaches a text box hosted in a table cell', () => {
+    const doc = readOoxmlPart(
+      `<w:document ${NS}><w:body>` +
+        '<w:tbl><w:tblPr><w:tblW w:w="9000" w:type="dxa"/></w:tblPr>' +
+        '<w:tblGrid><w:gridCol w:w="9000"/></w:tblGrid>' +
+        '<w:tr><w:tc><w:tcPr><w:tcW w:w="9000" w:type="dxa"/></w:tcPr>' +
+        `<w:p><w:r>${textboxDrawing(numberedParagraph('alpha') + numberedParagraph('beta'))}</w:r></w:p>` +
+        '</w:tc></w:tr></w:tbl>' +
+        '<w:p><w:r><w:t>after the table</w:t></w:r></w:p>' +
+        '</w:body></w:document>',
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!doc.ok) throw new Error(doc.reason);
+    const session = createLayoutSession();
+    const drawingLayout = drawingLayoutFor(doc.part);
+    const boxMarkers = (revision: number, lvlText: string): string[] => {
+      const layout = layoutSemanticDocument(doc.part, revision, {
+        measurer,
+        producer: 'test',
+        inlineDrawingLayout: drawingLayout,
+        numberingIndex: numberingIndexFor(lvlText),
+        session,
+      });
+      const record = layout.pages[0]!.anchoredDrawings?.[0];
+      if (!record?.textboxStory) throw new Error('no textbox story on record');
+      return markerTexts(record.textboxStory);
+    };
+    expect(boxMarkers(1, '%1.')).toEqual(['1.', '2.']);
+    // The TABLE block's flow key must move too: its cell paragraphs carry no numbering of
+    // their own, so only the hosted-story token distinguishes the two numbering states.
+    expect(boxMarkers(2, '(%1)')).toEqual(['(1)', '(2)']);
+  });
+
+  test('a text-box list restarts at w:start, independent of the host story', () => {
+    const doc = readOoxmlPart(
+      `<w:document ${NS}><w:body>` +
+        numberedParagraph('host one') +
+        numberedParagraph('host two') +
+        `<w:p><w:r>${textboxDrawing(numberedParagraph('alpha') + numberedParagraph('beta'))}</w:r></w:p>` +
+        '</w:body></w:document>',
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!doc.ok) throw new Error(doc.reason);
+    const layout = layoutSemanticDocument(doc.part, 1, {
+      measurer,
+      producer: 'test',
+      inlineDrawingLayout: drawingLayoutFor(doc.part),
+      numberingIndex: numberingIndexFor('%1.'),
+    });
+    const bodyMarkers = layout.pages[0]!.fragments.flatMap((fragment) =>
+      fragment.kind === 'paragraph' && fragment.marker ? [fragment.marker.text] : []
+    );
+    // The host story numbers on its own counters; the box is its own story root and
+    // restarts at w:start with the same numId, like a header's or a note's list does.
+    expect(bodyMarkers).toEqual(['1.', '2.']);
+    const record = layout.pages[0]!.anchoredDrawings?.[0];
+    if (!record?.textboxStory) throw new Error('no textbox story on record');
+    expect(markerTexts(record.textboxStory)).toEqual(['1.', '2.']);
   });
 });

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -42,7 +42,7 @@ import {
   type ExclusionZone,
 } from './drawing-exclusion.ts';
 import { flowBlocksInBox } from './semantic-table-layout.ts';
-import { forEachStoryDrawing } from './semantic-record-queries.ts';
+import { forEachStoryDrawing, forEachStoryParagraphFragment } from './semantic-record-queries.ts';
 import { withResolvedListItems, type ResolvedListItem } from './list-resolve.ts';
 import type { NumberingIndex } from './numbering-index.ts';
 import { layoutTextboxStory } from './textbox-story-layout.ts';
@@ -170,7 +170,8 @@ function createBoundedContextCache(maxEntries: number): {
  */
 export interface HeaderFooterStoryInputs {
   /**
-   * `numbering.xml`, so a `w:numPr` paragraph in this story resolves a marker.
+   * `numbering.xml`, so a `w:numPr` paragraph in this story resolves a marker — directly or
+   * inside an anchored text box, which lays out with its own per-box counters.
    *
    * Absent, the story lays out exactly as before: no marker record, and no numbering indent
    * merged into the paragraph's own.
@@ -331,6 +332,7 @@ export function layoutHeaderFooterStory(
               ...(documentProperties ? { documentProperties } : {}),
               inlineDrawingLayout,
               ...(drawingTokenForParagraph ? { drawingTokenForParagraph } : {}),
+              ...(inputs?.numberingIndex ? { numberingIndex: inputs.numberingIndex } : {}),
             }),
           collectAnchoredDrawings: (drawings) => {
             pendingAnchoredDrawings.push(...drawings);
@@ -505,27 +507,22 @@ const storyListMarkerTokens = new WeakMap<HeaderFooterStoryLayout, string>();
  * pages showing the old header marker and the one rebuilt page showing the new one — two
  * different numbers for the same header in one section.
  *
- * Unlike {@link storyDrawingResourceToken} this walk stops at the story's own fragments: a
- * text-box story never resolves list items today (`layoutTextboxStory` receives no
- * `listItems`, so a `w:numPr` paragraph in a box carries no marker record). If text-box
- * stories ever grow markers, this token must descend with them or a `numbering.xml` edit
- * leaves a reused page showing the old number inside the box.
+ * Walks with {@link forEachStoryParagraphFragment}, which descends into each anchored
+ * drawing's text-box story exactly like {@link storyDrawingResourceToken}'s walk does: a
+ * `w:numPr` paragraph inside a `wps:txbx` carries a marker record too, and a `numbering.xml`
+ * edit moves neither `contentKey` nor `flowHeight`, so without the descent a reused page
+ * kept showing the old number inside the box.
  */
 export function storyListMarkerToken(story: HeaderFooterStoryLayout): string {
   const cached = storyListMarkerTokens.get(story);
   if (cached !== undefined) return cached;
   const tokens: string[] = [];
-  const visitBlock = (block: BlockFragmentRecord): void => {
-    if (block.kind === 'table') {
-      for (const row of block.rows) {
-        for (const cell of row.cells) for (const inner of cell.blocks) visitBlock(inner);
-      }
-      return;
+  forEachStoryParagraphFragment(story, (fragment) => {
+    const marker = fragment.marker;
+    if (marker) {
+      tokens.push(`${fragment.paragraphId}=${marker.text}@${marker.numFmt}:${marker.level}`);
     }
-    const marker = block.marker;
-    if (marker) tokens.push(`${block.paragraphId}=${marker.text}@${marker.numFmt}:${marker.level}`);
-  };
-  for (const block of story.fragments) visitBlock(block);
+  });
   const token = tokens.length === 0 ? '' : `|list:${tokens.join(',')}`;
   storyListMarkerTokens.set(story, token);
   return token;

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -190,7 +190,7 @@ import {
 } from './semantic-fragment-signature.ts';
 import { type FlowCheckpoint, type LayoutSession } from './layout-session.ts';
 import { furnitureForSection, layoutMultiSectionDocument } from './multi-section-layout.ts';
-import { layoutTextboxStory } from './textbox-story-layout.ts';
+import { hostedTextboxListToken, layoutTextboxStory } from './textbox-story-layout.ts';
 
 /** Extra full-document layouts after the reflow pass budget to detect a stable 2-cycle. */
 const MAX_DRAWING_EXCLUSION_STABILIZATION_PASSES = 2;
@@ -1031,10 +1031,19 @@ function layoutBlocksPass(
     // own id gave an empty token, and a renumbering that left the table's flow key untouched
     // reused the cell markers verbatim. The drawing token aggregates the same way, for the
     // same reason.
+    // The list state of any text-box story this block hosts, for the same reason the drawing
+    // token aggregates hosted-story atoms: a box's markers come from `numbering.xml`, and a
+    // numbering edit moves nothing else in this block's key.
+    const hostedListToken = hostedTextboxListToken(
+      block,
+      options.numberingIndex,
+      styleCascade,
+      displayMode
+    );
     const listToken =
-      block.kind === 'table'
+      (block.kind === 'table'
         ? listTokenForTableBlock(block, listItems)
-        : (listItems?.get(block.id)?.cacheToken ?? '');
+        : (listItems?.get(block.id)?.cacheToken ?? '')) + hostedListToken;
     const memo = preparedBlocks.get(block);
     if (
       memo &&
@@ -1053,7 +1062,9 @@ function layoutBlocksPass(
         table: block,
         key: paragraphLayoutKey({
           paragraph: block,
-          properties: [],
+          properties: hostedListToken
+            ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
+            : [],
           width: availableWidth,
           producer,
           ...(paragraphDrawingToken ? { drawingToken: paragraphDrawingToken } : {}),
@@ -1127,6 +1138,9 @@ function layoutBlocksPass(
             { localName: 'tabStops', attributes: { token: tabStopsCacheToken } },
             ...(listItem
               ? [{ localName: 'list', attributes: { token: listItem.cacheToken } }]
+              : []),
+            ...(hostedListToken
+              ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
               : []),
           ],
           width: available,
@@ -1651,6 +1665,7 @@ function layoutBlocksPass(
       ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
       ...(displayMode ? { displayMode } : {}),
       ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
+      ...(options.numberingIndex ? { numberingIndex: options.numberingIndex } : {}),
       inlineDrawingLayout: options.inlineDrawingLayout,
       drawingTokenForParagraph: options.drawingTokenForParagraph,
     });

--- a/packages/core/src/layout/semantic-record-queries.ts
+++ b/packages/core/src/layout/semantic-record-queries.ts
@@ -143,6 +143,31 @@ export function forEachStoryDrawing(
   visitStory(story, 0);
 }
 
+/**
+ * Visit every paragraph fragment one story paints — its own (table interiors flattened,
+ * header repeats included) and the fragments inside each anchored drawing's text-box story,
+ * recursively.
+ *
+ * The fragment sibling of {@link forEachStoryDrawing}, sharing its depth bound, for
+ * consumers that read per-paragraph published fields (list markers) rather than drawings.
+ * The furniture list-marker token walks with this; a fragment it misses leaves a reused
+ * page showing a stale marker.
+ */
+export function forEachStoryParagraphFragment(
+  story: StoryDrawingHost,
+  visit: (fragment: ParagraphFragmentRecord) => void
+): void {
+  const visitStory = (inner: StoryDrawingHost, depth: number): void => {
+    if (depth > MAX_STORY_DRAWING_WALK_DEPTH) return;
+    for (const drawing of inner.anchoredDrawings ?? []) {
+      // A text box is a story of its own, nested in the drawing that anchors it.
+      if (drawing.textboxStory) visitStory(drawing.textboxStory, depth + 1);
+    }
+    for (const fragment of paragraphFragmentsOfBlocks(inner.fragments, true)) visit(fragment);
+  };
+  visitStory(story, 0);
+}
+
 /** Every fragment belonging to one paragraph, in order, across page boundaries. */
 export function fragmentsOfParagraph(
   layout: SemanticLayout,

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -863,6 +863,7 @@ export {
   contentControlsOfLayout,
   effectiveContentControlLock,
   forEachStoryDrawing,
+  forEachStoryParagraphFragment,
   fragmentsOfParagraph,
   lineAtPosition,
   linesOf,

--- a/packages/core/src/layout/textbox-story-layout.ts
+++ b/packages/core/src/layout/textbox-story-layout.ts
@@ -15,11 +15,17 @@
 // convergence counter never moves because a textbox changed. All bounds are explicit:
 // nesting depth, fragment count, and the extent clip all fail closed with reasons.
 
-import type { OoxmlElement } from '@docx-editor.dev/core/store';
+import type { OoxmlElement, OoxmlNode } from '@docx-editor.dev/core/store';
 import type { DrawingProjection } from '../store/package/drawing-projection.ts';
 import { emuToPoints } from './drawing-layout.ts';
 import type { FieldPageContext } from './field-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
+import {
+  resolveStoryListItems,
+  withNumberingStyleLinks,
+  type ResolvedListItem,
+} from './list-resolve.ts';
+import type { NumberingIndex } from './numbering-index.ts';
 import type { PendingLine } from './paragraph-flow.ts';
 import type { RevisionDisplayMode } from './revision-projection.ts';
 import { flowBlocksInBox } from './semantic-table-layout.ts';
@@ -87,6 +93,15 @@ export interface TextboxStoryLayoutOptions {
   /** Story nesting depth; a textbox laid out from inside another textbox passes depth + 1. */
   readonly depth?: number;
   /**
+   * `numbering.xml`, so a `w:numPr` paragraph in the box resolves a marker.
+   *
+   * Absent, the story lays out as before: no marker record, and no numbering indent merged
+   * into the paragraph's own. Counters are PER BOX ({@link textboxStoryListItems}) — a text
+   * box is its own story root, like a note, so its lists restart at `w:start` rather than
+   * continuing the host story's.
+   */
+  readonly numberingIndex?: NumberingIndex;
+  /**
    * Inline drawing context for the part the text box lives in.
    *
    * A picture inside `w:txbxContent` is an ordinary inline drawing of the HOST part — same
@@ -104,6 +119,193 @@ export interface TextboxStoryLayoutOptions {
 /** Stable line-id namespace for one textbox story. */
 export function textboxLineIdPrefix(drawingNodeId: string): string {
   return `txbx-${drawingNodeId}`;
+}
+
+interface TextboxStoryListResolve {
+  readonly rawIndex: NumberingIndex;
+  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly displayMode: RevisionDisplayMode;
+  readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
+}
+
+/**
+ * Memoized per immutable `w:txbxContent` node, validated against the RAW inputs by identity.
+ * Sound because any edit inside the box republishes the content node; a numbering or cascade
+ * change keeps the node and misses on the input compare instead.
+ */
+const textboxStoryListResolves = new WeakMap<OoxmlNode, TextboxStoryListResolve>();
+
+/**
+ * Resolve every list paragraph of one text-box story, keyed by paragraph node id.
+ *
+ * Counters are created fresh per box — a text box is its own story root laid out
+ * independently of its host (the {@link textboxStoryBlocks} rule), so its lists restart at
+ * `w:start` the way a header's or a note's do, rather than continuing the host story's.
+ * Returns undefined when numbering is absent or the box holds no list paragraphs.
+ */
+export function textboxStoryListItems(
+  content: OoxmlNode,
+  numberingIndex: NumberingIndex | undefined,
+  styleCascade: StyleCascadeTable | undefined,
+  displayMode: RevisionDisplayMode = 'all-markup'
+): ReadonlyMap<string, ResolvedListItem> | undefined {
+  if (!numberingIndex || numberingIndex.nums.size === 0) return undefined;
+  const memo = textboxStoryListResolves.get(content);
+  if (
+    memo &&
+    memo.rawIndex === numberingIndex &&
+    memo.styleCascade === styleCascade &&
+    memo.displayMode === displayMode
+  ) {
+    return memo.listItems;
+  }
+  const linked = withNumberingStyleLinks(numberingIndex, styleCascade);
+  const blocks = textboxStoryBlocks(content, displayMode);
+  const resolved = resolveStoryListItems(blocks, linked, styleCascade);
+  const listItems = resolved.size > 0 ? resolved : undefined;
+  textboxStoryListResolves.set(content, {
+    rawIndex: numberingIndex,
+    styleCascade,
+    displayMode,
+    listItems,
+  });
+  return listItems;
+}
+
+/** Hard ceiling on nodes visited when discovering `w:txbxContent` under one block. */
+const MAX_HOSTED_STORY_SCAN_NODES = 20_000;
+
+interface HostedContentsScan {
+  readonly contents: readonly OoxmlNode[];
+  /** True when the budget stopped the walk before the whole subtree was seen. */
+  readonly truncated: boolean;
+}
+
+const NO_HOSTED_CONTENTS: HostedContentsScan = Object.freeze({
+  contents: Object.freeze([]),
+  truncated: false,
+});
+
+/**
+ * The `w:txbxContent` nodes a block hosts — a TREE fact, memoized per immutable block node.
+ *
+ * Found by name rather than through drawing projections, so an `mc:Fallback` twin of a live
+ * box is included too; its list state mirrors the live copy's, which only widens the token
+ * below, never wrongs it. No descent INTO a found content: a box inside a box does not lay
+ * out (nested stories degrade to the placeholder path), so its list state paints nothing.
+ */
+const hostedTextboxContentsByBlock = new WeakMap<OoxmlNode, HostedContentsScan>();
+
+function hostedTextboxContents(block: OoxmlNode): HostedContentsScan {
+  const cached = hostedTextboxContentsByBlock.get(block);
+  if (cached) return cached;
+  const found: OoxmlNode[] = [];
+  let visited = 0;
+  let truncated = false;
+  const stack: OoxmlNode[] = [block];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    visited += 1;
+    // Defensive, like every other file-derived walk — but a stopped scan can MISS a box, and
+    // an unseen box's list state must fail OPEN, not stale. The truncation flag is recorded
+    // so the token below stops naming individual items and keys on the numbering index
+    // itself: every numbering edit then re-lays the block, which wastes work on a hostile
+    // file but never reuses a page showing an old marker.
+    if (visited > MAX_HOSTED_STORY_SCAN_NODES) {
+      truncated = true;
+      break;
+    }
+    if (node.kind !== 'textValue' && node.localName === 'txbxContent') {
+      found.push(node);
+      continue;
+    }
+    if (!('children' in node)) continue;
+    for (let index = node.children.length - 1; index >= 0; index -= 1) {
+      stack.push(node.children[index]!);
+    }
+  }
+  const scan: HostedContentsScan =
+    found.length > 0 || truncated
+      ? Object.freeze({ contents: Object.freeze(found), truncated })
+      : NO_HOSTED_CONTENTS;
+  hostedTextboxContentsByBlock.set(block, scan);
+  return scan;
+}
+
+/**
+ * Stable per-object identity of a numbering index, for the truncated-scan token arm.
+ *
+ * A truncated scan cannot name the items it missed, so its token names the INDEX instead:
+ * any `numbering.xml` edit yields a new index object, a new id, and a changed key. Ids only
+ * grow with distinct index objects ever tokenized this way — a handful per document life.
+ */
+let nextNumberingIndexTokenId = 1;
+const numberingIndexTokenIds = new WeakMap<NumberingIndex, number>();
+
+function numberingIndexTokenId(index: NumberingIndex): number {
+  let id = numberingIndexTokenIds.get(index);
+  if (id === undefined) {
+    id = nextNumberingIndexTokenId;
+    nextNumberingIndexTokenId += 1;
+    numberingIndexTokenIds.set(index, id);
+  }
+  return id;
+}
+
+interface HostedListTokenMemo {
+  readonly rawIndex: NumberingIndex;
+  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly displayMode: RevisionDisplayMode;
+  readonly token: string;
+}
+
+const hostedListTokensByBlock = new WeakMap<OoxmlNode, HostedListTokenMemo>();
+
+/**
+ * Marker identity of every list item the text-box stories UNDER one block paint.
+ *
+ * The list sibling of the hosted-story arm of `drawingTokenForParagraph`, for the same
+ * reason: a box's markers come from `numbering.xml`, a DIFFERENT part from the one the host
+ * paragraph lives in, so a numbering edit moves neither the paragraph node nor its drawing
+ * token — and a flow key without this reuses pages showing the old number inside the box.
+ * Empty for the overwhelmingly common block with no text box, at the cost of one memoized
+ * subtree scan per immutable block node.
+ */
+export function hostedTextboxListToken(
+  block: OoxmlNode,
+  numberingIndex: NumberingIndex | undefined,
+  styleCascade: StyleCascadeTable | undefined,
+  displayMode: RevisionDisplayMode = 'all-markup'
+): string {
+  if (!numberingIndex || numberingIndex.nums.size === 0) return '';
+  const scan = hostedTextboxContents(block);
+  if (scan.contents.length === 0 && !scan.truncated) return '';
+  const memo = hostedListTokensByBlock.get(block);
+  if (
+    memo &&
+    memo.rawIndex === numberingIndex &&
+    memo.styleCascade === styleCascade &&
+    memo.displayMode === displayMode
+  ) {
+    return memo.token;
+  }
+  const parts: string[] = [];
+  for (const content of scan.contents) {
+    const items = textboxStoryListItems(content, numberingIndex, styleCascade, displayMode);
+    if (!items) continue;
+    for (const [paragraphId, item] of items) parts.push(`${paragraphId}=${item.cacheToken}`);
+  }
+  // A truncated scan may have MISSED a box, so it cannot vouch for "no list state": key on
+  // the index identity instead, which fails open — every numbering edit moves the key.
+  if (scan.truncated) parts.push(`truncated:${numberingIndexTokenId(numberingIndex)}`);
+  const token = parts.length === 0 ? '' : `|txbxlist:${parts.join(',')}`;
+  hostedListTokensByBlock.set(block, {
+    rawIndex: numberingIndex,
+    styleCascade,
+    displayMode,
+    token,
+  });
+  return token;
 }
 
 /**
@@ -149,6 +351,12 @@ export function layoutTextboxStory(
   }
 
   const blocks: readonly OoxmlElement[] = textboxStoryBlocks(story.content, options.displayMode);
+  const listItems = textboxStoryListItems(
+    story.content,
+    options.numberingIndex,
+    options.styleCascade,
+    options.displayMode
+  );
   const prefix = textboxLineIdPrefix(projection.drawingNodeId);
   let lineCounter = 0;
 
@@ -158,6 +366,7 @@ export function layoutTextboxStory(
     producer: `${options.producer}|txbx:${projection.drawingNodeId}`,
     nextLineId: () => `${prefix}-line-${lineCounter++}`,
     styleCascade: options.styleCascade,
+    ...(listItems ? { listItems } : {}),
     ...(options.pageContext ? { pageContext: options.pageContext } : {}),
     ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
     ...(options.defaultTabStopPt !== undefined


### PR DESCRIPTION
A `w:numPr` paragraph inside a `wps:txbx` rendered unnumbered: `layoutTextboxStory` never received list items. The box now resolves its own list items per story, so counters restart at `w:start` the way a note's or a header's do, on both the body and header/footer paths.

Two invalidation gaps close with it. `storyListMarkerToken` walks with the new `forEachStoryParagraphFragment`, the fragment sibling of `forEachStoryDrawing`, so a `numbering.xml` edit moves the furniture context of a box that shows a marker. On the body path, a memoized `hostedTextboxListToken` folds the box's list state into the host block's flow key, so a session resume re-lays the page instead of reusing the old marker; a truncated discovery scan fails open by keying on the numbering index identity.

Fixes #466

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790263303&installation_model_id=422592&pr_number=475&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F475&signature=5ef02940f3ed571ea0d2a4d5be88030ebf2bdee4812d61d50bc290e870370337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->