### PR TITLE
fix: adopt the replaceAt landing rule for cell rectangles and proposeTextChange (fixes #459)

### DIFF
--- a/.changeset/tracked-cell-rectangle-and-propose-landing.md
+++ b/.changeset/tracked-cell-rectangle-and-propose-landing.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix tracked replacements over a rectangle of table cells to land in the first cell after its struck content, and allow `proposeReplacement` to span paragraph marks with the same landing rule as typing. Text-carrying proposals (`proposeInsertion`, `proposeReplacement`, and the matching `proposeTextChange` kinds) now refuse empty or newline-containing text instead of committing it. Fixes #459

--- a/examples/write-agent/app/agent/tools.ts
+++ b/examples/write-agent/app/agent/tools.ts
@@ -107,7 +107,12 @@ export const WRITER_TOOLS = {
     inputSchema: z.object({
       paragraphId,
       search: exactPhrase,
-      replaceWith: z.string(),
+      // Matching the engine gate: non-empty, and no paragraph-breaking characters —
+      // an empty replacement is a proposeDeletion, and a newline is not a paragraph mark.
+      replaceWith: z
+        .string()
+        .min(1)
+        .regex(/^[^\r\n\v\f\u2028\u2029]*$/, 'one paragraph of text, no line breaks'),
     }),
   }),
   propose_insertion: tool({
@@ -115,7 +120,10 @@ export const WRITER_TOOLS = {
     inputSchema: z.object({
       paragraphId,
       after: exactPhrase,
-      text: z.string().min(1),
+      text: z
+        .string()
+        .min(1)
+        .regex(/^[^\r\n\v\f\u2028\u2029]*$/, 'one paragraph of text, no line breaks'),
     }),
   }),
   propose_deletion: tool({

--- a/packages/core/src/editor/__tests__/cell-rectangle-commands.test.ts
+++ b/packages/core/src/editor/__tests__/cell-rectangle-commands.test.ts
@@ -13,8 +13,7 @@ import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
 import type { PaginatedSurface } from '../paginated-surface.ts';
-import { cellSelectionBetween } from '../../layout/semantic-cell-selection.ts';
-import type { TableCellAddress } from '../../layout/semantic-hit-test.ts';
+import { selectCellRectangle } from './paginated-surface-fixtures.ts';
 import { findNode, paragraphTextOf } from '@docx-editor.dev/core/store';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -62,41 +61,6 @@ function mountEditor(body: string): DocxEditorInstance {
   return editor;
 }
 
-function tableOnPage(surface: PaginatedSurface) {
-  for (const page of surface.layout().pages) {
-    for (const fragment of page.fragments) if (fragment.kind === 'table') return fragment;
-  }
-  throw new Error('no table in layout');
-}
-
-function cellAddress(surface: PaginatedSurface, row: number, column: number): TableCellAddress {
-  const table = tableOnPage(surface);
-  const rowRecord = table.rows[row]!;
-  const cell = rowRecord.cells.find((candidate) => candidate.gridColumn === column)!;
-  return {
-    tableId: table.tableId,
-    rowId: rowRecord.id,
-    cellId: cell.id,
-    rowIndex: row,
-    gridColumn: cell.gridColumn,
-    gridSpan: cell.gridSpan,
-  };
-}
-
-function selectRect(
-  surface: PaginatedSurface,
-  from: { row: number; column: number },
-  to: { row: number; column: number }
-): void {
-  const rectangle = cellSelectionBetween(
-    surface.layout(),
-    cellAddress(surface, from.row, from.column),
-    cellAddress(surface, to.row, to.column)
-  );
-  if (!rectangle) throw new Error('cell rectangle failed');
-  surface.setCellSelection(rectangle);
-}
-
 function allText(surface: PaginatedSurface): string[] {
   return surface.session.paragraphIds().map((id) => paragraphTextOf(surface.session.part(), id));
 }
@@ -123,7 +87,7 @@ describe('a paragraph command over a cell rectangle', () => {
     const editor = mountEditor(TABLE_2X2 + p('after'));
     try {
       const surface = editor.surface!;
-      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 0 });
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 0 });
       expect(surface.state().cellSelection?.cellIds).toHaveLength(2);
       surface.setParagraphProperty('jc', { val: 'center' });
       expect(alignmentOf(surface, 'A1')).toBe('center');
@@ -144,7 +108,7 @@ describe('deleting over a cell rectangle', () => {
     const editor = mountEditor(TABLE_3X2 + p('after'));
     try {
       const surface = editor.surface!;
-      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
       expect(surface.state().cellSelection?.cellIds).toHaveLength(4);
       expect(editor.exec({ type: 'deleteRow' }).ok).toBe(true);
       expect(allText(surface)).toEqual(['A3', 'B3', 'after']);
@@ -157,7 +121,7 @@ describe('deleting over a cell rectangle', () => {
     const editor = mountEditor(TABLE_2X3 + p('after'));
     try {
       const surface = editor.surface!;
-      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
       expect(surface.state().cellSelection?.cellIds).toHaveLength(4);
       expect(editor.exec({ type: 'deleteColumn' }).ok).toBe(true);
       expect(allText(surface)).toEqual(['C1', 'C2', 'after']);
@@ -172,7 +136,7 @@ describe('deleting over a cell rectangle', () => {
     const editor = mountEditor(TABLE_2X2 + p('after'));
     try {
       const surface = editor.surface!;
-      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
       expect(editor.exec({ type: 'deleteRow' }).ok).toBe(true);
       expect(allText(surface)).toEqual(['after']);
     } finally {
@@ -184,9 +148,26 @@ describe('deleting over a cell rectangle', () => {
     const editor = mountEditor(TABLE_2X2 + p('after'));
     try {
       const surface = editor.surface!;
-      selectRect(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
       expect(editor.exec({ type: 'deleteColumn' }).ok).toBe(true);
       expect(allText(surface)).toEqual(['after']);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('a proposed replacement over a single EMPTY cell is accepted, as typing is', () => {
+    // One empty cell mirrors a COLLAPSED text range, but the rectangle still covers a cell
+    // the user selected — `can` and `exec` must both take it, exactly as the keyboard does.
+    const table = `<w:tbl>${GRID2}${tr(tc('<w:p/>') + tc(p('B1')))}${tr(tc(p('A2')) + tc(p('B2')))}</w:tbl>`;
+    const editor = mountEditor(table + p('after'));
+    try {
+      const surface = editor.surface!;
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 0, column: 0 });
+      const command = { type: 'proposeReplacement' as const, replaceWith: 'X' };
+      expect(editor.can(command)).toEqual({ ok: true });
+      expect(editor.exec(command)).toMatchObject({ ok: true, changed: true });
+      expect(allText(surface)).toEqual(['X', 'B1', 'A2', 'B2', 'after']);
     } finally {
       editor.destroy();
     }

--- a/packages/core/src/editor/__tests__/paginated-surface-fixtures.ts
+++ b/packages/core/src/editor/__tests__/paginated-surface-fixtures.ts
@@ -13,6 +13,8 @@ import { zipSync, strToU8 } from 'fflate';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '@docx-editor.dev/core/layout';
 import { readOoxmlPackage } from '@docx-editor.dev/core/store';
+import { cellSelectionBetween } from '../../layout/semantic-cell-selection.ts';
+import type { TableCellAddress } from '../../layout/semantic-hit-test.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -50,6 +52,46 @@ export function putCaret(surface: PaginatedSurface, offset: number, paragraphInd
     anchor: { paragraphId, offset },
     head: { paragraphId, offset },
   });
+}
+
+/**
+ * Select a rectangle of cells on the FIRST table in the layout, by row ordinal and grid
+ * column.
+ *
+ * Every rectangle suite hand-rolled the same fragment lookup, `TableCellAddress`
+ * construction and `cellSelectionBetween` call; a contract change in any of those had to
+ * be fixed once per file. This is the one copy.
+ */
+export function selectCellRectangle(
+  surface: PaginatedSurface,
+  from: { row: number; column: number },
+  to: { row: number; column: number }
+): void {
+  const table = surface
+    .layout()
+    .pages.flatMap((page) => page.fragments)
+    .find((fragment) => fragment.kind === 'table');
+  if (!table || table.kind !== 'table') throw new Error('no table in layout');
+  const address = (row: number, column: number): TableCellAddress => {
+    const rowRecord = table.rows[row]!;
+    const cell = rowRecord.cells.find((candidate) => candidate.gridColumn === column);
+    if (!cell) throw new Error(`no cell at row ${row}, grid column ${column}`);
+    return {
+      tableId: table.tableId,
+      rowId: rowRecord.id,
+      cellId: cell.id,
+      rowIndex: row,
+      gridColumn: cell.gridColumn,
+      gridSpan: cell.gridSpan,
+    };
+  };
+  const rectangle = cellSelectionBetween(
+    surface.layout(),
+    address(from.row, from.column),
+    address(to.row, to.column)
+  );
+  if (!rectangle) throw new Error('cell rectangle failed');
+  surface.setCellSelection(rectangle);
 }
 
 export function mount(body: string): { surface: PaginatedSurface; container: HTMLElement } {

--- a/packages/core/src/editor/__tests__/propose-commands.test.ts
+++ b/packages/core/src/editor/__tests__/propose-commands.test.ts
@@ -89,6 +89,57 @@ describe('explicit tracked-change commands', () => {
     }
   });
 
+  test('proposeInsertion at a caret inside a tracked deletion lands past it, in order', () => {
+    const { editor, dispose } = mounted('Agent');
+    try {
+      const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+      editor.surface!.setSelection({
+        anchor: { paragraphId, offset: 1 },
+        head: { paragraphId, offset: 3 },
+      });
+      expect(editor.exec({ type: 'proposeDeletion' })).toMatchObject({ ok: true });
+      // The caret rests INSIDE the struck 'bc'. The store relocates each insert past the
+      // deletion; the reported caret must move the same way, or the second proposal lands
+      // before the first and the output comes out reversed.
+      editor.surface!.setSelection({
+        anchor: { paragraphId, offset: 2 },
+        head: { paragraphId, offset: 2 },
+      });
+      expect(editor.exec({ type: 'proposeInsertion', text: 'A' })).toMatchObject({ ok: true });
+      expect(editor.exec({ type: 'proposeInsertion', text: 'B' })).toMatchObject({ ok: true });
+      const xml = xmlOf(editor);
+      expect(xml).toContain('<w:delText>bc</w:delText>');
+      expect(xml).toMatch(/<w:t[^>]*>AB<\/w:t>/);
+    } finally {
+      dispose();
+    }
+  });
+
+  test('proposeReplacement spans paragraph marks and lands after the last struck paragraph', () => {
+    const { editor, dispose } = mounted('Agent');
+    try {
+      // 'abcd' then a split: two paragraphs, 'abcd' and 'second'.
+      editor.surface!.insertPlainText('\nsecond');
+      const ids = editor.surface!.session.paragraphIds();
+      editor.surface!.setSelection({
+        anchor: { paragraphId: ids[0]!, offset: 1 },
+        head: { paragraphId: ids[1]!, offset: 3 },
+      });
+      const command = { type: 'proposeReplacement' as const, replaceWith: 'XY' };
+      expect(editor.can(command)).toEqual({ ok: true });
+      expect(editor.exec(command)).toMatchObject({ ok: true, changed: true });
+      const xml = xmlOf(editor);
+      // Both paragraphs keep their struck halves, the mark becomes a merge proposal, and
+      // the replacement is one insertion after the LAST struck head — the keyboard's rule.
+      expect(xml).toContain('<w:delText>bcd</w:delText>');
+      expect(xml).toMatch(
+        /<w:delText[^>]*>sec<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t[^>]*>XY<\/w:t>/
+      );
+    } finally {
+      dispose();
+    }
+  });
+
   test('proposeReplacement retracts the same author’s insertion in edit mode', () => {
     const { editor, dispose } = mounted('Agent');
     try {
@@ -136,6 +187,13 @@ describe('explicit tracked-change commands', () => {
       const multiline = { type: 'proposeInsertion' as const, text: 'one\ntwo' };
       expect(withAuthor.editor.can(multiline)).toMatchObject({ ok: false, code: 'invalidArgs' });
       expect(withAuthor.editor.exec(multiline)).toMatchObject({ ok: false, code: 'invalidArgs' });
+      // Empty text is refused too: it would commit a phantom empty w:ins.
+      const empty = { type: 'proposeReplacement' as const, replaceWith: '' };
+      expect(withAuthor.editor.can(empty)).toMatchObject({ ok: false, code: 'invalidArgs' });
+      expect(withAuthor.editor.exec(empty)).toMatchObject({ ok: false, code: 'invalidArgs' });
+      // The surface backstop mirrors the facade gate for direct callers.
+      expect(withAuthor.editor.surface!.proposeTextChange('replacement', '')).toBe(false);
+      expect(withAuthor.editor.surface!.proposeTextChange('insertion', 'a\nb')).toBe(false);
     } finally {
       withAuthor.dispose();
     }

--- a/packages/core/src/editor/__tests__/story-and-rectangle-writes.test.ts
+++ b/packages/core/src/editor/__tests__/story-and-rectangle-writes.test.ts
@@ -16,12 +16,10 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
-import { docx as bodyDocx } from './paginated-surface-fixtures.ts';
-import { cellSelectionBetween } from '../../layout/semantic-cell-selection.ts';
+import { docx as bodyDocx, selectCellRectangle } from './paginated-surface-fixtures.ts';
 import { paragraphIndentOf } from '../surface-formatting.ts';
 import { paragraphTextOf } from '../../store/store/tree-op-apply.ts';
 import { findNode } from '@docx-editor.dev/core/store';
-import type { TableCellAddress } from '@docx-editor.dev/core/layout';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -160,25 +158,7 @@ describe('a cell rectangle is not the range it stands in for', () => {
   }
 
   function selectColumn(surface: PaginatedSurface, column: number): void {
-    const table = surface
-      .layout()
-      .pages.flatMap((page) => page.fragments.filter((fragment) => fragment.kind === 'table'))[0];
-    if (!table || table.kind !== 'table') throw new Error('no table in layout');
-    const address = (rowIndex: number): TableCellAddress => {
-      const row = table.rows[rowIndex]!;
-      const cell = row.cells.find((candidate) => candidate.gridColumn === column)!;
-      return {
-        tableId: table.tableId,
-        rowId: row.id,
-        cellId: cell.id,
-        rowIndex,
-        gridColumn: cell.gridColumn,
-        gridSpan: cell.gridSpan,
-      };
-    };
-    const rectangle = cellSelectionBetween(surface.layout(), address(0), address(1));
-    if (!rectangle) throw new Error('cell rectangle failed');
-    surface.setCellSelection(rectangle);
+    selectCellRectangle(surface, { row: 0, column }, { row: 1, column });
   }
 
   const textOf = (surface: PaginatedSurface, id: string) =>

--- a/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-keystrokes.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
 import { serializeOoxmlPart, type OoxmlNode } from '@docx-editor.dev/core/store';
+import { selectCellRectangle } from './paginated-surface-fixtures.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -381,6 +382,37 @@ describe('replacing a selection that spans paragraphs, in suggesting mode', () =
     });
   });
 
+  test('a section break over a selection splits AFTER the struck words', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      selectIn(surface, 0, 0, 'Alpha'.length);
+      surface.insertSectionBreak();
+      expect(surface.state().lastRejection).toBeNull();
+      // The struck head stays with the section mark; splitting at the range START cut the
+      // paragraph in FRONT of the struck words instead.
+      expect(paragraphTexts(surface)).toEqual(['Alpha', ' one']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:delText[^>]*>Alpha<\/w:delText>/);
+    });
+  });
+
+  test('a section break over a selection ending in a table cell still commits', () => {
+    const cellXml = (text: string) =>
+      `<w:tc><w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>${plainParagraph(text)}</w:tc>`;
+    const table =
+      '<w:tbl><w:tblPr><w:tblW w:w="8000" w:type="dxa"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>' +
+      `<w:tr>${cellXml('CellA')}${cellXml('CellB')}</w:tr></w:tbl>`;
+    withSurface(plainParagraph('Alpha one') + table + plainParagraph('after'), (surface) => {
+      // A section mark cannot live in a cell, so the landing falls back to the surviving
+      // range start rather than letting one refused op veto the strike with it.
+      selectAcross(surface, 0, 0, 1, 2);
+      expect(surface.insertSectionBreak()).toBe(true);
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:delText[^>]*>Alpha one<\/w:delText>/);
+    });
+  });
+
   test('a Tab over a selection lands after the struck words, as a proposal', () => {
     withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
       selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
@@ -454,6 +486,29 @@ describe('replacing a selection that spans paragraphs, in suggesting mode', () =
     });
   });
 
+  test('a range ENDING inside a removed table lands after the struck survivor', () => {
+    const cell = (text: string) =>
+      `<w:tc><w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>${plainParagraph(text)}</w:tc>`;
+    const table =
+      '<w:tbl><w:tblPr><w:tblW w:w="8000" w:type="dxa"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>' +
+      `<w:tr>${cell('CellA')}${cell('CellB')}</w:tr></w:tbl>`;
+    withSurface(plainParagraph('Alpha one') + table + plainParagraph('Beta two'), (surface) => {
+      // Ends at the far edge of the LAST cell paragraph, so the table is fully covered and
+      // goes with the range — the last paragraph of the range does not survive. The
+      // replacement then belongs after the struck tail of the surviving start paragraph,
+      // in typing order.
+      selectAcross(surface, 0, 0, 2, 'CellB'.length);
+      typeEach(surface, 'New');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['Alpha oneNew', 'Beta two']);
+      expect(surface.state().selection.head).toEqual({
+        paragraphId: surface.session.paragraphIds()[0]!,
+        offset: 'Alpha oneNew'.length,
+      });
+    });
+  });
+
   test('a range that removes a table still lands after the last struck paragraph', () => {
     const cell = (text: string) =>
       `<w:tc><w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>${plainParagraph(text)}</w:tc>`;
@@ -469,6 +524,273 @@ describe('replacing a selection that spans paragraphs, in suggesting mode', () =
       // The fully covered table goes; the last paragraph survives and hosts the replacement.
       expect(paragraphTexts(surface)).toEqual(['Alpha one', 'Beta twoNew']);
       expect(surface.state().selection.head.offset).toBe('Beta twoNew'.length);
+    });
+  });
+});
+
+describe('typing over a cell rectangle, in suggesting mode', () => {
+  const cell = (content: string) => `<w:tc>${content}</w:tc>`;
+  const GRID2 =
+    '<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="3000"/><w:gridCol w:w="3000"/></w:tblGrid>';
+  const TABLE_2X2 =
+    `<w:tbl>${GRID2}` +
+    `<w:tr>${cell(plainParagraph('Aa'))}${cell(plainParagraph('Bb'))}</w:tr>` +
+    `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+    '</w:tbl>';
+
+  test('the replacement lands in the FIRST cell, after its struck content', () => {
+    withSurface(TABLE_2X2 + plainParagraph('after'), (surface) => {
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      typeEach(surface, 'XY');
+      expect(surface.state().lastRejection).toBeNull();
+      // Every covered cell keeps its struck text; only the first one hosts the replacement.
+      expect(paragraphTexts(surface)).toEqual(['AaXY', 'Bb', 'Cc', 'Dd', 'after']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(
+        /<w:delText[^>]*>Aa<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t[^>]*>XY<\/w:t>/
+      );
+      for (const struck of ['Bb', 'Cc', 'Dd']) {
+        expect(xml).toMatch(new RegExp(`<w:delText[^>]*>${struck}</w:delText>`));
+      }
+      // The caret follows the typing — that is what made the SECOND character land after
+      // the first instead of relocating back in front of it.
+      expect(surface.state().selection.head).toEqual({
+        paragraphId: surface.session.paragraphIds()[0]!,
+        offset: 'AaXY'.length,
+      });
+    });
+  });
+
+  test('a first cell holding two paragraphs lands after the LAST one', () => {
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('One') + plainParagraph('Two'))}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['One', 'TwoX', 'Bb', 'Cc', 'Dd', 'after']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(
+        /<w:delText[^>]*>Two<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t[^>]*>X<\/w:t>/
+      );
+    });
+  });
+
+  test('a trailing EMPTY paragraph in the first cell does not strand the landing', () => {
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('One') + '<w:p/>')}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      // Adjacent to the struck words — landing in the empty paragraph below separated the
+      // replacement from the strike it belongs to.
+      expect(paragraphTexts(surface)).toEqual(['OneX', '', 'Bb', 'Cc', 'Dd', 'after']);
+    });
+  });
+
+  test('a whitespace-only spacer paragraph does not strand the landing either', () => {
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('One') + plainParagraph('   '))}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['OneX', '   ', 'Bb', 'Cc', 'Dd', 'after']);
+    });
+  });
+
+  test('a pending insertion beside a surviving space does not win the landing', () => {
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('Hello') + plainParagraph(' '))}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      // The trailing paragraph holds a pre-existing space plus this author's own pending
+      // 'xyz'. The insertion retracts with the strike, leaving whitespace only — so the
+      // worded 'Hello' hosts the landing, not the paragraph that LOOKS worded before the
+      // plan runs.
+      caretTo(surface, 1, 1);
+      typeEach(surface, 'xyz');
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['HelloX', ' ', 'Bb', 'Cc', 'Dd', 'after']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).not.toMatch(/xyz/);
+    });
+  });
+
+  test('a pending insertion CONTAINING whitespace still leaves its paragraph worded', () => {
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('A') + plainParagraph(' '))}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      // Pending 'b c' retracts whitespace and words alike; the surviving 'A' still makes
+      // the first paragraph the worded landing — length arithmetic could not tell.
+      caretTo(surface, 0, 1);
+      typeEach(surface, 'b c');
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['AX', ' ', 'Bb', 'Cc', 'Dd', 'after']);
+    });
+  });
+
+  test('a cell with ONLY whitespace text still hosts the landing beside it', () => {
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('   ') + '<w:p/>')}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      // With no worded paragraph to prefer, whitespace still beats an empty paragraph as
+      // a neighbour — the trailing empty one would strand X a line below the strike.
+      expect(paragraphTexts(surface)).toEqual(['   X', '', 'Bb', 'Cc', 'Dd', 'after']);
+    });
+  });
+
+  test('a nested table in the first cell does not steal the landing', () => {
+    const nested =
+      '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="1500"/></w:tblGrid>' +
+      `<w:tr><w:tc>${plainParagraph('Inner')}</w:tc></w:tr></w:tbl>`;
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('One') + nested + '<w:p/>')}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      // The landing is the cell's OWN last paragraph with text, never the nested table's.
+      expect(paragraphTexts(surface)).toEqual(['OneX', 'Inner', '', 'Bb', 'Cc', 'Dd', 'after']);
+    });
+  });
+
+  test('a trailing paragraph holding only your OWN pending insertion retracts, not hosts', () => {
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('One') + '<w:p/>')}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    withSurface(table + plainParagraph('after'), (surface) => {
+      caretTo(surface, 1, 0);
+      typeEach(surface, 'Mine');
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.type('X');
+      expect(surface.state().lastRejection).toBeNull();
+      // 'Mine' retracts with the strike, so hosting the landing there would strand X in an
+      // emptied paragraph a line below the struck 'One'.
+      expect(paragraphTexts(surface)).toEqual(['OneX', '', 'Bb', 'Cc', 'Dd', 'after']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).not.toMatch(/Mine/);
+    });
+  });
+
+  test('a paste over the rectangle lands in the same place as typing', () => {
+    withSurface(TABLE_2X2 + plainParagraph('after'), (surface) => {
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      surface.insertPlainText('Zz');
+      expect(surface.state().lastRejection).toBeNull();
+      expect(paragraphTexts(surface)).toEqual(['AaZz', 'Bb', 'Cc', 'Dd', 'after']);
+      expect(surface.state().selection.head).toEqual({
+        paragraphId: surface.session.paragraphIds()[0]!,
+        offset: 'AaZz'.length,
+      });
+    });
+  });
+
+  test('a drawing-only paragraph is a worded landing: X follows the struck image', () => {
+    const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+    const IMG = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
+    const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+    const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+    const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+    const PNG_1X1 = Uint8Array.from(
+      atob(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+      ),
+      (c) => c.charCodeAt(0)
+    );
+    const drawingParagraph =
+      '<w:p><w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+      '<wp:extent cx="228600" cy="114300"/><wp:docPr id="1" name="pic1"/>' +
+      `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
+      '<pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr>' +
+      '<pic:blipFill><a:blip r:embed="rIdImg"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+      '<pic:spPr><a:xfrm><a:ext cx="228600" cy="114300"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>' +
+      '</pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>';
+    const table =
+      `<w:tbl>${GRID2}` +
+      `<w:tr>${cell(plainParagraph('One') + drawingParagraph)}${cell(plainParagraph('Bb'))}</w:tr>` +
+      `<w:tr>${cell(plainParagraph('Cc'))}${cell(plainParagraph('Dd'))}</w:tr>` +
+      '</w:tbl>';
+    const bytes = zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+          '<Default Extension="png" ContentType="image/png"/>' +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/_rels/document.xml.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${IMG}" Target="media/image1.png"/></Relationships>`
+      ),
+      'word/media/image1.png': PNG_1X1,
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}">` +
+          `<w:body>${table + plainParagraph('after')}</w:body></w:document>`
+      ),
+    });
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(container, bytes, { author: 'Ada Lovelace' });
+    if (!opened.ok) throw new Error(opened.reason);
+    try {
+      opened.surface.setEditingMode('suggest');
+      selectCellRectangle(opened.surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      opened.surface.type('X');
+      expect(opened.surface.state().lastRejection).toBeNull();
+      // The image occupies one model character, so its paragraph is the last WORDED one:
+      // X belongs after the struck image, never stranded in the paragraph above it.
+      expect(paragraphTexts(opened.surface)).toEqual(['One', 'X', 'Bb', 'Cc', 'Dd', 'after']);
+    } finally {
+      opened.surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('this author’s own pending insertion in the first cell retracts', () => {
+    withSurface(TABLE_2X2 + plainParagraph('after'), (surface) => {
+      caretTo(surface, 0, 1);
+      typeEach(surface, 'ZZ');
+      selectCellRectangle(surface, { row: 0, column: 0 }, { row: 1, column: 1 });
+      typeEach(surface, 'QR');
+      expect(surface.state().lastRejection).toBeNull();
+      // The struck halves stay, the author's own insertion leaves, and the replacement
+      // sits after what remains of the first cell's struck content — in typing order.
+      expect(paragraphTexts(surface)).toEqual(['AaQR', 'Bb', 'Cc', 'Dd', 'after']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).not.toMatch(/ZZ/);
     });
   });
 });

--- a/packages/core/src/editor/__tests__/surface-table-interaction.test.ts
+++ b/packages/core/src/editor/__tests__/surface-table-interaction.test.ts
@@ -16,8 +16,7 @@ import { planTableCommand } from '../table-command-plan.ts';
 import { paragraphTextOf } from '../../store/store/tree-ops.ts';
 import { readEditableTableTopology } from '../../store/store/tree-op-table-topology.ts';
 import { wmlAttributeValue, wmlChildNamed } from '../../store/store/tree-op-table-shared.ts';
-import { cellSelectionBetween } from '../../layout/semantic-cell-selection.ts';
-import type { TableCellAddress } from '../../layout/semantic-hit-test.ts';
+import { selectCellRectangle } from './paginated-surface-fixtures.ts';
 import {
   findTableOccurrence,
   tableColumnOccurrenceTargetFrom,
@@ -207,34 +206,6 @@ function paragraphByText(surface: PaginatedSurface, text: string): string {
     if (paragraphTextOf(surface.session.part(), id) === text) return id;
   }
   throw new Error(`paragraph ${text} not found`);
-}
-
-function cellAddress(surface: PaginatedSurface, row: number, column: number): TableCellAddress {
-  const table = tableOnPage(surface.layout());
-  const rowRec = table.rows[row]!;
-  const cell = rowRec.cells.find((candidate) => candidate.gridColumn === column)!;
-  return {
-    tableId: table.tableId,
-    rowId: rowRec.id,
-    cellId: cell.id,
-    rowIndex: row,
-    gridColumn: cell.gridColumn,
-    gridSpan: cell.gridSpan,
-  };
-}
-
-function selectCellRectangle(
-  surface: PaginatedSurface,
-  from: { row: number; column: number },
-  to: { row: number; column: number }
-): void {
-  const rect = cellSelectionBetween(
-    surface.layout(),
-    cellAddress(surface, from.row, from.column),
-    cellAddress(surface, to.row, to.column)
-  );
-  if (!rect) throw new Error('cell rectangle failed');
-  surface.setCellSelection(rect);
 }
 
 async function revealInsertRowAt(

--- a/packages/core/src/editor/__tests__/table-command-plan.test.ts
+++ b/packages/core/src/editor/__tests__/table-command-plan.test.ts
@@ -26,8 +26,7 @@ import {
   applyThemeTint,
   applyThemeShade,
 } from '../color-value-lower.ts';
-import { cellSelectionBetween } from '../../layout/semantic-cell-selection.ts';
-import type { TableCellAddress } from '../../layout/semantic-hit-test.ts';
+import { selectCellRectangle } from './paginated-surface-fixtures.ts';
 import {
   tableColumnDividerResizeTargetOf,
   tableRightEdgeResizeTargetOf,
@@ -180,38 +179,6 @@ function tableFragment(surface: NonNullable<DocxEditorInstance['surface']>) {
     if (block?.kind === 'table') return block;
   }
   throw new Error('no table in layout');
-}
-
-function cellAddress(
-  surface: NonNullable<DocxEditorInstance['surface']>,
-  row: number,
-  column: number
-): TableCellAddress {
-  const table = tableFragment(surface);
-  const rowRec = table.rows[row]!;
-  const cell = rowRec.cells.find((c) => c.gridColumn === column)!;
-  return {
-    tableId: table.tableId,
-    rowId: rowRec.id,
-    cellId: cell.id,
-    rowIndex: row,
-    gridColumn: cell.gridColumn,
-    gridSpan: cell.gridSpan,
-  };
-}
-
-function selectCellRectangle(
-  surface: NonNullable<DocxEditorInstance['surface']>,
-  from: { row: number; column: number },
-  to: { row: number; column: number }
-): void {
-  const rect = cellSelectionBetween(
-    surface.layout(),
-    cellAddress(surface, from.row, from.column),
-    cellAddress(surface, to.row, to.column)
-  );
-  if (!rect) throw new Error('cell rectangle failed');
-  surface.setCellSelection(rect);
 }
 
 function assertCanExecParity(

--- a/packages/core/src/editor/docx-editor-support.ts
+++ b/packages/core/src/editor/docx-editor-support.ts
@@ -533,7 +533,17 @@ export function classifyCommand(command: EditorCommand): CommandSupport {
     case 'proposeInsertion':
     case 'proposeReplacement': {
       const text = command.type === 'proposeInsertion' ? command.text : command.replaceWith;
-      if (typeof text !== 'string' || /[\r\n\v\f\u2028\u2029]/.test(text)) {
+      // Empty text refused too: it would commit a phantom `w:ins` holding nothing, a
+      // tracked change the review pane must carry with no content to show for it. A
+      // replacement that only removes is `proposeDeletion`.
+      if (typeof text !== 'string' || text.length === 0) {
+        return {
+          supported: false,
+          code: 'invalidArgs',
+          reason: `${command.type} requires non-empty text`,
+        };
+      }
+      if (/[\r\n\v\f\u2028\u2029]/.test(text)) {
         return {
           supported: false,
           code: 'invalidArgs',

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -2009,18 +2009,18 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         if (!resolved.ok) return resolved;
         const { anchor, head } = resolved.selection;
         const collapsed = anchor.paragraphId === head.paragraphId && anchor.offset === head.offset;
-        if (command.type !== 'proposeInsertion' && collapsed) {
+        // A rectangle over one empty cell mirrors a collapsed range but still covers a cell
+        // the surface replaces over, so `can` agrees — replacement only (a deletion over
+        // empty cells commits nothing), and only when no explicit target overrides it.
+        const rectangleReplacement =
+          command.type === 'proposeReplacement' &&
+          command.target === undefined &&
+          surface!.state().cellSelection !== null;
+        if (command.type !== 'proposeInsertion' && collapsed && !rectangleReplacement) {
           return {
             ok: false,
             code: 'invalidArgs',
             reason: `${command.type} needs a non-collapsed selection`,
-          };
-        }
-        if (command.type === 'proposeReplacement' && anchor.paragraphId !== head.paragraphId) {
-          return {
-            ok: false,
-            code: 'unsupported',
-            reason: 'tracked replacement across paragraph marks is not supported',
           };
         }
       }

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -26,8 +26,9 @@ import {
   type TreeDocOp,
   type TreeModelChange,
 } from '@docx-editor.dev/core/store';
-import { retractedLengthOf } from '../store/store/tree-op-retraction.ts';
+import { retractedLengthOf, retractedRangesOf } from '../store/store/tree-op-retraction.ts';
 import { retractsOwnParagraphMark } from '../store/store/tree-op-tracked.ts';
+import { directParagraphsInCells } from '../layout/semantic-cell-selection.ts';
 import { syncActiveFieldShading } from './surface-field-shading.ts';
 import {
   createLayoutScheduler,
@@ -1166,40 +1167,61 @@ export function mountPaginatedSurface(
       options.onChange?.(currentState());
       return false;
     }
+    // Empty text would commit a phantom `w:ins` holding nothing — a tracked change the
+    // review pane must carry with no content to show. A replacement that only removes is
+    // a deletion. A newline is not a paragraph mark: written into `w:t` it renders as
+    // whitespace while claiming to be a break. The facade's support gate refuses the same
+    // SHAPES (docx-editor-support.ts), so the automation `can` and this `exec` agree; the
+    // messages differ only in naming the kind versus the command.
+    if (kind !== 'deletion' && text.length === 0) {
+      lastRejection = `${kind} requires non-empty text`;
+      options.onChange?.(currentState());
+      return false;
+    }
+    if (kind !== 'deletion' && /[\r\n\v\f\u2028\u2029]/.test(text)) {
+      lastRejection = `${kind} requires text without a paragraph mark`;
+      options.onChange?.(currentState());
+      return false;
+    }
     const revision = { author, date: trackedDate() };
     const range = orderedRange();
     const collapsed =
       range.from.paragraphId === range.to.paragraphId && range.from.offset === range.to.offset;
-    if (kind !== 'insertion' && collapsed) {
+    // A rectangle over a single EMPTY cell mirrors a collapsed text range, but it still
+    // covers a cell the user selected — the keyboard replaces over it, so automation must.
+    // REPLACEMENT only: it always carries its insert op. A deletion over an all-empty
+    // rectangle would commit zero ops, so it keeps the refusal `can` gives it.
+    if (kind !== 'insertion' && collapsed && !(kind === 'replacement' && cellSelection)) {
       lastRejection = `${kind} needs a non-collapsed selection`;
       options.onChange?.(currentState());
       return false;
     }
-    if (kind === 'replacement' && range.from.paragraphId !== range.to.paragraphId) {
-      lastRejection = 'tracked replacement across paragraph marks is not supported';
-      options.onChange?.(currentState());
-      return false;
-    }
-
-    const plan =
+    // The deletion is tracked whatever the surface's editing mode is, so the plan computes
+    // `replaceAt` as suggesting would — for THIS author, who may not be the configured one.
+    // An insertion aimed INSIDE an existing deletion relocates past it in the store; the
+    // caret math maps the same way here, or the next proposal lands before this one.
+    const plan: RangeDeletionPlan =
       kind === 'insertion'
-        ? { ops: [] as readonly TreeDocOp[], collapseTo: range.from }
-        : deleteSelectionPlan();
+        ? {
+            ops: [] as readonly TreeDocOp[],
+            collapseTo: positionPastDeletion(currentLayout, range.from),
+          }
+        : deleteSelectionPlan(author);
     const ops = attributeTrackedOps(plan.ops, revision);
     let caret = plan.collapseTo;
     if (kind === 'insertion' || kind === 'replacement') {
-      const insertAt =
-        kind === 'replacement'
-          ? range.to.offset - retractedByInsertionAuthor(range.from, range.to, author)
-          : range.from.offset;
+      // The plan's `replaceAt` owns the landing rule — after the struck words, in the last
+      // surviving paragraph of the range — so the automation object model and the keyboard
+      // agree, spanning selections included.
+      const target = kind === 'replacement' ? (plan.replaceAt ?? plan.collapseTo) : plan.collapseTo;
       ops.push({
         op: 'insertText',
-        paragraphId: plan.collapseTo.paragraphId,
-        offset: insertAt,
+        paragraphId: target.paragraphId,
+        offset: target.offset,
         text,
         revision,
       });
-      caret = { paragraphId: plan.collapseTo.paragraphId, offset: insertAt + text.length };
+      caret = { paragraphId: target.paragraphId, offset: target.offset + text.length };
     }
 
     let committed = false;
@@ -5296,12 +5318,29 @@ export function mountPaginatedSurface(
    * one has no start left to insert at, and an op naming a paragraph the same transaction
    * deleted vetoes the whole transaction.
    */
-  function deleteSelectionPlan(): RangeDeletionPlan {
+  function deleteSelectionPlan(trackedAuthor?: string): RangeDeletionPlan {
     // Every replacing lane reads `replaceAt` from the plan it already holds, so the landing
     // rule cannot be skipped by a lane that never heard of it — that is how tabs, breaks and
     // the PAGE field each kept landing in FRONT of the words a suggestion strikes.
+    // `trackedAuthor` is the automation lane's: its deletion is tracked whatever the editing
+    // mode is, and under an author who may not be the configured one. Normalized here so
+    // every reader below sees either a non-empty author or undefined, never a blank.
+    const author = trackedAuthor?.trim() || undefined;
     const plan = rangeDeletionPlan();
-    return { ...plan, replaceAt: replacementTarget(plan) };
+    // A GETTER, so delete-only lanes — Backspace, Delete, proposeDeletion — never pay for a
+    // landing they do not read. Replacing lanes read it once, before the ops apply, which is
+    // the only window where the pre-edit layout it consults is the right oracle. The
+    // rectangle is captured NOW, not read at getter time: `commit` nulls `cellSelection` at
+    // its head, so a late read would answer for a selection the plan was not built from.
+    const rectangle = cellSelection;
+    let landing: SemanticPosition | null = null;
+    return {
+      ...plan,
+      get replaceAt(): SemanticPosition {
+        landing ??= replacementTarget(plan, author, rectangle);
+        return landing;
+      },
+    };
   }
 
   function rangeDeletionPlan(): RangeDeletionPlan {
@@ -5350,31 +5389,29 @@ export function mountPaginatedSurface(
   }
 
   /**
-   * How many characters of `[from, to)` a suggesting-mode deletion takes OUT of the
-   * paragraph, rather than striking in place.
-   *
-   * Only ever this author's own pending insertion — everything else stays and keeps its
-   * offsets. Zero outside suggesting, across a paragraph boundary (the paragraphs are not
-   * joined, so nothing shifts within the first one), and with no author configured, which is
-   * the case where nothing is tracked at all.
-   */
-  /**
-   * Where a replacement for `[from, to)` belongs, once suggesting has had its say.
+   * Where a replacement for `[from, to)` belongs, once the tracked strike has had its say.
    *
    * The struck characters STAY, so the new text goes after them — minus whatever of the range
-   * was this author's own pending insertion, which leaves. Identity in editing mode, where
-   * the range simply goes. Every lane that replaces a range has to ask: `type()` was fixed
-   * first, and the paste, the IME readback and the note reference each landed in front of the
-   * words they were replacing until they asked it too.
+   * was the acting author's own pending insertion, which leaves the paragraph entirely.
+   * Identity in editing mode, where the range simply goes. Every lane that replaces a range
+   * has to ask: `type()` was fixed first, and the paste, the IME readback and the note
+   * reference each landed in front of the words they were replacing until they asked it too.
    */
-  function replacementOffset(from: SemanticPosition, to: SemanticPosition): number {
-    if (editingMode !== 'suggest' || from.paragraphId !== to.paragraphId) return from.offset;
+  function replacementOffset(
+    from: SemanticPosition,
+    to: SemanticPosition,
+    trackedAuthor?: string
+  ): number {
+    // `trackedAuthor` marks a deletion that is tracked regardless of the editing mode — the
+    // automation lane's — so the after-the-strike rule applies under that author instead.
+    const tracked = trackedAuthor !== undefined || editingMode === 'suggest';
+    if (!tracked || from.paragraphId !== to.paragraphId) return from.offset;
     // A range end INSIDE a pre-existing deletion aims the insert at the interior of that
     // `w:del`: the store relocates it past the deletion, the caret math does not hear about
     // it, and the next keystroke lands before the previous one. Map past the old deletion
     // FIRST; the retracted characters all sit before it, so the subtraction still holds.
     const past = positionPastDeletion(currentLayout, to);
-    return past.offset - retractedByOwnInsertion(from, past);
+    return past.offset - retractedByInsertionAuthor(from, past, trackedAuthor ?? options.author);
   }
 
   /**
@@ -5393,19 +5430,113 @@ export function mountPaginatedSurface(
    * previous one: a typed replacement came out reversed, parked after the first struck
    * paragraph instead of the last.
    */
-  function replacementTarget(plan: RangeDeletionPlan): SemanticPosition {
+  function replacementTarget(
+    plan: RangeDeletionPlan,
+    trackedAuthor: string | undefined,
+    rectangle: CellSelection | null
+  ): SemanticPosition {
     const start = plan.collapseTo;
-    if (editingMode !== 'suggest' || cellSelection) return start;
+    if (trackedAuthor === undefined && editingMode !== 'suggest') return start;
+    if (rectangle) {
+      // A RECTANGLE strikes every selected cell in place and, as Word does, hands the
+      // replacement to the FIRST cell — after that cell's struck content, like every other
+      // tracked replacement. Nothing merges, so the landing is simply the first cell's last
+      // paragraph, past its struck text. Landing at `collapseTo` (offset 0 of the first
+      // paragraph) aimed the insert at the front edge of the fresh `w:del`, where the store
+      // relocates it past the strike — a relocation the caret math never heard about, so
+      // typed characters came out reversed: the linear-range misplacement all over again.
+      //
+      // The first cell with a paragraph, not blindly `cellIds[0]`: a vertical merge split
+      // across pages can re-open as a placed cell with no blocks at all, and a landing that
+      // silently fell back to `collapseTo` would be the front-of-strike misplacement again.
+      for (const cellId of rectangle.cellIds) {
+        // The cell's OWN paragraphs: the recursive walk drifted the landing into a nested
+        // table whenever one sat past the cell's last direct paragraph. A cell with no
+        // direct paragraph at all (schema-edge) falls back to whatever it does hold.
+        const direct = directParagraphsInCells(currentLayout, [cellId]);
+        const cellParagraphs =
+          direct.length > 0 ? direct : paragraphsInCells(currentLayout, [cellId]);
+        if (cellParagraphs.length === 0) continue;
+        const offsets = new Map<string, number>();
+        const landingOffset = (id: string): number => {
+          let value = offsets.get(id);
+          if (value === undefined) {
+            value = replacementOffset(
+              { paragraphId: id, offset: 0 },
+              { paragraphId: id, offset: textOf(id).length },
+              trackedAuthor
+            );
+            offsets.set(id, value);
+          }
+          return value;
+        };
+        // Whether at least one non-whitespace character SURVIVES the plan's strike: the
+        // LAYOUT text — the same visibility oracle every offset here reads, so an image's
+        // object character and a painted field result count as content — minus the ranges
+        // this author's own pending insertion retracts. Judging the raw text let a
+        // paragraph whose words were all pending insertion win over a worded one, and no
+        // length arithmetic can tell a surviving word from retracted whitespace.
+        const author = (trackedAuthor ?? options.author)?.trim();
+        const survivesWorded = (id: string): boolean => {
+          const text = textOf(id);
+          // No author: nothing retracts, the same bail the retraction helpers take.
+          if (!author) return /\S/.test(text);
+          // A pure ancestry read: `partOfNodeId`, never `partFor`, which would permanently
+          // retain a story store for what is only a lookup.
+          const node = findNode(partOfNodeId(session, id) ?? session.part(), id);
+          if (!node || node.kind !== 'paragraph') return /\S/.test(text);
+          let surviving = '';
+          let cursor = 0;
+          for (const range of retractedRangesOf(node, 0, text.length, author)) {
+            surviving += text.slice(cursor, Math.max(cursor, range.start));
+            cursor = Math.max(cursor, range.end);
+          }
+          surviving += text.slice(cursor);
+          return /\S/.test(surviving);
+        };
+        // ADJACENT to the struck words, so the pane can fold strike and insert into one
+        // card: the last paragraph whose SURVIVING text is more than whitespace. A trailing
+        // empty or spacer paragraph — or one holding only this author's own pending
+        // insertion, which the plan retracts — would strand the replacement a line below
+        // the strike. When no paragraph qualifies, RELAX rather than jump to the blind
+        // last: whitespace-only content still beats an empty paragraph as a neighbour, and
+        // only a cell with nothing surviving at all keeps its last paragraph. The linear
+        // branch below needs none of this: a spanning range proposes its marks away, so
+        // accepting the merge restores adjacency — a rectangle never merges anything.
+        let landing: string | null = null;
+        for (let index = cellParagraphs.length - 1; index >= 0; index -= 1) {
+          const id = cellParagraphs[index]!;
+          if (!survivesWorded(id)) continue;
+          landing = id;
+          break;
+        }
+        if (landing === null) {
+          for (let index = cellParagraphs.length - 1; index >= 0; index -= 1) {
+            const id = cellParagraphs[index]!;
+            if (landingOffset(id) === 0) continue;
+            landing = id;
+            break;
+          }
+        }
+        landing ??= cellParagraphs[cellParagraphs.length - 1]!;
+        return { paragraphId: landing, offset: landingOffset(landing) };
+      }
+      return start;
+    }
     const { from, to } = orderedRange();
     // Collapsed: `collapseTo` already sits past any deletion the caret rested in.
     if (from.paragraphId === to.paragraphId && from.offset === to.offset) return start;
     if (from.paragraphId === to.paragraphId) {
-      return { paragraphId: to.paragraphId, offset: replacementOffset(from, to) };
+      return { paragraphId: to.paragraphId, offset: replacementOffset(from, to, trackedAuthor) };
     }
     // A fully covered table is REMOVED, not struck, so a last paragraph INSIDE one does not
-    // survive the transaction — an insert naming it would veto the whole edit. The range
-    // start is the position `collapseTo` guarantees survives. A removed block elsewhere in
-    // the range leaves the last paragraph standing, so only its own ancestry decides.
+    // survive the transaction — an insert naming it would veto the whole edit. The
+    // replacement then belongs after the struck TAIL of the surviving start paragraph, the
+    // last struck text still standing. Falling back to `collapseTo` itself aimed the insert
+    // at the front edge of that fresh strike, where the store relocates it — the reversed
+    // caret misplacement again, this time only for ranges ending inside a removed block. A
+    // removed block elsewhere in the range leaves the last paragraph standing, so only its
+    // own ancestry decides.
     const removedBlocks = new Set(
       plan.ops.flatMap((op) => (op.op === 'deleteBlock' ? [op.blockId] : []))
     );
@@ -5417,7 +5548,15 @@ export function mountPaginatedSurface(
         node;
         node = parentNodeOf(part, node.id)
       ) {
-        if (removedBlocks.has(node.id)) return start;
+        if (!removedBlocks.has(node.id)) continue;
+        const endOfStart = {
+          paragraphId: start.paragraphId,
+          offset: textOf(start.paragraphId).length,
+        };
+        return {
+          paragraphId: start.paragraphId,
+          offset: replacementOffset(start, endOfStart, trackedAuthor),
+        };
       }
     }
     // A planned join whose mark is this author's OWN pending insertion REALLY joins — the
@@ -5427,7 +5566,7 @@ export function mountPaginatedSurface(
     // as the merged host, and count each folded member's struck length into its offsets.
     // The merged mark is always the SECOND paragraph's (`withSectionMarkOf`), so each
     // member's ORIGINAL mark decides whether the member after it folds in.
-    const author = options.author?.trim();
+    const author = (trackedAuthor ?? options.author)?.trim();
     if (!author) return start;
     const joinedSecondIds = new Set(
       plan.ops.flatMap((op) => (op.op === 'joinParagraphs' ? [op.secondId] : []))
@@ -5461,14 +5600,11 @@ export function mountPaginatedSurface(
           : { paragraphId: id, offset: textOf(id).length };
       if (index === hostIndex) offset += coveredFrom.offset;
       offset +=
-        coveredTo.offset - coveredFrom.offset - retractedByOwnInsertion(coveredFrom, coveredTo);
+        coveredTo.offset -
+        coveredFrom.offset -
+        retractedByInsertionAuthor(coveredFrom, coveredTo, author);
     }
     return { paragraphId: order[hostIndex]!, offset };
-  }
-
-  function retractedByOwnInsertion(from: SemanticPosition, to: SemanticPosition): number {
-    if (editingMode !== 'suggest') return 0;
-    return retractedByInsertionAuthor(from, to, options.author);
   }
 
   function retractedByInsertionAuthor(

--- a/packages/core/src/editor/surface-structure.ts
+++ b/packages/core/src/editor/surface-structure.ts
@@ -17,6 +17,7 @@ import {
   type SemanticSelection,
 } from '@docx-editor.dev/core/layout';
 import { sectionAnchorParagraphFor, sectionIndexForCaret } from './section-scope.ts';
+import { isTableNested } from '../store/store/tree-op-section-address.ts';
 import type { ListMarkerRecord } from '@docx-editor.dev/core/layout';
 import { fragmentHolding } from '../layout/line-segments.ts';
 import { paragraphTabStopsOf } from './surface-formatting.ts';
@@ -815,7 +816,15 @@ export function createSurfaceStructure(deps: SurfaceStructureDeps): StructureMet
       // Section breaks are body-only; refuse while a furniture scope is open.
       if (deps.storyScope().kind !== 'body') return false;
       const plan = deleteSelectionPlan();
-      const start = plan.collapseTo;
+      // The plan's `replaceAt`, like the tab and break lanes: in suggesting mode the struck
+      // words stay, and a split at the range START cut the paragraph in FRONT of them — the
+      // break and the strike read as two unrelated edits. EXCEPT when the landing sits in a
+      // table cell: a section mark cannot be minted there (the store refuses it, and one
+      // refused op vetoes the strike with it), so the break falls back to `collapseTo`.
+      // That only saves the gesture when the range STARTS outside the table — a selection
+      // wholly inside one is still refused by the store, as it always was.
+      const landing = plan.replaceAt ?? plan.collapseTo;
+      const start = isTableNested(session.part(), landing.paragraphId) ? plan.collapseTo : landing;
       const before = new Set(session.paragraphIds());
       let committed = false;
       commit(

--- a/packages/core/src/layout/semantic-cell-selection.ts
+++ b/packages/core/src/layout/semantic-cell-selection.ts
@@ -284,10 +284,34 @@ export function cellSelectionBetween(
   };
 }
 
+/**
+ * Paragraph ids that are DIRECT children of the cells — nested tables excluded — in
+ * document order, each once.
+ *
+ * The recursive walk answers "what does deleting these cells clear"; this one answers
+ * "which paragraphs are the cell's OWN". A replacement landing computed from the recursive
+ * list drifted into a nested table whenever one sat past the cell's last own paragraph.
+ */
+export function directParagraphsInCells(
+  layout: SemanticLayout,
+  cellIds: readonly string[]
+): readonly string[] {
+  return cellParagraphIds(layout, cellIds, true);
+}
+
 /** Paragraph ids inside a set of cells, in document order, each once. */
 export function paragraphsInCells(
   layout: SemanticLayout,
   cellIds: readonly string[]
+): readonly string[] {
+  return cellParagraphIds(layout, cellIds, false);
+}
+
+/** The one placed-cell walk both readers share; `directOnly` skips nested tables. */
+function cellParagraphIds(
+  layout: SemanticLayout,
+  cellIds: readonly string[],
+  directOnly: boolean
 ): readonly string[] {
   const wanted = new Set(cellIds);
   const found: string[] = [];
@@ -295,7 +319,10 @@ export function paragraphsInCells(
   for (const table of tableIndex(layout).values()) {
     for (const entry of table.placed) {
       if (entry.isHeaderRepeat || !wanted.has(entry.cell.id)) continue;
-      for (const block of entry.cell.blocks) collectParagraphs(block, found, seen);
+      for (const block of entry.cell.blocks) {
+        if (directOnly && block.kind !== 'paragraph') continue;
+        collectParagraphs(block, found, seen);
+      }
     }
   }
   return found;

--- a/packages/core/src/store/store/tree-op-retraction.ts
+++ b/packages/core/src/store/store/tree-op-retraction.ts
@@ -52,9 +52,31 @@ export function retractedLengthOf(
   end: number,
   author: string
 ): number {
-  if (end <= start) return 0;
-  const offsets = paragraphOffsetIndex(paragraph);
   let retracted = 0;
+  for (const range of retractedRangesOf(paragraph, start, end, author)) {
+    retracted += range.end - range.start;
+  }
+  return retracted;
+}
+
+/**
+ * The sub-ranges of `[start, end)` a tracked deletion RETRACTS, in the paragraph's own
+ * offset space, in document order.
+ *
+ * The walk {@link retractedLengthOf} sums over, exposed whole: a caller judging what a
+ * strike leaves STANDING — the landing pick for a replacement wants a paragraph whose
+ * surviving text is worded — needs the positions, because no arithmetic over the length
+ * can tell a surviving word from retracted whitespace.
+ */
+export function retractedRangesOf(
+  paragraph: OoxmlParagraphNode,
+  start: number,
+  end: number,
+  author: string
+): readonly { readonly start: number; readonly end: number }[] {
+  if (end <= start) return [];
+  const offsets = paragraphOffsetIndex(paragraph);
+  const ranges: { start: number; end: number }[] = [];
   const walk = (nodes: readonly OoxmlNode[], stack: readonly OoxmlNode[]): void => {
     for (const node of nodes) {
       if (node.kind === 'textValue') continue;
@@ -65,12 +87,12 @@ export function retractedLengthOf(
       if (!span || span.end <= start || span.start >= end) continue;
       if (node.kind === 'run') {
         if (insideDeletion(stack) || insertionAuthor(stack) !== author) continue;
-        retracted += Math.min(end, span.end) - Math.max(start, span.start);
+        ranges.push({ start: Math.max(start, span.start), end: Math.min(end, span.end) });
         continue;
       }
       walk(node.children, [...stack, node]);
     }
   };
   walk(paragraph.children, []);
-  return retracted;
+  return ranges;
 }


### PR DESCRIPTION
Typing over a rectangle of table cells in suggesting mode now strikes every selected cell and lands the replacement in the first cell, after that cell's struck content, with the caret following the insert. The landing prefers the cell's own last paragraph whose surviving text is worded, so a trailing empty, whitespace-only, or fully retracting paragraph doesn't strand the insert a line below the strike. `proposeTextChange('replacement')` accepts selections that span paragraph marks and reads the plan's `replaceAt`, so the automation object model and the keyboard share one landing rule instead of three encodings.

Routing every lane through the plan also fixes adjacent gaps: `proposeInsertion` maps its caret past an existing deletion the way the store relocates the text, a range ending inside a removed table lands after the struck survivor, section breaks over a selection split after the struck words (falling back to the range start when the landing sits in a table cell), and text-carrying proposals refuse empty or newline-containing text instead of committing malformed tracked insertions.

Placement follows Word's replace-selection behavior: the selected cells are struck and the typed text goes to the first cell, after its struck content. A selection that fully covers a table still removes the table rather than striking it, matching the keyboard lane.

Fixes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790264262&installation_model_id=422592&pr_number=477&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F477&signature=2e90fbaf5a4effeed3e9c7927e24291d82336f9d09436698094b15c8cffcbc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->