### PR TITLE
test(pro): gate the keystroke ratio on the fixture that can show a regression

### DIFF
--- a/packages/pro/src/collaboration/__tests__/local-keystroke-performance.test.ts
+++ b/packages/pro/src/collaboration/__tests__/local-keystroke-performance.test.ts
@@ -362,11 +362,17 @@ async function measureInsertRatio(bytes: Uint8Array): Promise<{
 describe('local keystroke path with a replica attached', () => {
   test('transact replicates on the commit and strands no journal', async () => {
     const bytes = proseBytes();
-    // Measured and logged, never gated — rule 5. This fixture's commit is ~0.1 ms, so its
-    // ratio reports the fixed Yjs write against a baseline too small to hide it, and three
-    // paragraphs cannot show the O(document) cost the ratio gate is for. The 200-page test
-    // below owns that gate. Keeping the numbers here still pays: a jump in this ratio with
-    // the 200-page ratio flat is what a fixed per-commit regression looks like.
+    // The RATIO here is measured and logged, never gated — rule 5. This fixture's commit is
+    // ~0.1 ms, so its ratio reports the fixed Yjs write against a baseline too small to hide
+    // it, and three paragraphs cannot show the O(document) cost the ratio gate is for. The
+    // 200-page test below owns that gate.
+    //
+    // What this fixture CAN gate is the fixed cost itself, as an absolute number, because a
+    // three-paragraph commit is almost entirely that fixed cost. It gets a loose backstop for
+    // the same reason the 200-page test has one: a wide absolute bound over the block minimum
+    // catches a large regression without pretending to resolve small ones. The bound is wide
+    // on purpose — anything tight enough to be interesting is the sub-millisecond wall-clock
+    // budget rule 5 exists to reject.
     const { solo, attached: insertAttached, blockRatios } = await measureInsertRatio(bytes);
 
     const gestures: readonly {
@@ -455,6 +461,17 @@ describe('local keystroke path with a replica attached', () => {
       );
     }
 
+    // The fixed per-commit cost of attaching, as a wall-clock backstop.
+    //
+    // Derived from measurement, with the margin stated so a later reader can retune it rather
+    // than guess: the fastest attached commit reads 0.13-0.17 ms locally — unmoved by 20-way
+    // CPU contention, because the block minimum discards one-sided noise — and 0.23-0.46 ms
+    // on CI hardware. The bound sits at 4 ms, about 9x the worst figure either machine has
+    // produced, so it cannot flake, and it fails on the regression class the ratio gate
+    // cannot see here: a constant added to every commit, such as re-encoding the whole Yjs
+    // document per keystroke. Small regressions pass this deliberately. Nothing on a
+    // three-paragraph fixture can resolve them without becoming the flake rule 5 removed.
+    const ATTACHED_FIXED_COST_MAX_MS = 4;
     // Log before the gates: a gate that fails without its measurement is not diagnosable.
     console.log(
       JSON.stringify({
@@ -462,12 +479,14 @@ describe('local keystroke path with a replica attached', () => {
         attachedInsert: insertAttached,
         blockRatios,
         blockRatioMin: Math.min(...blockRatios),
+        fixedCostBackstopMs: ATTACHED_FIXED_COST_MAX_MS,
         rows,
       })
     );
     // No gesture may leave a journal waiting, and every gesture must reach Yjs on its commit.
     expect(stranded).toEqual([]);
     expect(silent).toEqual([]);
+    expect(insertAttached.minMs).toBeLessThanOrEqual(ATTACHED_FIXED_COST_MAX_MS);
     expect(rows.length).toBe(gestures.length);
   });
 

--- a/packages/pro/src/collaboration/__tests__/local-keystroke-performance.test.ts
+++ b/packages/pro/src/collaboration/__tests__/local-keystroke-performance.test.ts
@@ -36,6 +36,17 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 //      minimum over back-to-back arms is not enough: each arm's whole sampling window is
 //      only ~10-30 ms, so one load spike covering one arm inflates every round of that
 //      arm, minimum included. CI run #1167 read 2.71x that way on a 1.28x path.
+//   5. Only the 200-page fixture gates the ratio. The cost of attaching is a FIXED per-commit
+//      Yjs encode and write, so the ratio is `1 + fixed / baseline` and the fixture chooses
+//      the denominator. The three-paragraph prose fixture commits in ~0.1 ms against a fixed
+//      cost of ~0.05-0.25 ms, which is 1.7x-3.1x with nothing wrong — it has no headroom
+//      under 2x on any machine, and the term that moves between machines is the one in the
+//      numerator. The 200-page fixture commits in ~0.4 ms and reads 1.2x-1.5x in every block.
+//      The gate exists to catch an O(document) capture cost, and three paragraphs cannot
+//      show one: the prose ratio was gating noise it could not tell from a regression, and
+//      it failed three of three CI runs on main while the 200-page arm passed all three.
+//      The prose arms stay measured and logged, because the ratio is still the diagnostic
+//      that names the fixed cost.
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
@@ -91,6 +102,11 @@ function summarize(values: readonly number[]): {
 
 function ratioPass(blockRatios: readonly number[]): boolean {
   // A pure ratio, with no flat slack, over the best temporally paired block.
+  //
+  // Rule 5 above: only a fixture whose own commit cost dominates the fixed cost of attaching
+  // may be gated on this. On a sub-millisecond baseline the ratio stops being scale-free and
+  // becomes the fixed Yjs write divided by however fast the machine is, which is an absolute
+  // budget again — the exact failure the slack removal was meant to end.
   //
   // The ratio has to carry the gate by itself, because this file shares a runner with the rest
   // of its shard: a flat slack added to a sub-millisecond baseline is an ABSOLUTE wall-clock
@@ -344,11 +360,13 @@ async function measureInsertRatio(bytes: Uint8Array): Promise<{
 }
 
 describe('local keystroke path with a replica attached', () => {
-  test('transact replicates on the commit and stays within 2x solo', async () => {
+  test('transact replicates on the commit and strands no journal', async () => {
     const bytes = proseBytes();
-    // The gated comparison: one solo arm against one lone attached replica, same gesture.
-    // The gesture sweep below re-measures `insert-text` for its row, but only this pair
-    // decides the ratio.
+    // Measured and logged, never gated — rule 5. This fixture's commit is ~0.1 ms, so its
+    // ratio reports the fixed Yjs write against a baseline too small to hide it, and three
+    // paragraphs cannot show the O(document) cost the ratio gate is for. The 200-page test
+    // below owns that gate. Keeping the numbers here still pays: a jump in this ratio with
+    // the 200-page ratio flat is what a fixed per-commit regression looks like.
     const { solo, attached: insertAttached, blockRatios } = await measureInsertRatio(bytes);
 
     const gestures: readonly {
@@ -443,14 +461,13 @@ describe('local keystroke path with a replica attached', () => {
         soloInsert: solo,
         attachedInsert: insertAttached,
         blockRatios,
-        ratioPass: ratioPass(blockRatios),
+        blockRatioMin: Math.min(...blockRatios),
         rows,
       })
     );
     // No gesture may leave a journal waiting, and every gesture must reach Yjs on its commit.
     expect(stranded).toEqual([]);
     expect(silent).toEqual([]);
-    expect(ratioPass(blockRatios)).toBe(true);
     expect(rows.length).toBe(gestures.length);
   });
 


### PR DESCRIPTION
The keystroke perf test failed three of three CI runs on `main` after the block pairing landed, always on the same assertion in `packages/pro/src/collaboration/__tests__/local-keystroke-performance.test.ts`.

## Cause

Attaching a replica costs a fixed Yjs encode and write per commit. The measured ratio is therefore `1 + fixed / baseline`, and the fixture picks the denominator:

| Fixture | Solo min | Attached min | Overhead | Gated block |
| --- | --- | --- | --- | --- |
| Prose, three paragraphs | 0.10 ms | 0.23-0.36 ms | 0.14-0.25 ms | 2.08-2.17x, fails |
| 200-page | 0.28-0.41 ms | 0.40-0.60 ms | 0.12-0.19 ms | 1.36x, passes |

The overhead is the same on both. The prose baseline is 4x smaller, so the same cost reads as 2-3x. That fixture has no headroom under 2x on any machine, and the term that varies between machines sits in the numerator.

The gate exists to catch an `O(document)` capture cost, and three paragraphs cannot show one. The prose ratio was gating noise it could not distinguish from a regression.

## Change

The 200-page fixture keeps the ratio gate. The prose test keeps its correctness gates, that the publish queue is empty and every gesture reaches Yjs, and gains an absolute bound on the fixed per-commit cost, which is what a three-paragraph commit almost entirely consists of.

## Verification

Both gates fail on the regression each one is for, confirmed by injecting the fault and then reverting it:

- An `O(document)` sweep in the publish path reads 16x-19x in every block on the 200-page fixture, against 1.12x-1.17x clean.
- A 6 ms constant in the publish path fails the new 4 ms bound.

The 4 ms bound is about 9x the worst figure measured: 0.13-0.17 ms locally, unmoved by 20-way CPU contention because the block minimum discards one-sided noise, and 0.23-0.46 ms on CI hardware.

Local gates: `bun run test` 10261 pass, `bun run typecheck`, `bun run lint` with 0 errors, and `bun run format`. The file also ran 20 consecutive times under 14-way CPU contention with no failure, worst gated block 1.32x.

No changeset, because this is a test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790486566&installation_model_id=422592&pr_number=552&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F552&signature=fe47c738ac3f09209210c6b2617f0d626e8505ef43543243994d728308cecac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->