### PR TITLE
fix(collaboration): replicate journals committed during a remote install

### DIFF
--- a/.changeset/late-hooks-replicate.md
+++ b/.changeset/late-hooks-replicate.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+An edit committed by a change subscriber while the session installs a remote package now replicates instead of staying on one replica behind a healthy status. Fixes #553.

--- a/docs/site/content/pro/collaboration.mdx
+++ b/docs/site/content/pro/collaboration.mdx
@@ -590,6 +590,28 @@ See the
 [server-backed Hocuspocus example](https://github.com/eigenpal/docx-editor/tree/main/examples/collaboration-hocuspocus)
 for persistence and DOCX export.
 
+## The room is the document
+
+While a room is live, the room holds the authoritative copy. An exported `.docx`
+file is a snapshot of the room at one moment, not a branch of it.
+
+A file edited outside the room cannot merge back in. Seeding the edited file
+creates a new room with new identity, and no three-way merge exists between a
+room and an external copy. This is the same rule the
+[recovery flow](#recover-a-diverged-replica) applies within a room: when two
+copies disagree, the room copy wins.
+
+Keep one authority per document at a time:
+
+- While people collaborate, treat the room as the document. Export snapshots for
+  backup, indexing, or review, and treat them as read-only.
+- When collaboration ends, export the room and make the file the authority
+  again.
+- To bring external edits into a live room, apply them as edits inside the room
+  — for example, paste the changed content — rather than re-seeding the file.
+- To restart collaboration on an externally edited file, create a new room from
+  those bytes and retire the old room.
+
 ## Use the replication contracts
 
 `@docx-editor.dev/core/collaboration/replication` holds the seam a replication

--- a/packages/pro/src/collaboration/__tests__/document-remote-window-journals.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-remote-window-journals.test.ts
@@ -1,0 +1,228 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// A journal published while the session installs a remote package must not be dropped.
+//
+// A `change` subscriber that transacts during a remote install commits locally and publishes
+// its journal into the `applyingRemote` window. Dropping it there left the edit on one
+// replica — never replicated, never refused, status `ready` — the silent divergence a
+// refusal exists to prevent. The session now holds such journals and applies them the moment
+// the install finishes; a refusal mid-drain abandons the rest of the buffer exactly as it
+// abandons the rest of a flush batch.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { Awareness } from 'y-protocols/awareness';
+import {
+  ORIGIN_IDS,
+  TreePackageStore,
+  normalizeParagraphIdentity,
+  readOoxmlPackage,
+  type StoryScope,
+} from '@docx-editor.dev/core/store';
+import {
+  createCollaborationDocumentPort,
+  type CanonicalPrimitiveJournal,
+  type CollaborationDocumentPort,
+} from '@docx-editor.dev/core/collaboration/replication';
+import {
+  createDocumentCollaboration,
+  type DocumentCollaborationHandle,
+} from '../document-session.ts';
+import { collaborationDocx } from './support.ts';
+import { packageFingerprint } from './document-support.ts';
+
+const DOCUMENT_ID = 'remote-window-room';
+const BODY: StoryScope = { kind: 'body' };
+
+interface Peer {
+  readonly ydoc: Y.Doc;
+  readonly awareness: Awareness;
+  readonly room: DocumentCollaborationHandle;
+  readonly store: TreePackageStore;
+  readonly port: CollaborationDocumentPort;
+  readonly emitJournal: (journal: CanonicalPrimitiveJournal) => void;
+}
+
+const opened: Peer[] = [];
+
+afterEach(() => {
+  for (const peer of opened.splice(0)) {
+    peer.room.destroy();
+    peer.awareness.destroy();
+    peer.ydoc.destroy();
+  }
+});
+
+async function createPeer(name: string, host?: Peer): Promise<Peer> {
+  const ydoc = new Y.Doc();
+  const awareness = new Awareness(ydoc);
+  if (host) Y.applyUpdate(ydoc, Y.encodeStateAsUpdate(host.ydoc), 'join');
+  const room = await createDocumentCollaboration({
+    ydoc,
+    awareness,
+    documentId: DOCUMENT_ID,
+    identity: { actorId: name, name },
+    bootstrap: host
+      ? { kind: 'join', timeoutMs: 5_000 }
+      : { kind: 'create', document: collaborationDocx() },
+  });
+  const loaded = readOoxmlPackage(room.document);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const main = loaded.package.parts.get(loaded.package.mainDocumentPart);
+  if (!main) throw new Error('no main part');
+  const store = new TreePackageStore(loaded.package, normalizeParagraphIdentity(main));
+  const base = createCollaborationDocumentPort(store, { documentId: DOCUMENT_ID });
+  // The session's contract is that journals arrive through `observePrimitiveJournal`, so the
+  // tap records the listener the session registers instead of adding a test-only port method.
+  let tap: ((journal: CanonicalPrimitiveJournal) => void) | null = null;
+  const port: CollaborationDocumentPort = {
+    ...base,
+    observePrimitiveJournal: (listener) => {
+      tap = listener;
+      return base.observePrimitiveJournal(listener);
+    },
+  };
+  room.session.attach(port);
+  const peer: Peer = {
+    ydoc,
+    awareness,
+    room,
+    store,
+    port,
+    emitJournal: (journal) => {
+      if (!tap) throw new Error('port is not tapped');
+      tap(journal);
+    },
+  };
+  opened.push(peer);
+  return peer;
+}
+
+function firstParagraphId(store: TreePackageStore): string {
+  let found: string | null = null;
+  const walk = (node: { kind: string; id: string; children?: readonly unknown[] }): void => {
+    if (found) return;
+    if (node.kind === 'paragraph') {
+      found = node.id;
+      return;
+    }
+    for (const child of node.children ?? []) walk(child as never);
+  };
+  walk(store.bodyStore().part.root as never);
+  if (!found) throw new Error('no paragraph');
+  return found;
+}
+
+function bodyText(store: TreePackageStore): string {
+  const texts: string[] = [];
+  const walk = (node: { kind: string; value?: string; children?: readonly unknown[] }): void => {
+    if (node.kind === 'textValue' && typeof node.value === 'string') texts.push(node.value);
+    for (const child of node.children ?? []) walk(child as never);
+  };
+  walk(store.bodyStore().part.root as never);
+  return texts.join('');
+}
+
+function type(peer: Peer, text: string): void {
+  const result = peer.store.transact(BODY, (context) => {
+    context.apply({
+      op: 'insertText',
+      paragraphId: firstParagraphId(peer.store),
+      offset: 0,
+      text,
+    });
+  });
+  if (!result.ok) throw new Error(result.detail ?? result.reason);
+  peer.port.flushPendingJournals();
+}
+
+function relay(from: Peer, to: Peer): void {
+  Y.applyUpdate(to.ydoc, Y.encodeStateAsUpdate(from.ydoc, Y.encodeStateVector(to.ydoc)), 'relay');
+}
+
+function expectConverged(left: Peer, right: Peer): void {
+  expect(packageFingerprint(right.store.currentPackage())).toBe(
+    packageFingerprint(left.store.currentPackage())
+  );
+}
+
+describe('journals published during a remote install', () => {
+  test('a change-subscriber edit during a remote install replicates', async () => {
+    const alice = await createPeer('alice');
+    const bob = await createPeer('bob', alice);
+    // Bob reacts to every remote install by writing — the shape a derivation hook has.
+    let reacted = false;
+    const stop = bob.store.subscribe((change) => {
+      if (reacted || change.origin !== ORIGIN_IDS.mutationRemote) return;
+      reacted = true;
+      type(bob, 'HOOK-');
+    });
+    try {
+      type(alice, 'A');
+      relay(alice, bob);
+      expect(reacted).toBe(true);
+      expect(bodyText(bob.store)).toContain('HOOK-');
+      expect(bob.room.session.statusSnapshot().status).toBe('ready');
+      // The hook's edit must reach the room. Before the fix it stayed on bob alone.
+      relay(bob, alice);
+      expect(bodyText(alice.store)).toContain('HOOK-');
+      expectConverged(alice, bob);
+    } finally {
+      stop();
+    }
+  });
+
+  test('a refusal mid-drain abandons the rest of the held journals', async () => {
+    const alice = await createPeer('alice');
+    const bob = await createPeer('bob', alice);
+    // Two journals land in the remote window: the first refuses (a node shared state does
+    // not hold), so the realign must abandon the second — it describes a tree the realign
+    // just took back, and pushing it would publish content this author cannot see.
+    let reacted = false;
+    const stop = bob.store.subscribe((change) => {
+      if (reacted || change.origin !== ORIGIN_IDS.mutationRemote) return;
+      reacted = true;
+      bob.emitJournal({
+        effects: [
+          {
+            kind: 'spliceText',
+            logicalId: 'no-such-node',
+            utf16Start: 0,
+            deleteCount: 0,
+            insert: 'X',
+          },
+        ],
+      });
+      bob.emitJournal({
+        effects: [
+          {
+            kind: 'spliceText',
+            logicalId: 'no-such-node-either',
+            utf16Start: 0,
+            deleteCount: 0,
+            insert: 'Y',
+          },
+        ],
+      });
+    });
+    try {
+      type(alice, 'A');
+      relay(alice, bob);
+      expect(reacted).toBe(true);
+      // One refusal recovers, and the second held journal never applies.
+      await Promise.resolve();
+      const snapshot = bob.room.session.statusSnapshot();
+      expect(snapshot.status).toBe('ready');
+      expect(snapshot.lastFailure?.code).toBe('unknown-logical-id');
+      relay(bob, alice);
+      expectConverged(alice, bob);
+      expect(bodyText(alice.store)).not.toContain('X');
+      expect(bodyText(alice.store)).not.toContain('Y');
+    } finally {
+      stop();
+    }
+  });
+});

--- a/packages/pro/src/collaboration/__tests__/remote-receive-wholesale-cost.test.ts
+++ b/packages/pro/src/collaboration/__tests__/remote-receive-wholesale-cost.test.ts
@@ -1,0 +1,219 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// What the WHOLESALE remote path costs, in work rather than in milliseconds.
+//
+// `remotePackageDelta` narrows only a main-part text change. Anything that touches the
+// package shell — a media part, a relationship, a content type — installs as `global`,
+// which is the worst case a receiving replica has. This file measures that case on the
+// 200-page fixture with the realistic trigger, an image insert, and pins two facts the
+// narrow-path gates cannot see:
+//
+//   1. Even a wholesale install reads the size of the EDIT, not the document. Unchanged
+//      parts arrive as the same objects, so validation and materialization must not walk
+//      them. The gates are deterministic counters, because a duration passes on a fast
+//      machine while the algorithm is still linear in the document.
+//   2. A burst of remote transactions does NOT coalesce: N received updates cost N
+//      materializer passes. That is the shipped behavior; pinning it here means a future
+//      coalescing change shows up as an improvement to this file, not as a surprise in
+//      production.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { canonicalFingerprintNodeVisits } from '../../../../core/src/store/package/ooxml-serialize.ts';
+import {
+  paragraphTextOf,
+  type ImageDecodePort,
+  type OoxmlNode,
+  type TreeModelChange,
+} from '@docx-editor.dev/core/store';
+import { materializedNodeReads, materializedPassCounts } from '../document/materialize.ts';
+import { BODY, createPeerHarness, walk, type Peer } from './document-peer-support.ts';
+
+const harness = createPeerHarness('remote-receive-wholesale');
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+const PNG_1X1 = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  ),
+  (character) => character.charCodeAt(0)
+);
+
+const decodePort: ImageDecodePort = {
+  decode: async () => ({ pixelWidth: 1, pixelHeight: 1, dpiX: 96, dpiY: 96 }),
+};
+
+function longFixtureBytes(): Uint8Array {
+  const fixture = resolve(import.meta.dir, '../../../../../e2e/fixtures/synthetic-long-edit.docx');
+  return new Uint8Array(readFileSync(fixture));
+}
+
+function bodyNodeCount(peer: Peer): number {
+  let count = 0;
+  walk(peer.store.bodyStore().part.root, () => {
+    count += 1;
+  });
+  return count;
+}
+
+function middleParagraphId(peer: Peer): string {
+  const ids: string[] = [];
+  walk(peer.store.bodyStore().part.root, (node: OoxmlNode) => {
+    if (node.kind === 'paragraph') ids.push(node.id);
+  });
+  const id = ids[Math.floor((ids.length - 1) * 0.5)];
+  if (!id) throw new Error('no middle paragraph');
+  return id;
+}
+
+async function insertImage(author: Peer, paragraphId: string, offset: number): Promise<void> {
+  const inserted = await author.store.insertImage(BODY, {
+    paragraphId,
+    offset,
+    bytes: PNG_1X1,
+    mime: 'image/png',
+    widthPoints: 12,
+    heightPoints: 12,
+    decodePort,
+    expectedPackageRevision: author.store.packageRevision,
+  });
+  if (!inserted.ok) throw new Error(inserted.detail ?? inserted.reason);
+  author.port.flushPendingJournals();
+}
+
+interface WholesaleSample {
+  readonly impact: TreeModelChange['impact'] | undefined;
+  readonly nodeReads: number;
+  readonly passes: number;
+  readonly fingerprintedNodes: number;
+  readonly elapsedMs: number;
+}
+
+async function receiveWholesale(
+  receiver: Peer,
+  edit: () => Promise<void>
+): Promise<WholesaleSample> {
+  let change: TreeModelChange | null = null;
+  const stop = receiver.store.subscribe((published) => {
+    change = published;
+  });
+  const readsBefore = materializedNodeReads();
+  const passesBefore = materializedPassCounts().passes;
+  const fingerprintBefore = canonicalFingerprintNodeVisits();
+  const started = performance.now();
+  await edit();
+  const elapsedMs = performance.now() - started;
+  stop();
+  const published = change as TreeModelChange | null;
+  return {
+    impact: published?.impact,
+    nodeReads: materializedNodeReads() - readsBefore,
+    passes: materializedPassCounts().passes - passesBefore,
+    fingerprintedNodes: canonicalFingerprintNodeVisits() - fingerprintBefore,
+    elapsedMs,
+  };
+}
+
+describe('cost of the wholesale remote path', () => {
+  test(
+    'an image insert installs wholesale without walking the document',
+    async () => {
+      const { alice, bob } = await harness.pair(longFixtureBytes());
+      const documentNodes = bodyNodeCount(bob);
+      const target = harness.paragraphIdAt(alice, 0);
+
+      // Reported for contrast: the first receive is the one that can still find a cold
+      // cache. The gates below are the steady state that follows it. Each round inserts
+      // AFTER the drawings the earlier rounds placed.
+      const samples: WholesaleSample[] = [];
+      for (let round = 0; round < 4; round += 1) {
+        samples.push(await receiveWholesale(bob, () => insertImage(alice, target, round)));
+      }
+      const [first, ...steady] = samples;
+
+      console.log(
+        JSON.stringify({
+          fixture: 'synthetic-long-edit.docx',
+          documentNodes,
+          firstReceive: {
+            impact: first?.impact,
+            nodeReads: first?.nodeReads,
+            passes: first?.passes,
+            elapsedMs: Number((first?.elapsedMs ?? 0).toFixed(3)),
+          },
+          steadyReceive: steady.map((sample) => ({
+            impact: sample.impact,
+            nodeReads: sample.nodeReads,
+            passes: sample.passes,
+            fingerprintedNodes: sample.fingerprintedNodes,
+            elapsedMs: Number(sample.elapsedMs.toFixed(3)),
+          })),
+        })
+      );
+
+      // A media part plus its relationship cannot be narrowed, so the classification is
+      // pinned here: the wholesale verdict is the case this whole file exists to measure.
+      for (const sample of steady) {
+        expect(sample.impact).toBe('global');
+      }
+      const readBudget = Math.max(256, Math.floor(documentNodes / 16));
+      for (const sample of steady) {
+        if (sample.nodeReads > readBudget) {
+          throw new Error(
+            `A wholesale remote install read ${sample.nodeReads} shared node records against a ` +
+              `budget of ${readBudget} in a ${documentNodes}-node document. Unchanged parts ` +
+              'arrive as the same objects, so the materializer must rebuild only the spine of ' +
+              'the edit and the package projections; reading a document-sized slice here means ' +
+              'the incremental pass lost its cache and the worst case became the whole file.'
+          );
+        }
+        if (sample.fingerprintedNodes !== 0) {
+          throw new Error(
+            `A wholesale remote install walked ${sample.fingerprintedNodes} nodes through the ` +
+              'canonical fingerprint. The install decision is made by object identity and the ' +
+              'relationship compare; reaching the fingerprint oracle makes every shell change ' +
+              'cost a full serialization of the document.'
+          );
+        }
+      }
+      harness.expectConverged(alice, bob);
+    },
+    { timeout: 120_000 }
+  );
+
+  test(
+    'a burst of remote transactions costs one pass per transaction',
+    async () => {
+      const { alice, bob } = await harness.pair(longFixtureBytes());
+      const target = middleParagraphId(alice);
+      const length = paragraphTextOf(alice.store.bodyStore().part, target)?.length ?? 0;
+      // Warm both caches so the burst measures the steady state.
+      harness.apply(alice, [{ op: 'insertText', paragraphId: target, offset: length, text: 'W' }]);
+
+      const burst = 10;
+      const before = materializedPassCounts().passes;
+      for (let round = 0; round < burst; round += 1) {
+        harness.apply(alice, [
+          { op: 'insertText', paragraphId: target, offset: length + 1 + round, text: 'X' },
+        ]);
+      }
+      const passes = materializedPassCounts().passes - before;
+
+      console.log(JSON.stringify({ burst, passes }));
+
+      // Pinned as fact, not aspiration: received updates do NOT coalesce — each transaction
+      // pays one incremental pass. A future batching change should move this number DOWN;
+      // a regression that re-materializes more than once per update would move it up.
+      expect(passes).toBe(burst);
+      harness.expectConverged(alice, bob);
+    },
+    { timeout: 120_000 }
+  );
+});

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -120,6 +120,9 @@ class DocumentSession implements DocumentCollaborationSession {
   private detachPort: (() => void) | null = null;
   private applyingRemote = false;
   private realignedInBatch = false;
+  /** Journals a `change` subscriber committed while a remote install ran. Never dropped. */
+  private readonly journalsHeldDuringRemote: CanonicalPrimitiveJournal[] = [];
+  private drainingHeldJournals = false;
   private remoteCounter = 0;
   private destroyed = false;
   private refusedInARow = 0;
@@ -237,7 +240,17 @@ class DocumentSession implements DocumentCollaborationSession {
     this.port = port;
     this.publishSharedToPort();
     const stopJournal = port.observePrimitiveJournal((journal) => {
-      if (this.destroyed || this.applyingRemote) return;
+      if (this.destroyed) return;
+      // A `change` subscriber that transacts while this session installs a remote package
+      // commits its edit locally and publishes its journal into this window. Dropping it
+      // here left that edit on this replica alone — never replicated, never refused, status
+      // `ready` — which is the silent divergence a refusal exists to prevent. The journal is
+      // held instead and applied the moment the install finishes; see the drain in
+      // `publishSharedToPort` for why its positions stay sound.
+      if (this.applyingRemote) {
+        this.journalsHeldDuringRemote.push(journal);
+        return;
+      }
       // A realign already took shared state back over this store, so every journal still queued
       // behind the refused one describes edits the store no longer holds. Applying them would
       // push content to the room that this author cannot see locally. The refusal status reports
@@ -658,6 +671,42 @@ class DocumentSession implements DocumentCollaborationSession {
       );
     } finally {
       this.applyingRemote = false;
+      this.drainJournalsHeldDuringRemote();
+    }
+  }
+
+  /**
+   * Apply the journals a `change` subscriber committed while the remote install ran.
+   *
+   * Their positions are sound: each was diffed against the tree AFTER
+   * `installAuthoritativePackageSnapshot`, and shared state equals that tree here because the
+   * whole `applyingRemote` window is synchronous — no other shared write can interleave.
+   * Draining after the `finally` also means `identityMap.reset()` has already run, and
+   * `applyJournal` translates at apply time, so freshly minted canonical ids map correctly.
+   * Re-entry is blocked by the `applyingRemote` guard, so the buffer never outlives the
+   * publish call that filled it.
+   *
+   * A refusal mid-drain realigns the store, which invalidates the rest of the buffer the
+   * same way it abandons the rest of a flush batch — those journals describe edits the
+   * realign just took back, so they are cleared, and the refusal status reports the loss.
+   * The re-entrancy guard is what makes that work: the realign's own publish ends before
+   * `realignedInBatch` is set, so an unguarded drain would consume the remaining buffer in
+   * that gap and push the very content the realign took back.
+   */
+  private drainJournalsHeldDuringRemote(): void {
+    if (this.drainingHeldJournals) return;
+    this.drainingHeldJournals = true;
+    try {
+      while (this.journalsHeldDuringRemote.length > 0) {
+        if (this.destroyed || this.realignedInBatch) {
+          this.journalsHeldDuringRemote.length = 0;
+          return;
+        }
+        const journal = this.journalsHeldDuringRemote.shift();
+        if (journal) this.applyJournal(journal);
+      }
+    } finally {
+      this.drainingHeldJournals = false;
     }
   }
 


### PR DESCRIPTION
A `change` subscriber that transacts while the session installs a remote package published its journal into the `applyingRemote` window, where the listener dropped it. The edit stayed on one replica, no refusal fired, and the status stayed `ready`. The session now holds such journals and drains them the moment the install finishes. A refusal mid-drain abandons the rest of the buffer, the same rule a flush batch already follows. Fixes #553.

Two additions from the same review effort:

- The docs now state the authority rule the architecture implies three times but never says: the room is the document, an export is a snapshot, and a file edited outside the room cannot merge back.
- A wholesale remote-receive gate measures the worst-case install path with deterministic counters. An image insert into the 200-page fixture reads 26 shared records out of 34,555 with zero fingerprint visits (about 20 ms steady), and a 10-update burst is pinned at one materializer pass per transaction, so the no-coalescing behavior is a recorded fact.

Writing the gate surfaced two pre-existing bugs, filed separately: #557 (a hyperlink across a tracked-insert run duplicates text on receiving peers) and #558 (`applyPackage` shell writes vanish from the author's package while the journal replicates them). Compaction and quarantine are scoped in #554 and #555.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790490333&installation_model_id=422592&pr_number=559&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F559&signature=080cb4f53e7418a9cad3995ed7d32f95e51c5780580b477d94c0c86086971f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->