### PR TITLE
fix(react): drop the DocxEditorShell review highlights that styled nothing (fixes #481)

### DIFF
--- a/.changeset/shell-drops-dead-review-highlights.md
+++ b/.changeset/shell-drops-dead-review-highlights.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Remove the `DocxEditorShell` review highlight styles, which targeted class names the editor does not render, so they never painted in any release. To mark the active comment or tracked change, use `Editor.setActiveReviewItem`. Fixes #481

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -782,7 +782,7 @@ export interface DocxEditorRulerProps {
     unit?: 'inch' | 'cm';
 }
 
-// @public @deprecated (undocumented)
+// @public @deprecated
 export function DocxEditorShell(input: {
     className: string | undefined;
     containerRef: React.Ref<HTMLDivElement>;
@@ -791,7 +791,7 @@ export function DocxEditorShell(input: {
     editorContainerStyle: CSSProperties;
     editorContentRef: React.Ref<HTMLDivElement>;
     editorScrollLeft: number;
-    expandedSidebarItem: string | null;
+    expandedSidebarItem?: string | null;
     fileInputs: ReactNode;
     horizontalRulerProps: HorizontalRulerProps_2;
     i18n: React.ComponentProps<typeof LocaleProvider>['i18n'];
@@ -815,7 +815,7 @@ export function DocxEditorShell(input: {
     sidebarOpen: boolean;
     toolbar: ReactNode;
     toolbarHeight: number;
-    trackedChanges: readonly TrackedChangeSummary[];
+    trackedChanges?: readonly TrackedChangeSummary[];
     verticalRulerProps: VerticalRulerProps$1;
 }): react.JSX.Element;
 

--- a/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
+++ b/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
@@ -63,11 +63,15 @@ interface OutlineProps {
  * + toggle button, plus slots for the toolbar, paged-area body,
  * overlays, dialogs, and hidden file inputs.
  *
- * The expanded-sidebar-item highlight styles are computed here from
- * `expandedSidebarItem` + `trackedChanges` because they need to live
- * inside the editor-content `<div>` for proper scoping.
+ * This shell renders NO review highlight of its own. Marking the active
+ * comment or tracked change belongs to the engine, which paints
+ * `docx-comment-band--active` and `docx-revision-band--active` for the item
+ * the caret is in, or for the one an `Editor.setActiveReviewItem` pin names
+ * instead. One source for which item is active, so a host sidebar and the
+ * painted document cannot disagree about it.
+ *
+ * @deprecated Use `<DocxEditor>` from the composition layer instead.
  */
-/** @deprecated Use `<DocxEditor>` from the composition layer instead. */
 export function DocxEditorShell({
   i18n,
   isDark,
@@ -87,8 +91,6 @@ export function DocxEditorShell({
   minLayoutWidth,
   toolbarHeight,
   editorScrollLeft,
-  expandedSidebarItem,
-  trackedChanges,
   onScrollContainerMouseDown,
   onEditorBgMouseDown,
   onEditorContextMenu,
@@ -121,8 +123,18 @@ export function DocxEditorShell({
   minLayoutWidth: number;
   toolbarHeight: number;
   editorScrollLeft: number;
-  expandedSidebarItem: string | null;
-  trackedChanges: readonly TrackedChangeSummary[];
+  /**
+   * @deprecated Ignored. Mark the active comment or tracked change with
+   * `Editor.setActiveReviewItem`, which paints the band the engine draws.
+   */
+  expandedSidebarItem?: string | null;
+  /**
+   * @deprecated Ignored. Read tracked changes with `Editor.getTrackedChanges`;
+   * activation goes through `Editor.setActiveReviewItem`. Its keys are
+   * `` `${kind}-${id}` ``, so a tracked change is `revision-<id>`, not the
+   * `tc-<id>` this shell once took.
+   */
+  trackedChanges?: readonly TrackedChangeSummary[];
   onScrollContainerMouseDown: (e: React.MouseEvent) => void;
   onEditorBgMouseDown: (e: React.MouseEvent) => void;
   onEditorContextMenu: (e: React.MouseEvent) => void;
@@ -237,24 +249,6 @@ export function DocxEditorShell({
                             <VerticalRuler {...verticalRulerProps} />
                           </div>
                         )}
-                        {/* Brightened highlight for the focused/expanded sidebar item. */}
-                        {expandedSidebarItem && expandedSidebarItem.startsWith('comment-') && (
-                          <style>{`.paged-editor__pages [data-comment-id="${expandedSidebarItem.replace('comment-', '')}"] { background-color: var(--doc-comment-active-bg) !important; border-bottom-width: 2px !important; border-bottom-style: solid !important; border-bottom-color: var(--doc-comment-active-border) !important; }`}</style>
-                        )}
-                        {expandedSidebarItem?.startsWith('tc-') &&
-                          (() => {
-                            const revId = expandedSidebarItem.split('-')[1];
-                            // The contract addresses a tracked change by its single id;
-                            // the same id styles the insertion and deletion halves.
-                            const tc = trackedChanges.find((c) => String(c.id) === revId);
-                            const activeId = tc?.id ?? revId;
-                            return (
-                              <style>{`
-                            .paged-editor__pages .docx-insertion[data-revision-id="${activeId}"] { background-color: rgba(52, 168, 83, 0.2) !important; border-bottom: 2px solid #2e7d32 !important; }
-                            .paged-editor__pages .docx-deletion[data-revision-id="${activeId}"] { background-color: rgba(211, 47, 47, 0.2) !important; text-decoration-thickness: 2px !important; }
-                          `}</style>
-                            );
-                          })()}
                         {pagedArea}
                       </div>
                     </div>


### PR DESCRIPTION
`DocxEditorShell` injected two `<style>` blocks: one to brighten the expanded comment, one to mark the active tracked change. Every selector needed a `.paged-editor__pages` ancestor, and the revision rules also needed `.docx-insertion` / `.docx-deletion`. The editor renders none of those, so neither highlight ever painted. The emitter for that ancestor class went away before the 2.x line, so no released version showed them.

## Delete rather than repoint

The engine already owns this. It paints `docx-comment-band--active` and `docx-revision-band--active` for the item the caret is in, or for the one an `Editor.setActiveReviewItem` pin names instead. Repointing would have rebuilt a second, competing answer to "which review item is active", which a host sidebar and the painted document could then disagree about.

Deleting also closes a CSS-injection sink. The comment rule interpolated an id straight into a live stylesheet:

```
.paged-editor__pages [data-comment-id="${…}"] { … }
```

Comment ids come from `comments.xml`, which the sender controls, so an id carrying `"` or `}` could have injected arbitrary rules. A repoint would have had to carry that interpolation forward and add escaping. The removal also drops three hardcoded colors that bypassed the `--doc-*` tokens.

## Props

`expandedSidebarItem` and `trackedChanges` fed only those rules. They stay in the signature, now optional and documented as ignored, rather than being removed: the published packages are one fixed version group, so deleting two members of a `@public` signature would force a major across all eight to tidy a component that is already `@deprecated` and has no in-repo consumer. Required to optional is a widening, so this is a `patch`. The `trackedChanges` note records that engine activation keys are `revision-<id>`, not the `tc-<id>` this shell took, so a host reusing its old string does not get a silently inert key.

## Not fixed here

Two pre-existing geometry constants in the same component were wrong and were filed as #486, which #488 has since fixed on `main`; the rebase drops the annotations this PR had left at those call sites. The `paddingTop: 48` above the first page is left documented in place rather than filed, because `pagedArea` is caller-supplied and nothing can derive it. Filed separately: #485 (`ErrorBoundary`'s global `@keyframes slideIn`), fixed by #489.

## Verification

No test covered the removed styles, and the component has no in-repo consumer, so this is verified by grep and gates rather than by a new test: `paged-editor__pages`, `docx-insertion`, `docx-deletion`, and `data-comment-id` now appear nowhere in `packages/*/src`. `typecheck`, `lint`, `test` (8920 pass), `check:parity`, `api:check` against a fresh build, and `i18n:validate` all pass, with a clean tree after each.

Fixes #481

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790317224&installation_model_id=422592&pr_number=487&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F487&signature=f4361935aafd53b3ece2be99b49e57f80973735633330829e06633a51a33d9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
