### PR TITLE
fix: track page field, hyperlink, and note insertion in suggesting mode

### DIFF
--- a/.changeset/tracked-field-link-note-insertions.md
+++ b/.changeset/tracked-field-link-note-insertions.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Suggesting mode now records page field, hyperlink, and footnote/endnote insertion as tracked changes, and an armed caret format survives an IME replacement. Fixes #463

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -2130,6 +2130,7 @@ export type NoteLifecycleOp = {
     readonly offset: number;
     readonly op: 'insertNote';
     readonly paragraphId: string;
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly noteId: number;
     readonly noteKind: NoteKind;
@@ -2165,7 +2166,7 @@ export interface NoteLifecycleOptions {
 }
 
 // @public
-export type NoteLifecycleRejection = 'invalidArgs' | 'tree-invariant';
+export type NoteLifecycleRejection = 'invalidArgs' | 'invalid-property-value' | 'tree-invariant';
 
 // @public
 export type NoteLifecycleResult = {
@@ -4002,6 +4003,7 @@ export type TreeDocOp = {
     readonly offset: number;
     readonly op: 'insertPageField';
     readonly paragraphId: string;
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly level: number;
     readonly op: 'setListLevel';
@@ -4212,6 +4214,7 @@ export type TreeDocOp = {
     readonly offset: number;
     readonly op: 'insertNote';
     readonly paragraphId: string;
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly noteId: number;
     readonly noteKind: 'footnote' | 'endnote';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -315,6 +315,7 @@ export default [
       'packages/core/src/editor/paginated-surface-contract.ts',
       'packages/core/src/layout/semantic-table.ts',
       'packages/core/src/store/__tests__/table-resize-ops.test.ts',
+      'packages/core/src/store/store/tree-op-tracked.ts',
     ],
     rules: {
       'max-lines': ['error', { max: 1100, skipBlankLines: false, skipComments: false }],
@@ -325,7 +326,6 @@ export default [
     files: [
       'packages/core/src/editor/surface-pointer.ts',
       'packages/core/src/store/package/ooxml-drawing-rules.ts',
-      'packages/core/src/store/store/tree-op-tracked.ts',
       'packages/react/src/editor/menu/parts.tsx',
     ],
     rules: {

--- a/packages/core/src/editor/__tests__/composition-readback.test.ts
+++ b/packages/core/src/editor/__tests__/composition-readback.test.ts
@@ -30,6 +30,7 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -389,6 +390,67 @@ describe('#383 a composition begun over a range spanning two paragraphs', () => 
       repaintParagraphAs(container, id, `${COMPOSED} beta`);
       pages.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
       expect(surface.session.bodyText()).toBe(`${COMPOSED} beta`);
+    });
+  });
+});
+
+// AN ARMED FORMAT SURVIVES A COMPOSED REPLACEMENT (#463).
+//
+// The IME readback lands a replacement at `replacementOffset(from, to)`, which relocates
+// past struck words and subtracts this author's own retracted insertion. The armed caret
+// format used to relocate by `positionPastDeletion` alone, so whenever the composition
+// REPLACED anything — which is how reconversion and kana-to-kanji commits arrive — the two
+// positions disagreed by construction and the armed format silently dropped.
+describe('#463 an armed format rides a composed replacement', () => {
+  function withAuthoredSurface(
+    bytes: Uint8Array,
+    mode: 'edit' | 'suggest',
+    run: (surface: PaginatedSurface, container: HTMLElement) => void
+  ): void {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const opened = mountPaginatedSurface(container, bytes, { scale: 1, author: 'Ada Lovelace' });
+    if (!opened.ok) throw new Error(opened.reason);
+    try {
+      opened.surface.setEditingMode(mode);
+      run(opened.surface, container);
+    } finally {
+      opened.surface.destroy();
+      container.remove();
+      document.getSelection()?.removeAllRanges();
+    }
+  }
+
+  test('in edit mode, bold armed at the caret styles the composed replacement', () => {
+    withAuthoredSurface(docx(p('abc')), 'edit', (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 3);
+      surface.toggleRunProperty('b');
+      compose(container, (scope) => repaintParagraphAs(scope, id, 'X'));
+      expect(surface.state().lastRejection).toBeNull();
+      expect(surface.session.bodyText()).toBe('X');
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:r><w:rPr><w:b\/><\/w:rPr><w:t[^>]*>X<\/w:t><\/w:r>/);
+    });
+  });
+
+  test('in suggesting mode, replacing your OWN pending text keeps the armed format', () => {
+    withAuthoredSurface(docx('<w:p/>'), 'suggest', (surface, container) => {
+      const id = surface.session.paragraphIds()[0]!;
+      caretAt(surface, id, 0);
+      surface.type('abc');
+      // Land the buffered burst so the composition diffs against the committed model.
+      surface.layout();
+      surface.toggleRunProperty('b');
+      compose(container, (scope) => repaintParagraphAs(scope, id, 'X'));
+      expect(surface.state().lastRejection).toBeNull();
+      // The author's own pending insertion retracted; the composed text replaced it.
+      expect(surface.session.bodyText()).toBe('X');
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(
+        /<w:ins[^>]*><w:r><w:rPr><w:b\/><\/w:rPr><w:t[^>]*>X<\/w:t><\/w:r><\/w:ins>/
+      );
+      expect(xml).not.toContain('abc');
     });
   });
 });

--- a/packages/core/src/editor/__tests__/content-control-formatting.test.ts
+++ b/packages/core/src/editor/__tests__/content-control-formatting.test.ts
@@ -47,55 +47,6 @@ const RED = { localName: 'color', attributes: { val: 'FF0000' } } as const;
 const ranges = (part: OoxmlPart, start: number, end: number): string[] =>
   runPropertyEdits(part, PARAGRAPH, start, end, RED).map((edit) => `${edit.start}..${edit.end}`);
 
