### PR TITLE
test(pro): stop the local keystroke perf gate flaking under load

### DIFF
--- a/packages/pro/src/collaboration/__tests__/local-keystroke-performance.test.ts
+++ b/packages/pro/src/collaboration/__tests__/local-keystroke-performance.test.ts
@@ -19,6 +19,20 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 // remote update moves that tree, and the stale position stays in bounds. `transactMs` below
 // includes the Yjs write for exactly that reason, and is what the recorded transact budget
 // is compared against.
+//
+// The two arms must measure the same gesture on the same shape, in the same time window, or
+// the ratio reports the difference between the arms rather than the cost of attaching. Four
+// rules keep them comparable, and all four are load-bearing:
+//   1. The attached arm holds ONE replica. The harness relays a paired peer's updates
+//      synchronously, so a second peer's whole inbound apply lands inside the timed
+//      transact. That is a harness artifact — a real peer is another process — and it
+//      measured 3.6x solo where a lone replica measures 1.28x.
+//   2. Both arms insert at the end of the same paragraph. Inserting at offset 0 costs
+//      about 1.5x inserting at the end, which alone moves the ratio.
+//   3. `gateOperations` sits outside the timed span. A detached store cannot call it at
+//      all, so timing it charges the attached arm for work the solo arm can never do.
+//   4. The gate compares each arm's FASTEST round, not its median, because the arms are
+//      sampled one after the other and load drifts between them — see `measureInsertRatio`.
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
@@ -53,30 +67,42 @@ const LONG_TEXT = 'abcdefghijklmnopqrstuvwxyz '.repeat(12);
 const BUDGET_RATIO = 2;
 
 function summarize(values: readonly number[]): {
+  readonly minMs: number;
   readonly medianMs: number;
   readonly p95Ms: number;
   readonly maxMs: number;
 } {
   const sorted = [...values].sort((left, right) => left - right);
   const at = (p: number) => sorted[Math.max(0, Math.ceil(sorted.length * p) - 1)] ?? 0;
-  return { medianMs: at(0.5), p95Ms: at(0.95), maxMs: sorted[sorted.length - 1] ?? 0 };
+  return {
+    minMs: sorted[0] ?? 0,
+    medianMs: at(0.5),
+    p95Ms: at(0.95),
+    maxMs: sorted[sorted.length - 1] ?? 0,
+  };
 }
 
 function ratioPass(
-  solo: { readonly medianMs: number; readonly p95Ms: number },
-  attached: { readonly medianMs: number; readonly p95Ms: number }
+  solo: { readonly minMs: number },
+  attached: { readonly minMs: number }
 ): boolean {
-  // The median is the sharp gate: it is stable under a loaded CI worker pool, and its flat
-  // slack must stay SMALLER than the regression it exists to catch — the O(document) capture
-  // cost measured ~2.19 ms against a ~0.39 ms solo, so a 2 ms floor would have admitted it.
-  // The p95 of a sub-millisecond baseline is scheduler-dominated — one preemption during one
-  // of 40 samples blows a 2x bound — so it gets a wider flat slack instead of a looser ratio.
-  const medianSlack = 1;
-  const p95Slack = 8;
-  return (
-    attached.medianMs <= Math.max(solo.medianMs * BUDGET_RATIO, solo.medianMs + medianSlack) &&
-    attached.p95Ms <= Math.max(solo.p95Ms * BUDGET_RATIO, solo.p95Ms + p95Slack)
-  );
+  // A pure ratio, with no flat slack, over the fastest round of each arm.
+  //
+  // The ratio has to carry the gate by itself, because this file shares a runner with the rest
+  // of its shard: a flat slack added to a sub-millisecond baseline is an ABSOLUTE wall-clock
+  // budget wearing a ratio's clothes, and an absolute budget is a different test on every
+  // machine. The old +1 ms median slack admitted about 11x a solo transact, far above the
+  // regression it was written to catch — the O(document) capture cost, which moved the figure
+  // ~5x. Removing the slack makes this gate stricter, not looser.
+  //
+  // The minimum is the estimator because contention noise is one-sided: a preempted or
+  // GC-interrupted round can only read HIGH, never low, so the fastest of RUNS rounds is the
+  // closest each arm gets to its own cost. Neither tail statistic is gated. The p95 of 40
+  // sub-millisecond samples measures GC and scheduler pauses — under 16-way contention the p95
+  // ratio reached 21.5 while the min ratio stayed near 1.2 — and it catches nothing the gate
+  // misses, since an O(document) regression moves every statistic together. Both stay in the
+  // logged rows for diagnosis.
+  return attached.minMs <= solo.minMs * BUDGET_RATIO;
 }
 
 const harness = createPeerHarness('keystroke-perf');
