### PR TITLE
fix: mark tracked insertion and deletion of drawings (fixes #479)

### DIFF
--- a/.changeset/tracked-drawing-revision-marking.md
+++ b/.changeset/tracked-drawing-revision-marking.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Mark a drawing inside a tracked insertion or deletion with a revision outline, the standard revision datasets, and a margin change bar; a deleted picture stays visible and dimmed under all-markup and disappears from the proposed result. Fixes #479
+Mark a drawing inside a tracked insertion or deletion with a revision outline, the standard revision datasets, and a margin change bar; a deleted picture stays visible and dimmed under all-markup and disappears from the proposed result. Deleting a selected image in suggesting mode now proposes a tracked deletion instead of refusing. Fixes #479

--- a/.changeset/tracked-drawing-revision-marking.md
+++ b/.changeset/tracked-drawing-revision-marking.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Mark a drawing inside a tracked insertion or deletion with a revision outline, the standard revision datasets, and a margin change bar; a deleted picture stays visible and dimmed under all-markup and disappears from the proposed result. Fixes #479

--- a/.changeset/tracked-drawing-revision-marking.md
+++ b/.changeset/tracked-drawing-revision-marking.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Mark a drawing inside a tracked insertion or deletion with a revision outline, the standard revision datasets, and a margin change bar; a deleted picture stays visible and dimmed under all-markup and disappears from the proposed result. Deleting a selected image in suggesting mode now proposes a tracked deletion instead of refusing. Fixes #479
+Mark a drawing inside a tracked insertion or deletion with a revision outline, the standard revision datasets, and a margin change bar; a deleted picture stays visible and dimmed under all-markup and disappears from the proposed result. In suggesting mode, inserting an image proposes a tracked insertion, deleting a selected image proposes a tracked deletion, and Delete on a pointer-selected picture deletes the picture instead of the paragraph break beside it. Fixes #479

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -131,6 +131,7 @@ export interface TreeDocxSessionView {
         readonly parentCommentId?: string;
     }[], scope?: StoryScope, noteId?: number): boolean;
     deleteImage(scope: StoryScope, drawingNodeId: string): ImageIntentResult;
+    deleteImageTracked(scope: StoryScope, drawingNodeId: string, revision: RevisionAttributionInput): ImageIntentResult;
     documentFonts(): readonly string[];
     documentOutline(): readonly DocumentOutlineEntry[];
     documentProperties(): DocumentProperties;

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -2216,6 +2216,7 @@ export interface TreeDocxSessionView {
         readonly parentCommentId?: string;
     }[], scope?: StoryScope, noteId?: number): boolean;
     deleteImage(scope: StoryScope, drawingNodeId: string): ImageIntentResult;
