### PR TITLE
fix: break CJK lines between ideographs with kinsoku (fixes #526)

### DIFF
--- a/.changeset/cjk-line-breaking.md
+++ b/.changeset/cjk-line-breaking.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+CJK text now wraps at the column width with UAX #14 ideographic break opportunities and basic kinsoku, instead of breaking only at run boundaries or spaces. Fixes #526

--- a/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
@@ -49,6 +49,25 @@ describe('CJK text wraps at the column width', () => {
     ).toEqual(['天地玄黄宇宙洪荒日月', '盈昃辰宿列张寒来暑往', '秋收冬藏']);
   });
 
+  test('ideographic break opportunities do not fragment the painted spans', () => {
+    // Break opportunities between ideographs make every character its own placement
+    // candidate; the closed line merges them back, so a clause paints as one span per
+    // style run rather than one per character.
+    const lines = breakParagraph(
+      paragraph(`<w:p>${run('天地玄黄宇宙洪荒日月盈昃辰宿列张寒来暑往秋收冬藏')}</w:p>`),
+      'p',
+      0,
+      60,
+      measurer,
+      undefined,
+      null
+    );
+    expect(lines.map((line) => line.spans.length)).toEqual([1, 1, 1]);
+    expect(lines[0]!.spans[0]!.text).toBe('天地玄黄宇宙洪荒日月');
+    expect(lines[0]!.spans[0]!.range).toEqual({ paragraphId: 'p', start: 0, end: 10 });
+    expect(lines[0]!.spans[0]!.box.width).toBeCloseTo(60, 5);
+  });
+
   test('a CJK clause split across runs wraps at the margin, not at the run seam (#526)', () => {
     // Seven ideographs per run. Under space-only rules the seam was the only boundary, so
     // the first line carried seven characters and the margin was ignored.

--- a/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
@@ -189,6 +189,44 @@ describe('kinsoku beside tabs and inside the chop', () => {
     }
   });
 
+  test('a protected group split across runs never breaks at the run seam', () => {
+    // The group is unbreakable and starts the line, so there is nothing to carry down and
+    // nothing legal to chop: it is pushed out past the measure, which is what the same text
+    // in ONE run already did. Before this, the overflow branch closed the line at the seam
+    // and the veto never applied — a line opened on 、 and one ended on （.
+    for (const width of [7, 13]) {
+      // A no-break-before character behind the seam.
+      expect(linesOf(`<w:p>${run('月')}${run('、盈')}</w:p>`, width)).toEqual(['月、', '盈']);
+      // A no-break-after character in front of it.
+      expect(linesOf(`<w:p>${run('（')}${run('以来')}</w:p>`, width)).toEqual(['（以', '来']);
+      // The half-width prolonged-sound mark, reachable only since the range covers ｰ.
+      expect(linesOf(`<w:p>${run('ア')}${run('ｰ月')}</w:p>`, width)).toEqual(['アｰ', '月']);
+    }
+  });
+
+  test('a grapheme cluster split across runs never orphans its combining mark', () => {
+    // U+3099 is inside the ideographic ranges and outside both kinsoku sets, so the seam
+    // reads as an ordinary ideographic break opportunity. `wordBoundaries` filters cuts
+    // through `segmentGraphemes`, but a cluster split across pieces has no single text to
+    // segment: the two code points around the seam are segmented on their own.
+    for (const width of [7, 13]) {
+      const lines = linesOf(`<w:p>${run('か')}${run('\u3099月')}</w:p>`, width);
+      expect(lines.join('')).toBe('か\u3099月');
+      for (const line of lines) expect(line.charCodeAt(0)).not.toBe(0x3099);
+    }
+  });
+
+  test('a Latin word split across runs still chops at the margin', () => {
+    // The other reason a candidate cannot open a line. A word wider than its line has no
+    // legal cut of its own and IS chopped; only a group a rule protects is pushed out.
+    expect(linesOf(`<w:p>${run('01234')}${run('56789ABCDE')}</w:p>`, 25)).toEqual([
+      '0123',
+      '4567',
+      '89AB',
+      'CDE',
+    ]);
+  });
+
   test('the chop never cuts inside a surrogate pair', () => {
     const text = '𠀋𠀌𠀍𠀎';
     const lines = linesOf(`<w:p>${run(text)}</w:p>`, 13);

--- a/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
@@ -1,0 +1,128 @@
+// CJK text breaks at the margin, not at run seams (#526).
+//
+// A Chinese clause carries no spaces, so under space-only break rules it was one giant
+// "word": a single-run paragraph wrapped only through the wider-than-empty-line chop, and a
+// clause split across runs wrapped AT THE RUN SEAM — the only "boundary" it had. A numbered
+// clause ("1." in one piece, the clause in the next) stranded the number alone on its line,
+// because the line was never empty and the chop never ran. UAX #14 instead gives ideographic
+// characters a break opportunity on both sides, minus the kinsoku prohibitions: a line must
+// not start with a closing mark (。，、」…) and must not end with an opening one (「（…).
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlNode } from '@docx-editor.dev/core/store';
+import { breakParagraph } from '../paragraph-flow.ts';
+import { createFixedMeasurer } from '../semantic-layout.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+/** 6pt per character, so a 60pt measure holds exactly ten. */
+const measurer = createFixedMeasurer(6, 14);
+
+function paragraph(body: string): OoxmlNode {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  const found = result.part.root.children[0]!.children.find((child) => child.kind === 'paragraph');
+  if (!found) throw new Error('no paragraph');
+  return found;
+}
+
+const linesOf = (body: string, width = 60): string[] =>
+  breakParagraph(paragraph(body), 'p', 0, width, measurer, undefined, null).map((line) =>
+    line.spans.map((span) => span.text).join('')
+  );
+
+// The 6pt measurer base describes an 11pt run, so runs author `w:sz="22"` rather than the
+// 10pt terminal fallback (see `DEFAULT_RUN_STYLE`), which widens the measure by 11/10.
+const run = (text: string) =>
+  `<w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t xml:space="preserve">${text}</w:t></w:r>`;
+
+const LINE_START_FORBIDDEN = /^[。，、；：？！」』）】]/;
+const LINE_END_FORBIDDEN = /[「『（【]$/;
+
+describe('CJK text wraps at the column width', () => {
+  test('a single all-CJK run fills every line', () => {
+    // 24 ideographs at 6pt each against a 60pt measure: ten per line, no chop needed.
+    expect(
+      linesOf(`<w:p>${run('天地玄黄宇宙洪荒日月盈昃辰宿列张寒来暑往秋收冬藏')}</w:p>`)
+    ).toEqual(['天地玄黄宇宙洪荒日月', '盈昃辰宿列张寒来暑往', '秋收冬藏']);
+  });
+
+  test('a CJK clause split across runs wraps at the margin, not at the run seam (#526)', () => {
+    // Seven ideographs per run. Under space-only rules the seam was the only boundary, so
+    // the first line carried seven characters and the margin was ignored.
+    expect(linesOf(`<w:p>${run('天地玄黄宇宙洪')}${run('荒日月盈昃辰宿')}</w:p>`)).toEqual([
+      '天地玄黄宇宙洪荒日月',
+      '盈昃辰宿',
+    ]);
+  });
+
+  test('a numbered clause fills its first line instead of stranding the number', () => {
+    // "1." in its own piece, the clause in the next — the shape the eastAsia font-slot split
+    // produces for 「1.甲方…」. The number must stay glued to the first ideograph (no break
+    // between "." and 甲) and the line must fill to the measure.
+    const lines = linesOf(`<w:p>${run('1.')}${run('甲方必须遵守安全管理规定')}</w:p>`);
+    expect(lines).toEqual(['1.甲方必须遵守安全', '管理规定']);
+  });
+});
+
+describe('kinsoku prohibitions', () => {
+  test('a closing mark never opens a line; its carrier wraps down with it', () => {
+    // Ten ideographs fill the line exactly, and the eleventh character is 、 — breaking
+    // before it would fit ten but start the next line with the mark, so 月 wraps down too.
+    expect(linesOf(`<w:p>${run('天地玄黄宇宙洪荒日月、盈昃辰宿')}</w:p>`)).toEqual([
+      '天地玄黄宇宙洪荒日',
+      '月、盈昃辰宿',
+    ]);
+  });
+
+  test('an opening bracket never ends a line; it wraps down to its content', () => {
+    expect(linesOf(`<w:p>${run('天地玄黄宇宙洪荒日「月盈昃辰宿')}</w:p>`)).toEqual([
+      '天地玄黄宇宙洪荒日',
+      '「月盈昃辰宿',
+    ]);
+  });
+
+  test('no wrap position violates kinsoku across a punctuated paragraph', () => {
+    const text =
+      '甲方（以下简称「买方」）应当按照本合同第３条、第４条之约定，向乙方支付全部价款。逾期未付的，每日加收０．５％。';
+    for (const width of [36, 48, 60, 72, 90]) {
+      const lines = linesOf(`<w:p>${run(text)}</w:p>`, width);
+      expect(lines.join('')).toBe(text);
+      for (const line of lines) {
+        expect(line).not.toMatch(LINE_START_FORBIDDEN);
+        expect(line).not.toMatch(LINE_END_FORBIDDEN);
+      }
+    }
+  });
+
+  test('a literal space before a full-width comma no longer forces a premature break', () => {
+    // The authored-space shape 「…职责 ，因此…」: the space boundary sits directly before 、
+    // a closing mark, which used to hand the comma's whole tail to the next line and close
+    // this one seven characters early. The space stays a break opportunity everywhere else;
+    // only the position directly before the comma is vetoed.
+    expect(linesOf(`<w:p>${run('安全管理职责 ，因此甲乙双方')}</w:p>`)).toEqual([
+      '安全管理职责 ，因此',
+      '甲乙双方',
+    ]);
+  });
+});
+
+describe('Latin behaviour is unchanged', () => {
+  test('spaces stay the only boundary inside Latin text', () => {
+    expect(linesOf(`<w:p>${run('aaa ')}${run('bbbbb')}${run('ccccc')}</w:p>`)).toEqual([
+      'aaa ',
+      'bbbbbccccc',
+    ]);
+  });
+
+  test('a Latin word beside CJK stays whole while the CJK wraps freely', () => {
+    // 玄黄ABCD宇 is bounded by ideograph|Latin seams on both sides of ABCD; no new
+    // opportunity appears inside or beside the Latin word, so it wraps as one unit.
+    expect(linesOf(`<w:p>${run('天地玄黄ABCD宇宙洪荒日月盈')}</w:p>`)).toEqual([
+      '天地玄黄ABCD宇宙',
+      '洪荒日月盈',
+    ]);
+  });
+});

--- a/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
@@ -104,9 +104,11 @@ describe('kinsoku prohibitions', () => {
   });
 
   test('no wrap position violates kinsoku across a punctuated paragraph', () => {
+    // Widths below 36 push clauses through the wider-than-empty-line chop, which must
+    // uphold the same prohibitions as the boundary rules.
     const text =
       '甲方（以下简称「买方」）应当按照本合同第３条、第４条之约定，向乙方支付全部价款。逾期未付的，每日加收０．５％。';
-    for (const width of [36, 48, 60, 72, 90]) {
+    for (const width of [7, 13, 25, 36, 48, 60, 72, 90]) {
       const lines = linesOf(`<w:p>${run(text)}</w:p>`, width);
       expect(lines.join('')).toBe(text);
       for (const line of lines) {
@@ -125,6 +127,127 @@ describe('kinsoku prohibitions', () => {
       '安全管理职责 ，因此',
       '甲乙双方',
     ]);
+  });
+});
+
+describe('kinsoku beside tabs and inside the chop', () => {
+  test('a tab keeps its stop when a no-break-before character follows it', () => {
+    // The ー veto must not cancel the forced word-open a tab grants: with it cancelled,
+    // an overflow at ー took the mid-word carry, re-laid the tab with a stale advance
+    // that no longer reached its stop, and closed the first line seven characters early.
+    const body = `<w:p>${run('AA BBBB')}<w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:tab/></w:r>${run('ー天地玄黄宇宙洪')}</w:p>`;
+    const lines = breakParagraph(paragraph(body), 'p', 0, 60, measurer, undefined, null);
+    expect(lines.map((line) => line.spans.map((span) => span.text).join(''))).toEqual([
+      'AA BBBB\t',
+      'ー天地玄黄宇宙洪',
+    ]);
+    const tab = lines[0]!.spans.find((span) => span.text === '\t')!;
+    expect(tab.box.x + tab.box.width).toBeCloseTo(60, 5);
+  });
+
+  test('unit signs outside the ideographic ranges cannot change Latin wrapping', () => {
+    // ‰ ′ ″ ℃ appear in ordinary scientific prose; while they sat in the no-break-before
+    // set the veto applied with no East Asian context at all, and 'aa bb ℃cccc' wrapped
+    // differently from 'aa bb Ccccc' against the byte-identical guarantee.
+    expect(linesOf(`<w:p>${run('aa bb ℃cccc')}</w:p>`)).toEqual(['aa bb ', '℃cccc']);
+  });
+
+  test('the ideographic space and the middle dot never open a line', () => {
+    expect(linesOf(`<w:p>${run('天地玄黄宇宙洪荒日月　盈昃')}</w:p>`)).toEqual([
+      '天地玄黄宇宙洪荒日',
+      '月　盈昃',
+    ]);
+    expect(linesOf(`<w:p>${run('天地玄黄宇宙洪荒日月・盈昃')}</w:p>`)).toEqual([
+      '天地玄黄宇宙洪荒日',
+      '月・盈昃',
+    ]);
+  });
+
+  test('half-width katakana wraps at the margin, not the run seam', () => {
+    expect(linesOf(`<w:p>${run('ｱｲｳｴｵｶｷｸ')}${run('ｹｺｻｼｽｾｿﾀ')}</w:p>`)).toEqual([
+      'ｱｲｳｴｵｶｷｸｹｺ',
+      'ｻｼｽｾｿﾀ',
+    ]);
+  });
+
+  test('the half-width prolonged-sound mark never opens a line', () => {
+    // ｰ sat in the no-break-before set but outside every ideographic range, so no
+    // boundary could reach it; its carrier must wrap down with it.
+    expect(linesOf(`<w:p>${run('ｱｲｳｴｵｶｷｸｹｺｰｻｼ')}</w:p>`)).toEqual(['ｱｲｳｴｵｶｷｸｹ', 'ｺｰｻｼ']);
+  });
+
+  test('NFD kana never orphans its combining voicing mark', () => {
+    const nfd = 'あ' + 'が'.repeat(7);
+    const lines = linesOf(`<w:p>${run(nfd)}</w:p>`, 54);
+    expect(lines.join('')).toBe(nfd);
+    for (const line of lines) expect(line.charCodeAt(0)).not.toBe(0x3099);
+  });
+
+  test('the chop upholds kinsoku at a one- and a two-character measure', () => {
+    for (const width of [7, 13]) {
+      expect(linesOf(`<w:p>${run('天。地。人。')}</w:p>`, width)).toEqual(['天。', '地。', '人。']);
+    }
+  });
+
+  test('the chop never cuts inside a surrogate pair', () => {
+    const text = '𠀋𠀌𠀍𠀎';
+    const lines = linesOf(`<w:p>${run(text)}</w:p>`, 13);
+    expect(lines.join('')).toBe(text);
+    for (const line of lines) expect(line.length % 2).toBe(0);
+  });
+});
+
+describe('span merging under decorations', () => {
+  // decorationsMatch works by reference equality, which holds only because placement
+  // passes piece.revisions / piece.link through without copying — these pin that a
+  // defensive copy on that path cannot silently return CJK to one span per ideograph.
+  test('a tracked-insert CJK run still paints one span per line', () => {
+    const ins = `<w:ins w:id="1" w:author="QA" w:date="2026-03-26T11:00:00Z">${run('天地玄黄宇宙洪荒日月盈昃辰宿')}</w:ins>`;
+    const lines = breakParagraph(
+      paragraph(`<w:p>${ins}</w:p>`),
+      'p',
+      0,
+      60,
+      measurer,
+      undefined,
+      null
+    );
+    expect(lines.map((line) => line.spans.length)).toEqual([1, 1]);
+    expect(lines[0]!.spans[0]!.revisions?.length).toBe(1);
+  });
+
+  test('a hyperlinked CJK run still paints one span per line', () => {
+    const body = `<w:p><w:hyperlink w:anchor="top">${run('天地玄黄宇宙洪荒日月盈昃辰宿')}</w:hyperlink></w:p>`;
+    const lines = breakParagraph(
+      paragraph(body),
+      'p',
+      0,
+      60,
+      measurer,
+      undefined,
+      null,
+      [],
+      undefined,
+      undefined,
+      undefined,
+      { projectLink: () => ({ id: 'link', kind: 'internal', href: '#top', anchor: 'top' }) }
+    );
+    expect(lines.map((line) => line.spans.length)).toEqual([1, 1]);
+    expect(lines[0]!.spans[0]!.link).toBeDefined();
+  });
+});
+
+describe('layout-owned pieces stay whole', () => {
+  test('a CJK field result neither splits per ideograph nor wraps mid-result', () => {
+    // Every span of a layout-owned piece publishes the piece's whole model range, so a
+    // per-ideograph split painted dozens of spans all claiming the same range and let a
+    // DATE/REF/TOC result wrap in the middle.
+    const body =
+      '<w:p><w:fldSimple w:instr=" DATE "><w:r><w:t>二〇二六年八月三十日签署完成生效</w:t></w:r></w:fldSimple></w:p>';
+    const lines = breakParagraph(paragraph(body), 'p', 0, 60, measurer, undefined, null);
+    expect(lines.length).toBe(1);
+    expect(lines[0]!.spans.length).toBe(1);
+    expect(lines[0]!.spans[0]!.text).toBe('二〇二六年八月三十日签署完成生效');
   });
 });
 

--- a/packages/core/src/layout/anchor-line-probe.ts
+++ b/packages/core/src/layout/anchor-line-probe.ts
@@ -1,0 +1,119 @@
+// Which line an anchored drawing lands on, predicted before the paragraph is placed.
+//
+// `synthesizeParagraphWrapExclusionZones` and `zoneApplies` need an anchor's line start
+// while that line is still being built, so this walks the pieces once with the placement
+// loop's own word state — the SAME open decision (`lineOpenDecisionAt`) and the same
+// mid-word carry — and reports where each anchor offset would land. Any rule the two
+// loops do not share puts the predicted start one character off, and text then wraps
+// around a hole one line early: a veto-less probe did exactly that whenever a closing
+// mark wrapped down with its carrier.
+//
+// It stays an ESTIMATE on the paths it has always approximated: the oversized-word chop
+// and horizontal float passages are placement-time decisions this pass cannot see.
+
+import { PAGE_BREAK_CHAR } from '@docx-editor.dev/core/store';
+import type { FieldAwarePiece } from './field-projection.ts';
+import { lineOpenDecisionAt, wordBoundaries } from './cjk-line-break.ts';
+import { measureInlineDrawing } from './drawing-layout.ts';
+import { styleForFontSlot } from './script-itemization.ts';
+import type { EquationSpanRecord } from './equation-layout.ts';
+import type { TextMeasurer } from './semantic-records.ts';
+
+/** Model offset of the first character of the line each anchor start falls on. */
+export function anchorLineStartsByModelOffset(input: {
+  readonly pieces: readonly FieldAwarePiece[];
+  readonly measurer: TextMeasurer;
+  readonly available: number;
+  readonly firstLineOffset: number;
+  readonly anchorStarts: readonly number[];
+  readonly equationLayoutOf: (piece: FieldAwarePiece) => EquationSpanRecord | null;
+}): Map<number, number> {
+  const { pieces, measurer, available, firstLineOffset, anchorStarts, equationLayoutOf } = input;
+  const out = new Map<number, number>();
+  if (anchorStarts.length === 0) return out;
+  let probeLineStart = 0;
+  let probeWidth = 0;
+  let probeLineIndex = 0;
+  // Mirrors the placement loop's word state — the same open decision (`lineOpenDecisionAt`)
+  // and the same mid-word carry — so the probe's predicted line starts cannot diverge
+  // from real placement on a kinsoku line. A veto-less probe put the predicted start
+  // one character off whenever a closing mark wrapped down with its carrier, and
+  // `zoneApplies` then keyed off the wrong line.
+  let probeLastEmitted = '';
+  let probeWordStart = 0;
+  let probeWordStartWidth = -1;
+  const probeLineOffset = (): number => (probeLineIndex === 0 ? firstLineOffset : 0);
+  const probeLineAvail = (): number => Math.max(1, available - probeLineOffset());
+  const closeProbeLine = (nextStart: number): void => {
+    probeLineStart = nextStart;
+    probeWidth = 0;
+    probeLineIndex += 1;
+  };
+  for (const piece of pieces) {
+    const equation = equationLayoutOf(piece);
+    if (equation) {
+      const width = equation.geometry.box.width;
+      if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
+      if (anchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
+      probeWidth += width;
+      probeLastEmitted = '';
+      probeWordStartWidth = -1;
+      continue;
+    }
+    if (piece.inlineDrawing) {
+      const width = measureInlineDrawing(piece.inlineDrawing.projection).totalWidth;
+      if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
+      if (anchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
+      probeWidth += width;
+      probeLastEmitted = '';
+      probeWordStartWidth = -1;
+      continue;
+    }
+    if (piece.text === '\n' || piece.text === PAGE_BREAK_CHAR) {
+      closeProbeLine(piece.end);
+      continue;
+    }
+    const probePieceLayoutOwned =
+      Boolean(piece.projected) ||
+      Boolean(piece.positionalTab) ||
+      piece.end - piece.start !== piece.text.length;
+    let consumed = 0;
+    for (const boundary of wordBoundaries(piece.text, !probePieceLayoutOwned)) {
+      const candidate = piece.text.slice(consumed, boundary);
+      if (candidate.length === 0) continue;
+      const style = styleForFontSlot(piece.style, piece.fontSlot);
+      const width = measurer.measure(candidate, style);
+      const modelStart = piece.start + consumed;
+      const probeDecision = lineOpenDecisionAt(probeLastEmitted, candidate, consumed > 0);
+      const opens = probeDecision === 'opens';
+      if (opens) {
+        probeWordStart = modelStart;
+        probeWordStartWidth = probeWidth;
+      }
+      if (probeWidth > 0 && probeWidth + width > probeLineAvail()) {
+        if (probeDecision === 'forbidden' && probeWordStartWidth <= 0) {
+          // Placement pushes the group out past the measure rather than opening a line
+          // before it, so this probe line does not end here either.
+        } else if (opens || probeWordStartWidth <= 0) {
+          closeProbeLine(modelStart);
+        } else {
+          // Mid-word overflow: placement carries the whole word down, so the next
+          // probe line starts at the word start, not at this candidate.
+          const carried = probeWidth - probeWordStartWidth;
+          closeProbeLine(probeWordStart);
+          probeWidth = carried;
+        }
+        probeWordStartWidth = 0;
+      }
+      if (anchorStarts.includes(modelStart)) out.set(modelStart, probeLineStart);
+      if (anchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
+      probeWidth += width;
+      probeLastEmitted = candidate;
+      consumed = boundary;
+    }
+  }
+  for (const anchorStart of anchorStarts) {
+    if (!out.has(anchorStart)) out.set(anchorStart, probeLineStart);
+  }
+  return out;
+}

--- a/packages/core/src/layout/cjk-line-break.ts
+++ b/packages/core/src/layout/cjk-line-break.ts
@@ -1,18 +1,32 @@
-// CJK line-break opportunities (UAX #14, minimal ideographic form).
+// Line-break opportunities: Latin word boundaries and CJK ideographic breaking
+// (UAX #14, minimal ideographic form).
 //
-// Latin scripts break at spaces, so `wordBoundaries` in `paragraph-flow.ts` only cut after
-// spaces, dashes and tabs. CJK prose carries no spaces at all: a Chinese clause was one
-// giant "word", wrapped only through the wider-than-empty-line chop, and any run or piece
-// seam inside it became the only place a line could end (#526). UAX #14 gives ideographic
-// characters (class ID) a break opportunity on BOTH sides instead, subject to the kinsoku
-// prohibitions: a line must not START with a closing character (。，、」…) and must not END
-// with an opening one (「（…).
+// Latin scripts break at spaces, dashes and tabs — `wordBoundaries` below. CJK prose
+// carries no spaces at all: a Chinese clause was one giant "word", wrapped only through
+// the wider-than-empty-line chop, and any run or piece seam inside it became the only
+// place a line could end (#526). UAX #14 gives ideographic characters (class ID) a break
+// opportunity on BOTH sides instead, subject to the kinsoku prohibitions: a line must not
+// START with a closing character (。，、」…) and must not END with an opening one (「（…).
 //
-// Scope is deliberately the ideographic classes only — Han, Kana, CJK symbols and
-// punctuation, compatibility ideographs, and the full-width forms. A break between an
-// ideograph and Latin/digit text (UAX #14 allows one) is NOT introduced, so every existing
-// Latin break decision stays byte-identical and "1." stays glued to the 甲 that follows it.
-// Hangul, JIS kinsoku levels and other tailorings are out of scope.
+// Scope is deliberately the ideographic classes only — Han, Kana (half-width forms
+// included), CJK symbols and punctuation, compatibility ideographs, and the full-width
+// forms. A break between an ideograph and Latin/digit text (UAX #14 allows one) is NOT
+// introduced, so every existing Latin break decision stays byte-identical and "1." stays
+// glued to the 甲 that follows it. Named cuts, so the follow-ups stay discoverable:
+//
+// - Full-width digits and letters sit inside the ideographic ranges, so a figure group
+//   such as ０．５ can split across lines where Word keeps it together.
+// - The kinsoku sets carry the ideographic-class subset only. Word's East Asian tables
+//   also veto ASCII and Latin-1 punctuation (!%,.:;?°′″℃) at a line start, but only in
+//   East Asian context — honouring that needs script itemization these boundaries do not
+//   see, and vetoing unconditionally changes pure-Latin wrapping.
+// - Justification still stretches only trailing spaces. A justified CJK paragraph
+//   (`w:jc` set to `both`, the Normal-style default in Chinese and Japanese templates)
+//   paints ragged-right on kinsoku-shortened lines where Word distributes
+//   inter-character slack.
+// - Hangul, JIS kinsoku levels and other tailorings are out of scope.
+
+import { segmentGraphemes } from './grapheme.ts';
 
 /**
  * Whether the code point takes ideographic line breaking — a break opportunity on both
@@ -20,8 +34,8 @@
  *
  * Ranges: CJK radicals/Kangxi through symbols-and-punctuation and Kana (U+2E80–U+312F),
  * strokes/Katakana-ext through the unified block (U+31C0–U+9FFF), compatibility ideographs
- * (U+F900–U+FAFF), vertical/compat forms (U+FE30–U+FE4F), full- and half-width forms
- * (U+FF01–U+FF65), and the supplementary ideographic planes (U+20000–U+3134F).
+ * (U+F900–U+FAFF), vertical/compat forms (U+FE30–U+FE4F), full-width forms and half-width
+ * Katakana (U+FF01–U+FF9F), and the supplementary ideographic planes (U+20000–U+3134F).
  */
 export function isIdeographicForLineBreak(codePoint: number): boolean {
   return (
@@ -29,7 +43,7 @@ export function isIdeographicForLineBreak(codePoint: number): boolean {
     (codePoint >= 0x31c0 && codePoint <= 0x9fff) ||
     (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
     (codePoint >= 0xfe30 && codePoint <= 0xfe4f) ||
-    (codePoint >= 0xff01 && codePoint <= 0xff65) ||
+    (codePoint >= 0xff01 && codePoint <= 0xff9f) ||
     (codePoint >= 0x20000 && codePoint <= 0x3134f)
   );
 }
@@ -39,21 +53,23 @@ const codePointsOf = (text: string): ReadonlySet<number> =>
 
 /**
  * Characters a line must not START with (kinsoku 行頭禁則): closing brackets and quotes,
- * CJK full stops and commas (their half-width forms too), sentence-final marks, iteration
- * and prolonged-sound marks, small kana, and unit/percent signs that trail a figure.
- * Everything here is outside ASCII, so Latin layout cannot observe the set.
+ * CJK full stops and commas (their half-width forms too), sentence-final marks, the
+ * ideographic space and middle dots, iteration and prolonged-sound marks, and small kana
+ * (full- and half-width, with the half-width voicing marks that lean on the kana before
+ * them). Every member sits at or above the first ideographic code unit, so Latin layout
+ * cannot observe these sets.
  */
 export const CJK_NO_BREAK_BEFORE: ReadonlySet<number> = codePointsOf(
-  '。．，、；：？！」』）】〉》〕〗〙〛｝］＞％' +
-    '｡｣､･ｰ' +
+  '。．，、；：？！」』）】〉》〕〗〙〛｝］＞％　・' +
+    '｡｣､･ｰﾞﾟ' +
     '々〜ゝゞヽヾー' +
     'ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮヵヶ' +
-    '‰′″℃'
+    'ｧｨｩｪｫｬｭｮｯ'
 );
 
 /**
  * Characters a line must not END with (kinsoku 行末禁則): opening brackets and quotes,
- * and currency signs that prefix a figure. Also entirely outside ASCII.
+ * and currency signs that prefix a figure. Also entirely above the Latin range.
  */
 export const CJK_NO_BREAK_AFTER: ReadonlySet<number> =
   codePointsOf('「『（【〈《〔〖〘〚｛［＜｢＄￥');
@@ -81,4 +97,179 @@ export function lastCodePointOf(text: string): number | undefined {
     return text.codePointAt(text.length - 2)!;
   }
   return lastUnit;
+}
+
+/**
+ * Dashes a line may break AFTER, the way Word wraps "ALPHA-PRIME" as "ALPHA-" / "PRIME":
+ * hyphen-minus, hyphen, en dash, em dash. U+2011 NON-BREAKING HYPHEN is deliberately
+ * absent — its whole meaning is "no wrap here".
+ */
+export const BREAK_AFTER_DASH: ReadonlySet<string> = new Set(['-', '‐', '–', '—']);
+
+/** Every kinsoku member and every ideographic range sits at or above this code unit. */
+const FIRST_IDEOGRAPHIC_UNIT = 0x2e80;
+
+/**
+ * UTF-16 positions where a grapheme cluster starts, for vetoing a cut inside one.
+ *
+ * Built lazily: the Latin boundary rules cut beside spaces, tabs and dashes, which are
+ * cluster boundaries by construction, so only the ideographic pass pays for segmentation —
+ * once per text, and only when it found a break to check. The oversized-word chop steps by
+ * cluster already, so it needs only the kinsoku half (`cjkChopCutAllowedAt`).
+ */
+function clusterCutTester(text: string): (position: number) => boolean {
+  let starts: Set<number> | null = null;
+  return (position: number): boolean => {
+    if (starts === null) {
+      starts = new Set();
+      for (const segment of segmentGraphemes(text)) starts.add(segment.utf16From);
+      starts.add(text.length);
+    }
+    return starts.has(position);
+  };
+}
+
+/** Merge two strictly-increasing, disjoint boundary lists. */
+function mergeBoundaries(latin: readonly number[], cjk: readonly number[]): number[] {
+  const merged: number[] = [];
+  let latinAt = 0;
+  let cjkAt = 0;
+  while (latinAt < latin.length || cjkAt < cjk.length) {
+    const nextLatin = latinAt < latin.length ? latin[latinAt]! : Number.POSITIVE_INFINITY;
+    const nextCjk = cjkAt < cjk.length ? cjk[cjkAt]! : Number.POSITIVE_INFINITY;
+    if (nextLatin < nextCjk) {
+      merged.push(nextLatin);
+      latinAt += 1;
+    } else {
+      merged.push(nextCjk);
+      cjkAt += 1;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Break points inside a piece: after each run of spaces (words stay whole), after a dash
+ * that sits between non-space text, with each tab as its own atom so tab-stop geometry can
+ * size `\t` independently of neighbouring text — and, when `ideographic` allows it,
+ * between ideographic characters, where UAX #14 allows a line to end (kinsoku vetoes
+ * aside). Layout-owned pieces pass `ideographic: false`: every span they emit publishes
+ * the piece's whole model range, so they are documented as staying whole, and a
+ * per-ideograph split would wrap a field result mid-text with every line claiming the
+ * same range.
+ *
+ * A dash run breaks only after its LAST dash, mirroring how a run of spaces is one
+ * boundary; a dash beside a space adds nothing the space boundary does not already give.
+ */
+export function wordBoundaries(text: string, ideographic: boolean): number[] {
+  const boundaries: number[] = [];
+  for (let index = 0; index < text.length; index += 1) {
+    const ch = text[index]!;
+    if (ch === '\t') {
+      if (index > 0 && boundaries[boundaries.length - 1] !== index) boundaries.push(index);
+      boundaries.push(index + 1);
+    } else if (ch === ' ') {
+      boundaries.push(index + 1);
+    } else if (
+      BREAK_AFTER_DASH.has(ch) &&
+      index > 0 &&
+      text[index - 1] !== ' ' &&
+      index + 1 < text.length &&
+      text[index + 1] !== ' ' &&
+      !BREAK_AFTER_DASH.has(text[index + 1]!)
+    ) {
+      boundaries.push(index + 1);
+    }
+  }
+  // CJK pass, by code point so a supplementary-plane ideograph is never cut inside its
+  // surrogate pair, filtered through the grapheme boundary so NFD text (か + U+3099) is
+  // never cut inside a cluster either. Kept separate from the loop above so the Latin
+  // rules stay byte-identical; both lists are strictly increasing and can never share a
+  // position (every Latin cut borders a space, tab or dash, none of which is
+  // ideographic), so an O(n) merge replaces them without a sort.
+  let merged = boundaries;
+  if (ideographic) {
+    const cjk: number[] = [];
+    const clusterCutAt = clusterCutTester(text);
+    for (let index = 0; index < text.length; ) {
+      const before = text.codePointAt(index)!;
+      const next = index + (before > 0xffff ? 2 : 1);
+      if (next >= text.length) break;
+      if (cjkBreakAllowedBetween(before, text.codePointAt(next)!) && clusterCutAt(next)) {
+        cjk.push(next);
+      }
+      index = next;
+    }
+    if (cjk.length > 0) merged = mergeBoundaries(boundaries, cjk);
+  }
+  if (merged[merged.length - 1] !== text.length) merged.push(text.length);
+  return merged;
+}
+
+/** Whether a cut between two adjacent code points is legal under the kinsoku sets. */
+export function cjkCutAllowedBetween(
+  before: number | undefined,
+  after: number | undefined
+): boolean {
+  if (after !== undefined && CJK_NO_BREAK_BEFORE.has(after)) return false;
+  if (before !== undefined && CJK_NO_BREAK_AFTER.has(before)) return false;
+  return true;
+}
+
+/**
+ * Whether the oversized-word chop may cut `text` at `index`.
+ *
+ * The chop measures a fit length that knows nothing about kinsoku — at a one-character
+ * measure 天。地。人。 rendered every other line starting with 。 —  and
+ * `chopOversizedWord` walks the cut to the nearest position this accepts. Grapheme and
+ * surrogate safety is the chop's own (it steps by cluster), so only the kinsoku sets are
+ * asked here.
+ */
+export function cjkChopCutAllowedAt(text: string, index: number): boolean {
+  if (index <= 0 || index >= text.length) return true;
+  return cjkCutAllowedBetween(lastCodePointOf(text.slice(0, index)), text.codePointAt(index));
+}
+
+/**
+ * Whether a candidate may OPEN a line — the decision the placement loop and the
+ * anchor-line probe must share, or their predicted line starts diverge.
+ *
+ * A candidate is a break opportunity at any `wordBoundaries` cut inside its piece
+ * (`afterIntraPieceCut`). The FIRST candidate of a piece continues whatever the previous
+ * piece ended with, so it is one only if that ended in whitespace — or in a dash or an
+ * ideograph, which stay break opportunities across run boundaries (a tracked change can
+ * split "ALPHA-" and "PRIME" into different runs without gluing them, and a CJK clause
+ * split across runs must not wrap at the seam instead of the margin, #526). The kinsoku
+ * sets then veto the whole decision: no opportunity ever puts 。，、」 at a line start or
+ * leaves 「（ at a line end — a space or a run seam directly before a closing mark would
+ * otherwise create one. A tab outranks the veto: a tab is a hard break opportunity whose
+ * following text must be able to open a line, or an overflow takes the mid-word carry
+ * path and re-lays the tab with a stale advance that no longer reaches its stop.
+ */
+export function wordOpensAt(
+  lastEmitted: string,
+  candidate: string,
+  afterIntraPieceCut: boolean
+): boolean {
+  const opportunity =
+    afterIntraPieceCut ||
+    lastEmitted === '' ||
+    /[\s ]$/.test(lastEmitted) ||
+    /^[\s ]/.test(candidate) ||
+    (BREAK_AFTER_DASH.has(lastEmitted[lastEmitted.length - 1]!) &&
+      !BREAK_AFTER_DASH.has(candidate[0]!));
+  // Both seam units below the first ideographic range: no CJK rule can observe the seam,
+  // so the pre-ideographic decision above is final. This is the hot path for pure-Latin
+  // text — no decode, no set lookups. (A surrogate unit is above the threshold.)
+  const lastUnit = lastEmitted.length === 0 ? 0 : lastEmitted.charCodeAt(lastEmitted.length - 1);
+  if (lastUnit < FIRST_IDEOGRAPHIC_UNIT && candidate.charCodeAt(0) < FIRST_IDEOGRAPHIC_UNIT) {
+    return opportunity;
+  }
+  if (lastUnit === 0x09) return true;
+  const previous = lastCodePointOf(lastEmitted);
+  const first = candidate.codePointAt(0)!;
+  return (
+    (opportunity || (previous !== undefined && cjkBreakAllowedBetween(previous, first))) &&
+    cjkCutAllowedBetween(previous, first)
+  );
 }

--- a/packages/core/src/layout/cjk-line-break.ts
+++ b/packages/core/src/layout/cjk-line-break.ts
@@ -24,6 +24,9 @@
 //   (`w:jc` set to `both`, the Normal-style default in Chinese and Japanese templates)
 //   paints ragged-right on kinsoku-shortened lines where Word distributes
 //   inter-character slack.
+// - A protected group that starts its line and does not fit is PUSHED OUT past the measure,
+//   Word's 追い出し. Word can also compress inter-character space to pull the offender back
+//   in (追い込み); that needs justification slack this layer does not distribute.
 // - Hangul, JIS kinsoku levels and other tailorings are out of scope.
 
 import { segmentGraphemes } from './grapheme.ts';
@@ -231,8 +234,36 @@ export function cjkChopCutAllowedAt(text: string, index: number): boolean {
 }
 
 /**
+ * Whether a cluster boundary exists between two adjacent code points, memoized by the pair.
+ *
+ * Only reached at a piece seam whose neighbours are at or above the ideographic range, so
+ * Latin placement never pays for it.
+ */
+const clusterBreakCache = new Map<number, boolean>();
+function clusterBreaksBetween(before: number, after: number): boolean {
+  const key = before * 0x110000 + after;
+  const cached = clusterBreakCache.get(key);
+  if (cached !== undefined) return cached;
+  let count = 0;
+  for (const _segment of segmentGraphemes(String.fromCodePoint(before, after))) count += 1;
+  const breaks = count > 1;
+  clusterBreakCache.set(key, breaks);
+  return breaks;
+}
+
+/** Why a candidate may or may not open a line. */
+export type LineOpenDecision =
+  /** A real break opportunity: the line may end before this candidate. */
+  | 'opens'
+  /** No opportunity here — mid-word, as a Latin word split across runs is. */
+  | 'continues'
+  /** An opportunity a rule forbids: a kinsoku seam, or one inside a grapheme cluster. */
+  | 'forbidden';
+
+/**
  * Whether a candidate may OPEN a line — the decision the placement loop and the
- * anchor-line probe must share, or their predicted line starts diverge.
+ * anchor-line probe must share, or their predicted line starts diverge — and, when it may
+ * not, WHY.
  *
  * A candidate is a break opportunity at any `wordBoundaries` cut inside its piece
  * (`afterIntraPieceCut`). The FIRST candidate of a piece continues whatever the previous
@@ -245,12 +276,18 @@ export function cjkChopCutAllowedAt(text: string, index: number): boolean {
  * otherwise create one. A tab outranks the veto: a tab is a hard break opportunity whose
  * following text must be able to open a line, or an overflow takes the mid-word carry
  * path and re-lays the tab with a stale advance that no longer reaches its stop.
+ *
+ * `continues` and `forbidden` are both "may not open", and the caller must tell them
+ * apart. A Latin word wider than its line has no legal cut of its own, so it is CHOPPED at
+ * the margin; a kinsoku group has no legal cut either, but chopping it is exactly the break
+ * the rule forbids, so it is pushed out past the measure instead — the same answer
+ * `chopOversizedWord` reaches when no accepted cut is left.
  */
-export function wordOpensAt(
+export function lineOpenDecisionAt(
   lastEmitted: string,
   candidate: string,
   afterIntraPieceCut: boolean
-): boolean {
+): LineOpenDecision {
   const opportunity =
     afterIntraPieceCut ||
     lastEmitted === '' ||
@@ -263,13 +300,26 @@ export function wordOpensAt(
   // text — no decode, no set lookups. (A surrogate unit is above the threshold.)
   const lastUnit = lastEmitted.length === 0 ? 0 : lastEmitted.charCodeAt(lastEmitted.length - 1);
   if (lastUnit < FIRST_IDEOGRAPHIC_UNIT && candidate.charCodeAt(0) < FIRST_IDEOGRAPHIC_UNIT) {
-    return opportunity;
+    return opportunity ? 'opens' : 'continues';
   }
-  if (lastUnit === 0x09) return true;
+  if (lastUnit === 0x09) return 'opens';
   const previous = lastCodePointOf(lastEmitted);
   const first = candidate.codePointAt(0)!;
-  return (
-    (opportunity || (previous !== undefined && cjkBreakAllowedBetween(previous, first))) &&
-    cjkCutAllowedBetween(previous, first)
-  );
+  // A grapheme cluster SPLIT ACROSS PIECES has no single text for `wordBoundaries` to
+  // segment, so the two code points around the seam are segmented on their own: NFD kana
+  // (か in one run, U+3099 in the next) would otherwise orphan its voicing mark, the
+  // combining marks being inside the ideographic ranges and outside the kinsoku sets.
+  if (previous !== undefined && !clusterBreaksBetween(previous, first)) return 'forbidden';
+  if (!cjkCutAllowedBetween(previous, first)) return 'forbidden';
+  if (opportunity) return 'opens';
+  return previous !== undefined && cjkBreakAllowedBetween(previous, first) ? 'opens' : 'continues';
+}
+
+/** `lineOpenDecisionAt` for callers that need only the yes/no. */
+export function wordOpensAt(
+  lastEmitted: string,
+  candidate: string,
+  afterIntraPieceCut: boolean
+): boolean {
+  return lineOpenDecisionAt(lastEmitted, candidate, afterIntraPieceCut) === 'opens';
 }

--- a/packages/core/src/layout/cjk-line-break.ts
+++ b/packages/core/src/layout/cjk-line-break.ts
@@ -1,0 +1,84 @@
+// CJK line-break opportunities (UAX #14, minimal ideographic form).
+//
+// Latin scripts break at spaces, so `wordBoundaries` in `paragraph-flow.ts` only cut after
+// spaces, dashes and tabs. CJK prose carries no spaces at all: a Chinese clause was one
+// giant "word", wrapped only through the wider-than-empty-line chop, and any run or piece
+// seam inside it became the only place a line could end (#526). UAX #14 gives ideographic
+// characters (class ID) a break opportunity on BOTH sides instead, subject to the kinsoku
+// prohibitions: a line must not START with a closing character (。，、」…) and must not END
+// with an opening one (「（…).
+//
+// Scope is deliberately the ideographic classes only — Han, Kana, CJK symbols and
+// punctuation, compatibility ideographs, and the full-width forms. A break between an
+// ideograph and Latin/digit text (UAX #14 allows one) is NOT introduced, so every existing
+// Latin break decision stays byte-identical and "1." stays glued to the 甲 that follows it.
+// Hangul, JIS kinsoku levels and other tailorings are out of scope.
+
+/**
+ * Whether the code point takes ideographic line breaking — a break opportunity on both
+ * sides, before the kinsoku sets below veto one direction.
+ *
+ * Ranges: CJK radicals/Kangxi through symbols-and-punctuation and Kana (U+2E80–U+312F),
+ * strokes/Katakana-ext through the unified block (U+31C0–U+9FFF), compatibility ideographs
+ * (U+F900–U+FAFF), vertical/compat forms (U+FE30–U+FE4F), full- and half-width forms
+ * (U+FF01–U+FF65), and the supplementary ideographic planes (U+20000–U+3134F).
+ */
+export function isIdeographicForLineBreak(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x2e80 && codePoint <= 0x312f) ||
+    (codePoint >= 0x31c0 && codePoint <= 0x9fff) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe4f) ||
+    (codePoint >= 0xff01 && codePoint <= 0xff65) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3134f)
+  );
+}
+
+const codePointsOf = (text: string): ReadonlySet<number> =>
+  new Set([...text].map((ch) => ch.codePointAt(0)!));
+
+/**
+ * Characters a line must not START with (kinsoku 行頭禁則): closing brackets and quotes,
+ * CJK full stops and commas (their half-width forms too), sentence-final marks, iteration
+ * and prolonged-sound marks, small kana, and unit/percent signs that trail a figure.
+ * Everything here is outside ASCII, so Latin layout cannot observe the set.
+ */
+export const CJK_NO_BREAK_BEFORE: ReadonlySet<number> = codePointsOf(
+  '。．，、；：？！」』）】〉》〕〗〙〛｝］＞％' +
+    '｡｣､･ｰ' +
+    '々〜ゝゞヽヾー' +
+    'ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮヵヶ' +
+    '‰′″℃'
+);
+
+/**
+ * Characters a line must not END with (kinsoku 行末禁則): opening brackets and quotes,
+ * and currency signs that prefix a figure. Also entirely outside ASCII.
+ */
+export const CJK_NO_BREAK_AFTER: ReadonlySet<number> =
+  codePointsOf('「『（【〈《〔〖〘〚｛［＜｢＄￥');
+
+/**
+ * Whether a line may break between these two adjacent code points.
+ *
+ * Both sides must be ideographic — the minimal-scope rule above — and neither kinsoku set
+ * may veto its direction. The closing and opening characters are themselves inside the
+ * ideographic ranges, so 「 glues to the character after it and 。 to the one before,
+ * while both still break freely on their permitted side.
+ */
+export function cjkBreakAllowedBetween(before: number, after: number): boolean {
+  if (!isIdeographicForLineBreak(before) || !isIdeographicForLineBreak(after)) return false;
+  if (CJK_NO_BREAK_AFTER.has(before)) return false;
+  if (CJK_NO_BREAK_BEFORE.has(after)) return false;
+  return true;
+}
+
+/** The final code point of the text, stepping back over a surrogate pair; undefined when empty. */
+export function lastCodePointOf(text: string): number | undefined {
+  if (text.length === 0) return undefined;
+  const lastUnit = text.charCodeAt(text.length - 1);
+  if (lastUnit >= 0xdc00 && lastUnit <= 0xdfff && text.length >= 2) {
+    return text.codePointAt(text.length - 2)!;
+  }
+  return lastUnit;
+}

--- a/packages/core/src/layout/oversized-word-break.ts
+++ b/packages/core/src/layout/oversized-word-break.ts
@@ -21,6 +21,29 @@ export interface OversizedWordRemainder extends OversizedWordPrefix {
  * line's measure. At least one grapheme remains for ordinary placement; if one grapheme alone
  * is wider than an empty line, it is the indivisible unit that is allowed to overflow.
  */
+/**
+ * Move a grapheme-safe cut to one `cutAllowedAt` also accepts: shorter first, so the line
+ * stays inside its measure; longer only when no shorter cut is left, pushing the offending
+ * character out with its carrier. A text with no accepted cut at all (。。。) keeps the
+ * measured one, so the chop always makes progress.
+ */
+function acceptedCut(
+  text: string,
+  graphemes: readonly { readonly utf16To: number }[],
+  graphemeFrom: number,
+  fitTo: number,
+  cutAllowedAt: ((text: string, utf16Index: number) => boolean) | undefined
+): number {
+  if (cutAllowedAt === undefined || cutAllowedAt(text, graphemes[fitTo - 1]!.utf16To)) return fitTo;
+  for (let candidate = fitTo - 1; candidate > graphemeFrom; candidate -= 1) {
+    if (cutAllowedAt(text, graphemes[candidate - 1]!.utf16To)) return candidate;
+  }
+  for (let candidate = fitTo + 1; candidate <= graphemes.length; candidate += 1) {
+    if (cutAllowedAt(text, graphemes[candidate - 1]!.utf16To)) return candidate;
+  }
+  return fitTo;
+}
+
 export function chopOversizedWord(
   text: string,
   modelStart: number,
@@ -32,6 +55,12 @@ export function chopOversizedWord(
     readonly appendPrefix: (prefix: OversizedWordPrefix) => void;
     readonly closeLine: () => void;
     readonly overflowTolerancePt: number;
+    /**
+     * Whether the cut at a UTF-16 index is allowed on top of grapheme safety — the kinsoku
+     * sets, for CJK text. A rejected cut shrinks to the nearest accepted one; when none is
+     * left inside the measure it GROWS past it instead, which is Word's kinsoku push-out.
+     */
+    readonly cutAllowedAt?: (text: string, utf16Index: number) => boolean;
   }
 ): OversizedWordRemainder {
   if (width <= options.remainingLineWidth() + options.overflowTolerancePt) {
@@ -82,6 +111,7 @@ export function chopOversizedWord(
     // An empty line that cannot fit one grapheme must overflow by that whole grapheme, never
     // by one UTF-16 code unit (which could split a surrogate pair or combining sequence).
     if (fitTo === graphemeFrom) fitTo += 1;
+    fitTo = acceptedCut(text, graphemes, graphemeFrom, fitTo, options.cutAllowedAt);
 
     const utf16To = graphemes[fitTo - 1]!.utf16To;
     const prefixText = text.slice(utf16From, utf16To);

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -33,7 +33,7 @@ import {
   type RevisionDisplayMode,
 } from './revision-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
-import { cjkChopCutAllowedAt, wordBoundaries, wordOpensAt } from './cjk-line-break.ts';
+import { cjkChopCutAllowedAt, lineOpenDecisionAt, wordBoundaries } from './cjk-line-break.ts';
 import {
   EMPTY_TAB_STOPS,
   nextTabDestination,
@@ -78,6 +78,7 @@ import {
   type ExclusionZone,
 } from './drawing-exclusion.ts';
 import { createEquationLayouter } from './equation-layout.ts';
+import { anchorLineStartsByModelOffset } from './anchor-line-probe.ts';
 import { isCollapsibleLineEndWhitespace } from './line-end-whitespace.ts';
 import { chopOversizedWord } from './oversized-word-break.ts';
 
@@ -729,91 +730,14 @@ export function breakParagraph(
     ...wrapAnchorStarts,
   ];
 
-  const anchorLineStartByOffset = (() => {
-    const out = new Map<number, number>();
-    if (sameParagraphAnchorStarts.length === 0) return out;
-    let probeLineStart = 0;
-    let probeWidth = 0;
-    let probeLineIndex = 0;
-    // Mirrors the placement loop's word state — the same open decision (`wordOpensAt`)
-    // and the same mid-word carry — so the probe's predicted line starts cannot diverge
-    // from real placement on a kinsoku line. A veto-less probe put the predicted start
-    // one character off whenever a closing mark wrapped down with its carrier, and
-    // `zoneApplies` then keyed off the wrong line.
-    let probeLastEmitted = '';
-    let probeWordStart = 0;
-    let probeWordStartWidth = -1;
-    const probeLineOffset = (): number => (probeLineIndex === 0 ? firstLineOffset : 0);
-    const probeLineAvail = (): number => Math.max(1, available - probeLineOffset());
-    const closeProbeLine = (nextStart: number): void => {
-      probeLineStart = nextStart;
-      probeWidth = 0;
-      probeLineIndex += 1;
-    };
-    for (const piece of pieces) {
-      const equation = equationLayoutOf(piece);
-      if (equation) {
-        const width = equation.geometry.box.width;
-        if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
-        if (sameParagraphAnchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
-        probeWidth += width;
-        probeLastEmitted = '';
-        probeWordStartWidth = -1;
-        continue;
-      }
-      if (piece.inlineDrawing) {
-        const width = measureInlineDrawing(piece.inlineDrawing.projection).totalWidth;
-        if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
-        if (sameParagraphAnchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
-        probeWidth += width;
-        probeLastEmitted = '';
-        probeWordStartWidth = -1;
-        continue;
-      }
-      if (piece.text === '\n' || piece.text === PAGE_BREAK_CHAR) {
-        closeProbeLine(piece.end);
-        continue;
-      }
-      const probePieceLayoutOwned =
-        Boolean(piece.projected) ||
-        Boolean(piece.positionalTab) ||
-        piece.end - piece.start !== piece.text.length;
-      let consumed = 0;
-      for (const boundary of wordBoundaries(piece.text, !probePieceLayoutOwned)) {
-        const candidate = piece.text.slice(consumed, boundary);
-        if (candidate.length === 0) continue;
-        const style = styleForFontSlot(piece.style, piece.fontSlot);
-        const width = measurer.measure(candidate, style);
-        const modelStart = piece.start + consumed;
-        const opens = wordOpensAt(probeLastEmitted, candidate, consumed > 0);
-        if (opens) {
-          probeWordStart = modelStart;
-          probeWordStartWidth = probeWidth;
-        }
-        if (probeWidth > 0 && probeWidth + width > probeLineAvail()) {
-          if (opens || probeWordStartWidth <= 0) {
-            closeProbeLine(modelStart);
-          } else {
-            // Mid-word overflow: placement carries the whole word down, so the next
-            // probe line starts at the word start, not at this candidate.
-            const carried = probeWidth - probeWordStartWidth;
-            closeProbeLine(probeWordStart);
-            probeWidth = carried;
-          }
-          probeWordStartWidth = 0;
-        }
-        if (sameParagraphAnchorStarts.includes(modelStart)) out.set(modelStart, probeLineStart);
-        if (sameParagraphAnchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
-        probeWidth += width;
-        probeLastEmitted = candidate;
-        consumed = boundary;
-      }
-    }
-    for (const anchorStart of sameParagraphAnchorStarts) {
-      if (!out.has(anchorStart)) out.set(anchorStart, probeLineStart);
-    }
-    return out;
-  })();
+  const anchorLineStartByOffset = anchorLineStartsByModelOffset({
+    pieces,
+    measurer,
+    available,
+    firstLineOffset,
+    anchorStarts: sameParagraphAnchorStarts,
+    equationLayoutOf,
+  });
 
   for (const start of wrapAnchorStarts) {
     const lineStart = anchorLineStartByOffset.get(start);
@@ -1540,8 +1464,9 @@ export function breakParagraph(
       const measureSource = piece.measureText ?? candidate;
       let width = measurer.measure(displayText(measureSource, faceStyle), faceStyle);
       // A candidate may open a line only at a real break opportunity — the shared
-      // decision in `wordOpensAt`, which the anchor-line probe above consumes too.
-      const opensWord = wordOpensAt(lastEmitted, candidate, consumed > 0);
+      // decision in `lineOpenDecisionAt`, which the anchor-line probe above consumes too.
+      const openDecision = lineOpenDecisionAt(lastEmitted, candidate, consumed > 0);
+      const opensWord = openDecision === 'opens';
       if (opensWord) {
         wordStartSpan = line.spans.length;
         wordStartWidth = line.width;
@@ -1558,7 +1483,14 @@ export function breakParagraph(
         line.width + width > lineAvailable() + OVERFLOW_TOLERANCE_PT &&
         (line.spans.length > 0 || line.drawings.length > 0)
       ) {
-        if (!opensWord && wordStartSpan === 0) {
+        if (openDecision === 'forbidden' && wordStartSpan <= 0) {
+          // The group starts this line and a rule forbids opening before it: a kinsoku seam,
+          // or one inside a grapheme cluster split across pieces. There is nothing to carry
+          // down, and chopping is the very break the rule forbids, so it is pushed out past
+          // the measure — Word's kinsoku push-out, and what the chop below reaches by itself
+          // when no accepted cut is left. `wordBoundaries` already cut at the next legal seam
+          // inside the piece, so what overflows is one protected group, not the clause.
+        } else if (!opensWord && wordStartSpan === 0) {
           // Prefer a later float passage; otherwise fill this one's remainder in the chop below.
           tryAdvanceToNextPassage();
         } else if (opensWord || wordStartSpan < 0) {
@@ -1614,7 +1546,8 @@ export function breakParagraph(
       const canChopWord = !layoutOwned && piece.measureText === undefined;
       if (
         canChopWord &&
-        (line.spans.length === 0 || (!opensWord && wordStartSpan === 0)) &&
+        (line.spans.length === 0 ||
+          (!opensWord && wordStartSpan === 0 && openDecision !== 'forbidden')) &&
         width > remainingLineWidth() + OVERFLOW_TOLERANCE_PT
       ) {
         const chopped = chopOversizedWord(candidate, remainingStart, width, {

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -34,6 +34,12 @@ import {
 } from './revision-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
 import {
+  CJK_NO_BREAK_AFTER,
+  CJK_NO_BREAK_BEFORE,
+  cjkBreakAllowedBetween,
+  lastCodePointOf,
+} from './cjk-line-break.ts';
+import {
   EMPTY_TAB_STOPS,
   nextTabDestination,
   tabAdvanceWidth,
@@ -259,8 +265,9 @@ const BREAK_AFTER_DASH = new Set(['-', '‐', '–', '—']);
 
 /**
  * Break points inside a piece: after each run of spaces (words stay whole), after a dash
- * that sits between non-space text, and with each tab as its own atom so tab-stop
- * geometry can size `\t` independently of neighbouring text.
+ * that sits between non-space text, with each tab as its own atom so tab-stop geometry can
+ * size `\t` independently of neighbouring text — and between ideographic characters, where
+ * UAX #14 allows a line to end (kinsoku vetoes aside, see `cjk-line-break.ts`).
  *
  * A dash run breaks only after its LAST dash, mirroring how a run of spaces is one
  * boundary; a dash beside a space adds nothing the space boundary does not already give.
@@ -285,8 +292,18 @@ function wordBoundaries(text: string): number[] {
       boundaries.push(index + 1);
     }
   }
-  if (boundaries[boundaries.length - 1] !== text.length) boundaries.push(text.length);
-  return boundaries;
+  // CJK pass, by code point so a supplementary-plane ideograph is never cut inside its
+  // surrogate pair. Kept separate from the loop above so the Latin rules stay byte-identical.
+  for (let index = 0; index < text.length; ) {
+    const before = text.codePointAt(index)!;
+    const next = index + (before > 0xffff ? 2 : 1);
+    if (next >= text.length) break;
+    if (cjkBreakAllowedBetween(before, text.codePointAt(next)!)) boundaries.push(next);
+    index = next;
+  }
+  const ordered = [...new Set(boundaries)].sort((a, b) => a - b);
+  if (ordered[ordered.length - 1] !== text.length) ordered.push(text.length);
+  return ordered;
 }
 
 /**
@@ -1532,18 +1549,28 @@ export function breakParagraph(
       const measureSource = piece.measureText ?? candidate;
       let width = measurer.measure(displayText(measureSource, faceStyle), faceStyle);
       // A candidate may open a line only at a real break opportunity. Within a piece,
-      // `wordBoundaries` cuts after spaces, dashes and tabs, so every candidate but the
-      // first is one. The FIRST candidate of a piece continues whatever the previous piece
-      // ended with, so it is a break opportunity only if that ended in whitespace \u2014 or in a
-      // dash, which stays a break opportunity across run boundaries (a tracked change can
-      // split "ALPHA-" and "PRIME" into different runs without gluing them).
+      // `wordBoundaries` cuts after spaces, dashes, tabs and between ideographs, so every
+      // candidate but the first is one. The FIRST candidate of a piece continues whatever
+      // the previous piece ended with, so it is a break opportunity only if that ended in
+      // whitespace \u2014 or in a dash or an ideograph, which stay break opportunities across
+      // run boundaries (a tracked change can split "ALPHA-" and "PRIME" into different runs
+      // without gluing them, and a CJK clause split across runs must not wrap at the seam
+      // instead of the margin, #526). The kinsoku sets then veto the whole decision: no
+      // opportunity ever puts \u3002\uff0c\u3001\u300d at a line start or leaves \u300c\uff08 at a line end \u2014 a space
+      // or a run seam directly before a closing mark would otherwise create one.
+      const previousCodePoint = lastCodePointOf(lastEmitted);
+      const firstCodePoint = candidate.codePointAt(0)!;
       const opensWord =
-        consumed > 0 ||
-        lastEmitted === '' ||
-        /[\s\u00a0]$/.test(lastEmitted) ||
-        /^[\s\u00a0]/.test(candidate) ||
-        (BREAK_AFTER_DASH.has(lastEmitted[lastEmitted.length - 1]!) &&
-          !BREAK_AFTER_DASH.has(candidate[0]!));
+        (consumed > 0 ||
+          lastEmitted === '' ||
+          /[\s\u00a0]$/.test(lastEmitted) ||
+          /^[\s\u00a0]/.test(candidate) ||
+          (BREAK_AFTER_DASH.has(lastEmitted[lastEmitted.length - 1]!) &&
+            !BREAK_AFTER_DASH.has(candidate[0]!)) ||
+          (previousCodePoint !== undefined &&
+            cjkBreakAllowedBetween(previousCodePoint, firstCodePoint))) &&
+        !CJK_NO_BREAK_BEFORE.has(firstCodePoint) &&
+        !(previousCodePoint !== undefined && CJK_NO_BREAK_AFTER.has(previousCodePoint));
       if (opensWord) {
         wordStartSpan = line.spans.length;
         wordStartWidth = line.width;

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -33,12 +33,7 @@ import {
   type RevisionDisplayMode,
 } from './revision-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
-import {
-  CJK_NO_BREAK_AFTER,
-  CJK_NO_BREAK_BEFORE,
-  cjkBreakAllowedBetween,
-  lastCodePointOf,
-} from './cjk-line-break.ts';
+import { cjkChopCutAllowedAt, wordBoundaries, wordOpensAt } from './cjk-line-break.ts';
 import {
   EMPTY_TAB_STOPS,
   nextTabDestination,
@@ -254,56 +249,6 @@ interface Piece {
 
 export function propertiesOf(container: OoxmlNode | undefined): OoxmlProperty[] {
   return propertiesOfRunContainer(container);
-}
-
-/**
- * Dashes a line may break AFTER, the way Word wraps "ALPHA-PRIME" as "ALPHA-" / "PRIME":
- * hyphen-minus, hyphen, en dash, em dash. U+2011 NON-BREAKING HYPHEN is deliberately
- * absent — its whole meaning is "no wrap here".
- */
-const BREAK_AFTER_DASH = new Set(['-', '‐', '–', '—']);
-
-/**
- * Break points inside a piece: after each run of spaces (words stay whole), after a dash
- * that sits between non-space text, with each tab as its own atom so tab-stop geometry can
- * size `\t` independently of neighbouring text — and between ideographic characters, where
- * UAX #14 allows a line to end (kinsoku vetoes aside, see `cjk-line-break.ts`).
- *
- * A dash run breaks only after its LAST dash, mirroring how a run of spaces is one
- * boundary; a dash beside a space adds nothing the space boundary does not already give.
- */
-function wordBoundaries(text: string): number[] {
-  const boundaries: number[] = [];
-  for (let index = 0; index < text.length; index += 1) {
-    const ch = text[index]!;
-    if (ch === '\t') {
-      if (index > 0 && boundaries[boundaries.length - 1] !== index) boundaries.push(index);
-      boundaries.push(index + 1);
-    } else if (ch === ' ') {
-      boundaries.push(index + 1);
-    } else if (
-      BREAK_AFTER_DASH.has(ch) &&
-      index > 0 &&
-      text[index - 1] !== ' ' &&
-      index + 1 < text.length &&
-      text[index + 1] !== ' ' &&
-      !BREAK_AFTER_DASH.has(text[index + 1]!)
-    ) {
-      boundaries.push(index + 1);
-    }
-  }
-  // CJK pass, by code point so a supplementary-plane ideograph is never cut inside its
-  // surrogate pair. Kept separate from the loop above so the Latin rules stay byte-identical.
-  for (let index = 0; index < text.length; ) {
-    const before = text.codePointAt(index)!;
-    const next = index + (before > 0xffff ? 2 : 1);
-    if (next >= text.length) break;
-    if (cjkBreakAllowedBetween(before, text.codePointAt(next)!)) boundaries.push(next);
-    index = next;
-  }
-  const ordered = [...new Set(boundaries)].sort((a, b) => a - b);
-  if (ordered[ordered.length - 1] !== text.length) ordered.push(text.length);
-  return ordered;
 }
 
 /**
@@ -790,6 +735,14 @@ export function breakParagraph(
     let probeLineStart = 0;
     let probeWidth = 0;
     let probeLineIndex = 0;
+    // Mirrors the placement loop's word state — the same open decision (`wordOpensAt`)
+    // and the same mid-word carry — so the probe's predicted line starts cannot diverge
+    // from real placement on a kinsoku line. A veto-less probe put the predicted start
+    // one character off whenever a closing mark wrapped down with its carrier, and
+    // `zoneApplies` then keyed off the wrong line.
+    let probeLastEmitted = '';
+    let probeWordStart = 0;
+    let probeWordStartWidth = -1;
     const probeLineOffset = (): number => (probeLineIndex === 0 ? firstLineOffset : 0);
     const probeLineAvail = (): number => Math.max(1, available - probeLineOffset());
     const closeProbeLine = (nextStart: number): void => {
@@ -804,6 +757,8 @@ export function breakParagraph(
         if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
         if (sameParagraphAnchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
         probeWidth += width;
+        probeLastEmitted = '';
+        probeWordStartWidth = -1;
         continue;
       }
       if (piece.inlineDrawing) {
@@ -811,23 +766,46 @@ export function breakParagraph(
         if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
         if (sameParagraphAnchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
         probeWidth += width;
+        probeLastEmitted = '';
+        probeWordStartWidth = -1;
         continue;
       }
       if (piece.text === '\n' || piece.text === PAGE_BREAK_CHAR) {
         closeProbeLine(piece.end);
         continue;
       }
+      const probePieceLayoutOwned =
+        Boolean(piece.projected) ||
+        Boolean(piece.positionalTab) ||
+        piece.end - piece.start !== piece.text.length;
       let consumed = 0;
-      for (const boundary of wordBoundaries(piece.text)) {
+      for (const boundary of wordBoundaries(piece.text, !probePieceLayoutOwned)) {
         const candidate = piece.text.slice(consumed, boundary);
         if (candidate.length === 0) continue;
         const style = styleForFontSlot(piece.style, piece.fontSlot);
         const width = measurer.measure(candidate, style);
         const modelStart = piece.start + consumed;
-        if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(modelStart);
+        const opens = wordOpensAt(probeLastEmitted, candidate, consumed > 0);
+        if (opens) {
+          probeWordStart = modelStart;
+          probeWordStartWidth = probeWidth;
+        }
+        if (probeWidth > 0 && probeWidth + width > probeLineAvail()) {
+          if (opens || probeWordStartWidth <= 0) {
+            closeProbeLine(modelStart);
+          } else {
+            // Mid-word overflow: placement carries the whole word down, so the next
+            // probe line starts at the word start, not at this candidate.
+            const carried = probeWidth - probeWordStartWidth;
+            closeProbeLine(probeWordStart);
+            probeWidth = carried;
+          }
+          probeWordStartWidth = 0;
+        }
         if (sameParagraphAnchorStarts.includes(modelStart)) out.set(modelStart, probeLineStart);
         if (sameParagraphAnchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
         probeWidth += width;
+        probeLastEmitted = candidate;
         consumed = boundary;
       }
     }
@@ -1454,21 +1432,24 @@ export function breakParagraph(
     // resolution — plus the slot, and re-resolve through the same helper.
     const faceStyle = styleForFontSlot(piece.style, piece.fontSlot);
     const metrics = measurer.lineMetrics(faceStyle);
+    // Projected PAGE/NUMPAGES digits publish the suppressed cached-result model range (or a
+    // zero-width insertion point when the cache was empty) so surrounding source offsets
+    // stay aligned with binding / paragraphTextOf.
+    // A projected field publishes the model range it stands in for; a `w:ptab` publishes
+    // its ZERO-WIDTH insertion point, because it contributes no text to the paragraph.
+    // Defensive: any piece whose display length disagrees with its model range is also
+    // layout-owned (inert DATE/TOC/REF/… cache before `projected` was set).
+    // Layout-owned pieces get no ideographic boundaries: they are documented below as
+    // staying whole, and a per-ideograph split wrapped a CJK field result mid-text with
+    // every span claiming the same model range.
+    const layoutOwned =
+      Boolean(piece.projected) ||
+      Boolean(piece.positionalTab) ||
+      piece.end - piece.start !== piece.text.length;
     let consumed = 0;
-    for (const boundary of wordBoundaries(piece.text)) {
+    for (const boundary of wordBoundaries(piece.text, !layoutOwned)) {
       const candidate = piece.text.slice(consumed, boundary);
       if (candidate.length === 0) continue;
-      // Projected PAGE/NUMPAGES digits publish the suppressed cached-result model range (or a
-      // zero-width insertion point when the cache was empty) so surrounding source offsets
-      // stay aligned with binding / paragraphTextOf.
-      // A projected field publishes the model range it stands in for; a `w:ptab` publishes
-      // its ZERO-WIDTH insertion point, because it contributes no text to the paragraph.
-      // Defensive: any piece whose display length disagrees with its model range is also
-      // layout-owned (inert DATE/TOC/REF/… cache before `projected` was set).
-      const layoutOwned =
-        Boolean(piece.projected) ||
-        Boolean(piece.positionalTab) ||
-        piece.end - piece.start !== piece.text.length;
       const spanRange = layoutOwned
         ? { paragraphId, start: piece.start, end: piece.end }
         : { paragraphId, start: piece.start + consumed, end: piece.start + boundary };
@@ -1558,29 +1539,9 @@ export function breakParagraph(
       // a wider measureText (eachPage) while painting the real digits.
       const measureSource = piece.measureText ?? candidate;
       let width = measurer.measure(displayText(measureSource, faceStyle), faceStyle);
-      // A candidate may open a line only at a real break opportunity. Within a piece,
-      // `wordBoundaries` cuts after spaces, dashes, tabs and between ideographs, so every
-      // candidate but the first is one. The FIRST candidate of a piece continues whatever
-      // the previous piece ended with, so it is a break opportunity only if that ended in
-      // whitespace \u2014 or in a dash or an ideograph, which stay break opportunities across
-      // run boundaries (a tracked change can split "ALPHA-" and "PRIME" into different runs
-      // without gluing them, and a CJK clause split across runs must not wrap at the seam
-      // instead of the margin, #526). The kinsoku sets then veto the whole decision: no
-      // opportunity ever puts \u3002\uff0c\u3001\u300d at a line start or leaves \u300c\uff08 at a line end \u2014 a space
-      // or a run seam directly before a closing mark would otherwise create one.
-      const previousCodePoint = lastCodePointOf(lastEmitted);
-      const firstCodePoint = candidate.codePointAt(0)!;
-      const opensWord =
-        (consumed > 0 ||
-          lastEmitted === '' ||
-          /[\s\u00a0]$/.test(lastEmitted) ||
-          /^[\s\u00a0]/.test(candidate) ||
-          (BREAK_AFTER_DASH.has(lastEmitted[lastEmitted.length - 1]!) &&
-            !BREAK_AFTER_DASH.has(candidate[0]!)) ||
-          (previousCodePoint !== undefined &&
-            cjkBreakAllowedBetween(previousCodePoint, firstCodePoint))) &&
-        !CJK_NO_BREAK_BEFORE.has(firstCodePoint) &&
-        !(previousCodePoint !== undefined && CJK_NO_BREAK_AFTER.has(previousCodePoint));
+      // A candidate may open a line only at a real break opportunity — the shared
+      // decision in `wordOpensAt`, which the anchor-line probe above consumes too.
+      const opensWord = wordOpensAt(lastEmitted, candidate, consumed > 0);
       if (opensWord) {
         wordStartSpan = line.spans.length;
         wordStartWidth = line.width;
@@ -1688,6 +1649,9 @@ export function breakParagraph(
           },
           closeLine,
           overflowTolerancePt: OVERFLOW_TOLERANCE_PT,
+          // The measured fit knows nothing about kinsoku: at a one-character measure
+          // 天。地。人。 chopped every other line onto a leading 。.
+          cutAllowedAt: cjkChopCutAllowedAt,
         });
         remaining = chopped.text;
         remainingStart = chopped.modelStart;
@@ -1698,25 +1662,34 @@ export function breakParagraph(
           wordStartEnd = line.end;
         }
       }
-      line.spans.push({
-        range: layoutOwned
-          ? spanRange
-          : { paragraphId, start: remainingStart, end: piece.start + boundary },
-        text: remaining,
-        props: piece.props,
-        style: piece.style,
-        box: { x: lineOrigin() + line.width, y: 0, width: remainingWidth, height: metrics.height },
-        ...(piece.link ? { link: piece.link } : {}),
-        ...(layoutOwned && !piece.positionalTab ? { projected: true as const } : {}),
-        ...(piece.noteNav ? { noteNav: piece.noteNav } : {}),
-        ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
-        ...(lineEndWhitespace ? { lineEndWhitespace: true as const } : {}),
-        ...revisionsOf(piece),
-      });
-      line.width += remainingWidth;
-      line.height = Math.max(line.height, metrics.height);
-      line.baseline = Math.max(line.baseline, metrics.baseline);
-      line.end = layoutOwned ? piece.end : piece.start + boundary;
+      // A kinsoku push-out can consume the whole candidate (天。 at a one-character measure):
+      // the chop emitted it as one overflowing line and left nothing for this placement.
+      if (remaining.length > 0) {
+        line.spans.push({
+          range: layoutOwned
+            ? spanRange
+            : { paragraphId, start: remainingStart, end: piece.start + boundary },
+          text: remaining,
+          props: piece.props,
+          style: piece.style,
+          box: {
+            x: lineOrigin() + line.width,
+            y: 0,
+            width: remainingWidth,
+            height: metrics.height,
+          },
+          ...(piece.link ? { link: piece.link } : {}),
+          ...(layoutOwned && !piece.positionalTab ? { projected: true as const } : {}),
+          ...(piece.noteNav ? { noteNav: piece.noteNav } : {}),
+          ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
+          ...(lineEndWhitespace ? { lineEndWhitespace: true as const } : {}),
+          ...revisionsOf(piece),
+        });
+        line.width += remainingWidth;
+        line.height = Math.max(line.height, metrics.height);
+        line.baseline = Math.max(line.baseline, metrics.baseline);
+        line.end = layoutOwned ? piece.end : piece.start + boundary;
+      }
       lastEmitted = candidate;
       consumed = boundary;
     }

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -422,12 +422,19 @@ function positionalTabDestination(
 // The pending-line record and its budget/freeze helpers live in pending-line.ts;
 // re-exported so every existing import through this module stays stable.
 import {
+  coalesceIdeographicSpans,
   frozenLine,
   pendingLineFlowExtent,
   pendingLineFlowExtentAtPlacement,
   type PendingLine,
 } from './pending-line.ts';
-export { frozenLine, pendingLineFlowExtent, pendingLineFlowExtentAtPlacement, type PendingLine };
+export {
+  coalesceIdeographicSpans,
+  frozenLine,
+  pendingLineFlowExtent,
+  pendingLineFlowExtentAtPlacement,
+  type PendingLine,
+};
 
 /**
  * Soft ceiling on an indent, in twips (31_680 ≈ 22"), matching the paragraph-spacing and
@@ -1254,6 +1261,9 @@ export function breakParagraph(
       else delete (line as { exclusionSkipBefore?: number }).exclusionSkipBefore;
     };
     finalizeTopAndBottomClearance();
+    // Before `markWrapAdvances`, so wrap-advance marking sees the merged shape — which is
+    // the shape paint gets.
+    coalesceIdeographicSpans(line);
     markWrapAdvances();
     const deleted = deletedWithin(line.start, line.end);
     if (deleted.length > 0) line.deletedRanges = deleted;

--- a/packages/core/src/layout/pending-line.ts
+++ b/packages/core/src/layout/pending-line.ts
@@ -45,21 +45,41 @@ export interface PendingLine {
 }
 
 /**
+ * Every {@link StyleSpanRecord} field outside range, text and box, as a checked record:
+ * a new field fails to compile here until it is added (blocking the merge below when it
+ * differs) or consciously exempted beside range/text/box in the `Exclude`.
+ */
+const SPAN_DECORATIONS: Record<Exclude<keyof StyleSpanRecord, 'range' | 'text' | 'box'>, true> = {
+  props: true,
+  style: true,
+  fontSlot: true,
+  caretEdges: true,
+  tabLeader: true,
+  tabLeaderAdvancePt: true,
+  link: true,
+  wrapAdvanceBefore: true,
+  revisions: true,
+  fieldAtom: true,
+  projected: true,
+  equation: true,
+  noteNav: true,
+  lineEndWhitespace: true,
+};
+
+const SPAN_DECORATION_KEYS = Object.keys(SPAN_DECORATIONS) as readonly (keyof StyleSpanRecord)[];
+
+/**
  * Everything outside a span's range, text and box, compared by reference.
  *
  * Two spans that share every decoration share the objects, because they come from one run's
- * one resolution. Reference equality is therefore the exact test, and it is also the safe
- * one: a decoration this function has never heard of still blocks the merge.
+ * one resolution — placement passes `piece.revisions`, `piece.link` and the rest through
+ * without copying. Reference equality is therefore the exact test; the span-count tests in
+ * `cjk-line-breaking.test.ts` pin a revised and a linked run so a future defensive copy on
+ * that path cannot silently return CJK to one span per ideograph.
  */
 function decorationsMatch(previous: StyleSpanRecord, current: StyleSpanRecord): boolean {
-  const keys = new Set([...Object.keys(previous), ...Object.keys(current)]);
-  keys.delete('range');
-  keys.delete('text');
-  keys.delete('box');
-  for (const key of keys) {
-    const left = (previous as unknown as Record<string, unknown>)[key];
-    const right = (current as unknown as Record<string, unknown>)[key];
-    if (left !== right) return false;
+  for (const key of SPAN_DECORATION_KEYS) {
+    if (previous[key] !== current[key]) return false;
   }
   return true;
 }
@@ -93,20 +113,43 @@ function seamIsMergeable(previous: StyleSpanRecord, current: StyleSpanRecord): b
  */
 export function coalesceIdeographicSpans(line: PendingLine): void {
   if (line.spans.length < 2) return;
-  const merged: StyleSpanRecord[] = [line.spans[0]!];
-  for (let index = 1; index < line.spans.length; index += 1) {
-    const current = line.spans[index]!;
-    const previous = merged[merged.length - 1]!;
-    if (!seamIsMergeable(previous, current)) {
-      merged.push(current);
+  const merged: StyleSpanRecord[] = [];
+  for (let index = 0; index < line.spans.length; ) {
+    // Scan the whole mergeable group first, then build ONE span from it — merging into a
+    // growing accumulator re-copied every seam, an O(m²) cost per group. Adjacent-pair
+    // seams test the same conditions the accumulator did: the decoration and height
+    // checks are transitive, and the x-abutment check against the true neighbour is
+    // tighter than against an accumulated width.
+    let groupEnd = index;
+    while (
+      groupEnd + 1 < line.spans.length &&
+      seamIsMergeable(line.spans[groupEnd]!, line.spans[groupEnd + 1]!)
+    ) {
+      groupEnd += 1;
+    }
+    const first = line.spans[index]!;
+    if (groupEnd === index) {
+      merged.push(first);
+      index += 1;
       continue;
     }
-    merged[merged.length - 1] = {
-      ...previous,
-      range: { ...previous.range, end: current.range.end },
-      text: previous.text + current.text,
-      box: { ...previous.box, width: previous.box.width + current.box.width },
-    };
+    const parts: string[] = [];
+    // The merged width is the SUM of the per-ideograph advances the line was broken and
+    // justified against, not a re-measure of the joined text: paint must fill exactly the
+    // box the line reserved, and a face that kerned across ideograph seams would make the
+    // two disagree. CJK faces advance ideographs uniformly, so the sum is also the shape.
+    let width = 0;
+    for (let cursor = index; cursor <= groupEnd; cursor += 1) {
+      parts.push(line.spans[cursor]!.text);
+      width += line.spans[cursor]!.box.width;
+    }
+    merged.push({
+      ...first,
+      range: { ...first.range, end: line.spans[groupEnd]!.range.end },
+      text: parts.join(''),
+      box: { ...first.box, width },
+    });
+    index = groupEnd + 1;
   }
   if (merged.length === line.spans.length) return;
   line.spans.length = 0;

--- a/packages/core/src/layout/pending-line.ts
+++ b/packages/core/src/layout/pending-line.ts
@@ -2,6 +2,7 @@
 // budgets, before placement publishes a LineRecord from it. Extracted from paragraph-flow
 // so the flow module stays under its line budget; paragraph-flow re-exports everything here.
 
+import { isIdeographicForLineBreak, lastCodePointOf } from './cjk-line-break.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { StyleSpanRecord } from './semantic-records.ts';
 import type { InlineDrawingRecord } from './drawing-layout.ts';
@@ -41,6 +42,75 @@ export interface PendingLine {
   exclusionSkipBefore?: number;
   /** Tracked anchored-drawing attributions on this line; see {@link LineRecord.anchorRevisions}. */
   anchorRevisions?: readonly RevisionAttribution[];
+}
+
+/**
+ * Everything outside a span's range, text and box, compared by reference.
+ *
+ * Two spans that share every decoration share the objects, because they come from one run's
+ * one resolution. Reference equality is therefore the exact test, and it is also the safe
+ * one: a decoration this function has never heard of still blocks the merge.
+ */
+function decorationsMatch(previous: StyleSpanRecord, current: StyleSpanRecord): boolean {
+  const keys = new Set([...Object.keys(previous), ...Object.keys(current)]);
+  keys.delete('range');
+  keys.delete('text');
+  keys.delete('box');
+  for (const key of keys) {
+    const left = (previous as unknown as Record<string, unknown>)[key];
+    const right = (current as unknown as Record<string, unknown>)[key];
+    if (left !== right) return false;
+  }
+  return true;
+}
+
+/** Whether one ideographic seam between two closed spans carries no information. */
+function seamIsMergeable(previous: StyleSpanRecord, current: StyleSpanRecord): boolean {
+  // `caretEdges` is measured against a span's own text, so a merge would invalidate it.
+  // Placement attaches it AFTER this runs; the guard keeps that ordering from being load-bearing.
+  if (previous.caretEdges !== undefined || current.caretEdges !== undefined) return false;
+  const before = lastCodePointOf(previous.text);
+  const after = current.text.codePointAt(0);
+  if (before === undefined || after === undefined) return false;
+  if (!isIdeographicForLineBreak(before) || !isIdeographicForLineBreak(after)) return false;
+  if (previous.range.paragraphId !== current.range.paragraphId) return false;
+  if (previous.range.end !== current.range.start) return false;
+  if (Math.abs(previous.box.x + previous.box.width - current.box.x) > 0.01) return false;
+  if (previous.box.height !== current.box.height) return false;
+  return decorationsMatch(previous, current);
+}
+
+/**
+ * Merge a closed line's ideographic span seams back into one span per style run.
+ *
+ * Ideographic word boundaries make every character a placement candidate, so the placement
+ * loop emits one span per ideograph. The break decisions are right, but a clause that used
+ * to paint as a single span now paints and hit-tests as dozens. Once the line is closed
+ * those seams carry no information, so they merge back.
+ *
+ * Latin word seams are deliberately left alone: their trailing spaces are where
+ * justification stretches, and their span shape predates ideographic breaking.
+ */
+export function coalesceIdeographicSpans(line: PendingLine): void {
+  if (line.spans.length < 2) return;
+  const merged: StyleSpanRecord[] = [line.spans[0]!];
+  for (let index = 1; index < line.spans.length; index += 1) {
+    const current = line.spans[index]!;
+    const previous = merged[merged.length - 1]!;
+    if (!seamIsMergeable(previous, current)) {
+      merged.push(current);
+      continue;
+    }
+    merged[merged.length - 1] = {
+      ...previous,
+      range: { ...previous.range, end: current.range.end },
+      text: previous.text + current.text,
+      box: { ...previous.box, width: previous.box.width + current.box.width },
+    };
+  }
+  if (merged.length === line.spans.length) return;
+  line.spans.length = 0;
+  for (const span of merged) line.spans.push(span);
 }
 
 /** Vertical extent of a pending line for flow/pagination budget checks (skip + box + optional tail). */


### PR DESCRIPTION
### Problem

CJK text has no break opportunities of its own, so a Chinese or Japanese
clause lays out as one unbreakable word.

- **#526:** CJK text inside a paragraph does not wrap at the column width.
  When the clause spans several runs, the line breaks at the run boundary
  instead. A paragraph of two 7-character runs against a 10-character
  measure renders as 7 + 7 instead of 10 + 4.
- A numbered clause whose number sits in its own piece strands the number.
  With `1.` in one piece and the clause in the next, the first line renders
  as `1.` alone and the clause starts on line 2. In a rental-contract
  fixture, the paragraph renders 2/35/35/... instead of Word's 34/35/19.
- A literal space before a full-width comma (`…职责 ，因此…`) closes the
  line at the space, seven characters early, because the whole comma-led
  tail is one "word".

### Root cause

`wordBoundaries` in `packages/core/src/layout/paragraph-flow.ts` cuts only
after spaces, dashes, and tabs, and `opensWord` accepts a new line only at
those cuts. CJK prose therefore wraps only through the
wider-than-empty-line fallback chop, which requires an empty line. Any
piece that starts mid-line — a run seam, a numbered clause's text — cannot
break internally, so the line closes wherever the previous piece ended.

### Approach

Add ideographic break opportunities per UAX #14, in a minimal form, in a
new module `packages/core/src/layout/cjk-line-break.ts`:

- A break opportunity exists between two ideographic-class code points
  (CJK radicals through the unified block, Kana, compatibility ideographs,
  vertical forms, full- and half-width forms, supplementary planes).
- Kinsoku prohibitions veto a direction: a line never starts with a
  closing or trailing character (`。，、；：？！」』）】＞％‰′″℃`, small
  kana, iteration and prolonged-sound marks) and never ends with an
  opening one (`「『（【〈《〔｛［＄￥`…).

`wordBoundaries` gains a separate code-point pass that emits these cuts,
and `opensWord` accepts the same opportunity across piece seams, so a
clause split by runs or tracked changes wraps at the margin instead of the
seam. The kinsoku sets also veto opportunities that spaces or seams would
otherwise create directly before a closing mark, which fixes the premature
break at `…职责 ，`.

Both kinsoku sets sit entirely outside ASCII and the between-ideographs
rule requires an ideograph on both sides, so Latin break decisions are
byte-identical. This also keeps `1.` glued to the ideograph after it,
which is why the numbered clause now fills its first line.

### Out of scope

- Breaks between an ideograph and Latin or digit text (UAX #14 allows
  them; not introduced to keep Latin layout untouched).
- Hangul syllable breaking.
- JIS kinsoku levels, `w:kinsoku`/`w:overflowPunct` document settings, and
  other UAX #14 tailorings.
- Hanging punctuation.

### Tests

`packages/core/src/layout/__tests__/cjk-line-breaking.test.ts`, 9 tests
with the fixed measurer: single-run CJK fills every line; a clause split
across runs wraps at the margin, not the seam; a numbered clause fills its
first line; a closing mark never opens a line and an opening bracket never
ends one (asserted across five measures on a punctuated paragraph); the
space-before-full-width-comma case; Latin word-across-runs and
mixed-CJK-Latin behavior unchanged.

Full `packages/core` suite: 7802 pass / 0 fail. Typecheck and lint clean.
No public API change, so no api-extractor drift.

### Note for maintainers

Each minimal legal unit (usually one ideograph) becomes its own layout
span, so an all-CJK line holds ~35 spans instead of one. Measurement
caching absorbs the measure calls; if span count matters for paint or
memory, a same-style span coalescing step at line close would be a
follow-up, not part of this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790449317&installation_model_id=422592&pr_number=540&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F540&signature=338e41de9a3b2209d39b2d4bd76b0dafd35b921d1adba646bc1068127583024a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->