### PR TITLE
fix: publish layout synchronously for image drawing ops so the selection overlay follows a resize

### DIFF
--- a/.changeset/image-overlay-follows-resize.md
+++ b/.changeset/image-overlay-follows-resize.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Fix the image selection overlay keeping the drawing's old frame after a resize, move, wrap, or transform: image ops now commit through the same layout/paint tail as keystrokes, and overlay geometry reads flush any pending layout pass first.
+Fix the image selection overlay keeping the drawing's old frame after a resize, move, wrap, or transform. Image ops now commit through the same layout/paint tail as keystrokes, and multi-section layout no longer republishes a previous pass's sheets for a section that changed inside a balancing or re-run pass.

--- a/.changeset/image-overlay-follows-resize.md
+++ b/.changeset/image-overlay-follows-resize.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix the image selection overlay keeping the drawing's old frame after a resize, move, wrap, or transform: image ops now commit through the same layout/paint tail as keystrokes, and overlay geometry reads flush any pending layout pass first.

--- a/packages/core/src/editor/__tests__/docx-editor-images.test.ts
+++ b/packages/core/src/editor/__tests__/docx-editor-images.test.ts
@@ -16,6 +16,7 @@ import { resolveImageResourceLimits } from '../../store/runtime/limits.ts';
 import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
 import type { OoxmlDrawingNode, OoxmlElement } from '../../store/package/ooxml-tree.ts';
 import { createInlineDrawingLayoutBundle } from '../../layout/inline-drawing-source.ts';
+import { findDrawingOverlayFrameInLayout } from '../../layout/semantic-hit-test.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
 import { selectedDrawingOverlayTargetOf } from '../docx-editor-images.ts';
 
