### PR TITLE
fix: derive the outline toggle offset from the ruler height and gate insets on the vertical ruler

### DIFF
--- a/.changeset/outline-toggle-ruler-geometry.md
+++ b/.changeset/outline-toggle-ruler-geometry.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+Align the `DocxEditorShell` outline toggle with the page top when the ruler is shown, and stop insetting the outline past a vertical ruler that read-only mode hides. Fixes #486

--- a/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
+++ b/packages/react/src/components/DocxEditor/DocxEditorShell.tsx
@@ -4,7 +4,7 @@ import type { RulerPageSetup, RulerTabStop } from '../ui/HorizontalRuler';
 import { LocaleProvider } from '../../i18n';
 import { cn } from '../../lib/utils';
 import { ErrorBoundary, ErrorProvider } from '../ErrorBoundary';
-import { HorizontalRuler } from '../ui/HorizontalRuler';
+import { HorizontalRuler, RULER_HEIGHT } from '../ui/HorizontalRuler';
 import { VerticalRuler, RULER_WIDTH } from '../ui/VerticalRuler';
 import type { ReactNode } from 'react';
 import {
@@ -137,6 +137,9 @@ export function DocxEditorShell({
   dialogs: ReactNode;
   fileInputs: ReactNode;
 }) {
+  // The vertical ruler renders only when editable; the outline insets must
+  // gate on the same condition or they clear a ruler that is not on screen.
+  const showVerticalRuler = showRuler && !readOnlyProp;
   return (
     // The container below carries the scope class, so chrome parts inside it
     // must not add their own — see editor/scope-context.ts.
@@ -216,7 +219,7 @@ export function DocxEditorShell({
                       >
                         {/* Vertical ruler — sits at the editor content's left
                           edge so it scrolls horizontally with the page. */}
-                        {showRuler && !readOnlyProp && (
+                        {showVerticalRuler && (
                           <div
                             style={{
                               position: 'absolute',
@@ -224,8 +227,10 @@ export function DocxEditorShell({
                               top: 0,
                               // Above the inline HF editor so it stays readable on horizontal scroll.
                               zIndex: Z_INDEX.ruler,
-                              // Must match `.paged-editor__pages` padding-top
-                              // (24 viewport + 24 pages container) in editor.css.
+                              // Must match the space above the first page in
+                              // editor.css: `.docx-editor-one-surface__viewport`
+                              // padding (24) + `.docx-paginated-surface` top
+                              // margin (24).
                               paddingTop: 48,
                             }}
                           >
@@ -269,7 +274,7 @@ export function DocxEditorShell({
                   {showOutline && (
                     <DocumentOutline
                       {...outlineProps}
-                      leftOffset={OUTLINE_LEFT_OFFSET + (showRuler ? RULER_WIDTH : 0)}
+                      leftOffset={OUTLINE_LEFT_OFFSET + (showVerticalRuler ? RULER_WIDTH : 0)}
                     />
                   )}
 
@@ -277,11 +282,13 @@ export function DocxEditorShell({
                     <OutlineToggleButton
                       onClick={onToggleOutline}
                       // Aligns with the page top: toolbar + horizontal ruler row
-                      // (22 ruler + 8 py-1 padding) + PagedEditor viewport
-                      // padding-top (24) + pages container padding (24).
-                      topPx={toolbarHeight + (showRuler ? 30 : 0) + 48}
+                      // (RULER_HEIGHT + 8 py-1 padding) + viewport padding (24)
+                      // + first-page top margin (24), per editor.css.
+                      topPx={toolbarHeight + (showRuler ? RULER_HEIGHT + 8 : 0) + 48}
                       scrollLeft={editorScrollLeft}
-                      leftOffset={OUTLINE_BUTTON_LEFT_OFFSET + (showRuler ? RULER_WIDTH : 0)}
+                      leftOffset={
+                        OUTLINE_BUTTON_LEFT_OFFSET + (showVerticalRuler ? RULER_WIDTH : 0)
+                      }
                     />
                   )}
                 </div>

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -100,7 +100,8 @@ const TWIPS_PER_CM = 567;
 const STRIP_HEIGHT = 20;
 /** The left box hangs BELOW the strip, which is how it and the hanging triangle coexist. */
 const BOX_HEIGHT = 6;
-const RULER_HEIGHT = STRIP_HEIGHT + BOX_HEIGHT + 2;
+/** Full ruler height; consumers that stack chrome below the ruler derive from this. */
+export const RULER_HEIGHT = STRIP_HEIGHT + BOX_HEIGHT + 2;
 
 const RULER_TEXT_COLOR = 'var(--doc-text-muted)';
 const RULER_TICK_COLOR = 'var(--doc-text-subtle)';


### PR DESCRIPTION
Fixes two geometry constants in `DocxEditorShell` that restated values they are meant to track (#486).

The outline toggle's `topPx` counted the horizontal ruler row as 30px, but the row is `RULER_HEIGHT` (28) plus 8px of `py-1` padding. The offset now derives from `RULER_HEIGHT`, exported from `HorizontalRuler`, so the next height change cannot desynchronize the button.

The outline panel and toggle insets gated on `showRuler` alone, while the vertical ruler renders under `showRuler && !readOnlyProp`. Both insets now gate on the shared condition, so read-only mode no longer insets past a ruler that is not on screen.

Fixes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1f6VuvzRagCVNedbT4eWW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790318193&installation_model_id=422592&pr_number=488&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F488&signature=ed81604f9afcc537a72498a3b643ad5e57a5ac40e3b81827674aff87b14bb74a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->