### PR TITLE
fix: reconcile the leftover .layout-* stylesheet rules with the painter (fixes #239)

### DIFF
--- a/.changeset/reconcile-layout-stylesheet-rules.md
+++ b/.changeset/reconcile-layout-stylesheet-rules.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Remove leftover stylesheet rules for class names the painter no longer emits, and restore the text cursor over the page content area. Fixes #239

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"04befb1b-2999-4a82-8755-8e08db52c541","pid":52523,"procStart":"Tue Aug 25 08:57:11 2026","acquiredAt":1787650912974}
+{"sessionId":"5b51f561-276f-4068-bddd-bd6b072d092a","pid":62177,"procStart":"Tue Aug 25 20:44:47 2026","acquiredAt":1787692487853}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"5b51f561-276f-4068-bddd-bd6b072d092a","pid":62177,"procStart":"Tue Aug 25 20:44:47 2026","acquiredAt":1787692487853}
+{"sessionId":"04befb1b-2999-4a82-8755-8e08db52c541","pid":52523,"procStart":"Tue Aug 25 08:57:11 2026","acquiredAt":1787650912974}

--- a/openspec/specs/core-cell-selection-highlight/spec.md
+++ b/openspec/specs/core-cell-selection-highlight/spec.md
@@ -8,19 +8,19 @@ Defines framework-neutral contracts for behavior shared by supported adapters.
 
 ### Requirement: Cell-selection highlight available to both adapters
 
-`@docx-editor.dev/core` SHALL expose `applyCellSelectionHighlight(container, state, options?)` as a framework-neutral DOM projection helper. It SHALL paint the `.layout-table-cell-selected` class on painted cells whose PM positions fall inside an active `CellSelection`, scoped by `options.scope` (`body` | `header` | `footer`). Both the React and Vue adapters SHALL call it.
+`@docx-editor.dev/core` SHALL paint the cell-selection highlight itself, so every adapter shows it without adapter code. When a `CellSelection` is active, the paginated surface SHALL compute one rectangle per selected cell from the layout records (`cellSelectionRects` in `packages/core/src/layout/semantic-cell-selection.ts`) and SHALL draw each as a `.docx-cell-selection-rect` element in the selection overlay layer (`paintSelectionOverlay` in `packages/core/src/output/semantic-selection-overlay.ts`). The overlay layer SHALL be a sibling of the painted pages, never a child, so the page painter cannot sweep it and a keystroke cannot land in it. Adapters SHALL NOT paint their own cell-selection highlight.
 
 #### Scenario: Active cell selection is projected
 
-- **WHEN** a CellSelection is active and `applyCellSelectionHighlight` runs against the body scope
-- **THEN** exactly the cells whose mapped positions intersect the active `CellSelection` receive `.layout-table-cell-selected`
+- **WHEN** a `CellSelection` is active and the surface renders its overlay
+- **THEN** exactly the cells in the selection's rectangle are covered by `.docx-cell-selection-rect` elements at the painted cell geometry
 
-#### Scenario: Vue gains cell-selection highlight
+#### Scenario: Every adapter shows the highlight
 
-- **WHEN** a user selects multiple table cells in the Vue editor
-- **THEN** the selected cells are visually highlighted consistently in every supported adapter
+- **WHEN** a user selects multiple table cells in any supported adapter
+- **THEN** the selected cells are visually highlighted, because the highlight is painted by the core surface both adapters mount
 
 #### Scenario: Non-cell selection clears highlight
 
-- **WHEN** the selection is not a CellSelection
-- **THEN** no cell carries the selected class in the scoped container
+- **WHEN** the selection is not a `CellSelection`
+- **THEN** no `.docx-cell-selection-rect` element remains in the selection overlay

--- a/openspec/specs/core-cell-selection-highlight/spec.md
+++ b/openspec/specs/core-cell-selection-highlight/spec.md
@@ -8,7 +8,7 @@ Defines framework-neutral contracts for behavior shared by supported adapters.
 
 ### Requirement: Cell-selection highlight available to both adapters
 