@@ -434,6 +435,38 @@ describe('docx-editor image commands', () => {
     editor.exec({ type: 'undo' });
     selectInlineDrawing(editor);
     expect(editor.snapshot().image?.id).toBe(id);
+  });
+
+  test('resize publishes layout and overlay geometry synchronously', async () => {
+    // The resize lane used to apply its ops without the commit tail, so layout reached the
+    // screen through the scheduler's timer task — after a host's `change` handlers had read
+    // geometry — and the selection overlay kept the drawing's old frame.
+    const editor = mountEditor(inlinePictureDocument());
+    selectInlineDrawing(editor);
+    await settleDrawingResources(editor);
+    const before = selectedDrawingOverlayTargetOf(editor.surface);
+    expect(before).not.toBeNull();
+    expect(before!.width).toBeCloseTo(72, 5);
+
+    const result = editor.exec({
+      type: 'setImageProperties',
+      widthEmu: 457_200,
+      heightEmu: 457_200,
+    });
+    expect(result).toEqual({ ok: true, changed: true });
+
+    // No timer flush between the exec and these reads: the commit itself must publish.
+    const frame = findDrawingOverlayFrameInLayout(editor.surface!.publishedLayout(), before!.id);
+    expect(frame).not.toBeNull();
+    expect(frame!.width).toBeCloseTo(36, 5);
+    expect(frame!.height).toBeCloseTo(36, 5);
+
+    const target = selectedDrawingOverlayTargetOf(editor.surface);
+    expect(target).not.toBeNull();
+    expect(target!.widthEmu).toBe(457_200);
+    expect(target!.heightEmu).toBe(457_200);
+    expect(target!.width).toBeCloseTo(36, 5);
+    expect(target!.height).toBeCloseTo(36, 5);
   });
 
   test('refuses image commands without a selected picture', () => {

--- a/packages/core/src/editor/__tests__/image-resize-published-layout.test.ts
+++ b/packages/core/src/editor/__tests__/image-resize-published-layout.test.ts
@@ -1,0 +1,113 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { validateRasterHeader, type ImageDecodePort } from '../../store/package/image-resources.ts';
+import { resolveImageResourceLimits } from '../../store/runtime/limits.ts';
+import type { SemanticLayout } from '../../layout/index.ts';
+import { createDocxEditor } from '../docx-editor.ts';
+
+// The demo document, because the bug needs its shape: a multi-section body whose balanced
+// section lays out more than once inside one pass. The balancing attempt advances the
+// section session, the final call identity-returns against it, and the span-reuse gate in
+// `layoutMultiSectionDocument` then republished the PREVIOUS pass's sheets — the image
+// repainted at the new size while the published fragment kept the pre-resize frame.
+const SAMPLE = new Uint8Array(
+  readFileSync(new URL('../../../../../examples/vite/public/sample.docx', import.meta.url))
+);
+
+function testDecodePort(): ImageDecodePort {
+  return Object.freeze({
+    async decode(bytes: Uint8Array, mime: string) {
+      const header = validateRasterHeader(bytes, mime as never);
+      if (!header) throw new Error('invalid image');
+      const limits = resolveImageResourceLimits();
+      if (header.pixelWidth * header.pixelHeight > limits.maxPixels) throw new Error('too large');
+      return Object.freeze({
+        pixelWidth: header.pixelWidth,
+        pixelHeight: header.pixelHeight,
+        dpiX: 96,
+        dpiY: 96,
+      });
+    },
+  });
+}
+
+function inlineFrameOf(
+  layout: SemanticLayout,
+  id: string
+): { readonly w: number; readonly h: number } | null {
+  for (const page of layout.pages) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind !== 'paragraph') continue;
+      for (const line of fragment.lines) {
+        for (const drawing of line.drawings ?? []) {
+          if (drawing.drawingNodeId === id) return { w: drawing.width, h: drawing.height };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+test('a resize in a multi-section document publishes the new frame synchronously', async () => {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({
+    container,
+    document: SAMPLE,
+    imageDecodePort: testDecodePort(),
+  });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  const surface = editor.surface;
+
+  // Let drawing resources settle the way the browser does, so the pass under test starts
+  // from a fully settled layout instead of a resource-invalidation churn.
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  surface.layout();
+
+  // The widest inline drawing in the document — a block image well past icon size.
+  let drawingId: string | null = null;
+  let paragraphId: string | null = null;
+  let start = 0;
+  for (const page of surface.publishedLayout().pages) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind !== 'paragraph') continue;
+      for (const line of fragment.lines) {
+        for (const drawing of line.drawings ?? []) {
+          if (drawing.width > 150) {
+            drawingId = drawing.drawingNodeId;
+            paragraphId = drawing.paragraphId;
+            start = drawing.start;
+          }
+        }
+      }
+    }
+  }
+  if (!drawingId || !paragraphId) throw new Error('no wide inline drawing in sample.docx');
+
+  surface.setSelection({
+    anchor: { paragraphId, offset: start },
+    head: { paragraphId, offset: start },
+  });
+  expect(editor.getSelectedImage()).not.toBeNull();
+
+  const result = editor.exec({
+    type: 'setImageProperties',
+    widthEmu: 1_143_000,
+    heightEmu: 304_800,
+  });
+  expect(result).toEqual({ ok: true, changed: true });
+
+  // No timer flush between the exec and this read: the commit itself must publish pages
+  // that carry the resized frame. 1143000 x 304800 EMU is 90 x 24 points.
+  const frame = inlineFrameOf(surface.publishedLayout(), drawingId);
+  expect(frame).not.toBeNull();
+  expect(frame!.w).toBeCloseTo(90, 3);
+  expect(frame!.h).toBeCloseTo(24, 3);
+
+  // The surface registers document-level listeners; the serial run shares one document.
+  editor.destroy();
+});

--- a/packages/core/src/editor/docx-editor-images.ts
+++ b/packages/core/src/editor/docx-editor-images.ts
@@ -1095,7 +1095,10 @@ export function selectedDrawingOverlayTargetOf(
   const record = resolveSelectedDrawingRecord(surface);
   if (!record) return null;
   if (record.accessibility.hidden) return null;
-  const layout = surface.publishedLayout();
+  // `layout()`, not `publishedLayout()`: the caller is about to act on this geometry — place
+  // handles, stamp a drag session — so a pass still parked on the scheduler's timer must land
+  // first. Nothing pending makes this a plain read.
+  const layout = surface.layout();
   const frame = findDrawingOverlayFrameInLayout(layout, record.drawingNodeId);
   if (!frame) return null;
   const projection = projectDrawingForRecord(surface, record);

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -2673,9 +2673,9 @@ export function mountPaginatedSurface(
     scope: StoryScope = storyScope(),
     checkSelection = true
   ): ReturnType<TreeDocxSession['applyTreeOps']> {
-    // Direct op lanes (image ops, automation) bypass `commit`; buffered typing
-    // still lands first so their ops address the post-burst document. No-op on
-    // the commit path, whose head-flush already ran.
+    // Every live lane reaches here inside `commit`, whose head-flush already ran, so this
+    // is a defensive no-op — kept so a future direct caller still lands buffered typing
+    // before its ops address the document.
     flushTypeBuffer();
     const refusal = writeRefusal(ops.some(isDocumentEdit), ops, checkSelection);
     if (refusal !== null) return { committed: false, rejected: true, opCount: 0, reason: refusal };

--- a/packages/core/src/editor/surface-image-ops.ts
+++ b/packages/core/src/editor/surface-image-ops.ts
@@ -74,7 +74,16 @@ export function createImageOps(deps: {
       if (deps.editingMode() === 'view') return refuseViewing();
       if (deps.editingMode() === 'suggest') return refuseSuggestingPropertyEdit();
       const mark = deps.selectionMark();
-      return deps.applyOps(ops, mark, mark);
+      // Through `commit`, not `applyOps` alone: the commit tail is what publishes layout and
+      // paint synchronously. Applied bare, the resize reached the screen through the
+      // scheduler's timer task — after the host's `change` handlers had already read the
+      // superseded geometry — so the selection overlay kept the drawing's old frame.
+      let result: TreeApplyResult = { committed: false, rejected: true, opCount: 0 };
+      deps.commit(() => {
+        result = deps.applyOps(ops, mark, mark);
+        return result;
+      });
+      return result;
     },
 
     applyImageProperties(input) {

--- a/packages/core/src/layout/layout-session.ts
+++ b/packages/core/src/layout/layout-session.ts
@@ -58,6 +58,18 @@ export interface SectionStackSpan {
   readonly sheetY: number;
   /** Remapped pages (projectors intact) from the last pass for this section. */
   readonly remappedPages: readonly PageRecord[];
+  /**
+   * The section-local pages this span's pass returned — identity evidence for reuse. (On a
+   * continuous section the host tail merges instead of remapping, so `remappedPages` covers
+   * only the overflow sheets while this list still holds every returned page.)
+   *
+   * A section can lay out more than once inside one document pass (a reserve re-run, a
+   * balancing probe), and the last run then reports "nothing placed" against its OWN session
+   * even though an earlier run this pass rebuilt the pages. Counts and stats cannot tell
+   * those apart; only these object identities can say the span still describes the pages the
+   * section just returned.
+   */
+  readonly sourcePages: readonly PageRecord[];
 }
 
 /** Orchestrator state for multi-section incremental layout. */

--- a/packages/core/src/layout/multi-section-layout.ts
+++ b/packages/core/src/layout/multi-section-layout.ts
@@ -379,6 +379,7 @@ export function layoutMultiSectionDocument(
         pageCount: 0,
         sheetY: startSheetY,
         remappedPages: [],
+        sourcePages: [],
       });
       continue;
     }
@@ -444,7 +445,14 @@ export function layoutMultiSectionDocument(
       sectionSession.stats.placed === 0 &&
       sectionSession.stats.reusedPages === laid.pages.length &&
       prevSpan !== undefined &&
-      prevSpan.pageCount === laid.pages.length;
+      prevSpan.pageCount === laid.pages.length &&
+      // IDENTITY, not counts: the section may have laid out more than once inside this
+      // document pass (a reserve re-run, a balancing probe), and the final run then reports
+      // "nothing placed" against its own session even though an earlier run this pass
+      // rebuilt the pages. Reusing the previous pass's sheets on stats alone republished a
+      // resize's pre-edit geometry — the image repainted, the frame the span carried did not.
+      prevSpan.sourcePages.length === laid.pages.length &&
+      prevSpan.sourcePages.every((page, index) => page === laid.pages[index]);
 
     const stackUnchanged =
       prevSpan !== undefined &&
@@ -539,6 +547,7 @@ export function layoutMultiSectionDocument(
       pageCount: remapped.length,
       sheetY: startSheetY,
       remappedPages: remapped,
+      sourcePages: laid.pages,
     });
   }
 

--- a/packages/react/src/editor/images/ImageSelectionOverlay.tsx
+++ b/packages/react/src/editor/images/ImageSelectionOverlay.tsx
@@ -228,9 +228,14 @@ export function ImageSelectionOverlay({
       pointerId: number
     ) => {
       if (!editor?.surface) return;
+      // The flushing read FIRST: a pass still parked on the scheduler's timer would
+      // otherwise publish mid-drag and fail the commit's staleness check for nothing, so
+      // the session is stamped against the flushed layout. Preconditions are captured
+      // after it, so a flush that lands buffered input cannot stamp a selection the
+      // flush is about to move.
+      const layout = editor.surface.layout();
       const pre = captureImageMutationPreconditions(editor);
       if (!pre) return;
-      const layout = editor.surface.publishedLayout();
       pointerStartRef.current = Object.freeze({ x: clientX, y: clientY });
       captureTargetRef.current = captureTarget;
       (captureTarget as HTMLElement & { _lastPointerId?: number })._lastPointerId = pointerId;

--- a/packages/vue/src/editor/images/ImageSelectionOverlay.tsx
+++ b/packages/vue/src/editor/images/ImageSelectionOverlay.tsx
@@ -247,9 +247,14 @@ export const ImageSelectionOverlay = defineComponent({
     ): void => {
       const editor = editorRef.value;
       if (!editor?.surface) return;
+      // The flushing read FIRST: a pass still parked on the scheduler's timer would
+      // otherwise publish mid-drag and fail the commit's staleness check for nothing, so
+      // the session is stamped against the flushed layout. Preconditions are captured
+      // after it, so a flush that lands buffered input cannot stamp a selection the
+      // flush is about to move.
+      const layout = editor.surface.layout();
       const pre = captureImageMutationPreconditions(editor);
       if (!pre) return;
-      const layout = editor.surface.publishedLayout();
       pointerStartRef.value = Object.freeze({ x: clientX, y: clientY });
       captureTargetRef.value = captureTarget;
       (captureTarget as HTMLElement & { _lastPointerId?: number })._lastPointerId = pointerId;


### PR DESCRIPTION
After a resize, move, wrap change, or transform, the image selection overlay kept the drawing's old frame. Two defects combined to cause it.

The drawing-op lane applied its tree ops without the surface commit tail, so layout published later on the scheduler's timer task. Overlay syncs run on a microtask after the `change` event, read the superseded geometry, and nothing re-synced them afterward. Image drawing ops now commit through the same path as keystrokes, and overlay geometry reads use the flushing `layout()` read.

Even then, the commit's own layout pass could republish stale pages: a column-balancing attempt advances a section's incremental session inside one document pass, the final run reports nothing placed, and the multi-section span-reuse gate read that as unchanged since the previous pass. Each span now records the section-local pages its sheets were built from, and reuse requires identity with the pages the section just returned.

Regression tests cover both defects and fail without their fixes.

