### PR TITLE
docs: refresh collaboration and example guides

### DIFF
--- a/docs/site/content/collaboration.mdx
+++ b/docs/site/content/collaboration.mdx
@@ -18,6 +18,11 @@ editor module. You can use peer-to-peer WebRTC, a
 [Hocuspocus server](https://tiptap.dev/docs/hocuspocus), or an existing Yjs
 provider.
 
+The adapters provide room hooks, a wired collaboration root, status fields, and
+custom presence renderers. Server code can also export synchronized room state
+as DOCX bytes. The [real-time collaboration guide](/docs/2.x/pro/collaboration)
+documents these interfaces and their recovery behavior.
+
 ## Start in one component
 
 Use the framework hook to own the room. With `create-or-join`, the first peer
@@ -93,6 +98,10 @@ Pro package also provides these presence components and hooks:
   component. The component renders in the adapter tree, so hooks work in it.
 - `useCollaborationStatus` and `useCollaborationParticipants` provide data for
   connection and participant interfaces.
+
+Presence renderers receive the resolved color and optional participant data.
+They also receive a locally declared `avatarUrl`. You can omit `session` inside
+the editor provider tree.
 
 See the [presence interface guide](/docs/2.x/pro/collaboration#presence-ui).
 

--- a/docs/site/content/pro/collaboration.mdx
+++ b/docs/site/content/pro/collaboration.mdx
@@ -35,11 +35,18 @@ flowchart LR
 
 ## Prerequisites
 
-Install the Pro package and Yjs. Add `y-webrtc` for the WebRTC helper. Add
-`@hocuspocus/provider` for the Hocuspocus helper.
+Install the Pro package, Yjs, and the provider for your transport.
+
+For WebRTC, run:
 
 ```bash
 npm install @docx-editor.dev/pro yjs y-webrtc
+```
+
+For Hocuspocus, run:
+
+```bash
+npm install @docx-editor.dev/pro yjs @hocuspocus/provider
 ```
 
 `yjs`, `y-webrtc`, and `@hocuspocus/provider` are optional Pro peer
@@ -57,15 +64,17 @@ Import `@docx-editor.dev/pro/react/webrtc` or
 Pass `room` to connect when the component mounts. Call `leave` to end the
 session. Do not mount the editor while `pending` is true.
 
-The hook returns a `CollaborationSession`. It exposes identity, status,
-presence, and undo. It does not expose `attach` or `gateOperations`.
+The hook returns an object. Its `session` field contains a
+`CollaborationSession`. The session exposes identity, status, presence, and
+undo. It does not expose `attach` or `gateOperations`.
 `CollaborationSession`, `CollaborationStatus`, and `CollaborationFailure` are
 exported types from `@docx-editor.dev/pro/react` and
 `@docx-editor.dev/pro/vue`.
 
-`connect` and `rejoin` resolve with a `CollaborationFailure`, or `null` on
-success. They do not reject, so `onClick={() => connect(options)}` is safe.
-`error` reports the same failure for renderers:
+Room failures make `connect` and `rejoin` resolve to a
+`CollaborationFailure`. Success resolves to `null`. `rejoin` still throws if
+you call it before a connection attempt. The hook also puts room failures in
+`error` for rendering:
 
 ```tsx
 const failure = await connect(options);
@@ -74,10 +83,11 @@ if (failure?.code === 'initialization-timeout') {
 }
 ```
 
-Branch on `failure.code` or `error.code` instead of matching message strings. It reports two things: a connect that failed, and a session
-that failed after connecting. A token that expires on reconnect, a
-`concurrent-seed`, or a digest mismatch all happen after a successful join, so
-checking `error` is enough to know that collaboration is not working.
+Branch on `failure.code` or `error.code` instead of matching message strings.
+`error` reports an initial connection failure or a session failure after
+connection. An expired token, `concurrent-seed`, or digest mismatch can occur
+after a successful join. Always handle `error`, even when `document` is not
+`null`.
 
 The `<DocxEditor>` host accepts `document` and `modules`. You do not need
 `DocxEditor.Root` for collaboration.
@@ -199,57 +209,138 @@ Import `@docx-editor.dev/pro/collaboration` for Yjs factories. Import
 
 ## Mount the editor
 
-A collaborative Root takes three props from the room, and each one fails quietly if you get
-it wrong: the `key`, so a new session remounts and the collaboration module attaches; the
-`document`, which must be the room's bytes; and the `modules`, which must be the hook's array.
-`DocxEditorCollaborationRoot` writes all three:
+A collaborative root needs three values from the room. `key` remounts the
+editor for a new session. `document` contains the room bytes. `modules` contains
+the hook modules. Incorrect values can create a working editor that does not
+replicate edits.
+
+`DocxEditorCollaborationRoot` sets all three values. Import it with
+`DocxEditorCollaboration` from the framework entry. It also uses the room
+identity name as `author`. Set `author` to override this value. Other
+`DocxEditor.Root` props pass through.
+
+<FrameworkTabs>
+<Framework value="react">
 
 ```tsx
-const collaboration = useHocuspocusCollaboration({ modules: MODULES, room });
+import { DocxEditor } from '@docx-editor.dev/react';
+import { DocxEditorCollaboration, DocxEditorCollaborationRoot } from '@docx-editor.dev/pro/react';
+import {
+  useHocuspocusCollaboration,
+  type UseHocuspocusCollaborationConnectOptions,
+} from '@docx-editor.dev/pro/react/hocuspocus';
 
-<DocxEditorCollaborationRoot collaboration={collaboration} fallback={<p>Connecting…</p>}>
-  <DocxEditor.Toolbar />
-  <DocxEditor.Viewport>
-    <DocxEditor.Content />
-    <DocxEditorCollaboration.CaretLabels />
-  </DocxEditor.Viewport>
-</DocxEditorCollaborationRoot>;
+interface CollaborativeEditorProps {
+  room: UseHocuspocusCollaborationConnectOptions;
+}
+
+export function CollaborativeEditor({ room }: CollaborativeEditorProps) {
+  const collaboration = useHocuspocusCollaboration({ room });
+
+  if (collaboration.error) {
+    return <p>{collaboration.error.detail ?? collaboration.error.code}</p>;
+  }
+
+  return (
+    <DocxEditorCollaborationRoot collaboration={collaboration} fallback={<p>Connecting…</p>}>
+      <DocxEditor.Toolbar />
+      <DocxEditor.Viewport>
+        <DocxEditor.Content />
+        <DocxEditorCollaboration.CaretLabels />
+      </DocxEditor.Viewport>
+    </DocxEditorCollaborationRoot>
+  );
+}
 ```
 
-It also takes `author` from the room's identity, so comments and tracked changes are signed
-with the name the room shows. Set `author` yourself to override it. Everything else
-`DocxEditor.Root` accepts passes through.
+React renders the `fallback` prop whenever `document` is `null`. The root
+cannot distinguish a pending connection from a failure. Handle `error` before
+you render the root.
+
+</Framework>
+<Framework value="vue">
+
+```vue
+<script setup lang="ts">
+import { reactive } from 'vue';
+import { DocxEditor } from '@docx-editor.dev/vue';
+import { DocxEditorCollaboration, DocxEditorCollaborationRoot } from '@docx-editor.dev/pro/vue';
+import {
+  useHocuspocusCollaboration,
+  type UseHocuspocusCollaborationConnectOptions,
+} from '@docx-editor.dev/pro/vue/hocuspocus';
+
+const props = defineProps<{ room: UseHocuspocusCollaborationConnectOptions }>();
+const collaboration = reactive(useHocuspocusCollaboration({ room: props.room }));
+</script>
+
+<template>
+  <p v-if="collaboration.error">
+    {{ collaboration.error.detail ?? collaboration.error.code }}
+  </p>
+  <DocxEditorCollaborationRoot v-else :collaboration="collaboration">
+    <DocxEditor.Toolbar />
+    <DocxEditor.Viewport>
+      <DocxEditor.Content />
+      <DocxEditorCollaboration.CaretLabels />
+    </DocxEditor.Viewport>
+    <template #fallback><p>Connecting…</p></template>
+  </DocxEditorCollaborationRoot>
+</template>
+```
+
+Vue composables return refs. Wrap the return with `reactive` before you pass it
+to `DocxEditorCollaborationRoot`. Vue renders the named `fallback` slot whenever
+`document` is `null`. Without that slot, it renders nothing. Handle `error`
+before you render the root.
+
+</Framework>
+</FrameworkTabs>
 
 Use `DocxEditor.Root` directly when one page mounts two rooms, or when the bytes come from
 somewhere the component cannot see:
 
 ```tsx
-<DocxEditor.Root
-  key={collaboration.session?.sessionId ?? 'local'}
-  document={collaboration.document}
-  modules={collaboration.modules}
-  author={identity.name}
-/>
+if (collaboration.error) {
+  return <p>{collaboration.error.detail ?? collaboration.error.code}</p>;
+}
+if (!collaboration.document) {
+  return <p>Connecting…</p>;
+}
+
+return (
+  <DocxEditor.Root
+    key={collaboration.session?.sessionId ?? 'local'}
+    document={collaboration.document}
+    modules={collaboration.modules}
+    author={collaboration.session?.identity.name}
+  >
+    <DocxEditor.Viewport>
+      <DocxEditor.Content />
+    </DocxEditor.Viewport>
+  </DocxEditor.Root>
+);
 ```
 
 ## Show status and participants
 
-`useCollaborationStatus()` returns the live status and last failure, plus three
-derived flags:
+`useCollaborationStatus()` returns these fields:
 
-- `live`: edits made now reach the room.
-- `diverged`: this replica no longer agrees with the room. Only `rejoin`
-  recovers it, so this is separate from "not live".
-- `attached`: an editor has attached its document port. False with a live
-  session means the host did not remount the editor when the session appeared,
-  so nothing replicates whatever `status` says.
+- `status` gives the session state, or `inactive` when no session exists.
+- `reason` gives the failure for the present state. It clears after recovery.
+- `lastFailure` keeps the latest terminal error after the status changes.
+- `live` is true when edits made now reach the room.
+- `diverged` is true when `status` is `error` or `destroyed`. Call `rejoin` to
+  recover a room that the hook connected before.
+- `attached` is true when an editor has attached its document port. A live,
+  unattached session usually means the editor did not remount for the session.
 
 `useCollaborationParticipants()` returns the room participants.
 
-Neither takes a `session` argument. Both read the one the editor above them
-holds, which `useCollaborationSession()` also returns. Pass a session
-explicitly only for a room this editor does not own. The presence parts follow
-the same rule: `session` is optional on `DocxEditorCollaboration.Avatars` and
+Both hooks accept an optional `session`. Omit it to read the session from the
+editor provider. Pass it for a room that the editor does not own. The presence
+parts use the same rule. `session` is optional on
+`DocxEditorCollaboration.Avatars` and
 `DocxEditorCollaboration.CaretLabels`.
 
 All of these are available from `@docx-editor.dev/pro/react` and
@@ -268,12 +359,30 @@ anywhere in the editor provider tree.
 local participant first.
 
 ```tsx
-<DocxEditorCollaboration.Avatars session={session} max={4} />
+<DocxEditorCollaboration.Avatars max={4} />
 ```
 
 Avatar colors match each collaborator's tracked changes and comments. `max`
 collapses extra avatars into a `+N` chip. Use
 `DocxEditorCollaboration.Avatar` to render one participant.
+
+You can replace each avatar disc with a renderer. It receives `participant`,
+`color`, `initials`, and the locally resolved optional `avatarUrl`.
+
+```tsx
+<DocxEditorCollaboration.Avatars max={4}>
+  {({ participant, avatarUrl, initials }) =>
+    avatarUrl ? (
+      <img src={avatarUrl} alt={participant.name} />
+    ) : (
+      <span aria-label={participant.name}>{initials}</span>
+    )
+  }
+</DocxEditorCollaboration.Avatars>
+```
+
+`participant` contains `actorId`, `name`, optional `color`, optional `role`, and
+`isLocal`.
 
 Avatars show the picture declared for a collaborator, so one declaration covers
 every surface that draws that person:
@@ -297,8 +406,10 @@ tree, so editor and review hooks work inside it.
 <Framework value="react">
 
 ```tsx
-<DocxEditorCollaboration.CaretLabels session={session}>
-  {({ selection, color }) => <MyLabel name={selection.name} color={color} />}
+<DocxEditorCollaboration.CaretLabels>
+  {({ selection, participant, color, avatarUrl }) => (
+    <MyLabel name={participant?.name ?? selection.name} color={color} avatarUrl={avatarUrl} />
+  )}
 </DocxEditorCollaboration.CaretLabels>
 ```
 
@@ -306,17 +417,21 @@ tree, so editor and review hooks work inside it.
 <Framework value="vue">
 
 ```vue
-<DocxEditorCollaboration.CaretLabels :session="session" v-slot="{ selection, color }">
-  <MyLabel :name="selection.name" :color="color" />
+<DocxEditorCollaboration.CaretLabels v-slot="{ selection, participant, color, avatarUrl }">
+  <MyLabel
+    :name="participant?.name ?? selection.name"
+    :color="color"
+    :avatar-url="avatarUrl"
+  />
 </DocxEditorCollaboration.CaretLabels>
 ```
 
 </Framework>
 </FrameworkTabs>
 
-In Vue, the renderer is the default scoped slot. It receives
-`{ selection, participant, color }`. Without a renderer, the label shows the
-collaborator's name.
+The renderer receives `selection`, optional `participant`, `color`, and optional
+`avatarUrl`. In Vue, it is the default scoped slot. Without a renderer, the
+label shows the collaborator's name.
 
 The engine marks the label layer `aria-hidden` and disables pointer events.
 Screen readers do not announce label content. Label content cannot receive
@@ -328,26 +443,24 @@ For CSS styling, use the `docx-remote-caret-label` class,
 
 ## Recover a diverged replica
 
-`status` `error` is terminal: the replica refused an update and kept the copy it
-had, so it is editing a document the others do not have. Waiting does not fix
-it. `rejoin` does:
+A status of `error` is terminal. The replica refused an update and kept its
+copy. It now edits a document that other peers do not have. Waiting does not fix
+the replica. Call `rejoin`:
 
 ```tsx
-const { session, rejoin } = useHocuspocusCollaboration({ room });
-const { diverged } = useCollaborationStatus();
+const { rejoin } = useHocuspocusCollaboration({ room });
 
-if (diverged) {
-  return (
-    <button onClick={() => editor.save().then((bytes) => rejoin(new Uint8Array(bytes)))}>
-      Rejoin
-    </button>
-  );
+async function rejoinRoom() {
+  const saved = await editorRef.current?.save();
+  if (saved) {
+    await rejoin(new Uint8Array(saved));
+  }
 }
 ```
 
-`rejoin` leaves with the bytes you pass, then joins the same room again with
-`{ kind: 'join' }`. If the join succeeds, the server's copy replaces those bytes
-and the edits made while diverged are gone. If it fails, nothing is lost: the
+Save the editor bytes before you call `rejoin`. It leaves with those bytes, then
+joins the same room with `{ kind: 'join' }`. A successful join uses the room
+copy, so it drops edits made after divergence. After a failed join, the saved
 bytes stay mounted locally.
 
 ## Edit offline
@@ -413,8 +526,10 @@ callback instead of a string. The provider calls it for each reconnection.
 A rejected token during the initial join produces `initialization-aborted`.
 After a successful join, rejection sets the status to `error` and `error.code`
 to `authentication-failed`. Handle that code by refreshing the credential and
-calling `rejoin`; `transport-disconnected` recovers on its own. `syncedTimeoutMs` limits the initial sync wait. Its
-default is 30 seconds. A timeout produces `initialization-timeout`.
+calling `rejoin`. A `transport-disconnected` failure recovers on its own.
+
+`syncedTimeoutMs` limits the initial sync wait. Its default is 30 seconds. A
+timeout produces `initialization-timeout`.
 
 The `createHocuspocusCollaboration` factory accepts the same options. Import it
 from `@docx-editor.dev/pro/collaboration/hocuspocus`. It returns the room,
@@ -429,13 +544,17 @@ The Hocuspocus v4 server runs on Node, not Bun. Use
 Use it for export, autosave to your own storage, search indexing, or rendering.
 
 ```ts
+import { writeFile } from 'node:fs/promises';
+import type * as Y from 'yjs';
 import { readCollaborationDocument } from '@docx-editor.dev/pro/collaboration';
 
-// Hocuspocus hands `onStoreDocument` the synchronized Y.Doc already.
-async onStoreDocument({ documentName, document }) {
+async function exportRoom(documentName: string, document: Y.Doc) {
   await writeFile(`${documentName}.docx`, readCollaborationDocument(document));
 }
 ```
+
+Call `exportRoom` from Hocuspocus `onStoreDocument`, which receives the
+synchronized `Y.Doc`.
 
 It joins nothing. There is no identity, no `Awareness`, and no session, so the
 job never appears in a room's participant list, and it creates no editing gate.
@@ -444,6 +563,14 @@ It does not write to the `Y.Doc`.
 The `Y.Doc` must already hold the room's state. Connect your provider and wait
 for its initial sync first. A document nobody seeded throws `not-initialized`
 instead of returning a truncated file.
+
+The function throws `CollaborationSchemaError` for `not-initialized`,
+`concurrent-seed`, `blob-digest-mismatch`, materialization failures, and
+resource-limit failures. Handle the error and keep the last valid export.
+
+See the
+[server-backed Hocuspocus example](https://github.com/eigenpal/docx-editor/tree/main/examples/collaboration-hocuspocus)
+for persistence and DOCX export.
 
 ## Write a provider
 
@@ -572,92 +699,18 @@ const runtime = await DocxEditor.createCollaborative(room.document, room.session
 
 Call `room.destroy()` to stop the replica.
 
-## Compose the editor
+## Compose custom controls
 
-Use `DocxEditor.Root`, `Viewport`, and `Content` for custom controls. Pass the
-same `document` and `modules` values.
+Add custom controls as children of the collaboration root shown in
+[Mount the editor](#mount-the-editor). The root supplies `key`, `document`,
+`modules`, and the default author. Status and presence hooks inside it find the
+session without a `session` argument.
 
-<FrameworkTabs>
-<Framework value="react">
+In Vue, wrap the composable return with `reactive` before you pass it to
+`DocxEditorCollaborationRoot`.
 
-```tsx
-import { DocxEditor } from '@docx-editor.dev/react';
-import { useCollaborationStatus, type CollaborationSession } from '@docx-editor.dev/pro/react';
-import { useWebrtcCollaboration } from '@docx-editor.dev/pro/react/webrtc';
-
-function Status({ session }: { session: CollaborationSession | null }) {
-  const { status } = useCollaborationStatus(session);
-  return <span>{status}</span>;
-}
-
-type CollaborativeEditorProps = {
-  roomId: string;
-  bytes: Uint8Array;
-};
-
-export function CollaborativeEditor({ roomId, bytes }: CollaborativeEditorProps) {
-  const collaboration = useWebrtcCollaboration({
-    room: {
-      roomId,
-      identity: { actorId: 'alex', name: 'Alex' },
-      bootstrap: { kind: 'create', document: bytes },
-    },
-  });
-  if (collaboration.pending || !collaboration.document) {
-    return <p>Connecting…</p>;
-  }
-  return (
-    <DocxEditor.Root document={collaboration.document} modules={collaboration.modules}>
-      <Status session={collaboration.session} />
-      <DocxEditor.Viewport>
-        <DocxEditor.Content />
-      </DocxEditor.Viewport>
-    </DocxEditor.Root>
-  );
-}
-```
-
-</Framework>
-<Framework value="vue">
-
-```vue
-<script setup lang="ts">
-import { DocxEditor } from '@docx-editor.dev/vue';
-import { useCollaborationStatus } from '@docx-editor.dev/pro/vue';
-import { useWebrtcCollaboration } from '@docx-editor.dev/pro/vue/webrtc';
-
-const props = defineProps<{ roomId: string; bytes: Uint8Array }>();
-
-const { document, modules, pending, session } = useWebrtcCollaboration({
-  room: {
-    roomId: props.roomId,
-    identity: { actorId: 'alex', name: 'Alex' },
-    bootstrap: { kind: 'create-or-join', document: props.bytes },
-  },
-});
-const { status } = useCollaborationStatus(session);
-</script>
-
-<template>
-  <p v-if="pending || !document">Connecting…</p>
-  <DocxEditor.Root v-else :document="document" :modules="modules">
-    <span>{{ status }}</span>
-    <DocxEditor.Viewport>
-      <DocxEditor.Content />
-    </DocxEditor.Viewport>
-  </DocxEditor.Root>
-</template>
-```
-
-</Framework>
-</FrameworkTabs>
-
-Destructure the composable return into top-level bindings. Vue unwraps these
-bindings in the template.
-
-Do not destroy the room from an effect that depends on the room object.
-StrictMode can run the cleanup before remounting. The hook owns the room
-lifecycle.
+Let the room hook manage cleanup. An effect cleanup can destroy the room before
+React StrictMode remounts the component.
 
 ## Limits
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,43 +1,92 @@
 # Examples
 
-Runnable examples for every framework adapter. From the repo root:
+Install dependencies from the repository root. Build the workspace packages before you run an
+example that imports package output.
 
 ```bash
-# Vite + Vue together (the default dev target)
-bun run dev
+bun install
+bun run build:packages
+```
 
-# Pick one
-bun run dev:react   # examples/vite
-bun run dev:agent   # examples/agent (needs OPENAI_API_KEY)
-bun run dev:igloo   # examples/igloo
-bun run dev:vue     # examples/vue
-bun run dev:nextjs  # examples/nextjs
-bun run dev:nuxt    # examples/nuxt
-bun run dev:remix   # examples/remix
-bun run dev:astro   # examples/astro
+## Run an example
 
-# Server-backed collaboration: room server in one terminal, app in another
+Use one root script for each development server:
+
+```bash
+bun run dev                 # React and Vue
+bun run dev:react           # Vite and React
+bun run dev:vue             # Vite and Vue
+bun run dev:happypath       # Packaged React component
+bun run dev:igloo           # Customized React interface
+bun run dev:custom-nodes    # Custom content controls
+bun run dev:nextjs          # Next.js
+bun run dev:nuxt            # Nuxt; run build:packages:vue first
+bun run dev:remix           # Remix
+bun run dev:astro           # Astro
+bun run dev:agent           # Document review agent
+bun run dev:write-agent     # Document writing agent
+bun run dev:collaboration   # Peer-to-peer collaboration
+```
+
+Set `OPENAI_API_KEY` as described in each agent example before you run `dev:agent` or
+`dev:write-agent`.
+
+Install Node 22.18 or later for the Hocuspocus server. Run the server and app in
+separate terminals:
+
+```bash
 bun run dev:collaboration-hocuspocus:server
 bun run dev:collaboration-hocuspocus
 ```
 
-## Catalogue
+The Hocuspocus server uses `ws://127.0.0.1:1234`. The app uses
+`http://localhost:5176`.
 
-| Path                        | What it shows                                                                                                                                                                                                                                      |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `vite/`                     | Vanilla Vite + React, composed (`DocxEditor.Root`/`Viewport`/`Content`). Default React dev target. Registers the PRO review module + a `defineCustomNode` citation definition; the review pane comes from `@docx-editor.dev/pro/react`.            |
-| `igloo/`                    | Deep customization (see [`docs/CUSTOMIZING.md`](../docs/CUSTOMIZING.md)): every `DocxEditor.*` part re-skinned, re-iconed and re-labelled under one theme, plus a host-composed context menu. Point people here who ask "how far can I take this?" |
-| `vue/`                      | Vue 3 adapter composable parity demo; mirrors the Vite React example.                                                                                                                                                                              |
-| `nextjs/`                   | Next.js App Router integration.                                                                                                                                                                                                                    |
-| `nuxt/`                     | Nuxt 3/4 module (`@docx-editor.dev/nuxt`).                                                                                                                                                                                                         |
-| `astro/`                    | Astro with React island.                                                                                                                                                                                                                           |
-| `remix/`                    | Remix integration.                                                                                                                                                                                                                                 |
-| `collaboration/`            | Real-time collab proof-of-concept.                                                                                                                                                                                                                 |
-| `collaboration-hocuspocus/` | Server-backed collaboration: a Hocuspocus room server plus a React host that joins it with `useHocuspocusCollaboration`. Remote carets carry the collaborator's avatar and name through `DocxEditorCollaboration.CaretLabels`.                     |
-| `parity/`                   | Single deployment serving React + Vue adapters with a switcher pill. Used by `bun run preview`.                                                                                                                                                    |
-| `automation/`               | `@docx-editor.dev/editor-api` driving a document with no browser and no framework: a template filled from a script, plus what the browser subpath adds.                                                                                            |
-| `agent/`                    | An LLM agent reading and commenting on the live document. Tool calls run in the browser through `editor-api/browser`; comments land through pro's review API. Point people here who ask "how do I plug a model into this?"                         |
-| `shared/`                   | Shared switcher widgets + the demo `sample.docx`. Not a runnable example; imported by `vite/` and `vue/`.                                                                                                                                          |
-| `dev-all.sh`                | Spins up several adapters at once for cross-adapter dogfooding. Backs `bun run dev:demo`.                                                                                                                                                          |
+Run all main framework examples together:
 
-Adding a new example: drop it under `examples/<name>/`, add a row above, and if the example has its own `package.json` with dependencies, add its path to the root `package.json` `workspaces` list (skip for static/imported-only examples like `parity/` and `shared/`).
+```bash
+bun run dev:demo
+```
+
+Build and serve the combined React and Vue preview:
+
+```bash
+bun run preview
+```
+
+Fill a DOCX template without a browser:
+
+```bash
+bun run --filter './examples/automation' fill
+```
+
+The React Vite example and the peer-to-peer collaboration example both use port `5173`.
+Stop one server before you start the other.
+
+## Catalog
+
+- `vite/` shows the composed React API with Vite. It includes review features
+  under the EigenPal Pro License and a custom citation node.
+- `vue/` shows the Vue 3 adapter and mirrors the React example.
+- `happy-path/` shows the packaged `<DocxEditor>` component with minimal host code.
+- `igloo/` shows extensive interface customization. See
+  [Customize the editor](../docs/CUSTOMIZING.md).
+- `custom-nodes/` defines and edits a custom citation content control.
+- `nextjs/` shows Next.js App Router integration.
+- `nuxt/` shows the `@docx-editor.dev/nuxt` module.
+- `remix/` shows Remix integration.
+- `astro/` shows an Astro page with a React island.
+- `agent/` uses an AI agent to read and comment on an open document.
+- `write-agent/` uses an AI agent to create a document and propose tracked changes.
+- `automation/` fills a DOCX template with `@docx-editor.dev/editor-api`.
+- `collaboration/` uses `y-webrtc` for peer-to-peer collaboration without an application
+  server.
+- `collaboration-hocuspocus/` uses a Hocuspocus server for authenticated rooms and durable
+  storage.
+- `parity/` serves the React and Vue builds through `bun run preview`.
+- `shared/` contains reusable example chrome, links, branding, and framework switchers. It is
+  not runnable.
+- `dev-all.sh` starts the main framework examples for `bun run dev:demo`.
+
+When you add an example, add its path to this catalog. Add packages with dependencies to the
+root `workspaces` list.

--- a/examples/agent/README.md
+++ b/examples/agent/README.md
@@ -8,13 +8,22 @@ The agent is read + comment only. It has no tool that edits text.
 
 ## Run it
 
+From the repository root, install dependencies and build the workspace packages:
+
 ```bash
 bun install
-bun run build:packages          # from the repo root
+bun run build:packages
 cp examples/agent/.env.example examples/agent/.env.local
-# put your OPENAI_API_KEY in .env.local
-bun run dev:agent               # http://localhost:3003
 ```
+
+Set `OPENAI_API_KEY` in `examples/agent/.env.local`. You can also set
+`OPENAI_MODEL` and `ALLOWED_ORIGINS`. Then start the example:
+
+```bash
+bun run dev:agent
+```
+
+Open `http://localhost:3003`.
 
 The demo boots with a short document of deliberately terrible prose. Click a
 suggestion, or open your own `.docx` from the title bar.
@@ -72,7 +81,7 @@ Two phases, and the first is not optional. `text` is a property of a
 Paragraphs are addressed by `uniqueLocalId`, issued by the runtime, so every
 paragraph has one whether or not the file carried an id for it.
 
-### Comments come from pro
+### Comments use EigenPal Pro License
 
 editor-api can read, reply to and resolve comments, but it cannot create one. So
 `add_comment` selects the phrase through editor-api and lands the comment
@@ -96,8 +105,8 @@ lands on the wrong occurrence, or on the whole block.
 
 ## Three things that hang the panel
 
-Each of these fails silently, with the chat sitting on "Reading the document"
-for ever and nothing in the console.
+Each of these fails silently. The chat stays on "Reading the document," and the
+console shows no error.
 
 1. **A tool that throws without answering.** `onToolCall` must reach
    `addToolResult` on every path. Catch inside it and hand the failure to the
@@ -124,4 +133,5 @@ capped, so it can search for the rest instead of assuming it saw everything.
 The route spends your API key for anyone who can reach it. Set
 `ALLOWED_ORIGINS`, and add a rate limit before it is public.
 
-Docs: https://www.docx-editor.dev/docs/editor-api
+For more information, see the
+[editor API documentation](https://www.docx-editor.dev/docs/editor-api).

--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -1,25 +1,22 @@
 # Astro example
 
-`@docx-editor.dev/react` as an Astro island. Astro ships zero JS by
-default. The editor is interactive and browser-only, so it loads with the
-`client:only` directive, which skips SSR for that component entirely.
+This example loads the React editor as an Astro island.
 
-## Run it
+## Run the example
 
-This example resolves the `@docx-editor.dev/*` packages from their built output, so
-build the workspace packages once first. From the repo root:
+From the repository root, build the workspace packages before you start Astro:
 
 ```bash
 bun install
 bun run build:packages
-bun run dev:astro      # http://localhost:4321
+bun run dev:astro
 ```
 
-Or from this directory: `bun run dev`.
+Open `http://localhost:4321`.
 
-## The island
+## Create the island
 
-`src/pages/index.astro` renders the React editor as a client-only island:
+Use `client:only="react"` because the editor measures layout in the browser:
 
 ```astro
 ---
@@ -28,26 +25,18 @@ import { Editor } from '../components/Editor';
 <Editor client:only="react" />
 ```
 
-`client:only="react"` is the key: `client:load` would still server-render the
-component first and crash on `window`. `client:only` renders it in the
-browser only. The page shell, fonts, and styles are still static HTML.
+`client:load` still renders the component on the server.
+That behavior fails when the editor accesses `window`.
 
-## Files
-
-| File                        | What it does                            |
-| --------------------------- | --------------------------------------- |
-| `src/pages/index.astro`     | Page shell + the `client:only` island   |
-| `src/components/Editor.tsx` | React `<DocxEditor />` component        |
-| `astro.config.mjs`          | `@astrojs/react` integration + Tailwind |
-
-## Use it in your own Astro app
+## Add the editor to Astro
 
 ```bash
 npm install @docx-editor.dev/react @docx-editor.dev/core
 npx astro add react
 ```
 
-Always mount the editor with `client:only="react"`. Toolbar icons are
-bundled as inline SVG, so there is no icon font to load.
+Import `@docx-editor.dev/core/styles/editor.css` once.
+Mount the editor with `client:only="react"`.
 
-Docs: https://www.docx-editor.dev/docs/1.x/react
+For more information, see the
+[Astro integration guide](https://www.docx-editor.dev/docs/2.x/frameworks/astro).

--- a/examples/automation/README.md
+++ b/examples/automation/README.md
@@ -4,11 +4,21 @@
 needs a framework, and the server half needs no browser: it opens DOCX bytes, edits them and
 writes them back.
 
+From a clean clone, install dependencies and build the workspace packages:
+
 ```bash
-bun run examples/automation/fill-template.ts examples/remix/public/sample.docx out.docx
+bun install
+bun run build:packages
+bun run --filter './examples/automation' fill
 ```
 
-## The shape of it
+The `fill` package script runs `fill-template.ts` with the sample input. It writes
+`examples/automation/filled.docx`.
+
+## Use the API
+
+The following example shows the server API directly. It is not the complete
+`fill-template.ts` script.
 
 ```ts
 import { DocxEditor } from '@docx-editor.dev/editor-api';
@@ -72,8 +82,8 @@ Four rules carry most of the API:
 
 ## In a page, on a document already open
 
-The browser subpath takes an editor the host already created — from
-`@docx-editor.dev/react`, `@docx-editor.dev/vue`, or a plain page — and drives it in place.
+The browser subpath takes an editor that the host created with
+`@docx-editor.dev/react`, `@docx-editor.dev/vue`, or a plain page. It drives that editor in place.
 Edits land in the open document, with the reader's undo stack intact, so there is no `save()`
 here: the host saves the way it already did.
 
@@ -103,13 +113,13 @@ else's document.
 
 Deletion needs no author. `Comment.delete()` removes the root thread and anchors;
 `CommentReply.delete()` removes only that reply. Queue several calls before one `sync()` to make
-them one atomic edit and one Undo unit in a browser. Browser comment writes require the Pro review
-module and a writable, attached editor; creating a new root comment is not part of editor-api.
+them one atomic edit and one Undo unit in a browser. Browser comment writes require the
+EigenPal Pro License review module and a writable, attached editor. Editor-api cannot create a
+new root comment.
 
-Not every host can do everything, and `runtime.capabilities` says which — `save` is false for a
-browser runtime, `selection`, `scrolling` and `layout` are false for a server one. Branch on it
-rather than on which entry you imported; it is frozen for the life of the runtime, so one read
-stays true.
+`runtime.capabilities` reports the available host features. `save` is false for a browser runtime.
+`selection`, `scrolling`, and `layout` are false for a server runtime. Branch on these values
+instead of the imported entry. The values do not change during the runtime.
 
 ## What this is, and is not
 

--- a/examples/collaboration-hocuspocus/README.md
+++ b/examples/collaboration-hocuspocus/README.md
@@ -1,140 +1,83 @@
-# Server-backed collaboration with avatar carets
+# Server-backed collaboration
 
-Two people editing one DOCX through a [Hocuspocus](https://tiptap.dev/docs/hocuspocus) room,
-with each remote caret labelled by the collaborator's photo and name.
+This example connects a React editor to a
+[Hocuspocus collaboration server](https://tiptap.dev/docs/hocuspocus). Remote carets show each
+person's name and avatar.
 
-The example has two halves:
+The example has two parts:
 
-- `server/server.ts` — the room server. It authenticates connections, holds the shared
-  document, and writes it to disk so a room survives a restart.
-- `src/` — a React host that joins the room with `useHocuspocusCollaboration` and replaces the
-  engine's caret labels with `DocxEditorCollaboration.CaretLabels`.
+- `server/server.ts` authenticates connections and stores rooms.
+- `src/` joins a room with `useHocuspocusCollaboration`.
 
-## Run it
+## Run the example
 
-The server needs Node 22.18 or later: it strips the types in `server/server.ts` as it runs
-them, and Hocuspocus v4 targets Node rather than Bun.
+Use Node 22.18 or later for the server. Hocuspocus v4 targets Node, and Node runs the TypeScript
+server with type stripping.
 
-Run the server and the app in two terminals, from the repository root:
+Install and build from the repository root:
 
 ```bash
 bun install
-
-# terminal 1
-bun run dev:collaboration-hocuspocus:server   # ws://127.0.0.1:1234
-
-# terminal 2
-bun run dev:collaboration-hocuspocus          # http://localhost:5176
+bun run build:packages
 ```
 
-Then:
+Start the server in the first terminal:
 
-1. Open `http://localhost:5176` and take a seat. Keys `1` to `4` pick one.
-2. Select the room id in the bar to copy the invite link.
-3. Open the link in a second browser profile or a private window, and take a different seat.
-4. Type in both windows. Each caret carries the other person's avatar and name.
-
-Rooms are stored in `server/.data/`, as a `.ydoc` the server reads back and a `.docx` it
-exports beside it. Delete that directory to start over.
-
-Two carets a few characters apart overlap, because the engine positions every label above its
-own caret and does no collision avoidance. With four seats in the demo you will see it.
-
-## One photo per person, in three places
-
-The demo's four people live in `src/people.ts`: an id, a display name, a color, and an image
-URL. That one record reaches the remote carets, the room bar, and the comment cards.
-
-The photos are illustrative portraits drawn for this demo and served from `public/avatars/`,
-so the example ships no third-party imagery and needs no network. Point `avatarUrl` at your own
-images.
-
-### The caret label
-
-Presence carries an actor id, a display name, and a color. It never carries a photo, and it
-must not: a peer publishes its own presence, so an avatar URL on the wire is a URL that any
-room member can point at any host.
-
-So the photo is resolved locally, on each replica, and arrives already resolved:
-
-```tsx
-<DocxEditorCollaboration.CaretLabels session={session}>
-  {({ selection, color, avatarUrl }) => (
-    <CollaboratorCaret selection={selection} color={color} avatarUrl={avatarUrl} />
-  )}
-</DocxEditorCollaboration.CaretLabels>
+```bash
+bun run dev:collaboration-hocuspocus:server
 ```
 
-`CollaboratorCaret` renders `avatarUrl` straight from the render prop — the engine has already
-resolved it from the `AuthorStyle` declared for that collaborator. There is no directory call
-in the component, and no lookup keyed on `actorId`.
+Start the app in the second terminal:
 
-The NAME is the one the peer published, not a local one. A peer picks its own actor id and its
-own display name, so the picture follows a value the peer controls: someone who joins calling
-themselves "Galadriel" gets Galadriel's declared photo. That is the right trade for a demo with
-no identity provider, and the wrong one for production — derive the display name from the token
-your server verified, the way `onAuthenticate` in `server/server.ts` describes.
-
-The engine keeps creating, positioning, and coloring one label element per remote caret. The
-part portals your content into each one, inside the normal React tree, so every provider above
-it still works. Removing the part restores the engine's own name labels.
-
-An `actorId` identifies one attachment, not one person: the same person in two tabs is two
-carets, so it cannot be a user id. Nothing here decodes it.
-
-The label layer is furniture — `aria-hidden`, no pointer events. Nothing inside a label is
-announced or clickable. Interactive presence chrome belongs elsewhere, which is why the room
-bar holds the avatar stack and the invite link.
-
-### Comments and tracked changes
-
-The review side keys on a different value. A comment card resolves `w:author`, the display name
-the document was saved with, because the actor id is not in the file at all. Declare the photo
-against that name:
-
-```tsx
-<DocxEditor.AuthorStyle author={person.name} color={person.color} avatarUrl={person.avatarUrl} />
+```bash
+bun run dev:collaboration-hocuspocus
 ```
 
-`AuthorStyle` renders nothing. The packaged review card reads `avatarUrl` off it, so
-`<DocxEditorReview />` shows the same face with no render prop. `avatarUrl` accepts `http`,
-`https`, non-SVG `data:`, `blob:`, and same-origin relative URLs; anything else is dropped.
+The server uses `ws://127.0.0.1:1234`. Open the app at `http://localhost:5176`.
 
-Select some text and add a comment to see it.
+1. Choose a seat in the first browser.
+2. Select the room ID to copy the invite link.
+3. Open the link in a private window or another browser profile.
+4. Choose a different seat, and edit in both windows.
 
-### What you do not have to wire
+## Configure the connection
 
-Anything else. Colour and picture both resolve from the same declaration, on every surface that
-draws that person. `src/people.ts` is a plain list with no lookups in it, and no component in
-`src/` reads it at render time — `App.tsx` declares it once and the engine does the rest.
+The default shared token is `demo-token`. Set matching server and client values when you change
+it.
 
-The one thing the declaration cannot answer for is somebody it does not name. An undeclared
-collaborator falls back to initials on a colour from the author ramp, which is what you get for
-anyone outside your directory.
+- `PORT` sets the Hocuspocus server port.
+- `COLLAB_TOKEN` sets the server token.
+- `VITE_COLLAB_URL` sets the WebSocket URL for the app.
+- `VITE_COLLAB_TOKEN` sets the token that the app sends.
 
-## Authentication
+The server checks the token before it opens a document. A production server should verify a
+signed token and derive the user identity from that token.
 
-The provider sends a token in its handshake, and the server checks it in `onAuthenticate`
-before any message reaches a document:
+## Store and export rooms
 
-```ts
-async onAuthenticate({ token, documentName }) {
-  if (token !== TOKEN) throw new Error('invalid token');
-  return { room: documentName };
-}
-```
+The server stores rooms in `server/.data/`. It reads each `.ydoc` file when a room opens.
+It also exports a `.docx` file beside each Yjs document.
 
-The demo checks one shared secret. A real deployment verifies a signed token, returns the user
-it names as the connection context, and stops trusting the client's own display name. If your
-tokens expire, pass a callback instead of a string: the provider re-evaluates it on every
-reconnect.
+Delete `server/.data/` to remove all local rooms. Replace `onLoadDocument` and
+`onStoreDocument` when you need database or object storage.
 
-Set `VITE_COLLAB_URL`, `VITE_COLLAB_TOKEN`, `PORT`, and `COLLAB_TOKEN` to point the two halves
-somewhere else.
+The server never parses Office Open XML (OOXML). Hocuspocus stores the canonical package as an
+opaque `Y.Doc`. `readCollaborationDocument` creates the DOCX export from that replica.
 
-## What the server does not do
+## Customize people and carets
 
-It never parses OOXML. What travels the socket is the Yjs replica of the canonical package, and
-Hocuspocus treats it as an opaque `Y.Doc`. Persistence is therefore one Yjs update per room in
-`server/.data/`. Swap `onLoadDocument` and `onStoreDocument` for your database and the shape of
-the call stays the same.
+`src/people.ts` defines each person's ID, name, color, and local avatar URL. The
+app uses this record for carets, the room bar, and comment cards under the
+EigenPal Pro License.
+
+Presence sends an actor ID, display name, and color. Each replica resolves the avatar locally
+through `DocxEditor.AuthorStyle`. The demo serves its avatar files from `public/avatars/`.
+
+An `actorId` identifies one editor attachment, not one person. The same person in two tabs has
+two actor IDs. The DOCX stores comment authors as `w:author`, not as actor IDs.
+
+`DocxEditorCollaboration.CaretLabels` renders custom labels inside the React tree. Removing it
+restores the standard name labels. Caret labels use `aria-hidden` and do not accept pointer
+events.
+
+Close carets can produce overlapping labels. The editor does not apply collision avoidance.

--- a/examples/collaboration/README.md
+++ b/examples/collaboration/README.md
@@ -1,50 +1,57 @@
-# Peer-to-peer collaboration proof
+# Peer-to-peer collaboration
 
-This example replicates the whole document between two browsers, with no server between them.
+This example uses `y-webrtc` to replicate a document between browsers. It has no application
+server or durable shared storage.
 
-It uses `y-webrtc` and public signaling. For a server-backed room, see
-[`examples/collaboration-hocuspocus`](../collaboration-hocuspocus/README.md).
+For server-backed rooms, see the
+[Hocuspocus collaboration example](../collaboration-hocuspocus/README.md).
+
+## Set up the example
+
+Run these commands from the repository root on each machine:
+
+```bash
+bun install
+bun run build:packages
+bun run dev:collaboration
+```
+
+The example uses `http://localhost:5173`. The React Vite example also uses port `5173`.
+Stop `bun run dev` or `bun run dev:react` before you start this example.
 
 ## Test from two machines
 
-1. Check out the same branch on both machines.
-2. Run `bun install` on both machines.
-3. Run `bun run dev:collaboration` on both machines.
-4. Open `http://localhost:5173` on the first machine.
-5. Enter a display name, and select **Create room**.
-6. Copy the join link from the page.
-7. Send the join link to the second person.
-8. Open the link on the second machine after its local demo starts.
-9. Type in both browsers.
-10. Test selection, undo, redo, disconnect, reconnect, and DOCX save.
+1. Open `http://localhost:5173` on the first machine.
+2. Enter a display name, and select **Create room**.
+3. Copy the join link that the page shows.
+4. Send the link to the second person.
+5. Open the link after the second machine starts its local example.
+6. Edit the document in both browsers.
 
-Each join link uses `localhost:5173`. Therefore, it opens the demo that runs on the recipient's
-machine.
+The link uses `localhost:5173`. Each person must run the example on their own machine.
 
-The demo removes the creator role from the address after initialization. Share only the join link
-shown on the page. Do not initialize the same room from two creator pages. The room status reports
-schema readiness. Confirm peer discovery with the connected-participant count.
+Share only the join link that the page shows. Do not initialize one room from two creator pages.
+Use the participant count to confirm peer discovery.
 
-A join link has the shape `?room=<id>#collab=<key>`. The query string carries the public room id,
-which is the signaling topic. The fragment carries a generated encryption key that the demo passes
-to `y-webrtc` as the room password. Browsers don't send the fragment to servers, so the signaling
-host never sees the key. Anyone who has the full link can join and decrypt the room.
+The link has the form `?room=<id>#collab=<key>`. The query value identifies the public signaling
+topic. The fragment contains the `y-webrtc` encryption key. Browsers do not send fragments to
+servers, but anyone with the full link can join the room.
 
 ## Limits
 
-- Public signaling supports this proof only.
-- A room identifier is not access control. The `#collab=` fragment key encrypts signaling, but
-  the full link still grants join access.
-- WebRTC can require a TURN relay on restrictive networks.
-- The room has no durable shared storage.
-- Concurrent creators with different baselines enter an error state after their updates meet.
-- Peer-to-peer only. Every browser holds a full replica, so a room costs each peer the whole
-  document.
+- Public signaling makes this example unsuitable for production.
+- The full join link grants access to the room.
+- Some networks require a Traversal Using Relays around NAT (TURN) server.
+- Every browser stores a full document replica.
+- Two creators with different starting documents cause a schema error.
 
 ## Run the headless proof
 
-Run `bun run --filter './examples/collaboration' headless`.
+Run this command from the repository root:
 
-The script creates two independent canonical stores and two Yjs documents. An in-process provider
-forwards Yjs updates. The agent edits through `createDocumentCollaboration` without layout, paint,
-ProseMirror, React, WebRTC, or a browser DOM.
+```bash
+bun run --filter './examples/collaboration' headless
+```
+
+The script connects two stores through in-process Yjs updates. It does not use React, WebRTC, or
+a browser.

--- a/examples/custom-nodes/README.md
+++ b/examples/custom-nodes/README.md
@@ -1,22 +1,25 @@
 # Custom nodes
 
-An inline node type you define, stored as a Word content control. This example defines a legal
-citation: insert one at the caret, see it painted as a chip, right-click to edit it, and save.
+This example stores a custom legal citation as a Word content control. You can
+insert, edit, and save the citation.
+
+From the repository root, run:
 
 ```bash
 bun install
-bun run build:packages   # from the repo root, once
-bun run dev:custom-nodes # http://localhost:5179
+bun run dev:custom-nodes
 ```
+
+Open `http://localhost:5179`.
 
 Open any `.docx`, put the caret somewhere, and click **Insert citation**.
 
 ## What to read
 
-| File | What it shows |
-|---|---|
-| `src/citation.ts` | `defineCustomNode`: identity, tag prefix, recognition, chip colour, sidebar card |
-| `src/App.tsx` | Registering the module, `CustomNodeChrome`, the context menu, insert and update |
+| File              | What it shows                                                                   |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `src/citation.ts` | `defineCustomNode`: identity, tag prefix, recognition, chip color, sidebar card |
+| `src/App.tsx`     | Registering the module, `CustomNodeChrome`, the context menu, insert and update |
 
 ## The round trip
 

--- a/examples/happy-path/README.md
+++ b/examples/happy-path/README.md
@@ -1,75 +1,56 @@
 # Happy path
 
-The packaged `<DocxEditor>` component, with nothing composed by hand.
+This example uses the packaged `<DocxEditor>` component without custom
+composition.
+
+From the repository root, run:
 
 ```bash
 bun install
-bun run dev:happypath   # http://localhost:5175/
+bun run dev:happypath
 ```
 
-The app opens the demo document, and you get the full editor: title bar, menu bar,
-toolbar, rulers, navigation pane, hyperlink popover, and context menu. None of that is in
-this app's source. It arrives with the component.
+Open `http://localhost:5175/`.
 
-## What the component gives you
+## Use the packaged editor
 
-Everything above, from one element. Two more lines add comments and tracked changes:
-`modules={[reviewModule()]}` from `@docx-editor.dev/pro`, and `<DocxEditorReview />` as a
-child. `children` is the component's in-viewport slot, so the review rail scrolls with
-the document and you never drop to the primitives. Without the module, the Comments &
-Changes control and suggesting mode stay disabled and say why.
+The component provides the title bar, menus, toolbar, rulers, navigation pane,
+hyperlink popover, and context menu.
 
-## What the host owns
+The example adds comments and tracked changes with `reviewModule()`.
+It adds `<DocxEditorReview />` as a child.
+The child slot stays in the viewport, so the review rail scrolls with the
+document.
 
-`src/HappyPath.tsx` is one component, and it adds only what a library cannot decide for
-you:
+## Add host behavior
 
-- **New** — `blankDocumentBytes()` from `@docx-editor.dev/core/editor`, which is Word's
-  blank template with its Calibri 11pt defaults authored.
-- **Open** — a `.docx` file picker whose bytes go to the `document` prop. The menu's
-  File › Open row points at the same picker through `onOpen`.
-- **Save** — `ref.save()` through `DocxEditorRef`, downloaded as a `.docx`.
+`src/HappyPath.tsx` adds the behavior that the host must control:
 
-The document title is host state too, through `title` and `onTitleChange`.
+- **New** uses fresh bytes from `blankDocumentBytes()`.
+- **Open** passes selected `.docx` bytes to the `document` prop.
+- **Save** calls `ref.save()` and downloads the result.
 
-## What it leaves out
+The host also controls the title through `title` and `onTitleChange`.
 
-No saved or unsaved indicator. Tracking that means holding the revision `onChange` reports
-against the one you last wrote out, resetting both on every open, and reading the revision
-before `save()` awaits so an edit landing mid-save is not marked clean. That is a real
-pattern, and it belongs in a real app — but it is host bookkeeping, not editor API, and it
-would be the largest thing in a file whose point is how little there is.
+## Understand loading
 
-For the same reason there is no autosave, no error surface, and no dialog before New
-discards the open document.
+The `document` prop stays `undefined` until the demo bytes arrive.
+The packaged loading screen displays during that time.
+
+Use `document="blank"` when you need an empty document.
+Do not reuse `"blank"` for a repeated **New** action because its identity never
+changes.
+This example passes fresh `blankDocumentBytes()` for each **New** action.
 
 ## Styling
 
-`src/styles.css` styles the host strip and nothing else. Every color is a `--doc-*` token
-from the editor's own stylesheet, so the strip follows the editor into dark mode if you
-pass `colorMode`. The example itself stays in light mode, because the document canvas is
-Word-faithful rather than themed.
-
-## The other end of the same API
-
-`examples/vite` drives `DocxEditor.Root` / `.Viewport` / `.Content` and builds its own
-chrome over the hooks. Compare the two files to see what the packaged component does for
-you, and what you give up when you replace it.
-
-## Loading
-
-`document` is `undefined` until the bytes arrive, and the packaged loading screen holds
-that window. `undefined` is not an empty document: it means no document. For an empty
-one, pass `document="blank"`.
-
-**New** does not pass `'blank'`. `'blank'` is a constant, so a second `'blank'` is the
-same value: the prop never changes identity, nothing reloads, and whatever the user typed
-stays on the page. **New** has to work every time it is pressed, so it passes fresh
-`blankDocumentBytes()` instead.
+`src/styles.css` styles only the host controls.
+It uses the editor's `--doc-*` color tokens.
 
 ## Package resolution
 
-`vite.config.ts` aliases `@docx-editor.dev/*` to package SOURCE, so the app runs the
-working tree and needs no build step. The demo document is served from
-`examples/vite/public/sample.docx` at request time, so there is one copy of those bytes
-in the repo.
+`vite.config.ts` aliases `@docx-editor.dev/*` to workspace source.
+The app therefore needs no package build.
+It loads the demo document from `examples/vite/public/sample.docx`.
+
+For a custom interface, compare this example with `examples/vite`.

--- a/examples/igloo/README.md
+++ b/examples/igloo/README.md
@@ -1,206 +1,135 @@
 # Igloo Editor
 
-A fully themed editor, built to answer one question: **how much of this is mine?**
+Igloo Editor shows how you can theme and compose the editor.
+
+## Run the example
+
+From the repository root, install dependencies and build the workspace packages:
 
 ```bash
-bun run dev:igloo   # http://localhost:5178
+bun install
+bun run build:packages
+bun run dev:igloo
 ```
 
-Everything on screen composes under `<DocxEditor.Root>`. The arrangement, the icons, the
-labels, the colours and the art are the demo's. The engine, the rows, the pickers and every
-enabled state are the library's — and none of them had to be reimplemented to be re-skinned.
+Open `http://localhost:5178`.
 
-## What each file demonstrates
+## Customization points
 
-| File                   | Customization point                                                                                                                                                               |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `IglooEditor.tsx`      | The composition root: `Root` / `Viewport` / `Content` / `Loading`, the workspace row a floating navigation pane anchors to, and where host art goes relative to the page          |
-| `IglooToolbar.tsx`     | `Toolbar preset={false}` — a hand-ordered bar, every packaged part re-iconed, the Editing/Suggesting/Viewing pill, and two `Toolbar.Action`s of the demo's own on their own plate |
-| `IglooContextMenu.tsx` | `ContextMenu` — packaged rows re-iconed, one removed, a chrome slot pulled in, host rows, two submenus, and the PRO custom-node section                                           |
-| `IglooMenu.tsx`        | `Menu` — the registry's menus re-iconed in place, one row appended to Insert, a whole menu the library has never heard of, and Help replaced                                      |
-| `IglooReview.tsx`      | The PRO review rail, re-cut: `furniture`, part overrides, a replaced card body, and an appended element of the demo's own                                                         |
-| `specimens.ts`         | `defineCustomNode` — two document nodes the library has never heard of, with recognition, chip colour and rail cards                                                              |
-| `useSpecimens.tsx`     | The write side: `insertCustomNode` / `updateCustomNode`, the caret capture, and one owner for the dialog, the popover and the notice                                              |
-| `SpecimenDialog.tsx`   | Authoring a node: collect attrs, then one call. The whole form is the host's                                                                                                      |
-| `SpecimenPopover.tsx`  | What a chip click opens, anchored on the activation's own rect                                                                                                                    |
-| `useFrost.ts`          | One host action shared by the toolbar, the menu and the context menu, gated on `Editor.can`                                                                                       |
-| `labels.ts`            | A `t` catalogue: the same override path a real locale takes                                                                                                                       |
-| `igloo.css`            | The theme. Almost entirely `--doc-*` token overrides                                                                                                                              |
-| `icons/`               | The demo's own glyphs — `Frost.tsx` is the shared SVG frame, `toolbar.tsx`, `menu.tsx` and `review.tsx` the three sets                                                            |
-| `art/`                 | `IceSea`, `Iceberg`, `Blizzard`, the two specimen glyphs, and their shared seeded RNG. The library knows nothing about any of it                                                  |
+Everything on the screen composes under `<DocxEditor.Root>`. The demo owns the
+arrangement, icons, labels, colors, and art. The library owns the engine,
+controls, and enabled states.
 
-Everything at the top level is the API demonstration; `icons/` and `art/` are the theme's own
-decoration, kept apart so the composition reads without them.
+| File                       | Customization point                                                                           |
+| -------------------------- | --------------------------------------------------------------------------------------------- |
+| `src/IglooEditor.tsx`      | Composes `Root`, `Viewport`, `Content`, `Loading`, the workspace, and host art.               |
+| `src/IglooToolbar.tsx`     | Builds a custom toolbar with `preset={false}`, custom icons, editing modes, and host actions. |
+| `src/IglooContextMenu.tsx` | Changes packaged rows and adds host rows, submenus, and custom nodes.                         |
+| `src/IglooMenu.tsx`        | Changes registry menus, adds an Insert row, and defines a host menu.                          |
+| `src/IglooReview.tsx`      | Changes the EigenPal Pro License review rail with part overrides and host content.            |
+| `src/specimens.ts`         | Defines two custom nodes with recognition, chip colors, and rail cards.                       |
+| `src/useSpecimens.tsx`     | Owns custom-node writes, caret capture, dialogs, popovers, and notices.                       |
+| `src/SpecimenDialog.tsx`   | Collects custom-node attributes and inserts one node.                                         |
+| `src/SpecimenPopover.tsx`  | Opens custom-node details at the activation rectangle.                                        |
+| `src/useFrost.ts`          | Shares one host action and checks it with `Editor.can`.                                       |
+| `src/labels.ts`            | Defines label overrides through the same path as a locale.                                    |
+| `src/igloo.css`            | Changes the theme through `--doc-*` token overrides.                                          |
+| `src/icons/`               | Contains the demo SVG components.                                                             |
+| `src/art/`                 | Contains the background art and custom-node glyphs.                                           |
 
-## The review rail
+The top-level files demonstrate the API. The `icons/` and `art/` directories
+contain theme decoration.
 
-`DocxEditorReview` from `@docx-editor.dev/pro/react` is the rail. Anchoring, stacking,
-virtualization, the collapse-when-displaced rule, accept/reject and the reply box stay the
-library's; everything a reader sees is this demo's, through five different rungs at once:
+## Customize the review rail
 
-- **`furniture`** — the ice core log above the cards, reading the same `useReview()` the rail
-  reads.
-- **part `className` / `icon`** — the avatar's rime ring; thaw and refreeze in place of the
-  packaged tick and cross. The accessible names stay the library's, which is right: a screen
-  reader should hear what the button does, not what the theme calls it.
-- **a part's `children`** — `<Review.Summary>` wraps the demo's own body, so `Added` and
-  `Deleted` become `Frozen in` and `Calved off` while the packaged wrapper (and its test id,
-  and its selectable marking) stays.
-- **an unrecognized child** — appended inside every card. That is how the icicle fringe and
-  the specimen panel get into a card whose body the library owns.
-- **`--doc-*` tokens on the rail** — the author colour ramp restated in cold hues, so Word's
-  per-author identity survives the theme instead of being overridden away.
+`DocxEditorReview` from `@docx-editor.dev/pro/react` provides the review rail.
+The library keeps anchoring, stacking, virtualization, review actions, and the
+reply box.
 
-`Toolbar.Comments` opens and shuts it. That is the packaged part on the `review.comments`
-slot, so its pressed state is the engine's answer to "is the pane open" — which matters,
-because the pane also opens when you click a margin marker or start a comment, and a boolean
-kept in this demo would be a third opinion about it. A shut rail gives up its width for a
-32px strip of markers, and the rail unmounts its own `furniture` when that happens — the core
-log here does nothing to arrange it.
+The demo changes the rail through these extension points:
 
-**Tracked changes on the page are themed too, and they are the only canvas thing that is.**
-Every mark reads `--doc-revision-*`, so restating those on the page wrapper turns insertions
-glacier and deletions meltwater grey. That is not a contradiction of the rule below: revision
-marks are the reviewer's chrome drawn over the document, not the document. Switch the toolbar
-pill to **Suggesting** and type to see them.
+- The `furniture` prop adds the ice core log.
+- Part `className` and `icon` props change packaged controls.
+- `<Review.Summary>` replaces the card summary content.
+- Unrecognized children add host content to each card.
+- `--doc-*` tokens change the author color ramp.
 
-## Where the custom things are
+`Toolbar.Comments` controls the `review.comments` slot. Its pressed state stays
+synchronized when another action opens the rail.
 
-The demo has to answer "which of this did the product add?" as clearly as it answers "how much
-of this is mine?", so origin decides placement:
+The page wrapper changes `--doc-revision-*` tokens for tracked changes. These
+marks belong to review chrome. The document canvas remains Word-faithful.
 
-- **The menu bar keeps its conventional names.** File, Format, Insert, Help. An earlier pass
-  renamed them to Expedition, Sculpt, Deposit and Survival guide, and it was a mistake twice
-  over: a menu bar is navigation, and those four names are the one part of an editor a user
-  arrives already knowing — and with every trigger renamed, the product's own menu was just a
-  fifth invented word in a row of invented words. Rows _inside_ a menu are fair game, and
-  `labels.ts` renames plenty; by then the user has already found the menu they wanted.
-- **A capability the editor already has goes where a Word user expects it**, under a themed
-  name. A page break is an ordinary insert, so `Split the floe` sits at the bottom of
-  **Insert** — appended to the registry's rows, not replacing them (`preset` defaults to
-  `true`, which is what appends).
-- **What the product added lives in its own menu**, `Custom Actions`, under a `Custom
-elements` heading. It holds the two custom node types and nothing else; the host actions
-  that drive real engine commands sit below a separator, under their own heading.
-- **The right-click menu keeps two submenus** rather than one mixed list — engine inserts in
-  `Carve…`, custom nodes in `Custom elements…`.
-- **In the toolbar, the demo's own buttons sit on a dashed plate.** A hand-ordered bar loses
-  the one signal the packaged arrangement gives for free: everything else there is a chrome
-  slot, and these two are not.
-- **Every greyed row says why.** `Freeze` carries the engine's own words, from `Editor.can`.
-  The node rows carry the host's, because there is no `can` for a node write — the engine's
-  verbatim refusal arrives in the notice strip if you get as far as attempting one.
+## Organize host actions
 
-The Editing / Suggesting / Viewing pill is the **packaged** `Toolbar.EditingMode`, restyled by
-class. The modes, the radio semantics, the keyboard menu and the engine's refusal on a
-read-only document are all the library's — writing a host toggle instead would have been the
-mistake this demo is about.
+Keep familiar menu names such as File, Format, Insert, and Help. You can change
+rows inside each menu without changing its navigation label.
 
-## Custom nodes
+Add existing editor commands where users expect them. The demo appends the page
+break command to **Insert** and keeps the registry rows.
 
-`defineCustomNode` registers an **iceberg** and an **igloo**. On disk each is an ordinary
-run-level `w:sdt` whose `w:tag` carries the identity and attrs (`igloo:iceberg?depth=412`),
-with the label as its content — Word and the free tier open both as plain text, so nothing is
-lost either way.
+Put product-specific commands in a separate menu. Igloo Editor uses **Custom
+Actions** for custom nodes and host actions.
 
-From that one registration the library supplies the chip tint, the click dispatch, the
-context-menu Edit/Remove section, and a rail card per node. What each node _means_ is the
-demo's:
+Keep engine and host actions in separate context-menu submenus. The demo uses
+**Carve** for engine inserts and **Custom elements** for custom nodes.
 
-- an **iceberg** shows its tip in the paragraph; clicking it surfaces what is under the
-  water,
-- an **igloo** lays another block on every click — a real `updateCustomNode` write, so the
-  paragraph's label, the rail card and the saved file all move in one undo step.
+Ask the engine before you run a host action. `useFrost.ts` calls `Editor.can`
+with the command that it will run. It also uses the engine refusal as the
+disabled reason.
 
-Insert one from the **Custom Actions** menu or the right-click **Custom elements…** submenu:
-author your own, or
-take whatever the water gives. Attrs ride in a `w:tag` Word caps at 64 characters, so the
-engine refuses an oversized one with its own reason — which the notice strip repeats verbatim
-rather than inventing.
+## Define custom nodes
 
-## Three things worth copying
+`defineCustomNode` registers an iceberg and an igloo. Each node uses a run-level
+`w:sdt`. Its `w:tag` stores the identity and attributes.
 
-**Re-skinning is token overrides, not component rewrites.** The library's chrome is built on
-the `--doc-*` palette, so restating that palette under one scope re-themes the toolbar, menu
-bar, panels, pickers, rulers and navigation pane at once. `igloo.css` is mostly that list.
+Word and readers without the definition show each node as plain text. They
+preserve the content during a save and reopen cycle.
 
-The navigation pane is the sharpest example: it has no panel at all here, just white headings
-floating on the sea. That is `--doc-*` restated on `.igloo-nav` and nothing else — custom
-properties inherit, so the scope IS the override, and the shell, tabs, search box, rows,
-hover and current-item states all follow without one library class being touched.
+Use **Custom Actions** or the **Custom elements** context menu to insert a node.
+The dialog collects attributes and calls `insertCustomNode`. The popover calls
+`updateCustomNode` for later changes.
 
-**A host action still asks the engine.** `Freeze this passage` has no chrome slot, so its
-label, glyph and effect are the demo's — but whether it may run comes from `Editor.can` on
-the very command it will exec, so it cannot offer something about to be refused, and its
-tooltip carries the engine's words rather than a guess. `frost.ts` is that pattern, shared by
-both surfaces that expose the action.
+Word limits `w:tag` to 64 characters. The engine refuses an oversized tag, and
+the demo shows the refusal in the notice strip.
 
-**The document canvas is not themed, on purpose.** Painter output stays Word-faithful. A page
-that looked like ice would be a lie about what the file contains, so the theme lives in the
-chrome, in the sea behind, and in the berg the page rides on. Tracked-change marks are the one
-exception, and for a reason: they are the reviewer's chrome drawn over the document rather
-than anything the file says.
+## Reuse the theme patterns
 
-Full reference: [`docs/CUSTOMIZING.md`](../../docs/CUSTOMIZING.md).
+Set `--doc-*` tokens under one host scope to theme the editor chrome.
+`igloo.css` uses this pattern for the toolbar, menus, panels, pickers, rulers,
+and navigation pane.
 
-## Notes
+Use props and public tokens instead of `docx-*` implementation classes. The
+demo does not use `!important`.
 
-- The berg is `position: fixed` rather than stretched behind the page. A document is any
-  number of pages tall; one berg stretched over that box smears the crown into a spike.
-- Neither the workspace row nor the viewport sets a `z-index`. Either would open a stacking
-  context around the context menu, and a `position: fixed` panel cannot escape the context it
-  is declared in — it would render under the chrome bar however high its own z-index went.
-- Nothing here styles a `docx-*` class or uses `!important`. Those names are implementation
-  details, so every visual change goes through a prop, a `--doc-*` token, or an element this
-  demo owns. Where that was not possible the library grew a prop instead — trigger icons,
-  colour-split icons, and the page's centring margin all came out of writing this. So did
-  four fixes: the review rail measures its position from client rects rather than `offsetLeft`
-  (a positioned page wrapper used to land it a page-width to the left), `furniture` no longer
-  pushes every card down by its own height, a custom node's context-menu card wraps instead of
-  setting the width of the whole menu, and the editing-mode menu right-aligns to its pill so a
-  toolbar-end control does not open off-screen.
-- One constant, `--igloo-stage-top`, is how far below the scroll container the first page
-  starts. Three things have to agree with it or they describe a page they are not level with:
-  the stage's own top padding, the vertical ruler's zero, and the rail's core log.
-- The rail takes no `t` prop, so its own strings (`Accept`, `Reject`, the reply placeholder)
-  come from the bundled catalogue. The theme's vocabulary for the tracked-change kinds goes
-  through the summary override instead, which is the honest place for it — those are the
-  theme's words for the decisions, not a translation of them.
-- Help's one packaged row is removed with `<Menu.ReportIssue hidden />`, not with
-  `preset={false}`. Help passes that row as a child of its own so the ordinary merge rules
-  can reach it, which means `preset={false}` renders it too.
-- The menu parts are rows, separators and submenus — no group or heading among them — so the
-  section headings are this demo's own `role="presentation"` elements, rendered as
-  unrecognized children. Visual grouping only: a bare `div` carrying a role inside
-  `role="menu"` would break the ownership a screen reader derives its counts from.
-- The sea and the blizzard both honour `prefers-reduced-motion`.
-- The share card in `public/og/` is drawn from the same palette the theme is: `igloo-card.svg`
-  is the source and `igloo.png` the checked-in render, so a link preview shows this demo's ice
-  rather than the site's. Re-render with
-  `rsvg-convert -w 1200 -h 630 public/og/igloo-card.svg -o public/og/igloo.png`.
-- The default document is `public/sample-igloo.docx` — the shared sample with an iceberg and
-  an igloo already saved into it, so the custom nodes and their rail cards are on screen
-  before anyone touches a menu. `?fixture=sample.docx` swaps in the Vite example's copy,
-  mapped onto the real path by a vite plugin so a second copy of somebody else's file cannot
-  drift. That is the only fixture the plugin serves; `e2e/fixtures/` is off limits, because
-  those files change to suit a test run and this demo is deployed.
+Keep the document canvas Word-faithful. Put host art behind the pages and keep
+document formatting separate from chrome formatting.
 
-## Deploying
+For more information, see the
+[editor customization guide](../../docs/CUSTOMIZING.md).
 
-`vercel.json` covers the build. It is its own Vercel project, separate from the parity demo
-the repo root deploys, with **Root Directory** set to `examples/igloo`.
+## Implementation notes
 
-Two settings live in the project rather than the file, and it does not build without either:
+- The background art uses `position: fixed` so long documents do not stretch it.
+- The workspace and viewport avoid a `z-index` that would trap fixed overlays.
+- `--igloo-stage-top` aligns the stage padding, vertical ruler, and rail log.
+- Custom menu headings use `role="presentation"` to preserve menu ownership.
+- The sea and blizzard follow `prefers-reduced-motion`.
+- `public/sample-igloo.docx` includes the custom nodes used by the first screen.
 
-- **Include source files outside of the Root Directory: on.** `vite.config.ts` aliases the
-  library to `../../packages/*/src`, and the fixture plugin reads
-  `../../examples/vite/public/sample.docx` and emits it into the bundle.
-- **Production Branch: `docx-editor-v2`.** This directory does not exist on `main`.
+## Deploy the example
 
-`build:packages:demo` runs first because only `react`, `vue`, `i18n` and the `core/*` subpaths are
-aliased to source. `pro` and `fonts` resolve through node_modules to their `dist/`, which a
-clean clone does not have. The install step clears `node_modules` for the reason the root
-`vercel.json` does: the build cache and a symlinked workspace disagree.
+`vercel.json` defines the build for a Vercel project with **Root Directory** set
+to `examples/igloo`.
 
-An **Ignored Build Step** of `git diff --quiet HEAD^ HEAD -- examples/igloo packages` keeps
-docs and spec commits from rebuilding it.
+Enable **Include source files outside of the Root Directory**. The Vite
+configuration imports workspace source and a fixture outside this directory.
+
+The deployment build runs `build:packages:demo`. Packages that resolve through
+`node_modules` need their `dist/` files in a clean clone.
+
+Use this **Ignored Build Step** to skip unrelated changes:
+
+```bash
+git diff --quiet HEAD^ HEAD -- examples/igloo packages
+```

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,29 +1,26 @@
 # Next.js example
 
-`@docx-editor.dev/react` in the Next.js App Router. The editor reads
-the DOM and measures layout in the browser, so it cannot run during server
-rendering. The fix is one `dynamic()` import with `ssr: false`.
+This App Router example loads the React editor in the browser.
 
-## Run it
+## Run the example
 
-This example depends on the `@docx-editor.dev/*` workspace packages, so build them
-once first. From the repo root:
+From the repository root, build the workspace packages before you start Next.js:
 
 ```bash
 bun install
 bun run build:packages
-bun run dev:nextjs     # http://localhost:3000
+bun run dev:nextjs
 ```
 
-Or from this directory: `bun run dev`.
+Open `http://localhost:3000`.
 
-## The SSR boundary
+## Set the client boundary
 
-`app/page.tsx` keeps the route a Server Component shell and pulls the editor
-in client-only:
+`app/page.tsx` is a Client Component. It uses `dynamic()` with `ssr: false`:
 
 ```tsx
 'use client';
+
 import dynamic from 'next/dynamic';
 
 const Editor = dynamic(() => import('./components/Editor').then((m) => m.Editor), {
@@ -36,27 +33,17 @@ export default function Page() {
 }
 ```
 
-`app/components/Editor.tsx` is a `'use client'` component that renders
-`<DocxEditor />`. Without `ssr: false` the build fails on `window`/`document`
-access during prerender.
+Next.js requires the `dynamic()` call inside a Client Component.
+`app/components/Editor.tsx` also uses `'use client'` and renders `<DocxEditor />`.
 
-## Files
-
-| File                        | What it does                             |
-| --------------------------- | ---------------------------------------- |
-| `app/page.tsx`              | Server shell, client-only editor import  |
-| `app/components/Editor.tsx` | `'use client'` editor component          |
-| `app/layout.tsx`            | Page metadata, icons, share tags         |
-| `next.config.ts`            | Monorepo file tracing + build-time flags |
-
-## Use it in your own Next.js app
+## Add the editor to Next.js
 
 ```bash
 npm install @docx-editor.dev/react @docx-editor.dev/core
 ```
 
-Always import `DocxEditor` through `dynamic(..., { ssr: false })`, or wrap it
-in a `'use client'` component that only renders after mount. Toolbar icons are
-bundled as inline SVG, so there is no icon font to load.
+Import `@docx-editor.dev/core/styles/editor.css` once.
+Load your editor component with `dynamic(..., { ssr: false })`.
 
-Docs: https://www.docx-editor.dev/docs/1.x/react
+For more information, see the
+[React adapter guide](https://www.docx-editor.dev/docs/2.x/react).

--- a/examples/nuxt/README.md
+++ b/examples/nuxt/README.md
@@ -1,24 +1,23 @@
 # Nuxt example
 
-`@docx-editor.dev/nuxt`, the Nuxt 3 & 4 module wrapping the Vue adapter.
-Registering the module is the whole integration: it auto-imports an
-SSR-safe `<DocxEditor>` component and injects the editor stylesheet. No
-manual import, no `<ClientOnly>` wrapper.
+This repository example uses the private `@docx-editor.dev/nuxt` workspace
+module. The module wraps the Vue adapter for Nuxt 3 and Nuxt 4.
 
-## Run it
+## Run the example
 
-From the repo root:
+From the repository root, build the Vue and Nuxt packages before you start Nuxt:
 
 ```bash
 bun install
-bun run dev:nuxt       # http://localhost:3002
+bun run build:packages:vue
+bun run dev:nuxt
 ```
 
-Or from this directory: `bun run dev`.
+Open `http://localhost:3002`.
 
-## The integration
+## Use the workspace module
 
-`nuxt.config.ts` is the entire setup:
+Register the module in `nuxt.config.ts`:
 
 ```ts
 export default defineNuxtConfig({
@@ -26,37 +25,24 @@ export default defineNuxtConfig({
 });
 ```
 
-Then use `<DocxEditor>` anywhere. The module auto-imports it and registers it
-client-only, so it never renders during SSR:
+The module auto-imports `<DocxEditor>` as a client-only component.
+It also injects the editor stylesheet.
 
 ```vue
-<script setup lang="ts">
-import { ref } from 'vue';
-import { createEmptyDocument } from '@docx-editor.dev/core';
-
-const doc = ref(createEmptyDocument());
-</script>
-
 <template>
-  <DocxEditor :document="doc" :show-toolbar="true" />
+  <DocxEditor document="blank" author="Demo Reviewer" />
 </template>
 ```
 
-## Files
+`app.vue` shows the complete workspace example.
+It imports `DocxEditorToolbar` from `@docx-editor.dev/vue`.
+It passes document bytes, review modules, an author, and a `ready` handler.
 
-| File             | What it does                                 |
-| ---------------- | -------------------------------------------- |
-| `nuxt.config.ts` | Registers the module, sets the page icons    |
-| `app.vue`        | Opens a `.docx` and renders `<DocxEditor>`   |
+## Use Nuxt outside this repository
 
-## Use it in your own Nuxt app
+The workspace module has `"private": true`, so npm does not publish it.
+External applications must use the published Vue adapter with a client-only
+component.
 
-```bash
-npm install @docx-editor.dev/nuxt @docx-editor.dev/core
-```
-
-Add the module to `nuxt.config.ts`. The module handles the client-only
-boundary and the stylesheet. Toolbar icons are bundled as inline SVG, so
-there is no icon font to load.
-
-Docs: https://www.docx-editor.dev/docs/1.x/vue/nuxt
+Follow the
+[Nuxt integration guide](https://www.docx-editor.dev/docs/2.x/frameworks/nuxt).

--- a/examples/parity/README.md
+++ b/examples/parity/README.md
@@ -1,59 +1,41 @@
 # Parity demo
 
-Single deployment that serves the React and Vue adapter examples on the same domain. A switcher pill in each editor's toolbar flips between adapters with a normal page navigation. No iframes, no chrome wrapper — each adapter owns the full viewport.
+This demo serves the React and Vue examples from one origin.
+Each adapter owns the full viewport without an iframe or shared wrapper.
 
-## Why this exists
+## Run source development
 
-The 1.0.0 unification renames packages and ships React and Vue adapters from a shared `@docx-editor.dev/core`. The community-trust signal is "the same DOCX renders identically in both adapters when installed from npm." This deployment proves it by serving both adapters from real `node_modules` resolution paths, not source aliases.
-
-The build trick: dev mode aliases `@docx-editor.dev/*` to `packages/*/src` for HMR. Parity mode sets `USE_PUBLISHED_PACKAGES=true` so vite resolves through `node_modules` → workspace `dist/` — the exact bytes a consumer downloads from npm.
-
-## Routes
-
-| Path      | Source               | Adapter                          |
-| --------- | -------------------- | -------------------------------- |
-| `/`       | (vercel.json)        | 307 redirects to `/react/`       |
-| `/react/` | `examples/vite/dist` | React (`@docx-editor.dev/react`) |
-| `/vue/`   | `examples/vue/dist`  | Vue (`@docx-editor.dev/vue`)     |
-
-The switcher pill in each editor's toolbar (`examples/shared/AdapterSwitcher.tsx` for React, inline HTML in Vue's `App.vue`) is just two anchor tags pointing at `/react/` and `/vue/`. Click is a normal navigation.
-
-## Build
+From the repository root, run both source-based development servers:
 
 ```bash
-bun run build
-```
-
-Sequence:
-
-1. Build all five workspace packages (`bun run build:packages`) so each has a `dist/`.
-2. Build the React example with `USE_PUBLISHED_PACKAGES=true VITE_BASE_PATH=/react/` — vite skips workspace source aliases and resolves package names normally.
-3. Build the Vue example with `USE_PUBLISHED_PACKAGES=true VITE_BASE_PATH=/vue/`.
-4. Merge into `examples/parity/dist/{react,vue}/` and copy this folder's `index.html` to the root.
-
-## Local preview
-
-For live source development, start both adapter servers:
-
-```bash
+bun install
 bun run dev
 ```
 
-Open React at `http://localhost:5173/react/` or Vue at
-`http://localhost:5174/vue/`. The switcher moves between these routes.
+Open React at `http://localhost:5173/`.
+Open Vue at `http://localhost:5174/`.
 
-For the assembled production build on one origin, run:
+## Build the parity site
+
+Build and preview the assembled site from the repository root:
 
 ```bash
 bun run preview
 ```
 
-## Deploying to Vercel
+Open `http://localhost:4173/react/` or `http://localhost:4173/vue/`.
 
-Root `vercel.json` declares `bun run build` as the build, `examples/parity/dist` as the output, and the right SPA rewrites for `/react/*` and `/vue/*`. So any Vercel project pointed at this repo gets the parity preview by default — no dashboard overrides needed.
+The build performs these steps:
 
-To stand up a preview for the `1.0.0-release` branch on a custom URL:
+1. It builds the six demo workspace packages.
+2. It builds both adapters from workspace `dist/` output.
+3. It sets `/react/` and `/vue/` as the respective base paths.
+4. It assembles both builds in `examples/parity/dist/`.
 
-- In your Vercel project Settings → Domains, add a domain (e.g. `next.docx-editor.dev` or `1-0-0-release.docx-editor.dev`) and set its Git Branch to `1.0.0-release`. Every push to that branch redeploys.
+The root path redirects to `/react/`.
 
-The existing `latest.docx-editor.dev` deployment off `main` will pick up the parity build on its next deploy after this change merges. `/` redirects to `/react/`, the React adapter takes the full viewport, and a switcher pill in the toolbar flips to `/vue/`. A yellow banner on each editor route notes that this is a preview deployment and links back to `docx-editor.dev`.
+## Adapter switcher
+
+The React switcher is in `examples/shared/AdapterSwitcher.tsx`.
+The Vue switcher is in `examples/vue/src/AdapterSwitcher.vue`.
+The production links use `/react/` and `/vue/`.

--- a/examples/remix/README.md
+++ b/examples/remix/README.md
@@ -1,26 +1,22 @@
 # Remix example
 
-`@docx-editor.dev/react` in Remix (Vite). Remix renders on the server by
-default, and the editor is browser-only, so the route gates it behind a
-mount check and a `lazy()` import.
+This Remix and Vite example loads the React editor after the route mounts.
 
-## Run it
+## Run the example
 
-This example resolves the `@docx-editor.dev/*` packages from their built output, so
-build the workspace packages once first. From the repo root:
+From the repository root, build the workspace packages before you start Remix:
 
 ```bash
 bun install
 bun run build:packages
-bun run dev:remix      # http://localhost:3001
+bun run dev:remix
 ```
 
-Or from this directory: `bun run dev`.
+Open `http://localhost:3001`.
 
-## The SSR boundary
+## Set the client boundary
 
-`app/routes/_index.tsx` renders a loading state on the server and the first
-client paint, then swaps in the editor after mount:
+`app/routes/_index.tsx` uses a mount check and a lazy import:
 
 ```tsx
 import { lazy, Suspense, useEffect, useState } from 'react';
@@ -40,27 +36,17 @@ export default function Index() {
 }
 ```
 
-The `mounted` guard keeps the server and first-render markup identical so
-hydration does not mismatch. `lazy()` keeps the editor bundle out of the
-server build.
+The mount check keeps the server markup and first client markup identical.
+The lazy import keeps the editor out of the server build.
 
-## Files
-
-| File                        | What it does                               |
-| --------------------------- | ------------------------------------------ |
-| `app/routes/_index.tsx`     | Mount guard + lazy editor import           |
-| `app/components/Editor.tsx` | `<DocxEditor />` and file handling         |
-| `app/root.tsx`              | Document shell, page icons                 |
-| `vite.config.ts`            | Remix Vite plugin + Tailwind/PostCSS setup |
-
-## Use it in your own Remix app
+## Add the editor to Remix
 
 ```bash
 npm install @docx-editor.dev/react @docx-editor.dev/core
 ```
 
-Render the editor only after mount (the `useState`/`useEffect` pattern
-above) or it will crash server rendering on `window`. Load the Material
-Symbols font in `app/root.tsx`.
+Import `@docx-editor.dev/core/styles/editor.css` once.
+Render the editor only after the component mounts.
 
-Docs: https://www.docx-editor.dev/docs/1.x/react
+For more information, see the
+[Remix integration guide](https://www.docx-editor.dev/docs/2.x/frameworks/remix).

--- a/examples/shared/README.md
+++ b/examples/shared/README.md
@@ -1,0 +1,4 @@
+# Shared example components
+
+This directory is not a runnable example. It contains reusable branding, links, preview
+messages, and framework switchers for the runnable examples.

--- a/examples/vite/README.md
+++ b/examples/vite/README.md
@@ -1,41 +1,35 @@
 # Vite example
 
-`@docx-editor.dev/react` in a plain Vite + React SPA. One editor, no surface
-picker: what you see here is what the package gives you.
+This Vite and React app shows the editor composition API with custom chrome.
 
-## Run it
+## Run the example
 
-From the repo root:
+From the repository root, run:
 
 ```bash
 bun install
-bun run dev:react      # http://localhost:5173
+bun run dev:react
 ```
 
-Or from this directory: `bun run dev`.
+Open `http://localhost:5173`.
 
-## Files
+The default document is `public/sample.docx`. In development,
+`?fixture=<name>.docx` resolves a file with that name from `e2e/fixtures/`.
+Production builds include only the fixtures listed in `vite.config.ts`.
 
-| File                         | What it does                                                         |
-| ---------------------------- | -------------------------------------------------------------------- |
-| `src/main.tsx`               | React root; mounts the one editor                                    |
-| `src/ComposedEditorDemo.tsx` | The editor: composition API, custom header, library toolbar          |
-| `src/ThemeToggle.tsx`        | Light/dark switch used by the demo header                            |
-| `src/demoButtons.ts`         | Inline button styles for the demo header                             |
-| `src/styles.css`             | Demo-only chrome styles (the library ships its own)                  |
-| `src/test-harness/`          | Playwright-only tree-binding harness (`?treeFirst=1`), not a surface |
-| `index.html`                 | Page shell, icons, and share tags                                    |
-| `vite.config.ts`             | Aliases `@docx-editor.dev/*` to workspace source in dev              |
+## Add the editor to Vite
 
-The default document is served from `e2e/fixtures/` by a vite plugin, so the demo and
-the e2e suite read the same bytes. `?fixture=<name>.docx` loads any `.docx` in `public/`
-instead.
+Install the adapter and its engine peer:
 
-## Minimal integration
+```bash
+npm install @docx-editor.dev/react @docx-editor.dev/core
+```
 
-A working editor is one component. Chrome and English labels are the default:
+Import `@docx-editor.dev/core/styles/editor.css` once in your application entry.
+Then render the editor:
 
 ```tsx
+import '@docx-editor.dev/core/styles/editor.css';
 import { useRef } from 'react';
 import { DocxEditor, type DocxEditorRef } from '@docx-editor.dev/react';
 
@@ -55,26 +49,9 @@ function Editor({ file }: { file: ArrayBuffer }) {
 `DocumentHandle`. `fonts` is optional: omit it and the engine resolves faces
 from the document's own embedded fonts.
 
-Chrome labels default to the bundled English catalogue. To show another language,
-pass `t` — any function from an i18n key to display text. The keys are the ones in
-`packages/i18n/en.json`, and `@docx-editor.dev/i18n` ships the translated
-catalogues plus a `createT` helper:
+## Build custom chrome
 
-```tsx
-import { createT, de } from '@docx-editor.dev/i18n';
-
-<DocxEditor ref={editorRef} document={file} t={createT(de, 'de')} />;
-```
-
-`chrome={false}` renders the painted document alone, for hosts supplying their own
-frame.
-
-## Building your own chrome
-
-`DocxEditor` is sugar over primitives you can use directly, which is what
-`ComposedEditorDemo` does: a custom header built from `useDocxEditor`,
-`useEditorState`, `useEditorCommand` and `useFontFamily`, with the library
-toolbar alongside it and one slot overridden in place.
+`src/ComposedEditorDemo.tsx` uses the editor primitives and hooks directly.
 
 ```tsx
 <DocxEditor.Root document={bytes}>
@@ -86,12 +63,5 @@ toolbar alongside it and one slot overridden in place.
 </DocxEditor.Root>
 ```
 
-## Use it in your own Vite app
-
-```bash
-npm install @docx-editor.dev/react
-```
-
-Toolbar icons are bundled as inline SVG, so there is no icon font to load.
-
-Docs: https://www.docx-editor.dev/docs/2.x/react
+For more information, see the
+[React adapter guide](https://www.docx-editor.dev/docs/2.x/react).

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -17,17 +17,11 @@ async function fetchGitHubStars(): Promise<number | null> {
 }
 
 /**
- * Serve the canonical comprehensive fixture from ONE byte source (task M6D.1).
+ * Serve named test fixtures without copying them into the demo.
  *
- * The demo's bare `/` must load `e2e/fixtures/comprehensive-word-element-test.docx`.
- * Copying it into `examples/vite/public/` would create a second DOCX that silently
- * drifts from the fixture the e2e suite asserts against — the task explicitly calls
- * for an asset mapping or an automated byte-identical copy instead. This maps the URL
- * onto the real file at request time, so there is exactly one source of bytes and it
- * cannot go stale.
- *
- * `build` copies it once into the output, so the deployed demo serves the same bytes
- * rather than depending on a dev-only route.
+ * The default document stays in `public/sample.docx`. In development, the
+ * `?fixture=<name>.docx` query loads that name from `e2e/fixtures/`. Production
+ * builds include only the named entries below.
  */
 function canonicalFixturePlugin(): Plugin {
   const fixtures = new Map([

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -1,56 +1,44 @@
 # Vue example
 
-`@docx-editor.dev/vue` in a plain Vue 3 + Vite SPA. Same editor and same
-surface as the React adapter, with Vue components and refs. No SSR, so the
-editor mounts directly.
+This Vue 3 and Vite app uses the Vue adapter and the shared editor engine.
 
-## Run it
+## Run the example
 
-From the repo root:
+From the repository root, run:
 
 ```bash
 bun install
-bun run dev:vue        # http://localhost:5174
+bun run dev:vue
 ```
 
-Or from this directory: `bun run dev`.
+Open `http://localhost:5174`.
 
-## Files
+`src/main.ts` starts the app and loads `src/ComposedEditorDemo.vue`.
+`src/styles.css` imports the editor stylesheet and adds demo styles.
 
-| File             | What it does                                            |
-| ---------------- | ------------------------------------------------------- |
-| `src/App.vue`    | The editor: open `.docx`, edit, agent panel             |
-| `src/main.ts`    | Vue app root; demo chrome in `styles.css`               |
-| `index.html`     | Page shell, icons, and share tags                       |
-| `vite.config.ts` | Aliases `@docx-editor.dev/*` to workspace source in dev |
+## Add the editor to Vue
 
-## Minimal integration
+Install the adapter and its engine peer:
+
+```bash
+npm install @docx-editor.dev/vue @docx-editor.dev/core
+```
+
+Import the stylesheet once. Then pass `"blank"` to create an empty document:
 
 ```vue
 <script setup lang="ts">
 import { DocxEditor } from '@docx-editor.dev/vue';
 import '@docx-editor.dev/vue/styles.css';
-import { createEmptyDocument } from '@docx-editor.dev/core';
-
-const doc = createEmptyDocument();
 </script>
 
 <template>
-  <DocxEditor :document="doc" />
+  <DocxEditor document="blank" />
 </template>
 ```
 
 To open a real file, read it as an `ArrayBuffer` or `Uint8Array` and pass it as
 `:document`.
 
-## Use it in your own Vue app
-
-```bash
-npm install @docx-editor.dev/vue @docx-editor.dev/core
-```
-
-Unlike the React adapter, the Vue adapter ships a stylesheet you must import
-once: `@docx-editor.dev/vue/styles.css`. Toolbar icons are bundled as inline
-SVG, so there is no icon font to load.
-
-Docs: https://www.docx-editor.dev/docs/2.x/vue
+For more information, see the
+[Vue adapter guide](https://www.docx-editor.dev/docs/2.x/vue).

--- a/examples/write-agent/README.md
+++ b/examples/write-agent/README.md
@@ -5,16 +5,21 @@ It keeps `examples/agent` unchanged.
 
 ## Run the example
 
-1. Copy `.env.example` to `.env.local`.
-2. Set `OPENAI_API_KEY`.
-3. Optionally set `OPENAI_MODEL` and `ALLOWED_ORIGINS`.
-4. From the repository root, run:
+From the repository root, install dependencies and create the environment file:
 
-   ```bash
-   bun dev:write-agent
-   ```
+```bash
+bun install
+cp examples/write-agent/.env.example examples/write-agent/.env.local
+```
 
-5. Open `http://localhost:3004`.
+Set `OPENAI_API_KEY` in `examples/write-agent/.env.local`. You can also set
+`OPENAI_MODEL` and `ALLOWED_ORIGINS`. Then start the example:
+
+```bash
+bun run dev:write-agent
+```
+
+Open `http://localhost:3004`.
 
 Without `OPENAI_API_KEY`, the chat route returns HTTP 503 with a clear message.
 The editor and direct tool tests still work.


### PR DESCRIPTION
## Summary
- Align collaboration guidance with the room failure, root, presence, and server export APIs.
- Give every example concise setup commands, prerequisites, paths, and current documentation links.

## Test plan
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run api:check`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444261&installation_model_id=422592&pr_number=537&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F537&signature=1cf318c6b9ae94cbf1b5689b2284b2e1751825338770f2143dfe2cc591ea9541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->