### PR TITLE
fix: raise toolbar chrome popups above the navigation pane

### DIFF
--- a/.changeset/font-dropdown-overlay-band.md
+++ b/.changeset/font-dropdown-overlay-band.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Fix toolbar and menu bar popups rendering behind the open navigation pane. Fixes #522

--- a/examples/vite/src/styles.css
+++ b/examples/vite/src/styles.css
@@ -45,7 +45,9 @@
    shadow) closes the `--doc-surface` band DIRECTLY under the toolbar pill. The
    ruler row lives outside, on the gray `--doc-bg` workspace below the seam.
    `z-index` lifts the seam shadow over the workspace; the demo menus open
-   inside this stacking context, above everything below. */
+   inside this stacking context, above everything below — so the band must sit
+   in the overlay band, or the navigation pane (chrome band, 40) paints over
+   every menu the toolbar opens. */
 .demo-chrome {
   flex: none;
   display: flex;
@@ -54,7 +56,7 @@
   border-bottom: 1px solid var(--doc-border);
   box-shadow: 0 1px 3px var(--doc-shadow-subtle);
   position: relative;
-  z-index: 30;
+  z-index: var(--doc-z-overlay, 50);
 }
 
 /* Header bar: brand + menus | editable title | live status + switchers.

--- a/examples/vue/src/FontPreviewItems.vue
+++ b/examples/vue/src/FontPreviewItems.vue
@@ -1,14 +1,9 @@
 <template>
-  <template v-if="font.options.length === 0">
+  <template v-if="options.length === 0">
     <div class="demo-font-empty">No fonts declared in this document</div>
   </template>
   <template v-else>
-    <FontFamilyItem
-      v-for="family in font.options"
-      :key="family"
-      :value="family"
-      class="demo-font-item"
-    >
+    <FontFamilyItem v-for="family in options" :key="family" :value="family" class="demo-font-item">
       <span class="demo-font-item__name" :style="{ fontFamily: family }">{{ family }}</span>
     </FontFamilyItem>
   </template>
@@ -18,5 +13,6 @@
 import { DocxEditorToolbar, useFontFamily } from '@docx-editor.dev/vue';
 
 const FontFamilyItem = DocxEditorToolbar.FontFamily.Item;
-const font = useFontFamily();
+// Destructure so `options` is a top-level ref binding, which the template unwraps.
+const { options } = useFontFamily();
 </script>

--- a/examples/vue/src/styles.css
+++ b/examples/vue/src/styles.css
@@ -45,7 +45,9 @@
    shadow) closes the `--doc-surface` band DIRECTLY under the toolbar pill. The
    ruler row lives outside, on the gray `--doc-bg` workspace below the seam.
    `z-index` lifts the seam shadow over the workspace; the demo menus open
-   inside this stacking context, above everything below. */
+   inside this stacking context, above everything below — so the band must sit
+   in the overlay band, or the navigation pane (chrome band, 40) paints over
+   every menu the toolbar opens. */
 .demo-chrome {
   flex: none;
   display: flex;
@@ -54,7 +56,7 @@
   border-bottom: 1px solid var(--doc-border);
   box-shadow: 0 1px 3px var(--doc-shadow-subtle);
   position: relative;
-  z-index: 30;
+  z-index: var(--doc-z-overlay, 50);
 }
 
 /* Header bar: brand + menus | editable title | live status + switchers.

--- a/packages/core/src/styles/__tests__/chrome-layering.test.ts
+++ b/packages/core/src/styles/__tests__/chrome-layering.test.ts
@@ -29,6 +29,8 @@ const OVERLAY_SELECTORS = [
   '.docx-toolbar__mode-menu',
   '.docx-toolbar__image-wrap-menu',
   '.docx-toolbar__alt-text-panel',
+  '.docx-toolbar__font-family-content',
+  '.docx-toolbar__style-content',
 ];
 const CHROME_SELECTORS = ['.docx-nav', '.docx-table-chrome__panel', '.docx-editor__outline-toggle'];
 const CONTEXT_SELECTORS = ['.docx-contextmenu'];

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -3162,6 +3162,20 @@ a.docx-hyperlink:focus-visible {
   overflow-y: visible;
 }
 
+/* Same hatch for the font and style pickers: their 300px lists are popovers too,
+ * and the panel's scrollport would clip them when the group collapses into More. */
+.docx-toolbar__more-panel:has(.docx-toolbar__font-family-content),
+.docx-toolbar__more-panel:has(.docx-toolbar__style-content) {
+  overflow-y: visible;
+}
+
+/* Right-edge escape, matching the font-size menu below. */
+.docx-toolbar__more-panel .docx-toolbar__font-family-content,
+.docx-toolbar__more-panel .docx-toolbar__style-content {
+  right: 0;
+  left: auto;
+}
+
 /* Right-edge controls open toward the panel instead of beyond the viewport. */
 .docx-toolbar__more-panel .docx-toolbar__font-size-menu {
   right: 0;
@@ -3309,9 +3323,12 @@ a.docx-hyperlink:focus-visible {
 }
 
 /* The font-family compound: the trigger is the transparent picker trigger
- * ("Arial ∨"); the popup is the shared dropdown card. */
+ * ("Arial ∨"); the popup is the shared dropdown card. The root is the
+ * positioning context the absolute popup anchors to. */
 .docx-toolbar__font-family,
 .docx-toolbar__style {
+  position: relative;
+  display: inline-block;
   flex: none;
 }
 
@@ -3450,9 +3467,19 @@ a.docx-hyperlink:focus-visible {
   color: var(--doc-text);
 }
 
+/* Anchored under the trigger. The z-index is the overlay band token, like every
+ * other transient toolbar surface — a literal here once left the popup UNDER the
+ * navigation panel, which sits in the chrome band. */
 .docx-toolbar__font-family-content,
 .docx-toolbar__style-content {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: var(--doc-z-overlay);
   margin-top: 4px;
+  min-width: 100%;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .docx-toolbar__font-family-item,

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -141,14 +141,16 @@ const VERTICAL_RULER_STYLE: CSSProperties = {
  * the band in two and leaves the toolbar with no ground of its own.
  *
  * `z-index` lifts the seam's shadow over the workspace, and the menus that open from
- * this row stack inside its context, above everything below.
+ * this row stack inside its context, above everything below. The band is a stacking
+ * context, so it caps every popup inside it: it must sit in the overlay band, or the
+ * navigation pane (chrome band, 40) paints over every menu the toolbar opens.
  */
 const CHROME_BAND_STYLE: CSSProperties = {
   flex: 'none',
   display: 'flex',
   flexDirection: 'column',
   position: 'relative',
-  zIndex: 30,
+  zIndex: 'var(--doc-z-overlay)',
   backgroundColor: 'var(--doc-surface)',
   // Longhand on purpose: the `border-bottom` shorthand does not survive a var()
   // in every DOM implementation the suite runs against.

--- a/packages/react/src/editor/toolbar/FontFamily.tsx
+++ b/packages/react/src/editor/toolbar/FontFamily.tsx
@@ -179,17 +179,9 @@ function FontFamilyContent({ asChild, className, children }: FontFamilyPartProps
   if (!context || !context.open) return null;
   const shared = {
     role: 'listbox' as const,
+    // Anchoring, layering and colors all come from the core stylesheet — the popup
+    // must sit in the overlay band, above ambient chrome like the navigation panel.
     className: `docx-toolbar__menu docx-toolbar__font-family-content${className ? ` ${className}` : ''}`,
-    // Anchored under the trigger; colors come from the chrome tokens, never literals.
-    style: {
-      position: 'absolute' as const,
-      top: '100%',
-      left: 0,
-      zIndex: 30,
-      minWidth: '100%',
-      maxHeight: 300,
-      overflowY: 'auto' as const,
-    },
   };
   // The default menu is the grouped picker: small gray semibold headings for
   // the classified families, a plain trailing group for the rest, ✓ on the current
@@ -284,11 +276,10 @@ export function FontFamilyRoot({ hidden, asChild, className, children }: FontFam
 
   if (hidden) return null;
   const shared = {
+    // The positioning context for the absolute Content comes from the core stylesheet.
     className: `docx-toolbar__font-family${className ? ` ${className}` : ''}`,
     // Stable slot identity, matching the other parts' `data-slot` markers.
     'data-slot': 'font.family',
-    // The positioning context for the absolute Content.
-    style: { position: 'relative' as const, display: 'inline-block' as const },
   };
   const body = children ?? (
     <>

--- a/packages/react/src/editor/toolbar/ParagraphStyle.tsx
+++ b/packages/react/src/editor/toolbar/ParagraphStyle.tsx
@@ -201,16 +201,9 @@ function ParagraphStyleContent({ asChild, className, children }: ParagraphStyleP
   if (!context || !context.open) return null;
   const shared = {
     role: 'listbox' as const,
+    // Anchoring, layering and colors all come from the core stylesheet — the popup
+    // must sit in the overlay band, above ambient chrome like the navigation panel.
     className: `docx-toolbar__menu docx-toolbar__style-content${className ? ` ${className}` : ''}`,
-    style: {
-      position: 'absolute' as const,
-      top: '100%',
-      left: 0,
-      zIndex: 30,
-      minWidth: '100%',
-      maxHeight: 300,
-      overflowY: 'auto' as const,
-    },
   };
   const items =
     children ??
@@ -287,9 +280,9 @@ export function ParagraphStyleRoot({ hidden, asChild, className, children }: Par
 
   if (hidden) return null;
   const shared = {
+    // The positioning context for the absolute Content comes from the core stylesheet.
     className: `docx-toolbar__style${className ? ` ${className}` : ''}`,
     'data-slot': 'styles.style',
-    style: { position: 'relative' as const, display: 'inline-block' as const },
   };
   const body = children ?? (
     <>

--- a/packages/react/test/sugar-chrome-band.test.tsx
+++ b/packages/react/test/sugar-chrome-band.test.tsx
@@ -68,4 +68,12 @@ describe('the packaged frame chrome band', () => {
     const { container } = render(<DocxEditor chrome={false} />);
     expect(container.querySelector('.docx-toolbar')).toBeNull();
   });
+
+  // The band is a stacking context, so it caps every popup inside it. A literal
+  // below the chrome band (40) put the font picker and the File menu UNDER the
+  // open navigation pane (#522); the overlay token keeps them above it.
+  test('the band stacks in the overlay band, above ambient chrome', () => {
+    const { container } = render(<DocxEditor />);
+    expect(band(container)!.style.zIndex).toBe('var(--doc-z-overlay)');
+  });
 });

--- a/packages/react/test/toolbar-overflow-react.test.tsx
+++ b/packages/react/test/toolbar-overflow-react.test.tsx
@@ -435,11 +435,24 @@ describe('toolbar overflow integration', () => {
       )?.[0] ?? '';
     expect(zoomRule).toContain('overflow-y: visible');
 
+    const pickerHatch =
+      coreCss.match(
+        /\.docx-toolbar__more-panel:has\(\.docx-toolbar__font-family-content\),\s*\.docx-toolbar__more-panel:has\(\.docx-toolbar__style-content\)\s*\{[^}]+\}/
+      )?.[0] ?? '';
+    expect(pickerHatch).toContain('overflow-y: visible');
+
     const fontSizeRule =
       coreCss.match(/\.docx-toolbar__more-panel \.docx-toolbar__font-size-menu\s*\{[^}]+\}/)?.[0] ??
       '';
     expect(fontSizeRule).toContain('right: 0');
     expect(fontSizeRule).toContain('left: auto');
+
+    const pickerEdgeRule =
+      coreCss.match(
+        /\.docx-toolbar__more-panel \.docx-toolbar__font-family-content,\s*\.docx-toolbar__more-panel \.docx-toolbar__style-content\s*\{[^}]+\}/
+      )?.[0] ?? '';
+    expect(pickerEdgeRule).toContain('right: 0');
+    expect(pickerEdgeRule).toContain('left: auto');
 
     const lowerMenuRule =
       coreCss.match(

--- a/packages/vue/src/components/DocxEditor.tsx
+++ b/packages/vue/src/components/DocxEditor.tsx
@@ -86,12 +86,15 @@ const VERTICAL_RULER_STYLE: CSSProperties = {
   pointerEvents: 'none',
 };
 
+// The band is a stacking context, so it caps every popup inside it: it must sit in
+// the overlay band, or the navigation pane (chrome band, 40) paints over every menu
+// the toolbar opens.
 const CHROME_BAND_STYLE: CSSProperties = {
   flex: 'none',
   display: 'flex',
   flexDirection: 'column',
   position: 'relative',
-  zIndex: 30,
+  zIndex: 'var(--doc-z-overlay)',
   backgroundColor: 'var(--doc-surface)',
   borderBottomWidth: '1px',
   borderBottomStyle: 'solid',

--- a/packages/vue/src/editor/toolbar/FontFamily.tsx
+++ b/packages/vue/src/editor/toolbar/FontFamily.tsx
@@ -113,16 +113,9 @@ const FontFamilyContent = defineComponent({
       if (!context || !context.open.value) return null;
       const shared = {
         role: 'listbox' as const,
+        // Anchoring, layering and colors all come from the core stylesheet — the popup
+        // must sit in the overlay band, above ambient chrome like the navigation panel.
         class: `docx-toolbar__menu docx-toolbar__font-family-content${props.className ? ` ${props.className}` : ''}`,
-        style: {
-          position: 'absolute' as const,
-          top: '100%',
-          left: 0,
-          zIndex: 30,
-          minWidth: '100%',
-          maxHeight: '300px',
-          overflowY: 'auto' as const,
-        },
       };
       let items: VNode[] | undefined;
       if (slots.default) {
@@ -239,9 +232,9 @@ const FontFamilyRoot = defineComponent({
     return () => {
       if (props.hidden) return null;
       const shared = {
+        // The positioning context for the absolute Content comes from the core stylesheet.
         class: `docx-toolbar__font-family${props.className ? ` ${props.className}` : ''}`,
         'data-slot': 'font.family',
-        style: { position: 'relative' as const, display: 'inline-block' as const },
       };
       const body = slots.default?.() ?? [<FontFamilyTrigger />, <FontFamilyContent />];
       if (props.asChild) {

--- a/packages/vue/src/editor/toolbar/ParagraphStyle.tsx
+++ b/packages/vue/src/editor/toolbar/ParagraphStyle.tsx
@@ -115,16 +115,9 @@ const ParagraphStyleContent = defineComponent({
       if (!context || !context.open.value) return null;
       const shared = {
         role: 'listbox' as const,
+        // Anchoring, layering and colors all come from the core stylesheet — the popup
+        // must sit in the overlay band, above ambient chrome like the navigation panel.
         class: `docx-toolbar__menu docx-toolbar__style-content${props.className ? ` ${props.className}` : ''}`,
-        style: {
-          position: 'absolute' as const,
-          top: '100%',
-          left: 0,
-          zIndex: 30,
-          minWidth: '100%',
-          maxHeight: '300px',
-          overflowY: 'auto' as const,
-        },
       };
       const items =
         slots.default?.() ??
@@ -225,9 +218,9 @@ const ParagraphStyleRoot = defineComponent({
     return () => {
       if (props.hidden) return null;
       const shared = {
+        // The positioning context for the absolute Content comes from the core stylesheet.
         class: `docx-toolbar__style${props.className ? ` ${props.className}` : ''}`,
         'data-slot': 'styles.style',
-        style: { position: 'relative' as const, display: 'inline-block' as const },
       };
       const body = slots.default?.() ?? [<ParagraphStyleTrigger />, <ParagraphStyleContent />];
       if (props.asChild) {

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -371,4 +371,17 @@ describe('packaged chrome band', () => {
     expect(view.container.querySelector('.docx-toolbar')).toBeNull();
     view.unmount();
   });
+
+  // The band is a stacking context, so it caps every popup inside it. A literal
+  // below the chrome band (40) put the font picker and the File menu UNDER the
+  // open navigation pane (#522); the overlay token keeps them above it.
+  test('the band stacks in the overlay band, above ambient chrome', async () => {
+    const view = await mountSugarAsync({});
+    await view.flush();
+    const toolbar = view.container.querySelector('.docx-toolbar');
+    const band = (toolbar?.parentElement?.parentElement ?? null) as HTMLElement | null;
+    expect(band).not.toBeNull();
+    expect(band!.style.zIndex).toBe('var(--doc-z-overlay)');
+    view.unmount();
+  });
 });


### PR DESCRIPTION
Fixes #522.

With the navigation pane open, the font family dropdown — and every other menu the toolbar or menu bar opens — rendered behind the pane. Two layering defects caused this:

- The font family and paragraph style popups carried an inline `z-index: 30`, below the pane's chrome band (40).
- The packaged chrome band and the demos' chrome wrapper created a `z-index: 30` stacking context, which capped every popup inside it at 30 regardless of the popup's own value.

The pickers' anchoring now lives in the core stylesheet in the overlay band, and the chrome band stacks at `--doc-z-overlay`. The layering contract test covers both popup selectors, and the packaged-frame tests in both adapters pin the band's token. The More panel gets the same scrollport escape hatches as its sibling popovers. The Vue example's font preview items also read the composable's nested `options` ref without destructuring, so its popup never rendered.

Verified in the browser against both demos with the pane open: the font dropdown and the File menu paint above the pane, and hit tests in the overlap region land on the popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pxk6EVD1fUWDqFcfkThB2x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790411108&installation_model_id=422592&pr_number=524&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F524&signature=4da4e0d4e95b8d005aa70166178cf8b845a4769cde3a03db49dc88058830f134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->