### PR TITLE
fix: preserve Word paste fidelity

### DIFF
--- a/.changeset/tidy-clouds-repeat.md
+++ b/.changeset/tidy-clouds-repeat.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
-Pasting copied content into a non-empty document keeps its formatting instead of silently degrading to plain text, and pasting text copied from Word on macOS no longer inserts a rendered image of that text next to it.
+Pasting rich content into non-empty documents no longer degrades to plain text or inserts Word's macOS preview image. Word headings, captions, and image dimensions now retain their source semantics and physical size.

--- a/.changeset/tidy-clouds-repeat.md
+++ b/.changeset/tidy-clouds-repeat.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': minor
+'@docx-editor.dev/core': patch
 ---
 
 Pasting rich content into non-empty documents no longer degrades to plain text or inserts Word's macOS preview image. Word headings, captions, and image dimensions now retain their source semantics and physical size.

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4806,6 +4806,8 @@ export function usedParaIds(root: OoxmlElement): ReadonlySet<string>;
 
 // @public
 export interface ValidatedRasterHeader {
+    readonly dpiX?: number;
+    readonly dpiY?: number;
     // (undocumented)
     readonly pixelHeight: number;
     // (undocumented)

--- a/packages/core/src/editor/__tests__/blank-document-styles.test.ts
+++ b/packages/core/src/editor/__tests__/blank-document-styles.test.ts
@@ -118,6 +118,7 @@ describe("the blank template's style gallery", () => {
       'Heading8',
       'Heading9',
       'Quote',
+      'Caption',
       'NoSpacing',
       'ListParagraph',
     ]);
@@ -141,6 +142,13 @@ describe("the blank template's style gallery", () => {
     expect(editor.exec({ type: 'setParagraphStyle', styleId: 'Heading1' }).ok).toBe(true);
     // 16pt text where the default is 11pt: the line has to grow.
     expect(blockHeights(surface)[0]!).toBeGreaterThan(plain);
+  });
+
+  test('it defines the built-in Caption style for pasted Word captions', async () => {
+    const { editor } = mount(blankDocumentBytes());
+    const styles = await savedStyles(editor);
+    expect(styles).toContain('w:styleId="Caption"');
+    expect(styles).toContain('<w:sz w:val="18"/>');
   });
 });
 

--- a/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
@@ -16,6 +16,28 @@ import { strFromU8 } from '../../store/package/zip.ts';
 const TINY_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
 