-/** Paragraph text using the same inline-length rules as the hyperlink lane. */
-function paragraphText(part: OoxmlPart, paragraphId: string): string {
-  const paragraph = findParagraph(part, paragraphId);
-  if (!paragraph) return '';
-  let text = '';
-  const append = (node: OoxmlNode): void => {
-    if (node.kind === 'textValue') {
-      text += node.value;
-      return;
-    }
-    if (node.kind === 'tab') {
-      text += '\t';
-      return;
-    }
-    if (node.kind === 'hardBreak') {
-      text += '\n';
-      return;
-    }
-    if (node.kind === 'runProperties' || node.kind === 'generic') return;
-    if ((node as { kind: string }).kind === 'contentControl') {
-      for (const child of node.children) {
-        if ((child as { kind: string }).kind !== 'contentControlContent') continue;
-        for (const inner of child.children) append(inner);
-      }
-      return;
-    }
-    if (node.kind === 'hyperlink') {
-      for (const inner of node.children) append(inner);
-      return;
-    }
-    for (const child of node.children) append(child);
-  };
-  for (const child of paragraph.children) append(child);
-  return text;
-}
-
-function findParagraph(part: OoxmlPart, paragraphId: string): OoxmlNode | null {
-  const walk = (node: OoxmlNode): OoxmlNode | null => {
-    if (node.kind === 'textValue') return node.id === paragraphId ? node : null;
-    if (node.id === paragraphId) return node;
-    for (const child of node.children) {
-      const found = walk(child);
-      if (found) return found;
-    }
-    return null;
-  };
-  return walk(part.root);
-}
-
 const noopResolve = () => null;
 
 describe('formatting through typed inline content controls', () => {
@@ -169,8 +120,7 @@ describe('hyperlinks composed with typed inline content controls', () => {
         '<w:r><w:t>.</w:t></w:r>' +
         '</w:p>'
     );
-    const text = paragraphText(linkInControl, PARAGRAPH);
-    const links = hyperlinksInParagraph(linkInControl, PARAGRAPH, noopResolve, () => text);
+    const links = hyperlinksInParagraph(linkInControl, PARAGRAPH, noopResolve);
     expect(links).toHaveLength(1);
     expect(links[0]!.start).toBe(4);
     expect(links[0]!.end).toBe(8);
@@ -203,8 +153,7 @@ describe('hyperlinks composed with typed inline content controls', () => {
         '</w:sdtContent></w:sdt>' +
         '</w:p>'
     );
-    const text = paragraphText(mixed, PARAGRAPH);
-    const links = hyperlinksInParagraph(mixed, PARAGRAPH, noopResolve, () => text);
+    const links = hyperlinksInParagraph(mixed, PARAGRAPH, noopResolve);
     expect(ranges(mixed, 0, 6)).toEqual(['0..3', '3..6']);
     expect(links).toHaveLength(1);
     expect(links[0]!.start).toBe(3);

--- a/packages/core/src/editor/__tests__/suggesting-insert-lanes.test.ts
+++ b/packages/core/src/editor/__tests__/suggesting-insert-lanes.test.ts
@@ -1,0 +1,528 @@
+// The INSERT LANES in suggesting mode: page fields, hyperlinks, and note citations.
+//
+// Split from suggesting-keystrokes.test.ts, which pins the plain keystroke sequences; what
+// is pinned here is that every insert lane writes a reviewable tracked change — the page
+// field as one `w:ins` atom, the link as a strike plus a tracked wrapped copy, the note as
+// a tracked citation whose rejection sweeps the body — and that the link reads (offsets,
+// live display text) stay on the shared offset model while it happens.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { serializeOoxmlPart, type OoxmlNode } from '@docx-editor.dev/core/store';
+import { selectCellRectangle } from './paginated-surface-fixtures.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const NUM = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
+
+const NUMBERING =
+  `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">` +
+  '<w:start w:val="1"/><w:numFmt w:val="upperRoman"/><w:lvlText w:val="%1."/>' +
+  '<w:lvlJc w:val="left"/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>' +
+  '</w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${NUM}" Target="numbering.xml"/></Relationships>`
+    ),
+    'word/numbering.xml': strToU8(NUMBERING),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const listItem = (text: string) =>
+  '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+  `<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+const styledParagraph = (text: string) =>
+  `<w:p><w:pPr><w:ind w:left="720"/></w:pPr><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+const plainParagraph = (text: string) =>
+  `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+function withSurface(body: string, run: (surface: PaginatedSurface) => void): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(body), { author: 'Ada Lovelace' });
+  if (!opened.ok) throw new Error(opened.reason);
+  try {
+    opened.surface.setEditingMode('suggest');
+    run(opened.surface);
+  } finally {
+    opened.surface.destroy();
+    container.remove();
+  }
+}
+
+/** Every paragraph's text, in document order. */
+function paragraphTexts(surface: PaginatedSurface): string[] {
+  const out: string[] = [];
+  const collect = (node: OoxmlNode, into: string[]): void => {
+    if (node.kind === 'textValue') {
+      into.push(node.value);
+      return;
+    }
+    for (const child of node.children) collect(child, into);
+  };
+  const walk = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.kind === 'paragraph') {
+      const parts: string[] = [];
+      collect(node, parts);
+      out.push(parts.join(''));
+      return;
+    }
+    for (const child of node.children) walk(child);
+  };
+  walk(surface.session.part().root);
+  return out;
+}
+
+function caretTo(surface: PaginatedSurface, index: number, offset: number): void {
+  const paragraphId = surface.session.paragraphIds()[index]!;
+  surface.setSelection({
+    anchor: { paragraphId, offset },
+    head: { paragraphId, offset },
+  });
+}
+
+function selectIn(surface: PaginatedSurface, index: number, start: number, end: number): void {
+  const paragraphId = surface.session.paragraphIds()[index]!;
+  surface.setSelection({
+    anchor: { paragraphId, offset: start },
+    head: { paragraphId, offset: end },
+  });
+}
+
+function selectAcross(
+  surface: PaginatedSurface,
+  fromIndex: number,
+  fromOffset: number,
+  toIndex: number,
+  toOffset: number
+): void {
+  const ids = surface.session.paragraphIds();
+  surface.setSelection({
+    anchor: { paragraphId: ids[fromIndex]!, offset: fromOffset },
+    head: { paragraphId: ids[toIndex]!, offset: toOffset },
+  });
+}
+
+/** Type `text` one character at a time, the way a keyboard delivers it. */
+function typeEach(surface: PaginatedSurface, text: string): void {
+  for (const character of text) surface.type(character);
+}
+
+describe('insert lanes in suggesting mode', () => {
+  test('retargeting a link with new display text keeps the copy INSIDE the link', () => {
+    withSurface(plainParagraph('Alpha Docs Beta'), (surface) => {
+      surface.setEditingMode('edit');
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Docs'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com' })).toBe(true);
+      surface.setEditingMode('suggest');
+      caretTo(surface, 0, 'Alpha Do'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.org', text: 'Guide' })).toBe(
+        true
+      );
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // Struck old text, then the tracked copy — BOTH inside the w:hyperlink. The copy
+      // placed beside the link meant accepting the pair emptied and swept it, silently
+      // unlinking the accepted text.
+      expect(xml).toMatch(
+        /<w:hyperlink[^>]*><w:del[^>]*><w:r><w:delText[^>]*>Docs<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t[^>]*>Guide<\/w:t><\/w:r><\/w:ins><\/w:hyperlink>/
+      );
+      const accepted = surface.session.applyTreeOps([{ op: 'acceptAllRevisions' }]);
+      expect(accepted.committed).toBe(true);
+      const after = serializeOoxmlPart(surface.session.part());
+      expect(after).toMatch(/<w:hyperlink[^>]*><w:r><w:t[^>]*>Guide<\/w:t><\/w:r><\/w:hyperlink>/);
+    });
+  });
+
+  test('a link made at a caret resting in struck words lands past the deletion, whole', () => {
+    withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
+      surface.deleteBackward();
+      caretTo(surface, 0, 'Alpha Be'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com', text: 'docs' })).toBe(
+        true
+      );
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // The tracked display text relocates past the deletion; the wrap must cover the SAME
+      // landing, or the committed link slices the deletion and the fresh insertion.
+      expect(xml).toMatch(
+        /<w:delText[^>]*>Beta<\/w:delText><\/w:r><\/w:del><w:hyperlink[^>]*><w:ins[^>]*><w:r><w:t[^>]*>docs<\/w:t><\/w:r><\/w:ins><\/w:hyperlink>/
+      );
+    });
+  });
+
+  test('link offsets stay on the shared model after a complex field', () => {
+    withSurface(
+      '<w:p><w:r><w:t xml:space="preserve">A</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="begin"/><w:instrText xml:space="preserve"> PAGE </w:instrText>' +
+        '<w:fldChar w:fldCharType="separate"/><w:t>7</w:t><w:fldChar w:fldCharType="end"/></w:r>' +
+        '<w:hyperlink w:anchor="top"><w:r><w:t xml:space="preserve">link</w:t></w:r></w:hyperlink></w:p>',
+      (surface) => {
+        caretTo(surface, 0, 3);
+        // The field is ONE model unit. A private length walk counted its instruction
+        // characters, so the link after it read back five positions to the right.
+        const link = surface.hyperlinks.linksInCaretParagraph()[0]!;
+        expect(link.start).toBe(2);
+        expect(link.end).toBe(6);
+        expect(link.text).toBe('link');
+      }
+    );
+  });
+
+  test('a footnote lands where the caret is, after this author’s own pending text', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      typeEach(surface, 'abc');
+      expect(surface.insertNote('footnote')).toBe(true);
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // The citation goes AFTER the pending insertion, where the caret was — INSIDE the
+      // author's own `w:ins`, one continuous proposal. The lifecycle lane's private offset
+      // walk counted wrapped runs as nothing, so the reference validated against a shorter
+      // paragraph and landed three characters to the left.
+      expect(xml).toMatch(
+        /<w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:t[^>]*>abc<\/w:t><\/w:r><w:r><w:rPr><w:rStyle w:val="FootnoteReference"\/><\/w:rPr><w:footnoteReference/
+      );
+      expect(xml.match(/<w:ins /g)).toHaveLength(1);
+    });
+  });
+
+  test('renaming a link whose text is your OWN pending insertion keeps a link', () => {
+    withSurface(plainParagraph('Alpha Beta'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com', text: 'docs' })).toBe(
+        true
+      );
+      caretTo(surface, 0, 'Alpha do'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.org', text: 'guide' })).toBe(
+        true
+      );
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // The strike retracts the pending 'docs' physically and sweeps the emptied link, so
+      // a plain retarget had nothing left to hold the new text — the renamed link came out
+      // silently unlinked. A fresh proposal wraps the copy instead.
+      expect(xml).toMatch(
+        /<w:hyperlink[^>]*><w:ins[^>]*><w:r><w:t[^>]*>guide<\/w:t><\/w:r><\/w:ins><\/w:hyperlink>/
+      );
+      expect(xml).not.toContain('docs');
+    });
+  });
+
+  test('renaming a link reports the LIVE display text, not the struck slice', () => {
+    withSurface(plainParagraph('Alpha Docs Beta'), (surface) => {
+      surface.setEditingMode('edit');
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Docs'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com' })).toBe(true);
+      surface.setEditingMode('suggest');
+      caretTo(surface, 0, 'Alpha Do'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.org', text: 'Guide' })).toBe(
+        true
+      );
+      // The popover seeds its text input from `.text`: the raw offset slice spans the
+      // struck 'Docs' too, and prefilled the field with 'DocsGuide'.
+      const link = surface.hyperlinks.linksInCaretParagraph()[0]!;
+      expect(link.text).toBe('Guide');
+    });
+  });
+
+  test('a link holding only a simple field still reads back', () => {
+    withSurface(
+      '<w:p><w:r><w:t xml:space="preserve">Go </w:t></w:r>' +
+        '<w:hyperlink w:anchor="x"><w:fldSimple w:instr=" REF bm ">' +
+        '<w:r><w:t>Chapter 1</w:t></w:r></w:fldSimple></w:hyperlink></w:p>',
+      (surface) => {
+        caretTo(surface, 0, 3);
+        // A `w:fldSimple` atom's segment carries no run id, so a run-id-only match
+        // reported this link as owning no offsets at all — clicking it did nothing.
+        const link = surface.hyperlinks.linksInCaretParagraph()[0]!;
+        expect(link.start).toBe(3);
+        expect(link.end).toBe(4);
+        expect(link.text).toBe('Chapter 1');
+      }
+    );
+  });
+
+  test('a footnote inserted MID your own pending text joins the proposal', () => {
+    withSurface(plainParagraph('Alpha'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      typeEach(surface, 'ab');
+      caretTo(surface, 0, 'Alphaa'.length);
+      expect(surface.insertNote('footnote')).toBe(true);
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // The reference is a sibling RUN between the split halves, inside the same `w:ins` —
+      // keeping its own reference style rather than the formatting at the caret. This
+      // ordinary gesture (type, arrow left, insert footnote) used to dead-end in a refusal.
+      expect(xml).toMatch(
+        /<w:ins[^>]*><w:r><w:t[^>]*>a<\/w:t><\/w:r><w:r><w:rPr><w:rStyle w:val="FootnoteReference"\/><\/w:rPr><w:footnoteReference[^>]*\/><\/w:r><w:r><w:t[^>]*>b<\/w:t><\/w:r><\/w:ins>/
+      );
+    });
+  });
+
+  test('renaming a link wrapped in a content control strikes and lands INSIDE it', () => {
+    withSurface(
+      '<w:p><w:r><w:t xml:space="preserve">See </w:t></w:r>' +
+        '<w:sdt><w:sdtPr><w:tag w:val="t1"/></w:sdtPr><w:sdtContent>' +
+        '<w:hyperlink w:anchor="x"><w:r><w:t>Docs</w:t></w:r></w:hyperlink>' +
+        '</w:sdtContent></w:sdt></w:p>',
+      (surface) => {
+        caretTo(surface, 0, 'See Do'.length);
+        expect(
+          surface.hyperlinks.applyHyperlink({ url: 'https://example.org', text: 'Guide' })
+        ).toBe(true);
+        expect(surface.state().lastRejection).toBeNull();
+        const xml = serializeOoxmlPart(surface.session.part());
+        // The strike reaches through the control, and the tracked copy follows its
+        // deletion into the link inside it. The lane used to no-op the strike silently
+        // and drop the copy beside the control.
+        expect(xml).toMatch(
+          /<w:hyperlink[^>]*><w:del[^>]*><w:r><w:delText[^>]*>Docs<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t[^>]*>Guide<\/w:t><\/w:r><\/w:ins><\/w:hyperlink>/
+        );
+      }
+    );
+  });
+
+  test('suggesting refuses to delete a note outright', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      expect(surface.insertNote('footnote')).toBe(true);
+      const before = serializeOoxmlPart(surface.session.part());
+      const noteId = Number(/footnoteReference w:id="(\d+)"/.exec(before)![1]);
+      // Outright removal has no tracked form: the reference and body would go with no
+      // `w:del` and no card. Striking the reference is the proposal lane.
+      expect(surface.deleteNote('footnote', noteId)).toBe(false);
+      expect(serializeOoxmlPart(surface.session.part())).toMatch(/footnoteReference/);
+    });
+  });
+
+  test('in EDIT mode a footnote lands between two runs INSIDE a link', () => {
+    withSurface(
+      '<w:p><w:r><w:t xml:space="preserve">See </w:t></w:r>' +
+        '<w:hyperlink w:anchor="x"><w:r><w:t>Gu</w:t></w:r><w:r><w:t>ide</w:t></w:r></w:hyperlink></w:p>',
+      (surface) => {
+        surface.setEditingMode('edit');
+        caretTo(surface, 0, 'See Gu'.length);
+        expect(surface.insertNote('footnote')).toBe(true);
+        expect(surface.state().lastRejection).toBeNull();
+        const xml = serializeOoxmlPart(surface.session.part());
+        // The citation joins the link's own content at the caret, not before the whole
+        // link and not at the paragraph's end.
+        expect(xml).toMatch(
+          /Gu<\/w:t><\/w:r><w:r><w:rPr><w:rStyle w:val="FootnoteReference"\/><\/w:rPr><w:footnoteReference[^>]*\/><\/w:r><w:r><w:t[^>]*>ide/
+        );
+      }
+    );
+  });
+
+  test('in EDIT mode a link made at a caret in struck words lands past the deletion too', () => {
+    withSurface(
+      '<w:p><w:r><w:t xml:space="preserve">Alpha </w:t></w:r>' +
+        '<w:del w:id="5" w:author="Grace Hopper" w:date="2026-01-01T00:00:00Z">' +
+        '<w:r><w:delText>Beta</w:delText></w:r></w:del>' +
+        '<w:r><w:t xml:space="preserve"> Gamma</w:t></w:r></w:p>',
+      (surface) => {
+        surface.setEditingMode('edit');
+        caretTo(surface, 0, 'Alpha Be'.length);
+        expect(
+          surface.hyperlinks.applyHyperlink({ url: 'https://example.com', text: 'docs' })
+        ).toBe(true);
+        expect(surface.state().lastRejection).toBeNull();
+        const xml = serializeOoxmlPart(surface.session.part());
+        // The untracked insert relocates beside the deletion exactly as the tracked one
+        // does; a wrap built on the raw caret offset sliced the w:del instead.
+        expect(xml).toMatch(
+          /<\/w:del><w:hyperlink[^>]*><w:r><w:t[^>]*>docs<\/w:t><\/w:r><\/w:hyperlink>/
+        );
+      }
+    );
+  });
+
+  test('renaming a link with a strike abutting its end still accepts as a LINK', () => {
+    withSurface(plainParagraph('Alpha Docs tail'), (surface) => {
+      surface.setEditingMode('edit');
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Docs'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com' })).toBe(true);
+      surface.setEditingMode('suggest');
+      // Strike the character right after the link, so the deletion abuts its closing edge.
+      selectIn(surface, 0, 'Alpha Docs'.length, 'Alpha Docs '.length);
+      surface.deleteBackward();
+      caretTo(surface, 0, 'Alpha Do'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.org', text: 'Guide' })).toBe(
+        true
+      );
+      expect(surface.state().lastRejection).toBeNull();
+      const accepted = surface.session.applyTreeOps([{ op: 'acceptAllRevisions' }]);
+      expect(accepted.committed).toBe(true);
+      // Whichever branch placed the copy, the accepted rename must stay LINKED: the copy
+      // relocating past the abutting deletion used to land it beside the link, and
+      // accepting swept the emptied link and left plain text.
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:hyperlink[^>]*>(?:(?!<\/w:hyperlink>).)*Guide/);
+    });
+  });
+
+  test('an authored EMPTY link is still reachable and removable', () => {
+    withSurface(
+      '<w:p><w:r><w:t xml:space="preserve">Go </w:t></w:r>' +
+        '<w:hyperlink w:anchor="x"/><w:r><w:t>on</w:t></w:r></w:p>',
+      (surface) => {
+        caretTo(surface, 0, 3);
+        const link = surface.hyperlinks.linksInCaretParagraph()[0]!;
+        expect(link.start).toBe(3);
+        expect(link.end).toBe(3);
+        expect(surface.hyperlinks.removeHyperlink(link.id)).toBe(true);
+        expect(serializeOoxmlPart(surface.session.part())).not.toMatch(/<w:hyperlink/);
+      }
+    );
+  });
+
+  test('in EDIT mode a footnote lands between runs nested TWO containers deep', () => {
+    withSurface(
+      '<w:p><w:r><w:t xml:space="preserve">See </w:t></w:r>' +
+        '<w:sdt><w:sdtPr><w:tag w:val="t1"/></w:sdtPr><w:sdtContent>' +
+        '<w:r><w:t>Gu</w:t></w:r><w:r><w:t>ide</w:t></w:r>' +
+        '</w:sdtContent></w:sdt></w:p>',
+      (surface) => {
+        surface.setEditingMode('edit');
+        caretTo(surface, 0, 'See Gu'.length);
+        expect(surface.insertNote('footnote')).toBe(true);
+        expect(surface.state().lastRejection).toBeNull();
+        const xml = serializeOoxmlPart(surface.session.part());
+        expect(xml).toMatch(
+          /Gu<\/w:t><\/w:r><w:r><w:rPr><w:rStyle w:val="FootnoteReference"\/><\/w:rPr><w:footnoteReference[^>]*\/><\/w:r><w:r><w:t[^>]*>ide/
+        );
+      }
+    );
+  });
+
+  test('a hyperlink over a selection proposes a tracked replacement, wrapped', () => {
+    withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com' })).toBe(true);
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // Struck original first, then the linked copy as this author's proposal — the same
+      // reading order every replacement writes. The link wraps ONLY the copy.
+      expect(xml).toMatch(
+        /<w:del[^>]*><w:r><w:delText[^>]*>Beta<\/w:delText><\/w:r><\/w:del><w:hyperlink[^>]*r:id="[^"]+"[^>]*><w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:t[^>]*>Beta<\/w:t><\/w:r><\/w:ins><\/w:hyperlink>/
+      );
+      // The caret lands after the linked copy, where the next keystroke belongs.
+      expect(surface.state().selection.head.offset).toBe('Alpha BetaBeta'.length);
+      // The link reads back at the copy's own offsets: the offset walk counts the runs the
+      // tracked edit wraps, or the popover would open on a zero-length link.
+      const link = surface.hyperlinks.linksInCaretParagraph()[0]!;
+      expect(link.text).toBe('Beta');
+      expect(link.start).toBe('Alpha Beta'.length);
+      expect(link.end).toBe('Alpha BetaBeta'.length);
+    });
+  });
+
+  test('rejecting the link proposal restores the original words and sweeps the link', () => {
+    withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com' })).toBe(true);
+      const rejected = surface.session.applyTreeOps([{ op: 'rejectAllRevisions' }]);
+      expect(rejected.committed).toBe(true);
+      expect(paragraphTexts(surface)).toEqual(['Alpha Beta Gamma']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).not.toMatch(/<w:hyperlink/);
+      expect(xml).not.toMatch(/<w:ins /);
+      expect(xml).not.toMatch(/<w:del /);
+    });
+  });
+
+  test('accepting the link proposal keeps the link and removes the struck words', () => {
+    withSurface(plainParagraph('Alpha Beta Gamma'), (surface) => {
+      selectIn(surface, 0, 'Alpha '.length, 'Alpha Beta'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com' })).toBe(true);
+      const accepted = surface.session.applyTreeOps([{ op: 'acceptAllRevisions' }]);
+      expect(accepted.committed).toBe(true);
+      expect(paragraphTexts(surface)).toEqual(['Alpha Beta Gamma']);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:hyperlink[^>]*><w:r><w:t[^>]*>Beta<\/w:t><\/w:r><\/w:hyperlink>/);
+      expect(xml).not.toMatch(/<w:del /);
+    });
+  });
+
+  test('a link at a collapsed caret wraps its own tracked display text', () => {
+    withSurface(plainParagraph('Alpha Beta'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      expect(surface.hyperlinks.applyHyperlink({ url: 'https://example.com', text: 'docs' })).toBe(
+        true
+      );
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(
+        /<w:hyperlink[^>]*><w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:t[^>]*>docs<\/w:t><\/w:r><\/w:ins><\/w:hyperlink>/
+      );
+    });
+  });
+
+  test('a page field is ONE tracked proposal, atom and all', () => {
+    withSurface(plainParagraph('Page '), (surface) => {
+      const paragraphId = surface.session.paragraphIds()[0]!;
+      const result = surface.applyAutomationOps(() => [
+        { op: 'insertPageField', paragraphId, offset: 'Page '.length, field: 'PAGE' },
+      ]);
+      expect(result.committed).toBe(true);
+      const xml = serializeOoxmlPart(surface.session.part());
+      expect(xml).toMatch(/<w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:fldChar/);
+      const rejected = surface.session.applyTreeOps([{ op: 'rejectAllRevisions' }]);
+      expect(rejected.committed).toBe(true);
+      expect(serializeOoxmlPart(surface.session.part())).not.toMatch(/fldChar/);
+    });
+  });
+
+  test('a footnote citation is proposed, and rejecting it sweeps the note body', () => {
+    withSurface(plainParagraph('Alpha one'), (surface) => {
+      caretTo(surface, 0, 'Alpha'.length);
+      expect(surface.insertNote('footnote')).toBe(true);
+      expect(surface.state().lastRejection).toBeNull();
+      const xml = serializeOoxmlPart(surface.session.part());
+      // The citing reference is the proposal; the note body stays plain.
+      expect(xml).toMatch(
+        /<w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:rPr><w:rStyle w:val="FootnoteReference"\/><\/w:rPr><w:footnoteReference w:id="\d+"\/><\/w:r><\/w:ins>/
+      );
+      const notesPartName = [...surface.session.currentPackage().parts.keys()].find((name) =>
+        name.includes('footnotes')
+      )!;
+      expect(
+        serializeOoxmlPart(surface.session.currentPackage().parts.get(notesPartName)!)
+      ).toMatch(/<w:footnote w:id="\d+"/);
+
+      const rejected = surface.session.applyTreeOps([{ op: 'rejectAllRevisions' }]);
+      expect(rejected.committed).toBe(true);
+      const after = serializeOoxmlPart(surface.session.part());
+      expect(after).not.toMatch(/footnoteReference/);
+      expect(after).not.toMatch(/<w:ins /);
+      // The orphaned body goes with the rejected citation — the same cascade an untracked
+      // reference deletion takes.
+      const notesAfter = serializeOoxmlPart(
+        surface.session.currentPackage().parts.get(notesPartName)!
+      );
+      expect(notesAfter).not.toMatch(/<w:footnote w:id="[1-9]/);
+    });
+  });
+});

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -27,7 +27,7 @@ import {
   type TreeModelChange,
 } from '@docx-editor.dev/core/store';
 import { retractedLengthOf, retractedRangesOf } from '../store/store/tree-op-retraction.ts';
