### PR TITLE
docs: update pricing links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,4 +119,4 @@ Open an issue at [github.com/eigenpal/docx-editor/issues](https://github.com/eig
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under [Apache 2.0](LICENSE), except in `packages/editor-api/` and `packages/pro/`, which carry the EigenPal Pro Evaluation License 1.0.
+By contributing, you agree that your contributions are licensed under [Apache 2.0](LICENSE), except contributions to `packages/editor-api/` and `packages/pro/`, which are licensed under the EigenPal Pro License.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the [React](#react) or [Vue](#vue) quick start below.
 | [`@docx-editor.dev/pro`](https://www.npmjs.com/package/@docx-editor.dev/pro)               | Tracked changes, comments, and custom nodes.                                                                                                                                   | [Docs](https://www.docx-editor.dev/docs/2.x/pro)        |
 | [`@docx-editor.dev/editor-api`](https://www.npmjs.com/package/@docx-editor.dev/editor-api) | Office.js-compatible editing API: a batching object model that edits a document from a server, or an editor already open in a page.                                            | [Docs](https://www.docx-editor.dev/docs/2.x/editor-api) |
 
-Every package above is Apache 2.0 except `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro`, which are licensed under the EigenPal Pro Evaluation License 1.0 ([editor-api](packages/editor-api/LICENSE.md), [pro](packages/pro/LICENSE.md)): free to evaluate, production use requires a commercial agreement — **[licensing@eigenpal.com](mailto:licensing@eigenpal.com)**.
+`@docx-editor.dev/editor-api` and `@docx-editor.dev/pro` are licensed under the EigenPal Pro License ([editor-api](packages/editor-api/LICENSE.md), [pro](packages/pro/LICENSE.md)), and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 > **Forking the adapter?** Keep your fork thin. Depend on `@docx-editor.dev/core` directly so parser, serializer, and rendering fixes land in your build automatically, without backporting each upstream change by hand.
 
@@ -150,7 +150,7 @@ bun run i18n:status      # check translation coverage
 
 ## License
 
-[Apache 2.0](LICENSE), except `packages/editor-api/` and `packages/pro/`, which are licensed under the EigenPal Pro Evaluation License 1.0 ([editor-api](packages/editor-api/LICENSE.md), [pro](packages/pro/LICENSE.md)). That licence permits internal, non-production evaluation; production use requires a written commercial agreement, available from **[licensing@eigenpal.com](mailto:licensing@eigenpal.com)**.
+This repository is licensed under [Apache 2.0](LICENSE), except `packages/editor-api/` and `packages/pro/`, which are licensed under the EigenPal Pro License ([editor-api](packages/editor-api/LICENSE.md), [pro](packages/pro/LICENSE.md)); you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 ## Commercial Support
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,7 +18,7 @@ Releases follow the canonical [`changesets/action@v1`](https://github.com/change
 | `@docx-editor.dev/i18n`       | `packages/i18n`       | ✅ (shared locale JSONs) |
 | `@docx-editor.dev/nuxt`       | `packages/nuxt`       | ✅                       |
 
-Four of the five publish under Apache 2.0. `@docx-editor.dev/editor-api` publishes under the [EigenPal Pro Evaluation License 1.0](../packages/editor-api/LICENSE.md) (`LicenseRef-EigenPal-Pro-Evaluation-1.0` in its manifest, `LICENSE.md` in its tarball), so its releases carry commercial terms that the others do not.
+Four packages use Apache 2.0, while `@docx-editor.dev/editor-api` uses the [EigenPal Pro License](../packages/editor-api/LICENSE.md) with `LicenseRef-EigenPal-Pro-Evaluation-1.0` in its manifest.
 
 All five packages are in a **fixed group** in `.changeset/config.json` — they always ship the same version. A changeset only needs to declare the bump for one; the others follow automatically. `@docx-editor.dev/i18n` ships the locale JSONs that the React and Vue adapters both consume, so adding a new key to `en.json` only needs a changeset on `@docx-editor.dev/i18n` (the consumers pick it up at build time).
 

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -38,13 +38,13 @@ permissions are not capability fields.
 
 Use these prerequisites:
 
-| Task                          | Prerequisite                                                                                     |
-| ----------------------------- | ------------------------------------------------------------------------------------------------ |
-| Create a server runtime       | DOCX bytes and one resolved copy of `@docx-editor.dev/core`                                      |
-| Create a browser runtime      | An attached editor from `@docx-editor.dev/react`, `@docx-editor.dev/vue`, or the core editor API |
-| Write a comment or reply      | A non-empty `author`                                                                             |
-| Write browser review data     | The Pro review module, an editable mode, and a host that accepts the write                       |
-| Use the package in production | A written commercial agreement                                                                   |
+| Task                      | Prerequisite                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| Create a server runtime   | DOCX bytes and one resolved copy of `@docx-editor.dev/core`                                      |
+| Create a browser runtime  | An attached editor from `@docx-editor.dev/react`, `@docx-editor.dev/vue`, or the core editor API |
+| Write a comment or reply  | A non-empty `author`                                                                             |
+| Write browser review data | The Pro review module, an editable mode, and a host that accepts the write                       |
+| License and support       | See the [pricing page](https://www.docx-editor.dev/pricing)                                      |
 
 A refusal from `sync()` is authoritative.
 
@@ -314,7 +314,7 @@ and insert after the phrase.
 
 ## License
 
-This package is not Apache 2.0 like the editor packages. It is licensed under the [EigenPal Pro Evaluation License 1.0](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/LICENSE.md), which lets you read, run and modify it internally, free of charge, to evaluate it. Browser comment replies and deletions additionally require the separately installed Pro review module, which carries the same evaluation-only production boundary. Production use (a live or customer-facing environment, live or business-operational data, or either package inside a product you distribute to customers) requires a written commercial agreement, and so does redistribution. Commercial licensing: [licensing@eigenpal.com](mailto:licensing@eigenpal.com).
+This package is licensed under the [EigenPal Pro License](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/LICENSE.md), and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 ## Next steps
 

--- a/docs/site/content/index.mdx
+++ b/docs/site/content/index.mdx
@@ -29,19 +29,17 @@ state as a DOCX file. Browser editing needs no upload or conversion service.
 
 ## Packages
 
-| Package                                               | Purpose                                                                        | License                             |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------- |
-| [`@docx-editor.dev/react`](/docs/2.x/react)           | React adapter and composition hooks                                            | Apache 2.0                          |
-| [`@docx-editor.dev/vue`](/docs/2.x/vue)               | Vue 3 adapter and composables                                                  | Apache 2.0                          |
-| [`@docx-editor.dev/core`](/docs/2.x/core)             | Framework-independent OOXML, document, layout, paint, and editor engine        | Apache 2.0                          |
-| [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) | Browser and server automation through a documented Office.js-compatible subset | EigenPal Pro Evaluation License 1.0 |
-| [`@docx-editor.dev/pro`](/docs/2.x/pro)               | Tracked changes, comments, and custom nodes                                    | EigenPal Pro Evaluation License 1.0 |
-| [`@docx-editor.dev/i18n`](/docs/2.x/i18n)             | Shared interface translations                                                  | Apache 2.0                          |
-| [`@docx-editor.dev/fonts`](/docs/2.x/guides/fonts)    | Metric-compatible substitutes for common Word fonts                            | Apache-2.0 AND OFL-1.1              |
+| Package                                               | Purpose                                                                        | License                |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------ | ---------------------- |
+| [`@docx-editor.dev/react`](/docs/2.x/react)           | React adapter and composition hooks                                            | Apache 2.0             |
+| [`@docx-editor.dev/vue`](/docs/2.x/vue)               | Vue 3 adapter and composables                                                  | Apache 2.0             |
+| [`@docx-editor.dev/core`](/docs/2.x/core)             | Framework-independent OOXML, document, layout, paint, and editor engine        | Apache 2.0             |
+| [`@docx-editor.dev/editor-api`](/docs/2.x/editor-api) | Browser and server automation through a documented Office.js-compatible subset | EigenPal Pro License   |
+| [`@docx-editor.dev/pro`](/docs/2.x/pro)               | Tracked changes, comments, and custom nodes                                    | EigenPal Pro License   |
+| [`@docx-editor.dev/i18n`](/docs/2.x/i18n)             | Shared interface translations                                                  | Apache 2.0             |
+| [`@docx-editor.dev/fonts`](/docs/2.x/guides/fonts)    | Metric-compatible substitutes for common Word fonts                            | Apache-2.0 AND OFL-1.1 |
 
-All packages use one fixed version group. Internal, non-production evaluation of
-Pro packages is free. Production use requires a
-[separate written commercial agreement signed by EigenPal, Inc.](mailto:licensing@eigenpal.com).
+The Pro packages are licensed under the EigenPal Pro License, and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 ## Select packages
 

--- a/docs/site/content/installation.mdx
+++ b/docs/site/content/installation.mdx
@@ -37,11 +37,11 @@ The other packages are the same for both adapters:
 
 ```bash
 # Tracked changes, comments, custom nodes
-# Commercially licensed: free to evaluate, production use needs an agreement
+# EigenPal Pro License: https://www.docx-editor.dev/pricing
 npm install @docx-editor.dev/pro
 
 # Office.js-compatible editing API, on a server or with an active editor instance
-# Commercially licensed: same terms
+# EigenPal Pro License: https://www.docx-editor.dev/pricing
 npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 
 # Metric-compatible substitutes for Word's default fonts (optional)

--- a/docs/site/content/pro/index.mdx
+++ b/docs/site/content/pro/index.mdx
@@ -191,11 +191,7 @@ To arrange editor parts, see [Vue composition](/docs/2.x/vue/composition) or [Re
 
 ## Licensing
 
-The EigenPal Pro Evaluation License 1.0 covers `@docx-editor.dev/pro`.
-
-You can use the package without charge for internal, non-production evaluation. Production use requires a commercial agreement.
-
-Contact [EigenPal licensing](mailto:licensing@eigenpal.com) for a commercial agreement.
+This package is licensed under the [EigenPal Pro License](https://github.com/eigenpal/docx-editor/blob/main/packages/pro/LICENSE.md), and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 Both module factories accept an optional `licenseKey`.
 

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -156,16 +156,13 @@ Your application controls any data sent to another service or model.
 | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `@docx-editor.dev/core`, `@docx-editor.dev/react`, `@docx-editor.dev/vue`, and `@docx-editor.dev/i18n` | Apache 2.0                                                                                                   |
 | `@docx-editor.dev/fonts`                                                                               | Apache-2.0 AND OFL-1.1                                                                                       |
-| `@docx-editor.dev/editor-api`                                                                          | EigenPal Pro Evaluation License 1.0                                                                          |
-| `@docx-editor.dev/pro`                                                                                 | EigenPal Pro Evaluation License 1.0                                                                          |
-| Pro evaluation                                                                                         | Free for internal, non-production evaluation                                                                 |
-| Pro production use                                                                                     | Requires a separate written commercial agreement signed by [EigenPal, Inc.](mailto:licensing@eigenpal.com)   |
+| `@docx-editor.dev/editor-api`                                                                          | EigenPal Pro License                                                                                         |
+| `@docx-editor.dev/pro`                                                                                 | EigenPal Pro License                                                                                         |
 | Versions                                                                                               | Semantic Versioning with one fixed version group                                                             |
 | Public API                                                                                             | CI checks generated API Extractor snapshots                                                                  |
 | Contributions                                                                                          | Require a one-time [Contributor License Agreement](https://github.com/eigenpal/docx-editor/blob/main/CLA.md) |
 
-For priority features and support contracts, email
-[docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com).
+The Pro packages are licensed under the EigenPal Pro License, and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 ## Next steps
 

--- a/packages/editor-api/README.md
+++ b/packages/editor-api/README.md
@@ -163,20 +163,9 @@ Upgrading from the reviewer/bridge/MCP/chat surfaces this package used to ship? 
 | [`@docx-editor.dev/pro`](https://www.npmjs.com/package/@docx-editor.dev/pro)               | Tracked changes, comments, and custom nodes.                                                      |
 | [`@docx-editor.dev/editor-api`](https://www.npmjs.com/package/@docx-editor.dev/editor-api) | Office.js-compatible editing API: a batching object model, on a server or against an open editor. |
 
-The editor packages above are Apache 2.0. This one is not — see below.
-
 ## License
 
-This package is licensed under the
-[EigenPal Pro Evaluation License 1.0](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/LICENSE.md).
-You may read, run and modify it internally, free of charge, to evaluate whether it fits your
-application. Browser comment creation, replies, and deletions also require `@docx-editor.dev/pro`,
-under the same evaluation-only production boundary. Production use — a live or customer-facing environment, live
-or business-operational data, or either package embedded in something you offer to others —
-requires a written commercial agreement, and so does redistribution.
-
-> [!IMPORTANT]
-> Commercial licensing: **[licensing@eigenpal.com](mailto:licensing@eigenpal.com)**.
+This package is licensed under the [EigenPal Pro License](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/LICENSE.md), and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 ## Contributing
 

--- a/packages/pro/README.md
+++ b/packages/pro/README.md
@@ -125,13 +125,7 @@ Every value reaching `fromDocx` came out of a `.docx`, so treat `attrs` and `tex
 
 ## Licensing
 
-Unlike the editor packages, this one is not Apache 2.0. It is licensed under the
-[EigenPal Pro Evaluation License 1.0](https://github.com/eigenpal/docx-editor/blob/main/packages/pro/LICENSE.md):
-free to read, run, and modify internally to evaluate. Production use (a live or customer-facing
-environment, business-operational data, or this package inside something you offer to others)
-requires a written commercial agreement, and so does redistribution.
-
-Commercial licensing: [licensing@eigenpal.com](mailto:licensing@eigenpal.com)
+This package is licensed under the [EigenPal Pro License](https://github.com/eigenpal/docx-editor/blob/main/packages/pro/LICENSE.md), and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
 Both module factories accept an optional `licenseKey`. Construction never validates it and never
 touches the network.


### PR DESCRIPTION
## Summary
- Replace long Pro license text with concise pricing links.

## Test plan
- `bun run check:docs-mdx`
- `bun run format`
- `bun run lint`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790405108&installation_model_id=422592&pr_number=521&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F521&signature=e9b2c23bc9ded2c91a900fdaf695ce3ee6aea17ba02c4fb8fee84c30cda0ff73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->