### PR TITLE
fix(test): stop the zoom tests leaking process-wide state (fixes #527)

### DIFF
--- a/packages/core/src/editor/__tests__/zoom-controller.test.ts
+++ b/packages/core/src/editor/__tests__/zoom-controller.test.ts
@@ -48,6 +48,7 @@ class FakeResizeObserver {
     observerCallbacks.push(callback);
   }
   observe(): void {}
+  unobserve(): void {}
   disconnect(): void {
     observerCallbacks = observerCallbacks.filter((entry) => entry !== this.callback);
   }
@@ -65,6 +66,9 @@ interface Harness {
   settle(): Promise<void>;
 }
 
+/** Every editor this file mounts, so `afterEach` can destroy each one. */
+let mounted: DocxEditorInstance[] = [];
+
 function mount(options: Parameters<typeof createDocxEditor>[0] = {}): Harness {
   const scroller = document.createElement('div');
   scroller.className = 'docx-editor__scroll-container';
@@ -76,6 +80,7 @@ function mount(options: Parameters<typeof createDocxEditor>[0] = {}): Harness {
   Object.defineProperty(scroller, 'clientWidth', { get: () => width, configurable: true });
 
   const editor = createDocxEditor({ container, document: docx(''), ...options });
+  mounted.push(editor);
 
   return {
     editor,
@@ -96,13 +101,31 @@ function mount(options: Parameters<typeof createDocxEditor>[0] = {}): Harness {
   };
 }
 
+// `globalThis.ResizeObserver` is process-wide, and `bun test` runs every file in one
+// process. Restore the real constructor after each test, or every later file observes
+// through this stand-in.
+const RealResizeObserver = globalThis.ResizeObserver;
+
 beforeEach(() => {
   observerCallbacks = [];
+  mounted = [];
   (globalThis as { ResizeObserver?: unknown }).ResizeObserver = FakeResizeObserver;
 });
 
 afterEach(() => {
-  document.body.innerHTML = '';
+  // `destroy()` first, and before the ResizeObserver restore: the surface holds
+  // `selectionchange` and capture-phase `scroll` listeners on the shared `document`, which
+  // clearing the body does not remove, and only the stand-in's `disconnect()` drops its
+  // callback. `destroy()` is idempotent, so a test that already called it is no problem.
+  // In a `finally`, because a throw here would leave the stand-in on `globalThis` for
+  // every later file in the process — the failure this teardown exists to prevent.
+  try {
+    for (const editor of mounted) editor.destroy();
+  } finally {
+    mounted = [];
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = RealResizeObserver;
+    document.body.innerHTML = '';
+  }
 });
 
 describe('the default mode', () => {

--- a/packages/react/test/fit-to-viewport.test.tsx
+++ b/packages/react/test/fit-to-viewport.test.tsx
@@ -50,6 +50,7 @@ class WidthObserver {
     observers.push(this);
   }
   observe(): void {}
+  unobserve(): void {}
   disconnect(): void {
     observers = observers.filter((entry) => entry !== this);
   }
@@ -118,13 +119,27 @@ function mount(props: Record<string, unknown> = {}) {
   };
 }
 
+// `globalThis.ResizeObserver` is process-wide, and `bun test` runs every file in one
+// process. Restore the real constructor after each test, or every later file observes
+// through this stand-in.
+const RealResizeObserver = globalThis.ResizeObserver;
+
 beforeEach(() => {
   viewportWidth = 1600;
   observers = [];
   (globalThis as { ResizeObserver?: unknown }).ResizeObserver = WidthObserver;
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  // The restore sits in a `finally`: `cleanup()` unmounts inside `act`, and an effect
+  // cleanup that throws would otherwise leave the stand-in on `globalThis` for every
+  // later file in the process.
+  try {
+    cleanup();
+  } finally {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = RealResizeObserver;
+  }
+});
 
 describe('useZoom', () => {
   test('reports the resolved scale AND where it came from', () => {


### PR DESCRIPTION
`bun run test:serial` failed 62 tests on `main`. All 62 came from one cause.

`bun test` runs every test file in one process. Two files installed a `ResizeObserver` stand-in on `globalThis` in `beforeEach` and never put the real constructor back, and neither stand-in had `unobserve`. Every later React and Vue review-rail test that unmounts a card reached `unobserve` in `packages/pro/src/react/use-review-slot-sizing.ts` and threw. The failures named the review rail; the defect was in the zoom tests.

Fixes #527 

`packages/core/src/editor/__tests__/zoom-controller.test.ts` leaked a second way. It called `mount()` 25 times and only one test called `destroy()`. Clearing `document.body` does not remove the `selectionchange` and capture-phase `scroll` listeners the surface registers on the shared document, so 25 detached surfaces stayed subscribed for the rest of the run.

Both teardowns now sit in a `try`/`finally`, so a throw cannot leave the stand-in installed for every later file.

## Result

`bun run test:serial` passes: 10000 tests across 771 files. The gate can report a new state leak again, which is what #527 asks for.

Destroying the editors also cut the serial run from 382 seconds to 279 seconds.

## Verification

`bun run format`, `bun run lint`, `bun run typecheck`, `bun run test`, `bun run test:serial`, `bun run check:parity`, `bun run api:check`, `bun run i18n:validate`, and `openspec validate typed-ooxml-paragraph-editor --strict` all pass.

No changeset: the change is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWtaF2KuchSNateTEc3DZs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790430296&installation_model_id=422592&pr_number=531&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F531&signature=8b785cd711ffbb5e407e31d5c021e86087f057cdebcdc7d7f52869a50bf34954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->