### PR TITLE
fix: prefix the notification toast keyframes and guard component-injected @keyframes names

### DIFF
--- a/.changeset/prefix-notification-keyframes.md
+++ b/.changeset/prefix-notification-keyframes.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/react': patch
+---
+
+The error notification toast animates with a `docx-` prefixed keyframes name from the core stylesheet instead of injecting a global `@keyframes slideIn`, so it no longer collides with a host application's animation of the same name. Fixes #485

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,6 +82,31 @@ const SECURITY_SINK_SELECTORS = [
   },
 ];
 
+// `@keyframes` names are document-global — no selector strategy can scope them, so
+// the shipped stylesheet's namespace guard (scripts/core-css-assertions.mjs) requires
+// a docx-/hf- prefix on every name in dist/editor.css. That guard cannot see CSS a
+// component injects from a <style> element, which is exactly how an unprefixed
+// `@keyframes slideIn` shipped and collided with host apps (#485). These selectors
+// close that gap at the source: any `@keyframes <name>` inside a string or template
+// literal in package source must carry the same prefix. They ride alongside
+// SECURITY_SINK_SELECTORS in every `no-restricted-syntax` value below, for the same
+// flat-config replacement reason.
+const NO_GLOBAL_KEYFRAMES_MSG =
+  '@keyframes names are document-global. Give the name a docx-/hf- prefix, or move the ' +
+  'keyframes — under a docx-/hf- prefixed name, since inline animation references are ' +
+  'not rewritten by the build — into packages/core/src/styles/editor.css where the ' +
+  'namespace guard (scripts/core-css-assertions.mjs) covers it.';
+const GLOBAL_KEYFRAMES_SELECTORS = [
+  {
+    selector: 'TemplateElement[value.raw=/@(-\\w+-)?keyframes\\s+(?!docx-|hf-)/]',
+    message: NO_GLOBAL_KEYFRAMES_MSG,
+  },
+  {
+    selector: 'Literal[value=/@(-\\w+-)?keyframes\\s+(?!docx-|hf-)/]',
+    message: NO_GLOBAL_KEYFRAMES_MSG,
+  },
+];
+
 // ESLint's `no-restricted-imports` skips `await import(...)` (it's an
 // `ImportExpression` AST node, not `ImportDeclaration`). Use
 // `no-restricted-syntax` to match dynamic imports by literal source value.
@@ -89,6 +114,7 @@ const restrictDynamic = (specifiers, message) => ({
   'no-restricted-syntax': [
     'error',
     ...SECURITY_SINK_SELECTORS,
+    ...GLOBAL_KEYFRAMES_SELECTORS,
     ...specifiers.map((s) => ({
       selector: `ImportExpression[source.value=${JSON.stringify(s)}]`,
       message,
@@ -189,7 +215,9 @@ export default [
   {
     files: ['packages/*/src/**/*.{ts,tsx,vue}'],
     ignores: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx'],
-    rules: { 'no-restricted-syntax': ['error', ...SECURITY_SINK_SELECTORS] },
+    rules: {
+      'no-restricted-syntax': ['error', ...SECURITY_SINK_SELECTORS, ...GLOBAL_KEYFRAMES_SELECTORS],
+    },
   },
 
   // The DOM-free engine lanes additionally ban spreading an array into a call. A
@@ -208,6 +236,7 @@ export default [
       'no-restricted-syntax': [
         'error',
         ...SECURITY_SINK_SELECTORS,
+        ...GLOBAL_KEYFRAMES_SELECTORS,
         {
           selector:
             "CallExpression:not([callee.object.name='Math'])" +

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -1606,6 +1606,21 @@ a.docx-hyperlink:focus-visible {
   }
 }
 
+/* Error notification toast entrance (the React adapter's NotificationToast sets
+    `animation: docx-notification-slide-in ...` inline; the rest of its styling is
+    inline too). Keyframes names are document-global, so it lives here where the
+    build's namespace guard (scripts/core-css-assertions.mjs) covers it. */
+@keyframes docx-notification-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 /* Section break indicator */
 .docx-section-break {
   position: relative;

--- a/packages/react/src/components/ErrorBoundary.tsx
+++ b/packages/react/src/components/ErrorBoundary.tsx
@@ -251,7 +251,10 @@ function NotificationToast({ notification, onDismiss }: NotificationToastProps) 
     borderRadius: '8px',
     padding: '12px 16px',
     boxShadow: '0 2px 8px var(--doc-shadow)',
-    animation: 'slideIn 0.3s ease-out',
+    // Keyframes live in the core stylesheet (editor.css) — keyframes names are
+    // document-global, so the name carries the docx- prefix and the build's
+    // namespace guard covers it.
+    animation: 'docx-notification-slide-in 0.3s ease-out',
   };
 
   const headerStyle: CSSProperties = {
@@ -354,20 +357,6 @@ function NotificationToast({ notification, onDismiss }: NotificationToastProps) 
       className={`docx-notification-toast docx-notification-${notification.severity}`}
       style={toastStyle}
     >
-      <style>
-        {`
-          @keyframes slideIn {
-            from {
-              opacity: 0;
-              transform: translateX(100%);
-            }
-            to {
-              opacity: 1;
-              transform: translateX(0);
-            }
-          }
-        `}
-      </style>
       <div style={headerStyle}>
         <span style={iconStyle}>{getIcon(notification.severity)}</span>
         <div style={contentStyle}>


### PR DESCRIPTION
The React error notification toast injected a global `@keyframes slideIn` from a component `<style>` element. Keyframe names are document-global, so a host application's own `slideIn` collided with the editor's in both directions. The keyframes now live in the core stylesheet as `docx-notification-slide-in`, where the build's namespace guard covers the name, and the toast references it inline.

A new `no-restricted-syntax` lint ban catches the next component-injected `@keyframes` without a `docx-`/`hf-` prefix in package source, closing the gap the `dist/editor.css`-only guard cannot see.

Fixes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f2p8jSc7z9haBmNdSFtMB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790318228&installation_model_id=422592&pr_number=489&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F489&signature=1ed946368e8cd7837b88946d077207806e1015c0cff99387d29c31558cbe3c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->