### PR TITLE
harden the collaboration receive path and extend the expressibility guarantee (gaps 2, 3, 4)

### DIFF
--- a/.changeset/harden-receive-path.md
+++ b/.changeset/harden-receive-path.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Harden the collaboration receive path against a hostile peer: a malformed shared node record no longer crashes `applyUpdate`, the derived-index rebuild, or the materializer on every replica. A crafted value now degrades to an absent node instead of throwing. Fixes #567.

--- a/packages/pro/src/collaboration/__tests__/collaboration-teardown.test.ts
+++ b/packages/pro/src/collaboration/__tests__/collaboration-teardown.test.ts
@@ -110,16 +110,19 @@ describe('collaboration teardown', () => {
   test('a bootstrap that fails while materializing leaves no observers behind', async () => {
     const host = await seededRoom();
     host.destroy();
-    // Corrupt one element record the way a hostile peer could: drop its child array, which
-    // makes materializing THROW (`no children at …`) rather than refuse with a typed code.
+    // Delete a part-root node record so materialize refuses with `missing-root` and the
+    // factory throws. (A malformed-but-present record no longer throws — the receive-path
+    // hardening degrades it — so the failure has to come from an unmaterializable part.)
     const nodes = host.ydoc.getMap<Y.Map<unknown>>('docx-package-nodes-v1');
-    let corrupted = false;
-    nodes.forEach((record) => {
-      if (corrupted || !(record instanceof Y.Map) || !record.has('children')) return;
-      record.delete('children');
-      corrupted = true;
+    const parts = host.ydoc.getMap<Y.Map<unknown>>('docx-package-parts-v1');
+    let rootId: string | undefined;
+    parts.forEach((entry) => {
+      if (!rootId && entry instanceof Y.Map && typeof entry.get('rootId') === 'string') {
+        rootId = entry.get('rootId') as string;
+      }
     });
-    expect(corrupted).toBe(true);
+    expect(rootId).toBeTruthy();
+    host.ydoc.transact(() => nodes.delete(rootId!));
     const before = totalObservers(host.ydoc);
     const awareness = new Awareness(host.ydoc);
     await expect(

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
@@ -50,11 +50,34 @@ function drawingId(peer: Peer): string {
   return found;
 }
 
-/** Apply two concurrent edits with the wire paused, reconnect, and assert convergence. */
+function bodyText(peer: Peer): string {
+  const texts: string[] = [];
+  walk(peer.store.bodyStore().part.root, (node) => {
+    if (node.kind === 'textValue') texts.push(node.value);
+  });
+  return texts.join('');
+}
+
+function hasElement(peer: Peer, localName: string): boolean {
+  let present = false;
+  walk(peer.store.bodyStore().part.root, (node) => {
+    if (node.kind !== 'textValue' && node.localName === localName) present = true;
+  });
+  return present;
+}
+
+/**
+ * Apply two concurrent edits with the wire paused, reconnect, and assert convergence.
+ *
+ * Convergence is peer-to-peer equality, which two identically-corrupt replicas also satisfy,
+ * so the caller passes an `expect` that checks the merged document is actually CORRECT — the
+ * edits present, the text intact. Without it a silent drop or a silent duplication passes.
+ */
 async function converges(
   bytes: Uint8Array,
   aliceOp: (peer: Peer) => readonly TreeDocOp[],
   bobOp: (peer: Peer) => readonly TreeDocOp[],
+  check: (peer: Peer) => void,
   scope: StoryScope = BODY
 ): Promise<void> {
   const { alice, bob, pause, resume } = await harness.pair(bytes);
@@ -63,11 +86,14 @@ async function converges(
   harness.apply(bob, bobOp(bob), scope);
   resume();
   harness.expectConverged(alice, bob);
+  check(alice);
+  check(bob);
 }
 
 describe('concurrent variant edits converge', () => {
   test('two indents on DIFFERENT paragraphs', async () => {
-    // Independent property edits merge cleanly — the ordinary collaborative case.
+    // Independent property edits merge cleanly — the ordinary collaborative case. Both
+    // indents survive and neither paragraph's text is disturbed.
     await converges(
       proseDoc(),
       (peer) => [
@@ -83,11 +109,17 @@ describe('concurrent variant edits converge', () => {
           paragraphId: harness.paragraphIdAt(peer, 1),
           properties: [{ localName: 'ind', attributes: { start: '1440' } }],
         },
-      ]
+      ],
+      (peer) => {
+        expect(hasElement(peer, 'ind')).toBe(true);
+        expect(bodyText(peer)).toBe('Alpha bravo canvas delta editorSecond paragraph');
+      }
     );
   });
 
-  test('bold and italic on overlapping ranges', async () => {
+  test('bold and text on different paragraphs', async () => {
+    // Run formatting on one paragraph, text on another: independent, so both apply with the
+    // text intact.
     await converges(
       proseDoc(),
       (peer) => [
@@ -100,15 +132,45 @@ describe('concurrent variant edits converge', () => {
         },
       ],
       (peer) => [
-        {
-          op: 'setRunProperties',
-          paragraphId: harness.paragraphIdAt(peer, 0),
-          start: 3,
-          end: 9,
-          properties: [{ localName: 'i' }],
-        },
-      ]
+        { op: 'insertText', paragraphId: harness.paragraphIdAt(peer, 1), offset: 0, text: 'Z' },
+      ],
+      (peer) => {
+        expect(hasElement(peer, 'b')).toBe(true);
+        expect(bodyText(peer)).toBe('Alpha bravo canvas delta editorZSecond paragraph');
+      }
     );
+  });
+
+  test('same-paragraph run-property edits silently duplicate text (#581)', async () => {
+    // Pinning current CORRUPTION, not endorsing it: two concurrent `setRunProperties` on the
+    // same paragraph rebuild its runs additively, so the merged text doubles on both peers.
+    // The peers still agree (convergence holds), which is why a convergence-only oracle
+    // missed it. When #581 is fixed this expectation flips.
+    const { alice, bob, pause, resume } = await harness.pair(proseDoc());
+    pause();
+    harness.apply(alice, [
+      {
+        op: 'setRunProperties',
+        paragraphId: harness.paragraphIdAt(alice, 0),
+        start: 0,
+        end: 5,
+        properties: [{ localName: 'b' }],
+      },
+    ]);
+    harness.apply(bob, [
+      {
+        op: 'setRunProperties',
+        paragraphId: harness.paragraphIdAt(bob, 0),
+        start: 3,
+        end: 9,
+        properties: [{ localName: 'i' }],
+      },
+    ]);
+    resume();
+    harness.expectConverged(alice, bob);
+    // The bug: paragraph 0's text is duplicated. Documented so a fix visibly flips it.
+    expect(bodyText(alice)).toContain('editorAlpha bravo canvas delta editor');
+    expect(bodyText(bob)).toBe(bodyText(alice));
   });
 
   test('sequential wrap changes on one drawing replicate', async () => {
@@ -131,11 +193,16 @@ describe('concurrent variant edits converge', () => {
     harness.apply(alice, [
       { op: 'setDrawingWrap', drawingNodeId: drawingId(alice), wrap: 'tight' },
     ]);
+    // The wrap must actually reach bob: assert the anchor now carries a wrapTight element,
+    // not merely that a drawing exists.
     expect(bob.room.session.statusSnapshot().status).toBe('ready');
-    expect(drawingId(bob)).toBeTruthy();
+    expect(hasElement(bob, 'wrapTight')).toBe(true);
+    harness.expectConverged(alice, bob);
   });
 
   test('a shared paragraph property and a concurrent text edit', async () => {
+    // Different concerns on one paragraph — a property rebuild and a text insert. They
+    // converge with the text intact (jc present, the inserted X kept, no duplication).
     await converges(
       proseDoc(),
       (peer) => [
@@ -147,7 +214,11 @@ describe('concurrent variant edits converge', () => {
       ],
       (peer) => [
         { op: 'insertText', paragraphId: harness.paragraphIdAt(peer, 0), offset: 0, text: 'X' },
-      ]
+      ],
+      (peer) => {
+        expect(hasElement(peer, 'jc')).toBe(true);
+        expect(bodyText(peer)).toBe('XAlpha bravo canvas delta editorSecond paragraph');
+      }
     );
   });
 
@@ -172,7 +243,12 @@ describe('concurrent variant edits converge', () => {
       },
     ]);
     resume();
-    expect(alice.room.session.statusSnapshot().status).toBe('error');
-    expect(bob.room.session.statusSnapshot().status).toBe('error');
+    // Pin the reason too, so this cannot start passing on some unrelated future error.
+    const aliceSnap = alice.room.session.statusSnapshot();
+    const bobSnap = bob.room.session.statusSnapshot();
+    expect(aliceSnap.status).toBe('error');
+    expect(bobSnap.status).toBe('error');
+    expect(aliceSnap.reason?.code).toBe('remote-apply-failed');
+    expect(bobSnap.reason?.code).toBe('remote-apply-failed');
   });
 });

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
@@ -66,6 +66,18 @@ function hasElement(peer: Peer, localName: string): boolean {
   return present;
 }
 
+/** Every value of one attribute across all elements of a localName, so a dropped or
+ * duplicated instance is visible — `hasElement` alone matches any single survivor. */
+function attributeValues(peer: Peer, localName: string, attribute: string): string[] {
+  const values: string[] = [];
+  walk(peer.store.bodyStore().part.root, (node) => {
+    if (node.kind === 'textValue' || node.localName !== localName) return;
+    const found = node.attributes.find((a) => a.localName === attribute);
+    if (found) values.push(found.value);
+  });
+  return values.sort();
+}
+
 /**
  * Apply two concurrent edits with the wire paused, reconnect, and assert convergence.
  *
@@ -111,7 +123,9 @@ describe('concurrent variant edits converge', () => {
         },
       ],
       (peer) => {
-        expect(hasElement(peer, 'ind')).toBe(true);
+        // BOTH indents must survive — a count/value check, not `hasElement`, which any
+        // single survivor would satisfy.
+        expect(attributeValues(peer, 'ind', 'start')).toEqual(['1440', '720']);
         expect(bodyText(peer)).toBe('Alpha bravo canvas delta editorSecond paragraph');
       }
     );

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
@@ -1,0 +1,178 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Concurrent variant edits converge (gap 3).
+//
+// The journal-coverage gate proves each variant replays a SINGLE author's edit onto a fresh
+// replica. That is not the same claim as: two peers editing the same target CONCURRENTLY
+// converge. This drives real Yjs merges through the production registry + materializer — two
+// peers each author a different variant of the same property on the same node with the wire
+// paused, then reconnect — and asserts both replicas reach one document (fingerprint plus
+// save/reopen digest). A variant whose merge diverged would fail here, where the
+// single-author gate could not see it.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { ImageDecodePort, StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
+import { BODY, createPeerHarness, walk, zipDocument, type Peer } from './document-peer-support.ts';
+
+const harness = createPeerHarness('concurrent-variants-room');
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+const PNG = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  ),
+  (character) => character.charCodeAt(0)
+);
+
+const decodePort: ImageDecodePort = {
+  decode: async () => ({ pixelWidth: 1, pixelHeight: 1, dpiX: 96, dpiY: 96 }),
+};
+
+function proseDoc(): Uint8Array {
+  return zipDocument(
+    '<w:p><w:r><w:t>Alpha bravo canvas delta editor</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>Second paragraph</w:t></w:r></w:p><w:sectPr/>'
+  );
+}
+
+function drawingId(peer: Peer): string {
+  let found: string | undefined;
+  walk(peer.store.bodyStore().part.root, (node) => {
+    if (!found && node.kind === 'drawing') found = node.id;
+  });
+  if (!found) throw new Error('missing drawing');
+  return found;
+}
+
+/** Apply two concurrent edits with the wire paused, reconnect, and assert convergence. */
+async function converges(
+  bytes: Uint8Array,
+  aliceOp: (peer: Peer) => readonly TreeDocOp[],
+  bobOp: (peer: Peer) => readonly TreeDocOp[],
+  scope: StoryScope = BODY
+): Promise<void> {
+  const { alice, bob, pause, resume } = await harness.pair(bytes);
+  pause();
+  harness.apply(alice, aliceOp(alice), scope);
+  harness.apply(bob, bobOp(bob), scope);
+  resume();
+  harness.expectConverged(alice, bob);
+}
+
+describe('concurrent variant edits converge', () => {
+  test('two indents on DIFFERENT paragraphs', async () => {
+    // Independent property edits merge cleanly — the ordinary collaborative case.
+    await converges(
+      proseDoc(),
+      (peer) => [
+        {
+          op: 'setParagraphProperties',
+          paragraphId: harness.paragraphIdAt(peer, 0),
+          properties: [{ localName: 'ind', attributes: { start: '720' } }],
+        },
+      ],
+      (peer) => [
+        {
+          op: 'setParagraphProperties',
+          paragraphId: harness.paragraphIdAt(peer, 1),
+          properties: [{ localName: 'ind', attributes: { start: '1440' } }],
+        },
+      ]
+    );
+  });
+
+  test('bold and italic on overlapping ranges', async () => {
+    await converges(
+      proseDoc(),
+      (peer) => [
+        {
+          op: 'setRunProperties',
+          paragraphId: harness.paragraphIdAt(peer, 0),
+          start: 0,
+          end: 5,
+          properties: [{ localName: 'b' }],
+        },
+      ],
+      (peer) => [
+        {
+          op: 'setRunProperties',
+          paragraphId: harness.paragraphIdAt(peer, 0),
+          start: 3,
+          end: 9,
+          properties: [{ localName: 'i' }],
+        },
+      ]
+    );
+  });
+
+  test('sequential wrap changes on one drawing replicate', async () => {
+    // A drawing created through the real image lane, then a wrap change, reaching the peer.
+    // (Two CONCURRENT wrap changes on one drawing are a same-node property race — the same
+    // limitation as concurrent paragraph properties, tracked in #579.)
+    const { alice, bob } = await harness.pair(proseDoc());
+    const inserted = await alice.store.insertImage(BODY, {
+      paragraphId: harness.paragraphIdAt(alice, 0),
+      offset: 0,
+      bytes: PNG,
+      mime: 'image/png',
+      widthPoints: 12,
+      heightPoints: 12,
+      decodePort,
+      expectedPackageRevision: alice.store.packageRevision,
+    });
+    if (!inserted.ok) throw new Error(inserted.detail ?? inserted.reason);
+    alice.port.flushPendingJournals();
+    harness.apply(alice, [
+      { op: 'setDrawingWrap', drawingNodeId: drawingId(alice), wrap: 'tight' },
+    ]);
+    expect(bob.room.session.statusSnapshot().status).toBe('ready');
+    expect(drawingId(bob)).toBeTruthy();
+  });
+
+  test('a shared paragraph property and a concurrent text edit', async () => {
+    await converges(
+      proseDoc(),
+      (peer) => [
+        {
+          op: 'setParagraphProperties',
+          paragraphId: harness.paragraphIdAt(peer, 0),
+          properties: [{ localName: 'jc', attributes: { val: 'center' } }],
+        },
+      ],
+      (peer) => [
+        { op: 'insertText', paragraphId: harness.paragraphIdAt(peer, 0), offset: 0, text: 'X' },
+      ]
+    );
+  });
+
+  test('same-paragraph property rebuilds are a known non-convergence (#579)', async () => {
+    // Pinning the current boundary, not endorsing it: two peers rebuilding the SAME `w:pPr`
+    // concurrently each realign to their own edit and escalate to `error`. When #579 makes
+    // this converge, this expectation flips and the assertion is updated.
+    const { alice, bob, pause, resume } = await harness.pair(proseDoc());
+    pause();
+    harness.apply(alice, [
+      {
+        op: 'setParagraphProperties',
+        paragraphId: harness.paragraphIdAt(alice, 0),
+        properties: [{ localName: 'ind', attributes: { start: '720' } }],
+      },
+    ]);
+    harness.apply(bob, [
+      {
+        op: 'setParagraphProperties',
+        paragraphId: harness.paragraphIdAt(bob, 0),
+        properties: [{ localName: 'ind', attributes: { start: '1440' } }],
+      },
+    ]);
+    resume();
+    expect(alice.room.session.statusSnapshot().status).toBe('error');
+    expect(bob.room.session.statusSnapshot().status).toBe('error');
+  });
+});

--- a/packages/pro/src/collaboration/__tests__/document-hostile-shapes.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-hostile-shapes.test.ts
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// A peer is not a trust boundary (issue #567). The shared node map is peer-writable, so a
+// hostile update can plant a scalar where a record belongs. The receive path — the registry
+// observers that fire during `applyUpdate`, the derived-index rebuild, and the materializer —
+// must treat a malformed value as an absent node and keep running, never throw synchronously
+// into the provider's message handler and take down every replica in the room.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { DocumentRegistry, PackageMaterializer, MemoryBlobStore } from '../document/index.ts';
+import { createPeerHarness } from './document-peer-support.ts';
+import { collaborationDocx } from './support.ts';
+
+const harness = createPeerHarness('hostile-shapes-room');
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+const NODES = 'docx-package-nodes-v1';
+const PARTS = 'docx-package-parts-v1';
+
+/** Apply a hostile mutation on a doc mirroring the room, then deliver it to `target`. */
+function deliverHostile(source: Y.Doc, target: Y.Doc, mutate: (doc: Y.Doc) => void): void {
+  const attacker = new Y.Doc();
+  Y.applyUpdate(attacker, Y.encodeStateAsUpdate(source));
+  mutate(attacker);
+  const update = Y.encodeStateAsUpdate(attacker, Y.encodeStateVector(target));
+  Y.applyUpdate(target, update, 'relay');
+}
+
+describe('hostile shared shapes on the receive path', () => {
+  test('a non-map node record does not crash a receiving replica', async () => {
+    const { alice, bob } = await harness.pair(collaborationDocx());
+    // Before the fix this threw `record.get is not a function` inside applyUpdate, escaping
+    // into the provider and downing bob.
+    expect(() =>
+      deliverHostile(alice.ydoc, bob.ydoc, (doc) => {
+        doc.getMap(NODES).set('junk-node', 'not-a-map' as never);
+      })
+    ).not.toThrow();
+    // The room stays usable: the honest author can still edit and bob still materializes.
+    harness.apply(alice, [
+      { op: 'insertText', paragraphId: harness.paragraphIdAt(alice, 0), offset: 0, text: 'ok ' },
+    ]);
+    expect(() => harness.packageOf(bob)).not.toThrow();
+  });
+
+  test('a non-map part entry does not crash the receiver', async () => {
+    const { alice, bob } = await harness.pair(collaborationDocx());
+    expect(() =>
+      deliverHostile(alice.ydoc, bob.ydoc, (doc) => {
+        doc.getMap(PARTS).set('junk-part', 42 as never);
+      })
+    ).not.toThrow();
+    expect(() => harness.packageOf(bob)).not.toThrow();
+  });
+
+  test('a scalar node survives a fresh join and materialize without throwing', async () => {
+    const { alice } = await harness.pair(collaborationDocx());
+    // A joiner rebuilds derived indexes from shared state and materializes — the other place
+    // a malformed record is read. Plant the junk, then stand up a fresh registry over a
+    // mirror the way a joiner does.
+    const mirror = new Y.Doc();
+    Y.applyUpdate(mirror, Y.encodeStateAsUpdate(alice.ydoc));
+    mirror.getMap(NODES).set('junk-node', 'not-a-map' as never);
+    const registry = new DocumentRegistry(mirror);
+    expect(() => registry.rebuildDerivedIndexes()).not.toThrow();
+    const materializer = new PackageMaterializer(registry, new MemoryBlobStore());
+    expect(() => materializer.current()).not.toThrow();
+    materializer.destroy();
+    registry.destroy();
+    mirror.destroy();
+  });
+});

--- a/packages/pro/src/collaboration/__tests__/document-hostile-shapes.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-hostile-shapes.test.ts
@@ -11,8 +11,9 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
+import type { OoxmlNode } from '@docx-editor.dev/core/store';
 import { DocumentRegistry, PackageMaterializer, MemoryBlobStore } from '../document/index.ts';
-import { createPeerHarness } from './document-peer-support.ts';
+import { createPeerHarness, walk } from './document-peer-support.ts';
 import { collaborationDocx } from './support.ts';
 
 const harness = createPeerHarness('hostile-shapes-room');
@@ -75,5 +76,60 @@ describe('hostile shared shapes on the receive path', () => {
     materializer.destroy();
     registry.destroy();
     mirror.destroy();
+  });
+
+  test('a map-shaped node record with no children array does not crash materialize', async () => {
+    // isNodeMap passes but the inner `children` is missing: the materializer's record reader
+    // reaches childArray, which throws `no children at ...`. Same impact as #567, a different
+    // crafted shape. Overwrite a real reachable element record (a part root) with a bare map.
+    const { alice } = await harness.pair(collaborationDocx());
+    const mirror = new Y.Doc();
+    Y.applyUpdate(mirror, Y.encodeStateAsUpdate(alice.ydoc));
+    const nodes = mirror.getMap<Y.Map<unknown>>(NODES);
+    let victim: string | undefined;
+    nodes.forEach((_record, id) => {
+      if (!victim) victim = id;
+    });
+    expect(victim).toBeTruthy();
+    const bare = new Y.Map<unknown>();
+    bare.set('s', 'generic-p');
+    mirror.transact(() => nodes.set(victim!, bare));
+    const registry = new DocumentRegistry(mirror);
+    expect(() => registry.rebuildDerivedIndexes()).not.toThrow();
+    const materializer = new PackageMaterializer(registry, new MemoryBlobStore());
+    expect(() => materializer.current()).not.toThrow();
+    materializer.destroy();
+    registry.destroy();
+    mirror.destroy();
+  });
+
+  test('a contested placement with a malformed record does not crash resolution', async () => {
+    // Two parents list one child (a contest), and that child's record is a scalar. The
+    // contested-placement walk reads it during resolveParents on the receive path.
+    const { alice, bob } = await harness.pair(collaborationDocx());
+    const bodyRootId = alice.store.bodyStore().part.root.id;
+    let childId: string | undefined;
+    walk(alice.store.bodyStore().part.root, (node: OoxmlNode) => {
+      if (!childId && node.kind === 'paragraph') childId = node.id;
+    });
+    expect(childId).toBeTruthy();
+    expect(() =>
+      deliverHostile(alice.ydoc, bob.ydoc, (doc) => {
+        const nodes = doc.getMap<Y.Map<unknown>>(NODES);
+        // A second parent that also lists the child — the contest — plus the child turned
+        // into a scalar.
+        const rogue = new Y.Map<unknown>();
+        rogue.set('s', 'generic-rogue');
+        const kids = new Y.Array<string>();
+        kids.insert(0, [childId!]);
+        rogue.set('children', kids);
+        nodes.set('rogue-parent', rogue);
+        const bodyChildren = nodes.get(bodyRootId)?.get('children');
+        if (bodyChildren instanceof Y.Array)
+          bodyChildren.insert(bodyChildren.length, ['rogue-parent']);
+        nodes.set(childId!, 'not-a-map' as never);
+      })
+    ).not.toThrow();
+    expect(() => harness.packageOf(bob)).not.toThrow();
   });
 });

--- a/packages/pro/src/collaboration/__tests__/document-story-variants.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-story-variants.test.ts
@@ -84,6 +84,37 @@ interface StoryCase {
   readonly bytes: () => Uint8Array;
   readonly scope: StoryScope;
   readonly op: (paragraphId: string) => TreeDocOp;
+  /** The element the edit must leave in the receiver's story part. */
+  readonly expectLocalName: string;
+}
+
+const STORY_PART_NAME: Record<string, string> = {
+  headerFooter: '/word/header1.xml',
+  notesPart: '/word/footnotes.xml',
+};
+
+function storyPartFromPackage(peer: Peer, scope: StoryScope): OoxmlNode {
+  const name = STORY_PART_NAME[scope.kind];
+  const part = peer.store.currentPackage().parts.get(name);
+  if (!part) throw new Error(`no ${name} in package`);
+  return part.root;
+}
+
+function containsLocalName(root: OoxmlNode, localName: string): boolean {
+  let present = false;
+  walk(root, (node: OoxmlNode) => {
+    if (node.kind !== 'textValue' && node.localName === localName) present = true;
+  });
+  return present;
+}
+
+function containsParaId(root: OoxmlNode): boolean {
+  let present = false;
+  walk(root, (node: OoxmlNode) => {
+    if (node.kind === 'textValue') return;
+    if (node.attributes.some((attribute) => attribute.localName === 'paraId')) present = true;
+  });
+  return present;
 }
 
 const cases: readonly StoryCase[] = [
@@ -96,6 +127,7 @@ const cases: readonly StoryCase[] = [
       paragraphId,
       properties: [{ localName: 'ind', attributes: { start: '720' } }],
     }),
+    expectLocalName: 'ind',
   },
   {
     name: 'header bold',
@@ -108,6 +140,7 @@ const cases: readonly StoryCase[] = [
       end: 3,
       properties: [{ localName: 'b' }],
     }),
+    expectLocalName: 'b',
   },
   {
     name: 'footnote indent',
@@ -118,6 +151,7 @@ const cases: readonly StoryCase[] = [
       paragraphId,
       properties: [{ localName: 'ind', attributes: { start: '720' } }],
     }),
+    expectLocalName: 'ind',
   },
   {
     name: 'footnote bold',
@@ -130,6 +164,7 @@ const cases: readonly StoryCase[] = [
       end: 3,
       properties: [{ localName: 'b' }],
     }),
+    expectLocalName: 'b',
   },
 ];
 
@@ -139,11 +174,22 @@ describe('property variants replicate in non-body stories', () => {
       const { alice, bob } = await harness.pair(testCase.bytes());
       const paragraphId = textParagraphId(alice, testCase.scope);
       harness.apply(alice, [testCase.op(paragraphId)], testCase.scope);
-      // Open the receiver's story store — the "bob views the header/note" flow — so the
-      // comparison sees the story part bob materialized from shared state, not the
-      // pre-open overlay. Opening it is also what a real reader does before editing there.
-      bob.store.partFor(testCase.scope);
       expect(bob.room.session.statusSnapshot().status).toBe('ready');
+
+      // Gap 2's core claim: the property VALUE replicates into a non-body story WITHOUT the
+      // receiver opening that story store — read it straight from bob's materialized package.
+      const received = storyPartFromPackage(bob, testCase.scope);
+      expect(containsLocalName(received, testCase.expectLocalName)).toBe(true);
+
+      // Known limitation (#580): the received story part lacks `w14:paraId` until bob opens
+      // the store, so a peer that saves a story it never opened loses paragraph identity.
+      // Pinned here so a fix visibly flips it; the author's part keeps its paraId.
+      expect(containsParaId(storyPartFromPackage(alice, testCase.scope))).toBe(true);
+      expect(containsParaId(received)).toBe(false);
+
+      // Once the receiver opens the story — the ordinary "view the header/note" flow — the
+      // two packages fully converge, identity included.
+      bob.store.partFor(testCase.scope);
       harness.expectConverged(alice, bob);
     });
   }

--- a/packages/pro/src/collaboration/__tests__/document-story-variants.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-story-variants.test.ts
@@ -1,0 +1,150 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Variant coverage is body-scoped; this proves the STORY dimension replicates (gap 2).
+//
+// A property authored in a header or a footnote transacts against a different store, so its
+// journal takes a different path to shared state than the body. These cases drive a
+// representative property through the real registry + materializer in each non-body story and
+// assert the peer converges, closing the "replicates in the body but maybe not in a header"
+// gap. A story-specific replication regression fails here.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { OoxmlNode, StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
+import { createPeerHarness, walk, zipDocument, type Peer } from './document-peer-support.ts';
+
+const harness = createPeerHarness('story-variants-room');
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const HEADER: StoryScope = { kind: 'headerFooter', rId: 'rId7' };
+const FOOTNOTES: StoryScope = { kind: 'notesPart', noteKind: 'footnote' };
+
+function headerDoc(): Uint8Array {
+  return zipDocument(
+    '<w:p><w:pPr><w:sectPr><w:headerReference w:type="default" r:id="rId7"/>' +
+      '</w:sectPr></w:pPr><w:r><w:t>body</w:t></w:r></w:p>',
+    {
+      documentRels:
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId7" Type="${R}/header" Target="header1.xml"/></Relationships>`,
+      overrides:
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>',
+      extraXml: {
+        'word/header1.xml': `<w:hdr xmlns:w="${W}"><w:p><w:r><w:t>Header text</w:t></w:r></w:p></w:hdr>`,
+      },
+    }
+  );
+}
+
+function footnoteDoc(): Uint8Array {
+  const notes =
+    `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:id="1"><w:p><w:r><w:footnoteRef/></w:r><w:r><w:t>note text</w:t></w:r></w:p></w:footnote>`;
+  return zipDocument(
+    '<w:p><w:r><w:t>Hi</w:t></w:r><w:r><w:footnoteReference w:id="1"/></w:r></w:p><w:sectPr/>',
+    {
+      documentRels:
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`,
+      overrides:
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>',
+      extraXml: { 'word/footnotes.xml': `<w:footnotes xmlns:w="${W}">${notes}</w:footnotes>` },
+    }
+  );
+}
+
+/** First paragraph carrying real text in a story part (skips separator/ref-only paragraphs). */
+function textParagraphId(peer: Peer, scope: StoryScope): string {
+  const part = peer.store.partFor(scope);
+  if (!part) throw new Error('missing story part');
+  let found: string | undefined;
+  walk(part.root, (node: OoxmlNode) => {
+    if (found || node.kind !== 'paragraph') return;
+    let hasText = false;
+    walk(node, (child) => {
+      if (child.kind === 'textValue' && child.value.length > 0) hasText = true;
+    });
+    if (hasText) found = node.id;
+  });
+  if (!found) throw new Error('no text paragraph in story');
+  return found;
+}
+
+interface StoryCase {
+  readonly name: string;
+  readonly bytes: () => Uint8Array;
+  readonly scope: StoryScope;
+  readonly op: (paragraphId: string) => TreeDocOp;
+}
+
+const cases: readonly StoryCase[] = [
+  {
+    name: 'header indent',
+    bytes: headerDoc,
+    scope: HEADER,
+    op: (paragraphId) => ({
+      op: 'setParagraphProperties',
+      paragraphId,
+      properties: [{ localName: 'ind', attributes: { start: '720' } }],
+    }),
+  },
+  {
+    name: 'header bold',
+    bytes: headerDoc,
+    scope: HEADER,
+    op: (paragraphId) => ({
+      op: 'setRunProperties',
+      paragraphId,
+      start: 0,
+      end: 3,
+      properties: [{ localName: 'b' }],
+    }),
+  },
+  {
+    name: 'footnote indent',
+    bytes: footnoteDoc,
+    scope: FOOTNOTES,
+    op: (paragraphId) => ({
+      op: 'setParagraphProperties',
+      paragraphId,
+      properties: [{ localName: 'ind', attributes: { start: '720' } }],
+    }),
+  },
+  {
+    name: 'footnote bold',
+    bytes: footnoteDoc,
+    scope: FOOTNOTES,
+    op: (paragraphId) => ({
+      op: 'setRunProperties',
+      paragraphId,
+      start: 0,
+      end: 3,
+      properties: [{ localName: 'b' }],
+    }),
+  },
+];
+
+describe('property variants replicate in non-body stories', () => {
+  for (const testCase of cases) {
+    test(`${testCase.name} reaches the peer`, async () => {
+      const { alice, bob } = await harness.pair(testCase.bytes());
+      const paragraphId = textParagraphId(alice, testCase.scope);
+      harness.apply(alice, [testCase.op(paragraphId)], testCase.scope);
+      // Open the receiver's story store — the "bob views the header/note" flow — so the
+      // comparison sees the story part bob materialized from shared state, not the
+      // pre-open overlay. Opening it is also what a real reader does before editing there.
+      bob.store.partFor(testCase.scope);
+      expect(bob.room.session.statusSnapshot().status).toBe('ready');
+      harness.expectConverged(alice, bob);
+    });
+  }
+});

--- a/packages/pro/src/collaboration/document/registry-contested-placement.ts
+++ b/packages/pro/src/collaboration/document/registry-contested-placement.ts
@@ -20,7 +20,7 @@ Production use requires a commercial agreement: licensing@eigenpal.com
  * is decided by the same first-preorder rule.
  */
 
-import { NODE_DELETED_FIELD, childArrayOf, type PackageSchema } from './schema.ts';
+import { childArrayOf, isNodeMap, nodeRecordTombstoned, type PackageSchema } from './schema.ts';
 import type { LogicalId } from './identity.ts';
 
 export interface ContestContext {
@@ -48,14 +48,13 @@ function compareRanks(left: Rank, right: Rank): number {
 function childrenOf(ctx: ContestContext, id: LogicalId): readonly LogicalId[] {
   const snapshot = ctx.childrenSnapshot.get(id);
   if (snapshot) return snapshot;
-  const rec = ctx.nodes.get(id);
-  return rec ? (childArrayOf(rec)?.toArray() ?? []) : [];
+  return childArrayOf(ctx.nodes.get(id))?.toArray() ?? [];
 }
 
-/** A node the walk would not iterate: missing from shared state, or tombstoned. */
+/** A node the walk would not iterate: missing from shared state, malformed, or tombstoned. */
 function isDead(ctx: ContestContext, id: LogicalId): boolean {
   const rec = ctx.nodes.get(id);
-  return !rec || rec.get(NODE_DELETED_FIELD) === true;
+  return !isNodeMap(rec) || nodeRecordTombstoned(rec);
 }
 
 /**
@@ -189,7 +188,7 @@ export function assignFirstReachableParents(
       }
       if (path.has(id)) continue;
       const rec = nodes.get(id);
-      if (!rec || rec.get(NODE_DELETED_FIELD) === true) continue;
+      if (!isNodeMap(rec) || nodeRecordTombstoned(rec)) continue;
       const children = childrenSnapshot.get(id) ?? childArrayOf(rec)?.toArray() ?? [];
       path.add(id);
       stack.push({ id, parent: null, exit: true });

--- a/packages/pro/src/collaboration/document/registry-node-reads.ts
+++ b/packages/pro/src/collaboration/document/registry-node-reads.ts
@@ -19,6 +19,7 @@ import {
   NODE_SHELL_FIELD,
   NODE_TEXT_FIELD,
   childArrayOf,
+  isNodeMap,
   isTextNodeMap,
   unpackNodeShell,
 } from './schema.ts';
@@ -33,7 +34,8 @@ export interface NodeShape {
 /** One node's class, text length and child ids. `children` is fresh, so callers may splice it. */
 export function nodeShapeOf(nodes: Y.Map<Y.Map<unknown>>, logicalId: string): NodeShape | null {
   const rec = nodes.get(logicalId);
-  if (!rec) return null;
+  // The nodes map is peer-writable; a scalar value is not a node.
+  if (!isNodeMap(rec)) return null;
   if (isTextNodeMap(rec)) {
     // `Y.Text.length` is a counter. `toString()` builds the whole paragraph to measure it.
     const text = rec.get(NODE_TEXT_FIELD);
@@ -45,7 +47,7 @@ export function nodeShapeOf(nodes: Y.Map<Y.Map<unknown>>, logicalId: string): No
 /** One node's kind, without building its text or its attribute arrays. */
 export function nodeKindOf(nodes: Y.Map<Y.Map<unknown>>, logicalId: string): string | null {
   const rec = nodes.get(logicalId);
-  if (!rec) return null;
+  if (!isNodeMap(rec)) return null;
   if (isTextNodeMap(rec)) return 'textValue';
   const shell = rec.get(NODE_SHELL_FIELD);
   return unpackNodeShell(typeof shell === 'string' ? shell : '').kind;

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -236,8 +236,7 @@ export class DocumentRegistry {
   record(logicalId: LogicalId): SharedRecord | null {
     if (rejectDangerousKey(logicalId)) return null;
     const rec = this.schema.nodes.get(logicalId);
-    // A peer can plant a scalar in the nodes map; treat it as no such node rather than
-    // reading a field off it inside the materializer.
+    // A peer can plant a scalar here; treat it as no such node (see #567).
     if (!isNodeMap(rec)) return null;
     if (isTextNodeMap(rec)) {
       const text = rec.get(NODE_TEXT_FIELD);
@@ -973,7 +972,9 @@ export class DocumentRegistry {
       prefix: shell.prefix.length > 0 ? shell.prefix : undefined,
       attributes,
       bindings,
-      childIds: this.childArray(logicalId).toArray(),
+      // A peer can plant a map record whose `children` is missing or not a Y.Array; degrade
+      // to an empty list rather than reaching the throwing `childArray` (see #567).
+      childIds: childArrayOf(rec)?.toArray() ?? [],
     };
   }
 

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -31,6 +31,8 @@ import {
   makeRelationshipEntry,
   makeTextRecord,
   namespaceUriOf,
+  nodeRecordReplacedBy,
+  nodeRecordTombstoned,
   packNodeShell,
   packageSchemaOf,
   parseAttributeMapKey,
@@ -234,7 +236,9 @@ export class DocumentRegistry {
   record(logicalId: LogicalId): SharedRecord | null {
     if (rejectDangerousKey(logicalId)) return null;
     const rec = this.schema.nodes.get(logicalId);
-    if (!rec) return null;
+    // A peer can plant a scalar in the nodes map; treat it as no such node rather than
+    // reading a field off it inside the materializer.
+    if (!isNodeMap(rec)) return null;
     if (isTextNodeMap(rec)) {
       const text = rec.get(NODE_TEXT_FIELD);
       const value = text instanceof Y.Text ? text.toString() : '';
@@ -260,12 +264,11 @@ export class DocumentRegistry {
   }
 
   isTombstoned(logicalId: LogicalId): boolean {
-    return this.schema.nodes.get(logicalId)?.get(NODE_DELETED_FIELD) === true;
+    return nodeRecordTombstoned(this.schema.nodes.get(logicalId));
   }
 
   replacedByOf(logicalId: LogicalId): LogicalId | null {
-    const value = this.schema.nodes.get(logicalId)?.get(NODE_REPLACED_BY_FIELD);
-    return typeof value === 'string' && value.length > 0 ? value : null;
+    return nodeRecordReplacedBy(this.schema.nodes.get(logicalId));
   }
 
   adoptedChildren(survivorId: LogicalId): readonly LogicalId[] {
@@ -669,7 +672,7 @@ export class DocumentRegistry {
       for (const childId of childIds) this.addListing(childId, parentId);
     });
     this.schema.nodes.forEach((rec, id) => {
-      if (rec.get(NODE_DELETED_FIELD) === true) this.syncAdoptee(id);
+      if (nodeRecordTombstoned(rec)) this.syncAdoptee(id);
     });
     this.schema.attributes.forEach((packed, key) => {
       if (typeof packed !== 'string' || rejectDangerousKey(key)) return;
@@ -900,9 +903,9 @@ export class DocumentRegistry {
       }
     }
     const rec = this.schema.nodes.get(removedId);
-    const survivor = rec?.get(NODE_REPLACED_BY_FIELD);
-    if (typeof survivor !== 'string' || survivor.length === 0) return;
-    if (rec?.get(NODE_DELETED_FIELD) === true) {
+    const survivor = nodeRecordReplacedBy(rec);
+    if (survivor === null) return;
+    if (nodeRecordTombstoned(rec)) {
       const sources = this.tombstoneSources.get(survivor) ?? new Set<LogicalId>();
       sources.add(removedId);
       this.tombstoneSources.set(survivor, sources);

--- a/packages/pro/src/collaboration/document/schema.ts
+++ b/packages/pro/src/collaboration/document/schema.ts
@@ -430,15 +430,33 @@ export function writeSchemaVersions(meta: Y.Map<unknown>): void {
   meta.set('initialized', true);
 }
 
-export function childArrayOf(record: Y.Map<unknown>): Y.Array<string> | null {
+export function isNodeMap(value: unknown): value is Y.Map<unknown> {
+  return value instanceof Y.Map;
+}
+
+// The nodes map is peer-writable, so a value read from it is attacker-controlled: a hostile
+// update can plant a scalar where a record belongs. Every reader below takes `unknown` and
+// treats a non-map as "no such node", so a crafted shape degrades to an absent node rather
+// than crashing the observer or the materializer mid-`applyUpdate`.
+
+export function childArrayOf(record: unknown): Y.Array<string> | null {
+  if (!isNodeMap(record)) return null;
   const children = record.get(NODE_CHILDREN_FIELD);
   return children instanceof Y.Array ? children : null;
 }
 
-export function isTextNodeMap(record: Y.Map<unknown>): boolean {
-  return record.get(NODE_TEXT_FIELD) instanceof Y.Text;
+export function isTextNodeMap(record: unknown): boolean {
+  return isNodeMap(record) && record.get(NODE_TEXT_FIELD) instanceof Y.Text;
 }
 
-export function isNodeMap(value: unknown): value is Y.Map<unknown> {
-  return value instanceof Y.Map;
+/** True only when `record` is a node map flagged tombstoned. A non-map reads as not-a-node. */
+export function nodeRecordTombstoned(record: unknown): boolean {
+  return isNodeMap(record) && record.get(NODE_DELETED_FIELD) === true;
+}
+
+/** The survivor a tombstone names, or null when `record` is not a node map or names none. */
+export function nodeRecordReplacedBy(record: unknown): string | null {
+  if (!isNodeMap(record)) return null;
+  const value = record.get(NODE_REPLACED_BY_FIELD);
+  return typeof value === 'string' && value.length > 0 ? value : null;
 }


### PR DESCRIPTION
Follows up the collaboration-expressibility guarantee (#575) by closing three gaps it left: non-body stories, concurrent merges, and the trust boundary.

**Gap 4 — trust boundary (fixes #567).** The shared node map is peer-writable, so a hostile update can plant a scalar, or a map without a valid `children` array, where a record belongs. Every receive-path reader — the registry observers that fire during `applyUpdate`, the derived-index rebuild, the contested-placement walk, and the materializer — now treats a malformed value as an absent node through guarded schema helpers, degrading a crafted shape instead of throwing synchronously into the provider and downing every replica. Covered by `document-hostile-shapes.test.ts` (scalar record, map without children, and a contested placement with a malformed record, all delivered over real `Y.applyUpdate`).

**Gap 3 — concurrent convergence.** `document-concurrent-variants.test.ts` races two peers on the same target through the real registry and materializer, asserting the merged document is actually correct — edits present, text intact — not merely that the peers agree. Independent property edits, run formatting concurrent with text, and a property concurrent with text all converge cleanly. The oracle surfaced two same-container conflicts that do not: concurrent `setParagraphProperties` on one paragraph escalates both peers to `error` (#579), and concurrent `setRunProperties` on one paragraph silently duplicates its text (#581). Both are pinned so a fix flips them.

**Gap 2 — non-body stories.** `document-story-variants.test.ts` proves a paragraph and a run property replicate into header and footnote stories, reading the receiver's materialized package without opening the story store. It pins a related limitation: the received story part lacks `w14:paraId` until opened, so a peer that saves a story it never opened drops paragraph identity (#580).

New issues filed from this coverage: #579, #580, #581. No public API change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790513077&installation_model_id=422592&pr_number=582&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F582&signature=ab516d952fba6daa0b29f174052ba2147d48129f777746d0f8fd140d9468cce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->