### PR TITLE
fix(store): lower a moved node's subtree edit into the journal

### DIFF
--- a/.changeset/moved-nodes-carry-edits.md
+++ b/.changeset/moved-nodes-carry-edits.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+A collaborative edit that moves an existing node while changing its content — a hyperlink inserted across a tracked-change run — now replicates the change instead of duplicating the old text on every receiving peer. Fixes #557.

--- a/packages/core/src/store/package/canonical-primitive-lower.ts
+++ b/packages/core/src/store/package/canonical-primitive-lower.ts
@@ -111,8 +111,23 @@ function nodeDescriptor(node: OoxmlNode): CanonicalNodeDescriptor {
   };
 }
 
-function expandInserted(node: OoxmlNode, knownIds?: KnownIds): void {
-  if (knownIds?.has(node.id)) return;
+function expandInserted(
+  node: OoxmlNode,
+  knownIds?: KnownIds,
+  previousNodes?: ReadonlyMap<string, OoxmlNode>
+): void {
+  if (knownIds?.has(node.id)) {
+    // A node the document already holds is MOVED here, not created — re-expanding it would
+    // duplicate its text on replay. But a move can carry an edit: `insertHyperlink` moves
+    // the split `w:ins` inside the new `w:hyperlink` WITH its children replaced. The subtree
+    // index from the enclosing capture holds the previous version, so the move lowers as a
+    // same-identity diff. Skipping the diff left the journal silent about the moved node's
+    // new content, and every receiving replica kept its OLD subtree beside the split pieces
+    // the journal did describe — duplicated text on every peer but the author.
+    const prior = previousNodes?.get(node.id);
+    if (prior && prior !== node) lowerSameIdentity(prior, node, knownIds, previousNodes);
+    return;
+  }
   recordPutNode(nodeDescriptor(node));
   if (node.kind === 'textValue') {
     // Initial fill of a shell this journal put. Apply replaces the node's current value,
@@ -127,7 +142,7 @@ function expandInserted(node: OoxmlNode, knownIds?: KnownIds): void {
     recordSetNamespaceBinding(node.id, binding.prefix, binding.namespaceUri);
   }
   if (node.children.length === 0) return;
-  for (const child of node.children) expandInserted(child, knownIds);
+  for (const child of node.children) expandInserted(child, knownIds, previousNodes);
   recordSpliceChildren(
     node.id,
     0,
@@ -216,8 +231,10 @@ function lowerChildList(
       continue;
     }
     // Existing document nodes that MOVE into this parent must not be re-expanded. Re-emitting
-    // putNode/spliceText for a joined run duplicates its text on replay.
-    if (!knownIds?.has(node.id)) expandInserted(node, knownIds);
+    // putNode/spliceText for a joined run duplicates its text on replay. `expandInserted`
+    // still diffs a moved node against its indexed previous version, so a move that also
+    // edits the subtree reaches the journal.
+    expandInserted(node, knownIds, previousNodes);
   }
   recordSpliceChildren(
     parentLogicalId,
@@ -286,7 +303,11 @@ export function captureReplaceNode(
   if (!parent) return;
   const index = parent.children.findIndex((child) => child.id === previous.id);
   if (index < 0) return;
-  if (!knownIds?.has(replacement.id)) expandInserted(replacement, knownIds);
+  // Index the replaced subtree, so a known node MOVED into the replacement still lowers as a
+  // same-identity diff of its edit rather than replaying with its previous content.
+  const previousNodes = new Map<string, OoxmlNode>();
+  indexSubtree(previous, previousNodes);
+  expandInserted(replacement, knownIds, previousNodes);
   recordSpliceChildren(parent.id, index, 1, [replacement.id]);
 }
 

--- a/packages/pro/src/collaboration/__tests__/document-tracked-hyperlink.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-tracked-hyperlink.test.ts
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// A hyperlink across a tracked-insert run must replicate exactly (issue #557).
+//
+// `insertHyperlink` over a range that crosses into a `w:ins` run MOVES the split tracked
+// wrapper inside the new `w:hyperlink` with its children replaced. The journal lowering used
+// to skip a moved node's subtree diff, so every receiving replica kept the moved node's OLD
+// run beside the split pieces the journal did describe — duplicated text on every peer but
+// the author, converging as authoritative state.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { OoxmlNode, StoryScope } from '@docx-editor.dev/core/store';
+import { BODY, createPeerHarness, walk, zipDocument, type Peer } from './document-peer-support.ts';
+
+const harness = createPeerHarness('tracked-hyperlink-room');
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const PLAIN_LEAD = 'Synthetic paragraph 1600. ';
+const TRACKED = 'page quality render section table update verify alpha ';
+const PLAIN_TAIL = 'format geometry header index layout';
+
+function trackedRunBytes(): Uint8Array {
+  return zipDocument(
+    '<w:p>' +
+      `<w:r><w:t xml:space="preserve">${PLAIN_LEAD}</w:t></w:r>` +
+      '<w:ins w:author="A" w:date="2020-01-01T00:00:00Z" w:id="7">' +
+      `<w:r><w:t xml:space="preserve">${TRACKED}</w:t></w:r>` +
+      '</w:ins>' +
+      `<w:r><w:t>${PLAIN_TAIL}</w:t></w:r>` +
+      '</w:p><w:sectPr/>',
+    {
+      documentRels:
+        `<Relationships xmlns="${REL}">` +
+        '<Relationship Id="rId9" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/pre" TargetMode="External"/>' +
+        '</Relationships>',
+    }
+  );
+}
+
+function bodyText(peer: Peer): string {
+  const texts: string[] = [];
+  walk(peer.store.bodyStore().part.root, (node: OoxmlNode) => {
+    if (node.kind === 'textValue') texts.push(node.value);
+  });
+  return texts.join('');
+}
+
+function linkRange(author: Peer, paragraphId: string, start: number): void {
+  const scope: StoryScope = BODY;
+  const result = author.store.transact(scope, (context) => {
+    context.apply({
+      op: 'insertHyperlink',
+      paragraphId,
+      start,
+      end: start + 3,
+      relationshipId: 'rId9',
+    });
+  });
+  if (!result.ok) throw new Error(result.detail ?? result.reason);
+  author.port.flushPendingJournals();
+}
+
+describe('hyperlink over tracked-change runs', () => {
+  test('a link that crosses into a w:ins run replicates without duplicating text', async () => {
+    const { alice, bob } = await harness.pair(trackedRunBytes());
+    const target = harness.paragraphIdAt(alice, 0);
+    const expected = PLAIN_LEAD + TRACKED + PLAIN_TAIL;
+    // Round 24 is the one that corrupted: it starts in the plain lead run and ends inside
+    // the tracked run, so the op splits the `w:ins` and moves it inside the new hyperlink.
+    // The plain rounds guard the baseline the crossing round builds on.
+    for (const start of [0, 12, 24, 36]) {
+      linkRange(alice, target, start);
+      expect(bodyText(bob)).toBe(expected);
+      harness.expectConverged(alice, bob);
+    }
+  });
+
+  test('a link entirely inside a w:ins run replicates without duplicating text', async () => {
+    const { alice, bob } = await harness.pair(trackedRunBytes());
+    const target = harness.paragraphIdAt(alice, 0);
+    // Fully inside the tracked run: both edges split the same `w:ins`.
+    linkRange(alice, target, PLAIN_LEAD.length + 5);
+    expect(bodyText(bob)).toBe(PLAIN_LEAD + TRACKED + PLAIN_TAIL);
+    harness.expectConverged(alice, bob);
+  });
+});


### PR DESCRIPTION
`expandInserted` in the journal lowering returned early for a node the document already holds, treating every such insertion as a pure move. A move that also edits the subtree — `insertHyperlink` splits a `w:ins` run and relocates it inside the new `w:hyperlink` with replaced children — therefore produced a journal with no record of the moved node's new content. Every receiving replica kept the old full-text run beside the split pieces, and the duplicated text converged as authoritative state. Fixes #557.

A moved known node now lowers as a same-identity diff against the capture's indexed previous subtree, in both the child-list and replace-node paths. The regression test pins the crossing-range case end to end: receiver body text plus the fingerprint and save/reopen convergence oracles.

The extra `indexSubtree` walk runs only on structural `replaceNode` captures, never on the keystroke path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790496250&installation_model_id=422592&pr_number=562&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F562&signature=dac976ec23b91d5e231e6999d59524602e12c311abf5ce1f1da1f6da87678ce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->