### PR TITLE
docs: separate collaboration quickstart and reference

### DIFF
--- a/docs/site/content/collaboration.mdx
+++ b/docs/site/content/collaboration.mdx
@@ -1,59 +1,66 @@
 ---
-title: 'Collaboration'
-description: 'Let people edit one DOCX together with presence, personal undo, and offline editing.'
+title: 'Get started with DOCX collaboration'
+description: 'Connect two React or Vue DOCX editors through one WebRTC room.'
 category: 'Getting Started'
-seoTitle: 'Real-time DOCX collaboration with presence and offline editing'
+seoTitle: 'Real-time DOCX collaboration quickstart for React and Vue'
 ---
 
-Collaboration replicates the document across peers. Each peer edits a local
-replica, and the replicas converge. Local typing stays responsive during
-network delays.
+This quickstart uses `useWebrtcCollaboration` to add real-time DOCX
+collaboration to a React or Vue editor. It connects two editors through WebRTC
+and shows each participant's changes.
 
-Peers also share presence. You see each participant, caret, and selection in the
-participant's author color. The same color marks their tracked changes and
-comments.
+Start with a working editor from the [Quickstart](/docs/2.x/quickstart). For
+provider options and failure states, see the
+[collaboration reference](/docs/2.x/pro/collaboration).
 