@@ -157,10 +183,10 @@ function runOps(peer: Peer, ops: readonly TreeDocOp[]): Sample {
   const onUpdate = (): void => {
     yUpdatesDuringTransact += 1;
   };
-  peer.ydoc.on('update', onUpdate);
-  const transactStarted = performance.now();
   const refusal = peer.room.session.gateOperations(ops, BODY);
   if (refusal) throw new Error(`gate refused: ${refusal}`);
+  peer.ydoc.on('update', onUpdate);
+  const transactStarted = performance.now();
   const result = peer.store.transact(BODY, (context) => {
     for (const op of ops) context.apply(op);
   });
@@ -191,6 +217,9 @@ async function measure(
   let yUpdatesDuringTransact = 0;
   let peakPending = 0;
   const bobParagraph = firstTextParagraph(bob);
+  // Rule 1 above: keep the second replica only for the gesture that types on it. Everywhere
+  // else the relay would apply alice's update into bob inside alice's timed transact.
+  if (options?.peerEdits !== true) harness.leave(bob);
   for (let round = 0; round < WARMUP + RUNS; round += 1) {
     const sample = runOps(alice, gesture(alice, round));
     yUpdatesDuringTransact += sample.yUpdatesDuringTransact;
@@ -219,33 +248,69 @@ async function measure(
 }
 
 async function soloStore(bytes: Uint8Array) {
-  const { alice } = await harness.pair(bytes);
+  const { alice, bob } = await harness.pair(bytes);
+  harness.leave(bob);
   alice.detach();
   return alice;
+}
+
+function insertAtEnd(peer: Peer): readonly TreeDocOp[] {
+  const target = firstTextParagraph(peer);
+  return [{ op: 'insertText', paragraphId: target.id, offset: target.length, text: 'X' }];
+}
+
+/**
+ * Sample the solo arm, then the attached arm, and compare their FASTEST rounds.
+ *
+ * Rule 4: the arms are sampled one after the other, so they see different machine load — this
+ * file shares a worker pool with the rest of its shard — and a median comparison reports that
+ * drift as attach cost. Over 128 runs at 16-way contention, drift alone produced a 2.25x median
+ * reading on a path that costs 1.29x.
+ *
+ * Alternating the arms round by round looks like the fix and is not: at this scale each arm
+ * evicts the other's working set, which cost the attached arm a flat ~0.09 ms and pushed the
+ * ratio from 1.19x to 1.91x. Contention noise is one-sided — it only ever adds time — so the
+ * minimum of RUNS rounds is the drift-resistant estimator, and it keeps each arm's rounds
+ * contiguous and cache-warm.
+ */
+async function measureInsertRatio(bytes: Uint8Array): Promise<{
+  readonly solo: ReturnType<typeof summarize>;
+  readonly attached: ReturnType<typeof summarize>;
+}> {
+  harness.cleanup();
+  // Order matters: the harness relays each JOINING peer to every peer already open, so the
+  // attached pair must be built after the solo peer is detached and its partner has left.
+  // Neither `alice` is ever a join, so the two arms are never relayed to each other.
+  const soloPeer = await soloStore(bytes);
+  const attachedPair = await harness.pair(bytes);
+  harness.leave(attachedPair.bob);
+  const attachedPeer = attachedPair.alice;
+  const soloTimes: number[] = [];
+  for (let round = 0; round < WARMUP + RUNS; round += 1) {
+    const soloOps = insertAtEnd(soloPeer);
+    const started = performance.now();
+    const result = soloPeer.store.transact(BODY, (context) => {
+      for (const op of soloOps) context.apply(op);
+    });
+    const ms = performance.now() - started;
+    if (!result.ok) throw new Error(result.detail ?? result.reason);
+    if (round >= WARMUP) soloTimes.push(ms);
+  }
+  const attachedTimes: number[] = [];
+  for (let round = 0; round < WARMUP + RUNS; round += 1) {
+    const sample = runOps(attachedPeer, insertAtEnd(attachedPeer));
+    if (round >= WARMUP) attachedTimes.push(sample.transactMs);
+  }
+  return { solo: summarize(soloTimes), attached: summarize(attachedTimes) };
 }
 
 describe('local keystroke path with a replica attached', () => {
   test('transact replicates on the commit and stays within 2x solo', async () => {
     const bytes = proseBytes();
-    harness.cleanup();
-    const soloPeer = await soloStore(bytes);
-    const insertAt = firstTextParagraph(soloPeer);
-    const soloTimes: number[] = [];
-    for (let round = 0; round < WARMUP + RUNS; round += 1) {
-      const started = performance.now();
-      const result = soloPeer.store.transact(BODY, (context) => {
-        context.apply({
-          op: 'insertText',
-          paragraphId: insertAt.id,
-          offset: 0,
-          text: 'X',
-        });
-      });
-      const ms = performance.now() - started;
-      if (!result.ok) throw new Error(result.detail ?? result.reason);
-      if (round >= WARMUP) soloTimes.push(ms);
-    }
-    const solo = summarize(soloTimes);
+    // The gated comparison: one solo arm against one lone attached replica, same gesture.
+    // The gesture sweep below re-measures `insert-text` for its row, but only this pair
+    // decides the ratio.
+    const { solo, attached: insertAttached } = await measureInsertRatio(bytes);
 
     const gestures: readonly {
       readonly name: string;
@@ -256,10 +321,7 @@ describe('local keystroke path with a replica attached', () => {
       {
         name: 'insert-text',
         bytes,
-        gesture: (peer) => {
-          const target = firstTextParagraph(peer);
-          return [{ op: 'insertText', paragraphId: target.id, offset: target.length, text: 'X' }];
-        },
+        gesture: (peer) => insertAtEnd(peer),
       },
       {
         name: 'backspace',
@@ -310,22 +372,17 @@ describe('local keystroke path with a replica attached', () => {
         name: 'insert-while-peer-edits',
         bytes,
         peerEdits: true,
-        gesture: (peer) => {
-          const target = firstTextParagraph(peer);
-          return [{ op: 'insertText', paragraphId: target.id, offset: target.length, text: 'X' }];
-        },
+        gesture: (peer) => insertAtEnd(peer),
       },
     ];
 
     const rows: string[] = [];
     const stranded: string[] = [];
     const silent: string[] = [];
-    let insertAttached = solo;
     for (const item of gestures) {
       const measured = await measure(item.bytes, item.gesture, {
         peerEdits: item.peerEdits === true,
       });
-      if (item.name === 'insert-text') insertAttached = measured.transact;
       if (measured.peakPending !== 0) stranded.push(item.name);
       if (measured.yUpdatesDuringTransact === 0) silent.push(item.name);
       rows.push(
@@ -421,11 +478,18 @@ describe('local keystroke path with a replica attached', () => {
       visit(soloStore.bodyStore().part.root, soloIds);
       const soloId = soloIds[Math.floor((soloIds.length - 1) * 0.5)];
       if (!soloId) throw new Error('no middle paragraph');
+      // Rule 2 above: end-of-paragraph inserts, the same gesture the attached arm runs.
+      const soloLength = paragraphTextOf(soloStore.bodyStore().part, soloId)?.length ?? 0;
       const soloTimes: number[] = [];
       for (let round = 0; round < WARMUP + RUNS; round += 1) {
         const started = performance.now();
         const result = soloStore.transact(BODY, (context) => {
-          context.apply({ op: 'insertText', paragraphId: soloId, offset: 0, text: 'X' });
+          context.apply({
+            op: 'insertText',
+            paragraphId: soloId,
+            offset: soloLength + round,
+            text: 'X',
+          });
         });
         const ms = performance.now() - started;
         if (!result.ok) throw new Error(result.detail ?? result.reason);
@@ -479,16 +543,18 @@ describe('local keystroke path with a replica attached', () => {
       }
       const attached = summarize(transact);
       const attachedFlush = summarize(flush);
-      // The ratio is the gate, and the absolute pair is only a backstop.
+      // The ratio is the gate, and the absolute number is only a backstop.
       //
-      // These absolute numbers were measured when lowering copied every id in the part into a
-      // Set on each primitive, which cost O(document) per keystroke — 34,555 string hashes on
-      // this fixture. Attached now runs at about 1.2x solo, so 18.6 ms would let a 10x
-      // regression through unnoticed. The ratio rule scales with the machine instead, which
-      // matters because this file shares a CI runner with the rest of its shard: an absolute
-      // budget silently becomes a different test on slower hardware.
-      const TRANSACTION_MEDIAN_MAX_MS = 18.612418000000616;
-      const TRANSACTION_P95_MAX_MS = 21.630750000000262;
+      // This number was measured when lowering copied every id in the part into a Set on each
+      // primitive, which cost O(document) per keystroke — 34,555 string hashes on this
+      // fixture. Attached now runs at about 1.2x solo, so 18.6 ms would let a 10x regression
+      // through unnoticed. The ratio rule scales with the machine instead, which matters
+      // because this file shares a CI runner with the rest of its shard: an absolute budget
+      // silently becomes a different test on slower hardware.
+      //
+      // Only the fastest round gets a backstop, for the same reason the ratio uses it. The p95
+      // backstop was an absolute wall-clock wall over a statistic that measures GC pauses.
+      const TRANSACTION_MIN_MAX_MS = 18.612418000000616;
       console.log(
         JSON.stringify({
           fixture: 'synthetic-long-edit.docx',
@@ -497,14 +563,12 @@ describe('local keystroke path with a replica attached', () => {
           attachedFlush,
           yUpdatesDuringTransact,
           ratioPass: ratioPass(solo, attached),
-          medianBackstopMs: TRANSACTION_MEDIAN_MAX_MS,
-          p95BackstopMs: TRANSACTION_P95_MAX_MS,
+          minBackstopMs: TRANSACTION_MIN_MAX_MS,
         })
       );
       expect(yUpdatesDuringTransact).toBeGreaterThan(0);
       expect(ratioPass(solo, attached)).toBe(true);
-      expect(attached.medianMs).toBeLessThanOrEqual(TRANSACTION_MEDIAN_MAX_MS);
-      expect(attached.p95Ms).toBeLessThanOrEqual(TRANSACTION_P95_MAX_MS);
+      expect(attached.minMs).toBeLessThanOrEqual(TRANSACTION_MIN_MAX_MS);
       detach();
       room.destroy();
       awareness.destroy();


### PR DESCRIPTION
`local-keystroke-performance.test.ts` fails on a loaded worker pool. The code under test is fine. The gate is what fails.

## What fails

`ratioPass` compares the two arms on both the median and the p95. Only the p95 limb fails. Running 10 to 16 concurrent copies of the file reproduces it:

| Gate limb | Test 1 | Test 3 |
| --------- | ------ | ------ |
| median    | 0/80 fail | 0/96 fail |
| p95       | 9/80 fail | 2/96 fail |

At 40 sub-millisecond samples, the p95 measures GC and scheduler pauses rather than the attach path. Under contention its ratio reached 21.5 while the median ratio stayed near 1.3.

## Why the p95 limb existed

The measurement was inflated past a plain 2x ratio, so flat slacks of `+1ms` and `+8ms` were added to hold it green. Against a 0.1 ms baseline, a flat slack is an absolute wall-clock budget rather than a ratio, and an absolute budget is a different test on every machine.

Three defects inflated the reading:

1. `measure()` timed a second replica. `harness.pair()` relays the local update into the second peer synchronously, so that peer's whole inbound apply ran inside the timed `transact`. A real peer is another process. Measured: 3.6x solo with the relayed peer, 1.28x with a lone replica.
2. The arms ran different gestures. The solo arm inserted at offset 0, which costs about 1.5x an end insert. The attached arm inserted at the end.
3. `gateOperations` sat inside the timed span. A detached store cannot call it at all, so it charged the attached arm for work the solo arm can never do.

## The change

Test-only, one file. All three defects are corrected. The gate then compares each arm's fastest round at a pure 2x ratio with no flat slack. Contention noise only adds time, so the minimum is the drift-resistant estimator. Both tail statistics stay in the logged rows for diagnosis, but neither gates.

Interleaving the arms round by round is the usual fix for this kind of drift, and it backfires at this scale: each arm evicts the other's working set, which cost the attached arm a flat 0.09 ms and moved the ratio from 1.19x to 1.91x. The file records that so nobody repeats it.

## Results

Over 128 runs of each gate at 16-way contention:

- Test 1 min ratio: p50 1.303, max 1.577, against a 2.0 gate. 0 failures.
- Test 3 min ratio: p50 1.193, max 1.323. 0 failures.
- 128 of 128 whole-file runs clean, against about 11% failing before.

The gate is stricter than before, not looser. The old `+1ms` slack admitted about 11x a solo transact. The new gate admits 2x. The `O(document)` regression this file guards against moved the figure about 5x, so it is still caught.

## Verification

`bun run typecheck`, `bun run lint` (0 errors), `bun run format`, and `bun run test` (10223 pass, 0 fail) all pass. No changeset: the change touches only a test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790438313&installation_model_id=422592&pr_number=533&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F533&signature=f4d2e2e25290648b205a763b8e933f678e4c9e20bac6119d11e8fb7ea580dfb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->