### PR TITLE
fix(store): keep transact applyPackage shell writes in the package

### DIFF
--- a/.changeset/shell-writes-stay.md
+++ b/.changeset/shell-writes-stay.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+A relationship, content type, or extra part written through a transaction's `applyPackage` now survives into the package, the save, and one shared undo unit with the story edit, instead of replicating to peers while vanishing from the author's own document. Fixes #558.

--- a/packages/core/src/store/__tests__/transact-package-shell.test.ts
+++ b/packages/core/src/store/__tests__/transact-package-shell.test.ts
@@ -1,0 +1,145 @@
+// A `ctx.applyPackage` write beyond the story part survives the transaction (issue #558).
+//
+// The transact tail syncs the STORY PART back into the package. A relationship, content type,
+// or extra part written through `ctx.applyPackage` needs the package-unit promotion the image
+// and paste lanes perform. Before the fix, that write reached the primitive journal — every
+// collaboration peer replayed it — while `currentPackage()` lost it, so the author saved a
+// `w:hyperlink` whose `r:id` resolved to nothing.
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import {
+  TreePackageStore,
+  ensureHyperlinkRelationship,
+  normalizeParagraphIdentity,
+  readOoxmlPackage,
+  writeOoxmlPackage,
+  type OoxmlNode,
+  type StoryScope,
+  type TreeModelChange,
+} from '../index.ts';
+
+const BODY: StoryScope = { kind: 'body' };
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function documentBytes(): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>` +
+        '<w:p><w:r><w:t>alpha bravo canvas</w:t></w:r></w:p>' +
+        '<w:sectPr/></w:body></w:document>'
+    ),
+  });
+}
+
+function storeOf(): TreePackageStore {
+  const loaded = readOoxmlPackage(documentBytes());
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const main = loaded.package.parts.get(loaded.package.mainDocumentPart);
+  if (!main) throw new Error('no main part');
+  return new TreePackageStore(loaded.package, normalizeParagraphIdentity(main));
+}
+
+function firstParagraphId(store: TreePackageStore): string {
+  const walkFor = (node: OoxmlNode): string | null => {
+    if (node.kind === 'paragraph') return node.id;
+    if (node.kind === 'textValue') return null;
+    for (const child of node.children) {
+      const found = walkFor(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  const id = walkFor(store.bodyStore().part.root);
+  if (!id) throw new Error('no paragraph');
+  return id;
+}
+
+function linkThroughApplyPackage(store: TreePackageStore): string {
+  let relationshipId = '';
+  const result = store.transact(BODY, (context) => {
+    context.applyPackage((pkg) => {
+      const ensured = ensureHyperlinkRelationship(pkg, 'https://example.com/doc');
+      if (!ensured) throw new Error('hyperlink relationship refused');
+      relationshipId = ensured.relationshipId;
+      return ensured.pkg;
+    });
+    context.apply({
+      op: 'insertHyperlink',
+      paragraphId: firstParagraphId(store),
+      start: 0,
+      end: 5,
+      relationshipId,
+    });
+  });
+  if (!result.ok) throw new Error(result.detail ?? result.reason);
+  return relationshipId;
+}
+
+function relationshipTargets(store: TreePackageStore): string[] {
+  const pkg = store.currentPackage();
+  return (pkg.relationships.get(pkg.mainDocumentPart) ?? []).map((record) => record.rawTarget);
+}
+
+describe('applyPackage shell writes inside transact', () => {
+  test('the relationship survives in currentPackage and in the saved bytes', () => {
+    const store = storeOf();
+    const relationshipId = linkThroughApplyPackage(store);
+    const pkg = store.currentPackage();
+    const records = pkg.relationships.get(pkg.mainDocumentPart) ?? [];
+    expect(records.some((record) => record.id === relationshipId)).toBe(true);
+    const reopened = readOoxmlPackage(writeOoxmlPackage(pkg));
+    if (!reopened.ok) throw new Error(reopened.reason);
+    const saved = reopened.package.relationships.get(reopened.package.mainDocumentPart) ?? [];
+    // Before the fix the author's save held a `w:hyperlink` with a dangling `r:id`.
+    expect(saved.some((record) => record.id === relationshipId)).toBe(true);
+  });
+
+  test('one undo restores the story edit and the package write together', () => {
+    const store = storeOf();
+    const before = relationshipTargets(store);
+    linkThroughApplyPackage(store);
+    expect(relationshipTargets(store)).toContain('https://example.com/doc');
+    const undone = store.undo();
+    expect(undone).not.toBeNull();
+    // A story-only undo pointer would restore the text and leave the relationship: the
+    // promotion makes the pair one package unit.
+    expect(relationshipTargets(store)).toEqual(before);
+  });
+
+  test('a story-only applyPackage keeps its own change classification', () => {
+    const store = storeOf();
+    let published: TreeModelChange | null = null;
+    const stop = store.subscribe((change) => {
+      published = change;
+    });
+    const result = store.transact(BODY, (context) => {
+      context.apply({
+        op: 'insertText',
+        paragraphId: firstParagraphId(store),
+        offset: 0,
+        text: 'X',
+      });
+      // Identity edit on the story part alone: no shell promotion, no synthetic global.
+      context.applyPackage((pkg) => pkg);
+    });
+    stop();
+    if (!result.ok) throw new Error(result.detail ?? result.reason);
+    const change = published as TreeModelChange | null;
+    expect(change).not.toBeNull();
+    expect(change?.impact).toBe('text-local');
+  });
+});

--- a/packages/core/src/store/__tests__/transact-package-shell.test.ts
+++ b/packages/core/src/store/__tests__/transact-package-shell.test.ts
@@ -120,6 +120,32 @@ describe('applyPackage shell writes inside transact', () => {
     expect(relationshipTargets(store)).toEqual(before);
   });
 
+  test('the promotion keeps shell state the working package never saw', () => {
+    const store = storeOf();
+    // A lifecycle op writes /word/footnotes.xml, its relationship, and its content-type
+    // override into the COORDINATOR's package; the body store's own working package never
+    // sees them. A promotion that installed the stale working package erased all three —
+    // the author's save silently dropped every footnote.
+    const inserted = store.applyLifecycleOp({
+      op: 'insertNote',
+      noteKind: 'footnote',
+      paragraphId: firstParagraphId(store),
+      offset: 5,
+    });
+    if (!inserted.ok) throw new Error(inserted.reason);
+    expect(store.currentPackage().parts.has('/word/footnotes.xml')).toBe(true);
+    linkThroughApplyPackage(store);
+    const pkg = store.currentPackage();
+    expect(pkg.parts.has('/word/footnotes.xml')).toBe(true);
+    expect(pkg.contentTypes.overrides.has('/word/footnotes.xml')).toBe(true);
+    const records = pkg.relationships.get(pkg.mainDocumentPart) ?? [];
+    expect(records.some((record) => record.rawTarget.includes('footnotes.xml'))).toBe(true);
+    expect(records.some((record) => record.rawTarget === 'https://example.com/doc')).toBe(true);
+    const reopened = readOoxmlPackage(writeOoxmlPackage(pkg));
+    if (!reopened.ok) throw new Error(reopened.reason);
+    expect(reopened.package.parts.has('/word/footnotes.xml')).toBe(true);
+  });
+
   test('a story-only applyPackage keeps its own change classification', () => {
     const store = storeOf();
     let published: TreeModelChange | null = null;

--- a/packages/core/src/store/store/package-shell-delta.ts
+++ b/packages/core/src/store/store/package-shell-delta.ts
@@ -1,0 +1,33 @@
+// Whether a package edit reached beyond one story part.
+//
+// `TreePackageStore.transact` syncs the transacted STORY PART back into the package after a
+// commit. Everything else a `ctx.applyPackage` edit can write — a relationship, a content
+// type, binary part bytes, another part — needs the package-unit promotion the image and
+// paste lanes perform. This predicate is how the transact tail decides, so it compares by
+// identity only: an edit produces new objects exactly where it wrote.
+
+import type { OoxmlPackage } from '../package/ooxml-package.ts';
+
+/** True when `next` differs from `previous` anywhere the story-part sync cannot carry. */
+export function packageEditTouchesShell(
+  previous: OoxmlPackage,
+  next: OoxmlPackage,
+  storyPartName: string
+): boolean {
+  if (
+    previous.relationships !== next.relationships ||
+    previous.contentTypes !== next.contentTypes ||
+    previous.partBytes !== next.partBytes ||
+    previous.externalTargets !== next.externalTargets ||
+    previous.mainDocumentPart !== next.mainDocumentPart
+  ) {
+    return true;
+  }
+  if (previous.parts === next.parts) return false;
+  if (previous.parts.size !== next.parts.size) return true;
+  for (const [name, part] of next.parts) {
+    if (name === storyPartName) continue;
+    if (previous.parts.get(name) !== part) return true;
+  }
+  return false;
+}

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -414,6 +414,14 @@ export class TreePackageStore {
     // because comparing whole packages afterwards would blame pre-existing drift on this
     // transaction.
     let packageShellTouched = false;
+    // The working package must start at the coordinator's truth. Shell writes made through
+    // lifecycle ops, package undo, remote installs, or the comment lanes never reach this
+    // story store's own package, so an `applyPackage` edit basing on the stale copy would
+    // commit — and the promotion below would install — a document that has forgotten them:
+    // a footnote part inserted a moment earlier would vanish from the author's save. The
+    // graft is the same precondition the comment and custom-node lanes take before their
+    // transactions, and it is one memoized read plus one assignment.
+    store.graftPackage(() => this.currentPackage());
     const result = store.transact(
       (ctx) => {
         build({
@@ -567,7 +575,13 @@ export class TreePackageStore {
     if (result.change) {
       this.packageRev += 1;
       const promoted = cascaded || promotedShellWrite;
-      if (!compositionWasOpen && (store.historyDepth > beforeDepth || promoted)) {
+      // `recordsHistory: false` opts a caller out of undo entirely; the promoted branch must
+      // not push a package pointer for it either.
+      if (
+        !compositionWasOpen &&
+        options.recordsHistory !== false &&
+        (store.historyDepth > beforeDepth || promoted)
+      ) {
         if (promoted) {
           // Promote to package undo so the story edit and the package write restore together.
           this.pushUndoPointer({

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -17,6 +17,7 @@
 import type { OoxmlPart } from '../package/ooxml-tree.ts';
 import { normalizeParagraphIdentity } from '../package/para-id.ts';
 import { openStoryPartsOf, openStoryTokenOf } from './open-story-parts.ts';
+import { packageEditTouchesShell } from './package-shell-delta.ts';
 import { settingsPartOf } from '../package/note-properties.ts';
 import { ensureListParagraphContextualSpacing } from '../package/list-style-part.ts';
 import { withPart, type OoxmlExternalTarget, type OoxmlPackage } from '../package/ooxml-package.ts';
@@ -407,6 +408,12 @@ export class TreePackageStore {
     const commentTargets = new Set<string>();
     let turnsListOn = false;
     let listStyleId: string | undefined;
+    // A `ctx.applyPackage` edit can write beyond the story part — a relationship, a content
+    // type, another part. The story sync after the commit cannot carry those, so the tail
+    // promotes to a package unit when one did. Detected at the edit, input against output,
+    // because comparing whole packages afterwards would blame pre-existing drift on this
+    // transaction.
+    let packageShellTouched = false;
     const result = store.transact(
       (ctx) => {
         build({
@@ -414,6 +421,14 @@ export class TreePackageStore {
           // `applyPackage` are how a transaction writes the comment or numbering part in the
           // same unit as the story, and rebuilding the object dropped them.
           ...ctx,
+          applyPackage: (edit) =>
+            ctx.applyPackage((current) => {
+              const next = edit(current);
+              if (next !== current && !packageShellTouched) {
+                packageShellTouched = packageEditTouchesShell(current, next, story.partName);
+              }
+              return next;
+            }),
           apply: (op) => {
             if (op.op === 'setListNumbering' && op.numId !== null) turnsListOn = true;
             if (op.op === 'setParagraphProperties') {
@@ -479,6 +494,20 @@ export class TreePackageStore {
     }
 
     this.syncPackageFromStore(store);
+    // The shell write the sync above cannot carry: adopt the transaction's working package,
+    // exactly as the image and paste lanes promote theirs. Without this the write reached
+    // the primitive journal (peers replayed it) while `currentPackage()` lost it — the
+    // author saved dangling references to relationships every other replica had.
+    let promotedShellWrite = false;
+    if (result.change && packageShellTouched) {
+      this.installPackageSnapshotInternal(store.package);
+      if (!compositionWasOpen) {
+        store.restoreHistoryStacks(checkpoint);
+      } else if (this.compositionSession) {
+        this.compositionSession.packageWideEffects = true;
+      }
+      promotedShellWrite = true;
+    }
     if (turnsListOn && listStyleId) {
       const repaired = ensureListParagraphContextualSpacing(this.pkg, listStyleId);
       if (repaired) this.replacePackageShell(repaired);
@@ -537,9 +566,10 @@ export class TreePackageStore {
 
     if (result.change) {
       this.packageRev += 1;
-      if (!compositionWasOpen && (store.historyDepth > beforeDepth || cascaded)) {
-        if (cascaded) {
-          // Promote to package undo so reference+body restore together.
+      const promoted = cascaded || promotedShellWrite;
+      if (!compositionWasOpen && (store.historyDepth > beforeDepth || promoted)) {
+        if (promoted) {
+          // Promote to package undo so the story edit and the package write restore together.
           this.pushUndoPointer({
             kind: 'package',
             before: beforePackage,
@@ -549,10 +579,10 @@ export class TreePackageStore {
           this.pushUndoPointer({ kind: 'story', partName: story.partName, story });
         }
       }
-      const change = cascaded
+      const change = promoted
         ? this.publishSynthetic(result.change.origin, 'global', story, result.change.created)
         : result.change;
-      if (!cascaded) this.publish(change);
+      if (!promoted) this.publish(change);
       return { ok: true, change };
     }
     return { ok: true, change: result.change };

--- a/packages/pro/src/collaboration/__tests__/document-session.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-session.test.ts
@@ -745,8 +745,11 @@ describe('full-document collaboration replicates every authorable change class',
     expect(nodesOf(alice, 'hyperlink')).toHaveLength(1);
     expect(nodesOf(bob, 'hyperlink')).toHaveLength(1);
     expect(textOf(bob)).toContain('Alpha');
-    // The authoring store copies only the story part after applyPackage, so alice.store
-    // does not hold the new `.rels` part. Peers that materialize from shared state do.
+    // The AUTHOR keeps the relationship too: the transact promotes the applyPackage write to
+    // a package unit, so alice's package and save agree with the journal every peer
+    // replayed. Losing it here saved a `w:hyperlink` whose rId resolved to nothing (#558).
+    const authorRecords = packageOf(alice).relationships.get(owner) ?? [];
+    expect(authorRecords.some((record) => record.id === relationshipId)).toBe(true);
     const carol = await joinPeer(alice, 'carol');
     expectConverged(bob, carol);
   });


### PR DESCRIPTION
A relationship, content type, or extra part written through a transaction's `applyPackage` reached the primitive journal — every collaboration peer replayed it — while the transact tail synced only the story part. The author's `currentPackage()` and save lost the write, so a hyperlink saved with a dangling `r:id` while every other replica resolved it. Fixes #558.

Two coordinated changes in `TreePackageStore.transact`:

- The working package grafts from `currentPackage()` at transaction start, the same precondition the comment and custom-node lanes already take, so package edits and the promoted snapshot base on coordinator truth instead of the story store's stale copy.
- A shell delta, detected per edit by identity (input against output, so pre-existing drift is never blamed), promotes the transaction to one package undo unit — the protocol the image and paste lanes already use. Story-only edits keep their own change classification and story-level history, and `recordsHistory: false` still opts out of undo.

The graft also makes header-scope `applyPackage` shell writes work, which previously refused against a stub package. A pre-existing sibling gap remains out of scope: `applyTo` writes to a non-story part are not detected; the issue trail notes it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790499331&installation_model_id=422592&pr_number=564&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F564&signature=f86a81349b353d5d315b7f834818042d2127e6adf49676655d1b12b519b4e533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->