### PR TITLE
fix: resolve the eastAsia font slot so CJK text measures and paints in its own face

### DIFF
--- a/.changeset/eastasia-font-slot.md
+++ b/.changeset/eastasia-font-slot.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+CJK text now measures and paints in the `eastAsia` font the document names (`w:rFonts w:eastAsia` / `w:eastAsiaTheme`, including through `w:docDefaults` and the theme's `a:ea` typefaces) instead of the run's Latin face. `ResolvedRunStyle` gains `fontFamilyEastAsia`.

--- a/.changeset/eastasia-font-slot.md
+++ b/.changeset/eastasia-font-slot.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-CJK text now measures and paints in the `eastAsia` font the document names (`w:rFonts w:eastAsia` / `w:eastAsiaTheme`, including through `w:docDefaults` and the theme's `a:ea` typefaces) instead of the run's Latin face. `ResolvedRunStyle` gains `fontFamilyEastAsia`.
+CJK text now measures and paints in the `eastAsia` font the document names (`w:rFonts w:eastAsia` / `w:eastAsiaTheme`, including through `w:docDefaults` and the theme's `a:ea` typefaces) instead of the run's Latin face. `ResolvedRunStyle` gains `fontFamilyEastAsia`, and `StyleSpanRecord` gains `fontSlot`; the format painter copies the East Asian face into `w:eastAsia`, and the font catalog lists the theme's East Asian faces.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -3147,12 +3147,16 @@ export interface StyleDefinition {
 }
 
 // @public
+export function styleForFontSlot(style: ResolvedRunStyle, slot: FontSlot | undefined): ResolvedRunStyle;
+
+// @public
 export interface StyleSpanRecord {
     // (undocumented)
     readonly box: LayoutBox;
     readonly caretEdges?: readonly number[];
     readonly equation?: EquationSpanRecord;
     readonly fieldAtom?: FieldAtomMarker;
+    readonly fontSlot?: FontSlot;
     readonly link?: SpanLinkRecord;
     readonly noteNav?: {
         readonly direction: 'to-note' | 'to-body';

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2291,6 +2291,7 @@ export interface ResolvedRunStyle {
     readonly doubleStrike: boolean;
     // (undocumented)
     readonly fontFamily: string | null;
+    readonly fontFamilyEastAsia: string | null;
     readonly fontSizePt: number;
     readonly hidden: boolean;
     readonly highlight: string | null;

--- a/packages/core/src/binding/__tests__/document-catalog.test.ts
+++ b/packages/core/src/binding/__tests__/document-catalog.test.ts
@@ -124,6 +124,42 @@ describe('documentFonts', () => {
     expect(collectDocumentFonts([result.part.root])).toEqual([]);
   });
 
+  test('an eastAsiaTheme reference surfaces the a:ea face, not the Latin one', () => {
+    // Word's own templates author the body's CJK face as `w:eastAsiaTheme="minorEastAsia"`.
+    // Mapping that token to the LATIN minor face meant the East Asian face never entered
+    // `documentFonts()`, so a function-form `resolveFonts` never fetched it and
+    // `detectFontSubstitutions` could not warn about it.
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:pPr><w:rPr>` +
+        '<w:rFonts w:eastAsiaTheme="minorEastAsia"/>' +
+        '</w:rPr></w:pPr></w:p></w:body></w:document>',
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    const root = result.part.root;
+    expect(
+      collectDocumentFonts([root], {
+        major: 'Aptos Display',
+        minor: 'Aptos',
+        majorEastAsia: 'MS Gothic',
+        minorEastAsia: 'SimSun',
+      })
+    ).toEqual(['SimSun']);
+    // The East Asian faces are part of the per-subtree memo key: the same immutable
+    // subtree re-asked under a retheme answers the NEW face, not a stale hit.
+    expect(
+      collectDocumentFonts([root], {
+        major: 'Aptos Display',
+        minor: 'Aptos',
+        majorEastAsia: 'MS Gothic',
+        minorEastAsia: 'DengXian',
+      })
+    ).toEqual(['DengXian']);
+    // A theme with no `a:ea` faces contributes nothing for the reference — an honest
+    // absence beats listing the Latin face the text does not render in.
+    expect(collectDocumentFonts([root], { major: 'Aptos Display', minor: 'Aptos' })).toEqual([]);
+  });
+
   test('header fonts require the header to be referenced by the section', () => {
     // The header PART exists but no sectPr references it, so resolveHeaderFooterParts
     // resolves nothing — its fonts must not leak in through mere part presence.

--- a/packages/core/src/binding/__tests__/document-run-defaults.test.ts
+++ b/packages/core/src/binding/__tests__/document-run-defaults.test.ts
@@ -90,16 +90,29 @@ describe('createRunDefaultsResolver', () => {
     expect(result).toEqual({ fontFamily: 'Calibri Light', fontSizeHalfPoints: 22 });
   });
 
-  test('EastAsia/Bidi theme slots do not resolve to the latin typeface', () => {
-    const resolve = createRunDefaultsResolver(
-      stylesRoot(
-        '<w:docDefaults><w:rPrDefault><w:rPr>' +
-          '<w:rFonts w:asciiTheme="minorEastAsia"/><w:sz w:val="22"/>' +
-          '</w:rPr></w:rPrDefault></w:docDefaults>'
-      ),
-      { major: 'Calibri Light', minor: 'Calibri' }
+  test('an East Asian token on a Latin slot resolves the a:ea face, never the Latin one', () => {
+    // `w:asciiTheme="minorEastAsia"` is legal: Word's "use East Asian fonts also on
+    // Latin text". The token decides the face; the attribute that carried it does not.
+    const styles = stylesRoot(
+      '<w:docDefaults><w:rPrDefault><w:rPr>' +
+        '<w:rFonts w:asciiTheme="minorEastAsia"/><w:sz w:val="22"/>' +
+        '</w:rPr></w:rPrDefault></w:docDefaults>'
     );
-    expect(resolve(null).fontFamily).toBeNull();
+    const withEastAsia = createRunDefaultsResolver(styles, {
+      major: 'Calibri Light',
+      minor: 'Calibri',
+      majorEastAsia: 'MS Gothic',
+      minorEastAsia: 'SimSun',
+    });
+    expect(withEastAsia(null).fontFamily).toBe('SimSun');
+    // A theme with no `a:ea` faces answers an honest null, not the Latin face.
+    const withoutEastAsia = createRunDefaultsResolver(styles, {
+      major: 'Calibri Light',
+      minor: 'Calibri',
+      majorEastAsia: null,
+      minorEastAsia: null,
+    });
+    expect(withoutEastAsia(null).fontFamily).toBeNull();
   });
 
   test('invalid names and out-of-range sizes are dropped, never repaired', () => {

--- a/packages/core/src/binding/document-catalog.ts
+++ b/packages/core/src/binding/document-catalog.ts
@@ -9,6 +9,7 @@
 
 import type { OoxmlElement, OoxmlNode } from '../store/package/ooxml-tree.ts';
 import { WML_NAMESPACE_URI } from '../store/package/ooxml-shared.ts';
+import { themeFontFamilyOf, type ThemeSchemeFaces } from '../store/package/theme-font-scheme.ts';
 
 /**
  * The same shape `semantic-paint.ts` enforces at the CSS sink (its `FONT_NAME`):
@@ -47,7 +48,7 @@ function attributeValue(node: OoxmlElement, localName: string): string | undefin
  */
 export function collectDocumentFonts(
   roots: readonly OoxmlElement[],
-  themeFonts?: { readonly major: string | null; readonly minor: string | null }
+  themeFonts?: ThemeSchemeFaces
 ): readonly string[] {
   const byFold = new Map<string, string>();
   // Composed from per-subtree memos: every keystroke publishes a new root whose children
@@ -73,6 +74,8 @@ export function collectDocumentFonts(
 interface SubtreeFontsMemo {
   readonly major: string | null;
   readonly minor: string | null;
+  readonly majorEastAsia: string | null;
+  readonly minorEastAsia: string | null;
   readonly byFold: ReadonlyMap<string, string>;
 }
 const subtreeFontsMemos = new WeakMap<OoxmlElement, SubtreeFontsMemo>();
@@ -88,13 +91,26 @@ const MAX_COMPOSE_DEPTH = 32;
 
 function subtreeFontsOf(
   subtree: OoxmlElement,
-  themeFonts: { readonly major: string | null; readonly minor: string | null } | undefined,
+  themeFonts: ThemeSchemeFaces | undefined,
   depth = 0
 ): ReadonlyMap<string, string> {
   const major = themeFonts?.major ?? null;
   const minor = themeFonts?.minor ?? null;
+  // The East Asian faces are part of the memo key for the same reason the Latin pair is:
+  // the theme decides what a theme slot reference contributes, so a memo keyed on fewer
+  // faces than the resolution reads would answer stale fonts after a retheme.
+  const majorEastAsia = themeFonts?.majorEastAsia ?? null;
+  const minorEastAsia = themeFonts?.minorEastAsia ?? null;
   const cached = subtreeFontsMemos.get(subtree);
-  if (cached && cached.major === major && cached.minor === minor) return cached.byFold;
+  if (
+    cached &&
+    cached.major === major &&
+    cached.minor === minor &&
+    cached.majorEastAsia === majorEastAsia &&
+    cached.minorEastAsia === minorEastAsia
+  ) {
+    return cached.byFold;
+  }
   if (
     subtree.children.length >= COMPOSE_CHILD_THRESHOLD &&
     depth < MAX_COMPOSE_DEPTH &&
@@ -107,7 +123,7 @@ function subtreeFontsOf(
         if (!merged.has(fold)) merged.set(fold, family);
       }
     }
-    subtreeFontsMemos.set(subtree, { major, minor, byFold: merged });
+    subtreeFontsMemos.set(subtree, { major, minor, majorEastAsia, minorEastAsia, byFold: merged });
     return merged;
   }
   const byFold = new Map<string, string>();
@@ -133,16 +149,13 @@ function subtreeFontsOf(
       // theme otherwise reported "no fonts" while every run rendered in one.
       if (themeFonts) {
         for (const attr of RFONTS_THEME_ATTRS) {
-          const slot = attributeValue(node, attr);
-          if (slot === undefined) continue;
-          if (slot.startsWith('major')) add(themeFonts.major);
-          else if (slot.startsWith('minor')) add(themeFonts.minor);
+          add(themeFontFamilyOf(attributeValue(node, attr), themeFonts));
         }
       }
     }
     for (let i = node.children.length - 1; i >= 0; i -= 1) stack.push(node.children[i]!);
   }
-  subtreeFontsMemos.set(subtree, { major, minor, byFold });
+  subtreeFontsMemos.set(subtree, { major, minor, majorEastAsia, minorEastAsia, byFold });
   return byFold;
 }
 

--- a/packages/core/src/binding/document-run-defaults.ts
+++ b/packages/core/src/binding/document-run-defaults.ts
@@ -13,6 +13,7 @@
 // a `basedOn` loop is file content too.
 
 import type { OoxmlElement, OoxmlNode } from '../store/package/ooxml-tree.ts';
+import { themeFontFamilyOf } from '../store/package/theme-font-scheme.ts';
 import type { DocumentThemeFonts } from './document-theme.ts';
 
 /** What a run inherits at one point of the chain — null means "nothing authored". */
@@ -60,17 +61,6 @@ export function validStyleId(raw: string | undefined): string | null {
 }
 
 /**
- * A theme rFonts attribute (`asciiTheme`/`hAnsiTheme`) resolved to a typeface. Only the
- * LATIN slot values resolve — `minorEastAsia`/`minorBidi` (and major) name the `a:ea`/
- * `a:cs` faces this module does not harvest, and an honest null beats the wrong font.
- */
-function themeFamilyOf(value: string | undefined, themeFonts: DocumentThemeFonts): string | null {
-  if (value === 'minorAscii' || value === 'minorHAnsi') return themeFonts.minor;
-  if (value === 'majorAscii' || value === 'majorHAnsi') return themeFonts.major;
-  return null;
-}
-
-/**
  * The family an `w:rFonts` element names: the theme attributes through the font scheme,
  * then `ascii ?? hAnsi` (the spelling the engine reads back).
  *
@@ -83,9 +73,12 @@ export function familyFromRFonts(
   rFonts: OoxmlElement,
   themeFonts: DocumentThemeFonts
 ): string | null {
+  // The shared token table (`theme-font-scheme.ts`) resolves the East Asian tokens too:
+  // `w:asciiTheme="minorEastAsia"` is Word's "use East Asian fonts on Latin text", and
+  // this reader must answer the same face the layout lane paints.
   const themed =
-    themeFamilyOf(attributeValue(rFonts, 'asciiTheme'), themeFonts) ??
-    themeFamilyOf(attributeValue(rFonts, 'hAnsiTheme'), themeFonts);
+    themeFontFamilyOf(attributeValue(rFonts, 'asciiTheme'), themeFonts) ??
+    themeFontFamilyOf(attributeValue(rFonts, 'hAnsiTheme'), themeFonts);
   if (themed !== null) return themed;
   const direct = attributeValue(rFonts, 'ascii') ?? attributeValue(rFonts, 'hAnsi');
   if (direct === undefined) return null;
@@ -176,8 +169,8 @@ export function createRunDefaultsResolver(
     // precedence `familyFromRFonts` applies within one element.
     const rFonts = runProperties?.find((property) => property.localName === 'rFonts');
     const runTheme = rFonts
-      ? (themeFamilyOf(rFonts.attributes?.asciiTheme, themeFonts) ??
-        themeFamilyOf(rFonts.attributes?.hAnsiTheme, themeFonts))
+      ? (themeFontFamilyOf(rFonts.attributes?.asciiTheme, themeFonts) ??
+        themeFontFamilyOf(rFonts.attributes?.hAnsiTheme, themeFonts))
       : null;
     return runTheme === null ? chain : { ...chain, fontFamily: runTheme };
   };

--- a/packages/core/src/binding/document-theme.ts
+++ b/packages/core/src/binding/document-theme.ts
@@ -68,22 +68,26 @@ function elementChild(parent: OoxmlElement, localName?: string): OoxmlElement | 
   return null;
 }
 
-/** The theme's two font slots, for resolving `w:rFonts` theme attributes. */
+/** The theme's font slots, for resolving `w:rFonts` theme attributes. */
 export interface DocumentThemeFonts {
   /** `a:majorFont` latin typeface — headings. */
   readonly major: string | null;
   /** `a:minorFont` latin typeface — body text. */
   readonly minor: string | null;
+  /** `a:majorFont` east asian typeface (`a:ea`) — headings. */
+  readonly majorEastAsia: string | null;
+  /** `a:minorFont` east asian typeface (`a:ea`) — body text. */
+  readonly minorEastAsia: string | null;
 }
 
 /** The CSS-sink shape font names must satisfy (document-catalog's `FONT_NAME`). */
 const FONT_NAME = /^[\p{L}\p{N}\p{M} \-.+_]{1,64}$/u;
 
-/** A validated `a:latin` typeface under `a:majorFont`/`a:minorFont`, or null. */
-function latinTypeface(scheme: OoxmlElement, slot: string): string | null {
+/** A validated `a:latin`/`a:ea` typeface under `a:majorFont`/`a:minorFont`, or null. */
+function schemeTypeface(scheme: OoxmlElement, slot: string, face: 'latin' | 'ea'): string | null {
   const font = elementChild(scheme, slot);
-  const latin = font ? elementChild(font, 'latin') : null;
-  const raw = latin ? attributeValue(latin, 'typeface') : undefined;
+  const element = font ? elementChild(font, face) : null;
+  const raw = element ? attributeValue(element, 'typeface') : undefined;
   return raw !== undefined && FONT_NAME.test(raw) ? raw : null;
 }
 
@@ -93,12 +97,15 @@ function latinTypeface(scheme: OoxmlElement, slot: string): string | null {
  * all-or-nothing rule, because each resolves a different `w:rFonts` attribute.
  */
 export function collectDocumentThemeFonts(themeRoot: OoxmlElement | null): DocumentThemeFonts {
-  if (!themeRoot) return { major: null, minor: null };
+  const empty = { major: null, minor: null, majorEastAsia: null, minorEastAsia: null };
+  if (!themeRoot) return empty;
   const scheme = findElement(themeRoot, 'fontScheme');
-  if (!scheme) return { major: null, minor: null };
+  if (!scheme) return empty;
   return {
-    major: latinTypeface(scheme, 'majorFont'),
-    minor: latinTypeface(scheme, 'minorFont'),
+    major: schemeTypeface(scheme, 'majorFont', 'latin'),
+    minor: schemeTypeface(scheme, 'minorFont', 'latin'),
+    majorEastAsia: schemeTypeface(scheme, 'majorFont', 'ea'),
+    minorEastAsia: schemeTypeface(scheme, 'minorFont', 'ea'),
   };
 }
 

--- a/packages/core/src/editor/__tests__/format-painter.test.ts
+++ b/packages/core/src/editor/__tests__/format-painter.test.ts
@@ -179,6 +179,28 @@ describe('the capture', () => {
     });
   });
 
+  test('a copy starting on CJK text keeps each face in its own w:rFonts slot', () => {
+    // The source run resolves BOTH faces. The capture must write the Latin one into
+    // `w:ascii`/`w:hAnsi` and the East Asian one into `w:eastAsia` — copying from a CJK
+    // span must never put the East Asian face onto the target's Latin text.
+    const CJK = p(
+      textRun('甲方shall', '<w:rPr><w:rFonts w:ascii="Georgia" w:eastAsia="SimSun"/></w:rPr>')
+    );
+    withEditor(CJK + PLAIN, (editor) => {
+      // The selection starts ON the CJK span of the mixed run.
+      select(editor, [0, 0], [0, 2]);
+      expect(editor.exec({ type: 'copyFormatting' })).toMatchObject({ ok: true });
+      select(editor, [1, 0], [1, 5]);
+      expect(editor.exec({ type: 'pasteFormatting' })).toMatchObject({ ok: true });
+
+      expect(runPropertyAttributes(editor, 1, 'rFonts')).toEqual({
+        ascii: 'Georgia',
+        hAnsi: 'Georgia',
+        eastAsia: 'SimSun',
+      });
+    });
+  });
+
   test('a range inside one paragraph copies character formatting alone', () => {
     withEditor(STYLED + PLAIN, (editor) => {
       // Two characters short of the paragraph's end, so no paragraph mark is covered.

--- a/packages/core/src/editor/surface-format-painter.ts
+++ b/packages/core/src/editor/surface-format-painter.ts
@@ -165,14 +165,20 @@ function runPropertiesOf(style: ResolvedRunStyle): readonly SurfaceProperty[] {
   // measured in the surface's own default, which is not a document fact and must not be
   // written into a paragraph as if it were.
   //
-  // `ascii` and `hAnsi` only. `w:rFonts` merges per SLOT (`mergedFontProperty`), so a target
-  // keeps its East Asian and complex-script faces — deliberately, and for the same reason a
-  // CJK list marker keeps its own face when the Latin text beside it changes. The resolver
-  // publishes ONE family, so there is no East Asian answer to copy even if that were wanted.
-  if (style.fontFamily) {
+  // Per SLOT, matching how `w:rFonts` merges (`mergedFontProperty`): `style.fontFamily` is
+  // the ascii/hAnsi answer and `style.fontFamilyEastAsia` the eastAsia one, so a copy that
+  // starts on CJK text writes the East Asian face into `w:eastAsia` — never into the
+  // target's Latin slots. A source with no resolved East Asian face leaves the target's
+  // `w:eastAsia` alone, for the same reason a CJK list marker keeps its own face when the
+  // Latin text beside it changes. The complex-script face is not resolved yet, so `w:cs`
+  // stays untouched.
+  if (style.fontFamily || style.fontFamilyEastAsia) {
     properties.push({
       localName: 'rFonts',
-      attributes: { ascii: style.fontFamily, hAnsi: style.fontFamily },
+      attributes: {
+        ...(style.fontFamily ? { ascii: style.fontFamily, hAnsi: style.fontFamily } : {}),
+        ...(style.fontFamilyEastAsia ? { eastAsia: style.fontFamilyEastAsia } : {}),
+      },
     });
   }
   return properties;

--- a/packages/core/src/editor/surface-formatting.ts
+++ b/packages/core/src/editor/surface-formatting.ts
@@ -631,6 +631,11 @@ export function formattingAt(
   // docDefaults, theme fonts). A caret in an empty paragraph inherits too.
   const hasDirect = (span: (typeof spans)[number], localName: string): boolean =>
     span.props.some((property) => property.localName === localName);
+  // The LATIN (ascii/hAnsi) face, deliberately, even for a span whose text paints through
+  // the eastAsia slot: a span's `style` carries the run's full resolution, so a mixed
+  // CJK+Latin run answers ONE family here, and it is the same slot the font picker writes
+  // (`w:ascii`/`w:hAnsi`) — pick a font and this readback reflects it. Word's single font
+  // box behaves the same way; a per-slot readback needs a per-slot control first.
   const familyOf = (span: (typeof spans)[number]): string | null =>
     span.style.fontFamily ?? inherited?.(span.range.paragraphId, span.props).fontFamily ?? null;
   const sizeOf = (span: (typeof spans)[number]): number =>

--- a/packages/core/src/layout/__tests__/font-slot-pieces.test.ts
+++ b/packages/core/src/layout/__tests__/font-slot-pieces.test.ts
@@ -1,0 +1,92 @@
+// applyEastAsiaFontSlots: how the paragraph-wide slot answer lands on pieces.
+
+import { describe, expect, test } from 'bun:test';
+import { applyEastAsiaFontSlots, type FieldAwarePiece } from '../field-pieces.ts';
+import { resolveRunStyle } from '../run-style.ts';
+
+const cjkStyle = resolveRunStyle([
+  { localName: 'rFonts', attributes: { ascii: 'Arial', eastAsia: 'SimSun' } },
+]);
+const latinOnlyStyle = resolveRunStyle([{ localName: 'rFonts', attributes: { ascii: 'Arial' } }]);
+
+let nextStart = 0;
+function piece(text: string, overrides: Partial<FieldAwarePiece> = {}): FieldAwarePiece {
+  const start = overrides.start ?? nextStart;
+  const end = overrides.end ?? start + text.length;
+  nextStart = end;
+  return { text, props: [], style: cjkStyle, start, end, ...overrides };
+}
+
+describe('applyEastAsiaFontSlots', () => {
+  test('splits mixed literal text into slot-homogeneous pieces, offsets contiguous', () => {
+    nextStart = 0;
+    const out = applyEastAsiaFontSlots([piece('甲方shall履行')]);
+    expect(out.map(({ text, start, end, fontSlot }) => ({ text, start, end, fontSlot }))).toEqual([
+      { text: '甲方', start: 0, end: 2, fontSlot: 'eastAsia' },
+      { text: 'shall', start: 2, end: 7, fontSlot: undefined },
+      { text: '履行', start: 7, end: 9, fontSlot: 'eastAsia' },
+    ]);
+    // The style object is untouched and SHARED across the slices: readback and the
+    // format painter see the run's real resolution, whichever slice they start on.
+    expect(out[0]!.style).toBe(cjkStyle);
+    expect(out[1]!.style).toBe(cjkStyle);
+  });
+
+  test('a weak character alone in its own run inherits across the run boundary', () => {
+    nextStart = 0;
+    const out = applyEastAsiaFontSlots([piece('甲'), piece('，'), piece('方')]);
+    expect(out.map((item) => item.fontSlot)).toEqual(['eastAsia', 'eastAsia', 'eastAsia']);
+    expect(out.map((item) => item.text)).toEqual(['甲', '，', '方']);
+  });
+
+  test('ASCII punctuation between CJK runs stays in the base slots', () => {
+    nextStart = 0;
+    const out = applyEastAsiaFontSlots([piece('中文'), piece(', '), piece('Hello')]);
+    expect(out.map((item) => item.fontSlot)).toEqual(['eastAsia', undefined, undefined]);
+  });
+
+  test('layout-owned pieces stay whole: uniform text takes the slot, mixed keeps base', () => {
+    // A projected field result covers ONE model unit however long its display text is;
+    // slicing its range would corrupt every offset after it.
+    nextStart = 0;
+    const uniform = piece('二〇二六', { projected: true, start: 0, end: 1 });
+    const mixed = piece('二〇二六年8月', { projected: true, start: 1, end: 2 });
+    const out = applyEastAsiaFontSlots([uniform, mixed]);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.fontSlot).toBe('eastAsia');
+    expect(out[0]!.start).toBe(0);
+    expect(out[0]!.end).toBe(1);
+    expect(out[1]!.fontSlot).toBeUndefined();
+  });
+
+  test('an unsupported code point costs itself the face, not its piece', () => {
+    nextStart = 0;
+    const out = applyEastAsiaFontSlots([piece('甲த文')]);
+    expect(out.map(({ text, fontSlot }) => ({ text, fontSlot }))).toEqual([
+      { text: '甲', fontSlot: 'eastAsia' },
+      { text: 'த', fontSlot: undefined },
+      { text: '文', fontSlot: 'eastAsia' },
+    ]);
+  });
+
+  test('no distinct eastAsia face anywhere returns the input array untouched', () => {
+    nextStart = 0;
+    const pieces = [piece('甲方', { style: latinOnlyStyle })];
+    expect(applyEastAsiaFontSlots(pieces)).toBe(pieces);
+  });
+
+  test('CJK text in a run WITHOUT its own eastAsia face keeps the base slots', () => {
+    nextStart = 0;
+    const out = applyEastAsiaFontSlots([piece('甲方'), piece('乙方', { style: latinOnlyStyle })]);
+    expect(out[0]!.fontSlot).toBe('eastAsia');
+    expect(out[1]!.fontSlot).toBeUndefined();
+  });
+
+  test('control pieces neither classify nor split', () => {
+    nextStart = 0;
+    const tab = piece('\t', { breakKind: undefined });
+    const out = applyEastAsiaFontSlots([piece('甲'), tab, piece('方')]);
+    expect(out.map((item) => item.text)).toEqual(['甲', '\t', '方']);
+    expect(out[1]!.fontSlot).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout/__tests__/run-style.test.ts
+++ b/packages/core/src/layout/__tests__/run-style.test.ts
@@ -1,7 +1,13 @@
 // The accepted run property boundary, resolved for layout (task 7.2).
 
 import { describe, expect, test } from 'bun:test';
-import { DEFAULT_RUN_STYLE, displayText, resolveRunStyle, runStylesEqual } from '../run-style.ts';
+import {
+  DEFAULT_RUN_STYLE,
+  displayText,
+  eastAsiaSlotStyle,
+  resolveRunStyle,
+  runStylesEqual,
+} from '../run-style.ts';
 
 const resolve = (localName: string, attributes?: Record<string, string>) =>
   resolveRunStyle([attributes ? { localName, attributes } : { localName }]);
@@ -140,7 +146,7 @@ describe('a w:rFonts theme reference resolves against the theme part', () => {
   });
 
   test('an unresolvable slot falls back to the explicit name, not to nothing', () => {
-    // `minorBidi` / `minorEastAsia` name the `a:cs` / `a:ea` faces this lane does not read.
+    // `minorBidi` names the `a:cs` face this lane does not read.
     expect(themed({ ascii: 'Calibri', asciiTheme: 'minorBidi' })).toBe('Calibri');
     // A theme whose slot is empty leaves the run inheriting rather than naming null.
     expect(
@@ -149,6 +155,73 @@ describe('a w:rFonts theme reference resolves against the theme part', () => {
         minor: null,
       }).fontFamily
     ).toBeNull();
+  });
+});
+
+describe('the w:rFonts eastAsia slot resolves beside the Latin one', () => {
+  const theme = {
+    major: 'Aharoni',
+    minor: 'Grandview',
+    majorEastAsia: 'MS Gothic',
+    minorEastAsia: 'SimSun',
+  };
+  const resolved = (attributes: Record<string, string>, themeFonts = theme) =>
+    resolveRunStyle([{ localName: 'rFonts', attributes }], themeFonts);
+
+  test('an explicit w:eastAsia resolves without touching the Latin family', () => {
+    const style = resolved({ eastAsia: 'SimSun' });
+    expect(style.fontFamilyEastAsia).toBe('SimSun');
+    expect(style.fontFamily).toBeNull();
+  });
+
+  test('a Latin-only rFonts leaves the eastAsia slot inherited', () => {
+    expect(resolved({ ascii: 'Arial' }).fontFamilyEastAsia).toBeNull();
+  });
+
+  test('w:eastAsiaTheme resolves against the a:ea typefaces', () => {
+    expect(resolved({ eastAsiaTheme: 'minorEastAsia' }).fontFamilyEastAsia).toBe('SimSun');
+    expect(resolved({ eastAsiaTheme: 'majorEastAsia' }).fontFamilyEastAsia).toBe('MS Gothic');
+  });
+
+  test('the theme attribute overrides the explicit name beside it (§17.3.2.26)', () => {
+    expect(
+      resolved({ eastAsia: 'PMingLiU', eastAsiaTheme: 'minorEastAsia' }).fontFamilyEastAsia
+    ).toBe('SimSun');
+  });
+
+  test('an unresolvable theme slot falls back to the explicit name, not to nothing', () => {
+    expect(
+      resolved(
+        { eastAsia: 'PMingLiU', eastAsiaTheme: 'minorEastAsia' },
+        { major: null, minor: null }
+      ).fontFamilyEastAsia
+    ).toBe('PMingLiU');
+  });
+
+  test('styles differing only in the eastAsia face are not equal', () => {
+    expect(
+      runStylesEqual(resolved({ eastAsia: 'SimSun' }), resolved({ eastAsia: 'MS Mincho' }))
+    ).toBe(false);
+  });
+});
+
+describe('eastAsiaSlotStyle derives the face an eastAsia piece uses', () => {
+  test('swaps the eastAsia family into fontFamily and memoizes per style object', () => {
+    const style = resolveRunStyle([
+      { localName: 'rFonts', attributes: { ascii: 'Arial', eastAsia: 'SimSun' } },
+    ]);
+    const derived = eastAsiaSlotStyle(style);
+    expect(derived.fontFamily).toBe('SimSun');
+    expect(derived.fontSizePt).toBe(style.fontSizePt);
+    expect(eastAsiaSlotStyle(style)).toBe(derived);
+  });
+
+  test('answers the style itself when the slot adds nothing', () => {
+    expect(eastAsiaSlotStyle(DEFAULT_RUN_STYLE)).toBe(DEFAULT_RUN_STYLE);
+    const same = resolveRunStyle([
+      { localName: 'rFonts', attributes: { ascii: 'SimSun', eastAsia: 'SimSun' } },
+    ]);
+    expect(eastAsiaSlotStyle(same)).toBe(same);
   });
 });
 

--- a/packages/core/src/layout/__tests__/run-style.test.ts
+++ b/packages/core/src/layout/__tests__/run-style.test.ts
@@ -4,10 +4,11 @@ import { describe, expect, test } from 'bun:test';
 import {
   DEFAULT_RUN_STYLE,
   displayText,
-  eastAsiaSlotStyle,
   resolveRunStyle,
   runStylesEqual,
+  withFontFamily,
 } from '../run-style.ts';
+import { styleForFontSlot } from '../script-itemization.ts';
 
 const resolve = (localName: string, attributes?: Record<string, string>) =>
   resolveRunStyle([attributes ? { localName, attributes } : { localName }]);
@@ -198,6 +199,14 @@ describe('the w:rFonts eastAsia slot resolves beside the Latin one', () => {
     ).toBe('PMingLiU');
   });
 
+  test('the East Asian tokens are legal on the LATIN theme attributes too', () => {
+    // Word's "use East Asian fonts also on Latin text" writes `w:asciiTheme="minorEastAsia"`;
+    // both scripts then paint in the East Asian face rather than Latin falling to the default.
+    const style = resolved({ asciiTheme: 'minorEastAsia', eastAsiaTheme: 'minorEastAsia' });
+    expect(style.fontFamily).toBe('SimSun');
+    expect(style.fontFamilyEastAsia).toBe('SimSun');
+  });
+
   test('styles differing only in the eastAsia face are not equal', () => {
     expect(
       runStylesEqual(resolved({ eastAsia: 'SimSun' }), resolved({ eastAsia: 'MS Mincho' }))
@@ -205,23 +214,45 @@ describe('the w:rFonts eastAsia slot resolves beside the Latin one', () => {
   });
 });
 
-describe('eastAsiaSlotStyle derives the face an eastAsia piece uses', () => {
-  test('swaps the eastAsia family into fontFamily and memoizes per style object', () => {
+describe('withFontFamily — the one memoized face derivation', () => {
+  test('swaps the family and memoizes per (style, family)', () => {
     const style = resolveRunStyle([
       { localName: 'rFonts', attributes: { ascii: 'Arial', eastAsia: 'SimSun' } },
     ]);
-    const derived = eastAsiaSlotStyle(style);
+    const derived = withFontFamily(style, 'SimSun');
     expect(derived.fontFamily).toBe('SimSun');
+    expect(derived.fontFamilyEastAsia).toBe('SimSun');
     expect(derived.fontSizePt).toBe(style.fontSizePt);
-    expect(eastAsiaSlotStyle(style)).toBe(derived);
+    expect(withFontFamily(style, 'SimSun')).toBe(derived);
+    expect(withFontFamily(style, 'Cambria Math')).not.toBe(derived);
   });
 
-  test('answers the style itself when the slot adds nothing', () => {
-    expect(eastAsiaSlotStyle(DEFAULT_RUN_STYLE)).toBe(DEFAULT_RUN_STYLE);
+  test('answers the style itself when the family already matches', () => {
+    const same = resolveRunStyle([{ localName: 'rFonts', attributes: { ascii: 'SimSun' } }]);
+    expect(withFontFamily(same, 'SimSun')).toBe(same);
+  });
+});
+
+describe('styleForFontSlot resolves the face a slotted piece measures and paints in', () => {
+  test('the eastAsia slot answers the eastAsia face, memoized', () => {
+    const style = resolveRunStyle([
+      { localName: 'rFonts', attributes: { ascii: 'Arial', eastAsia: 'SimSun' } },
+    ]);
+    const derived = styleForFontSlot(style, 'eastAsia');
+    expect(derived.fontFamily).toBe('SimSun');
+    expect(styleForFontSlot(style, 'eastAsia')).toBe(derived);
+  });
+
+  test('no slot, no eastAsia face, or a matching face answer the style itself', () => {
+    const style = resolveRunStyle([
+      { localName: 'rFonts', attributes: { ascii: 'Arial', eastAsia: 'SimSun' } },
+    ]);
+    expect(styleForFontSlot(style, undefined)).toBe(style);
+    expect(styleForFontSlot(DEFAULT_RUN_STYLE, 'eastAsia')).toBe(DEFAULT_RUN_STYLE);
     const same = resolveRunStyle([
       { localName: 'rFonts', attributes: { ascii: 'SimSun', eastAsia: 'SimSun' } },
     ]);
-    expect(eastAsiaSlotStyle(same)).toBe(same);
+    expect(styleForFontSlot(same, 'eastAsia')).toBe(same);
   });
 });
 

--- a/packages/core/src/layout/__tests__/script-itemization.test.ts
+++ b/packages/core/src/layout/__tests__/script-itemization.test.ts
@@ -4,7 +4,7 @@ import {
   itemizeScriptFontSlots,
   type BidiEmbeddingLevels,
 } from '../index.ts';
-import { eastAsiaSlotRanges } from '../script-itemization.ts';
+import { eastAsiaRunsOfSegments } from '../script-itemization.ts';
 
 const ltr = (text: string): BidiEmbeddingLevels => ({
   paragraphs: [{ from: 0, to: text.length, level: 0 }],
@@ -134,39 +134,77 @@ describe('deterministic script itemization', () => {
   });
 });
 
-describe('eastAsiaSlotRanges — the slot-only projection for piece splitting', () => {
+describe('eastAsiaRunsOfSegments — the slot projection for piece splitting', () => {
+  const one = (text: string) => eastAsiaRunsOfSegments([text]);
+
   test('mixed CJK and Latin text answers the merged eastAsia ranges in order', () => {
-    expect(eastAsiaSlotRanges('甲方shall履行')).toEqual([
-      { from: 0, to: 2 },
-      { from: 7, to: 9 },
+    expect(one('甲方shall履行')).toEqual([
+      { segment: 0, from: 0, to: 2 },
+      { segment: 0, from: 7, to: 9 },
     ]);
   });
 
-  test('Common characters inherit the surrounding strong classification', () => {
-    // The comma and space take the preceding CJK answer, so one range covers all four.
-    expect(eastAsiaSlotRanges('甲, 方')).toEqual([{ from: 0, to: 4 }]);
-    // Leading Common text takes the FOLLOWING strong item, same as itemization.
-    expect(eastAsiaSlotRanges('"甲"')).toEqual([{ from: 0, to: 3 }]);
+  test('non-ASCII Common characters inherit the surrounding strong classification', () => {
+    // The fullwidth comma (U+FF0C, Common) takes the preceding CJK answer.
+    expect(one('甲，方')).toEqual([{ segment: 0, from: 0, to: 3 }]);
+    // Leading non-ASCII Common text takes the FOLLOWING strong item, same as itemization.
+    expect(one('§甲')).toEqual([{ segment: 0, from: 0, to: 2 }]);
+  });
+
+  test('ASCII characters never resolve through the eastAsia slot (ECMA-376 w:ascii)', () => {
+    // Word measures the `, ` in `中文, Hello` in the Latin face; inheriting the eastAsia
+    // slot painted the same separator at two widths depending on which side it sat.
+    expect(one('中文, Hello')).toEqual([{ segment: 0, from: 0, to: 2 }]);
+    expect(one('Hello, 中文')).toEqual([{ segment: 0, from: 7, to: 9 }]);
+    // An ASCII comma BETWEEN ideographs still stays in the base slots.
+    expect(one('甲, 方')).toEqual([
+      { segment: 0, from: 0, to: 1 },
+      { segment: 0, from: 3, to: 4 },
+    ]);
   });
 
   test('Latin-only text answers no ranges', () => {
-    expect(eastAsiaSlotRanges('shall perform')).toEqual([]);
-    expect(eastAsiaSlotRanges('')).toEqual([]);
+    expect(one('shall perform')).toEqual([]);
+    expect(one('')).toEqual([]);
+    expect(eastAsiaRunsOfSegments([])).toEqual([]);
   });
 
-  test('an unsupported script answers [] rather than throwing through layout', () => {
-    // U+1C50 OL CHIKI is outside every supported range; the whole text stays in the
-    // base slot, which is the pre-slot behaviour.
-    expect(() => itemizeScriptFontSlots('᱐甲', 0, ltr('᱐甲'))).toThrow(UnsupportedScriptError);
-    expect(eastAsiaSlotRanges('᱐甲')).toEqual([]);
+  test('classification crosses segment boundaries — a weak character alone in its own run', () => {
+    // A fullwidth comma alone in its own `w:t` between two CJK runs is East Asian text;
+    // per-piece classification saw no strong neighbour and dropped it to the Latin face.
+    expect(eastAsiaRunsOfSegments(['甲', '，', '方'])).toEqual([
+      { segment: 0, from: 0, to: 1 },
+      { segment: 1, from: 0, to: 1 },
+      { segment: 2, from: 0, to: 1 },
+    ]);
+    // A pure-ASCII segment between them keeps its own text Latin and blocks nothing else.
+    expect(eastAsiaRunsOfSegments(['中文', ', ', 'Hello'])).toEqual([
+      { segment: 0, from: 0, to: 2 },
+    ]);
   });
 
-  test('agrees with full itemization on the slot boundary', () => {
+  test('an unsupported code point costs itself the face, not its whole piece', () => {
+    // U+0BA4 TAMIL LETTER TA is outside every supported range. Full itemization throws;
+    // slot resolution confines the fallback to that one character.
+    expect(() => itemizeScriptFontSlots('த甲', 0, ltr('த甲'))).toThrow(UnsupportedScriptError);
+    expect(one('甲த文')).toEqual([
+      { segment: 0, from: 0, to: 1 },
+      { segment: 0, from: 2, to: 3 },
+    ]);
+  });
+
+  test('surrogate-pair ideographs stay whole', () => {
+    // U+20000 (Ext B) is two UTF-16 units; the range must cover both.
+    expect(one('\u{20000}a')).toEqual([{ segment: 0, from: 0, to: 2 }]);
+  });
+
+  test('agrees with full itemization on strong slot boundaries', () => {
     const text = 'A甲B';
     const slots = itemizeScriptFontSlots(text, 0, ltr(text));
-    const ranges = eastAsiaSlotRanges(text);
-    expect(ranges).toEqual(
-      slots.filter((item) => item.slot === 'eastAsia').map(({ from, to }) => ({ from, to }))
+    expect(one(text)).toEqual(
+      slots
+        .filter((item) => item.slot === 'eastAsia')
+        .map(({ from, to }) => ({ segment: 0, from, to }))
     );
   });
 });

--- a/packages/core/src/layout/__tests__/script-itemization.test.ts
+++ b/packages/core/src/layout/__tests__/script-itemization.test.ts
@@ -4,6 +4,7 @@ import {
   itemizeScriptFontSlots,
   type BidiEmbeddingLevels,
 } from '../index.ts';
+import { eastAsiaSlotRanges } from '../script-itemization.ts';
 
 const ltr = (text: string): BidiEmbeddingLevels => ({
   paragraphs: [{ from: 0, to: text.length, level: 0 }],
@@ -130,5 +131,42 @@ describe('deterministic script itemization', () => {
       { text: 'עברית', script: 'Hebr', slot: 'cs' },
       { text: '。漢字', script: 'Hani', slot: 'eastAsia' },
     ]);
+  });
+});
+
+describe('eastAsiaSlotRanges — the slot-only projection for piece splitting', () => {
+  test('mixed CJK and Latin text answers the merged eastAsia ranges in order', () => {
+    expect(eastAsiaSlotRanges('甲方shall履行')).toEqual([
+      { from: 0, to: 2 },
+      { from: 7, to: 9 },
+    ]);
+  });
+
+  test('Common characters inherit the surrounding strong classification', () => {
+    // The comma and space take the preceding CJK answer, so one range covers all four.
+    expect(eastAsiaSlotRanges('甲, 方')).toEqual([{ from: 0, to: 4 }]);
+    // Leading Common text takes the FOLLOWING strong item, same as itemization.
+    expect(eastAsiaSlotRanges('"甲"')).toEqual([{ from: 0, to: 3 }]);
+  });
+
+  test('Latin-only text answers no ranges', () => {
+    expect(eastAsiaSlotRanges('shall perform')).toEqual([]);
+    expect(eastAsiaSlotRanges('')).toEqual([]);
+  });
+
+  test('an unsupported script answers [] rather than throwing through layout', () => {
+    // U+1C50 OL CHIKI is outside every supported range; the whole text stays in the
+    // base slot, which is the pre-slot behaviour.
+    expect(() => itemizeScriptFontSlots('᱐甲', 0, ltr('᱐甲'))).toThrow(UnsupportedScriptError);
+    expect(eastAsiaSlotRanges('᱐甲')).toEqual([]);
+  });
+
+  test('agrees with full itemization on the slot boundary', () => {
+    const text = 'A甲B';
+    const slots = itemizeScriptFontSlots(text, 0, ltr(text));
+    const ranges = eastAsiaSlotRanges(text);
+    expect(ranges).toEqual(
+      slots.filter((item) => item.slot === 'eastAsia').map(({ from, to }) => ({ from, to }))
+    );
   });
 });

--- a/packages/core/src/layout/__tests__/style-cascade.test.ts
+++ b/packages/core/src/layout/__tests__/style-cascade.test.ts
@@ -657,3 +657,70 @@ describe('layout applies Heading1 / Heading2 cascade', () => {
     });
   });
 });
+
+describe('the eastAsia font slot cascades from docDefaults to the painted spans', () => {
+  // The docDefaults case is the one that bit: Word's own templates author the body's CJK
+  // face as `w:eastAsiaTheme="minorEastAsia"` in `w:docDefaults/w:rPrDefault`, and no run
+  // in the document ever re-states it. Dropping it measured and painted every ideograph
+  // in the LATIN face.
+  const THEME_FONTS = {
+    major: 'Aharoni',
+    minor: 'Grandview',
+    majorEastAsia: null,
+    minorEastAsia: 'SimSun',
+  };
+  const THEMED_DEFAULTS =
+    `<w:docDefaults><w:rPrDefault><w:rPr>` +
+    `<w:rFonts w:asciiTheme="minorHAnsi" w:eastAsiaTheme="minorEastAsia"/><w:sz w:val="22"/>` +
+    `</w:rPr></w:rPrDefault><w:pPrDefault/></w:docDefaults>`;
+
+  test('docDefaults resolve both slots through the theme part', () => {
+    const table = buildStyleCascadeTable(loadStyles(THEMED_DEFAULTS), THEME_FONTS);
+    expect(resolveRunStyle(table.docDefaultsRun, table.themeFonts)).toMatchObject({
+      fontFamily: 'Grandview',
+      fontFamilyEastAsia: 'SimSun',
+    });
+  });
+
+  test('a Latin-only direct rFonts does not evict the inherited eastAsia face', () => {
+    const table = buildStyleCascadeTable(loadStyles(THEMED_DEFAULTS), THEME_FONTS);
+    const merged = cascadeRunProperties(
+      [],
+      [{ localName: 'rFonts', attributes: { ascii: 'Courier New' } }],
+      table
+    );
+    expect(resolveRunStyle([...table.docDefaultsRun, ...merged], table.themeFonts)).toMatchObject({
+      fontFamily: 'Courier New',
+      fontFamilyEastAsia: 'SimSun',
+    });
+  });
+
+  test('a mixed CJK+Latin run splits into slot-homogeneous spans, measured per face', () => {
+    const table = buildStyleCascadeTable(loadStyles(THEMED_DEFAULTS), THEME_FONTS);
+    const measured: { text: string; family: string | null }[] = [];
+    const fixed = createFixedMeasurer(6, 14);
+    const recording = {
+      measure: (text: string, style: Parameters<typeof fixed.measure>[1]) => {
+        measured.push({ text, family: style.fontFamily });
+        return fixed.measure(text, style);
+      },
+      lineMetrics: fixed.lineMetrics,
+    };
+    const part = loadDocument(`<w:p><w:r><w:t>甲方shall</w:t></w:r></w:p>`);
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: recording,
+      styleCascade: table,
+    });
+    const spans = linesOf(layout).flatMap((line) => line.spans);
+    expect(spans.map((span) => span.text)).toEqual(['甲方', 'shall']);
+    expect(spans[0]!.style.fontFamily).toBe('SimSun');
+    expect(spans[1]!.style.fontFamily).toBe('Grandview');
+    // Model offsets stay contiguous across the split, so the caret walks through it.
+    expect(spans[0]!.range.end).toBe(spans[1]!.range.start);
+    // The measurer saw the CJK text only under the eastAsia face, never the Latin one.
+    const families = new Set(
+      measured.filter((call) => call.text.includes('甲')).map((call) => call.family)
+    );
+    expect(families).toEqual(new Set(['SimSun']));
+  });
+});

--- a/packages/core/src/layout/__tests__/style-cascade.test.ts
+++ b/packages/core/src/layout/__tests__/style-cascade.test.ts
@@ -713,8 +713,14 @@ describe('the eastAsia font slot cascades from docDefaults to the painted spans'
     });
     const spans = linesOf(layout).flatMap((line) => line.spans);
     expect(spans.map((span) => span.text)).toEqual(['甲方', 'shall']);
-    expect(spans[0]!.style.fontFamily).toBe('SimSun');
-    expect(spans[1]!.style.fontFamily).toBe('Grandview');
+    // The span keeps the run's REAL resolution — both faces — and carries the slot
+    // beside it; the face swap happens at the measurer/paint boundary. Formatting
+    // readback and the format painter therefore see one Latin answer for both spans.
+    expect(spans[0]!.fontSlot).toBe('eastAsia');
+    expect(spans[1]!.fontSlot).toBeUndefined();
+    expect(spans[0]!.style).toBe(spans[1]!.style);
+    expect(spans[0]!.style.fontFamily).toBe('Grandview');
+    expect(spans[0]!.style.fontFamilyEastAsia).toBe('SimSun');
     // Model offsets stay contiguous across the split, so the caret walks through it.
     expect(spans[0]!.range.end).toBe(spans[1]!.range.start);
     // The measurer saw the CJK text only under the eastAsia face, never the Latin one.

--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -30,6 +30,7 @@ import {
   type RevisionDisplayMode,
 } from './revision-projection.ts';
 import { measureDisplayText } from './run-style.ts';
+import { styleForFontSlot } from './script-itemization.ts';
 import {
   drawingGeometryFromProjection,
   clipGeometryToRegion,
@@ -1117,17 +1118,24 @@ export function anchorCharacterXOnLine(
       readonly box: LayoutBox;
       readonly text?: string;
       readonly style?: import('./run-style.ts').ResolvedRunStyle;
+      readonly fontSlot?: import('./script-itemization.ts').FontSlot;
     }[];
   },
   modelOffset: number,
   measurer?: import('./semantic-records.ts').TextMeasurer
 ): number {
+  // As drawn: the span's font slot decides the face this prefix measures in.
+  const measured = (
+    text: string,
+    style: import('./run-style.ts').ResolvedRunStyle,
+    slot: import('./script-itemization.ts').FontSlot | undefined
+  ): number => measureDisplayText(text, styleForFontSlot(style, slot), measurer!);
   for (const span of line.spans) {
     if (modelOffset < span.range.start) break;
     if (modelOffset < span.range.end) {
       if (measurer && span.text !== undefined && span.style !== undefined) {
         const within = modelOffset - span.range.start;
-        return span.box.x + measureDisplayText(span.text.slice(0, within), span.style, measurer);
+        return span.box.x + measured(span.text.slice(0, within), span.style, span.fontSlot);
       }
       const spanLength = span.range.end - span.range.start;
       if (spanLength <= 0) return span.box.x;
@@ -1136,7 +1144,7 @@ export function anchorCharacterXOnLine(
     }
     if (modelOffset === span.range.end) {
       if (measurer && span.text !== undefined && span.style !== undefined) {
-        return span.box.x + measureDisplayText(span.text, span.style, measurer);
+        return span.box.x + measured(span.text, span.style, span.fontSlot);
       }
       return span.box.x + span.box.width;
     }
@@ -1147,7 +1155,7 @@ export function anchorCharacterXOnLine(
   }
   if (trailing) {
     if (measurer && trailing.text !== undefined && trailing.style !== undefined) {
-      return trailing.box.x + measureDisplayText(trailing.text, trailing.style, measurer);
+      return trailing.box.x + measured(trailing.text, trailing.style, trailing.fontSlot);
     }
     return trailing.box.x + trailing.box.width;
   }

--- a/packages/core/src/layout/equation-layout.ts
+++ b/packages/core/src/layout/equation-layout.ts
@@ -1,7 +1,7 @@
 // Deterministic DOM-free geometry for the bounded equation expression tree.
 
 import type { EquationExpression, OmmlEquationProjection } from '@docx-editor.dev/core/store';
-import { measureDisplayText, type ResolvedRunStyle } from './run-style.ts';
+import { measureDisplayText, withFontFamily, type ResolvedRunStyle } from './run-style.ts';
 import type { LayoutBox, TextMeasurer } from './semantic-records.ts';
 
 const SCRIPT_SCALE = 0.7;
@@ -10,9 +10,9 @@ const EQUATION_FONT_FAMILY = 'Cambria Math';
 
 /** Use Word's math face when installed while retaining the measurer's safe fallback stack. */
 export function equationRunStyle(style: ResolvedRunStyle): ResolvedRunStyle {
-  return style.fontFamily === EQUATION_FONT_FAMILY
-    ? style
-    : Object.freeze({ ...style, fontFamily: EQUATION_FONT_FAMILY });
+  // The shared memoized derivation: measurers amortize font resolution over style object
+  // identity, and a fresh object per call would defeat their caches.
+  return withFontFamily(style, EQUATION_FONT_FAMILY);
 }
 
 interface EquationGeometryBase {

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -12,6 +12,7 @@ import { WML_NAMESPACE_URI, type OoxmlNode, type OoxmlProperty } from '@docx-edi
 import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
+import { eastAsiaRunsOfSegments, type FontSlot } from './script-itemization.ts';
 import type { ButtonFieldSpec } from './field-button.ts';
 import type { DocPropertyField } from './field-doc-property.ts';
 import type { FormFieldKind } from './field-form.ts';
@@ -138,6 +139,13 @@ export interface FieldAwarePiece {
   readonly revisions?: readonly RevisionAttribution[];
   /** Present when this piece is a field's displayed result; literal or projected. */
   readonly fieldAtom?: FieldAtomMarker;
+  /**
+   * The `w:rFonts` slot this piece's text resolves its face through; absent means the base
+   * (ascii/hAnsi) slots. Set by {@link applyEastAsiaFontSlots}, and carried through to the
+   * style spans, so every consumer that measures or paints the text resolves the face with
+   * `styleForFontSlot` while the piece's `style` stays the run's real resolution.
+   */
+  readonly fontSlot?: FontSlot;
 }
 
 /** A half-open model-offset range, in the paragraph's own UTF-16 offset space. */
@@ -372,4 +380,126 @@ export interface PendingFieldProjection {
    * the one run in the link painting with no href.
    */
   resultLink?: SpanLinkRecord;
+}
+
+/** A slice of `piece` covering `[from, to)` of its text, in the given font slot. */
+function fontSlotSlice(
+  piece: FieldAwarePiece,
+  from: number,
+  to: number,
+  fontSlot: FontSlot | undefined
+): FieldAwarePiece {
+  return {
+    ...piece,
+    text: piece.text.slice(from, to),
+    start: piece.start + from,
+    end: piece.start + to,
+    ...(fontSlot ? { fontSlot } : {}),
+  };
+}
+
+/**
+ * Mark the text that resolves through the `eastAsia` font slot, after a paragraph's pieces
+ * are all assembled.
+ *
+ * A post-pass over the WHOLE paragraph, not a per-piece one, because Common characters
+ * inherit their slot from strong neighbours and `w:t`/run boundaries are not script
+ * boundaries: a fullwidth comma alone in its own run between two CJK runs is East Asian
+ * text, and only a pass that sees both neighbours can say so. Classification is
+ * `eastAsiaRunsOfSegments`; this function owns which pieces participate and how the answer
+ * lands on them:
+ *
+ * - Ordinary literal text (model range 1:1 with its text) is SPLIT into slot-homogeneous
+ *   pieces. Piece boundaries are not break opportunities (`opensWord` in
+ *   `paragraph-flow.ts` carries words across them), so the split changes which face a
+ *   character resolves to and nothing else.
+ * - Layout-owned text — projected results, field atoms, note marks, `measureText`
+ *   reservations — stays WHOLE: its spans publish the piece's model range, and slicing
+ *   that range would corrupt offsets. Such a piece takes the slot only when ALL of its
+ *   text resolves eastAsia; a mixed one keeps the base face, which is what it painted
+ *   before slots existed.
+ * - Control pieces (tabs, breaks, drawings, equations) neither classify nor split.
+ *
+ * The style objects are untouched: a piece carries the run's real resolution and the slot
+ * beside it, and the face is derived at the measurer/paint boundary via `styleForFontSlot`.
+ */
+export function applyEastAsiaFontSlots(pieces: FieldAwarePiece[]): FieldAwarePiece[] {
+  // Nothing to resolve unless some run authors a DISTINCT East Asian face. This is the
+  // cheap common-case exit for Latin-defaulted documents; documents whose docDefaults
+  // author one for every run instead lean on the pure-ASCII prescan inside
+  // `eastAsiaRunsOfSegments`, which costs two compares per character.
+  if (
+    !pieces.some(
+      ({ style }) =>
+        style.fontFamilyEastAsia !== null && style.fontFamilyEastAsia !== style.fontFamily
+    )
+  ) {
+    return pieces;
+  }
+
+  /** Indices of the pieces whose text joins the classification, in paragraph order. */
+  const streamed: number[] = [];
+  const segments: string[] = [];
+  for (let index = 0; index < pieces.length; index += 1) {
+    const piece = pieces[index]!;
+    if (piece.positionalTab || piece.breakKind || piece.inlineDrawing) continue;
+    if (piece.anchoredAtom || piece.equation) continue;
+    if (piece.text.length === 0) continue;
+    streamed.push(index);
+    segments.push(piece.text);
+  }
+  const ranges = eastAsiaRunsOfSegments(segments);
+  if (ranges.length === 0) return pieces;
+
+  const rangesBySegment = new Map<number, { from: number; to: number }[]>();
+  for (const range of ranges) {
+    const list = rangesBySegment.get(range.segment);
+    if (list) list.push({ from: range.from, to: range.to });
+    else rangesBySegment.set(range.segment, [{ from: range.from, to: range.to }]);
+  }
+
+  const out: FieldAwarePiece[] = [];
+  let segment = 0;
+  for (let index = 0; index < pieces.length; index += 1) {
+    const piece = pieces[index]!;
+    if (streamed[segment] !== index) {
+      out.push(piece);
+      continue;
+    }
+    const pieceRanges = rangesBySegment.get(segment);
+    segment += 1;
+    const { style } = piece;
+    if (
+      !pieceRanges ||
+      style.fontFamilyEastAsia === null ||
+      style.fontFamilyEastAsia === style.fontFamily
+    ) {
+      out.push(piece);
+      continue;
+    }
+    const literal =
+      !piece.projected &&
+      !piece.fieldAtom &&
+      !piece.noteNav &&
+      piece.measureText === undefined &&
+      piece.end - piece.start === piece.text.length;
+    if (!literal) {
+      const whole =
+        pieceRanges.length === 1 &&
+        pieceRanges[0]!.from === 0 &&
+        pieceRanges[0]!.to === piece.text.length;
+      out.push(whole ? { ...piece, fontSlot: 'eastAsia' } : piece);
+      continue;
+    }
+    let cursor = 0;
+    for (const range of pieceRanges) {
+      if (range.from > cursor) out.push(fontSlotSlice(piece, cursor, range.from, undefined));
+      out.push(fontSlotSlice(piece, range.from, range.to, 'eastAsia'));
+      cursor = range.to;
+    }
+    if (cursor < piece.text.length) {
+      out.push(fontSlotSlice(piece, cursor, piece.text.length, undefined));
+    }
+  }
+  return out;
 }

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -79,6 +79,7 @@ import { synthesizeAtomicField } from './field-synthesis.ts';
 import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
 import {
   appendModelRange,
+  applyEastAsiaFontSlots,
   positionalTabOf,
   type FieldAtomMarker,
   type FieldAwarePiece,
@@ -114,7 +115,6 @@ import {
   type RevisionDisplayMode,
 } from './revision-projection.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
-import { splitByEastAsiaSlot } from './script-itemization.ts';
 import { equationRunStyle } from './equation-layout.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
 import {
@@ -279,37 +279,17 @@ export function piecesOfParagraph(
       return;
     }
     if (text.length === 0) return;
-    const emit = (
-      sliceText: string,
-      sliceStyle: ResolvedRunStyle,
-      sliceStart: number,
-      sliceEnd: number
-    ): void => {
-      pieces.push({
-        text: sliceText,
-        props,
-        style: sliceStyle,
-        start: sliceStart,
-        end: sliceEnd,
-        ...(extras?.positionalTab ? { positionalTab: extras.positionalTab } : {}),
-        ...(extras?.breakKind ? { breakKind: extras.breakKind } : {}),
-        ...link,
-        ...attribution,
-      });
-    };
-    // A run with an eastAsia face that differs from its Latin face is split into
-    // slot-homogeneous pieces, so measurement, paint and hit-testing all see one face per
-    // piece without any of them re-itemizing. Piece boundaries are NOT break
-    // opportunities (`opensWord` in `paragraph-flow.ts` carries words across them), so the
-    // split changes which face a character resolves to and nothing else. Tabs and hard
-    // breaks are single control characters and skip the scan.
-    const slices =
-      extras?.positionalTab || extras?.breakKind ? null : splitByEastAsiaSlot(text, style, start);
-    if (slices) {
-      for (const piece of slices) emit(piece.text, piece.style, piece.start, piece.end);
-    } else {
-      emit(text, style, start, end);
-    }
+    pieces.push({
+      text,
+      props,
+      style,
+      start,
+      end,
+      ...(extras?.positionalTab ? { positionalTab: extras.positionalTab } : {}),
+      ...(extras?.breakKind ? { breakKind: extras.breakKind } : {}),
+      ...link,
+      ...attribution,
+    });
   };
 
   const commitAtomicField = (): void => {
@@ -880,7 +860,7 @@ export function piecesOfParagraph(
    * their nesting. Content-control nesting shares {@link MAX_CONTENT_CONTROL_NESTING} with
    * block flattening; field-scan depth stays separate.
    */
-  if (!consumeScanNode(budget)) return pieces;
+  if (!consumeScanNode(budget)) return applyEastAsiaFontSlots(pieces);
   const paragraphScope = emptyNamespaceScope();
 
   /**
@@ -998,5 +978,7 @@ export function piecesOfParagraph(
   // Malformed field missing end: demote — surface cached/buffered text, no live projection.
   abandonPending();
 
-  return pieces;
+  // Slot resolution is a paragraph-wide question (Common characters inherit across run
+  // boundaries), so it runs after the walk, over the assembled pieces.
+  return applyEastAsiaFontSlots(pieces);
 }

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -114,6 +114,7 @@ import {
   type RevisionDisplayMode,
 } from './revision-projection.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
+import { splitByEastAsiaSlot } from './script-itemization.ts';
 import { equationRunStyle } from './equation-layout.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
 import {
@@ -278,17 +279,37 @@ export function piecesOfParagraph(
       return;
     }
     if (text.length === 0) return;
-    pieces.push({
-      text,
-      props,
-      style,
-      start,
-      end,
-      ...(extras?.positionalTab ? { positionalTab: extras.positionalTab } : {}),
-      ...(extras?.breakKind ? { breakKind: extras.breakKind } : {}),
-      ...link,
-      ...attribution,
-    });
+    const emit = (
+      sliceText: string,
+      sliceStyle: ResolvedRunStyle,
+      sliceStart: number,
+      sliceEnd: number
+    ): void => {
+      pieces.push({
+        text: sliceText,
+        props,
+        style: sliceStyle,
+        start: sliceStart,
+        end: sliceEnd,
+        ...(extras?.positionalTab ? { positionalTab: extras.positionalTab } : {}),
+        ...(extras?.breakKind ? { breakKind: extras.breakKind } : {}),
+        ...link,
+        ...attribution,
+      });
+    };
+    // A run with an eastAsia face that differs from its Latin face is split into
+    // slot-homogeneous pieces, so measurement, paint and hit-testing all see one face per
+    // piece without any of them re-itemizing. Piece boundaries are NOT break
+    // opportunities (`opensWord` in `paragraph-flow.ts` carries words across them), so the
+    // split changes which face a character resolves to and nothing else. Tabs and hard
+    // breaks are single control characters and skip the scan.
+    const slices =
+      extras?.positionalTab || extras?.breakKind ? null : splitByEastAsiaSlot(text, style, start);
+    if (slices) {
+      for (const piece of slices) emit(piece.text, piece.style, piece.start, piece.end);
+    } else {
+      emit(text, style, start, end);
+    }
   };
 
   const commitAtomicField = (): void => {

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -84,6 +84,7 @@ export { setHarfBuzzWasmUrl } from './harfbuzz-wasm-binary.ts';
 export {
   UnsupportedScriptError,
   itemizeScriptFontSlots,
+  styleForFontSlot,
   type FontSlot,
   type ScriptItem,
 } from './script-itemization.ts';

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -53,6 +53,7 @@ import {
   type ResolvedRunStyle,
   type ThemeFonts,
 } from './run-style.ts';
+import { styleForFontSlot } from './script-itemization.ts';
 import type { LayoutBox, StyleSpanRecord, TextMeasurer } from './semantic-records.ts';
 import {
   buildInlineDrawingRecord,
@@ -231,6 +232,13 @@ interface Piece {
   readonly inlineDrawing?: import('./drawing-layout.ts').InlineDrawingLayoutInput;
   /** Bounded OMML equation occupying one UTF-16 model unit. */
   readonly equation?: FieldAwarePiece['equation'];
+  /**
+   * The `w:rFonts` slot this piece's text resolves its face through, from
+   * `applyEastAsiaFontSlots`. `style` stays the run's real resolution; every measurement
+   * below resolves the face with `styleForFontSlot`, and the slot is republished on the
+   * span so paint and hit-testing resolve the same one.
+   */
+  readonly fontSlot?: FieldAwarePiece['fontSlot'];
 }
 
 export function propertiesOf(container: OoxmlNode | undefined): OoxmlProperty[] {
@@ -319,6 +327,7 @@ function measureFollowingTabSegment(
   let sawDecimal = false;
   for (let index = pieceIndex; index < pieces.length; index += 1) {
     const piece = pieces[index]!;
+    const style = styleForFontSlot(piece.style, piece.fontSlot);
     const from = index === pieceIndex ? offsetInPiece : 0;
     for (let cursor = from; cursor < piece.text.length; ) {
       const ch = piece.text[cursor]!;
@@ -329,7 +338,7 @@ function measureFollowingTabSegment(
       // contract (UTF-16), matching how source offsets are counted elsewhere.
       const next = cursor + 1;
       const glyph = piece.text.slice(cursor, next);
-      const advance = measurer.measure(displayText(glyph, piece.style), piece.style);
+      const advance = measurer.measure(displayText(glyph, style), style);
       if (!sawDecimal && ch === '.') {
         sawDecimal = true;
         // Decimal point itself sits ON the stop — offset is the advance before it.
@@ -506,7 +515,10 @@ export function alignSpans(
   // JUSTIFIED non-last line, where an over-reported `trailing` inflates `slack` and
   // over-stretches the line.
   const trailing =
-    visible === last.text ? 0 : last.box.width - measureDisplayText(visible, last.style, measurer);
+    visible === last.text
+      ? 0
+      : last.box.width -
+        measureDisplayText(visible, styleForFontSlot(last.style, last.fontSlot), measurer);
   const used = lineUsedWidth ?? last.box.x - indentLeft + last.box.width - trailing;
   const slack = available - used;
   if (slack <= 0) return spans;
@@ -732,7 +744,7 @@ export function breakParagraph(
       for (const boundary of wordBoundaries(piece.text)) {
         const candidate = piece.text.slice(consumed, boundary);
         if (candidate.length === 0) continue;
-        const style = piece.style;
+        const style = styleForFontSlot(piece.style, piece.fontSlot);
         const width = measurer.measure(candidate, style);
         const modelStart = piece.start + consumed;
         if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(modelStart);
@@ -1073,7 +1085,10 @@ export function breakParagraph(
   const textBandHeight = (fallback: number): number => {
     let height = 0;
     for (const span of line.spans) {
-      height = Math.max(height, measurer.lineMetrics(span.style).height);
+      height = Math.max(
+        height,
+        measurer.lineMetrics(styleForFontSlot(span.style, span.fontSlot)).height
+      );
     }
     return height > 0 ? height : fallback;
   };
@@ -1352,7 +1367,10 @@ export function breakParagraph(
     ) {
       advancePastAnchorExclusionForPlacement(piece.start);
     }
-    const metrics = measurer.lineMetrics(piece.style);
+    // The face this piece MEASURES in. Spans keep `piece.style` — the run's real
+    // resolution — plus the slot, and re-resolve through the same helper.
+    const faceStyle = styleForFontSlot(piece.style, piece.fontSlot);
+    const metrics = measurer.lineMetrics(faceStyle);
     let consumed = 0;
     for (const boundary of wordBoundaries(piece.text)) {
       const candidate = piece.text.slice(consumed, boundary);
@@ -1456,7 +1474,7 @@ export function breakParagraph(
       // would size the line for characters the reader never sees. Note marks may reserve
       // a wider measureText (eachPage) while painting the real digits.
       const measureSource = piece.measureText ?? candidate;
-      const width = measurer.measure(displayText(measureSource, piece.style), piece.style);
+      const width = measurer.measure(displayText(measureSource, faceStyle), faceStyle);
       // A candidate may open a line only at a real break opportunity. Within a piece,
       // `wordBoundaries` cuts after spaces, dashes and tabs, so every candidate but the
       // first is one. The FIRST candidate of a piece continues whatever the previous piece
@@ -1497,13 +1515,13 @@ export function breakParagraph(
           line.height = 0;
           line.baseline = 0;
           for (const span of line.spans) {
-            const spanMetrics = measurer.lineMetrics(span.style);
+            const spanMetrics = measurer.lineMetrics(styleForFontSlot(span.style, span.fontSlot));
             line.height = Math.max(line.height, spanMetrics.height);
             line.baseline = Math.max(line.baseline, spanMetrics.baseline);
           }
           closeLine();
           for (const span of carried) {
-            const spanMetrics = measurer.lineMetrics(span.style);
+            const spanMetrics = measurer.lineMetrics(styleForFontSlot(span.style, span.fontSlot));
             line.spans.push({
               ...span,
               box: { ...span.box, x: lineOrigin() + line.width },
@@ -1545,8 +1563,8 @@ export function breakParagraph(
           while (low <= high) {
             const mid = (low + high) >> 1;
             const midWidth = measurer.measure(
-              displayText(remaining.slice(0, mid), piece.style),
-              piece.style
+              displayText(remaining.slice(0, mid), faceStyle),
+              faceStyle
             );
             if (midWidth <= lineAvailable()) {
               fitLength = mid;
@@ -1556,7 +1574,7 @@ export function breakParagraph(
             }
           }
           const prefix = remaining.slice(0, fitLength);
-          const prefixWidth = measurer.measure(displayText(prefix, piece.style), piece.style);
+          const prefixWidth = measurer.measure(displayText(prefix, faceStyle), faceStyle);
           line.spans.push({
             range: { paragraphId, start: remainingStart, end: remainingStart + fitLength },
             text: prefix,
@@ -1565,6 +1583,7 @@ export function breakParagraph(
             box: { x: lineOrigin() + line.width, y: 0, width: prefixWidth, height: metrics.height },
             ...(piece.link ? { link: piece.link } : {}),
             ...(piece.noteNav ? { noteNav: piece.noteNav } : {}),
+            ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
             ...revisionsOf(piece),
           });
           line.width += prefixWidth;
@@ -1574,7 +1593,7 @@ export function breakParagraph(
           closeLine();
           remaining = remaining.slice(fitLength);
           remainingStart += fitLength;
-          remainingWidth = measurer.measure(displayText(remaining, piece.style), piece.style);
+          remainingWidth = measurer.measure(displayText(remaining, faceStyle), faceStyle);
         }
       }
       line.spans.push({
@@ -1588,6 +1607,7 @@ export function breakParagraph(
         ...(piece.link ? { link: piece.link } : {}),
         ...(layoutOwned && !piece.positionalTab ? { projected: true as const } : {}),
         ...(piece.noteNav ? { noteNav: piece.noteNav } : {}),
+        ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
         ...revisionsOf(piece),
       });
       line.width += remainingWidth;

--- a/packages/core/src/layout/run-style.ts
+++ b/packages/core/src/layout/run-style.ts
@@ -35,6 +35,16 @@ export interface ResolvedUnderline {
  */
 export interface ResolvedRunStyle {
   readonly fontFamily: string | null;
+  /**
+   * The `eastAsia` slot's typeface (`w:rFonts w:eastAsia`/`w:eastAsiaTheme`), or null when
+   * no level authors one.
+   *
+   * OOXML picks a run's face per SCRIPT: `fontFamily` covers the ascii/hAnsi slots, and
+   * ideographic/kana/hangul text resolves through this one instead. Kept beside — not
+   * folded into — `fontFamily`, because a mixed run needs both at once and the split into
+   * slot-homogeneous pieces happens downstream (`piecesOfParagraph`).
+   */
+  readonly fontFamilyEastAsia: string | null;
   /** Points. `w:sz` is half-points, so 22 becomes 11. */
   readonly fontSizePt: number;
   /** RRGGBB, or null for the inherited/automatic colour. */
@@ -81,6 +91,7 @@ export interface ResolvedRunStyle {
 /** The style a run inherits when it authors nothing. */
 export const DEFAULT_RUN_STYLE: ResolvedRunStyle = Object.freeze({
   fontFamily: null,
+  fontFamilyEastAsia: null,
   // OOXML leaves the terminal fallback application-defined when no level in the style
   // hierarchy authors `w:sz`. Microsoft Word uses 10pt; 11pt comes from modern Normal
   // templates explicitly authoring `w:sz="22"`, not from the absence of a size.
@@ -117,28 +128,46 @@ function hexColor(raw: string | undefined): string | null {
 }
 
 /**
- * The theme part's two Latin typefaces, for resolving `w:rFonts` theme attributes.
+ * The theme part's typefaces, for resolving `w:rFonts` theme attributes.
  *
  * Structurally identical to the binding lane's `DocumentThemeFonts` and assignable from it.
- * Declared here so this lane reads two validated strings rather than the theme tree.
+ * Declared here so this lane reads validated strings rather than the theme tree.
  */
 export interface ThemeFonts {
   /** `a:majorFont` latin typeface — headings. */
   readonly major: string | null;
   /** `a:minorFont` latin typeface — body text. */
   readonly minor: string | null;
+  /** `a:majorFont` east asian typeface (`a:ea`) — headings. Optional for back-compat. */
+  readonly majorEastAsia?: string | null;
+  /** `a:minorFont` east asian typeface (`a:ea`) — body text. Optional for back-compat. */
+  readonly minorEastAsia?: string | null;
 }
 
+/** A document with no theme part: every theme reference falls back to its explicit name. */
+export const NO_THEME_FONTS: ThemeFonts = {
+  major: null,
+  minor: null,
+  majorEastAsia: null,
+  minorEastAsia: null,
+};
+
 /**
- * A `w:rFonts` theme attribute resolved to a typeface.
+ * A LATIN `w:rFonts` theme attribute resolved to a typeface.
  *
- * Only the LATIN slots resolve: `minorEastAsia`/`minorBidi` (and major) name the `a:ea`/
- * `a:cs` faces this lane does not read, and an honest null — which falls back to the
- * explicit attribute beside it — beats the wrong font.
+ * `minorBidi`/`majorBidi` name the `a:cs` face this lane does not read yet, and an honest
+ * null — which falls back to the explicit attribute beside it — beats the wrong font.
  */
 function themeFamilyOf(value: string | undefined, themeFonts: ThemeFonts): string | null {
   if (value === 'minorAscii' || value === 'minorHAnsi') return themeFonts.minor;
   if (value === 'majorAscii' || value === 'majorHAnsi') return themeFonts.major;
+  return null;
+}
+
+/** The `w:eastAsiaTheme` counterpart of {@link themeFamilyOf}, over the `a:ea` typefaces. */
+function themeEastAsiaFamilyOf(value: string | undefined, themeFonts: ThemeFonts): string | null {
+  if (value === 'minorEastAsia') return themeFonts.minorEastAsia ?? null;
+  if (value === 'majorEastAsia') return themeFonts.majorEastAsia ?? null;
   return null;
 }
 
@@ -177,6 +206,17 @@ export function resolveRunStyle(
           : null;
         const family = themed ?? attributes?.ascii ?? attributes?.hAnsi;
         if (family && family.length <= 128) style.fontFamily = family;
+        // The eastAsia slot resolves independently, on the same theme-over-explicit rule.
+        // An rFonts that authors only Latin faces leaves an inherited eastAsia face alone,
+        // which is how the docDefaults' `w:eastAsiaTheme` survives a style chain that only
+        // ever re-states `w:ascii`.
+        const themedEastAsia = themeFonts
+          ? themeEastAsiaFamilyOf(attributes?.eastAsiaTheme, themeFonts)
+          : null;
+        const familyEastAsia = themedEastAsia ?? attributes?.eastAsia;
+        if (familyEastAsia && familyEastAsia.length <= 128) {
+          style.fontFamilyEastAsia = familyEastAsia;
+        }
         break;
       }
       case 'sz': {
@@ -269,6 +309,28 @@ export function resolveRunStyle(
   return style;
 }
 
+const eastAsiaSlotStyles = new WeakMap<ResolvedRunStyle, ResolvedRunStyle>();
+
+/**
+ * The style an eastAsia-slot piece measures and paints in: the same resolution with the
+ * eastAsia typeface as its effective family.
+ *
+ * Memoized PER STYLE OBJECT, because the shaped measurer amortizes font resolution over
+ * style object identity — a fresh derived object per piece would re-resolve the face on
+ * every measurement probe.
+ */
+export function eastAsiaSlotStyle(style: ResolvedRunStyle): ResolvedRunStyle {
+  if (style.fontFamilyEastAsia === null || style.fontFamilyEastAsia === style.fontFamily) {
+    return style;
+  }
+  let derived = eastAsiaSlotStyles.get(style);
+  if (!derived) {
+    derived = Object.freeze({ ...style, fontFamily: style.fontFamilyEastAsia });
+    eastAsiaSlotStyles.set(style, derived);
+  }
+  return derived;
+}
+
 /** The text as it is DRAWN, after case transforms. Measurement must use this, not the source. */
 export function displayText(text: string, style: ResolvedRunStyle): string {
   if (style.caps) return text.toUpperCase();
@@ -294,6 +356,7 @@ export function measureDisplayText(
 export function runStylesEqual(a: ResolvedRunStyle, b: ResolvedRunStyle): boolean {
   return (
     a.fontFamily === b.fontFamily &&
+    a.fontFamilyEastAsia === b.fontFamilyEastAsia &&
     a.fontSizePt === b.fontSizePt &&
     a.color === b.color &&
     a.bold === b.bold &&

--- a/packages/core/src/layout/run-style.ts
+++ b/packages/core/src/layout/run-style.ts
@@ -11,6 +11,7 @@
 // which is what the D8 boundary covers.
 
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+import { themeFontFamilyOf } from '../store/package/theme-font-scheme.ts';
 import { resolveOoxmlShadingFill } from './ooxml-shading.ts';
 // One reading of `CT_OnOff` for the whole lane. The style cascade combines toggle levels with
 // it and this resolver reads the combined result with it, so the two cannot drift apart.
@@ -153,25 +154,6 @@ export const NO_THEME_FONTS: ThemeFonts = {
 };
 
 /**
- * A LATIN `w:rFonts` theme attribute resolved to a typeface.
- *
- * `minorBidi`/`majorBidi` name the `a:cs` face this lane does not read yet, and an honest
- * null — which falls back to the explicit attribute beside it — beats the wrong font.
- */
-function themeFamilyOf(value: string | undefined, themeFonts: ThemeFonts): string | null {
-  if (value === 'minorAscii' || value === 'minorHAnsi') return themeFonts.minor;
-  if (value === 'majorAscii' || value === 'majorHAnsi') return themeFonts.major;
-  return null;
-}
-
-/** The `w:eastAsiaTheme` counterpart of {@link themeFamilyOf}, over the `a:ea` typefaces. */
-function themeEastAsiaFamilyOf(value: string | undefined, themeFonts: ThemeFonts): string | null {
-  if (value === 'minorEastAsia') return themeFonts.minorEastAsia ?? null;
-  if (value === 'majorEastAsia') return themeFonts.majorEastAsia ?? null;
-  return null;
-}
-
-/**
  * Resolve one run's direct formatting.
  *
  * Unrecognised values are DROPPED rather than guessed: a `w:sz` of `"large"` leaves the
@@ -201,8 +183,8 @@ export function resolveRunStyle(
         // nothing, because a stale face still beats no face at all.
         const attributes = property.attributes;
         const themed = themeFonts
-          ? (themeFamilyOf(attributes?.asciiTheme, themeFonts) ??
-            themeFamilyOf(attributes?.hAnsiTheme, themeFonts))
+          ? (themeFontFamilyOf(attributes?.asciiTheme, themeFonts) ??
+            themeFontFamilyOf(attributes?.hAnsiTheme, themeFonts))
           : null;
         const family = themed ?? attributes?.ascii ?? attributes?.hAnsi;
         if (family && family.length <= 128) style.fontFamily = family;
@@ -211,7 +193,7 @@ export function resolveRunStyle(
         // which is how the docDefaults' `w:eastAsiaTheme` survives a style chain that only
         // ever re-states `w:ascii`.
         const themedEastAsia = themeFonts
-          ? themeEastAsiaFamilyOf(attributes?.eastAsiaTheme, themeFonts)
+          ? themeFontFamilyOf(attributes?.eastAsiaTheme, themeFonts)
           : null;
         const familyEastAsia = themedEastAsia ?? attributes?.eastAsia;
         if (familyEastAsia && familyEastAsia.length <= 128) {
@@ -309,24 +291,28 @@ export function resolveRunStyle(
   return style;
 }
 
-const eastAsiaSlotStyles = new WeakMap<ResolvedRunStyle, ResolvedRunStyle>();
+const derivedFamilyStyles = new WeakMap<ResolvedRunStyle, Map<string, ResolvedRunStyle>>();
 
 /**
- * The style an eastAsia-slot piece measures and paints in: the same resolution with the
- * eastAsia typeface as its effective family.
+ * `style` with `family` as its effective `fontFamily`, memoized per (style, family).
  *
- * Memoized PER STYLE OBJECT, because the shaped measurer amortizes font resolution over
- * style object identity — a fresh derived object per piece would re-resolve the face on
- * every measurement probe.
+ * The one sanctioned way to derive a style that differs only in face: measurers amortize
+ * font resolution and width caches over STYLE OBJECT IDENTITY, so a fresh derived object
+ * per call would re-resolve the face on every measurement probe. Serves the font-slot
+ * resolution at the measurer boundary ({@link styleForFontSlot} in `script-itemization.ts`)
+ * and the equation face in `equation-layout.ts` — one memo, not one per caller.
  */
-export function eastAsiaSlotStyle(style: ResolvedRunStyle): ResolvedRunStyle {
-  if (style.fontFamilyEastAsia === null || style.fontFamilyEastAsia === style.fontFamily) {
-    return style;
+export function withFontFamily(style: ResolvedRunStyle, family: string): ResolvedRunStyle {
+  if (style.fontFamily === family) return style;
+  let byFamily = derivedFamilyStyles.get(style);
+  if (!byFamily) {
+    byFamily = new Map();
+    derivedFamilyStyles.set(style, byFamily);
   }
-  let derived = eastAsiaSlotStyles.get(style);
+  let derived = byFamily.get(family);
   if (!derived) {
-    derived = Object.freeze({ ...style, fontFamily: style.fontFamilyEastAsia });
-    eastAsiaSlotStyles.set(style, derived);
+    derived = Object.freeze({ ...style, fontFamily: family });
+    byFamily.set(family, derived);
   }
   return derived;
 }

--- a/packages/core/src/layout/script-itemization.ts
+++ b/packages/core/src/layout/script-itemization.ts
@@ -1,6 +1,6 @@
 import type { BidiEmbeddingLevels } from './bidi.ts';
 import type { TextDirection } from './shaped-run.ts';
-import { eastAsiaSlotStyle, type ResolvedRunStyle } from './run-style.ts';
+import { withFontFamily, type ResolvedRunStyle } from './run-style.ts';
 
 /**
  * Which `w:rFonts` slot a character resolves its face through.
@@ -239,75 +239,133 @@ export function itemizeScriptFontSlots(
 }
 
 /**
- * The `[from, to)` UTF-16 ranges of `text` that resolve through the `eastAsia` font slot,
- * merged and in order. `[]` means the whole text stays in the base (Latin) slots.
+ * The style a piece's text is MEASURED AND PAINTED in, given the font slot it carries.
  *
- * The slot-only projection of {@link itemizeScriptFontSlots}, with the same inheritance
- * policy for Common characters, but independent of bidi analysis: which FACE a character
- * uses does not depend on its embedding level. A code point this engine does not itemize
- * answers `[]` — the whole text falls back to the base slot, which is exactly what the
- * pre-slot behaviour was — rather than throwing through layout.
+ * This is the measurer-boundary resolution: pieces and spans keep the run's real resolved
+ * style — with `fontFamily` and `fontFamilyEastAsia` both intact, so formatting readback
+ * and the format painter see the run as authored — and every consumer that turns text into
+ * geometry or ink resolves the face through here. The derived object is memoized per
+ * (style, family) by {@link withFontFamily}, so measurers amortizing over style identity
+ * keep their caches.
  */
-export function eastAsiaSlotRanges(text: string): readonly { from: number; to: number }[] {
-  let codePoints: { from: number; to: number; classified: Classified }[];
-  try {
-    codePoints = classifiedCodePoints(text);
-  } catch (error) {
-    if (error instanceof UnsupportedScriptError) return [];
-    throw error;
-  }
-  const out: { from: number; to: number }[] = [];
-  for (const item of codePoints) {
-    if (item.classified?.slot !== 'eastAsia') continue;
-    const previous = out.at(-1);
-    if (previous && previous.to === item.from) previous.to = item.to;
-    else out.push({ from: item.from, to: item.to });
-  }
-  return out;
+export function styleForFontSlot(
+  style: ResolvedRunStyle,
+  slot: FontSlot | undefined
+): ResolvedRunStyle {
+  if (slot !== 'eastAsia') return style;
+  const family = style.fontFamilyEastAsia;
+  return family === null ? style : withFontFamily(style, family);
 }
 
-/** One slot-homogeneous slice of a run's text, carrying the face that slot resolves to. */
-export interface FontSlotSlice {
-  readonly text: string;
-  readonly style: ResolvedRunStyle;
-  readonly start: number;
-  readonly end: number;
+/** An eastAsia-slot run of text inside segment `segment` of the classified sequence. */
+export interface SegmentSlotRange {
+  readonly segment: number;
+  readonly from: number;
+  readonly to: number;
 }
+
+/** How one code point participates in slot resolution. */
+type SlotClass = 'eastAsia' | 'base' | 'common';
 
 /**
- * Split one piece of run text into slot-homogeneous slices, or null when no split applies.
+ * {@link classify}, projected to the eastAsia-or-not question, never throwing.
  *
- * The seam `piecesOfParagraph` cuts mixed CJK+Latin text on: each eastAsia range takes the
- * style {@link eastAsiaSlotStyle} derives, the rest keep the base style, and model offsets
- * stay contiguous. Null (the common case — no eastAsia face, or nothing to split) tells the
- * caller to emit the piece unchanged.
+ * An unsupported code point answers 'base' — a strong classification confined to that one
+ * character, so a single Tamil sign in a CJK piece costs itself the East Asian face and
+ * nothing else.
  */
-export function splitByEastAsiaSlot(
-  text: string,
-  style: ResolvedRunStyle,
-  start: number
-): readonly FontSlotSlice[] | null {
-  if (style.fontFamilyEastAsia === null || style.fontFamilyEastAsia === style.fontFamily) {
-    return null;
+const slotClassOf = (codePoint: number): SlotClass => {
+  let classified: Classified;
+  try {
+    classified = classify(codePoint);
+  } catch (error) {
+    if (error instanceof UnsupportedScriptError) return 'base';
+    throw error;
   }
-  const ranges = eastAsiaSlotRanges(text);
-  if (ranges.length === 0) return null;
-  const slotStyle = eastAsiaSlotStyle(style);
-  const slices: FontSlotSlice[] = [];
-  let cursor = 0;
-  const slice = (from: number, to: number, sliceStyle: ResolvedRunStyle): void => {
-    slices.push({
-      text: text.slice(from, to),
-      style: sliceStyle,
-      start: start + from,
-      end: start + to,
-    });
+  if (classified === null) return 'common';
+  return classified.slot === 'eastAsia' ? 'eastAsia' : 'base';
+};
+
+/** Whether `text` holds only code units below U+0080 — text that can never touch the eastAsia slot. */
+const pureAscii = (text: string): boolean => {
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) >= 0x80) return false;
+  }
+  return true;
+};
+
+/**
+ * The `[from, to)` UTF-16 ranges that resolve through the `eastAsia` font slot, across a
+ * SEQUENCE of text segments classified as one paragraph. Merged and in order; `[]` means
+ * everything stays in the base (Latin) slots.
+ *
+ * One classification over the whole sequence, not one per segment, because Common
+ * characters inherit from their strong neighbours and `w:t` boundaries are not script
+ * boundaries: a fullwidth comma alone in its own run between two CJK runs is East Asian
+ * text. Inheritance follows {@link itemizeScriptFontSlots} — preceding strong item first,
+ * following strong item for leading Common text — with one restriction: an ASCII code
+ * point NEVER resolves through the eastAsia slot, because ECMA-376 routes ASCII-range
+ * characters through `w:ascii` and Word measures the `, ` in `中文, Hello` in the Latin
+ * face. Which face a character uses does not depend on its embedding level, so this pass
+ * is independent of bidi analysis.
+ *
+ * Cost discipline: a pure-ASCII segment (`charCodeAt` prescan) contributes its strong
+ * class without per-code-point classification, so the pure-Latin paragraphs of a document
+ * whose docDefaults author an East Asian face pay two compares per character, not a
+ * classifier call.
+ */
+export function eastAsiaRunsOfSegments(segments: readonly string[]): readonly SegmentSlotRange[] {
+  const out: SegmentSlotRange[] = [];
+  const addEastAsia = (segment: number, from: number, to: number): void => {
+    const previous = out.at(-1);
+    if (previous && previous.segment === segment && previous.to === from) {
+      out[out.length - 1] = { segment, from: previous.from, to };
+    } else {
+      out.push({ segment, from, to });
+    }
   };
-  for (const range of ranges) {
-    if (range.from > cursor) slice(cursor, range.from, style);
-    slice(range.from, range.to, slotStyle);
-    cursor = range.to;
+
+  /** Strongly classified text seen so far, or null while only Common text has streamed by. */
+  let precedingStrong: Exclude<SlotClass, 'common'> | null = null;
+  /** Leading Common units waiting for the FOLLOWING strong item; `ascii` blocks eastAsia. */
+  const pending: { segment: number; from: number; to: number; ascii: boolean }[] = [];
+  const resolvePending = (strong: Exclude<SlotClass, 'common'>): void => {
+    for (const unit of pending) {
+      if (strong === 'eastAsia' && !unit.ascii) addEastAsia(unit.segment, unit.from, unit.to);
+    }
+    pending.length = 0;
+  };
+
+  for (let segment = 0; segment < segments.length; segment += 1) {
+    const text = segments[segment]!;
+    if (pureAscii(text)) {
+      // Never eastAsia, so only the strong/Common distinction matters: any alphanumeric
+      // is a strong Latin item; pure punctuation and whitespace stay transparent.
+      if (/[0-9A-Za-z]/.test(text)) {
+        resolvePending('base');
+        precedingStrong = 'base';
+      }
+      continue;
+    }
+    for (let from = 0; from < text.length; ) {
+      const codePoint = text.codePointAt(from)!;
+      const to = from + (codePoint > 0xffff ? 2 : 1);
+      const slotClass = slotClassOf(codePoint);
+      if (slotClass === 'common') {
+        if (precedingStrong === null) {
+          pending.push({ segment, from, to, ascii: codePoint <= 0x7f });
+        } else if (precedingStrong === 'eastAsia' && codePoint > 0x7f) {
+          addEastAsia(segment, from, to);
+        }
+      } else {
+        resolvePending(slotClass);
+        precedingStrong = slotClass;
+        if (slotClass === 'eastAsia') addEastAsia(segment, from, to);
+      }
+      from = to;
+    }
   }
-  if (cursor < text.length) slice(cursor, text.length, style);
-  return slices;
+  // A sequence of nothing but Common text has no strong item to inherit from on either
+  // side; it stays in the base slots, exactly as it did before slot resolution existed.
+  return out;
 }

--- a/packages/core/src/layout/script-itemization.ts
+++ b/packages/core/src/layout/script-itemization.ts
@@ -1,5 +1,6 @@
 import type { BidiEmbeddingLevels } from './bidi.ts';
 import type { TextDirection } from './shaped-run.ts';
+import { eastAsiaSlotStyle, type ResolvedRunStyle } from './run-style.ts';
 
 /**
  * Which `w:rFonts` slot a character resolves its face through.
@@ -160,16 +161,13 @@ const classify = (codePoint: number): Classified => {
 };
 
 /**
- * Split text into shapeable runs by script, bidi level and font slot.
- *
- * Consumes the bidi levels rather than re-deriving direction, so itemization and reordering agree
- * by construction instead of by two implementations happening to match.
+ * Per-code-point classification with the inheritance passes applied: Common/inherited
+ * characters take the preceding strong item's answer, and leading Common text takes the
+ * following one. Shared by full itemization and the slot-only pass below.
  */
-export function itemizeScriptFontSlots(
-  text: string,
-  paragraphOffset: number,
-  embedding: BidiEmbeddingLevels
-): readonly ScriptItem[] {
+function classifiedCodePoints(
+  text: string
+): { from: number; to: number; classified: Classified }[] {
   const codePoints: { from: number; to: number; classified: Classified }[] = [];
   for (let from = 0; from < text.length; ) {
     const codePoint = text.codePointAt(from)!;
@@ -188,6 +186,21 @@ export function itemizeScriptFontSlots(
     if (item.classified) inherited = item.classified;
     else if (inherited) item.classified = inherited;
   }
+  return codePoints;
+}
+
+/**
+ * Split text into shapeable runs by script, bidi level and font slot.
+ *
+ * Consumes the bidi levels rather than re-deriving direction, so itemization and reordering agree
+ * by construction instead of by two implementations happening to match.
+ */
+export function itemizeScriptFontSlots(
+  text: string,
+  paragraphOffset: number,
+  embedding: BidiEmbeddingLevels
+): readonly ScriptItem[] {
+  const codePoints = classifiedCodePoints(text);
 
   const out: ScriptItem[] = [];
   const commonOnlySlot: FontSlot = codePoints.every(({ from }) => text.codePointAt(from)! <= 0x7f)
@@ -223,4 +236,78 @@ export function itemizeScriptFontSlots(
     }
   }
   return out;
+}
+
+/**
+ * The `[from, to)` UTF-16 ranges of `text` that resolve through the `eastAsia` font slot,
+ * merged and in order. `[]` means the whole text stays in the base (Latin) slots.
+ *
+ * The slot-only projection of {@link itemizeScriptFontSlots}, with the same inheritance
+ * policy for Common characters, but independent of bidi analysis: which FACE a character
+ * uses does not depend on its embedding level. A code point this engine does not itemize
+ * answers `[]` — the whole text falls back to the base slot, which is exactly what the
+ * pre-slot behaviour was — rather than throwing through layout.
+ */
+export function eastAsiaSlotRanges(text: string): readonly { from: number; to: number }[] {
+  let codePoints: { from: number; to: number; classified: Classified }[];
+  try {
+    codePoints = classifiedCodePoints(text);
+  } catch (error) {
+    if (error instanceof UnsupportedScriptError) return [];
+    throw error;
+  }
+  const out: { from: number; to: number }[] = [];
+  for (const item of codePoints) {
+    if (item.classified?.slot !== 'eastAsia') continue;
+    const previous = out.at(-1);
+    if (previous && previous.to === item.from) previous.to = item.to;
+    else out.push({ from: item.from, to: item.to });
+  }
+  return out;
+}
+
+/** One slot-homogeneous slice of a run's text, carrying the face that slot resolves to. */
+export interface FontSlotSlice {
+  readonly text: string;
+  readonly style: ResolvedRunStyle;
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * Split one piece of run text into slot-homogeneous slices, or null when no split applies.
+ *
+ * The seam `piecesOfParagraph` cuts mixed CJK+Latin text on: each eastAsia range takes the
+ * style {@link eastAsiaSlotStyle} derives, the rest keep the base style, and model offsets
+ * stay contiguous. Null (the common case — no eastAsia face, or nothing to split) tells the
+ * caller to emit the piece unchanged.
+ */
+export function splitByEastAsiaSlot(
+  text: string,
+  style: ResolvedRunStyle,
+  start: number
+): readonly FontSlotSlice[] | null {
+  if (style.fontFamilyEastAsia === null || style.fontFamilyEastAsia === style.fontFamily) {
+    return null;
+  }
+  const ranges = eastAsiaSlotRanges(text);
+  if (ranges.length === 0) return null;
+  const slotStyle = eastAsiaSlotStyle(style);
+  const slices: FontSlotSlice[] = [];
+  let cursor = 0;
+  const slice = (from: number, to: number, sliceStyle: ResolvedRunStyle): void => {
+    slices.push({
+      text: text.slice(from, to),
+      style: sliceStyle,
+      start: start + from,
+      end: start + to,
+    });
+  };
+  for (const range of ranges) {
+    if (range.from > cursor) slice(cursor, range.from, style);
+    slice(range.from, range.to, slotStyle);
+    cursor = range.to;
+  }
+  if (cursor < text.length) slice(cursor, text.length, style);
+  return slices;
 }

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -25,6 +25,7 @@ import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
 import { graphemeBoundaryEpoch, segmentGraphemes } from './grapheme.ts';
 import { lineSegments, type LineSegment } from './line-segments.ts';
 import { baselineShiftPtOf, measureDisplayText } from './run-style.ts';
+import { styleForFontSlot } from './script-itemization.ts';
 import type { CaretGeometry, SemanticPosition } from './semantic-interaction.ts';
 import type {
   BlockFragmentRecord,
@@ -926,7 +927,13 @@ function prefixWidth(span: StyleSpanRecord, utf16: number, measurer: TextMeasure
   // As DRAWN, matching `caretEdges` and the advance `breakParagraph` reserved: a `w:caps`
   // run paints uppercase, and measuring the source text would disagree with both.
   const width =
-    utf16 <= 0 ? 0 : measureDisplayText(span.text.slice(0, utf16), span.style, measurer);
+    utf16 <= 0
+      ? 0
+      : measureDisplayText(
+          span.text.slice(0, utf16),
+          styleForFontSlot(span.style, span.fontSlot),
+          measurer
+        );
   widths.set(utf16, width);
   return width;
 }
@@ -1086,7 +1093,7 @@ export function caretBoxOnLine(
   // painter baseline-aligns the glyphs in CSS. Taking the box directly drew a small run's
   // caret at the top of a tall line, floating above the text it belonged to. Aligning it the
   // way the text is aligned needs the run's own ascent, which is what the measurer answers.
-  const metrics = measurer?.lineMetrics(chosen.style);
+  const metrics = measurer?.lineMetrics(styleForFontSlot(chosen.style, chosen.fontSlot));
   if (!metrics || metrics.height <= 0) {
     return { x, y: line.box.y, height: line.box.height };
   }

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -24,6 +24,7 @@ import type { FieldAtomMarker, ModelRange } from './field-pieces.ts';
 import type { InlineDrawingRecord, AnchoredDrawingRecord } from './drawing-layout.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
+import type { FontSlot } from './script-itemization.ts';
 import type { ResolvedCellBorders } from './table-borders.ts';
 import type { EquationSpanRecord } from './equation-layout.ts';
 
@@ -132,6 +133,14 @@ export interface StyleSpanRecord {
    * point put the caret where no glyph is.
    */
   readonly style: ResolvedRunStyle;
+  /**
+   * The `w:rFonts` slot this span's text resolves its face through; absent means the base
+   * (ascii/hAnsi) slots. {@link style} stays the run's full resolution — with both
+   * `fontFamily` and `fontFamilyEastAsia` — so formatting readback and the format painter
+   * see the run as authored; measurement, paint and hit-testing resolve the effective face
+   * with `styleForFontSlot(span.style, span.fontSlot)`.
+   */
+  readonly fontSlot?: FontSlot;
   readonly box: LayoutBox;
   /**
    * Cumulative advances from {@link box}.x to each UTF-16 caret boundary in {@link text}.

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -46,7 +46,7 @@ import {
   tabStopsFingerprint,
   type ResolvedTabStops,
 } from './paragraph-tabs.ts';
-import type { ThemeFonts } from './run-style.ts';
+import { NO_THEME_FONTS, type ThemeFonts } from './run-style.ts';
 import { combineStyleToggles } from './style-toggles.ts';
 
 /** Soft ceiling on `basedOn` chain length — enough for real templates, refuses hostile graphs. */
@@ -116,7 +116,7 @@ export interface StyleCascadeTable {
    */
   readonly defaultTableStyleId: string | null;
   /**
-   * The theme part's Latin typefaces, for `w:rFonts` theme references.
+   * The theme part's typefaces, for `w:rFonts` theme references.
    *
    * Lives on the cascade because it is document-level style material with the same
    * lifetime, and because every site that resolves run properties already holds this table.
@@ -124,9 +124,6 @@ export interface StyleCascadeTable {
   readonly themeFonts: ThemeFonts;
   readonly styles: ReadonlyMap<string, StyleDefinition>;
 }
-
-/** A document with no theme part: every theme reference falls back to its explicit name. */
-export const NO_THEME_FONTS: ThemeFonts = { major: null, minor: null };
 
 /**
  * A paragraph's properties after the cascade, plus the same list WITHOUT its own `w:pPr`.

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -14,6 +14,7 @@
 
 import { baselineShiftPtOf, TAB_LEADER_GLYPH } from '@docx-editor.dev/core/layout';
 import { DEFAULT_CANVAS_FONT_STACK } from '../layout/canvas-measurer.ts';
+import { styleForFontSlot } from '../layout/script-itemization.ts';
 import {
   REVIEW_AUTHOR_SLOTS,
   reviewAuthorSlotColor,
@@ -1115,11 +1116,14 @@ function paintSpan(
   extraLeadingPt: number
 ): HTMLElement {
   const element = document.createElement('span');
+  // Ink resolves the face through the span's font slot; `span.style` itself stays the
+  // run's full resolution for every consumer that reads formatting rather than glyphs.
+  const faceStyle = styleForFontSlot(span.style, span.fontSlot);
   if (span.equation) {
     element.dataset.paragraphId = span.range.paragraphId;
     element.dataset.start = String(span.range.start);
     element.dataset.end = String(span.range.end);
-    applyRunFaceStyle(element, span.style, ctx);
+    applyRunFaceStyle(element, faceStyle, ctx);
     mountEquationGeometry(document, element, span.equation, ctx.scale);
     applyRevisionPresentation(element, span, ctx);
     return element;
@@ -1162,7 +1166,7 @@ function paintSpan(
     element.setAttribute('aria-hidden', 'true');
     element.contentEditable = 'false';
   }
-  applyRunFaceStyle(element, span.style, ctx);
+  applyRunFaceStyle(element, faceStyle, ctx);
   applyFieldShading(element, span, ctx);
   applyRevisionPresentation(element, span, ctx);
   // Layout owns advances that the browser cannot reconstruct: horizontal scaling (transform

--- a/packages/core/src/store/package/theme-font-scheme.ts
+++ b/packages/core/src/store/package/theme-font-scheme.ts
@@ -1,0 +1,54 @@
+// The `w:rFonts` theme-token table, shared by every lane that resolves one.
+//
+// ECMA-376 §17.18.96 (ST_Theme) names eight tokens; each is a (major|minor) × (ascii|
+// hAnsi|eastAsia|bidi) pair pointing into the theme part's font scheme. The layout lane
+// (`layout/run-style.ts`) and the binding lane (`binding/document-run-defaults.ts`,
+// `binding/document-catalog.ts`) each resolve these tokens, and until this module they
+// each kept a private copy of the mapping — copies that drifted the moment one lane
+// learned the `a:ea` faces. Lives beside `theme-color-resolution.ts` for the same reason
+// that table does: theme resolution is package material both lanes may read.
+
+/**
+ * The faces a theme's font scheme offers, per script slot.
+ *
+ * Structurally satisfied by both lanes' theme-font shapes (`DocumentThemeFonts`,
+ * layout's `ThemeFonts`). The East Asian faces are optional so callers that have not
+ * harvested them yet still type-check; an absent face resolves to null, which every
+ * caller already treats as "fall back to the explicit attribute".
+ */
+export interface ThemeSchemeFaces {
+  /** `a:majorFont` latin typeface — headings. */
+  readonly major: string | null;
+  /** `a:minorFont` latin typeface — body text. */
+  readonly minor: string | null;
+  /** `a:majorFont` east asian typeface (`a:ea`). */
+  readonly majorEastAsia?: string | null;
+  /** `a:minorFont` east asian typeface (`a:ea`). */
+  readonly minorEastAsia?: string | null;
+}
+
+// A Map, not an object literal: the token is file content, and `__proto__` must answer
+// undefined — the same rule `theme-color-resolution.ts` applies to its tables.
+const TOKEN_FACE: ReadonlyMap<string, (faces: ThemeSchemeFaces) => string | null> = new Map([
+  ['minorAscii', (faces: ThemeSchemeFaces) => faces.minor],
+  ['minorHAnsi', (faces: ThemeSchemeFaces) => faces.minor],
+  ['majorAscii', (faces: ThemeSchemeFaces) => faces.major],
+  ['majorHAnsi', (faces: ThemeSchemeFaces) => faces.major],
+  // The East Asian tokens are legal on the LATIN theme attributes too: Word's "use East
+  // Asian fonts also on Latin text" writes `w:asciiTheme="minorEastAsia"`, and both
+  // scripts then paint in the East Asian face. The token decides the face; which
+  // attribute carried it does not.
+  ['minorEastAsia', (faces: ThemeSchemeFaces) => faces.minorEastAsia ?? null],
+  ['majorEastAsia', (faces: ThemeSchemeFaces) => faces.majorEastAsia ?? null],
+  // `minorBidi`/`majorBidi` name the `a:cs` face no lane harvests yet; an honest null —
+  // which falls back to the explicit attribute beside the token — beats the wrong font.
+]);
+
+/** A `w:rFonts` theme token resolved to its theme face, or null when it names none we hold. */
+export function themeFontFamilyOf(
+  token: string | undefined,
+  faces: ThemeSchemeFaces
+): string | null {
+  if (token === undefined) return null;
+  return TOKEN_FACE.get(token)?.(faces) ?? null;
+}

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -44,7 +44,7 @@ const SLACK_EXEMPT = new Map([
 const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6260],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
-  ['packages/core/src/output/semantic-paint.ts', 3005],
+  ['packages/core/src/output/semantic-paint.ts', 3009],
   ['packages/core/src/layout/note-pagination.ts', 2954],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);


### PR DESCRIPTION
### Problem

A document that names its CJK face only through the `eastAsia` slot renders every
ideograph in the run's Latin face. The common authoring shape triggers it: Word
templates put `w:rFonts w:eastAsiaTheme="minorEastAsia"` in
`w:docDefaults/w:rPrDefault`, the theme's `a:minorFont/a:ea` names SimSun, and no
run ever re-states the family. The engine measures the CJK text with the Latin
font's metrics and paints it in the Latin stack, so body text loses its serif
face and long CJK paragraphs overflow the content column.

### Root cause

`resolveRunStyle` resolves one `fontFamily` from the `ascii`/`hAnsi` attributes
and their theme references, and drops `w:eastAsia`/`w:eastAsiaTheme`.
`collectDocumentThemeFonts` reads only the `a:latin` typefaces, so the theme's
`a:ea` face is not available to resolve against. `itemizeScriptFontSlots` already
classifies characters into the four `w:rFonts` slots, but nothing in the
measurement or paint path consumes the `eastAsia` slot.

### Approach

- `ResolvedRunStyle` gains `fontFamilyEastAsia`, resolved in `resolveRunStyle`
  on the same rule as the Latin slot: theme reference over explicit attribute,
  explicit attribute as the fallback for an unresolvable theme slot. A
  Latin-only `w:rFonts` leaves an inherited eastAsia face alone, so the
  docDefaults face survives style chains that only re-state `w:ascii`.
- `collectDocumentThemeFonts` also reads `a:majorFont/a:ea` and
  `a:minorFont/a:ea`; `ThemeFonts` carries them as optional members so existing
  constructors stay valid. The cascade's `cacheToken` already hashes the theme
  fonts object, so an `a:ea` retheme invalidates cached breaks.
- `piecesOfParagraph` splits run text into slot-homogeneous pieces at eastAsia
  boundaries (`splitByEastAsiaSlot`, built on the itemizer's classification).
  An eastAsia piece carries a derived style whose effective family is the
  eastAsia face (`eastAsiaSlotStyle`, memoized per style object so the shaped
  measurer's per-object font cache still amortizes). Measurement, paint,
  hit-testing and the caret all consume piece styles, so one seam feeds all of
  them; piece boundaries are not break opportunities, so the split changes
  which face a character resolves through and nothing else.
- `runStylesEqual` compares the new member, so spans differing only in their
  eastAsia face do not merge.

Public API change: one added readonly member on `ResolvedRunStyle` (snapshot
updated), plus optional members on `ThemeFonts`/`DocumentThemeFonts`. The new
helpers are internal to the layout lane and not exported from the barrel.

### Deliberately out of scope

- The `cs`/bidi slot (`w:cs`/`w:cstheme`, `szCs`/`bCs`/`iCs`): same shape of
  fix, separate change.
- Line breaking across piece boundaries (#526). The split makes an existing
  divergence easier to reach: a paragraph such as `1.甲方必须…` whose unspaced
  CJK "word" is wider than the line now has a piece boundary after `1.`, and the
  break-at-margin path only fills from an empty line, so the `1.` strands alone
  on the first line where Word fills the line. The faces and column fit are
  correct; the fill belongs to the #526 fix. Numbers below.
- Field results, note marks and list markers keep single-face resolution.

### Test coverage

- `run-style.test.ts`: explicit `w:eastAsia`, `w:eastAsiaTheme` against `a:ea`
  typefaces, theme-over-explicit precedence, fallback for an unresolvable slot,
  equality, and `eastAsiaSlotStyle` derivation/memoization.
- `script-itemization.test.ts`: `eastAsiaSlotRanges` merged ranges, Common-character
  inheritance, unsupported-script fallback to no split, agreement with
  `itemizeScriptFontSlots`.
- `style-cascade.test.ts`: docDefaults `w:eastAsiaTheme` through
  `buildStyleCascadeTable`; a Latin-only direct `w:rFonts` not evicting the
  inherited face; an end-to-end `layoutSemanticDocument` case asserting a mixed
  `甲方shall` run splits into a SimSun span and a Grandview span with contiguous
  model offsets, and that the measurer saw the CJK text only under the eastAsia
  face.

Full `packages/core` suite: 7809 pass / 0 fail (baseline before the change:
7793 / 0). Workspace typecheck, lint, format and the core API snapshot check
pass.

### Verification against a real document

92-paragraph Chinese contract (SimSun body via docDefaults `minorEastAsia`,
Times New Roman Latin), shaped measurer with SimSun/SimHei/FangSong/KaiTi
registered as byte-backed sources:

- Measurer stays `shaped`; the CJK faces resolve as embedded sources.
- The clause paragraph that previously overflowed the content column now fits
  (max span right edge 7 px inside the column).
- Mixed line paints per slot: `ISP`, `IDC`, `2.` in Times New Roman; ideographs
  and `、` in SimSun.
- Full CJK lines break at 35 characters against the reference PDF's 34, and the
  leading `1.` strands on its own line (the #526 interaction described above;
  the pre-fix rendering instead overflowed the column in a sans fallback face).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790448371&installation_model_id=422592&pr_number=539&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F539&signature=1259fe7759219d26bf2f39ec82473c3b38b8c3440349ad5ebbfc0265b8612c30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->