+    deleteImageTracked(scope: StoryScope, drawingNodeId: string, revision: RevisionAttributionInput): ImageIntentResult;
     documentFonts(): readonly string[];
     documentOutline(): readonly DocumentOutlineEntry[];
     documentProperties(): DocumentProperties;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1343,6 +1343,7 @@ export function lineEndOffset(layout: SemanticLayout, line: LineRecord): number;
 
 // @public
 export interface LineRecord {
+    readonly anchorRevisions?: readonly RevisionAttribution[];
     readonly baseline: number;
     // (undocumented)
     readonly box: LayoutBox;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4350,6 +4350,7 @@ export type TreeDocOp = {
     readonly offset: number;
     readonly op: 'insertDrawing';
     readonly paragraphId: string;
+    readonly revision?: RevisionAttributionInput;
 } | {
     readonly drawingNodeId: string;
     readonly op: 'replaceDrawingResource';

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4636,6 +4636,7 @@ export class TreePackageStore {
     compositionSessionOpen(): boolean;
     currentPackage(): OoxmlPackage;
     deleteImage(scope: StoryScope, drawingNodeId: string): ImageIntentResult;
+    deleteImageTracked(scope: StoryScope, drawingNodeId: string, revision: RevisionAttributionInput): ImageIntentResult;
     embedExternalImage(scope: StoryScope, drawingNodeId: string, url: string, port: ExternalImageFetchPort, signal: AbortSignal, decodePort: ImageDecodePort): Promise<ImageIntentResult>;
     // (undocumented)
     endComposition(): void;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -379,6 +379,7 @@ export default [
   {
     files: [
       'packages/core/src/layout/drawing-layout.ts',
+      'packages/core/src/binding/tree-session.ts',
       'packages/core/src/store/__tests__/image-resources.test.ts',
     ],
     rules: {
@@ -427,7 +428,6 @@ export default [
 
   {
     files: [
-      'packages/core/src/binding/tree-session.ts',
       'packages/core/src/contracts/editor.ts',
       'packages/core/src/layout/paragraph-flow.ts',
       'packages/pro/src/__tests__/review-facade.test.ts',

--- a/packages/core/src/__tests__/part-for-call-sites.test.ts
+++ b/packages/core/src/__tests__/part-for-call-sites.test.ts
@@ -26,7 +26,8 @@ const SCANNED_ROOTS = ['core/src', 'pro/src', 'editor-api/src', 'react/src', 'vu
 /** file (relative to packages/) → number of `partFor(` occurrences, definitions included. */
 const PINNED_CALL_SITES: Readonly<Record<string, number>> = {
   'core/src/automation/server-host.ts': 1,
-  'core/src/binding/tree-session.ts': 7, // includes the TreeEditingSession facade definition
+  'core/src/binding/tree-session.ts': 6, // includes the TreeEditingSession facade definition
+  'core/src/binding/tree-session-contract.ts': 1, // the session view's partFor declaration
   'core/src/editor/doc-target-resolution.ts': 2,
   'core/src/editor/docx-editor-derive.ts': 1,
   'core/src/editor/docx-editor-images.ts': 1,

--- a/packages/core/src/binding/tree-session-contract.ts
+++ b/packages/core/src/binding/tree-session-contract.ts
@@ -1,0 +1,448 @@
+// The read/write contract every editor surface holds a session by.
+//
+// Extracted from tree-session.ts so the session module stays under its line budget; the
+// binding-only extension (TreeDocxSession, which exchanges ProseMirror projections) stays
+// there. tree-session.ts re-exports both names, so existing imports resolve unchanged.
+
+import type {
+  BookmarkIndex,
+  EmbeddedFont,
+  HeaderFooterParts,
+  HeaderFooterSectionResolution,
+  ListKind,
+  OoxmlElement,
+  OoxmlPackage,
+  OoxmlPart,
+  ReviewItem,
+  SelectionMark,
+  StoryScope,
+  StoryTargetRejection,
+  TreeDocOp,
+  TreeModelChange,
+} from '@docx-editor.dev/core/store';
+import type { TreeBindingRejection } from './tree-binding.ts';
+import type {
+  CustomNodeSweepOutcome,
+  CustomNodeWriteResult,
+  InsertCustomNodeWrite,
+} from '../store/store/custom-node-writes.ts';
+import type { DocumentStyleEntry } from './document-catalog.ts';
+import type { DocumentThemeColorEntry, DocumentThemeFonts } from './document-theme.ts';
+import type { DocumentOutlineEntry } from './document-outline.ts';
+import type { DocumentSearchOptions, DocumentSearchResult } from './document-search.ts';
+import type { ParagraphAnchorIndex } from './paragraph-anchors.ts';
+import type { RunPropertyLike, StyleRunDefaults } from './document-run-defaults.ts';
+import type { DocumentTrackingSettings } from '../store/package/tracking-settings.ts';
+import type { DocumentProperties } from '../store/package/document-properties.ts';
+
+/**
+ * What applying ops produced: whether it committed, and why not when it did not.
+ *
+ * `committed` and `rejected` are separate flags because they are not opposites — a batch of zero
+ * ops neither commits nor is rejected.
+ */
+export interface TreeApplyResult {
+  readonly committed: boolean;
+  readonly rejected: boolean;
+  readonly opCount: number;
+  /** Present when the edit was refused, so a host can report WHY rather than a silent no-op. */
+  readonly reason?: TreeBindingRejection | StoryTargetRejection | string;
+}
+
+/**
+ * One open document: the canonical tree, and the only write path into it.
+ *
+ * `applyTreeOps` is that path. Every mutation is a `TreeDocOp` addressed by node id plus UTF-16
+ * offset, applied in one transaction, which is what makes cell and nested paragraphs ordinary
+ * rather than special cases.
+ *
+ * Holds the whole package, not just the body — headers, footers, notes, comments and styles are
+ * all reachable through it, and parts the engine does not model are preserved verbatim.
+ */
+export interface TreeDocxSessionView {
+  /** Whether the body holds at least one editable paragraph. */
+  readonly editable: boolean;
+  /** Canonical node ids of the body paragraphs, in order. */
+  paragraphIds(): string[];
+  /**
+   * Canonical node ids of paragraphs in a story scope. Defaults to the body.
+   * Header/footer scopes address the part `EditorScope { kind: 'headerFooter'; rId }` names.
+   */
+  paragraphIdsIn(scope?: StoryScope): string[];
+  /** The current canonical BODY part — what layout reads for the main story. */
+  part(): OoxmlPart;
+  /** The current part for a story scope, or null when the target is refused. */
+  partFor(scope: StoryScope): OoxmlPart | null;
+  /**
+   * The current package with every opened story store merged in. Authority for layout
+   * resolution and save — never a swapped single-part view.
+   */
+  currentPackage(): OoxmlPackage;
+  /**
+   * Commit typed tree ops directly, as ONE transaction.
+   *
+   * The paginated surface has no ProseMirror doc to diff, so it addresses the model the way
+   * the ops already do — by node id and offset — rather than round-tripping an edit through
+   * a projection just to have it diffed back out.
+   *
+   * `scope` defaults to the body. Pass `{ kind: 'headerFooter', rId }` to target an existing
+   * header/footer part; the transaction publishes one ModelChange (HF → `global` impact)
+   * and one undo unit without swapping the body store.
+   */
+  applyTreeOps(
+    ops: readonly TreeDocOp[],
+    selectionBefore?: SelectionMark | null,
+    selectionAfter?: SelectionMark | null,
+    scope?: StoryScope
+  ): TreeApplyResult;
+  /**
+   * Every part that holds a story, body first, then headers, footers and note parts.
+   *
+   * A READ: parts come from the package, so this opens no story store and spends none of the
+   * 64 editable-store slots. Use it for any query that must answer about the whole document
+   * rather than about the caret — an enumeration that reads only the body reports a document
+   * the reader is not looking at.
+   */
+  storyParts(): readonly OoxmlPart[];
+  /** Body text, paragraphs joined by newlines, read from the CANONICAL tree. */
+  bodyText(): string;
+  /** Text of a story scope, paragraphs joined by newlines. */
+  storyText(scope: StoryScope): string | null;
+  /** Body-store revision (independent of header/footer store revisions). */
+  revision(): number;
+  /** Per-story revision, or null when the target is refused. */
+  revisionFor(scope: StoryScope): number | null;
+  /** Package-wide revision — bumps on any story commit (body or HF). */
+  packageRevision(): number;
+  canUndo(): boolean;
+  canRedo(): boolean;
+  /**
+   * Undo the last entry, returning the selection to restore.
+   *
+   * The selection is part of the entry, not something a host can recompute: after undoing a
+   * split the caret belongs where the user was typing, and offsets in the reverted tree do
+   * not correspond to offsets in the one that replaced it. `null` means nothing was undone
+   * or the entry recorded no selection.
+   */
+  undo(): SelectionMark | null;
+  redo(): SelectionMark | null;
+  beginComposition(scope?: StoryScope): void;
+  endComposition(): void;
+  subscribe(onChange: (change: TreeModelChange) => void): () => void;
+  /** Serialize the whole package back to DOCX bytes. */
+  save(): Uint8Array;
+  /**
+   * The resolved header/footer parts of the section, by variant (phase 2).
+   *
+   * Returns the FINAL section's effective parts after OOXML inheritance. Prefer
+   * `headerFooterPartsBySection` for multi-section pagination.
+   *
+   * Re-resolved after any package revision so an edited shared part is visible everywhere
+   * it is attached.
+   */
+  headerFooterParts(): HeaderFooterParts;
+  /**
+   * Per-section header/footer parts after OOXML inheritance, index-aligned with
+   * `enumerateDocumentSections`.
+   */
+  headerFooterPartsBySection(): readonly HeaderFooterParts[];
+  /**
+   * Per-section resolution with declared-vs-inherited metadata for "Same as previous"
+   * chrome. Index-aligned with `headerFooterPartsBySection`.
+   */
+  headerFooterResolutionBySection(): readonly HeaderFooterSectionResolution[];
+  /**
+   * Font family names the document uses, from every `w:rFonts` in the CURRENT main
+   * part plus the styles and header/footer parts — validated, deduplicated, sorted.
+   * Memoized per package revision.
+   */
+  documentFonts(): readonly string[];
+  /**
+   * Whether the document puts any literal character on a page, over the same roots
+   * {@link TreeDocxSessionView.documentFonts} reads. Memoized per package revision.
+   *
+   * The font-substitution notice needs it: `documentFonts` reports what the document
+   * DECLARES, and a brand-new document declares Word's Calibri default over a single
+   * empty paragraph — a declaration with no glyph behind it.
+   */
+  rendersText(): boolean;
+  /** Validated style-picker projection. A document without styles answers `[]`. */
+  documentStyles(): readonly DocumentStyleEntry[];
+  /** Current styles root for layout, or `null` when the package has no styles part. */
+  stylesRoot(): OoxmlElement | null;
+  /**
+   * The theme part's Latin typefaces, for resolving `w:rFonts` theme references in layout.
+   *
+   * Memoized once: theme editing is a later slice. A document with no theme part answers
+   * `{ major: null, minor: null }`, which leaves every theme reference on the explicit
+   * font name beside it.
+   */
+  documentThemeFonts(): DocumentThemeFonts;
+  /**
+   * Root of the numbering part tree (`w:numbering`), for list layout. Memoized once;
+   * `null` when the package has no numbering part. Numbering editing is a later slice.
+   */
+  numberingRoot(): OoxmlElement | null;
+  /**
+   * Root of the settings part tree (`w:settings`), for document-wide layout constants such
+   * as `w:defaultTabStop`. Memoized once; `null` when the package has no settings part.
+   * Settings editing is a later slice, so this is immutable for the session.
+   */
+  settingsRoot(): OoxmlElement | null;
+  /**
+   * The document's own metadata from `docProps/core.xml` and `docProps/app.xml`, for
+   * document-property fields (TITLE, AUTHOR, SUBJECT, KEYWORDS, LASTSAVEDBY, COMMENTS). Read
+   * once per package revision; an empty object when the parts are absent.
+   */
+  documentProperties(): DocumentProperties;
+  /**
+   * What `settings.xml` says about tracking — `w:trackRevisions`, the tracked-changes
+   * protection, and the two do-not-track switches.
+   *
+   * Read from the document rather than assumed, because Word records the tracking state on
+   * the FILE: a package that asks to be edited as tracked changes, presented as an ordinary
+   * editable one, takes its first keystroke as an untracked edit.
+   */
+  trackingSettings(): DocumentTrackingSettings;
+  /**
+   * The theme's ten picker colours (`a:clrScheme`), in Word's column order, or `[]`
+   * when the package has no complete scheme. Memoized once: the theme part is
+   * immutable for the session's lifetime.
+   */
+  documentThemeColors(): readonly DocumentThemeColorEntry[];
+  /**
+   * The run formatting a paragraph's content INHERITS when it authors none: the
+   * paragraph style's `basedOn` chain, then `w:docDefaults`, with theme `rFonts`
+   * attributes resolved through the font scheme. `runProperties` (the span's own
+   * authored properties) lets a theme-only run-level `w:rFonts` resolve too. This is
+   * what lets a toolbar always show the effective font, the way Word does.
+   */
+  effectiveRunDefaults(
+    paragraphId: string,
+    runProperties?: readonly RunPropertyLike[]
+  ): StyleRunDefaults;
+  /**
+   * The heading outline of the BODY story, in document order: paragraphs whose
+   * `w:pStyle` resolves to a heading through the styles part (built-in `heading N`
+   * name, or the style's own `w:outlineLvl` 0..8). Memoized per main-part revision —
+   * an edit can retitle, add or remove a heading, but the styles part cannot change
+   * in-session.
+   */
+  documentOutline(): readonly DocumentOutlineEntry[];
+
+  /**
+   * Every pending review decision in the document, memoized per revision.
+   *
+   * Derived from the canonical TREE — the queue is a property of the document, and one derived
+   * from laid-out spans empties by half whenever the reader switches to a resolved view.
+   */
+  reviewItems(): readonly ReviewItem[];
+
+  /**
+   * Whether the document carries review content — tracked changes or comment
+   * anchors — regardless of any review module. Derived from store vocabulary
+   * only (never the review model), memoized per revision: it is the free
+   * tier's honest "this document has more than you are seeing" signal.
+   */
+  hasReviewContent(): boolean;
+
+  /**
+   * Reply to a comment, or add one over a revision's range. Returns the new comment's id.
+   *
+   * `scope` names the story the anchor lives in and defaults to the body. A header or
+   * footer anchor written against the body store addresses a paragraph that store has
+   * never heard of, so the transaction is refused and the reply is lost — which is what
+   * replying to a header card did.
+   */
+  replyToComment(
+    parentCommentId: string | null,
+    anchor: { paragraphId: string; start: number; end: number; endParagraphId?: string },
+    text: string,
+    author: string,
+    /** ISO-8601. Omitted writes no `@w:date`, because inventing one is a content change. */
+    date?: string,
+    scope?: StoryScope
+  ): string | null;
+  /**
+   * Resolve a comment thread, or reopen it. False when the document holds no such comment.
+   *
+   * The same package transaction shape as a reply, and for the same reason: `@w15:done` lives in
+   * `commentsExtended.xml`, a part a document with no thread does not have, so the state and the
+   * part that records it commit together.
+   */
+  setCommentResolved(commentId: string, resolved: boolean): boolean;
+  /**
+   * Delete a comment thread outright — body, thread state and story markers.
+   *
+   * A THREAD, like resolving one: a reply whose parent is gone has nothing left to answer.
+   * `scope` names the owning story and defaults to the body; `noteId` names one note inside a
+   * shared notes part. False when the document holds no such comment, or when the removal was
+   * refused.
+   */
+  deleteComment(commentId: string, scope?: StoryScope, noteId?: number): boolean;
+  /**
+   * Delete several comment objects as one package transaction and one undo unit.
+   *
+   * A root removes its thread; a reply removes only itself and reparents any foreign nested
+   * descendants to its parent. Marker stripping is scoped to `scope` / `noteId`.
+   */
+  deleteComments(
+    comments: readonly { readonly commentId: string; readonly parentCommentId?: string }[],
+    scope?: StoryScope,
+    noteId?: number
+  ): boolean;
+  /**
+   * Insert a custom node, with the payload it carries, as ONE transaction.
+   *
+   * A package write reaching through the body store, exactly as a comment is: the customXml data
+   * part, the node inside it and the bound `w:sdt` commit together or not at all. A control bound
+   * to a store that was never written is a document Word offers to repair.
+   *
+   * Omitting the payload authors the ordinary tagged control, which is what a node small enough
+   * to live in its `w:tag` needs.
+   */
+  /** `scope` names the story the paragraph is in, and defaults to the body. */
+  insertCustomNode(write: InsertCustomNodeWrite, scope?: StoryScope): CustomNodeWriteResult;
+  /**
+   * Remove a custom node and, in the same transaction, the payload it bound.
+   *
+   * The sweep would collect the payload on the next open regardless; doing it here means a
+   * document saved between the deletion and that open does not carry a payload for a chip that
+   * is gone.
+   */
+  /**
+   * Remove a custom node and the payload it bound. `scope` names the story holding it and
+   * defaults to the body; a chip in a header is refused against the body store.
+   */
+  removeCustomNode(controlNodeId: string, scope?: StoryScope): CustomNodeWriteResult;
+  /**
+   * Drop every payload no control binds, in the stores whose namespaces a module claims.
+   *
+   * Called ON OPEN and nowhere else — see `sweepCustomNodePayloads`. Answers the ids collected,
+   * so a host can report what a document arrived carrying.
+   */
+  sweepCustomNodePayloads(namespaces: readonly string[]): CustomNodeSweepOutcome;
+  /**
+   * Every occurrence of `query` in the BODY story, in document order, addressed in the
+   * same offset vocabulary the tree ops and the surface selection use — so a match can be
+   * handed straight to `setSelection` without re-deriving anything.
+   *
+   * Memoized one deep, keyed on the revision AND the question asked: a find panel asks the
+   * same question on every tick, and a different query replaces the entry rather than
+   * growing a cache the session would have to bound.
+   */
+  findText(query: string, options?: DocumentSearchOptions): DocumentSearchResult;
+  /**
+   * The faces the package EMBEDS (`word/fontTable.xml` embed relationships),
+   * deobfuscated — the only font source that needs neither a substitute nor a network.
+   * Extraction asserts nothing about validity; admitting a face is the font resource
+   * lane's job. Memoized once: the font table and font parts are immutable in-session.
+   */
+  embeddedFonts(): readonly EmbeddedFont[];
+  /**
+   * The `w:numId` of a bullet or numbered list definition, creating one where the document
+   * has none — including `numbering.xml` itself, its relationship and its content type.
+   *
+   * A document Word has never numbered carries no numbering part at all, so the first
+   * bullet a user asks for has to bring the whole definition with it. An existing
+   * definition of the same kind is reused rather than duplicated.
+   */
+  /**
+   * What the owning part's relationships answer for one `r:id` under `scope` (default:
+   * body): the authored target and whether it is external. `null` for an id the part does
+   * not declare, or when the scoped part is not open.
+   *
+   * Live rather than memoized: inserting a link mints a relationship mid-session, and a
+   * cached resolver would report the link this session just created as dangling.
+   */
+  relationshipTarget(
+    relationshipId: string,
+    scope?: StoryScope
+  ): { readonly target: string; readonly external: boolean } | null;
+  /**
+   * `bookmarkName -> { paragraphId, offset }` over the main part, memoized per revision.
+   *
+   * What an internal hyperlink's `w:anchor` resolves through. Keyed on the store revision
+   * because an edit can move, split or delete the paragraph a bookmark sits in.
+   */
+  bookmarks(): BookmarkIndex;
+  /**
+   * The relationship id for an external hyperlink target on the part owning `scope`
+   * (default: body), minting one if that part has none, or `null` when the URL is refused
+   * or the scoped part cannot be resolved.
+   *
+   * Lives on the PACKAGE, outside `store.transact`, like the numbering definitions: the
+   * undoable half is the tree op that names the id. An unreferenced relationship left
+   * behind by an undo is inert and is what Word writes anyway. Scoped inserts mint onto
+   * the story's own `.rels` so a header/footer or note link never creates a stray body
+   * relationship.
+   */
+  ensureHyperlinkRelationship(url: string, scope?: StoryScope): string | null;
+  ensureListDefinition(kind: ListKind): string | null;
+  /**
+   * Declare `level` in the list definition `numId` names, with Word's default format for
+   * that depth, or answer false.
+   *
+   * Word never greys Increase Indent out on a list item: demoting past the deepest level
+   * a definition declares makes Word define the level, cycling its stock bullets and
+   * number formats. An already-declared level answers true without changing anything.
+   *
+   * The declaration lives on the PACKAGE, outside the store's history — undoing the edit
+   * that needed it restores the paragraph but leaves the level declared, which is
+   * harmless: an unreferenced level renders nothing and Word writes files full of them.
+   */
+  ensureNumberingLevel(numId: string, level: number, kind: ListKind): boolean;
+  /**
+   * The `w14:paraId` ↔ node-id index over the full editable set of the MAIN part,
+   * memoized per revision. Every editable paragraph carries a valid, part-unique id
+   * (established at open, maintained by the split appliers), so every paragraph is
+   * mapped. Header/footer paragraphs become addressable through `partFor` once their
+   * story store is open.
+   */
+  paragraphAnchors(): ParagraphAnchorIndex;
+  /** `w14:paraId` of a canonical paragraph node id, verbatim, or null. */
+  paraIdOf(nodeId: string): string | null;
+  /** Canonical node id for a `w14:paraId`, matched case-insensitively, or null. */
+  nodeIdOf(paraId: string): string | null;
+
+  /** Insert a validated raster image as one package undo unit (task 12). */
+  insertImage(
+    scope: StoryScope,
+    input: import('../store/store/tree-package-images.ts').InsertImageInput
+  ): Promise<import('../store/store/tree-package-images.ts').ImageIntentResult>;
+
+  /** Replace a picture drawing's embedded media in one package undo unit. */
+  replaceImage(
+    scope: StoryScope,
+    drawingNodeId: string,
+    bytes: Uint8Array,
+    mime: import('../store/package/image-resources.ts').SupportedImageMime,
+    decodePort: import('../store/package/image-resources.ts').ImageDecodePort,
+    options: import('../store/store/tree-package-images.ts').ReplaceImageOptions
+  ): Promise<import('../store/store/tree-package-images.ts').ImageIntentResult>;
+
+  /** Delete a picture drawing and collect orphaned media in one package undo unit. */
+  deleteImage(
+    scope: StoryScope,
+    drawingNodeId: string
+  ): import('../store/store/tree-package-images.ts').ImageIntentResult;
+
+  /** Propose the drawing's deletion as a tracked change (`w:del`); media stays untouched. */
+  deleteImageTracked(
+    scope: StoryScope,
+    drawingNodeId: string,
+    revision: import('../store/store/tree-op-types.ts').RevisionAttributionInput
+  ): import('../store/store/tree-package-images.ts').ImageIntentResult;
+
+  /** Apply image property tree ops plus hyperlink relationship wiring atomically. */
+  applyImageProperties(
+    scope: StoryScope,
+    input: import('../store/store/tree-package-images.ts').ApplyImagePropertiesInput
+  ): import('../store/store/tree-package-images.ts').ImageIntentResult;
+
+  /** Land a clipboard fragment (resource merge + blocks) as one package undo unit. */
+  applyFragmentPaste(
+    scope: StoryScope,
+    input: import('../store/store/tree-package-fragment.ts').FragmentPasteInput
+  ): import('../store/store/tree-package-fragment.ts').FragmentPasteResult;
+}

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -32,9 +32,7 @@ import {
   insertCustomNodeWrite,
   removeCustomNodeWrite,
   sweepCustomNodePayloads,
-  type CustomNodeSweepOutcome,
   type CustomNodeWriteResult,
-  type InsertCustomNodeWrite,
 } from '../store/store/custom-node-writes.ts';
 import {
   deleteCommentReply,
@@ -62,17 +60,13 @@ import {
   collectRevisionSites,
   type BookmarkIndex,
   type EmbeddedFont,
-  type ListKind,
   type HeaderFooterParts,
   type HeaderFooterSectionResolution,
   type OoxmlElement,
   type OoxmlPackage,
   type OoxmlPackageRejection,
   type OoxmlPart,
-  type SelectionMark,
   type StoryScope,
-  type StoryTargetRejection,
-  type TreeDocOp,
   type TreeDocumentStore,
   type TreeModelChange,
 } from '@docx-editor.dev/core/store';
@@ -88,11 +82,7 @@ import {
   paragraphStyleId,
   type DocumentOutlineEntry,
 } from './document-outline.ts';
-import {
-  collectTextMatches,
-  type DocumentSearchOptions,
-  type DocumentSearchResult,
-} from './document-search.ts';
+import { collectTextMatches, type DocumentSearchResult } from './document-search.ts';
 import {
   collectDocumentThemeColors,
   collectDocumentThemeFonts,
@@ -105,434 +95,24 @@ import {
   type StyleRunDefaults,
 } from './document-run-defaults.ts';
 import { allParagraphs, docToTreeOps, reconcileDoc, treeToDoc } from './tree-binding.ts';
-import type { TreeBindingRejection } from './tree-binding.ts';
 import {
   buildParagraphAnchorIndex,
   refreshParagraphAnchorParts,
   type ParagraphAnchorIndex,
 } from './paragraph-anchors.ts';
 import { directParaIdOf } from './paragraph-anchor-direct-read.ts';
-import {
-  readTrackingSettings,
-  type DocumentTrackingSettings,
-} from '../store/package/tracking-settings.ts';
+import { readTrackingSettings } from '../store/package/tracking-settings.ts';
 import {
   EMPTY_DOCUMENT_PROPERTIES,
   readDocumentProperties,
   type DocumentProperties,
 } from '../store/package/document-properties.ts';
 
-/**
- * What applying ops produced: whether it committed, and why not when it did not.
- *
- * `committed` and `rejected` are separate flags because they are not opposites — a batch of zero
- * ops neither commits nor is rejected.
- */
-export interface TreeApplyResult {
-  readonly committed: boolean;
-  readonly rejected: boolean;
-  readonly opCount: number;
-  /** Present when the edit was refused, so a host can report WHY rather than a silent no-op. */
-  readonly reason?: TreeBindingRejection | StoryTargetRejection | string;
-}
-
-/**
- * One open document: the canonical tree, and the only write path into it.
- *
- * `applyTreeOps` is that path. Every mutation is a `TreeDocOp` addressed by node id plus UTF-16
- * offset, applied in one transaction, which is what makes cell and nested paragraphs ordinary
- * rather than special cases.
- *
- * Holds the whole package, not just the body — headers, footers, notes, comments and styles are
- * all reachable through it, and parts the engine does not model are preserved verbatim.
- */
-export interface TreeDocxSessionView {
-  /** Whether the body holds at least one editable paragraph. */
-  readonly editable: boolean;
-  /** Canonical node ids of the body paragraphs, in order. */
-  paragraphIds(): string[];
-  /**
-   * Canonical node ids of paragraphs in a story scope. Defaults to the body.
-   * Header/footer scopes address the part `EditorScope { kind: 'headerFooter'; rId }` names.
-   */
-  paragraphIdsIn(scope?: StoryScope): string[];
-  /** The current canonical BODY part — what layout reads for the main story. */
-  part(): OoxmlPart;
-  /** The current part for a story scope, or null when the target is refused. */
-  partFor(scope: StoryScope): OoxmlPart | null;
-  /**
-   * The current package with every opened story store merged in. Authority for layout
-   * resolution and save — never a swapped single-part view.
-   */
-  currentPackage(): OoxmlPackage;
-  /**
-   * Commit typed tree ops directly, as ONE transaction.
-   *
-   * The paginated surface has no ProseMirror doc to diff, so it addresses the model the way
-   * the ops already do — by node id and offset — rather than round-tripping an edit through
-   * a projection just to have it diffed back out.
-   *
-   * `scope` defaults to the body. Pass `{ kind: 'headerFooter', rId }` to target an existing
-   * header/footer part; the transaction publishes one ModelChange (HF → `global` impact)
-   * and one undo unit without swapping the body store.
-   */
-  applyTreeOps(
-    ops: readonly TreeDocOp[],
-    selectionBefore?: SelectionMark | null,
-    selectionAfter?: SelectionMark | null,
-    scope?: StoryScope
-  ): TreeApplyResult;
-  /**
-   * Every part that holds a story, body first, then headers, footers and note parts.
-   *
-   * A READ: parts come from the package, so this opens no story store and spends none of the
-   * 64 editable-store slots. Use it for any query that must answer about the whole document
-   * rather than about the caret — an enumeration that reads only the body reports a document
-   * the reader is not looking at.
-   */
-  storyParts(): readonly OoxmlPart[];
-  /** Body text, paragraphs joined by newlines, read from the CANONICAL tree. */
-  bodyText(): string;
-  /** Text of a story scope, paragraphs joined by newlines. */
-  storyText(scope: StoryScope): string | null;
-  /** Body-store revision (independent of header/footer store revisions). */
-  revision(): number;
-  /** Per-story revision, or null when the target is refused. */
-  revisionFor(scope: StoryScope): number | null;
-  /** Package-wide revision — bumps on any story commit (body or HF). */
-  packageRevision(): number;
-  canUndo(): boolean;
-  canRedo(): boolean;
-  /**
-   * Undo the last entry, returning the selection to restore.
-   *
-   * The selection is part of the entry, not something a host can recompute: after undoing a
-   * split the caret belongs where the user was typing, and offsets in the reverted tree do
-   * not correspond to offsets in the one that replaced it. `null` means nothing was undone
-   * or the entry recorded no selection.
-   */
-  undo(): SelectionMark | null;
-  redo(): SelectionMark | null;
-  beginComposition(scope?: StoryScope): void;
-  endComposition(): void;
-  subscribe(onChange: (change: TreeModelChange) => void): () => void;
-  /** Serialize the whole package back to DOCX bytes. */
-  save(): Uint8Array;
-  /**
-   * The resolved header/footer parts of the section, by variant (phase 2).
-   *
-   * Returns the FINAL section's effective parts after OOXML inheritance. Prefer
-   * `headerFooterPartsBySection` for multi-section pagination.
-   *
-   * Re-resolved after any package revision so an edited shared part is visible everywhere
-   * it is attached.
-   */
-  headerFooterParts(): HeaderFooterParts;
-  /**
-   * Per-section header/footer parts after OOXML inheritance, index-aligned with
-   * `enumerateDocumentSections`.
-   */
-  headerFooterPartsBySection(): readonly HeaderFooterParts[];
-  /**
-   * Per-section resolution with declared-vs-inherited metadata for "Same as previous"
-   * chrome. Index-aligned with `headerFooterPartsBySection`.
-   */
-  headerFooterResolutionBySection(): readonly HeaderFooterSectionResolution[];
-  /**
-   * Font family names the document uses, from every `w:rFonts` in the CURRENT main
-   * part plus the styles and header/footer parts — validated, deduplicated, sorted.
-   * Memoized per package revision.
-   */
-  documentFonts(): readonly string[];
-  /**
-   * Whether the document puts any literal character on a page, over the same roots
-   * {@link TreeDocxSessionView.documentFonts} reads. Memoized per package revision.
-   *
-   * The font-substitution notice needs it: `documentFonts` reports what the document
-   * DECLARES, and a brand-new document declares Word's Calibri default over a single
-   * empty paragraph — a declaration with no glyph behind it.
-   */
-  rendersText(): boolean;
-  /** Validated style-picker projection. A document without styles answers `[]`. */
-  documentStyles(): readonly DocumentStyleEntry[];
-  /** Current styles root for layout, or `null` when the package has no styles part. */
-  stylesRoot(): OoxmlElement | null;
-  /**
-   * The theme part's Latin typefaces, for resolving `w:rFonts` theme references in layout.
-   *
-   * Memoized once: theme editing is a later slice. A document with no theme part answers
-   * `{ major: null, minor: null }`, which leaves every theme reference on the explicit
-   * font name beside it.
-   */
-  documentThemeFonts(): DocumentThemeFonts;
-  /**
-   * Root of the numbering part tree (`w:numbering`), for list layout. Memoized once;
-   * `null` when the package has no numbering part. Numbering editing is a later slice.
-   */
-  numberingRoot(): OoxmlElement | null;
-  /**
-   * Root of the settings part tree (`w:settings`), for document-wide layout constants such
-   * as `w:defaultTabStop`. Memoized once; `null` when the package has no settings part.
-   * Settings editing is a later slice, so this is immutable for the session.
-   */
-  settingsRoot(): OoxmlElement | null;
-  /**
-   * The document's own metadata from `docProps/core.xml` and `docProps/app.xml`, for
-   * document-property fields (TITLE, AUTHOR, SUBJECT, KEYWORDS, LASTSAVEDBY, COMMENTS). Read
-   * once per package revision; an empty object when the parts are absent.
-   */
-  documentProperties(): DocumentProperties;
-  /**
-   * What `settings.xml` says about tracking — `w:trackRevisions`, the tracked-changes
-   * protection, and the two do-not-track switches.
-   *
-   * Read from the document rather than assumed, because Word records the tracking state on
-   * the FILE: a package that asks to be edited as tracked changes, presented as an ordinary
-   * editable one, takes its first keystroke as an untracked edit.
-   */
-  trackingSettings(): DocumentTrackingSettings;
-  /**
-   * The theme's ten picker colours (`a:clrScheme`), in Word's column order, or `[]`
-   * when the package has no complete scheme. Memoized once: the theme part is
-   * immutable for the session's lifetime.
-   */
-  documentThemeColors(): readonly DocumentThemeColorEntry[];
-  /**
-   * The run formatting a paragraph's content INHERITS when it authors none: the
-   * paragraph style's `basedOn` chain, then `w:docDefaults`, with theme `rFonts`
-   * attributes resolved through the font scheme. `runProperties` (the span's own
-   * authored properties) lets a theme-only run-level `w:rFonts` resolve too. This is
-   * what lets a toolbar always show the effective font, the way Word does.
-   */
-  effectiveRunDefaults(
-    paragraphId: string,
-    runProperties?: readonly RunPropertyLike[]
-  ): StyleRunDefaults;
-  /**
-   * The heading outline of the BODY story, in document order: paragraphs whose
-   * `w:pStyle` resolves to a heading through the styles part (built-in `heading N`
-   * name, or the style's own `w:outlineLvl` 0..8). Memoized per main-part revision —
-   * an edit can retitle, add or remove a heading, but the styles part cannot change
-   * in-session.
-   */
-  documentOutline(): readonly DocumentOutlineEntry[];
-
-  /**
-   * Every pending review decision in the document, memoized per revision.
-   *
-   * Derived from the canonical TREE — the queue is a property of the document, and one derived
-   * from laid-out spans empties by half whenever the reader switches to a resolved view.
-   */
-  reviewItems(): readonly ReviewItem[];
-
-  /**
-   * Whether the document carries review content — tracked changes or comment
-   * anchors — regardless of any review module. Derived from store vocabulary
-   * only (never the review model), memoized per revision: it is the free
-   * tier's honest "this document has more than you are seeing" signal.
-   */
-  hasReviewContent(): boolean;
-
-  /**
-   * Reply to a comment, or add one over a revision's range. Returns the new comment's id.
-   *
-   * `scope` names the story the anchor lives in and defaults to the body. A header or
-   * footer anchor written against the body store addresses a paragraph that store has
-   * never heard of, so the transaction is refused and the reply is lost — which is what
-   * replying to a header card did.
-   */
-  replyToComment(
-    parentCommentId: string | null,
-    anchor: { paragraphId: string; start: number; end: number; endParagraphId?: string },
-    text: string,
-    author: string,
-    /** ISO-8601. Omitted writes no `@w:date`, because inventing one is a content change. */
-    date?: string,
-    scope?: StoryScope
-  ): string | null;
-  /**
-   * Resolve a comment thread, or reopen it. False when the document holds no such comment.
-   *
-   * The same package transaction shape as a reply, and for the same reason: `@w15:done` lives in
-   * `commentsExtended.xml`, a part a document with no thread does not have, so the state and the
-   * part that records it commit together.
-   */
-  setCommentResolved(commentId: string, resolved: boolean): boolean;
-  /**
-   * Delete a comment thread outright — body, thread state and story markers.
-   *
-   * A THREAD, like resolving one: a reply whose parent is gone has nothing left to answer.
-   * `scope` names the owning story and defaults to the body; `noteId` names one note inside a
-   * shared notes part. False when the document holds no such comment, or when the removal was
-   * refused.
-   */
-  deleteComment(commentId: string, scope?: StoryScope, noteId?: number): boolean;
-  /**
-   * Delete several comment objects as one package transaction and one undo unit.
-   *
-   * A root removes its thread; a reply removes only itself and reparents any foreign nested
-   * descendants to its parent. Marker stripping is scoped to `scope` / `noteId`.
-   */
-  deleteComments(
-    comments: readonly { readonly commentId: string; readonly parentCommentId?: string }[],
-    scope?: StoryScope,
-    noteId?: number
-  ): boolean;
-  /**
-   * Insert a custom node, with the payload it carries, as ONE transaction.
-   *
-   * A package write reaching through the body store, exactly as a comment is: the customXml data
-   * part, the node inside it and the bound `w:sdt` commit together or not at all. A control bound
-   * to a store that was never written is a document Word offers to repair.
-   *
-   * Omitting the payload authors the ordinary tagged control, which is what a node small enough
-   * to live in its `w:tag` needs.
-   */
-  /** `scope` names the story the paragraph is in, and defaults to the body. */
-  insertCustomNode(write: InsertCustomNodeWrite, scope?: StoryScope): CustomNodeWriteResult;
-  /**
-   * Remove a custom node and, in the same transaction, the payload it bound.
-   *
-   * The sweep would collect the payload on the next open regardless; doing it here means a
-   * document saved between the deletion and that open does not carry a payload for a chip that
-   * is gone.
-   */
-  /**
-   * Remove a custom node and the payload it bound. `scope` names the story holding it and
-   * defaults to the body; a chip in a header is refused against the body store.
-   */
-  removeCustomNode(controlNodeId: string, scope?: StoryScope): CustomNodeWriteResult;
-  /**
-   * Drop every payload no control binds, in the stores whose namespaces a module claims.
-   *
-   * Called ON OPEN and nowhere else — see `sweepCustomNodePayloads`. Answers the ids collected,
-   * so a host can report what a document arrived carrying.
-   */
-  sweepCustomNodePayloads(namespaces: readonly string[]): CustomNodeSweepOutcome;
-  /**
-   * Every occurrence of `query` in the BODY story, in document order, addressed in the
-   * same offset vocabulary the tree ops and the surface selection use — so a match can be
-   * handed straight to `setSelection` without re-deriving anything.
-   *
-   * Memoized one deep, keyed on the revision AND the question asked: a find panel asks the
-   * same question on every tick, and a different query replaces the entry rather than
-   * growing a cache the session would have to bound.
-   */
-  findText(query: string, options?: DocumentSearchOptions): DocumentSearchResult;
-  /**
-   * The faces the package EMBEDS (`word/fontTable.xml` embed relationships),
-   * deobfuscated — the only font source that needs neither a substitute nor a network.
-   * Extraction asserts nothing about validity; admitting a face is the font resource
-   * lane's job. Memoized once: the font table and font parts are immutable in-session.
-   */
-  embeddedFonts(): readonly EmbeddedFont[];
-  /**
-   * The `w:numId` of a bullet or numbered list definition, creating one where the document
-   * has none — including `numbering.xml` itself, its relationship and its content type.
-   *
-   * A document Word has never numbered carries no numbering part at all, so the first
-   * bullet a user asks for has to bring the whole definition with it. An existing
-   * definition of the same kind is reused rather than duplicated.
-   */
-  /**
-   * What the owning part's relationships answer for one `r:id` under `scope` (default:
-   * body): the authored target and whether it is external. `null` for an id the part does
-   * not declare, or when the scoped part is not open.
-   *
-   * Live rather than memoized: inserting a link mints a relationship mid-session, and a
-   * cached resolver would report the link this session just created as dangling.
-   */
-  relationshipTarget(
-    relationshipId: string,
-    scope?: StoryScope
-  ): { readonly target: string; readonly external: boolean } | null;
-  /**
-   * `bookmarkName -> { paragraphId, offset }` over the main part, memoized per revision.
-   *
-   * What an internal hyperlink's `w:anchor` resolves through. Keyed on the store revision
-   * because an edit can move, split or delete the paragraph a bookmark sits in.
-   */
-  bookmarks(): BookmarkIndex;
-  /**
-   * The relationship id for an external hyperlink target on the part owning `scope`
-   * (default: body), minting one if that part has none, or `null` when the URL is refused
-   * or the scoped part cannot be resolved.
-   *
-   * Lives on the PACKAGE, outside `store.transact`, like the numbering definitions: the
-   * undoable half is the tree op that names the id. An unreferenced relationship left
-   * behind by an undo is inert and is what Word writes anyway. Scoped inserts mint onto
-   * the story's own `.rels` so a header/footer or note link never creates a stray body
-   * relationship.
-   */
-  ensureHyperlinkRelationship(url: string, scope?: StoryScope): string | null;
-  ensureListDefinition(kind: ListKind): string | null;
-  /**
-   * Declare `level` in the list definition `numId` names, with Word's default format for
-   * that depth, or answer false.
-   *
-   * Word never greys Increase Indent out on a list item: demoting past the deepest level
-   * a definition declares makes Word define the level, cycling its stock bullets and
-   * number formats. An already-declared level answers true without changing anything.
-   *
-   * The declaration lives on the PACKAGE, outside the store's history — undoing the edit
-   * that needed it restores the paragraph but leaves the level declared, which is
-   * harmless: an unreferenced level renders nothing and Word writes files full of them.
-   */
-  ensureNumberingLevel(numId: string, level: number, kind: ListKind): boolean;
-  /**
-   * The `w14:paraId` ↔ node-id index over the full editable set of the MAIN part,
-   * memoized per revision. Every editable paragraph carries a valid, part-unique id
-   * (established at open, maintained by the split appliers), so every paragraph is
-   * mapped. Header/footer paragraphs become addressable through `partFor` once their
-   * story store is open.
-   */
-  paragraphAnchors(): ParagraphAnchorIndex;
-  /** `w14:paraId` of a canonical paragraph node id, verbatim, or null. */
-  paraIdOf(nodeId: string): string | null;
-  /** Canonical node id for a `w14:paraId`, matched case-insensitively, or null. */
-  nodeIdOf(paraId: string): string | null;
-
-  /** Insert a validated raster image as one package undo unit (task 12). */
-  insertImage(
-    scope: StoryScope,
-    input: import('../store/store/tree-package-images.ts').InsertImageInput
-  ): Promise<import('../store/store/tree-package-images.ts').ImageIntentResult>;
-
-  /** Replace a picture drawing's embedded media in one package undo unit. */
-  replaceImage(
-    scope: StoryScope,
-    drawingNodeId: string,
-    bytes: Uint8Array,
-    mime: import('../store/package/image-resources.ts').SupportedImageMime,
-    decodePort: import('../store/package/image-resources.ts').ImageDecodePort,
-    options: import('../store/store/tree-package-images.ts').ReplaceImageOptions
-  ): Promise<import('../store/store/tree-package-images.ts').ImageIntentResult>;
-
-  /** Delete a picture drawing and collect orphaned media in one package undo unit. */
-  deleteImage(
-    scope: StoryScope,
-    drawingNodeId: string
-  ): import('../store/store/tree-package-images.ts').ImageIntentResult;
-
-  /** Propose the drawing's deletion as a tracked change (`w:del`); media stays untouched. */
-  deleteImageTracked(
-    scope: StoryScope,
-    drawingNodeId: string,
-    revision: import('../store/store/tree-op-types.ts').RevisionAttributionInput
-  ): import('../store/store/tree-package-images.ts').ImageIntentResult;
-
-  /** Apply image property tree ops plus hyperlink relationship wiring atomically. */
-  applyImageProperties(
-    scope: StoryScope,
-    input: import('../store/store/tree-package-images.ts').ApplyImagePropertiesInput
-  ): import('../store/store/tree-package-images.ts').ImageIntentResult;
-
-  /** Land a clipboard fragment (resource merge + blocks) as one package undo unit. */
-  applyFragmentPaste(
-    scope: StoryScope,
-    input: import('../store/store/tree-package-fragment.ts').FragmentPasteInput
-  ): import('../store/store/tree-package-fragment.ts').FragmentPasteResult;
-}
+// The session view contract (TreeApplyResult + TreeDocxSessionView) lives in
+// tree-session-contract.ts; re-exported so every existing import through this module stays
+// stable.
+import type { TreeApplyResult, TreeDocxSessionView } from './tree-session-contract.ts';
+export type { TreeApplyResult, TreeDocxSessionView };
 
 /**
  * Binding-only session methods that exchange ProseMirror projections.

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -514,6 +514,13 @@ export interface TreeDocxSessionView {
     drawingNodeId: string
   ): import('../store/store/tree-package-images.ts').ImageIntentResult;
 
+  /** Propose the drawing's deletion as a tracked change (`w:del`); media stays untouched. */
+  deleteImageTracked(
+    scope: StoryScope,
+    drawingNodeId: string,
+    revision: import('../store/store/tree-op-types.ts').RevisionAttributionInput
+  ): import('../store/store/tree-package-images.ts').ImageIntentResult;
+
   /** Apply image property tree ops plus hyperlink relationship wiring atomically. */
   applyImageProperties(
     scope: StoryScope,
@@ -1676,6 +1683,10 @@ export function openTreeSession(
 
       deleteImage(scope, drawingNodeId) {
         return packageStore.deleteImage(scope, drawingNodeId);
+      },
+
+      deleteImageTracked(scope, drawingNodeId, revision) {
+        return packageStore.deleteImageTracked(scope, drawingNodeId, revision);
       },
 
       applyImageProperties(scope, input) {

--- a/packages/core/src/editor/__tests__/caret-after-wide-image.test.ts
+++ b/packages/core/src/editor/__tests__/caret-after-wide-image.test.ts
@@ -1,0 +1,114 @@
+// The caret at the offset AFTER a picture that owns its whole line.
+//
+// That offset is shared by two lines: the drawing-only line it ends and the text line it
+// opens. `caretAt` used to keep the first match — the picture's right edge — so a click
+// before the following text resolved the right offset but painted the caret a full picture
+// away, and no click ever showed a caret at the text's start. The rule now mirrors the
+// hard-break one: a drawing-only line's end belongs to the line the drawing opened, and the
+// picture's right edge stays the answer only when the picture ends its paragraph.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { caretAt, hitTestSemantic } from '../../layout/index.ts';
+import {
+  CT_NS,
+  DRAWING_NS,
+  IMG_REL,
+  OD_REL,
+  PNG_1X1,
+  REL_NS,
+  decodePort,
+  picture,
+  settle,
+} from './image-decode-harness.ts';
+
+/** A 460pt-wide inline picture: too wide to share a 468pt line with any text. */
+function wideInlinePicture(id: number): string {
+  return (
+    '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    `<wp:extent cx="5842000" cy="1270000"/><wp:docPr id="${id}" name="pic"/>` +
+    `${picture(id)}</wp:inline></w:drawing></w:r>`
+  );
+}
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT_NS}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="png" ContentType="image/png"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rIdImg" Type="${IMG_REL}" Target="media/image1.png"/></Relationships>`
+    ),
+    'word/media/image1.png': PNG_1X1,
+    'word/document.xml': strToU8(`<w:document ${DRAWING_NS}><w:body>${body}</w:body></w:document>`),
+  });
+}
+
+async function mount(body: string): Promise<{ surface: PaginatedSurface; container: HTMLElement }> {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(body), {
+    scale: 1,
+    imageDecodePort: decodePort(),
+  });
+  if (!opened.ok) throw new Error(opened.reason);
+  await settle();
+  return { surface: opened.surface, container };
+}
+
+describe('the caret after a picture that owns its line', () => {
+  test('paints before the following text, where the click that placed it landed', async () => {
+    const { surface, container } = await mount(
+      `<w:p>${wideInlinePicture(5)}<w:r><w:t xml:space="preserve">1.1 Basic Text Formatting</w:t></w:r></w:p>`
+    );
+    try {
+      const layout = surface.layout();
+      const [p1] = surface.session.paragraphIds();
+      const lines = layout.pages[0]!.fragments.flatMap((block) =>
+        block.kind === 'paragraph' ? block.lines : []
+      );
+      // The premise: the picture owns line 1 outright, the text opens line 2 at offset 1.
+      expect(lines[0]!.range).toMatchObject({ start: 0, end: 1 });
+      expect(lines[1]!.range.start).toBe(1);
+
+      const caret = caretAt(layout, { paragraphId: p1!, offset: 1 })!;
+      expect(caret.lineId).toBe(lines[1]!.id);
+      expect(caret.y).toBe(lines[1]!.box.y);
+      expect(caret.x).toBe(0);
+
+      // The click before the "1" resolves the same offset AND the same geometry.
+      const hit = hitTestSemantic(layout, { x: 1, y: lines[1]!.box.y + 2, pageIndex: 0 })!;
+      expect(hit.position).toEqual({ paragraphId: p1!, offset: 1 });
+      expect(hit.lineId).toBe(caret.lineId);
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('keeps the picture-edge answer when the picture ends its paragraph', async () => {
+    const { surface, container } = await mount(`<w:p>${wideInlinePicture(5)}</w:p>`);
+    try {
+      const layout = surface.layout();
+      const [p1] = surface.session.paragraphIds();
+      const caret = caretAt(layout, { paragraphId: p1!, offset: 1 })!;
+      expect(caret).not.toBeNull();
+      expect(caret.x).toBe(460);
+      expect(caret.y).toBe(0);
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});

--- a/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
@@ -281,6 +281,84 @@ describe('tracked drawings carry and paint their revision', () => {
     }
   });
 
+  test('suggesting insertImage proposes the picture as a tracked insertion', async () => {
+    const { surface, container } = await mount(
+      docx('<w:p><w:r><w:t xml:space="preserve">text</w:t></w:r></w:p>'),
+      undefined,
+      { author: 'Demo Reviewer', editingMode: 'suggest' }
+    );
+    try {
+      const [p1] = surface.session.paragraphIds();
+      surface.setSelection({
+        anchor: { paragraphId: p1!, offset: 4 },
+        head: { paragraphId: p1!, offset: 4 },
+      });
+      const result = await surface.insertImage({
+        paragraphId: p1!,
+        offset: 4,
+        bytes: PNG_1X1,
+        mime: 'image/png',
+        widthPoints: 36,
+        heightPoints: 36,
+        expectedPackageRevision: surface.session.packageRevision(),
+      });
+      expect(result.ok).toBe(true);
+      await settle();
+
+      const drawings = lineDrawings(surface);
+      expect(drawings).toHaveLength(1);
+      expect(drawings[0]!.revisions![0]).toMatchObject({
+        kind: 'insert',
+        author: 'Demo Reviewer',
+      });
+      const element = container.querySelector<HTMLElement>('.docx-drawing');
+      expect(element!.classList.contains('docx-drawing--revision-insertion')).toBe(true);
+
+      const items = revisionItemsOf(surface.session.part());
+      expect(items).toHaveLength(1);
+      expect(items[0]!.revisionKind).toBe('insert');
+
+      // One undo takes the whole proposal back — the picture and its wrapper together.
+      surface.undo();
+      expect(lineDrawings(surface)).toHaveLength(0);
+      expect(revisionItemsOf(surface.session.part())).toHaveLength(0);
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('Delete on a pointer-selected picture strikes the picture, not the paragraph break', async () => {
+    const { surface, container } = await mount(
+      docx(
+        `<w:p>${inlinePicture(6)}</w:p><w:p><w:r><w:t xml:space="preserve">after</w:t></w:r></w:p>`
+      ),
+      undefined,
+      { author: 'Demo Reviewer', editingMode: 'suggest' }
+    );
+    try {
+      const painted = container.querySelector<HTMLElement>('.docx-drawing')!;
+      // The object-selection gesture: a primary press on the painted drawing.
+      painted.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      expect(surface.drawingSelectionIntent().kind).toBe('pointer');
+      painted.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true, cancelable: true })
+      );
+
+      const drawings = lineDrawings(surface);
+      expect(drawings).toHaveLength(1);
+      expect(drawings[0]!.revisions![0]!.kind).toBe('delete');
+      // No paragraph-mark card: the key deleted the OBJECT, not the break beside it.
+      const items = revisionItemsOf(surface.session.part());
+      expect(items).toHaveLength(1);
+      expect(items[0]!.revisionKind).toBe('delete');
+      expect(items[0]!.markDirection).toBeUndefined();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
   test('suggesting deleteImage without an author is refused', async () => {
     const { surface, container } = await mount(docx(`<w:p>${inlinePicture(6)}</w:p>`), undefined, {
       editingMode: 'suggest',

--- a/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
@@ -11,8 +11,10 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import type { SurfaceEditingMode } from '../paginated-surface-contract.ts';
 import type { RevisionDisplayMode } from '../../layout/revision-projection.ts';
 import type { InlineDrawingRecord } from '../../layout/drawing-layout.ts';
+import { revisionItemsOf } from '../../store/store/review-reads.ts';
 import {
   CT_NS,
   DRAWING_NS,
@@ -67,7 +69,8 @@ function docx(body: string): Uint8Array {
 
 async function mount(
   bytes: Uint8Array,
-  revisionDisplayMode?: RevisionDisplayMode
+  revisionDisplayMode?: RevisionDisplayMode,
+  extra?: { readonly author?: string; readonly editingMode?: SurfaceEditingMode }
 ): Promise<{ surface: PaginatedSurface; container: HTMLElement }> {
   const container = document.createElement('div');
   document.body.append(container);
@@ -75,6 +78,8 @@ async function mount(
     scale: 1,
     imageDecodePort: decodePort(),
     ...(revisionDisplayMode ? { revisionDisplayMode } : {}),
+    ...(extra?.author ? { author: extra.author } : {}),
+    ...(extra?.editingMode ? { editingMode: extra.editingMode } : {}),
   });
   if (!opened.ok) throw new Error(opened.reason);
   await settle();
@@ -230,6 +235,54 @@ describe('tracked drawings carry and paint their revision', () => {
         .flatMap((block) => (block.kind === 'paragraph' ? block.lines : []));
       expect(cellLines.some((line) => (line.anchorRevisions ?? []).length > 0)).toBe(true);
       expect(container.querySelector('.docx-change-bar-insertion')).not.toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('suggesting deleteImage proposes the deletion, not a paragraph break', async () => {
+    const { surface, container } = await mount(
+      docx(
+        `<w:p>${inlinePicture(6)}</w:p><w:p><w:r><w:t xml:space="preserve">after</w:t></w:r></w:p>`
+      ),
+      undefined,
+      { author: 'Demo Reviewer', editingMode: 'suggest' }
+    );
+    try {
+      const target = lineDrawings(surface)[0]!;
+      const result = surface.deleteImage(target.drawingNodeId);
+      expect(result.ok).toBe(true);
+
+      // The picture stays on the page as a pending removal.
+      const after = lineDrawings(surface);
+      expect(after).toHaveLength(1);
+      expect(after[0]!.revisions![0]).toMatchObject({ kind: 'delete', author: 'Demo Reviewer' });
+      const element = container.querySelector<HTMLElement>('.docx-drawing');
+      expect(element!.classList.contains('docx-drawing--revision-deletion')).toBe(true);
+      expect(container.querySelector('.docx-change-bar-deletion')).not.toBeNull();
+
+      // The review queue offers the deletion itself — NOT a "deleted paragraph break" card.
+      const items = revisionItemsOf(surface.session.part());
+      expect(items).toHaveLength(1);
+      expect(items[0]!.revisionKind).toBe('delete');
+      expect(items[0]!.markDirection).toBeUndefined();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('suggesting deleteImage without an author is refused', async () => {
+    const { surface, container } = await mount(docx(`<w:p>${inlinePicture(6)}</w:p>`), undefined, {
+      editingMode: 'suggest',
+    });
+    try {
+      const target = lineDrawings(surface)[0]!;
+      const result = surface.deleteImage(target.drawingNodeId);
+      expect(result.ok).toBe(false);
+      expect(lineDrawings(surface)).toHaveLength(1);
+      expect(lineDrawings(surface)[0]!.revisions).toBeUndefined();
     } finally {
       surface.destroy();
       container.remove();

--- a/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
@@ -267,6 +267,14 @@ describe('tracked drawings carry and paint their revision', () => {
       expect(items).toHaveLength(1);
       expect(items[0]!.revisionKind).toBe('delete');
       expect(items[0]!.markDirection).toBeUndefined();
+
+      // A second Delete on the struck picture says nothing new: no phantom undo unit, so
+      // ONE undo restores the untracked picture instead of visibly doing nothing first.
+      const again = surface.deleteImage(after[0]!.drawingNodeId);
+      expect(again.ok).toBe(true);
+      expect(revisionItemsOf(surface.session.part())).toHaveLength(1);
+      surface.undo();
+      expect(lineDrawings(surface)[0]!.revisions).toBeUndefined();
     } finally {
       surface.destroy();
       container.remove();

--- a/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
@@ -203,25 +203,52 @@ describe('tracked drawings carry and paint their revision', () => {
       expect(element).not.toBeNull();
       expect(element!.classList.contains('docx-drawing--revision-insertion')).toBe(true);
       expect(element!.dataset.revisionKind).toBe('insert');
+
+      // The anchor line carries no span or line drawing for the picture, so the bar reads
+      // the line's own anchor attribution.
+      expect(container.querySelector('.docx-change-bar-insertion')).not.toBeNull();
     } finally {
       surface.destroy();
       container.remove();
     }
   });
 
-  test('the original view drops an inserted anchored picture', async () => {
-    const { surface, container } = await mount(
-      docx(
-        `<w:p><w:r><w:t xml:space="preserve">anchor line</w:t></w:r>${ins(anchoredPicture(9))}</w:p>`
-      ),
-      'original'
-    );
-    try {
-      expect(surface.layout().pages[0]!.anchoredDrawings ?? []).toHaveLength(0);
-      expect(container.querySelector('.docx-drawing-layer .docx-drawing')).toBeNull();
-    } finally {
-      surface.destroy();
-      container.remove();
-    }
+  test('the original view drops an inserted anchored picture, its bar, and its wrap hole', async () => {
+    const topAndBottom = anchoredPicture(9).replace('<wp:wrapNone/>', '<wp:wrapTopAndBottom/>');
+    const body = (drawing: string): Uint8Array =>
+      docx(`<w:p>${drawing}<w:r><w:t xml:space="preserve">anchor line</w:t></w:r></w:p>`);
+    const firstLineY = async (
+      bytes: Uint8Array,
+      mode?: RevisionDisplayMode
+    ): Promise<{ y: number; bars: number; drawings: number }> => {
+      const { surface, container } = await mount(bytes, mode);
+      try {
+        const line = surface
+          .layout()
+          .pages[0]!.fragments.flatMap((block) =>
+            block.kind === 'paragraph' ? block.lines : []
+          )[0]!;
+        return {
+          y: line.box.y,
+          bars: container.querySelectorAll('.docx-change-bar').length,
+          drawings: (surface.layout().pages[0]!.anchoredDrawings ?? []).length,
+        };
+      } finally {
+        surface.destroy();
+        container.remove();
+      }
+    };
+    const markup = await firstLineY(body(ins(topAndBottom)));
+    const original = await firstLineY(body(ins(topAndBottom)), 'original');
+    const plain = await firstLineY(body(''));
+    // Under all-markup the inserted picture shows: it pushes the text down and draws a bar.
+    expect(markup.drawings).toBe(1);
+    expect(markup.y).toBeGreaterThan(plain.y);
+    expect(markup.bars).toBeGreaterThan(0);
+    // The original view promises the document before the insertion: no record, no bar, and
+    // no phantom text-wrap hole where the hidden picture would sit.
+    expect(original.drawings).toBe(0);
+    expect(original.bars).toBe(0);
+    expect(original.y).toBe(plain.y);
   });
 });

--- a/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
@@ -213,6 +213,29 @@ describe('tracked drawings carry and paint their revision', () => {
     }
   });
 
+  test('a tracked anchored picture in a table cell cues a change bar too', async () => {
+    const { surface, container } = await mount(
+      docx(
+        '<w:tbl><w:tblGrid><w:gridCol w:w="4800"/></w:tblGrid><w:tr><w:tc>' +
+          `<w:p><w:r><w:t xml:space="preserve">cell text</w:t></w:r>${ins(anchoredPicture(9))}</w:p>` +
+          '</w:tc></w:tr></w:tbl><w:p><w:r><w:t>after</w:t></w:r></w:p>'
+      )
+    );
+    try {
+      const cellLines = surface
+        .layout()
+        .pages[0]!.fragments.flatMap((block) => (block.kind === 'table' ? block.rows : []))
+        .flatMap((row) => row.cells)
+        .flatMap((cell) => cell.blocks)
+        .flatMap((block) => (block.kind === 'paragraph' ? block.lines : []));
+      expect(cellLines.some((line) => (line.anchorRevisions ?? []).length > 0)).toBe(true);
+      expect(container.querySelector('.docx-change-bar-insertion')).not.toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
   test('the original view drops an inserted anchored picture, its bar, and its wrap hole', async () => {
     const topAndBottom = anchoredPicture(9).replace('<wp:wrapNone/>', '<wp:wrapTopAndBottom/>');
     const body = (drawing: string): Uint8Array =>

--- a/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-drawing-revisions.test.ts
@@ -1,0 +1,227 @@
+// A drawing inside a tracked insertion or deletion carries the change (#479).
+//
+// The record folds the owning run's revision stack in, paint marks the element with the
+// same `data-revision-*` datasets spans carry plus a kind-coloured outline class, deleted
+// pictures stay laid out under `all-markup` (dimmed, like struck text), and the resolved
+// display modes remove what they resolve away — inline and anchored alike.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import type { RevisionDisplayMode } from '../../layout/revision-projection.ts';
+import type { InlineDrawingRecord } from '../../layout/drawing-layout.ts';
+import {
+  CT_NS,
+  DRAWING_NS,
+  IMG_REL,
+  OD_REL,
+  PNG_1X1,
+  REL_NS,
+  decodePort,
+  inlinePicture,
+  picture,
+  settle,
+} from './image-decode-harness.ts';
+
+/** An anchored picture at the paragraph's top-left corner, wrapping nothing. */
+function anchoredPicture(id: number): string {
+  return (
+    '<w:r><w:drawing>' +
+    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" behindDoc="0" locked="0" ' +
+    'layoutInCell="1" allowOverlap="1" relativeHeight="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    `<wp:extent cx="457200" cy="457200"/><wp:wrapNone/><wp:docPr id="${id}" name="pic"/>` +
+    `${picture(id)}</wp:anchor></w:drawing></w:r>`
+  );
+}
+
+const ins = (inner: string): string =>
+  `<w:ins w:id="11" w:author="Alice" w:date="2024-01-01T00:00:00Z">${inner}</w:ins>`;
+const del = (inner: string): string =>
+  `<w:del w:id="12" w:author="Bob" w:date="2024-01-02T00:00:00Z">${inner}</w:del>`;
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT_NS}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="png" ContentType="image/png"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rIdImg" Type="${IMG_REL}" Target="media/image1.png"/></Relationships>`
+    ),
+    'word/media/image1.png': PNG_1X1,
+    'word/document.xml': strToU8(`<w:document ${DRAWING_NS}><w:body>${body}</w:body></w:document>`),
+  });
+}
+
+async function mount(
+  bytes: Uint8Array,
+  revisionDisplayMode?: RevisionDisplayMode
+): Promise<{ surface: PaginatedSurface; container: HTMLElement }> {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, bytes, {
+    scale: 1,
+    imageDecodePort: decodePort(),
+    ...(revisionDisplayMode ? { revisionDisplayMode } : {}),
+  });
+  if (!opened.ok) throw new Error(opened.reason);
+  await settle();
+  return { surface: opened.surface, container };
+}
+
+function lineDrawings(surface: PaginatedSurface): readonly InlineDrawingRecord[] {
+  return surface
+    .layout()
+    .pages.flatMap((page) => page.fragments)
+    .flatMap((block) => (block.kind === 'paragraph' ? block.lines : []))
+    .flatMap((line) => line.drawings ?? []);
+}
+
+describe('tracked drawings carry and paint their revision', () => {
+  test('an inserted inline picture is outlined, attributed, and gets a change bar', async () => {
+    const { surface, container } = await mount(
+      docx(`<w:p><w:r><w:t xml:space="preserve">before </w:t></w:r>${ins(inlinePicture(5))}</w:p>`)
+    );
+    try {
+      const drawings = lineDrawings(surface);
+      expect(drawings).toHaveLength(1);
+      expect(drawings[0]!.revisions).toEqual([
+        {
+          kind: 'insert',
+          id: '11',
+          author: 'Alice',
+          date: '2024-01-01T00:00:00Z',
+          nodeId: expect.any(String),
+        },
+      ]);
+
+      const element = container.querySelector<HTMLElement>('.docx-drawing');
+      expect(element).not.toBeNull();
+      expect(element!.classList.contains('docx-drawing--revision')).toBe(true);
+      expect(element!.classList.contains('docx-drawing--revision-insertion')).toBe(true);
+      expect(element!.dataset.revisionKind).toBe('insert');
+      expect(element!.dataset.revisionId).toBe('11');
+      expect(element!.dataset.reviewAuthor).toBe('Alice');
+
+      // The line's only change is the picture — no revision span — and the margin still says
+      // something changed on it.
+      expect(container.querySelector('.docx-change-bar-insertion')).not.toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('a deleted inline picture stays laid out under all-markup, marked as a removal', async () => {
+    const { surface, container } = await mount(
+      docx(`<w:p><w:r><w:t xml:space="preserve">keep </w:t></w:r>${del(inlinePicture(6))}</w:p>`)
+    );
+    try {
+      const drawings = lineDrawings(surface);
+      expect(drawings).toHaveLength(1);
+      expect(drawings[0]!.revisions![0]!.kind).toBe('delete');
+
+      const element = container.querySelector<HTMLElement>('.docx-drawing');
+      expect(element).not.toBeNull();
+      expect(element!.classList.contains('docx-drawing--revision-deletion')).toBe(true);
+      expect(element!.dataset.revisionKind).toBe('delete');
+      expect(element!.dataset.reviewAuthor).toBe('Bob');
+      expect(container.querySelector('.docx-change-bar-deletion')).not.toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('the proposed result drops a deleted picture; the original drops an inserted one', async () => {
+    const body =
+      `<w:p><w:r><w:t xml:space="preserve">text </w:t></w:r>${del(inlinePicture(6))}</w:p>` +
+      `<w:p>${ins(inlinePicture(7))}</w:p>`;
+    const proposed = await mount(docx(body), 'proposed');
+    try {
+      const drawings = lineDrawings(proposed.surface);
+      expect(drawings).toHaveLength(1);
+      expect(drawings[0]!.revisions![0]!.kind).toBe('insert');
+    } finally {
+      proposed.surface.destroy();
+      proposed.container.remove();
+    }
+    const original = await mount(docx(body), 'original');
+    try {
+      const drawings = lineDrawings(original.surface);
+      expect(drawings).toHaveLength(1);
+      expect(drawings[0]!.revisions![0]!.kind).toBe('delete');
+    } finally {
+      original.surface.destroy();
+      original.container.remove();
+    }
+  });
+
+  test('an untracked picture paints no revision marking', async () => {
+    const { surface, container } = await mount(docx(`<w:p>${inlinePicture(8)}</w:p>`));
+    try {
+      expect(lineDrawings(surface)[0]!.revisions).toBeUndefined();
+      const element = container.querySelector<HTMLElement>('.docx-drawing');
+      expect(element).not.toBeNull();
+      expect(element!.classList.contains('docx-drawing--revision')).toBe(false);
+      expect(element!.dataset.revisionKind).toBeUndefined();
+      expect(container.querySelector('.docx-change-bar')).toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('an inserted anchored picture is published with its revision and marked in paint', async () => {
+    const { surface, container } = await mount(
+      docx(
+        `<w:p><w:r><w:t xml:space="preserve">anchor line</w:t></w:r>${ins(anchoredPicture(9))}</w:p>`
+      )
+    );
+    try {
+      const anchored = surface.layout().pages[0]!.anchoredDrawings ?? [];
+      expect(anchored).toHaveLength(1);
+      expect(anchored[0]!.revisions![0]).toMatchObject({
+        kind: 'insert',
+        id: '11',
+        author: 'Alice',
+      });
+
+      const element = container.querySelector<HTMLElement>('.docx-drawing-layer .docx-drawing');
+      expect(element).not.toBeNull();
+      expect(element!.classList.contains('docx-drawing--revision-insertion')).toBe(true);
+      expect(element!.dataset.revisionKind).toBe('insert');
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('the original view drops an inserted anchored picture', async () => {
+    const { surface, container } = await mount(
+      docx(
+        `<w:p><w:r><w:t xml:space="preserve">anchor line</w:t></w:r>${ins(anchoredPicture(9))}</w:p>`
+      ),
+      'original'
+    );
+    try {
+      expect(surface.layout().pages[0]!.anchoredDrawings ?? []).toHaveLength(0);
+      expect(container.querySelector('.docx-drawing-layer .docx-drawing')).toBeNull();
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});

--- a/packages/core/src/editor/docx-editor-images.ts
+++ b/packages/core/src/editor/docx-editor-images.ts
@@ -486,13 +486,19 @@ export function asyncImageCommandRefusal(
   };
 }
 
-function asyncImageExecutionGate(surface: PaginatedSurface | null): ExecResult | null {
+function asyncImageExecutionGate(
+  surface: PaginatedSurface | null,
+  commandType: 'insertImage' | 'replaceImage'
+): ExecResult | null {
   if (!surface) return { ok: false, code: 'notFound', reason: 'no document is loaded' };
   const mode = surface.editingMode();
   if (mode === 'view') {
     return { ok: false, code: 'locked', reason: 'the document is open for viewing' };
   }
-  if (mode === 'suggest') {
+  // Suggesting inserts a picture as a TRACKED insertion (the surface lane wraps it in
+  // `w:ins`); replacing one still refuses — swapping bytes inside an existing drawing has
+  // no tracked-change representation.
+  if (mode === 'suggest' && commandType === 'replaceImage') {
     return {
       ok: false,
       code: 'invalidArgs',
@@ -744,7 +750,7 @@ export function canExecuteImageCommand(
   command: Extract<EditorCommand, { type: 'insertImage' | 'replaceImage' }>,
   surface: PaginatedSurface | null
 ): CanResult {
-  const modeGate = asyncImageExecutionGate(surface);
+  const modeGate = asyncImageExecutionGate(surface, command.type);
   if (modeGate) return modeGate;
   const gate = gateImageCommand(command, surface);
   if (gate) return gate;
@@ -934,7 +940,7 @@ export async function executeImageCommand(
 ): Promise<ExecResult> {
   const surface = editor.surface;
   if (!surface) return { ok: false, code: 'notFound', reason: 'no document is loaded' };
-  const modeGate = asyncImageExecutionGate(surface);
+  const modeGate = asyncImageExecutionGate(surface, command.type);
   if (modeGate) return modeGate;
   const gate = gateImageCommand(command, surface);
   if (gate) return gate;

--- a/packages/core/src/editor/docx-editor-images.ts
+++ b/packages/core/src/editor/docx-editor-images.ts
@@ -587,14 +587,10 @@ export function gateImageCommand(
   if (!image) {
     return { ok: false, code: 'notFound', reason: 'no drawing is selected' };
   }
-  if (surface.editingMode() === 'suggest') {
-    if (command.type === 'deleteImage') {
-      return {
-        ok: false,
-        code: 'invalidArgs',
-        reason: 'trackedDrawingDeletionUnsupported',
-      };
-    }
+  // Suggesting supports exactly one image command: proposing the deletion. Every other
+  // image edit (resize, wrap, position, replace) still refuses — a tracked form of those
+  // does not exist yet, and a silent untracked commit is the one thing the mode forbids.
+  if (surface.editingMode() === 'suggest' && command.type !== 'deleteImage') {
     return {
       ok: false,
       code: 'invalidArgs',

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -28,6 +28,7 @@ import {
 } from '@docx-editor.dev/core/store';
 import { retractedLengthOf, retractedRangesOf } from '../store/store/tree-op-retraction.ts';
 import { retractsOwnParagraphMark } from '../store/store/tree-op-tracked-marks.ts';
+import { resolveSelectedDrawingRecord } from './docx-editor-images.ts';
 import { directParagraphsInCells } from '../layout/semantic-cell-selection.ts';
 import { syncActiveFieldShading } from './surface-field-shading.ts';
 import {
@@ -5944,6 +5945,32 @@ export function mountPaginatedSurface(
   };
   const onDrawingKeyGesture = (event: Event): void => {
     if (event instanceof KeyboardEvent && NON_DESELECTING_KEYS.has(event.key)) return;
+    // Delete/Backspace ON a selected drawing deletes THE DRAWING — Word's object gesture.
+    // Without this the key fell through to the text keymap at a collapsed caret, where a
+    // Delete beside the picture read as a paragraph JOIN: in suggesting mode that proposed
+    // a "deleted paragraph break" while the selected picture stayed untouched. Handled
+    // here, in the same capture listener that owns the intent, because it must consume the
+    // key BEFORE the text keymap on this element sees it. The host overlay's own handler
+    // (when the overlay is focused) never reaches this listener at all.
+    const deleteKey =
+      (event instanceof KeyboardEvent &&
+        (event.key === 'Delete' || event.key === 'Backspace') &&
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey) ||
+      (event instanceof InputEvent &&
+        (event.inputType === 'deleteContentBackward' ||
+          event.inputType === 'deleteContentForward'));
+    if (deleteKey && drawingIntent.kind === 'pointer') {
+      const target = resolveSelectedDrawingRecord(surface);
+      if (target !== null) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        setDrawingIntent({ kind: 'none' }, true);
+        surface.deleteImage(target.drawingNodeId);
+        return;
+      }
+    }
     setDrawingIntent({ kind: 'none' }, true);
   };
   pagesLayer.addEventListener('pointerdown', onDrawingPointerGesture, { capture: true });

--- a/packages/core/src/editor/surface-image-ops.ts
+++ b/packages/core/src/editor/surface-image-ops.ts
@@ -142,16 +142,21 @@ export function createImageOps(deps: {
       if (deps.editingMode() === 'view') {
         return Promise.resolve({ ok: false, reason: 'invalidArgs', detail: VIEWING_REFUSAL });
       }
-      if (deps.editingMode() === 'suggest') {
+      // Suggesting PROPOSES the picture: the inserted run goes into a `w:ins`, so the page
+      // paints it with the insertion cues and the review queue offers one Accept.
+      const tracked = deps.editingMode() === 'suggest';
+      const author = deps.author();
+      if (tracked && (author === undefined || author === '')) {
         return Promise.resolve({
           ok: false,
           reason: 'invalidArgs',
-          detail: SUGGESTING_IMAGE_REFUSAL,
+          detail: TRACKED_AUTHOR_REFUSAL,
         });
       }
       return deps.session.insertImage(deps.storyScope(), {
         ...input,
         decodePort: deps.decodePort(),
+        ...(tracked ? { revision: { author: author!, date: deps.trackedDate() } } : {}),
       });
     },
 

--- a/packages/core/src/editor/surface-image-ops.ts
+++ b/packages/core/src/editor/surface-image-ops.ts
@@ -17,7 +17,7 @@ import type { SurfaceEditingMode } from './paginated-surface-contract.ts';
 
 const VIEWING_REFUSAL = 'the document is open for viewing';
 const SUGGESTING_IMAGE_REFUSAL = 'image changes are not supported in suggesting mode';
-const TRACKED_DRAWING_DELETION = 'trackedDrawingDeletionUnsupported';
+const TRACKED_AUTHOR_REFUSAL = 'tracked changes need a non-empty author';
 
 export function createImageOps(deps: {
   session: TreeDocxSessionView;
@@ -110,16 +110,24 @@ export function createImageOps(deps: {
       if (deps.editingMode() === 'view') {
         return { ok: false, reason: 'invalidArgs', detail: VIEWING_REFUSAL };
       }
-      if (deps.editingMode() === 'suggest') {
-        return {
-          ok: false,
-          reason: 'invalidArgs',
-          detail: TRACKED_DRAWING_DELETION,
-        };
+      // Suggesting PROPOSES the deletion instead of performing it: the drawing's model unit
+      // goes into a `w:del` through the same tracked lane a struck word takes, so the page
+      // keeps the picture (dimmed, outlined, change-barred) and the review queue offers one
+      // Accept. Deleting it outright here would be a silent untracked edit in a mode whose
+      // whole promise is that nothing changes without a reviewable proposal.
+      const tracked = deps.editingMode() === 'suggest';
+      const author = deps.author();
+      if (tracked && (author === undefined || author === '')) {
+        return { ok: false, reason: 'invalidArgs', detail: TRACKED_AUTHOR_REFUSAL };
       }
       let result: ImageIntentResult = { ok: false, reason: 'invalidArgs' };
       deps.commit(() => {
-        result = deps.session.deleteImage(deps.storyScope(), drawingNodeId);
+        result = tracked
+          ? deps.session.deleteImageTracked(deps.storyScope(), drawingNodeId, {
+              author: author!,
+              date: deps.trackedDate(),
+            })
+          : deps.session.deleteImage(deps.storyScope(), drawingNodeId);
         return {
           committed: result.ok,
           rejected: !result.ok,

--- a/packages/core/src/layout/drawing-exclusion.ts
+++ b/packages/core/src/layout/drawing-exclusion.ts
@@ -14,6 +14,11 @@ import {
   type InlineDrawingLayoutContext,
 } from './drawing-layout.ts';
 import { drawingGeometryFromProjection } from './drawing-geometry.ts';
+import {
+  DEFAULT_REVISION_DISPLAY_MODE,
+  revisionsVisible,
+  type RevisionDisplayMode,
+} from './revision-projection.ts';
 import type { OoxmlNode } from '@docx-editor.dev/core/store';
 import type { DrawingGeometry } from './drawing-geometry.ts';
 import {
@@ -505,13 +510,19 @@ export function synthesizeParagraphWrapExclusionZones(options: {
   readonly anchorLineTopByModelStart: ReadonlyMap<number, number>;
   readonly sourceOrderOf?: (drawingNodeId: string) => number | undefined;
   readonly anchorCellBox?: LayoutBox | null;
+  /** Which revisions this pass resolves away — see {@link publishAnchoredDrawingsForParagraph}. */
+  readonly displayMode?: RevisionDisplayMode;
 }): readonly ExclusionZone[] {
   const atoms = anchoredDrawingAtomsInParagraph(options.paragraph, options.drawingLayout);
   if (atoms.length === 0) return Object.freeze([]);
   const offsets = drawingModelOffsetsInParagraph(options.paragraph);
+  const displayMode = options.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE;
   const contentWidth = Math.max(1, options.contentRight - options.contentLeft);
   const zones: ExclusionZone[] = [];
   for (const atom of atoms) {
+    // A drawing the display mode resolves away publishes no record, so it must carve no
+    // hole either: the original view must not wrap text around an insertion it hides.
+    if (!revisionsVisible(atom.revisions, displayMode)) continue;
     if (atom.projection.anchor?.behindDocument) continue;
     if (!wrapProducesExclusion(atom.projection.wrap) || atom.projection.wrap === 'topAndBottom')
       continue;
@@ -598,12 +609,17 @@ export function synthesizeParagraphTopAndBottomZones(options: {
   readonly anchorLineTopByModelStart: ReadonlyMap<number, number>;
   readonly sourceOrderOf?: (drawingNodeId: string) => number | undefined;
   readonly columnIndex?: number;
+  /** Which revisions this pass resolves away — see {@link publishAnchoredDrawingsForParagraph}. */
+  readonly displayMode?: RevisionDisplayMode;
 }): readonly ExclusionZone[] {
   const atoms = anchoredDrawingAtomsInParagraph(options.paragraph, options.drawingLayout);
   if (atoms.length === 0) return Object.freeze([]);
   const offsets = drawingModelOffsetsInParagraph(options.paragraph);
+  const displayMode = options.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE;
   const zones: ExclusionZone[] = [];
   for (const atom of atoms) {
+    // Same rule as the wrap zones above: no record, no hole.
+    if (!revisionsVisible(atom.revisions, displayMode)) continue;
     if (atom.projection.anchor?.behindDocument) continue;
     if (atom.projection.wrap !== 'topAndBottom') continue;
     const modelStart = offsets.get(atom.atomId);

--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -19,6 +19,16 @@ import {
 } from '../store/package/drawing-projection.ts';
 import type { OoxmlNode } from '../store/package/ooxml-tree.ts';
 import type { ImageResourceState } from '../store/package/image-resources.ts';
+import {
+  DEFAULT_REVISION_DISPLAY_MODE,
+  NO_REVISIONS,
+  isRevisionWrapper,
+  revisionAttributionOf,
+  revisionsVisible,
+  withRevision,
+  type RevisionAttribution,
+  type RevisionDisplayMode,
+} from './revision-projection.ts';
 import { measureDisplayText } from './run-style.ts';
 import {
   drawingGeometryFromProjection,
@@ -316,6 +326,12 @@ export interface InlineDrawingRecord {
   readonly placeholderGraphicKind: string | null;
   /** Typed solid-geometry payload for a renderable `wps:wsp` shape; null otherwise. */
   readonly vectorShape: VectorShapeProjection | null;
+  /**
+   * The revision wrappers enclosing the owning run, outermost first — the same stack spans
+   * carry, so paint and review chrome give a tracked picture the same cues as tracked text.
+   * Absent when the drawing is untracked.
+   */
+  readonly revisions?: readonly RevisionAttribution[];
 }
 
 export type LineLayoutAtom =
@@ -965,6 +981,7 @@ export function buildAnchoredDrawingRecord(options: {
   readonly clipRegion?: LayoutBox;
   readonly sourceOrder?: number;
   readonly textboxStory?: import('./textbox-story-layout.ts').TextboxStoryLayout | null;
+  readonly revisions?: readonly RevisionAttribution[];
 }): AnchoredDrawingRecord {
   const projection = options.input.projection;
   const anchorMeta = projection.anchor;
@@ -1006,6 +1023,7 @@ export function buildAnchoredDrawingRecord(options: {
     ...(options.sourceOrder !== undefined ? { sourceOrder: options.sourceOrder } : {}),
     ...(options.resolved.layoutFallback ? { layoutFallback: options.resolved.layoutFallback } : {}),
     ...(options.textboxStory ? { textboxStory: options.textboxStory } : {}),
+    ...(options.revisions && options.revisions.length > 0 ? { revisions: options.revisions } : {}),
     paintBounds,
     hitBounds,
     geometry: options.clipRegion ? clipGeometryToRegion(geometry, options.clipRegion) : geometry,
@@ -1019,27 +1037,38 @@ export function buildAnchoredDrawingRecord(options: {
 export function anchoredDrawingAtomsInParagraph(
   paragraph: OoxmlNode,
   context: InlineDrawingLayoutContext
-): readonly { readonly atomId: string; readonly projection: DrawingProjection }[] {
+): readonly {
+  readonly atomId: string;
+  readonly projection: DrawingProjection;
+  /** Enclosing revision wrappers, outermost first — the stack spans carry (see #479). */
+  readonly revisions: readonly RevisionAttribution[];
+}[] {
   if (paragraph.kind !== 'paragraph') return [];
-  const atoms: { atomId: string; projection: DrawingProjection }[] = [];
-  const visit = (node: OoxmlNode): void => {
+  const atoms: {
+    atomId: string;
+    projection: DrawingProjection;
+    revisions: readonly RevisionAttribution[];
+  }[] = [];
+  const visit = (node: OoxmlNode, revisions: readonly RevisionAttribution[]): void => {
     if (node.kind === 'drawing') {
       const projection =
         context.projectionForAtom?.(node.id) ??
         context.project(node as import('../store/package/ooxml-tree.ts').OoxmlDrawingNode);
-      if (projection?.kind === 'anchored') atoms.push({ atomId: node.id, projection });
+      if (projection?.kind === 'anchored') atoms.push({ atomId: node.id, projection, revisions });
       return;
     }
     if (isRunLevelMcAlternateContent(node)) {
       const projection = context.projectionForAtom?.(node.id) ?? null;
-      if (projection?.kind === 'anchored') atoms.push({ atomId: node.id, projection });
+      if (projection?.kind === 'anchored') atoms.push({ atomId: node.id, projection, revisions });
       return;
     }
     if ('children' in node) {
-      for (const child of node.children) visit(child);
+      const attribution = isRevisionWrapper(node) ? revisionAttributionOf(node) : null;
+      const enclosing = attribution ? withRevision(revisions, attribution) : revisions;
+      for (const child of node.children) visit(child, enclosing);
     }
   };
-  for (const child of paragraph.children) visit(child);
+  for (const child of paragraph.children) visit(child, NO_REVISIONS);
   return Object.freeze(atoms);
 }
 
@@ -1061,19 +1090,19 @@ export function drawingModelOffsetsInParagraph(paragraph: OoxmlNode): ReadonlyMa
       for (const child of node.children) visitRunContent(child);
     }
   };
-  for (const child of paragraph.children) {
+  // Descends hyperlinks and revision wrappers in either order: a `w:ins` wraps runs and
+  // hyperlinks the model still counts, so skipping it left every drawing after (or inside)
+  // the wrapper at a stale offset and an anchored drawing in a tracked insertion invisible.
+  const visitInlineChild = (child: OoxmlNode): void => {
     if (child.kind === 'run') {
       for (const grand of child.children) visitRunContent(grand);
-      continue;
+      return;
     }
-    if (child.kind === 'hyperlink') {
-      for (const grand of child.children) {
-        if (grand.kind === 'run') {
-          for (const great of grand.children) visitRunContent(great);
-        }
-      }
+    if (child.kind === 'hyperlink' || isRevisionWrapper(child)) {
+      for (const grand of child.children) visitInlineChild(grand);
     }
-  }
+  };
+  for (const child of paragraph.children) visitInlineChild(child);
   return offsets;
 }
 
@@ -1206,6 +1235,12 @@ export function publishAnchoredDrawingsForParagraph(options: {
   readonly measurer?: import('./semantic-records.ts').TextMeasurer;
   readonly sourceOrderOf?: (drawingNodeId: string) => number | undefined;
   /**
+   * Which revisions are resolved before publishing. A deleted anchor survives `all-markup`
+   * (marked, like deleted text) and disappears from the proposed result; an inserted one
+   * disappears from the original. Defaults to `all-markup`, which shows everything.
+   */
+  readonly displayMode?: RevisionDisplayMode;
+  /**
    * Lays out a textbox drawing's story (host-supplied closure over flow deps and the page
    * context). Absent hosts degrade textbox drawings to the placeholder path.
    */
@@ -1216,10 +1251,12 @@ export function publishAnchoredDrawingsForParagraph(options: {
   const atoms = anchoredDrawingAtomsInParagraph(options.paragraph, options.drawingLayout);
   if (atoms.length === 0) return [];
   const offsets = drawingModelOffsetsInParagraph(options.paragraph);
+  const displayMode = options.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE;
   const records: AnchoredDrawingRecord[] = [];
   for (const atom of atoms) {
     const projection = atom.projection;
     if (projection.hidden) continue;
+    if (!revisionsVisible(atom.revisions, displayMode)) continue;
     const start = offsets.get(atom.atomId);
     if (start === undefined) continue;
     if (
@@ -1265,6 +1302,7 @@ export function publishAnchoredDrawingsForParagraph(options: {
       start: characterFrameOffset,
       resolved,
       clipRegion,
+      revisions: atom.revisions,
       ...(options.sourceOrderOf ? { sourceOrder: options.sourceOrderOf(atom.atomId) } : {}),
       ...(projection.textboxStory && options.layoutTextboxStory
         ? { textboxStory: options.layoutTextboxStory(projection) }
@@ -1286,6 +1324,7 @@ export function buildInlineDrawingRecord(options: {
   readonly contentRight: number;
   readonly contentTop?: number;
   readonly contentBottom?: number;
+  readonly revisions?: readonly RevisionAttribution[];
 }): InlineDrawingRecord {
   const measure = measureInlineDrawing(options.input.projection);
   const extentX = options.slotX + measure.distL + measure.effectL;
@@ -1338,5 +1377,6 @@ export function buildInlineDrawingRecord(options: {
     resource: options.input.resource,
     accessibility: drawingAccessibility(options.input.projection),
     ...drawingPaintFields(options.input.projection),
+    ...(options.revisions && options.revisions.length > 0 ? { revisions: options.revisions } : {}),
   });
 }

--- a/packages/core/src/layout/field-drawing-atom.ts
+++ b/packages/core/src/layout/field-drawing-atom.ts
@@ -1,0 +1,77 @@
+// What one run-level drawing atom contributes to the piece walk.
+//
+// A `w:drawing` (or an MC wrapper carrying one) occupies one UTF-16 model unit whatever it
+// paints. This decides, purely, what the walk pushes for it and whether its unit joins the
+// deleted ranges; the walk owns the offset advance and the push itself.
+
+import type { OoxmlNode } from '../store/package/ooxml-tree.ts';
+import { isRunLevelMcAlternateContent } from '../store/package/drawing-projection.ts';
+import type { InlineDrawingLayoutContext, InlineDrawingLayoutInput } from './drawing-layout.ts';
+import {
+  revisionsAreDeletion,
+  revisionsVisible,
+  type RevisionAttribution,
+  type RevisionDisplayMode,
+} from './revision-projection.ts';
+
+export interface RunDrawingAtomPlan {
+  /** The unit joins the deleted ranges (an INLINE drawing under a tracked deletion). */
+  readonly recordDeleted: boolean;
+  /** Push a projected `'￼'` piece for the unit; false leaves the offset reserved only. */
+  readonly emit: boolean;
+  /** Piece extras: the inline drawing payload, or the anchored change-bar marker. */
+  readonly extras?:
+    | { readonly inlineDrawing: InlineDrawingLayoutInput }
+    | { readonly anchoredAtom: true };
+}
+
+/** True for the two run children this plan covers. */
+export function isRunDrawingAtom(node: OoxmlNode): boolean {
+  return node.kind === 'drawing' || isRunLevelMcAlternateContent(node);
+}
+
+export function runDrawingAtomPlan(options: {
+  readonly node: OoxmlNode;
+  readonly layout: InlineDrawingLayoutContext;
+  /** The owning run resolved to `w:vanish`. */
+  readonly hiddenRun: boolean;
+  readonly revisions: readonly RevisionAttribution[];
+  readonly displayMode: RevisionDisplayMode;
+}): RunDrawingAtomPlan {
+  const { node, layout, revisions, displayMode } = options;
+  // Only the projection lookup differs between the two atom kinds: an MC wrapper has no
+  // direct `project` fallback.
+  const projection =
+    layout.projectionForAtom?.(node.id) ?? (node.kind === 'drawing' ? layout.project(node) : null);
+  if (!projection || projection.kind !== 'inline') {
+    // The marker only for a drawing that will actually PUBLISH: hidden anchors and failed
+    // projections paint nothing, so they must cue no change bar either.
+    const anchored = projection?.kind === 'anchored' && !projection.hidden;
+    return anchored
+      ? { recordDeleted: false, emit: true, extras: { anchoredAtom: true } }
+      : { recordDeleted: false, emit: true };
+  }
+  // A tracked-deleted picture stays LAID OUT in `all-markup`, exactly as deleted text does —
+  // the reader is looking at a pending removal, and dropping it showed the proposed result
+  // under a mode that promises the markup (#479). Its model range is still recorded as
+  // deleted in every mode, because the offset exists in every mode.
+  const recordDeleted = revisionsAreDeletion(revisions);
+  const suppressed = options.hiddenRun || !revisionsVisible(revisions, displayMode);
+  if (projection.hidden || suppressed) {
+    // A hidden drawing keeps a bare placeholder so surrounding offsets stay aligned; a
+    // mode- or vanish-suppressed one emits nothing at all.
+    return projection.hidden ? { recordDeleted, emit: true } : { recordDeleted, emit: false };
+  }
+  return {
+    recordDeleted,
+    emit: true,
+    extras: {
+      inlineDrawing: Object.freeze({
+        drawingNodeId: node.id,
+        ownerPartName: layout.ownerPartName,
+        projection,
+        resource: layout.resourceOf(projection),
+      }),
+    },
+  };
+}

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -104,6 +104,12 @@ export interface FieldAwarePiece {
   };
   /** Typed inline drawing occupying one UTF-16 model unit. */
   readonly inlineDrawing?: InlineDrawingLayoutInput;
+  /**
+   * This piece is a visible ANCHORED drawing's zero-glyph placeholder. The record paints
+   * from the page layer, not from a span — so this marker is how the anchor line still
+   * learns it carries a tracked change (the margin bar reads it; see #479).
+   */
+  readonly anchoredAtom?: true;
   /** Bounded paragraph-level OMML projection occupying one UTF-16 model unit. */
   readonly equation?: OmmlEquationProjection;
   /**

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -411,10 +411,14 @@ export function piecesOfParagraph(
       start: number,
       end: number
     ): void => {
+      // A tracked-deleted picture stays LAID OUT in `all-markup`, exactly as deleted text
+      // does \u2014 the reader is looking at a pending removal, and dropping it showed the
+      // proposed result under a mode that promises the markup (#479). Its model range is
+      // still recorded as deleted in every mode, because the offset exists in every mode.
       const deleted = revisionsAreDeletion(revisions);
-      const suppressed = style.hidden || !revisionsVisible(revisions, displayMode) || deleted;
+      if (deleted && deletedRanges) appendModelRange(deletedRanges, start, end);
+      const suppressed = style.hidden || !revisionsVisible(revisions, displayMode);
       if (projection.hidden || suppressed) {
-        if (deleted && deletedRanges) appendModelRange(deletedRanges, start, end);
         if (!projection.hidden) return;
         push('\uFFFC', props, style, true, start, end);
         return;

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -88,7 +88,7 @@ import {
   type PositionalTab,
 } from './field-pieces.ts';
 import type { InlineDrawingLayoutContext, InlineDrawingLayoutInput } from './drawing-layout.ts';
-import { isRunLevelMcAlternateContent } from '../store/package/drawing-projection.ts';
+import { isRunDrawingAtom, runDrawingAtomPlan } from './field-drawing-atom.ts';
 import { legacyFormFieldDataOf, parsedFieldSpansOf } from '../store/package/field-nodes.ts';
 import {
   emptyNamespaceScope,
@@ -407,60 +407,22 @@ export function piecesOfParagraph(
     props: readonly OoxmlProperty[],
     style: ResolvedRunStyle
   ): void => {
-    const emitInlineDrawing = (
-      drawingNodeId: string,
-      projection: NonNullable<ReturnType<InlineDrawingLayoutContext['project']>>,
-      start: number,
-      end: number
-    ): void => {
-      // A tracked-deleted picture stays LAID OUT in `all-markup`, exactly as deleted text
-      // does \u2014 the reader is looking at a pending removal, and dropping it showed the
-      // proposed result under a mode that promises the markup (#479). Its model range is
-      // still recorded as deleted in every mode, because the offset exists in every mode.
-      const deleted = revisionsAreDeletion(revisions);
-      if (deleted && deletedRanges) appendModelRange(deletedRanges, start, end);
-      const suppressed = style.hidden || !revisionsVisible(revisions, displayMode);
-      if (projection.hidden || suppressed) {
-        if (!projection.hidden) return;
-        push('\uFFFC', props, style, true, start, end);
-        return;
-      }
-      push('\uFFFC', props, style, true, start, end, {
-        inlineDrawing: Object.freeze({
-          drawingNodeId,
-          ownerPartName: inlineDrawingLayout!.ownerPartName,
-          projection,
-          resource: inlineDrawingLayout!.resourceOf(projection),
-        }),
-      });
-    };
-
     // One branch for both run-level drawing atoms \u2014 `w:drawing` and an MC wrapper carrying
-    // one. Only the projection lookup differs: MC has no direct `project` fallback.
-    if (grand.kind === 'drawing' || isRunLevelMcAlternateContent(grand)) {
+    // one; the plan itself (visibility, deletion, payload) lives in field-drawing-atom.ts.
+    if (isRunDrawingAtom(grand)) {
       const start = offset;
       offset += 1;
       const end = offset;
       if (!inlineDrawingLayout) return;
-      const projection =
-        inlineDrawingLayout.projectionForAtom?.(grand.id) ??
-        (grand.kind === 'drawing' ? inlineDrawingLayout.project(grand) : null);
-      if (!projection || projection.kind !== 'inline') {
-        // The marker only for a drawing that will actually PUBLISH: hidden anchors and
-        // failed projections paint nothing, so they must cue no change bar either.
-        const anchored = projection?.kind === 'anchored' && !projection.hidden;
-        push(
-          '\uFFFC',
-          props,
-          style,
-          true,
-          start,
-          end,
-          anchored ? { anchoredAtom: true } : undefined
-        );
-        return;
-      }
-      emitInlineDrawing(grand.id, projection, start, end);
+      const plan = runDrawingAtomPlan({
+        node: grand,
+        layout: inlineDrawingLayout,
+        hiddenRun: style.hidden,
+        revisions,
+        displayMode,
+      });
+      if (plan.recordDeleted && deletedRanges) appendModelRange(deletedRanges, start, end);
+      if (plan.emit) push('\uFFFC', props, style, true, start, end, plan.extras);
       return;
     }
     if (isProjectableNoteAtom(grand)) {

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -237,6 +237,7 @@ export function piecesOfParagraph(
       readonly measureText?: string;
       readonly noteNav?: FieldAwarePiece['noteNav'];
       readonly inlineDrawing?: InlineDrawingLayoutInput;
+      readonly anchoredAtom?: true;
       readonly equation?: FieldAwarePiece['equation'];
       /**
        * Attribution to attach INSTEAD of the walk's live stack, for text emitted after the
@@ -265,6 +266,7 @@ export function piecesOfParagraph(
         ...(extras?.measureText !== undefined ? { measureText: extras.measureText } : {}),
         ...(extras?.noteNav ? { noteNav: extras.noteNav } : {}),
         ...(extras?.inlineDrawing ? { inlineDrawing: extras.inlineDrawing } : {}),
+        ...(extras?.anchoredAtom ? { anchoredAtom: true as const } : {}),
         ...(extras?.equation ? { equation: extras.equation } : {}),
         ...(extras?.fieldAtom ? { fieldAtom: extras.fieldAtom } : {}),
         ...link,
@@ -433,7 +435,9 @@ export function piecesOfParagraph(
       });
     };
 
-    if (grand.kind === 'drawing') {
+    // One branch for both run-level drawing atoms \u2014 `w:drawing` and an MC wrapper carrying
+    // one. Only the projection lookup differs: MC has no direct `project` fallback.
+    if (grand.kind === 'drawing' || isRunLevelMcAlternateContent(grand)) {
       const start = offset;
       offset += 1;
       const end = offset;
@@ -442,20 +446,18 @@ export function piecesOfParagraph(
         inlineDrawingLayout.projectionForAtom?.(grand.id) ??
         (grand.kind === 'drawing' ? inlineDrawingLayout.project(grand) : null);
       if (!projection || projection.kind !== 'inline') {
-        push('\uFFFC', props, style, true, start, end);
-        return;
-      }
-      emitInlineDrawing(grand.id, projection, start, end);
-      return;
-    }
-    if (isRunLevelMcAlternateContent(grand)) {
-      const start = offset;
-      offset += 1;
-      const end = offset;
-      if (!inlineDrawingLayout) return;
-      const projection = inlineDrawingLayout.projectionForAtom?.(grand.id) ?? null;
-      if (!projection || projection.kind !== 'inline') {
-        push('\uFFFC', props, style, true, start, end);
+        // The marker only for a drawing that will actually PUBLISH: hidden anchors and
+        // failed projections paint nothing, so they must cue no change bar either.
+        const anchored = projection?.kind === 'anchored' && !projection.hidden;
+        push(
+          '\uFFFC',
+          props,
+          style,
+          true,
+          start,
+          end,
+          anchored ? { anchoredAtom: true } : undefined
+        );
         return;
       }
       emitInlineDrawing(grand.id, projection, start, end);

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -27,6 +27,7 @@ import {
 } from './field-projection.ts';
 import {
   DEFAULT_REVISION_DISPLAY_MODE,
+  revisionsVisible,
   type RevisionAttribution,
   type RevisionDisplayMode,
 } from './revision-projection.ts';
@@ -373,93 +374,15 @@ function positionalTabDestination(
   };
 }
 
-export interface PendingLine {
-  readonly spans: StyleSpanRecord[];
-  readonly drawings: InlineDrawingRecord[];
-  readonly start: number;
-  end: number;
-  width: number;
-  height: number;
-  baseline: number;
-  /**
-   * Space ABOVE the glyph band inside {@link height}.
-   *
-   * Exact spacing can center the glyphs and move the baseline. Auto/atLeast spacing leaves
-   * this at zero and puts its extra depth below instead.
-   */
-  leading: number;
-  /**
-   * Auto/atLeast line-spacing depth below the painted glyph band.
-   *
-   * Word lets this external depth cross the bottom text margin when the glyphs themselves
-   * still fit. Pagination therefore budgets {@link height} minus this amount at a page
-   * bottom, while paint keeps the full box and padding.
-   */
-  trailingSpacing: number;
-  /** When true, layout must start a new page after this line is placed. */
-  pageBreakAfter?: boolean;
-  /** When true, layout must advance to the next authored section column. */
-  columnBreakAfter?: boolean;
-  /** Model ranges on this line covering deleted content; see {@link LineRecord.deletedRanges}. */
-  deletedRanges?: readonly ModelRange[];
-  /** Vertical gap inserted before this line to clear a topAndBottom exclusion band. */
-  exclusionSkipBefore?: number;
-}
-
-/** Vertical extent of a pending line for flow/pagination budget checks (skip + box + optional tail). */
-export function pendingLineFlowExtent(
-  line: Pick<PendingLine, 'height' | 'trailingSpacing' | 'exclusionSkipBefore'>,
-  tail = 0
-): number {
-  return (line.exclusionSkipBefore ?? 0) + Math.max(0, line.height - line.trailingSpacing) + tail;
-}
-
-/** Recompute topAndBottom skip at placement time from live page zones and absolute line top. */
-export function pendingLineFlowExtentAtPlacement(
-  lineTopY: number,
-  line: Pick<PendingLine, 'height' | 'trailingSpacing' | 'exclusionSkipBefore'>,
-  zones: readonly ExclusionZone[],
-  tail = 0
-): number {
-  const skip =
-    zones.length > 0
-      ? topAndBottomSkipBeforeLine(lineTopY, line.height, zones)
-      : (line.exclusionSkipBefore ?? 0);
-  return skip + Math.max(0, line.height - line.trailingSpacing) + tail;
-}
-
-/**
- * A cached line, safe to hand back on every later hit.
- *
- * Placement copies span boxes rather than mutating them, but a cache entry outlives the
- * layout that produced it — freezing means a future change to the placement path cannot
- * quietly corrupt every subsequent reuse.
- */
-export function frozenLine(line: PendingLine): PendingLine {
-  return Object.freeze({
-    spans: line.spans.map((span) =>
-      Object.freeze({ ...span, box: Object.freeze({ ...span.box }) })
-    ),
-    drawings: line.drawings.map((drawing) =>
-      Object.freeze({
-        ...drawing,
-        paintBounds: Object.freeze({ ...drawing.paintBounds }),
-        hitBounds: Object.freeze({ ...drawing.hitBounds }),
-      })
-    ),
-    start: line.start,
-    end: line.end,
-    width: line.width,
-    height: line.height,
-    baseline: line.baseline,
-    leading: line.leading,
-    trailingSpacing: line.trailingSpacing,
-    ...(line.pageBreakAfter ? { pageBreakAfter: true } : {}),
-    ...(line.columnBreakAfter ? { columnBreakAfter: true } : {}),
-    ...(line.deletedRanges ? { deletedRanges: Object.freeze(line.deletedRanges) } : {}),
-    ...(line.exclusionSkipBefore ? { exclusionSkipBefore: line.exclusionSkipBefore } : {}),
-  }) as PendingLine;
-}
+// The pending-line record and its budget/freeze helpers live in pending-line.ts;
+// re-exported so every existing import through this module stays stable.
+import {
+  frozenLine,
+  pendingLineFlowExtent,
+  pendingLineFlowExtentAtPlacement,
+  type PendingLine,
+} from './pending-line.ts';
+export { frozenLine, pendingLineFlowExtent, pendingLineFlowExtentAtPlacement, type PendingLine };
 
 /**
  * Soft ceiling on an indent, in twips (31_680 ≈ 22"), matching the paragraph-spacing and
@@ -752,11 +675,16 @@ export function breakParagraph(
   let topAndBottomSkipApplied = false;
   const anchorLineTopByModelStart = new Map<number, number>();
 
+  // The break-time wrap synthesis follows the published records: a drawing the display mode
+  // resolves away publishes no record, so it must reserve no line top and carve no hole.
+  const anchorDisplayMode = flow?.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE;
+
   const topAndBottomAnchorStarts = (() => {
     const starts = new Set<number>();
     if (!flow?.inlineDrawingLayout) return starts;
     const offsets = drawingModelOffsetsInParagraph(paragraph);
     for (const atom of anchoredDrawingAtomsInParagraph(paragraph, flow.inlineDrawingLayout)) {
+      if (!revisionsVisible(atom.revisions, anchorDisplayMode)) continue;
       if (atom.projection.wrap !== 'topAndBottom') continue;
       const modelStart = offsets.get(atom.atomId);
       if (modelStart !== undefined) starts.add(modelStart);
@@ -769,6 +697,7 @@ export function breakParagraph(
     if (!flow?.inlineDrawingLayout) return starts;
     const offsets = drawingModelOffsetsInParagraph(paragraph);
     for (const atom of anchoredDrawingAtomsInParagraph(paragraph, flow.inlineDrawingLayout)) {
+      if (!revisionsVisible(atom.revisions, anchorDisplayMode)) continue;
       if (atom.projection.anchor?.behindDocument) continue;
       if (
         atom.projection.wrap === 'topAndBottom' ||
@@ -880,6 +809,7 @@ export function breakParagraph(
             paragraphStartY: flow.paragraphStartY ?? 0,
             anchorLineTopByModelStart,
             anchorCellBox: flow.anchorCellBox,
+            displayMode: anchorDisplayMode,
           })
         : Object.freeze([]);
     const synthesized =
@@ -892,6 +822,7 @@ export function breakParagraph(
             contentRight,
             paragraphStartY: flow?.paragraphStartY ?? 0,
             anchorLineTopByModelStart,
+            displayMode: anchorDisplayMode,
           })
         : Object.freeze([]);
     return Object.freeze([...pageZones, ...synthesizedWrap, ...synthesized]);
@@ -1348,6 +1279,17 @@ export function breakParagraph(
     }
     if (piece.projected && !piece.inlineDrawing && piece.text === '\uFFFC') {
       recordTopAndBottomAnchorLineTop(piece.start);
+      // A tracked anchored drawing paints from the page layer and leaves no span on its
+      // anchor line, so the line records the attribution itself \u2014 that is all the margin
+      // change bar has to read. Gated exactly like the published record: a drawing the
+      // display mode resolves away must cue no bar.
+      if (
+        piece.anchoredAtom &&
+        piece.revisions !== undefined &&
+        revisionsVisible(piece.revisions, anchorDisplayMode)
+      ) {
+        line.anchorRevisions = [...(line.anchorRevisions ?? []), ...piece.revisions];
+      }
       line.end = piece.end;
       continue;
     }

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1370,6 +1370,7 @@ export function breakParagraph(
           baseline: line.baseline,
           contentLeft,
           contentRight,
+          ...(piece.revisions ? { revisions: piece.revisions } : {}),
         })
       );
       line.width += atomWidth;

--- a/packages/core/src/layout/pending-line.ts
+++ b/packages/core/src/layout/pending-line.ts
@@ -1,0 +1,100 @@
+// The broken-but-unplaced line: the record breakParagraph accumulates and pagination
+// budgets, before placement publishes a LineRecord from it. Extracted from paragraph-flow
+// so the flow module stays under its line budget; paragraph-flow re-exports everything here.
+
+import type { RevisionAttribution } from './revision-projection.ts';
+import type { StyleSpanRecord } from './semantic-records.ts';
+import type { InlineDrawingRecord } from './drawing-layout.ts';
+import { topAndBottomSkipBeforeLine, type ExclusionZone } from './drawing-exclusion.ts';
+import type { ModelRange } from './field-pieces.ts';
+
+export interface PendingLine {
+  readonly spans: StyleSpanRecord[];
+  readonly drawings: InlineDrawingRecord[];
+  readonly start: number;
+  end: number;
+  width: number;
+  height: number;
+  baseline: number;
+  /**
+   * Space ABOVE the glyph band inside {@link height}.
+   *
+   * Exact spacing can center the glyphs and move the baseline. Auto/atLeast spacing leaves
+   * this at zero and puts its extra depth below instead.
+   */
+  leading: number;
+  /**
+   * Auto/atLeast line-spacing depth below the painted glyph band.
+   *
+   * Word lets this external depth cross the bottom text margin when the glyphs themselves
+   * still fit. Pagination therefore budgets {@link height} minus this amount at a page
+   * bottom, while paint keeps the full box and padding.
+   */
+  trailingSpacing: number;
+  /** When true, layout must start a new page after this line is placed. */
+  pageBreakAfter?: boolean;
+  /** When true, layout must advance to the next authored section column. */
+  columnBreakAfter?: boolean;
+  /** Model ranges on this line covering deleted content; see {@link LineRecord.deletedRanges}. */
+  deletedRanges?: readonly ModelRange[];
+  /** Vertical gap inserted before this line to clear a topAndBottom exclusion band. */
+  exclusionSkipBefore?: number;
+  /** Tracked anchored-drawing attributions on this line; see {@link LineRecord.anchorRevisions}. */
+  anchorRevisions?: readonly RevisionAttribution[];
+}
+
+/** Vertical extent of a pending line for flow/pagination budget checks (skip + box + optional tail). */
+export function pendingLineFlowExtent(
+  line: Pick<PendingLine, 'height' | 'trailingSpacing' | 'exclusionSkipBefore'>,
+  tail = 0
+): number {
+  return (line.exclusionSkipBefore ?? 0) + Math.max(0, line.height - line.trailingSpacing) + tail;
+}
+
+/** Recompute topAndBottom skip at placement time from live page zones and absolute line top. */
+export function pendingLineFlowExtentAtPlacement(
+  lineTopY: number,
+  line: Pick<PendingLine, 'height' | 'trailingSpacing' | 'exclusionSkipBefore'>,
+  zones: readonly ExclusionZone[],
+  tail = 0
+): number {
+  const skip =
+    zones.length > 0
+      ? topAndBottomSkipBeforeLine(lineTopY, line.height, zones)
+      : (line.exclusionSkipBefore ?? 0);
+  return skip + Math.max(0, line.height - line.trailingSpacing) + tail;
+}
+
+/**
+ * A cached line, safe to hand back on every later hit.
+ *
+ * Placement copies span boxes rather than mutating them, but a cache entry outlives the
+ * layout that produced it — freezing means a future change to the placement path cannot
+ * quietly corrupt every subsequent reuse.
+ */
+export function frozenLine(line: PendingLine): PendingLine {
+  return Object.freeze({
+    spans: line.spans.map((span) =>
+      Object.freeze({ ...span, box: Object.freeze({ ...span.box }) })
+    ),
+    drawings: line.drawings.map((drawing) =>
+      Object.freeze({
+        ...drawing,
+        paintBounds: Object.freeze({ ...drawing.paintBounds }),
+        hitBounds: Object.freeze({ ...drawing.hitBounds }),
+      })
+    ),
+    start: line.start,
+    end: line.end,
+    width: line.width,
+    height: line.height,
+    baseline: line.baseline,
+    leading: line.leading,
+    trailingSpacing: line.trailingSpacing,
+    ...(line.pageBreakAfter ? { pageBreakAfter: true } : {}),
+    ...(line.columnBreakAfter ? { columnBreakAfter: true } : {}),
+    ...(line.deletedRanges ? { deletedRanges: Object.freeze(line.deletedRanges) } : {}),
+    ...(line.exclusionSkipBefore ? { exclusionSkipBefore: line.exclusionSkipBefore } : {}),
+    ...(line.anchorRevisions ? { anchorRevisions: Object.freeze(line.anchorRevisions) } : {}),
+  }) as PendingLine;
+}

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -155,6 +155,26 @@ function endsWithLineBreak(line: {
   return last === '\n' || last === PAGE_BREAK_CHAR;
 }
 
+/**
+ * Whether this paragraph's slice of the line is ONE inline drawing and nothing else — a
+ * picture too wide to share its line, painted as a block in text clothing.
+ *
+ * That is the other case where the position shared by two lines is not ambiguous, and it is
+ * the hard-break case wearing an image: the drawing is what ended the line, so the caret at
+ * the offset after it belongs before the text that follows. Painting it at the picture's
+ * right edge instead meant a click before that text resolved the right offset but drew the
+ * caret a full picture away — the caret looked stuck beside the following words, and there
+ * was no click that showed one at the text's start.
+ */
+function isDrawingOnlySegment(line: LineRecord, segment: LineSegment): boolean {
+  if (segment.end - segment.start !== 1) return false;
+  if (!line.drawings?.some((drawing) => drawing.start === segment.start)) return false;
+  for (const span of segment.spans) {
+    if (span.range.end > span.range.start) return false;
+  }
+  return true;
+}
+
 function pushLineCaretStops(
   stops: CaretGeometry[],
   layout: SemanticLayout,
@@ -415,10 +435,12 @@ export function caretAt(
       position.offset === segment.end &&
       position.offset > segment.start &&
       lineSegments(line).length === 1 &&
-      endsWithLineBreak(line)
+      (endsWithLineBreak(line) || isDrawingOnlySegment(line, segment))
     ) {
       // Remember it, but keep looking for the line that STARTS here. Falling back to it
-      // keeps a caret placed rather than lost if no such line was laid out.
+      // keeps a caret placed rather than lost if no such line was laid out — for the
+      // drawing-only line, that fallback is exactly the picture-ends-its-paragraph case,
+      // where the right edge of the picture IS the answer.
       afterBreak ??= { line, pageIndex };
       continue;
     }

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -2777,6 +2777,7 @@ function layoutBlocksPass(
             measurer,
             sourceOrderOf,
             layoutTextboxStory: layoutTextboxStoryForBody,
+            displayMode,
           })
         );
       }

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1907,6 +1907,7 @@ function layoutBlocksPass(
       paragraphStartY: fragmentParagraphStartY,
       anchorLineTopByModelStart,
       columnIndex: flowColumnIndex,
+      displayMode,
     });
     return Object.freeze([...pageZones, ...synthesized]);
   };
@@ -2949,6 +2950,7 @@ function layoutBlocksPass(
         trailingSpacing: pendingLine.trailingSpacing,
         ...(pendingLine.deletedRanges ? { deletedRanges: pendingLine.deletedRanges } : {}),
         ...(alignedDrawings.length > 0 ? { drawings: alignedDrawings } : {}),
+        ...(pendingLine.anchorRevisions ? { anchorRevisions: pendingLine.anchorRevisions } : {}),
       };
       lineCounter += 1;
       if (pending.length === 0) fragmentFirstLineSkip = skipBefore;

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -290,6 +290,15 @@ export interface LineRecord {
    * are omitted — they remain in the tree and projection but publish no geometry.
    */
   readonly drawings?: readonly InlineDrawingRecord[];
+  /**
+   * Revision attributions of tracked ANCHORED drawings whose anchor sits on this line,
+   * absent when there are none.
+   *
+   * An anchored drawing paints from the page layer and leaves no span or line drawing at its
+   * anchor offset, so this is the only carrier the margin change bar can read for it. Only
+   * attributions the display mode lays out are recorded, matching the published records.
+   */
+  readonly anchorRevisions?: readonly RevisionAttribution[];
 }
 
 /**

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -376,6 +376,7 @@ function publishDeferredRowAnchors(
         pageClip: deps.pageContentClip(),
         measurer: deps.measurer,
         ...(deps.layoutTextboxStoryFor ? { layoutTextboxStory: deps.layoutTextboxStoryFor } : {}),
+        ...(deps.displayMode ? { displayMode: deps.displayMode } : {}),
       })
     );
   }
@@ -417,6 +418,7 @@ function republishAnchoredParagraphsInBlocks(
         pageClip: deps.pageContentClip(),
         measurer: deps.measurer,
         ...(deps.layoutTextboxStoryFor ? { layoutTextboxStory: deps.layoutTextboxStoryFor } : {}),
+        ...(deps.displayMode ? { displayMode: deps.displayMode } : {}),
       })
     );
   }
@@ -1010,6 +1012,7 @@ function placeCellParagraph(
           pageClip: deps.pageContentClip(),
           measurer: deps.measurer,
           ...(deps.layoutTextboxStoryFor ? { layoutTextboxStory: deps.layoutTextboxStoryFor } : {}),
+          ...(deps.displayMode ? { displayMode: deps.displayMode } : {}),
         })
       );
     }

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -796,6 +796,7 @@ function placeCellParagraph(
       leading: pendingLine.leading,
       trailingSpacing: pendingLine.trailingSpacing,
       ...(pendingLine.deletedRanges ? { deletedRanges: pendingLine.deletedRanges } : {}),
+      ...(pendingLine.anchorRevisions ? { anchorRevisions: pendingLine.anchorRevisions } : {}),
     });
     y += pendingLine.height;
     nextLineIndex = lineIndex + 1;

--- a/packages/core/src/output/__tests__/semantic-paint-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-drawings.test.ts
@@ -29,6 +29,7 @@ import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semant
 import { paintSemanticLayout } from '../semantic-paint.ts';
 import {
   DEFAULT_DRAWING_PAINT_STRINGS,
+  drawingUrlRegistryFor,
   paintDrawingRecord,
   type PaintImageUrlPort,
 } from '../semantic-paint-drawings.ts';
@@ -290,6 +291,35 @@ describe('paints validated raster records', () => {
       null
     );
     expect(element).toBeNull();
+  });
+
+  test('a reused ready element scrubs the revision marking once the decision resolves', () => {
+    const { port } = fakeUrlPort();
+    const registry = drawingUrlRegistryFor(document.createElement('div'), port);
+    const untracked = readyRecordFromXml(inlinePictureXml());
+    const tracked: InlineDrawingRecord = Object.freeze({
+      ...untracked,
+      revisions: Object.freeze([{ kind: 'delete' as const, id: '9', author: 'Bob', nodeId: 'n9' }]),
+    });
+    const ctx = {
+      scale: 1,
+      strings: DEFAULT_DRAWING_PAINT_STRINGS,
+      imageUrlPort: port,
+      paintInstance: 'p0',
+    };
+    const origin = Object.freeze({ x: 0, y: 0, width: 600, height: 800 });
+    const first = paintDrawingRecord(document, tracked, ctx, registry, origin)!;
+    expect(first.classList.contains('docx-drawing--revision-deletion')).toBe(true);
+    expect(first.dataset.revisionKind).toBe('delete');
+    // Same drawing, decision resolved: identical paint signature, so the registry hands the
+    // SAME element back — the marking must be scrubbed, not left to a rebuild.
+    const second = paintDrawingRecord(document, untracked, ctx, registry, origin)!;
+    expect(second).toBe(first);
+    expect(second.classList.contains('docx-drawing--revision')).toBe(false);
+    expect(second.classList.contains('docx-drawing--revision-deletion')).toBe(false);
+    expect(second.dataset.revisionKind).toBeUndefined();
+    expect(second.dataset.revisionId).toBeUndefined();
+    expect(second.dataset.reviewAuthor).toBeUndefined();
   });
 });
 

--- a/packages/core/src/output/revision-presentation.ts
+++ b/packages/core/src/output/revision-presentation.ts
@@ -457,6 +457,19 @@ function blockAuthors(blocks: readonly BlockFragmentRecord[]): readonly string[]
         }
       }
     }
+    for (const line of fragment.lines) {
+      // Tracked inline DRAWINGS, after the line's spans: a reviewer whose only change is a
+      // picture is still a reviewer, and leaving them out silently painted their cue in
+      // slot 0's colour. A separate pass so a drawing mid-line cannot renumber the text
+      // authors around it relative to the pre-#479 assignment.
+      const drawings = line.drawings;
+      if (drawings === undefined) continue;
+      for (let i = 0; i < drawings.length; i += 1) {
+        const revisions = drawings[i]!.revisions;
+        if (revisions === undefined) continue;
+        for (let j = 0; j < revisions.length; j += 1) see(revisions[j]!.author);
+      }
+    }
     // The paragraph MARK last: it carries no span of its own, and the pilcrow paints at the
     // END of the fragment's final line. Reading it first gave a reviewer who only pressed
     // Enter a lower slot than the author of the text beside them.
@@ -517,6 +530,14 @@ export function authorSlotsOf(layout: SemanticLayout): ReadonlyMap<string, numbe
     ]) {
       if (!anchored) continue;
       for (const drawing of anchored) {
+        // The anchored drawing's own tracked change, then any story inside it.
+        const revisions = drawing.revisions;
+        if (revisions !== undefined) {
+          for (let i = 0; i < revisions.length; i += 1) {
+            const author = revisions[i]!.author;
+            if (author !== '' && !slots.has(author)) slots.set(author, slots.size);
+          }
+        }
         if (drawing.textboxStory) fold(drawing.textboxStory.fragments);
       }
     }

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -20,6 +20,11 @@ import type {
 import { forEachStoryDrawing } from '../layout/semantic-record-queries.ts';
 import type { SemanticLayout } from '@docx-editor.dev/core/layout';
 import { paintLayerOf } from '../layout/drawing-exclusion.ts';
+import {
+  REVIEW_AUTHOR_SLOTS,
+  revisionPresentationOf,
+  type RevisionStyleContext,
+} from './revision-presentation.ts';
 
 /** Host port for safe blob URLs — only called for {@link ImageResourceState.kind} `ready`. */
 export interface PaintImageUrlPort {
@@ -60,6 +65,8 @@ export interface DrawingPaintContext {
     document: Document,
     fragment: ParagraphFragmentRecord | TableFragmentRecord
   ) => HTMLElement;
+  /** Resolved author colouring, so a tracked drawing's cue follows the span scheme. */
+  readonly revisionStyles?: RevisionStyleContext;
 }
 
 const MIME_FORMAT_LABEL: Readonly<Record<string, string>> = Object.freeze({
@@ -620,7 +627,89 @@ function paintTextboxStory(
   return outer;
 }
 
+/**
+ * The tracked-change cue on a painted drawing (#479).
+ *
+ * The same statement `applyRevisionPresentation` makes for text, translated to a box: the
+ * stylesheet draws an insertion- or deletion-coloured outline under
+ * `docx-drawing--revision-*` and dims a pending removal, and the element carries the same
+ * `data-revision-*` datasets spans do, so review chrome resolves a hovered picture to its
+ * decision exactly like a hovered word.
+ *
+ * Applied on EVERY paint — including the ready-image path's signature-matched reuse, whose
+ * cached element would otherwise keep the marking of a decision the document no longer
+ * records. That is also why the untracked branch scrubs rather than returns.
+ */
+function applyDrawingRevisionPresentation(
+  element: HTMLElement,
+  drawing: InlineDrawingRecord | AnchoredDrawingRecord,
+  ctx: DrawingPaintContext
+): void {
+  const colors = ctx.revisionStyles;
+  const presentation = revisionPresentationOf(
+    drawing.revisions,
+    colors?.authorSlots,
+    colors?.styles
+  );
+  if (!presentation) {
+    if (element.dataset.revisionKind === undefined) return;
+    element.classList.remove(
+      'docx-drawing--revision',
+      'docx-drawing--revision-insertion',
+      'docx-drawing--revision-deletion'
+    );
+    delete element.dataset.revisionKind;
+    delete element.dataset.revisionId;
+    delete element.dataset.reviewAuthor;
+    delete element.dataset.revisionDate;
+    delete element.dataset.reviewAuthorSlot;
+    element.style.outlineColor = '';
+    return;
+  }
+  const { attribution } = presentation;
+  element.classList.add(
+    'docx-drawing--revision',
+    presentation.deleted ? 'docx-drawing--revision-deletion' : 'docx-drawing--revision-insertion'
+  );
+  element.classList.remove(
+    presentation.deleted ? 'docx-drawing--revision-insertion' : 'docx-drawing--revision-deletion'
+  );
+  element.dataset.revisionKind = attribution.kind;
+  element.dataset.revisionId = attribution.id;
+  if (attribution.author !== '') element.dataset.reviewAuthor = attribution.author;
+  else delete element.dataset.reviewAuthor;
+  if (attribution.date !== undefined) element.dataset.revisionDate = attribution.date;
+  else delete element.dataset.revisionDate;
+  // The spans' selective ink rule: the outline follows the author under author colouring
+  // (inline style beats the stylesheet's kind colour), and stays on the kind tokens
+  // otherwise. `spanClassName` tokens are NOT mirrored here — they are documented as span
+  // classes, and a reused image element would accumulate stale host tokens no scrub knows.
+  const authorStyle = colors?.styles.get(attribution.author);
+  const byAuthor =
+    colors !== undefined && (authorStyle?.color !== undefined || colors.others === 'author');
+  if (colors) {
+    element.dataset.reviewAuthorSlot = String(
+      (colors.authorSlots.get(attribution.author) ?? 0) % REVIEW_AUTHOR_SLOTS
+    );
+  } else {
+    delete element.dataset.reviewAuthorSlot;
+  }
+  element.style.outlineColor = byAuthor ? presentation.authorColor : '';
+}
+
 export function paintDrawingRecord(
+  document: Document,
+  drawing: InlineDrawingRecord | AnchoredDrawingRecord,
+  ctx: DrawingPaintContext,
+  urlRegistry: UrlRegistry | null,
+  origin?: LayoutBox
+): HTMLElement | null {
+  const element = paintDrawingRecordElement(document, drawing, ctx, urlRegistry, origin);
+  if (element) applyDrawingRevisionPresentation(element, drawing, ctx);
+  return element;
+}
+
+function paintDrawingRecordElement(
   document: Document,
   drawing: InlineDrawingRecord | AnchoredDrawingRecord,
   ctx: DrawingPaintContext,

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -306,6 +306,7 @@ function resolvedDrawingPaint(ctx: ResolvedPaintContext): DrawingPaintContext {
     ...(ctx.imageUrlPort ? { imageUrlPort: ctx.imageUrlPort } : {}),
     ...(ctx.inertLinks ? { inertLinks: true } : {}),
     ...(ctx.paintInstance ? { paintInstance: ctx.paintInstance } : {}),
+    ...(ctx.revisionStyles ? { revisionStyles: ctx.revisionStyles } : {}),
     paintStoryFragment: (
       document: Document,
       fragment: ParagraphFragmentRecord | TableFragmentRecord
@@ -1045,6 +1046,10 @@ function paintChangeBars(
   for (const line of fragment.lines) {
     const revisions = [
       ...line.spans.flatMap((span) => span.revisions ?? []),
+      // Inline drawings too: a line whose ONLY change is an inserted or deleted picture
+      // carries no revision span — the atom is projected, not a span — and without this the
+      // margin said nothing had changed on it (#479).
+      ...(line.drawings ?? []).flatMap((drawing) => drawing.revisions ?? []),
       ...(line === markLine ? (fragment.markRevisions ?? []) : []),
     ];
     if (revisions.length === 0) continue;

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1046,10 +1046,12 @@ function paintChangeBars(
   for (const line of fragment.lines) {
     const revisions = [
       ...line.spans.flatMap((span) => span.revisions ?? []),
-      // Inline drawings too: a line whose ONLY change is an inserted or deleted picture
-      // carries no revision span — the atom is projected, not a span — and without this the
-      // margin said nothing had changed on it (#479).
+      // Drawings too: a line whose ONLY change is an inserted or deleted picture carries no
+      // revision span — an inline atom is projected, not a span, and an anchored drawing
+      // paints from the page layer — and without these the margin said nothing had changed
+      // on it (#479).
       ...(line.drawings ?? []).flatMap((drawing) => drawing.revisions ?? []),
+      ...(line.anchorRevisions ?? []),
       ...(line === markLine ? (fragment.markRevisions ?? []) : []),
     ];
     if (revisions.length === 0) continue;

--- a/packages/core/src/store/store/story-part-locate.ts
+++ b/packages/core/src/store/store/story-part-locate.ts
@@ -1,0 +1,60 @@
+// Header/footer story-part resolution: relationship id -> the hdr/ftr part it names.
+//
+// Extracted from tree-package-store so the store facade stays under its line budget. The
+// checks are the trust boundary's: only the header/footer relationship types resolve, an
+// external target refuses, and the target part must actually root a `w:hdr`/`w:ftr`.
+
+import type { OoxmlPart } from '../package/ooxml-tree.ts';
+import type { OoxmlPackage } from '../package/ooxml-package.ts';
+import { resolveRelationship, type RelationshipRecord } from '../package/relationships.ts';
+import type { StoryTargetRejection } from './tree-package-store.ts';
+
+export const HEADER_REL_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
+export const FOOTER_REL_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
+
+export function locateHeaderFooterPart(
+  pkg: OoxmlPackage,
+  rId: string
+):
+  | { readonly ok: true; readonly partName: string; readonly part: OoxmlPart }
+  | { readonly ok: false; readonly reason: StoryTargetRejection; readonly detail?: string } {
+  const relationships = pkg.relationships.get(pkg.mainDocumentPart) ?? [];
+  const record = relationships.find((rel) => rel.id === rId);
+  if (!record) {
+    return { ok: false, reason: 'dangling-relationship', detail: rId };
+  }
+  if (record.type !== HEADER_REL_TYPE && record.type !== FOOTER_REL_TYPE) {
+    return { ok: false, reason: 'wrong-relationship-type', detail: record.type };
+  }
+  return resolveInternalStoryPart(pkg, record);
+}
+
+export function resolveInternalStoryPart(
+  pkg: OoxmlPackage,
+  record: RelationshipRecord
+):
+  | { readonly ok: true; readonly partName: string; readonly part: OoxmlPart }
+  | { readonly ok: false; readonly reason: StoryTargetRejection; readonly detail?: string } {
+  const resolved = resolveRelationship(record);
+  if (resolved.mode === 'External') {
+    return { ok: false, reason: 'external-relationship', detail: record.id };
+  }
+  if (!resolved.target.ok) {
+    return {
+      ok: false,
+      reason: 'bad-relationship-target',
+      detail: resolved.target.reason,
+    };
+  }
+  const part = pkg.parts.get(resolved.target.partName);
+  if (!part) {
+    return { ok: false, reason: 'missing-part', detail: resolved.target.partName };
+  }
+  const rootName = part.root.localName;
+  if (rootName !== 'hdr' && rootName !== 'ftr') {
+    return { ok: false, reason: 'not-a-story-part', detail: rootName || part.name };
+  }
+  return { ok: true, partName: part.name, part };
+}

--- a/packages/core/src/store/store/tree-op-drawings.ts
+++ b/packages/core/src/store/store/tree-op-drawings.ts
@@ -40,6 +40,8 @@ import {
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
 import { cloneWithNewIds, fromEdit, parentOf, TEXT_DEPS } from './tree-op-nodes.ts';
+import { applyInsertTrackedRun, build as buildTrackedNode } from './tree-op-tracked.ts';
+import { invalidRevisionAttribution } from './tree-op-types.ts';
 import { insertRunPayloadAtOffset, offsetInsideAtomicSegment } from './tree-op-insert-offset.ts';
 import { isTableNested } from './tree-op-section-address.ts';
 import { isParagraph, paragraphLength, segmentsOf, splitsSurrogate } from './tree-op-segments.ts';
@@ -379,6 +381,11 @@ export function validateDrawingOp(part: OoxmlPart, op: DrawingTreeDocOp): TreeOp
       if (!anchor) return 'not-a-drawing';
       const projection = projectionOf(part, op.drawing);
       if (!isPictureProjection(projection)) return 'not-a-picture-drawing';
+      // `CT_TrackChange` makes `@w:author` required, so a tracked variant with an empty one
+      // would serialize a proposal no reader can attribute or resolve.
+      if (op.revision !== undefined && invalidRevisionAttribution(op.revision)) {
+        return 'invalid-property-value';
+      }
       if (isTableNested(part, op.paragraphId) && op.offset !== len && op.offset !== 0) {
         const boundary = segmentsOf(paragraph).find((segment) => segment.start === op.offset);
         if (!boundary) return 'cross-cell-drawing';
@@ -1495,6 +1502,40 @@ export function applyDrawingOp(
   switch (op.op) {
     case 'insertDrawing': {
       const paragraph = findNode(part, op.paragraphId) as OoxmlParagraphNode;
+      // Tracked: the drawing's run goes into a `w:ins` through the SAME placement typed text
+      // follows (own-insertion extension, relocation past struck words), so suggesting mode
+      // proposes the picture rather than committing an unattributed edit. The drawing clones
+      // inside the tracked mint — a second allocator over the same part would collide.
+      if (op.revision) {
+        let clonedId: string | null = null;
+        const result = applyInsertTrackedRun(
+          part,
+          paragraph,
+          op.offset,
+          (mint) => {
+            const cloned = withDrawingNamespaceBindings(
+              cloneWithNewIds(op.drawing, mint) as OoxmlDrawingNode
+            );
+            clonedId = cloned.id;
+            return buildTrackedNode(mint(), 'run', 'r', [], [cloned]);
+          },
+          op.revision,
+          options
+        );
+        if (!result.ok) return result;
+        // The tracked apply reports the text-lane effect; a drawing insert moves geometry
+        // beyond the line, so it keeps the drawing op's own impact and created set.
+        return {
+          ...result,
+          effect: {
+            dirty: [paragraph.id, ...(clonedId !== null ? [clonedId] : [])],
+            created: clonedId !== null ? [clonedId] : [],
+            deleted: [],
+            dependencyKeys: TEXT_DEPS,
+            impact: drawingOpImpact(op),
+          },
+        };
+      }
       const cloned = withDrawingNamespaceBindings(
         cloneWithNewIds(op.drawing, nextId) as OoxmlDrawingNode
       );

--- a/packages/core/src/store/store/tree-op-types.ts
+++ b/packages/core/src/store/store/tree-op-types.ts
@@ -952,6 +952,8 @@ export type TreeDocOp =
       readonly paragraphId: string;
       readonly offset: number;
       readonly drawing: OoxmlDrawingNode;
+      /** Present in suggesting mode: the drawing's run goes into a `w:ins` as one proposal. */
+      readonly revision?: RevisionAttributionInput;
     }
   | {
       readonly op: 'replaceDrawingResource';

--- a/packages/core/src/store/store/tree-package-images.ts
+++ b/packages/core/src/store/store/tree-package-images.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_DRAWING_PROJECTION_LIMITS,
   DEFAULT_SUPPORTED_MC_REQUIRES,
   createDrawingRelationshipResolver,
+  isRunLevelMcAlternateContent,
 } from '../package/drawing-projection.ts';
 import {
   buildInlinePictureDrawing,
@@ -478,20 +479,59 @@ export function deleteImage(
 /**
  * The drawing atom's model unit within its owning paragraph, from the SAME offset authority
  * the tracked ops strike by (`paragraphOffsetIndex`), so the proposal covers exactly the
- * unit `applyDeleteTracked` re-labels. Null when the drawing is not addressable content —
- * unknown id, or chrome swallowed by a field atom (zero-length span).
+ * unit `applyDeleteTracked` re-labels. Null when the target is not an addressable drawing
+ * atom — unknown id, a node that is not a `w:drawing` or a run-level MC wrapper, or chrome
+ * swallowed by a field atom (zero-length span). `alreadyDeleted` reports an enclosing
+ * `w:del`/`w:moveFrom`, so the caller can answer a repeat proposal without writing one.
  */
 function locateDrawingModelUnit(
   part: OoxmlPart,
   drawingNodeId: string
-): { readonly paragraphId: string; readonly start: number; readonly end: number } | null {
-  let found: { paragraphId: string; start: number; end: number } | null = null;
+): {
+  readonly paragraphId: string;
+  readonly start: number;
+  readonly end: number;
+  readonly alreadyDeleted: boolean;
+} | null {
+  let found: {
+    paragraphId: string;
+    start: number;
+    end: number;
+    alreadyDeleted: boolean;
+  } | null = null;
+  const insideDeletion = (paragraph: OoxmlNode): boolean => {
+    let seen = false;
+    let deleted = false;
+    const walk = (node: OoxmlNode, enclosed: boolean): void => {
+      if (seen || node.kind === 'textValue') return;
+      if (node.id === drawingNodeId) {
+        seen = true;
+        deleted = enclosed;
+        return;
+      }
+      const next = enclosed || node.kind === 'revisionDelete' || node.kind === 'revisionMoveFrom';
+      for (const child of node.children) walk(child, next);
+    };
+    walk(paragraph, false);
+    return deleted;
+  };
   const visit = (node: OoxmlNode): void => {
     if (found !== null || node.kind === 'textValue') return;
     if (node.kind === 'paragraph') {
       const span = paragraphOffsetIndex(node).spanOf(drawingNodeId);
       if (span !== null && span.end > span.start) {
-        found = { paragraphId: node.id, start: span.start, end: span.end };
+        // Only a drawing atom may be struck through this lane: every run node has a span,
+        // and a public caller handing a text node's id must be refused, not obeyed.
+        const target = findNode(part, drawingNodeId);
+        if (!target || (target.kind !== 'drawing' && !isRunLevelMcAlternateContent(target))) {
+          return;
+        }
+        found = {
+          paragraphId: node.id,
+          start: span.start,
+          end: span.end,
+          alreadyDeleted: insideDeletion(node),
+        };
       }
       // No descent past the paragraph: a nested paragraph only exists inside a textbox
       // story, which is not an editable lane and publishes no selectable drawing.
@@ -507,8 +547,9 @@ function locateDrawingModelUnit(
  * Propose the deletion instead of performing it: the drawing's single model unit goes into
  * a `w:del`, exactly as a struck word does, so the page keeps the picture (dimmed, outlined)
  * and the review queue offers one Accept. Media and relationships stay untouched — the file
- * still shows the picture until someone accepts — and the author's own pending insertion is
- * removed outright by the tracked apply, the same rule struck text follows.
+ * still shows the picture until someone accepts, and the one branch that removes the drawing
+ * now (the author striking their OWN pending insertion) leaves the media part orphaned,
+ * which is the same shape the accept lane produces and valid OPC.
  */
 export function deleteImageTracked(
   store: TreePackageStore,
@@ -530,6 +571,11 @@ export function deleteImageTracked(
   if (!part) return { ok: false, reason: 'unknown-drawing' };
   const located = locateDrawingModelUnit(part, drawingNodeId);
   if (!located) return { ok: false, reason: 'unknown-drawing' };
+  // Already proposed away: the strike stands, and there is nothing further to say. The
+  // tracked apply would push the runs through unchanged, but the rebuilt wrapper still
+  // committed a unit — so the dimmed (still selectable) picture took one Delete per press
+  // into the undo stack, and the first Ctrl+Z visibly did nothing.
+  if (located.alreadyDeleted) return { ok: true, change: null };
   return transactPackageImage(store, scope, (ctx) => {
     if (
       !ctx.apply({

--- a/packages/core/src/store/store/tree-package-images.ts
+++ b/packages/core/src/store/store/tree-package-images.ts
@@ -52,6 +52,8 @@ export interface InsertImageInput {
   readonly title?: string;
   readonly description?: string;
   readonly hyperlink?: string;
+  /** Present in suggesting mode: the inserted drawing's run goes into a `w:ins`. */
+  readonly revision?: RevisionAttributionInput;
 }
 
 export interface ReplaceImageOptions {
@@ -337,6 +339,7 @@ export async function insertImage(
           paragraphId: input.paragraphId,
           offset: input.offset,
           drawing: drawing as OoxmlDrawingNode,
+          ...(input.revision ? { revision: input.revision } : {}),
         })
       ) {
         return null;

--- a/packages/core/src/store/store/tree-package-images.ts
+++ b/packages/core/src/store/store/tree-package-images.ts
@@ -26,9 +26,15 @@ import {
 } from '../package/hyperlink-part.ts';
 import { resolveImageRelationship } from '../package/relationships.ts';
 import type { ImageDecodePort, SupportedImageMime } from '../package/image-resources.ts';
-import type { OoxmlDrawingNode, OoxmlElement, OoxmlPart } from '../package/ooxml-tree.ts';
+import type {
+  OoxmlDrawingNode,
+  OoxmlElement,
+  OoxmlNode,
+  OoxmlPart,
+} from '../package/ooxml-tree.ts';
 import { docPrHyperlinkRelationshipId, setDocPrHyperlinkRelationship } from './tree-op-drawings.ts';
-import type { DrawingTreeDocOp } from './tree-op-types.ts';
+import { paragraphOffsetIndex } from './tree-op-segments.ts';
+import type { DrawingTreeDocOp, RevisionAttributionInput } from './tree-op-types.ts';
 import type { PackageTransactResult, StoryScope, TreePackageStore } from './tree-package-store.ts';
 import type { TransactionContext, TreeDocumentStore } from './tree-store.ts';
 
@@ -465,6 +471,77 @@ export function deleteImage(
     ctx.applyPackage((current) =>
       cleanupOrphanImageMedia(current, owner, previousPart, previousRel)
     );
+    return drawingNodeId;
+  });
+}
+
+/**
+ * The drawing atom's model unit within its owning paragraph, from the SAME offset authority
+ * the tracked ops strike by (`paragraphOffsetIndex`), so the proposal covers exactly the
+ * unit `applyDeleteTracked` re-labels. Null when the drawing is not addressable content —
+ * unknown id, or chrome swallowed by a field atom (zero-length span).
+ */
+function locateDrawingModelUnit(
+  part: OoxmlPart,
+  drawingNodeId: string
+): { readonly paragraphId: string; readonly start: number; readonly end: number } | null {
+  let found: { paragraphId: string; start: number; end: number } | null = null;
+  const visit = (node: OoxmlNode): void => {
+    if (found !== null || node.kind === 'textValue') return;
+    if (node.kind === 'paragraph') {
+      const span = paragraphOffsetIndex(node).spanOf(drawingNodeId);
+      if (span !== null && span.end > span.start) {
+        found = { paragraphId: node.id, start: span.start, end: span.end };
+      }
+      // No descent past the paragraph: a nested paragraph only exists inside a textbox
+      // story, which is not an editable lane and publishes no selectable drawing.
+      return;
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(part.root);
+  return found;
+}
+
+/**
+ * Propose the deletion instead of performing it: the drawing's single model unit goes into
+ * a `w:del`, exactly as a struck word does, so the page keeps the picture (dimmed, outlined)
+ * and the review queue offers one Accept. Media and relationships stay untouched — the file
+ * still shows the picture until someone accepts — and the author's own pending insertion is
+ * removed outright by the tracked apply, the same rule struck text follows.
+ */
+export function deleteImageTracked(
+  store: TreePackageStore,
+  scope: StoryScope,
+  drawingNodeId: string,
+  revision: RevisionAttributionInput
+): ImageIntentResult {
+  const resolved = store.resolveStory(scope);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      reason: resolved.reason,
+      ...(resolved.detail ? { detail: resolved.detail } : {}),
+    };
+  }
+  const blocked = imageIntentBlockedDuringComposition(store, resolved.store);
+  if (blocked) return blocked;
+  const part = store.currentPackage().parts.get(resolved.story.partName);
+  if (!part) return { ok: false, reason: 'unknown-drawing' };
+  const located = locateDrawingModelUnit(part, drawingNodeId);
+  if (!located) return { ok: false, reason: 'unknown-drawing' };
+  return transactPackageImage(store, scope, (ctx) => {
+    if (
+      !ctx.apply({
+        op: 'deleteText',
+        paragraphId: located.paragraphId,
+        start: located.start,
+        end: located.end,
+        revision,
+      })
+    ) {
+      return null;
+    }
     return drawingNodeId;
   });
 }

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -42,6 +42,7 @@ import {
 } from '../package/package-shell-persistence.ts';
 import { ORIGIN_IDS } from '../registry/frozen-ids.ts';
 import type { ImpactClass, TreeDocOp, TreeOpRejection } from './tree-ops.ts';
+import type { RevisionAttributionInput } from './tree-op-types.ts';
 import {
   deleteBlockMayStrandNote,
   deleteMayEmptyCommentRange,
@@ -60,6 +61,7 @@ import {
 import {
   applyImagePropertiesIntent,
   deleteImage as deleteImageIntent,
+  deleteImageTracked as deleteImageTrackedIntent,
   embedExternalImage as embedExternalImageIntent,
   insertImage as insertImageIntent,
   replaceImage as replaceImageIntent,
@@ -828,6 +830,15 @@ export class TreePackageStore {
   /** Delete a picture drawing and collect orphaned media in one package undo unit. */
   deleteImage(scope: StoryScope, drawingNodeId: string): ImageIntentResult {
     return deleteImageIntent(this, scope, drawingNodeId);
+  }
+
+  /** Propose the deletion as a tracked change: the drawing goes into a `w:del`, media stays. */
+  deleteImageTracked(
+    scope: StoryScope,
+    drawingNodeId: string,
+    revision: RevisionAttributionInput
+  ): ImageIntentResult {
+    return deleteImageTrackedIntent(this, scope, drawingNodeId, revision);
   }
 
   /** Fetch external bytes explicitly and embed them; no fetch on open/load. */

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -20,7 +20,8 @@ import { openStoryPartsOf, openStoryTokenOf } from './open-story-parts.ts';
 import { settingsPartOf } from '../package/note-properties.ts';
 import { ensureListParagraphContextualSpacing } from '../package/list-style-part.ts';
 import { withPart, type OoxmlExternalTarget, type OoxmlPackage } from '../package/ooxml-package.ts';
-import { resolveRelationship, type RelationshipRecord } from '../package/relationships.ts';
+import { resolveRelationship } from '../package/relationships.ts';
+import { FOOTER_REL_TYPE, HEADER_REL_TYPE, locateHeaderFooterPart } from './story-part-locate.ts';
 import {
   applyHeaderFooterLifecycleOp,
   isHeaderFooterLifecycleOp,
@@ -101,11 +102,6 @@ const CONTENT_REMOVING_OPS: ReadonlySet<string> = new Set([
   'removeContentControl',
   'removeRepeatingSectionItem',
 ]);
-
-const HEADER_REL_TYPE =
-  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
-const FOOTER_REL_TYPE =
-  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
 
 /**
  * Editable story target.
@@ -1260,49 +1256,4 @@ export class TreePackageStore {
     this.publish(change);
     return change;
   }
-}
-
-function locateHeaderFooterPart(
-  pkg: OoxmlPackage,
-  rId: string
-):
-  | { readonly ok: true; readonly partName: string; readonly part: OoxmlPart }
-  | { readonly ok: false; readonly reason: StoryTargetRejection; readonly detail?: string } {
-  const relationships = pkg.relationships.get(pkg.mainDocumentPart) ?? [];
-  const record = relationships.find((rel) => rel.id === rId);
-  if (!record) {
-    return { ok: false, reason: 'dangling-relationship', detail: rId };
-  }
-  if (record.type !== HEADER_REL_TYPE && record.type !== FOOTER_REL_TYPE) {
-    return { ok: false, reason: 'wrong-relationship-type', detail: record.type };
-  }
-  return resolveInternalStoryPart(pkg, record);
-}
-
-function resolveInternalStoryPart(
-  pkg: OoxmlPackage,
-  record: RelationshipRecord
-):
-  | { readonly ok: true; readonly partName: string; readonly part: OoxmlPart }
-  | { readonly ok: false; readonly reason: StoryTargetRejection; readonly detail?: string } {
-  const resolved = resolveRelationship(record);
-  if (resolved.mode === 'External') {
-    return { ok: false, reason: 'external-relationship', detail: record.id };
-  }
-  if (!resolved.target.ok) {
-    return {
-      ok: false,
-      reason: 'bad-relationship-target',
-      detail: resolved.target.reason,
-    };
-  }
-  const part = pkg.parts.get(resolved.target.partName);
-  if (!part) {
-    return { ok: false, reason: 'missing-part', detail: resolved.target.partName };
-  }
-  const rootName = part.root.localName;
-  if (rootName !== 'hdr' && rootName !== 'ftr') {
-    return { ok: false, reason: 'not-a-story-part', detail: rootName || part.name };
-  }
-  return { ok: true, partName: part.name, part };
 }

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -1716,6 +1716,23 @@ a.docx-hyperlink:focus-visible {
   background-color: var(--doc-revision-deletion-wash);
 }
 
+/* A DRAWING inside a tracked change. The outline is the box's underline/strike: there is no
+   text to decorate, so the frame carries the claim, in the same kind tokens the text rules
+   use. Drawn INSIDE the box (negative offset) because pages, cells and clipped paint bounds
+   crop at the box edge and would shave an outer ring off. Under author colouring the painter
+   overrides `outline-color` inline, exactly as span ink follows the author. */
+.docx-drawing--revision-insertion {
+  outline: 2px solid var(--doc-revision-insertion);
+  outline-offset: -2px;
+}
+
+.docx-drawing--revision-deletion {
+  outline: 2px solid var(--doc-revision-deletion);
+  outline-offset: -2px;
+  /* Pending removal reads as on its way out — the box twin of the strike-through. */
+  opacity: 0.6;
+}
+
 /* FIELD SHADING — the grey block Word draws behind computed text (a page number, a
    cross-reference, the blank in a form). It marks where text came from, not what it says.
 


### PR DESCRIPTION
A drawing inside a tracked insertion or deletion now carries the change. Layout folds the owning run's revision wrappers into the inline and anchored drawing records, and paint marks the element with an insertion- or deletion-colored outline, the same `data-revision-*` datasets spans carry, and a margin change bar. A tracked-deleted picture stays visible and dimmed under all-markup instead of disappearing, and the resolved display modes remove the picture, its change bar, and its text-wrap hole together. Applies to inline and anchored drawings in the body, table cells, and header and footer stories.

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175GAkSSeqbnnChDkqoiZmR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790319340&installation_model_id=422592&pr_number=490&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F490&signature=082b7ef359b7b9f80ceb9d49c983f42dd4bbd322d3f50fce141924628332f9e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->