### PR TITLE
fix: paint theme and group shapes

### DIFF
--- a/.changeset/bright-shapes-paint.md
+++ b/.changeset/bright-shapes-paint.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Paint theme-coloured DrawingML shapes and grouped vector graphics.

--- a/.changeset/bright-shapes-paint.md
+++ b/.changeset/bright-shapes-paint.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
 Paint theme-coloured DrawingML shapes and grouped vector graphics.

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -3238,6 +3238,8 @@ export function projectDrawing(drawing: OoxmlDrawingNode, context: Readonly<{
     namespaceScope?: ReadonlyMap<string, string>;
     ownerPartName: string;
     resolveRelationship?: RelationshipTargetResolver;
+    resolveSchemeColor?: ShapeSchemeColorResolver;
+    resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
     supportedMcRequires: ReadonlySet<string>;
 }>): DrawingProjection | null;
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -171,7 +171,8 @@ Alt text uses `@descr`, then `@title`; `@name` is never announced. A picture wit
 
 | Drawing content                                         | Status                                               |
 | ------------------------------------------------------- | ---------------------------------------------------- |
-| Charts, SmartArt, groups, and canvases                  | Preserve the extent and show a labeled placeholder   |
+| Solid shapes and bounded shape groups                   | Render geometry with sRGB or theme colors            |
+| Charts, SmartArt, unsupported groups, and canvases      | Preserve the extent and show a labeled placeholder   |
 | Anchored text boxes                                     | Render the story read-only and clip it to the extent |
 | Page fields in anchored header or footer text boxes     | Evaluate per page                                    |
 | Inline text boxes, linked chains, autofit, and rotation | Show a placeholder                                   |

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -563,7 +563,7 @@ export const wordFeatures: WordFeature[] = [
     tier: 'community',
     docsLink: '/docs/2.x/guides/images',
     notes:
-      'Charts, groups, canvases, and custom geometry reserve their extent with a placeholder. Unsupported payloads stay generic in the canonical tree.',
+      'Solid rectangles, ellipses, bounded polygon geometry, and grouped shapes render with sRGB or theme colors. Other payloads reserve their extent with a placeholder.',
   },
   {
     id: 'images.crop',

--- a/packages/core/src/binding/document-theme.ts
+++ b/packages/core/src/binding/document-theme.ts
@@ -10,6 +10,7 @@
 // receive values this module has already bounded.
 
 import type { OoxmlElement, OoxmlNode } from '../store/package/ooxml-tree.ts';
+import { collectThemeColorScheme } from '../store/package/theme-color-resolution.ts';
 
 /**
  * The scheme slots the picker shows, in Word's column order.
@@ -38,14 +39,6 @@ export interface DocumentThemeColorEntry {
   readonly hex: string;
 }
 
-const HEX_COLOR = /^[0-9A-Fa-f]{6}$/;
-
-/** `a:sysClr` values when `lastClr` is absent — the OS colours Word resolves them to. */
-const SYS_COLOR_DEFAULTS: Record<string, string> = {
-  windowText: '000000',
-  window: 'FFFFFF',
-};
-
 function isElement(node: OoxmlNode): node is OoxmlElement {
   return node.kind !== 'textValue';
 }
@@ -73,27 +66,6 @@ function elementChild(parent: OoxmlElement, localName?: string): OoxmlElement | 
     if (localName === undefined || child.localName === localName) return child;
   }
   return null;
-}
-
-/** The hex a scheme slot resolves to: `a:srgbClr@val`, or `a:sysClr` via `lastClr`. */
-function slotHex(slot: OoxmlElement): string | null {
-  const color = elementChild(slot);
-  if (!color) return null;
-  let raw: string | undefined;
-  if (color.localName === 'srgbClr') {
-    raw = attributeValue(color, 'val');
-  } else if (color.localName === 'sysClr') {
-    // Guarded lookup: the `val` is file content, and a key like `__proto__` must
-    // answer undefined rather than a prototype member.
-    const sys = attributeValue(color, 'val') ?? '';
-    raw =
-      attributeValue(color, 'lastClr') ??
-      (Object.prototype.hasOwnProperty.call(SYS_COLOR_DEFAULTS, sys)
-        ? SYS_COLOR_DEFAULTS[sys]
-        : undefined);
-  }
-  if (raw === undefined || !HEX_COLOR.test(raw)) return null;
-  return raw.toUpperCase();
 }
 
 /** The theme's two font slots, for resolving `w:rFonts` theme attributes. */
@@ -138,14 +110,11 @@ export function collectDocumentThemeFonts(themeRoot: OoxmlElement | null): Docum
 export function collectDocumentThemeColors(
   themeRoot: OoxmlElement | null
 ): readonly DocumentThemeColorEntry[] {
-  if (!themeRoot) return [];
-  const scheme = findElement(themeRoot, 'clrScheme');
-  if (!scheme) return [];
+  const scheme = collectThemeColorScheme(themeRoot);
   const entries: DocumentThemeColorEntry[] = [];
   for (const slot of PICKER_SLOTS) {
-    const element = elementChild(scheme, slot);
-    const hex = element ? slotHex(element) : null;
-    if (hex === null) return [];
+    const hex = scheme.get(slot);
+    if (!hex) return [];
     entries.push({ slot, hex });
   }
   return entries;

--- a/packages/core/src/editor/__tests__/theme-shape-paint.test.ts
+++ b/packages/core/src/editor/__tests__/theme-shape-paint.test.ts
@@ -1,0 +1,158 @@
+// A theme-filled shape has to reach paint through the REAL package path.
+//
+// Every other colour suite injects a stub `resolveSchemeColor`/`resolveStyleMatrixReference`
+// straight into `indexInlineDrawingProjectionsInPart`, so none of them covers the one place
+// that builds those resolvers for the editor: `createPartDrawingContextSlot` in
+// `layout/inline-drawing-source.ts`. Drop either resolver there and the shapes below stop
+// resolving a colour and paint a placeholder card instead, which is exactly the regression
+// this file exists to catch. It mounts real bytes and reads the painted SVG.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { CT_NS, DRAWING_NS, OD_REL, REL_NS, mountWithImages } from './image-decode-harness.ts';
+
+const THEME_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme';
+const ACCENT1 = '6F55D7';
+
+/** An inline `prstGeom` rectangle whose fill comes from `spPr`, `wps:style`, or neither. */
+function themedRectangle(id: number, spPrFill: string, style: string): string {
+  return (
+    '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    `<wp:extent cx="457200" cy="457200"/><wp:docPr id="${id}" name="Rect ${id}"/>` +
+    '<a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">' +
+    '<wps:wsp><wps:cNvSpPr/><wps:spPr>' +
+    '<a:xfrm><a:off x="0" y="0"/><a:ext cx="457200" cy="457200"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>' +
+    `${spPrFill}<a:ln><a:noFill/></a:ln>` +
+    `</wps:spPr>${style}<wps:bodyPr/></wps:wsp>` +
+    '</a:graphicData></a:graphic></wp:inline></w:drawing></w:r>'
+  );
+}
+
+function theme(): string {
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  return (
+    `<a:theme xmlns:a="${A}" name="Fixture"><a:themeElements>` +
+    '<a:clrScheme name="Fixture">' +
+    '<a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>' +
+    '<a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>' +
+    '<a:dk2><a:srgbClr val="44546A"/></a:dk2><a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>' +
+    `<a:accent1><a:srgbClr val="${ACCENT1}"/></a:accent1>` +
+    '<a:accent2><a:srgbClr val="ED7D31"/></a:accent2>' +
+    '<a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>' +
+    '<a:accent4><a:srgbClr val="FFC000"/></a:accent4>' +
+    '<a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>' +
+    '<a:accent6><a:srgbClr val="70AD47"/></a:accent6>' +
+    '<a:hlink><a:srgbClr val="0563C1"/></a:hlink>' +
+    '<a:folHlink><a:srgbClr val="954F72"/></a:folHlink>' +
+    '</a:clrScheme><a:fontScheme name="Fixture">' +
+    '<a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>' +
+    '<a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>' +
+    '</a:fontScheme><a:fmtScheme name="Fixture">' +
+    // The style matrix a `fillRef idx="2"` selects: `phClr` stands in for the reference's
+    // own colour, so a shape with no authored fill still paints the theme colour.
+    '<a:fillStyleLst>' +
+    '<a:solidFill><a:srgbClr val="123456"/></a:solidFill>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '</a:fillStyleLst>' +
+    '<a:lnStyleLst/><a:effectStyleLst/>' +
+    '<a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst>' +
+    '</a:fmtScheme></a:themeElements></a:theme>'
+  );
+}
+
+function docx(options: { readonly mapAccent1To?: string } = {}): Uint8Array {
+  const parts: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT_NS}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>' +
+        '<Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}">` +
+        `<Relationship Id="rIdTheme" Type="${THEME_REL}" Target="theme/theme1.xml"/>` +
+        '<Relationship Id="rIdSettings" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/>' +
+        '</Relationships>'
+    ),
+    'word/theme/theme1.xml': strToU8(theme()),
+    'word/settings.xml': strToU8(
+      `<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${
+        options.mapAccent1To ? `<w:clrSchemeMapping w:accent1="${options.mapAccent1To}"/>` : ''
+      }</w:settings>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document ${DRAWING_NS}><w:body>` +
+        // 1: `spPr` fill through `a:schemeClr` — needs `resolveSchemeColor`.
+        '<w:p>' +
+        themedRectangle(
+          1,
+          '<a:solidFill><a:schemeClr val="accent1"><a:lumMod val="50000"/></a:schemeClr></a:solidFill>',
+          ''
+        ) +
+        '</w:p>' +
+        // 2: no authored fill — needs `resolveStyleMatrixReference` AND `resolveSchemeColor`.
+        '<w:p>' +
+        themedRectangle(
+          2,
+          '',
+          '<wps:style><a:fillRef idx="2"><a:schemeClr val="accent1"/></a:fillRef></wps:style>'
+        ) +
+        '</w:p>' +
+        // 3: `spPr` fill through `a:schemeClr` with `a:shade` — the linear-light blend.
+        '<w:p>' +
+        themedRectangle(
+          3,
+          '<a:solidFill><a:schemeClr val="accent1"><a:shade val="50000"/></a:schemeClr></a:solidFill>',
+          ''
+        ) +
+        '</w:p>' +
+        '<w:sectPr><w:pgSz w:w="11906" w:h="16838"/>' +
+        '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720"/>' +
+        '</w:sectPr></w:body></w:document>'
+    ),
+  };
+  return zipSync(parts);
+}
+
+function paintedFills(container: HTMLElement): readonly string[] {
+  return [...container.querySelectorAll('.docx-drawing-shape svg path')].map(
+    (path) => path.getAttribute('fill') ?? ''
+  );
+}
+
+describe('theme-filled shapes paint through the real package', () => {
+  test('an authored, a style-matrix and a shaded theme fill all resolve', async () => {
+    const { surface, container } = await mountWithImages(docx());
+    try {
+      expect(container.querySelectorAll('.docx-drawing-placeholder-card')).toHaveLength(0);
+      // accent1 6F55D7 with `lumMod 50000` (HSL), the style matrix's `phClr` (verbatim),
+      // and accent1 with `shade 50000` (linear light). Each value is the pixel a reference
+      // renderer paints for that fill.
+      expect(paintedFills(container)).toEqual(['#2F1D79', '#6F55D7', '#523E9F']);
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+
+  test('the settings colour mapping reaches the same shapes', async () => {
+    const { surface, container } = await mountWithImages(docx({ mapAccent1To: 'accent3' }));
+    try {
+      // `w:clrSchemeMapping w:accent1="accent3"` remaps the slot, so every fill above now
+      // derives from accent3 (A5A5A5) instead of accent1.
+      expect(paintedFills(container)).toEqual(['#535353', '#A5A5A5', '#7A7A7A']);
+    } finally {
+      surface.destroy();
+      container.remove();
+    }
+  });
+});

--- a/packages/core/src/layout/__tests__/drawing-placeholder-kind.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-placeholder-kind.test.ts
@@ -1,6 +1,10 @@
-// `graphicData@uri` is sender-controlled and keys the placeholder label a refused graphic
-// paints. Looked up on an object literal, a uri of `constructor` or `__proto__` hands back a
-// prototype member, and the card announces a stringified function instead of naming a kind.
+// Two file-derived drawing reads that must not be taken at face value.
+//
+// `graphicData@uri` keys the placeholder label a refused graphic paints. Looked up on an
+// object literal, a uri of `constructor` or `__proto__` hands back a prototype member, and
+// the card announces a stringified function instead of naming a kind.
+//
+// A picture's `a:xfrm` flip is `xsd:boolean`, so reading only `1` silently dropped `true`.
 
 import { describe, expect, test } from 'bun:test';
 import {
@@ -11,6 +15,7 @@ import {
 } from '../../store/package/ooxml-tree.ts';
 import {
   DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
   projectDrawing,
 } from '../../store/package/drawing-projection.ts';
 import type { ImageResourceState } from '../../store/package/image-resources.ts';
@@ -92,5 +97,54 @@ describe('placeholder graphic kind', () => {
     for (const hostile of ['constructor', '__proto__', 'toString', 'valueOf']) {
       expect(`${hostile}: ${placeholderKindFor(hostile)}`).toBe(`${hostile}: graphic`);
     }
+  });
+});
+
+// A picture's `a:xfrm` flip is `xsd:boolean` too, but unlike a vector shape's the engine CAN
+// paint it, so the policy differs: a legal true mirrors, and a spelling the schema forbids
+// reads as unset rather than refusing and losing the picture.
+describe('picture transform flip', () => {
+  const flipsFor = (attrs: string): { h: boolean; v: boolean } => {
+    const xml =
+      `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+      `xmlns:pic="${PIC}" xmlns:r="${R}"><w:body><w:p><w:r><w:drawing>` +
+      '<wp:inline distT="0" distB="0" distL="0" distR="0">' +
+      '<wp:extent cx="914400" cy="457200"/><wp:docPr id="1" name="pic"/>' +
+      `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
+      '<pic:nvPicPr><pic:cNvPr id="1" name="pic"/><pic:cNvPicPr/></pic:nvPicPr>' +
+      '<pic:blipFill><a:blip r:embed="rId9"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+      `<pic:spPr><a:xfrm${attrs}><a:ext cx="914400" cy="457200"/></a:xfrm>` +
+      '<a:prstGeom prst="rect"/></pic:spPr>' +
+      '</pic:pic></a:graphicData></a:graphic>' +
+      '</wp:inline></w:drawing></w:r></w:p></w:body></w:document>';
+    const result = readOoxmlPart(xml, {
+      name: OWNER,
+      contentType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+    });
+    if (!result.ok) throw new Error(result.reason);
+    const projection = [...indexInlineDrawingProjectionsInPart(result.part).values()][0]!;
+    const transform = projection.picture!.transform;
+    return { h: transform.flipHorizontal, v: transform.flipVertical };
+  };
+
+  test('every legal true mirrors and everything else does not', () => {
+    expect(flipsFor('')).toEqual({ h: false, v: false });
+    for (const set of ['1', 'true', ' 1 ', '\ntrue\n']) {
+      expect(`flipH=${JSON.stringify(set)}: ${flipsFor(` flipH="${set}"`).h}`).toBe(
+        `flipH=${JSON.stringify(set)}: true`
+      );
+      expect(`flipV=${JSON.stringify(set)}: ${flipsFor(` flipV="${set}"`).v}`).toBe(
+        `flipV=${JSON.stringify(set)}: true`
+      );
+    }
+    for (const unset of ['0', 'false', ' 0 ', 'TRUE', 'True', 'yes', '2', '']) {
+      expect(`flipH=${JSON.stringify(unset)}: ${flipsFor(` flipH="${unset}"`).h}`).toBe(
+        `flipH=${JSON.stringify(unset)}: false`
+      );
+    }
+    // A schema-invalid flip must not cost the picture itself.
+    expect(flipsFor(' flipH="TRUE"')).toEqual({ h: false, v: false });
+    expect(flipsFor(' flipH="1" flipV="1"')).toEqual({ h: true, v: true });
   });
 });

--- a/packages/core/src/layout/__tests__/drawing-placeholder-kind.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-placeholder-kind.test.ts
@@ -1,0 +1,96 @@
+// `graphicData@uri` is sender-controlled and keys the placeholder label a refused graphic
+// paints. Looked up on an object literal, a uri of `constructor` or `__proto__` hands back a
+// prototype member, and the card announces a stringified function instead of naming a kind.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  WML_NAMESPACE_URI,
+  type OoxmlDrawingNode,
+  type OoxmlElement,
+} from '../../store/package/ooxml-tree.ts';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import type { ImageResourceState } from '../../store/package/image-resources.ts';
+import { buildInlineDrawingRecord } from '../drawing-layout.ts';
+
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const OWNER = '/word/document.xml';
+
+const RESOURCE: ImageResourceState = Object.freeze({ kind: 'missing', partName: null });
+
+function inlineDrawing(): OoxmlDrawingNode {
+  const xml =
+    `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+    `xmlns:pic="${PIC}" xmlns:r="${R}"><w:body><w:p><w:r><w:drawing>` +
+    '<wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    '<wp:extent cx="914400" cy="457200"/><wp:docPr id="1" name="pic"/>' +
+    `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
+    '<pic:nvPicPr><pic:cNvPr id="1" name="pic"/><pic:cNvPicPr/></pic:nvPicPr>' +
+    '<pic:blipFill><a:blip r:embed="rId9"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+    '<pic:spPr><a:xfrm><a:ext cx="914400" cy="457200"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"/></pic:spPr>' +
+    '</pic:pic></a:graphicData></a:graphic>' +
+    '</wp:inline></w:drawing></w:r></w:p></w:body></w:document>';
+  const result = readOoxmlPart(xml, {
+    name: OWNER,
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  const stack: OoxmlElement[] = [result.part.root];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (node.kind === 'drawing') return node;
+    for (const child of node.children) if (child.kind !== 'textValue') stack.push(child);
+  }
+  throw new Error('missing drawing');
+}
+
+/** The record a refused graphic with this `unsupported-graphic` detail lays out to. */
+function placeholderKindFor(detail: string): string | null {
+  const projection = projectDrawing(inlineDrawing(), {
+    ownerPartName: OWNER,
+    limits: DEFAULT_DRAWING_PROJECTION_LIMITS,
+    supportedMcRequires: new Set<string>(),
+  })!;
+  const record = buildInlineDrawingRecord({
+    input: {
+      drawingNodeId: 'n1',
+      ownerPartName: OWNER,
+      // A refused graphic: no picture, and one diagnostic naming the uri that refused.
+      projection: {
+        ...projection,
+        picture: null,
+        diagnostics: [{ code: 'unsupported-graphic', nodeId: 'n1', detail }],
+      },
+      resource: RESOURCE,
+    },
+    paragraphId: 'p1',
+    start: 0,
+    slotX: 0,
+    y: 0,
+    baseline: 0,
+    contentLeft: 0,
+    contentRight: 500,
+  } as Parameters<typeof buildInlineDrawingRecord>[0]);
+  return record.placeholderGraphicKind;
+}
+
+describe('placeholder graphic kind', () => {
+  test('a known uri names the graphic and a prototype member never does', () => {
+    expect(placeholderKindFor('http://schemas.openxmlformats.org/drawingml/2006/chart')).toBe(
+      'chart'
+    );
+    expect(
+      placeholderKindFor('http://schemas.microsoft.com/office/word/2010/wordprocessingGroup')
+    ).toBe('group');
+    for (const hostile of ['constructor', '__proto__', 'toString', 'valueOf']) {
+      expect(`${hostile}: ${placeholderKindFor(hostile)}`).toBe(`${hostile}: graphic`);
+    }
+  });
+});

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import {
   readOoxmlPackage,
   readOoxmlPart,
@@ -11,6 +11,7 @@ import {
   drawingAtomIdentities,
   drawingTokenForTableBlock,
   drawingTokenForTableBlockMemo,
+  vectorShapeLayoutToken,
 } from '../inline-drawing-source.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -204,4 +205,82 @@ test('an undefined epoch always recomputes and never reads or arms the cache', (
   // A warm epoch entry does not leak into the epoch-free path either.
   drawingTokenForTableBlockMemo(table, undefined, counted.fn);
   expect(counted.calls()).toBe(walkCost * 4);
+});
+
+// `vectorShapeLayoutToken` is a DIGEST, not a serialization: it is what stops
+// `isCompatibleWith` from paying ~48 KB of `JSON.stringify` per shape per atom. A digest is
+// only worth having if it still separates shapes that differ, so each case below changes one
+// field and nothing else.
+describe('vector shape layout token', () => {
+  const point = (x: number, y: number) => Object.freeze({ x, y });
+  const shape = (
+    overrides: Partial<{
+      readonly points: readonly Readonly<{ x: number; y: number }>[];
+      readonly fillHex: string | null;
+      readonly fillAlpha: number;
+      readonly strokeHex: string | null;
+      readonly strokeAlpha: number;
+      readonly strokeWidthEmu: number;
+      readonly cx: number;
+      readonly extraComponent: boolean;
+      readonly splitSubpaths: boolean;
+    }> = {}
+  ) => {
+    const points = overrides.points ?? [point(0, 0), point(100, 0), point(100, 50.5)];
+    const component = {
+      subpathsEmu: overrides.splitSubpaths ? [points.slice(0, 1), points.slice(1)] : [points],
+      fillHex: overrides.fillHex === undefined ? '4472C4' : overrides.fillHex,
+      fillAlpha: overrides.fillAlpha ?? 1,
+      strokeHex: overrides.strokeHex ?? null,
+      strokeAlpha: overrides.strokeAlpha ?? 1,
+      strokeWidthEmu: overrides.strokeWidthEmu ?? 0,
+    };
+    return {
+      extentEmu: { cx: overrides.cx ?? 1000, cy: 500 },
+      subpathsEmu: component.subpathsEmu,
+      fillHex: component.fillHex,
+      fillAlpha: component.fillAlpha,
+      strokeHex: component.strokeHex,
+      strokeAlpha: component.strokeAlpha,
+      strokeWidthEmu: component.strokeWidthEmu,
+      components: overrides.extraComponent
+        ? [component, { ...component, fillHex: 'FF0000' }]
+        : [component],
+    };
+  };
+
+  test('equal shapes agree and each single difference separates them', () => {
+    const baseline = vectorShapeLayoutToken(shape());
+    expect(vectorShapeLayoutToken(shape())).toBe(baseline);
+    const differences = {
+      'a moved point': shape({ points: [point(0, 0), point(100, 0), point(100, 50.6)] }),
+      'a sub-unit move': shape({ points: [point(0, 0), point(100, 0), point(100, 50.5001)] }),
+      'a swapped x and y': shape({ points: [point(0, 0), point(0, 100), point(100, 50.5)] }),
+      'a reordered point': shape({ points: [point(100, 0), point(0, 0), point(100, 50.5)] }),
+      'a dropped point': shape({ points: [point(0, 0), point(100, 0)] }),
+      'the same points in two subpaths': shape({ splitSubpaths: true }),
+      'a different fill': shape({ fillHex: '4472C5' }),
+      'no fill': shape({ fillHex: null }),
+      'a different fill opacity': shape({ fillAlpha: 0.5 }),
+      'a stroke': shape({ strokeHex: '000000' }),
+      'a stroke opacity': shape({ strokeAlpha: 0.5 }),
+      'a stroke width': shape({ strokeWidthEmu: 12_700 }),
+      'a different extent': shape({ cx: 1001 }),
+      'a second component': shape({ extraComponent: true }),
+    };
+    for (const [label, changed] of Object.entries(differences)) {
+      expect(`${label} collides: ${vectorShapeLayoutToken(changed) === baseline}`).toBe(
+        `${label} collides: false`
+      );
+    }
+  });
+
+  test('the token stays small for a shape at the point budget', () => {
+    const points = Array.from({ length: 1024 }, (_, index) =>
+      point(index * 37.5, (index * 53) % 100_000)
+    );
+    const token = vectorShapeLayoutToken(shape({ points }));
+    // `JSON.stringify` of the same shape is ~48 KB. Anything near that is the regression.
+    expect(token.length).toBeLessThan(200);
+  });
 });

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -224,11 +224,17 @@ describe('vector shape layout token', () => {
       readonly cx: number;
       readonly extraComponent: boolean;
       readonly splitSubpaths: boolean;
+      readonly splitAt: number;
     }> = {}
   ) => {
     const points = overrides.points ?? [point(0, 0), point(100, 0), point(100, 50.5)];
     const component = {
-      subpathsEmu: overrides.splitSubpaths ? [points.slice(0, 1), points.slice(1)] : [points],
+      subpathsEmu:
+        overrides.splitAt !== undefined
+          ? [points.slice(0, overrides.splitAt), points.slice(overrides.splitAt)]
+          : overrides.splitSubpaths
+            ? [points.slice(0, 1), points.slice(1)]
+            : [points],
       fillHex: overrides.fillHex === undefined ? '4472C4' : overrides.fillHex,
       fillAlpha: overrides.fillAlpha ?? 1,
       strokeHex: overrides.strokeHex ?? null,
@@ -248,6 +254,16 @@ describe('vector shape layout token', () => {
         : [component],
     };
   };
+
+  // The point stream and the subpath COUNT are both equal here, so only the per-subpath
+  // length in the token separates them: 8 points split [3,5] against the same 8 split [4,4]
+  // produce identical FNV accumulators.
+  test('two subpaths of the same points split at a different index differ', () => {
+    const points = Array.from({ length: 8 }, (_, index) => point(index * 11, index * 7.25));
+    expect(vectorShapeLayoutToken(shape({ points, splitAt: 3 }))).not.toBe(
+      vectorShapeLayoutToken(shape({ points, splitAt: 4 }))
+    );
+  });
 
   test('equal shapes agree and each single difference separates them', () => {
     const baseline = vectorShapeLayoutToken(shape());
@@ -283,4 +299,95 @@ describe('vector shape layout token', () => {
     // `JSON.stringify` of the same shape is ~48 KB. Anything near that is the regression.
     expect(token.length).toBeLessThan(200);
   });
+});
+
+// A theme swap has to invalidate the drawing slot.
+//
+// `isCompatibleWith` short-circuits on `nextPart === part`, which is true whenever only
+// `theme1.xml` or `settings.xml` moved — the document part is untouched. Without the
+// `cacheToken` comparison ahead of that short-circuit, every drawing keeps the colours the
+// OLD theme resolved and nothing is left to invalidate them for the rest of the session.
+test('a theme-part swap refuses the slot even though the document part is identical', () => {
+  const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+  const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+  const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+  const THEME_PART = '/word/theme/theme1.xml';
+
+  const themeXml = (accent1: string) =>
+    `<a:theme xmlns:a="${A}" name="T"><a:themeElements><a:clrScheme name="T">` +
+    `<a:accent1><a:srgbClr val="${accent1}"/></a:accent1>` +
+    '</a:clrScheme></a:themeElements></a:theme>';
+
+  const bytes = zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        `<Override PartName="${THEME_PART}" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>` +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/theme/theme1.xml': strToU8(themeXml('6F55D7')),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
+        '<w:body><w:p><w:r><w:drawing>' +
+        '<wp:inline distT="0" distB="0" distL="0" distR="0">' +
+        '<wp:extent cx="457200" cy="457200"/><wp:docPr id="1" name="Rect"/>' +
+        `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp><wps:cNvSpPr/><wps:spPr>` +
+        '<a:xfrm><a:off x="0" y="0"/><a:ext cx="457200" cy="457200"/></a:xfrm>' +
+        '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>' +
+        '<a:solidFill><a:schemeClr val="accent1"/></a:solidFill><a:ln><a:noFill/></a:ln>' +
+        '</wps:spPr><wps:bodyPr/></wps:wsp></a:graphicData></a:graphic>' +
+        '</wp:inline></w:drawing></w:r></w:p></w:body></w:document>'
+    ),
+  });
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  let pkg = loaded.package;
+  // The document part object never changes; only the theme part does.
+  const documentPart = pkg.parts.get(pkg.mainDocumentPart)!;
+  let revision = 0;
+  const session = {
+    packageRevision: () => revision,
+    currentPackage: () => pkg,
+    part: () => documentPart,
+  };
+  const resourceLookup: ImageResourceLookup = {
+    resolveEmbedded: async () => Object.freeze({ kind: 'missing' as const }),
+    resolveLinked: () => Object.freeze({ kind: 'missing' as const }),
+    resolveForProjection: async () => Object.freeze({ kind: 'missing' as const }),
+    liveReferenceCount: () => 0,
+    dispose: () => {},
+  };
+  const bundle = createInlineDrawingLayoutBundle({
+    session,
+    decodePort: Object.freeze({
+      decode: async () => {
+        throw new Error('unused');
+      },
+    }),
+    resourceLookup,
+    onResourcesChanged: () => {},
+  });
+
+  const atomId = [...(drawingAtomIdentities(documentPart)?.keys() ?? [])][0]!;
+  const fill = () => bundle.bodyContext.projectionForAtom?.(atomId)?.vectorShape?.fillHex ?? null;
+  expect(fill()).toBe('6F55D7');
+
+  const swapped = readOoxmlPart(themeXml('79C9B1'), {
+    name: THEME_PART,
+    contentType: 'application/vnd.openxmlformats-officedocument.theme+xml',
+  });
+  if (!swapped.ok) throw new Error(swapped.reason);
+  // Only the theme part moves: `partBytes`, `relationships` and `contentTypes` keep their
+  // identity, so `resetPackage` takes the substrate-unchanged path and asks the slot.
+  pkg = Object.freeze({ ...pkg, parts: new Map(pkg.parts).set(THEME_PART, swapped.part) });
+  revision += 1;
+  bundle.sync(session);
+
+  expect(fill()).toBe('79C9B1');
 });

