### PR TITLE
fix(collaboration): keep failed rooms recoverable and status honest

### DIFF
--- a/.changeset/hardy-rooms-recover.md
+++ b/.changeset/hardy-rooms-recover.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Collaboration rooms recover cleanly from failure: a failed seed no longer marks the room initialized, `readCollaborationDocument` and session teardown release their document observers, refusal recovery keeps a disconnected status instead of reporting ready, and undo obeys the same gate as every other edit. Fixes #541, #542, #544, #545.

--- a/packages/pro/src/collaboration/__tests__/collaboration-teardown.test.ts
+++ b/packages/pro/src/collaboration/__tests__/collaboration-teardown.test.ts
@@ -25,7 +25,11 @@ const SCHEMA_MAP_KEYS = [
   'docx-package-binaries-v1',
   'docx-package-attributes-v1',
   'docx-package-bindings-v1',
+  'docx-package-meta-v1',
+  'docx-package-blobs-v1',
 ] as const;
+
+const SEED_RECORDS_KEY = 'docx-collaboration-seeds-v1';
 
 /** Handler lists Yjs keeps per type: `_eH` observes the type, `_dEH` observes it deeply. */
 interface ObservableInternals {
@@ -33,14 +37,22 @@ interface ObservableInternals {
   readonly _dEH: { readonly l: readonly unknown[] };
 }
 
-function observerCount(ydoc: Y.Doc, key: string): number {
-  const type = ydoc.getMap(key) as unknown as ObservableInternals;
-  return type._eH.l.length + type._dEH.l.length;
+function typeObserverCount(type: unknown): number {
+  const internals = type as ObservableInternals;
+  return internals._eH.l.length + internals._dEH.l.length;
 }
 
+/**
+ * Every handler the collaboration lane can register on the document: the schema maps, the
+ * blob map, the seed-record array, and the doc-level `afterTransaction` listeners the
+ * session, the undo manager, and the initialization waits attach.
+ */
 function totalObservers(ydoc: Y.Doc): number {
   let total = 0;
-  for (const key of SCHEMA_MAP_KEYS) total += observerCount(ydoc, key);
+  for (const key of SCHEMA_MAP_KEYS) total += typeObserverCount(ydoc.getMap(key));
+  total += typeObserverCount(ydoc.getArray(SEED_RECORDS_KEY));
+  const observers = (ydoc as unknown as { _observers: Map<string, Set<unknown>> })._observers;
+  total += observers.get('afterTransaction')?.size ?? 0;
   return total;
 }
 
@@ -92,6 +104,37 @@ describe('collaboration teardown', () => {
     const host = await seededRoom();
     host.destroy();
     expect(totalObservers(host.ydoc)).toBe(0);
+    host.ydoc.destroy();
+  });
+
+  test('a bootstrap that fails while materializing leaves no observers behind', async () => {
+    const host = await seededRoom();
+    host.destroy();
+    // Corrupt one element record the way a hostile peer could: drop its child array, which
+    // makes materializing THROW (`no children at …`) rather than refuse with a typed code.
+    const nodes = host.ydoc.getMap<Y.Map<unknown>>('docx-package-nodes-v1');
+    let corrupted = false;
+    nodes.forEach((record) => {
+      if (corrupted || !(record instanceof Y.Map) || !record.has('children')) return;
+      record.delete('children');
+      corrupted = true;
+    });
+    expect(corrupted).toBe(true);
+    const before = totalObservers(host.ydoc);
+    const awareness = new Awareness(host.ydoc);
+    await expect(
+      createDocumentCollaboration({
+        ydoc: host.ydoc,
+        awareness,
+        documentId: 'teardown-room',
+        identity: { actorId: 'late', name: 'Late' },
+        bootstrap: { kind: 'join', timeoutMs: 1_000 },
+      })
+    ).rejects.toThrow();
+    // The materializer registered its dirty observers before the throw; the factory must
+    // hand them back, or every retry on this document leaks another set.
+    expect(totalObservers(host.ydoc)).toBe(before);
+    awareness.destroy();
     host.ydoc.destroy();
   });
 

--- a/packages/pro/src/collaboration/__tests__/collaboration-teardown.test.ts
+++ b/packages/pro/src/collaboration/__tests__/collaboration-teardown.test.ts
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Teardown gives every observer back. The caller owns the Y.Doc and it can outlive any
+// registry built over it: a server export runs once per autosave on a document that lives as
+// long as the room, and a refused bootstrap is followed by a retry on the same document. A
+// leaked observer taxes every later transaction and retains the whole derived index.
+
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { Awareness } from 'y-protocols/awareness';
+import { createDocumentCollaboration } from '../document-session.ts';
+import { readCollaborationDocument } from '../document-read.ts';
+import { CollaborationSchemaError } from '../schema.ts';
+import { collaborationDocx } from './support.ts';
+
+const SCHEMA_MAP_KEYS = [
+  'docx-package-nodes-v1',
+  'docx-package-parts-v1',
+  'docx-package-rels-v1',
+  'docx-package-overrides-v1',
+  'docx-package-defaults-v1',
+  'docx-package-binaries-v1',
+  'docx-package-attributes-v1',
+  'docx-package-bindings-v1',
+] as const;
+
+/** Handler lists Yjs keeps per type: `_eH` observes the type, `_dEH` observes it deeply. */
+interface ObservableInternals {
+  readonly _eH: { readonly l: readonly unknown[] };
+  readonly _dEH: { readonly l: readonly unknown[] };
+}
+
+function observerCount(ydoc: Y.Doc, key: string): number {
+  const type = ydoc.getMap(key) as unknown as ObservableInternals;
+  return type._eH.l.length + type._dEH.l.length;
+}
+
+function totalObservers(ydoc: Y.Doc): number {
+  let total = 0;
+  for (const key of SCHEMA_MAP_KEYS) total += observerCount(ydoc, key);
+  return total;
+}
+
+async function seededRoom(): Promise<{
+  ydoc: Y.Doc;
+  destroy: () => void;
+}> {
+  const ydoc = new Y.Doc();
+  const awareness = new Awareness(ydoc);
+  const room = await createDocumentCollaboration({
+    ydoc,
+    awareness,
+    documentId: 'teardown-room',
+    identity: { actorId: 'seed', name: 'Seed' },
+    bootstrap: { kind: 'create', document: collaborationDocx() },
+  });
+  return {
+    ydoc,
+    destroy: () => {
+      room.destroy();
+      awareness.destroy();
+    },
+  };
+}
+
+describe('collaboration teardown', () => {
+  test('readCollaborationDocument leaves no observers behind', async () => {
+    const host = await seededRoom();
+    const before = totalObservers(host.ydoc);
+    for (let call = 0; call < 3; call += 1) {
+      expect(readCollaborationDocument(host.ydoc).byteLength).toBeGreaterThan(0);
+    }
+    // A server autosave calls this per store interval for the life of the room, so each call
+    // must give back exactly what it registered.
+    expect(totalObservers(host.ydoc)).toBe(before);
+    host.destroy();
+    host.ydoc.destroy();
+  });
+
+  test('a refusing readCollaborationDocument still cleans up', async () => {
+    const ydoc = new Y.Doc();
+    const before = totalObservers(ydoc);
+    expect(() => readCollaborationDocument(ydoc)).toThrow(CollaborationSchemaError);
+    expect(totalObservers(ydoc)).toBe(before);
+    ydoc.destroy();
+  });
+
+  test('destroying the session detaches every schema observer', async () => {
+    const host = await seededRoom();
+    host.destroy();
+    expect(totalObservers(host.ydoc)).toBe(0);
+    host.ydoc.destroy();
+  });
+
+  test('a refused bootstrap leaves no observers behind', async () => {
+    const ydoc = new Y.Doc();
+    const awareness = new Awareness(ydoc);
+    const before = totalObservers(ydoc);
+    // A join on an empty room times out: the factory refuses, and the caller keeps `ydoc`.
+    await expect(
+      createDocumentCollaboration({
+        ydoc,
+        awareness,
+        documentId: 'teardown-room',
+        identity: { actorId: 'late', name: 'Late' },
+        bootstrap: { kind: 'join', timeoutMs: 25 },
+      })
+    ).rejects.toThrow(CollaborationSchemaError);
+    expect(totalObservers(ydoc)).toBe(before);
+    awareness.destroy();
+    ydoc.destroy();
+  });
+});

--- a/packages/pro/src/collaboration/__tests__/document-seed-failure.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-seed-failure.test.ts
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// A failed seed must stay invisible. Yjs commits everything a transaction wrote before the
+// refusal stopped it, so the one thing the seed controls is WHAT is written before the first
+// possible refusal. Marking the room initialized first left a failed seed advertising a
+// joinable room: joiners passed the initialization wait and then hit `document-id-mismatch`,
+// and a retried `create` refused with `already-initialized` — the room id was bricked.
+
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { DocumentRegistry, seedPackage } from '../document/index.ts';
+import { openBaselinePackage } from '../document-bootstrap.ts';
+import { collaborationDocx } from './support.ts';
+
+function baseline(): ReturnType<typeof openBaselinePackage> {
+  return openBaselinePackage(collaborationDocx());
+}
+
+describe('seed failure', () => {
+  test('a refused seed leaves the room uninitialized', async () => {
+    const ydoc = new Y.Doc();
+    const registry = new DocumentRegistry(ydoc, { maxNodes: 5 });
+    const seeded = await seedPackage(registry, baseline());
+    expect(seeded.ok).toBe(false);
+    // The flag is the joiner's whole signal, so a failed seed must never set it.
+    expect(registry.schema.meta.get('initialized')).toBeUndefined();
+    expect(registry.schema.meta.get('mainDocumentPart')).toBeUndefined();
+    registry.destroy();
+    ydoc.destroy();
+  });
+
+  test('a joiner never observes a failed seed as an initialized room', async () => {
+    const seeder = new Y.Doc();
+    const limited = new DocumentRegistry(seeder, { maxNodes: 5 });
+    const seeded = await seedPackage(limited, baseline());
+    expect(seeded.ok).toBe(false);
+    // The failed transaction still broadcast: replay it onto a joiner's document.
+    const joiner = new Y.Doc();
+    Y.applyUpdate(joiner, Y.encodeStateAsUpdate(seeder), 'join');
+    expect(joiner.getMap('docx-package-meta-v1').get('initialized')).not.toBe(true);
+    limited.destroy();
+    seeder.destroy();
+    joiner.destroy();
+  });
+
+  test('the same room accepts a retried seed after a refusal', async () => {
+    const ydoc = new Y.Doc();
+    const limited = new DocumentRegistry(ydoc, { maxNodes: 5 });
+    const refused = await seedPackage(limited, baseline());
+    expect(refused.ok).toBe(false);
+    limited.destroy();
+    // The retry a host performs after fixing its baseline: same document, default limits.
+    const registry = new DocumentRegistry(ydoc);
+    const seeded = await seedPackage(registry, baseline());
+    expect(seeded.ok).toBe(true);
+    expect(registry.schema.meta.get('initialized')).toBe(true);
+    expect(typeof registry.schema.meta.get('mainDocumentPart')).toBe('string');
+    registry.destroy();
+    ydoc.destroy();
+  });
+});

--- a/packages/pro/src/collaboration/__tests__/document-session-status.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-session-status.test.ts
@@ -1,0 +1,188 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Status is one axis and it must not lie. A refusal realign repairs the DOCUMENT, so recovery
+// restores the status the replica held before it — a refusal that arrived while the transport
+// was down must not report `ready`. And a status that refuses edits refuses undo too: undo
+// writes shared state exactly as a keystroke does.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { Awareness } from 'y-protocols/awareness';
+import {
+  TreePackageStore,
+  normalizeParagraphIdentity,
+  readOoxmlPackage,
+  type StoryScope,
+  type TreeDocOp,
+} from '@docx-editor.dev/core/store';
+import {
+  createCollaborationDocumentPort,
+  type CanonicalPrimitiveJournal,
+  type CollaborationDocumentPort,
+} from '@docx-editor.dev/core/collaboration/replication';
+import {
+  createDocumentCollaboration,
+  type DocumentCollaborationHandle,
+} from '../document-session.ts';
+import { collaborationDocx } from './support.ts';
+
+const DOCUMENT_ID = 'session-status-room';
+const BODY: StoryScope = { kind: 'body' };
+
+interface Peer {
+  readonly ydoc: Y.Doc;
+  readonly awareness: Awareness;
+  readonly room: DocumentCollaborationHandle;
+  readonly store: TreePackageStore;
+  readonly port: CollaborationDocumentPort;
+  readonly emitJournal: (journal: CanonicalPrimitiveJournal) => void;
+}
+
+const opened: Peer[] = [];
+
+afterEach(() => {
+  for (const peer of opened.splice(0)) {
+    peer.room.destroy();
+    peer.awareness.destroy();
+    peer.ydoc.destroy();
+  }
+});
+
+async function createPeer(options?: { readonly offlineEditing?: boolean }): Promise<Peer> {
+  const ydoc = new Y.Doc();
+  const awareness = new Awareness(ydoc);
+  const room = await createDocumentCollaboration({
+    ydoc,
+    awareness,
+    documentId: DOCUMENT_ID,
+    identity: { actorId: 'alice', name: 'Alice' },
+    bootstrap: { kind: 'create', document: collaborationDocx() },
+    ...options,
+  });
+  const loaded = readOoxmlPackage(room.document);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const main = loaded.package.parts.get(loaded.package.mainDocumentPart);
+  if (!main) throw new Error('no main part');
+  const store = new TreePackageStore(loaded.package, normalizeParagraphIdentity(main));
+  const base = createCollaborationDocumentPort(store, { documentId: DOCUMENT_ID });
+  // The session's contract is that journals arrive through `observePrimitiveJournal`, so the
+  // tap records the listener the session registers instead of adding a test-only port method.
+  let tap: ((journal: CanonicalPrimitiveJournal) => void) | null = null;
+  const port: CollaborationDocumentPort = {
+    ...base,
+    observePrimitiveJournal: (listener) => {
+      tap = listener;
+      return base.observePrimitiveJournal(listener);
+    },
+  };
+  room.session.attach(port);
+  const peer: Peer = {
+    ydoc,
+    awareness,
+    room,
+    store,
+    port,
+    emitJournal: (journal) => {
+      if (!tap) throw new Error('port is not tapped');
+      tap(journal);
+    },
+  };
+  opened.push(peer);
+  return peer;
+}
+
+/** A journal naming a node shared state does not hold is refused whatever the state. */
+function refuse(peer: Peer): void {
+  peer.emitJournal({
+    effects: [
+      { kind: 'spliceText', logicalId: 'no-such-node', utf16Start: 0, deleteCount: 0, insert: 'X' },
+    ],
+  });
+}
+
+function firstParagraphId(peer: Peer): string {
+  const paragraph = peer.port.paragraphs()[0];
+  if (!paragraph) throw new Error('no paragraph');
+  return paragraph.nodeId;
+}
+
+function type(peer: Peer, text: string): void {
+  const ops: readonly TreeDocOp[] = [
+    { op: 'insertText', paragraphId: firstParagraphId(peer), offset: 0, text },
+  ];
+  const refusal = peer.room.session.gateOperations(ops, BODY);
+  if (refusal) throw new Error(`gate refused: ${refusal}`);
+  const result = peer.store.transact(BODY, (context) => {
+    for (const op of ops) context.apply(op);
+  });
+  if (!result.ok) throw new Error(result.detail ?? result.reason);
+  peer.port.flushPendingJournals();
+}
+
+describe('refusal recovery restores the prior status', () => {
+  test('a refusal while ready recovers to ready', async () => {
+    const peer = await createPeer();
+    refuse(peer);
+    await Promise.resolve();
+    expect(peer.room.session.status()).toBe('ready');
+    expect(peer.room.session.statusSnapshot().reason).toBeUndefined();
+    expect(peer.room.session.statusSnapshot().lastFailure?.code).toBe('unknown-logical-id');
+  });
+
+  test('a refusal while disconnected recovers to disconnected, not ready', async () => {
+    const peer = await createPeer({ offlineEditing: true });
+    peer.room.session.setTransportStatus('disconnected', 'transport-disconnected', 'wire down');
+    refuse(peer);
+    await Promise.resolve();
+    // The realign repaired the document; the transport is still down and only the provider
+    // may say otherwise.
+    const snapshot = peer.room.session.statusSnapshot();
+    expect(snapshot.status).toBe('disconnected');
+    expect(snapshot.reason?.code).toBe('transport-disconnected');
+    expect(snapshot.reason?.detail).toBe('wire down');
+    expect(snapshot.lastFailure?.code).toBe('unknown-logical-id');
+  });
+});
+
+describe('undo obeys the operation gate', () => {
+  test('an errored session refuses undo', async () => {
+    const peer = await createPeer();
+    type(peer, 'undo me ');
+    expect(peer.room.session.canUndo()).toBe(true);
+    // Three refusals in separate flush tasks take the session to terminal `error`.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      refuse(peer);
+      await Promise.resolve();
+    }
+    expect(peer.room.session.status()).toBe('error');
+    const before = Y.encodeStateAsUpdate(peer.ydoc);
+    expect(peer.room.session.canUndo()).toBe(false);
+    expect(peer.room.session.undo()).toBe(false);
+    expect(peer.room.session.canRedo()).toBe(false);
+    expect(peer.room.session.redo()).toBe(false);
+    // The diverged replica wrote nothing to the room.
+    expect(Y.encodeStateAsUpdate(peer.ydoc)).toEqual(before);
+  });
+
+  test('a disconnected session without offline editing refuses undo until reconnect', async () => {
+    const peer = await createPeer();
+    type(peer, 'undo me ');
+    peer.room.session.setTransportStatus('disconnected', 'transport-disconnected', 'wire down');
+    expect(peer.room.session.canUndo()).toBe(false);
+    expect(peer.room.session.undo()).toBe(false);
+    peer.room.session.setTransportStatus('ready');
+    expect(peer.room.session.canUndo()).toBe(true);
+    expect(peer.room.session.undo()).toBe(true);
+  });
+
+  test('offline editing keeps undo available while disconnected', async () => {
+    const peer = await createPeer({ offlineEditing: true });
+    type(peer, 'undo me ');
+    peer.room.session.setTransportStatus('disconnected', 'transport-disconnected', 'wire down');
+    expect(peer.room.session.canUndo()).toBe(true);
+    expect(peer.room.session.undo()).toBe(true);
+  });
+});

--- a/packages/pro/src/collaboration/document-awareness.ts
+++ b/packages/pro/src/collaboration/document-awareness.ts
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+/**
+ * Identity validation and the awareness-payload codec for the full-document session.
+ *
+ * Everything here sits on a trust boundary: identity fields come from the host, and an
+ * awareness record comes from a PEER, so a claim is checked rather than believed.
+ */
+
+import type { CollaborationIdentity } from '@docx-editor.dev/core/collaboration';
+import { safeParticipantColor } from '@docx-editor.dev/core/collaboration';
+import { CollaborationSchemaError } from './schema.ts';
+
+export const AWARENESS_FIELD = 'docxEditor';
+export const MAX_IDENTITY_LENGTH = 256;
+export const MAX_AWARENESS_STATES = 256;
+
+export interface EncodedSelectionAddress {
+  readonly paragraphId: string;
+  readonly offset: number;
+}
+
+export interface EncodedSelection {
+  readonly anchor: EncodedSelectionAddress;
+  readonly head: EncodedSelectionAddress;
+  readonly kind?: 'cells';
+}
+
+export interface AwarenessPayload {
+  readonly actorId: string;
+  readonly name: string;
+  readonly color?: string;
+  readonly role: 'human' | 'agent';
+  readonly selection?: EncodedSelection;
+}
+
+export function validateIdentity(identity: CollaborationIdentity): CollaborationIdentity {
+  const actorId = identity.actorId.trim();
+  const name = identity.name.trim();
+  if (
+    actorId.length === 0 ||
+    actorId.length > MAX_IDENTITY_LENGTH ||
+    name.length === 0 ||
+    name.length > MAX_IDENTITY_LENGTH
+  ) {
+    throw new CollaborationSchemaError('invalid-identity');
+  }
+  if (identity.color !== undefined && identity.color.length > 64) {
+    throw new CollaborationSchemaError('invalid-identity-color');
+  }
+  return Object.freeze({
+    actorId,
+    name,
+    ...(identity.color ? { color: identity.color } : {}),
+    role: identity.role ?? 'human',
+  });
+}
+
+export function validateDocumentId(value: string): string {
+  const documentId = value.trim();
+  if (documentId.length === 0 || documentId.length > MAX_IDENTITY_LENGTH) {
+    throw new CollaborationSchemaError('invalid-document-id');
+  }
+  return documentId;
+}
+
+export function sessionIdentity(value: string | undefined): string {
+  const sessionId = value?.trim() || globalThis.crypto.randomUUID();
+  if (sessionId.length > MAX_IDENTITY_LENGTH) {
+    throw new CollaborationSchemaError('invalid-session-id');
+  }
+  return sessionId;
+}
+
+function encodedSelectionAddress(value: unknown): EncodedSelectionAddress | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.paragraphId !== 'string' ||
+    record.paragraphId.length !== 8 ||
+    !Number.isSafeInteger(record.offset) ||
+    (record.offset as number) < 0
+  ) {
+    return null;
+  }
+  return { paragraphId: record.paragraphId.toUpperCase(), offset: record.offset as number };
+}
+
+export function encodedSelection(value: unknown): EncodedSelection | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const selected = value as Record<string, unknown>;
+  const anchor = encodedSelectionAddress(selected.anchor);
+  const head = encodedSelectionAddress(selected.head);
+  if (anchor && head) {
+    return selected.kind === 'cells' ? { anchor, head, kind: 'cells' } : { anchor, head };
+  }
+  if (
+    typeof selected.paragraphId === 'string' &&
+    selected.paragraphId.length === 8 &&
+    Number.isSafeInteger(selected.start) &&
+    Number.isSafeInteger(selected.end) &&
+    (selected.start as number) >= 0 &&
+    (selected.end as number) >= 0
+  ) {
+    const paragraphId = selected.paragraphId.toUpperCase();
+    return {
+      anchor: { paragraphId, offset: selected.start as number },
+      head: { paragraphId, offset: selected.end as number },
+    };
+  }
+  return undefined;
+}
+
+export function awarenessPayload(value: unknown): AwarenessPayload | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.actorId !== 'string' ||
+    record.actorId.length === 0 ||
+    record.actorId.length > MAX_IDENTITY_LENGTH ||
+    typeof record.name !== 'string' ||
+    record.name.length === 0 ||
+    record.name.length > MAX_IDENTITY_LENGTH
+  ) {
+    return null;
+  }
+  // Trust boundary for a peer's presence record. The color flows into `participants()` and
+  // `remoteSelections()`, and hosts paint it into CSS (`background:` via a custom property),
+  // where `url(//host/t)` is a zero-click GET. Only the shapes this engine itself produces
+  // pass; anything else drops so every consumer falls back to the accent color.
+  const color = safeParticipantColor(typeof record.color === 'string' ? record.color : undefined);
+  const role: 'human' | 'agent' = record.role === 'agent' ? 'agent' : 'human';
+  const base = { actorId: record.actorId, name: record.name, ...(color ? { color } : {}), role };
+  const selection = encodedSelection(record.selection);
+  return selection ? { ...base, selection } : base;
+}