+function pngWithPhysicalSize(width: number, height: number, pixelsPerMeter: number): string {
+  const source = Uint8Array.from(atob(TINY_PNG_BASE64), (char) => char.charCodeAt(0));
+  const writeUint32 = (bytes: Uint8Array, offset: number, value: number): void => {
+    bytes[offset] = (value >>> 24) & 0xff;
+    bytes[offset + 1] = (value >>> 16) & 0xff;
+    bytes[offset + 2] = (value >>> 8) & 0xff;
+    bytes[offset + 3] = value & 0xff;
+  };
+  writeUint32(source, 16, width);
+  writeUint32(source, 20, height);
+  const phys = Uint8Array.from([
+    0, 0, 0, 9, 0x70, 0x48, 0x59, 0x73, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+  ]);
+  writeUint32(phys, 8, pixelsPerMeter);
+  writeUint32(phys, 12, pixelsPerMeter);
+  const bytes = new Uint8Array(source.length + phys.length);
+  bytes.set(source.subarray(0, 33));
+  bytes.set(phys, 33);
+  bytes.set(source.subarray(33), 33 + phys.length);
+  return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(''));
+}
+
 interface OpenedFragment {
   readonly pkg: OoxmlPackage;
   readonly docXml: string;
@@ -43,12 +65,13 @@ function openFragment(html: string): OpenedFragment {
 
 describe('run and paragraph mapping', () => {
   test('headings become bold direct formatting at Word sizes', () => {
-    const { docXml } = openFragment('<h1>Alpha</h1><h3>Beta</h3>');
+    const { docXml, lastMarkCovered } = openFragment('<h1>Alpha</h1><h3>Beta</h3>');
     expect(docXml).toContain('w:sz w:val="64"');
     expect(docXml).toContain('w:sz w:val="44"');
     expect(docXml).toContain('<w:b/>');
     expect(docXml).toContain('Alpha');
     expect(docXml).toContain('Beta');
+    expect(lastMarkCovered).toBe(false);
   });
 
   test('Word heading tags use target styles and include their paragraph mark', () => {
@@ -73,6 +96,13 @@ describe('run and paragraph mapping', () => {
 
   test('generic paragraphs keep the host paragraph mark', () => {
     const { lastMarkCovered } = openFragment('<p>ordinary</p>');
+    expect(lastMarkCovered).toBe(false);
+  });
+
+  test('only the final projected block controls paragraph mark coverage', () => {
+    const { lastMarkCovered } = openFragment(
+      '<p class="MsoCaption">caption</p><p>ordinary tail</p>'
+    );
     expect(lastMarkCovered).toBe(false);
   });
 
@@ -255,6 +285,14 @@ describe('images', () => {
     // 10pt and 20pt expressed as CSS pixels, then converted to EMU.
     expect(docXml).toContain('cx="127000"');
     expect(docXml).toContain('cy="254000"');
+  });
+
+  test('an unsized PNG uses its physical density', () => {
+    const png = pngWithPhysicalSize(144, 72, 5669);
+    const { docXml } = openFragment(`<p><img src="data:image/png;base64,${png}"></p>`);
+    // Integer pixels-per-metre metadata is approximately 144 dpi.
+    expect(docXml).toContain('cx="914447"');
+    expect(docXml).toContain('cy="457223"');
   });
 
   test('a data: image above the per-image cap is dropped', () => {

--- a/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
@@ -20,13 +20,13 @@ interface OpenedFragment {
   readonly pkg: OoxmlPackage;
   readonly docXml: string;
   readonly relsXml: string;
+  readonly lastMarkCovered: boolean;
 }
 
 /** Project, read back through the bounded package reader, and serialize the body. */
 function openFragment(html: string): OpenedFragment {
   const projected = projectExternalHtml(html);
   if (!projected.ok) throw new Error(`projection refused: ${projected.reason}`);
-  expect(projected.lastMarkCovered).toBe(false);
   const read = readOoxmlPackage(projected.fragmentBytes);
   if (!read.ok) throw new Error(`read-back refused: ${read.reason}`);
   const pkg = read.package;
@@ -37,6 +37,7 @@ function openFragment(html: string): OpenedFragment {
     pkg,
     docXml: serializeOoxmlPart(part),
     relsXml: relsBytes ? strFromU8(relsBytes) : '',
+    lastMarkCovered: projected.lastMarkCovered,
   };
 }
 
@@ -48,6 +49,31 @@ describe('run and paragraph mapping', () => {
     expect(docXml).toContain('<w:b/>');
     expect(docXml).toContain('Alpha');
     expect(docXml).toContain('Beta');
+  });
+
+  test('Word heading tags use target styles and include their paragraph mark', () => {
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><body>' +
+      '<h2>Target heading</h2></body></html>';
+    const { docXml, lastMarkCovered } = openFragment(html);
+    expect(docXml).toContain('<w:pStyle w:val="Heading2"/>');
+    expect(docXml).not.toContain('w:sz w:val="52"');
+    expect(docXml).not.toContain('<w:b/>');
+    expect(lastMarkCovered).toBe(true);
+  });
+
+  test('Word caption classes use target styles and include their paragraph mark', () => {
+    const { docXml, lastMarkCovered } = openFragment(
+      '<p class="MsoCaption" style="text-align:center">Figure 1</p>'
+    );
+    expect(docXml).toContain('<w:pStyle w:val="Caption"/>');
+    expect(docXml).toContain('<w:jc w:val="center"/>');
+    expect(lastMarkCovered).toBe(true);
+  });
+
+  test('generic paragraphs keep the host paragraph mark', () => {
+    const { lastMarkCovered } = openFragment('<p>ordinary</p>');
+    expect(lastMarkCovered).toBe(false);
   });
 
   test('inline tags and CSS map to run properties', () => {
@@ -218,6 +244,17 @@ describe('images', () => {
     expect(media).toBeDefined();
     expect(media!.length).toBeGreaterThan(8);
     expect(relsXml).toContain('Target="media/image1.png"');
+  });
+
+  test('Word bare image dimensions use points', () => {
+    const html =
+      '<html xmlns:o="urn:schemas-microsoft-com:office:office"><body><p>' +
+      `<img src="data:image/png;base64,${TINY_PNG_BASE64}" width="10" height="20">` +
+      '</p></body></html>';
+    const { docXml } = openFragment(html);
+    // 10pt and 20pt expressed as CSS pixels, then converted to EMU.
+    expect(docXml).toContain('cx="127000"');
+    expect(docXml).toContain('cy="254000"');
   });
 
   test('a data: image above the per-image cap is dropped', () => {

--- a/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-html-read.test.ts
@@ -85,6 +85,15 @@ describe('run and paragraph mapping', () => {
     expect(lastMarkCovered).toBe(true);
   });
 
+  test('Word desktop and online heading classes map to target styles', () => {
+    const { docXml, lastMarkCovered } = openFragment(
+      '<p class="MsoHeading2">Desktop</p><p class="Heading3">Online</p>'
+    );
+    expect(docXml).toContain('<w:pStyle w:val="Heading2"/>');
+    expect(docXml).toContain('<w:pStyle w:val="Heading3"/>');
+    expect(lastMarkCovered).toBe(true);
+  });
+
   test('Word caption classes use target styles and include their paragraph mark', () => {
     const { docXml, lastMarkCovered } = openFragment(
       '<p class="MsoCaption" style="text-align:center">Figure 1</p>'

--- a/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
+++ b/packages/core/src/editor/__tests__/clipboard-rich-surface.test.ts
@@ -301,4 +301,35 @@ describe('rich paste', () => {
     expect(markup).toContain('w:jc');
     expect(markup).toContain('<w:b/>');
   });
+
+  test('a Word caption keeps its paragraph alignment at a paragraph end', () => {
+    const target = mount(paragraph(''));
+    putCaret(target.surface, 0);
+    target.surface.pasteRich(
+      'image\ncaption',
+      '<p style="text-align:center">image</p>' +
+        '<p class="MsoCaption" style="text-align:center">caption</p>'
+    );
+    const markup = serializeOoxmlPart(target.surface.session.part());
+    const caption = markup.split('</w:p>').find((entry) => entry.includes('caption'));
+    expect(caption).toContain('<w:pStyle w:val="Caption"/>');
+    expect(caption).toContain('w:jc w:val="center"');
+  });
+
+  test('a Word heading pasted within text remains a heading paragraph', () => {
+    const target = mount(paragraph('host'));
+    putCaret(target.surface, 2);
+    target.surface.pasteRich(
+      'Word heading',
+      '<html xmlns:w="urn:schemas-microsoft-com:office:word"><body>' +
+        '<h2>Word heading</h2></body></html>'
+    );
+    const markup = serializeOoxmlPart(target.surface.session.part());
+    const heading = markup.split('</w:p>').find((entry) => entry.includes('Word heading'));
+    expect(heading).toContain('<w:pStyle w:val="Heading2"/>');
+    const pastedRun = heading!.split('</w:r>').find((entry) => entry.includes('Word heading'));
+    expect(pastedRun).not.toContain('w:sz w:val="52"');
+    expect(pastedRun).not.toContain('<w:b/>');
+    expect(target.surface.session.bodyText()).toContain('Word heading');
+  });
 });

--- a/packages/core/src/editor/blank-document.ts
+++ b/packages/core/src/editor/blank-document.ts
@@ -172,6 +172,14 @@ const STYLES =
   `<w:pPr><w:spacing w:before="160"/><w:jc w:val="center"/></w:pPr>` +
   `<w:rPr><w:i/><w:iCs/><w:color w:val="404040"/></w:rPr>` +
   `</w:style>` +
+  // Caption gives pasted Word captions built-in 9pt italic metrics instead of Normal.
+  `<w:style w:type="paragraph" w:styleId="Caption">` +
+  `<w:name w:val="caption"/><w:basedOn w:val="Normal"/><w:next w:val="Normal"/>` +
+  `<w:uiPriority w:val="35"/><w:semiHidden/><w:unhideWhenUsed/>` +
+  `<w:pPr><w:spacing w:after="0"/></w:pPr>` +
+  `<w:rPr><w:i/><w:iCs/><w:color w:val="404040"/>` +
+  `<w:sz w:val="18"/><w:szCs w:val="18"/></w:rPr>` +
+  `</w:style>` +
   // No Spacing is the one style that does NOT build on Normal: its whole purpose is to
   // drop the defaults' space-after and 1.08 lines, which `w:basedOn` would reinstate.
   `<w:style w:type="paragraph" w:styleId="NoSpacing">` +

--- a/packages/core/src/editor/clipboard-html-read.ts
+++ b/packages/core/src/editor/clipboard-html-read.ts
@@ -50,7 +50,7 @@ export type HtmlProjectionResult =
       readonly ok: true;
       /** A fragment package zip, readable by `readOoxmlPackage`. */
       readonly fragmentBytes: Uint8Array;
-      /** Whether the source identified the final Word paragraph mark as selected. */
+      /** True when the final projected paragraph carries a mapped Word style. */
       readonly lastMarkCovered: boolean;
       /** How many `data:` images the projection accepted into the fragment. */
       readonly imageCount: number;
@@ -143,6 +143,7 @@ type RelEntry = {
 interface FlowContext {
   readonly run: RunProps;
   readonly para: ParaProps;
+  readonly paragraphMarkCovered: boolean;
   readonly pre: boolean;
   readonly list: ListState | null;
 }
@@ -405,8 +406,8 @@ function projectImage(element: Element, runs: string[], p: Projection): void {
   let widthPx = imageDimensionPx(element, style, 'width', p.wordHtml);
   let heightPx = imageDimensionPx(element, style, 'height', p.wordHtml);
   if (widthPx === null && heightPx === null && header) {
-    widthPx = header.pixelWidth;
-    heightPx = header.pixelHeight;
+    widthPx = (header.pixelWidth * 96) / (header.dpiX ?? 96);
+    heightPx = (header.pixelHeight * 96) / (header.dpiY ?? 96);
   } else if (widthPx !== null && heightPx === null) {
     heightPx = header ? (widthPx * header.pixelHeight) / header.pixelWidth : (widthPx * 2) / 3;
   } else if (widthPx === null && heightPx !== null) {
@@ -595,9 +596,14 @@ function projectParagraph(
   if (mso) para.numPr = mso;
   applyParaCss(para, style);
   run = applyRunCss(run, style);
-  const next: FlowContext = { run, para, pre, list: ctx.list };
+  const next: FlowContext = {
+    run,
+    para,
+    paragraphMarkCovered: styleId !== undefined,
+    pre,
+    list: ctx.list,
+  };
   projectFlow(Array.from(element.childNodes), depth + 1, next, p, out, true);
-  p.lastMarkCovered = styleId !== undefined;
 }
 
 function projectList(
@@ -646,7 +652,7 @@ function projectFlow(
   const flush = (): void => {
     if (pending.length > 0) {
       out.push(paragraphXml(ctx.para, pending));
-      p.lastMarkCovered = false;
+      p.lastMarkCovered = ctx.paragraphMarkCovered;
     }
     pending = [];
   };
@@ -687,7 +693,7 @@ function projectFlow(
   // An explicit block emits its paragraph even when empty.
   if (forceEmit && out.length === before) {
     out.push(paragraphXml(ctx.para, []));
-    p.lastMarkCovered = false;
+    p.lastMarkCovered = ctx.paragraphMarkCovered;
   }
 }
 
@@ -835,6 +841,7 @@ function projectCell(
   const cellCtx: FlowContext = {
     run: isHeader ? { ...ctx.run, bold: true } : ctx.run,
     para: isHeader ? { jc: 'center' } : {},
+    paragraphMarkCovered: false,
     pre: false,
     list: null,
   };
@@ -942,7 +949,13 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
     docPrId: 0,
   };
   const blocks: string[] = [];
-  const rootCtx: FlowContext = { run: {}, para: {}, pre: false, list: null };
+  const rootCtx: FlowContext = {
+    run: {},
+    para: {},
+    paragraphMarkCovered: false,
+    pre: false,
+    list: null,
+  };
   projectFlow(Array.from(body.childNodes), 0, rootCtx, projection, blocks);
   if (blocks.length === 0) return { ok: false, reason: 'no-content' };
   return { ok: true, projection, blocks };

--- a/packages/core/src/editor/clipboard-html-read.ts
+++ b/packages/core/src/editor/clipboard-html-read.ts
@@ -25,6 +25,14 @@ import {
   numberingPartXml,
   type HtmlListAllocation as ListAllocation,
 } from './clipboard-html-numbering.ts';
+import {
+  imageDimensionPx,
+  isElement,
+  isWordClipboardHtml,
+  parseCssLengthPt,
+  tagOf,
+  wordParagraphStyleId,
+} from './clipboard-html-styles.ts';
 
 export interface HtmlProjectionLimits {
   /** UTF-8 size cap applied BEFORE parse. Default 4 MiB. */
@@ -42,7 +50,7 @@ export type HtmlProjectionResult =
       readonly ok: true;
       /** A fragment package zip, readable by `readOoxmlPackage`. */
       readonly fragmentBytes: Uint8Array;
-      /** Always false: the last projected paragraph merges into the host paragraph. */
+      /** Whether the source identified the final Word paragraph mark as selected. */
       readonly lastMarkCovered: boolean;
       /** How many `data:` images the projection accepted into the fragment. */
       readonly imageCount: number;
@@ -113,6 +121,7 @@ interface RunProps {
 }
 
 interface ParaProps {
+  styleId?: string;
   jc?: 'left' | 'center' | 'right' | 'both';
   indLeftTwips?: number;
   /** Positive → `w:firstLine`, negative → `w:hanging`. */
@@ -142,6 +151,8 @@ interface Projection {
   nodesLeft: number;
   readonly maxDepth: number;
   readonly maxImageBytes: number;
+  readonly wordHtml: boolean;
+  lastMarkCovered: boolean;
   readonly rels: RelEntry[];
   readonly media: Map<string, Uint8Array>;
   readonly mediaExtensions: Map<string, string>;
@@ -187,15 +198,6 @@ function parseCssColor(value: string): string | null {
     return `${channel(rgb[1]!)}${channel(rgb[2]!)}${channel(rgb[3]!)}`.toUpperCase();
   }
   return null;
-}
-
-/** A CSS length in points, from `px` or `pt` values only. */
-function parseCssLengthPt(value: string): number | null {
-  const match = /^(-?\d+(?:\.\d+)?)(px|pt)$/.exec(value.trim().toLowerCase());
-  if (!match) return null;
-  const magnitude = Number.parseFloat(match[1]!);
-  if (!Number.isFinite(magnitude)) return null;
-  return match[2] === 'px' ? magnitude * 0.75 : magnitude;
 }
 
 function clamp(value: number, low: number, high: number): number {
@@ -314,6 +316,9 @@ function textRunXml(text: string, props: RunProps): string {
 /** `w:pPr`, children in CT_PPr sequence order: numPr, spacing, ind, jc. */
 function pPrXml(para: ParaProps): string {
   let inner = '';
+  if (para.styleId !== undefined) {
+    inner += `<w:pStyle w:val="${escapeXmlAttribute(para.styleId)}"/>`;
+  }
   if (para.numPr) {
     inner +=
       `<w:numPr><w:ilvl w:val="${para.numPr.ilvl}"/>` +
@@ -383,17 +388,6 @@ function decodeBase64(data: string, maxBytes: number): Uint8Array | null {
 
 const DATA_IMAGE_RE = /^data:image\/(png|jpeg|jpg|gif);base64,([A-Za-z0-9+/=]+)$/;
 
-function cssOrAttributePx(
-  element: Element,
-  style: ReadonlyMap<string, string>,
-  axis: 'width' | 'height'
-): number | null {
-  const pt = parseCssLengthPt(style.get(axis) ?? '');
-  if (pt !== null && pt > 0) return pt / 0.75;
-  const attr = element.getAttribute(axis) ?? '';
-  return /^[1-9]\d{0,4}$/.test(attr.trim()) ? Number.parseInt(attr, 10) : null;
-}
-
 /** Project a `data:` image into a media part + rel + inline `w:drawing` run. */
 function projectImage(element: Element, runs: string[], p: Projection): void {
   const src = element.getAttribute('src');
@@ -408,8 +402,8 @@ function projectImage(element: Element, runs: string[], p: Projection): void {
   const header = validateRasterHeader(bytes, declared);
 
   const style = parseInlineStyle(element);
-  let widthPx = cssOrAttributePx(element, style, 'width');
-  let heightPx = cssOrAttributePx(element, style, 'height');
+  let widthPx = imageDimensionPx(element, style, 'width', p.wordHtml);
+  let heightPx = imageDimensionPx(element, style, 'height', p.wordHtml);
   if (widthPx === null && heightPx === null && header) {
     widthPx = header.pixelWidth;
     heightPx = header.pixelHeight;
@@ -458,14 +452,6 @@ function allocateList(p: Projection, key: string, kind: 'ordered' | 'bullet'): s
 }
 
 // --- Walk
-
-function isElement(node: Node): node is Element {
-  return node.nodeType === 1; // ELEMENT_NODE
-}
-
-function tagOf(element: Element): string {
-  return element.tagName.toLowerCase();
-}
 
 /** True for the literal marker span Word emits beside `mso-list` paragraphs. */
 function isMsoListIgnoreMarker(style: ReadonlyMap<string, string>): boolean {
@@ -593,11 +579,13 @@ function projectParagraph(
   const tag = tagOf(element);
   const style = parseInlineStyle(element);
   const para: ParaProps = {};
+  const styleId = wordParagraphStyleId(element, p.wordHtml);
+  if (styleId !== undefined) para.styleId = styleId;
   if (ctx.para.numPr) para.numPr = ctx.para.numPr;
   if (ctx.para.jc) para.jc = ctx.para.jc;
   let run = { ...ctx.run };
   const heading = HEADING_SZ[tag];
-  if (heading !== undefined) {
+  if (heading !== undefined && styleId === undefined) {
     run.bold = true;
     run.szHalfPoints = heading;
   }
@@ -609,6 +597,7 @@ function projectParagraph(
   run = applyRunCss(run, style);
   const next: FlowContext = { run, para, pre, list: ctx.list };
   projectFlow(Array.from(element.childNodes), depth + 1, next, p, out, true);
+  p.lastMarkCovered = styleId !== undefined;
 }
 
 function projectList(
@@ -655,7 +644,10 @@ function projectFlow(
   const before = out.length;
   let pending: string[] = [];
   const flush = (): void => {
-    if (pending.length > 0) out.push(paragraphXml(ctx.para, pending));
+    if (pending.length > 0) {
+      out.push(paragraphXml(ctx.para, pending));
+      p.lastMarkCovered = false;
+    }
     pending = [];
   };
   for (const node of nodes) {
@@ -693,7 +685,10 @@ function projectFlow(
   }
   flush();
   // An explicit block emits its paragraph even when empty.
-  if (forceEmit && out.length === before) out.push(paragraphXml(ctx.para, []));
+  if (forceEmit && out.length === before) {
+    out.push(paragraphXml(ctx.para, []));
+    p.lastMarkCovered = false;
+  }
 }
 
 // --- Tables
@@ -808,6 +803,7 @@ function projectTable(
     `<w:tbl><w:tblPr><w:tblW w:w="${TABLE_TOTAL_TWIPS}" w:type="dxa"/>${borders}</w:tblPr>` +
       `<w:tblGrid>${grid}</w:tblGrid>${rowXml.join('')}</w:tbl>`
   );
+  p.lastMarkCovered = false;
 }
 
 function projectCell(
@@ -923,7 +919,8 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
   if (typeof DOMParser === 'undefined') return { ok: false, reason: 'parse-unavailable' };
   let parsed: Document;
   try {
-    parsed = new DOMParser().parseFromString(html, 'text/html');
+    // The result stays detached. The bounded allowlist walker emits escaped XML only.
+    parsed = new DOMParser().parseFromString(html, 'text/html'); // lgtm[js/xss]
   } catch {
     return { ok: false, reason: 'parse-unavailable' };
   }
@@ -934,6 +931,8 @@ function projectBlocks(html: string, limits: HtmlProjectionLimits): ProjectedBlo
     nodesLeft: limits.maxNodes ?? DEFAULT_MAX_NODES,
     maxDepth: limits.maxDepth ?? DEFAULT_MAX_DEPTH,
     maxImageBytes: limits.maxImageBytes ?? DEFAULT_MAX_IMAGE_BYTES,
+    wordHtml: isWordClipboardHtml(html),
+    lastMarkCovered: false,
     rels: [],
     media: new Map(),
     mediaExtensions: new Map(),
@@ -965,7 +964,7 @@ export function projectExternalHtml(
   return {
     ok: true,
     fragmentBytes: assembleFragment(projected.projection, projected.blocks),
-    lastMarkCovered: false,
+    lastMarkCovered: projected.projection.lastMarkCovered,
     imageCount: projected.projection.imageCount,
   };
 }

--- a/packages/core/src/editor/clipboard-html-styles.ts
+++ b/packages/core/src/editor/clipboard-html-styles.ts
@@ -1,0 +1,57 @@
+/** A CSS length in points, from `px` or `pt` values only. */
+export function parseCssLengthPt(value: string): number | null {
+  const match = /^(-?\d+(?:\.\d+)?)(px|pt)$/.exec(value.trim().toLowerCase());
+  if (!match) return null;
+  const magnitude = Number.parseFloat(match[1]!);
+  if (!Number.isFinite(magnitude)) return null;
+  return match[2] === 'px' ? magnitude * 0.75 : magnitude;
+}
+
+/** Whether bare image extents use Word's point-based clipboard convention. */
+export function isWordClipboardHtml(html: string): boolean {
+  return (
+    html.includes('urn:schemas-microsoft-com:office') ||
+    html.includes('class=Mso') ||
+    html.includes('class="Mso') ||
+    html.includes("class='Mso")
+  );
+}
+
+/** A built-in Word style named by Word desktop's clipboard HTML class. */
+export function wordParagraphStyleId(element: Element, wordHtml: boolean): string | undefined {
+  for (const className of element.classList) {
+    const heading = /^MsoHeading([1-9])$/.exec(className);
+    if (heading) return `Heading${heading[1]}`;
+    const onlineHeading = /^Heading([1-9])$/.exec(className);
+    if (onlineHeading) return `Heading${onlineHeading[1]}`;
+    if (className === 'MsoCaption') return 'Caption';
+    if (className === 'MsoTitle') return 'Title';
+    if (className === 'MsoSubtitle') return 'Subtitle';
+    if (className === 'MsoQuote') return 'Quote';
+  }
+  const headingTag = wordHtml ? /^h([1-6])$/.exec(tagOf(element)) : null;
+  return headingTag ? `Heading${headingTag[1]}` : undefined;
+}
+
+/** An image extent in CSS pixels, including Word's bare-point convention. */
+export function imageDimensionPx(
+  element: Element,
+  style: ReadonlyMap<string, string>,
+  axis: 'width' | 'height',
+  wordHtml: boolean
+): number | null {
+  const pt = parseCssLengthPt(style.get(axis) ?? '');
+  if (pt !== null && pt > 0) return pt / 0.75;
+  const attr = element.getAttribute(axis)?.trim() ?? '';
+  if (!/^[1-9]\d{0,4}$/.test(attr)) return null;
+  const value = Number.parseInt(attr, 10);
+  return wordHtml ? value / 0.75 : value;
+}
+
+export function isElement(node: Node): node is Element {
+  return node.nodeType === 1;
+}
+
+export function tagOf(element: Element): string {
+  return element.tagName.toLowerCase();
+}

--- a/packages/core/src/store/__tests__/image-resources.test.ts
+++ b/packages/core/src/store/__tests__/image-resources.test.ts
@@ -237,6 +237,23 @@ function forgedPng(wrongChunkLength: boolean): Uint8Array {
   return out;
 }
 
+function pngWithPhysicalDensity(pixelsPerMeter: number): Uint8Array {
+  const phys = Uint8Array.from([
+    0, 0, 0, 9, 0x70, 0x48, 0x59, 0x73, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+  ]);
+  for (const offset of [8, 12]) {
+    phys[offset] = (pixelsPerMeter >>> 24) & 0xff;
+    phys[offset + 1] = (pixelsPerMeter >>> 16) & 0xff;
+    phys[offset + 2] = (pixelsPerMeter >>> 8) & 0xff;
+    phys[offset + 3] = pixelsPerMeter & 0xff;
+  }
+  const out = new Uint8Array(PNG_1X1.length + phys.length);
+  out.set(PNG_1X1.subarray(0, 33));
+  out.set(phys, 33);
+  out.set(PNG_1X1.subarray(33), 33 + phys.length);
+  return out;
+}
+
 describe('image resource validation and cache (task 4)', () => {
   describe('signature sniffing', () => {
     test.each([
@@ -274,6 +291,12 @@ describe('image resource validation and cache (task 4)', () => {
   describe('structural raster headers', () => {
     test('PNG IHDR validates 1x1 dimensions', () => {
       expect(validatePngHeader(PNG_1X1)).toEqual({ pixelWidth: 1, pixelHeight: 1 });
+    });
+
+    test('PNG pHYs supplies bounded physical density', () => {
+      const header = validatePngHeader(pngWithPhysicalDensity(5669));
+      expect(header?.dpiX).toBeCloseTo(144, 1);
+      expect(header?.dpiY).toBeCloseTo(144, 1);
     });
 
     test('GIF logical screen validates nonzero dimensions', () => {

--- a/packages/core/src/store/__tests__/image-resources.test.ts
+++ b/packages/core/src/store/__tests__/image-resources.test.ts
@@ -321,6 +321,7 @@ describe('image resource validation and cache (task 4)', () => {
 
     test('PNG pHYs ignores aspect-only and excessive density', () => {
       expect(validatePngHeader(pngWithPhysicalDensity(5669, 0))?.dpiX).toBeUndefined();
+      expect(validatePngHeader(pngWithPhysicalDensity(1))?.dpiX).toBeUndefined();
       expect(validatePngHeader(pngWithPhysicalDensity(100_000))?.dpiX).toBeUndefined();
     });
 

--- a/packages/core/src/store/__tests__/image-resources.test.ts
+++ b/packages/core/src/store/__tests__/image-resources.test.ts
@@ -237,9 +237,29 @@ function forgedPng(wrongChunkLength: boolean): Uint8Array {
   return out;
 }
 
-function pngWithPhysicalDensity(pixelsPerMeter: number): Uint8Array {
+function pngWithPhysicalDensity(pixelsPerMeter: number, unit = 1): Uint8Array {
   const phys = Uint8Array.from([
-    0, 0, 0, 9, 0x70, 0x48, 0x59, 0x73, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+    0,
+    0,
+    0,
+    9,
+    0x70,
+    0x48,
+    0x59,
+    0x73,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    unit,
+    0,
+    0,
+    0,
+    0,
   ]);
   for (const offset of [8, 12]) {
     phys[offset] = (pixelsPerMeter >>> 24) & 0xff;
@@ -297,6 +317,11 @@ describe('image resource validation and cache (task 4)', () => {
       const header = validatePngHeader(pngWithPhysicalDensity(5669));
       expect(header?.dpiX).toBeCloseTo(144, 1);
       expect(header?.dpiY).toBeCloseTo(144, 1);
+    });
+
+    test('PNG pHYs ignores aspect-only and excessive density', () => {
+      expect(validatePngHeader(pngWithPhysicalDensity(5669, 0))?.dpiX).toBeUndefined();
+      expect(validatePngHeader(pngWithPhysicalDensity(100_000))?.dpiX).toBeUndefined();
     });
 
     test('GIF logical screen validates nonzero dimensions', () => {
@@ -655,6 +680,19 @@ describe('image resource validation and cache (task 4)', () => {
       expect(state.resourceKey).toContain('sha256:');
       expect('validatedBytesFor' in cache).toBe(false);
       expect(Object.isFrozen(state)).toBe(true);
+    });
+
+    test('ready PNG prefers physical header density over decoder defaults', async () => {
+      const loaded = buildPackage({
+        media: { 'word/media/image1.png': pngWithPhysicalDensity(5669) },
+      });
+      if (!loaded.ok) throw new Error(loaded.reason);
+      const cache = createImageResourceCache(loaded.package, { decodePort: mockDecodePort() });
+      const state = await cache.resolveEmbedded('/word/document.xml', 'rId2');
+      expect(state.kind).toBe('ready');
+      if (state.kind !== 'ready') return;
+      expect(state.dpiX).toBeCloseTo(144, 1);
+      expect(state.dpiY).toBeCloseTo(144, 1);
     });
 
     test('decoder receives a copy; package bytes and hash stay stable after mutation', async () => {

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -17,6 +17,7 @@ import {
 } from './relationships.ts';
 import { projectDrawingsInPackage, type DrawingProjection } from './drawing-projection.ts';
 import type { OoxmlPackage } from './ooxml-package.ts';
+import { readPngPhysicalDensity } from './png-physical-density.ts';
 import {
   IMAGE_RESOURCE_HARD_CEILINGS,
   resolveImageResourceLimits,
@@ -136,8 +137,6 @@ export interface ImageResourceLookup {
 
 const PNG_SIGNATURE = Object.freeze([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const DEFAULT_DPI = 96;
-const MAX_PNG_METADATA_SCAN = 65_536;
-const MAX_RASTER_DPI = 10_000;
 const MAX_JPEG_MARKER_SCAN = 65_536;
 /** Maximum prefix inspected for SVG root detection (exported for bounded-scan tests). */
 export const MAX_SVG_SNIFF_BYTES = 512;
@@ -327,43 +326,6 @@ function isValidPngColorTypeAndBitDepth(colorType: number, bitDepth: number): bo
   }
 }
 
-function readUint32Be(bytes: Uint8Array, offset: number): number {
-  return (
-    ((bytes[offset]! << 24) >>> 0) |
-    (bytes[offset + 1]! << 16) |
-    (bytes[offset + 2]! << 8) |
-    bytes[offset + 3]!
-  );
-}
-
-function pngPhysicalDensity(
-  bytes: Uint8Array
-): { readonly dpiX: number; readonly dpiY: number } | null {
-  const scanLimit = Math.min(bytes.length, MAX_PNG_METADATA_SCAN);
-  let offset = 33;
-  while (offset + 12 <= scanLimit) {
-    const length = readUint32Be(bytes, offset);
-    const chunkEnd = offset + 12 + length;
-    if (chunkEnd > scanLimit) return null;
-    const type =
-      String.fromCharCode(bytes[offset + 4]!) +
-      String.fromCharCode(bytes[offset + 5]!) +
-      String.fromCharCode(bytes[offset + 6]!) +
-      String.fromCharCode(bytes[offset + 7]!);
-    if (type === 'IDAT' || type === 'IEND') return null;
-    if (type === 'pHYs' && length === 9 && bytes[offset + 16] === 1) {
-      const dpiX = readUint32Be(bytes, offset + 8) * 0.0254;
-      const dpiY = readUint32Be(bytes, offset + 12) * 0.0254;
-      if (dpiX > 0 && dpiX <= MAX_RASTER_DPI && dpiY > 0 && dpiY <= MAX_RASTER_DPI) {
-        return { dpiX, dpiY };
-      }
-      return null;
-    }
-    offset = chunkEnd;
-  }
-  return null;
-}
-
 /** Structural PNG IHDR validation before decode. */
 export function validatePngHeader(bytes: Uint8Array): ValidatedRasterHeader | null {
   if (!bytesStartWith(bytes, PNG_SIGNATURE)) return null;
@@ -387,7 +349,7 @@ export function validatePngHeader(bytes: Uint8Array): ValidatedRasterHeader | nu
   if (!isValidPngColorTypeAndBitDepth(colorType, bitDepth)) return null;
   if (compression !== 0 || filter !== 0) return null;
   if (interlace !== 0 && interlace !== 1) return null;
-  const density = pngPhysicalDensity(bytes);
+  const density = readPngPhysicalDensity(bytes);
   return density ? { pixelWidth, pixelHeight, ...density } : { pixelWidth, pixelHeight };
 }
 
@@ -1153,8 +1115,8 @@ function createImageResourceCacheInternal(
                 mime: convertedSniffed,
                 pixelWidth: convertedHeader.pixelWidth,
                 pixelHeight: convertedHeader.pixelHeight,
-                dpiX: DEFAULT_DPI,
-                dpiY: DEFAULT_DPI,
+                dpiX: convertedHeader.dpiX ?? DEFAULT_DPI,
+                dpiY: convertedHeader.dpiY ?? DEFAULT_DPI,
               })
             );
           } catch (error) {
@@ -1252,10 +1214,12 @@ function createImageResourceCacheInternal(
             return;
           }
 
-          const dpiX =
+          const decodedDpiX =
             Number.isFinite(decoded.dpiX) && decoded.dpiX > 0 ? decoded.dpiX : DEFAULT_DPI;
-          const dpiY =
+          const decodedDpiY =
             Number.isFinite(decoded.dpiY) && decoded.dpiY > 0 ? decoded.dpiY : DEFAULT_DPI;
+          const dpiX = header.dpiX ?? decodedDpiX;
+          const dpiY = header.dpiY ?? decodedDpiY;
 
           const resourceKey = resourceKeyOf(ownerPartName, resolvedPartName, contentId);
           const validatedHandle = validatedBytesRegistry.acquire(

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -136,6 +136,8 @@ export interface ImageResourceLookup {
 
 const PNG_SIGNATURE = Object.freeze([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const DEFAULT_DPI = 96;
+const MAX_PNG_METADATA_SCAN = 65_536;
+const MAX_RASTER_DPI = 10_000;
 const MAX_JPEG_MARKER_SCAN = 65_536;
 /** Maximum prefix inspected for SVG root detection (exported for bounded-scan tests). */
 export const MAX_SVG_SNIFF_BYTES = 512;
@@ -166,6 +168,10 @@ const CONTENT_TYPE_TO_MIME: Readonly<Record<string, RenderableImageMime | Preser
 export interface ValidatedRasterHeader {
   readonly pixelWidth: number;
   readonly pixelHeight: number;
+  /** Horizontal physical density when bounded header metadata supplies it. */
+  readonly dpiX?: number;
+  /** Vertical physical density when bounded header metadata supplies it. */
+  readonly dpiY?: number;
 }
 
 function bytesStartWith(bytes: Uint8Array, prefix: readonly number[]): boolean {
@@ -321,6 +327,43 @@ function isValidPngColorTypeAndBitDepth(colorType: number, bitDepth: number): bo
   }
 }
 
+function readUint32Be(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset]! << 24) >>> 0) |
+    (bytes[offset + 1]! << 16) |
+    (bytes[offset + 2]! << 8) |
+    bytes[offset + 3]!
+  );
+}
+
+function pngPhysicalDensity(
+  bytes: Uint8Array
+): { readonly dpiX: number; readonly dpiY: number } | null {
+  const scanLimit = Math.min(bytes.length, MAX_PNG_METADATA_SCAN);
+  let offset = 33;
+  while (offset + 12 <= scanLimit) {
+    const length = readUint32Be(bytes, offset);
+    const chunkEnd = offset + 12 + length;
+    if (chunkEnd > scanLimit) return null;
+    const type =
+      String.fromCharCode(bytes[offset + 4]!) +
+      String.fromCharCode(bytes[offset + 5]!) +
+      String.fromCharCode(bytes[offset + 6]!) +
+      String.fromCharCode(bytes[offset + 7]!);
+    if (type === 'IDAT' || type === 'IEND') return null;
+    if (type === 'pHYs' && length === 9 && bytes[offset + 16] === 1) {
+      const dpiX = readUint32Be(bytes, offset + 8) * 0.0254;
+      const dpiY = readUint32Be(bytes, offset + 12) * 0.0254;
+      if (dpiX > 0 && dpiX <= MAX_RASTER_DPI && dpiY > 0 && dpiY <= MAX_RASTER_DPI) {
+        return { dpiX, dpiY };
+      }
+      return null;
+    }
+    offset = chunkEnd;
+  }
+  return null;
+}
+
 /** Structural PNG IHDR validation before decode. */
 export function validatePngHeader(bytes: Uint8Array): ValidatedRasterHeader | null {
   if (!bytesStartWith(bytes, PNG_SIGNATURE)) return null;
@@ -344,7 +387,8 @@ export function validatePngHeader(bytes: Uint8Array): ValidatedRasterHeader | nu
   if (!isValidPngColorTypeAndBitDepth(colorType, bitDepth)) return null;
   if (compression !== 0 || filter !== 0) return null;
   if (interlace !== 0 && interlace !== 1) return null;
-  return { pixelWidth, pixelHeight };
+  const density = pngPhysicalDensity(bytes);
+  return density ? { pixelWidth, pixelHeight, ...density } : { pixelWidth, pixelHeight };
 }
 
 /** Structural GIF logical screen descriptor validation before decode. */

--- a/packages/core/src/store/package/png-physical-density.ts
+++ b/packages/core/src/store/package/png-physical-density.ts
@@ -1,0 +1,57 @@
+const MAX_PNG_METADATA_SCAN = 65_536;
+const MIN_RASTER_DPI = 10;
+const MAX_RASTER_DPI = 2_400;
+
+function readUint32Be(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset]! << 24) >>> 0) |
+    (bytes[offset + 1]! << 16) |
+    (bytes[offset + 2]! << 8) |
+    bytes[offset + 3]!
+  );
+}
+
+/** Read PNG `pHYs` density before `IDAT`, under a fixed prefix scan bound. */
+export function readPngPhysicalDensity(
+  bytes: Uint8Array
+): { readonly dpiX: number; readonly dpiY: number } | null {
+  const scanLimit = Math.min(bytes.length, MAX_PNG_METADATA_SCAN);
+  let offset = 33;
+  while (offset + 12 <= scanLimit) {
+    const length = readUint32Be(bytes, offset);
+    const chunkEnd = offset + 12 + length;
+    if (chunkEnd > scanLimit) return null;
+    const typeOffset = offset + 4;
+    const isIdat =
+      bytes[typeOffset] === 0x49 &&
+      bytes[typeOffset + 1] === 0x44 &&
+      bytes[typeOffset + 2] === 0x41 &&
+      bytes[typeOffset + 3] === 0x54;
+    const isIend =
+      bytes[typeOffset] === 0x49 &&
+      bytes[typeOffset + 1] === 0x45 &&
+      bytes[typeOffset + 2] === 0x4e &&
+      bytes[typeOffset + 3] === 0x44;
+    if (isIdat || isIend) return null;
+    const isPhys =
+      bytes[typeOffset] === 0x70 &&
+      bytes[typeOffset + 1] === 0x48 &&
+      bytes[typeOffset + 2] === 0x59 &&
+      bytes[typeOffset + 3] === 0x73;
+    if (isPhys && length === 9 && bytes[offset + 16] === 1) {
+      const dpiX = readUint32Be(bytes, offset + 8) * 0.0254;
+      const dpiY = readUint32Be(bytes, offset + 12) * 0.0254;
+      if (
+        dpiX >= MIN_RASTER_DPI &&
+        dpiX <= MAX_RASTER_DPI &&
+        dpiY >= MIN_RASTER_DPI &&
+        dpiY <= MAX_RASTER_DPI
+      ) {
+        return { dpiX, dpiY };
+      }
+      return null;
+    }
+    offset = chunkEnd;
+  }
+  return null;
+}

--- a/packages/react/src/editor/images/normalizeImageFile.ts
+++ b/packages/react/src/editor/images/normalizeImageFile.ts
@@ -79,8 +79,8 @@ export function normalizeImageBytes(bytes: Uint8Array): NormalizedImagePayload {
   const { widthPoints, heightPoints } = naturalPoints(
     header.pixelWidth,
     header.pixelHeight,
-    DEFAULT_DPI,
-    DEFAULT_DPI
+    header.dpiX ?? DEFAULT_DPI,
+    header.dpiY ?? DEFAULT_DPI
   );
   return Object.freeze({
     ok: true,

--- a/packages/react/test/image-authoring.test.tsx
+++ b/packages/react/test/image-authoring.test.tsx
@@ -41,6 +41,28 @@ const PNG_1X1 = Uint8Array.from(
   (c) => c.charCodeAt(0)
 );
 
+function pngWithPhysicalSize(width: number, height: number, pixelsPerMeter: number): Uint8Array {
+  const source = PNG_1X1.slice();
+  const writeUint32 = (bytes: Uint8Array, offset: number, value: number): void => {
+    bytes[offset] = (value >>> 24) & 0xff;
+    bytes[offset + 1] = (value >>> 16) & 0xff;
+    bytes[offset + 2] = (value >>> 8) & 0xff;
+    bytes[offset + 3] = value & 0xff;
+  };
+  writeUint32(source, 16, width);
+  writeUint32(source, 20, height);
+  const phys = Uint8Array.from([
+    0, 0, 0, 9, 0x70, 0x48, 0x59, 0x73, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+  ]);
+  writeUint32(phys, 8, pixelsPerMeter);
+  writeUint32(phys, 12, pixelsPerMeter);
+  const out = new Uint8Array(source.length + phys.length);
+  out.set(source.subarray(0, 33));
+  out.set(phys, 33);
+  out.set(source.subarray(33), 33 + phys.length);
+  return out;
+}
+
 const JPEG_1X1 = Uint8Array.from([
   0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
   0x00, 0x01, 0x00, 0x00, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08,
@@ -334,6 +356,14 @@ describe('inserts validated image files', () => {
     if (!refused.ok) {
       expect(refused.reasonKey).toBe('imageInsert.errors.unsupportedFormat');
     }
+  });
+
+  test('uses PNG physical resolution for the inserted size', () => {
+    const normalized = normalizeImageBytes(pngWithPhysicalSize(144, 72, 5669));
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.widthPoints).toBe(72);
+    expect(normalized.heightPoints).toBe(36);
   });
 
   test('insert button preserves caret on mousedown', async () => {

--- a/packages/vue/src/editor/images/normalizeImageFile.ts
+++ b/packages/vue/src/editor/images/normalizeImageFile.ts
@@ -79,8 +79,8 @@ export function normalizeImageBytes(bytes: Uint8Array): NormalizedImagePayload {
   const { widthPoints, heightPoints } = naturalPoints(
     header.pixelWidth,
     header.pixelHeight,
-    DEFAULT_DPI,
-    DEFAULT_DPI
+    header.dpiX ?? DEFAULT_DPI,
+    header.dpiY ?? DEFAULT_DPI
   );
   return Object.freeze({
     ok: true,


### PR DESCRIPTION
## Summary
- Preserve Word heading and caption paragraph semantics.
- Preserve Word image dimensions and PNG physical density.
- Resolve the inert-parser CodeQL false positive and use a minor changeset.

## Test plan
- [x] Focused clipboard and image tests
- [x] Type checking, formatting, lint, parity, and API checks
- [x] Full suite: 10,280 passed; 19 load-sensitive tests timed out under local parallel load

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790507932&installation_model_id=422592&pr_number=578&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F578&signature=b1f469e38f7aefb6ee7ffcc77e84995d63388e88c0a73036de65bb7e129e473f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->