### PR TITLE
feat(examples): compose the packaged fonts with the Google catalog

### DIFF
--- a/examples/vite/src/ComposedEditorDemo.tsx
+++ b/examples/vite/src/ComposedEditorDemo.tsx
@@ -31,6 +31,7 @@ import { CustomNodeContextMenu, DocxEditorReview } from '@docx-editor.dev/pro/re
 import { useWebrtcCollaboration } from '@docx-editor.dev/pro/react/webrtc';
 import { blankDocumentBytes } from '@docx-editor.dev/core/editor';
 import { packagedFonts } from '@docx-editor.dev/fonts';
+import { googleFonts } from '@docx-editor.dev/fonts/google';
 import { BrandLogo } from '../../shared/BrandLogo';
 import { AdapterSwitcher } from '../../shared/AdapterSwitcher';
 import { SourceLink } from '../../shared/SourceLink';
@@ -613,14 +614,21 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
   // on-demand path there is no font work in flight to cancel, because none starts until
   // the engine has parsed the document.
   //
-  // `packagedFonts()` resolves ON DEMAND: the engine calls it after the parse with the
+  // Both resolvers resolve ON DEMAND: the engine calls them after the parse with the
   // families this fixture declares. A family loads when the document names it, or when it
   // is the document's default face — Calibri here, so Carlito comes along whatever the
   // fixture says. What it avoids is loading all five eager families up front.
   //
-  // Nothing is fetched from a third party — the bytes are the ones inside
-  // `@docx-editor.dev/fonts`. Add
-  // `googleFonts()` next to it and the catalog covers what the packaged families do not.
+  // ORDER IS PRECEDENCE, and this direction is the point. `packagedFonts()` answers first
+  // from bytes inside `@docx-editor.dev/fonts`, so a document naming Calibri never touches
+  // the network. `googleFonts()` sees what the packaged origin already covers and fetches
+  // only the rest, so composing the two never downloads the same face twice. Reverse them
+  // and a local byte would lose to a CDN round trip.
+  //
+  // The catalog IS a third party: naming a family the bundle does not carry costs a
+  // request to jsdelivr. The family name never becomes part of that URL — it is a lookup
+  // key against a closed, commit-pinned catalog — and a failed fetch degrades to the fixed
+  // measurer rather than breaking the document.
   //
   // The trade is one reflow. Nothing can know the families before the parse, so the
   // document opens on the fixed measurer and re-paginates when the faces land; the eager
@@ -630,7 +638,7 @@ export function ComposedEditorDemo({ fixtureUrl }: { fixtureUrl: string }) {
     document: bytes,
     fonts,
     error: loadError,
-  } = useDocxSource(fixtureUrl, { fonts: packagedFonts() });
+  } = useDocxSource(fixtureUrl, { fonts: [packagedFonts(), googleFonts()] });
 
   const activeDocument = collaboration.document ?? bytes;
 

--- a/examples/vue/src/ComposedEditorDemo.vue
+++ b/examples/vue/src/ComposedEditorDemo.vue
@@ -93,6 +93,7 @@ import {
   DocxEditorReview,
 } from '@docx-editor.dev/pro/vue';
 import { packagedFonts } from '@docx-editor.dev/fonts';
+import { googleFonts } from '@docx-editor.dev/fonts/google';
 import EditorChrome from './EditorChrome.vue';
 import PerfHud from './PerfHud.vue';
 import CitationDialog from './CitationDialog.vue';
@@ -125,12 +126,18 @@ const title = ref(
 const colorMode = ref<'light' | 'dark'>('light');
 const citationForm = ref<CitationFormState | null>(null);
 
+// ORDER IS PRECEDENCE. `packagedFonts()` answers first from bytes inside
+// `@docx-editor.dev/fonts`, so a document naming Calibri never touches the network.
+// `googleFonts()` is told which faces the packaged origin already covers and fetches only
+// the rest, so composing the two never downloads the same face twice. The catalog IS a
+// third party: naming a family the bundle does not carry costs a request to jsdelivr, and
+// a failed fetch reaches `onFontError` below and degrades to the fixed measurer.
 const {
   document: bytes,
   fonts,
   error: loadError,
 } = useDocxSource(props.fixtureUrl, {
-  fonts: packagedFonts(),
+  fonts: [packagedFonts(), googleFonts()],
 });
 
 function onFontError(error: { code: string; message: string }): void {


### PR DESCRIPTION
The vite and Vue demos served only the six packaged families. A document naming anything else fell back to the fixed measurer, so the demos never showed the composition the fonts package is built for.

Both now compose `packagedFonts()` with `googleFonts()`.

## What changes

Order is precedence, and the direction carries the behavior:

1. `packagedFonts()` answers first, from bytes inside `@docx-editor.dev/fonts`. A document naming Calibri never touches the network.
2. `googleFonts()` is told which faces the packaged origin already covers, and fetches only the rest.

Composing the two never fetches the same face twice. Reverse them and a local byte loses to a CDN round trip.

## Measured behavior

For a request naming Montserrat and Lato with Calibri as the default face:

| Source | Faces |
| --- | --- |
| Bundle | 4 Carlito |
| Catalog | 8: Montserrat and Lato |
| Carlito refetched from the catalog | 0 |

## Security

Opening a document now performs network requests, which the engine never does on its own. Two properties keep that safe, both verified in the code rather than assumed:

- A document-declared family is only a lookup key against a closed, commit-pinned catalog. The name never becomes part of a URL: `face.url` comes from the generated catalog entry.
- Every face is trusted by content hash, not by origin.

The app opts in explicitly by composing the resolver. A document cannot cause a fetch on its own.

## Failure behavior

A failed fetch degrades to the fixed measurer and does not break the document. Both demos already pass `onFontError`, so a rejected face reports its code and message to the console.

## Scope

The vite E2E harnesses keep eager `defaultFonts`, so a benchmark still measures layout rather than font arrival. The happy-path, igloo, and collaboration demos are unchanged.

No changeset: both demos are private packages and publish nothing, matching the examples-only precedent in #500.

## Merge order

This targets `feat/font-setup-dx` because `packagedFonts()` and the origin-list form land in #573. Retarget it to `main` once #573 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790527203&installation_model_id=422592&pr_number=593&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F593&signature=bac2f8a09d321cab65e6609c633844842297a934f2cbb1b2f127bfaecfb83ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->