-`@docx-editor.dev/core` SHALL paint the cell-selection highlight itself, so every adapter shows it without adapter code. When a `CellSelection` is active, the paginated surface SHALL compute one rectangle per selected cell from the layout records (`cellSelectionRects` in `packages/core/src/layout/semantic-cell-selection.ts`) and SHALL draw each as a `.docx-cell-selection-rect` element in the selection overlay layer (`paintSelectionOverlay` in `packages/core/src/output/semantic-selection-overlay.ts`). The overlay layer SHALL be a sibling of the painted pages, never a child, so the page painter cannot sweep it and a keystroke cannot land in it. Adapters SHALL NOT paint their own cell-selection highlight.
+`@docx-editor.dev/core` SHALL paint the cell-selection highlight itself, so every adapter shows it without adapter code. When a `CellSelection` is active, the paginated surface SHALL compute one rectangle per painted occurrence of each selected cell from the layout records (`cellSelectionRects` in `packages/core/src/layout/semantic-cell-selection.ts`) and SHALL draw each as a `.docx-cell-selection-rect` element in the selection overlay layer (`paintSelectionOverlay` in `packages/core/src/output/semantic-selection-overlay.ts`). The overlay layer SHALL be a sibling of the painted pages, never a child, so the page painter cannot sweep it and a keystroke cannot land in it. Adapters SHALL NOT paint their own cell-selection highlight.
 
 #### Scenario: Active cell selection is projected
 

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -2172,10 +2172,9 @@ function paintPage(
   // ever stealing a repeated header image from a sibling page.
   const options = { ...baseOptions, paintInstance: `p${page.index}` };
   const element = positioned(document, 'div', page.box, options.scale);
-  // Deliberately NOT `layout-page`: that class carries the legacy lane's whole-frame
-  // inversion, which would flip the paper itself. The sheet keeps the canvas colour its
-  // token names and only `.docx-page-content` below is inverted, so the theme and print
-  // rules name that class instead.
+  // The FRAME is never lightness-inverted — flipping it would flip the paper itself. The
+  // sheet keeps the canvas colour its token names and only `.docx-page-content` below is
+  // inverted, so the theme and print rules name that class instead.
   element.className = 'docx-page';
   // The measurer's own fallback stack, so an unstyled run — or one whose declared family
   // the platform cannot resolve — RENDERS in the same face it was MEASURED in. Left to

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -426,8 +426,7 @@
   * invert(1) hue-rotate(180deg) flips lightness but preserves hue for ALL
   * authored colors, so nothing is unreadable. Media is double-inverted back so
   * photos/logos render normally. */
-.docx-editor.dark .layout-page,
-/* The paginated lane paints its content into `.docx-page-content`; inverting the page
+/* The painter paints its content into `.docx-page-content`; inverting the page
    FRAME as well would flip the paper itself, so the sheet keeps its own token background
    and only the content it holds is lightness-inverted. */
 /* Highlights are COUNTER-INVERTED, like images.
@@ -436,8 +435,7 @@
    where it clamps to zero, landing on a dark olive that reads as a redaction bar. Word keeps
    a highlight its authored colour, so the run is inverted back — the same treatment media
    already gets, for the same reason. */
-.docx-editor.dark .docx-page-content [data-highlight],
-.docx-editor.dark .layout-page [data-highlight] {
+.docx-editor.dark .docx-page-content [data-highlight] {
   filter: invert(1) hue-rotate(180deg);
 }
 
@@ -457,17 +455,6 @@
     * light glow) with a 1px ring. Pre-invert dark → post-invert a subtle light
     * border, matching Word's framed dark page. */
 }
-/* The ring replaces the page frame's drop shadow, so it belongs to the FRAME. Applied to
-   the content box as well it outlined the text area — a box Word never draws — while the
-   real page edge lost its separation from the workspace. */
-.docx-editor.dark .layout-page {
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18) !important;
-}
-.docx-editor.dark .layout-page img,
-.docx-editor.dark .layout-page svg,
-.docx-editor.dark .layout-page canvas,
-.docx-editor.dark .layout-page video,
-.docx-editor.dark .layout-page [data-no-color-invert],
 .docx-editor.dark .docx-page-content img,
 .docx-editor.dark .docx-page-content svg,
 .docx-editor.dark .docx-page-content canvas,
@@ -490,13 +477,6 @@
      file was one more unnamed token. Stays #000 in both themes so the content inversion
      lands on near-white. */
     --doc-page-text: #000000;
