### PR TITLE
fix: apply run formatting to text inside tracked changes

### DIFF
--- a/.changeset/tracked-text-formatting.md
+++ b/.changeset/tracked-text-formatting.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Run formatting (bold, italic, font family, font size, color) now applies to text inside tracked changes; it previously did nothing over runs wrapped in `w:ins` or `w:del`. Fixes #493

--- a/packages/core/src/editor/__tests__/tracked-text-formatting.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-text-formatting.test.ts
@@ -1,0 +1,176 @@
+// Run formatting over tracked-change text (fixes #493).
+//
+// Runs inside a revision wrapper (`w:ins` / `w:del` / `w:moveFrom` / `w:moveTo`) have
+// offsets — `segmentsOf` descends into the wrapper — but the edit-planning walks stopped at
+// the wrapper node. The plan came back empty, so Bold, font and size changes over tracked
+// text emitted no ops at all, silently. These tests pin the walks descending: the surface
+// lane (`surface-formatting.ts`) through the toolbar path, and the store lane
+// (`direct-properties.ts`) directly.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+import { runPropertyEdits, runsCovering, type OoxmlNode } from '@docx-editor.dev/core/store';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function withSurface(body: string, run: (surface: PaginatedSurface) => void): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const opened = mountPaginatedSurface(container, docx(body));
+  if (!opened.ok) throw new Error(opened.reason);
+  try {
+    run(opened.surface);
+  } finally {
+    opened.surface.destroy();
+    container.remove();
+  }
+}
+
+const ins = (runs: string) =>
+  `<w:ins w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">${runs}</w:ins>`;
+const textRun = (text: string) => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
+
+function firstParagraphNode(surface: PaginatedSurface): OoxmlNode {
+  const found = findFirst(
+    surface.session.part().root,
+    (candidate) => candidate.kind === 'paragraph'
+  );
+  if (!found) throw new Error('no paragraph');
+  return found;
+}
+
+function findFirst(node: OoxmlNode, match: (node: OoxmlNode) => boolean): OoxmlNode | null {
+  if (match(node)) return node;
+  if (node.kind === 'textValue') return null;
+  for (const child of node.children) {
+    const found = findFirst(child, match);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Every run under `node`, each as its authored `w:rPr` names plus its text, in order. */
+function runShapes(node: OoxmlNode): { props: string[]; text: string; tracked: boolean }[] {
+  const shapes: { props: string[]; text: string; tracked: boolean }[] = [];
+  const walk = (current: OoxmlNode, tracked: boolean): void => {
+    if (current.kind === 'textValue') return;
+    if (current.kind === 'run') {
+      const rPr = current.children.find((child) => child.kind === 'runProperties');
+      const props =
+        rPr && rPr.kind !== 'textValue'
+          ? rPr.children.flatMap((child) => (child.kind === 'textValue' ? [] : [child.localName]))
+          : [];
+      let text = '';
+      const collect = (inner: OoxmlNode): void => {
+        if (inner.kind === 'textValue') text += inner.value;
+        else for (const grand of inner.children) collect(grand);
+      };
+      collect(current);
+      shapes.push({ props, text, tracked });
+      return;
+    }
+    const inside = tracked || current.kind === 'revisionInsert';
+    for (const child of current.children) walk(child, inside);
+  };
+  walk(node, false);
+  return shapes;
+}
+
+function select(surface: PaginatedSurface, start: number, end: number): void {
+  const id = surface.session.paragraphIds()[0]!;
+  surface.setSelection({
+    anchor: { paragraphId: id, offset: start },
+    head: { paragraphId: id, offset: end },
+  });
+}
+
+describe('run formatting over tracked-change text', () => {
+  test('bold applies to a run inside w:ins and keeps it tracked', () => {
+    withSurface(`<w:p>${ins(textRun('hello'))}</w:p>`, (surface) => {
+      select(surface, 0, 5);
+      expect(surface.formatting().bold).toBe(false);
+      surface.toggleRunProperty('b');
+      expect(surface.formatting().bold).toBe(true);
+      expect(runShapes(firstParagraphNode(surface))).toEqual([
+        { props: ['b'], text: 'hello', tracked: true },
+      ]);
+    });
+  });
+
+  test('formatting part of a tracked run splits it inside the wrapper', () => {
+    withSurface(`<w:p>${ins(textRun('hello world'))}</w:p>`, (surface) => {
+      select(surface, 0, 5);
+      surface.toggleRunProperty('b');
+      expect(runShapes(firstParagraphNode(surface))).toEqual([
+        { props: ['b'], text: 'hello', tracked: true },
+        { props: [], text: ' world', tracked: true },
+      ]);
+    });
+  });
+
+  test('a selection mixing plain and tracked runs formats both', () => {
+    withSurface(`<w:p>${textRun('plain ')}${ins(textRun('tracked'))}</w:p>`, (surface) => {
+      select(surface, 0, 'plain tracked'.length);
+      surface.toggleRunProperty('b');
+      expect(runShapes(firstParagraphNode(surface))).toEqual([
+        { props: ['b'], text: 'plain ', tracked: false },
+        { props: ['b'], text: 'tracked', tracked: true },
+      ]);
+    });
+  });
+
+  test('font size applies over a tracked insertion', () => {
+    withSurface(`<w:p>${ins(textRun('hello'))}</w:p>`, (surface) => {
+      select(surface, 0, 5);
+      surface.setRunProperty('sz', { val: '48' });
+      expect(surface.formatting().fontSizeHalfPoints).toBe(48);
+      expect(runShapes(firstParagraphNode(surface))).toEqual([
+        { props: ['sz'], text: 'hello', tracked: true },
+      ]);
+    });
+  });
+
+  test('pending caret formatting reads the tracked run to the left', () => {
+    // `authoredRunPropertiesAt` walks the same surface; a caret inside a tracked bold run
+    // must arm over that run's bag rather than the paragraph mark's.
+    withSurface(
+      `<w:p>${ins('<w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r>')}</w:p>`,
+      (surface) => {
+        select(surface, 4, 4);
+        expect(surface.formatting().bold).toBe(true);
+      }
+    );
+  });
+
+  test('the store lane plans edits and covers runs inside w:ins', () => {
+    withSurface(`<w:p>${ins(textRun('hello'))}</w:p>`, (surface) => {
+      const part = surface.session.part();
+      const id = surface.session.paragraphIds()[0]!;
+      const edits = runPropertyEdits(part, id, 0, 5, { localName: 'b' });
+      expect(edits).toEqual([{ start: 0, end: 5, properties: [{ localName: 'b' }] }]);
+      expect(runsCovering(part, id, 0, 5)).toHaveLength(1);
+    });
+  });
+});

--- a/packages/core/src/editor/__tests__/tracked-text-formatting.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-text-formatting.test.ts
@@ -144,6 +144,36 @@ describe('run formatting over tracked-change text', () => {
     );
   });
 
+  test('a selection across a tracked deletion leaves the deleted runs alone', () => {
+    // The deletion's runs are hidden in the default display mode but keep offsets, so the
+    // write must skip them: restyling text the user cannot see surfaces only when the
+    // deletion is rejected. Display-mode-aware inclusion is #497.
+    const del =
+      '<w:del w:id="2" w:author="A" w:date="2026-01-01T00:00:00Z">' +
+      '<w:r><w:delText xml:space="preserve">XYZ</w:delText></w:r></w:del>';
+    withSurface(`<w:p>${textRun('abc')}${del}${textRun('def')}</w:p>`, (surface) => {
+      select(surface, 0, 'abcXYZdef'.length);
+      surface.toggleRunProperty('b');
+      expect(runShapes(firstParagraphNode(surface))).toEqual([
+        { props: ['b'], text: 'abc', tracked: false },
+        { props: [], text: 'XYZ', tracked: false },
+        { props: ['b'], text: 'def', tracked: false },
+      ]);
+    });
+  });
+
+  test('the store lane plans no edits over a tracked deletion', () => {
+    const del =
+      '<w:del w:id="2" w:author="A" w:date="2026-01-01T00:00:00Z">' +
+      '<w:r><w:delText xml:space="preserve">XYZ</w:delText></w:r></w:del>';
+    withSurface(`<w:p>${del}</w:p>`, (surface) => {
+      const part = surface.session.part();
+      const id = surface.session.paragraphIds()[0]!;
+      expect(runPropertyEdits(part, id, 0, 3, { localName: 'b' })).toEqual([]);
+      expect(runsCovering(part, id, 0, 3)).toHaveLength(0);
+    });
+  });
+
   test('the store lane plans edits and covers runs inside w:ins', () => {
     withSurface(`<w:p>${ins(textRun('hello'))}</w:p>`, (surface) => {
       const part = surface.session.part();

--- a/packages/core/src/editor/__tests__/tracked-text-formatting.test.ts
+++ b/packages/core/src/editor/__tests__/tracked-text-formatting.test.ts
@@ -11,29 +11,9 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
-import { zipSync, strToU8 } from 'fflate';
 import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
 import { runPropertyEdits, runsCovering, type OoxmlNode } from '@docx-editor.dev/core/store';
-
-const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
-const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
-const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
-
-function docx(body: string): Uint8Array {
-  return zipSync({
-    '[Content_Types].xml': strToU8(
-      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
-        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
-    ),
-    '_rels/.rels': strToU8(
-      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
-    ),
-    'word/document.xml': strToU8(
-      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
-    ),
-  });
-}
+import { docx } from './paginated-surface-fixtures.ts';
 
 function withSurface(body: string, run: (surface: PaginatedSurface) => void): void {
   const container = document.createElement('div');

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -34,8 +34,7 @@ import {
   type OoxmlPart,
   type RunPropertyEdit,
 } from '@docx-editor.dev/core/store';
-import { isContentRevisionKind, mergedMultiSettingProperty } from '@docx-editor.dev/core/store';
-import { runsUnder } from '../store/store/tree-op-segments.ts';
+import { mergedMultiSettingProperty } from '@docx-editor.dev/core/store';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { SurfaceFormatting } from './paginated-surface-contract.ts';
 import { lineSegments } from '../layout/line-segments.ts';
@@ -288,16 +287,33 @@ export {
 
 /**
  * The runs one paragraph child contributes to the formatting lane: the run itself, or every
- * run inside a revision wrapper (`w:ins` / `w:del` / `w:moveFrom` / `w:moveTo`).
+ * run inside a SURVIVING revision wrapper (`w:ins` / `w:moveTo`).
  *
  * `walkParagraphInline` descends links and content controls but hands a revision wrapper
  * over whole, and `segmentsOf` gives tracked runs offsets — so stopping at the wrapper made
  * every property write over tracked text plan zero edits, silently.
+ *
+ * The DELETION halves (`w:del` / `w:moveFrom`) stay out, subtree and all: their runs are
+ * hidden in the default display mode, so a write over a visible selection must not restyle
+ * text the user cannot see, and a `w:moveFrom` write would desynchronize the move pair (its
+ * `w:moveTo` twin sits at other offsets). Display-mode-aware inclusion is #497.
  */
-function formattableRunsOf(child: OoxmlNode): readonly OoxmlNode[] {
+function formattableRunsOf(child: OoxmlNode, depth = 0): readonly OoxmlNode[] {
   if (child.kind === 'run') return [child];
-  return isContentRevisionKind(child.kind) ? runsUnder(child) : [];
+  if (child.kind === 'textValue' || depth >= MAX_FORMATTABLE_RUN_DEPTH) return [];
+  if (child.kind === 'revisionDelete' || child.kind === 'revisionMoveFrom') return [];
+  if (
+    child.kind === 'hyperlink' ||
+    child.kind === 'revisionInsert' ||
+    child.kind === 'revisionMoveTo'
+  ) {
+    return child.children.flatMap((inner) => formattableRunsOf(inner, depth + 1));
+  }
+  return [];
 }
+
+/** Matches the nesting cap `runsUnder` applies to the same containers. */
+const MAX_FORMATTABLE_RUN_DEPTH = 32;
 
 /**
  * Surface range formatting uses the shared authored-property model while retaining v2's

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -34,7 +34,8 @@ import {
   type OoxmlPart,
   type RunPropertyEdit,
 } from '@docx-editor.dev/core/store';
-import { mergedMultiSettingProperty } from '@docx-editor.dev/core/store';
+import { isContentRevisionKind, mergedMultiSettingProperty } from '@docx-editor.dev/core/store';
+import { runsUnder } from '../store/store/tree-op-segments.ts';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { SurfaceFormatting } from './paginated-surface-contract.ts';
 import { lineSegments } from '../layout/line-segments.ts';
@@ -286,6 +287,19 @@ export {
 } from '@docx-editor.dev/core/store';
 
 /**
+ * The runs one paragraph child contributes to the formatting lane: the run itself, or every
+ * run inside a revision wrapper (`w:ins` / `w:del` / `w:moveFrom` / `w:moveTo`).
+ *
+ * `walkParagraphInline` descends links and content controls but hands a revision wrapper
+ * over whole, and `segmentsOf` gives tracked runs offsets — so stopping at the wrapper made
+ * every property write over tracked text plan zero edits, silently.
+ */
+function formattableRunsOf(child: OoxmlNode): readonly OoxmlNode[] {
+  if (child.kind === 'run') return [child];
+  return isContentRevisionKind(child.kind) ? runsUnder(child) : [];
+}
+
+/**
  * Surface range formatting uses the shared authored-property model while retaining v2's
  * content-control-aware inline walk. The automation lane consumes the same store primitives;
  * this wrapper is only the layout-backed surface traversal.
@@ -303,25 +317,26 @@ export function runPropertyEdits(
   const runRanges = runAddressRanges(paragraph);
   const formatOwned = formatOwnedRunIds(paragraph);
   walkParagraphInline(paragraph.children, 0, (child) => {
-    if (child.kind !== 'run') return;
-    const range = runRanges.get(child.id);
-    if (!range || range.end <= range.start) return;
-    const from = Math.max(range.start, start);
-    const to = Math.min(range.end, end);
-    if (from >= to) return;
-    const authored = authoredProperties(
-      propertyContainer(child, 'runProperties', 'rPr'),
-      AUTHORABLE_RUN_PROPERTIES
-    );
-    edits.push({
-      start: from,
-      end: to,
-      // Merged per attribute for the two run properties carrying several independent
-      // settings, the same rule the store lane's own walk applies — see
-      // `mergedMultiSettingProperty`.
-      properties: mergedProperties(authored, mergedMultiSettingProperty(authored, incoming)),
-      ...(formatOwned.has(child.id) ? { targetRunIds: [child.id] } : {}),
-    });
+    for (const run of formattableRunsOf(child)) {
+      const range = runRanges.get(run.id);
+      if (!range || range.end <= range.start) continue;
+      const from = Math.max(range.start, start);
+      const to = Math.min(range.end, end);
+      if (from >= to) continue;
+      const authored = authoredProperties(
+        propertyContainer(run, 'runProperties', 'rPr'),
+        AUTHORABLE_RUN_PROPERTIES
+      );
+      edits.push({
+        start: from,
+        end: to,
+        // Merged per attribute for the two run properties carrying several independent
+        // settings, the same rule the store lane's own walk applies — see
+        // `mergedMultiSettingProperty`.
+        properties: mergedProperties(authored, mergedMultiSettingProperty(authored, incoming)),
+        ...(formatOwned.has(run.id) ? { targetRunIds: [run.id] } : {}),
+      });
+    }
   });
   return edits;
 }
@@ -349,17 +364,19 @@ export function hasAuthoredRunProperties(
   let found = false;
   const visitRun = (child: OoxmlNode): void => {
     if (found) return;
-    if (child.kind !== 'run') return;
-    const range = runRanges.get(child.id);
-    if (!range || range.end <= range.start) return;
-    if (Math.max(range.start, start) >= Math.min(range.end, end)) return;
-    if (
-      authoredProperties(
-        propertyContainer(child, 'runProperties', 'rPr'),
-        AUTHORABLE_RUN_PROPERTIES
-      ).length > 0
-    ) {
-      found = true;
+    for (const run of formattableRunsOf(child)) {
+      const range = runRanges.get(run.id);
+      if (!range || range.end <= range.start) continue;
+      if (Math.max(range.start, start) >= Math.min(range.end, end)) continue;
+      if (
+        authoredProperties(
+          propertyContainer(run, 'runProperties', 'rPr'),
+          AUTHORABLE_RUN_PROPERTIES
+        ).length > 0
+      ) {
+        found = true;
+        return;
+      }
     }
   };
   walkParagraphInline(paragraph.children, 0, visitRun);
@@ -386,11 +403,12 @@ export function authoredRunPropertiesAt(
   let left: OoxmlNode | null = null;
   let right: OoxmlNode | null = null;
   const visitRun = (child: OoxmlNode): void => {
-    if (child.kind !== 'run') return;
-    const range = runRanges.get(child.id);
-    if (!range || range.end <= range.start) return;
-    if (range.start < offset && offset <= range.end) left = child;
-    if (right === null && range.start <= offset && offset < range.end) right = child;
+    for (const run of formattableRunsOf(child)) {
+      const range = runRanges.get(run.id);
+      if (!range || range.end <= range.start) continue;
+      if (range.start < offset && offset <= range.end) left = run;
+      if (right === null && range.start <= offset && offset < range.end) right = run;
+    }
   };
   walkParagraphInline(paragraph.children, 0, visitRun);
   const owner = left ?? right;

--- a/packages/core/src/store/store/direct-properties.ts
+++ b/packages/core/src/store/store/direct-properties.ts
@@ -328,6 +328,11 @@ export function runPropertyEdits(
     // A revision wrapper (`w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`) is a run container the
     // same way a link is, and `segmentsOf` gives its runs offsets — stopping at the wrapper
     // made every property write over tracked text plan zero edits, silently.
+    // The DELETION halves stay out: their runs are hidden in the default display mode, so a
+    // write over a visible selection must not restyle text the user cannot see, and a
+    // `w:moveFrom` write would desynchronize the pair anyway (its `w:moveTo` twin sits at
+    // other offsets). Display-mode-aware inclusion is #497.
+    if (child.kind === 'revisionDelete' || child.kind === 'revisionMoveFrom') return;
     if (child.kind === 'hyperlink' || isContentRevisionKind(child.kind)) {
       for (const inner of child.children) visit(inner);
       return;
@@ -379,6 +384,11 @@ export function runsCovering(
   const visit = (child: OoxmlNode): void => {
     if (child.kind === 'textValue') return;
     // Same containers as `runPropertyEdits` — the read must cover the runs the write splits.
+    // The DELETION halves stay out: their runs are hidden in the default display mode, so a
+    // write over a visible selection must not restyle text the user cannot see, and a
+    // `w:moveFrom` write would desynchronize the pair anyway (its `w:moveTo` twin sits at
+    // other offsets). Display-mode-aware inclusion is #497.
+    if (child.kind === 'revisionDelete' || child.kind === 'revisionMoveFrom') return;
     if (child.kind === 'hyperlink' || isContentRevisionKind(child.kind)) {
       for (const inner of child.children) visit(inner);
       return;

--- a/packages/core/src/store/store/direct-properties.ts
+++ b/packages/core/src/store/store/direct-properties.ts
@@ -17,7 +17,7 @@
 // `surface-formatting.ts` re-exports these under the names the editor lane already used.
 
 import { findNode } from '../package/ooxml-edit.ts';
-import { WML_NAMESPACE_URI } from '../package/ooxml-shared.ts';
+import { isContentRevisionKind, WML_NAMESPACE_URI } from '../package/ooxml-shared.ts';
 import type { OoxmlNode, OoxmlPart } from '../package/ooxml-tree.ts';
 import { nullRecord } from '../package/safe-record.ts';
 import { segmentsOf } from './tree-op-segments.ts';
@@ -324,16 +324,11 @@ export function runPropertyEdits(
   const runRanges = runAddressRanges(paragraph);
   const formatOwned = formatOwnedRunIds(paragraph);
   const visit = (child: OoxmlNode): void => {
+    if (child.kind === 'textValue') return;
     // A revision wrapper (`w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`) is a run container the
     // same way a link is, and `segmentsOf` gives its runs offsets — stopping at the wrapper
     // made every property write over tracked text plan zero edits, silently.
-    if (
-      child.kind === 'hyperlink' ||
-      child.kind === 'revisionInsert' ||
-      child.kind === 'revisionDelete' ||
-      child.kind === 'revisionMoveFrom' ||
-      child.kind === 'revisionMoveTo'
-    ) {
+    if (child.kind === 'hyperlink' || isContentRevisionKind(child.kind)) {
       for (const inner of child.children) visit(inner);
       return;
     }
@@ -382,14 +377,9 @@ export function runsCovering(
   const runRanges = runAddressRanges(paragraph);
   const runs: OoxmlNode[] = [];
   const visit = (child: OoxmlNode): void => {
+    if (child.kind === 'textValue') return;
     // Same containers as `runPropertyEdits` — the read must cover the runs the write splits.
-    if (
-      child.kind === 'hyperlink' ||
-      child.kind === 'revisionInsert' ||
-      child.kind === 'revisionDelete' ||
-      child.kind === 'revisionMoveFrom' ||
-      child.kind === 'revisionMoveTo'
-    ) {
+    if (child.kind === 'hyperlink' || isContentRevisionKind(child.kind)) {
       for (const inner of child.children) visit(inner);
       return;
     }

--- a/packages/core/src/store/store/direct-properties.ts
+++ b/packages/core/src/store/store/direct-properties.ts
@@ -324,7 +324,16 @@ export function runPropertyEdits(
   const runRanges = runAddressRanges(paragraph);
   const formatOwned = formatOwnedRunIds(paragraph);
   const visit = (child: OoxmlNode): void => {
-    if (child.kind === 'hyperlink') {
+    // A revision wrapper (`w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`) is a run container the
+    // same way a link is, and `segmentsOf` gives its runs offsets — stopping at the wrapper
+    // made every property write over tracked text plan zero edits, silently.
+    if (
+      child.kind === 'hyperlink' ||
+      child.kind === 'revisionInsert' ||
+      child.kind === 'revisionDelete' ||
+      child.kind === 'revisionMoveFrom' ||
+      child.kind === 'revisionMoveTo'
+    ) {
       for (const inner of child.children) visit(inner);
       return;
     }
@@ -373,7 +382,14 @@ export function runsCovering(
   const runRanges = runAddressRanges(paragraph);
   const runs: OoxmlNode[] = [];
   const visit = (child: OoxmlNode): void => {
-    if (child.kind === 'hyperlink') {
+    // Same containers as `runPropertyEdits` — the read must cover the runs the write splits.
+    if (
+      child.kind === 'hyperlink' ||
+      child.kind === 'revisionInsert' ||
+      child.kind === 'revisionDelete' ||
+      child.kind === 'revisionMoveFrom' ||
+      child.kind === 'revisionMoveTo'
+    ) {
       for (const inner of child.children) visit(inner);
       return;
     }


### PR DESCRIPTION
Formatting over tracked-change text did nothing: the edit-planning walks stopped at revision wrappers (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`), so Bold, font, and size changes planned zero edits and emitted no ops. The store lane's `runPropertyEdits` and `runsCovering` now descend into revision wrappers the same way they descend into `w:hyperlink`, and the surface lane's walks flatten a wrapper into its runs, matching the offsets `segmentsOf` already assigns. The apply side needed no change. A run split by a partial-range format stays inside its wrapper.

Fixes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqvcnm8neUHWyBc8AB8gJw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331590&installation_model_id=422592&pr_number=494&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F494&signature=aee5f07d9305a7740c7600fa27805774c470851cb45dd2fa90f8ab702f4f1e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->