--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -39,13 +39,15 @@ import type { LayoutBox } from './semantic-records.ts';
 
 export type { DrawingGeometry } from './drawing-geometry.ts';
 
-const GRAPHIC_URI_KIND: Readonly<Record<string, string>> = Object.freeze({
-  'http://schemas.openxmlformats.org/drawingml/2006/chart': 'chart',
-  'http://schemas.openxmlformats.org/drawingml/2006/diagram': 'diagram',
-  'http://schemas.microsoft.com/office/word/2010/wordprocessingGroup': 'group',
-  'http://schemas.microsoft.com/office/word/2010/wordprocessingShape': 'textbox',
-  'http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas': 'canvas',
-});
+// A Map, not an object literal: the key is a `graphicData@uri` out of the file, so a value
+// of `__proto__` or `constructor` must answer undefined, not a prototype member.
+const GRAPHIC_URI_KIND: ReadonlyMap<string, string> = new Map([
+  ['http://schemas.openxmlformats.org/drawingml/2006/chart', 'chart'],
+  ['http://schemas.openxmlformats.org/drawingml/2006/diagram', 'diagram'],
+  ['http://schemas.microsoft.com/office/word/2010/wordprocessingGroup', 'group'],
+  ['http://schemas.microsoft.com/office/word/2010/wordprocessingShape', 'textbox'],
+  ['http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas', 'canvas'],
+]);
 
 const EMPTY_TRANSFORM: DrawingTransform = Object.freeze({
   rotationDegrees: 0,
@@ -75,7 +77,7 @@ function drawingPaintFields(projection: DrawingProjection): {
     for (const diagnostic of projection.diagnostics) {
       if (diagnostic.code !== 'unsupported-graphic') continue;
       const uri = diagnostic.detail ?? '';
-      placeholderGraphicKind = GRAPHIC_URI_KIND[uri] ?? 'graphic';
+      placeholderGraphicKind = GRAPHIC_URI_KIND.get(uri) ?? 'graphic';
       break;
     }
     if (placeholderGraphicKind === null) placeholderGraphicKind = 'graphic';

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -32,6 +32,7 @@ import {
   retainValidatedImageBytes,
   type ValidatedImageBytesReleaseToken,
 } from '../store/package/validated-image-bytes.ts';
+import { createPackageShapeThemeResolvers } from '../store/package/theme-color-resolution.ts';
 import type { OoxmlPackage } from '../store/package/ooxml-package.ts';
 import type { InlineDrawingLayoutContext } from './drawing-layout.ts';
 
@@ -174,6 +175,7 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
   const anchor = projection.anchor;
   const picture = projection.picture;
   const wrap = projection.wrapGeometry;
+  const vector = projection.vectorShape;
   return [
     projection.drawingNodeId,
     projection.ownerPartName,
@@ -207,6 +209,7 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
           picture.presetGeometry ?? '',
         ].join(':')
       : '',
+    vector ? JSON.stringify(vector) : '',
     wrap
       ? [
           wrap.element,
@@ -309,8 +312,11 @@ function createPartDrawingContextSlot(options: {
   let resourceEpoch = 0;
 
   const resolveRelationshipTarget = createDrawingRelationshipResolver(pkg, ownerPartName);
+  const theme = createPackageShapeThemeResolvers(pkg);
   const atomProjections = indexInlineDrawingProjectionsInPart(part, {
     resolveRelationship: resolveRelationshipTarget,
+    resolveSchemeColor: theme.resolveSchemeColor,
+    resolveStyleMatrixReference: theme.resolveStyleMatrixReference,
   });
   const atomIdentities = drawingAtomIdentities(part);
 
@@ -456,6 +462,8 @@ function createPartDrawingContextSlot(options: {
       `${ownerPartName}|${resourceEpoch}|${generation}|${atomProjections.size}`,
     drawingTokenForParagraph,
     isCompatibleWith: (nextPart, nextPkg) => {
+      const nextTheme = createPackageShapeThemeResolvers(nextPkg);
+      if (nextTheme.cacheToken !== theme.cacheToken) return false;
       if (nextPart === part) return true;
       const nextAtomIdentities = drawingAtomIdentities(nextPart);
       if (atomIdentities && nextAtomIdentities && atomIdentities.size === nextAtomIdentities.size) {
@@ -470,6 +478,8 @@ function createPartDrawingContextSlot(options: {
       }
       const nextProjections = indexInlineDrawingProjectionsInPart(nextPart, {
         resolveRelationship: createDrawingRelationshipResolver(nextPkg, ownerPartName),
+        resolveSchemeColor: nextTheme.resolveSchemeColor,
+        resolveStyleMatrixReference: nextTheme.resolveStyleMatrixReference,
       });
       if (nextProjections.size !== atomProjections.size) return false;
       for (const [atomId, projection] of atomProjections) {

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -170,6 +170,60 @@ export function drawingAtomIdentities(part: OoxmlPart): ReadonlyMap<string, Ooxm
   return facts.atoms;
 }
 
+// Scratch view used to fold a coordinate in by its exact IEEE-754 bits. Coordinates are not
+// integers once a group transform has scaled them, so rounding would fold real geometry
+// changes together.
+const COORDINATE_SCRATCH = new Float64Array(1);
+const COORDINATE_BITS = new Uint32Array(COORDINATE_SCRATCH.buffer);
+
+/**
+ * Digest of one vector shape's geometry and chrome, for the layout reuse token.
+ *
+ * Deliberately NOT a serialization. `JSON.stringify` of a shape at the 1024-point budget is
+ * ~48 KB and ~230 us, and `isCompatibleWith` reads this token twice per atom whenever the
+ * atom-identity fast path misses, so the serialization dominated a document full of shapes.
+ * Every other field in the enclosing token is a cheap scalar join; this one folds the point
+ * stream into two 32-bit FNV-1a accumulators and joins the scalars verbatim. The shape of
+ * the component list (its length, and each subpath's length) is joined literally rather than
+ * hashed, so a structural change can never hide inside the digest.
+ */
+export function vectorShapeLayoutToken(
+  vector: NonNullable<DrawingProjection['vectorShape']>
+): string {
+  let hashA = 0x811c_9dc5;
+  let hashB = 0x1000_0193;
+  const scalars: string[] = [];
+  for (const component of vector.components) {
+    scalars.push(
+      component.fillHex ?? '',
+      String(component.fillAlpha),
+      component.strokeHex ?? '',
+      String(component.strokeAlpha),
+      String(component.strokeWidthEmu),
+      String(component.subpathsEmu.length)
+    );
+    for (const subpath of component.subpathsEmu) {
+      scalars.push(String(subpath.length));
+      for (const point of subpath) {
+        COORDINATE_SCRATCH[0] = point.x;
+        hashA = Math.imul(hashA ^ COORDINATE_BITS[0]!, 0x0100_0193);
+        hashB = Math.imul(hashB ^ COORDINATE_BITS[1]!, 0x0100_01b3);
+        COORDINATE_SCRATCH[0] = point.y;
+        hashA = Math.imul(hashA ^ COORDINATE_BITS[1]!, 0x0100_0193);
+        hashB = Math.imul(hashB ^ COORDINATE_BITS[0]!, 0x0100_01b3);
+      }
+    }
+  }
+  return [
+    String(vector.extentEmu.cx),
+    String(vector.extentEmu.cy),
+    String(vector.components.length),
+    scalars.join(','),
+    (hashA >>> 0).toString(36),
+    (hashB >>> 0).toString(36),
+  ].join(';');
+}
+
 function drawingProjectionLayoutToken(projection: DrawingProjection): string {
   const position = projection.position;
   const anchor = projection.anchor;
@@ -209,7 +263,7 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
           picture.presetGeometry ?? '',
         ].join(':')
       : '',
-    vector ? JSON.stringify(vector) : '',
+    vector ? vectorShapeLayoutToken(vector) : '',
     wrap
       ? [
           wrap.element,

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -186,6 +186,13 @@ const COORDINATE_BITS = new Uint32Array(COORDINATE_SCRATCH.buffer);
  * stream into two 32-bit FNV-1a accumulators and joins the scalars verbatim. The shape of
  * the component list (its length, and each subpath's length) is joined literally rather than
  * hashed, so a structural change can never hide inside the digest.
+ *
+ * This is a cache key, NOT a security primitive. FNV-1a is trivially invertible — its round
+ * is `h = (h ^ d) * p` with an odd, hence modularly invertible, `p` — so a chosen last
+ * coordinate can drive both accumulators to any target in closed form. That buys nothing
+ * here, because forging a collision needs two shapes under the same `drawingNodeId` in two
+ * revisions of one document, and the payoff is a stale repaint. Do not reuse this digest
+ * anywhere an attacker profits from a collision.
  */
 export function vectorShapeLayoutToken(
   vector: NonNullable<DrawingProjection['vectorShape']>

--- a/packages/core/src/output/__tests__/semantic-paint-vector-shape.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-vector-shape.test.ts
@@ -113,4 +113,47 @@ describe('vector shape paint', () => {
     expect(d.startsWith('M6696075 38100L')).toBe(true);
     expect((d.match(/Z/g) ?? []).length).toBe(2);
   });
+
+  test('paints grouped components with independent colours and opacity', () => {
+    const base = shapeRecord();
+    const firstPath = vectorShape().subpathsEmu[0]!;
+    const secondPath = vectorShape().subpathsEmu[1]!;
+    const record = {
+      ...base,
+      vectorShape: {
+        ...vectorShape(),
+        components: [
+          {
+            subpathsEmu: [firstPath],
+            fillHex: '4472C4',
+            fillAlpha: 0.5,
+            strokeHex: null,
+            strokeAlpha: 1,
+            strokeWidthEmu: 0,
+          },
+          {
+            subpathsEmu: [secondPath],
+            fillHex: 'FF0000',
+            fillAlpha: 1,
+            strokeHex: '000000',
+            strokeAlpha: 0.25,
+            strokeWidthEmu: 12_700,
+          },
+        ],
+      },
+    } as InlineDrawingRecord;
+    const element = paintDrawingRecord(
+      document,
+      record,
+      { scale: 1, strings: DEFAULT_DRAWING_PAINT_STRINGS, imageUrlPort: null, inertLinks: true },
+      null
+    )!;
+    const paths = element.querySelectorAll('path');
+    expect(paths).toHaveLength(2);
+    expect(paths[0]!.getAttribute('fill')).toBe('#4472C4');
+    expect(paths[0]!.getAttribute('fill-opacity')).toBe('0.5');
+    expect(paths[1]!.getAttribute('fill')).toBe('#FF0000');
+    expect(paths[1]!.getAttribute('stroke')).toBe('#000000');
+    expect(paths[1]!.getAttribute('stroke-opacity')).toBe('0.25');
+  });
 });

--- a/packages/core/src/output/__tests__/semantic-paint-vector-shape.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-vector-shape.test.ts
@@ -11,26 +11,38 @@ import { DEFAULT_DRAWING_PAINT_STRINGS, paintDrawingRecord } from '../semantic-p
 
 const EXTENT = Object.freeze({ cx: 6_696_075, cy: 47_625 });
 
+const SUBPATHS = Object.freeze([
+  Object.freeze([
+    Object.freeze({ x: 6_696_075, y: 38_100 }),
+    Object.freeze({ x: 0, y: 38_100 }),
+    Object.freeze({ x: 0, y: 47_625 }),
+    Object.freeze({ x: 6_696_075, y: 47_625 }),
+  ]),
+  Object.freeze([
+    Object.freeze({ x: 6_696_075, y: 0 }),
+    Object.freeze({ x: 0, y: 0 }),
+    Object.freeze({ x: 0, y: 9_525 }),
+    Object.freeze({ x: 6_696_075, y: 9_525 }),
+  ]),
+]);
+
 function vectorShape(): VectorShapeProjection {
   return Object.freeze({
     extentEmu: EXTENT,
-    subpathsEmu: Object.freeze([
-      Object.freeze([
-        Object.freeze({ x: 6_696_075, y: 38_100 }),
-        Object.freeze({ x: 0, y: 38_100 }),
-        Object.freeze({ x: 0, y: 47_625 }),
-        Object.freeze({ x: 6_696_075, y: 47_625 }),
-      ]),
-      Object.freeze([
-        Object.freeze({ x: 6_696_075, y: 0 }),
-        Object.freeze({ x: 0, y: 0 }),
-        Object.freeze({ x: 0, y: 9_525 }),
-        Object.freeze({ x: 6_696_075, y: 9_525 }),
-      ]),
-    ]),
+    subpathsEmu: SUBPATHS,
     fillHex: '000000',
     strokeHex: null,
     strokeWidthEmu: 0,
+    components: Object.freeze([
+      Object.freeze({
+        subpathsEmu: SUBPATHS,
+        fillHex: '000000',
+        fillAlpha: 1,
+        strokeHex: null,
+        strokeAlpha: 1,
+        strokeWidthEmu: 0,
+      }),
+    ]),
   });
 }
 

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -69,13 +69,15 @@ export interface DrawingPaintContext {
   readonly revisionStyles?: RevisionStyleContext;
 }
 
-const MIME_FORMAT_LABEL: Readonly<Record<string, string>> = Object.freeze({
-  'image/svg+xml': 'SVG',
-  'image/tiff': 'TIFF',
-  'image/x-emf': 'EMF',
-  'image/x-wmf': 'WMF',
-  unknown: 'Unknown',
-});
+// A Map, not an object literal: the key is a MIME read off the package, so a value naming a
+// prototype member must answer undefined and fall through to the label below.
+const MIME_FORMAT_LABEL: ReadonlyMap<string, string> = new Map([
+  ['image/svg+xml', 'SVG'],
+  ['image/tiff', 'TIFF'],
+  ['image/x-emf', 'EMF'],
+  ['image/x-wmf', 'WMF'],
+]);
+const UNKNOWN_FORMAT_LABEL = 'Unknown';
 
 interface UrlRegistry {
   readonly urlForReady: (
@@ -287,7 +289,7 @@ function refusalLabel(
       switch (resource.reason) {
         case 'unsupported-format':
           return strings.unsupportedFormat(
-            MIME_FORMAT_LABEL[resource.mime] ?? MIME_FORMAT_LABEL.unknown
+            MIME_FORMAT_LABEL.get(resource.mime) ?? UNKNOWN_FORMAT_LABEL
           );
         case 'non-picture-graphic':
           return strings.nonPictureGraphic(drawing.placeholderGraphicKind ?? 'graphic');
@@ -545,17 +547,9 @@ function paintVectorShape(
   svg.setAttribute('height', '100%');
   svg.style.display = 'block';
 
-  const components = shape.components ?? [
-    {
-      subpathsEmu: shape.subpathsEmu,
-      fillHex: shape.fillHex,
-      fillAlpha: shape.fillAlpha ?? 1,
-      strokeHex: shape.strokeHex,
-      strokeAlpha: shape.strokeAlpha ?? 1,
-      strokeWidthEmu: shape.strokeWidthEmu,
-    },
-  ];
-  for (const component of components) {
+  // `components` is the paint authority and is always non-empty; the top-level `fillHex`
+  // and `strokeHex` describe a one-component shape only.
+  for (const component of shape.components) {
     const path = document.createElementNS(SVG_NAMESPACE, 'path');
     const d = component.subpathsEmu
       .map(

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -69,8 +69,10 @@ export interface DrawingPaintContext {
   readonly revisionStyles?: RevisionStyleContext;
 }
 
-// A Map, not an object literal: the key is a MIME read off the package, so a value naming a
-// prototype member must answer undefined and fall through to the label below.
+// A Map, not an object literal. `ImageResourceState.mime` is a closed union — it comes from
+// `sniffImageMime` or from the content-type lookup, both of which already refuse anything
+// else — so this is hardening at a sink that is not currently reachable, kept because the
+// union is the only thing standing between a file-derived string and this lookup.
 const MIME_FORMAT_LABEL: ReadonlyMap<string, string> = new Map([
   ['image/svg+xml', 'SVG'],
   ['image/tiff', 'TIFF'],

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -545,22 +545,40 @@ function paintVectorShape(
   svg.setAttribute('height', '100%');
   svg.style.display = 'block';
 
-  const path = document.createElementNS(SVG_NAMESPACE, 'path');
-  const d = shape.subpathsEmu
-    .map(
-      (points) =>
-        `M${points.map((point) => `${finiteStyle(point.x)} ${finiteStyle(point.y)}`).join('L')}Z`
-    )
-    .join('');
-  path.setAttribute('d', d);
-  // SAFE: hex colors are validated 6-digit sRGB at the projection trust boundary.
-  path.setAttribute('fill', shape.fillHex !== null ? `#${shape.fillHex}` : 'none');
-  path.setAttribute('fill-rule', 'evenodd');
-  if (shape.strokeHex !== null) {
-    path.setAttribute('stroke', `#${shape.strokeHex}`);
-    path.setAttribute('stroke-width', finiteStyle(Math.max(1, shape.strokeWidthEmu)));
+  const components = shape.components ?? [
+    {
+      subpathsEmu: shape.subpathsEmu,
+      fillHex: shape.fillHex,
+      fillAlpha: shape.fillAlpha ?? 1,
+      strokeHex: shape.strokeHex,
+      strokeAlpha: shape.strokeAlpha ?? 1,
+      strokeWidthEmu: shape.strokeWidthEmu,
+    },
+  ];
+  for (const component of components) {
+    const path = document.createElementNS(SVG_NAMESPACE, 'path');
+    const d = component.subpathsEmu
+      .map(
+        (points) =>
+          `M${points.map((point) => `${finiteStyle(point.x)} ${finiteStyle(point.y)}`).join('L')}Z`
+      )
+      .join('');
+    path.setAttribute('d', d);
+    // SAFE: colours are validated 6-digit sRGB at the projection trust boundary.
+    path.setAttribute('fill', component.fillHex !== null ? `#${component.fillHex}` : 'none');
+    path.setAttribute('fill-rule', 'evenodd');
+    if (component.fillAlpha < 1) {
+      path.setAttribute('fill-opacity', finiteStyle(Math.max(0, component.fillAlpha)));
+    }
+    if (component.strokeHex !== null) {
+      path.setAttribute('stroke', `#${component.strokeHex}`);
+      path.setAttribute('stroke-width', finiteStyle(Math.max(1, component.strokeWidthEmu)));
+      if (component.strokeAlpha < 1) {
+        path.setAttribute('stroke-opacity', finiteStyle(Math.max(0, component.strokeAlpha)));
+      }
+    }
+    svg.append(path);
   }
-  svg.append(path);
   frame.append(svg);
   outer.append(frame);
 

--- a/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
+++ b/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
@@ -4,23 +4,27 @@
 // (2) type solid-fill polygon geometry so paint can draw the shape instead of a card.
 
 import { describe, expect, test } from 'bun:test';
-import { readOoxmlPart, WML_NAMESPACE_URI } from '../index.ts';
+import { readOoxmlPart, WML_NAMESPACE_URI, type OoxmlPackage } from '../index.ts';
 import {
   indexInlineDrawingProjectionsInPart,
   DEFAULT_DRAWING_PROJECTION_LIMITS,
 } from '../package/drawing-projection.ts';
+import { createPackageShapeThemeResolvers } from '../package/theme-color-resolution.ts';
 
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+const WPG = 'http://schemas.microsoft.com/office/word/2010/wordprocessingGroup';
 const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
 const V = 'urn:schemas-microsoft-com:vml';
 const OWNER = '/word/document.xml';
+const ELLIPSE_POINT_COUNT = 32;
 
 function parsePart(body: string) {
   const xml =
     `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
-    `xmlns:wps="${WPS}" xmlns:mc="${MC}" xmlns:v="${V}"><w:body>${body}</w:body></w:document>`;
+    `xmlns:wps="${WPS}" xmlns:wpg="${WPG}" xmlns:mc="${MC}" xmlns:v="${V}">` +
+    `<w:body>${body}</w:body></w:document>`;
   const parsed = readOoxmlPart(xml, {
     name: OWNER,
     contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
@@ -78,6 +82,59 @@ function mcWrapped(drawing: string): string {
 }
 
 describe('wps vector shape projection', () => {
+  test('package theme colours honor the settings colour mapping', () => {
+    const theme = readOoxmlPart(
+      `<a:theme xmlns:a="${A}"><a:themeElements><a:clrScheme name="Test">` +
+        '<a:accent1><a:srgbClr val="112233"/></a:accent1>' +
+        '<a:accent2><a:srgbClr val="AABBCC"/></a:accent2>' +
+        '<a:dk2><a:srgbClr val="334455"/></a:dk2>' +
+        '</a:clrScheme><a:fmtScheme name="Test">' +
+        '<a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst>' +
+        '<a:lnStyleLst/><a:effectStyleLst/><a:bgFillStyleLst/>' +
+        '</a:fmtScheme></a:themeElements></a:theme>',
+      { name: '/word/theme/theme1.xml', contentType: 'application/xml' }
+    );
+    const settings = readOoxmlPart(
+      `<w:settings xmlns:w="${WML_NAMESPACE_URI}">` +
+        '<w:clrSchemeMapping w:accent1="accent2" w:bg1="dark2"/>' +
+        '</w:settings>',
+      { name: '/word/settings.xml', contentType: 'application/xml' }
+    );
+    if (!theme.ok || !settings.ok) throw new Error('test package parts must parse');
+    const pkg = {
+      parts: new Map([
+        ['/word/theme/theme1.xml', theme.part],
+        ['/word/settings.xml', settings.part],
+      ]),
+      partBytes: new Map(),
+      relationships: new Map(),
+      externalTargets: [],
+      contentTypes: {},
+      mainDocumentPart: OWNER,
+    } as unknown as OoxmlPackage;
+    const themeResolvers = createPackageShapeThemeResolvers(pkg);
+    const resolve = themeResolvers.resolveSchemeColor;
+    expect(resolve('accent1')).toBe('AABBCC');
+    expect(resolve('accent2')).toBe('AABBCC');
+    expect(resolve('bg1')).toBe('334455');
+    expect(resolve('missing')).toBeNull();
+    expect(themeResolvers.resolveStyleMatrixReference('fill', 1)?.localName).toBe('solidFill');
+    const changedTheme = readOoxmlPart(
+      `<a:theme xmlns:a="${A}"><a:themeElements><a:clrScheme name="Changed">` +
+        '<a:accent1><a:srgbClr val="FFFFFF"/></a:accent1>' +
+        '</a:clrScheme></a:themeElements></a:theme>',
+      { name: '/word/theme/theme1.xml', contentType: 'application/xml' }
+    );
+    if (!changedTheme.ok) throw new Error(changedTheme.reason);
+    const changedPackage = {
+      ...pkg,
+      parts: new Map(pkg.parts).set('/word/theme/theme1.xml', changedTheme.part),
+    };
+    expect(createPackageShapeThemeResolvers(changedPackage).cacheToken).not.toBe(
+      themeResolvers.cacheToken
+    );
+  });
+
   test('MC-wrapped anchored custGeom shape projects with typed vector geometry', () => {
     const part = parsePart(`<w:p><w:r>${mcWrapped(doubleRuleShapeDrawing())}</w:r></w:p>`);
     const atoms = indexInlineDrawingProjectionsInPart(part);
@@ -114,6 +171,215 @@ describe('wps vector shape projection', () => {
     const atoms = indexInlineDrawingProjectionsInPart(part);
     expect(atoms.size).toBe(1);
     expect([...atoms.values()][0]!.vectorShape).not.toBeNull();
+  });
+
+  test('scheme colours apply luminance and alpha transforms', () => {
+    const drawing = doubleRuleShapeDrawing().replace(
+      '<a:solidFill><a:srgbClr val="000000"/></a:solidFill>',
+      '<a:solidFill><a:schemeClr val="accent1">' +
+        '<a:lumMod val="50000"/><a:alpha val="50000"/>' +
+        '</a:schemeClr></a:solidFill>'
+    );
+    const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+    const atoms = indexInlineDrawingProjectionsInPart(part, {
+      resolveSchemeColor: (token) => (token === 'accent1' ? '4472C4' : null),
+    });
+    const shape = [...atoms.values()][0]!.vectorShape!;
+    expect(shape.fillHex).toBe('203864');
+    expect(shape.fillAlpha).toBe(0.5);
+  });
+
+  test('theme colours apply tint, shade, and luminance offset transforms', () => {
+    const cases = [
+      ['tint', '50000', 'C0C0C0'],
+      ['shade', '50000', '404040'],
+      ['lumOff', '10000', '9A9A9A'],
+    ] as const;
+    for (const [transform, value, expected] of cases) {
+      const drawing = doubleRuleShapeDrawing().replace(
+        '<a:solidFill><a:srgbClr val="000000"/></a:solidFill>',
+        `<a:solidFill><a:schemeClr val="accent1"><a:${transform} val="${value}"/>` +
+          '</a:schemeClr></a:solidFill>'
+      );
+      const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+      const atoms = indexInlineDrawingProjectionsInPart(part, {
+        resolveSchemeColor: () => '808080',
+      });
+      expect([...atoms.values()][0]!.vectorShape?.fillHex).toBe(expected);
+    }
+  });
+
+  test('a shape style fill reference resolves its theme colour', () => {
+    const drawing = doubleRuleShapeDrawing()
+      .replace('<a:solidFill><a:srgbClr val="000000"/></a:solidFill>', '')
+      .replace(
+        '</wps:spPr>',
+        '</wps:spPr><wps:style><a:fillRef idx="1">' +
+          '<a:schemeClr val="accent1"/>' +
+          '</a:fillRef></wps:style>'
+      );
+    const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+    const matrix = readOoxmlPart(
+      `<a:solidFill xmlns:a="${A}"><a:schemeClr val="phClr"/></a:solidFill>`,
+      { name: '/word/theme/test.xml', contentType: 'application/xml' }
+    );
+    if (!matrix.ok) throw new Error(matrix.reason);
+    const atoms = indexInlineDrawingProjectionsInPart(part, {
+      resolveSchemeColor: () => '4472C4',
+      resolveStyleMatrixReference: () => matrix.part.root,
+    });
+    expect([...atoms.values()][0]!.vectorShape?.fillHex).toBe('4472C4');
+  });
+
+  test('explicit noFill does not fall through to a style fill reference', () => {
+    const drawing = doubleRuleShapeDrawing()
+      .replace('<a:solidFill><a:srgbClr val="000000"/></a:solidFill>', '<a:noFill/>')
+      .replace(
+        '</wps:spPr>',
+        '</wps:spPr><wps:style><a:fillRef idx="1">' +
+          '<a:schemeClr val="accent1"/>' +
+          '</a:fillRef></wps:style>'
+      );
+    const matrix = readOoxmlPart(
+      `<a:solidFill xmlns:a="${A}"><a:schemeClr val="phClr"/></a:solidFill>`,
+      { name: '/word/theme/test.xml', contentType: 'application/xml' }
+    );
+    if (!matrix.ok) throw new Error(matrix.reason);
+    const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+    const projection = [
+      ...indexInlineDrawingProjectionsInPart(part, {
+        resolveSchemeColor: () => '4472C4',
+        resolveStyleMatrixReference: () => matrix.part.root,
+      }).values(),
+    ][0]!;
+    expect(projection.vectorShape).toBeNull();
+  });
+
+  test('a line style reference paints without a direct line node', () => {
+    const drawing = doubleRuleShapeDrawing().replace(
+      '</wps:spPr>',
+      '</wps:spPr><wps:style><a:lnRef idx="1">' +
+        '<a:schemeClr val="accent1"/>' +
+        '</a:lnRef></wps:style>'
+    );
+    const matrix = readOoxmlPart(
+      `<a:ln xmlns:a="${A}" w="25400">` +
+        '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+        '</a:ln>',
+      { name: '/word/theme/test.xml', contentType: 'application/xml' }
+    );
+    if (!matrix.ok) throw new Error(matrix.reason);
+    const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+    const shape = [
+      ...indexInlineDrawingProjectionsInPart(part, {
+        resolveSchemeColor: () => '4472C4',
+        resolveStyleMatrixReference: () => matrix.part.root,
+      }).values(),
+    ][0]!.vectorShape!;
+    expect(shape.strokeHex).toBe('4472C4');
+    expect(shape.strokeWidthEmu).toBe(25_400);
+  });
+
+  test('an out-of-range colour transform refuses the vector payload', () => {
+    const drawing = doubleRuleShapeDrawing().replace(
+      '<a:solidFill><a:srgbClr val="000000"/></a:solidFill>',
+      '<a:solidFill><a:schemeClr val="accent1">' +
+        '<a:lumMod val="100001"/>' +
+        '</a:schemeClr></a:solidFill>'
+    );
+    const part = parsePart(`<w:p><w:r>${mcWrapped(drawing)}</w:r></w:p>`);
+    const atoms = indexInlineDrawingProjectionsInPart(part, {
+      resolveSchemeColor: () => '4472C4',
+    });
+    expect(atoms.size).toBe(0);
+  });
+
+  test('an MC wpg group projects each child with its own geometry and colour', () => {
+    const drawing =
+      '<w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+      '<wp:extent cx="200000" cy="100000"/><wp:docPr id="13" name="Group 13"/>' +
+      `<a:graphic><a:graphicData uri="${WPG}"><wpg:wgp><wpg:grpSpPr>` +
+      '<a:xfrm><a:chOff x="0" y="0"/><a:chExt cx="200000" cy="100000"/></a:xfrm>' +
+      '</wpg:grpSpPr>' +
+      '<wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm>' +
+      '<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>' +
+      '<a:solidFill><a:schemeClr val="accent1"/></a:solidFill></wps:spPr></wps:wsp>' +
+      '<wps:wsp><wps:spPr><a:xfrm><a:off x="100000" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm>' +
+      '<a:custGeom><a:pathLst><a:path w="100000" h="100000">' +
+      '<a:moveTo><a:pt x="0" y="0"/></a:moveTo>' +
+      '<a:cubicBezTo><a:pt x="25000" y="0"/><a:pt x="75000" y="100000"/>' +
+      '<a:pt x="100000" y="100000"/></a:cubicBezTo><a:close/>' +
+      '</a:path></a:pathLst></a:custGeom>' +
+      '<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></wps:spPr></wps:wsp>' +
+      '</wpg:wgp></a:graphicData></a:graphic></wp:inline></w:drawing>';
+    const wrapped =
+      '<mc:AlternateContent><mc:Choice Requires="wpg">' +
+      drawing +
+      '</mc:Choice><mc:Fallback><w:pict><v:shape id="fallback"/></w:pict></mc:Fallback>' +
+      '</mc:AlternateContent>';
+    const directPart = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+    expect(
+      indexInlineDrawingProjectionsInPart(directPart, {
+        resolveSchemeColor: () => '4472C4',
+      }).size
+    ).toBe(1);
+    const part = parsePart(`<w:p><w:r>${wrapped}</w:r></w:p>`);
+    const atoms = indexInlineDrawingProjectionsInPart(part, {
+      resolveSchemeColor: () => '4472C4',
+    });
+    expect(atoms.size).toBe(1);
+    const shape = [...atoms.values()][0]!.vectorShape!;
+    expect(shape.components).toHaveLength(2);
+    expect(shape.components?.map((component) => component.fillHex)).toEqual(['4472C4', 'FF0000']);
+    expect(shape.components?.[0]!.subpathsEmu[0]).toHaveLength(ELLIPSE_POINT_COUNT);
+    expect(shape.components?.[1]!.subpathsEmu[0]![0]).toEqual({ x: 100000, y: 0 });
+
+    const rotated = parsePart(
+      `<w:p><w:r>${drawing.replace('<a:xfrm><a:chOff', '<a:xfrm rot="60000"><a:chOff')}</w:r></w:p>`
+    );
+    expect(
+      [
+        ...indexInlineDrawingProjectionsInPart(rotated, {
+          resolveSchemeColor: () => '4472C4',
+        }).values(),
+      ][0]!.vectorShape
+    ).toBeNull();
+
+    const childFlipped = parsePart(
+      `<w:p><w:r>${drawing.replace(
+        '<wps:wsp><wps:spPr><a:xfrm>',
+        '<wps:wsp><wps:spPr><a:xfrm flipH="true">'
+      )}</w:r></w:p>`
+    );
+    expect(
+      [
+        ...indexInlineDrawingProjectionsInPart(childFlipped, {
+          resolveSchemeColor: () => '4472C4',
+        }).values(),
+      ][0]!.vectorShape
+    ).toBeNull();
+
+    const withMetadata = parsePart(
+      `<w:p><w:r>${drawing.replace('<wpg:wgp>', '<wpg:wgp><wpg:cNvPr id="1"/>')}</w:r></w:p>`
+    );
+    expect(
+      [
+        ...indexInlineDrawingProjectionsInPart(withMetadata, {
+          resolveSchemeColor: () => '4472C4',
+        }).values(),
+      ][0]!.vectorShape
+    ).not.toBeNull();
+
+    const nested = parsePart(
+      `<w:p><w:r>${drawing.replace('</wpg:wgp>', '<wpg:grpSp/></wpg:wgp>')}</w:r></w:p>`
+    );
+    expect(
+      [
+        ...indexInlineDrawingProjectionsInPart(nested, {
+          resolveSchemeColor: () => '4472C4',
+        }).values(),
+      ][0]!.vectorShape
+    ).toBeNull();
   });
 
   test('an MC-wrapped wps textbox projects a story; the VML fallback never renders', () => {
@@ -174,7 +440,7 @@ describe('wps vector shape projection', () => {
   test('unsupported path verbs refuse vector geometry and stay invisible under MC', () => {
     const bezier = doubleRuleShapeDrawing().replace(
       '<a:lnTo><a:pt x="0" y="38100"/></a:lnTo>',
-      '<a:cubicBezTo><a:pt x="1" y="1"/><a:pt x="2" y="2"/><a:pt x="0" y="38100"/></a:cubicBezTo>'
+      '<a:quadBezTo><a:pt x="1" y="1"/><a:pt x="0" y="38100"/></a:quadBezTo>'
     );
     const part = parsePart(`<w:p><w:r>${mcWrapped(bezier)}</w:r></w:p>`);
     const atoms = indexInlineDrawingProjectionsInPart(part);
@@ -183,6 +449,22 @@ describe('wps vector shape projection', () => {
 
   test('limits are respected', () => {
     expect(DEFAULT_DRAWING_PROJECTION_LIMITS.maxVisitedElements).toBeGreaterThan(0);
+  });
+
+  test('an over-limit group does not project unbounded child geometry', () => {
+    const child =
+      '<wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="10" cy="10"/></a:xfrm>' +
+      '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>' +
+      '<a:solidFill><a:srgbClr val="000000"/></a:solidFill></wps:spPr></wps:wsp>';
+    const drawing =
+      '<w:drawing><wp:inline><wp:extent cx="100" cy="100"/><wp:docPr id="14" name="Group"/>' +
+      `<a:graphic><a:graphicData uri="${WPG}"><wpg:wgp><wpg:grpSpPr>` +
+      '<a:xfrm><a:chOff x="0" y="0"/><a:chExt cx="100" cy="100"/></a:xfrm>' +
+      `</wpg:grpSpPr>${child.repeat(129)}</wpg:wgp></a:graphicData></a:graphic>` +
+      '</wp:inline></w:drawing>';
+    const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+    const projection = [...indexInlineDrawingProjectionsInPart(part).values()][0]!;
+    expect(projection.vectorShape).toBeNull();
   });
 
   test('a drawing deep in a large document is still discovered', () => {

--- a/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
+++ b/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
@@ -81,6 +81,33 @@ function mcWrapped(drawing: string): string {
   );
 }
 
+/** Attribute-escape a raw value so a hostile spelling reaches the parser intact. */
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+}
+
+/** A `wpg:wgp` group of two independently filled children, with a group `a:xfrm`. */
+function groupShapeDrawing(): string {
+  return (
+    '<w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    '<wp:extent cx="200000" cy="100000"/><wp:docPr id="13" name="Group 13"/>' +
+    `<a:graphic><a:graphicData uri="${WPG}"><wpg:wgp><wpg:grpSpPr>` +
+    '<a:xfrm><a:chOff x="0" y="0"/><a:chExt cx="200000" cy="100000"/></a:xfrm>' +
+    '</wpg:grpSpPr>' +
+    '<wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm>' +
+    '<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>' +
+    '<a:solidFill><a:schemeClr val="accent1"/></a:solidFill></wps:spPr></wps:wsp>' +
+    '<wps:wsp><wps:spPr><a:xfrm><a:off x="100000" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm>' +
+    '<a:custGeom><a:pathLst><a:path w="100000" h="100000">' +
+    '<a:moveTo><a:pt x="0" y="0"/></a:moveTo>' +
+    '<a:cubicBezTo><a:pt x="25000" y="0"/><a:pt x="75000" y="100000"/>' +
+    '<a:pt x="100000" y="100000"/></a:cubicBezTo><a:close/>' +
+    '</a:path></a:pathLst></a:custGeom>' +
+    '<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></wps:spPr></wps:wsp>' +
+    '</wpg:wgp></a:graphicData></a:graphic></wp:inline></w:drawing>'
+  );
+}
+
 describe('wps vector shape projection', () => {
   test('package theme colours honor the settings colour mapping', () => {
     const theme = readOoxmlPart(
@@ -233,8 +260,13 @@ describe('wps vector shape projection', () => {
 
   // `a:tint` and `a:shade` are a blend in LINEAR light, and `val` is the fraction of the
   // INPUT colour (ECMA-376 20.1.2.3.34/20.1.2.3.31) — not of white, and not a blend on the
-  // stored channel. Each base/value pair below is picked so all three readings disagree, and
-  // every expectation is the pixel LibreOffice paints for that exact fill:
+  // stored channel. Every expectation below is the pixel LibreOffice paints for that exact
+  // fill; the two right-hand columns are what the readings this engine rejects would give.
+  //
+  // `a:shade` has only two readings, since the white-fraction question does not arise. Of the
+  // tint rows, `0000FF` and `336699` separate all three; `808080` at 50% is the one point
+  // where the two rejected readings agree with each other, and it is here only to pin the
+  // case the old fixture leaned on:
   //
   //   base    transform        this engine   `val` as white-fraction   blend in gamma space
   //   0000FF  tint  20000      E7E7FF        3333FF                    CCCCFF
@@ -273,6 +305,42 @@ describe('wps vector shape projection', () => {
     }
   });
 
+  // ECMA-376 gives `val` two legal spellings: the 1000ths-of-a-percent integer Word writes
+  // (`50000`, Part 4 Transitional) and the percentage literal (`50%`, Part 1 Strict), which
+  // is what the spec's own worked examples use. Both must resolve, and to the same colour.
+  test('a colour transform accepts both the integer and the percentage spelling', () => {
+    const fillFor = (val: string): string | null => {
+      const drawing = doubleRuleShapeDrawing().replace(
+        '<a:solidFill><a:srgbClr val="000000"/></a:solidFill>',
+        `<a:solidFill><a:srgbClr val="00FF00"><a:shade val="${val}"/></a:srgbClr></a:solidFill>`
+      );
+      const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+      return (
+        [...indexInlineDrawingProjectionsInPart(part).values()][0]?.vectorShape?.fillHex ?? null
+      );
+    };
+    // ECMA-376 Part 1 20.1.2.3.31's worked `a:shade` example: `00FF00` at 50% is `00BC00`.
+    // It is the one check on this colour model that does not come from a renderer, so it is
+    // pinned in both spellings. A blend on the stored channel would give `008000`; note the
+    // sRGB curve would give `00BB00`, so this example separates the two BLENDS decisively and
+    // the two CURVES only just.
+    expect(fillFor('50%')).toBe('00BC00');
+    expect(fillFor('50000')).toBe('00BC00');
+    for (const [percent, integer] of [
+      ['0%', '0'],
+      ['100%', '100000'],
+      ['12.5%', '12500'],
+      ['99.99%', '99990'],
+    ] as const) {
+      expect(`${percent}: ${fillFor(percent)}`).toBe(`${percent}: ${fillFor(integer)}`);
+      expect(fillFor(percent)).not.toBeNull();
+    }
+    // Everything else refuses, and a refused transform fails the whole colour closed.
+    for (const rejected of ['101%', '-5%', ' 50% ', '50.123%', '1e2%', '%', '50 %', '1000000']) {
+      expect(`${rejected}: ${fillFor(rejected)}`).toBe(`${rejected}: null`);
+    }
+  });
+
   // A ratio of 100000 is the identity, so the round trip through linear light and back must
   // return the authored byte. The floor in `channelFromLinear` is one ulp away from turning
   // every channel into the one below it, which no other case here would catch.
@@ -297,34 +365,73 @@ describe('wps vector shape projection', () => {
   // `flipH`/`flipV` are `xsd:boolean`. The engine cannot paint a flip, so a set flag refuses
   // the shape — and a spelling the schema does not allow must refuse too, not fall through
   // to "unset" and paint the shape the wrong way round.
-  test('an unset flip paints and any other spelling refuses', () => {
-    const cases = [
+  //
+  // Four call sites read a flip: `flipH` and `flipV` on a shape's own `a:xfrm`, and the same
+  // pair on a group's `wpg:grpSpPr/a:xfrm`. The group pair is the lane this file exists for,
+  // so every spelling runs against all four.
+  test('an unset flip paints and any other spelling refuses, at all four sites', () => {
+    const spellings = [
+      // Legal `xsd:boolean` false, including the forms the fixed `whiteSpace="collapse"`
+      // facet makes valid. The XML reader does not trim, so the helper has to.
       [undefined, true],
       ['0', true],
       ['false', true],
+      [' 0 ', true],
+      ['\nfalse\n', true],
+      // Legal true — the engine cannot paint a flip, so it refuses.
       ['1', false],
       ['true', false],
+      [' 1 ', false],
+      // Schema-invalid: refuse rather than read as unset.
       ['TRUE', false],
       ['True', false],
       ['yes', false],
       ['2', false],
       ['', false],
+      ['0 1', false],
     ] as const;
-    for (const [value, paints] of cases) {
-      const xfrm =
-        value === undefined
-          ? '<a:xfrm><a:off x="0" y="0"/><a:ext cx="6696075" cy="47625"/></a:xfrm>'
-          : `<a:xfrm flipH="${value}"><a:off x="0" y="0"/>` +
-            '<a:ext cx="6696075" cy="47625"/></a:xfrm>';
-      const drawing = doubleRuleShapeDrawing().replace(
-        '<a:xfrm><a:off x="0" y="0"/><a:ext cx="6696075" cy="47625"/></a:xfrm>',
-        xfrm
-      );
-      const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
-      const shape = [...indexInlineDrawingProjectionsInPart(part).values()][0]?.vectorShape;
-      expect(`flipH=${value}: ${shape !== null && shape !== undefined}`).toBe(
-        `flipH=${value}: ${paints}`
-      );
+
+    const SHAPE_XFRM = '<a:xfrm><a:off x="0" y="0"/><a:ext cx="6696075" cy="47625"/></a:xfrm>';
+    const GROUP_XFRM = '<a:xfrm><a:chOff x="0" y="0"/><a:chExt cx="200000" cy="100000"/></a:xfrm>';
+    const sites = [
+      {
+        name: 'shape flipH',
+        drawing: (attrs: string) =>
+          doubleRuleShapeDrawing().replace(SHAPE_XFRM, `<a:xfrm${attrs}>${SHAPE_XFRM.slice(9)}`),
+        attr: 'flipH',
+      },
+      {
+        name: 'shape flipV',
+        drawing: (attrs: string) =>
+          doubleRuleShapeDrawing().replace(SHAPE_XFRM, `<a:xfrm${attrs}>${SHAPE_XFRM.slice(9)}`),
+        attr: 'flipV',
+      },
+      {
+        name: 'group flipH',
+        drawing: (attrs: string) =>
+          groupShapeDrawing().replace(GROUP_XFRM, `<a:xfrm${attrs}>${GROUP_XFRM.slice(9)}`),
+        attr: 'flipH',
+      },
+      {
+        name: 'group flipV',
+        drawing: (attrs: string) =>
+          groupShapeDrawing().replace(GROUP_XFRM, `<a:xfrm${attrs}>${GROUP_XFRM.slice(9)}`),
+        attr: 'flipV',
+      },
+    ];
+
+    for (const site of sites) {
+      for (const [value, paints] of spellings) {
+        const attrs = value === undefined ? '' : ` ${site.attr}="${escapeAttribute(value)}"`;
+        const part = parsePart(`<w:p><w:r>${site.drawing(attrs)}</w:r></w:p>`);
+        const shape = [
+          ...indexInlineDrawingProjectionsInPart(part, {
+            resolveSchemeColor: () => '4472C4',
+          }).values(),
+        ][0]?.vectorShape;
+        const label = `${site.name}=${JSON.stringify(value)}`;
+        expect(`${label}: ${shape !== null && shape !== undefined}`).toBe(`${label}: ${paints}`);
+      }
     }
   });
 
@@ -455,23 +562,7 @@ describe('wps vector shape projection', () => {
   });
 
   test('an MC wpg group projects each child with its own geometry and colour', () => {
-    const drawing =
-      '<w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
-      '<wp:extent cx="200000" cy="100000"/><wp:docPr id="13" name="Group 13"/>' +
-      `<a:graphic><a:graphicData uri="${WPG}"><wpg:wgp><wpg:grpSpPr>` +
-      '<a:xfrm><a:chOff x="0" y="0"/><a:chExt cx="200000" cy="100000"/></a:xfrm>' +
-      '</wpg:grpSpPr>' +
-      '<wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm>' +
-      '<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>' +
-      '<a:solidFill><a:schemeClr val="accent1"/></a:solidFill></wps:spPr></wps:wsp>' +
-      '<wps:wsp><wps:spPr><a:xfrm><a:off x="100000" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm>' +
-      '<a:custGeom><a:pathLst><a:path w="100000" h="100000">' +
-      '<a:moveTo><a:pt x="0" y="0"/></a:moveTo>' +
-      '<a:cubicBezTo><a:pt x="25000" y="0"/><a:pt x="75000" y="100000"/>' +
-      '<a:pt x="100000" y="100000"/></a:cubicBezTo><a:close/>' +
-      '</a:path></a:pathLst></a:custGeom>' +
-      '<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></wps:spPr></wps:wsp>' +
-      '</wpg:wgp></a:graphicData></a:graphic></wp:inline></w:drawing>';
+    const drawing = groupShapeDrawing();
     const wrapped =
       '<mc:AlternateContent><mc:Choice Requires="wpg">' +
       drawing +

--- a/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
+++ b/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
@@ -135,6 +135,48 @@ describe('wps vector shape projection', () => {
     );
   });
 
+  // `word/settings.xml` and `word/theme/theme1.xml` are sender-controlled, so an attribute
+  // name or value that names a prototype member must answer "no mapping" rather than a
+  // function. Before the lookups became Maps, `w:accent1="constructor"` made
+  // `resolveSchemeColor('accent1')` return null and every accent1-filled shape in the
+  // document stop painting.
+  test('a prototype-member name in the colour mapping does not break resolution', () => {
+    const theme = readOoxmlPart(
+      `<a:theme xmlns:a="${A}"><a:themeElements><a:clrScheme name="T">` +
+        '<a:accent1><a:srgbClr val="112233"/></a:accent1>' +
+        '<a:accent2><a:srgbClr val="AABBCC"/></a:accent2>' +
+        '<a:constructor><a:srgbClr val="DDEEFF"/></a:constructor>' +
+        '</a:clrScheme></a:themeElements></a:theme>',
+      { name: '/word/theme/theme1.xml', contentType: 'application/xml' }
+    );
+    const hostile = readOoxmlPart(
+      `<w:settings xmlns:w="${WML_NAMESPACE_URI}">` +
+        '<w:clrSchemeMapping w:accent1="constructor" w:accent2="__proto__" ' +
+        'w:__proto__="accent2" w:constructor="accent2"/>' +
+        '</w:settings>',
+      { name: '/word/settings.xml', contentType: 'application/xml' }
+    );
+    if (!theme.ok || !hostile.ok) throw new Error('test package parts must parse');
+    const resolvers = createPackageShapeThemeResolvers({
+      parts: new Map([
+        ['/word/theme/theme1.xml', theme.part],
+        ['/word/settings.xml', hostile.part],
+      ]),
+      partBytes: new Map(),
+      relationships: new Map(),
+      externalTargets: [],
+      contentTypes: {},
+      mainDocumentPart: OWNER,
+    } as unknown as OoxmlPackage);
+    // Unmappable values leave the default mapping in place, so both slots still resolve.
+    expect(resolvers.resolveSchemeColor('accent1')).toBe('112233');
+    expect(resolvers.resolveSchemeColor('accent2')).toBe('AABBCC');
+    // A prototype member is never a slot, and nothing was polluted along the way.
+    expect(resolvers.resolveSchemeColor('__proto__')).toBeNull();
+    expect(resolvers.resolveSchemeColor('toString')).toBeNull();
+    expect(({} as Record<string, unknown>)['accent2']).toBeUndefined();
+  });
+
   test('MC-wrapped anchored custGeom shape projects with typed vector geometry', () => {
     const part = parsePart(`<w:p><w:r>${mcWrapped(doubleRuleShapeDrawing())}</w:r></w:p>`);
     const atoms = indexInlineDrawingProjectionsInPart(part);
@@ -189,13 +231,35 @@ describe('wps vector shape projection', () => {
     expect(shape.fillAlpha).toBe(0.5);
   });
 
+  // `a:tint` and `a:shade` are a blend in LINEAR light, and `val` is the fraction of the
+  // INPUT colour (ECMA-376 20.1.2.3.34/20.1.2.3.31) — not of white, and not a blend on the
+  // stored channel. Each base/value pair below is picked so all three readings disagree, and
+  // every expectation is the pixel a reference renderer paints for that exact fill:
+  //
+  //   base    transform        this engine   `val` as white-fraction   blend in gamma space
+  //   0000FF  tint  20000      E7E7FF        3333FF                    CCCCFF
+  //   0000FF  shade 20000      00007E        —                         000033
+  //   808080  tint  50000      CCCCCC        C0C0C0                    C0C0C0
+  //   808080  shade 50000      5E5E5E        —                         404040
+  //   336699  tint  60000      ADB8CA        7A94AE                    8FA6BE
+  //   336699  shade 40000      224466        —                         143D5C
+  //
+  // Mid-gray at 50% is exactly where the white-fraction reading and the input-fraction
+  // reading agree, so it cannot be the only tint case.
   test('theme colours apply tint, shade, and luminance offset transforms', () => {
     const cases = [
-      ['tint', '50000', 'C0C0C0'],
-      ['shade', '50000', '404040'],
-      ['lumOff', '10000', '9A9A9A'],
+      ['0000FF', 'tint', '20000', 'E7E7FF'],
+      ['0000FF', 'shade', '20000', '00007E'],
+      ['808080', 'tint', '50000', 'CCCCCC'],
+      ['808080', 'shade', '50000', '5E5E5E'],
+      ['336699', 'tint', '60000', 'ADB8CA'],
+      ['336699', 'shade', '40000', '224466'],
+      // `lumMod`/`lumOff` are NOT linear-light: they stay in HSL over the stored channels.
+      ['808080', 'lumOff', '10000', '9A9A9A'],
+      ['6F55D7', 'lumMod', '50000', '2F1D79'],
+      ['6F55D7', 'lumMod', '75000', '472BB6'],
     ] as const;
-    for (const [transform, value, expected] of cases) {
+    for (const [base, transform, value, expected] of cases) {
       const drawing = doubleRuleShapeDrawing().replace(
         '<a:solidFill><a:srgbClr val="000000"/></a:solidFill>',
         `<a:solidFill><a:schemeClr val="accent1"><a:${transform} val="${value}"/>` +
@@ -203,10 +267,67 @@ describe('wps vector shape projection', () => {
       );
       const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
       const atoms = indexInlineDrawingProjectionsInPart(part, {
-        resolveSchemeColor: () => '808080',
+        resolveSchemeColor: () => base,
       });
       expect([...atoms.values()][0]!.vectorShape?.fillHex).toBe(expected);
     }
+  });
+
+  // A ratio of 100000 is the identity, so the round trip through linear light and back must
+  // return the authored byte. The floor in `channelFromLinear` is one ulp away from turning
+  // every channel into the one below it, which no other case here would catch.
+  test('a full-strength tint or shade returns the authored colour unchanged', () => {
+    for (const transform of ['tint', 'shade'] as const) {
+      const drawing = doubleRuleShapeDrawing().replace(
+        '<a:solidFill><a:srgbClr val="000000"/></a:solidFill>',
+        `<a:solidFill><a:srgbClr val="010203"><a:${transform} val="100000"/></a:srgbClr>` +
+          '</a:solidFill>'
+      );
+      const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+      const atoms = indexInlineDrawingProjectionsInPart(part);
+      expect([...atoms.values()][0]!.vectorShape?.fillHex).toBe('010203');
+    }
+  });
+
+  // One bound (16 entries) covers the fill list, the background fill list based at 1001 and
+  // the line list. The index is file content, so both edges of each range must refuse.
+  test('a style matrix index past the list size resolves to nothing', () => {
+    const entries = (name: string, tag: string): string =>
+      `<a:${name}>` +
+      Array.from({ length: 20 }, (_, index) => `<${tag} n="${index}"/>`).join('') +
+      `</a:${name}>`;
+    const theme = readOoxmlPart(
+      `<a:theme xmlns:a="${A}"><a:themeElements><a:clrScheme name="T">` +
+        '<a:accent1><a:srgbClr val="112233"/></a:accent1>' +
+        '</a:clrScheme><a:fmtScheme name="T">' +
+        entries('fillStyleLst', 'a:solidFill') +
+        entries('lnStyleLst', 'a:ln') +
+        '<a:effectStyleLst/>' +
+        entries('bgFillStyleLst', 'a:gradFill') +
+        '</a:fmtScheme></a:themeElements></a:theme>',
+      { name: '/word/theme/theme1.xml', contentType: 'application/xml' }
+    );
+    if (!theme.ok) throw new Error(theme.reason);
+    const resolvers = createPackageShapeThemeResolvers({
+      parts: new Map([['/word/theme/theme1.xml', theme.part]]),
+      partBytes: new Map(),
+      relationships: new Map(),
+      externalTargets: [],
+      contentTypes: {},
+      mainDocumentPart: OWNER,
+    } as unknown as OoxmlPackage);
+    const resolved = (kind: 'fill' | 'line', index: number): string | null =>
+      resolvers.resolveStyleMatrixReference(kind, index)?.localName ?? null;
+    expect(resolved('fill', 1)).toBe('solidFill');
+    expect(resolved('fill', 16)).toBe('solidFill');
+    expect(resolved('fill', 17)).toBeNull();
+    expect(resolved('fill', 1001)).toBe('gradFill');
+    expect(resolved('fill', 1016)).toBe('gradFill');
+    expect(resolved('fill', 1017)).toBeNull();
+    expect(resolved('line', 16)).toBe('ln');
+    expect(resolved('line', 17)).toBeNull();
+    // A line index never selects the background list, however large it is.
+    expect(resolved('line', 1001)).toBeNull();
   });
 
   test('a shape style fill reference resolves its theme colour', () => {

--- a/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
+++ b/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
@@ -234,15 +234,15 @@ describe('wps vector shape projection', () => {
   // `a:tint` and `a:shade` are a blend in LINEAR light, and `val` is the fraction of the
   // INPUT colour (ECMA-376 20.1.2.3.34/20.1.2.3.31) — not of white, and not a blend on the
   // stored channel. Each base/value pair below is picked so all three readings disagree, and
-  // every expectation is the pixel a reference renderer paints for that exact fill:
+  // every expectation is the pixel LibreOffice paints for that exact fill:
   //
   //   base    transform        this engine   `val` as white-fraction   blend in gamma space
   //   0000FF  tint  20000      E7E7FF        3333FF                    CCCCFF
   //   0000FF  shade 20000      00007E        —                         000033
   //   808080  tint  50000      CCCCCC        C0C0C0                    C0C0C0
   //   808080  shade 50000      5E5E5E        —                         404040
-  //   336699  tint  60000      ADB8CA        7A94AE                    8FA6BE
-  //   336699  shade 40000      224466        —                         143D5C
+  //   336699  tint  60000      ADB8CA        ADC2D6                    85A3C2
+  //   336699  shade 40000      224466        —                         14293D
   //
   // Mid-gray at 50% is exactly where the white-fraction reading and the input-fraction
   // reading agree, so it cannot be the only tint case.
@@ -276,6 +276,11 @@ describe('wps vector shape projection', () => {
   // A ratio of 100000 is the identity, so the round trip through linear light and back must
   // return the authored byte. The floor in `channelFromLinear` is one ulp away from turning
   // every channel into the one below it, which no other case here would catch.
+  //
+  // This is the ONE expectation in this file asserted from first principles rather than
+  // measured: LibreOffice renders `010203` + `tint val="100000"` as `000103`, because it
+  // quantises through an integer percentage and loses the bottom channel. A 100% tint is by
+  // definition a no-op, so do not "correct" this toward the oracle.
   test('a full-strength tint or shade returns the authored colour unchanged', () => {
     for (const transform of ['tint', 'shade'] as const) {
       const drawing = doubleRuleShapeDrawing().replace(
@@ -286,6 +291,40 @@ describe('wps vector shape projection', () => {
       const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
       const atoms = indexInlineDrawingProjectionsInPart(part);
       expect([...atoms.values()][0]!.vectorShape?.fillHex).toBe('010203');
+    }
+  });
+
+  // `flipH`/`flipV` are `xsd:boolean`. The engine cannot paint a flip, so a set flag refuses
+  // the shape — and a spelling the schema does not allow must refuse too, not fall through
+  // to "unset" and paint the shape the wrong way round.
+  test('an unset flip paints and any other spelling refuses', () => {
+    const cases = [
+      [undefined, true],
+      ['0', true],
+      ['false', true],
+      ['1', false],
+      ['true', false],
+      ['TRUE', false],
+      ['True', false],
+      ['yes', false],
+      ['2', false],
+      ['', false],
+    ] as const;
+    for (const [value, paints] of cases) {
+      const xfrm =
+        value === undefined
+          ? '<a:xfrm><a:off x="0" y="0"/><a:ext cx="6696075" cy="47625"/></a:xfrm>'
+          : `<a:xfrm flipH="${value}"><a:off x="0" y="0"/>` +
+            '<a:ext cx="6696075" cy="47625"/></a:xfrm>';
+      const drawing = doubleRuleShapeDrawing().replace(
+        '<a:xfrm><a:off x="0" y="0"/><a:ext cx="6696075" cy="47625"/></a:xfrm>',
+        xfrm
+      );
+      const part = parsePart(`<w:p><w:r>${drawing}</w:r></w:p>`);
+      const shape = [...indexInlineDrawingProjectionsInPart(part).values()][0]?.vectorShape;
+      expect(`flipH=${value}: ${shape !== null && shape !== undefined}`).toBe(
+        `flipH=${value}: ${paints}`
+      );
     }
   });
 

--- a/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
+++ b/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
@@ -336,7 +336,21 @@ describe('wps vector shape projection', () => {
       expect(fillFor(percent)).not.toBeNull();
     }
     // Everything else refuses, and a refused transform fails the whole colour closed.
-    for (const rejected of ['101%', '-5%', ' 50% ', '50.123%', '1e2%', '%', '50 %', '1000000']) {
+    // `100.99%` is the case the PATTERN admits but the value space does not: 22.9.2.10's
+    // regex matches it, and it is 1.0099 as a ratio. The explicit ceiling refuses it, the
+    // same way the integer branch refuses `100001`.
+    for (const rejected of [
+      '101%',
+      '100.99%',
+      '100.1%',
+      '-5%',
+      ' 50% ',
+      '50.123%',
+      '1e2%',
+      '%',
+      '50 %',
+      '1000000',
+    ]) {
       expect(`${rejected}: ${fillFor(rejected)}`).toBe(`${rejected}: null`);
     }
   });
@@ -424,6 +438,54 @@ describe('wps vector shape projection', () => {
       for (const [value, paints] of spellings) {
         const attrs = value === undefined ? '' : ` ${site.attr}="${escapeAttribute(value)}"`;
         const part = parsePart(`<w:p><w:r>${site.drawing(attrs)}</w:r></w:p>`);
+        const shape = [
+          ...indexInlineDrawingProjectionsInPart(part, {
+            resolveSchemeColor: () => '4472C4',
+          }).values(),
+        ][0]?.vectorShape;
+        const label = `${site.name}=${JSON.stringify(value)}`;
+        expect(`${label}: ${shape !== null && shape !== undefined}`).toBe(`${label}: ${paints}`);
+      }
+    }
+  });
+
+  // `rot` is `ST_Angle`, which derives from `xsd:int` — so it carries the same fixed
+  // `whiteSpace="collapse"` facet as the flip flags, plus a sign and leading zeros. Every
+  // spelling of zero below is a shape Word paints upright; comparing the raw string to `'0'`
+  // refused all but the bare one. Both `a:xfrm` sites read `rot`, so both are driven.
+  test('every legal spelling of a zero rotation paints, and any real angle refuses', () => {
+    const spellings = [
+      [undefined, true],
+      ['0', true],
+      [' 0 ', true],
+      ['\n0\n', true],
+      ['00', true],
+      ['+0', true],
+      ['-0', true],
+      ['000000', true],
+      // A real angle: the engine cannot paint a rotated vector shape.
+      ['60000', false],
+      ['-60000', false],
+      ['1', false],
+      // Not a legal `xsd:int` at all.
+      ['0.0', false],
+      ['0deg', false],
+      ['', false],
+      ['0 0', false],
+    ] as const;
+
+    const SHAPE_XFRM = '<a:xfrm><a:off x="0" y="0"/><a:ext cx="6696075" cy="47625"/></a:xfrm>';
+    const GROUP_XFRM = '<a:xfrm><a:chOff x="0" y="0"/><a:chExt cx="200000" cy="100000"/></a:xfrm>';
+    const sites = [
+      { name: 'shape rot', base: SHAPE_XFRM, drawing: doubleRuleShapeDrawing },
+      { name: 'group rot', base: GROUP_XFRM, drawing: groupShapeDrawing },
+    ];
+
+    for (const site of sites) {
+      for (const [value, paints] of spellings) {
+        const attrs = value === undefined ? '' : ` rot="${escapeAttribute(value)}"`;
+        const xml = site.drawing().replace(site.base, `<a:xfrm${attrs}>${site.base.slice(9)}`);
+        const part = parsePart(`<w:p><w:r>${xml}</w:r></w:p>`);
         const shape = [
           ...indexInlineDrawingProjectionsInPart(part, {
             resolveSchemeColor: () => '4472C4',

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -45,11 +45,14 @@ import {
   type OoxmlPart,
 } from './ooxml-tree.ts';
 import type { OoxmlPackage } from './ooxml-package.ts';
+import { createPackageShapeThemeResolvers } from './theme-color-resolution.ts';
 import {
   findDirectChild,
   parseEmu,
   projectTextboxStory,
   projectVectorShape,
+  type ShapeSchemeColorResolver,
+  type ShapeStyleMatrixResolver,
   type TextboxStoryProjection,
   type VectorShapeProjection,
 } from './drawing-shape-projection.ts';
@@ -264,6 +267,7 @@ export const DEFAULT_SUPPORTED_MC_REQUIRES: ReadonlySet<string> = new Set([
   // Word wraps `wps:wsp` shapes in `mc:Choice Requires="wps"`; the engine renders the
   // solid-geometry subset and placeholders the rest, so the Choice branch is understood.
   'http://schemas.microsoft.com/office/word/2010/wordprocessingShape',
+  'http://schemas.microsoft.com/office/word/2010/wordprocessingGroup',
 ]);
 
 const PIC_GRAPHIC_DATA_URI = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
@@ -287,6 +291,8 @@ interface ProjectionContext {
   readonly supportedMcRequires: ReadonlySet<string>;
   readonly limits: DrawingProjectionLimits;
   readonly resolveRelationship?: RelationshipTargetResolver;
+  readonly resolveSchemeColor?: ShapeSchemeColorResolver;
+  readonly resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
 }
 
 /** Resolve `(ownerPartName, r:id)` against a package's relationship records. */
@@ -1265,6 +1271,22 @@ function freezeDrawingProjection(projection: DrawingProjection): DrawingProjecti
               Object.freeze(points.map((point) => Object.freeze({ ...point })))
             )
           ),
+          ...(projection.vectorShape.components
+            ? {
+                components: Object.freeze(
+                  projection.vectorShape.components.map((component) =>
+                    Object.freeze({
+                      ...component,
+                      subpathsEmu: Object.freeze(
+                        component.subpathsEmu.map((points) =>
+                          Object.freeze(points.map((point) => Object.freeze({ ...point })))
+                        )
+                      ),
+                    })
+                  )
+                ),
+              }
+            : {}),
         })
       : null,
     // `content` is a canonical-tree node shared with the store; it is not deep-frozen here.
@@ -1382,7 +1404,7 @@ export function drawingAccessibility(projection: DrawingProjection): DrawingAcce
  * reports `hidden` and its locks rather than throwing, so an unusable drawing degrades to
  * something the surface can skip.
  */
-export function projectDrawing(
+function projectDrawingWithTheme(
   drawing: OoxmlDrawingNode,
   context: Readonly<{
     ownerPartName: string;
@@ -1390,6 +1412,8 @@ export function projectDrawing(
     limits: DrawingProjectionLimits;
     namespaceScope?: ReadonlyMap<string, string>;
     resolveRelationship?: RelationshipTargetResolver;
+    resolveSchemeColor?: ShapeSchemeColorResolver;
+    resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
   }>
 ): DrawingProjection | null {
   const ctx: ProjectionContext = {
@@ -1397,6 +1421,8 @@ export function projectDrawing(
     supportedMcRequires: context.supportedMcRequires,
     limits: context.limits,
     resolveRelationship: context.resolveRelationship,
+    resolveSchemeColor: context.resolveSchemeColor,
+    resolveStyleMatrixReference: context.resolveStyleMatrixReference,
   };
   const namespaceScope = context.namespaceScope ?? emptyNamespaceScope();
   const compatibilityMode = isCompatibilityDrawing(drawing);
@@ -1487,6 +1513,25 @@ export function projectDrawing(
           allowOverlap: schemaAttributeValue(anchor.attributes, 'allowOverlap') !== '0',
         })
       : null;
+  const vectorShape = pictureResult.picture
+    ? null
+    : projectVectorShape(
+        anchor,
+        extent,
+        compatibilityMode,
+        ctx.resolveSchemeColor,
+        ctx.resolveStyleMatrixReference
+      );
+  const textboxStory = pictureResult.picture
+    ? null
+    : projectTextboxStory(anchor, extent, ctx.resolveSchemeColor, ctx.resolveStyleMatrixReference);
+  if (vectorShape) {
+    for (let index = state.diagnostics.length - 1; index >= 0; index -= 1) {
+      if (state.diagnostics[index]?.code === 'unsupported-graphic') {
+        state.diagnostics.splice(index, 1);
+      }
+    }
+  }
   return freezeDrawingProjection(
     Object.freeze({
       drawingNodeId: drawing.id,
@@ -1507,16 +1552,28 @@ export function projectDrawing(
       position,
       anchor: anchorMeta,
       picture: pictureResult.picture,
-      vectorShape: pictureResult.picture
-        ? null
-        : projectVectorShape(anchor, extent, compatibilityMode),
-      textboxStory: pictureResult.picture ? null : projectTextboxStory(anchor, extent),
+      vectorShape,
+      textboxStory,
       locks,
       effects: pictureResult.effects,
       compatibilityBranchNodeId: state.compatibilityBranchNodeId,
       diagnostics: state.diagnostics,
     })
   );
+}
+
+/** Project one drawing without package-level theme resolution. */
+export function projectDrawing(
+  drawing: OoxmlDrawingNode,
+  context: Readonly<{
+    ownerPartName: string;
+    supportedMcRequires: ReadonlySet<string>;
+    limits: DrawingProjectionLimits;
+    namespaceScope?: ReadonlyMap<string, string>;
+    resolveRelationship?: RelationshipTargetResolver;
+  }>
+): DrawingProjection | null {
+  return projectDrawingWithTheme(drawing, context);
 }
 
 /** Project a drawing nested under a run-level MC wrapper. */
@@ -1528,6 +1585,8 @@ export function projectRunLevelMcDrawing(
     limits: DrawingProjectionLimits;
     namespaceScope: ReadonlyMap<string, string>;
     resolveRelationship?: RelationshipTargetResolver;
+    resolveSchemeColor?: ShapeSchemeColorResolver;
+    resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
   }>
 ): DrawingProjection | null {
   const atom = resolveRunLevelMcAtom(
@@ -1537,7 +1596,7 @@ export function projectRunLevelMcDrawing(
     context.limits
   );
   if (atom.drawing === null) return null;
-  const projection = projectDrawing(atom.drawing, {
+  const projection = projectDrawingWithTheme(atom.drawing, {
     ...context,
     namespaceScope: context.namespaceScope,
   });
@@ -1629,7 +1688,7 @@ function collectDrawingsInPartBounded(
     const scope = namespaceScopeForNode(frame.namespaceScope, frame.node);
 
     if (frame.node.kind === 'drawing') {
-      const projected = projectDrawing(frame.node, { ...ctx, namespaceScope: scope });
+      const projected = projectDrawingWithTheme(frame.node, { ...ctx, namespaceScope: scope });
       if (projected) {
         out.push(projected);
         atomIndex?.set(frame.node.id, projected);
@@ -1645,6 +1704,8 @@ function collectDrawingsInPartBounded(
         limits: ctx.limits,
         namespaceScope: scope,
         resolveRelationship: ctx.resolveRelationship,
+        resolveSchemeColor: ctx.resolveSchemeColor,
+        resolveStyleMatrixReference: ctx.resolveStyleMatrixReference,
       });
       if (projected) {
         out.push(projected);
@@ -1683,6 +1744,8 @@ export function projectDrawingsInPart(
     supportedMcRequires: ReadonlySet<string>;
     limits: DrawingProjectionLimits;
     resolveRelationship?: RelationshipTargetResolver;
+    resolveSchemeColor?: ShapeSchemeColorResolver;
+    resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
   }>
 ): readonly DrawingProjection[] {
   const ctx: ProjectionContext = {
@@ -1690,6 +1753,8 @@ export function projectDrawingsInPart(
     supportedMcRequires: context?.supportedMcRequires ?? DEFAULT_SUPPORTED_MC_REQUIRES,
     limits: context?.limits ?? DEFAULT_DRAWING_PROJECTION_LIMITS,
     resolveRelationship: context?.resolveRelationship,
+    resolveSchemeColor: context?.resolveSchemeColor,
+    resolveStyleMatrixReference: context?.resolveStyleMatrixReference,
   };
   const out: DrawingProjection[] = [];
   collectDrawingsInPartBounded(part.root, part.name, ctx, out);
@@ -1703,6 +1768,8 @@ export function indexInlineDrawingProjectionsInPart(
     supportedMcRequires: ReadonlySet<string>;
     limits: DrawingProjectionLimits;
     resolveRelationship?: RelationshipTargetResolver;
+    resolveSchemeColor?: ShapeSchemeColorResolver;
+    resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
   }>
 ): ReadonlyMap<string, DrawingProjection> {
   const ctx: ProjectionContext = {
@@ -1710,6 +1777,8 @@ export function indexInlineDrawingProjectionsInPart(
     supportedMcRequires: context?.supportedMcRequires ?? DEFAULT_SUPPORTED_MC_REQUIRES,
     limits: context?.limits ?? DEFAULT_DRAWING_PROJECTION_LIMITS,
     resolveRelationship: context?.resolveRelationship,
+    resolveSchemeColor: context?.resolveSchemeColor,
+    resolveStyleMatrixReference: context?.resolveStyleMatrixReference,
   };
   const out: DrawingProjection[] = [];
   const atomIndex = new Map<string, DrawingProjection>();
@@ -1728,6 +1797,7 @@ export function projectDrawingsInPackage(
   }>
 ): readonly DrawingProjection[] {
   const projections: DrawingProjection[] = [];
+  const theme = createPackageShapeThemeResolvers(pkg);
   for (const [partName, part] of pkg.parts) {
     if (!STORY_PART_RE.test(partName)) continue;
     // Appended in a loop rather than spread: the count is file-controlled, and a spread of
@@ -1735,6 +1805,8 @@ export function projectDrawingsInPackage(
     const inPart = projectDrawingsInPart(part, {
       ...context,
       resolveRelationship: createDrawingRelationshipResolver(pkg, partName),
+      resolveSchemeColor: theme.resolveSchemeColor,
+      resolveStyleMatrixReference: theme.resolveStyleMatrixReference,
     });
     for (const projection of inPart) projections.push(projection);
   }

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -1404,7 +1404,7 @@ export function drawingAccessibility(projection: DrawingProjection): DrawingAcce
  * reports `hidden` and its locks rather than throwing, so an unusable drawing degrades to
  * something the surface can skip.
  */
-function projectDrawingWithTheme(
+export function projectDrawing(
   drawing: OoxmlDrawingNode,
   context: Readonly<{
     ownerPartName: string;
@@ -1562,20 +1562,6 @@ function projectDrawingWithTheme(
   );
 }
 
-/** Project one drawing without package-level theme resolution. */
-export function projectDrawing(
-  drawing: OoxmlDrawingNode,
-  context: Readonly<{
-    ownerPartName: string;
-    supportedMcRequires: ReadonlySet<string>;
-    limits: DrawingProjectionLimits;
-    namespaceScope?: ReadonlyMap<string, string>;
-    resolveRelationship?: RelationshipTargetResolver;
-  }>
-): DrawingProjection | null {
-  return projectDrawingWithTheme(drawing, context);
-}
-
 /** Project a drawing nested under a run-level MC wrapper. */
 export function projectRunLevelMcDrawing(
   wrapper: OoxmlGenericElementNode,
@@ -1596,7 +1582,7 @@ export function projectRunLevelMcDrawing(
     context.limits
   );
   if (atom.drawing === null) return null;
-  const projection = projectDrawingWithTheme(atom.drawing, {
+  const projection = projectDrawing(atom.drawing, {
     ...context,
     namespaceScope: context.namespaceScope,
   });
@@ -1688,7 +1674,7 @@ function collectDrawingsInPartBounded(
     const scope = namespaceScopeForNode(frame.namespaceScope, frame.node);
 
     if (frame.node.kind === 'drawing') {
-      const projected = projectDrawingWithTheme(frame.node, { ...ctx, namespaceScope: scope });
+      const projected = projectDrawing(frame.node, { ...ctx, namespaceScope: scope });
       if (projected) {
         out.push(projected);
         atomIndex?.set(frame.node.id, projected);

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -1271,22 +1271,20 @@ function freezeDrawingProjection(projection: DrawingProjection): DrawingProjecti
               Object.freeze(points.map((point) => Object.freeze({ ...point })))
             )
           ),
-          ...(projection.vectorShape.components
-            ? {
-                components: Object.freeze(
-                  projection.vectorShape.components.map((component) =>
-                    Object.freeze({
-                      ...component,
-                      subpathsEmu: Object.freeze(
-                        component.subpathsEmu.map((points) =>
-                          Object.freeze(points.map((point) => Object.freeze({ ...point })))
-                        )
-                      ),
-                    })
+          // `components` is required and non-empty: paint iterates it, so a conditional
+          // spread that ever took the empty branch would strip the field and throw.
+          components: Object.freeze(
+            projection.vectorShape.components.map((component) =>
+              Object.freeze({
+                ...component,
+                subpathsEmu: Object.freeze(
+                  component.subpathsEmu.map((points) =>
+                    Object.freeze(points.map((point) => Object.freeze({ ...point })))
                   )
                 ),
-              }
-            : {}),
+              })
+            )
+          ),
         })
       : null,
     // `content` is a canonical-tree node shared with the store; it is not deep-frozen here.

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -49,6 +49,7 @@ import { createPackageShapeThemeResolvers } from './theme-color-resolution.ts';
 import {
   findDirectChild,
   parseEmu,
+  schemaFlagIsSet,
   projectTextboxStory,
   projectVectorShape,
   type ShapeSchemeColorResolver,
@@ -1202,8 +1203,15 @@ function projectPicture(
   const rotEmu = rotRaw !== undefined ? parseEmu(rotRaw, false) : null;
   const transform: DrawingTransform = Object.freeze({
     rotationDegrees: rotEmu === null ? 0 : rotEmu / 60_000,
-    flipHorizontal: xfrm ? schemaAttributeValue(xfrm.attributes, 'flipH') === '1' : false,
-    flipVertical: xfrm ? schemaAttributeValue(xfrm.attributes, 'flipV') === '1' : false,
+    // `xsd:boolean`, so `true` is as legal as `1`; reading only `1` painted a mirrored
+    // picture the right way round. A picture flip IS paintable, so a schema-invalid value
+    // reads as unset here rather than refusing the whole picture.
+    flipHorizontal: schemaFlagIsSet(
+      xfrm ? schemaAttributeValue(xfrm.attributes, 'flipH') : undefined
+    ),
+    flipVertical: schemaFlagIsSet(
+      xfrm ? schemaAttributeValue(xfrm.attributes, 'flipV') : undefined
+    ),
     offsetEmu: Object.freeze({
       x: offNode ? (parseEmu(schemaAttributeValue(offNode.attributes, 'x'), false) ?? 0) : 0,
       y: offNode ? (parseEmu(schemaAttributeValue(offNode.attributes, 'y'), false) ?? 0) : 0,

--- a/packages/core/src/store/package/drawing-shape-projection.ts
+++ b/packages/core/src/store/package/drawing-shape-projection.ts
@@ -51,7 +51,7 @@ export function parseEmu(value: string | undefined, clamp = true): number | null
  */
 function schemaFlagIsUnset(value: string | undefined): boolean {
   if (value === undefined) return true;
-  const collapsed = collapseSchemaFlag(value);
+  const collapsed = collapseSchemaWhitespace(value);
   return collapsed === '0' || collapsed === 'false';
 }
 
@@ -67,13 +67,35 @@ function schemaFlagIsUnset(value: string | undefined): boolean {
  */
 export function schemaFlagIsSet(value: string | undefined): boolean {
   if (value === undefined) return false;
-  const collapsed = collapseSchemaFlag(value);
+  const collapsed = collapseSchemaWhitespace(value);
   return collapsed === '1' || collapsed === 'true';
 }
 
-function collapseSchemaFlag(value: string): string {
-  // XML whitespace is exactly space, tab, LF and CR — not `\s`, which is wider.
+/**
+ * Apply the fixed `whiteSpace="collapse"` facet every `xsd:` simple type below carries.
+ *
+ * XML 1.0's `S` production is exactly `#x20 | #x9 | #xD | #xA`. JavaScript's `\s` is wider —
+ * it also matches `\v`, `\f`, NBSP and U+FEFF — so using it here would accept a `val` the
+ * schema does not.
+ */
+function collapseSchemaWhitespace(value: string): string {
   return value.replace(/[ \t\n\r]+/g, ' ').trim();
+}
+
+/**
+ * `rot` on an `a:xfrm`, tested for "not rotated".
+ *
+ * `ST_Angle` derives from `xsd:int`, so it carries the same collapse facet as `xsd:boolean`
+ * and the same freedom over sign and leading zeros: ` 0 `, `00`, `+0` and `-0` are all a
+ * zero rotation. Comparing the raw string to `'0'` refused every one of them and dropped the
+ * shape to a placeholder. A non-zero angle still refuses — the engine cannot paint a rotated
+ * vector shape — and so does anything that is not a legal `xsd:int`.
+ */
+function schemaAngleIsZero(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  const collapsed = collapseSchemaWhitespace(value);
+  // Bounded digit count: `rot` is an int, and this only ever compares it against zero.
+  return /^[+-]?\d{1,12}$/.test(collapsed) && Number(collapsed) === 0;
 }
 
 export function findDirectChild(
@@ -281,13 +303,18 @@ function hslToRgb([hue, saturation, lightness]: readonly number[]): [number, num
  *
  * - The 1000ths-of-a-percent integer (`50000`). This is `ST_Percentage`'s Transitional
  *   spelling (ECMA-376 Part 4), and it is what Word writes, so it is the common case.
- * - The percentage literal (`50%`, `12.5%`). This is the Strict spelling (Part 1
- *   20.1.10.40/20.1.10.41) and the one the spec's own worked examples use. Refusing it
- *   dropped the shape to a placeholder card.
+ * - The percentage literal (`50%`, `12.5%`). This is the Strict spelling
+ *   (`ST_PositiveFixedPercentage`, Part 1 20.1.10.45, whose pattern is 22.9.2.10) and the
+ *   one the spec's own worked examples use. Refusing it dropped the shape to a placeholder.
  *
  * Both regexes are anchored, bounded and have no nested quantifier, so a hostile `val`
  * cannot make either backtrack. Anything else — a sign, an exponent, whitespace, 7 digits —
  * refuses, and the caller fails the whole colour closed rather than guessing.
+ *
+ * The percentage PATTERN is wider than the value space it belongs to: 22.9.2.10 admits
+ * `100.99%`, which is 1.0099 as a ratio. The explicit ceiling below is what keeps the
+ * result in 0..1, not the regex, and it refuses the overshoot the same way the integer
+ * branch refuses `100001`.
  */
 function transformRatio(node: OoxmlElement): number | null {
   const value = schemaAttributeValue(node.attributes, 'val');
@@ -297,8 +324,8 @@ function transformRatio(node: OoxmlElement): number | null {
     return Number.isInteger(parsed) && parsed >= 0 && parsed <= 100_000 ? parsed / 100_000 : null;
   }
   if (/^(?:100|\d{1,2})(?:\.\d{1,2})?%$/.test(value)) {
-    // The regex already bounds this to 0..100, so the divide cannot leave the ratio range.
-    return Number(value.slice(0, -1)) / 100;
+    const percent = Number(value.slice(0, -1));
+    return percent >= 0 && percent <= 100 ? percent / 100 : null;
   }
   return null;
 }
@@ -583,8 +610,7 @@ function projectWspComponent(
     localName: 'xfrm',
   });
   if (xfrm) {
-    const rot = schemaAttributeValue(xfrm.attributes, 'rot');
-    if (rot !== undefined && rot !== '0') return null;
+    if (!schemaAngleIsZero(schemaAttributeValue(xfrm.attributes, 'rot'))) return null;
     if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipH'))) return null;
     if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipV'))) return null;
   }
@@ -794,8 +820,7 @@ export function projectVectorShape(
       : null;
     if (!group || !childExtent) return null;
     if (xfrm) {
-      const rotation = schemaAttributeValue(xfrm.attributes, 'rot');
-      if (rotation !== undefined && rotation !== '0') return null;
+      if (!schemaAngleIsZero(schemaAttributeValue(xfrm.attributes, 'rot'))) return null;
       if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipH'))) return null;
       if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipV'))) return null;
     }

--- a/packages/core/src/store/package/drawing-shape-projection.ts
+++ b/packages/core/src/store/package/drawing-shape-projection.ts
@@ -36,6 +36,17 @@ export function parseEmu(value: string | undefined, clamp = true): number | null
   return parsed;
 }
 
+/**
+ * An `xsd:boolean` attribute read fail-closed.
+ *
+ * The schema allows exactly `0`, `1`, `false` and `true`. Only `0`, `false` and an absent
+ * attribute mean "not set"; every other spelling — `TRUE`, `yes`, `2` — is schema-invalid,
+ * and the sender chose it, so it refuses the shape rather than painting as if unset.
+ */
+function schemaFlagIsUnset(value: string | undefined): boolean {
+  return value === undefined || value === '0' || value === 'false';
+}
+
 export function findDirectChild(
   nodes: readonly OoxmlNode[],
   options: {
@@ -153,12 +164,27 @@ function channelsHex(channels: readonly number[]): string {
 }
 
 /**
- * DrawingML blends `a:tint` and `a:shade` in linear light, not in the stored sRGB channel.
- * The colour-space gamma the renderers use for that conversion is 2.3, not the sRGB
- * piecewise curve, and the linear result truncates back to a byte. Both are load-bearing:
- * with `Math.round`, or with the sRGB curve, the result drifts 1-2 levels away from the
- * reference rendering on most inputs. `lumMod`/`lumOff` are NOT linear-light — they stay in
- * HSL over the stored channels, so they keep `channelsHex`'s rounding.
+ * DrawingML blends `a:tint` and `a:shade` in linear light, not on the stored sRGB channel.
+ * The conversion uses a plain 2.3 colour-space gamma, not the sRGB piecewise curve, and the
+ * linear result truncates back to a byte rather than rounding.
+ *
+ * Where those two constants come from, precisely, because they look arbitrary:
+ *
+ * - Measured against LibreOffice, rendering purpose-built `.docx` files to PDF and sampling
+ *   the pixel. Word was not available on the machine that wrote this, so it is NOT the
+ *   oracle here. Treat this as one renderer's behaviour reproduced exactly (47 of 47
+ *   base/ratio pairs), not as Word's behaviour confirmed. Note also that 2.3 is LibreOffice's
+ *   own colour-space gamma, so agreement with it is partly circular.
+ * - The one independent, spec-side check: ECMA-376 20.1.2.3.31's worked `a:shade` example,
+ *   `00FF00` at `val="50000"`, gives `00BC00`. This model reproduces that exactly; a blend on
+ *   the stored channel gives `007F00`.
+ *
+ * Both constants are load-bearing. With `Math.round` the result moves one level on most
+ * inputs; with the sRGB piecewise curve it moves up to four (`336699` + `shade 40000` is
+ * `224466` here and `1E4164` through sRGB).
+ *
+ * `lumMod`/`lumOff` are NOT linear-light: they stay in HSL over the stored channels and keep
+ * `channelsHex`'s rounding. That path is confirmed against Word itself, so do not fold it in.
  */
 const SHAPE_COLOR_GAMMA = 2.3;
 
@@ -500,10 +526,8 @@ function projectWspComponent(
   if (xfrm) {
     const rot = schemaAttributeValue(xfrm.attributes, 'rot');
     if (rot !== undefined && rot !== '0') return null;
-    const flipHorizontal = schemaAttributeValue(xfrm.attributes, 'flipH');
-    const flipVertical = schemaAttributeValue(xfrm.attributes, 'flipV');
-    if (flipHorizontal === '1' || flipHorizontal === 'true') return null;
-    if (flipVertical === '1' || flipVertical === 'true') return null;
+    if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipH'))) return null;
+    if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipV'))) return null;
   }
 
   const authoredFill = directFill(spPr, resolveSchemeColor);
@@ -712,11 +736,9 @@ export function projectVectorShape(
     if (!group || !childExtent) return null;
     if (xfrm) {
       const rotation = schemaAttributeValue(xfrm.attributes, 'rot');
-      const flipHorizontal = schemaAttributeValue(xfrm.attributes, 'flipH');
-      const flipVertical = schemaAttributeValue(xfrm.attributes, 'flipV');
       if (rotation !== undefined && rotation !== '0') return null;
-      if (flipHorizontal === '1' || flipHorizontal === 'true') return null;
-      if (flipVertical === '1' || flipVertical === 'true') return null;
+      if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipH'))) return null;
+      if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipV'))) return null;
     }
     const chOffX = childOffset
       ? (parseEmu(schemaAttributeValue(childOffset.attributes, 'x'), false) ?? 0)

--- a/packages/core/src/store/package/drawing-shape-projection.ts
+++ b/packages/core/src/store/package/drawing-shape-projection.ts
@@ -39,12 +39,41 @@ export function parseEmu(value: string | undefined, clamp = true): number | null
 /**
  * An `xsd:boolean` attribute read fail-closed.
  *
- * The schema allows exactly `0`, `1`, `false` and `true`. Only `0`, `false` and an absent
- * attribute mean "not set"; every other spelling — `TRUE`, `yes`, `2` — is schema-invalid,
- * and the sender chose it, so it refuses the shape rather than painting as if unset.
+ * Ignoring whitespace, the schema allows exactly `0`, `1`, `false` and `true`. Only `0`,
+ * `false` and an absent attribute mean "not set"; every other spelling — `TRUE`, `yes`, `2`
+ * — is schema-invalid, and the sender chose it, so it refuses the shape rather than painting
+ * as if the flag were unset.
+ *
+ * The collapse is load-bearing. `xsd:boolean` carries a fixed `whiteSpace="collapse"` facet,
+ * so ` 0 ` and `0\n` are valid false, but the XML reader keeps attribute values verbatim
+ * (`trimValues: false`). Comparing the raw string would refuse a shape Word paints, which is
+ * the one way a fail-closed read like this can be worse than the permissive one it replaced.
  */
 function schemaFlagIsUnset(value: string | undefined): boolean {
-  return value === undefined || value === '0' || value === 'false';
+  if (value === undefined) return true;
+  const collapsed = collapseSchemaFlag(value);
+  return collapsed === '0' || collapsed === 'false';
+}
+
+/**
+ * The complement of {@link schemaFlagIsUnset}: an `xsd:boolean` that legally reads true.
+ *
+ * A value is neither set nor unset when it is schema-invalid, and the two callers want
+ * opposite things there. A flag the engine cannot HONOUR (a flipped vector shape) refuses
+ * through `schemaFlagIsUnset`, because painting it unflipped would be a wrong render. A flag
+ * the engine can honour (a flipped picture) reads through here and treats anything invalid
+ * as unset, because refusing would drop the picture entirely — a worse outcome than a
+ * mirror the sender spelled illegally.
+ */
+export function schemaFlagIsSet(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const collapsed = collapseSchemaFlag(value);
+  return collapsed === '1' || collapsed === 'true';
+}
+
+function collapseSchemaFlag(value: string): string {
+  // XML whitespace is exactly space, tab, LF and CR — not `\s`, which is wider.
+  return value.replace(/[ \t\n\r]+/g, ' ').trim();
 }
 
 export function findDirectChild(
@@ -175,13 +204,21 @@ function channelsHex(channels: readonly number[]): string {
  *   oracle here. Treat this as one renderer's behaviour reproduced exactly (47 of 47
  *   base/ratio pairs), not as Word's behaviour confirmed. Note also that 2.3 is LibreOffice's
  *   own colour-space gamma, so agreement with it is partly circular.
- * - The one independent, spec-side check: ECMA-376 20.1.2.3.31's worked `a:shade` example,
- *   `00FF00` at `val="50000"`, gives `00BC00`. This model reproduces that exactly; a blend on
- *   the stored channel gives `007F00`.
+ * - The one check that does not come from a renderer: ECMA-376 Part 1 20.1.2.3.31's worked
+ *   `a:shade` example, `00FF00` at `val="50%"`, gives `00BC00`. This model reproduces it
+ *   exactly. Read what that does and does not settle — a blend on the stored channel gives
+ *   `008000`, so the example rules that reading out decisively, but the sRGB curve gives
+ *   `00BB00`, one level away, so it barely speaks to the choice of curve.
  *
- * Both constants are load-bearing. With `Math.round` the result moves one level on most
- * inputs; with the sRGB piecewise curve it moves up to four (`336699` + `shade 40000` is
- * `224466` here and `1E4164` through sRGB).
+ * On the spelling in that citation: Part 1 (Strict) writes percentages as `50%`, and its
+ * `ST_PositiveFixedPercentage` does not admit `50000` at all. The 1000ths-of-a-percent
+ * integer Word writes is Part 4 (Transitional). `transformRatio` takes both.
+ *
+ * Both constants are load-bearing, though neither is dramatic on any single colour. Against
+ * `Math.round` the result moves a level on about half of a uniform base/ratio grid. Against
+ * the sRGB piecewise curve, holding this floor fixed, it moves on about half as well, by
+ * four levels on `336699` + `shade 40000` (`224466` here, `1E4163` through sRGB) and by as
+ * much as eleven at the dark end.
  *
  * `lumMod`/`lumOff` are NOT linear-light: they stay in HSL over the stored channels and keep
  * `channelsHex`'s rounding. That path is confirmed against Word itself, so do not fold it in.
@@ -237,11 +274,33 @@ function hslToRgb([hue, saturation, lightness]: readonly number[]): [number, num
   return [channel(1 / 3) * 255, channel(0) * 255, channel(-1 / 3) * 255];
 }
 
+/**
+ * `val` on a colour transform, as a 0..1 ratio, or null to refuse the colour.
+ *
+ * Two spellings are legal and both appear in the wild:
+ *
+ * - The 1000ths-of-a-percent integer (`50000`). This is `ST_Percentage`'s Transitional
+ *   spelling (ECMA-376 Part 4), and it is what Word writes, so it is the common case.
+ * - The percentage literal (`50%`, `12.5%`). This is the Strict spelling (Part 1
+ *   20.1.10.40/20.1.10.41) and the one the spec's own worked examples use. Refusing it
+ *   dropped the shape to a placeholder card.
+ *
+ * Both regexes are anchored, bounded and have no nested quantifier, so a hostile `val`
+ * cannot make either backtrack. Anything else — a sign, an exponent, whitespace, 7 digits —
+ * refuses, and the caller fails the whole colour closed rather than guessing.
+ */
 function transformRatio(node: OoxmlElement): number | null {
   const value = schemaAttributeValue(node.attributes, 'val');
-  if (value === undefined || !/^\d{1,6}$/.test(value)) return null;
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed >= 0 && parsed <= 100_000 ? parsed / 100_000 : null;
+  if (value === undefined) return null;
+  if (/^\d{1,6}$/.test(value)) {
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed >= 0 && parsed <= 100_000 ? parsed / 100_000 : null;
+  }
+  if (/^(?:100|\d{1,2})(?:\.\d{1,2})?%$/.test(value)) {
+    // The regex already bounds this to 0..100, so the divide cannot leave the ratio range.
+    return Number(value.slice(0, -1)) / 100;
+  }
+  return null;
 }
 
 function resolveColorNode(

--- a/packages/core/src/store/package/drawing-shape-projection.ts
+++ b/packages/core/src/store/package/drawing-shape-projection.ts
@@ -61,26 +61,36 @@ export function findDirectChild(
 }
 
 /**
- * The renderable subset of a `wps:wsp` non-picture graphic: closed polygon subpaths
- * (`a:custGeom` with move/line/close verbs only, or `a:prstGeom prst="rect"`) with a
- * solid sRGB fill and/or stroke. Anything richer (curves, theme fills, text bodies,
- * rotation) projects as `null` and paints the labelled placeholder instead.
+ * The renderable subset of a `wps:wsp` non-picture graphic, or of one bounded `wpg:wgp`
+ * group of them: closed polygon subpaths (`a:custGeom` with move/line/close/cubicBezTo
+ * verbs, or a supported `a:prstGeom`) with a solid fill and/or stroke. The colour may come
+ * from `a:srgbClr` or from the theme, through `a:schemeClr` or a `wps:style` matrix
+ * reference. Anything richer (gradient and picture fills, text bodies, rotation, a nested
+ * group) projects as `null` and paints the labelled placeholder instead.
  */
 export interface VectorShapeProjection {
   /** The drawing extent that frames the subpath coordinate space. */
   readonly extentEmu: Readonly<{ cx: number; cy: number }>;
-  /** Closed subpath polygons in extent-EMU space; fill rule is even-odd. */
+  /**
+   * Every component's subpath polygons, flattened, in extent-EMU space; fill rule is
+   * even-odd. Painting reads `components`, which keeps each polygon with its own colours;
+   * this stays the geometry summary (bounds, hit tests, wrap holes).
+   */
   readonly subpathsEmu: readonly (readonly Readonly<{ x: number; y: number }>[])[];
-  /** Validated 6-digit sRGB hex (no `#`), or null for no fill. */
+  /**
+   * Validated 6-digit sRGB hex (no `#`) of the one component, or null. A group of two or
+   * more components has no single fill, so this is null there as well: null means "no one
+   * fill to name", not "nothing is filled". Read `components` to paint.
+   */
   readonly fillHex: string | null;
   readonly fillAlpha?: number;
-  /** Validated 6-digit sRGB hex (no `#`), or null for no stroke. */
+  /** As `fillHex`, for the stroke: the one component's stroke, else null. */
   readonly strokeHex: string | null;
   readonly strokeAlpha?: number;
-  /** Stroke width in EMU; 0 when absent. */
+  /** The one component's stroke width in EMU; 0 when absent or when grouped. */
   readonly strokeWidthEmu: number;
-  /** Independently styled paths. A direct shape has one component. */
-  readonly components?: readonly VectorShapeComponent[];
+  /** Independently styled paths, always non-empty. A direct shape has one component. */
+  readonly components: readonly VectorShapeComponent[];
 }
 
 export interface VectorShapeComponent {
@@ -140,6 +150,27 @@ function channelsHex(channels: readonly number[]): string {
     )
     .join('')
     .toUpperCase();
+}
+
+/**
+ * DrawingML blends `a:tint` and `a:shade` in linear light, not in the stored sRGB channel.
+ * The colour-space gamma the renderers use for that conversion is 2.3, not the sRGB
+ * piecewise curve, and the linear result truncates back to a byte. Both are load-bearing:
+ * with `Math.round`, or with the sRGB curve, the result drifts 1-2 levels away from the
+ * reference rendering on most inputs. `lumMod`/`lumOff` are NOT linear-light — they stay in
+ * HSL over the stored channels, so they keep `channelsHex`'s rounding.
+ */
+const SHAPE_COLOR_GAMMA = 2.3;
+
+function linearFromChannel(channel: number): number {
+  return (Math.max(0, Math.min(255, channel)) / 255) ** SHAPE_COLOR_GAMMA;
+}
+
+function channelFromLinear(linear: number): number {
+  const channel = Math.max(0, Math.min(1, linear)) ** (1 / SHAPE_COLOR_GAMMA) * 255;
+  // The epsilon only absorbs the round-trip error of the two `**` calls, so a ratio of
+  // 100000 (the identity transform) returns the input channel instead of the one below it.
+  return Math.max(0, Math.min(255, Math.floor(channel + 1e-6)));
 }
 
 function rgbToHsl([red, green, blue]: readonly number[]): [number, number, number] {
@@ -218,13 +249,15 @@ function resolveColorNode(
     if (ratio === null) return null;
     if (child.localName === 'alpha') alpha = ratio;
     else if (child.localName === 'tint') {
-      channels = channels.map((channel) => channel + (255 - channel) * ratio) as [
-        number,
-        number,
-        number,
-      ];
+      // ECMA-376 20.1.2.3.34: `val` is the fraction of the INPUT colour, the rest white.
+      channels = channels.map((channel) =>
+        channelFromLinear(linearFromChannel(channel) * ratio + (1 - ratio))
+      ) as [number, number, number];
     } else if (child.localName === 'shade') {
-      channels = channels.map((channel) => channel * ratio) as [number, number, number];
+      // ECMA-376 20.1.2.3.31: `val` is the fraction of the input colour, the rest black.
+      channels = channels.map((channel) =>
+        channelFromLinear(linearFromChannel(channel) * ratio)
+      ) as [number, number, number];
     } else if (child.localName === 'lumMod' || child.localName === 'lumOff') {
       const hsl = rgbToHsl(channels);
       hsl[2] = Math.max(

--- a/packages/core/src/store/package/drawing-shape-projection.ts
+++ b/packages/core/src/store/package/drawing-shape-projection.ts
@@ -8,10 +8,21 @@ import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
 import { DRAWINGML_MAIN_NAMESPACE_URI, type OoxmlElement, type OoxmlNode } from './ooxml-tree.ts';
 
 const WPS_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+const WPG_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingGroup';
 const WPS_GRAPHIC_DATA_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+const WPG_GRAPHIC_DATA_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingGroup';
 const SHAPE_HEX_RE = /^[0-9A-Fa-f]{6}$/;
 const MAX_VECTOR_SHAPE_SUBPATHS = 64;
 const MAX_VECTOR_SHAPE_POINTS = 1024;
+const MAX_GROUP_SHAPE_CHILDREN = 128;
+const ELLIPSE_POINTS = 32;
+const CUBIC_BEZIER_SEGMENTS = 8;
+
+export type ShapeSchemeColorResolver = (scheme: string) => string | null;
+export type ShapeStyleMatrixResolver = (
+  kind: 'fill' | 'line',
+  index: number
+) => OoxmlElement | null;
 
 export const MAX_EMU = 2 ** 31 - 1;
 
@@ -62,9 +73,22 @@ export interface VectorShapeProjection {
   readonly subpathsEmu: readonly (readonly Readonly<{ x: number; y: number }>[])[];
   /** Validated 6-digit sRGB hex (no `#`), or null for no fill. */
   readonly fillHex: string | null;
+  readonly fillAlpha?: number;
   /** Validated 6-digit sRGB hex (no `#`), or null for no stroke. */
   readonly strokeHex: string | null;
+  readonly strokeAlpha?: number;
   /** Stroke width in EMU; 0 when absent. */
+  readonly strokeWidthEmu: number;
+  /** Independently styled paths. A direct shape has one component. */
+  readonly components?: readonly VectorShapeComponent[];
+}
+
+export interface VectorShapeComponent {
+  readonly subpathsEmu: readonly (readonly Readonly<{ x: number; y: number }>[])[];
+  readonly fillHex: string | null;
+  readonly fillAlpha: number;
+  readonly strokeHex: string | null;
+  readonly strokeAlpha: number;
   readonly strokeWidthEmu: number;
 }
 
@@ -94,20 +118,219 @@ export interface TextboxStoryProjection {
   readonly strokeWidthEmu: number;
 }
 
-/** Direct `a:solidFill > a:srgbClr @val` under `parent`; only a validated 6-hex passes. */
-function readSolidFillHex(parent: OoxmlElement): string | null {
+interface ShapeColor {
+  readonly hex: string;
+  readonly alpha: number;
+}
+
+function colorChannels(hex: string): [number, number, number] {
+  return [
+    Number.parseInt(hex.slice(0, 2), 16),
+    Number.parseInt(hex.slice(2, 4), 16),
+    Number.parseInt(hex.slice(4, 6), 16),
+  ];
+}
+
+function channelsHex(channels: readonly number[]): string {
+  return channels
+    .map((channel) =>
+      Math.round(Math.max(0, Math.min(255, channel)))
+        .toString(16)
+        .padStart(2, '0')
+    )
+    .join('')
+    .toUpperCase();
+}
+
+function rgbToHsl([red, green, blue]: readonly number[]): [number, number, number] {
+  const r = red! / 255;
+  const g = green! / 255;
+  const b = blue! / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const lightness = (max + min) / 2;
+  if (max === min) return [0, 0, lightness];
+  const delta = max - min;
+  const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+  const hue =
+    max === r
+      ? (g - b) / delta + (g < b ? 6 : 0)
+      : max === g
+        ? (b - r) / delta + 2
+        : (r - g) / delta + 4;
+  return [hue / 6, saturation, lightness];
+}
+
+function hslToRgb([hue, saturation, lightness]: readonly number[]): [number, number, number] {
+  if (saturation === 0) return [lightness! * 255, lightness! * 255, lightness! * 255];
+  const q =
+    lightness! < 0.5
+      ? lightness! * (1 + saturation!)
+      : lightness! + saturation! - lightness! * saturation!;
+  const p = 2 * lightness! - q;
+  const channel = (offset: number): number => {
+    let value = hue! + offset;
+    if (value < 0) value += 1;
+    if (value > 1) value -= 1;
+    if (value < 1 / 6) return p + (q - p) * 6 * value;
+    if (value < 1 / 2) return q;
+    if (value < 2 / 3) return p + (q - p) * (2 / 3 - value) * 6;
+    return p;
+  };
+  return [channel(1 / 3) * 255, channel(0) * 255, channel(-1 / 3) * 255];
+}
+
+function transformRatio(node: OoxmlElement): number | null {
+  const value = schemaAttributeValue(node.attributes, 'val');
+  if (value === undefined || !/^\d{1,6}$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 && parsed <= 100_000 ? parsed / 100_000 : null;
+}
+
+function resolveColorNode(
+  color: OoxmlNode,
+  resolveSchemeColor?: ShapeSchemeColorResolver,
+  placeholder?: ShapeColor
+): ShapeColor | null {
+  if (
+    !isElement(color) ||
+    !('namespaceUri' in color) ||
+    color.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI ||
+    (color.localName !== 'srgbClr' && color.localName !== 'schemeClr')
+  ) {
+    return null;
+  }
+  const token = schemaAttributeValue(color.attributes, 'val');
+  let alpha = 1;
+  let hex: string | null | undefined;
+  if (color.localName === 'srgbClr') hex = token;
+  else if (token === 'phClr' && placeholder) {
+    hex = placeholder.hex;
+    alpha = placeholder.alpha;
+  } else {
+    hex = token !== undefined ? resolveSchemeColor?.(token) : null;
+  }
+  if (!hex || !SHAPE_HEX_RE.test(hex)) return null;
+  let channels = colorChannels(hex);
+  for (const child of color.children) {
+    if (!isElement(child) || child.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) continue;
+    const ratio = transformRatio(child);
+    if (ratio === null) return null;
+    if (child.localName === 'alpha') alpha = ratio;
+    else if (child.localName === 'tint') {
+      channels = channels.map((channel) => channel + (255 - channel) * ratio) as [
+        number,
+        number,
+        number,
+      ];
+    } else if (child.localName === 'shade') {
+      channels = channels.map((channel) => channel * ratio) as [number, number, number];
+    } else if (child.localName === 'lumMod' || child.localName === 'lumOff') {
+      const hsl = rgbToHsl(channels);
+      hsl[2] = Math.max(
+        0,
+        Math.min(1, child.localName === 'lumMod' ? hsl[2] * ratio : hsl[2] + ratio)
+      );
+      channels = hslToRgb(hsl);
+    } else {
+      return null;
+    }
+  }
+  hex = channelsHex(channels);
+  return { hex, alpha };
+}
+
+/** Resolve and transform one DrawingML solid fill at the store trust boundary. */
+function readSolidFill(
+  parent: OoxmlElement,
+  resolveSchemeColor?: ShapeSchemeColorResolver,
+  placeholder?: ShapeColor
+): ShapeColor | null {
   const solidFill = findDirectChild(parent.children, {
     namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
     localName: 'solidFill',
   });
   if (!solidFill) return null;
-  const srgb = findDirectChild(solidFill.children, {
-    namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
-    localName: 'srgbClr',
+  const color = solidFill.children.find(isElement);
+  return color ? resolveColorNode(color, resolveSchemeColor, placeholder) : null;
+}
+
+const FILL_ELEMENT_NAMES = new Set([
+  'noFill',
+  'solidFill',
+  'gradFill',
+  'blipFill',
+  'pattFill',
+  'grpFill',
+]);
+
+function directFill(
+  parent: OoxmlElement,
+  resolveSchemeColor?: ShapeSchemeColorResolver,
+  placeholder?: ShapeColor
+): { readonly present: boolean; readonly color: ShapeColor | null } {
+  const authored = parent.children.find(
+    (child) =>
+      isElement(child) &&
+      child.namespaceUri === DRAWINGML_MAIN_NAMESPACE_URI &&
+      FILL_ELEMENT_NAMES.has(child.localName)
+  );
+  if (!authored || !isElement(authored)) return { present: false, color: null };
+  return {
+    present: true,
+    color:
+      authored.localName === 'solidFill'
+        ? readSolidFill(parent, resolveSchemeColor, placeholder)
+        : null,
+  };
+}
+
+function readStyleReference(
+  wsp: OoxmlElement,
+  referenceName: 'fillRef' | 'lnRef',
+  resolveSchemeColor?: ShapeSchemeColorResolver,
+  resolveStyleMatrixReference?: ShapeStyleMatrixResolver
+): { readonly color: ShapeColor; readonly strokeWidthEmu?: number } | null {
+  const style = findDirectChild(wsp.children, {
+    namespaceUri: WPS_NAMESPACE_URI,
+    localName: 'style',
   });
-  if (!srgb) return null;
-  const value = schemaAttributeValue(srgb.attributes, 'val');
-  return value !== undefined && SHAPE_HEX_RE.test(value) ? value : null;
+  const reference = style
+    ? findDirectChild(style.children, {
+        namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+        localName: referenceName,
+      })
+    : null;
+  const color = reference?.children.find(isElement);
+  const rawIndex = reference ? schemaAttributeValue(reference.attributes, 'idx') : undefined;
+  if (!color || !rawIndex || !/^\d{1,4}$/.test(rawIndex)) return null;
+  const index = Number(rawIndex);
+  const placeholder = resolveColorNode(color, resolveSchemeColor);
+  const matrix = resolveStyleMatrixReference?.(
+    referenceName === 'fillRef' ? 'fill' : 'line',
+    index
+  );
+  if (!placeholder || !matrix) return null;
+  if (referenceName === 'fillRef') {
+    if (
+      !isElement(matrix) ||
+      matrix.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI ||
+      matrix.localName !== 'solidFill'
+    ) {
+      return null;
+    }
+    const matrixColor = matrix.children.find(isElement);
+    const resolved = matrixColor
+      ? resolveColorNode(matrixColor, resolveSchemeColor, placeholder)
+      : null;
+    return resolved ? { color: resolved } : null;
+  }
+  const lineFill = directFill(matrix, resolveSchemeColor, placeholder);
+  if (!lineFill.present || !lineFill.color) return null;
+  return {
+    color: lineFill.color,
+    strokeWidthEmu: parseEmu(schemaAttributeValue(matrix.attributes, 'w')) ?? 12_700,
+  };
 }
 
 /** Polygon subpaths of one `a:path` — move/line/close verbs only; anything else refuses. */
@@ -124,6 +347,46 @@ function readShapePathPolygons(
     if (verb.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) return false;
     if (verb.localName === 'close') {
       current = null;
+      continue;
+    }
+    if (verb.localName === 'cubicBezTo') {
+      if (current === null || pointBudget.remaining < CUBIC_BEZIER_SEGMENTS) return false;
+      const controls = verb.children.filter(isElement);
+      if (
+        controls.length !== 3 ||
+        controls.some(
+          (point) => point.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI || point.localName !== 'pt'
+        )
+      ) {
+        return false;
+      }
+      const parsed = controls.map((point) => {
+        const x = parseEmu(schemaAttributeValue(point.attributes, 'x'), false);
+        const y = parseEmu(schemaAttributeValue(point.attributes, 'y'), false);
+        return x === null || y === null ? null : { x: x * scaleX, y: y * scaleY };
+      });
+      if (parsed.some((point) => point === null)) return false;
+      const start = current[current.length - 1]!;
+      const control1 = parsed[0]!;
+      const control2 = parsed[1]!;
+      const end = parsed[2]!;
+      for (let index = 1; index <= CUBIC_BEZIER_SEGMENTS; index += 1) {
+        const t = index / CUBIC_BEZIER_SEGMENTS;
+        const inverse = 1 - t;
+        current.push({
+          x:
+            inverse ** 3 * start.x +
+            3 * inverse ** 2 * t * control1.x +
+            3 * inverse * t ** 2 * control2.x +
+            t ** 3 * end.x,
+          y:
+            inverse ** 3 * start.y +
+            3 * inverse ** 2 * t * control1.y +
+            3 * inverse * t ** 2 * control2.y +
+            t ** 3 * end.y,
+        });
+      }
+      pointBudget.remaining -= CUBIC_BEZIER_SEGMENTS;
       continue;
     }
     if (verb.localName !== 'moveTo' && verb.localName !== 'lnTo') return false;
@@ -150,8 +413,7 @@ function readShapePathPolygons(
   return true;
 }
 
-/** The `wps:wsp` under the anchor's graphic data, or null when the payload is something else. */
-function findWspInAnchor(anchor: OoxmlElement): OoxmlElement | null {
+function findGraphicData(anchor: OoxmlElement): OoxmlElement | null {
   // Non-picture graphic payloads demote to generic nodes even under a typed
   // `drawingGraphic`, so the generic lookup is always in play here.
   const graphic =
@@ -167,6 +429,12 @@ function findWspInAnchor(anchor: OoxmlElement): OoxmlElement | null {
       namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
       localName: 'graphicData',
     });
+  return data;
+}
+
+/** The `wps:wsp` under the anchor's graphic data, or null when the payload is something else. */
+function findWspInAnchor(anchor: OoxmlElement): OoxmlElement | null {
+  const data = findGraphicData(anchor);
   if (!data) return null;
   if (schemaAttributeValue(data.attributes, 'uri') !== WPS_GRAPHIC_DATA_URI) return null;
   return (
@@ -177,19 +445,13 @@ function findWspInAnchor(anchor: OoxmlElement): OoxmlElement | null {
   );
 }
 
-/**
- * Renderable-subset projection of a `wps:wsp` graphic. Returns null (→ placeholder) for
- * text bodies, rotated/flipped transforms, non-solid fills, curves, or over-limit paths.
- */
-export function projectVectorShape(
-  anchor: OoxmlElement,
+function projectWspComponent(
+  wsp: OoxmlElement,
   extent: Readonly<{ cx: number; cy: number }>,
-  compatibilityMode: boolean
-): VectorShapeProjection | null {
-  void compatibilityMode;
-  if (extent.cx <= 0 || extent.cy <= 0) return null;
-  const wsp = findWspInAnchor(anchor);
-  if (!wsp) return null;
+  pointBudget: { remaining: number },
+  resolveSchemeColor?: ShapeSchemeColorResolver,
+  resolveStyleMatrixReference?: ShapeStyleMatrixResolver
+): VectorShapeComponent | null {
   if (findDirectChild(wsp.children, { namespaceUri: WPS_NAMESPACE_URI, localName: 'txbx' })) {
     return null;
   }
@@ -205,19 +467,35 @@ export function projectVectorShape(
   if (xfrm) {
     const rot = schemaAttributeValue(xfrm.attributes, 'rot');
     if (rot !== undefined && rot !== '0') return null;
-    if (schemaAttributeValue(xfrm.attributes, 'flipH') === '1') return null;
-    if (schemaAttributeValue(xfrm.attributes, 'flipV') === '1') return null;
+    const flipHorizontal = schemaAttributeValue(xfrm.attributes, 'flipH');
+    const flipVertical = schemaAttributeValue(xfrm.attributes, 'flipV');
+    if (flipHorizontal === '1' || flipHorizontal === 'true') return null;
+    if (flipVertical === '1' || flipVertical === 'true') return null;
   }
 
-  const fillHex = readSolidFillHex(spPr);
+  const authoredFill = directFill(spPr, resolveSchemeColor);
+  const styleFill = authoredFill.present
+    ? null
+    : readStyleReference(wsp, 'fillRef', resolveSchemeColor, resolveStyleMatrixReference);
+  const fill = authoredFill.present ? authoredFill.color : (styleFill?.color ?? null);
   const ln = findDirectChild(spPr.children, {
     namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
     localName: 'ln',
   });
-  const strokeHex = ln ? readSolidFillHex(ln) : null;
+  const authoredStroke = ln ? directFill(ln, resolveSchemeColor) : null;
+  const styleStroke =
+    authoredStroke?.present === true
+      ? null
+      : readStyleReference(wsp, 'lnRef', resolveSchemeColor, resolveStyleMatrixReference);
+  const stroke =
+    authoredStroke?.present === true ? authoredStroke.color : (styleStroke?.color ?? null);
   const strokeWidthEmu =
-    strokeHex !== null ? (parseEmu(schemaAttributeValue(ln!.attributes, 'w')) ?? 12_700) : 0;
-  if (fillHex === null && strokeHex === null) return null;
+    stroke !== null
+      ? ((ln ? parseEmu(schemaAttributeValue(ln.attributes, 'w')) : null) ??
+        styleStroke?.strokeWidthEmu ??
+        12_700)
+      : 0;
+  if (fill === null && stroke === null) return null;
 
   const subpaths: { x: number; y: number }[][] = [];
   const custGeom = findDirectChild(spPr.children, {
@@ -230,7 +508,6 @@ export function projectVectorShape(
       localName: 'pathLst',
     });
     if (!pathLst) return null;
-    const pointBudget = { remaining: MAX_VECTOR_SHAPE_POINTS };
     for (const child of pathLst.children) {
       if (!isElement(child)) continue;
       if (child.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI || child.localName !== 'path') {
@@ -250,22 +527,226 @@ export function projectVectorShape(
       namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
       localName: 'prstGeom',
     });
-    if (!prstGeom || schemaAttributeValue(prstGeom.attributes, 'prst') !== 'rect') return null;
-    subpaths.push([
-      { x: 0, y: 0 },
-      { x: extent.cx, y: 0 },
-      { x: extent.cx, y: extent.cy },
-      { x: 0, y: extent.cy },
-    ]);
+    const preset = prstGeom ? schemaAttributeValue(prstGeom.attributes, 'prst') : undefined;
+    if (preset === 'rect') {
+      if (pointBudget.remaining < 4) return null;
+      subpaths.push([
+        { x: 0, y: 0 },
+        { x: extent.cx, y: 0 },
+        { x: extent.cx, y: extent.cy },
+        { x: 0, y: extent.cy },
+      ]);
+      pointBudget.remaining -= 4;
+    } else if (preset === 'ellipse' && pointBudget.remaining >= ELLIPSE_POINTS) {
+      const ellipse: { x: number; y: number }[] = [];
+      for (let index = 0; index < ELLIPSE_POINTS; index += 1) {
+        const angle = (index / ELLIPSE_POINTS) * Math.PI * 2;
+        ellipse.push({
+          x: extent.cx / 2 + (Math.cos(angle) * extent.cx) / 2,
+          y: extent.cy / 2 + (Math.sin(angle) * extent.cy) / 2,
+        });
+      }
+      pointBudget.remaining -= ELLIPSE_POINTS;
+      subpaths.push(ellipse);
+    } else {
+      return null;
+    }
   }
   const polygons = subpaths.filter((points) => points.length >= 3);
   if (polygons.length === 0) return null;
   return {
-    extentEmu: { cx: extent.cx, cy: extent.cy },
     subpathsEmu: polygons,
-    fillHex,
-    strokeHex,
+    fillHex: fill?.hex ?? null,
+    fillAlpha: fill?.alpha ?? 1,
+    strokeHex: stroke?.hex ?? null,
+    strokeAlpha: stroke?.alpha ?? 1,
     strokeWidthEmu,
+  };
+}
+
+function transformComponent(
+  component: VectorShapeComponent,
+  offset: Readonly<{ x: number; y: number }>,
+  scaleX: number,
+  scaleY: number
+): VectorShapeComponent {
+  return {
+    ...component,
+    subpathsEmu: component.subpathsEmu.map((path) =>
+      path.map((point) => ({
+        x: offset.x + point.x * scaleX,
+        y: offset.y + point.y * scaleY,
+      }))
+    ),
+    strokeWidthEmu: component.strokeWidthEmu * ((Math.abs(scaleX) + Math.abs(scaleY)) / 2),
+  };
+}
+
+function childTransform(wsp: OoxmlElement): {
+  readonly offset: Readonly<{ x: number; y: number }>;
+  readonly extent: Readonly<{ cx: number; cy: number }>;
+} | null {
+  const spPr = findDirectChild(wsp.children, {
+    namespaceUri: WPS_NAMESPACE_URI,
+    localName: 'spPr',
+  });
+  const xfrm = spPr
+    ? findDirectChild(spPr.children, {
+        namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+        localName: 'xfrm',
+      })
+    : null;
+  const off = xfrm
+    ? findDirectChild(xfrm.children, {
+        namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+        localName: 'off',
+      })
+    : null;
+  const ext = xfrm
+    ? findDirectChild(xfrm.children, {
+        namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+        localName: 'ext',
+      })
+    : null;
+  const cx = ext ? parseEmu(schemaAttributeValue(ext.attributes, 'cx')) : null;
+  const cy = ext ? parseEmu(schemaAttributeValue(ext.attributes, 'cy')) : null;
+  if (cx === null || cy === null || cx <= 0 || cy <= 0) return null;
+  return {
+    offset: {
+      x: off ? (parseEmu(schemaAttributeValue(off.attributes, 'x'), false) ?? 0) : 0,
+      y: off ? (parseEmu(schemaAttributeValue(off.attributes, 'y'), false) ?? 0) : 0,
+    },
+    extent: { cx, cy },
+  };
+}
+
+/**
+ * Renderable-subset projection of direct `wps:wsp` and one bounded `wpg:wgp` group.
+ */
+export function projectVectorShape(
+  anchor: OoxmlElement,
+  extent: Readonly<{ cx: number; cy: number }>,
+  compatibilityMode: boolean,
+  resolveSchemeColor?: ShapeSchemeColorResolver,
+  resolveStyleMatrixReference?: ShapeStyleMatrixResolver
+): VectorShapeProjection | null {
+  void compatibilityMode;
+  if (extent.cx <= 0 || extent.cy <= 0) return null;
+  const pointBudget = { remaining: MAX_VECTOR_SHAPE_POINTS };
+  const wsp = findWspInAnchor(anchor);
+  let components: VectorShapeComponent[] = [];
+  if (wsp) {
+    const component = projectWspComponent(
+      wsp,
+      extent,
+      pointBudget,
+      resolveSchemeColor,
+      resolveStyleMatrixReference
+    );
+    if (!component) return null;
+    components = [component];
+  } else {
+    const data = findGraphicData(anchor);
+    if (!data || schemaAttributeValue(data.attributes, 'uri') !== WPG_GRAPHIC_DATA_URI) return null;
+    const group = findDirectChild(data.children, {
+      namespaceUri: WPG_NAMESPACE_URI,
+      localName: 'wgp',
+    });
+    const groupProperties = group
+      ? findDirectChild(group.children, {
+          namespaceUri: WPG_NAMESPACE_URI,
+          localName: 'grpSpPr',
+        })
+      : null;
+    const xfrm = groupProperties
+      ? findDirectChild(groupProperties.children, {
+          namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+          localName: 'xfrm',
+        })
+      : null;
+    const childOffset = xfrm
+      ? findDirectChild(xfrm.children, {
+          namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+          localName: 'chOff',
+        })
+      : null;
+    const childExtent = xfrm
+      ? findDirectChild(xfrm.children, {
+          namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+          localName: 'chExt',
+        })
+      : null;
+    if (!group || !childExtent) return null;
+    if (xfrm) {
+      const rotation = schemaAttributeValue(xfrm.attributes, 'rot');
+      const flipHorizontal = schemaAttributeValue(xfrm.attributes, 'flipH');
+      const flipVertical = schemaAttributeValue(xfrm.attributes, 'flipV');
+      if (rotation !== undefined && rotation !== '0') return null;
+      if (flipHorizontal === '1' || flipHorizontal === 'true') return null;
+      if (flipVertical === '1' || flipVertical === 'true') return null;
+    }
+    const chOffX = childOffset
+      ? (parseEmu(schemaAttributeValue(childOffset.attributes, 'x'), false) ?? 0)
+      : 0;
+    const chOffY = childOffset
+      ? (parseEmu(schemaAttributeValue(childOffset.attributes, 'y'), false) ?? 0)
+      : 0;
+    const chExtX = parseEmu(schemaAttributeValue(childExtent.attributes, 'cx'));
+    const chExtY = parseEmu(schemaAttributeValue(childExtent.attributes, 'cy'));
+    if (chExtX === null || chExtY === null || chExtX <= 0 || chExtY <= 0) return null;
+    let childCount = 0;
+    for (const child of group.children) {
+      if (!isElement(child)) continue;
+      if (
+        child.namespaceUri === WPG_NAMESPACE_URI &&
+        (child.localName === 'cNvPr' ||
+          child.localName === 'cNvGrpSpPr' ||
+          child.localName === 'grpSpPr')
+      ) {
+        continue;
+      }
+      // One group level is the enforced nesting cap. Do not paint a partial nested group.
+      if (child.namespaceUri !== WPS_NAMESPACE_URI || child.localName !== 'wsp') return null;
+      childCount += 1;
+      if (childCount > MAX_GROUP_SHAPE_CHILDREN) return null;
+      const transform = childTransform(child);
+      if (!transform) return null;
+      const component = projectWspComponent(
+        child,
+        transform.extent,
+        pointBudget,
+        resolveSchemeColor,
+        resolveStyleMatrixReference
+      );
+      if (!component) return null;
+      components.push(
+        transformComponent(
+          component,
+          {
+            x: ((transform.offset.x - chOffX) * extent.cx) / chExtX,
+            y: ((transform.offset.y - chOffY) * extent.cy) / chExtY,
+          },
+          extent.cx / chExtX,
+          extent.cy / chExtY
+        )
+      );
+    }
+    if (components.length === 0) return null;
+  }
+  const subpathsEmu: (readonly Readonly<{ x: number; y: number }>[])[] = [];
+  for (const component of components) {
+    for (const path of component.subpathsEmu) subpathsEmu.push(path);
+  }
+  const first = components.length === 1 ? components[0]! : null;
+  return {
+    extentEmu: { cx: extent.cx, cy: extent.cy },
+    subpathsEmu,
+    fillHex: first?.fillHex ?? null,
+    fillAlpha: first?.fillAlpha ?? 1,
+    strokeHex: first?.strokeHex ?? null,
+    strokeAlpha: first?.strokeAlpha ?? 1,
+    strokeWidthEmu: first?.strokeWidthEmu ?? 0,
+    components,
   };
 }
 
@@ -280,7 +761,9 @@ const DEFAULT_TEXTBOX_INSET_TB_EMU = 45_720;
  */
 export function projectTextboxStory(
   anchor: OoxmlElement,
-  extent: Readonly<{ cx: number; cy: number }>
+  extent: Readonly<{ cx: number; cy: number }>,
+  resolveSchemeColor?: ShapeSchemeColorResolver,
+  resolveStyleMatrixReference?: ShapeStyleMatrixResolver
 ): TextboxStoryProjection | null {
   if (extent.cx <= 0 || extent.cy <= 0) return null;
   const wsp = findWspInAnchor(anchor);
@@ -332,16 +815,32 @@ export function projectTextboxStory(
     namespaceUri: WPS_NAMESPACE_URI,
     localName: 'spPr',
   });
-  const fillHex = spPr ? readSolidFillHex(spPr) : null;
+  const authoredFill = spPr ? directFill(spPr, resolveSchemeColor) : null;
+  const styleFill =
+    authoredFill?.present === true
+      ? null
+      : readStyleReference(wsp, 'fillRef', resolveSchemeColor, resolveStyleMatrixReference);
+  const fillHex =
+    (authoredFill?.present === true ? authoredFill.color?.hex : styleFill?.color.hex) ?? null;
   const ln = spPr
     ? findDirectChild(spPr.children, {
         namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
         localName: 'ln',
       })
     : null;
-  const strokeHex = ln ? readSolidFillHex(ln) : null;
+  const authoredStroke = ln ? directFill(ln, resolveSchemeColor) : null;
+  const styleStroke =
+    authoredStroke?.present === true
+      ? null
+      : readStyleReference(wsp, 'lnRef', resolveSchemeColor, resolveStyleMatrixReference);
+  const strokeHex =
+    (authoredStroke?.present === true ? authoredStroke.color?.hex : styleStroke?.color.hex) ?? null;
   const strokeWidthEmu =
-    strokeHex !== null ? (parseEmu(schemaAttributeValue(ln!.attributes, 'w')) ?? 12_700) : 0;
+    strokeHex !== null
+      ? ((ln ? parseEmu(schemaAttributeValue(ln.attributes, 'w')) : null) ??
+        styleStroke?.strokeWidthEmu ??
+        12_700)
+      : 0;
 
   return {
     contentNodeId: content.id,

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -145,22 +145,31 @@ export const MAX_SVG_ROOT_SCAN_BYTES = 8192;
 const DEFAULT_SVG_INTRINSIC_WIDTH = 300;
 const DEFAULT_SVG_INTRINSIC_HEIGHT = 150;
 
-const CONTENT_TYPE_TO_MIME: Readonly<Record<string, RenderableImageMime | PreservedImageMime>> =
-  Object.freeze({
-    'image/png': 'image/png',
-    'image/jpeg': 'image/jpeg',
-    'image/jpg': 'image/jpeg',
-    'image/gif': 'image/gif',
+// A Map, not an object literal: the key is a `[Content_Types].xml` value the sender controls,
+// and this is the upstream of the `mime` that reaches paint's format label.
+//
+// No exploit reaches it today, and the reason is worth recording so nobody relaxes the wrong
+// guard later: `readContentTypes` refuses anything that is not `type/subtype`
+// (`MIME_ESSENCE_RE` in content-types.ts) and fails the whole package with
+// `bad-content-types`, and no member of `Object.prototype` contains a slash. The Map removes
+// the hazard at the source instead of depending on that coincidence holding.
+const CONTENT_TYPE_TO_MIME: ReadonlyMap<string, RenderableImageMime | PreservedImageMime> = new Map(
+  [
+    ['image/png', 'image/png'],
+    ['image/jpeg', 'image/jpeg'],
+    ['image/jpg', 'image/jpeg'],
+    ['image/gif', 'image/gif'],
     // `image/bmp` is the registered type; Word and older producers also write these two.
-    'image/bmp': 'image/bmp',
-    'image/x-ms-bmp': 'image/bmp',
-    'image/x-bmp': 'image/bmp',
-    'image/webp': 'image/webp',
-    'image/svg+xml': 'image/svg+xml',
-    'image/tiff': 'image/tiff',
-    'image/x-emf': 'image/x-emf',
-    'image/x-wmf': 'image/x-wmf',
-  });
+    ['image/bmp', 'image/bmp'],
+    ['image/x-ms-bmp', 'image/bmp'],
+    ['image/x-bmp', 'image/bmp'],
+    ['image/webp', 'image/webp'],
+    ['image/svg+xml', 'image/svg+xml'],
+    ['image/tiff', 'image/tiff'],
+    ['image/x-emf', 'image/x-emf'],
+    ['image/x-wmf', 'image/x-wmf'],
+  ]
+);
 
 /** A raster header that passed structural validation: its real MIME type and pixel extent. */
 export interface ValidatedRasterHeader {
@@ -720,7 +729,7 @@ function claimedMimeForPart(
 ): RenderableImageMime | PreservedImageMime | 'unknown' {
   const resolved = resolveContentType(pkg.contentTypes, partName);
   if (!resolved.ok) return 'unknown';
-  return CONTENT_TYPE_TO_MIME[resolved.contentType.toLowerCase()] ?? 'unknown';
+  return CONTENT_TYPE_TO_MIME.get(resolved.contentType.toLowerCase()) ?? 'unknown';
 }
 
 function snapshotBytes(bytes: Uint8Array): Uint8Array {

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -536,17 +536,30 @@ export function validateTiffHeader(bytes: Uint8Array): ValidatedRasterHeader | n
   return { pixelWidth, pixelHeight };
 }
 
-/** CSS absolute length units, in CSS pixels. Percentages are not intrinsic and are refused. */
-const CSS_ABSOLUTE_UNIT_PX: Readonly<Record<string, number>> = Object.freeze({
-  '': 1,
-  px: 1,
-  pt: 96 / 72,
-  pc: 16,
-  in: 96,
-  cm: 96 / 2.54,
-  mm: 96 / 25.4,
-  q: 96 / 101.6,
-});
+/**
+ * CSS absolute length units, in CSS pixels. Percentages are not intrinsic and are refused.
+ *
+ * A Map, not an object literal. Unlike the content-type lookup above, this key IS reachable
+ * from file content — it is the unit suffix of an embedded SVG's root `width`/`height`, so
+ * `width="1constructor"` indexed the literal to `Object` and sailed past the
+ * `scale === undefined` guard.
+ *
+ * No input changes its answer either way, and that is worth stating rather than implying a
+ * fix that is not one: every member of `Object.prototype` is a function or an object, so
+ * `number * scale` is always `NaN` and the finiteness check below already returns null. The
+ * Map removes a read that only luck made safe, so a later edit to that check cannot turn it
+ * into a live defect.
+ */
+const CSS_ABSOLUTE_UNIT_PX: ReadonlyMap<string, number> = new Map([
+  ['', 1],
+  ['px', 1],
+  ['pt', 96 / 72],
+  ['pc', 16],
+  ['in', 96],
+  ['cm', 96 / 2.54],
+  ['mm', 96 / 25.4],
+  ['q', 96 / 101.6],
+]);
 
 /** A CSS absolute length in px, or null for a percentage, a bad unit, or a non-number. */
 function parseCssAbsoluteLength(raw: string): number | null {
@@ -572,7 +585,7 @@ function parseCssAbsoluteLength(raw: string): number | null {
     }
     if (digits > 0) index = scan;
   }
-  const scale = CSS_ABSOLUTE_UNIT_PX[value.slice(index).trim().toLowerCase()];
+  const scale = CSS_ABSOLUTE_UNIT_PX.get(value.slice(index).trim().toLowerCase());
   if (scale === undefined) return null;
   const px = number * scale;
   return Number.isFinite(px) && px > 0 ? px : null;

--- a/packages/core/src/store/package/theme-color-resolution.ts
+++ b/packages/core/src/store/package/theme-color-resolution.ts
@@ -13,52 +13,58 @@ const THEME_RELATIONSHIP =
 const SETTINGS_RELATIONSHIP =
   'http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings';
 const HEX = /^[0-9A-Fa-f]{6}$/;
-const SYSTEM_COLORS: Readonly<Record<string, string>> = Object.freeze({
-  window: 'FFFFFF',
-  windowText: '000000',
-});
-const DEFAULT_MAPPING: Readonly<Record<string, string>> = Object.freeze({
-  bg1: 'lt1',
-  tx1: 'dk1',
-  bg2: 'lt2',
-  tx2: 'dk2',
-  accent1: 'accent1',
-  accent2: 'accent2',
-  accent3: 'accent3',
-  accent4: 'accent4',
-  accent5: 'accent5',
-  accent6: 'accent6',
-  hlink: 'hlink',
-  folHlink: 'folHlink',
-});
-const MAPPING_ATTRIBUTE_TO_TOKEN: Readonly<Record<string, string>> = Object.freeze({
-  bg1: 'bg1',
-  t1: 'tx1',
-  bg2: 'bg2',
-  t2: 'tx2',
-  accent1: 'accent1',
-  accent2: 'accent2',
-  accent3: 'accent3',
-  accent4: 'accent4',
-  accent5: 'accent5',
-  accent6: 'accent6',
-  hyperlink: 'hlink',
-  followedHyperlink: 'folHlink',
-});
-const MAPPING_VALUE_TO_SLOT: Readonly<Record<string, string>> = Object.freeze({
-  dark1: 'dk1',
-  light1: 'lt1',
-  dark2: 'dk2',
-  light2: 'lt2',
-  accent1: 'accent1',
-  accent2: 'accent2',
-  accent3: 'accent3',
-  accent4: 'accent4',
-  accent5: 'accent5',
-  accent6: 'accent6',
-  hyperlink: 'hlink',
-  followedHyperlink: 'folHlink',
-});
+/** Entries a `fmtScheme` style list may hold; a reference past it resolves to nothing. */
+const MAX_STYLE_MATRIX_ENTRIES = 16;
+// Every key below is looked up with a value out of `theme*.xml` or `settings.xml`, which
+// the sender controls. These are Maps, not object literals, so a `val` of `__proto__` or
+// `constructor` answers undefined instead of reaching a prototype member — the same reason
+// `SYSTEM_COLORS` used to need `hasOwnProperty`.
+const SYSTEM_COLORS: ReadonlyMap<string, string> = new Map([
+  ['window', 'FFFFFF'],
+  ['windowText', '000000'],
+]);
+const DEFAULT_MAPPING: ReadonlyMap<string, string> = new Map([
+  ['bg1', 'lt1'],
+  ['tx1', 'dk1'],
+  ['bg2', 'lt2'],
+  ['tx2', 'dk2'],
+  ['accent1', 'accent1'],
+  ['accent2', 'accent2'],
+  ['accent3', 'accent3'],
+  ['accent4', 'accent4'],
+  ['accent5', 'accent5'],
+  ['accent6', 'accent6'],
+  ['hlink', 'hlink'],
+  ['folHlink', 'folHlink'],
+]);
+const MAPPING_ATTRIBUTE_TO_TOKEN: ReadonlyMap<string, string> = new Map([
+  ['bg1', 'bg1'],
+  ['t1', 'tx1'],
+  ['bg2', 'bg2'],
+  ['t2', 'tx2'],
+  ['accent1', 'accent1'],
+  ['accent2', 'accent2'],
+  ['accent3', 'accent3'],
+  ['accent4', 'accent4'],
+  ['accent5', 'accent5'],
+  ['accent6', 'accent6'],
+  ['hyperlink', 'hlink'],
+  ['followedHyperlink', 'folHlink'],
+]);
+const MAPPING_VALUE_TO_SLOT: ReadonlyMap<string, string> = new Map([
+  ['dark1', 'dk1'],
+  ['light1', 'lt1'],
+  ['dark2', 'dk2'],
+  ['light2', 'lt2'],
+  ['accent1', 'accent1'],
+  ['accent2', 'accent2'],
+  ['accent3', 'accent3'],
+  ['accent4', 'accent4'],
+  ['accent5', 'accent5'],
+  ['accent6', 'accent6'],
+  ['hyperlink', 'hlink'],
+  ['followedHyperlink', 'folHlink'],
+]);
 
 export type ShapeStyleMatrixKind = 'fill' | 'line';
 
@@ -168,11 +174,7 @@ function colorHex(slot: OoxmlGenericElementNode): string | null {
     value = attribute(color, DRAWINGML_MAIN_NAMESPACE_URI, 'val');
   } else if (color.localName === 'sysClr') {
     const system = attribute(color, DRAWINGML_MAIN_NAMESPACE_URI, 'val') ?? '';
-    value =
-      attribute(color, DRAWINGML_MAIN_NAMESPACE_URI, 'lastClr') ??
-      (Object.prototype.hasOwnProperty.call(SYSTEM_COLORS, system)
-        ? SYSTEM_COLORS[system]
-        : undefined);
+    value = attribute(color, DRAWINGML_MAIN_NAMESPACE_URI, 'lastClr') ?? SYSTEM_COLORS.get(system);
   }
   return value && HEX.test(value) ? value.toUpperCase() : null;
 }
@@ -201,15 +203,15 @@ export function createPackageShapeThemeResolvers(pkg: OoxmlPackage): PackageShap
   const theme = relatedRoot(pkg, THEME_RELATIONSHIP, '/word/theme/theme1.xml');
   const settings = relatedRoot(pkg, SETTINGS_RELATIONSHIP, '/word/settings.xml');
   const colors = collectThemeColorScheme(theme);
-  const mapping = new Map<string, string>(Object.entries(DEFAULT_MAPPING));
+  const mapping = new Map<string, string>(DEFAULT_MAPPING);
   const mappingNode = settings
     ? firstDescendant(settings, WML_NAMESPACE_URI, 'clrSchemeMapping')
     : null;
   if (mappingNode) {
     for (const entry of mappingNode.attributes) {
       if (entry.namespaceUri !== WML_NAMESPACE_URI) continue;
-      const token = MAPPING_ATTRIBUTE_TO_TOKEN[entry.localName];
-      const slot = MAPPING_VALUE_TO_SLOT[entry.value];
+      const token = MAPPING_ATTRIBUTE_TO_TOKEN.get(entry.localName);
+      const slot = MAPPING_VALUE_TO_SLOT.get(entry.value);
       if (!token || !slot) continue;
       mapping.set(token, slot);
     }
@@ -221,19 +223,26 @@ export function createPackageShapeThemeResolvers(pkg: OoxmlPackage): PackageShap
     kind: ShapeStyleMatrixKind,
     index: number
   ): { readonly list: OoxmlElement; readonly offset: number } | null => {
-    if (!formatScheme || !Number.isSafeInteger(index) || index <= 0 || index > 1016) return null;
-    if (kind === 'line') {
-      const list = directGeneric(formatScheme, DRAWINGML_MAIN_NAMESPACE_URI, 'lnStyleLst');
-      return list && index <= 16 ? { list, offset: index - 1 } : null;
-    }
-    const background = index >= 1001;
+    if (!formatScheme) return null;
+    // ECMA-376 20.1.4.1.19/20.1.4.1.24: the index is 1-based into the matching style list,
+    // and a fill index of 1001 or more selects the background list from 1001.
+    const background = kind === 'fill' && index >= 1001;
     const list = directGeneric(
       formatScheme,
       DRAWINGML_MAIN_NAMESPACE_URI,
-      background ? 'bgFillStyleLst' : 'fillStyleLst'
+      kind === 'line' ? 'lnStyleLst' : background ? 'bgFillStyleLst' : 'fillStyleLst'
     );
+    // One total bound, for both lists and both bases: a negative, fractional, huge or NaN
+    // index fails it too. Only the ceiling is observable through the entry walk below — the
+    // walk answers null for any offset it cannot reach — so a second, narrower ceiling
+    // beside this one would be a bound with nothing to hold it in step.
     const offset = background ? index - 1001 : index - 1;
-    return list && offset >= 0 && offset < 16 ? { list, offset } : null;
+    const usable =
+      list !== null &&
+      Number.isSafeInteger(offset) &&
+      offset >= 0 &&
+      offset < MAX_STYLE_MATRIX_ENTRIES;
+    return usable ? { list: list!, offset } : null;
   };
   const result: PackageShapeThemeResolvers = Object.freeze({
     resolveSchemeColor: (token: string): string | null => {

--- a/packages/core/src/store/package/theme-color-resolution.ts
+++ b/packages/core/src/store/package/theme-color-resolution.ts
@@ -1,0 +1,261 @@
+import { resolveRelationship } from './relationships.ts';
+import type { OoxmlPackage } from './ooxml-package.ts';
+import {
+  DRAWINGML_MAIN_NAMESPACE_URI,
+  type OoxmlElement,
+  type OoxmlGenericElementNode,
+  type OoxmlNode,
+} from './ooxml-tree.ts';
+import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
+
+const THEME_RELATIONSHIP =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme';
+const SETTINGS_RELATIONSHIP =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings';
+const HEX = /^[0-9A-Fa-f]{6}$/;
+const SYSTEM_COLORS: Readonly<Record<string, string>> = Object.freeze({
+  window: 'FFFFFF',
+  windowText: '000000',
+});
+const DEFAULT_MAPPING: Readonly<Record<string, string>> = Object.freeze({
+  bg1: 'lt1',
+  tx1: 'dk1',
+  bg2: 'lt2',
+  tx2: 'dk2',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hlink: 'hlink',
+  folHlink: 'folHlink',
+});
+const MAPPING_ATTRIBUTE_TO_TOKEN: Readonly<Record<string, string>> = Object.freeze({
+  bg1: 'bg1',
+  t1: 'tx1',
+  bg2: 'bg2',
+  t2: 'tx2',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hyperlink: 'hlink',
+  followedHyperlink: 'folHlink',
+});
+const MAPPING_VALUE_TO_SLOT: Readonly<Record<string, string>> = Object.freeze({
+  dark1: 'dk1',
+  light1: 'lt1',
+  dark2: 'dk2',
+  light2: 'lt2',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hyperlink: 'hlink',
+  followedHyperlink: 'folHlink',
+});
+
+export type ShapeStyleMatrixKind = 'fill' | 'line';
+
+export interface PackageShapeThemeResolvers {
+  readonly resolveSchemeColor: (scheme: string) => string | null;
+  readonly resolveStyleMatrixReference: (
+    kind: ShapeStyleMatrixKind,
+    index: number
+  ) => OoxmlElement | null;
+  readonly cacheToken: string;
+}
+const PACKAGE_THEME_CACHE = new WeakMap<OoxmlPackage, PackageShapeThemeResolvers>();
+const THEME_ROOT_IDS = new WeakMap<OoxmlElement, number>();
+let nextThemeRootId = 1;
+
+function rootIdentity(root: OoxmlElement | null): number {
+  if (!root) return 0;
+  const existing = THEME_ROOT_IDS.get(root);
+  if (existing !== undefined) return existing;
+  const id = nextThemeRootId;
+  nextThemeRootId += 1;
+  THEME_ROOT_IDS.set(root, id);
+  return id;
+}
+
+const element = (node: OoxmlNode): node is OoxmlElement => node.kind !== 'textValue';
+const genericElement = (node: OoxmlNode): node is OoxmlGenericElementNode =>
+  element(node) && 'namespaceUri' in node && 'localName' in node;
+
+function attribute(
+  node: OoxmlElement,
+  namespaceUri: string,
+  localName: string
+): string | undefined {
+  return node.attributes.find(
+    (entry) =>
+      entry.localName === localName &&
+      (entry.namespaceUri === namespaceUri || entry.namespaceUri === '')
+  )?.value;
+}
+
+function firstDescendant(
+  root: OoxmlElement,
+  namespaceUri: string,
+  localName: string
+): OoxmlGenericElementNode | null {
+  const stack: OoxmlElement[] = [root];
+  let visited = 0;
+  while (stack.length > 0 && visited < 4096) {
+    const node = stack.pop()!;
+    visited += 1;
+    if (
+      genericElement(node) &&
+      node.namespaceUri === namespaceUri &&
+      node.localName === localName
+    ) {
+      return node;
+    }
+    for (let index = node.children.length - 1; index >= 0; index -= 1) {
+      const child = node.children[index]!;
+      if (element(child)) stack.push(child);
+    }
+  }
+  return null;
+}
+
+function directGeneric(
+  parent: OoxmlElement,
+  namespaceUri: string,
+  localName: string
+): OoxmlGenericElementNode | null {
+  for (const child of parent.children) {
+    if (
+      genericElement(child) &&
+      child.namespaceUri === namespaceUri &&
+      child.localName === localName
+    ) {
+      return child;
+    }
+  }
+  return null;
+}
+
+function relatedRoot(
+  pkg: OoxmlPackage,
+  relationshipType: string,
+  fallbackName: string
+): OoxmlElement | null {
+  const record = (pkg.relationships.get(pkg.mainDocumentPart) ?? []).find(
+    (candidate) => candidate.type === relationshipType
+  );
+  if (record) {
+    const resolved = resolveRelationship(record);
+    if (resolved.mode === 'Internal' && resolved.target.ok) {
+      const part = pkg.parts.get(resolved.target.partName);
+      if (part) return part.root;
+    }
+  }
+  return pkg.parts.get(fallbackName)?.root ?? null;
+}
+
+function colorHex(slot: OoxmlGenericElementNode): string | null {
+  const color = slot.children.find(genericElement);
+  if (!color || color.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) return null;
+  let value: string | undefined;
+  if (color.localName === 'srgbClr') {
+    value = attribute(color, DRAWINGML_MAIN_NAMESPACE_URI, 'val');
+  } else if (color.localName === 'sysClr') {
+    const system = attribute(color, DRAWINGML_MAIN_NAMESPACE_URI, 'val') ?? '';
+    value =
+      attribute(color, DRAWINGML_MAIN_NAMESPACE_URI, 'lastClr') ??
+      (Object.prototype.hasOwnProperty.call(SYSTEM_COLORS, system)
+        ? SYSTEM_COLORS[system]
+        : undefined);
+  }
+  return value && HEX.test(value) ? value.toUpperCase() : null;
+}
+
+/** Read validated base colours from one DrawingML theme colour scheme. */
+export function collectThemeColorScheme(
+  themeRoot: OoxmlElement | null
+): ReadonlyMap<string, string> {
+  const scheme = themeRoot
+    ? firstDescendant(themeRoot, DRAWINGML_MAIN_NAMESPACE_URI, 'clrScheme')
+    : null;
+  const colors = new Map<string, string>();
+  if (!scheme) return colors;
+  for (const child of scheme.children) {
+    if (!genericElement(child) || child.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) continue;
+    const hex = colorHex(child);
+    if (hex) colors.set(child.localName, hex);
+  }
+  return colors;
+}
+
+/** Resolve theme colours and style-matrix entries from one immutable package snapshot. */
+export function createPackageShapeThemeResolvers(pkg: OoxmlPackage): PackageShapeThemeResolvers {
+  const cached = PACKAGE_THEME_CACHE.get(pkg);
+  if (cached) return cached;
+  const theme = relatedRoot(pkg, THEME_RELATIONSHIP, '/word/theme/theme1.xml');
+  const settings = relatedRoot(pkg, SETTINGS_RELATIONSHIP, '/word/settings.xml');
+  const colors = collectThemeColorScheme(theme);
+  const mapping = new Map<string, string>(Object.entries(DEFAULT_MAPPING));
+  const mappingNode = settings
+    ? firstDescendant(settings, WML_NAMESPACE_URI, 'clrSchemeMapping')
+    : null;
+  if (mappingNode) {
+    for (const entry of mappingNode.attributes) {
+      if (entry.namespaceUri !== WML_NAMESPACE_URI) continue;
+      const token = MAPPING_ATTRIBUTE_TO_TOKEN[entry.localName];
+      const slot = MAPPING_VALUE_TO_SLOT[entry.value];
+      if (!token || !slot) continue;
+      mapping.set(token, slot);
+    }
+  }
+  const formatScheme = theme
+    ? firstDescendant(theme, DRAWINGML_MAIN_NAMESPACE_URI, 'fmtScheme')
+    : null;
+  const styleList = (
+    kind: ShapeStyleMatrixKind,
+    index: number
+  ): { readonly list: OoxmlElement; readonly offset: number } | null => {
+    if (!formatScheme || !Number.isSafeInteger(index) || index <= 0 || index > 1016) return null;
+    if (kind === 'line') {
+      const list = directGeneric(formatScheme, DRAWINGML_MAIN_NAMESPACE_URI, 'lnStyleLst');
+      return list && index <= 16 ? { list, offset: index - 1 } : null;
+    }
+    const background = index >= 1001;
+    const list = directGeneric(
+      formatScheme,
+      DRAWINGML_MAIN_NAMESPACE_URI,
+      background ? 'bgFillStyleLst' : 'fillStyleLst'
+    );
+    const offset = background ? index - 1001 : index - 1;
+    return list && offset >= 0 && offset < 16 ? { list, offset } : null;
+  };
+  const result: PackageShapeThemeResolvers = Object.freeze({
+    resolveSchemeColor: (token: string): string | null => {
+      const mapped = mapping.get(token) ?? token;
+      return colors.get(mapped) ?? null;
+    },
+    resolveStyleMatrixReference: (
+      kind: ShapeStyleMatrixKind,
+      index: number
+    ): OoxmlElement | null => {
+      const selected = styleList(kind, index);
+      if (!selected) return null;
+      let offset = 0;
+      for (const child of selected.list.children) {
+        if (!genericElement(child)) continue;
+        if (offset === selected.offset) return child;
+        offset += 1;
+      }
+      return null;
+    },
+    cacheToken: `${rootIdentity(theme)}|${rootIdentity(settings)}`,
+  });
+  PACKAGE_THEME_CACHE.set(pkg, result);
+  return result;
+}

--- a/packages/core/src/store/package/theme-color-resolution.ts
+++ b/packages/core/src/store/package/theme-color-resolution.ts
@@ -232,10 +232,11 @@ export function createPackageShapeThemeResolvers(pkg: OoxmlPackage): PackageShap
       DRAWINGML_MAIN_NAMESPACE_URI,
       kind === 'line' ? 'lnStyleLst' : background ? 'bgFillStyleLst' : 'fillStyleLst'
     );
-    // One total bound, for both lists and both bases: a negative, fractional, huge or NaN
-    // index fails it too. Only the ceiling is observable through the entry walk below — the
-    // walk answers null for any offset it cannot reach — so a second, narrower ceiling
-    // beside this one would be a bound with nothing to hold it in step.
+    // One bound, for both lists and both bases. Only the ceiling has a test: the entry walk
+    // below already answers null for any offset it cannot reach, so the floor and the
+    // integer check are defence in depth against a future direct index, not behaviour a
+    // caller can observe today. That is also why there is no second, narrower ceiling — it
+    // would be a bound with nothing to hold it in step.
     const offset = background ? index - 1001 : index - 1;
     const usable =
       list !== null &&


### PR DESCRIPTION
## Summary
- Resolve theme and style-matrix colors for bounded vector shapes and groups. Fixes #508.

## Test plan
- [x] Run the full verification suite and browser editing benchmark.
- [x] Confirm no critical, high, or medium review findings remain.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790470374&installation_model_id=422592&pr_number=549&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F549&signature=b8cfc8a224a08d9fb177e8671a641540f7759962b78fa22cbe584a3b927cfccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->