### PR TITLE
test(core): typecheck collaboration tests

### DIFF
--- a/packages/core/src/collaboration/__tests__/document-port.test.ts
+++ b/packages/core/src/collaboration/__tests__/document-port.test.ts
@@ -5,6 +5,7 @@ import { normalizeParagraphIdentity, paraIdOf } from '../../store/package/para-i
 import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
 import { TreePackageStore } from '../../store/store/tree-package-store.ts';
 import { ORIGIN_IDS } from '../../store/registry/frozen-ids.ts';
+import type { CollaborationApplyResult } from '../replication.ts';
 
 function bytesWithParagraphIds(ids: readonly (string | null)[]): Uint8Array {
   const paragraphs = ids
@@ -117,7 +118,7 @@ describe('canonical collaboration document port', () => {
       actorId: 'bob',
       operationId: 'bob-bad-id-1',
     };
-    const refused = { ok: false, reason: 'unknown-paragraph-id' };
+    const refused: CollaborationApplyResult = { ok: false, reason: 'unknown-paragraph-id' };
 
     expect(
       port.applyParagraphTexts(

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -36,10 +36,6 @@
     "src/layout/__tests__",
     "src/output/__tests__",
     "src/binding/__tests__",
-    "src/collaboration/__tests__",
-    "src/sync/__tests__",
-    "src/server/__tests__",
-    "src/clients/__tests__",
     "src/editor/__tests__"
   ]
 }


### PR DESCRIPTION
## Summary
Typecheck core collaboration tests and other clean test directories. This is the first staged part of #514.

## Test plan
- [x] Run the full test suite.
- [x] Run lint, type checks, API checks, parity checks, and OpenSpec validation.
- [x] Run the browser edit benchmark.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790471825&installation_model_id=422592&pr_number=551&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F551&signature=11db4fa80060b27d3f0969c80bd309bcdc78caedfb1c1ccb68c3430af277c58e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->