-  }
-  .docx-editor.dark .layout-page,
-  .docx-editor.dark .layout-page img,
-  .docx-editor.dark .layout-page svg,
-  .docx-editor.dark .layout-page canvas,
-  .docx-editor.dark .layout-page video {
-    filter: none;
   }
 }
 
@@ -785,22 +765,6 @@ a.docx-hyperlink:focus-visible {
 .docx-ai-selection-preview {
   background-color: rgba(156, 39, 176, 0.2);
   border-bottom: 2px dashed rgba(156, 39, 176, 0.6);
-}
-
-/* Transient paragraph flash used by scrollToParaId({ highlight }). */
-.docx-editor .layout-paragraph.docx-paragraph-flash {
-  animation: docx-paragraph-flash-fade var(--docx-paragraph-flash-duration, 1200ms) ease-out both;
-}
-
-@keyframes docx-paragraph-flash-fade {
-  0%,
-  70% {
-    box-shadow: inset 0 0 0 9999px var(--docx-paragraph-flash-color, rgba(255, 235, 59, 0.55));
-  }
-
-  100% {
-    box-shadow: inset 0 0 0 9999px transparent;
-  }
 }
 
 /* ============================================================================
@@ -1195,6 +1159,9 @@ a.docx-hyperlink:focus-visible {
 
 .docx-drawing {
   pointer-events: auto;
+  /* An arrow over pictures, as Word shows. Inline drawings paint INSIDE the line, so
+   * without this they inherit the content box's I-beam. */
+  cursor: default;
 }
 
 .docx-drawing-layer {
@@ -2818,7 +2785,8 @@ a.docx-hyperlink:focus-visible {
 
 /* The text column shows an I-beam over its whole box, as Word does — over the gaps
  * between paragraphs and below the last one, not only over glyphs (where selectable
- * text already produces one). Drawings live in sibling layers, so they keep theirs. */
+ * text already produces one). Anchored drawings live in sibling layers; inline
+ * drawings opt back to the arrow on `.docx-drawing`. */
 .docx-paginated-surface .docx-page-content {
   cursor: text;
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -316,9 +316,8 @@
   * via these token overrides (as below), never via a `dark:` utility placed
   * directly on the `.docx-editor` node.
   * ====================================================================== */
-/* Also targets nested `.docx-editor` elements (e.g. the paged-editor root, Radix
-  * portals) so the base `.docx-editor` light tokens don't shadow these inside a
-  * dark tree. */
+/* Also targets nested `.docx-editor` elements (e.g. Radix portals) so the base
+  * `.docx-editor` light tokens don't shadow these inside a dark tree. */
 .docx-editor.dark,
 .docx-editor.dark .docx-editor {
   /* Palette sampled from Microsoft Word Online dark mode (chrome + canvas).
@@ -1294,10 +1293,6 @@ a.docx-hyperlink:focus-visible {
   cursor: pointer;
 }
 
-.docx-editor .paged-editor--readonly .docx-table-furniture {
-  display: none !important;
-}
-
 /* Table chrome — contextual border/fill controls (Task 9). */
 .docx-table-chrome {
   display: inline-flex;
@@ -1480,24 +1475,6 @@ a.docx-hyperlink:focus-visible {
   * LAYOUT TABLE COLUMN RESIZE
   * ============================================================================ */
 
-/* ============================================================================
-  * TABLE CELL SELECTION (visible layout table cells)
-  * ============================================================================ */
-
-.docx-editor .layout-table-cell-selected {
-  position: relative;
-  outline: 2px solid var(--doc-selection);
-  outline-offset: -2px;
-}
-
-.docx-editor .layout-table-cell-selected::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-color: rgba(66, 133, 244, 0.15);
-  pointer-events: none;
-}
-
 .docx-editor .layout-table-resize-handle {
   background-color: transparent;
   transition: background-color 0.15s;
@@ -1532,8 +1509,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* Row resize handles */
-.docx-editor .layout-table-row-resize-handle,
-.docx-editor .layout-table-edge-handle-bottom {
+.docx-editor .layout-table-row-resize-handle {
   background-color: transparent;
   transition: background-color 0.15s;
 }
@@ -1552,9 +1528,7 @@ a.docx-hyperlink:focus-visible {
 }
 
 .docx-editor .layout-table-row-resize-handle:hover,
-.docx-editor .layout-table-row-resize-handle.dragging,
-.docx-editor .layout-table-edge-handle-bottom:hover,
-.docx-editor .layout-table-edge-handle-bottom.dragging {
+.docx-editor .layout-table-row-resize-handle.dragging {
   background-color: transparent;
 }
 
@@ -1581,30 +1555,6 @@ a.docx-hyperlink:focus-visible {
 .docx-editor .layout-table-edge-handle-right:hover::after,
 .docx-editor .layout-table-edge-handle-right.dragging::after {
   opacity: 1;
-}
-
-/* ============================================================================
-  * READONLY MODE — suppress interactive editing cues
-  * ============================================================================ */
-
-/* Hide table resize handles */
-.docx-editor .paged-editor--readonly .layout-table-resize-handle,
-.docx-editor .paged-editor--readonly .layout-table-row-resize-handle,
-.docx-editor .paged-editor--readonly .layout-table-edge-handle-bottom,
-.docx-editor .paged-editor--readonly .layout-table-edge-handle-right {
-  display: none !important;
-}
-
-/* Remove header/footer hover effects and edit hints */
-.docx-editor .paged-editor--readonly .layout-page-header,
-.docx-editor .paged-editor--readonly .layout-page-footer {
-  cursor: default;
-  pointer-events: none;
-}
-
-/* Remove text cursor from page content */
-.docx-editor .paged-editor--readonly .layout-page-content {
-  cursor: default;
 }
 
 /* Outline heading hover */
@@ -1657,158 +1607,6 @@ a.docx-hyperlink:focus-visible {
   outline-offset: 2px;
 }
 
-/* ============================================================================
-  * HEADER / FOOTER EDITING
-  *
-  * These styles are needed when editing headers/footers inline (Google Docs style).
-  * They must be in dist/styles.css since the runtime CSS import in
-  * OffscreenEditorHost.tsx is stripped by tsup (injectStyle: false).
-  * ============================================================================ */
-
-/* Page content area — show text cursor when hovering over editable content */
-.docx-editor .layout-page-content {
-  cursor: text;
-}
-
-/* Block-level Structured Document Tag (content control) boundary.
-    The painter lays body fragments as flat absolutely-positioned siblings, so
-    the boundary is a single overlay box per control (see renderSdtBoundaryBoxes)
-    spanning its fragments at content width — drawn as one rounded rectangle
-    like Word, with a corner label chip revealed on hover/focus. The box is
-    non-interactive so it never steals clicks from the editable content under it.
-    Nested controls each draw their own (slightly inset) box. */
-.docx-editor .layout-block-sdt-box {
-  pointer-events: none;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  box-sizing: border-box;
-  transition: border-color 0.1s ease;
-  z-index: 1;
-}
-.docx-editor .layout-block-sdt-box.is-active,
-.docx-editor .layout-block-sdt-box.is-focused {
-  border-color: rgba(25, 103, 210, 0.5);
-}
-/* Corner label chip — hidden until its control is hovered/active. */
-.docx-editor .layout-block-sdt-label {
-  position: absolute;
-  left: -1px;
-  bottom: 100%;
-  max-width: 160px;
-  height: 16px;
-  padding: 0 6px;
-  font-size: 10px;
-  line-height: 16px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: #fff;
-  background-color: rgba(25, 103, 210, 0.92);
-  border-radius: 4px 4px 0 0;
-  display: none;
-}
-.docx-editor .layout-block-sdt-box.is-active .layout-block-sdt-label,
-.docx-editor .layout-block-sdt-box.is-focused .layout-block-sdt-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-}
-
-/* Header/footer CONTENT is non-interactive in normal mode: a single click on a
-    header/footer is already a no-op (Word parity), and — crucially — a page- or
-    margin-anchored shape (e.g. a full-page letterhead in a header) overflows the
-    band and would otherwise sit on top of the body and swallow clicks meant for
-    the document text (#856). The band element itself keeps pointer events so it
-    stays the double-click-to-edit target; only its content is passed through.
-    Kept here (not only in prosemirror/editor.css) so the React adapter's
-    styles.css build — which compiles this file — ships the rule. */
-.docx-editor .layout-page-header > *,
-.docx-editor .layout-page-footer > * {
-  pointer-events: none;
-}
-
-/* While editing a region, its content must be hittable again so clicks map to
-    header/footer caret positions. */
-.docx-editor .paged-editor--editing-header .layout-page-header > *,
-.docx-editor .paged-editor--editing-footer .layout-page-footer > * {
-  pointer-events: auto;
-}
-
-/* Header/footer areas — double-click hint */
-.docx-editor .layout-page-header,
-.docx-editor .layout-page-footer {
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-}
-.docx-editor .layout-page-header:hover,
-.docx-editor .layout-page-footer:hover {
-  background-color: rgba(37, 99, 235, 0.06);
-}
-/* Show "Double-click to edit" hint on hover when area is empty */
-.docx-editor .layout-page-header:empty:hover::after {
-  content: 'Double-click to add header';
-  display: block;
-  text-align: center;
-  color: var(--doc-text-subtle);
-  font-size: 11px;
-  padding: 4px 0;
-}
-.docx-editor .layout-page-footer:empty:hover::after {
-  content: 'Double-click to add footer';
-  display: block;
-  text-align: center;
-  color: var(--doc-text-subtle);
-  font-size: 11px;
-  padding: 4px 0;
-}
-
-/*
-  * Phase 5 of HF editing unification (openspec/changes/unify-hf-editing/):
-  * the inline overlay no longer mounts a PM EditorView, so the entire
-  * `.hf-editor-pm` rule block (font-strut zeroing, table-layout overrides,
-  * `top: 0.4em` shim, line-height resets) is gone. Painter + persistent
-  * hidden PM are the only HF rendering paths now.
-  */
-
-/* Dim body content when editing header/footer */
-.docx-editor .paged-editor--hf-editing .layout-page-content {
-  opacity: 0.4;
-  pointer-events: none;
-  transition: opacity 0.15s ease;
-}
-
-/* While editing one HF region, the sibling region (and the non-edited area)
-    shows a normal arrow, not the double-click "pointer" hint. The active
-    region's `cursor: text` below wins via later source order. */
-.docx-editor .paged-editor--hf-editing .layout-page-header,
-.docx-editor .paged-editor--hf-editing .layout-page-footer {
-  cursor: default;
-}
-
-/* Dotted border on active header area; text caret since it's being edited */
-.docx-editor .paged-editor--editing-header .layout-page-header {
-  border-bottom: 1px dotted var(--doc-primary);
-  cursor: text;
-}
-
-/* Dotted border on active footer area; text caret since it's being edited */
-.docx-editor .paged-editor--editing-footer .layout-page-footer {
-  border-top: 1px dotted var(--doc-primary);
-  cursor: text;
-}
-
-/*
-  * HF editing unification phase 2 (openspec/changes/unify-hf-editing/):
-  * removed; the painter is now the sole visible HF renderer in both modes
-  * and the inline overlay's PM container moves off-screen instead.
-  */
-
-/* Remove hover effect on header/footer when in editing mode */
-.docx-editor .paged-editor--hf-editing .layout-page-header:hover,
-.docx-editor .paged-editor--hf-editing .layout-page-footer:hover {
-  background-color: transparent;
-}
-
 /* Body caret blink for the Vue adapter's painted caret (useSelectionSync sets
     `animation: docx-editor-caret-blink ...` inline). React drives its caret's blink from a
     JS timer instead; both land on the same 530ms half-period, which is the
@@ -1859,25 +1657,6 @@ a.docx-hyperlink:focus-visible {
   background: var(--doc-bg-hover);
 }
 
-/* =============================================================================
-  * ProseMirror decoration forwarding overlay
-  *
-  * Generic surface for decorations published via PM plugins' `props.decorations`
-  * (the painter doesn't render them itself — see `DecorationLayer.tsx`).
-  * Children are absolutely-positioned inside this container; pointer-events
-  * are off by default so editing isn't blocked. Plugins that need hover/click
-  * on a decoration (e.g. cursor name labels) opt in via inline styles.
-  *
-  * z-index: 11 — one above SelectionOverlay (10) so cursor name labels render
-  * above the local caret.
-  * ============================================================================= */
-.docx-editor .paged-editor__decoration-overlay {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 11;
-}
-
 /* Default styles for y-prosemirror remote cursor decorations. Consumers can
   * override by providing their own `.ProseMirror-yjs-cursor` rules.
   *
@@ -1908,152 +1687,10 @@ a.docx-hyperlink:focus-visible {
   pointer-events: none;
 }
 
-/* Tracked-revision styles live in core (prosemirror/editor.css), shared
-    by React + Vue adapters. Do not duplicate here. */
-
-/* Interactive trigger for typed controls (checkbox/dropdown/date). The box is
-    pointer-events:none; the trigger re-enables them so it is clickable. Sits at
-    the top-right corner of the control box. */
-.docx-editor .layout-sdt-widget {
-  position: absolute;
-  top: 1px;
-  right: 1px;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 3px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  line-height: 1;
-  color: var(--doc-primary);
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 103, 210, 0.5);
-  border-radius: 3px;
-  cursor: pointer;
-  pointer-events: auto;
-  opacity: 0.55;
-  transition: opacity 0.1s ease;
-}
-.docx-editor .layout-block-sdt-box.is-active .layout-sdt-widget,
-.docx-editor .layout-block-sdt-box.is-focused .layout-sdt-widget,
-.docx-editor .layout-sdt-widget:focus {
-  opacity: 1;
-}
-.docx-editor .layout-sdt-widget:hover {
-  background: var(--doc-primary-light);
-}
-
-.docx-editor .layout-inline-sdt-widget {
-  cursor: pointer;
-  pointer-events: auto;
-  border-radius: 2px;
-  outline-offset: 1px;
-  user-select: none;
-}
-.docx-editor .layout-inline-sdt-widget:hover,
-.docx-editor .layout-inline-sdt-widget:focus {
-  background: var(--doc-primary-light);
-  outline: 1px solid rgba(25, 103, 210, 0.55);
-}
-
-/* Popup for dropdown/date content-control widgets (rendered by the adapter). */
-.docx-editor .layout-sdt-widget-popup {
-  min-width: 120px;
-  max-height: 240px;
-  overflow-y: auto;
-  background: var(--doc-surface);
-  border: 1px solid var(--doc-border-light);
-  border-radius: 6px;
-  box-shadow: 0 2px 10px var(--doc-shadow);
-  padding: 4px;
-  font-size: 13px;
-}
-.docx-editor .layout-sdt-widget-option {
-  display: block;
-  width: 100%;
-  text-align: left;
-  padding: 6px 10px;
-  border: 0;
-  background: transparent;
-  border-radius: 4px;
-  cursor: pointer;
-  color: var(--doc-text);
-}
-.docx-editor .layout-sdt-widget-option:hover {
-  background: var(--doc-primary-light);
-}
-.docx-editor .layout-sdt-widget-empty {
-  padding: 6px 10px;
-  color: var(--doc-text-muted);
-}
-.docx-editor .layout-sdt-widget-date {
-  font: inherit;
-  padding: 4px 6px;
-  border: 1px solid var(--doc-border-light);
-  border-radius: 4px;
-}
-.docx-editor .layout-sdt-widget-option.is-selected {
-  font-weight: 600;
-  background: var(--doc-bg-hover);
-}
-
-/* Repeating-section item add/remove affordances (bottom-right of the item box). */
-.docx-editor .layout-sdt-repeat-controls {
-  position: absolute;
-  bottom: 1px;
-  right: 1px;
-  display: flex;
-  gap: 2px;
-  opacity: 0.55;
-  pointer-events: none;
-}
-.docx-editor .layout-block-sdt-box.is-active .layout-sdt-repeat-controls,
-.docx-editor .layout-block-sdt-box.is-focused .layout-sdt-repeat-controls {
-  opacity: 1;
-}
-.docx-editor .layout-sdt-repeat-btn {
-  min-width: 16px;
-  height: 16px;
-  padding: 0 3px;
-  font-size: 11px;
-  line-height: 1;
-  color: var(--doc-primary);
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 103, 210, 0.5);
-  border-radius: 3px;
-  cursor: pointer;
-  pointer-events: auto;
-}
-.docx-editor .layout-sdt-repeat-btn:hover {
-  background: var(--doc-primary-light);
-}
-
 /* ============================================================================
   * Revision indicators shared by both adapters.
   * Visible painter cues live here so React and Vue stay in lockstep.
   * ========================================================================== */
-
-.docx-editor .layout-revision-bars {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-
-.docx-editor .layout-revision-change-bar {
-  position: absolute;
-  left: -10px;
-  width: 2px;
-  pointer-events: none;
-}
-
-.docx-editor .layout-revision-change-bar.layout-revision-ins {
-  background-color: var(--doc-revision-insertion);
-}
-
-.docx-editor .layout-revision-change-bar.layout-revision-del {
-  background-color: var(--doc-revision-deletion);
-}
 
 .docx-table-row--revision::before {
   content: '';
@@ -2133,27 +1770,6 @@ a.docx-hyperlink:focus-visible {
   text-decoration-color: var(--doc-revision-format);
 }
 
-.docx-editor .layout-revision-pmark {
-  position: relative;
-}
-
-.docx-editor .layout-revision-pmark-glyph {
-  display: inline;
-  margin-left: 2px;
-  font-weight: normal;
-  opacity: 0.75;
-  pointer-events: none;
-}
-
-.docx-editor .layout-revision-pmark-glyph.layout-revision-ins {
-  color: var(--doc-revision-insertion);
-}
-
-.docx-editor .layout-revision-pmark-glyph.layout-revision-del {
-  color: var(--doc-revision-deletion);
-  text-decoration: line-through;
-}
-
 .docx-editor-revision-cell.docx-editor-revision-ins {
   box-shadow: inset 0 3px 0 var(--doc-revision-insertion);
   background-color: var(--doc-revision-insertion-tint);
@@ -2169,29 +1785,6 @@ a.docx-hyperlink:focus-visible {
 .docx-editor-revision-cell.docx-editor-revision-merge {
   box-shadow: inset 0 3px 0 var(--doc-text-muted);
   background-color: color-mix(in srgb, var(--doc-text-muted) 8%, transparent);
-}
-
-.docx-editor .layout-run-image.docx-insertion,
-.docx-editor .layout-run-image-wrapper.docx-insertion > .layout-run-image,
-.docx-editor .layout-block-image.docx-insertion,
-.docx-editor .layout-image.docx-insertion,
-.docx-editor .layout-page-floating-image.docx-insertion > img,
-.docx-editor .layout-cell-floating-image.docx-insertion > img,
-.docx-editor .layout-header-footer-floating-image.docx-insertion > img {
-  outline: 2px solid var(--doc-revision-insertion);
-  outline-offset: 1px;
-}
-
-.docx-editor .layout-run-image.docx-deletion,
-.docx-editor .layout-run-image-wrapper.docx-deletion > .layout-run-image,
-.docx-editor .layout-block-image.docx-deletion,
-.docx-editor .layout-image.docx-deletion,
-.docx-editor .layout-page-floating-image.docx-deletion > img,
-.docx-editor .layout-cell-floating-image.docx-deletion > img,
-.docx-editor .layout-header-footer-floating-image.docx-deletion > img {
-  outline: 2px solid var(--doc-revision-deletion);
-  outline-offset: 1px;
-  opacity: 0.6;
 }
 
 /* ========================================================================
@@ -3221,6 +2814,13 @@ a.docx-hyperlink:focus-visible {
    per-line metrics instead of the uniform band a hand-drawn rectangle produces. */
 .docx-paginated-surface .docx-pages {
   outline: none;
+}
+
+/* The text column shows an I-beam over its whole box, as Word does — over the gaps
+ * between paragraphs and below the last one, not only over glyphs (where selectable
+ * text already produces one). Drawings live in sibling layers, so they keep theirs. */
+.docx-paginated-surface .docx-page-content {
+  cursor: text;
 }
 
 /* Inactive furniture: Word-like affordance that the band is enterable. Active band and

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -1162,6 +1162,11 @@ a.docx-hyperlink:focus-visible {
   cursor: default;
 }
 
+/* Text boxes carry rendered text, so they keep the I-beam the arrow above would cover. */
+.docx-drawing-textbox {
+  cursor: text;
+}
+
 .docx-drawing-layer {
   position: absolute;
   inset: 0;

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -449,11 +449,9 @@
 .docx-editor.dark .docx-page-content {
   /* contrast(0.92) softens the pure black/white extremes a plain invert
     * produces, landing on Word's gentler off-white text / dark-grey fills
-    * rather than #fff on #000. */
+    * rather than #fff on #000. The page FRAME sits outside this filter, so
+    * its own shadow needs no counter-treatment. */
   filter: invert(1) hue-rotate(180deg) contrast(0.92);
-  /* Replace the painter's drop shadow (the filter would turn it into a weird
-    * light glow) with a 1px ring. Pre-invert dark → post-invert a subtle light
-    * border, matching Word's framed dark page. */
 }
 .docx-editor.dark .docx-page-content img,
 .docx-editor.dark .docx-page-content svg,

--- a/scripts/core-css-assertions.mjs
+++ b/scripts/core-css-assertions.mjs
@@ -29,8 +29,8 @@ const SCOPE = '.docx-editor';
  * `.ProseMirror-yjs-cursor` is y-prosemirror's, so a host running its own
  * ProseMirror editor got our rules on its elements.
  *
- * `.layout-` and `.paged-editor` we do mint, but the names are generic enough
- * that a host could mint them too (`.layout-page-header`, `.layout-page-content`).
+ * `.layout-` we do mint, but the names are generic enough that a host could
+ * mint them too (`.layout-page`, `.layout-paragraph`).
  * The old rationale — that they match painted document elements rather than
  * chrome, so the scope class "would be wrong" — does not hold: painted elements
  * are always inside the viewport, which always carries the scope class. They are

--- a/scripts/core-css-assertions.mjs
+++ b/scripts/core-css-assertions.mjs
@@ -30,7 +30,7 @@ const SCOPE = '.docx-editor';
  * ProseMirror editor got our rules on its elements.
  *
  * `.layout-` we do mint, but the names are generic enough that a host could
- * mint them too (`.layout-page`, `.layout-paragraph`).
+ * mint them too (`.layout-paragraph`, `.layout-run-text`).
  * The old rationale — that they match painted document elements rather than
  * chrome, so the scope class "would be wrong" — does not hold: painted elements
  * are always inside the viewport, which always carries the scope class. They are


### PR DESCRIPTION
Classifies every `.layout-*` / `.paged-editor*` rule in `packages/core/src/styles/editor.css` against what the painter emits, per #239:

- **Deleted**: every rule whose class nothing emits — the SDT widget cluster, the legacy header/footer editing block, the readonly-mode block, the change-bar and pilcrow rules, the image insertion/deletion outlines, the cell-selection highlight, `.layout-table-edge-handle-bottom`, `.paged-editor__decoration-overlay`, the `.layout-page` dark/print rules (the painter deliberately emits `docx-page`; every deleted declaration has a live `.docx-page-content` twin), and the unemitted `docx-paragraph-flash` rule.
- **Repointed**: the content-area text cursor moves to `.docx-paginated-surface .docx-page-content`. Drawings opt back to the arrow; text boxes keep the I-beam.
- **Filed**: tracked insertions and deletions of drawings paint no visual marking (#479, the one real regression), the stale `header-footer-editing` spec (#480), and the dead `DocxEditorShell` selectors (#481).

`openspec/specs/core-cell-selection-highlight/spec.md` now describes the core-painted overlay (`paintSelectionOverlay` → `.docx-cell-selection-rect`); `applyCellSelectionHighlight` no longer exists.

Verified in a browser against fixtures exercising tables, content controls, floating images, and tracked changes: viewport screenshots with the old and new stylesheet are byte-identical (the only differing captures show the caret mid-blink), in light and dark mode. Live chrome still styles: table resize handles, change bars, cell-selection rectangles, header/footer affordances. View mode paints no handles (gated in `surface-table-interaction.ts`).

Gates: `typecheck`, `lint`, `test` (8920 pass), `check:parity`, `api:check`, `i18n:validate`, `openspec validate --specs --strict`, and the core CSS anchor guard all pass.

Fixes #239

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790286172&installation_model_id=422592&pr_number=482&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F482&signature=16bd8e9fb2f048c33217f87361564408060ad61d6f4226941a3173ef1bdb36cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->