-The [`@docx-editor.dev/pro` package](/docs/2.x/pro) provides collaboration as an
-editor module. You can use peer-to-peer WebRTC, a
-[Hocuspocus server](https://tiptap.dev/docs/hocuspocus), or an existing Yjs
-provider.
+## Install the packages
 
-The adapters provide room hooks, a wired collaboration root, status fields, and
-custom presence renderers. Server code can also export synchronized room state
-as DOCX bytes. The [real-time collaboration guide](/docs/2.x/pro/collaboration)
-documents these interfaces and their recovery behavior.
+Install the Pro package, Yjs, and the WebRTC provider:
 
-## Start in one component
+```bash
+npm install @docx-editor.dev/pro yjs y-webrtc
+```
 
-Use the framework hook to own the room. With `create-or-join`, the first peer
-seeds the room from your document bytes. Later peers join the room.
+You also need `@docx-editor.dev/react` or `@docx-editor.dev/vue` in your
+application.
+
+## Create a room ID
+
+Create one room ID and send it to each participant:
+
+```ts
+import { createCollaborationRoomId } from '@docx-editor.dev/pro/collaboration/webrtc';
+
+const roomId = createCollaborationRoomId();
+```
+
+Store the room ID in your application state or URL. Do not create a new ID
+during each render.
+
+## Add a collaborative editor
+
+Call `useWebrtcCollaboration` with a room ID, an identity, and the initial DOCX
+bytes. The first editor creates the room. Later editors join its document.
 
 ```tsx
-import { useRef } from 'react';
-import { DocxEditor, type DocxEditorRef } from '@docx-editor.dev/react';
+import { DocxEditor } from '@docx-editor.dev/react';
 import { useWebrtcCollaboration } from '@docx-editor.dev/pro/react/webrtc';
 
 interface CollaborativeEditorProps {
   roomId: string;
   bytes: Uint8Array;
+  actorId: string;
+  name: string;
 }
 
-export function CollaborativeEditor({ roomId, bytes }: CollaborativeEditorProps) {
-  const editorRef = useRef<DocxEditorRef>(null);
-  const { document, modules, session, pending, error, leave } = useWebrtcCollaboration({
+export function CollaborativeEditor({ roomId, bytes, actorId, name }: CollaborativeEditorProps) {
+  const { document, modules, session, pending, error } = useWebrtcCollaboration({
     room: {
       roomId,
-      identity: { actorId: 'alex', name: 'Alex' },
+      identity: { actorId, name },
       bootstrap: { kind: 'create-or-join', document: bytes },
     },
   });
-
-  async function leaveRoom() {
-    const saved = await editorRef.current?.save();
-    if (saved) {
-      leave(new Uint8Array(saved));
-    }
-  }
 
   if (error) {
     return <p>{error.detail ?? error.code}</p>;
@@ -62,70 +69,34 @@ export function CollaborativeEditor({ roomId, bytes }: CollaborativeEditorProps)
     return <p>Connecting…</p>;
   }
 
-  return (
-    <>
-      <button type="button" onClick={leaveRoom}>
-        Leave
-      </button>
-      <DocxEditor ref={editorRef} key={session?.sessionId} document={document} modules={modules} />
-    </>
-  );
+  return <DocxEditor key={session?.sessionId} document={document} modules={modules} />;
 }
 ```
 
-Vue provides the same hook at `@docx-editor.dev/pro/vue/webrtc`. For setup
-details, see the [real-time collaboration guide](/docs/2.x/pro/collaboration).
+Vue provides the composable at `@docx-editor.dev/pro/vue/webrtc`. Select Vue in
+the [collaboration API reference](/docs/2.x/pro/collaboration#connect-with-usewebrtccollaboration)
+for a complete component.
 
-## What replicates
+## Test the room
 
-Replicated content includes text, formatting, document structure, tables,
-headers, footers, notes, images, comments, tracked-change decisions, tables of
-contents, and custom nodes. Each person can undo only their own edits.
+1. Open the application in one browser tab.
+2. Open a second tab with the same `roomId` and a different `actorId`.
+3. Type in either editor.
 
-Review workflows also work in a room. One person can suggest changes while
-another person accepts or rejects them. The review sidebar stays live for every
-peer. See the [tracked changes guide](/docs/2.x/pro/tracked-changes) and
-[comments guide](/docs/2.x/pro/comments).
+Open the first tab before the second tab. This sequence prevents both peers from
+seeding an empty room at the same time.
 
-## Show presence
+The example uses the public demo signaling service when you omit `signaling`.
+Configure your own signaling URLs and TURN servers for production.
 
-After module registration, the editor paints remote carets and selections. The
-Pro package also provides these presence components and hooks:
+## Continue the setup
 
-- `DocxEditorCollaboration.Avatars` renders the participant stack, colored to
-  match each participant's review markup.
-- `DocxEditorCollaboration.CaretLabels` replaces caret labels with your
-  component. The component renders in the adapter tree, so hooks work in it.
-- `useCollaborationStatus` and `useCollaborationParticipants` provide data for
-  connection and participant interfaces.
-
-Presence renderers receive the resolved color and optional participant data.
-They also receive a locally declared `avatarUrl`. You can omit `session` inside
-the editor provider tree.
-
-See the [presence interface guide](/docs/2.x/pro/collaboration#presence-ui).
-
-## Pick a transport
-
-| Transport             | Use case                              | Integration                                                                   |
-| --------------------- | ------------------------------------- | ----------------------------------------------------------------------------- |
-| WebRTC                | Demos and small teams                 | Use `useWebrtcCollaboration` and configure production signaling.              |
-| Hocuspocus            | Hosted authentication and persistence | Use `useHocuspocusCollaboration`. Validate tokens in server `onAuthenticate`. |
-| Your own Yjs provider | An existing Yjs deployment            | Use `createDocumentCollaboration` with your `Y.Doc` and provider.             |
-
-Use Yjs 13 with each server. The standard `y-websocket` server and Hocuspocus
-work without changes.
-
-## Offline editing
-
-Set `offlineEditing: true` to continue editing after a transport disconnection.
-Buffered edits merge with concurrent edits after reconnection. Show connection
-status so people know when their edits have not reached the room.
-
-## Learn more
-
-- [Real-time collaboration](/docs/2.x/pro/collaboration): rooms, providers,
-  presence, limits, and recovery.
+- [Production WebRTC setup](/docs/2.x/pro/collaboration#use-your-own-signaling):
+  configure signaling and TURN servers.
+- [Hocuspocus setup](/docs/2.x/pro/collaboration#connect-to-a-hocuspocus-server):
+  connect authentication and persistence.
+- [Custom Yjs providers](/docs/2.x/pro/collaboration#integrate-a-custom-yjs-provider):
+  connect an existing Yjs deployment.
 - [Tracked changes](/docs/2.x/pro/tracked-changes): suggesting mode and the
   review sidebar.
 - [Build a DOCX agent](/docs/2.x/build-a-docx-agent): connect a headless replica

--- a/docs/site/content/pro/collaboration.mdx
+++ b/docs/site/content/pro/collaboration.mdx
@@ -1,15 +1,21 @@
 ---
-title: 'Real-time collaboration'
-description: 'Replicate a DOCX across peers with the Pro collaboration module.'
+title: 'DOCX collaboration reference'
+description: 'Reference for Pro providers, room lifecycles, presence, offline editing, recovery, and limits.'
 category: 'Pro'
 order: 64
+seoTitle: 'DOCX collaboration API reference'
 ---
 
-Real-time collaboration replicates the document across peers.
+This reference documents the complete configuration and API behavior for
+real-time DOCX collaboration with the Pro package. It covers providers, room
+lifecycles, presence, recovery, and resource limits.
 
-It covers text, structure, formatting, tables, headers, footers, notes,
-drawings, relationships, and embedded parts. Peers also share presence and
-remote selections across paragraphs.
+For a basic WebRTC setup, use the
+[real-time collaboration quickstart](/docs/2.x/collaboration).
+
+The Pro module replicates text, structure, formatting, tables, headers, footers,
+notes, drawings, relationships, and embedded parts. Peers also share presence
+and remote selections across paragraphs.
 
 Collaboration requires the collaboration module from
 [`@docx-editor.dev/pro`](/docs/2.x/pro).
@@ -52,7 +58,7 @@ npm install @docx-editor.dev/pro yjs @hocuspocus/provider
 `yjs`, `y-webrtc`, and `@hocuspocus/provider` are optional Pro peer
 dependencies. Pro installs `y-protocols`.
 
-## Open a room with the hook
+## Connect with `useWebrtcCollaboration`
 
 `useWebrtcCollaboration` owns the WebRTC room. It creates the replica and
 builds `modules`. It destroys the room when you leave.
@@ -103,14 +109,16 @@ import { useWebrtcCollaboration } from '@docx-editor.dev/pro/react/webrtc';
 type CollaborativeEditorProps = {
   roomId: string;
   bytes: Uint8Array;
+  actorId: string;
+  name: string;
 };
 
-export function CollaborativeEditor({ roomId, bytes }: CollaborativeEditorProps) {
+export function CollaborativeEditor({ roomId, bytes, actorId, name }: CollaborativeEditorProps) {
   const editorRef = useRef<DocxEditorRef>(null);
   const { document, modules, session, pending, error, leave } = useWebrtcCollaboration({
     room: {
       roomId,
-      identity: { actorId: 'alex', name: 'Alex' },
+      identity: { actorId, name },
       bootstrap: { kind: 'create-or-join', document: bytes },
     },
   });
@@ -146,13 +154,18 @@ import { ref } from 'vue';
 import { DocxEditor, type DocxEditorRef } from '@docx-editor.dev/vue';
 import { useWebrtcCollaboration } from '@docx-editor.dev/pro/vue/webrtc';
 
-const props = defineProps<{ roomId: string; bytes: Uint8Array }>();
+const props = defineProps<{
+  roomId: string;
+  bytes: Uint8Array;
+  actorId: string;
+  name: string;
+}>();
 
 const editorRef = ref<DocxEditorRef | null>(null);
 const { document, modules, session, pending, error, leave } = useWebrtcCollaboration({
   room: {
     roomId: props.roomId,
-    identity: { actorId: 'alex', name: 'Alex' },
+    identity: { actorId: props.actorId, name: props.name },
     bootstrap: { kind: 'create-or-join', document: props.bytes },
   },
 });
@@ -179,9 +192,10 @@ async function leaveRoom() {
 </Framework>
 </FrameworkTabs>
 
-With `create-or-join`, every peer uses the same options. The first peer seeds
-the empty room from `document`. Later peers join the existing room. Use
-`create` or `join` when each host already knows its role.
+With `create-or-join`, every peer uses the same room and bootstrap settings.
+Each peer must use a unique `actorId`. The first peer seeds the empty room from
+`document`. Later peers join the existing room. Use `create` or `join` when each
+host already knows its role.
 
 Two isolated peers can seed the same room at the same time. This creates a room
 that clients cannot repair. Each replica reports `concurrent-seed` and stops.
@@ -349,7 +363,7 @@ All of these are available from `@docx-editor.dev/pro/react` and
 If you own the Yjs resources, use `useDocumentCollaboration` from the same
 entries. It provides the same `connect` and `leave` lifecycle without WebRTC.
 
-## Presence UI
+## Show avatars and caret labels
 
 `DocxEditorCollaboration` provides presence controls. Import it from
 `@docx-editor.dev/pro/react` or `@docx-editor.dev/pro/vue`. Mount its parts
@@ -444,8 +458,8 @@ For CSS styling, use the `docx-remote-caret-label` class,
 ## Recover a diverged replica
 
 A status of `error` is terminal. The replica refused an update and kept its
-copy. It now edits a document that other peers do not have. Waiting does not fix
-the replica. Call `rejoin`:
+copy. The session now refuses edits, and other peers might not have its latest
+changes. Waiting does not fix the replica. Call `rejoin`:
 
 ```tsx
 const { rejoin } = useHocuspocusCollaboration({ room });
@@ -460,8 +474,8 @@ async function rejoinRoom() {
 
 Save the editor bytes before you call `rejoin`. It leaves with those bytes, then
 joins the same room with `{ kind: 'join' }`. A successful join uses the room
-copy, so it drops edits made after divergence. After a failed join, the saved
-bytes stay mounted locally.
+copy. It can drop unreplicated changes that existed when the session failed.
+After a failed join, the saved bytes stay mounted locally.
 
 ## Edit offline
 
@@ -480,7 +494,7 @@ For production, pass your signaling URLs to `connect` or `room`. Also provide
 your own Traversal Using Relays around NAT (TURN) servers. Many networks block
 direct WebRTC connections without TURN.
 
-## Hocuspocus
+## Connect to a Hocuspocus server
 
 `useHocuspocusCollaboration` owns a room on a
 [Hocuspocus](https://tiptap.dev/docs/hocuspocus) server. It has the same
@@ -498,17 +512,21 @@ export function ServerBackedEditor({
   roomId,
   token,
   bytes,
+  actorId,
+  name,
 }: {
   roomId: string;
   token: string;
   bytes: Uint8Array;
+  actorId: string;
+  name: string;
 }) {
   const { document, modules, session, pending, error } = useHocuspocusCollaboration({
     room: {
       url: 'wss://collab.example.test',
       roomId,
       token,
-      identity: { actorId: 'alex', name: 'Alex' },
+      identity: { actorId, name },
       bootstrap: { kind: 'create-or-join', document: bytes },
     },
   });
@@ -572,7 +590,7 @@ See the
 [server-backed Hocuspocus example](https://github.com/eigenpal/docx-editor/tree/main/examples/collaboration-hocuspocus)
 for persistence and DOCX export.
 
-## Write a provider
+## Use the replication contracts
 
 `@docx-editor.dev/core/collaboration/replication` holds the seam a replication
 implementation binds to: the document port an adapter writes through, the
@@ -589,7 +607,7 @@ A host that renders presence and reads a status needs none of it, which is why
 it is a separate subpath. Import `@docx-editor.dev/core/collaboration` for the
 consumer types: identity, participants, remote selections, status, and failures.
 
-## Own a Yjs document
+## Integrate a custom Yjs provider
 
 If you own a `Y.Doc` and awareness instance, call
 `createDocumentCollaboration` from `@docx-editor.dev/pro/collaboration`. It
@@ -618,6 +636,8 @@ import { createDocumentCollaboration } from '@docx-editor.dev/pro/collaboration'
 const ydoc = new Y.Doc();
 const awareness = new Awareness(ydoc);
 const provider = new WebsocketProvider('wss://example.test', 'room-1', ydoc, { awareness });
+declare const currentUser: { id: string; name: string };
+const identity = { actorId: currentUser.id, name: currentUser.name };
 
 await new Promise((resolve) => provider.once('sync', resolve));
 
@@ -625,7 +645,7 @@ const room = await createDocumentCollaboration({
   ydoc,
   awareness,
   documentId: 'room-1',
-  identity: { actorId: 'alex', name: 'Alex' },
+  identity,
   bootstrap: { kind: 'join' },
 });
 
@@ -675,7 +695,7 @@ The same entry exports the experimental `createTextCollaboration`. It only
 replicates paragraph text and rejects structural edits. Use
 `createDocumentCollaboration`.
 
-## Headless replica
+## Create a headless replica
 
 `DocxEditor.createCollaborative` from `@docx-editor.dev/editor-api` opens a
 Document Object Model (DOM)-free replica.
@@ -712,7 +732,7 @@ In Vue, wrap the composable return with `reactive` before you pass it to
 Let the room hook manage cleanup. An effect cleanup can destroy the room before
 React StrictMode remounts the component.
 
-## Limits
+## Collaboration behavior and limits
 
 The WebRTC helper connects peers directly. A room exists while at least one
 peer remains connected.

--- a/docs/site/content/pro/index.mdx
+++ b/docs/site/content/pro/index.mdx
@@ -13,7 +13,7 @@ order: 60
 - [**Comments**](/docs/2.x/pro/comments): Add threads and replies to a text range.
 - [**Review colors and styling**](/docs/2.x/pro/review-styling): Color review content by author or by change type.
 - [**Custom nodes**](/docs/2.x/pro/custom-nodes): Store your inline node types as Word content controls.
-- [**Real-time collaboration**](/docs/2.x/pro/collaboration): Replicate a document across peers with a Yjs session.
+- [**DOCX collaboration reference**](/docs/2.x/pro/collaboration): Configure rooms, providers, presence, and recovery.
 
 Both adapter entries export custom-node chip and context-menu chrome.
 


### PR DESCRIPTION
## Summary
- Separate the collaboration quickstart from the Pro API reference.
- Correct room identity, room ID, and recovery guidance found during the SEO review.

## Test plan
- [x] `bun run check:docs-mdx`
- [x] `bun run check:docs-vue-refs`
- [x] `bun run check:public-docs-surface`
- [x] `bun run docs:json`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790488447&installation_model_id=422592&pr_number=556&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F556&signature=160b1b28e850b3879c8e8f2549dbc8e06165257ac98758b703aca11d7760dec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->