### PR TITLE
fix: restack inserted note overflow sheets

### DIFF
--- a/.changeset/clean-notes-stack.md
+++ b/.changeset/clean-notes-stack.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep note overflow sheets in separate page rectangles after insertion. Fixes #513.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -689,7 +689,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Both adapters have a typed note model, note layout (pageBottom, beneathText, sectEnd, docEnd), scoped note editing, insert, delete, convert, and chrome slots. Editing inside a note matches the body: lists, tables, content controls, pictures, fonts, comments, bookmarks, and page setup. Tracked note inserts and notes in headers and footers are out of scope.',
+      'Both adapters have a typed note model, note layout (pageBottom, beneathText, sectEnd, docEnd), scoped note editing, insert, delete, convert, and chrome slots. Overflow sheets retain separate page rectangles for painting and hit testing. Editing inside a note matches the body: lists, tables, content controls, pictures, fonts, comments, bookmarks, and page setup. Tracked note inserts and notes in headers and footers are out of scope.',
   },
   {
     id: 'layout.columns',

--- a/packages/core/src/layout/__tests__/note-overflow-page-insets.test.ts
+++ b/packages/core/src/layout/__tests__/note-overflow-page-insets.test.ts
@@ -20,6 +20,7 @@ import { layoutSemanticDocument } from '../semantic-layout.ts';
 import { layoutHeaderFooterStory } from '../hf-layout.ts';
 import { enumerateDocumentSections, geometryOfSection } from '../index.ts';
 import type { NotesLayoutInput } from '../note-pagination.ts';
+import { SHEET_GUTTER_PT } from '../section-page-furniture.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -125,6 +126,14 @@ describe('note overflow sheets on a title-page section', () => {
 
     const drain = layout.pages.filter((page) => page.noteStream === 'footnote-drain');
     expect(drain.length).toBeGreaterThan(0);
+    expect(new Set(layout.pages.map((page) => page.box.y)).size).toBe(layout.pages.length);
+    for (let index = 1; index < layout.pages.length; index += 1) {
+      const previous = layout.pages[index - 1]!;
+      expect(layout.pages[index]!.box.y).toBeCloseTo(
+        previous.box.y + previous.box.height + SHEET_GUTTER_PT,
+        6
+      );
+    }
     for (const page of drain) {
       // The box AND the furniture come from the same variant. Taking one without the other
       // paints an empty band exactly a header high.

--- a/packages/core/src/layout/multi-section-layout.ts
+++ b/packages/core/src/layout/multi-section-layout.ts
@@ -36,6 +36,7 @@ import {
   type OverflowPageShell,
   type PageContentInsets,
 } from './page-furniture-insets.ts';
+import { SHEET_GUTTER_PT } from './section-page-furniture.ts';
 
 export interface SectionLayoutResult {
   readonly layout: SemanticLayout;
@@ -561,7 +562,7 @@ export function layoutMultiSectionDocument(
       for (const page of laid.pages.slice(1)) {
         const next = remapPage(page, pages.length + built.length, sheetY);
         built.push(next);
-        sheetY = next.box.y + next.box.height + 24;
+        sheetY = next.box.y + next.box.height + SHEET_GUTTER_PT;
       }
       // Local page 0 lived on the host; overflow pages start at displayedStart + 1.
       // SECTIONPAGES counts the host contribution plus overflow sheets.
@@ -578,7 +579,7 @@ export function layoutMultiSectionDocument(
       for (const page of remapped) {
         pages.push(page);
         remappedAll.push(page);
-        sheetY = page.box.y + page.box.height + 24;
+        sheetY = page.box.y + page.box.height + SHEET_GUTTER_PT;
       }
       nextDisplayed = displayedStart + remapped.length;
     } else {
@@ -593,7 +594,7 @@ export function layoutMultiSectionDocument(
           format
         );
         built.push(next);
-        sheetY = next.box.y + next.box.height + 24;
+        sheetY = next.box.y + next.box.height + SHEET_GUTTER_PT;
       }
       remapped = built;
       for (const page of remapped) {

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -45,6 +45,7 @@ import {
   type LayoutNoteStoryOptions,
 } from './note-layout.ts';
 import { noteMarkKey, type NoteMarkContext } from './note-projection.ts';
+import { reindexAndRestackPages } from './page-restacking.ts';
 import type {
   BlockFragmentRecord,
   LineRecord,
@@ -1627,20 +1628,13 @@ function sectionEndInsertBound(
   return pages.length;
 }
 
-function reindexPages(pages: readonly PageRecord[]): PageRecord[] {
-  return pages.map((page, index) => {
-    if (page.index === index && page.id === `page-${index}`) return page;
-    return { ...page, id: `page-${index}`, index };
-  });
-}
-
 /**
  * After note overflow insertion, reindex sheets and re-project allowlisted PAGE fields.
  * Inserted overflow pages already carry a `pageFieldSource` cloned from the section template;
  * document-level NUMPAGES and furniture text need finalize against the new page count.
  */
 function reindexAndFinalizeFields(pages: readonly PageRecord[]): PageRecord[] {
-  const reindexed = reindexPages(pages);
+  const reindexed = reindexAndRestackPages(pages);
   return [...finalizePageFieldProjection({ revision: 0, pages: reindexed }).pages];
 }
 

--- a/packages/core/src/layout/page-restacking.ts
+++ b/packages/core/src/layout/page-restacking.ts
@@ -1,0 +1,15 @@
+import { remapPage } from './hf-layout.ts';
+import { SHEET_GUTTER_PT } from './section-page-furniture.ts';
+import type { PageRecord } from './semantic-records.ts';
+
+/** Reindex pages and move every absolute page box into one non-overlapping sheet stack. */
+export function reindexAndRestackPages(pages: readonly PageRecord[]): PageRecord[] {
+  let sheetY = 0;
+  return pages.map((page, index) => {
+    const id = `page-${index}`;
+    const unchanged = page.index === index && page.id === id && page.box.y === sheetY;
+    const reindexed = unchanged ? page : remapPage(page, index, sheetY);
+    sheetY += page.box.height + SHEET_GUTTER_PT;
+    return reindexed;
+  });
+}

--- a/packages/core/src/layout/section-page-furniture.ts
+++ b/packages/core/src/layout/section-page-furniture.ts
@@ -51,7 +51,7 @@ export interface SectionPageFurniture {
 }
 
 /** 24pt gutter between sheets, for the scroll surface. */
-const SHEET_GUTTER_PT = 24;
+export const SHEET_GUTTER_PT = 24;
 
 export function createSectionPageFurniture(
   inputs: SectionPageFurnitureInputs


### PR DESCRIPTION
## Summary
Restack inserted note overflow sheets and their absolute page geometry. Fixes #513.

## Test plan
- [x] Run the full test suite.
- [x] Run lint, type checks, API checks, parity checks, and OpenSpec validation.
- [x] Run the browser edit benchmark.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790471178&installation_model_id=422592&pr_number=550&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F550&signature=ff0baba084b86c445ca6ccf85dd50cbed2e2a4a2c3079968dd240c703d0f1776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->