### PR TITLE
chore: clarify Pro license naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ Keep technical items exact. File paths, function names, flags, and numbers do no
 change. For example, write `packages/core/src/layout/semantic-layout.ts` and
 `w:contextualSpacing` in full.
 
+In user-facing text, always use the name `EigenPal Pro License`. Do not rename
+the legal license files or `LicenseRef-EigenPal-Pro-Evaluation-1.0` metadata.
+
 ## Packages
 
 One engine. Thin chrome on top.


### PR DESCRIPTION
## Summary
- Use `EigenPal Pro License` in user-facing text without changing legal metadata.

## Test plan
- Not run because this change only updates agent guidance.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790411405&installation_model_id=422592&pr_number=525&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F525&signature=345e61002cb1e3131f6a43304a81eabc7037e70f1afe386928907f754e8fabf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->