### PR TITLE
fix: keep rich clipboard pastes rich and stop duplicate image inserts

### DIFF
--- a/.changeset/tidy-clouds-repeat.md
+++ b/.changeset/tidy-clouds-repeat.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Pasting copied content into a non-empty document keeps its formatting instead of silently degrading to plain text, and pasting text copied from Word on macOS no longer inserts a rendered image of that text next to it.

--- a/.changeset/tidy-clouds-repeat.md
+++ b/.changeset/tidy-clouds-repeat.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Pasting copied content into a non-empty document keeps its formatting instead of silently degrading to plain text, and pasting text copied from Word on macOS no longer inserts a rendered image of that text next to it.
+Pasting rich content into non-empty documents no longer degrades to plain text or inserts Word's macOS preview image. Word headings, captions, and image dimensions now retain their source semantics and physical size.

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -677,10 +677,10 @@ export function chromeSlotId(group: {
 // @public
 export function chromeSlotIsToggle(slotId: ChromeSlotId): boolean;
 
-// @public
+// @internal
 export function clipboardDropLandsText(transfer: DataTransfer | null | undefined): boolean;
 
-// @public
+// @internal
 export function clipboardPasteLandsContent(transfer: DataTransfer | null | undefined): boolean;
 
 // @public

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -678,7 +678,10 @@ export function chromeSlotId(group: {
 export function chromeSlotIsToggle(slotId: ChromeSlotId): boolean;
 
 // @public
-export function clipboardHtmlLandsContent(html: string): boolean;
+export function clipboardDropLandsText(html: string, text: string): boolean;
+
+// @public
+export function clipboardPasteLandsContent(html: string, text: string): boolean;
 
 // @public
 export interface CollaborationModuleContribution {

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -678,10 +678,10 @@ export function chromeSlotId(group: {
 export function chromeSlotIsToggle(slotId: ChromeSlotId): boolean;
 
 // @public
-export function clipboardDropLandsText(html: string, text: string): boolean;
+export function clipboardDropLandsText(transfer: DataTransfer | null | undefined): boolean;
 
 // @public
-export function clipboardPasteLandsContent(html: string, text: string): boolean;
+export function clipboardPasteLandsContent(transfer: DataTransfer | null | undefined): boolean;
 
 // @public
 export interface CollaborationModuleContribution {

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -678,6 +678,9 @@ export function chromeSlotId(group: {
 export function chromeSlotIsToggle(slotId: ChromeSlotId): boolean;
 
 // @public
+export function clipboardHtmlLandsContent(html: string): boolean;
+
+// @public
 export interface CollaborationModuleContribution {
     readonly session: EditorCollaborationSession;
 }

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4806,6 +4806,8 @@ export function usedParaIds(root: OoxmlElement): ReadonlySet<string>;
 
 // @public
 export interface ValidatedRasterHeader {
+    readonly dpiX?: number;
+    readonly dpiY?: number;
     // (undocumented)
     readonly pixelHeight: number;
     // (undocumented)

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -794,7 +794,7 @@ export interface CreateImageResourceCacheOptions {
 }
 
 // @public
-export function createNodeIdAllocator(part: OoxmlPart, family?: string): () => string;
+export function createNodeIdAllocator(part: OoxmlPart, family?: 'new' | 'paste'): () => string;
 
 // @public
 export function createNoteReferenceScanBudget(maxVisited?: number, maxParts?: number): NoteReferenceScanBudget;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -794,7 +794,7 @@ export interface CreateImageResourceCacheOptions {
 }
 
 // @public
-export function createNodeIdAllocator(part: OoxmlPart): () => string;
+export function createNodeIdAllocator(part: OoxmlPart, family?: string): () => string;
 
 // @public
 export function createNoteReferenceScanBudget(maxVisited?: number, maxParts?: number): NoteReferenceScanBudget;

--- a/packages/core/src/editor/__tests__/blank-document-styles.test.ts
+++ b/packages/core/src/editor/__tests__/blank-document-styles.test.ts
@@ -118,6 +118,7 @@ describe("the blank template's style gallery", () => {
       'Heading8',
       'Heading9',
       'Quote',
+      'Caption',
       'NoSpacing',
       'ListParagraph',
     ]);
@@ -141,6 +142,13 @@ describe("the blank template's style gallery", () => {
     expect(editor.exec({ type: 'setParagraphStyle', styleId: 'Heading1' }).ok).toBe(true);
     // 16pt text where the default is 11pt: the line has to grow.
     expect(blockHeights(surface)[0]!).toBeGreaterThan(plain);
+  });
+
+  test('it defines the built-in Caption style for pasted Word captions', async () => {
+    const { editor } = mount(blankDocumentBytes());
+    const styles = await savedStyles(editor);
+    expect(styles).toContain('w:styleId="Caption"');
+    expect(styles).toContain('<w:sz w:val="18"/>');
   });
 });
 

--- a/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
@@ -157,7 +157,8 @@ describe('run and paragraph mapping', () => {
     const { docXml } = openFragment('<p><span style="background:yellow">y</span></p>');
     const run = docXml.split('<w:r>').find((piece) => piece.includes('>y<'));
     expect(run).not.toContain('w:highlight');
-    expect(run).toContain('w:shd w:val="clear" w:color="auto" w:fill="FFFF00"');
+    expect(run).toContain('<w:shd ');
+    expect(run).toContain('w:fill="FFFF00"');
   });
 
   test('background shorthand that is not a solid colour is refused', () => {

--- a/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
@@ -16,17 +16,39 @@ import { strFromU8 } from '../../store/package/zip.ts';
 const TINY_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
 
+function pngWithPhysicalSize(width: number, height: number, pixelsPerMeter: number): string {
+  const source = Uint8Array.from(atob(TINY_PNG_BASE64), (char) => char.charCodeAt(0));
+  const writeUint32 = (bytes: Uint8Array, offset: number, value: number): void => {
+    bytes[offset] = (value >>> 24) & 0xff;
+    bytes[offset + 1] = (value >>> 16) & 0xff;
+    bytes[offset + 2] = (value >>> 8) & 0xff;
+    bytes[offset + 3] = value & 0xff;
+  };
+  writeUint32(source, 16, width);
+  writeUint32(source, 20, height);
+  const phys = Uint8Array.from([
+    0, 0, 0, 9, 0x70, 0x48, 0x59, 0x73, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+  ]);
+  writeUint32(phys, 8, pixelsPerMeter);
+  writeUint32(phys, 12, pixelsPerMeter);
+  const bytes = new Uint8Array(source.length + phys.length);
+  bytes.set(source.subarray(0, 33));
+  bytes.set(phys, 33);
+  bytes.set(source.subarray(33), 33 + phys.length);
+  return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(''));
+}
+
 interface OpenedFragment {
   readonly pkg: OoxmlPackage;
   readonly docXml: string;
   readonly relsXml: string;
+  readonly lastMarkCovered: boolean;
 }
 
 /** Project, read back through the bounded package reader, and serialize the body. */
 function openFragment(html: string): OpenedFragment {
   const projected = projectExternalHtml(html);
   if (!projected.ok) throw new Error(`projection refused: ${projected.reason}`);
-  expect(projected.lastMarkCovered).toBe(false);
   const read = readOoxmlPackage(projected.fragmentBytes);
   if (!read.ok) throw new Error(`read-back refused: ${read.reason}`);
   const pkg = read.package;
@@ -37,17 +59,60 @@ function openFragment(html: string): OpenedFragment {
     pkg,
     docXml: serializeOoxmlPart(part),
     relsXml: relsBytes ? strFromU8(relsBytes) : '',
+    lastMarkCovered: projected.lastMarkCovered,
   };
 }
 
 describe('run and paragraph mapping', () => {
   test('headings become bold direct formatting at Word sizes', () => {
-    const { docXml } = openFragment('<h1>Alpha</h1><h3>Beta</h3>');
+    const { docXml, lastMarkCovered } = openFragment('<h1>Alpha</h1><h3>Beta</h3>');
     expect(docXml).toContain('w:sz w:val="64"');
     expect(docXml).toContain('w:sz w:val="44"');
     expect(docXml).toContain('<w:b/>');
     expect(docXml).toContain('Alpha');
     expect(docXml).toContain('Beta');
+    expect(lastMarkCovered).toBe(false);
+  });
+
+  test('Word heading tags use target styles and include their paragraph mark', () => {
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><body>' +
+      '<h2>Target heading</h2></body></html>';
+    const { docXml, lastMarkCovered } = openFragment(html);
+    expect(docXml).toContain('<w:pStyle w:val="Heading2"/>');
+    expect(docXml).not.toContain('w:sz w:val="52"');
+    expect(docXml).not.toContain('<w:b/>');
+    expect(lastMarkCovered).toBe(true);
+  });
+
+  test('Word desktop and online heading classes map to target styles', () => {
+    const { docXml, lastMarkCovered } = openFragment(
+      '<p class="MsoHeading2">Desktop</p><p class="Heading3">Online</p>'
+    );
+    expect(docXml).toContain('<w:pStyle w:val="Heading2"/>');
+    expect(docXml).toContain('<w:pStyle w:val="Heading3"/>');
+    expect(lastMarkCovered).toBe(true);
+  });
+
+  test('Word caption classes use target styles and include their paragraph mark', () => {
+    const { docXml, lastMarkCovered } = openFragment(
+      '<p class="MsoCaption" style="text-align:center">Figure 1</p>'
+    );
+    expect(docXml).toContain('<w:pStyle w:val="Caption"/>');
+    expect(docXml).toContain('<w:jc w:val="center"/>');
+    expect(lastMarkCovered).toBe(true);
+  });
+
+  test('generic paragraphs keep the host paragraph mark', () => {
+    const { lastMarkCovered } = openFragment('<p>ordinary</p>');
+    expect(lastMarkCovered).toBe(false);
+  });
+
+  test('only the final projected block controls paragraph mark coverage', () => {
+    const { lastMarkCovered } = openFragment(
+      '<p class="MsoCaption">caption</p><p>ordinary tail</p>'
+    );
+    expect(lastMarkCovered).toBe(false);
   });
 
   test('inline tags and CSS map to run properties', () => {
@@ -218,6 +283,25 @@ describe('images', () => {
     expect(media).toBeDefined();
     expect(media!.length).toBeGreaterThan(8);
     expect(relsXml).toContain('Target="media/image1.png"');
+  });
+
+  test('Word bare image dimensions use points', () => {
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><body><p>' +
+      `<img src="data:image/png;base64,${TINY_PNG_BASE64}" width="10" height="20">` +
+      '</p></body></html>';
+    const { docXml } = openFragment(html);
+    // 10pt and 20pt expressed as CSS pixels, then converted to EMU.
+    expect(docXml).toContain('cx="127000"');
+    expect(docXml).toContain('cy="254000"');
+  });
+
+  test('an unsized PNG uses its physical density', () => {
+    const png = pngWithPhysicalSize(144, 72, 5669);
+    const { docXml } = openFragment(`<p><img src="data:image/png;base64,${png}"></p>`);
+    // Integer pixels-per-metre metadata is approximately 144 dpi.
+    expect(docXml).toContain('cx="914447"');
+    expect(docXml).toContain('cy="457223"');
   });
 
   test('a data: image above the per-image cap is dropped', () => {

--- a/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
@@ -8,6 +8,7 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import { projectExternalHtml } from '../clipboard-html-read.ts';
+import { WORD_STYLE_TEXT_MAX, wordClassAlignmentsFromStyleText } from '../clipboard-html-styles.ts';
 import { readOoxmlPackage, type OoxmlPackage } from '../../store/package/ooxml-package.ts';
 import { serializeOoxmlPart } from '../../store/package/ooxml-tree.ts';
 import { strFromU8 } from '../../store/package/zip.ts';
@@ -132,6 +133,48 @@ describe('run and paragraph mapping', () => {
     expect(docXml).toContain('w:fill="FFFF00"');
   });
 
+  test('Word highlighter named colours become w:highlight, not shading', () => {
+    const cases: Array<{ css: string; val: string; text: string }> = [
+      { css: 'background:yellow;mso-highlight:yellow', val: 'yellow', text: 'y' },
+      { css: 'background:aqua;mso-highlight:aqua', val: 'cyan', text: 'a' },
+      { css: 'background:fuchsia;mso-highlight:fuchsia', val: 'magenta', text: 'f' },
+      { css: 'background:lime;mso-highlight:lime', val: 'green', text: 'l' },
+      { css: 'background:olive;mso-highlight:olive', val: 'darkYellow', text: 'o' },
+    ];
+    const html = `<p>${cases
+      .map((entry) => `<span style="${entry.css}">${entry.text}</span>`)
+      .join('')}</p>`;
+    const { docXml } = openFragment(html);
+    for (const entry of cases) {
+      const run = docXml.split('<w:r>').find((piece) => piece.includes(`>${entry.text}<`));
+      expect(run).toBeDefined();
+      expect(run!).toContain(`w:highlight w:val="${entry.val}"`);
+      expect(run!).not.toContain('w:shd');
+    }
+  });
+
+  test('a named background colour without mso-highlight remains shading', () => {
+    const { docXml } = openFragment('<p><span style="background:yellow">y</span></p>');
+    const run = docXml.split('<w:r>').find((piece) => piece.includes('>y<'));
+    expect(run).not.toContain('w:highlight');
+    expect(run).toContain('w:shd w:val="clear" w:color="auto" w:fill="FFFF00"');
+  });
+
+  test('background shorthand that is not a solid colour is refused', () => {
+    const { docXml } = openFragment(
+      '<p><span style="background:yellow url(https://evil.example/x.png)">keep</span>' +
+        '<span style="background:url(https://evil.example/x.png)">also</span></p>'
+    );
+    const keep = docXml.split('<w:r>').find((piece) => piece.includes('>keep<'));
+    const also = docXml.split('<w:r>').find((piece) => piece.includes('>also<'));
+    expect(keep).toBeDefined();
+    expect(keep!).not.toContain('w:highlight');
+    expect(keep!).not.toContain('w:shd');
+    expect(also!).not.toContain('w:highlight');
+    expect(also!).not.toContain('w:shd');
+    expect(docXml).not.toContain('evil.example');
+  });
+
   test('font-weight CSS overrides in both directions', () => {
     const { docXml } = openFragment(
       '<p><b style="font-weight:normal">off</b><span style="font-weight:700">on</span></p>'
@@ -157,6 +200,128 @@ describe('run and paragraph mapping', () => {
     expect(docXml).toContain('w:hanging="360"');
     expect(docXml).toContain('w:jc w:val="both"');
     expect(docXml).toContain('w:firstLine="360"');
+  });
+
+  test('Word stylesheet text-align on Title/Subtitle is copied as direct jc', () => {
+    // Word clipboard HTML puts alignment in a detached <style> block. Title often
+    // also carries inline text-align / align=center; Subtitle often does not.
+    // The fragment has no styles.xml, so merge reuses the target Title/Subtitle
+    // definitions, which have no w:jc. Direct jc on the paragraph is what survives.
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><head><style>' +
+      '<!--' +
+      'p.MsoTitle, li.MsoTitle, div.MsoTitle { text-align:center; }' +
+      'p.MsoSubtitle, li.MsoSubtitle, div.MsoSubtitle { text-align:center; }' +
+      'p.other { text-align:center; }' +
+      '-->' +
+      '</style></head><body>' +
+      '<p class=MsoTitle align=center style="text-align:center">DOCX-EDITOR.DEV</p>' +
+      '<p class=MsoSubtitle>ELEMENT TEST DOCUMENT</p>' +
+      '<p class="other">not a Word title</p>' +
+      '</body></html>';
+    const { docXml } = openFragment(html);
+    const paras = docXml.split('</w:p>');
+    const title = paras.find((para) => para.includes('DOCX-EDITOR.DEV'));
+    const subtitle = paras.find((para) => para.includes('ELEMENT TEST DOCUMENT'));
+    const other = paras.find((para) => para.includes('not a Word title'));
+    expect(title).toBeDefined();
+    expect(subtitle).toBeDefined();
+    expect(title!).toContain('<w:pStyle w:val="Title"/>');
+    expect(title!).toContain('<w:jc w:val="center"/>');
+    expect(subtitle!).toContain('<w:pStyle w:val="Subtitle"/>');
+    expect(subtitle!).toContain('<w:jc w:val="center"/>');
+    expect(other!).not.toContain('<w:jc w:val="center"/>');
+  });
+
+  test('a left-aligned Word Subtitle stylesheet is not forced to center', () => {
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><head><style>' +
+      'p.MsoTitle { text-align:center; }' +
+      'p.MsoSubtitle { text-align:left; }' +
+      '</style></head><body>' +
+      '<p class="MsoTitle">centred title</p>' +
+      '<p class="MsoSubtitle">left subtitle</p>' +
+      '</body></html>';
+    const { docXml } = openFragment(html);
+    const paras = docXml.split('</w:p>');
+    const title = paras.find((para) => para.includes('centred title'));
+    const subtitle = paras.find((para) => para.includes('left subtitle'));
+    expect(title!).toContain('<w:jc w:val="center"/>');
+    expect(subtitle!).toContain('<w:jc w:val="left"/>');
+    expect(subtitle!).not.toContain('<w:jc w:val="center"/>');
+  });
+
+  test('a Word title class with no stylesheet alignment is not forced to center', () => {
+    const { docXml } = openFragment('<p class="MsoSubtitle">plain subtitle</p>');
+    const subtitle = docXml.split('</w:p>').find((para) => para.includes('plain subtitle'));
+    expect(subtitle).toContain('<w:pStyle w:val="Subtitle"/>');
+    expect(subtitle).not.toContain('<w:jc');
+  });
+
+  test('inline text-align on a Word title class still wins over the stylesheet', () => {
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><head><style>' +
+      'p.MsoSubtitle { text-align:center; }' +
+      '</style></head><body>' +
+      '<p class="MsoSubtitle" style="text-align:left">left subtitle</p>' +
+      '</body></html>';
+    const { docXml } = openFragment(html);
+    const subtitle = docXml.split('</w:p>').find((para) => para.includes('left subtitle'));
+    expect(subtitle).toContain('<w:pStyle w:val="Subtitle"/>');
+    expect(subtitle).toContain('<w:jc w:val="left"/>');
+    expect(subtitle).not.toContain('<w:jc w:val="center"/>');
+  });
+
+  test('HTML align still wins over the stylesheet and loses to inline text-align', () => {
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><head><style>' +
+      'p.MsoTitle { text-align:left; }' +
+      '</style></head><body>' +
+      '<p class="MsoTitle" align="center">from align</p>' +
+      '<p class="MsoTitle" align="center" style="text-align:right">from inline</p>' +
+      '</body></html>';
+    const { docXml } = openFragment(html);
+    const paras = docXml.split('</w:p>');
+    const fromAlign = paras.find((para) => para.includes('from align'));
+    const fromInline = paras.find((para) => para.includes('from inline'));
+    expect(fromAlign!).toContain('<w:jc w:val="center"/>');
+    expect(fromInline!).toContain('<w:jc w:val="right"/>');
+    expect(fromInline!).not.toContain('<w:jc w:val="center"/>');
+  });
+});
+
+describe('Word stylesheet class alignment scan', () => {
+  test('unrelated and mixed selectors never contribute', () => {
+    const alignments = wordClassAlignmentsFromStyleText(
+      'p.other { text-align:center; }' +
+        'p.MsoSubtitle, p.other { text-align:center; }' +
+        'p .MsoSubtitle { text-align:center; }' +
+        'p.MsoTitle { text-align:center; }'
+    );
+    expect(alignments.get('MsoTitle')).toBe('center');
+    expect(alignments.get('MsoSubtitle')).toBeUndefined();
+    expect(alignments.get('other')).toBeUndefined();
+  });
+
+  test('malformed CSS does not throw and does not apply a truncated rule', () => {
+    const alignments = wordClassAlignmentsFromStyleText(
+      'p.MsoSubtitle { text-align:center\n' + 'p.MsoTitle { text-align:right; }'
+    );
+    expect(alignments.size).toBe(0);
+  });
+
+  test('oversized CSS is refused rather than scanned', () => {
+    const css = `${'x'.repeat(WORD_STYLE_TEXT_MAX + 1)}p.MsoSubtitle{text-align:center;}`;
+    expect(wordClassAlignmentsFromStyleText(css).size).toBe(0);
+  });
+
+  test('text-align values with url() or functions are refused', () => {
+    const alignments = wordClassAlignmentsFromStyleText(
+      'p.MsoSubtitle { text-align:url(https://evil.example/); }' +
+        'p.MsoTitle { text-align:center; }'
+    );
+    expect(alignments.get('MsoSubtitle')).toBeUndefined();
+    expect(alignments.get('MsoTitle')).toBe('center');
   });
 });
 

--- a/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
@@ -9,12 +9,11 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import {
-  clipboardDropLandsText,
-  clipboardPasteLandsContent,
   insertableText,
   plainTextFromHtml,
   plainTextFromTransfer,
 } from '../clipboard-plain-text.ts';
+import { clipboardDropLandsText, clipboardPasteLandsContent } from '../clipboard-file-lane.ts';
 import { isValidXmlText } from '../../store/package/sinks.ts';
 import { createClipboardHandlers } from '../surface-input.ts';
 import type { PaginatedSurface } from '../paginated-surface-contract.ts';
@@ -265,57 +264,126 @@ describe('the visible text of an HTML fragment', () => {
 });
 
 describe('clipboardPasteLandsContent — the image-file stand-down predicate for adapters', () => {
+  // A real 1x1 PNG: the projection sniffs magic bytes, so only a genuine image reads as
+  // one the engine lands.
+  const REAL_PNG =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
   test('a Word-for-Mac text copy (HTML with text, PNG file beside it) stands the file lane down', () => {
     const wordHtml =
       '<html xmlns:o="urn:schemas-microsoft-com:office:office"><head>' +
       '<meta name=ProgId content=Word.Document><style>p.MsoNormal{margin:0}</style></head>' +
       '<body><!--StartFragment--><p class=MsoNormal align=center><b>' +
       '<span style="font-size:26.0pt">DOCX TITLE</span></b></p><!--EndFragment--></body></html>';
-    expect(clipboardPasteLandsContent(wordHtml, 'DOCX TITLE')).toBe(true);
+    const payload = transfer({ 'text/html': wordHtml, 'text/plain': 'DOCX TITLE' });
+    expect(clipboardPasteLandsContent(payload)).toBe(true);
   });
 
-  test('an embedded fragment or a landable data: image lands through the engine', () => {
-    expect(clipboardPasteLandsContent('<div data-docx-fragment="AAAA"></div>', '')).toBe(true);
-    expect(clipboardPasteLandsContent('<img src="data:image/png;base64,AAAA">', '')).toBe(true);
+  test('an embedded fragment or a projectable data: image lands through the engine', () => {
+    expect(
+      clipboardPasteLandsContent(transfer({ 'text/html': '<div data-docx-fragment="AAAA"></div>' }))
+    ).toBe(true);
+    expect(
+      clipboardPasteLandsContent(
+        transfer({ 'text/html': `<img src="data:image/png;base64,${REAL_PNG}">` })
+      )
+    ).toBe(true);
   });
 
   test('a data: image the projection refuses keeps the file lane', () => {
-    // `data:image/webp` is not in the projection's accepted set; standing down for it
-    // dropped the real PNG file AND landed nothing — a dead paste gesture.
-    expect(clipboardPasteLandsContent('<img src="data:image/webp;base64,AAAA">', '')).toBe(false);
+    // Standing down for a payload the engine then refuses dropped the real PNG file AND
+    // landed nothing — a dead paste gesture. The predicate asks the projection itself.
+    expect(
+      clipboardPasteLandsContent(
+        transfer({ 'text/html': '<img src="data:image/webp;base64,AAAA">' })
+      )
+    ).toBe(false);
+    // Claims png, but the bytes are not a PNG: the magic-byte sniff refuses it.
+    expect(
+      clipboardPasteLandsContent(
+        transfer({ 'text/html': '<img src="data:image/png;base64,AAAA">' })
+      )
+    ).toBe(false);
+  });
+
+  test('a malformed fragment attribute keeps the file lane', () => {
+    expect(
+      clipboardPasteLandsContent(transfer({ 'text/html': '<span data-docx-fragment=""></span>' }))
+    ).toBe(false);
   });
 
   test('a browser copy-image payload and a bare screenshot keep the file lane', () => {
-    expect(clipboardPasteLandsContent('<img src="https://example.com/x.png">', '')).toBe(false);
-    expect(clipboardPasteLandsContent('', '')).toBe(false);
+    expect(
+      clipboardPasteLandsContent(transfer({ 'text/html': '<img src="https://example.com/x.png">' }))
+    ).toBe(false);
+    expect(clipboardPasteLandsContent(transfer({}))).toBe(false);
+    expect(clipboardPasteLandsContent(null)).toBe(false);
   });
 
-  test('invisible-only text does not count as content', () => {
-    // Zero-width wrappers around an external image (Slack/Notion-style markup) must not
-    // read as "the engine lands text" — it would land one invisible character.
-    expect(clipboardPasteLandsContent('<span>\u200b<img src="https://x/y.png"></span>', '')).toBe(
-      false
-    );
-    expect(clipboardPasteLandsContent('<p>&nbsp;</p>', '')).toBe(false);
+  test('a page title around a copied image does not count as content', () => {
+    // A full-document copy-image flavour carries a <title> no reader ever saw. Counting
+    // it stood the file lane down and pasted the word instead of the image.
+    const html =
+      '<html><head><title>Photos</title></head><body><img src="https://cdn/x.png"></body></html>';
+    expect(clipboardPasteLandsContent(transfer({ 'text/html': html }))).toBe(false);
+  });
+
+  test('invisible-only text does not stand the file lane down', () => {
+    // Zero-width wrappers around an external image (Slack/Notion-style markup), or a bare
+    // newline in text/plain. The engine may still land those invisible characters beside
+    // the file — the predicate deliberately values the image over suppressing them.
+    expect(
+      clipboardPasteLandsContent(
+        transfer({ 'text/html': '<span>\u200b<img src="https://x/y.png"></span>' })
+      )
+    ).toBe(false);
+    expect(clipboardPasteLandsContent(transfer({ 'text/html': '<p>&nbsp;</p>' }))).toBe(false);
+    expect(clipboardPasteLandsContent(transfer({ 'text/plain': '\u200b \n' }))).toBe(false);
   });
 
   test('a payload with no HTML stands down on visible plain text', () => {
     // text/plain + image file and no text/html: the engine's plain lane inserts the text,
     // so the file is Word's duplicate rendering.
-    expect(clipboardPasteLandsContent('', 'plain words')).toBe(true);
-    expect(clipboardPasteLandsContent('', '\u200b \n')).toBe(false);
+    expect(clipboardPasteLandsContent(transfer({ 'text/plain': 'plain words' }))).toBe(true);
+  });
+
+  test('visible text/plain wins even when the HTML flavour carries none', () => {
+    // A caption or URL beside a text-free HTML flavour: the plain lane lands it whatever
+    // the rich lanes do, so the file would be a second insertion.
+    const payload = transfer({
+      'text/html': '<img src="data:image/webp;base64,AAAA">',
+      'text/plain': 'a caption',
+    });
+    expect(clipboardPasteLandsContent(payload)).toBe(true);
   });
 });
 
 describe('clipboardDropLandsText — the image-file drop-lane stand-down', () => {
-  test('a dropped text selection stands the file lane down, either flavour', () => {
-    expect(clipboardDropLandsText('', 'dropped words')).toBe(true);
-    expect(clipboardDropLandsText('<p>dropped words</p>', '')).toBe(true);
+  test('a dropped text selection stands the file lane down', () => {
+    expect(
+      clipboardDropLandsText(
+        transfer({ 'text/html': '<p>dropped words</p>', 'text/plain': 'dropped words' })
+      )
+    ).toBe(true);
+  });
+
+  test('an image-file drag that mirrors its path into text/plain keeps the file lane', () => {
+    // Safari image drags and file managers put the path or URL in text/plain; the payload
+    // is still an IMAGE drag, so text/plain must not stand the file lane down.
+    expect(clipboardDropLandsText(transfer({ 'text/plain': 'file:///Users/a/photo.png' }))).toBe(
+      false
+    );
+    expect(
+      clipboardDropLandsText(
+        transfer({ 'text/plain': 'https://x/y.png', 'text/html': '<img src="https://x/y.png">' })
+      )
+    ).toBe(false);
   });
 
   test('fragments and data: images do NOT land from a drop, so they keep the file lane', () => {
-    // The drop lane is plain text only; only visible text stands the file lane down.
-    expect(clipboardDropLandsText('<div data-docx-fragment="AAAA"></div>', '')).toBe(false);
-    expect(clipboardDropLandsText('<img src="data:image/png;base64,AAAA">', '')).toBe(false);
+    // The drop lane is plain text only; only visible HTML text stands the file lane down.
+    expect(
+      clipboardDropLandsText(transfer({ 'text/html': '<div data-docx-fragment="AAAA"></div>' }))
+    ).toBe(false);
   });
 });

--- a/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
@@ -9,6 +9,7 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import {
+  clipboardHtmlLandsContent,
   insertableText,
   plainTextFromHtml,
   plainTextFromTransfer,
@@ -259,5 +260,26 @@ describe('the visible text of an HTML fragment', () => {
     const started = performance.now();
     expect(plainTextFromHtml(hostile)).toContain('z');
     expect(performance.now() - started).toBeLessThan(2_000);
+  });
+});
+
+describe('clipboardHtmlLandsContent — the image-file stand-down predicate for adapters', () => {
+  test('a Word-for-Mac text copy (HTML with text, PNG file beside it) stands the file lane down', () => {
+    const wordHtml =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><head>' +
+      '<meta name=ProgId content=Word.Document><style>p.MsoNormal{margin:0}</style></head>' +
+      '<body><!--StartFragment--><p class=MsoNormal align=center><b>' +
+      '<span style="font-size:26.0pt">DOCX TITLE</span></b></p><!--EndFragment--></body></html>';
+    expect(clipboardHtmlLandsContent(wordHtml)).toBe(true);
+  });
+
+  test('an embedded fragment or a data: image lands through the engine', () => {
+    expect(clipboardHtmlLandsContent('<div data-docx-fragment="AAAA"></div>')).toBe(true);
+    expect(clipboardHtmlLandsContent('<img src="data:image/png;base64,AAAA">')).toBe(true);
+  });
+
+  test('a browser copy-image payload and a bare screenshot keep the file lane', () => {
+    expect(clipboardHtmlLandsContent('<img src="https://example.com/x.png">')).toBe(false);
+    expect(clipboardHtmlLandsContent('')).toBe(false);
   });
 });

--- a/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
@@ -279,15 +279,20 @@ describe('clipboardPasteLandsContent — the image-file stand-down predicate for
     expect(clipboardPasteLandsContent(payload)).toBe(true);
   });
 
-  test('an embedded fragment or a projectable data: image lands through the engine', () => {
-    expect(
-      clipboardPasteLandsContent(transfer({ 'text/html': '<div data-docx-fragment="AAAA"></div>' }))
-    ).toBe(true);
+  test('a projectable data: image lands through the engine', () => {
     expect(
       clipboardPasteLandsContent(
         transfer({ 'text/html': `<img src="data:image/png;base64,${REAL_PNG}">` })
       )
     ).toBe(true);
+  });
+
+  test('a fragment that does not read as a package keeps the file lane', () => {
+    // The router refuses bytes `readOoxmlPackage` cannot open and would land nothing, so
+    // a decodable-but-garbage attribute must not stand the file lane down.
+    expect(
+      clipboardPasteLandsContent(transfer({ 'text/html': '<div data-docx-fragment="AAAA"></div>' }))
+    ).toBe(false);
   });
 
   test('a data: image the projection refuses keeps the file lane', () => {
@@ -345,6 +350,21 @@ describe('clipboardPasteLandsContent — the image-file stand-down predicate for
     // text/plain + image file and no text/html: the engine's plain lane inserts the text,
     // so the file is Word's duplicate rendering.
     expect(clipboardPasteLandsContent(transfer({ 'text/plain': 'plain words' }))).toBe(true);
+  });
+
+  test('text/plain that is just the image file name, path, or URL keeps the file lane', () => {
+    // File managers mirror the copied file into text/plain; it describes the image, so
+    // the picture wins over pasting a literal path.
+    expect(clipboardPasteLandsContent(transfer({ 'text/plain': 'photo.png' }))).toBe(false);
+    expect(
+      clipboardPasteLandsContent(transfer({ 'text/plain': 'file:///Users/a/photo.png' }))
+    ).toBe(false);
+    expect(
+      clipboardPasteLandsContent(transfer({ 'text/plain': 'https://cdn.example.com/x.jpeg' }))
+    ).toBe(false);
+    expect(clipboardPasteLandsContent(transfer({ 'text/plain': 'see photo.png attached' }))).toBe(
+      true
+    );
   });
 
   test('visible text/plain wins even when the HTML flavour carries none', () => {

--- a/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
@@ -352,19 +352,14 @@ describe('clipboardPasteLandsContent — the image-file stand-down predicate for
     expect(clipboardPasteLandsContent(transfer({ 'text/plain': 'plain words' }))).toBe(true);
   });
 
-  test('text/plain that is just the image file name, path, or URL keeps the file lane', () => {
-    // File managers mirror the copied file into text/plain; it describes the image, so
-    // the picture wins over pasting a literal path.
-    expect(clipboardPasteLandsContent(transfer({ 'text/plain': 'photo.png' }))).toBe(false);
+  test('bidi format characters are invisible too', () => {
+    // Directional marks around an external image render as nothing; counting them stood
+    // the file lane down and pasted two invisible characters instead of the picture.
     expect(
-      clipboardPasteLandsContent(transfer({ 'text/plain': 'file:///Users/a/photo.png' }))
+      clipboardPasteLandsContent(
+        transfer({ 'text/html': '&#x200E;<img src="https://x/y.png">&#x200F;' })
+      )
     ).toBe(false);
-    expect(
-      clipboardPasteLandsContent(transfer({ 'text/plain': 'https://cdn.example.com/x.jpeg' }))
-    ).toBe(false);
-    expect(clipboardPasteLandsContent(transfer({ 'text/plain': 'see photo.png attached' }))).toBe(
-      true
-    );
   });
 
   test('visible text/plain wins even when the HTML flavour carries none', () => {

--- a/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-plain-text.test.ts
@@ -9,7 +9,8 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import {
-  clipboardHtmlLandsContent,
+  clipboardDropLandsText,
+  clipboardPasteLandsContent,
   insertableText,
   plainTextFromHtml,
   plainTextFromTransfer,
@@ -263,23 +264,58 @@ describe('the visible text of an HTML fragment', () => {
   });
 });
 
-describe('clipboardHtmlLandsContent — the image-file stand-down predicate for adapters', () => {
+describe('clipboardPasteLandsContent — the image-file stand-down predicate for adapters', () => {
   test('a Word-for-Mac text copy (HTML with text, PNG file beside it) stands the file lane down', () => {
     const wordHtml =
       '<html xmlns:o="urn:schemas-microsoft-com:office:office"><head>' +
       '<meta name=ProgId content=Word.Document><style>p.MsoNormal{margin:0}</style></head>' +
       '<body><!--StartFragment--><p class=MsoNormal align=center><b>' +
       '<span style="font-size:26.0pt">DOCX TITLE</span></b></p><!--EndFragment--></body></html>';
-    expect(clipboardHtmlLandsContent(wordHtml)).toBe(true);
+    expect(clipboardPasteLandsContent(wordHtml, 'DOCX TITLE')).toBe(true);
   });
 
-  test('an embedded fragment or a data: image lands through the engine', () => {
-    expect(clipboardHtmlLandsContent('<div data-docx-fragment="AAAA"></div>')).toBe(true);
-    expect(clipboardHtmlLandsContent('<img src="data:image/png;base64,AAAA">')).toBe(true);
+  test('an embedded fragment or a landable data: image lands through the engine', () => {
+    expect(clipboardPasteLandsContent('<div data-docx-fragment="AAAA"></div>', '')).toBe(true);
+    expect(clipboardPasteLandsContent('<img src="data:image/png;base64,AAAA">', '')).toBe(true);
+  });
+
+  test('a data: image the projection refuses keeps the file lane', () => {
+    // `data:image/webp` is not in the projection's accepted set; standing down for it
+    // dropped the real PNG file AND landed nothing — a dead paste gesture.
+    expect(clipboardPasteLandsContent('<img src="data:image/webp;base64,AAAA">', '')).toBe(false);
   });
 
   test('a browser copy-image payload and a bare screenshot keep the file lane', () => {
-    expect(clipboardHtmlLandsContent('<img src="https://example.com/x.png">')).toBe(false);
-    expect(clipboardHtmlLandsContent('')).toBe(false);
+    expect(clipboardPasteLandsContent('<img src="https://example.com/x.png">', '')).toBe(false);
+    expect(clipboardPasteLandsContent('', '')).toBe(false);
+  });
+
+  test('invisible-only text does not count as content', () => {
+    // Zero-width wrappers around an external image (Slack/Notion-style markup) must not
+    // read as "the engine lands text" — it would land one invisible character.
+    expect(clipboardPasteLandsContent('<span>\u200b<img src="https://x/y.png"></span>', '')).toBe(
+      false
+    );
+    expect(clipboardPasteLandsContent('<p>&nbsp;</p>', '')).toBe(false);
+  });
+
+  test('a payload with no HTML stands down on visible plain text', () => {
+    // text/plain + image file and no text/html: the engine's plain lane inserts the text,
+    // so the file is Word's duplicate rendering.
+    expect(clipboardPasteLandsContent('', 'plain words')).toBe(true);
+    expect(clipboardPasteLandsContent('', '\u200b \n')).toBe(false);
+  });
+});
+
+describe('clipboardDropLandsText — the image-file drop-lane stand-down', () => {
+  test('a dropped text selection stands the file lane down, either flavour', () => {
+    expect(clipboardDropLandsText('', 'dropped words')).toBe(true);
+    expect(clipboardDropLandsText('<p>dropped words</p>', '')).toBe(true);
+  });
+
+  test('fragments and data: images do NOT land from a drop, so they keep the file lane', () => {
+    // The drop lane is plain text only; only visible text stands the file lane down.
+    expect(clipboardDropLandsText('<div data-docx-fragment="AAAA"></div>', '')).toBe(false);
+    expect(clipboardDropLandsText('<img src="data:image/png;base64,AAAA">', '')).toBe(false);
   });
 });

--- a/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
@@ -301,4 +301,35 @@ describe('rich paste', () => {
     expect(markup).toContain('w:jc');
     expect(markup).toContain('<w:b/>');
   });
+
+  test('a Word caption keeps its paragraph alignment at a paragraph end', () => {
+    const target = mount(paragraph(''));
+    putCaret(target.surface, 0);
+    target.surface.pasteRich(
+      'image\ncaption',
+      '<p style="text-align:center">image</p>' +
+        '<p class="MsoCaption" style="text-align:center">caption</p>'
+    );
+    const markup = serializeOoxmlPart(target.surface.session.part());
+    const caption = markup.split('</w:p>').find((entry) => entry.includes('caption'));
+    expect(caption).toContain('<w:pStyle w:val="Caption"/>');
+    expect(caption).toContain('w:jc w:val="center"');
+  });
+
+  test('a Word heading pasted within text remains a heading paragraph', () => {
+    const target = mount(paragraph('host'));
+    putCaret(target.surface, 2);
+    target.surface.pasteRich(
+      'Word heading',
+      '<html xmlns:w="urn:schemas-microsoft-com:office:word"><body>' +
+        '<h2>Word heading</h2></body></html>'
+    );
+    const markup = serializeOoxmlPart(target.surface.session.part());
+    const heading = markup.split('</w:p>').find((entry) => entry.includes('Word heading'));
+    expect(heading).toContain('<w:pStyle w:val="Heading2"/>');
+    const pastedRun = heading!.split('</w:r>').find((entry) => entry.includes('Word heading'));
+    expect(pastedRun).not.toContain('w:sz w:val="52"');
+    expect(pastedRun).not.toContain('<w:b/>');
+    expect(target.surface.session.bodyText()).toContain('Word heading');
+  });
 });

--- a/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
@@ -12,7 +12,8 @@ import { describe, expect, test, afterEach } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { zipSync, strToU8 } from 'fflate';
 import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
-import { fragmentFromHtml } from '../clipboard-fragment-codec.ts';
+import { fragmentFromHtml, wrapInteropHtml } from '../clipboard-fragment-codec.ts';
+import { clipboardPasteLandsContent } from '../clipboard-file-lane.ts';
 import { mountPaginatedSurface } from '../paginated-surface.ts';
 import { docx, mount, paragraph, putCaret } from './paginated-surface-fixtures.ts';
 
@@ -217,6 +218,16 @@ describe('fragment landings that rebuild the host root', () => {
 
     source.destroy();
     container.remove();
+  });
+});
+
+describe('the file-lane stand-down against real fragments', () => {
+  test('a fragment that reads as a package stands the file lane down without visible text', () => {
+    // An engine copy of image-only content: the interop half may carry no visible text,
+    // so the predicate must recognize the READABLE fragment itself.
+    const html = wrapInteropHtml('', { bytes: docx('<w:p/>'), lastMarkCovered: false });
+    const payload = { getData: (type: string) => (type === 'text/html' ? html : '') };
+    expect(clipboardPasteLandsContent(payload as unknown as DataTransfer)).toBe(true);
   });
 });
 

--- a/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
@@ -10,9 +10,16 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test, afterEach } from 'bun:test';
 import { readFileSync } from 'node:fs';
+import { zipSync, strToU8 } from 'fflate';
 import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { fragmentFromHtml } from '../clipboard-fragment-codec.ts';
 import { mountPaginatedSurface } from '../paginated-surface.ts';
 import { docx, mount, paragraph, putCaret } from './paginated-surface-fixtures.ts';
+
+const WML = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
 
 afterEach(() => {
   document.getSelection()?.removeAllRanges();
@@ -102,6 +109,114 @@ describe('full-document fidelity through the real surface', () => {
     target.destroy();
     container.remove();
     container2.remove();
+  });
+
+  test('select-all copy of the sample pastes back into the sample itself, rich', () => {
+    // The user gesture behind the report: Ctrl+A, copy, paste at the end of the SAME
+    // document. The host has real paragraphs on both sides of the landing, so the
+    // split/join sequence mints node ids MID-transaction — and the fragment carries
+    // `xml:space` plus drawing prefixes, which used to rebuild the root, reset the mint
+    // frontier, and refuse the whole landing as duplicate ids. The refusal was silent:
+    // the router degraded to plain text and every table, list and run format vanished.
+    const bytes = new Uint8Array(readFileSync(SAMPLE));
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const mounted = mountPaginatedSurface(container, bytes, { scale: 1 });
+    if (!mounted.ok) throw new Error(mounted.reason);
+    const surface = mounted.surface;
+    const sourceXml = serializeOoxmlPart(surface.session.part());
+    const count = (xml: string, re: RegExp): number => (xml.match(re) ?? []).length;
+
+    surface.selectAll();
+    const flavours = surface.copyFlavours();
+    const ids = surface.session.paragraphIds();
+    surface.setSelection({
+      anchor: { paragraphId: ids[ids.length - 1]!, offset: 0 },
+      head: { paragraphId: ids[ids.length - 1]!, offset: 0 },
+    });
+    surface.pasteRich(flavours.text, flavours.html);
+
+    const pastedXml = serializeOoxmlPart(surface.session.part());
+    expect(count(pastedXml, /<w:tbl>/g)).toBe(2 * count(sourceXml, /<w:tbl>/g));
+    expect(count(pastedXml, /<w:sdt>/g)).toBe(2 * count(sourceXml, /<w:sdt>/g));
+    expect(count(pastedXml, /<w:numPr>/g)).toBe(2 * count(sourceXml, /<w:numPr>/g));
+    expect(count(pastedXml, /<w:drawing>/g)).toBe(2 * count(sourceXml, /<w:drawing>/g));
+    expect(count(pastedXml, /<w:b\/>/g)).toBe(2 * count(sourceXml, /<w:b\/>/g));
+
+    surface.destroy();
+    container.remove();
+  });
+});
+
+describe('fragment landings that rebuild the host root', () => {
+  // A fragment legitimately carries prefixes the TARGET root never bound (`w14:` here).
+  // Binding them rebuilds the root, and a rebuilt root starts a fresh id-mint frontier —
+  // so the ids minted for the DETACHED block clones collided with the ids the split/join
+  // sequence minted afterwards, and the landing was refused as duplicate ids. The clones
+  // now mint in their own id family, disjoint from every in-transaction mint.
+  const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+  const docxWithW14 = (body: string): Uint8Array =>
+    zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${WML}" xmlns:w14="${W14}"><w:body>${body}</w:body></w:document>`
+      ),
+    });
+
+  test('a fragment with prefixes the host never bound lands rich mid-paragraph', () => {
+    const container = document.createElement('div');
+    const mounted = mountPaginatedSurface(
+      container,
+      docxWithW14(
+        '<w:p w14:paraId="1A2B3C4D"><w:r><w:rPr><w:b/></w:rPr>' +
+          '<w:t xml:space="preserve">first </w:t></w:r></w:p>' +
+          '<w:p w14:paraId="2B3C4D5E"><w:r><w:t>second</w:t></w:r></w:p>'
+      ),
+      { scale: 1 }
+    );
+    if (!mounted.ok) throw new Error(mounted.reason);
+    const source = mounted.surface;
+    putCaret(source, 0);
+    source.selectAll();
+    const flavours = source.copyFlavours();
+    expect(flavours.html).toContain('data-docx-fragment="');
+    const embedded = fragmentFromHtml(flavours.html!);
+    expect(embedded).not.toBeNull();
+
+    // Mid-text caret in a NON-empty host paragraph: the landing must split and join,
+    // which is where the colliding mints happened. The FIRST lane is asserted directly —
+    // through `pasteRich` a refusal here degraded down the ladder and could still land
+    // something, which is exactly the silence that hid this bug.
+    const target = mount(paragraph('host text'));
+    putCaret(target.surface, 4);
+    const hostId = target.surface.session.paragraphIds()[0]!;
+    const landed = target.surface.session.applyFragmentPaste(
+      { kind: 'body' },
+      {
+        paragraphId: hostId,
+        offset: 4,
+        fragmentBytes: embedded!.bytes,
+        lastMarkCovered: embedded!.lastMarkCovered,
+        priorOps: [],
+      }
+    );
+    expect(landed.ok).toBe(true);
+
+    const markup = serializeOoxmlPart(target.surface.session.part());
+    expect(target.surface.session.bodyText()).toContain('first');
+    expect(target.surface.session.bodyText()).toContain('second');
+    expect(markup).toContain('<w:b/>');
+    // The reserved `xml` prefix is bound by the XML spec; the landing must not declare it.
+    expect(markup).not.toContain('xmlns:xml=');
+
+    source.destroy();
+    container.remove();
   });
 });
 

--- a/packages/core/src/editor/blank-document.ts
+++ b/packages/core/src/editor/blank-document.ts
@@ -172,6 +172,14 @@ const STYLES =
   `<w:pPr><w:spacing w:before="160"/><w:jc w:val="center"/></w:pPr>` +
   `<w:rPr><w:i/><w:iCs/><w:color w:val="404040"/></w:rPr>` +
   `</w:style>` +
+  // Caption gives pasted Word captions built-in 9pt italic metrics instead of Normal.
+  `<w:style w:type="paragraph" w:styleId="Caption">` +
+  `<w:name w:val="caption"/><w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
+  `<w:uiPriority w:val="35"/><w:semiHidden/><w:unhideWhenUsed/>` +
+  `<w:pPr><w:spacing w:after="0"/></w:pPr>` +
+  `<w:rPr><w:i/><w:iCs/><w:color w:val="404040"/>` +
+  `<w:sz w:val="18"/><w:szCs w:val="18"/></w:rPr>` +
+  `</w:style>` +
   // No Spacing is the one style that does NOT build on Normal: its whole purpose is to
   // drop the defaults' space-after and 1.08 lines, which `w:basedOn` would reinstate.
   `<w:style w:type="paragraph" w:styleId="NoSpacing">` +

--- a/packages/core/src/editor/clipboard-file-lane.ts
+++ b/packages/core/src/editor/clipboard-file-lane.ts
@@ -13,7 +13,6 @@
 // oversized payload, a malformed fragment attribute) correctly keeps the file lane and an
 // html flavour it lands correctly stands it down.
 
-import { readOoxmlPackage } from '@docx-editor.dev/core/store';
 import { fragmentFromHtml } from './clipboard-fragment-codec.ts';
 import { probeExternalHtml } from './clipboard-html-read.ts';
 import { hasVisibleChar, htmlHasVisibleText } from './clipboard-plain-text.ts';
@@ -29,44 +28,41 @@ function flavourOf(transfer: DataTransfer, type: string): string {
 }
 
 /**
- * A `text/plain` flavour that is just the copied FILE's name, path, or URL — one line,
- * ending in a raster extension. File managers and some browsers mirror the file into
- * `text/plain` this way; it describes the image rather than accompanying it, so it must
- * not stand the file lane down. Word-style text copies never look like this.
- */
-const IMAGE_PATH_TEXT =
-  /^\s*(?:(?:file|https?):\/\/\S+|[A-Za-z]:\\\S+|\/\S+|[^\s\\/]+)\.(?:png|jpe?g|gif|bmp|webp|tiff?)\s*$/i;
-
-/**
  * True when the engine's PASTE lanes will land user-visible content from this payload, so
  * a host's image-FILE lane must stand down or insert a duplicate.
  *
  * In order of cost: visible `text/plain` (the plain lane's unconditional fallback), visible
- * HTML text (the projection and the plain lane's HTML fallback both land it), a readable
- * embedded fragment, and finally the projection probe for text-free HTML — the exact
- * decision the paste router makes for `data:` images, without paying for the zip.
+ * HTML text (the projection and the plain lane's HTML fallback both land it), a
+ * zip-shaped embedded fragment, and finally the projection probe for text-free HTML — the
+ * exact decision the paste router makes for `data:` images, without paying for the zip.
  *
  * Deliberate asymmetries against the router's letter: text made only of invisible
- * characters (zero-width wrappers, a bare newline) does not count — the router technically
- * lands it, but standing down for it would drop a real image for characters nobody can
- * see. A `text/plain` that is just the image's own filename or URL does not count either.
- * And engine-state gates the adapter cannot observe (suggesting mode, cell selections,
- * the force-plain window) are ignored; in those states the engine may land nothing where
- * this predicate said it would.
+ * characters (zero-width wrappers, bidi marks, a bare newline) does not count — the router
+ * technically lands it, but standing down for it would drop a real image for characters
+ * nobody can see. And engine-state gates the adapter cannot observe (suggesting mode, cell
+ * selections, the force-plain window) are ignored; in those states the engine may land
+ * nothing where this predicate said it would.
+ *
+ * One trade the adapter cannot win: a payload whose `text/plain` is just the copied file's
+ * own name or URL stands the lane down and pastes that text without the picture. The
+ * engine's plain lane inserts any visible text REGARDLESS of what a host does, so the only
+ * alternative is the path text AND the picture — a duplicate, which is the bug this
+ * predicate exists to prevent.
  *
  * @public
  */
 export function clipboardPasteLandsContent(transfer: DataTransfer | null | undefined): boolean {
   if (!transfer) return false;
-  const text = flavourOf(transfer, 'text/plain');
-  if (hasVisibleChar(text) && !IMAGE_PATH_TEXT.test(text)) return true;
+  if (hasVisibleChar(flavourOf(transfer, 'text/plain'))) return true;
   const html = flavourOf(transfer, 'text/html');
   if (html.length === 0) return false;
   if (htmlHasVisibleText(html)) return true;
-  // Text-free HTML. An embedded fragment counts only when it READS as a package — the
-  // router refuses undecodable bytes and would land nothing.
+  // Text-free HTML. An embedded fragment counts only when its bytes are at least
+  // zip-shaped — the router refuses everything else and would land nothing. (A zip that
+  // fails deeper package reads still slips through; fully validating it here would
+  // duplicate the router's whole bounded open per gesture.)
   const embedded = fragmentFromHtml(html);
-  if (embedded !== null && readOoxmlPackage(embedded.bytes).ok) return true;
+  if (embedded !== null && embedded.bytes[0] === 0x50 && embedded.bytes[1] === 0x4b) return true;
   // Otherwise only a projected IMAGE counts. The projection also lands invisible runs and
   // empty paragraphs as blocks, and standing down for those would trade a real image file
   // for content nobody can see.

--- a/packages/core/src/editor/clipboard-file-lane.ts
+++ b/packages/core/src/editor/clipboard-file-lane.ts
@@ -33,8 +33,7 @@ function flavourOf(transfer: DataTransfer, type: string): string {
  *
  * In order of cost: visible `text/plain` (the plain lane's unconditional fallback), visible
  * HTML text (the projection and the plain lane's HTML fallback both land it), a
- * zip-shaped embedded fragment, and finally the projection probe for text-free HTML — the
- * exact decision the paste router makes for `data:` images, without paying for the zip.
+ * zip-shaped embedded fragment, and finally the projection probe for text-free HTML.
  *
  * Deliberate asymmetries against the router's letter: text made only of invisible
  * characters (zero-width wrappers, bidi marks, a bare newline) does not count — the router
@@ -43,13 +42,7 @@ function flavourOf(transfer: DataTransfer, type: string): string {
  * selections, the force-plain window) are ignored; in those states the engine may land
  * nothing where this predicate said it would.
  *
- * One trade the adapter cannot win: a payload whose `text/plain` is just the copied file's
- * own name or URL stands the lane down and pastes that text without the picture. The
- * engine's plain lane inserts any visible text REGARDLESS of what a host does, so the only
- * alternative is the path text AND the picture — a duplicate, which is the bug this
- * predicate exists to prevent.
- *
- * @public
+ * @internal
  */
 export function clipboardPasteLandsContent(transfer: DataTransfer | null | undefined): boolean {
   if (!transfer) return false;
@@ -80,7 +73,7 @@ export function clipboardPasteLandsContent(transfer: DataTransfer | null | undef
  * that carries an image file beside it (Word's rendering PNG again) always carries the
  * text in HTML too.
  *
- * @public
+ * @internal
  */
 export function clipboardDropLandsText(transfer: DataTransfer | null | undefined): boolean {
   if (!transfer) return false;

--- a/packages/core/src/editor/clipboard-file-lane.ts
+++ b/packages/core/src/editor/clipboard-file-lane.ts
@@ -13,8 +13,9 @@
 // oversized payload, a malformed fragment attribute) correctly keeps the file lane and an
 // html flavour it lands correctly stands it down.
 
+import { readOoxmlPackage } from '@docx-editor.dev/core/store';
 import { fragmentFromHtml } from './clipboard-fragment-codec.ts';
-import { projectExternalHtml } from './clipboard-html-read.ts';
+import { probeExternalHtml } from './clipboard-html-read.ts';
 import { hasVisibleChar, htmlHasVisibleText } from './clipboard-plain-text.ts';
 
 /** One flavour, defensively: a stand-in transfer without `getData` reads as absent. */
@@ -28,35 +29,48 @@ function flavourOf(transfer: DataTransfer, type: string): string {
 }
 
 /**
+ * A `text/plain` flavour that is just the copied FILE's name, path, or URL — one line,
+ * ending in a raster extension. File managers and some browsers mirror the file into
+ * `text/plain` this way; it describes the image rather than accompanying it, so it must
+ * not stand the file lane down. Word-style text copies never look like this.
+ */
+const IMAGE_PATH_TEXT =
+  /^\s*(?:(?:file|https?):\/\/\S+|[A-Za-z]:\\\S+|\/\S+|[^\s\\/]+)\.(?:png|jpe?g|gif|bmp|webp|tiff?)\s*$/i;
+
+/**
  * True when the engine's PASTE lanes will land user-visible content from this payload, so
  * a host's image-FILE lane must stand down or insert a duplicate.
  *
  * In order of cost: visible `text/plain` (the plain lane's unconditional fallback), visible
- * HTML text (the projection and the plain lane's HTML fallback both land it), a decodable
- * embedded fragment, and finally the projection itself for text-free HTML — the exact
- * decision the paste router makes for `data:` images.
+ * HTML text (the projection and the plain lane's HTML fallback both land it), a readable
+ * embedded fragment, and finally the projection probe for text-free HTML — the exact
+ * decision the paste router makes for `data:` images, without paying for the zip.
  *
- * Two deliberate asymmetries against the router's letter: text made only of invisible
+ * Deliberate asymmetries against the router's letter: text made only of invisible
  * characters (zero-width wrappers, a bare newline) does not count — the router technically
  * lands it, but standing down for it would drop a real image for characters nobody can
- * see. And engine-state gates the adapter cannot observe (suggesting mode, cell
- * selections, the force-plain window) are ignored; in those states the engine may land
- * nothing where this predicate said it would.
+ * see. A `text/plain` that is just the image's own filename or URL does not count either.
+ * And engine-state gates the adapter cannot observe (suggesting mode, cell selections,
+ * the force-plain window) are ignored; in those states the engine may land nothing where
+ * this predicate said it would.
  *
  * @public
  */
 export function clipboardPasteLandsContent(transfer: DataTransfer | null | undefined): boolean {
   if (!transfer) return false;
-  if (hasVisibleChar(flavourOf(transfer, 'text/plain'))) return true;
+  const text = flavourOf(transfer, 'text/plain');
+  if (hasVisibleChar(text) && !IMAGE_PATH_TEXT.test(text)) return true;
   const html = flavourOf(transfer, 'text/html');
   if (html.length === 0) return false;
   if (htmlHasVisibleText(html)) return true;
-  if (fragmentFromHtml(html) !== null) return true;
-  // Text-free HTML: only a projected IMAGE counts. The projection also lands invisible
-  // runs and empty paragraphs as blocks, and standing down for those would trade a real
-  // image file for content nobody can see.
-  const projected = projectExternalHtml(html);
-  return projected.ok && projected.imageCount > 0;
+  // Text-free HTML. An embedded fragment counts only when it READS as a package — the
+  // router refuses undecodable bytes and would land nothing.
+  const embedded = fragmentFromHtml(html);
+  if (embedded !== null && readOoxmlPackage(embedded.bytes).ok) return true;
+  // Otherwise only a projected IMAGE counts. The projection also lands invisible runs and
+  // empty paragraphs as blocks, and standing down for those would trade a real image file
+  // for content nobody can see.
+  return probeExternalHtml(html).imageCount > 0;
 }
 
 /**

--- a/packages/core/src/editor/clipboard-file-lane.ts
+++ b/packages/core/src/editor/clipboard-file-lane.ts
@@ -1,0 +1,78 @@
+// The image-FILE stand-down policy for host paste and drop lanes (React/Vue Content).
+//
+// The engine's own clipboard listeners run on the pages layer regardless of what a host
+// handler does afterwards, so a host file lane can only ever ADD an insertion — the
+// question these predicates answer is whether that addition duplicates content the engine
+// already lands. Word on macOS is the payload that forced the policy: it puts a rendered
+// PNG of copied TEXT on the pasteboard beside the HTML, and a host that inserts the file
+// whenever one is present pastes that rendering on top of the text.
+//
+// Rather than re-modelling the paste router, the paste predicate asks the router's own
+// machinery: the fragment codec for embedded fragments and the bounded HTML projection for
+// everything else, so an html flavour the projection refuses (a webp `data:` image, an
+// oversized payload, a malformed fragment attribute) correctly keeps the file lane and an
+// html flavour it lands correctly stands it down.
+
+import { fragmentFromHtml } from './clipboard-fragment-codec.ts';
+import { projectExternalHtml } from './clipboard-html-read.ts';
+import { hasVisibleChar, htmlHasVisibleText } from './clipboard-plain-text.ts';
+
+/** One flavour, defensively: a stand-in transfer without `getData` reads as absent. */
+function flavourOf(transfer: DataTransfer, type: string): string {
+  if (typeof transfer.getData !== 'function') return '';
+  try {
+    return transfer.getData(type) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * True when the engine's PASTE lanes will land user-visible content from this payload, so
+ * a host's image-FILE lane must stand down or insert a duplicate.
+ *
+ * In order of cost: visible `text/plain` (the plain lane's unconditional fallback), visible
+ * HTML text (the projection and the plain lane's HTML fallback both land it), a decodable
+ * embedded fragment, and finally the projection itself for text-free HTML — the exact
+ * decision the paste router makes for `data:` images.
+ *
+ * Two deliberate asymmetries against the router's letter: text made only of invisible
+ * characters (zero-width wrappers, a bare newline) does not count — the router technically
+ * lands it, but standing down for it would drop a real image for characters nobody can
+ * see. And engine-state gates the adapter cannot observe (suggesting mode, cell
+ * selections, the force-plain window) are ignored; in those states the engine may land
+ * nothing where this predicate said it would.
+ *
+ * @public
+ */
+export function clipboardPasteLandsContent(transfer: DataTransfer | null | undefined): boolean {
+  if (!transfer) return false;
+  if (hasVisibleChar(flavourOf(transfer, 'text/plain'))) return true;
+  const html = flavourOf(transfer, 'text/html');
+  if (html.length === 0) return false;
+  if (htmlHasVisibleText(html)) return true;
+  if (fragmentFromHtml(html) !== null) return true;
+  // Text-free HTML: only a projected IMAGE counts. The projection also lands invisible
+  // runs and empty paragraphs as blocks, and standing down for those would trade a real
+  // image file for content nobody can see.
+  const projected = projectExternalHtml(html);
+  return projected.ok && projected.imageCount > 0;
+}
+
+/**
+ * True when the engine's DROP lane will land text from this payload, so a host's
+ * image-FILE drop lane must stand down — by NOT preventing the default, which is what
+ * lets the browser fire `insertFromDrop`, the engine's only drop path.
+ *
+ * Only visible HTML text counts. The drop lane is plain text end to end, so fragments and
+ * `data:` images never land from a drop — and `text/plain` says nothing about intent here,
+ * because image-file drags routinely mirror the file's path or URL into it. A text drag
+ * that carries an image file beside it (Word's rendering PNG again) always carries the
+ * text in HTML too.
+ *
+ * @public
+ */
+export function clipboardDropLandsText(transfer: DataTransfer | null | undefined): boolean {
+  if (!transfer) return false;
+  return htmlHasVisibleText(flavourOf(transfer, 'text/html'));
+}

--- a/packages/core/src/editor/clipboard-html-numbering.ts
+++ b/packages/core/src/editor/clipboard-html-numbering.ts
@@ -1,0 +1,58 @@
+// The numbering part the external-HTML projection assembles for its lists — split from
+// clipboard-html-read.ts at the max-lines cap. Same shape the store's numbering writer
+// produces; the projection allocates the numIds and this module renders the definitions.
+
+import { escapeXmlAttribute } from '../store/package/sinks.ts';
+
+const WML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+export type HtmlListAllocation = { readonly numId: string; readonly kind: 'ordered' | 'bullet' };
+
+// Symbol-font codepoints Word writes (private-use range), as escapes so they are not
+// invisible literals in the source; see store/package/numbering-part.ts.
+const BULLET_LEVELS = [
+  { text: '\uF0B7', font: 'Symbol' },
+  { text: 'o', font: 'Courier New' },
+  { text: '\uF0A7', font: 'Wingdings' },
+] as const;
+
+/** One `w:lvl` in strict CT_Lvl order: start, numFmt, lvlText, lvlJc, pPr, rPr. */
+function levelXml(kind: 'ordered' | 'bullet', ilvl: number): string {
+  const left = 720 * (ilvl + 1);
+  const indent = `<w:pPr><w:ind w:left="${left}" w:hanging="360"/></w:pPr>`;
+  if (kind === 'bullet') {
+    const bullet = BULLET_LEVELS[ilvl % BULLET_LEVELS.length]!;
+    return (
+      `<w:lvl w:ilvl="${ilvl}"><w:start w:val="1"/><w:numFmt w:val="bullet"/>` +
+      `<w:lvlText w:val="${escapeXmlAttribute(bullet.text)}"/><w:lvlJc w:val="left"/>${indent}` +
+      `<w:rPr><w:rFonts w:ascii="${bullet.font}" w:hAnsi="${bullet.font}" w:hint="default"/></w:rPr>` +
+      '</w:lvl>'
+    );
+  }
+  return (
+    `<w:lvl w:ilvl="${ilvl}"><w:start w:val="1"/><w:numFmt w:val="decimal"/>` +
+    `<w:lvlText w:val="%${ilvl + 1}."/><w:lvlJc w:val="left"/>${indent}</w:lvl>`
+  );
+}
+
+export function numberingPartXml(allocations: readonly HtmlListAllocation[]): string {
+  const abstracts = allocations
+    .map((allocation, index) => {
+      const levels = Array.from({ length: 9 }, (_, ilvl) => levelXml(allocation.kind, ilvl)).join(
+        ''
+      );
+      return (
+        `<w:abstractNum w:abstractNumId="${index}">` +
+        `<w:multiLevelType w:val="hybridMultilevel"/>${levels}</w:abstractNum>`
+      );
+    })
+    .join('');
+  const nums = allocations
+    .map(
+      (allocation, index) =>
+        `<w:num w:numId="${allocation.numId}"><w:abstractNumId w:val="${index}"/></w:num>`
+    )
+    .join('');
+  return `${XML_DECL}<w:numbering xmlns:w="${WML_NS}">${abstracts}${nums}</w:numbering>`;
+}

--- a/packages/core/src/editor/clipboard-html-read.ts
+++ b/packages/core/src/editor/clipboard-html-read.ts
@@ -26,12 +26,20 @@ import {
   type HtmlListAllocation as ListAllocation,
 } from './clipboard-html-numbering.ts';
 import {
+  applyParaCss,
+  applyRunCss,
+  applyWordParagraphAlignment,
   imageDimensionPx,
   isElement,
   isWordClipboardHtml,
-  parseCssLengthPt,
+  parseCssColor,
+  parseInlineStyle,
   tagOf,
+  wordClassAlignmentsFromDocument,
   wordParagraphStyleId,
+  type HtmlParagraphAlign,
+  type HtmlParaProps,
+  type HtmlRunProps,
 } from './clipboard-html-styles.ts';
 
 export interface HtmlProjectionLimits {
@@ -97,39 +105,8 @@ const CONTAINER_TAGS = new Set(
   )
 );
 
-const NAMED_COLORS = new Map(
-  (
-    'black:000000 white:FFFFFF red:FF0000 green:008000 blue:0000FF yellow:FFFF00 gray:808080 ' +
-    'grey:808080 silver:C0C0C0 maroon:800000 navy:000080 purple:800080 orange:FFA500'
-  )
-    .split(' ')
-    .map((pair) => pair.split(':') as [string, string])
-);
-
-interface RunProps {
-  bold?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strike?: boolean;
-  vertAlign?: 'subscript' | 'superscript';
-  /** RRGGBB uppercase. */
-  color?: string;
-  /** RRGGBB uppercase, run shading fill. */
-  shdFill?: string;
-  szHalfPoints?: number;
-  font?: string;
-}
-
-interface ParaProps {
-  styleId?: string;
-  jc?: 'left' | 'center' | 'right' | 'both';
-  indLeftTwips?: number;
-  /** Positive → `w:firstLine`, negative → `w:hanging`. */
-  firstLineTwips?: number;
-  /** `w:spacing w:line` in 240ths, `w:lineRule="auto"`. */
-  lineTwentieths?: number;
-  numPr?: { readonly numId: string; readonly ilvl: number };
-}
+type RunProps = HtmlRunProps;
+type ParaProps = HtmlParaProps;
 
 type ListState = { readonly numId: string; readonly level: number };
 
@@ -161,111 +138,11 @@ interface Projection {
   semanticListCount: number;
   imageCount: number;
   docPrId: number;
-}
-
-// --- CSS reading (inline `style` attributes only — no stylesheet cascade)
-
-/** Inline style declarations as a Map, so hostile property names never become object keys. */
-function parseInlineStyle(element: Element): ReadonlyMap<string, string> {
-  const out = new Map<string, string>();
-  const raw = element.getAttribute('style');
-  if (!raw || raw.length > 8192) return out;
-  for (const declaration of raw.split(';')) {
-    const colon = declaration.indexOf(':');
-    if (colon <= 0) continue;
-    const name = declaration.slice(0, colon).trim().toLowerCase();
-    const value = declaration.slice(colon + 1).trim();
-    if (name.length > 0 && value.length > 0 && !out.has(name)) out.set(name, value);
-  }
-  return out;
-}
-
-/** Normalize a CSS color to RRGGBB uppercase hex, or null when it does not parse. */
-function parseCssColor(value: string): string | null {
-  const v = value.trim().toLowerCase();
-  const named = NAMED_COLORS.get(v);
-  if (named) return named;
-  const hex6 = /^#([0-9a-f]{6})$/.exec(v);
-  if (hex6) return hex6[1]!.toUpperCase();
-  const hex3 = /^#([0-9a-f]{3})$/.exec(v);
-  if (hex3) {
-    const [r, g, b] = hex3[1]!;
-    return `${r}${r}${g}${g}${b}${b}`.toUpperCase();
-  }
-  const rgb = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]*)?\)$/.exec(v);
-  if (rgb) {
-    const channel = (part: string): string =>
-      Math.min(255, Number.parseInt(part, 10)).toString(16).padStart(2, '0');
-    return `${channel(rgb[1]!)}${channel(rgb[2]!)}${channel(rgb[3]!)}`.toUpperCase();
-  }
-  return null;
+  readonly classAlignments: ReadonlyMap<string, HtmlParagraphAlign>;
 }
 
 function clamp(value: number, low: number, high: number): number {
   return Math.min(high, Math.max(low, value));
-}
-
-function applyRunCss(base: RunProps, style: ReadonlyMap<string, string>): RunProps {
-  if (style.size === 0) return base;
-  const next: RunProps = { ...base };
-  const weight = style.get('font-weight')?.toLowerCase();
-  if (weight !== undefined) {
-    const numeric = Number.parseInt(weight, 10);
-    if (weight === 'bold' || numeric >= 600) next.bold = true;
-    else if (weight === 'normal' || numeric < 600) next.bold = false;
-  }
-  const fontStyle = style.get('font-style');
-  if (fontStyle !== undefined) next.italic = fontStyle.toLowerCase().includes('italic');
-  const decoration = (
-    style.get('text-decoration') ?? style.get('text-decoration-line')
-  )?.toLowerCase();
-  if (decoration !== undefined) {
-    if (decoration.includes('underline')) next.underline = true;
-    if (decoration.includes('line-through')) next.strike = true;
-    if (decoration.includes('none')) next.underline = next.strike = false;
-  }
-  const color = parseCssColor(style.get('color') ?? '');
-  if (color) next.color = color;
-  const background = style.get('background-color');
-  if (background !== undefined && background.toLowerCase() !== 'transparent') {
-    const parsed = parseCssColor(background);
-    if (parsed) next.shdFill = parsed;
-  }
-  const pt = parseCssLengthPt(style.get('font-size') ?? '');
-  if (pt !== null && pt > 0) next.szHalfPoints = clamp(Math.round(pt * 2), 2, 3276);
-  const family = style.get('font-family');
-  if (family !== undefined) {
-    const first = family
-      .split(',')[0]!
-      .trim()
-      .replace(/^['"]|['"]$/g, '');
-    if (first.length > 0 && first.length <= 64) next.font = first;
-  }
-  const vertical = style.get('vertical-align');
-  if (vertical === 'sub') next.vertAlign = 'subscript';
-  else if (vertical === 'super') next.vertAlign = 'superscript';
-  return next;
-}
-
-function applyParaCss(para: ParaProps, style: ReadonlyMap<string, string>): void {
-  const align = style.get('text-align')?.toLowerCase();
-  if (align === 'left' || align === 'start') para.jc = 'left';
-  else if (align === 'center') para.jc = 'center';
-  else if (align === 'right' || align === 'end') para.jc = 'right';
-  else if (align === 'justify') para.jc = 'both';
-  const marginPt = parseCssLengthPt(style.get('margin-left') ?? '');
-  if (marginPt !== null && marginPt > 0) {
-    para.indLeftTwips = clamp(Math.round(marginPt * 20), 0, 31_680);
-  }
-  const indentPt = parseCssLengthPt(style.get('text-indent') ?? '');
-  if (indentPt !== null && indentPt !== 0) {
-    const twips = clamp(Math.round(indentPt * 20), -31_680, 31_680);
-    if (twips !== 0) para.firstLineTwips = twips;
-  }
-  const lineHeight = style.get('line-height')?.trim() ?? '';
-  if (/^\d+(\.\d+)?$/.test(lineHeight) && Number.parseFloat(lineHeight) > 0) {
-    para.lineTwentieths = clamp(Math.round(240 * Number.parseFloat(lineHeight)), 24, 9600);
-  }
 }
 
 // --- XML emission
@@ -302,6 +179,9 @@ function rPrXml(props: RunProps): string {
   if (props.strike) inner += '<w:strike/>';
   if (props.color !== undefined) inner += `<w:color w:val="${props.color}"/>`;
   if (props.szHalfPoints !== undefined) inner += `<w:sz w:val="${props.szHalfPoints}"/>`;
+  if (props.highlight !== undefined) {
+    inner += `<w:highlight w:val="${escapeXmlAttribute(props.highlight)}"/>`;
+  }
   if (props.underline) inner += '<w:u w:val="single"/>';
   if (props.shdFill !== undefined) {
     inner += `<w:shd w:val="clear" w:color="auto" w:fill="${props.shdFill}"/>`;
@@ -594,6 +474,7 @@ function projectParagraph(
   if (tag === 'pre') run.font = 'Courier New';
   const mso = msoListNumPr(element, style, p);
   if (mso) para.numPr = mso;
+  applyWordParagraphAlignment(para, element, p.classAlignments);
   applyParaCss(para, style);
   run = applyRunCss(run, style);
   const next: FlowContext = {
@@ -927,7 +808,8 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
   let parsed: Document;
   try {
     // The result stays detached. The bounded allowlist walker emits escaped XML only.
-    parsed = new DOMParser().parseFromString(html, 'text/html'); // lgtm[js/xss]
+    // codeql[js/xss]
+    parsed = new DOMParser().parseFromString(html, 'text/html');
   } catch {
     return { ok: false, reason: 'parse-unavailable' };
   }
@@ -947,6 +829,7 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
     semanticListCount: 0,
     imageCount: 0,
     docPrId: 0,
+    classAlignments: wordClassAlignmentsFromDocument(parsed),
   };
   const blocks: string[] = [];
   const rootCtx: FlowContext = {

--- a/packages/core/src/editor/clipboard-html-read.ts
+++ b/packages/core/src/editor/clipboard-html-read.ts
@@ -21,6 +21,10 @@ import {
   type SupportedImageMime,
 } from '../store/package/image-resources.ts';
 import { writeZip, strToU8 } from '../store/package/zip.ts';
+import {
+  numberingPartXml,
+  type HtmlListAllocation as ListAllocation,
+} from './clipboard-html-numbering.ts';
 
 export interface HtmlProjectionLimits {
   /** UTF-8 size cap applied BEFORE parse. Default 4 MiB. */
@@ -40,6 +44,8 @@ export type HtmlProjectionResult =
       readonly fragmentBytes: Uint8Array;
       /** Always false: the last projected paragraph merges into the host paragraph. */
       readonly lastMarkCovered: boolean;
+      /** How many `data:` images the projection accepted into the fragment. */
+      readonly imageCount: number;
     }
   | { readonly ok: false; readonly reason: 'too-large' | 'no-content' | 'parse-unavailable' };
 
@@ -117,7 +123,7 @@ interface ParaProps {
 }
 
 type ListState = { readonly numId: string; readonly level: number };
-type ListAllocation = { readonly numId: string; readonly kind: 'ordered' | 'bullet' };
+
 type RelEntry = {
   readonly id: string;
   readonly type: string;
@@ -845,56 +851,6 @@ function projectCell(
   return `<w:tc><w:tcPr>${tcPr}</w:tcPr>${blocks.join('')}</w:tc>`;
 }
 
-// --- Numbering part
-
-// Symbol-font codepoints Word writes (private-use range), as escapes so they are not
-// invisible literals in the source; see store/package/numbering-part.ts.
-const BULLET_LEVELS = [
-  { text: '\uF0B7', font: 'Symbol' },
-  { text: 'o', font: 'Courier New' },
-  { text: '\uF0A7', font: 'Wingdings' },
-] as const;
-
-/** One `w:lvl` in strict CT_Lvl order: start, numFmt, lvlText, lvlJc, pPr, rPr. */
-function levelXml(kind: 'ordered' | 'bullet', ilvl: number): string {
-  const left = 720 * (ilvl + 1);
-  const indent = `<w:pPr><w:ind w:left="${left}" w:hanging="360"/></w:pPr>`;
-  if (kind === 'bullet') {
-    const bullet = BULLET_LEVELS[ilvl % BULLET_LEVELS.length]!;
-    return (
-      `<w:lvl w:ilvl="${ilvl}"><w:start w:val="1"/><w:numFmt w:val="bullet"/>` +
-      `<w:lvlText w:val="${escapeXmlAttribute(bullet.text)}"/><w:lvlJc w:val="left"/>${indent}` +
-      `<w:rPr><w:rFonts w:ascii="${bullet.font}" w:hAnsi="${bullet.font}" w:hint="default"/></w:rPr>` +
-      '</w:lvl>'
-    );
-  }
-  return (
-    `<w:lvl w:ilvl="${ilvl}"><w:start w:val="1"/><w:numFmt w:val="decimal"/>` +
-    `<w:lvlText w:val="%${ilvl + 1}."/><w:lvlJc w:val="left"/>${indent}</w:lvl>`
-  );
-}
-
-function numberingPartXml(allocations: readonly ListAllocation[]): string {
-  const abstracts = allocations
-    .map((allocation, index) => {
-      const levels = Array.from({ length: 9 }, (_, ilvl) => levelXml(allocation.kind, ilvl)).join(
-        ''
-      );
-      return (
-        `<w:abstractNum w:abstractNumId="${index}">` +
-        `<w:multiLevelType w:val="hybridMultilevel"/>${levels}</w:abstractNum>`
-      );
-    })
-    .join('');
-  const nums = allocations
-    .map(
-      (allocation, index) =>
-        `<w:num w:numId="${allocation.numId}"><w:abstractNumId w:val="${index}"/></w:num>`
-    )
-    .join('');
-  return `${XML_DECL}<w:numbering xmlns:w="${WML_NS}">${abstracts}${nums}</w:numbering>`;
-}
-
 // --- Zip assembly (entry names mirror the internal fragment extractor)
 
 function relationshipXml(rels: readonly RelEntry[]): string {
@@ -995,5 +951,10 @@ export function projectExternalHtml(
   const rootCtx: FlowContext = { run: {}, para: {}, pre: false, list: null };
   projectFlow(Array.from(body.childNodes), 0, rootCtx, projection, blocks);
   if (blocks.length === 0) return { ok: false, reason: 'no-content' };
-  return { ok: true, fragmentBytes: assembleFragment(projection, blocks), lastMarkCovered: false };
+  return {
+    ok: true,
+    fragmentBytes: assembleFragment(projection, blocks),
+    lastMarkCovered: false,
+    imageCount: projection.imageCount,
+  };
 }

--- a/packages/core/src/editor/clipboard-html-read.ts
+++ b/packages/core/src/editor/clipboard-html-read.ts
@@ -906,17 +906,12 @@ function assembleFragment(p: Projection, blocks: readonly string[]): Uint8Array 
 
 // --- Entry point
 
-/**
- * Project external `text/html` into a WordprocessingML fragment package.
- *
- * Pure over its input: parses into an inert document, walks under caps, and returns
- * fragment bytes the paste router reads through `readOoxmlPackage`. Never attaches
- * parsed nodes anywhere, never fetches, never executes.
- */
-export function projectExternalHtml(
-  html: string,
-  limits: HtmlProjectionLimits = {}
-): HtmlProjectionResult {
+type ProjectedBlocks =
+  | { readonly ok: true; readonly projection: Projection; readonly blocks: string[] }
+  | { readonly ok: false; readonly reason: 'too-large' | 'no-content' | 'parse-unavailable' };
+
+/** The shared parse-and-walk half: everything up to (but not including) zip assembly. */
+function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlocks {
   const maxHtmlBytes = limits.maxHtmlBytes ?? DEFAULT_MAX_HTML_BYTES;
   // UTF-16 length is a lower bound on UTF-8 bytes, so the cheap check refuses first;
   // borderline payloads get an exact byte count.
@@ -951,10 +946,42 @@ export function projectExternalHtml(
   const rootCtx: FlowContext = { run: {}, para: {}, pre: false, list: null };
   projectFlow(Array.from(body.childNodes), 0, rootCtx, projection, blocks);
   if (blocks.length === 0) return { ok: false, reason: 'no-content' };
+  return { ok: true, projection, blocks };
+}
+
+/**
+ * Project external `text/html` into a WordprocessingML fragment package.
+ *
+ * Pure over its input: parses into an inert document, walks under caps, and returns
+ * fragment bytes the paste router reads through `readOoxmlPackage`. Never attaches
+ * parsed nodes anywhere, never fetches, never executes.
+ */
+export function projectExternalHtml(
+  html: string,
+  limits: HtmlProjectionLimits = {}
+): HtmlProjectionResult {
+  const projected = projectBlocks(html, limits);
+  if (!projected.ok) return projected;
   return {
     ok: true,
-    fragmentBytes: assembleFragment(projection, blocks),
+    fragmentBytes: assembleFragment(projected.projection, projected.blocks),
     lastMarkCovered: false,
-    imageCount: projection.imageCount,
+    imageCount: projected.projection.imageCount,
   };
+}
+
+/**
+ * What the projection WOULD land, without paying for zip assembly.
+ *
+ * The file-lane stand-down predicate asks this per paste gesture; running the full
+ * projection just to read a boolean doubled the parse-and-deflate cost of every
+ * image-bearing paste (the router runs the real projection right after).
+ */
+export function probeExternalHtml(
+  html: string,
+  limits: HtmlProjectionLimits = {}
+): { readonly lands: boolean; readonly imageCount: number } {
+  const projected = projectBlocks(html, limits);
+  if (!projected.ok) return { lands: false, imageCount: 0 };
+  return { lands: true, imageCount: projected.projection.imageCount };
 }

--- a/packages/core/src/editor/clipboard-html-read.ts
+++ b/packages/core/src/editor/clipboard-html-read.ts
@@ -25,6 +25,14 @@ import {
   numberingPartXml,
   type HtmlListAllocation as ListAllocation,
 } from './clipboard-html-numbering.ts';
+import {
+  imageDimensionPx,
+  isElement,
+  isWordClipboardHtml,
+  parseCssLengthPt,
+  tagOf,
+  wordParagraphStyleId,
+} from './clipboard-html-styles.ts';
 
 export interface HtmlProjectionLimits {
   /** UTF-8 size cap applied BEFORE parse. Default 4 MiB. */
@@ -42,7 +50,7 @@ export type HtmlProjectionResult =
       readonly ok: true;
       /** A fragment package zip, readable by `readOoxmlPackage`. */
       readonly fragmentBytes: Uint8Array;
-      /** Always false: the last projected paragraph merges into the host paragraph. */
+      /** True when the final projected paragraph carries a mapped Word style. */
       readonly lastMarkCovered: boolean;
       /** How many `data:` images the projection accepted into the fragment. */
       readonly imageCount: number;
@@ -113,6 +121,7 @@ interface RunProps {
 }
 
 interface ParaProps {
+  styleId?: string;
   jc?: 'left' | 'center' | 'right' | 'both';
   indLeftTwips?: number;
   /** Positive → `w:firstLine`, negative → `w:hanging`. */
@@ -134,6 +143,7 @@ type RelEntry = {
 interface FlowContext {
   readonly run: RunProps;
   readonly para: ParaProps;
+  readonly paragraphMarkCovered: boolean;
   readonly pre: boolean;
   readonly list: ListState | null;
 }
@@ -142,6 +152,8 @@ interface Projection {
   nodesLeft: number;
   readonly maxDepth: number;
   readonly maxImageBytes: number;
+  readonly wordHtml: boolean;
+  lastMarkCovered: boolean;
   readonly rels: RelEntry[];
   readonly media: Map<string, Uint8Array>;
   readonly mediaExtensions: Map<string, string>;
@@ -187,15 +199,6 @@ function parseCssColor(value: string): string | null {
     return `${channel(rgb[1]!)}${channel(rgb[2]!)}${channel(rgb[3]!)}`.toUpperCase();
   }
   return null;
-}
-
-/** A CSS length in points, from `px` or `pt` values only. */
-function parseCssLengthPt(value: string): number | null {
-  const match = /^(-?\d+(?:\.\d+)?)(px|pt)$/.exec(value.trim().toLowerCase());
-  if (!match) return null;
-  const magnitude = Number.parseFloat(match[1]!);
-  if (!Number.isFinite(magnitude)) return null;
-  return match[2] === 'px' ? magnitude * 0.75 : magnitude;
 }
 
 function clamp(value: number, low: number, high: number): number {
@@ -314,6 +317,9 @@ function textRunXml(text: string, props: RunProps): string {
 /** `w:pPr`, children in CT_PPr sequence order: numPr, spacing, ind, jc. */
 function pPrXml(para: ParaProps): string {
   let inner = '';
+  if (para.styleId !== undefined) {
+    inner += `<w:pStyle w:val="${escapeXmlAttribute(para.styleId)}"/>`;
+  }
   if (para.numPr) {
     inner +=
       `<w:numPr><w:ilvl w:val="${para.numPr.ilvl}"/>` +
@@ -383,17 +389,6 @@ function decodeBase64(data: string, maxBytes: number): Uint8Array | null {
 
 const DATA_IMAGE_RE = /^data:image\/(png|jpeg|jpg|gif);base64,([A-Za-z0-9+/=]+)$/;
 
-function cssOrAttributePx(
-  element: Element,
-  style: ReadonlyMap<string, string>,
-  axis: 'width' | 'height'
-): number | null {
-  const pt = parseCssLengthPt(style.get(axis) ?? '');
-  if (pt !== null && pt > 0) return pt / 0.75;
-  const attr = element.getAttribute(axis) ?? '';
-  return /^[1-9]\d{0,4}$/.test(attr.trim()) ? Number.parseInt(attr, 10) : null;
-}
-
 /** Project a `data:` image into a media part + rel + inline `w:drawing` run. */
 function projectImage(element: Element, runs: string[], p: Projection): void {
   const src = element.getAttribute('src');
@@ -408,11 +403,11 @@ function projectImage(element: Element, runs: string[], p: Projection): void {
   const header = validateRasterHeader(bytes, declared);
 
   const style = parseInlineStyle(element);
-  let widthPx = cssOrAttributePx(element, style, 'width');
-  let heightPx = cssOrAttributePx(element, style, 'height');
+  let widthPx = imageDimensionPx(element, style, 'width', p.wordHtml);
+  let heightPx = imageDimensionPx(element, style, 'height', p.wordHtml);
   if (widthPx === null && heightPx === null && header) {
-    widthPx = header.pixelWidth;
-    heightPx = header.pixelHeight;
+    widthPx = (header.pixelWidth * 96) / (header.dpiX ?? 96);
+    heightPx = (header.pixelHeight * 96) / (header.dpiY ?? 96);
   } else if (widthPx !== null && heightPx === null) {
     heightPx = header ? (widthPx * header.pixelHeight) / header.pixelWidth : (widthPx * 2) / 3;
   } else if (widthPx === null && heightPx !== null) {
@@ -458,14 +453,6 @@ function allocateList(p: Projection, key: string, kind: 'ordered' | 'bullet'): s
 }
 
 // --- Walk
-
-function isElement(node: Node): node is Element {
-  return node.nodeType === 1; // ELEMENT_NODE
-}
-
-function tagOf(element: Element): string {
-  return element.tagName.toLowerCase();
-}
 
 /** True for the literal marker span Word emits beside `mso-list` paragraphs. */
 function isMsoListIgnoreMarker(style: ReadonlyMap<string, string>): boolean {
@@ -593,11 +580,13 @@ function projectParagraph(
   const tag = tagOf(element);
   const style = parseInlineStyle(element);
   const para: ParaProps = {};
+  const styleId = wordParagraphStyleId(element, p.wordHtml);
+  if (styleId !== undefined) para.styleId = styleId;
   if (ctx.para.numPr) para.numPr = ctx.para.numPr;
   if (ctx.para.jc) para.jc = ctx.para.jc;
   let run = { ...ctx.run };
   const heading = HEADING_SZ[tag];
-  if (heading !== undefined) {
+  if (heading !== undefined && styleId === undefined) {
     run.bold = true;
     run.szHalfPoints = heading;
   }
@@ -607,7 +596,13 @@ function projectParagraph(
   if (mso) para.numPr = mso;
   applyParaCss(para, style);
   run = applyRunCss(run, style);
-  const next: FlowContext = { run, para, pre, list: ctx.list };
+  const next: FlowContext = {
+    run,
+    para,
+    paragraphMarkCovered: styleId !== undefined,
+    pre,
+    list: ctx.list,
+  };
   projectFlow(Array.from(element.childNodes), depth + 1, next, p, out, true);
 }
 
@@ -655,7 +650,10 @@ function projectFlow(
   const before = out.length;
   let pending: string[] = [];
   const flush = (): void => {
-    if (pending.length > 0) out.push(paragraphXml(ctx.para, pending));
+    if (pending.length > 0) {
+      out.push(paragraphXml(ctx.para, pending));
+      p.lastMarkCovered = ctx.paragraphMarkCovered;
+    }
     pending = [];
   };
   for (const node of nodes) {
@@ -693,7 +691,10 @@ function projectFlow(
   }
   flush();
   // An explicit block emits its paragraph even when empty.
-  if (forceEmit && out.length === before) out.push(paragraphXml(ctx.para, []));
+  if (forceEmit && out.length === before) {
+    out.push(paragraphXml(ctx.para, []));
+    p.lastMarkCovered = ctx.paragraphMarkCovered;
+  }
 }
 
 // --- Tables
@@ -808,6 +809,7 @@ function projectTable(
     `<w:tbl><w:tblPr><w:tblW w:w="${TABLE_TOTAL_TWIPS}" w:type="dxa"/>${borders}</w:tblPr>` +
       `<w:tblGrid>${grid}</w:tblGrid>${rowXml.join('')}</w:tbl>`
   );
+  p.lastMarkCovered = false;
 }
 
 function projectCell(
@@ -839,6 +841,7 @@ function projectCell(
   const cellCtx: FlowContext = {
     run: isHeader ? { ...ctx.run, bold: true } : ctx.run,
     para: isHeader ? { jc: 'center' } : {},
+    paragraphMarkCovered: false,
     pre: false,
     list: null,
   };
@@ -923,7 +926,8 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
   if (typeof DOMParser === 'undefined') return { ok: false, reason: 'parse-unavailable' };
   let parsed: Document;
   try {
-    parsed = new DOMParser().parseFromString(html, 'text/html');
+    // The result stays detached. The bounded allowlist walker emits escaped XML only.
+    parsed = new DOMParser().parseFromString(html, 'text/html'); // lgtm[js/xss]
   } catch {
     return { ok: false, reason: 'parse-unavailable' };
   }
@@ -934,6 +938,8 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
     nodesLeft: limits.maxNodes ?? DEFAULT_MAX_NODES,
     maxDepth: limits.maxDepth ?? DEFAULT_MAX_DEPTH,
     maxImageBytes: limits.maxImageBytes ?? DEFAULT_MAX_IMAGE_BYTES,
+    wordHtml: isWordClipboardHtml(html),
+    lastMarkCovered: false,
     rels: [],
     media: new Map(),
     mediaExtensions: new Map(),
@@ -943,7 +949,13 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
     docPrId: 0,
   };
   const blocks: string[] = [];
-  const rootCtx: FlowContext = { run: {}, para: {}, pre: false, list: null };
+  const rootCtx: FlowContext = {
+    run: {},
+    para: {},
+    paragraphMarkCovered: false,
+    pre: false,
+    list: null,
+  };
   projectFlow(Array.from(body.childNodes), 0, rootCtx, projection, blocks);
   if (blocks.length === 0) return { ok: false, reason: 'no-content' };
   return { ok: true, projection, blocks };
@@ -965,7 +977,7 @@ export function projectExternalHtml(
   return {
     ok: true,
     fragmentBytes: assembleFragment(projected.projection, projected.blocks),
-    lastMarkCovered: false,
+    lastMarkCovered: projected.projection.lastMarkCovered,
     imageCount: projected.projection.imageCount,
   };
 }

--- a/packages/core/src/editor/clipboard-html-styles.ts
+++ b/packages/core/src/editor/clipboard-html-styles.ts
@@ -33,6 +33,206 @@ export function wordParagraphStyleId(element: Element, wordHtml: boolean): strin
   return headingTag ? `Heading${headingTag[1]}` : undefined;
 }
 
+export type HtmlParagraphAlign = 'left' | 'center' | 'right' | 'both';
+
+/** Cap on concatenated `<style>` text scanned for Word class `text-align`. */
+export const WORD_STYLE_TEXT_MAX = 32_768;
+const WORD_STYLE_ELEMENT_MAX = 8;
+const WORD_STYLE_RULE_MAX = 256;
+const WORD_STYLE_SELECTOR_MAX = 256;
+const WORD_STYLE_BLOCK_MAX = 2_048;
+const WORD_STYLE_SELECTOR_LIST_MAX = 8;
+
+const WORD_PARAGRAPH_CLASSES: ReadonlySet<string> = new Set([
+  'MsoTitle',
+  'MsoSubtitle',
+  'MsoCaption',
+  'MsoQuote',
+  ...Array.from({ length: 9 }, (_, index) => `MsoHeading${index + 1}`),
+  ...Array.from({ length: 9 }, (_, index) => `Heading${index + 1}`),
+]);
+
+const ALIGN_VALUES: ReadonlyMap<string, HtmlParagraphAlign> = new Map([
+  ['left', 'left'],
+  ['start', 'left'],
+  ['center', 'center'],
+  ['right', 'right'],
+  ['end', 'right'],
+  ['justify', 'both'],
+]);
+
+const WORD_CLASS_SELECTOR = /^\s*(p|li|div)\.([A-Za-z][A-Za-z0-9]{0,31})\s*$/i;
+
+function stripHtmlCommentMarkers(css: string): string {
+  let out = '';
+  for (let i = 0; i < css.length; i += 1) {
+    if (css.startsWith('<!--', i)) {
+      i += 3;
+      continue;
+    }
+    if (css.startsWith('-->', i)) {
+      i += 2;
+      continue;
+    }
+    out += css[i];
+  }
+  return out;
+}
+
+function skipBalancedBlock(text: string, open: number): number | null {
+  let depth = 0;
+  for (let i = open; i < text.length; i += 1) {
+    const char = text[i];
+    if (char === '{') {
+      depth += 1;
+      if (depth > 4) return null;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return null;
+}
+
+function skipAtRule(text: string, at: number): number | null {
+  for (let i = at + 1; i < text.length; i += 1) {
+    const char = text[i];
+    if (char === ';') return i + 1;
+    if (char === '{') return skipBalancedBlock(text, i);
+  }
+  return null;
+}
+
+function allowlistedClassesOf(selector: string): readonly string[] | null {
+  const parts = selector.split(',');
+  if (parts.length === 0 || parts.length > WORD_STYLE_SELECTOR_LIST_MAX) return null;
+  const classes: string[] = [];
+  for (const part of parts) {
+    const match = WORD_CLASS_SELECTOR.exec(part);
+    if (!match) return null;
+    const className = match[2]!;
+    if (!WORD_PARAGRAPH_CLASSES.has(className)) return null;
+    if (!classes.includes(className)) classes.push(className);
+  }
+  return classes;
+}
+
+function textAlignOf(block: string): HtmlParagraphAlign | undefined {
+  let found: HtmlParagraphAlign | undefined;
+  for (const declaration of block.split(';')) {
+    const colon = declaration.indexOf(':');
+    if (colon <= 0) continue;
+    const name = declaration.slice(0, colon).trim().toLowerCase();
+    if (name !== 'text-align') continue;
+    const raw = declaration
+      .slice(colon + 1)
+      .trim()
+      .toLowerCase();
+    if (raw.length === 0 || raw.length > 32 || raw.includes('(')) continue;
+    let end = 0;
+    while (end < raw.length && raw.charCodeAt(end)! > 32) end += 1;
+    const jc = ALIGN_VALUES.get(raw.slice(0, end));
+    if (jc !== undefined) found = jc;
+  }
+  return found;
+}
+
+/**
+ * Bounded scan of Word clipboard `<style>` text: exact `p|li|div.<allowlisted-class>`
+ * selectors only, `text-align` only. Not a CSS cascade. Oversized or malformed input
+ * yields no entries rather than a partial hostile parse.
+ */
+function scanWordClassAlignments(css: string): {
+  readonly ok: boolean;
+  readonly alignments: ReadonlyMap<string, HtmlParagraphAlign>;
+} {
+  const out = new Map<string, HtmlParagraphAlign>();
+  const failed = () => ({ ok: false, alignments: new Map<string, HtmlParagraphAlign>() });
+  if (css.length === 0) return { ok: true, alignments: out };
+  if (css.length > WORD_STYLE_TEXT_MAX) return failed();
+  const text = stripHtmlCommentMarkers(css);
+  let i = 0;
+  let rules = 0;
+  while (i < text.length && rules < WORD_STYLE_RULE_MAX) {
+    while (i < text.length && text.charCodeAt(i)! <= 32) i += 1;
+    if (i >= text.length) break;
+    if (text[i] === '@') {
+      const next = skipAtRule(text, i);
+      if (next === null) return failed();
+      i = next;
+      continue;
+    }
+    const brace = text.indexOf('{', i);
+    if (brace < 0) return failed();
+    const selector = text.slice(i, brace);
+    const close = text.indexOf('}', brace + 1);
+    if (close < 0) return failed();
+    const block = text.slice(brace + 1, close);
+    rules += 1;
+    i = close + 1;
+    if (selector.length > WORD_STYLE_SELECTOR_MAX || block.length > WORD_STYLE_BLOCK_MAX) {
+      return failed();
+    }
+    if (block.includes('{')) return failed();
+    const classes = allowlistedClassesOf(selector);
+    const jc = textAlignOf(block);
+    if (!classes || jc === undefined) continue;
+    for (const className of classes) out.set(className, jc);
+  }
+  while (i < text.length && text.charCodeAt(i)! <= 32) i += 1;
+  if (i < text.length) return failed();
+  return { ok: true, alignments: out };
+}
+
+export function wordClassAlignmentsFromStyleText(
+  css: string
+): ReadonlyMap<string, HtmlParagraphAlign> {
+  return scanWordClassAlignments(css).alignments;
+}
+
+/** `textContent` of inert `<style>` elements, capped, never `innerHTML`. */
+export function wordClassAlignmentsFromDocument(
+  doc: Document
+): ReadonlyMap<string, HtmlParagraphAlign> {
+  const out = new Map<string, HtmlParagraphAlign>();
+  const styles = doc.getElementsByTagName('style');
+  if (styles.length > WORD_STYLE_ELEMENT_MAX) return out;
+  let total = 0;
+  for (let index = 0; index < styles.length; index += 1) {
+    const raw = styles[index]?.textContent ?? '';
+    if (raw.length > WORD_STYLE_TEXT_MAX) return new Map();
+    if (total + raw.length > WORD_STYLE_TEXT_MAX) return new Map();
+    total += raw.length;
+    const scan = scanWordClassAlignments(raw);
+    if (!scan.ok) return new Map();
+    for (const [className, jc] of scan.alignments) {
+      out.set(className, jc);
+    }
+  }
+  return out;
+}
+
+/**
+ * Stylesheet class `text-align`, then the HTML `align` attribute Word still emits.
+ * Inline CSS wins afterwards in `applyParaCss`.
+ */
+export function applyWordParagraphAlignment(
+  para: HtmlParaProps,
+  element: Element,
+  classAlignments: ReadonlyMap<string, HtmlParagraphAlign>
+): void {
+  for (const className of element.classList) {
+    const jc = classAlignments.get(className);
+    if (jc !== undefined) {
+      para.jc = jc;
+      break;
+    }
+  }
+  const align = element.getAttribute('align')?.trim().toLowerCase();
+  if (align === 'left' || align === 'center' || align === 'right') para.jc = align;
+  else if (align === 'justify') para.jc = 'both';
+}
+
 /** An image extent in CSS pixels, including Word's bare-point convention. */
 export function imageDimensionPx(
   element: Element,
@@ -54,4 +254,205 @@ export function isElement(node: Node): node is Element {
 
 export function tagOf(element: Element): string {
   return element.tagName.toLowerCase();
+}
+
+export interface HtmlRunProps {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  vertAlign?: 'subscript' | 'superscript';
+  /** RRGGBB uppercase. */
+  color?: string;
+  /** ST_HighlightColor name. */
+  highlight?: string;
+  /** RRGGBB uppercase, run shading fill. */
+  shdFill?: string;
+  szHalfPoints?: number;
+  font?: string;
+}
+
+export interface HtmlParaProps {
+  styleId?: string;
+  jc?: HtmlParagraphAlign;
+  indLeftTwips?: number;
+  /** Positive → `w:firstLine`, negative → `w:hanging`. */
+  firstLineTwips?: number;
+  /** `w:spacing w:line` in 240ths, `w:lineRule="auto"`. */
+  lineTwentieths?: number;
+  numPr?: { readonly numId: string; readonly ilvl: number };
+}
+
+const NAMED_COLORS = new Map(
+  (
+    'black:000000 white:FFFFFF red:FF0000 green:008000 blue:0000FF yellow:FFFF00 gray:808080 ' +
+    'grey:808080 silver:C0C0C0 maroon:800000 navy:000080 purple:800080 orange:FFA500 ' +
+    'aqua:00FFFF cyan:00FFFF fuchsia:FF00FF magenta:FF00FF lime:00FF00 olive:808000'
+  )
+    .split(' ')
+    .map((pair) => pair.split(':') as [string, string])
+);
+
+/**
+ * CSS / `mso-highlight` names → `ST_HighlightColor`. Word's highlighter writes
+ * `background:yellow;mso-highlight:yellow` and the CSS1 aliases aqua/fuchsia/lime/olive.
+ */
+const HIGHLIGHT_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['yellow', 'yellow'],
+  ['aqua', 'cyan'],
+  ['cyan', 'cyan'],
+  ['fuchsia', 'magenta'],
+  ['magenta', 'magenta'],
+  ['lime', 'green'],
+  ['olive', 'darkYellow'],
+  ['red', 'red'],
+  ['blue', 'blue'],
+  ['black', 'black'],
+  ['white', 'white'],
+  ['darkblue', 'darkBlue'],
+  ['darkcyan', 'darkCyan'],
+  ['darkgray', 'darkGray'],
+  ['darkgrey', 'darkGray'],
+  ['darkgreen', 'darkGreen'],
+  ['darkmagenta', 'darkMagenta'],
+  ['darkred', 'darkRed'],
+  ['darkyellow', 'darkYellow'],
+  ['lightgray', 'lightGray'],
+  ['lightgrey', 'lightGray'],
+]);
+
+const UNSAFE_BACKGROUND = /url\s*\(|image\s*\(|image-set\s*\(|element\s*\(|cross-fade\s*\(/i;
+
+/** Inline style declarations as a Map, so hostile property names never become object keys. */
+export function parseInlineStyle(element: Element): ReadonlyMap<string, string> {
+  const out = new Map<string, string>();
+  const raw = element.getAttribute('style');
+  if (!raw || raw.length > 8192) return out;
+  for (const declaration of raw.split(';')) {
+    const colon = declaration.indexOf(':');
+    if (colon <= 0) continue;
+    const name = declaration.slice(0, colon).trim().toLowerCase();
+    const value = declaration.slice(colon + 1).trim();
+    if (name.length > 0 && value.length > 0 && !out.has(name)) out.set(name, value);
+  }
+  return out;
+}
+
+/** Normalize a CSS color to RRGGBB uppercase hex, or null when it does not parse. */
+export function parseCssColor(value: string): string | null {
+  const v = value.trim().toLowerCase();
+  const named = NAMED_COLORS.get(v);
+  if (named) return named;
+  const hex6 = /^#([0-9a-f]{6})$/.exec(v);
+  if (hex6) return hex6[1]!.toUpperCase();
+  const hex3 = /^#([0-9a-f]{3})$/.exec(v);
+  if (hex3) {
+    const [r, g, b] = hex3[1]!;
+    return `${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+  const rgb = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]*)?\)$/.exec(v);
+  if (rgb) {
+    const channel = (part: string): string =>
+      Math.min(255, Number.parseInt(part, 10)).toString(16).padStart(2, '0');
+    return `${channel(rgb[1]!)}${channel(rgb[2]!)}${channel(rgb[3]!)}`.toUpperCase();
+  }
+  return null;
+}
+
+/** A closed ST_HighlightColor name, or undefined when the token is not in the allowlist. */
+export function highlightNameOf(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const token = value.trim().toLowerCase();
+  if (token.length === 0 || token.length > 32 || /[^a-z]/.test(token)) return undefined;
+  return HIGHLIGHT_ALIASES.get(token);
+}
+
+/**
+ * A solid colour from `background` / `background-color`. Named highlighter colours
+ * remain shading. Only `mso-highlight` carries Word highlighter semantics.
+ * `url()`, images, and any shorthand that is not wholly a colour are refused.
+ */
+export function solidBackground(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 128) return null;
+  if (UNSAFE_BACKGROUND.test(trimmed)) return null;
+  const lower = trimmed.toLowerCase();
+  if (lower === 'transparent' || lower === 'none') return null;
+  return parseCssColor(trimmed);
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+export function applyRunCss(base: HtmlRunProps, style: ReadonlyMap<string, string>): HtmlRunProps {
+  if (style.size === 0) return base;
+  const next: HtmlRunProps = { ...base };
+  const weight = style.get('font-weight')?.toLowerCase();
+  if (weight !== undefined) {
+    const numeric = Number.parseInt(weight, 10);
+    if (weight === 'bold' || numeric >= 600) next.bold = true;
+    else if (weight === 'normal' || numeric < 600) next.bold = false;
+  }
+  const fontStyle = style.get('font-style');
+  if (fontStyle !== undefined) next.italic = fontStyle.toLowerCase().includes('italic');
+  const decoration = (
+    style.get('text-decoration') ?? style.get('text-decoration-line')
+  )?.toLowerCase();
+  if (decoration !== undefined) {
+    if (decoration.includes('underline')) next.underline = true;
+    if (decoration.includes('line-through')) next.strike = true;
+    if (decoration.includes('none')) next.underline = next.strike = false;
+  }
+  const color = parseCssColor(style.get('color') ?? '');
+  if (color) next.color = color;
+  const msoHighlight = highlightNameOf(style.get('mso-highlight'));
+  const backgroundRaw = style.get('background');
+  const backgroundColorRaw = style.get('background-color');
+  if (msoHighlight) {
+    next.highlight = msoHighlight;
+    delete next.shdFill;
+  } else if (backgroundRaw !== undefined) {
+    const parsed = solidBackground(backgroundRaw);
+    if (parsed) next.shdFill = parsed;
+  } else if (backgroundColorRaw !== undefined) {
+    const parsed = solidBackground(backgroundColorRaw);
+    if (parsed) next.shdFill = parsed;
+  }
+  const pt = parseCssLengthPt(style.get('font-size') ?? '');
+  if (pt !== null && pt > 0) next.szHalfPoints = clamp(Math.round(pt * 2), 2, 3276);
+  const family = style.get('font-family');
+  if (family !== undefined) {
+    const first = family
+      .split(',')[0]!
+      .trim()
+      .replace(/^['"]|['"]$/g, '');
+    if (first.length > 0 && first.length <= 64) next.font = first;
+  }
+  const vertical = style.get('vertical-align');
+  if (vertical === 'sub') next.vertAlign = 'subscript';
+  else if (vertical === 'super') next.vertAlign = 'superscript';
+  return next;
+}
+
+export function applyParaCss(para: HtmlParaProps, style: ReadonlyMap<string, string>): void {
+  const align = style.get('text-align')?.toLowerCase();
+  if (align === 'left' || align === 'start') para.jc = 'left';
+  else if (align === 'center') para.jc = 'center';
+  else if (align === 'right' || align === 'end') para.jc = 'right';
+  else if (align === 'justify') para.jc = 'both';
+  const marginPt = parseCssLengthPt(style.get('margin-left') ?? '');
+  if (marginPt !== null && marginPt > 0) {
+    para.indLeftTwips = clamp(Math.round(marginPt * 20), 0, 31_680);
+  }
+  const indentPt = parseCssLengthPt(style.get('text-indent') ?? '');
+  if (indentPt !== null && indentPt !== 0) {
+    const twips = clamp(Math.round(indentPt * 20), -31_680, 31_680);
+    if (twips !== 0) para.firstLineTwips = twips;
+  }
+  const lineHeight = style.get('line-height')?.trim() ?? '';
+  if (/^\d+(\.\d+)?$/.test(lineHeight) && Number.parseFloat(lineHeight) > 0) {
+    para.lineTwentieths = clamp(Math.round(240 * Number.parseFloat(lineHeight)), 24, 9600);
+  }
 }

--- a/packages/core/src/editor/clipboard-html-styles.ts
+++ b/packages/core/src/editor/clipboard-html-styles.ts
@@ -1,0 +1,57 @@
+/** A CSS length in points, from `px` or `pt` values only. */
+export function parseCssLengthPt(value: string): number | null {
+  const match = /^(-?\d+(?:\.\d+)?)(px|pt)$/.exec(value.trim().toLowerCase());
+  if (!match) return null;
+  const magnitude = Number.parseFloat(match[1]!);
+  if (!Number.isFinite(magnitude)) return null;
+  return match[2] === 'px' ? magnitude * 0.75 : magnitude;
+}
+
+/** Whether bare image extents use Word's point-based clipboard convention. */
+export function isWordClipboardHtml(html: string): boolean {
+  return (
+    html.includes('urn:schemas-microsoft-com:office') ||
+    html.includes('class=Mso') ||
+    html.includes('class="Mso') ||
+    html.includes("class='Mso")
+  );
+}
+
+/** A built-in Word style named by Word desktop's clipboard HTML class. */
+export function wordParagraphStyleId(element: Element, wordHtml: boolean): string | undefined {
+  for (const className of element.classList) {
+    const heading = /^MsoHeading([1-9])$/.exec(className);
+    if (heading) return `Heading${heading[1]}`;
+    const onlineHeading = /^Heading([1-9])$/.exec(className);
+    if (onlineHeading) return `Heading${onlineHeading[1]}`;
+    if (className === 'MsoCaption') return 'Caption';
+    if (className === 'MsoTitle') return 'Title';
+    if (className === 'MsoSubtitle') return 'Subtitle';
+    if (className === 'MsoQuote') return 'Quote';
+  }
+  const headingTag = wordHtml ? /^h([1-6])$/.exec(tagOf(element)) : null;
+  return headingTag ? `Heading${headingTag[1]}` : undefined;
+}
+
+/** An image extent in CSS pixels, including Word's bare-point convention. */
+export function imageDimensionPx(
+  element: Element,
+  style: ReadonlyMap<string, string>,
+  axis: 'width' | 'height',
+  wordHtml: boolean
+): number | null {
+  const pt = parseCssLengthPt(style.get(axis) ?? '');
+  if (pt !== null && pt > 0) return pt / 0.75;
+  const attr = element.getAttribute(axis)?.trim() ?? '';
+  if (!/^[1-9]\d{0,4}$/.test(attr)) return null;
+  const value = Number.parseInt(attr, 10);
+  return wordHtml ? value / 0.75 : value;
+}
+
+export function isElement(node: Node): node is Element {
+  return node.nodeType === 1;
+}
+
+export function tagOf(element: Element): string {
+  return element.tagName.toLowerCase();
+}

--- a/packages/core/src/editor/clipboard-plain-text.ts
+++ b/packages/core/src/editor/clipboard-plain-text.ts
@@ -304,6 +304,25 @@ export function insertableText(text: string): string {
 }
 
 /**
+ * True when the engine's paste router will land content from this `text/html` flavour —
+ * an embedded fragment, a `data:` image, or visible text.
+ *
+ * This is the adapters' stand-down predicate for the image-FILE paste lane. Word on macOS
+ * puts a rendered PNG of the copied TEXT on the pasteboard next to the HTML; a host that
+ * inserts the file whenever one is present pastes that rendering ON TOP of the text the
+ * engine lands. The file lane is only for payloads the engine ignores: a bare screenshot
+ * (no HTML at all), or a browser "copy image" whose HTML is a single external `<img>` the
+ * projection drops by design — both of which carry no visible text.
+ *
+ * @public
+ */
+export function clipboardHtmlLandsContent(html: string): boolean {
+  if (html.length === 0) return false;
+  if (html.includes('data-docx-fragment') || html.includes('data:image')) return true;
+  return plainTextFromHtml(html).length > 0;
+}
+
+/**
  * The text a paste or drop should insert, whatever flavours the payload carries.
  *
  * `text/plain` wins whenever it is present — it is what the source application chose to

--- a/packages/core/src/editor/clipboard-plain-text.ts
+++ b/packages/core/src/editor/clipboard-plain-text.ts
@@ -341,7 +341,11 @@ export function hasVisibleChar(text: string): boolean {
 export function htmlHasVisibleText(html: string): boolean {
   const bounded = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
   for (const piece of htmlTextPieces(bounded)) {
-    if (VISIBLE_CHAR.test(decodeEntities(piece))) return true;
+    // Entities decode per piece only when one can be present; a reference split across
+    // pieces by markup may still read as visible here — the full transform concatenates
+    // before decoding, so on such (hand-crafted) payloads this over-reports visibility.
+    const text = piece.includes('&') ? decodeEntities(piece) : piece;
+    if (VISIBLE_CHAR.test(text)) return true;
   }
   return false;
 }

--- a/packages/core/src/editor/clipboard-plain-text.ts
+++ b/packages/core/src/editor/clipboard-plain-text.ts
@@ -58,8 +58,13 @@ function decodeEntities(text: string): string {
   });
 }
 
-/** Tags whose CONTENT is source, not visible text: the whole element is dropped. */
-const RAW_TEXT_TAGS = new Set(['script', 'style']);
+/**
+ * Tags whose CONTENT is never visible text: the whole element is dropped. `title` and
+ * `template` join `script`/`style` because a full-document clipboard flavour (a browser's
+ * "copy image", say) carries a page title no reader ever saw — pasting it inserted the
+ * word instead of nothing, and made the payload read as text-bearing to the paste lanes.
+ */
+const RAW_TEXT_TAGS = new Set(['script', 'style', 'title', 'template']);
 /** Close tags that end a block, so what follows starts a new line. */
 const BLOCK_TAGS = new Set([
   'p',
@@ -322,67 +327,23 @@ export function insertableText(text: string): string {
  */
 const VISIBLE_CHAR = /[^\s\u200B-\u200D\u2060\uFEFF\u00AD]/;
 
-/**
- * A `data:` image the paste projection actually accepts — the same mime/base64 shape as
- * `DATA_IMAGE_RE` in clipboard-html-read.ts. A bare `data:image` substring also matched
- * webp/svg payloads the projection refuses, standing the file lane down for an image the
- * engine then dropped.
- */
-const LANDABLE_DATA_IMAGE = /\bdata:image\/(?:png|jpe?g|jpg|gif);base64,/;
+/** Whether the text holds at least one character the reader can see. */
+export function hasVisibleChar(text: string): boolean {
+  return VISIBLE_CHAR.test(text);
+}
 
-/** Early-exit visible-text scan: stops at the first visible character instead of
- * materializing the whole payload's text the way {@link plainTextFromHtml} does. */
-function htmlHasVisibleText(html: string): boolean {
+/**
+ * Early-exit visible-text scan: stops at the first visible character instead of
+ * materializing the whole payload's text the way {@link plainTextFromHtml} does. The two
+ * share {@link htmlTextPieces} and the same input cap, so they agree on WHERE text is —
+ * this one only answers sooner.
+ */
+export function htmlHasVisibleText(html: string): boolean {
   const bounded = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
   for (const piece of htmlTextPieces(bounded)) {
     if (VISIBLE_CHAR.test(decodeEntities(piece))) return true;
   }
   return false;
-}
-
-/**
- * True when the engine's PASTE router will land content from these clipboard flavours —
- * an embedded fragment, a `data:` image the projection accepts, visible HTML text, or
- * (with no HTML at all) visible plain text.
- *
- * This is the adapters' stand-down predicate for the image-FILE paste lane. Word on macOS
- * puts a rendered PNG of the copied TEXT on the pasteboard next to the HTML; a host that
- * inserts the file whenever one is present pastes that rendering ON TOP of the text the
- * engine lands. The file lane is only for payloads the engine ignores: a bare screenshot,
- * or a browser "copy image" whose HTML is a single external `<img>` the projection drops
- * by design.
- *
- * Known limits, on purpose: it cannot see the engine's own gating (suggesting mode, cell
- * selections, the force-plain window), and a payload mixing text with non-`data:` images
- * lands its text while the engine drops those images — text wins over a rendering that
- * would duplicate it.
- *
- * @public
- */
-export function clipboardPasteLandsContent(html: string, text: string): boolean {
-  if (html.length > 0) {
-    if (html.includes('data-docx-fragment="')) return true;
-    if (LANDABLE_DATA_IMAGE.test(html)) return true;
-    return htmlHasVisibleText(html);
-  }
-  // No HTML flavour at all: the plain lane inserts `text/plain` whenever it carries
-  // visible text, so an image file beside it is Word's duplicate rendering, not content.
-  return VISIBLE_CHAR.test(text);
-}
-
-/**
- * True when the engine's DROP lane will land text from these flavours.
- *
- * The drop lane is PLAIN TEXT only (see `createBeforeInputHandler`): fragments and `data:`
- * images never land from a drop, so only visible text — in either flavour, matching
- * {@link plainTextFromTransfer} — stands a host's image-file drop lane down. A host that
- * takes the file lane anyway swallows the browser's `insertFromDrop`, turning a dropped
- * text selection into a picture of that text.
- *
- * @public
- */
-export function clipboardDropLandsText(html: string, text: string): boolean {
-  return VISIBLE_CHAR.test(text) || htmlHasVisibleText(html);
 }
 
 /**

--- a/packages/core/src/editor/clipboard-plain-text.ts
+++ b/packages/core/src/editor/clipboard-plain-text.ts
@@ -170,33 +170,22 @@ function rawTextEnd(html: string, name: string, from: number): number {
 }
 
 /**
- * The visible text of an HTML fragment.
+ * The text pieces of an HTML fragment, in document order.
  *
- * A single forward walk, not a sequence of `replace` passes. The walk never re-reads what it
- * has already written, so no later stage can turn emitted text back into a tag, and every
- * branch moves the cursor forward over a range the next branch will not revisit — a hostile
- * payload costs one pass over its own length.
- *
- * It does NOT promise the output holds no angle brackets. A payload may write a literal `<`
- * that a browser also shows as text, and removing the element after it can leave that `<`
- * beside a word. That is fine here and only here: the result is inserted as run text through
- * the same path typed characters take, and is escaped again on save. Nothing re-parses it.
- *
- * Block boundaries become newlines and table cells become tabs, matching how this engine
- * already flattens a copied cell range — so an HTML table pasted here lands in the same
- * shape a table copied out of the document does.
+ * One forward walk shared by the full transform below and the early-exit predicate — every
+ * branch moves the cursor forward over a range the next branch will not revisit, so a
+ * hostile payload costs at most one pass over its own length. Yields raw text slices plus
+ * the `\n`/`\t` a block or cell boundary reads as; entity references are NOT decoded here.
  */
-export function plainTextFromHtml(html: string): string {
-  const bounded = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
-  let text = '';
+function* htmlTextPieces(bounded: string): Generator<string> {
   let at = 0;
   while (at < bounded.length) {
     const open = bounded.indexOf('<', at);
     if (open === -1) {
-      text += bounded.slice(at);
+      yield bounded.slice(at);
       break;
     }
-    text += bounded.slice(at, open);
+    if (open > at) yield bounded.slice(at, open);
     // Comments first: they can contain anything, including tag-shaped text.
     if (bounded.startsWith('<!--', open)) {
       // `<!-->` and `<!--->` close AT ONCE. Demanding a full `-->` after them found no
@@ -223,7 +212,7 @@ export function plainTextFromHtml(html: string): string {
     const tag = scanTag(bounded, open);
     if (tag === null) {
       // A `<` that starts no tag is text, exactly as a browser reads it.
-      text += '<';
+      yield '<';
       at = open + 1;
       continue;
     }
@@ -231,13 +220,35 @@ export function plainTextFromHtml(html: string): string {
     if (!tag.closing && RAW_TEXT_TAGS.has(tag.name)) {
       at = rawTextEnd(bounded, tag.name, tag.end);
     } else if (!tag.closing && tag.name === 'br') {
-      text += '\n';
+      yield '\n';
     } else if (tag.closing && CELL_TAGS.has(tag.name)) {
-      text += '\t';
+      yield '\t';
     } else if (tag.closing && BLOCK_TAGS.has(tag.name)) {
-      text += '\n';
+      yield '\n';
     }
   }
+}
+
+/**
+ * The visible text of an HTML fragment.
+ *
+ * A single forward walk (see {@link htmlTextPieces}), not a sequence of `replace` passes.
+ * The walk never re-reads what it has already written, so no later stage can turn emitted
+ * text back into a tag.
+ *
+ * It does NOT promise the output holds no angle brackets. A payload may write a literal `<`
+ * that a browser also shows as text, and removing the element after it can leave that `<`
+ * beside a word. That is fine here and only here: the result is inserted as run text through
+ * the same path typed characters take, and is escaped again on save. Nothing re-parses it.
+ *
+ * Block boundaries become newlines and table cells become tabs, matching how this engine
+ * already flattens a copied cell range — so an HTML table pasted here lands in the same
+ * shape a table copied out of the document does.
+ */
+export function plainTextFromHtml(html: string): string {
+  const bounded = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
+  let text = '';
+  for (const piece of htmlTextPieces(bounded)) text += piece;
   return (
     decodeEntities(text)
       // Collapse the runs of blank lines that block-level markup leaves behind, and drop
@@ -304,22 +315,74 @@ export function insertableText(text: string): string {
 }
 
 /**
- * True when the engine's paste router will land content from this `text/html` flavour —
- * an embedded fragment, a `data:` image, or visible text.
+ * A character the reader can actually see: not whitespace, and not one of the zero-width
+ * or invisible-format characters (`U+200B`–`U+200D`, `U+2060`, `U+FEFF`, soft hyphen) some
+ * applications wrap around inline content. Those survive `trim()` and would make an
+ * effectively empty payload read as "carries text".
+ */
+const VISIBLE_CHAR = /[^\s\u200B-\u200D\u2060\uFEFF\u00AD]/;
+
+/**
+ * A `data:` image the paste projection actually accepts — the same mime/base64 shape as
+ * `DATA_IMAGE_RE` in clipboard-html-read.ts. A bare `data:image` substring also matched
+ * webp/svg payloads the projection refuses, standing the file lane down for an image the
+ * engine then dropped.
+ */
+const LANDABLE_DATA_IMAGE = /\bdata:image\/(?:png|jpe?g|jpg|gif);base64,/;
+
+/** Early-exit visible-text scan: stops at the first visible character instead of
+ * materializing the whole payload's text the way {@link plainTextFromHtml} does. */
+function htmlHasVisibleText(html: string): boolean {
+  const bounded = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
+  for (const piece of htmlTextPieces(bounded)) {
+    if (VISIBLE_CHAR.test(decodeEntities(piece))) return true;
+  }
+  return false;
+}
+
+/**
+ * True when the engine's PASTE router will land content from these clipboard flavours —
+ * an embedded fragment, a `data:` image the projection accepts, visible HTML text, or
+ * (with no HTML at all) visible plain text.
  *
  * This is the adapters' stand-down predicate for the image-FILE paste lane. Word on macOS
  * puts a rendered PNG of the copied TEXT on the pasteboard next to the HTML; a host that
  * inserts the file whenever one is present pastes that rendering ON TOP of the text the
- * engine lands. The file lane is only for payloads the engine ignores: a bare screenshot
- * (no HTML at all), or a browser "copy image" whose HTML is a single external `<img>` the
- * projection drops by design — both of which carry no visible text.
+ * engine lands. The file lane is only for payloads the engine ignores: a bare screenshot,
+ * or a browser "copy image" whose HTML is a single external `<img>` the projection drops
+ * by design.
+ *
+ * Known limits, on purpose: it cannot see the engine's own gating (suggesting mode, cell
+ * selections, the force-plain window), and a payload mixing text with non-`data:` images
+ * lands its text while the engine drops those images — text wins over a rendering that
+ * would duplicate it.
  *
  * @public
  */
-export function clipboardHtmlLandsContent(html: string): boolean {
-  if (html.length === 0) return false;
-  if (html.includes('data-docx-fragment') || html.includes('data:image')) return true;
-  return plainTextFromHtml(html).length > 0;
+export function clipboardPasteLandsContent(html: string, text: string): boolean {
+  if (html.length > 0) {
+    if (html.includes('data-docx-fragment="')) return true;
+    if (LANDABLE_DATA_IMAGE.test(html)) return true;
+    return htmlHasVisibleText(html);
+  }
+  // No HTML flavour at all: the plain lane inserts `text/plain` whenever it carries
+  // visible text, so an image file beside it is Word's duplicate rendering, not content.
+  return VISIBLE_CHAR.test(text);
+}
+
+/**
+ * True when the engine's DROP lane will land text from these flavours.
+ *
+ * The drop lane is PLAIN TEXT only (see `createBeforeInputHandler`): fragments and `data:`
+ * images never land from a drop, so only visible text — in either flavour, matching
+ * {@link plainTextFromTransfer} — stands a host's image-file drop lane down. A host that
+ * takes the file lane anyway swallows the browser's `insertFromDrop`, turning a dropped
+ * text selection into a picture of that text.
+ *
+ * @public
+ */
+export function clipboardDropLandsText(html: string, text: string): boolean {
+  return VISIBLE_CHAR.test(text) || htmlHasVisibleText(html);
 }
 
 /**

--- a/packages/core/src/editor/clipboard-plain-text.ts
+++ b/packages/core/src/editor/clipboard-plain-text.ts
@@ -321,11 +321,12 @@ export function insertableText(text: string): string {
 
 /**
  * A character the reader can actually see: not whitespace, and not one of the zero-width
- * or invisible-format characters (`U+200B`–`U+200D`, `U+2060`, `U+FEFF`, soft hyphen) some
+ * or invisible-format characters (zero-widths, bidi marks and isolates, `U+2060`,
+ * `U+FEFF`, soft hyphen) some
  * applications wrap around inline content. Those survive `trim()` and would make an
  * effectively empty payload read as "carries text".
  */
-const VISIBLE_CHAR = /[^\s\u200B-\u200D\u2060\uFEFF\u00AD]/;
+const VISIBLE_CHAR = /[^\s\u200B-\u200F\u2060\u2066-\u2069\u061C\uFEFF\u00AD]/;
 
 /** Whether the text holds at least one character the reader can see. */
 export function hasVisibleChar(text: string): boolean {

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -32,6 +32,7 @@ export {
   type FontResolver,
 } from './font-composition.ts';
 export { blankDocumentBytes } from './blank-document.ts';
+export { clipboardHtmlLandsContent } from './clipboard-plain-text.ts';
 /**
  * The part a node id names, read from the live package.
  *

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -32,7 +32,7 @@ export {
   type FontResolver,
 } from './font-composition.ts';
 export { blankDocumentBytes } from './blank-document.ts';
-export { clipboardHtmlLandsContent } from './clipboard-plain-text.ts';
+export { clipboardDropLandsText, clipboardPasteLandsContent } from './clipboard-plain-text.ts';
 /**
  * The part a node id names, read from the live package.
  *

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -32,7 +32,7 @@ export {
   type FontResolver,
 } from './font-composition.ts';
 export { blankDocumentBytes } from './blank-document.ts';
-export { clipboardDropLandsText, clipboardPasteLandsContent } from './clipboard-plain-text.ts';
+export { clipboardDropLandsText, clipboardPasteLandsContent } from './clipboard-file-lane.ts';
 /**
  * The part a node id names, read from the live package.
  *

--- a/packages/core/src/store/__tests__/image-resources.test.ts
+++ b/packages/core/src/store/__tests__/image-resources.test.ts
@@ -237,6 +237,43 @@ function forgedPng(wrongChunkLength: boolean): Uint8Array {
   return out;
 }
 
+function pngWithPhysicalDensity(pixelsPerMeter: number, unit = 1): Uint8Array {
+  const phys = Uint8Array.from([
+    0,
+    0,
+    0,
+    9,
+    0x70,
+    0x48,
+    0x59,
+    0x73,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    unit,
+    0,
+    0,
+    0,
+    0,
+  ]);
+  for (const offset of [8, 12]) {
+    phys[offset] = (pixelsPerMeter >>> 24) & 0xff;
+    phys[offset + 1] = (pixelsPerMeter >>> 16) & 0xff;
+    phys[offset + 2] = (pixelsPerMeter >>> 8) & 0xff;
+    phys[offset + 3] = pixelsPerMeter & 0xff;
+  }
+  const out = new Uint8Array(PNG_1X1.length + phys.length);
+  out.set(PNG_1X1.subarray(0, 33));
+  out.set(phys, 33);
+  out.set(PNG_1X1.subarray(33), 33 + phys.length);
+  return out;
+}
+
 describe('image resource validation and cache (task 4)', () => {
   describe('signature sniffing', () => {
     test.each([
@@ -274,6 +311,18 @@ describe('image resource validation and cache (task 4)', () => {
   describe('structural raster headers', () => {
     test('PNG IHDR validates 1x1 dimensions', () => {
       expect(validatePngHeader(PNG_1X1)).toEqual({ pixelWidth: 1, pixelHeight: 1 });
+    });
+
+    test('PNG pHYs supplies bounded physical density', () => {
+      const header = validatePngHeader(pngWithPhysicalDensity(5669));
+      expect(header?.dpiX).toBeCloseTo(144, 1);
+      expect(header?.dpiY).toBeCloseTo(144, 1);
+    });
+
+    test('PNG pHYs ignores aspect-only and excessive density', () => {
+      expect(validatePngHeader(pngWithPhysicalDensity(5669, 0))?.dpiX).toBeUndefined();
+      expect(validatePngHeader(pngWithPhysicalDensity(1))?.dpiX).toBeUndefined();
+      expect(validatePngHeader(pngWithPhysicalDensity(100_000))?.dpiX).toBeUndefined();
     });
 
     test('GIF logical screen validates nonzero dimensions', () => {
@@ -632,6 +681,19 @@ describe('image resource validation and cache (task 4)', () => {
       expect(state.resourceKey).toContain('sha256:');
       expect('validatedBytesFor' in cache).toBe(false);
       expect(Object.isFrozen(state)).toBe(true);
+    });
+
+    test('ready PNG prefers physical header density over decoder defaults', async () => {
+      const loaded = buildPackage({
+        media: { 'word/media/image1.png': pngWithPhysicalDensity(5669) },
+      });
+      if (!loaded.ok) throw new Error(loaded.reason);
+      const cache = createImageResourceCache(loaded.package, { decodePort: mockDecodePort() });
+      const state = await cache.resolveEmbedded('/word/document.xml', 'rId2');
+      expect(state.kind).toBe('ready');
+      if (state.kind !== 'ready') return;
+      expect(state.dpiX).toBeCloseTo(144, 1);
+      expect(state.dpiY).toBeCloseTo(144, 1);
     });
 
     test('decoder receives a copy; package bytes and hash stay stable after mutation', async () => {

--- a/packages/core/src/store/package/hf-lifecycle.ts
+++ b/packages/core/src/store/package/hf-lifecycle.ts
@@ -9,7 +9,12 @@
 // validated integers only; content-types bytes are parse-and-prove patched; relationship
 // targets are relative safe paths; maps are prototype-safe; scans are bounded.
 
-import { createNodeIdAllocator, insertChildren, replaceChildren } from './ooxml-edit.ts';
+import {
+  carryIndexToRebuiltRoot,
+  createNodeIdAllocator,
+  insertChildren,
+  replaceChildren,
+} from './ooxml-edit.ts';
 import { readOoxmlPart, type OoxmlElement, type OoxmlNode, type OoxmlPart } from './ooxml-tree.ts';
 import type { OoxmlPackage } from './ooxml-package.ts';
 import { withPart } from './ooxml-package.ts';
@@ -521,6 +526,9 @@ function withRelationshipRootBinding(main: OoxmlPart): OoxmlPart | null {
       Object.freeze({ prefix: 'r', namespaceUri: R_NS }),
     ]),
   } as typeof main.root;
+  // A rebuilt root outside the edit primitives carries its index — see the invariant on
+  // `carryIndexToRebuiltRoot`.
+  carryIndexToRebuiltRoot(main.root, root);
   return { ...main, root };
 }
 

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -17,6 +17,7 @@ import {
 } from './relationships.ts';
 import { projectDrawingsInPackage, type DrawingProjection } from './drawing-projection.ts';
 import type { OoxmlPackage } from './ooxml-package.ts';
+import { readPngPhysicalDensity } from './png-physical-density.ts';
 import {
   IMAGE_RESOURCE_HARD_CEILINGS,
   resolveImageResourceLimits,
@@ -166,6 +167,10 @@ const CONTENT_TYPE_TO_MIME: Readonly<Record<string, RenderableImageMime | Preser
 export interface ValidatedRasterHeader {
   readonly pixelWidth: number;
   readonly pixelHeight: number;
+  /** Horizontal physical density when bounded header metadata supplies it. */
+  readonly dpiX?: number;
+  /** Vertical physical density when bounded header metadata supplies it. */
+  readonly dpiY?: number;
 }
 
 function bytesStartWith(bytes: Uint8Array, prefix: readonly number[]): boolean {
@@ -344,7 +349,8 @@ export function validatePngHeader(bytes: Uint8Array): ValidatedRasterHeader | nu
   if (!isValidPngColorTypeAndBitDepth(colorType, bitDepth)) return null;
   if (compression !== 0 || filter !== 0) return null;
   if (interlace !== 0 && interlace !== 1) return null;
-  return { pixelWidth, pixelHeight };
+  const density = readPngPhysicalDensity(bytes);
+  return density ? { pixelWidth, pixelHeight, ...density } : { pixelWidth, pixelHeight };
 }
 
 /** Structural GIF logical screen descriptor validation before decode. */
@@ -1109,8 +1115,8 @@ function createImageResourceCacheInternal(
                 mime: convertedSniffed,
                 pixelWidth: convertedHeader.pixelWidth,
                 pixelHeight: convertedHeader.pixelHeight,
-                dpiX: DEFAULT_DPI,
-                dpiY: DEFAULT_DPI,
+                dpiX: convertedHeader.dpiX ?? DEFAULT_DPI,
+                dpiY: convertedHeader.dpiY ?? DEFAULT_DPI,
               })
             );
           } catch (error) {
@@ -1208,10 +1214,12 @@ function createImageResourceCacheInternal(
             return;
           }
 
-          const dpiX =
+          const decodedDpiX =
             Number.isFinite(decoded.dpiX) && decoded.dpiX > 0 ? decoded.dpiX : DEFAULT_DPI;
-          const dpiY =
+          const decodedDpiY =
             Number.isFinite(decoded.dpiY) && decoded.dpiY > 0 ? decoded.dpiY : DEFAULT_DPI;
+          const dpiX = header.dpiX ?? decodedDpiX;
+          const dpiY = header.dpiY ?? decodedDpiY;
 
           const resourceKey = resourceKeyOf(ownerPartName, resolvedPartName, contentId);
           const validatedHandle = validatedBytesRegistry.acquire(

--- a/packages/core/src/store/package/ooxml-edit.ts
+++ b/packages/core/src/store/package/ooxml-edit.ts
@@ -268,6 +268,10 @@ function stealPatchedIndex(oldRoot: OoxmlElement, newRoot: OoxmlElement): void {
  * the fragment lane binding namespace prefixes — must do the same, or the new root starts
  * an orphaned index: the next lookup re-walks the whole part, and the mint frontier
  * restarts at 0 underneath ids already handed out.
+ *
+ * The carry STEALS, like every op executor: when a refusal path later discards the new
+ * root, the still-published old root re-walks once on its next lookup. That direction is
+ * accepted — refusals are exceptional, while the carried case is every successful landing.
  */
 export function carryIndexToRebuiltRoot(oldRoot: OoxmlElement, newRoot: OoxmlElement): void {
   stealPatchedIndex(oldRoot, newRoot);

--- a/packages/core/src/store/package/ooxml-edit.ts
+++ b/packages/core/src/store/package/ooxml-edit.ts
@@ -167,7 +167,10 @@ export function collectNodeIds(part: OoxmlPart): Set<string> {
  * Checks the part's node index directly rather than copying every id into a fresh set: the
  * copy was O(document) per op, and an allocator is created for every op.
  */
-export function createNodeIdAllocator(part: OoxmlPart, family = 'new'): () => string {
+export function createNodeIdAllocator(
+  part: OoxmlPart,
+  family: 'new' | 'paste' = 'new'
+): () => string {
   const index = nodeIndexFor(part.root);
   const minted = new Set<string>();
   let counter = index.mintFrontier;
@@ -255,6 +258,19 @@ function stealPatchedIndex(oldRoot: OoxmlElement, newRoot: OoxmlElement): void {
   partIndexes.delete(oldRoot);
   diffPatch(index, oldRoot, newRoot, null);
   partIndexes.set(newRoot, index);
+}
+
+/**
+ * Carry the index across a root rebuilt OUTSIDE the op executors.
+ *
+ * Every op executor moves the index with `stealPatchedIndex`, so the mint frontier and the
+ * diffed entries survive its root replacement. A helper that rebuilds the root directly —
+ * the fragment lane binding namespace prefixes — must do the same, or the new root starts
+ * an orphaned index: the next lookup re-walks the whole part, and the mint frontier
+ * restarts at 0 underneath ids already handed out.
+ */
+export function carryIndexToRebuiltRoot(oldRoot: OoxmlElement, newRoot: OoxmlElement): void {
+  stealPatchedIndex(oldRoot, newRoot);
 }
 
 function removeIndexedSubtree(index: PartIndex, node: OoxmlNode): void {

--- a/packages/core/src/store/package/ooxml-edit.ts
+++ b/packages/core/src/store/package/ooxml-edit.ts
@@ -158,18 +158,24 @@ export function collectNodeIds(part: OoxmlPart): Set<string> {
  * can never coincide, and the counter skips anything already taken so repeated edits in one
  * session stay unique.
  *
+ * The collision check only sees nodes that are IN the tree. A caller that clones a subtree
+ * and attaches it LATER — after other ops have replaced the root and reset the counter —
+ * must mint in its own `family`: two `new`-family allocators over different roots can hand
+ * out the same id, one to a detached clone and one to the tree, and the clone's insertion
+ * then fails the duplicate-id invariant.
+ *
  * Checks the part's node index directly rather than copying every id into a fresh set: the
  * copy was O(document) per op, and an allocator is created for every op.
  */
-export function createNodeIdAllocator(part: OoxmlPart): () => string {
+export function createNodeIdAllocator(part: OoxmlPart, family = 'new'): () => string {
   const index = nodeIndexFor(part.root);
   const minted = new Set<string>();
   let counter = index.mintFrontier;
   return () => {
-    let id = `${part.name}#new:${counter}`;
+    let id = `${part.name}#${family}:${counter}`;
     while (index.nodes.has(id) || minted.has(id)) {
       counter += 1;
-      id = `${part.name}#new:${counter}`;
+      id = `${part.name}#${family}:${counter}`;
     }
     minted.add(id);
     counter += 1;

--- a/packages/core/src/store/package/para-id.ts
+++ b/packages/core/src/store/package/para-id.ts
@@ -19,7 +19,7 @@
 // requires, and the collision bump provides it.
 
 import { MC_NAMESPACE_URI, W14_NAMESPACE_URI, WML_NAMESPACE_URI } from './ooxml-shared.ts';
-import { parentNodeOf } from './ooxml-edit.ts';
+import { carryIndexToRebuiltRoot, parentNodeOf } from './ooxml-edit.ts';
 import type { OoxmlAttribute, OoxmlElement, OoxmlNode, OoxmlPart } from './ooxml-tree.ts';
 import { validateOoxmlPart } from './ooxml-validate.ts';
 
@@ -357,6 +357,9 @@ export function normalizeParagraphIdentity(part: OoxmlPart): OoxmlPart {
     root = freezeElement({ ...root, namespaceBindings: bindings, attributes } as OoxmlElement);
   }
 
+  // A rebuilt root outside the edit primitives carries its index — a no-op at document
+  // open (no index exists yet), load-bearing when a story replacement normalizes mid-life.
+  carryIndexToRebuiltRoot(part.root, root);
   // Frozen like every part the edit primitives publish — layout memos key on part identity,
   // and the freeze discipline is what makes that identity trustworthy.
   const normalized: OoxmlPart = Object.freeze({ ...part, root });

--- a/packages/core/src/store/package/png-physical-density.ts
+++ b/packages/core/src/store/package/png-physical-density.ts
@@ -1,0 +1,57 @@
+const MAX_PNG_METADATA_SCAN = 65_536;
+const MIN_RASTER_DPI = 10;
+const MAX_RASTER_DPI = 2_400;
+
+function readUint32Be(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset]! << 24) >>> 0) |
+    (bytes[offset + 1]! << 16) |
+    (bytes[offset + 2]! << 8) |
+    bytes[offset + 3]!
+  );
+}
+
+/** Read PNG `pHYs` density before `IDAT`, under a fixed prefix scan bound. */
+export function readPngPhysicalDensity(
+  bytes: Uint8Array
+): { readonly dpiX: number; readonly dpiY: number } | null {
+  const scanLimit = Math.min(bytes.length, MAX_PNG_METADATA_SCAN);
+  let offset = 33;
+  while (offset + 12 <= scanLimit) {
+    const length = readUint32Be(bytes, offset);
+    const chunkEnd = offset + 12 + length;
+    if (chunkEnd > scanLimit) return null;
+    const typeOffset = offset + 4;
+    const isIdat =
+      bytes[typeOffset] === 0x49 &&
+      bytes[typeOffset + 1] === 0x44 &&
+      bytes[typeOffset + 2] === 0x41 &&
+      bytes[typeOffset + 3] === 0x54;
+    const isIend =
+      bytes[typeOffset] === 0x49 &&
+      bytes[typeOffset + 1] === 0x45 &&
+      bytes[typeOffset + 2] === 0x4e &&
+      bytes[typeOffset + 3] === 0x44;
+    if (isIdat || isIend) return null;
+    const isPhys =
+      bytes[typeOffset] === 0x70 &&
+      bytes[typeOffset + 1] === 0x48 &&
+      bytes[typeOffset + 2] === 0x59 &&
+      bytes[typeOffset + 3] === 0x73;
+    if (isPhys && length === 9 && bytes[offset + 16] === 1) {
+      const dpiX = readUint32Be(bytes, offset + 8) * 0.0254;
+      const dpiY = readUint32Be(bytes, offset + 12) * 0.0254;
+      if (
+        dpiX >= MIN_RASTER_DPI &&
+        dpiX <= MAX_RASTER_DPI &&
+        dpiY >= MIN_RASTER_DPI &&
+        dpiY <= MAX_RASTER_DPI
+      ) {
+        return { dpiX, dpiY };
+      }
+      return null;
+    }
+    offset = chunkEnd;
+  }
+  return null;
+}

--- a/packages/core/src/store/store/clipboard-fragment-merge.ts
+++ b/packages/core/src/store/store/clipboard-fragment-merge.ts
@@ -33,7 +33,11 @@ import { ensureNotesPart } from '../package/note-lifecycle.ts';
 import { resolveNotesPart } from '../package/note-references.ts';
 import { resolveInternalTarget } from '../package/opc-names.ts';
 import { readOoxmlPart } from '../package/ooxml-tree.ts';
-import { createNodeIdAllocator, insertChildren } from '../package/ooxml-edit.ts';
+import {
+  carryIndexToRebuiltRoot,
+  createNodeIdAllocator,
+  insertChildren,
+} from '../package/ooxml-edit.ts';
 import { sha256FontBytes } from '../package/sha256.ts';
 import { attributeValueOf, cloneWithNewIds } from './tree-op-nodes.ts';
 import {
@@ -815,6 +819,9 @@ export function mergeFragmentIntoPackage(
       };
       const nextRoot = dropCollidingMarkers(ownerPart.root) as OoxmlElement;
       if (nextRoot !== ownerPart.root) {
+        // A rebuilt root outside the op executors must carry its index — see the
+        // invariant on `carryIndexToRebuiltRoot`.
+        carryIndexToRebuiltRoot(ownerPart.root, nextRoot);
         pkg = withPart(pkg, { ...ownerPart, root: nextRoot });
       }
     }

--- a/packages/core/src/store/store/clipboard-fragment-merge.ts
+++ b/packages/core/src/store/store/clipboard-fragment-merge.ts
@@ -113,7 +113,10 @@ function appendToPart(
   index?: number
 ): OoxmlPackage | null {
   if (nodes.length === 0) return pkg;
-  const nextId = createNodeIdAllocator(part);
+  // Detached-clone shape, same as `applyInsertFragment`: the clones exist before the
+  // insert below, so they mint in the `paste` family where no in-transaction `new` mint
+  // can ever re-issue their ids.
+  const nextId = createNodeIdAllocator(part, 'paste');
   const cloned = nodes.map((node) => cloneWithNewIds(node, nextId));
   const bound = withRequiredNamespaceBindings(part, cloned);
   const at = index ?? bound.root.children.length;

--- a/packages/core/src/store/store/comment-writes.ts
+++ b/packages/core/src/store/store/comment-writes.ts
@@ -18,7 +18,12 @@ import {
   withRelationshipsPartFor,
 } from '../package/package-edit.ts';
 import { withPart, type OoxmlPackage } from '../package/ooxml-package.ts';
-import { insertChildren, findNode, replaceNode } from '../package/ooxml-edit.ts';
+import {
+  carryIndexToRebuiltRoot,
+  insertChildren,
+  findNode,
+  replaceNode,
+} from '../package/ooxml-edit.ts';
 import { relativeTarget } from '../package/custom-xml-part.ts';
 import { resolveInternalTarget } from '../package/opc-names.ts';
 import {
@@ -342,7 +347,11 @@ function withW14Binding(part: OoxmlPart): { part: OoxmlPart; prefix: string } {
   // Spreading a new root left the peer's comments part without `w14`, so `w14:paraId`
   // failed `invalid-qname` and the remote package was refused — markers never landed.
   const replaced = replaceNode(part, part.root.id, bound, { deferValidation: true });
-  return { part: replaced.ok ? replaced.part : { ...part, root: bound }, prefix: 'w14' };
+  if (replaced.ok) return { part: replaced.part, prefix: 'w14' };
+  // The direct-spread fallback rebuilds the root outside the edit primitives, so it must
+  // carry the index itself — see the invariant on `carryIndexToRebuiltRoot`.
+  carryIndexToRebuiltRoot(part.root, bound);
+  return { part: { ...part, root: bound }, prefix: 'w14' };
 }
 
 /**

--- a/packages/core/src/store/store/tree-op-fragment.ts
+++ b/packages/core/src/store/store/tree-op-fragment.ts
@@ -170,6 +170,11 @@ export function withRequiredNamespaceBindings(
     }
     const need = (prefix: string | undefined, namespaceUri: string): void => {
       if (prefix === undefined || prefix.length === 0 || namespaceUri.length === 0) return;
+      // `xml` and `xmlns` are bound by the XML spec itself, never by a declaration. Every
+      // real document copy carries `xml:space="preserve"`, so treating `xml` as unbound
+      // rebuilt the root for virtually every paste — and a rebuilt root resets the id-mint
+      // frontier, which is what made rich pastes into non-empty documents fail wholesale.
+      if (prefix === 'xml' || prefix === 'xmlns') return;
       if (local.get(prefix) === namespaceUri) return;
       if (rootBindings.get(prefix) === namespaceUri) return;
       if (rootBindings.has(prefix) || additions.has(prefix)) {
@@ -226,7 +231,13 @@ export function applyInsertFragment(
   // Clone every block with fresh node ids and fresh paragraph identities: the fragment's
   // ids belong to another document, and a second paste of the same payload must not
   // collide with the first.
-  const nextId = createNodeIdAllocator(hostPart);
+  //
+  // The clones stay DETACHED until the split/merge sequence below lands them, and every op
+  // in that sequence replaces the root — which resets the shared mint frontier, so a later
+  // `new`-family mint can re-issue an id a clone already holds. A dedicated family keeps
+  // the two disjoint by construction; in-tree occupancy (a prior paste) is still skipped by
+  // the allocator's index check.
+  const nextId = createNodeIdAllocator(hostPart, 'paste');
   const paraIds = new Set(usedParaIds(hostPart.root as OoxmlElement));
   const counter = { value: 0 };
   const blocks = op.blocks.map((block, index) =>

--- a/packages/core/src/store/store/tree-op-fragment.ts
+++ b/packages/core/src/store/store/tree-op-fragment.ts
@@ -15,6 +15,7 @@ import {
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
 import {
+  carryIndexToRebuiltRoot,
   createNodeIdAllocator,
   findNode,
   insertChildren,
@@ -170,10 +171,9 @@ export function withRequiredNamespaceBindings(
     }
     const need = (prefix: string | undefined, namespaceUri: string): void => {
       if (prefix === undefined || prefix.length === 0 || namespaceUri.length === 0) return;
-      // `xml` and `xmlns` are bound by the XML spec itself, never by a declaration. Every
-      // real document copy carries `xml:space="preserve"`, so treating `xml` as unbound
-      // rebuilt the root for virtually every paste — and a rebuilt root resets the id-mint
-      // frontier, which is what made rich pastes into non-empty documents fail wholesale.
+      // `xml` and `xmlns` are bound by the XML spec itself, never by a declaration.
+      // Treating `xml` as unbound declared it redundantly and rebuilt the root for
+      // virtually every paste — `xml:space="preserve"` is in every real document copy.
       if (prefix === 'xml' || prefix === 'xmlns') return;
       if (local.get(prefix) === namespaceUri) return;
       if (rootBindings.get(prefix) === namespaceUri) return;
@@ -202,6 +202,10 @@ export function withRequiredNamespaceBindings(
       ...[...additions].map(([prefix, namespaceUri]) => ({ prefix, namespaceUri })),
     ],
   } as typeof part.root;
+  // Same id, same children — only the bindings changed. Carry the index like every op
+  // executor does, or the rebuilt root re-walks the whole part on its next lookup and
+  // restarts the mint frontier underneath ids already handed out.
+  carryIndexToRebuiltRoot(part.root, root);
   for (const [prefix, namespaceUri] of additions) {
     recordSetNamespaceBinding(part.root.id, prefix, namespaceUri);
   }
@@ -232,11 +236,12 @@ export function applyInsertFragment(
   // ids belong to another document, and a second paste of the same payload must not
   // collide with the first.
   //
-  // The clones stay DETACHED until the split/merge sequence below lands them, and every op
-  // in that sequence replaces the root — which resets the shared mint frontier, so a later
-  // `new`-family mint can re-issue an id a clone already holds. A dedicated family keeps
-  // the two disjoint by construction; in-tree occupancy (a prior paste) is still skipped by
-  // the allocator's index check.
+  // The clones stay DETACHED until the split/merge sequence below lands them, so their ids
+  // are invisible to every later allocator's in-tree check — the frontier alone kept them
+  // apart, and losing it (an orphaned index after a root rebuild) re-issued a clone's id to
+  // the split's tail and refused the whole paste as duplicate ids. A dedicated family makes
+  // the disjointness structural instead of frontier-dependent; in-tree occupancy (a prior
+  // paste) is still skipped by the allocator's index check.
   const nextId = createNodeIdAllocator(hostPart, 'paste');
   const paraIds = new Set(usedParaIds(hostPart.root as OoxmlElement));
   const counter = { value: 0 };

--- a/packages/react/src/editor/DocxEditorContent.tsx
+++ b/packages/react/src/editor/DocxEditorContent.tsx
@@ -8,7 +8,7 @@
 // Paste and drop of supported raster formats route through the shared image-insert path.
 
 import { useCallback, useLayoutEffect, useRef } from 'react';
-import { clipboardHtmlLandsContent } from '@docx-editor.dev/core/editor';
+import { clipboardDropLandsText, clipboardPasteLandsContent } from '@docx-editor.dev/core/editor';
 import { useDocxEditor } from './context';
 import { useImageInsertOptional } from './images/ImageInsert';
 import { ImageSelectionOverlay } from './images/ImageSelectionOverlay.tsx';
@@ -62,15 +62,15 @@ export function DocxEditorContent({ className }: DocxEditorContentProps) {
       const items = event.clipboardData;
       if (!items) return;
       if (!hasImageFile(items)) return;
-      // STAND DOWN whenever the ENGINE will land content from the HTML flavour — an
-      // embedded fragment, a `data:` image, or plain visible text. Word on macOS pastes a
-      // rendered PNG of copied TEXT beside the HTML; taking this file lane for it inserted
-      // that rendering on top of the text. A browser "copy image" payload (external
-      // `<img src>`, no text) and a bare screenshot (no HTML) still need this lane.
-      // (`defaultPrevented` says nothing — the engine prevents every paste, even ones it
-      // ignores.)
-      const html = typeof items.getData === 'function' ? (items.getData('text/html') ?? '') : '';
-      if (clipboardHtmlLandsContent(html)) return;
+      // STAND DOWN whenever the ENGINE will land content from the payload — see the
+      // predicate's contract in core. Word on macOS pastes a rendered PNG of copied TEXT
+      // beside the HTML; taking this file lane for it inserted that rendering on top of
+      // the text. (`defaultPrevented` says nothing — the engine prevents every paste,
+      // even ones it ignores.)
+      const canRead = typeof items.getData === 'function';
+      const html = canRead ? (items.getData('text/html') ?? '') : '';
+      const text = canRead ? (items.getData('text/plain') ?? '') : '';
+      if (clipboardPasteLandsContent(html, text)) return;
       event.preventDefault();
       void imageInsert.insertFromDataTransfer(items);
     },
@@ -89,6 +89,14 @@ export function DocxEditorContent({ className }: DocxEditorContentProps) {
     (event: React.DragEvent) => {
       if (!imageInsert?.isEnabled) return;
       if (!hasImageFile(event.dataTransfer)) return;
+      // Same stand-down as paste, for the drop lane's plain-text-only reality: when the
+      // payload carries visible text, NOT preventing the default lets the browser fire
+      // `insertFromDrop`, which is the engine's only drop path. Word on macOS drags carry
+      // a rendered PNG beside the text; taking the file lane swallowed that event and
+      // turned dropped text into a picture of it.
+      const html = event.dataTransfer.getData('text/html') ?? '';
+      const text = event.dataTransfer.getData('text/plain') ?? '';
+      if (clipboardDropLandsText(html, text)) return;
       event.preventDefault();
       void imageInsert.insertFromDataTransfer(event.dataTransfer);
     },

--- a/packages/react/src/editor/DocxEditorContent.tsx
+++ b/packages/react/src/editor/DocxEditorContent.tsx
@@ -91,7 +91,16 @@ export function DocxEditorContent({ className }: DocxEditorContentProps) {
       // fire `insertFromDrop`, which is the engine's only drop path. Word on macOS drags
       // carry a rendered PNG beside the text; taking the file lane swallowed that event
       // and turned dropped text into a picture of it.
-      if (clipboardDropLandsText(event.dataTransfer)) return;
+      if (clipboardDropLandsText(event.dataTransfer)) {
+        // Only an EDITABLE target fires `insertFromDrop`. Anywhere else (page furniture,
+        // an inactive header band), the browser's default action for a file-carrying
+        // transfer is to NAVIGATE to the file — which destroys the session — so the drop
+        // is swallowed instead of released.
+        const target = event.target as HTMLElement | null;
+        if (target?.isContentEditable) return;
+        event.preventDefault();
+        return;
+      }
       event.preventDefault();
       void imageInsert.insertFromDataTransfer(event.dataTransfer);
     },

--- a/packages/react/src/editor/DocxEditorContent.tsx
+++ b/packages/react/src/editor/DocxEditorContent.tsx
@@ -95,9 +95,13 @@ export function DocxEditorContent({ className }: DocxEditorContentProps) {
         // Only an EDITABLE target fires `insertFromDrop`. Anywhere else (page furniture,
         // an inactive header band), the browser's default action for a file-carrying
         // transfer is to NAVIGATE to the file — which destroys the session — so the drop
-        // is swallowed instead of released.
-        const target = event.target as HTMLElement | null;
-        if (target?.isContentEditable) return;
+        // is swallowed instead of released. Resolved through the nearest annotated
+        // ancestor: `isContentEditable` does not exist on SVG elements (painted vector
+        // shapes), where a direct read answered undefined for an editable position.
+        const target = event.target instanceof Element ? event.target : null;
+        if (target?.closest('[contenteditable]')?.getAttribute('contenteditable') === 'true') {
+          return;
+        }
         event.preventDefault();
         return;
       }

--- a/packages/react/src/editor/DocxEditorContent.tsx
+++ b/packages/react/src/editor/DocxEditorContent.tsx
@@ -67,10 +67,7 @@ export function DocxEditorContent({ className }: DocxEditorContentProps) {
       // beside the HTML; taking this file lane for it inserted that rendering on top of
       // the text. (`defaultPrevented` says nothing — the engine prevents every paste,
       // even ones it ignores.)
-      const canRead = typeof items.getData === 'function';
-      const html = canRead ? (items.getData('text/html') ?? '') : '';
-      const text = canRead ? (items.getData('text/plain') ?? '') : '';
-      if (clipboardPasteLandsContent(html, text)) return;
+      if (clipboardPasteLandsContent(items)) return;
       event.preventDefault();
       void imageInsert.insertFromDataTransfer(items);
     },
@@ -90,13 +87,11 @@ export function DocxEditorContent({ className }: DocxEditorContentProps) {
       if (!imageInsert?.isEnabled) return;
       if (!hasImageFile(event.dataTransfer)) return;
       // Same stand-down as paste, for the drop lane's plain-text-only reality: when the
-      // payload carries visible text, NOT preventing the default lets the browser fire
-      // `insertFromDrop`, which is the engine's only drop path. Word on macOS drags carry
-      // a rendered PNG beside the text; taking the file lane swallowed that event and
-      // turned dropped text into a picture of it.
-      const html = event.dataTransfer.getData('text/html') ?? '';
-      const text = event.dataTransfer.getData('text/plain') ?? '';
-      if (clipboardDropLandsText(html, text)) return;
+      // payload carries visible HTML text, NOT preventing the default lets the browser
+      // fire `insertFromDrop`, which is the engine's only drop path. Word on macOS drags
+      // carry a rendered PNG beside the text; taking the file lane swallowed that event
+      // and turned dropped text into a picture of it.
+      if (clipboardDropLandsText(event.dataTransfer)) return;
       event.preventDefault();
       void imageInsert.insertFromDataTransfer(event.dataTransfer);
     },

--- a/packages/react/src/editor/DocxEditorContent.tsx
+++ b/packages/react/src/editor/DocxEditorContent.tsx
@@ -8,6 +8,7 @@
 // Paste and drop of supported raster formats route through the shared image-insert path.
 
 import { useCallback, useLayoutEffect, useRef } from 'react';
+import { clipboardHtmlLandsContent } from '@docx-editor.dev/core/editor';
 import { useDocxEditor } from './context';
 import { useImageInsertOptional } from './images/ImageInsert';
 import { ImageSelectionOverlay } from './images/ImageSelectionOverlay.tsx';
@@ -61,15 +62,15 @@ export function DocxEditorContent({ className }: DocxEditorContentProps) {
       const items = event.clipboardData;
       if (!items) return;
       if (!hasImageFile(items)) return;
-      // STAND DOWN only for payloads the ENGINE will land. Real word-processor clipboards
-      // carry `text/html` AND an image file for the same content, and the engine's paste
-      // router lands that image through the fragment or `data:` lane — intercepting here
-      // inserted it twice. But a browser "copy image" payload carries `text/html` with an
-      // EXTERNAL `<img src>` the projection drops by design, and a bare screenshot has no
-      // HTML at all; both still need this file lane. (`defaultPrevented` says nothing —
-      // the engine prevents every paste, even ones it ignores.)
+      // STAND DOWN whenever the ENGINE will land content from the HTML flavour — an
+      // embedded fragment, a `data:` image, or plain visible text. Word on macOS pastes a
+      // rendered PNG of copied TEXT beside the HTML; taking this file lane for it inserted
+      // that rendering on top of the text. A browser "copy image" payload (external
+      // `<img src>`, no text) and a bare screenshot (no HTML) still need this lane.
+      // (`defaultPrevented` says nothing — the engine prevents every paste, even ones it
+      // ignores.)
       const html = typeof items.getData === 'function' ? (items.getData('text/html') ?? '') : '';
-      if (html.includes('data-docx-fragment') || html.includes('data:image')) return;
+      if (clipboardHtmlLandsContent(html)) return;
       event.preventDefault();
       void imageInsert.insertFromDataTransfer(items);
     },

--- a/packages/react/src/editor/images/normalizeImageFile.ts
+++ b/packages/react/src/editor/images/normalizeImageFile.ts
@@ -79,8 +79,8 @@ export function normalizeImageBytes(bytes: Uint8Array): NormalizedImagePayload {
   const { widthPoints, heightPoints } = naturalPoints(
     header.pixelWidth,
     header.pixelHeight,
-    DEFAULT_DPI,
-    DEFAULT_DPI
+    header.dpiX ?? DEFAULT_DPI,
+    header.dpiY ?? DEFAULT_DPI
   );
   return Object.freeze({
     ok: true,

--- a/packages/react/test/image-authoring.test.tsx
+++ b/packages/react/test/image-authoring.test.tsx
@@ -41,6 +41,28 @@ const PNG_1X1 = Uint8Array.from(
   (c) => c.charCodeAt(0)
 );
 
+function pngWithPhysicalSize(width: number, height: number, pixelsPerMeter: number): Uint8Array {
+  const source = PNG_1X1.slice();
+  const writeUint32 = (bytes: Uint8Array, offset: number, value: number): void => {
+    bytes[offset] = (value >>> 24) & 0xff;
+    bytes[offset + 1] = (value >>> 16) & 0xff;
+    bytes[offset + 2] = (value >>> 8) & 0xff;
+    bytes[offset + 3] = value & 0xff;
+  };
+  writeUint32(source, 16, width);
+  writeUint32(source, 20, height);
+  const phys = Uint8Array.from([
+    0, 0, 0, 9, 0x70, 0x48, 0x59, 0x73, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+  ]);
+  writeUint32(phys, 8, pixelsPerMeter);
+  writeUint32(phys, 12, pixelsPerMeter);
+  const out = new Uint8Array(source.length + phys.length);
+  out.set(source.subarray(0, 33));
+  out.set(phys, 33);
+  out.set(source.subarray(33), 33 + phys.length);
+  return out;
+}
+
 const JPEG_1X1 = Uint8Array.from([
   0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
   0x00, 0x01, 0x00, 0x00, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08,
@@ -334,6 +356,14 @@ describe('inserts validated image files', () => {
     if (!refused.ok) {
       expect(refused.reasonKey).toBe('imageInsert.errors.unsupportedFormat');
     }
+  });
+
+  test('uses PNG physical resolution for the inserted size', () => {
+    const normalized = normalizeImageBytes(pngWithPhysicalSize(144, 72, 5669));
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.widthPoints).toBe(72);
+    expect(normalized.heightPoints).toBe(36);
   });
 
   test('insert button preserves caret on mousedown', async () => {

--- a/packages/vue/src/editor/DocxEditorContent.ts
+++ b/packages/vue/src/editor/DocxEditorContent.ts
@@ -82,7 +82,15 @@ export const DocxEditorContent = defineComponent({
       // payload carries visible HTML text, NOT preventing the default lets the browser
       // fire `insertFromDrop`, which is the engine's only drop path. Mirrors the React
       // adapter.
-      if (clipboardDropLandsText(transfer)) return;
+      if (clipboardDropLandsText(transfer)) {
+        // Only an EDITABLE target fires `insertFromDrop`. Anywhere else the browser's
+        // default action for a file-carrying transfer is to NAVIGATE to the file — which
+        // destroys the session — so the drop is swallowed instead of released.
+        const target = event.target as HTMLElement | null;
+        if (target?.isContentEditable) return;
+        event.preventDefault();
+        return;
+      }
       event.preventDefault();
       void insert.insertFromDataTransfer(transfer);
     };

--- a/packages/vue/src/editor/DocxEditorContent.ts
+++ b/packages/vue/src/editor/DocxEditorContent.ts
@@ -7,6 +7,7 @@ import {
   shallowRef,
   watch,
 } from 'vue';
+import { clipboardHtmlLandsContent } from '@docx-editor.dev/core/editor';
 import type { DocxEditorChildren } from '../docx-editor-children';
 import { useDocxEditor } from './context';
 import { useImageInsertOptional } from './images/ImageInsert';
@@ -56,11 +57,12 @@ export const DocxEditorContent = defineComponent({
       const items = event.clipboardData;
       if (!items) return;
       if (!hasImageFile(items)) return;
-      // STAND DOWN only for payloads the ENGINE will land (fragment or `data:` image in
-      // the HTML). External `<img src>` payloads and bare screenshots still need this
-      // file lane. Mirrors the React adapter exactly.
+      // STAND DOWN whenever the ENGINE will land content from the HTML flavour (fragment,
+      // `data:` image, or visible text — Word on macOS ships a rendered PNG beside copied
+      // text). External `<img src>` payloads and bare screenshots still need this file
+      // lane. Mirrors the React adapter exactly.
       const html = typeof items.getData === 'function' ? (items.getData('text/html') ?? '') : '';
-      if (html.includes('data-docx-fragment') || html.includes('data:image')) return;
+      if (clipboardHtmlLandsContent(html)) return;
       event.preventDefault();
       void insert.insertFromDataTransfer(items);
     };

--- a/packages/vue/src/editor/DocxEditorContent.ts
+++ b/packages/vue/src/editor/DocxEditorContent.ts
@@ -85,9 +85,13 @@ export const DocxEditorContent = defineComponent({
       if (clipboardDropLandsText(transfer)) {
         // Only an EDITABLE target fires `insertFromDrop`. Anywhere else the browser's
         // default action for a file-carrying transfer is to NAVIGATE to the file — which
-        // destroys the session — so the drop is swallowed instead of released.
-        const target = event.target as HTMLElement | null;
-        if (target?.isContentEditable) return;
+        // destroys the session — so the drop is swallowed instead of released. Resolved
+        // through the nearest annotated ancestor: `isContentEditable` does not exist on
+        // SVG elements (painted vector shapes). Mirrors the React adapter.
+        const target = event.target instanceof Element ? event.target : null;
+        if (target?.closest('[contenteditable]')?.getAttribute('contenteditable') === 'true') {
+          return;
+        }
         event.preventDefault();
         return;
       }

--- a/packages/vue/src/editor/DocxEditorContent.ts
+++ b/packages/vue/src/editor/DocxEditorContent.ts
@@ -60,10 +60,7 @@ export const DocxEditorContent = defineComponent({
       // STAND DOWN whenever the ENGINE will land content from the payload — see the
       // predicate's contract in core. Word on macOS ships a rendered PNG beside copied
       // text. Mirrors the React adapter exactly.
-      const canRead = typeof items.getData === 'function';
-      const html = canRead ? (items.getData('text/html') ?? '') : '';
-      const text = canRead ? (items.getData('text/plain') ?? '') : '';
-      if (clipboardPasteLandsContent(html, text)) return;
+      if (clipboardPasteLandsContent(items)) return;
       event.preventDefault();
       void insert.insertFromDataTransfer(items);
     };
@@ -82,11 +79,10 @@ export const DocxEditorContent = defineComponent({
       if (!transfer) return;
       if (!hasImageFile(transfer)) return;
       // Same stand-down as paste, for the drop lane's plain-text-only reality: when the
-      // payload carries visible text, NOT preventing the default lets the browser fire
-      // `insertFromDrop`, which is the engine's only drop path. Mirrors the React adapter.
-      const html = transfer.getData('text/html') ?? '';
-      const text = transfer.getData('text/plain') ?? '';
-      if (clipboardDropLandsText(html, text)) return;
+      // payload carries visible HTML text, NOT preventing the default lets the browser
+      // fire `insertFromDrop`, which is the engine's only drop path. Mirrors the React
+      // adapter.
+      if (clipboardDropLandsText(transfer)) return;
       event.preventDefault();
       void insert.insertFromDataTransfer(transfer);
     };

--- a/packages/vue/src/editor/DocxEditorContent.ts
+++ b/packages/vue/src/editor/DocxEditorContent.ts
@@ -7,7 +7,7 @@ import {
   shallowRef,
   watch,
 } from 'vue';
-import { clipboardHtmlLandsContent } from '@docx-editor.dev/core/editor';
+import { clipboardDropLandsText, clipboardPasteLandsContent } from '@docx-editor.dev/core/editor';
 import type { DocxEditorChildren } from '../docx-editor-children';
 import { useDocxEditor } from './context';
 import { useImageInsertOptional } from './images/ImageInsert';
@@ -57,12 +57,13 @@ export const DocxEditorContent = defineComponent({
       const items = event.clipboardData;
       if (!items) return;
       if (!hasImageFile(items)) return;
-      // STAND DOWN whenever the ENGINE will land content from the HTML flavour (fragment,
-      // `data:` image, or visible text — Word on macOS ships a rendered PNG beside copied
-      // text). External `<img src>` payloads and bare screenshots still need this file
-      // lane. Mirrors the React adapter exactly.
-      const html = typeof items.getData === 'function' ? (items.getData('text/html') ?? '') : '';
-      if (clipboardHtmlLandsContent(html)) return;
+      // STAND DOWN whenever the ENGINE will land content from the payload — see the
+      // predicate's contract in core. Word on macOS ships a rendered PNG beside copied
+      // text. Mirrors the React adapter exactly.
+      const canRead = typeof items.getData === 'function';
+      const html = canRead ? (items.getData('text/html') ?? '') : '';
+      const text = canRead ? (items.getData('text/plain') ?? '') : '';
+      if (clipboardPasteLandsContent(html, text)) return;
       event.preventDefault();
       void insert.insertFromDataTransfer(items);
     };
@@ -80,6 +81,12 @@ export const DocxEditorContent = defineComponent({
       const transfer = event.dataTransfer;
       if (!transfer) return;
       if (!hasImageFile(transfer)) return;
+      // Same stand-down as paste, for the drop lane's plain-text-only reality: when the
+      // payload carries visible text, NOT preventing the default lets the browser fire
+      // `insertFromDrop`, which is the engine's only drop path. Mirrors the React adapter.
+      const html = transfer.getData('text/html') ?? '';
+      const text = transfer.getData('text/plain') ?? '';
+      if (clipboardDropLandsText(html, text)) return;
       event.preventDefault();
       void insert.insertFromDataTransfer(transfer);
     };

--- a/packages/vue/src/editor/images/normalizeImageFile.ts
+++ b/packages/vue/src/editor/images/normalizeImageFile.ts
@@ -79,8 +79,8 @@ export function normalizeImageBytes(bytes: Uint8Array): NormalizedImagePayload {
   const { widthPoints, heightPoints } = naturalPoints(
     header.pixelWidth,
     header.pixelHeight,
-    DEFAULT_DPI,
-    DEFAULT_DPI
+    header.dpiX ?? DEFAULT_DPI,
+    header.dpiY ?? DEFAULT_DPI
   );
   return Object.freeze({
     ok: true,

--- a/packages/vue/test/image-authoring.test.ts
+++ b/packages/vue/test/image-authoring.test.ts
@@ -1,0 +1,45 @@
+// Image authoring preflight — parity with the React adapter's PNG physical-density sizing.
+
+import './dom-setup.ts';
+
+import { describe, expect, test } from 'bun:test';
+import { normalizeImageBytes } from '../src/editor/images/normalizeImageFile.ts';
+
+const PNG_1X1 = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  ),
+  (c) => c.charCodeAt(0)
+);
+
+function pngWithPhysicalSize(width: number, height: number, pixelsPerMeter: number): Uint8Array {
+  const source = PNG_1X1.slice();
+  const writeUint32 = (bytes: Uint8Array, offset: number, value: number): void => {
+    bytes[offset] = (value >>> 24) & 0xff;
+    bytes[offset + 1] = (value >>> 16) & 0xff;
+    bytes[offset + 2] = (value >>> 8) & 0xff;
+    bytes[offset + 3] = value & 0xff;
+  };
+  writeUint32(source, 16, width);
+  writeUint32(source, 20, height);
+  const phys = Uint8Array.from([
+    0, 0, 0, 9, 0x70, 0x48, 0x59, 0x73, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+  ]);
+  writeUint32(phys, 8, pixelsPerMeter);
+  writeUint32(phys, 12, pixelsPerMeter);
+  const out = new Uint8Array(source.length + phys.length);
+  out.set(source.subarray(0, 33));
+  out.set(phys, 33);
+  out.set(source.subarray(33), 33 + phys.length);
+  return out;
+}
+
+describe('inserts validated image files', () => {
+  test('uses PNG physical resolution for the inserted size', () => {
+    const normalized = normalizeImageBytes(pngWithPhysicalSize(144, 72, 5669));
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.widthPoints).toBe(72);
+    expect(normalized.heightPoints).toBe(36);
+  });
+});


### PR DESCRIPTION
Pasting a copied range into a non-empty document silently fell back to plain text. The fragment landing treated the reserved `xml` prefix — present as `xml:space` in virtually every real document copy — as unbound, rebuilt the part root without carrying its node index, and the reset mint frontier made the landing fail as duplicate ids. The paste router then degraded to the plain lane, losing every table, list, and run format. Reserved prefixes no longer count as unbound, rebuilt roots carry their index like every op executor, and pasted clones mint in their own id family so no in-transaction mint can collide with them.

Pasting or dropping text copied from Word on macOS also inserted a rendered PNG of that text next to it, because Word puts that rendering on the pasteboard beside the HTML. The React and Vue image-file lanes now stand down whenever the engine lands content from the payload, decided by the engine's own fragment codec and HTML projection through the new `clipboardPasteLandsContent` and `clipboardDropLandsText` predicates. A stood-down drop over a non-editable target is swallowed so the browser never navigates away to the dropped file.

Two trades are deliberate and documented on the predicates: visible text wins over an image file when a payload carries both, because the engine inserts visible text regardless of what a host does, and the predicates cannot observe engine-state gates such as suggesting mode or cell selections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790502259&installation_model_id=422592&pr_number=572&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F572&signature=fd88472a6dc9e408e24ac768dc842bd43618778d2834d6f3ac4c1d919422f130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->