-import { retractsOwnParagraphMark } from '../store/store/tree-op-tracked.ts';
+import { retractsOwnParagraphMark } from '../store/store/tree-op-tracked-marks.ts';
 import { directParagraphsInCells } from '../layout/semantic-cell-selection.ts';
 import { syncActiveFieldShading } from './surface-field-shading.ts';
 import {
@@ -556,7 +556,9 @@ export function mountPaginatedSurface(
   function consumePendingFormatOps(
     paragraphId: string,
     offset: number,
-    length: number
+    length: number,
+    /** The range the insert REPLACES, when the caller's insert stands in for one. */
+    replacing?: { readonly start: number; readonly end: number }
   ): TreeDocOp[] {
     const armed = armedAtCaret();
     if (!armed || length === 0) return [];
@@ -566,7 +568,26 @@ export function mountPaginatedSurface(
     // armed ops silently vanish: bold armed inside a `w:del`, then a character typed there,
     // landed correctly and unbold. Identity everywhere else, so the exact-position check
     // still guards a consumer that aims somewhere the caret never was.
-    const at = positionPastDeletion(currentLayout, pendingFormats!.position);
+    //
+    // A REPLACEMENT relocates further: `replacementOffset` also subtracts this author's own
+    // retracted insertion, so an anchor sitting anywhere in the replaced range must map
+    // through the SAME rule the caller's landing came from. The IME readback composes over
+    // the caret's own pending text — the anchor sat at the range end, the landing did not,
+    // and the armed format silently dropped on every composed replacement.
+    const anchor = pendingFormats!.position;
+    const at =
+      replacing &&
+      anchor.paragraphId === paragraphId &&
+      anchor.offset >= replacing.start &&
+      anchor.offset <= replacing.end
+        ? {
+            paragraphId,
+            offset: replacementOffset(
+              { paragraphId, offset: replacing.start },
+              { paragraphId, offset: replacing.end }
+            ),
+          }
+        : positionPastDeletion(currentLayout, anchor);
     if (at.paragraphId !== paragraphId || at.offset !== offset) return [];
     return [
       {
@@ -893,6 +914,16 @@ export function mountPaginatedSurface(
     // document open for reading left its target declared in `.rels`.
     refusesWrite: () => writeRefusal(true) !== null,
     storyScope,
+    // Non-null exactly when suggesting: the link lane then replaces the selection with
+    // tracked ops and wraps the fresh insertion, instead of writing an unattributed wrap.
+    // The landing is the SAME rule every replacing lane reads — past the struck words,
+    // minus this author's own retracted insertion.
+    suggestReplacementOffset: (paragraphId, start, end) =>
+      editingMode === 'suggest'
+        ? replacementOffset({ paragraphId, offset: start }, { paragraphId, offset: end })
+        : null,
+    insertionLanding: (paragraphId, offset) =>
+      positionPastDeletion(currentLayout, { paragraphId, offset }).offset,
     selection: () => selection,
     orderedRange: () => orderedRange(),
     selectionMark: () => selectionMark(),
@@ -2722,6 +2753,16 @@ export function mountPaginatedSurface(
     if (editingMode === 'suggest' && !options.author?.trim() && edits) {
       return 'suggesting needs an author before it can propose a change';
     }
+    // Deleting a note is a package-level removal with no tracked form: the reference and
+    // the body go outright, with no `w:del` and no card, while every insertion around it
+    // is a proposal. Striking the reference (Backspace over it) IS the tracked deletion —
+    // the body follows when the strike is accepted — so the outright lane is refused
+    // rather than left as a silent destructive edit in suggesting mode. Note CONVERSION
+    // and note properties stay direct on purpose: they destroy nothing, OOXML has no
+    // revision markup for them, and Word applies them the same way with tracking on.
+    if (editingMode === 'suggest' && ops.some((op) => op.op === 'deleteNote')) {
+      return 'suggesting cannot delete a note outright; strike its reference to propose the deletion';
+    }
     return null;
   }
 
@@ -2760,7 +2801,14 @@ export function mountPaginatedSurface(
    * Tabs and breaks are members because they are insertions too: passed through
    * unattributed, they serialized as a plain run beside the strike — an edit the review
    * pane could neither accept nor reject, in a document whose author believed everything
-   * they did was a proposal.
+   * they did was a proposal. A page field and a note citation are members for the same
+   * reason: the field's runs go into ONE `w:ins`, and the note's reference run is wrapped
+   * while its body stays plain (rejecting the reference sweeps the body).
+   *
+   * `insertHyperlink` is deliberately NOT a member. The wrap carries no content of its
+   * own; in suggesting mode the link lane replaces the selection with tracked ops first,
+   * so the `w:hyperlink` only ever wraps this author's own `w:ins` — which is the
+   * reviewable unit.
    */
   type RevisionCapableOp = Extract<
     TreeDocOp,
@@ -2771,6 +2819,8 @@ export function mountPaginatedSurface(
         | 'insertTab'
         | 'insertHardBreak'
         | 'insertPageBreak'
+        | 'insertPageField'
+        | 'insertNote'
         | 'insertTableRow'
         | 'deleteTableRow';
     }
@@ -2781,6 +2831,8 @@ export function mountPaginatedSurface(
     'insertTab',
     'insertHardBreak',
     'insertPageBreak',
+    'insertPageField',
+    'insertNote',
     'insertTableRow',
     'deleteTableRow',
   ]);
@@ -3140,8 +3192,8 @@ export function mountPaginatedSurface(
       syncActiveFieldShading(pagesLayer, collapsedCaretPosition());
     },
     textOf: (paragraphId) => textOf(paragraphId),
-    pendingFormatOps: (paragraphId, offset, length) =>
-      consumePendingFormatOps(paragraphId, offset, length),
+    pendingFormatOps: (paragraphId, offset, length, replacing) =>
+      consumePendingFormatOps(paragraphId, offset, length, replacing),
     selectionMark: () => selectionMark(),
     now,
     recordSelectionMs: (ms) => {

--- a/packages/core/src/editor/surface-hyperlinks.ts
+++ b/packages/core/src/editor/surface-hyperlinks.ts
@@ -13,8 +13,13 @@
 import { relationshipTargetIn, storyParagraphs, storyRootsOf } from '@docx-editor.dev/core/store';
 import type { TreeApplyResult, TreeDocxSessionView } from '@docx-editor.dev/core/binding';
 import {
+  hardBreakText,
   hyperlinkTargetOf,
+  isContentRevisionKind,
+  isInstrText,
+  paragraphOffsetIndex,
   type OoxmlNode,
+  type OoxmlParagraphNode,
   type OoxmlPart,
   type StoryScope,
   type TreeDocOp,
@@ -63,38 +68,35 @@ function elementChildren(node: OoxmlNode): readonly OoxmlNode[] {
   return node.kind === 'textValue' ? [] : node.children;
 }
 
-/** Every run under a node, at any depth — a `w:r`, or runs inside a link or inline control. */
-function runsUnder(node: OoxmlNode, depth = 0): OoxmlNode[] {
-  if (node.kind === 'run') return [node];
-  if (node.kind === 'hyperlink') {
-    return node.children.flatMap((child) => runsUnder(child, depth));
-  }
-  if (isContentControl(node)) {
-    if (depth >= MAX_SDT_NESTING) return [];
-    return elementChildren(node)
-      .filter((child) => isContentControlContent(child))
-      .flatMap((content) =>
-        elementChildren(content).flatMap((child) => runsUnder(child, depth + 1))
-      );
-  }
-  return [];
+/** The kinds whose nesting is file-controlled, and therefore depth-capped. */
+function isDepthCountedContainer(node: OoxmlNode): boolean {
+  return node.kind === 'hyperlink' || isContentControl(node) || isContentRevisionKind(node.kind);
 }
 
-function inlineLength(node: OoxmlNode): number {
-  if (node.kind === 'textValue') return node.value.length;
-  if (node.kind === 'tab' || node.kind === 'hardBreak') return 1;
-  if (node.kind === 'runProperties' || node.kind === 'generic') return 0;
-  if (isContentControl(node)) {
-    let total = 0;
-    for (const child of elementChildren(node)) {
-      if (!isContentControlContent(child)) continue;
-      for (const inner of elementChildren(child)) total += inlineLength(inner);
-    }
-    return total;
-  }
-  let total = 0;
-  for (const child of elementChildren(node)) total += inlineLength(child);
-  return total;
+/**
+ * The LIVE display text under a link: what survives once pending deletions resolve.
+ *
+ * A raw offset slice spans struck runs too, so retargeting a link in suggesting mode made
+ * the popover prefill with the struck old text glued to its replacement. Instruction text
+ * is code, not content, on the same terms `review-reads` states — `isInstrText` covers the
+ * typed kind, the parse-demoted generic, and `w:delInstrText`.
+ */
+function liveTextUnder(node: OoxmlNode, depth = 0): string {
+  if (node.kind === 'textValue') return node.value;
+  if (depth >= MAX_SDT_NESTING) return '';
+  if (node.kind === 'deletedText' || isContentRevisionDeletion(node.kind)) return '';
+  if (isInstrText(node) || node.kind === 'runProperties') return '';
+  if (node.kind === 'tab') return '\t';
+  if (node.kind === 'hardBreak') return hardBreakText(node);
+  const next = isDepthCountedContainer(node) ? depth + 1 : depth;
+  let text = '';
+  for (const child of node.children) text += liveTextUnder(child, next);
+  return text;
+}
+
+/** The two content revision kinds whose content is on its way OUT. */
+function isContentRevisionDeletion(kind: string): boolean {
+  return kind === 'revisionDelete' || kind === 'revisionMoveFrom';
 }
 
 /** Walk inline children in order, recursing through links and typed inline controls. */
@@ -103,13 +105,19 @@ function walkInlineChildren(
   depth: number,
   visit: (child: OoxmlNode) => void
 ): void {
+  if (depth >= MAX_SDT_NESTING) return;
   for (const child of children) {
     if (child.kind === 'hyperlink') {
       visit(child);
       continue;
     }
+    // Transparent, so a link a tracked edit wraps is still found and reported in order.
+    // Depth-counted like every descent here: wrapper nesting is file-derived.
+    if (isContentRevisionKind(child.kind)) {
+      walkInlineChildren(elementChildren(child), depth + 1, visit);
+      continue;
+    }
     if (isContentControl(child)) {
-      if (depth >= MAX_SDT_NESTING) continue;
       for (const inner of elementChildren(child)) {
         if (!isContentControlContent(inner)) continue;
         walkInlineChildren(elementChildren(inner), depth + 1, visit);
@@ -123,35 +131,40 @@ function walkInlineChildren(
 /**
  * Every typed hyperlink in one paragraph, with the offsets it covers.
  *
- * Walks the paragraph's inline children in order, accumulating the same offsets `segmentsOf`
- * produces, so a range reported here is a range the ops accept.
+ * Offsets come from `segmentsOf` — THE offset authority — never from a private length walk.
+ * The lane used to keep its own accumulator, and it disagreed with the model on exactly the
+ * shapes suggesting mode writes: a complex field counted its instruction characters instead
+ * of one atom unit, so every link after a tracked page field read back misplaced, and the
+ * popover opened on the wrong words.
  */
 export function hyperlinksInParagraph(
   part: OoxmlPart,
   paragraphId: string,
-  resolve: (relationshipId: string) => { target: string; external: boolean } | null,
-  textOf: (paragraphId: string) => string
+  resolve: (relationshipId: string) => { target: string; external: boolean } | null
 ): SurfaceHyperlink[] {
   const paragraph = findNode(part, paragraphId);
   if (!paragraph || paragraph.kind !== 'paragraph') return [];
-  const text = textOf(paragraphId);
+  // Memoized on paragraph identity, with a span per node — links included — so this read
+  // costs one lookup per child instead of a subtree scan against every segment.
+  const offsets = paragraphOffsetIndex(paragraph as OoxmlParagraphNode);
   const found: SurfaceHyperlink[] = [];
-  let offset = 0;
+  // The walk position so far: it is only read for a link whose content owns no offsets.
+  let cursor = 0;
   walkInlineChildren(paragraph.children, 0, (child) => {
-    if (child.kind === 'run') {
-      offset += inlineLength(child);
-      return;
-    }
+    const span = offsets.spanOf(child);
+    if (span) cursor = Math.max(cursor, span.end);
     if (child.kind !== 'hyperlink') return;
-    const start = offset;
-    for (const run of runsUnder(child)) offset += inlineLength(run);
+    // An authored EMPTY link still needs an address, or the popover cannot open on it and
+    // `removeHyperlink` cannot take it out: it reports zero-length at the walk position.
+    const start = span ? span.start : cursor;
+    const end = span ? span.end : cursor;
     const target = hyperlinkTargetOf(child, resolve);
     found.push({
       id: child.id,
       paragraphId,
       start,
-      end: offset,
-      text: text.slice(start, offset),
+      end,
+      text: liveTextUnder(child),
       kind: target.kind,
       href: target.href,
       authored: target.authored,
@@ -246,6 +259,28 @@ export interface HyperlinkOpsDeps {
   readonly refusesWrite: () => boolean;
   /** Active story for reads/writes — body, header/footer, or notes part. */
   storyScope(): StoryScope;
+  /**
+   * Where a replacement for `[start, end)` of one paragraph lands in SUGGESTING mode, or
+   * null outside it.
+   *
+   * Non-null switches link creation over a selection to a tracked replace: the covered
+   * words are struck in place, a fresh copy of the display text is inserted after them as
+   * this author's proposal, and the `w:hyperlink` wraps only that copy. A plain wrap wrote
+   * an unattributed edit — a link Accept/Reject could not act on — into a document whose
+   * author believed everything they did was a proposal.
+   */
+  readonly suggestReplacementOffset?: (
+    paragraphId: string,
+    start: number,
+    end: number
+  ) => number | null;
+  /**
+   * Where an insertion aimed at `offset` actually lands, in EVERY mode: past the deletion
+   * the caret rests in. Both insert appliers relocate beside a `w:del` rather than into
+   * it, so a link wrap built on the raw caret offset sliced the deletion its display text
+   * had landed beyond.
+   */
+  readonly insertionLanding?: (paragraphId: string, offset: number) => number;
   readonly selection: () => SemanticSelection;
   readonly orderedRange: () => { from: SemanticPosition; to: SemanticPosition };
   readonly selectionMark: () => { paragraphId: string; start: number; end: number } | null;
@@ -308,7 +343,7 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
   const linksIn = (paragraphId: string): SurfaceHyperlink[] => {
     const part = storyPart();
     if (!part) return [];
-    return hyperlinksInParagraph(part, paragraphId, resolve, deps.textOf);
+    return hyperlinksInParagraph(part, paragraphId, resolve);
   };
 
   const linkAtCaret = (): SurfaceHyperlink | null =>
@@ -341,7 +376,7 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
       for (const story of storyRootsOf(part)) {
         for (const paragraph of storyParagraphs(story.root)) {
           const paragraphId = paragraph.id;
-          const found = hyperlinksInParagraph(part, paragraphId, resolveHere, deps.textOf).find(
+          const found = hyperlinksInParagraph(part, paragraphId, resolveHere).find(
             (link) => link.id === linkId
           );
           if (found) return found;
@@ -394,18 +429,92 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
       // Ctrl+K on an existing link, and replacing the element would throw away its authored
       // `w:history` / `w:tgtFrame` and its identity.
       if (existing && (collapsed || withinLink(existing, range))) {
-        const ops: TreeDocOp[] = [{ op: 'setHyperlinkTarget', linkId: existing.id, ...target }];
+        const ops: TreeDocOp[] = [];
         // Replacing the display text is a delete plus an insert over the link's own range;
         // both land inside the link because the range is strictly inside it.
         if (input.text !== undefined && input.text !== existing.text) {
-          const replaced = replaceTextOps(
+          if (input.text.length === 0) return false;
+          const landing = deps.suggestReplacementOffset?.(
             existing.paragraphId,
             existing.start,
-            existing.end,
-            input.text
+            existing.end
           );
-          if (!replaced) return false;
-          ops.push(...replaced);
+          // The interior aim must not split a surrogate pair: a link whose display text
+          // begins with an astral character made `start + 1` an illegal offset, the store
+          // refused the transaction, and the rename silently did nothing.
+          const head = deps.textOf(existing.paragraphId).slice(existing.start, existing.start + 2);
+          const interiorAim =
+            existing.start +
+            (head.length === 2 &&
+            head.charCodeAt(0) >= 0xd800 &&
+            head.charCodeAt(0) <= 0xdbff &&
+            head.charCodeAt(1) >= 0xdc00 &&
+            head.charCodeAt(1) <= 0xdfff
+              ? 2
+              : 1);
+          if (
+            landing !== null &&
+            landing !== undefined &&
+            landing > existing.start &&
+            interiorAim < existing.end
+          ) {
+            // SUGGESTING strikes first and lands the replacement after the struck words,
+            // INSIDE the link. The insert aims at an INTERIOR offset of the struck text:
+            // the store's interior rule places it after the deletion inside the container
+            // that holds it, deterministically. Aiming at the link's end boundary relied
+            // on adjacent-deletion adoption, and a pre-existing strike abutting the link's
+            // closing edge joined that adoption, put the copy past the link, and accepting
+            // swept the emptied link — the renamed text came out silently unlinked.
+            ops.push(
+              { op: 'setHyperlinkTarget', linkId: existing.id, ...target },
+              {
+                op: 'deleteText',
+                paragraphId: existing.paragraphId,
+                start: existing.start,
+                end: existing.end,
+              },
+              {
+                op: 'insertText',
+                paragraphId: existing.paragraphId,
+                offset: interiorAim,
+                text: input.text,
+              }
+            );
+          } else if (landing !== null && landing !== undefined) {
+            // No interior offset to aim at: the whole display text is this author's own
+            // pending insertion (the strike retracts it physically and the emptied link is
+            // swept mid-transaction — nothing left to retarget), or it is a single unit.
+            // A copy left bare comes out unlinked once the strikes are accepted — so
+            // propose a FRESH link over the copy, and still retarget the old one in case
+            // a zero-length marker keeps it alive.
+            const styleId = hyperlinkStyleId(deps.session);
+            ops.push(
+              { op: 'setHyperlinkTarget', linkId: existing.id, ...target },
+              ...suggestReplaceOps(existing, landing, input.text),
+              {
+                op: 'insertHyperlink',
+                paragraphId: existing.paragraphId,
+                start: landing,
+                end: landing + input.text.length,
+                ...target,
+                ...(styleId ? { styleId } : {}),
+              }
+            );
+          } else {
+            const replaced = replaceTextOps(
+              existing.paragraphId,
+              existing.start,
+              existing.end,
+              input.text
+            );
+            if (!replaced) return false;
+            ops.push({ op: 'setHyperlinkTarget', linkId: existing.id, ...target }, ...replaced);
+          }
+        } else {
+          // A target-only retarget stays untracked in every mode: OOXML has no revision
+          // element for a hyperlink's target, and Word applies the same edit directly even
+          // with tracking on. The display text is what review can carry.
+          ops.push({ op: 'setHyperlinkTarget', linkId: existing.id, ...target });
         }
         let committed = false;
         deps.commit(
@@ -426,22 +535,44 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
       const paragraphId = range.from.paragraphId;
       if (range.to.paragraphId !== paragraphId) return false; // a link cannot span paragraphs
       const ops: TreeDocOp[] = [];
-      const start = range.from.offset;
+      let start = range.from.offset;
       let end = range.to.offset;
 
       if (collapsed) {
         const display = input.text ?? input.url ?? input.anchor ?? '';
         if (display.length === 0) return false;
+        // A caret resting in struck words relocates past the deletion before it inserts —
+        // the rule BOTH insert appliers follow, tracked and untracked — so the wrap must
+        // cover the SAME landing. Raw offsets committed a link that sliced the deletion
+        // the display text had actually landed beyond.
+        start = deps.insertionLanding?.(paragraphId, start) ?? start;
         ops.push({ op: 'insertText', paragraphId, offset: start, text: display });
         end = start + display.length;
-      } else if (
-        input.text !== undefined &&
-        input.text !== deps.textOf(paragraphId).slice(start, end)
-      ) {
-        const replaced = replaceTextOps(paragraphId, start, end, input.text);
-        if (!replaced) return false;
-        ops.push(...replaced);
-        end = start + input.text.length;
+      } else {
+        const landing = deps.suggestReplacementOffset?.(paragraphId, start, end);
+        if (landing !== null && landing !== undefined) {
+          // SUGGESTING proposes the link as a replacement, because a bare wrap of somebody
+          // else's words is an edit no review card can carry. The selection is struck in
+          // place (it stays, as every suggested deletion does), a copy of the display text
+          // lands after it as this author's tracked insertion — Word's struck-then-
+          // replacement reading order — and the `w:hyperlink` wraps only that copy.
+          // Rejecting the pair restores the original words and sweeps the emptied link.
+          // The attribution itself rides in on the surface's op interception, the same
+          // lane every keystroke takes.
+          const display = input.text ?? deps.textOf(paragraphId).slice(start, end);
+          if (display.length === 0) return false;
+          ops.push(...suggestReplaceOps({ paragraphId, start, end }, landing, display));
+          start = landing;
+          end = landing + display.length;
+        } else if (
+          input.text !== undefined &&
+          input.text !== deps.textOf(paragraphId).slice(start, end)
+        ) {
+          const replaced = replaceTextOps(paragraphId, start, end, input.text);
+          if (!replaced) return false;
+          ops.push(...replaced);
+          end = start + input.text.length;
+        }
       }
       if (end <= start) return false;
       // Word marks a new link's text with the `Hyperlink` CHARACTER STYLE, and without it
@@ -528,6 +659,25 @@ function withinLink(
     range.from.offset >= link.start &&
     range.to.offset <= link.end
   );
+}
+
+/**
+ * The suggesting-mode lowering of "replace `[start, end)` with `text`", spelled ONCE.
+ *
+ * Strike first — the struck words stay in place, as every suggested deletion does — then
+ * land the copy at the landing `suggestReplacementOffset` computed, where the tracked-insert
+ * core adopts the fresh deletion and follows it into the link that holds it. The reverse
+ * order put the copy at the range start, which the core places beside a link's boundary.
+ */
+function suggestReplaceOps(
+  at: { readonly paragraphId: string; readonly start: number; readonly end: number },
+  landing: number,
+  text: string
+): TreeDocOp[] {
+  return [
+    { op: 'deleteText', paragraphId: at.paragraphId, start: at.start, end: at.end },
+    { op: 'insertText', paragraphId: at.paragraphId, offset: landing, text },
+  ];
 }
 
 /**

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -75,8 +75,18 @@ export interface SurfaceSelectionSyncDeps {
    * readback is about to insert at `offset`, or `[]` when nothing is armed there. Word
    * applies the typing format to composed text exactly like typed text, and this is the
    * only insertion lane that does not go through `type()`.
+   *
+   * `replacing` is the range the insert stands in for, when the diff found one. The armed
+   * anchor relocates through the same landing rule as `replacementOffset`, so a
+   * composition that replaces the author's own pending text keeps the armed format
+   * instead of silently dropping it.
    */
-  pendingFormatOps?(paragraphId: string, offset: number, length: number): TreeDocOp[];
+  pendingFormatOps?(
+    paragraphId: string,
+    offset: number,
+    length: number,
+    replacing?: { readonly start: number; readonly end: number }
+  ): TreeDocOp[];
   selectionMark(): { paragraphId: string; start: number; end: number } | null;
   /** The surface's clock, so every phase timer reads the same one. */
   now(): number;
@@ -375,7 +385,12 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
         ? plan.ops.map((op) => (op === insert ? { ...insert, offset: landing } : op))
         : plan.ops;
     const formatOps = insert
-      ? (deps.pendingFormatOps?.(paragraphId, landing ?? insert.offset, insert.text.length) ?? [])
+      ? (deps.pendingFormatOps?.(
+          paragraphId,
+          landing ?? insert.offset,
+          insert.text.length,
+          remove ? { start: remove.start, end: remove.end } : undefined
+        ) ?? [])
       : [];
     const scope = deps.storyScope();
     deps.commit(() => {

--- a/packages/core/src/store/__tests__/tracked-edits.test.ts
+++ b/packages/core/src/store/__tests__/tracked-edits.test.ts
@@ -798,3 +798,178 @@ describe('an atomic field survives a tracked edit whole', () => {
     expect(serialized).toContain('w:instr=" PAGE "');
   });
 });
+
+// A TRACKED PAGE FIELD IS ONE PROPOSAL. The whole atom — begin, instruction, separator,
+// end — goes into a single `w:ins`, so rejecting it takes the complete field back rather
+// than leaving a `begin` no reader can resolve. Untracked, `insertPageField` wrote an
+// unattributed field in suggesting mode: an edit the review pane could not act on.
+describe('a tracked page field', () => {
+  test('the complete atom lands inside one w:ins', () => {
+    const before = part('<w:p><w:r><w:t>Page </w:t></w:r></w:p>');
+    const after = apply(before, {
+      op: 'insertPageField',
+      paragraphId: paragraphId(before),
+      offset: 5,
+      field: 'PAGE',
+      revision: ADA,
+    });
+    const out = xml(after);
+    expect(out).toMatch(/<w:ins[^>]*w:author="Ada Lovelace"[^>]*>/);
+    expect(out.match(/<w:ins /g)).toHaveLength(1);
+    // Every field node is inside the wrapper: nothing of the atom precedes it or escapes it.
+    const wrapper = out.slice(out.indexOf('<w:ins '), out.indexOf('</w:ins>'));
+    expect(wrapper).toContain('w:fldCharType="begin"');
+    expect(wrapper).toContain(' PAGE ');
+    expect(wrapper).toContain('w:fldCharType="separate"');
+    expect(wrapper).toContain('w:fldCharType="end"');
+  });
+
+  test('PAGE_X_OF_Y keeps both fields and the literal in the same proposal', () => {
+    const before = part('<w:p><w:r><w:t>footer</w:t></w:r></w:p>');
+    const after = apply(before, {
+      op: 'insertPageField',
+      paragraphId: paragraphId(before),
+      offset: 6,
+      field: 'PAGE_X_OF_Y',
+      revision: ADA,
+    });
+    const out = xml(after);
+    expect(out.match(/<w:ins /g)).toHaveLength(1);
+    const wrapper = out.slice(out.indexOf('<w:ins '), out.indexOf('</w:ins>'));
+    expect(wrapper).toContain(' PAGE ');
+    expect(wrapper).toContain(' NUMPAGES ');
+    expect(wrapper).toContain('> of <');
+  });
+
+  test('rejecting the proposal removes the whole atom; accepting unwraps it', () => {
+    const before = part('<w:p><w:r><w:t>Page </w:t></w:r></w:p>');
+    const proposed = apply(before, {
+      op: 'insertPageField',
+      paragraphId: paragraphId(before),
+      offset: 5,
+      field: 'PAGE',
+      revision: ADA,
+    });
+    const rejected = xml(apply(proposed, { op: 'rejectAllRevisions' }));
+    expect(rejected).not.toContain('fldChar');
+    // `<w:ins ` with the space: `<w:instrText` begins with the same characters.
+    expect(rejected).not.toContain('<w:ins ');
+    const accepted = xml(apply(proposed, { op: 'acceptAllRevisions' }));
+    expect(accepted).toContain('w:fldCharType="begin"');
+    expect(accepted).toContain('w:fldCharType="end"');
+    expect(accepted).not.toContain('<w:ins ');
+  });
+
+  test('a replacement beside a deletion INSIDE another author’s w:ins stays outside it', () => {
+    // The replacement follows its deletion into a HYPERLINK, never into somebody else's
+    // proposal: appended inside their `w:ins`, rejecting their revision deleted this
+    // author's replacement with it.
+    const before = part(
+      '<w:p><w:ins w:id="1" w:author="Grace Hopper" w:date="2026-01-02T03:04:05Z">' +
+        '<w:r><w:t>hello</w:t></w:r></w:ins></w:p>'
+    );
+    const struck = apply(before, {
+      op: 'deleteText',
+      paragraphId: paragraphId(before),
+      start: 2,
+      end: 5,
+      revision: ADA,
+    });
+    const replaced = apply(struck, {
+      op: 'insertText',
+      paragraphId: paragraphId(struck),
+      offset: 5,
+      text: 'XYZ',
+      revision: ADA,
+    });
+    const rejected = apply(replaced, {
+      op: 'rejectRevision',
+      revision: { id: '1', author: 'Grace Hopper', date: '2026-01-02T03:04:05Z' },
+    });
+    // Grace's insertion goes; Ada's replacement survives it.
+    const out = xml(rejected);
+    expect(out).toContain('XYZ');
+    expect(out).not.toContain('hello');
+  });
+
+  test('a replacement whose strike spills OUTSIDE the link lands outside it too', () => {
+    // The replacement stands in for the whole struck range, most of which was never
+    // linked. Following the deletion into the link turned "word link" replaced by "New"
+    // into linked text nobody asked for.
+    const before = part(
+      '<w:p><w:r><w:t xml:space="preserve">word </w:t></w:r>' +
+        '<w:hyperlink w:anchor="x"><w:r><w:t>link</w:t></w:r></w:hyperlink>' +
+        '<w:r><w:t xml:space="preserve"> tail</w:t></w:r></w:p>'
+    );
+    const struck = apply(before, {
+      op: 'deleteText',
+      paragraphId: paragraphId(before),
+      start: 0,
+      end: 9,
+      revision: ADA,
+    });
+    const replaced = apply(struck, {
+      op: 'insertText',
+      paragraphId: paragraphId(struck),
+      offset: 9,
+      text: 'New',
+      revision: ADA,
+    });
+    const out = xml(replaced);
+    expect(out).toMatch(/<\/w:hyperlink><w:ins[^>]*><w:r><w:t[^>]*>New<\/w:t>/);
+  });
+
+  test('a tracked strike reaches INSIDE an inline content control', () => {
+    // `w:sdtContent` takes `EG_PContent`, `w:del` included. Passing the control through
+    // whole made a suggested deletion over its text a silent no-op: the transaction
+    // committed and nothing was struck.
+    const before = part(
+      '<w:p><w:sdt><w:sdtPr><w:tag w:val="t1"/></w:sdtPr>' +
+        '<w:sdtContent><w:r><w:t>inside</w:t></w:r></w:sdtContent></w:sdt></w:p>'
+    );
+    const struck = apply(before, {
+      op: 'deleteText',
+      paragraphId: paragraphId(before),
+      start: 0,
+      end: 6,
+      revision: ADA,
+    });
+    const out = xml(struck);
+    expect(out).toMatch(
+      /<w:sdtContent><w:del[^>]*><w:r><w:delText[^>]*>inside<\/w:delText><\/w:r><\/w:del><\/w:sdtContent>/
+    );
+  });
+
+  test('retracting a control’s only pending content keeps the w:sdtContent element', () => {
+    // A control is document structure, not a revision wrapper: dropping its emptied
+    // content element left a `w:sdt` husk with properties and nowhere to type back into.
+    const before = part(
+      '<w:p><w:sdt><w:sdtPr><w:tag w:val="t1"/></w:sdtPr><w:sdtContent>' +
+        '<w:ins w:id="9" w:author="Ada Lovelace" w:date="2026-01-02T03:04:05Z">' +
+        '<w:r><w:t>mine</w:t></w:r></w:ins></w:sdtContent></w:sdt></w:p>'
+    );
+    const after = apply(before, {
+      op: 'deleteText',
+      paragraphId: paragraphId(before),
+      start: 0,
+      end: 4,
+      revision: ADA,
+    });
+    const out = xml(after);
+    expect(out).toContain('<w:sdtContent/>');
+    expect(out).not.toContain('mine');
+  });
+
+  test('an empty attributed author is refused, as every tracked insert is', () => {
+    const before = part('<w:p><w:r><w:t>Page </w:t></w:r></w:p>');
+    const result = applyTreeOp(before, {
+      op: 'insertPageField',
+      paragraphId: paragraphId(before),
+      offset: 5,
+      field: 'PAGE',
+      revision: { author: '' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid-property-value');
+  });
+});

--- a/packages/core/src/store/package/note-lifecycle.ts
+++ b/packages/core/src/store/package/note-lifecycle.ts
@@ -30,9 +30,7 @@ import { withPart } from './ooxml-package.ts';
 import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
 import {
   allocateNoteId,
-  atomicNoteSpansOf,
   findNoteById,
-  isNoteAtomNode,
   noteIdOf,
   noteKindOf,
   noteRefKindOf,
@@ -64,8 +62,12 @@ import {
   type NoteReferenceScanBudget,
 } from './note-references.ts';
 import { isValidXmlText } from './sinks.ts';
-import { atomicFieldSpansOf, isFldSimple } from './field-nodes.ts';
-import { isContentControl, walkParagraphInline } from './content-control-walk.ts';
+import { applyInsertTrackedRun } from '../store/tree-op-tracked.ts';
+import { paragraphOffsetIndex } from '../store/tree-op-segments.ts';
+import {
+  invalidRevisionAttribution,
+  type RevisionAttributionInput,
+} from '../store/tree-op-types.ts';
 
 const W = WML_NAMESPACE_URI;
 const FOOTNOTES_REL =
@@ -163,6 +165,13 @@ export type NoteLifecycleOp =
       readonly noteKind: NoteKind;
       readonly paragraphId: string;
       readonly offset: number;
+      /**
+       * Write the citing reference as a TRACKED insertion: the reference run goes inside a
+       * `w:ins` carrying this attribution. The note body stays plain — rejecting the
+       * reference removes it, and the orphaned body is swept by the same cascade an
+       * untracked reference deletion triggers.
+       */
+      readonly revision?: RevisionAttributionInput;
     }
   | {
       readonly op: 'deleteNote';
@@ -201,7 +210,7 @@ export type NoteLifecycleOp =
     };
 
 /** Why a note lifecycle op was refused. */
-export type NoteLifecycleRejection = 'invalidArgs' | 'tree-invariant';
+export type NoteLifecycleRejection = 'invalidArgs' | 'invalid-property-value' | 'tree-invariant';
 
 /**
  * A new package, or a typed rejection.
@@ -303,6 +312,13 @@ function applyInsertNote(
     return fail('invalidArgs', 'paragraphId');
   }
   if (!Number.isInteger(op.offset) || op.offset < 0) return fail('invalidArgs', 'offset');
+  // `CT_TrackChange` makes `@w:author` required, so a tracked variant with an empty one
+  // would serialize a proposal no reader can attribute or resolve. The SAME predicate and
+  // code every other tracked insert answers with, so a caller branching on the reason
+  // sees one fault.
+  if (op.revision !== undefined && invalidRevisionAttribution(op.revision)) {
+    return fail('invalid-property-value', 'revision-author');
+  }
 
   const located = locateInsertParagraph(pkg, op.paragraphId);
   if (!located.ok) return fail('invalidArgs', located.detail);
@@ -352,13 +368,38 @@ function applyInsertNote(
 
   const refLocal = op.noteKind === 'footnote' ? 'footnoteReference' : 'endnoteReference';
   const styleVal = op.noteKind === 'footnote' ? 'FootnoteReference' : 'EndnoteReference';
-  const storyNextId = createNodeIdAllocator(storyPart);
-  const refRun = noteReferenceRun(storyNextId, refLocal, noteId, styleVal);
-  const inserted = insertNodesAtOffset(storyPart, storyParagraph as OoxmlParagraphNode, op.offset, [
-    refRun,
-  ]);
-  if (!inserted) return fail('tree-invariant', 'reference-insert');
-  next = withPart(next, inserted);
+  // Suggesting proposes the CITATION: the reference run goes through the tracked-insert
+  // core, which owns every placement rule typed text follows — the `w:ins` wrapper,
+  // extending the author's own pending insertion, adopting the adjacent deletion of a
+  // replaced selection, relocating past struck words. The note body stays plain —
+  // rejecting the reference sweeps the orphaned body through the same cascade an
+  // untracked reference deletion takes.
+  if (op.revision) {
+    const tracked = applyInsertTrackedRun(
+      storyPart,
+      storyParagraph as OoxmlParagraphNode,
+      op.offset,
+      (mint) => noteReferenceRun(mint, refLocal, noteId, styleVal),
+      op.revision
+    );
+    if (!tracked.ok || !tracked.part) {
+      // Keep the core's typed reason in the detail — an offset refusal reported as a bare
+      // tree-invariant hides the actionable cause from the surface and automation hosts.
+      return fail('tree-invariant', (!tracked.ok && tracked.reason) || 'reference-insert');
+    }
+    next = withPart(next, tracked.part);
+  } else {
+    const storyNextId = createNodeIdAllocator(storyPart);
+    const refRun = noteReferenceRun(storyNextId, refLocal, noteId, styleVal);
+    const inserted = insertNodesAtOffset(
+      storyPart,
+      storyParagraph as OoxmlParagraphNode,
+      op.offset,
+      [refRun]
+    );
+    if (!inserted) return fail('tree-invariant', 'reference-insert');
+    next = withPart(next, inserted);
+  }
 
   return {
     ok: true,
@@ -840,72 +881,16 @@ function findParagraphInSubtree(
   return null;
 }
 
-/** Local UTF-16 length — mirrors store `segmentsOf` without importing the store package. */
+/**
+ * UTF-16 length in the SHARED offset model, from the MEMOIZED index.
+ *
+ * This module used to keep a private mirror of `segmentsOf`, and the mirror disagreed with
+ * the authority on the shapes suggesting mode writes: it counted a revision wrapper's runs
+ * as nothing, so a citation aimed at a caret after tracked content validated against a
+ * shorter paragraph and landed characters to the left of where the reader put it.
+ */
 function paragraphLength(paragraph: OoxmlParagraphNode): number {
-  return modelSegments(paragraph).reduce((max, segment) => Math.max(max, segment.end), 0);
-}
-
-interface ModelSegment {
-  readonly runId: string;
-  readonly node: OoxmlNode;
-  readonly start: number;
-  readonly end: number;
-}
-
-function modelSegments(paragraph: OoxmlParagraphNode): ModelSegment[] {
-  const segments: ModelSegment[] = [];
-  let offset = 0;
-  const fieldAtoms = atomicFieldSpansOf(paragraph);
-  const noteAtoms = atomicNoteSpansOf(paragraph);
-  const fieldById = new Map(fieldAtoms.map((span) => [span.node.id, span]));
-  const noteById = new Map(noteAtoms.map((span) => [span.node.id, span]));
-  const covered = new Set<string>();
-  for (const span of fieldAtoms) for (const id of span.removeNodeIds) covered.add(id);
-
-  const emit = (runId: string, node: OoxmlNode): void => {
-    segments.push({ runId, node, start: offset, end: offset + 1 });
-    offset += 1;
-  };
-
-  const visit = (node: OoxmlNode, runId: string): void => {
-    const field = fieldById.get(node.id);
-    if (field && field.kind === 'complex') {
-      emit(runId, node);
-      return;
-    }
-    if (covered.has(node.id)) return;
-    if (noteById.has(node.id) || isNoteAtomNode(node)) {
-      emit(runId, node);
-      return;
-    }
-    if (node.kind === 'textValue') {
-      segments.push({ runId, node, start: offset, end: offset + node.value.length });
-      offset += node.value.length;
-      return;
-    }
-    if (node.kind === 'tab' || node.kind === 'hardBreak') {
-      emit(runId, node);
-      return;
-    }
-    // Generic / misplaced run-inner control husks contribute no atoms.
-    if (node.kind === 'runProperties' || node.kind === 'generic' || isContentControl(node)) return;
-    if (node.kind === 'text') {
-      for (const child of node.children) visit(child, runId);
-      return;
-    }
-    for (const child of node.children) visit(child, runId);
-  };
-
-  walkParagraphInline(paragraph.children, 0, (child) => {
-    if (isFldSimple(child)) {
-      const field = fieldById.get(child.id);
-      if (field) emit('', child);
-      return;
-    }
-    if (child.kind !== 'run') return;
-    for (const grand of child.children) visit(grand, child.id);
-  });
-  return segments;
+  return paragraphOffsetIndex(paragraph).length;
 }
 
 function noteReferenceRun(
@@ -974,6 +959,27 @@ function noteReferenceRun(
   } as unknown as OoxmlNode;
 }
 
+/** Index of the paragraph child whose subtree holds `nodeId`, or -1. */
+function topChildIndexOf(paragraph: OoxmlParagraphNode, nodeId: string): number {
+  const holds = (node: OoxmlNode): boolean => {
+    if (node.id === nodeId) return true;
+    if (node.kind === 'textValue') return false;
+    return node.children.some(holds);
+  };
+  return paragraph.children.findIndex((child) => holds(child));
+}
+
+/** The node whose DIRECT child is `nodeId`, anywhere under `root`, or null. */
+function parentHolding(root: OoxmlNode, nodeId: string): OoxmlNode | null {
+  if (root.kind === 'textValue') return null;
+  for (const child of root.children) {
+    if (child.id === nodeId) return root;
+    const found = parentHolding(child, nodeId);
+    if (found) return found;
+  }
+  return null;
+}
+
 function insertNodesAtOffset(
   part: OoxmlPart,
   paragraph: OoxmlParagraphNode,
@@ -981,9 +987,13 @@ function insertNodesAtOffset(
   nodes: readonly OoxmlNode[]
 ): OoxmlPart | null {
   // Note references are authored as whole runs — always insert at paragraph child level.
-  const segments = modelSegments(paragraph);
+  // Offsets come from the memoized paragraph offset index — the SAME authority the caret
+  // uses — so a caret placed after tracked content addresses the position this write
+  // resolves, and the validation walk above is not repeated.
+  const offsets = paragraphOffsetIndex(paragraph);
+  const segments = offsets.segments;
   const nextId = createNodeIdAllocator(part);
-  const length = segments.reduce((max, segment) => Math.max(max, segment.end), 0);
+  const length = offsets.length;
 
   // Inside a text value: split the owning run, then place the note run between the halves.
   for (const segment of segments) {
@@ -995,6 +1005,9 @@ function insertNodesAtOffset(
     if (!textParent) return null;
     const run = findNode(part, segment.runId);
     if (!run || run.kind !== 'run') return null;
+    // A run nested inside a link or a revision wrapper cannot host the split — a citation
+    // spliced into somebody's `w:ins` would join their proposal. Refuse; the caller
+    // degrades to a rejection, never to a silently misplaced reference.
     const runIndex = paragraph.children.findIndex((child) => child.id === run.id);
     if (runIndex < 0) return null;
 
@@ -1035,19 +1048,55 @@ function insertNodesAtOffset(
     return inserted.ok ? inserted.part : null;
   }
 
-  // Boundary between segments: insert before the run that owns the boundary start.
+  // Boundary between segments: insert before the child holding the segment that starts
+  // here. A boundary whose run lives INSIDE a link or wrapper resolves to its TOP-LEVEL
+  // ancestor: at the container's leading edge "before the container" and "at the offset"
+  // are the same place, and an interior boundary one level down joins the container's own
+  // content — a citation mid-link belongs in the link, where the caret is. Deeper nesting
+  // is refused rather than misplaced. Matching direct children only was worse still — the
+  // boundary fell to the append fallback, at the paragraph's end.
   const boundary = segments.find((segment) => segment.start === offset);
-  if (boundary?.runId) {
-    const index = paragraph.children.findIndex((child) => child.id === boundary.runId);
-    if (index >= 0) {
-      const inserted = insertChildren(part, paragraph.id, index, nodes);
+  if (boundary) {
+    const anchorId = boundary.runId || boundary.node.id;
+    const direct = paragraph.children.findIndex((child) => child.id === anchorId);
+    if (direct >= 0) {
+      const inserted = insertChildren(part, paragraph.id, direct, nodes);
       return inserted.ok ? inserted.part : null;
     }
-  }
-  if (boundary && !boundary.runId) {
-    const index = paragraph.children.findIndex((child) => child.id === boundary.node.id);
-    const inserted = insertChildren(part, paragraph.id, Math.max(0, index), nodes);
-    return inserted.ok ? inserted.part : null;
+    const index = topChildIndexOf(paragraph, anchorId);
+    if (index >= 0) {
+      const top = paragraph.children[index]!;
+      const under = new Set<string>();
+      const collect = (node: OoxmlNode): void => {
+        under.add(node.id);
+        if (node.kind === 'textValue') return;
+        for (const child of node.children) collect(child);
+      };
+      collect(top);
+      const containerStart = segments.reduce(
+        (min, segment) =>
+          under.has(segment.runId) || under.has(segment.node.id)
+            ? Math.min(min, segment.start)
+            : min,
+        Number.POSITIVE_INFINITY
+      );
+      if (containerStart === offset) {
+        const inserted = insertChildren(part, paragraph.id, index, nodes);
+        return inserted.ok ? inserted.part : null;
+      }
+      // An interior boundary joins the DIRECT parent's content at the caret, whatever the
+      // nesting — a citation mid-link belongs in the link. ONLY neutral containers accept
+      // it: spliced into a revision wrapper, the citation would join somebody's proposal
+      // (or their deletion), and rejecting their revision would take the citation and its
+      // note body with it. Everything else refuses rather than misplaces.
+      const parent = parentHolding(top, anchorId);
+      if (parent && (parent.kind === 'hyperlink' || parent.kind === 'contentControlContent')) {
+        const at = parent.children.findIndex((child) => child.id === anchorId);
+        const inserted = insertChildren(part, parent.id, Math.max(0, at), nodes);
+        return inserted.ok ? inserted.part : null;
+      }
+      return null;
+    }
   }
 
   const inserted = insertChildren(part, paragraph.id, paragraph.children.length, nodes);

--- a/packages/core/src/store/package/ooxml-sdt.ts
+++ b/packages/core/src/store/package/ooxml-sdt.ts
@@ -270,6 +270,13 @@ export function validContentControlContentChildren(children: readonly OoxmlNode[
       // content control — legal markup the schema has always allowed.
       child.kind === 'commentRangeStart' ||
       child.kind === 'commentRangeEnd' ||
+      // Revision wrappers belong to `EG_RunLevelElts`, another member of the same content
+      // groups. Refusing them made a tracked strike of a control's text — markup Word
+      // writes with tracking on — invalidate the whole part.
+      child.kind === 'revisionInsert' ||
+      child.kind === 'revisionDelete' ||
+      child.kind === 'revisionMoveFrom' ||
+      child.kind === 'revisionMoveTo' ||
       child.kind === 'generic'
   );
 }

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -16,6 +16,7 @@
 import { WML_NAMESPACE_URI } from '../package/ooxml-tree.ts';
 import type { OoxmlElement, OoxmlNode, OoxmlPart } from '../package/ooxml-tree.ts';
 import { hardBreakText } from '../package/hard-break.ts';
+import { isInstrText } from '../package/field-nodes.ts';
 import { collectRevisionSites } from './tree-op-revisions.ts';
 import type { RevisionAddress } from './tree-op-types.ts';
 import {
@@ -93,6 +94,11 @@ function textUnder(node: OoxmlNode): string {
   // model counts for them.
   if (node.kind === 'tab') return '\t';
   if (node.kind === 'hardBreak') return hardBreakText(node);
+  // A field's instruction is CODE, not content: it measures nothing in the offset model,
+  // and a tracked page field would otherwise present its ` PAGE ` source as inserted
+  // words. `isInstrText` covers all three spellings — the typed kind, the parse-demoted
+  // generic, and `w:delInstrText`, which a struck field's card would otherwise read out.
+  if (isInstrText(node)) return '';
   let text = '';
   for (const child of node.children) text += textUnder(child);
   return text;

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -34,10 +34,13 @@ import {
   applyDeleteTracked,
   applyInsertTracked,
   applyInsertTrackedElement,
+  applyInsertTrackedElements,
+} from './tree-op-tracked.ts';
+import {
   applyParagraphMarkRevision,
   applyProposeParagraphMerge,
   retractsOwnParagraphMark,
-} from './tree-op-tracked.ts';
+} from './tree-op-tracked-marks.ts';
 import {
   isValidParaId,
   mintParaId,
@@ -90,7 +93,7 @@ import {
   applySetSectionMark,
   applySetSectionProperties,
 } from './tree-op-section.ts';
-import { pageFieldContentBuilders } from './tree-op-fields.ts';
+import { pageFieldContentBuilders, pageFieldModelLength } from './tree-op-fields.ts';
 import { applyInsertContentControl as applyAutomationInsertContentControl } from './tree-op-content-control-insert.ts';
 import {
   applyRemoveContentControl as applyAutomationRemoveContentControl,
@@ -418,14 +421,24 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
         options,
         nextId
       );
-    case 'insertPageField':
-      return applyInsertContent(
-        part,
-        paragraph,
-        op.offset,
-        pageFieldContentBuilders(op.field),
-        options
-      );
+    case 'insertPageField': {
+      // ONE builder list per field, shared by the tracked and untracked arms — the same
+      // rule the tab/break ops state, so suggesting mode cannot insert a different field
+      // shape than edit mode for the same command.
+      const builders = pageFieldContentBuilders(op.field);
+      if (op.revision) {
+        return applyInsertTrackedElements(
+          part,
+          paragraph,
+          op.offset,
+          (mint) => builders.map((build) => build(mint)),
+          pageFieldModelLength(op.field),
+          op.revision,
+          options
+        );
+      }
+      return applyInsertContent(part, paragraph, op.offset, builders, options);
+    }
     case 'deleteText':
       if (op.revision) {
         return applyDeleteTracked(part, paragraph, op.start, op.end, op.revision, options);
@@ -1338,7 +1351,14 @@ function hyperlinkElement(
  * the run's formatting entirely.
  */
 function withCharacterStyle(node: OoxmlNode, styleId: string, nextId: () => string): OoxmlNode {
-  if (node.kind === 'hyperlink') {
+  // A revision wrapper is not a run: the style goes on the runs INSIDE it. Marking the
+  // wrapper itself minted a `w:rPr` child on `w:ins` — a shape `CT_RunTrackChange` has no
+  // room for — the moment a link was applied over tracked display text, which is every
+  // link created in suggesting mode.
+  if (
+    node.kind !== 'textValue' &&
+    (node.kind === 'hyperlink' || isContentRevisionKind(node.kind))
+  ) {
     return withChildren(
       node,
       node.children.map((child) => withCharacterStyle(child, styleId, nextId)),

--- a/packages/core/src/store/store/tree-op-fields.ts
+++ b/packages/core/src/store/store/tree-op-fields.ts
@@ -66,6 +66,9 @@ function textElement(nextId: () => string, text: string): OoxmlNode {
   } as unknown as OoxmlNode;
 }
 
+/** The literal between the two fields of the PAGE_X_OF_Y composition. */
+const PAGE_X_OF_Y_SEPARATOR = ' of ';
+
 /** Run-child builders for one allowlisted page field (or PAGE X OF Y composition). */
 export function pageFieldContentBuilders(
   field: PageFieldKind
@@ -79,7 +82,21 @@ export function pageFieldContentBuilders(
     ] as const;
 
   if (field === 'PAGE_X_OF_Y') {
-    return [...complex('PAGE'), (mint) => textElement(mint, ' of '), ...complex('NUMPAGES')];
+    return [
+      ...complex('PAGE'),
+      (mint) => textElement(mint, PAGE_X_OF_Y_SEPARATOR),
+      ...complex('NUMPAGES'),
+    ];
   }
   return [...complex(field)];
+}
+
+/**
+ * The field's size in MODEL units, on `segmentsOf`'s terms.
+ *
+ * A complex field is one addressable unit at its `begin`; the instruction, separator and
+ * `end` measure nothing. Only the PAGE_X_OF_Y literal adds characters of its own.
+ */
+export function pageFieldModelLength(field: PageFieldKind): number {
+  return field === 'PAGE_X_OF_Y' ? 1 + PAGE_X_OF_Y_SEPARATOR.length + 1 : 1;
 }

--- a/packages/core/src/store/store/tree-op-tables.ts
+++ b/packages/core/src/store/store/tree-op-tables.ts
@@ -54,11 +54,12 @@ import { fromEdit, TEXT_DEPS } from './tree-op-nodes.ts';
 import { isWmlElement, wmlAttributeValue, wmlChildNamed } from './tree-op-table-shared.ts';
 import { readEditableTableTopology, type EditableTableTopology } from './tree-op-table-topology.ts';
 import { nextRevisionId } from './tree-op-revision-ids.ts';
-import type {
-  RevisionAttributionInput,
-  TreeOpEffect,
-  TreeOpRejection,
-  TreeOpResult,
+import {
+  invalidRevisionAttribution,
+  type RevisionAttributionInput,
+  type TreeOpEffect,
+  type TreeOpRejection,
+  type TreeOpResult,
 } from './tree-op-types.ts';
 
 const TR_PR_STRIP = new Set(['ins', 'del', 'trPrChange']);
@@ -692,12 +693,7 @@ export function validateTableRowOp(
   op: TableRowDocOp,
   limits: TableTopologyLimits = DEFAULT_TABLE_TOPOLOGY_LIMITS
 ): TreeOpRejection | null {
-  if (
-    op.revision !== undefined &&
-    (typeof op.revision.author !== 'string' ||
-      op.revision.author.trim().length === 0 ||
-      (op.revision.date !== undefined && typeof op.revision.date !== 'string'))
-  ) {
+  if (op.revision !== undefined && invalidRevisionAttribution(op.revision)) {
     return 'invalid-property-value';
   }
   const resolved = resolveTableTopologyLimits(limits);

--- a/packages/core/src/store/store/tree-op-tracked-marks.ts
+++ b/packages/core/src/store/store/tree-op-tracked-marks.ts
@@ -1,0 +1,226 @@
+// Tracked PARAGRAPH MARKS — the pilcrow's own revisions.
+//
+// Split from `tree-op-tracked.ts`, which owns run-level content wrappers and their
+// placement; this module owns the one tracked edit with no run in it: `w:pPr/w:rPr/w:ins`
+// and `w:del` (§17.13.5, `EG_ParaRPrTrackChanges`), the marks a split or a merge writes.
+// The node builders and the coalescing window are shared — one spelling of a wrapper's
+// attributes, one definition of "the same editing moment".
+
+import {
+  WML_NAMESPACE_URI,
+  type OoxmlNode,
+  type OoxmlParagraphNode,
+  type OoxmlPart,
+} from '../package/ooxml-tree.ts';
+import {
+  createNodeIdAllocator,
+  parentNodeOf as parentOf,
+  replaceChildren,
+} from '../package/ooxml-edit.ts';
+import { nextRevisionId } from './tree-op-revision-ids.ts';
+import { TEXT_DEPS, fromEdit } from './tree-op-nodes.ts';
+import {
+  build,
+  childrenOf,
+  isWmlNamed,
+  revisionAttributes,
+  sameEditingMoment,
+} from './tree-op-tracked.ts';
+import type { RevisionAttributionInput, TreeOpEffect, TreeOpResult } from './tree-op-validate.ts';
+
+/**
+ * Stamp a paragraph's own MARK as inserted or deleted.
+ *
+ * `w:pPr/w:rPr/w:ins|w:del` (§17.13.5, `EG_ParaRPrTrackChanges`) is how Word records a split
+ * or a merge: the mark is the pilcrow, and the pilcrow is what the edit added or removed.
+ * There is no text to strike, which is why this is the only tracked edit with no run in it.
+ *
+ * SPLIT stamps `w:ins` on the FIRST paragraph — its mark is the one that did not exist
+ * before. MERGE stamps `w:del` on the first as well: the mark being proposed for removal is
+ * the one between the two paragraphs, which belongs to the first. Rejecting the insert and
+ * accepting the delete both run the paragraph into the one after it, which is why
+ * `resolveRevisions` treats them the same way.
+ *
+ * An existing mark of the SAME kind and author is joined rather than replaced, so a run of
+ * Enters is one decision and one Accept.
+ */
+export function applyParagraphMarkRevision(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  kind: 'ins' | 'del',
+  revision: RevisionAttributionInput,
+  options?: { readonly deferValidation?: boolean }
+): TreeOpResult {
+  const mint = createNodeIdAllocator(part);
+  const effect: TreeOpEffect = {
+    dirty: [paragraph.id],
+    created: [],
+    deleted: [],
+    dependencyKeys: TEXT_DEPS,
+    impact: 'flow-structural',
+  };
+
+  const existing = paragraphMarkRevisionOf(paragraph, kind);
+  if (existing && existing.author === revision.author) {
+    // Already proposed by this author. A second Enter at the same mark is not a second
+    // decision, and stamping again would mint an id nothing else refers to.
+    return fromEdit({ ok: true, part }, effect);
+  }
+
+  const id = adjacentParagraphMarkId(part, paragraph, kind, revision) ?? nextRevisionId(part)();
+  const mark = build(mint(), 'generic', kind, revisionAttributes(id, revision), []);
+
+  const properties = childrenOf(paragraph).find((child) => child.kind === 'paragraphProperties');
+  const rest = childrenOf(paragraph).filter((child) => child.kind !== 'paragraphProperties');
+
+  // `w:rPr` sits near the END of `CT_PPr` — after the base properties (`w:jc`, `w:spacing`,
+  // `w:numPr`, …) and before `w:sectPr`/`w:pPrChange`, which are the only two that may
+  // follow it. Placing it first looked tidier and produced a `w:pPr` the tree invariants
+  // reject, which is the invariant reading the schema correctly.
+  const previousRPr = properties
+    ? childrenOf(properties).find((child) => isWmlNamed(child, 'rPr'))
+    : undefined;
+  // Only the SAME-KIND mark is replaced. `EG_ParaRPrTrackChanges` is `ins? del? moveFrom?
+  // moveTo?` — both an insert and a delete may sit here, and that pair is exactly what Word
+  // writes when B proposes removing a mark A proposed adding. Stripping every revision took
+  // A's out of the file, so rejecting B's deletion made A's break permanent and A's card
+  // vanished from every reviewer's pane.
+  const rPrRest = previousRPr
+    ? childrenOf(previousRPr).filter((child) => !isMarkRevisionOfKind(child, kind))
+    : [];
+  const siblingMark = rPrRest.filter(isMarkRevision);
+  const otherProperties = rPrRest.filter((child) => !isMarkRevision(child));
+  // `ins` before `del`, per the group's own order.
+  const marks = kind === 'ins' ? [mark, ...siblingMark] : [...siblingMark, mark];
+  const rPr = build(mint(), 'runProperties', 'rPr', [], [...marks, ...otherProperties]);
+  const pPrRest = properties
+    ? childrenOf(properties).filter((child) => !isWmlNamed(child, 'rPr'))
+    : [];
+  // `CT_PPr` puts `w:rPr` AFTER the base properties — only `w:sectPr` and `w:pPrChange` may
+  // follow it — so an existing `w:jc` stays in front. Placing `w:rPr` first looked tidier and
+  // produced a `w:pPr` the tree invariants reject, which is the invariant reading the schema
+  // correctly. A FRESH id, because the rebuilt container is a new node.
+  const trailing = pPrRest.filter(isTrailingParagraphProperty);
+  const leading = pPrRest.filter((child) => !isTrailingParagraphProperty(child));
+  const pPr = build(mint(), 'paragraphProperties', 'pPr', properties ? properties.attributes : [], [
+    ...leading,
+    rPr,
+    ...trailing,
+  ]);
+
+  return fromEdit(replaceChildren(part, paragraph.id, [pPr, ...rest], options), effect);
+}
+
+/**
+ * Propose merging `paragraph` into the paragraph before it.
+ *
+ * The mark that would go is its PREDECESSOR's, and only the tree knows which paragraph that
+ * is: addressing the merge by the first paragraph made a multi-paragraph delete stamp one
+ * paragraph N times and leave the rest untouched, so accepting produced an empty paragraph
+ * for every one selected.
+ */
+export function applyProposeParagraphMerge(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  revision: RevisionAttributionInput,
+  options?: { readonly deferValidation?: boolean }
+): TreeOpResult {
+  const parent = parentOf(part, paragraph.id);
+  if (!parent) return { ok: false, reason: 'tree-invariant' };
+  const siblings = parent.children;
+  const at = siblings.findIndex((child) => child.id === paragraph.id);
+  const previous = at > 0 ? siblings[at - 1] : undefined;
+  // A paragraph with nothing before it IN THE SAME CONTAINER has no mark to propose away.
+  // Marking across a container boundary wrote a `w:del` on the last paragraph of a `w:tc` —
+  // markup Word repairs, and which Accept then silently dropped, because there is no
+  // following paragraph to merge into.
+  if (!previous || previous.kind !== 'paragraph') {
+    return { ok: false, reason: 'not-adjacent-siblings' };
+  }
+  return applyParagraphMarkRevision(part, previous, 'del', revision, options);
+}
+
+/**
+ * Whether this paragraph's mark is an insertion THIS author proposed.
+ *
+ * Proposing to delete a mark you proposed adding is just taking the proposal back, so the
+ * caller performs a real join instead of writing a `w:del`. Re-labelling it left a paragraph
+ * break that Reject then made permanent — the opposite of what the user asked for. The
+ * module states this rule for text; the mark path did not have it.
+ */
+export function retractsOwnParagraphMark(paragraph: OoxmlParagraphNode, author: string): boolean {
+  const own = paragraphMarkRevisionOf(paragraph, 'ins');
+  return own !== undefined && own.author === author;
+}
+
+/** The revision of one KIND on a paragraph's own mark, or undefined. */
+function paragraphMarkRevisionOf(
+  paragraph: OoxmlParagraphNode,
+  kind: 'ins' | 'del'
+): { readonly localName: string; readonly author: string } | undefined {
+  const properties = childrenOf(paragraph).find((child) => child.kind === 'paragraphProperties');
+  const rPr = properties
+    ? childrenOf(properties).find((child) => isWmlNamed(child, 'rPr'))
+    : undefined;
+  const mark = rPr ? childrenOf(rPr).find((child) => isMarkRevisionOfKind(child, kind)) : undefined;
+  if (!mark || mark.kind === 'textValue') return undefined;
+  const author = mark.attributes.find(
+    (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'author'
+  );
+  return { localName: mark.localName, author: author?.value ?? '' };
+}
+
+/** The only two `CT_PPr` children that may follow `w:rPr`. */
+function isTrailingParagraphProperty(node: OoxmlNode): boolean {
+  return isWmlNamed(node, 'sectPr') || isWmlNamed(node, 'pPrChange');
+}
+
+function isMarkRevisionOfKind(node: OoxmlNode, kind: 'ins' | 'del'): boolean {
+  return node.kind !== 'textValue' && isWmlNamed(node, kind);
+}
+
+function isMarkRevision(node: OoxmlNode): boolean {
+  return (
+    node.kind !== 'textValue' &&
+    node.namespaceUri === WML_NAMESPACE_URI &&
+    (node.localName === 'ins' || node.localName === 'del')
+  );
+}
+
+/**
+ * The id of a same-kind, same-author, same-moment paragraph mark on a NEIGHBOURING paragraph.
+ *
+ * A run of Enters, or a run of Backspaces at a paragraph start, is one editing gesture — Word
+ * groups it under one revision and offers one Accept. Without this each press minted its own,
+ * and the pane filled with a card per keystroke.
+ */
+function adjacentParagraphMarkId(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  kind: 'ins' | 'del',
+  revision: RevisionAttributionInput
+): string | null {
+  const parent = parentOf(part, paragraph.id);
+  if (!parent) return null;
+  const siblings = parent.children;
+  const at = siblings.findIndex((child) => child.id === paragraph.id);
+  for (const neighbour of [siblings[at - 1], siblings[at + 1]]) {
+    if (!neighbour || neighbour.kind !== 'paragraph') continue;
+    const properties = childrenOf(neighbour).find((child) => child.kind === 'paragraphProperties');
+    const rPr = properties
+      ? childrenOf(properties).find((child) => isWmlNamed(child, 'rPr'))
+      : undefined;
+    const mark = rPr ? childrenOf(rPr).find(isMarkRevision) : undefined;
+    if (!mark || mark.kind === 'textValue' || mark.localName !== kind) continue;
+    const read = (localName: string): string | undefined =>
+      mark.attributes.find(
+        (attribute) =>
+          attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName
+      )?.value;
+    if (read('author') !== revision.author) continue;
+    if (!sameEditingMoment(read('date'), revision.date)) continue;
+    const id = read('id');
+    if (id !== undefined) return id;
+  }
+  return null;
+}

--- a/packages/core/src/store/store/tree-op-tracked.ts
+++ b/packages/core/src/store/store/tree-op-tracked.ts
@@ -33,11 +33,7 @@ import {
   type OoxmlParagraphNode,
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
-import {
-  createNodeIdAllocator,
-  parentNodeOf as parentOf,
-  replaceChildren,
-} from '../package/ooxml-edit.ts';
+import { createNodeIdAllocator, replaceChildren } from '../package/ooxml-edit.ts';
 import { equivalentNodes } from './ooxml-node-equality.ts';
 import { nextRevisionId } from './tree-op-revision-ids.ts';
 import { TEXT_DEPS, fromEdit } from './tree-op-nodes.ts';
@@ -55,7 +51,7 @@ function attr(localName: string, value: string) {
   };
 }
 
-function build(
+export function build(
   id: string,
   kind: OoxmlElement['kind'],
   localName: string,
@@ -74,7 +70,8 @@ function build(
   } as OoxmlElement;
 }
 
-function revisionAttributes(id: string, revision: RevisionAttributionInput) {
+/** The `CT_TrackChange` attribute triple, spelled once for every wrapper a tracked edit writes. */
+export function revisionAttributes(id: string, revision: RevisionAttributionInput) {
   return [
     attr('id', id),
     attr('author', revision.author),
@@ -120,7 +117,10 @@ function copy(mint: () => string, node: OoxmlNode): OoxmlNode {
  * minute apart are still one thought, two edits a month apart are not one revision. Two
  * dateless wrappers join — a file written with date stamping off has nothing else to go on.
  */
-function sameEditingMoment(existing: string | undefined, current: string | undefined): boolean {
+export function sameEditingMoment(
+  existing: string | undefined,
+  current: string | undefined
+): boolean {
   if (existing === undefined || current === undefined) return existing === current;
   const from = Date.parse(existing);
   const to = Date.parse(current);
@@ -146,6 +146,14 @@ function deletionId(node: OoxmlNode): string | null {
       (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id'
     )?.value ?? null
   );
+}
+
+/** How many deletion wrappers with this `@w:id` live under the node, itself included. */
+function deletionWrappersWithId(node: OoxmlNode, id: string): number {
+  if (node.kind === 'textValue') return 0;
+  let count = deletionId(node) === id ? 1 : 0;
+  for (const child of node.children) count += deletionWrappersWithId(child, id);
+  return count;
 }
 
 interface Cursor {
@@ -202,7 +210,7 @@ function holdsAtomBegin(node: OoxmlNode, atoms: AtomNodes): boolean {
 }
 
 /**
- * What a tracked insertion places: run text, or one run-level element (a tab or a break).
+ * What a tracked insertion places: run text, run-level elements, or one complete run.
  *
  * `length` is the payload's size in MODEL units, on `segmentsOf`'s terms — `text.length`
  * for characters, one for a tab or a break — so the extend-own-insertion path can step the
@@ -210,7 +218,18 @@ function holdsAtomBegin(node: OoxmlNode, atoms: AtomNodes): boolean {
  */
 interface TrackedInsertionPayload {
   readonly length: number;
-  readonly nodes: (mint: () => string) => readonly OoxmlNode[];
+  /**
+   * Run CHILDREN — text, a tab, a field's nodes — that inherit the host run's `w:rPr`:
+   * placed in one run under the wrapper, or spliced into the author's own run when
+   * extending. Null for a payload that is a complete run of its own.
+   */
+  readonly nodes: ((mint: () => string) => readonly OoxmlNode[]) | null;
+  /**
+   * A complete run carrying its OWN `w:rPr` — a note citation, whose reference style must
+   * not be replaced by the formatting at the caret. Placed as a sibling run: alone under
+   * the wrapper, or beside the split halves when extending the author's own `w:ins`.
+   */
+  readonly run?: (mint: () => string) => OoxmlNode;
 }
 
 /**
@@ -254,11 +273,67 @@ export function applyInsertTrackedElement(
   revision: RevisionAttributionInput,
   options?: { readonly deferValidation?: boolean }
 ): TreeOpResult {
+  return applyInsertTrackedElements(
+    part,
+    paragraph,
+    offset,
+    (mint) => [element(mint)],
+    1,
+    revision,
+    options
+  );
+}
+
+/**
+ * Insert a MULTI-NODE run payload — a complete complex field — as ONE tracked insertion.
+ *
+ * The nodes share one run inside one `w:ins`, exactly the grouping the untracked
+ * `insertPageField` writes, so the whole atom is one proposal: rejecting it takes the
+ * `begin`, instruction, separator and `end` back together, never leaving a field no reader
+ * can resolve. `length` is the payload's size in MODEL units on `segmentsOf`'s terms — one
+ * per field atom plus any literal text between them.
+ */
+export function applyInsertTrackedElements(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  offset: number,
+  elements: (mint: () => string) => readonly OoxmlNode[],
+  length: number,
+  revision: RevisionAttributionInput,
+  options?: { readonly deferValidation?: boolean }
+): TreeOpResult {
   return applyTrackedInsertion(
     part,
     paragraph,
     offset,
-    { length: 1, nodes: (mint) => [element(mint)] },
+    { length, nodes: elements },
+    revision,
+    options
+  );
+}
+
+/**
+ * Insert one COMPLETE run — a note citation — at `offset` as a tracked insertion.
+ *
+ * The run arrives with its own `w:rPr` (the reference style) and keeps it: it is placed as
+ * a sibling run under the wrapper, never spliced into a run whose formatting would restyle
+ * it. Everything else — adjacent-deletion adoption, extending the author's own `w:ins`,
+ * relocation past struck words — is the same placement typed text follows, which is what
+ * lets a citation inserted over a selection resolve as ONE reviewable replacement.
+ */
+export function applyInsertTrackedRun(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  offset: number,
+  run: (mint: () => string) => OoxmlNode,
+  revision: RevisionAttributionInput,
+  options?: { readonly deferValidation?: boolean }
+): TreeOpResult {
+  return applyTrackedInsertion(
+    part,
+    paragraph,
+    offset,
+    { length: 1, nodes: null, run },
     revision,
     options
   );
@@ -307,10 +382,26 @@ function applyTrackedInsertion(
   // adjacent deletion's id — every replace-typing keystroke — would pay that walk for nothing.
   const insertionId = replaced?.id ?? nextRevisionId(part)();
 
+  // Counted lazily and ONCE: the paragraph-wide count only matters when a container holds
+  // part of the adopted deletion, and it cannot change during the rebuild.
+  let replacedWrapperTotal: number | null = null;
+  const wrappersWithReplacedId = (): number => {
+    if (replaced === null) return 0;
+    replacedWrapperTotal ??= paragraph.children.reduce(
+      (count, child) => count + deletionWrappersWithId(child, replaced.id),
+      0
+    );
+    return replacedWrapperTotal;
+  };
+
   const wrap = (properties: readonly OoxmlNode[]): OoxmlNode =>
-    build(mint(), 'revisionInsert', 'ins', revisionAttributes(insertionId, attribution), [
-      runOf(mint, [...properties, ...payload.nodes(mint)]),
-    ]);
+    build(
+      mint(),
+      'revisionInsert',
+      'ins',
+      revisionAttributes(insertionId, attribution),
+      payload.nodes ? [runOf(mint, [...properties, ...payload.nodes(mint)])] : [payload.run!(mint)]
+    );
 
   const rebuild = (nodes: readonly OoxmlNode[], stack: readonly OoxmlNode[]): OoxmlNode[] => {
     const out: OoxmlNode[] = [];
@@ -327,6 +418,14 @@ function applyTrackedInsertion(
       // made, a list item, a styled blank line — was rejected, so suggesting mode looked
       // dead from the moment the caret landed in a new paragraph.
       if (node.kind !== 'textValue' && node.kind === 'paragraphProperties') {
+        out.push(node);
+        continue;
+      }
+      // A content control's property containers are the same shape: `CT_SdtRun` requires
+      // `w:sdtPr`/`w:sdtEndPr` ahead of `w:sdtContent`, they measure nothing, and the
+      // boundary rule below would otherwise put an insertion aimed at the control's first
+      // character in FRONT of them.
+      if (node.kind === 'contentControlProperties' || node.kind === 'contentControlEndProperties') {
         out.push(node);
         continue;
       }
@@ -359,6 +458,8 @@ function applyTrackedInsertion(
       const container =
         node.kind !== 'textValue' &&
         (node.kind === 'hyperlink' ||
+          node.kind === 'contentControl' ||
+          node.kind === 'contentControlContent' ||
           node.kind === 'revisionInsert' ||
           node.kind === 'revisionMoveTo');
       // Same MOMENT as well as the same author — the deletion path already gates on this.
@@ -368,11 +469,44 @@ function applyTrackedInsertion(
         container &&
         insertionAuthor([node]) === revision.author &&
         sameEditingMoment(revisionDateOf(node), revision.date);
+      // THE REPLACEMENT FOLLOWS THE DELETION IT REPLACES — into a link or a control, and
+      // only when the WHOLE deletion lives there. Replacing a link's display text strikes
+      // runs INSIDE the `w:hyperlink`, and the insertion adopting that deletion aims at
+      // the link's boundary: placed beside the link, accepting the pair emptied the link,
+      // the sweep removed it, and the accepted text came out silently unlinked. Two rules
+      // narrow it:
+      //   - a revision wrapper is NOT followed into: the same deletion can sit inside
+      //     another author's `w:ins`, and appending there would put this author's words
+      //     inside their proposal, where rejecting theirs deletes these;
+      //   - a deletion that also has pieces OUTSIDE the container is not followed either —
+      //     a replacement for "plain words plus the link's text" stands in for the whole
+      //     range, most of which was never linked.
+      // Checked lazily — the subtree scans run only for an in-bounds container while an
+      // adopted deletion exists at all.
+      const followable =
+        container &&
+        (node.kind === 'hyperlink' ||
+          node.kind === 'contentControl' ||
+          node.kind === 'contentControlContent');
+      const wrappersInside =
+        followable && replaced !== null && offset >= start && offset <= end
+          ? deletionWrappersWithId(node, replaced.id)
+          : 0;
+      const holdsReplaced = wrappersInside > 0 && wrappersInside === wrappersWithReplacedId();
       if (
         container &&
-        ((offset > start && offset < end) || (ownInsertion && offset >= start && offset <= end))
+        ((offset > start && offset < end) ||
+          ((ownInsertion || holdsReplaced) && offset >= start && offset <= end))
       ) {
-        out.push({ ...node, children: rebuild(node.children, [...stack, node]) } as OoxmlNode);
+        const rebuilt = rebuild(node.children, [...stack, node]);
+        // The adopted deletion ends exactly where the container does, so the inner walk
+        // comes back unplaced. The replacement still belongs beside the struck words,
+        // INSIDE the container that holds them.
+        if (!placed && holdsReplaced && offset === cursor.offset) {
+          rebuilt.push(wrap([]));
+          placed = true;
+        }
+        out.push({ ...node, children: rebuilt } as OoxmlNode);
         continue;
       }
 
@@ -435,7 +569,7 @@ function applyTrackedInsertion(
         // Inside our OWN pending insertion: extend it. A second `w:ins` nested in the first
         // says two people proposed the same words, which is not what happened.
         if (own === revision.author) {
-          out.push(splitRunAndInsert(mint, offsets, node, offset - start, payload.nodes(mint)));
+          out.push(...splitRunAndInsert(mint, offsets, node, offset - start, payload));
           placed = true;
           cursor.offset = end + payload.length;
           continue;
@@ -510,18 +644,28 @@ function splitRunAndInsert(
   offsets: ParagraphOffsetIndex,
   run: OoxmlNode,
   local: number,
-  nodes: readonly OoxmlNode[]
-): OoxmlNode {
+  payload: TrackedInsertionPayload
+): OoxmlNode[] {
   const [head, tail] = splitRun(mint, offsets, run, local);
-  const content = [
-    ...childrenOf(head).filter((child) => !isRunProperties(child)),
-    ...nodes,
-    ...childrenOf(tail).filter((child) => !isRunProperties(child)),
+  if (payload.nodes) {
+    const content = [
+      ...childrenOf(head).filter((child) => !isRunProperties(child)),
+      ...payload.nodes(mint),
+      ...childrenOf(tail).filter((child) => !isRunProperties(child)),
+    ];
+    const properties = childrenOf(run)
+      .filter(isRunProperties)
+      .map((child) => copy(mint, child));
+    return [runOf(mint, [...properties, ...coalesced(mint, content)])];
+  }
+  // A whole-run payload keeps its OWN `w:rPr`, so it goes between the halves as a sibling
+  // run inside the same wrapper — spliced into the host run, the citation would take on
+  // whatever formatting the caret sits in and lose its reference style.
+  return [
+    ...(contentOf(head).length > 0 ? [head] : []),
+    payload.run!(mint),
+    ...(contentOf(tail).length > 0 ? [tail] : []),
   ];
-  const properties = childrenOf(run)
-    .filter(isRunProperties)
-    .map((child) => copy(mint, child));
-  return runOf(mint, [...properties, ...coalesced(mint, content)]);
 }
 
 /**
@@ -554,7 +698,7 @@ function coalesced(mint: () => string, nodes: readonly OoxmlNode[]): OoxmlNode[]
 }
 
 /** A node's children, or none for a text value — the union's only childless member. */
-function childrenOf(node: OoxmlNode): readonly OoxmlNode[] {
+export function childrenOf(node: OoxmlNode): readonly OoxmlNode[] {
   return node.kind === 'textValue' ? [] : node.children;
 }
 
@@ -648,15 +792,27 @@ export function applyDeleteTracked(
       if (
         node.kind !== 'textValue' &&
         (node.kind === 'hyperlink' ||
+          // A content control is a run container too (`w:sdtContent` takes `EG_PContent`,
+          // `w:del` included). Passing it through whole made a suggested deletion over its
+          // text a silent NO-OP: the transaction committed, nothing was struck, and the
+          // reviewer's replacement landed beside words that were never proposed away.
+          node.kind === 'contentControl' ||
+          node.kind === 'contentControlContent' ||
           node.kind === 'revisionInsert' ||
           node.kind === 'revisionDelete' ||
           node.kind === 'revisionMoveFrom' ||
           node.kind === 'revisionMoveTo')
       ) {
         const rebuilt = rebuild(node.children, [...stack, node]);
-        // A wrapper emptied by the removal of our own insertion goes with it; one that still
-        // holds content stays, because it is still saying something about that content.
-        if (rebuilt.length > 0) out.push({ ...node, children: rebuilt } as OoxmlNode);
+        // A wrapper emptied by the removal of our own insertion goes with it; one that
+        // still holds content stays, because it is still saying something about that
+        // content. A CONTROL is not a wrapper: it is document structure the user placed,
+        // so it keeps its (possibly emptied) `w:sdtContent` — dropping it left a `w:sdt`
+        // husk with properties and no content element, a shape Word never writes.
+        const structural = node.kind === 'contentControl' || node.kind === 'contentControlContent';
+        if (rebuilt.length > 0 || structural) {
+          out.push({ ...node, children: rebuilt } as OoxmlNode);
+        }
         continue;
       }
 
@@ -912,207 +1068,11 @@ function toDeleted(mint: () => string, run: OoxmlNode): OoxmlNode {
   return { ...run, id: mint(), children } as OoxmlNode;
 }
 
-/**
- * Stamp a paragraph's own MARK as inserted or deleted.
- *
- * `w:pPr/w:rPr/w:ins|w:del` (§17.13.5, `EG_ParaRPrTrackChanges`) is how Word records a split
- * or a merge: the mark is the pilcrow, and the pilcrow is what the edit added or removed.
- * There is no text to strike, which is why this is the only tracked edit with no run in it.
- *
- * SPLIT stamps `w:ins` on the FIRST paragraph — its mark is the one that did not exist
- * before. MERGE stamps `w:del` on the first as well: the mark being proposed for removal is
- * the one between the two paragraphs, which belongs to the first. Rejecting the insert and
- * accepting the delete both run the paragraph into the one after it, which is why
- * `resolveRevisions` treats them the same way.
- *
- * An existing mark of the SAME kind and author is joined rather than replaced, so a run of
- * Enters is one decision and one Accept.
- */
-export function applyParagraphMarkRevision(
-  part: OoxmlPart,
-  paragraph: OoxmlParagraphNode,
-  kind: 'ins' | 'del',
-  revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
-): TreeOpResult {
-  const mint = createNodeIdAllocator(part);
-  const effect: TreeOpEffect = {
-    dirty: [paragraph.id],
-    created: [],
-    deleted: [],
-    dependencyKeys: TEXT_DEPS,
-    impact: 'flow-structural',
-  };
-
-  const existing = paragraphMarkRevisionOf(paragraph, kind);
-  if (existing && existing.author === revision.author) {
-    // Already proposed by this author. A second Enter at the same mark is not a second
-    // decision, and stamping again would mint an id nothing else refers to.
-    return fromEdit({ ok: true, part }, effect);
-  }
-
-  const id = adjacentParagraphMarkId(part, paragraph, kind, revision) ?? nextRevisionId(part)();
-  const mark = build(mint(), 'generic', kind, revisionAttributes(id, revision), []);
-
-  const properties = childrenOf(paragraph).find((child) => child.kind === 'paragraphProperties');
-  const rest = childrenOf(paragraph).filter((child) => child.kind !== 'paragraphProperties');
-
-  // `w:rPr` sits near the END of `CT_PPr` — after the base properties (`w:jc`, `w:spacing`,
-  // `w:numPr`, …) and before `w:sectPr`/`w:pPrChange`, which are the only two that may
-  // follow it. Placing it first looked tidier and produced a `w:pPr` the tree invariants
-  // reject, which is the invariant reading the schema correctly.
-  const previousRPr = properties
-    ? childrenOf(properties).find((child) => isWmlNamed(child, 'rPr'))
-    : undefined;
-  // Only the SAME-KIND mark is replaced. `EG_ParaRPrTrackChanges` is `ins? del? moveFrom?
-  // moveTo?` — both an insert and a delete may sit here, and that pair is exactly what Word
-  // writes when B proposes removing a mark A proposed adding. Stripping every revision took
-  // A's out of the file, so rejecting B's deletion made A's break permanent and A's card
-  // vanished from every reviewer's pane.
-  const rPrRest = previousRPr
-    ? childrenOf(previousRPr).filter((child) => !isMarkRevisionOfKind(child, kind))
-    : [];
-  const siblingMark = rPrRest.filter(isMarkRevision);
-  const otherProperties = rPrRest.filter((child) => !isMarkRevision(child));
-  // `ins` before `del`, per the group's own order.
-  const marks = kind === 'ins' ? [mark, ...siblingMark] : [...siblingMark, mark];
-  const rPr = build(mint(), 'runProperties', 'rPr', [], [...marks, ...otherProperties]);
-  const pPrRest = properties
-    ? childrenOf(properties).filter((child) => !isWmlNamed(child, 'rPr'))
-    : [];
-  // `CT_PPr` puts `w:rPr` AFTER the base properties — only `w:sectPr` and `w:pPrChange` may
-  // follow it — so an existing `w:jc` stays in front. Placing `w:rPr` first looked tidier and
-  // produced a `w:pPr` the tree invariants reject, which is the invariant reading the schema
-  // correctly. A FRESH id, because the rebuilt container is a new node.
-  const trailing = pPrRest.filter(isTrailingParagraphProperty);
-  const leading = pPrRest.filter((child) => !isTrailingParagraphProperty(child));
-  const pPr = build(mint(), 'paragraphProperties', 'pPr', properties ? properties.attributes : [], [
-    ...leading,
-    rPr,
-    ...trailing,
-  ]);
-
-  return fromEdit(replaceChildren(part, paragraph.id, [pPr, ...rest], options), effect);
-}
-
-/**
- * Propose merging `paragraph` into the paragraph before it.
- *
- * The mark that would go is its PREDECESSOR's, and only the tree knows which paragraph that
- * is: addressing the merge by the first paragraph made a multi-paragraph delete stamp one
- * paragraph N times and leave the rest untouched, so accepting produced an empty paragraph
- * for every one selected.
- */
-export function applyProposeParagraphMerge(
-  part: OoxmlPart,
-  paragraph: OoxmlParagraphNode,
-  revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
-): TreeOpResult {
-  const parent = parentOf(part, paragraph.id);
-  if (!parent) return { ok: false, reason: 'tree-invariant' };
-  const siblings = parent.children;
-  const at = siblings.findIndex((child) => child.id === paragraph.id);
-  const previous = at > 0 ? siblings[at - 1] : undefined;
-  // A paragraph with nothing before it IN THE SAME CONTAINER has no mark to propose away.
-  // Marking across a container boundary wrote a `w:del` on the last paragraph of a `w:tc` —
-  // markup Word repairs, and which Accept then silently dropped, because there is no
-  // following paragraph to merge into.
-  if (!previous || previous.kind !== 'paragraph') {
-    return { ok: false, reason: 'not-adjacent-siblings' };
-  }
-  return applyParagraphMarkRevision(part, previous, 'del', revision, options);
-}
-
-/**
- * Whether this paragraph's mark is an insertion THIS author proposed.
- *
- * Proposing to delete a mark you proposed adding is just taking the proposal back, so the
- * caller performs a real join instead of writing a `w:del`. Re-labelling it left a paragraph
- * break that Reject then made permanent — the opposite of what the user asked for. The
- * module states this rule for text; the mark path did not have it.
- */
-export function retractsOwnParagraphMark(paragraph: OoxmlParagraphNode, author: string): boolean {
-  const own = paragraphMarkRevisionOf(paragraph, 'ins');
-  return own !== undefined && own.author === author;
-}
-
-/** The revision of one KIND on a paragraph's own mark, or undefined. */
-function paragraphMarkRevisionOf(
-  paragraph: OoxmlParagraphNode,
-  kind: 'ins' | 'del'
-): { readonly localName: string; readonly author: string } | undefined {
-  const properties = childrenOf(paragraph).find((child) => child.kind === 'paragraphProperties');
-  const rPr = properties
-    ? childrenOf(properties).find((child) => isWmlNamed(child, 'rPr'))
-    : undefined;
-  const mark = rPr ? childrenOf(rPr).find((child) => isMarkRevisionOfKind(child, kind)) : undefined;
-  if (!mark || mark.kind === 'textValue') return undefined;
-  const author = mark.attributes.find(
-    (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'author'
-  );
-  return { localName: mark.localName, author: author?.value ?? '' };
-}
-
-/** The only two `CT_PPr` children that may follow `w:rPr`. */
-function isTrailingParagraphProperty(node: OoxmlNode): boolean {
-  return isWmlNamed(node, 'sectPr') || isWmlNamed(node, 'pPrChange');
-}
-
-function isMarkRevisionOfKind(node: OoxmlNode, kind: 'ins' | 'del'): boolean {
-  return node.kind !== 'textValue' && isWmlNamed(node, kind);
-}
-
-function isMarkRevision(node: OoxmlNode): boolean {
-  return (
-    node.kind !== 'textValue' &&
-    node.namespaceUri === WML_NAMESPACE_URI &&
-    (node.localName === 'ins' || node.localName === 'del')
-  );
-}
-
-function isWmlNamed(node: OoxmlNode, localName: string): boolean {
+/** Shared with `tree-op-tracked-marks.ts`, which writes the paragraph-mark wrappers. */
+export function isWmlNamed(node: OoxmlNode, localName: string): boolean {
   return (
     node.kind !== 'textValue' &&
     node.namespaceUri === WML_NAMESPACE_URI &&
     node.localName === localName
   );
-}
-
-/**
- * The id of a same-kind, same-author, same-moment paragraph mark on a NEIGHBOURING paragraph.
- *
- * A run of Enters, or a run of Backspaces at a paragraph start, is one editing gesture — Word
- * groups it under one revision and offers one Accept. Without this each press minted its own,
- * and the pane filled with a card per keystroke.
- */
-function adjacentParagraphMarkId(
-  part: OoxmlPart,
-  paragraph: OoxmlParagraphNode,
-  kind: 'ins' | 'del',
-  revision: RevisionAttributionInput
-): string | null {
-  const parent = parentOf(part, paragraph.id);
-  if (!parent) return null;
-  const siblings = parent.children;
-  const at = siblings.findIndex((child) => child.id === paragraph.id);
-  for (const neighbour of [siblings[at - 1], siblings[at + 1]]) {
-    if (!neighbour || neighbour.kind !== 'paragraph') continue;
-    const properties = childrenOf(neighbour).find((child) => child.kind === 'paragraphProperties');
-    const rPr = properties
-      ? childrenOf(properties).find((child) => isWmlNamed(child, 'rPr'))
-      : undefined;
-    const mark = rPr ? childrenOf(rPr).find(isMarkRevision) : undefined;
-    if (!mark || mark.kind === 'textValue' || mark.localName !== kind) continue;
-    const read = (localName: string): string | undefined =>
-      mark.attributes.find(
-        (attribute) =>
-          attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName
-      )?.value;
-    if (read('author') !== revision.author) continue;
-    if (!sameEditingMoment(read('date'), revision.date)) continue;
-    const id = read('id');
-    if (id !== undefined) return id;
-  }
-  return null;
 }

--- a/packages/core/src/store/store/tree-op-types.ts
+++ b/packages/core/src/store/store/tree-op-types.ts
@@ -168,6 +168,23 @@ export interface RevisionAttributionInput {
 }
 
 /**
+ * Whether an attribution cannot serialize, spelled ONCE for every validator.
+ *
+ * `CT_TrackChange` makes `@w:author` required, so an absent or whitespace-only author is a
+ * proposal no reader can attribute or resolve. Callers whose op makes the attribution
+ * OPTIONAL pass `op.revision` and skip the check when it is undefined; callers that require
+ * one refuse undefined themselves. The guard used to be copy-pasted per op, and the copies
+ * drifted: table rows refused a whitespace-only author while text inserts accepted it.
+ */
+export function invalidRevisionAttribution(revision: RevisionAttributionInput): boolean {
+  return (
+    typeof revision.author !== 'string' ||
+    revision.author.trim().length === 0 ||
+    (revision.date !== undefined && typeof revision.date !== 'string')
+  );
+}
+
+/**
  * Every mutation the store accepts, as one JSON-safe discriminated union.
  *
  * The ONLY write path into a document. Each op addresses nodes by id plus UTF-16 offset, which is
@@ -347,6 +364,14 @@ export type TreeDocOp =
       readonly paragraphId: string;
       readonly offset: number;
       readonly field: 'PAGE' | 'NUMPAGES' | 'SECTIONPAGES' | 'PAGE_X_OF_Y';
+      /**
+       * Write this as a TRACKED insertion, on the same terms as `insertText`.
+       *
+       * The whole field — every `w:fldChar`, the instruction, the `PAGE_X_OF_Y` literal —
+       * goes into ONE `w:ins`, because the field is one proposal: rejecting it must take
+       * the complete atom back, never leave a `begin` standing without its `end`.
+       */
+      readonly revision?: RevisionAttributionInput;
     }
   | {
       /**
@@ -799,6 +824,13 @@ export type TreeDocOp =
       readonly noteKind: 'footnote' | 'endnote';
       readonly paragraphId: string;
       readonly offset: number;
+      /**
+       * Write the citing REFERENCE as a tracked insertion (`w:ins` around the reference
+       * run), on the same terms as `insertText`. The note body itself is not revision
+       * markup: rejecting the reference removes it, and the body cascade sweeps the
+       * orphaned note exactly as an untracked reference deletion does.
+       */
+      readonly revision?: RevisionAttributionInput;
     }
   | {
       /**

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -69,6 +69,7 @@ import {
   ACCEPTED_PARAGRAPH_PROPERTIES,
   ACCEPTED_RUN_PROPERTIES,
   TREE_DOC_OP_KINDS,
+  invalidRevisionAttribution,
   type OoxmlProperty,
   type TreeDocOp,
   type TreeOpRejection,
@@ -548,7 +549,7 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
       return null;
     }
     case 'proposeParagraphMerge': {
-      if (typeof op.revision?.author !== 'string' || op.revision.author.length === 0) {
+      if (op.revision === undefined || invalidRevisionAttribution(op.revision)) {
         return 'invalid-property-value';
       }
       return null;
@@ -556,7 +557,7 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
     case 'setParagraphMarkRevision': {
       if (op.kind !== 'ins' && op.kind !== 'del') return 'invalid-range';
       // `CT_TrackChange` makes `@w:author` required, so a mark with none is invalid XML.
-      if (typeof op.revision?.author !== 'string' || op.revision.author.length === 0) {
+      if (op.revision === undefined || invalidRevisionAttribution(op.revision)) {
         return 'invalid-property-value';
       }
       return null;
@@ -644,10 +645,7 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
       }
       // `CT_TrackChange` makes `@w:author` required, so a tracked variant with an empty one
       // would serialize a proposal no reader can attribute or resolve.
-      if (
-        op.revision !== undefined &&
-        (typeof op.revision.author !== 'string' || op.revision.author.length === 0)
-      ) {
+      if (op.revision !== undefined && invalidRevisionAttribution(op.revision)) {
         return 'invalid-property-value';
       }
       if (splitsSurrogate(paragraph, op.offset)) return 'splits-surrogate-pair';
@@ -665,6 +663,11 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
         op.field !== 'PAGE_X_OF_Y'
       ) {
         return 'invalidArgs';
+      }
+      // `CT_TrackChange` makes `@w:author` required, so a tracked variant with an empty one
+      // would serialize a proposal no reader can attribute or resolve.
+      if (op.revision !== undefined && invalidRevisionAttribution(op.revision)) {
+        return 'invalid-property-value';
       }
       return rejectContentEdit(part, paragraph, op.offset, op.offset);
     }


### PR DESCRIPTION
Suggesting mode wrote page fields, hyperlinks, and footnote or endnote citations as untracked edits, and an armed caret format dropped when an IME replacement covered the author's own pending text.

Each insert lane now writes a reviewable tracked change. A page field lands as one `w:ins` atom. The link lane strikes the selection and wraps a tracked copy of the display text. The note citation routes through the tracked-insert core, and rejecting it sweeps the note body. The armed-format anchor maps through the same landing rule the IME readback uses. Target-only link retargets and note conversion stay direct because OOXML has no revision form for them.

Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790267302&installation_model_id=422592&pr_number=478&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F478&signature=200af415a3691c3bc7e277fc3b8a2df651291ddaf08ac578a938ee46191c1e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->