--- a/packages/pro/src/collaboration/document-read.ts
+++ b/packages/pro/src/collaboration/document-read.ts
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+/**
+ * Server-side read of one collaboration room: shared state to `.docx` bytes, joining nothing.
+ */
+
+import type * as Y from 'yjs';
+import { writeOoxmlPackage } from '@docx-editor.dev/core/store';
+import { DocumentRegistry, PackageMaterializer } from './document/index.ts';
+import { seedRecordCount } from './document-bootstrap.ts';
+import { SHARED_BLOBS_KEY, SharedBlobStore, limitFailure } from './shared-blob-store.ts';
+import { CollaborationSchemaError } from './schema.ts';
+
+/**
+ * Read the document a synchronized `Y.Doc` holds, as `.docx` bytes.
+ *
+ * This is the server side of a room: export, autosave to your own storage, search indexing, a
+ * nightly PDF, a webhook. It JOINS NOTHING. There is no identity, no `Awareness` and no
+ * session, so the job that calls it never appears in anyone's avatar stack, and it creates no
+ * editing gate, so it cannot write back.
+ *
+ * `ydoc` must already hold the room's state: connect your provider and wait for its initial
+ * sync first, exactly as a `{ kind: \'join\' }` bootstrap does. A document that was never
+ * seeded refuses with `not-initialized` rather than returning a truncated file.
+ *
+ * ```ts
+ * // Hocuspocus hands `onStoreDocument` the synced Y.Doc already:
+ * async onStoreDocument({ documentName, document }) {
+ *   await writeFile(`${documentName}.docx`, readCollaborationDocument(document));
+ * }
+ * ```
+ *
+ * Synchronous, and it materializes the whole package per call — this is a job, not a render.
+ *
+ * @throws CollaborationSchemaError — `not-initialized`, `concurrent-seed`,
+ * `blob-digest-mismatch`, or a limit code: the same refusals a joining replica makes, for the
+ * same reasons.
+ * @public
+ */
+export function readCollaborationDocument(ydoc: Y.Doc): Uint8Array {
+  const registry = new DocumentRegistry(ydoc);
+  let materializer: PackageMaterializer | null = null;
+  // Owned here, so released here — whether the read succeeded or refused. This runs once per
+  // export on a document that lives as long as the room, so a leaked observer would make
+  // every later transaction in the room pay for every export ever taken from it.
+  try {
+    // Shared state arrived before this registry existed and the parent index is built from
+    // child-array EVENTS — the same rebuild a joiner performs, for the same reason.
+    registry.rebuildDerivedIndexes();
+    if (typeof registry.schema.meta.get('documentId') !== 'string') {
+      throw new CollaborationSchemaError('not-initialized');
+    }
+    // Two merged seeds duplicate the whole document and no reader can pick a side, so an
+    // export refuses rather than writing a file with everything in it twice.
+    if (seedRecordCount(ydoc) > 1) throw new CollaborationSchemaError('concurrent-seed');
+    const blobs = new SharedBlobStore(ydoc.getMap<Uint8Array>(SHARED_BLOBS_KEY));
+    const exceeded = limitFailure(registry, blobs);
+    if (exceeded) throw new CollaborationSchemaError(exceeded.code, exceeded.detail);
+    materializer = new PackageMaterializer(registry, blobs);
+    const materialized = materializer.current();
+    const poisoned = blobs.poisonedDigest();
+    // A blob that does not hash to its key reads downstream as a blob that is not there. Say
+    // which it was, so a poisoned room is not exported as a truncated one.
+    if (poisoned) throw new CollaborationSchemaError('blob-digest-mismatch', poisoned);
+    if (!materialized.ok) throw new CollaborationSchemaError(materialized.code);
+    return writeOoxmlPackage(materialized.package);
+  } finally {
+    materializer?.destroy();
+    registry.destroy();
+  }
+}

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -61,6 +61,18 @@ import {
   waitForSharedInitialization,
 } from './document-bootstrap.ts';
 import { LogicalIdentityMap } from './document-identity.ts';
