### PR TITLE
test(store): enforce that every single-session action is collaboration-expressible

### DIFF
--- a/.changeset/collaboration-coverage-guarantee.md
+++ b/.changeset/collaboration-coverage-guarantee.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Every authorable op kind and every accepted property, image-wrap, and content-control variant is now proven to replicate through collaboration by a journal replay-convergence fixture, or declared not-expressible with a reason. Adding an editing capability without one fails the coverage gate.

--- a/docs/architecture/production-engine-packages.md
+++ b/docs/architecture/production-engine-packages.md
@@ -85,22 +85,33 @@ The bundle-graph test follows real `import` statements through re-export barrels
 to prove it, because one `export *` is enough to put a transport stack in every
 consumer's bundle while every manifest still looks correct.
 
-**Every single-session action is collaboration-expressible.** Collaboration
-replays a canonical primitive journal onto peers, so an authorable action that
-does not capture into that journal replicates to nobody. Every `TreeDocOp` kind,
-and every member of the accepted property, wrap, and content-control
-vocabularies (`ACCEPTED_PARAGRAPH_PROPERTIES`, `ACCEPTED_RUN_PROPERTIES`,
+**Every authorable op and accepted variant is collaboration-expressible.**
+Collaboration replays a canonical primitive journal onto peers, so an authorable
+action that does not capture into that journal replicates to nobody. Every
+`TreeDocOp` kind, and every member of the open-ended allow-list vocabularies
+(`ACCEPTED_PARAGRAPH_PROPERTIES`, `ACCEPTED_RUN_PROPERTIES`,
 `IMAGE_WRAP_TARGETS`, `INSERTABLE_CONTENT_CONTROL_TYPES`), MUST have a
 replay-convergence fixture: `canonical-primitive-journal-coverage.test.ts`
 captures the action's journal, proves it is author-deterministic, replays it
 onto a fresh replica, and compares the two by fingerprint and save/reopen
-digest. Adding an op kind or a vocabulary member with no fixture fails that
-gate. The one escape is an explicit, reasoned entry in
-`COLLABORATION_UNCOVERED` (`store/store/collaboration-coverage-contract.ts`):
-the gate accepts a declared reason in place of a fixture, so an action that
-genuinely cannot cross the collaboration boundary is recorded and reviewed,
-never dropped silently. When you add an editing capability, add its fixture, or
-add its reason.
+digest. A property fixture also asserts its element is present in the author
+tree, so a variant that converges to an empty change cannot pass. Adding an op
+kind or a vocabulary member with no fixture fails that gate.
+
+Those four vocabularies are gated at the variant level because a new member
+introduces a new element or localName — a new tree shape. Enumerated attribute
+values on an already-covered op (a new `w:numFmt`, a section orientation, a
+transform action) are NOT separately gated: the journal lowerer is a generic
+tree diff with no per-enum branching, so a new enum value replicates through the
+same path its op's kind fixture already proves. A brand-new op, or one that
+writes a part the journal does not capture, is still caught by the op-kind gate
+and the manifest apply-path partition.
+
+The one escape is an explicit, reasoned entry in `COLLABORATION_UNCOVERED`
+(`store/store/collaboration-coverage-contract.ts`): the gate accepts a declared
+reason in place of a fixture, so an action that genuinely cannot cross the
+collaboration boundary is recorded and reviewed, never dropped silently. When
+you add an editing capability, add its fixture, or add its reason.
 
 ## Guards must fail loudly
 

--- a/docs/architecture/production-engine-packages.md
+++ b/docs/architecture/production-engine-packages.md
@@ -85,6 +85,23 @@ The bundle-graph test follows real `import` statements through re-export barrels
 to prove it, because one `export *` is enough to put a transport stack in every
 consumer's bundle while every manifest still looks correct.
 
+**Every single-session action is collaboration-expressible.** Collaboration
+replays a canonical primitive journal onto peers, so an authorable action that
+does not capture into that journal replicates to nobody. Every `TreeDocOp` kind,
+and every member of the accepted property, wrap, and content-control
+vocabularies (`ACCEPTED_PARAGRAPH_PROPERTIES`, `ACCEPTED_RUN_PROPERTIES`,
+`IMAGE_WRAP_TARGETS`, `INSERTABLE_CONTENT_CONTROL_TYPES`), MUST have a
+replay-convergence fixture: `canonical-primitive-journal-coverage.test.ts`
+captures the action's journal, proves it is author-deterministic, replays it
+onto a fresh replica, and compares the two by fingerprint and save/reopen
+digest. Adding an op kind or a vocabulary member with no fixture fails that
+gate. The one escape is an explicit, reasoned entry in
+`COLLABORATION_UNCOVERED` (`store/store/collaboration-coverage-contract.ts`):
+the gate accepts a declared reason in place of a fixture, so an action that
+genuinely cannot cross the collaboration boundary is recorded and reviewed,
+never dropped silently. When you add an editing capability, add its fixture, or
+add its reason.
+
 ## Guards must fail loudly
 
 Every guard scans a lane by path and calls `collectSources` on the result.

--- a/packages/core/src/store/__tests__/authorable-mutation-manifest.test.ts
+++ b/packages/core/src/store/__tests__/authorable-mutation-manifest.test.ts
@@ -39,6 +39,7 @@ import {
   TREE_DOC_OP_KINDS,
   type TreeDocOp,
 } from '../store/tree-ops.ts';
+import { COLLABORATION_UNCOVERED } from '../store/collaboration-coverage-contract.ts';
 import { readOoxmlPart } from '../package/ooxml-tree.ts';
 
 const repoRoot = path.resolve(import.meta.dir, '../../../../../');
@@ -141,6 +142,15 @@ describe('authorable mutation manifest freeze (task 0.5)', () => {
       expect(applied.ok).toBe(false);
       if (!applied.ok) expect(applied.reason).toBe('unsupported');
     }
+  });
+
+  test('the frozen unsupported set matches the collaboration coverage contract', () => {
+    // The manifest freeze and the contract that gates collaboration coverage name the same
+    // not-expressible ops, so a change that promotes one to replicable cannot leave the other
+    // claiming it is still unsupported.
+    expect([...COLLABORATION_UNCOVERED.opKinds.keys()].sort()).toEqual(
+      [...manifest.applyPathSets.unsupported].sort()
+    );
   });
 
   test('property, control, and wrap vocabularies match the freeze', () => {

--- a/packages/core/src/store/__tests__/canonical-primitive-journal-coverage.test.ts
+++ b/packages/core/src/store/__tests__/canonical-primitive-journal-coverage.test.ts
@@ -22,6 +22,7 @@ import {
   captureOneJournal,
   openStore,
   replayAndCompare,
+  walkNodes,
 } from './canonical-primitive-journal-coverage-support.ts';
 
 const fixtures = authorableCoverageFixtures();
@@ -102,7 +103,8 @@ describe('canonical primitive journal completeness (tasks 3.6 and 3.8)', () => {
     ...variants.wrapTargets,
     ...variants.contentControlTypes,
   ];
-  for (const { token, fixture } of everyVariant) {
+  for (const variant of everyVariant) {
+    const { token, fixture, expectLocalName } = variant;
     test(`variant ${fixture.kind}:${token} journal replays to an equivalent replica`, () => {
       const first = openStore(fixture.bytes);
       const second = openStore(fixture.bytes);
@@ -111,6 +113,17 @@ describe('canonical primitive journal completeness (tasks 3.6 and 3.8)', () => {
       expect(captured.result.ok).toBe(true);
       if (!captured.result.ok) throw new Error(captured.result.reason ?? token);
       expect(captured.journal).not.toBeNull();
+      // Convergence of an EMPTY change is not coverage: a property the applier cannot express
+      // would leave the tree unchanged and still converge. Where the token names an element,
+      // assert the fixture actually produced it, so a passing gate means the variant is
+      // expressed, not merely survived.
+      if (expectLocalName) {
+        let present = false;
+        walkNodes(first.bodyStore().part.root, (node) => {
+          if (node.kind !== 'textValue' && node.localName === expectLocalName) present = true;
+        });
+        expect(present).toBe(true);
+      }
       const again = captureOneJournal(second, () => fixture.apply(second));
       expect(JSON.stringify(again.journal)).toBe(JSON.stringify(captured.journal));
       replayAndCompare(replica, first, captured.journal!);

--- a/packages/core/src/store/__tests__/canonical-primitive-journal-coverage.test.ts
+++ b/packages/core/src/store/__tests__/canonical-primitive-journal-coverage.test.ts
@@ -8,8 +8,16 @@ import {
 import { isHeaderFooterLifecycleOp } from '../package/hf-lifecycle.ts';
 import { isNoteLifecycleOp } from '../package/note-lifecycle.ts';
 import { applyTreeOp, TREE_DOC_OP_KINDS, type TreeDocOp } from '../store/tree-ops.ts';
+import {
+  COLLABORATION_COVERAGE_VOCABULARIES,
+  COLLABORATION_UNCOVERED,
+} from '../store/collaboration-coverage-contract.ts';
 import { readOoxmlPart } from '../package/ooxml-tree.ts';
 import { authorableCoverageFixtures } from './canonical-primitive-journal-coverage-ops.ts';
+import {
+  variantCoverageFixtures,
+  type VariantFixture,
+} from './canonical-primitive-variant-coverage.ts';
 import {
   captureOneJournal,
   openStore,
@@ -17,6 +25,7 @@ import {
 } from './canonical-primitive-journal-coverage-support.ts';
 
 const fixtures = authorableCoverageFixtures();
+const variants = variantCoverageFixtures();
 
 function dummyPart() {
   const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -38,18 +47,75 @@ function isUnsupportedKind(kind: (typeof TREE_DOC_OP_KINDS)[number]): boolean {
 }
 
 describe('canonical primitive journal completeness (tasks 3.6 and 3.8)', () => {
-  test('every authorable TREE_DOC_OP_KINDS member has a coverage fixture', () => {
+  test('every authorable TREE_DOC_OP_KINDS member has a fixture or a declared reason', () => {
     const covered = new Set(fixtures.map((fixture) => fixture.kind));
     expect(covered.size).toBe(fixtures.length);
+    // The forcing function: a kind is acceptable only if it has a replay-convergence fixture
+    // OR a reasoned entry in the contract. Nothing passes by default — an agent adding an op
+    // must prove it replicates or record why it cannot.
     for (const kind of TREE_DOC_OP_KINDS) {
-      if (isUnsupportedKind(kind)) continue;
+      if (COLLABORATION_UNCOVERED.opKinds.has(kind)) continue;
       expect(covered.has(kind)).toBe(true);
     }
-    expect(TREE_DOC_OP_KINDS.filter((kind) => isUnsupportedKind(kind))).toEqual([
-      'addRepeatingSectionItem',
-      'removeRepeatingSectionItem',
-    ]);
+    // The contract cannot rot: every declared-uncovered kind must ACTUALLY refuse at apply
+    // (no journal), and must not also carry a fixture that would prove it wrong.
+    for (const [kind, reason] of COLLABORATION_UNCOVERED.opKinds) {
+      expect(reason.length).toBeGreaterThan(0);
+      expect(covered.has(kind)).toBe(false);
+      expect(isUnsupportedKind(kind)).toBe(true);
+    }
+    // And every kind that refuses at apply must be declared, so a silently-unsupported op
+    // cannot slip the gate.
+    const refusing = TREE_DOC_OP_KINDS.filter((kind) => isUnsupportedKind(kind));
+    expect([...refusing].sort()).toEqual([...COLLABORATION_UNCOVERED.opKinds.keys()].sort());
   });
+
+  const VOCABULARY_LABELS = {
+    paragraphProperties: 'accepted paragraph property',
+    runProperties: 'accepted run property',
+    wrapTargets: 'image wrap target',
+    contentControlTypes: 'insertable content-control type',
+  } as const;
+
+  for (const key of Object.keys(VOCABULARY_LABELS) as (keyof typeof VOCABULARY_LABELS)[]) {
+    test(`every ${VOCABULARY_LABELS[key]} has a fixture or a declared reason`, () => {
+      const vocabulary = COLLABORATION_COVERAGE_VOCABULARIES[key] as readonly string[];
+      const excused = COLLABORATION_UNCOVERED[key] as ReadonlyMap<string, string>;
+      const covered = new Set(variants[key].map((entry) => entry.token));
+      for (const member of vocabulary) {
+        if (excused.has(member)) continue;
+        expect(covered.has(member)).toBe(true);
+      }
+      // No fixture may cover a token outside the vocabulary, and no excuse may name one that
+      // also has a fixture — the partition stays exact.
+      for (const token of covered) expect(vocabulary).toContain(token);
+      for (const [token, reason] of excused) {
+        expect(reason.length).toBeGreaterThan(0);
+        expect(covered.has(token)).toBe(false);
+      }
+    });
+  }
+
+  const everyVariant: readonly VariantFixture[] = [
+    ...variants.paragraphProperties,
+    ...variants.runProperties,
+    ...variants.wrapTargets,
+    ...variants.contentControlTypes,
+  ];
+  for (const { token, fixture } of everyVariant) {
+    test(`variant ${fixture.kind}:${token} journal replays to an equivalent replica`, () => {
+      const first = openStore(fixture.bytes);
+      const second = openStore(fixture.bytes);
+      const replica = openStore(fixture.bytes);
+      const captured = captureOneJournal(first, () => fixture.apply(first));
+      expect(captured.result.ok).toBe(true);
+      if (!captured.result.ok) throw new Error(captured.result.reason ?? token);
+      expect(captured.journal).not.toBeNull();
+      const again = captureOneJournal(second, () => fixture.apply(second));
+      expect(JSON.stringify(again.journal)).toBe(JSON.stringify(captured.journal));
+      replayAndCompare(replica, first, captured.journal!);
+    });
+  }
 
   test('repeating-section kinds refuse with no journal and no revision move', () => {
     const store = openStore(fixtures[0]!.bytes);

--- a/packages/core/src/store/__tests__/canonical-primitive-variant-coverage.ts
+++ b/packages/core/src/store/__tests__/canonical-primitive-variant-coverage.ts
@@ -1,0 +1,243 @@
+// Journal coverage fixtures for every VARIANT the accepted vocabularies admit.
+//
+// The kind-level fixtures (`canonical-primitive-journal-coverage-ops.ts`) prove each op
+// replicates with one representative value. These prove each MEMBER of the frozen
+// vocabularies replicates: every accepted paragraph and run property, every image wrap
+// target, every insertable content-control type. A new entry in any of those vocabularies
+// with no fixture here fails the coverage gate — the forcing function that keeps
+// collaboration able to express everything a single session can author.
+
+import { TreePackageStore } from '../store/tree-package-store.ts';
+import type { TreeDocOp } from '../store/tree-ops.ts';
+import type { AcceptedParagraphProperty, AcceptedRunProperty } from '../store/tree-op-types.ts';
+import type { ImageWrapTarget } from '../package/drawing-projection.ts';
+import type { InsertableContentControlKind } from '../store/tree-op-content-controls.ts';
+import {
+  firstParagraphId,
+  paragraphIds,
+  PIC_URI,
+  PNG,
+  plainDoc,
+  R,
+  transactBody,
+  W,
+  walkNodes,
+  zipDoc,
+  type JournalCoverageFixture,
+} from './canonical-primitive-journal-coverage-support.ts';
+
+/** A body fixture whose journal proves one variant token replicates. */
+export interface VariantFixture {
+  readonly token: string;
+  readonly fixture: JournalCoverageFixture;
+}
+
+function bodyVariant(
+  kind: JournalCoverageFixture['kind'],
+  token: string,
+  bytes: Uint8Array,
+  op: (store: TreePackageStore) => TreeDocOp
+): VariantFixture {
+  return { token, fixture: { kind, bytes, apply: (store) => transactBody(store, op(store)) } };
+}
+
+// --- Paragraph properties -------------------------------------------------------------------
+
+const NUMBERING =
+  `<w:numbering xmlns:w="${W}">` +
+  '<w:abstractNum w:abstractNumId="0"><w:multiLevelType w:val="hybridMultilevel"/>' +
+  '<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>' +
+  '<w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl></w:abstractNum>' +
+  '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>';
+
+function listDoc(): Uint8Array {
+  return zipDoc({
+    body:
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+      '<w:r><w:t>Item</w:t></w:r></w:p><w:p><w:r><w:t>Next</w:t></w:r></w:p><w:sectPr/>',
+    rels: `<Relationship Id="rIdN" Type="${R}/numbering" Target="numbering.xml"/>`,
+    overrides:
+      '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>',
+    extraXml: { 'word/numbering.xml': NUMBERING },
+  });
+}
+
+/** Author one paragraph property through `setParagraphProperties`. */
+function paraProp(
+  token: AcceptedParagraphProperty,
+  property: { readonly localName: string; readonly attributes?: Record<string, string> }
+): VariantFixture {
+  return bodyVariant('setParagraphProperties', token, plainDoc(), (store) => ({
+    op: 'setParagraphProperties',
+    paragraphId: firstParagraphId(store),
+    properties: [property],
+  }));
+}
+
+const PARAGRAPH_PROPERTY_FIXTURES: readonly VariantFixture[] = [
+  paraProp('pStyle', { localName: 'pStyle', attributes: { val: 'Heading1' } }),
+  paraProp('jc', { localName: 'jc', attributes: { val: 'center' } }),
+  paraProp('spacing', {
+    localName: 'spacing',
+    attributes: { before: '240', after: '240', line: '360', lineRule: 'auto' },
+  }),
+  paraProp('ind', {
+    localName: 'ind',
+    attributes: { start: '720', end: '360', firstLine: '240' },
+  }),
+  paraProp('keepNext', { localName: 'keepNext' }),
+  paraProp('keepLines', { localName: 'keepLines' }),
+  paraProp('widowControl', { localName: 'widowControl', attributes: { val: 'false' } }),
+  paraProp('pageBreakBefore', { localName: 'pageBreakBefore' }),
+  paraProp('contextualSpacing', { localName: 'contextualSpacing' }),
+  paraProp('shd', {
+    localName: 'shd',
+    attributes: { val: 'clear', color: 'auto', fill: 'FFFF00' },
+  }),
+  // Child-carrying properties: `OoxmlProperty` is flat, so their dedicated ops author them.
+  bodyVariant('setParagraphTabStops', 'tabs', plainDoc(), (store) => ({
+    op: 'setParagraphTabStops',
+    paragraphId: firstParagraphId(store),
+    stops: [{ positionTwips: 1440, alignment: 'left' }],
+  })),
+  bodyVariant('setListNumbering', 'numPr', listDoc(), (store) => ({
+    op: 'setListNumbering',
+    paragraphId: paragraphIds(store)[1]!,
+    numId: '1',
+    level: 0,
+  })),
+];
+
+// --- Run properties -------------------------------------------------------------------------
+
+function runProp(
+  token: AcceptedRunProperty,
+  property: { readonly localName: string; readonly attributes?: Record<string, string> }
+): VariantFixture {
+  return bodyVariant('setRunProperties', token, plainDoc(), (store) => ({
+    op: 'setRunProperties',
+    paragraphId: firstParagraphId(store),
+    start: 0,
+    end: 3,
+    properties: [property],
+  }));
+}
+
+const RUN_PROPERTY_FIXTURES: readonly VariantFixture[] = [
+  runProp('rFonts', { localName: 'rFonts', attributes: { ascii: 'Arial', hAnsi: 'Arial' } }),
+  runProp('sz', { localName: 'sz', attributes: { val: '28' } }),
+  runProp('szCs', { localName: 'szCs', attributes: { val: '28' } }),
+  runProp('color', { localName: 'color', attributes: { val: 'FF0000' } }),
+  runProp('b', { localName: 'b' }),
+  runProp('bCs', { localName: 'bCs' }),
+  runProp('i', { localName: 'i' }),
+  runProp('iCs', { localName: 'iCs' }),
+  runProp('u', { localName: 'u', attributes: { val: 'single' } }),
+  runProp('strike', { localName: 'strike' }),
+  runProp('dstrike', { localName: 'dstrike' }),
+  runProp('highlight', { localName: 'highlight', attributes: { val: 'yellow' } }),
+  runProp('vertAlign', { localName: 'vertAlign', attributes: { val: 'superscript' } }),
+  runProp('position', { localName: 'position', attributes: { val: '6' } }),
+  runProp('caps', { localName: 'caps' }),
+  runProp('smallCaps', { localName: 'smallCaps' }),
+  runProp('spacing', { localName: 'spacing', attributes: { val: '20' } }),
+  runProp('w', { localName: 'w', attributes: { val: '150' } }),
+  runProp('kern', { localName: 'kern', attributes: { val: '20' } }),
+];
+
+// --- Drawing wrap ---------------------------------------------------------------------------
+
+const PIC =
+  '<pic:pic><pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr>' +
+  '<pic:blipFill><a:blip r:embed="rId14"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+  '<pic:spPr><a:xfrm rot="0"><a:ext cx="152400" cy="152400"/></a:xfrm>' +
+  '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>';
+
+const ANCHOR_DRAWING =
+  '<w:p><w:r><w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" ' +
+  'behindDoc="0" locked="0" relativeHeight="1" allowOverlap="1" layoutInCell="1">' +
+  '<wp:simplePos x="0" y="0"/>' +
+  '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+  '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+  '<wp:extent cx="152400" cy="152400"/><wp:wrapSquare wrapText="bothSides"/>' +
+  '<wp:docPr id="2" name="float"/><wp:cNvGraphicFramePr/>' +
+  `<a:graphic><a:graphicData uri="${PIC_URI}">${PIC}</a:graphicData></a:graphic>` +
+  '</wp:anchor></w:drawing></w:r></w:p><w:p><w:r><w:t>y</w:t></w:r></w:p><w:sectPr/>';
+
+function anchorDrawingDoc(): Uint8Array {
+  return zipDoc({
+    body: ANCHOR_DRAWING,
+    rels: `<Relationship Id="rId14" Type="${R}/image" Target="media/image1.png"/>`,
+    extraBytes: { 'word/media/image1.png': PNG },
+  });
+}
+
+function drawingId(store: TreePackageStore): string {
+  let found: string | undefined;
+  walkNodes(store.bodyStore().part.root, (node) => {
+    if (!found && node.kind === 'drawing') found = node.id;
+  });
+  if (!found) throw new Error('missing drawing');
+  return found;
+}
+
+function wrapVariant(target: ImageWrapTarget): VariantFixture {
+  return bodyVariant('setDrawingWrap', target, anchorDrawingDoc(), (store) => ({
+    op: 'setDrawingWrap',
+    drawingNodeId: drawingId(store),
+    wrap: target,
+  }));
+}
+
+// Every wrap target starts from an ANCHORED drawing, so `inline` is a real anchored→inline
+// transition and the rest are anchor-shape changes.
+const WRAP_FIXTURES: readonly VariantFixture[] = (
+  [
+    'inline',
+    'square',
+    'squareLeft',
+    'squareRight',
+    'tight',
+    'through',
+    'topAndBottom',
+    'behind',
+    'inFront',
+  ] satisfies ImageWrapTarget[]
+).map(wrapVariant);
+
+// --- Content-control types ------------------------------------------------------------------
+
+function controlVariant(type: InsertableContentControlKind): VariantFixture {
+  return bodyVariant('insertContentControl', type, plainDoc(), (store) => ({
+    op: 'insertContentControl',
+    paragraphId: firstParagraphId(store),
+    start: 0,
+    end: 5,
+    type,
+  }));
+}
+
+const CONTENT_CONTROL_FIXTURES: readonly VariantFixture[] = (
+  [
+    'richText',
+    'plainText',
+    'dropDownList',
+    'comboBox',
+    'date',
+  ] satisfies InsertableContentControlKind[]
+).map(controlVariant);
+
+/** Variant fixtures grouped by the vocabulary they cover. */
+export function variantCoverageFixtures(): {
+  readonly paragraphProperties: readonly VariantFixture[];
+  readonly runProperties: readonly VariantFixture[];
+  readonly wrapTargets: readonly VariantFixture[];
+  readonly contentControlTypes: readonly VariantFixture[];
+} {
+  return {
+    paragraphProperties: PARAGRAPH_PROPERTY_FIXTURES,
+    runProperties: RUN_PROPERTY_FIXTURES,
+    wrapTargets: WRAP_FIXTURES,
+    contentControlTypes: CONTENT_CONTROL_FIXTURES,
+  };
+}

--- a/packages/core/src/store/__tests__/canonical-primitive-variant-coverage.ts
+++ b/packages/core/src/store/__tests__/canonical-primitive-variant-coverage.ts
@@ -30,15 +30,32 @@ import {
 export interface VariantFixture {
   readonly token: string;
   readonly fixture: JournalCoverageFixture;
+  /**
+   * The element localName the applied fixture must leave in the author tree.
+   *
+   * Convergence alone is not enough: a property authored as a flat `OoxmlProperty` that the
+   * applier cannot express would create an EMPTY element (or none), and an empty change
+   * converges to a document that expresses the variant nowhere — a passing gate proving
+   * nothing. Naming the element the fixture must produce closes that: the gate asserts it is
+   * present before it trusts the convergence. Set for the property vocabularies, where a token
+   * IS a localName; the wrap and control fixtures assert convergence of a whole structural op
+   * instead.
+   */
+  readonly expectLocalName?: string;
 }
 
 function bodyVariant(
   kind: JournalCoverageFixture['kind'],
   token: string,
   bytes: Uint8Array,
-  op: (store: TreePackageStore) => TreeDocOp
+  op: (store: TreePackageStore) => TreeDocOp,
+  expectLocalName?: string
 ): VariantFixture {
-  return { token, fixture: { kind, bytes, apply: (store) => transactBody(store, op(store)) } };
+  return {
+    token,
+    fixture: { kind, bytes, apply: (store) => transactBody(store, op(store)) },
+    ...(expectLocalName ? { expectLocalName } : {}),
+  };
 }
 
 // --- Paragraph properties -------------------------------------------------------------------
@@ -67,11 +84,17 @@ function paraProp(
   token: AcceptedParagraphProperty,
   property: { readonly localName: string; readonly attributes?: Record<string, string> }
 ): VariantFixture {
-  return bodyVariant('setParagraphProperties', token, plainDoc(), (store) => ({
-    op: 'setParagraphProperties',
-    paragraphId: firstParagraphId(store),
-    properties: [property],
-  }));
+  return bodyVariant(
+    'setParagraphProperties',
+    token,
+    plainDoc(),
+    (store) => ({
+      op: 'setParagraphProperties',
+      paragraphId: firstParagraphId(store),
+      properties: [property],
+    }),
+    property.localName
+  );
 }
 
 const PARAGRAPH_PROPERTY_FIXTURES: readonly VariantFixture[] = [
@@ -95,17 +118,29 @@ const PARAGRAPH_PROPERTY_FIXTURES: readonly VariantFixture[] = [
     attributes: { val: 'clear', color: 'auto', fill: 'FFFF00' },
   }),
   // Child-carrying properties: `OoxmlProperty` is flat, so their dedicated ops author them.
-  bodyVariant('setParagraphTabStops', 'tabs', plainDoc(), (store) => ({
-    op: 'setParagraphTabStops',
-    paragraphId: firstParagraphId(store),
-    stops: [{ positionTwips: 1440, alignment: 'left' }],
-  })),
-  bodyVariant('setListNumbering', 'numPr', listDoc(), (store) => ({
-    op: 'setListNumbering',
-    paragraphId: paragraphIds(store)[1]!,
-    numId: '1',
-    level: 0,
-  })),
+  bodyVariant(
+    'setParagraphTabStops',
+    'tabs',
+    plainDoc(),
+    (store) => ({
+      op: 'setParagraphTabStops',
+      paragraphId: firstParagraphId(store),
+      stops: [{ positionTwips: 1440, alignment: 'left' }],
+    }),
+    'tabs'
+  ),
+  bodyVariant(
+    'setListNumbering',
+    'numPr',
+    listDoc(),
+    (store) => ({
+      op: 'setListNumbering',
+      paragraphId: paragraphIds(store)[1]!,
+      numId: '1',
+      level: 0,
+    }),
+    'numPr'
+  ),
 ];
 
 // --- Run properties -------------------------------------------------------------------------
@@ -114,13 +149,19 @@ function runProp(
   token: AcceptedRunProperty,
   property: { readonly localName: string; readonly attributes?: Record<string, string> }
 ): VariantFixture {
-  return bodyVariant('setRunProperties', token, plainDoc(), (store) => ({
-    op: 'setRunProperties',
-    paragraphId: firstParagraphId(store),
-    start: 0,
-    end: 3,
-    properties: [property],
-  }));
+  return bodyVariant(
+    'setRunProperties',
+    token,
+    plainDoc(),
+    (store) => ({
+      op: 'setRunProperties',
+      paragraphId: firstParagraphId(store),
+      start: 0,
+      end: 3,
+      properties: [property],
+    }),
+    property.localName
+  );
 }
 
 const RUN_PROPERTY_FIXTURES: readonly VariantFixture[] = [

--- a/packages/core/src/store/store/collaboration-coverage-contract.ts
+++ b/packages/core/src/store/store/collaboration-coverage-contract.ts
@@ -1,0 +1,72 @@
+// The collaboration-expressibility contract.
+//
+// Every authorable action a single session can perform — every `TreeDocOp` kind, and every
+// member of the accepted property, wrap, and content-control vocabularies — MUST replicate.
+// Collaboration replays a canonical primitive journal onto peers, so "replicates" means: the
+// action's journal captures deterministically and replays to a convergent replica. The gate
+// that proves it is `canonical-primitive-journal-coverage.test.ts`, which requires a
+// replay-convergence fixture for every kind AND every variant.
+//
+// This registry is the ONE escape hatch. An action that genuinely cannot be expressed as a
+// journal — a purely local, non-replicable op — is declared here with a reason, and the gate
+// accepts a declared reason IN PLACE OF a fixture. Nothing else passes: an action with
+// neither a fixture nor an entry here fails the gate. That is the forcing function. An agent
+// adding a feature must either prove it replicates or record, here, why it does not — the
+// decision is explicit and reviewed, never silent.
+//
+// Removing an entry is how a later change promotes an action to replicable: delete the line,
+// add the fixture. Adding one is a deliberate, reviewable admission that a capability does
+// not cross the collaboration boundary yet.
+
+import { IMAGE_WRAP_TARGETS, type ImageWrapTarget } from '../package/drawing-projection.ts';
+import { INSERTABLE_CONTENT_CONTROL_TYPES } from './tree-op-content-controls.ts';
+import {
+  ACCEPTED_PARAGRAPH_PROPERTIES,
+  ACCEPTED_RUN_PROPERTIES,
+  TREE_DOC_OP_KINDS,
+  type AcceptedParagraphProperty,
+  type AcceptedRunProperty,
+  type TreeDocOpKind,
+} from './tree-op-types.ts';
+
+type InsertableControlType = (typeof INSERTABLE_CONTENT_CONTROL_TYPES)[number];
+
+/**
+ * Actions declared not collaboration-expressible, each with the reason it cannot replicate.
+ *
+ * The coverage gate reads this in place of a fixture. Keep every reason specific enough that a
+ * reader can decide whether it still holds.
+ */
+export interface CollaborationCoverageContract {
+  readonly opKinds: ReadonlyMap<TreeDocOpKind, string>;
+  readonly paragraphProperties: ReadonlyMap<AcceptedParagraphProperty, string>;
+  readonly runProperties: ReadonlyMap<AcceptedRunProperty, string>;
+  readonly wrapTargets: ReadonlyMap<ImageWrapTarget, string>;
+  readonly contentControlTypes: ReadonlyMap<InsertableControlType, string>;
+}
+
+const REPEATING_SECTION_REASON =
+  'Repeating-section items are refused at apply time (reason "unsupported"): the op reaches ' +
+  'no store mutation, so there is no journal to replicate. Promote by implementing the op, ' +
+  'then add a coverage fixture.';
+
+export const COLLABORATION_UNCOVERED: CollaborationCoverageContract = Object.freeze({
+  opKinds: new Map<TreeDocOpKind, string>([
+    ['addRepeatingSectionItem', REPEATING_SECTION_REASON],
+    ['removeRepeatingSectionItem', REPEATING_SECTION_REASON],
+  ]),
+  // Every accepted property, wrap target, and control type replicates today; none is excused.
+  paragraphProperties: new Map<AcceptedParagraphProperty, string>(),
+  runProperties: new Map<AcceptedRunProperty, string>(),
+  wrapTargets: new Map<ImageWrapTarget, string>(),
+  contentControlTypes: new Map<InsertableControlType, string>(),
+});
+
+/** The full vocabularies the contract partitions, for the gate to iterate. @internal */
+export const COLLABORATION_COVERAGE_VOCABULARIES = Object.freeze({
+  opKinds: TREE_DOC_OP_KINDS,
+  paragraphProperties: ACCEPTED_PARAGRAPH_PROPERTIES,
+  runProperties: ACCEPTED_RUN_PROPERTIES,
+  wrapTargets: IMAGE_WRAP_TARGETS,
+  contentControlTypes: INSERTABLE_CONTENT_CONTROL_TYPES,
+});


### PR DESCRIPTION
Collaboration replays a canonical primitive journal onto peers, so an authorable action that does not capture into that journal replicates to nobody. The coverage gate already proved every `TreeDocOp` kind replays to a convergent replica. This extends the same proof to every member of the open-ended allow-list vocabularies — paragraph properties (indent, spacing, shading, and the rest), run properties, all nine image wrap targets, all content-control types — each captured, replayed onto a fresh replica, and compared by fingerprint and save/reopen digest. A property fixture also asserts its element is present in the author tree, so a variant that converges to an empty change cannot pass.

The silent unsupported-op skip is replaced by `COLLABORATION_UNCOVERED`, a reasoned exclusion registry. A kind or variant passes the gate only with a replay-convergence fixture or a declared reason, so an agent adding an editing capability is forced to prove it replicates or record why it cannot. The manifest freeze and the architecture guarantees doc both reference the contract.

Adding an accepted property or wrap target with no fixture fails the gate; adding a genuinely non-replicable op requires a reasoned entry that the gate cross-checks against the op actually refusing at apply. Enumerated attribute values on an already-covered op replicate through the generic journal lowerer and stay gated at the op-kind level; the doc scopes the guarantee to match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790505129&installation_model_id=422592&pr_number=575&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F575&signature=277cf90fe668164d849f050cfc679d6b291b0b95bc37c1dea4941fb13ec8f124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->