### PR TITLE
feat(collaboration): report a room's replicated size against its limits

### DIFF
--- a/.changeset/rooms-show-their-size.md
+++ b/.changeset/rooms-show-their-size.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': minor
+---
+
+Collaboration rooms report their replicated size: `session.resourceUsage()` and the server-side `readCollaborationResourceUsage(ydoc)` return node, tombstone, relationship, part, and media-byte counts next to the hard limits, so a host can archive and re-room before growth turns terminal.

--- a/docs/api/docx-editor-pro/collaboration.api.md
+++ b/docs/api/docx-editor-pro/collaboration.api.md
@@ -52,6 +52,25 @@ export interface CollaborationModuleOptions extends ProLicenseOptions {
 }
 
 // @public
+export interface CollaborationResourceUsage {
+    readonly blobBytes: number;
+    // (undocumented)
+    readonly maxBlobBytes: number;
+    // (undocumented)
+    readonly maxNodes: number;
+    // (undocumented)
+    readonly maxParts: number;
+    // (undocumented)
+    readonly maxRelationships: number;
+    readonly nodes: number;
+    // (undocumented)
+    readonly parts: number;
+    // (undocumented)
+    readonly relationships: number;
+    readonly tombstonedNodes: number;
+}
+
+// @public
 export class CollaborationSchemaError extends Error {
     constructor(code: CollaborationFailureCode, detail?: string | undefined);
     // (undocumented)
@@ -133,6 +152,7 @@ export type DocumentCollaborationHandle = CollaborationHandle<DocumentCollaborat
 
 // @public
 export interface DocumentCollaborationSession extends TextCollaborationSession {
+    resourceUsage(): CollaborationResourceUsage;
     setIdentity(update: CollaborationIdentityUpdate): void;
 }
 
@@ -144,6 +164,9 @@ export const PROTOCOL_VERSION = 1;
 
 // @public
 export function readCollaborationDocument(ydoc: Y.Doc): Uint8Array;
+
+// @public
+export function readCollaborationResourceUsage(ydoc: Y.Doc): CollaborationResourceUsage;
 
 // @public
 export const SCHEMA_VERSION = 1;

--- a/docs/site/content/pro/collaboration.mdx
+++ b/docs/site/content/pro/collaboration.mdx
@@ -791,5 +791,28 @@ Most exceeded limits produce a typed failure code.
 Presence reads return only the first 256 participants. For Hocuspocus, increase
 `syncedTimeoutMs` when the initial synchronization needs more time.
 
+### Watch a room's size
+
+A room only grows. Deletion writes a tombstone, and deleted media bytes stay in
+the shared state, so a long-lived room under heavy editing moves toward the
+node and media limits. Crossing a limit is a terminal error for the room.
+
+Watch the growth and archive the room before that happens.
+`session.resourceUsage()` returns the replicated counts next to the limits:
+
+```ts
+const usage = session.resourceUsage();
+if (usage.nodes > usage.maxNodes * 0.8) {
+  // Export the room and create a new one from the saved bytes.
+}
+```
+
+On a server, call `readCollaborationResourceUsage(ydoc)` from
+`@docx-editor.dev/pro/collaboration`. It reads a synchronized `Y.Doc` the same
+way `readCollaborationDocument` does: it joins nothing and writes nothing.
+
+Both probes walk the node map once per call. Read them on a schedule, not on
+every edit.
+
 For module registration and licensing, see the
 [Pro package documentation](/docs/2.x/pro).

--- a/packages/pro/src/collaboration/__tests__/collaboration-resource-usage.test.ts
+++ b/packages/pro/src/collaboration/__tests__/collaboration-resource-usage.test.ts
@@ -9,6 +9,7 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 // the server-side probe agrees with the session's, and that the probe leaks nothing.
 
 import { afterEach, describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
 import type { TreeDocOp } from '@docx-editor.dev/core/store';
 import { readCollaborationResourceUsage } from '../resource-usage.ts';
 import { createPeerHarness } from './document-peer-support.ts';
@@ -58,6 +59,26 @@ describe('collaboration resource usage', () => {
     const afterJoin = session.resourceUsage();
     expect(afterJoin.tombstonedNodes).toBeGreaterThan(0);
     expect(afterJoin.nodes).toBeGreaterThanOrEqual(afterSplit.nodes);
+  });
+
+  test('hostile shared entries never make the probe throw or under-report', async () => {
+    const { alice } = await harness.pair(collaborationDocx());
+    // Mirror the room into a bare doc with no attached registry, so planting the hostile
+    // shapes does not trip the separate observer crash tracked in #567. The probe reads
+    // the pre-existing junk on a fresh registry, which is the server-side path.
+    const mirror = new Y.Doc();
+    Y.applyUpdate(mirror, Y.encodeStateAsUpdate(alice.ydoc));
+    const clean = readCollaborationResourceUsage(mirror);
+    // A hostile peer can write raw shapes the decoded readers skip. The probe must keep
+    // returning numbers — a metrics scraper crashes otherwise — and must count what the
+    // ENFORCING caps count, or it shows a healthy room right up to the terminal failure.
+    mirror.getMap('docx-package-nodes-v1').set('junk-node', 'not-a-map' as never);
+    mirror.getMap('docx-package-parts-v1').set('junk-part', 'not-a-map' as never);
+    const usage = readCollaborationResourceUsage(mirror);
+    expect(usage.nodes).toBe(clean.nodes + 1);
+    expect(usage.parts).toBe(clean.parts + 1);
+    expect(usage.tombstonedNodes).toBe(clean.tombstonedNodes);
+    mirror.destroy();
   });
 
   test('the server-side probe agrees with the session and leaks nothing', async () => {

--- a/packages/pro/src/collaboration/__tests__/collaboration-resource-usage.test.ts
+++ b/packages/pro/src/collaboration/__tests__/collaboration-resource-usage.test.ts
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Room-size observability (issue #554). A room only grows — deletion is a tombstone — and
+// the resource caps turn terminal when crossed. The usage probe is the interim mitigation
+// until compaction exists: these cases pin that it reports growth a host can act on, that
+// the server-side probe agrees with the session's, and that the probe leaks nothing.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { TreeDocOp } from '@docx-editor.dev/core/store';
+import { readCollaborationResourceUsage } from '../resource-usage.ts';
+import { createPeerHarness } from './document-peer-support.ts';
+import { collaborationDocx } from './support.ts';
+
+const harness = createPeerHarness('resource-usage-room');
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+function typeText(peer: Parameters<typeof harness.apply>[0], text: string): void {
+  const ops: readonly TreeDocOp[] = [
+    { op: 'insertText', paragraphId: harness.paragraphIdAt(peer, 0), offset: 0, text },
+  ];
+  harness.apply(peer, ops);
+}
+
+describe('collaboration resource usage', () => {
+  test('the session reports growth against the caps', async () => {
+    const { alice } = await harness.pair(collaborationDocx());
+    const session = alice.room.session;
+    const before = session.resourceUsage();
+    expect(before.nodes).toBeGreaterThan(0);
+    expect(before.nodes).toBeLessThanOrEqual(before.maxNodes);
+    expect(before.tombstonedNodes).toBe(0);
+    expect(before.parts).toBeGreaterThan(0);
+    // The fixture carries binary part bytes, so the blob reading is non-zero from the seed.
+    expect(before.blobBytes).toBeGreaterThan(0);
+    expect(before.blobBytes).toBeLessThanOrEqual(before.maxBlobBytes);
+
+    // A split mints nodes; the join that follows tombstones. Growth is monotonic: the
+    // tombstone still counts against `maxNodes`, which is the fact this probe exists to show.
+    harness.apply(alice, [
+      { op: 'splitParagraph', paragraphId: harness.paragraphIdAt(alice, 0), offset: 2 },
+    ]);
+    const afterSplit = session.resourceUsage();
+    expect(afterSplit.nodes).toBeGreaterThan(before.nodes);
+
+    harness.apply(alice, [
+      {
+        op: 'joinParagraphs',
+        firstId: harness.paragraphIdAt(alice, 0),
+        secondId: harness.paragraphIdAt(alice, 1),
+      },
+    ]);
+    const afterJoin = session.resourceUsage();
+    expect(afterJoin.tombstonedNodes).toBeGreaterThan(0);
+    expect(afterJoin.nodes).toBeGreaterThanOrEqual(afterSplit.nodes);
+  });
+
+  test('the server-side probe agrees with the session and leaks nothing', async () => {
+    const { alice, bob } = await harness.pair(collaborationDocx());
+    typeText(alice, 'grow ');
+    const fromSession = bob.room.session.resourceUsage();
+    const nodesMap = bob.ydoc.getMap('docx-package-nodes-v1') as unknown as {
+      _eH: { l: readonly unknown[] };
+      _dEH: { l: readonly unknown[] };
+    };
+    const observersBefore = nodesMap._eH.l.length + nodesMap._dEH.l.length;
+    const fromServer = readCollaborationResourceUsage(bob.ydoc);
+    expect(fromServer).toEqual(fromSession);
+    // A metrics scraper calls this for the life of the room, so it must give back every
+    // observer the probe registered.
+    expect(nodesMap._eH.l.length + nodesMap._dEH.l.length).toBe(observersBefore);
+  });
+});

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -61,6 +61,7 @@ import {
   waitForSharedInitialization,
 } from './document-bootstrap.ts';
 import { LogicalIdentityMap } from './document-identity.ts';
+import { resourceUsageOf, type CollaborationResourceUsage } from './resource-usage.ts';
 import {
   AWARENESS_FIELD,
   MAX_AWARENESS_STATES,
@@ -200,6 +201,10 @@ class DocumentSession implements DocumentCollaborationSession {
 
   statusSnapshot(): CollaborationStatusSnapshot {
     return this.statusState.snapshot();
+  }
+
+  resourceUsage(): CollaborationResourceUsage {
+    return resourceUsageOf(this.registry, this.blobs);
   }
 
   subscribeStatus(
@@ -760,6 +765,16 @@ export interface DocumentCollaborationSession extends TextCollaborationSession {
    * runtime property is ignored.
    */
   setIdentity(update: CollaborationIdentityUpdate): void;
+
+  /**
+   * One reading of the room's replicated size against this replica's hard limits.
+   *
+   * A room only grows — deletion is a tombstone — and the limits that bound hostile
+   * amplification turn terminal when crossed. Watch this to archive and re-room before that
+   * happens. The tombstone count walks the node map once per call, so read it on your own
+   * schedule rather than per keystroke.
+   */
+  resourceUsage(): CollaborationResourceUsage;
 }
 
 /** Owned full-document collaboration replica. @public */

--- a/packages/pro/src/collaboration/index.ts
+++ b/packages/pro/src/collaboration/index.ts
@@ -32,6 +32,10 @@ export {
   type DocumentCollaborationSession,
 } from './document-session.ts';
 export {
+  readCollaborationResourceUsage,
+  type CollaborationResourceUsage,
+} from './resource-usage.ts';
+export {
   MAX_BASELINE_BYTES,
   PROTOCOL_VERSION,
   SCHEMA_VERSION,

--- a/packages/pro/src/collaboration/resource-usage.ts
+++ b/packages/pro/src/collaboration/resource-usage.ts
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+/**
+ * Room-size observability.
+ *
+ * A room only grows: deletion is a tombstone, and deleted blob bytes stay in the shared blob
+ * map. The resource caps that bound hostile amplification run on every received edit and
+ * count that growth, so a long-lived room walks toward a terminal `too-many-nodes` or
+ * `blob-store-full` failure. Until compaction exists (the generation reset of issue #554),
+ * the honest interim is visibility: a host that can SEE the walk can archive and re-room
+ * before the caps end the session for it.
+ */
+
+import type * as Y from 'yjs';
+import { DocumentRegistry } from './document/index.ts';
+import { NODE_DELETED_FIELD } from './document/schema.ts';
+import { MAX_SHARED_BLOB_BYTES, SHARED_BLOBS_KEY, SharedBlobStore } from './shared-blob-store.ts';
+
+/**
+ * One reading of a room's replicated size against this replica's hard limits.
+ *
+ * Every `max*` value is the cap whose crossing turns the session status terminal.
+ * `tombstonedNodes` is included in `nodes`: a tombstone is never map-deleted, so it keeps
+ * counting against `maxNodes` for the life of the room. A reading is a snapshot — take a new
+ * one to observe growth.
+ *
+ * @public
+ */
+export interface CollaborationResourceUsage {
+  /** Replicated node records, tombstones included. */
+  readonly nodes: number;
+  /** The subset of `nodes` that is tombstoned: permanent, and only compaction reclaims it. */
+  readonly tombstonedNodes: number;
+  readonly maxNodes: number;
+  readonly relationships: number;
+  readonly maxRelationships: number;
+  readonly parts: number;
+  readonly maxParts: number;
+  /** Bytes in the shared blob map, unreferenced bytes included. */
+  readonly blobBytes: number;
+  readonly maxBlobBytes: number;
+}
+
+/** Count tombstoned node records. One walk over the node map, so this is a probe, not a poll. */
+function tombstoneCount(registry: DocumentRegistry): number {
+  let count = 0;
+  registry.schema.nodes.forEach((record) => {
+    if (record.get(NODE_DELETED_FIELD) === true) count += 1;
+  });
+  return count;
+}
+
+/** Read one usage snapshot from a live registry and blob store. */
+export function resourceUsageOf(
+  registry: DocumentRegistry,
+  blobs: SharedBlobStore
+): CollaborationResourceUsage {
+  return Object.freeze({
+    nodes: registry.nodeCount(),
+    tombstonedNodes: tombstoneCount(registry),
+    maxNodes: registry.limits.maxNodes,
+    relationships: registry.relationshipCount(),
+    maxRelationships: registry.limits.maxRelationships,
+    parts: registry.partCount(),
+    maxParts: registry.limits.maxParts,
+    blobBytes: blobs.totalByteLength(),
+    maxBlobBytes: MAX_SHARED_BLOB_BYTES,
+  });
+}
+
+/**
+ * Read a room's resource usage from a synchronized `Y.Doc`, joining nothing.
+ *
+ * The server-side sibling of `readCollaborationDocument`: call it from the same jobs — an
+ * autosave hook, a metrics scraper — to watch a room's growth against the caps that would
+ * end it. It creates no session and writes nothing, and it walks the node map once per call.
+ *
+ * @public
+ */
+export function readCollaborationResourceUsage(ydoc: Y.Doc): CollaborationResourceUsage {
+  const registry = new DocumentRegistry(ydoc);
+  try {
+    const blobs = new SharedBlobStore(ydoc.getMap<Uint8Array>(SHARED_BLOBS_KEY));
+    return resourceUsageOf(registry, blobs);
+  } finally {
+    // Owned here, so released here: a metrics scraper calls this for the life of the room.
+    registry.destroy();
+  }
+}

--- a/packages/pro/src/collaboration/resource-usage.ts
+++ b/packages/pro/src/collaboration/resource-usage.ts
@@ -14,9 +14,9 @@ Production use requires a commercial agreement: licensing@eigenpal.com
  * before the caps end the session for it.
  */
 
-import type * as Y from 'yjs';
+import * as Y from 'yjs';
 import { DocumentRegistry } from './document/index.ts';
-import { NODE_DELETED_FIELD } from './document/schema.ts';
+import { NODE_DELETED_FIELD, isNodeMap } from './document/schema.ts';
 import { MAX_SHARED_BLOB_BYTES, SHARED_BLOBS_KEY, SharedBlobStore } from './shared-blob-store.ts';
 
 /**
@@ -48,12 +48,30 @@ export interface CollaborationResourceUsage {
 function tombstoneCount(registry: DocumentRegistry): number {
   let count = 0;
   registry.schema.nodes.forEach((record) => {
-    if (record.get(NODE_DELETED_FIELD) === true) count += 1;
+    // The nodes map is peer-writable: a hostile update can plant a non-map value, and a
+    // probe that throws on it takes the metrics scraper down with attacker-chosen input.
+    if (isNodeMap(record) && record.get(NODE_DELETED_FIELD) === true) count += 1;
   });
   return count;
 }
 
-/** Read one usage snapshot from a live registry and blob store. */
+/** Raw relationship records, counted exactly the way `limitFailure` counts them. */
+function rawRelationshipCount(registry: DocumentRegistry): number {
+  let count = 0;
+  registry.schema.relationships.forEach((owner) => {
+    count += owner instanceof Y.Map ? owner.size : 0;
+  });
+  return count;
+}
+
+/**
+ * Read one usage snapshot from a live registry and blob store.
+ *
+ * Every count mirrors the ENFORCING read in `limitFailure`, not the decoded projection: the
+ * probe exists to show distance to the caps that end the room, and a hostile peer can pad
+ * shared state with malformed entries the decoded readers skip. A probe that under-reports
+ * against the enforcement would show a healthy room right up to the terminal failure.
+ */
 export function resourceUsageOf(
   registry: DocumentRegistry,
   blobs: SharedBlobStore
@@ -62,9 +80,9 @@ export function resourceUsageOf(
     nodes: registry.nodeCount(),
     tombstonedNodes: tombstoneCount(registry),
     maxNodes: registry.limits.maxNodes,
-    relationships: registry.relationshipCount(),
+    relationships: rawRelationshipCount(registry),
     maxRelationships: registry.limits.maxRelationships,
-    parts: registry.partCount(),
+    parts: registry.schema.parts.size,
     maxParts: registry.limits.maxParts,
     blobBytes: blobs.totalByteLength(),
     maxBlobBytes: MAX_SHARED_BLOB_BYTES,


### PR DESCRIPTION
A collaboration room only grows. Deletion writes a tombstone, and deleted media bytes stay in shared state, so the resource caps that bound hostile amplification turn a long-lived room's growth into a scheduled terminal failure. This adds the visibility a host needs to archive and re-room before that happens; the generation-reset compaction and the cap-policy decision stay in #554.

`session.resourceUsage()` and the server-side `readCollaborationResourceUsage(ydoc)` return node, tombstone, relationship, part, and media-byte counts next to the hard limits. Both mirror the enforcing reads exactly, so a room a hostile peer has padded with malformed entries reports its true distance to the caps rather than reading healthy up to the terminal failure, and neither probe throws on attacker-chosen shapes. The server probe joins nothing and writes nothing, the same contract as `readCollaborationDocument`, and both walk the node map once per call.

A separate, more severe receive-path crash on the same hostile shape is filed as #567.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790501555&installation_model_id=422592&pr_number=569&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F569&signature=4a33de770104f692df2bd2b35ff07c7e66a79e5963e7ea33a206d2964e78432d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->