+import {
+  AWARENESS_FIELD,
+  MAX_AWARENESS_STATES,
+  MAX_IDENTITY_LENGTH,
+  awarenessPayload,
+  sessionIdentity,
+  validateDocumentId,
+  validateIdentity,
+  type AwarenessPayload,
+  type EncodedSelection,
+  type EncodedSelectionAddress,
+} from './document-awareness.ts';
 import { CollaborationSchemaError } from './schema.ts';
 import type {
   CollaborationBootstrap,
@@ -69,9 +81,6 @@ import type {
   TextCollaborationSession,
 } from './session.ts';
 
-const AWARENESS_FIELD = 'docxEditor';
-const MAX_IDENTITY_LENGTH = 256;
-const MAX_AWARENESS_STATES = 256;
 /** One refused journal recovers; a run of them means the next edit refuses too. */
 const MAX_REFUSALS_IN_A_ROW = 3;
 /** Local journals inside this window share one actor undo item. */
@@ -88,127 +97,6 @@ const ATTACH_WATCHDOG_MS = 2_000;
 export const ATTACH_WATCHDOG_MS_FOR_TESTS: unique symbol = Symbol(
   'createDocumentCollaboration.attachWatchdogMs'
 );
-
-interface EncodedSelectionAddress {
-  readonly paragraphId: string;
-  readonly offset: number;
-}
-
-interface EncodedSelection {
-  readonly anchor: EncodedSelectionAddress;
-  readonly head: EncodedSelectionAddress;
-  readonly kind?: 'cells';
-}
-
-interface AwarenessPayload {
-  readonly actorId: string;
-  readonly name: string;
-  readonly color?: string;
-  readonly role: 'human' | 'agent';
-  readonly selection?: EncodedSelection;
-}
-
-function validateIdentity(identity: CollaborationIdentity): CollaborationIdentity {
-  const actorId = identity.actorId.trim();
-  const name = identity.name.trim();
-  if (
-    actorId.length === 0 ||
-    actorId.length > MAX_IDENTITY_LENGTH ||
-    name.length === 0 ||
-    name.length > MAX_IDENTITY_LENGTH
-  ) {
-    throw new CollaborationSchemaError('invalid-identity');
-  }
-  if (identity.color !== undefined && identity.color.length > 64) {
-    throw new CollaborationSchemaError('invalid-identity-color');
-  }
-  return Object.freeze({
-    actorId,
-    name,
-    ...(identity.color ? { color: identity.color } : {}),
-    role: identity.role ?? 'human',
-  });
-}
-
-function validateDocumentId(value: string): string {
-  const documentId = value.trim();
-  if (documentId.length === 0 || documentId.length > MAX_IDENTITY_LENGTH) {
-    throw new CollaborationSchemaError('invalid-document-id');
-  }
-  return documentId;
-}
-
-function sessionIdentity(value: string | undefined): string {
-  const sessionId = value?.trim() || globalThis.crypto.randomUUID();
-  if (sessionId.length > MAX_IDENTITY_LENGTH) {
-    throw new CollaborationSchemaError('invalid-session-id');
-  }
-  return sessionId;
-}
-
-function encodedSelectionAddress(value: unknown): EncodedSelectionAddress | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  if (
-    typeof record.paragraphId !== 'string' ||
-    record.paragraphId.length !== 8 ||
-    !Number.isSafeInteger(record.offset) ||
-    (record.offset as number) < 0
-  ) {
-    return null;
-  }
-  return { paragraphId: record.paragraphId.toUpperCase(), offset: record.offset as number };
-}
-
-function encodedSelection(value: unknown): EncodedSelection | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
-  const selected = value as Record<string, unknown>;
-  const anchor = encodedSelectionAddress(selected.anchor);
-  const head = encodedSelectionAddress(selected.head);
-  if (anchor && head) {
-    return selected.kind === 'cells' ? { anchor, head, kind: 'cells' } : { anchor, head };
-  }
-  if (
-    typeof selected.paragraphId === 'string' &&
-    selected.paragraphId.length === 8 &&
-    Number.isSafeInteger(selected.start) &&
-    Number.isSafeInteger(selected.end) &&
-    (selected.start as number) >= 0 &&
-    (selected.end as number) >= 0
-  ) {
-    const paragraphId = selected.paragraphId.toUpperCase();
-    return {
-      anchor: { paragraphId, offset: selected.start as number },
-      head: { paragraphId, offset: selected.end as number },
-    };
-  }
-  return undefined;
-}
-
-function awarenessPayload(value: unknown): AwarenessPayload | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  if (
-    typeof record.actorId !== 'string' ||
-    record.actorId.length === 0 ||
-    record.actorId.length > MAX_IDENTITY_LENGTH ||
-    typeof record.name !== 'string' ||
-    record.name.length === 0 ||
-    record.name.length > MAX_IDENTITY_LENGTH
-  ) {
-    return null;
-  }
-  // Trust boundary for a peer's presence record. The color flows into `participants()` and
-  // `remoteSelections()`, and hosts paint it into CSS (`background:` via a custom property),
-  // where `url(//host/t)` is a zero-click GET. Only the shapes this engine itself produces
-  // pass; anything else drops so every consumer falls back to the accent color.
-  const color = safeParticipantColor(typeof record.color === 'string' ? record.color : undefined);
-  const role: 'human' | 'agent' = record.role === 'agent' ? 'agent' : 'human';
-  const base = { actorId: record.actorId, name: record.name, ...(color ? { color } : {}), role };
-  const selection = encodedSelection(record.selection);
-  return selection ? { ...base, selection } : base;
-}
 
 class DocumentSession implements DocumentCollaborationSession {
   readonly documentId: string;
@@ -430,6 +318,9 @@ class DocumentSession implements DocumentCollaborationSession {
   undo(): boolean {
     if (!this.canWriteSharedState()) return false;
     this.flushPendingJournals();
+    // The flush can refuse the queued journal and take this session to terminal `error`,
+    // so the gate re-checks: undo must not write a room the session just diverged from.
+    if (!this.canWriteSharedState()) return false;
     if (this.undoManager.undoStack.length === 0) return false;
     this.undoManager.undo();
     return true;
@@ -438,6 +329,7 @@ class DocumentSession implements DocumentCollaborationSession {
   redo(): boolean {
     if (!this.canWriteSharedState()) return false;
     this.flushPendingJournals();
+    if (!this.canWriteSharedState()) return false;
     if (this.undoManager.redoStack.length === 0) return false;
     this.undoManager.redo();
     return true;
@@ -961,34 +853,44 @@ async function bootstrapDocumentReplica(
   if (exceeded) throw new CollaborationSchemaError(exceeded.code, exceeded.detail);
 
   const materializer = new PackageMaterializer(registry, blobs);
-  const materialized = materializer.current();
-  const poisoned = blobs.poisonedDigest();
-  if (poisoned) {
+  // Any throw between here and the return leaks the materializer's observers on the
+  // caller's document — `current()` can throw on hostile shared state, and the refusals
+  // below throw by design — so the whole tail hands the materializer back on the way out.
+  // On success, ownership passes to the session, which detaches it on destroy.
+  try {
+    const materialized = materializer.current();
+    const poisoned = blobs.poisonedDigest();
+    if (poisoned) {
+      // A blob that does not hash to its key reads downstream as a blob that is not there.
+      // Say which it was, so a poisoned room is not reported as a truncated one.
+      throw new CollaborationSchemaError('blob-digest-mismatch', poisoned);
+    }
+    if (!materialized.ok) {
+      throw new CollaborationSchemaError(materialized.code);
+    }
+    // Serialize before the session exists: a throw here must not orphan a live session
+    // whose registry and materializer the catch below is about to tear down.
+    const document = writeOoxmlPackage(materialized.package);
+    const session = new DocumentSession(
+      options.ydoc,
+      options.awareness,
+      documentId,
+      sessionId,
+      identity,
+      registry,
+      materializer,
+      identityMap,
+      blobs,
+      attachWatchdogMs,
+      options.offlineEditing === true
+    );
+    return Object.freeze({
+      document,
+      session,
+      destroy: () => session.destroy(),
+    });
+  } catch (error) {
     materializer.destroy();
-    // A blob that does not hash to its key reads downstream as a blob that is not there. Say
-    // which it was, so a poisoned room is not reported as a truncated one.
-    throw new CollaborationSchemaError('blob-digest-mismatch', poisoned);
+    throw error;
   }
-  if (!materialized.ok) {
-    materializer.destroy();
-    throw new CollaborationSchemaError(materialized.code);
-  }
-  const session = new DocumentSession(
-    options.ydoc,
-    options.awareness,
-    documentId,
-    sessionId,
-    identity,
-    registry,
-    materializer,
-    identityMap,
-    blobs,
-    attachWatchdogMs,
-    options.offlineEditing === true
-  );
-  return Object.freeze({
-    document: writeOoxmlPackage(materialized.package),
-    session,
-    destroy: () => session.destroy(),
-  });
 }

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -51,7 +51,7 @@ import {
   type BinaryPayload,
 } from './document/seed.ts';
 import { droppedContentDetail } from './document/schema.ts';
-import { SharedBlobStore, limitFailure } from './shared-blob-store.ts';
+import { SHARED_BLOBS_KEY, SharedBlobStore, limitFailure } from './shared-blob-store.ts';
 import {
   DEFAULT_INITIALIZATION_TIMEOUT_MS,
   observeSeedRecords,
@@ -70,7 +70,6 @@ import type {
 } from './session.ts';
 
 const AWARENESS_FIELD = 'docxEditor';
-const BLOBS_KEY = 'docx-package-blobs-v1';
 const MAX_IDENTITY_LENGTH = 256;
 const MAX_AWARENESS_STATES = 256;
 /** One refused journal recovers; a run of them means the next edit refuses too. */
@@ -391,34 +390,45 @@ class DocumentSession implements DocumentCollaborationSession {
     return null;
   }
 
+  /**
+   * The one readiness rule for writing shared state from this replica.
+   *
+   * A journal applies to the local Y.Doc either way, so a `disconnected` replica can keep
+   * editing and its buffered updates merge on reconnect exactly as concurrent online edits
+   * do. Only the host can show an offline indicator, so it opts in. `initializing` stays
+   * refused (the bootstrap has not published a first revision) and `error` stays terminal.
+   */
+  private canWriteSharedState(): boolean {
+    if (this.destroyed) return false;
+    const status = this.statusState.status();
+    return status === 'ready' || (this.offlineEditing && status === 'disconnected');
+  }
+
   /** Every authorable mutation replicates, so only session readiness gates a write. */
   gateOperations(_ops: readonly TreeDocOp[], _scope: StoryScope): CollaborationFailureCode | null {
     if (this.destroyed) return 'collaboration-session-destroyed';
-    const status = this.statusState.status();
-    // A journal applies to the local Y.Doc either way, so a `disconnected` replica can keep
-    // editing and its buffered updates merge on reconnect exactly as concurrent online edits
-    // do. Only the host can show an offline indicator, so it opts in. `initializing` stays
-    // refused (the bootstrap has not published a first revision) and `error` stays terminal.
-    if (status !== 'ready' && !(this.offlineEditing && status === 'disconnected')) {
-      return 'collaboration-session-not-ready';
-    }
+    if (!this.canWriteSharedState()) return 'collaboration-session-not-ready';
     if (!this.port) return 'collaboration-session-not-attached';
     return null;
   }
 
+  // Undo and redo write shared state exactly as a keystroke does — Y.UndoManager reverses the
+  // room's history and every peer applies the result — so they obey the same readiness rule
+  // the operation gate applies. Without it a replica in terminal `error`, which the gate has
+  // declared diverged and read-only, kept mutating the room through Ctrl+Z.
   canUndo(): boolean {
     return (
-      !this.destroyed &&
+      this.canWriteSharedState() &&
       ((this.port?.hasPendingJournals() ?? false) || this.undoManager.undoStack.length > 0)
     );
   }
 
   canRedo(): boolean {
-    return !this.destroyed && this.undoManager.redoStack.length > 0;
+    return this.canWriteSharedState() && this.undoManager.redoStack.length > 0;
   }
 
   undo(): boolean {
-    if (this.destroyed) return false;
+    if (!this.canWriteSharedState()) return false;
     this.flushPendingJournals();
     if (this.undoManager.undoStack.length === 0) return false;
     this.undoManager.undo();
@@ -426,7 +436,7 @@ class DocumentSession implements DocumentCollaborationSession {
   }
 
   redo(): boolean {
-    if (this.destroyed) return false;
+    if (!this.canWriteSharedState()) return false;
     this.flushPendingJournals();
     if (this.undoManager.redoStack.length === 0) return false;
     this.undoManager.redo();
@@ -571,6 +581,9 @@ class DocumentSession implements DocumentCollaborationSession {
     this.awareness.setLocalState(null);
     this.undoManager.destroy();
     this.materializer.destroy();
+    // The caller owns `ydoc` and can outlive this session, so the registry gives its
+    // observers back — a leaked handler would keep paying on every later transaction.
+    this.registry.destroy();
     this.setStatus('destroyed');
     this.statusListeners.clear();
     this.selectionListeners.clear();
@@ -654,6 +667,11 @@ class DocumentSession implements DocumentCollaborationSession {
 
   private refuseLocalJournal(refusal: CollaborationFailure): void {
     this.undoManager.stopCapturing();
+    // The status this replica held before the refusal. Recovery restores it, because a
+    // realign repairs the DOCUMENT, not the transport: with offline editing on, the refused
+    // journal arrived while `disconnected`, and recovering to `ready` would tell the host the
+    // connection came back when only the tree did.
+    const before = this.statusState.snapshot();
     // The local store already committed this edit, so leaving it would make this replica
     // silently different from the room. Shared state is the authority: take it back.
     this.refusedInARow += 1;
@@ -675,9 +693,10 @@ class DocumentSession implements DocumentCollaborationSession {
       this.statusState.status() === 'error' &&
       current !== undefined &&
       current.code === refusal.code &&
-      current.detail === refusal.detail
+      current.detail === refusal.detail &&
+      (before.status === 'ready' || before.status === 'disconnected')
     ) {
-      this.setStatus('ready');
+      this.setStatus(before.status, before.reason?.code, before.reason?.detail);
     }
   }
 
@@ -830,60 +849,7 @@ export interface CreateDocumentCollaborationOptions {
   readonly offlineEditing?: boolean;
 }
 
-/**
- * Read the document a synchronized `Y.Doc` holds, as `.docx` bytes.
- *
- * This is the server side of a room: export, autosave to your own storage, search indexing, a
- * nightly PDF, a webhook. It JOINS NOTHING. There is no identity, no `Awareness` and no
- * session, so the job that calls it never appears in anyone's avatar stack, and it creates no
- * editing gate, so it cannot write back.
- *
- * `ydoc` must already hold the room's state: connect your provider and wait for its initial
- * sync first, exactly as a `{ kind: \'join\' }` bootstrap does. A document that was never
- * seeded refuses with `not-initialized` rather than returning a truncated file.
- *
- * ```ts
- * // Hocuspocus hands `onStoreDocument` the synced Y.Doc already:
- * async onStoreDocument({ documentName, document }) {
- *   await writeFile(`${documentName}.docx`, readCollaborationDocument(document));
- * }
- * ```
- *
- * Synchronous, and it materializes the whole package per call — this is a job, not a render.
- *
- * @throws CollaborationSchemaError — `not-initialized`, `concurrent-seed`,
- * `blob-digest-mismatch`, or a limit code: the same refusals a joining replica makes, for the
- * same reasons.
- * @public
- */
-export function readCollaborationDocument(ydoc: Y.Doc): Uint8Array {
-  const registry = new DocumentRegistry(ydoc);
-  // Shared state arrived before this registry existed and the parent index is built from
-  // child-array EVENTS — the same rebuild a joiner performs, for the same reason.
-  registry.rebuildDerivedIndexes();
-  if (typeof registry.schema.meta.get('documentId') !== 'string') {
-    throw new CollaborationSchemaError('not-initialized');
-  }
-  // Two merged seeds duplicate the whole document and no reader can pick a side, so an
-  // export refuses rather than writing a file with everything in it twice.
-  if (seedRecordCount(ydoc) > 1) throw new CollaborationSchemaError('concurrent-seed');
-  const blobs = new SharedBlobStore(ydoc.getMap<Uint8Array>(BLOBS_KEY));
-  const exceeded = limitFailure(registry, blobs);
-  if (exceeded) throw new CollaborationSchemaError(exceeded.code, exceeded.detail);
-  const materializer = new PackageMaterializer(registry, blobs);
-  try {
-    const materialized = materializer.current();
-    const poisoned = blobs.poisonedDigest();
-    // A blob that does not hash to its key reads downstream as a blob that is not there. Say
-    // which it was, so a poisoned room is not exported as a truncated one.
-    if (poisoned) throw new CollaborationSchemaError('blob-digest-mismatch', poisoned);
-    if (!materialized.ok) throw new CollaborationSchemaError(materialized.code);
-    return writeOoxmlPackage(materialized.package);
-  } finally {
-    // Owned here, so released here — whether the read succeeded or refused.
-    materializer.destroy();
-  }
-}
+export { readCollaborationDocument } from './document-read.ts';
 
 /**
  * Create or join one full-document collaboration replica.
@@ -902,8 +868,38 @@ export async function createDocumentCollaboration(
   const sessionId = sessionIdentity(options.sessionId);
   const identity = validateIdentity(options.identity);
   const registry = new DocumentRegistry(options.ydoc);
+  // A bootstrap that refuses must not leave this registry observing the caller's document:
+  // the caller keeps `ydoc` (a retry, a different room), and a leaked observer taxes every
+  // later transaction. On success the session owns the registry and detaches it on destroy.
+  try {
+    return await bootstrapDocumentReplica(options, {
+      attachWatchdogMs,
+      documentId,
+      sessionId,
+      identity,
+      registry,
+    });
+  } catch (error) {
+    registry.destroy();
+    throw error;
+  }
+}
+
+interface DocumentReplicaContext {
+  readonly attachWatchdogMs: number;
+  readonly documentId: string;
+  readonly sessionId: string;
+  readonly identity: CollaborationIdentity;
+  readonly registry: DocumentRegistry;
+}
+
+async function bootstrapDocumentReplica(
+  options: CreateDocumentCollaborationOptions,
+  context: DocumentReplicaContext
+): Promise<DocumentCollaborationHandle> {
+  const { attachWatchdogMs, documentId, sessionId, identity, registry } = context;
   const identityMap = new LogicalIdentityMap((logicalId) => registry.hasNode(logicalId));
-  const blobs = new SharedBlobStore(options.ydoc.getMap<Uint8Array>(BLOBS_KEY));
+  const blobs = new SharedBlobStore(options.ydoc.getMap<Uint8Array>(SHARED_BLOBS_KEY));
 
   if (options.bootstrap.kind === 'create') {
     if (registry.schema.meta.get('initialized') === true) {

--- a/packages/pro/src/collaboration/document/registry-observers.ts
+++ b/packages/pro/src/collaboration/document/registry-observers.ts
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+/**
+ * Observer wiring for one `DocumentRegistry`.
+ *
+ * The registry derives every index from Yjs events, so it has to observe the shared types —
+ * but it does not own the document. Registration therefore returns the matching detach, and
+ * the registry exposes it as `destroy()`: a registry left observing outlives its consumer,
+ * every later transaction pays its handlers, and its derived indexes retain the whole tree.
+ */
+
+import type * as Y from 'yjs';
+import type { PackageSchema } from './schema.ts';
+
+export interface RegistryObserverHooks {
+  readonly onNodeEvents: (events: Y.YEvent<Y.AbstractType<unknown>>[]) => void;
+  readonly onAttributeEvent: (event: Y.YMapEvent<string>) => void;
+  readonly onBindingEvent: (event: Y.YMapEvent<string>) => void;
+  readonly onRelationshipChange: () => void;
+  readonly onPartChange: () => void;
+}
+
+/** Attach the registry's derived-index observers. Returns the matching detach. */
+export function observeRegistrySchema(
+  schema: PackageSchema,
+  hooks: RegistryObserverHooks
+): () => void {
+  schema.nodes.observeDeep(hooks.onNodeEvents);
+  schema.attributes.observe(hooks.onAttributeEvent);
+  schema.bindings.observe(hooks.onBindingEvent);
+  schema.relationships.observeDeep(hooks.onRelationshipChange);
+  schema.parts.observeDeep(hooks.onPartChange);
+  return () => {
+    schema.nodes.unobserveDeep(hooks.onNodeEvents);
+    schema.attributes.unobserve(hooks.onAttributeEvent);
+    schema.bindings.unobserve(hooks.onBindingEvent);
+    schema.relationships.unobserveDeep(hooks.onRelationshipChange);
+    schema.parts.unobserveDeep(hooks.onPartChange);
+  };
+}

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -47,6 +47,7 @@ import {
   type TextRecord,
 } from './schema.ts';
 import { readRelationships, relationshipKey } from './relationship-store.ts';
+import { observeRegistrySchema } from './registry-observers.ts';
 import {
   assignFirstReachableParents,
   resolveContestedPlacements,
@@ -110,32 +111,48 @@ export class DocumentRegistry {
   /** Part-entry total as of the last read. Negative means "not counted yet". */
   private partCountCache = -1;
 
+  private readonly stopObserving: () => void;
+
   constructor(
     readonly doc: Y.Doc,
     limits?: Partial<DocumentLimits>
   ) {
     this.schema = packageSchemaOf(doc);
     this.limits = mergeLimits(limits);
-    this.schema.nodes.observeDeep((events) => {
-      if (this.bulkLoad > 0) return;
-      this.applyChildArrayEvents(events);
+    this.stopObserving = observeRegistrySchema(this.schema, {
+      onNodeEvents: (events) => {
+        if (this.bulkLoad > 0) return;
+        this.applyChildArrayEvents(events);
+      },
+      onAttributeEvent: (event) => {
+        if (this.bulkLoad > 0) return;
+        this.applyAttributeMapEvent(event);
+      },
+      onBindingEvent: (event) => {
+        if (this.bulkLoad > 0) return;
+        this.applyBindingMapEvent(event);
+      },
+      // Dropping a stale count is safe at any time, so these run even during a bulk load. The
+      // deep observers catch a peer on an earlier build writing inside a nested owner map.
+      onRelationshipChange: () => {
+        this.relationshipCountCache = -1;
+      },
+      onPartChange: () => {
+        this.partCountCache = -1;
+      },
     });
-    this.schema.attributes.observe((event) => {
-      if (this.bulkLoad > 0) return;
-      this.applyAttributeMapEvent(event);
-    });
-    this.schema.bindings.observe((event) => {
-      if (this.bulkLoad > 0) return;
-      this.applyBindingMapEvent(event);
-    });
-    // Dropping a stale count is safe at any time, so these run even during a bulk load. The
-    // deep observers catch a peer on an earlier build writing inside a nested owner map.
-    this.schema.relationships.observeDeep(() => {
-      this.relationshipCountCache = -1;
-    });
-    this.schema.parts.observeDeep(() => {
-      this.partCountCache = -1;
-    });
+  }
+
+  /**
+   * Detach this registry's observers from the shared document.
+   *
+   * The registry does not own `doc`, so teardown has to give the observers back. A registry
+   * left observing outlives its consumer: every later transaction pays its handlers, and its
+   * derived indexes retain the whole tree. `readCollaborationDocument` builds one registry
+   * per call on a long-lived server document, so this detach is load-bearing.
+   */
+  destroy(): void {
+    this.stopObserving();
   }
 
   beginBulkLoad(): void {

--- a/packages/pro/src/collaboration/document/seed.ts
+++ b/packages/pro/src/collaboration/document/seed.ts
@@ -250,8 +250,6 @@ export async function seedPackage(
   try {
     registry.doc.transact(() => {
       for (const payload of binaries.payloads) blobs.put(payload.digest, payload.bytes);
-      writeSchemaVersions(registry.schema.meta);
-      registry.schema.meta.set('mainDocumentPart', pkg.mainDocumentPart);
       const counts = { nodes: 0 };
       for (const [name, part] of pkg.parts) {
         const partError = rejectPartName(name);
@@ -322,6 +320,15 @@ export async function seedPackage(
       for (const descriptor of binaries.descriptors) {
         registry.putBinary(descriptor);
       }
+      // Initialization is the LAST write. Yjs commits everything already written when a limit
+      // refusal stops this callback, so marking the room initialized first left a FAILED seed
+      // advertising a joinable room: joiners passed the initialization wait and then hit
+      // `document-id-mismatch`, and a retried `create` refused with `already-initialized`.
+      // Order inside one transaction is invisible to a peer — the update applies atomically —
+      // so writing the flag last only changes what a failed seed leaves behind: inert records
+      // in a room that still reads uninitialized, which a retry overwrites.
+      writeSchemaVersions(registry.schema.meta);
+      registry.schema.meta.set('mainDocumentPart', pkg.mainDocumentPart);
     }, BOOTSTRAP_ORIGIN);
   } finally {
     registry.endBulkLoad();

--- a/packages/pro/src/collaboration/session.ts
+++ b/packages/pro/src/collaboration/session.ts
@@ -499,12 +499,22 @@ class Session implements TextCollaborationSession {
     return null;
   }
 
+  // Undo and redo write shared state exactly as a keystroke does, so they obey the same
+  // readiness rule as `gateOperations`: only a `ready` replica may mutate the room.
   canUndo(): boolean {
-    return !this.destroyed && this.undoManager.undoStack.length > 0;
+    return (
+      !this.destroyed &&
+      this.statusState.status() === 'ready' &&
+      this.undoManager.undoStack.length > 0
+    );
   }
 
   canRedo(): boolean {
-    return !this.destroyed && this.undoManager.redoStack.length > 0;
+    return (
+      !this.destroyed &&
+      this.statusState.status() === 'ready' &&
+      this.undoManager.redoStack.length > 0
+    );
   }
 
   undo(): boolean {

--- a/packages/pro/src/collaboration/shared-blob-store.ts
+++ b/packages/pro/src/collaboration/shared-blob-store.ts
@@ -26,6 +26,9 @@ import { CollaborationSchemaError } from './schema.ts';
 /** Ceiling on the bytes one room carries beside its shared tree. */
 export const MAX_SHARED_BLOB_BYTES = 64 * 1024 * 1024;
 
+/** Top-level `Y.Map` key of the content-addressed blob bytes a room carries. */
+export const SHARED_BLOBS_KEY = 'docx-package-blobs-v1';
+
 function sharedBlobBytes(value: unknown): Uint8Array | null {
   if (value instanceof Uint8Array) return new Uint8Array(value);
   if (value instanceof ArrayBuffer) return new Uint8Array(value);


### PR DESCRIPTION
Fixes four defects in the seam between the canonical store and shared Yjs state:

- A failed seed no longer marks the room initialized. Yjs commits what a refused seed transaction already wrote, so the `initialized` flag and `mainDocumentPart` now land last: the room id stays creatable, and joiners keep waiting instead of failing with `document-id-mismatch`. Fixes #541.
- `DocumentRegistry` gains `destroy()`. `readCollaborationDocument`, session teardown, and every factory error path — including a throw while materializing — release their document observers instead of taxing the room's `Y.Doc` for its lifetime. Fixes #542.
- Refusal recovery restores the status the replica held before the refusal instead of forcing `ready` over a live disconnected transport. Fixes #544.
- Undo and redo obey the same readiness rule as `gateOperations` in both session kinds, so a replica in terminal `error` can no longer write the room through Ctrl+Z. Fixes #545.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790464323&installation_model_id=422592&pr_number=547&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F547&signature=d201312ee4e483370bafd0b6e63e8054b1e03d7049c0bd10f4aca0143330713c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->