### PR TITLE
fix(collaboration): converge a concurrent run-property edit (#581)

### DIFF
--- a/.changeset/converge-concurrent-run-format.md
+++ b/.changeset/converge-concurrent-run-format.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Two people formatting the same paragraph at once no longer duplicate its text. Concurrent run-property edits now converge deterministically — one peer's formatting wins and the text stays intact — instead of silently doubling it on every replica. Fixes #581.

--- a/.changeset/converge-concurrent-run-format.md
+++ b/.changeset/converge-concurrent-run-format.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/pro': patch
 ---
 
-Two people formatting the same paragraph at once no longer duplicate its text. Concurrent run-property edits now converge deterministically — one peer's formatting wins and the text stays intact — instead of silently doubling it on every replica. Fixes #581.
+Two people formatting the same paragraph at once no longer duplicate its text. A concurrent run-property edit now converges deterministically — one peer's formatting wins and the text stays intact — instead of silently doubling it on every replica. Fixes #581.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "examples/collaboration": {
       "name": "@docx-editor.dev/example-collaboration",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "@docx-editor.dev/editor-api": "workspace:*",
@@ -324,9 +324,9 @@
     },
     "packages/core": {
       "name": "@docx-editor.dev/core",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.10.0",
+        "@docx-editor.dev/i18n": "^2.11.0",
         "bidi-js": "1.0.3",
         "emf-converter": "2.0.2",
         "fast-xml-parser": "^5.10.1",
@@ -358,7 +358,7 @@
     },
     "packages/editor-api": {
       "name": "@docx-editor.dev/editor-api",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "@microsoft/api-extractor": "^7.50.0",
@@ -366,12 +366,12 @@
         "license-check-and-add": "^4.0.5",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.10.0",
+        "@docx-editor.dev/core": "~2.11.0",
       },
     },
     "packages/fonts": {
       "name": "@docx-editor.dev/fonts",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "typescript": "^5.3.3",
@@ -379,7 +379,7 @@
     },
     "packages/i18n": {
       "name": "@docx-editor.dev/i18n",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "devDependencies": {
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
@@ -387,7 +387,7 @@
     },
     "packages/nuxt": {
       "name": "@docx-editor.dev/nuxt",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
         "@docx-editor.dev/vue": "^2.9.1",
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
@@ -413,7 +413,7 @@
     },
     "packages/pro": {
       "name": "@docx-editor.dev/pro",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
         "y-protocols": "^1.0.7",
       },
@@ -437,9 +437,9 @@
         "zod": "^4.4.3",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.10.0",
-        "@docx-editor.dev/react": "~2.10.0",
-        "@docx-editor.dev/vue": "~2.10.0",
+        "@docx-editor.dev/core": "~2.11.0",
+        "@docx-editor.dev/react": "~2.11.0",
+        "@docx-editor.dev/vue": "~2.11.0",
         "@hocuspocus/provider": "^4.6.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
@@ -460,9 +460,9 @@
     },
     "packages/react": {
       "name": "@docx-editor.dev/react",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.10.0",
+        "@docx-editor.dev/i18n": "^2.11.0",
         "@radix-ui/react-select": "^2.3.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -472,7 +472,7 @@
         "fflate": "^0.8.2",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.10.0",
+        "@docx-editor.dev/core": "~2.11.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
       },
@@ -483,9 +483,9 @@
     },
     "packages/vue": {
       "name": "@docx-editor.dev/vue",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.10.0",
+        "@docx-editor.dev/i18n": "^2.11.0",
       },
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
@@ -493,7 +493,7 @@
         "vue": "^3.5.29",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.10.0",
+        "@docx-editor.dev/core": "~2.11.0",
         "vue": "^3.3.0",
       },
       "optionalPeers": [

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "examples/collaboration": {
       "name": "@docx-editor.dev/example-collaboration",
-      "version": "0.0.1",
+      "version": "0.0.0",
       "dependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "@docx-editor.dev/editor-api": "workspace:*",
@@ -324,9 +324,9 @@
     },
     "packages/core": {
       "name": "@docx-editor.dev/core",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.11.0",
+        "@docx-editor.dev/i18n": "^2.10.0",
         "bidi-js": "1.0.3",
         "emf-converter": "2.0.2",
         "fast-xml-parser": "^5.10.1",
@@ -358,7 +358,7 @@
     },
     "packages/editor-api": {
       "name": "@docx-editor.dev/editor-api",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "@microsoft/api-extractor": "^7.50.0",
@@ -366,12 +366,12 @@
         "license-check-and-add": "^4.0.5",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.11.0",
+        "@docx-editor.dev/core": "~2.10.0",
       },
     },
     "packages/fonts": {
       "name": "@docx-editor.dev/fonts",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
         "typescript": "^5.3.3",
@@ -379,7 +379,7 @@
     },
     "packages/i18n": {
       "name": "@docx-editor.dev/i18n",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "devDependencies": {
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
@@ -387,7 +387,7 @@
     },
     "packages/nuxt": {
       "name": "@docx-editor.dev/nuxt",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "dependencies": {
         "@docx-editor.dev/vue": "^2.9.1",
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
@@ -413,7 +413,7 @@
     },
     "packages/pro": {
       "name": "@docx-editor.dev/pro",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "dependencies": {
         "y-protocols": "^1.0.7",
       },
@@ -437,9 +437,9 @@
         "zod": "^4.4.3",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.11.0",
-        "@docx-editor.dev/react": "~2.11.0",
-        "@docx-editor.dev/vue": "~2.11.0",
+        "@docx-editor.dev/core": "~2.10.0",
+        "@docx-editor.dev/react": "~2.10.0",
+        "@docx-editor.dev/vue": "~2.10.0",
         "@hocuspocus/provider": "^4.6.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
@@ -460,9 +460,9 @@
     },
     "packages/react": {
       "name": "@docx-editor.dev/react",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.11.0",
+        "@docx-editor.dev/i18n": "^2.10.0",
         "@radix-ui/react-select": "^2.3.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -472,7 +472,7 @@
         "fflate": "^0.8.2",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.11.0",
+        "@docx-editor.dev/core": "~2.10.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
       },
@@ -483,9 +483,9 @@
     },
     "packages/vue": {
       "name": "@docx-editor.dev/vue",
-      "version": "2.11.0",
+      "version": "2.10.0",
       "dependencies": {
-        "@docx-editor.dev/i18n": "^2.11.0",
+        "@docx-editor.dev/i18n": "^2.10.0",
       },
       "devDependencies": {
         "@docx-editor.dev/core": "workspace:*",
@@ -493,7 +493,7 @@
         "vue": "^3.5.29",
       },
       "peerDependencies": {
-        "@docx-editor.dev/core": "~2.11.0",
+        "@docx-editor.dev/core": "~2.10.0",
         "vue": "^3.3.0",
       },
       "optionalPeers": [

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+// Concurrent run-property edits on one paragraph converge without duplicating text (#581).
+//
+// `setRunProperties` splits the target run and replaces it with new runs carrying copies of
+// the partitioned text. Two peers doing this at once left both run-sets in the paragraph, so
+// the text doubled and both replicas agreed on the corruption. Each new run now records the
+// origin run it superseded; materialize groups the concurrent splits under that origin and
+// keeps one replica's runs deterministically. These cases pin: no duplication, both peers
+// converge (fingerprint + save/reopen digest), a mark from the winner survives, and the
+// mechanism does not misfire on independent or single-author edits.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { OoxmlNode, StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
+import { BODY, createPeerHarness, walk, zipDocument, type Peer } from './document-peer-support.ts';
+
+const harness = createPeerHarness('concurrent-run-format-room');
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+const PARA0 = 'Alpha bravo canvas delta editor';
+const PARA1 = 'Second paragraph here';
+
+function doc(): Uint8Array {
+  return zipDocument(
+    `<w:p><w:r><w:t>${PARA0}</w:t></w:r></w:p>` +
+      `<w:p><w:r><w:t>${PARA1}</w:t></w:r></w:p><w:sectPr/>`
+  );
+}
+
+function bodyText(peer: Peer): string {
+  const texts: string[] = [];
+  walk(peer.store.bodyStore().part.root, (node: OoxmlNode) => {
+    if (node.kind === 'textValue') texts.push(node.value);
+  });
+  return texts.join('');
+}
+
+function markCount(peer: Peer, localName: string): number {
+  let count = 0;
+  walk(peer.store.bodyStore().part.root, (node: OoxmlNode) => {
+    if (node.kind !== 'textValue' && node.localName === localName) count += 1;
+  });
+  return count;
+}
+
+function runProps(
+  peer: Peer,
+  paraIndex: number,
+  start: number,
+  end: number,
+  localName: string
+): TreeDocOp {
+  return {
+    op: 'setRunProperties',
+    paragraphId: harness.paragraphIdAt(peer, paraIndex),
+    start,
+    end,
+    properties: [{ localName }],
+  };
+}
+
+async function race(
+  aliceOp: (peer: Peer) => TreeDocOp,
+  bobOp: (peer: Peer) => TreeDocOp,
+  scope: StoryScope = BODY
+): Promise<{ alice: Peer; bob: Peer }> {
+  const { alice, bob, pause, resume } = await harness.pair(doc());
+  pause();
+  harness.apply(alice, [aliceOp(alice)], scope);
+  harness.apply(bob, [bobOp(bob)], scope);
+  resume();
+  harness.expectConverged(alice, bob);
+  return { alice, bob };
+}
+
+describe('concurrent run-format convergence (#581)', () => {
+  test('overlapping formats on one paragraph keep the text once', async () => {
+    const { alice } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer) => runProps(peer, 0, 3, 9, 'i')
+    );
+    expect(bodyText(alice)).toBe(PARA0 + PARA1);
+    // One replica's split wins whole, so exactly one of the two marks survives.
+    expect(markCount(alice, 'b') + markCount(alice, 'i')).toBeGreaterThan(0);
+  });
+
+  test('non-overlapping formats on one paragraph keep the text once', async () => {
+    const { alice } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer) => runProps(peer, 0, 20, 25, 'i')
+    );
+    expect(bodyText(alice)).toBe(PARA0 + PARA1);
+  });
+
+  test('two multi-boundary splits at different mid positions converge', async () => {
+    // Both edits fall strictly inside the run, so each splits at two boundaries and produces
+    // an intermediate run that is removed and reinserted in one journal — the case where the
+    // origin has to be resolved to its root for every product.
+    const { alice } = await race(
+      (peer) => runProps(peer, 0, 6, 11, 'b'),
+      (peer) => runProps(peer, 0, 12, 17, 'i')
+    );
+    expect(bodyText(alice)).toBe(PARA0 + PARA1);
+  });
+
+  test('concurrent formats on DIFFERENT paragraphs both survive', async () => {
+    const { alice } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer) => runProps(peer, 1, 0, 6, 'i')
+    );
+    expect(bodyText(alice)).toBe(PARA0 + PARA1);
+    // Independent splits: neither is dropped, so both marks are present.
+    expect(markCount(alice, 'b')).toBeGreaterThan(0);
+    expect(markCount(alice, 'i')).toBeGreaterThan(0);
+  });
+
+  test('a single-author split still replicates its formatting', async () => {
+    const { alice, bob } = await harness.pair(doc());
+    harness.apply(alice, [runProps(alice, 0, 0, 5, 'b')]);
+    harness.expectConverged(alice, bob);
+    expect(bodyText(bob)).toBe(PARA0 + PARA1);
+    expect(markCount(bob, 'b')).toBe(1);
+  });
+});

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
@@ -3,7 +3,7 @@ Copyright (c) 2026 EigenPal, Inc. All rights reserved.
 Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
 Production use requires a commercial agreement: licensing@eigenpal.com
 */
-// Concurrent run-property edits on one paragraph converge without duplicating text (#581).
+// A concurrent run-property edit on one paragraph converges without duplicating text (#581).
 //
 // `setRunProperties` splits the target run and replaces it with new runs carrying copies of
 // the partitioned text. Two peers doing this at once left both run-sets in the paragraph, so
@@ -12,6 +12,10 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 // keeps one replica's runs deterministically. These cases pin: no duplication, both peers
 // converge (fingerprint + save/reopen digest), a mark from the winner survives, and the
 // mechanism does not misfire on independent or single-author edits.
+//
+// The dedup claims ONE round of concurrent splitting on a run. A later round tangles the runs
+// below what a projection repairs (issue #592); the dedup declines it and the session keeps
+// every replica on the same tree, duplicated but convergent — never divergent.
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import type { OoxmlNode, StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
@@ -146,12 +150,29 @@ describe('concurrent run-format convergence (#581)', () => {
     expect(bodyText(carol)).toBe(PARA0 + PARA1);
   });
 
+  test('a further edit after a concurrent split still converges on every replica', async () => {
+    // One round of concurrent splitting dedups to one text. A SECOND round — a peer splitting a
+    // run the first round made — tangles the runs below what this projection repairs, so the
+    // dedup declines it and every run materializes (issue #592). The point this pins is the
+    // no-regression guarantee: the editor, its collaborator, and a fresh join AGREE, so no
+    // replica saves a document another replica would not. Duplication is allowed here;
+    // divergence is not.
+    const { alice, bob } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer) => runProps(peer, 0, 3, 9, 'i')
+    );
+    harness.apply(bob, [runProps(bob, 0, 10, 16, 'b')]);
+    bob.port.flushPendingJournals();
+    harness.expectConverged(alice, bob);
+    const carol = await harness.join(bob, 'carol');
+    harness.expectConverged(bob, carol);
+  });
+
   test('concurrent typing and formatting converges without duplicating text', async () => {
-    // The dedup keeps a loser only when its text matches the winner's, so a run a peer grew by
-    // typing is never dropped as a duplicate. This peer's insert grows the origin run in place
-    // rather than splitting it, so the split still discards the typed characters when it copies
-    // the origin (issue #590, a separate concurrency gap); what this pins is that the dedup does
-    // not compound it — the peers converge and the text is not doubled.
+    // This peer's insert grows the origin run in place rather than splitting it, so it never
+    // enters the dedup. The concurrent format split still discards the typed characters when it
+    // copies the origin (issue #590, a separate concurrency gap); what this pins is that the
+    // dedup does not compound it — the peers converge and the text is not doubled.
     const { alice, bob } = await race(
       (peer) => runProps(peer, 0, 0, 5, 'b'),
       (peer): TreeDocOp => ({

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
@@ -127,4 +127,42 @@ describe('concurrent run-format convergence (#581)', () => {
     expect(bodyText(bob)).toBe(PARA0 + PARA1);
     expect(markCount(bob, 'b')).toBe(1);
   });
+
+  test('undo of a converged concurrent split does not re-double the text', async () => {
+    // The dropped runs are only skipped, never removed. Undo restores the origin run, so the
+    // dropped set would resurface next to it and re-manifest the duplication unless the origin
+    // being live suppresses them again. Both the peer that undoes and one joining afterward must
+    // agree on the single text.
+    const { alice, bob } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer) => runProps(peer, 0, 3, 9, 'i')
+    );
+    expect(alice.room.session.undo()).toBe(true);
+    alice.port.flushPendingJournals();
+    harness.expectConverged(alice, bob);
+    expect(bodyText(alice)).toBe(PARA0 + PARA1);
+    const carol = await harness.join(alice, 'carol');
+    harness.expectConverged(alice, carol);
+    expect(bodyText(carol)).toBe(PARA0 + PARA1);
+  });
+
+  test('concurrent typing and formatting converges without duplicating text', async () => {
+    // The dedup keeps a loser only when its text matches the winner's, so a run a peer grew by
+    // typing is never dropped as a duplicate. This peer's insert grows the origin run in place
+    // rather than splitting it, so the split still discards the typed characters when it copies
+    // the origin (issue #590, a separate concurrency gap); what this pins is that the dedup does
+    // not compound it — the peers converge and the text is not doubled.
+    const { alice, bob } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer): TreeDocOp => ({
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(peer, 0),
+        offset: 15,
+        text: 'ZZZ',
+      })
+    );
+    // Converged (asserted by race), and the base text appears once, not doubled.
+    expect(bodyText(alice)).toBe(PARA0 + PARA1);
+    expect(bodyText(bob)).toBe(PARA0 + PARA1);
+  });
 });

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-variants.test.ts
@@ -155,11 +155,11 @@ describe('concurrent variant edits converge', () => {
     );
   });
 
-  test('same-paragraph run-property edits silently duplicate text (#581)', async () => {
-    // Pinning current CORRUPTION, not endorsing it: two concurrent `setRunProperties` on the
-    // same paragraph rebuild its runs additively, so the merged text doubles on both peers.
-    // The peers still agree (convergence holds), which is why a convergence-only oracle
-    // missed it. When #581 is fixed this expectation flips.
+  test('same-paragraph run-property edits converge without duplicating text (#581)', async () => {
+    // Two concurrent `setRunProperties` on the same paragraph each split its runs; both
+    // peers stamp their new runs with the origin they replaced, and materialize keeps one
+    // replica's runs deterministically. The text is intact, not doubled, and one peer's
+    // formatting wins (last-writer-loses-formatting, never last-writer-loses-content).
     const { alice, bob, pause, resume } = await harness.pair(proseDoc());
     pause();
     harness.apply(alice, [
@@ -182,9 +182,9 @@ describe('concurrent variant edits converge', () => {
     ]);
     resume();
     harness.expectConverged(alice, bob);
-    // The bug: paragraph 0's text is duplicated. Documented so a fix visibly flips it.
-    expect(bodyText(alice)).toContain('editorAlpha bravo canvas delta editor');
-    expect(bodyText(bob)).toBe(bodyText(alice));
+    // Text intact and not duplicated; a formatting mark from the winning split survives.
+    expect(bodyText(alice)).toBe('Alpha bravo canvas delta editorSecond paragraph');
+    expect(hasElement(alice, 'b') || hasElement(alice, 'i')).toBe(true);
   });
 
   test('sequential wrap changes on one drawing replicate', async () => {

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -613,8 +613,14 @@ class DocumentSession implements DocumentCollaborationSession {
   private readonly onYjsTransaction = (transaction: Y.Transaction): void => {
     if (this.destroyed || !this.port) return;
     // The canonical store already holds a local commit. Materializing it back would rebuild
-    // the package for an edit the store authored.
-    if (transaction.origin === this.localOrigin) return;
+    // the package for an edit the store authored — so this normally skips a local transaction.
+    // The exception is a concurrent-split tangle the dedup declines (#581): the materialized
+    // tree then differs from what the store authored, and without reconciling it here the
+    // author would keep a clean view while every other replica converges on the duplicated one.
+    if (transaction.origin === this.localOrigin) {
+      if (this.registry.hasDeclinedSplitTangle()) this.publishSharedToPort();
+      return;
+    }
     // Nothing is published from here. A journal describes the tree as it stood when its
     // transaction committed, and its `spliceText` / `spliceChildren` positions are absolute.
     // This update has already integrated, so applying a journal now would address the wrong

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -621,8 +621,8 @@ class DocumentSession implements DocumentCollaborationSession {
     // author would keep a clean view while every other replica converges on the duplicated one.
     if (transaction.origin === this.localOrigin) {
       // Reconcile only on the edit that CREATES a tangle, not on every later keystroke while it
-      // persists: the event count rises once per tangle, so a steady stream of edits in an
-      // already-tangled document takes the early return with no materialize.
+      // persists: the marker changes on each tangle-creating edit, so a steady stream of edits
+      // in an already-tangled document takes the early return with no materialize.
       const tangles = this.registry.declinedSplitTangleEvents();
       if (tangles !== this.seenDeclinedTangles) {
         this.seenDeclinedTangles = tangles;

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -125,6 +125,8 @@ class DocumentSession implements DocumentCollaborationSession {
   private readonly journalsHeldDuringRemote: CanonicalPrimitiveJournal[] = [];
   private drainingHeldJournals = false;
   private remoteCounter = 0;
+  /** Declined-tangle events already reconciled into the author's store (#581). */
+  private seenDeclinedTangles = 0;
   private destroyed = false;
   private refusedInARow = 0;
   private readonly stopBlobWatch: () => void;
@@ -618,7 +620,14 @@ class DocumentSession implements DocumentCollaborationSession {
     // tree then differs from what the store authored, and without reconciling it here the
     // author would keep a clean view while every other replica converges on the duplicated one.
     if (transaction.origin === this.localOrigin) {
-      if (this.registry.hasDeclinedSplitTangle()) this.publishSharedToPort();
+      // Reconcile only on the edit that CREATES a tangle, not on every later keystroke while it
+      // persists: the event count rises once per tangle, so a steady stream of edits in an
+      // already-tangled document takes the early return with no materialize.
+      const tangles = this.registry.declinedSplitTangleEvents();
+      if (tangles !== this.seenDeclinedTangles) {
+        this.seenDeclinedTangles = tangles;
+        this.publishSharedToPort();
+      }
       return;
     }
     // Nothing is published from here. A journal describes the tree as it stood when its

--- a/packages/pro/src/collaboration/document/identity.ts
+++ b/packages/pro/src/collaboration/document/identity.ts
@@ -48,6 +48,19 @@ export function yjsItemKey(client: number, clock: number): string {
   return `yjs:${client}:${clock}`;
 }
 
+/**
+ * The replica that minted a logical id, or null for a baseline id.
+ *
+ * `lid:<32-hex replica>:<counter>` yields the replica; a baseline id
+ * (`/word/document.xml#…`) has no minting replica. Used to group concurrently-minted
+ * replacement runs so a deterministic winner can be chosen across peers.
+ */
+export function replicaOfLogicalId(id: string): string | null {
+  if (!id.startsWith('lid:')) return null;
+  const replica = id.slice(4, id.indexOf(':', 4));
+  return isReplicaIdentity(replica) ? replica : null;
+}
+
 export function wordFacingIdsOf(
   attributes: readonly { readonly localName: string; readonly value: string }[]
 ): string[] {

--- a/packages/pro/src/collaboration/document/journal.ts
+++ b/packages/pro/src/collaboration/document/journal.ts
@@ -499,10 +499,35 @@ function tombstoneRemoved(
 function recordSplitProvenance(registry: DocumentRegistry, planned: JournalPlan): void {
   for (const [removedId, insertedIds] of planned.replacementsByRemoved) {
     if (registry.kindOf(removedId) !== 'run') continue;
+    const root = resolveSplitRoot(registry, removedId, planned.reinserted);
     for (const runId of insertedIds) {
-      if (registry.kindOf(runId) === 'run') registry.recordSplitFrom(removedId, runId);
+      if (registry.kindOf(runId) === 'run') registry.recordSplitFrom(root, runId);
     }
   }
+}
+
+/**
+ * The run a split op started from, climbing through the intermediate runs THIS journal created.
+ *
+ * One op splits at both edges: it makes an intermediate run, then splits that. The intermediate
+ * is in `reinserted`, so climb its `splitFrom` to group every product of the op under the one
+ * run it superseded. Stop at a run from an EARLIER round — a later split of a survivor is its own
+ * origin, so two peers concurrently splitting that survivor meet at it and dedup, instead of one
+ * peer climbing past it to a stale ancestor while the other stops there.
+ */
+function resolveSplitRoot(
+  registry: DocumentRegistry,
+  removedId: LogicalId,
+  reinserted: ReadonlySet<LogicalId>
+): LogicalId {
+  let root = removedId;
+  for (let depth = 0; depth < registry.limits.maxTreeDepth; depth += 1) {
+    if (!reinserted.has(root)) break;
+    const parent = registry.splitOriginOf(root);
+    if (parent === null || parent === root) break;
+    root = parent;
+  }
+  return root;
 }
 
 function captureChildLists(

--- a/packages/pro/src/collaboration/document/journal.ts
+++ b/packages/pro/src/collaboration/document/journal.ts
@@ -364,6 +364,14 @@ interface JournalPlan {
    * see `applyEffect`.
    */
   readonly mintedText: ReadonlySet<string>;
+  /**
+   * For each removed id, the ids the SAME `spliceChildren` inserted in its place.
+   *
+   * A format split removes one run and inserts its head/tail at that slot; this is how a
+   * later tombstone learns which runs replaced the dropped one, so two concurrent splits of
+   * one run can be de-duplicated deterministically instead of duplicating the text (#581).
+   */
+  readonly replacementsByRemoved: ReadonlyMap<LogicalId, readonly LogicalId[]>;
 }
 
 /**
@@ -387,6 +395,7 @@ function planJournal(
   const removed: LogicalId[] = [];
   const reinserted = new Set<LogicalId>();
   const mintedText = new Set<string>();
+  const replacementsByRemoved = new Map<LogicalId, readonly LogicalId[]>();
   for (const effect of effects) {
     const refusal = validateEffect(registry, effect, projection);
     if (refusal) return refusal;
@@ -396,7 +405,12 @@ function planJournal(
         const end = effect.start + effect.deleteCount;
         for (let at = effect.start; at < end; at += 1) {
           const childId = parent.children[at];
-          if (childId !== undefined) removed.push(childId);
+          if (childId === undefined) continue;
+          removed.push(childId);
+          // The runs this same splice inserts at the dropped slot are its replacements.
+          if (effect.childLogicalIds.length > 0) {
+            replacementsByRemoved.set(childId, effect.childLogicalIds);
+          }
         }
       }
       for (const childId of effect.childLogicalIds) reinserted.add(childId);
@@ -407,7 +421,7 @@ function planJournal(
     }
     projectEffect(projection, effect);
   }
-  return { removed, reinserted, mintedText };
+  return { removed, reinserted, mintedText, replacementsByRemoved };
 }
 
 function mintedNodeCount(effects: readonly CanonicalPrimitiveEffect[]): number {
@@ -443,6 +457,7 @@ export function applyPrimitiveJournal(
     const formerChildren = captureChildLists(registry, planned.removed);
     for (const effect of journal.effects) applyEffect(registry, effect, planned.mintedText);
     tombstoneRemoved(registry, journal.effects, planned, formerChildren);
+    recordSplitProvenance(registry, planned);
   }, JOURNAL_ORIGIN);
   return { ok: true };
 }
@@ -468,6 +483,25 @@ function tombstoneRemoved(
     // added, which is the case adoption exists for.
     if (survivor) registry.unlistChildren(id, formerChildren.get(id) ?? []);
     registry.tombstone(id, survivor);
+  }
+}
+
+/**
+ * Stamp each run a format split minted with the run it replaced (#581).
+ *
+ * Runs the whole `replacementsByRemoved` map, not the tombstone loop, because one op splits
+ * at both edges: the intermediate run the first split produced is removed AND reinserted in
+ * the same journal, so the tombstone loop skips it and its second-split products would never
+ * be stamped. `recordSplitFrom` resolves the origin to its root, and the map is in effect
+ * order (the earlier split first), so a later split's origin already carries the root when it
+ * resolves.
+ */
+function recordSplitProvenance(registry: DocumentRegistry, planned: JournalPlan): void {
+  for (const [removedId, insertedIds] of planned.replacementsByRemoved) {
+    if (registry.kindOf(removedId) !== 'run') continue;
+    for (const runId of insertedIds) {
+      if (registry.kindOf(runId) === 'run') registry.recordSplitFrom(removedId, runId);
+    }
   }
 }
 

--- a/packages/pro/src/collaboration/document/materialize.ts
+++ b/packages/pro/src/collaboration/document/materialize.ts
@@ -108,6 +108,10 @@ export class PackageMaterializer {
   /** Adoptee signature per survivor at the end of the last pass. */
   private lastAdoption = new Map<LogicalId, string>();
   private placementContested = false;
+  /** Runs a concurrent format split superseded; skipped this pass. Recomputed each rebuild. */
+  private replacementLosers: ReadonlySet<LogicalId> = new Set();
+  /** The loser set the previous pass used, to dirty parents when the verdict flips. */
+  private lastLosers: ReadonlySet<LogicalId> = new Set();
   /**
    * What the last full pass decided for each contested id: the parent the registry resolved
    * then, `null` for none. Holds only ids that pass evidenced as contested, so a hostile peer
@@ -216,6 +220,22 @@ export class PackageMaterializer {
     return moved;
   }
 
+  /**
+   * Parents of runs whose format-split loser verdict flipped, so the incremental pass
+   * rebuilds them instead of reusing a cached subtree with the stale verdict (#581).
+   */
+  private loserChanges(losers: ReadonlySet<LogicalId>): readonly LogicalId[] {
+    const parents: LogicalId[] = [];
+    const flipped = (runId: LogicalId): void => {
+      const parent = this.registry.parentOf(runId);
+      if (parent !== null) parents.push(parent);
+    };
+    for (const runId of losers) if (!this.lastLosers.has(runId)) flipped(runId);
+    for (const runId of this.lastLosers) if (!losers.has(runId)) flipped(runId);
+    this.lastLosers = losers;
+    return parents;
+  }
+
   rebuild(): MaterializeResult {
     const rawDirty = new Set(this.pendingDirty);
     const packageChanged = this.pendingPackage;
@@ -234,6 +254,10 @@ export class PackageMaterializer {
     // delivered yet, so it disqualifies the package projections exactly as the flag does.
     if (packageChanged || unobserved) this.packageCache.invalidate();
     for (const survivor of this.adoptionChanges()) rawDirty.add(survivor);
+    // Recompute the split-loser set once here, dirty the parents whose verdict changed, and
+    // reuse it for the pass so incremental and cold agree on which runs to drop (#581).
+    this.replacementLosers = this.registry.replacementLoserRuns();
+    for (const parent of this.loserChanges(this.replacementLosers)) rawDirty.add(parent);
     const dirty = expandAncestors(this.registry, rawDirty);
     // A relationship-only change dirties no nodes. Reuse the node cache, then project `.rels`.
     //
@@ -318,6 +342,8 @@ export class PackageMaterializer {
     }
     this.customXmlRels = [];
     this.customXmlOverrides.clear();
+    // `this.replacementLosers` was set in `rebuild()`, which also dirtied the parents whose
+    // loser verdict changed so this pass rebuilds them (#581).
     const placed = new Set<LogicalId>();
     const parts = new Map<string, OoxmlPart>();
     for (const entry of this.registry.partEntries()) {
@@ -555,6 +581,13 @@ export class PackageMaterializer {
       seenChildren.add(childId);
       if (this.registry.isTombstoned(childId)) {
         this.push('deleted-referenced', childId);
+        continue;
+      }
+      // A run a concurrent split superseded: drop it, and mark it placed so reachability does
+      // not report it as stranded content — its loss is deliberate, the winning split's runs
+      // carry the text. Every replica picks the same loser, so this converges.
+      if (this.replacementLosers.has(childId)) {
+        placed.add(childId);
         continue;
       }
       // Existence only. Decoding the child's whole record here — attributes, bindings and

--- a/packages/pro/src/collaboration/document/registry-side-maps.ts
+++ b/packages/pro/src/collaboration/document/registry-side-maps.ts
@@ -20,6 +20,8 @@ import {
   namespaceIdOf,
   namespaceUriOf,
   packAttributeValue,
+  parseAttributeMapKey,
+  parseBindingMapKey,
   unpackAttributeValue,
   type EncodedAttribute,
   type EncodedBinding,
@@ -144,4 +146,53 @@ export function removeIndexedBinding(
   if (!bucket) return;
   bucket.delete(prefix);
   if (bucket.size === 0) index.delete(logicalId);
+}
+
+/** Apply one attribute-map event to the derived index. Peer-controlled keys are skipped. */
+export function applyAttributeMapEvent(
+  schema: PackageSchema,
+  index: AttributeIndex,
+  event: import('yjs').YMapEvent<string>
+): void {
+  for (const [key, change] of event.changes.keys) {
+    const parsed = parseAttributeMapKey(String(key));
+    if (!parsed || rejectDangerousKey(parsed.logicalId) || rejectDangerousKey(parsed.localName)) {
+      continue;
+    }
+    if (change.action === 'delete') {
+      removeIndexedAttribute(index, parsed.logicalId, parsed.namespaceId, parsed.localName);
+      continue;
+    }
+    const packed = schema.attributes.get(String(key));
+    if (typeof packed !== 'string') continue;
+    upsertIndexedAttribute(
+      schema,
+      index,
+      parsed.logicalId,
+      parsed.namespaceId,
+      parsed.localName,
+      packed
+    );
+  }
+}
+
+/** Apply one binding-map event to the derived index. Peer-controlled keys are skipped. */
+export function applyBindingMapEvent(
+  schema: PackageSchema,
+  index: BindingIndex,
+  event: import('yjs').YMapEvent<string>
+): void {
+  for (const [key, change] of event.changes.keys) {
+    const parsed = parseBindingMapKey(String(key));
+    if (!parsed || rejectDangerousKey(parsed.logicalId) || rejectDangerousKey(parsed.prefix)) {
+      continue;
+    }
+    if (change.action === 'delete') {
+      removeIndexedBinding(index, parsed.logicalId, parsed.prefix);
+      continue;
+    }
+    const namespaceId = schema.bindings.get(String(key));
+    if (typeof namespaceId !== 'string') continue;
+    upsertIndexedBinding(schema, index, parsed.logicalId, parsed.prefix, namespaceId);
+  }
 }

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -8,7 +8,7 @@ import type { CanonicalBinaryDescriptor } from '@docx-editor.dev/core/collaborat
 import { partNameKey } from '@docx-editor.dev/core/store';
 import { yjsItemKey, type LogicalId, type NodeIdentityMeta, wordFacingIdsOf } from './identity.ts';
 import { SplitDedupIndex } from './split-dedup.ts';
-import { runGroupText, runIsPresent } from './run-text-reads.ts';
+import { runIsPresent } from './run-text-reads.ts';
 import {
   DEFAULT_DOCUMENT_LIMITS,
   mergeLimits,
@@ -34,6 +34,7 @@ import {
   makeTextRecord,
   namespaceUriOf,
   nodeRecordReplacedBy,
+  nodeRecordSplitFrom,
   nodeRecordTombstoned,
   packNodeShell,
   packageSchemaOf,
@@ -125,7 +126,7 @@ export class DocumentRegistry {
   ) {
     this.schema = packageSchemaOf(doc);
     this.limits = mergeLimits(limits);
-    this.splitDedup = new SplitDedupIndex(this.schema.nodes, this.limits.maxTreeDepth);
+    this.splitDedup = new SplitDedupIndex(this.schema.nodes);
     this.stopObserving = observeRegistrySchema(this.schema, {
       onNodeEvents: (events) => {
         if (this.bulkLoad > 0) return;
@@ -484,17 +485,29 @@ export class DocumentRegistry {
     if (replacedBy) rec.set(NODE_REPLACED_BY_FIELD, replacedBy);
   }
 
-  /** Stamp each run a format split minted with the origin it superseded (#581). */
-  recordSplitFrom(originalId: LogicalId, runId: LogicalId): void {
-    this.splitDedup.record(originalId, runId);
+  /** Stamp a run with the root origin a concurrent split superseded (#581). */
+  recordSplitFrom(root: LogicalId, runId: LogicalId): void {
+    this.splitDedup.record(root, runId);
+  }
+
+  /** The run a given run split off from, or null — the caller resolves the chain (#581). */
+  splitOriginOf(logicalId: LogicalId): LogicalId | null {
+    return nodeRecordSplitFrom(this.schema.nodes.get(logicalId));
   }
 
   /** Runs a concurrent format split superseded and this replica must not materialize (#581). */
   replacementLoserRuns(): ReadonlySet<LogicalId> {
-    return this.splitDedup.loserRuns({
-      isPresent: (id) => runIsPresent(this, id),
-      groupText: (runIds) => runGroupText(this, runIds, this.limits.maxTreeDepth),
-    });
+    return this.splitDedup.loserRuns({ isPresent: (id) => runIsPresent(this, id) });
+  }
+
+  /**
+   * True when a run a concurrent split produced was split again — a tangle the dedup declines,
+   * so the materialized tree differs from what the local author authored (#581). The session
+   * reconciles the author's store to the materialization when this holds, keeping every replica
+   * on the same tree.
+   */
+  hasDeclinedSplitTangle(): boolean {
+    return this.splitDedup.hasDeclinedTangle();
   }
 
   /**

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -501,13 +501,13 @@ export class DocumentRegistry {
   }
 
   /**
-   * True when a run a concurrent split produced was split again — a tangle the dedup declines,
-   * so the materialized tree differs from what the local author authored (#581). The session
-   * reconciles the author's store to the materialization when this holds, keeping every replica
-   * on the same tree.
+   * How many times a local edit re-split a run a concurrent split produced — a tangle the dedup
+   * declines, leaving the materialized tree different from what the author authored (#581). The
+   * session reconciles the author's store when this rises, so every replica stays on one tree
+   * without a per-keystroke cost once the document is tangled.
    */
-  hasDeclinedSplitTangle(): boolean {
-    return this.splitDedup.hasDeclinedTangle();
+  declinedSplitTangleEvents(): number {
+    return this.splitDedup.declinedTangleEvents();
   }
 
   /**

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -8,6 +8,7 @@ import type { CanonicalBinaryDescriptor } from '@docx-editor.dev/core/collaborat
 import { partNameKey } from '@docx-editor.dev/core/store';
 import { yjsItemKey, type LogicalId, type NodeIdentityMeta, wordFacingIdsOf } from './identity.ts';
 import { SplitDedupIndex } from './split-dedup.ts';
+import { runGroupText, runIsPresent } from './run-text-reads.ts';
 import {
   DEFAULT_DOCUMENT_LIMITS,
   mergeLimits,
@@ -490,7 +491,10 @@ export class DocumentRegistry {
 
   /** Runs a concurrent format split superseded and this replica must not materialize (#581). */
   replacementLoserRuns(): ReadonlySet<LogicalId> {
-    return this.splitDedup.loserRuns((id) => this.isTombstoned(id));
+    return this.splitDedup.loserRuns({
+      isPresent: (id) => runIsPresent(this, id),
+      groupText: (runIds) => runGroupText(this, runIds, this.limits.maxTreeDepth),
+    });
   }
 
   /**

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -7,6 +7,7 @@ import * as Y from 'yjs';
 import type { CanonicalBinaryDescriptor } from '@docx-editor.dev/core/collaboration/replication';
 import { partNameKey } from '@docx-editor.dev/core/store';
 import { yjsItemKey, type LogicalId, type NodeIdentityMeta, wordFacingIdsOf } from './identity.ts';
+import { SplitDedupIndex } from './split-dedup.ts';
 import {
   DEFAULT_DOCUMENT_LIMITS,
   mergeLimits,
@@ -55,10 +56,10 @@ import {
   resolveContestedPlacements,
 } from './registry-contested-placement.ts';
 import {
+  applyAttributeMapEvent,
+  applyBindingMapEvent,
   deleteSharedAttribute,
   deleteSharedBinding,
-  removeIndexedAttribute,
-  removeIndexedBinding,
   upsertIndexedAttribute,
   upsertIndexedBinding,
   writeSharedAttribute,
@@ -102,6 +103,8 @@ export class DocumentRegistry {
   private tombstoneSurvivor = new Map<LogicalId, LogicalId>();
   private attributesByNode = new Map<LogicalId, Map<string, EncodedAttribute>>();
   private bindingsByNode = new Map<LogicalId, Map<string, EncodedBinding>>();
+  /** Deterministic dedup of concurrent format splits (#581). */
+  private readonly splitDedup: SplitDedupIndex;
   private bulkLoad = 0;
   private unobservedWrites = 0;
   /** Node total as of the last observed event batch. Negative means "not counted yet". */
@@ -121,6 +124,7 @@ export class DocumentRegistry {
   ) {
     this.schema = packageSchemaOf(doc);
     this.limits = mergeLimits(limits);
+    this.splitDedup = new SplitDedupIndex(this.schema.nodes, this.limits.maxTreeDepth);
     this.stopObserving = observeRegistrySchema(this.schema, {
       onNodeEvents: (events) => {
         if (this.bulkLoad > 0) return;
@@ -479,6 +483,16 @@ export class DocumentRegistry {
     if (replacedBy) rec.set(NODE_REPLACED_BY_FIELD, replacedBy);
   }
 
+  /** Stamp each run a format split minted with the origin it superseded (#581). */
+  recordSplitFrom(originalId: LogicalId, runId: LogicalId): void {
+    this.splitDedup.record(originalId, runId);
+  }
+
+  /** Runs a concurrent format split superseded and this replica must not materialize (#581). */
+  replacementLoserRuns(): ReadonlySet<LogicalId> {
+    return this.splitDedup.loserRuns((id) => this.isTombstoned(id));
+  }
+
   /**
    * Drop from a node's child array the children this replica had already seen there.
    *
@@ -662,6 +676,7 @@ export class DocumentRegistry {
     this.tombstoneSurvivor = new Map();
     this.attributesByNode = new Map();
     this.bindingsByNode = new Map();
+    this.splitDedup.reset();
     this.schema.nodes.forEach((rec, parentId) => {
       if (rejectDangerousKey(parentId)) return;
       const children = childArrayOf(rec);
@@ -672,6 +687,7 @@ export class DocumentRegistry {
     });
     this.schema.nodes.forEach((rec, id) => {
       if (nodeRecordTombstoned(rec)) this.syncAdoptee(id);
+      this.splitDedup.indexExisting(id);
     });
     this.schema.attributes.forEach((packed, key) => {
       if (typeof packed !== 'string' || rejectDangerousKey(key)) return;
@@ -729,6 +745,9 @@ export class DocumentRegistry {
             this.nodeCountCache += change.action === 'add' ? 1 : -1;
           }
           if (change.action === 'delete' || rejectDangerousKey(String(key))) continue;
+          // A run a peer split off carries its origin; index it so the loser-dedup sees the
+          // concurrent split the moment the remote record arrives, not only after a rebuild.
+          this.splitDedup.indexExisting(String(key));
           for (const childId of this.syncChildListings(String(key))) changed.add(childId);
         }
         continue;
@@ -753,54 +772,12 @@ export class DocumentRegistry {
 
   private applyAttributeMapEvent(event: Y.YMapEvent<string>): void {
     this.unobservedWrites = 0;
-    for (const [key, change] of event.changes.keys) {
-      const parsed = parseAttributeMapKey(String(key));
-      if (!parsed || rejectDangerousKey(parsed.logicalId) || rejectDangerousKey(parsed.localName)) {
-        continue;
-      }
-      if (change.action === 'delete') {
-        removeIndexedAttribute(
-          this.attributesByNode,
-          parsed.logicalId,
-          parsed.namespaceId,
-          parsed.localName
-        );
-        continue;
-      }
-      const packed = this.schema.attributes.get(String(key));
-      if (typeof packed !== 'string') continue;
-      upsertIndexedAttribute(
-        this.schema,
-        this.attributesByNode,
-        parsed.logicalId,
-        parsed.namespaceId,
-        parsed.localName,
-        packed
-      );
-    }
+    applyAttributeMapEvent(this.schema, this.attributesByNode, event);
   }
 
   private applyBindingMapEvent(event: Y.YMapEvent<string>): void {
     this.unobservedWrites = 0;
-    for (const [key, change] of event.changes.keys) {
-      const parsed = parseBindingMapKey(String(key));
-      if (!parsed || rejectDangerousKey(parsed.logicalId) || rejectDangerousKey(parsed.prefix)) {
-        continue;
-      }
-      if (change.action === 'delete') {
-        removeIndexedBinding(this.bindingsByNode, parsed.logicalId, parsed.prefix);
-        continue;
-      }
-      const namespaceId = this.schema.bindings.get(String(key));
-      if (typeof namespaceId !== 'string') continue;
-      upsertIndexedBinding(
-        this.schema,
-        this.bindingsByNode,
-        parsed.logicalId,
-        parsed.prefix,
-        namespaceId
-      );
-    }
+    applyBindingMapEvent(this.schema, this.bindingsByNode, event);
   }
 
   private syncChildListings(parentId: LogicalId): LogicalId[] {

--- a/packages/pro/src/collaboration/document/run-text-reads.ts
+++ b/packages/pro/src/collaboration/document/run-text-reads.ts
@@ -4,11 +4,10 @@ Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICE
 Production use requires a commercial agreement: licensing@eigenpal.com
 */
 /**
- * Reading a run's text from the shared tree, for the concurrent-split dedup (#581).
+ * Reading a run's placement in the shared tree, for the concurrent-split dedup (#581).
  *
- * The dedup keeps one replica's split and drops another's ONLY when both spell the same text, so
- * it needs the text a set of runs carries, concatenated in document order. These reads live apart
- * from the registry so it stays under its line cap; they use only the registry's public reads.
+ * This read lives apart from the registry so it stays under its line cap; it uses only the
+ * registry's public reads.
  */
 
 import { isElementRecord } from './schema.ts';
@@ -19,8 +18,8 @@ import type { LogicalId } from './identity.ts';
  * A run that still hangs off its parent, is not tombstoned, and exists.
  *
  * A multi-boundary split leaves an intermediate run detached from the paragraph but neither
- * tombstoned nor deleted; the dedup must not count its text, so it checks membership in the
- * parent's child array, not only the node map.
+ * tombstoned nor deleted; the dedup must not count it, so it checks membership in the parent's
+ * child array, not only the node map.
  */
 export function runIsPresent(registry: DocumentRegistry, logicalId: LogicalId): boolean {
   if (!registry.hasNode(logicalId) || registry.isTombstoned(logicalId)) return false;
@@ -28,47 +27,4 @@ export function runIsPresent(registry: DocumentRegistry, logicalId: LogicalId): 
   if (parent === null) return false;
   const rec = registry.record(parent);
   return rec !== null && isElementRecord(rec) && rec.childIds.includes(logicalId);
-}
-
-/**
- * The text a set of runs carries, concatenated in document order.
- *
- * The dedup compares this across replicas: a format split partitions the origin's text, so every
- * replica's products spell the same string, while a run a peer grew by typing does not.
- */
-export function runGroupText(
-  registry: DocumentRegistry,
-  runIds: readonly LogicalId[],
-  maxDepth: number
-): string {
-  const ordered = [...runIds].sort(
-    (a, b) => siblingIndexOf(registry, a) - siblingIndexOf(registry, b)
-  );
-  let text = '';
-  for (const id of ordered) text += runTextContent(registry, id, maxDepth, 0);
-  return text;
-}
-
-function siblingIndexOf(registry: DocumentRegistry, logicalId: LogicalId): number {
-  const parent = registry.parentOf(logicalId);
-  if (parent === null) return 0;
-  const rec = registry.record(parent);
-  if (!rec || !isElementRecord(rec)) return 0;
-  const index = rec.childIds.indexOf(logicalId);
-  return index < 0 ? 0 : index;
-}
-
-function runTextContent(
-  registry: DocumentRegistry,
-  logicalId: LogicalId,
-  maxDepth: number,
-  depth: number
-): string {
-  if (depth > maxDepth) return '';
-  const rec = registry.record(logicalId);
-  if (!rec) return '';
-  if (!isElementRecord(rec)) return rec.value;
-  let text = '';
-  for (const child of rec.childIds) text += runTextContent(registry, child, maxDepth, depth + 1);
-  return text;
 }

--- a/packages/pro/src/collaboration/document/run-text-reads.ts
+++ b/packages/pro/src/collaboration/document/run-text-reads.ts
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+/**
+ * Reading a run's text from the shared tree, for the concurrent-split dedup (#581).
+ *
+ * The dedup keeps one replica's split and drops another's ONLY when both spell the same text, so
+ * it needs the text a set of runs carries, concatenated in document order. These reads live apart
+ * from the registry so it stays under its line cap; they use only the registry's public reads.
+ */
+
+import { isElementRecord } from './schema.ts';
+import type { DocumentRegistry } from './registry.ts';
+import type { LogicalId } from './identity.ts';
+
+/**
+ * A run that still hangs off its parent, is not tombstoned, and exists.
+ *
+ * A multi-boundary split leaves an intermediate run detached from the paragraph but neither
+ * tombstoned nor deleted; the dedup must not count its text, so it checks membership in the
+ * parent's child array, not only the node map.
+ */
+export function runIsPresent(registry: DocumentRegistry, logicalId: LogicalId): boolean {
+  if (!registry.hasNode(logicalId) || registry.isTombstoned(logicalId)) return false;
+  const parent = registry.parentOf(logicalId);
+  if (parent === null) return false;
+  const rec = registry.record(parent);
+  return rec !== null && isElementRecord(rec) && rec.childIds.includes(logicalId);
+}
+
+/**
+ * The text a set of runs carries, concatenated in document order.
+ *
+ * The dedup compares this across replicas: a format split partitions the origin's text, so every
+ * replica's products spell the same string, while a run a peer grew by typing does not.
+ */
+export function runGroupText(
+  registry: DocumentRegistry,
+  runIds: readonly LogicalId[],
+  maxDepth: number
+): string {
+  const ordered = [...runIds].sort(
+    (a, b) => siblingIndexOf(registry, a) - siblingIndexOf(registry, b)
+  );
+  let text = '';
+  for (const id of ordered) text += runTextContent(registry, id, maxDepth, 0);
+  return text;
+}
+
+function siblingIndexOf(registry: DocumentRegistry, logicalId: LogicalId): number {
+  const parent = registry.parentOf(logicalId);
+  if (parent === null) return 0;
+  const rec = registry.record(parent);
+  if (!rec || !isElementRecord(rec)) return 0;
+  const index = rec.childIds.indexOf(logicalId);
+  return index < 0 ? 0 : index;
+}
+
+function runTextContent(
+  registry: DocumentRegistry,
+  logicalId: LogicalId,
+  maxDepth: number,
+  depth: number
+): string {
+  if (depth > maxDepth) return '';
+  const rec = registry.record(logicalId);
+  if (!rec) return '';
+  if (!isElementRecord(rec)) return rec.value;
+  let text = '';
+  for (const child of rec.childIds) text += runTextContent(registry, child, maxDepth, depth + 1);
+  return text;
+}

--- a/packages/pro/src/collaboration/document/schema.ts
+++ b/packages/pro/src/collaboration/document/schema.ts
@@ -29,6 +29,16 @@ export const NODE_TEXT_FIELD = 't';
 export const NODE_CHILDREN_FIELD = 'children';
 export const NODE_DELETED_FIELD = 'deleted';
 export const NODE_REPLACED_BY_FIELD = 'replacedBy';
+/**
+ * The run this run was split off from — the original run id a format split superseded.
+ *
+ * Written once by the peer that minted the run, so two peers splitting the same original
+ * concurrently write it on their OWN (different) run records, never racing one shared
+ * container. Both carry the same origin id, so materialize can group the concurrent splits
+ * and keep one replica's runs deterministically, dropping the duplicated text (#581).
+ * Internal shared state, never serialized to the `.docx`.
+ */
+export const NODE_SPLIT_FROM_FIELD = 'splitFrom';
 
 /** Unit separator. XML names and NCName prefixes cannot hold this character. */
 export const FIELD_SEP = '\u001f';
@@ -458,5 +468,12 @@ export function nodeRecordTombstoned(record: unknown): boolean {
 export function nodeRecordReplacedBy(record: unknown): string | null {
   if (!isNodeMap(record)) return null;
   const value = record.get(NODE_REPLACED_BY_FIELD);
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** The original run a split produced this one from, guarded against peer-planted shapes. */
+export function nodeRecordSplitFrom(record: unknown): string | null {
+  if (!isNodeMap(record)) return null;
+  const value = record.get(NODE_SPLIT_FROM_FIELD);
   return typeof value === 'string' && value.length > 0 ? value : null;
 }

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -34,6 +34,9 @@ export interface SplitDedupContext {
   readonly isPresent: (id: LogicalId) => boolean;
 }
 
+/** Cap on the `splitFrom` walk that classifies a re-split; stops a peer-crafted chain or cycle. */
+const RE_SPLIT_WALK_LIMIT = 256;
+
 export class SplitDedupIndex {
   /** Root origin run id → the runs split off from it, across all replicas. */
   private runsBySplitOrigin = new Map<LogicalId, Set<LogicalId>>();
@@ -81,10 +84,30 @@ export class SplitDedupIndex {
     if (root === runId) return;
     rec.set(NODE_SPLIT_FROM_FIELD, root);
     this.index(root, runId);
-    // A root that is ITSELF a split product means a later round re-split a run an earlier round
-    // made — the tangle the dedup declines. Count it, so the session reconciles the author's
-    // store only on the edit that creates the tangle, not on every keystroke while it persists.
-    if (nodeRecordSplitFrom(this.nodes.get(root)) !== null) this.declinedTangleCount += 1;
+    // A later round re-split a run an earlier round produced, and the shared origin was split by
+    // two replicas — the tangle the dedup declines. Count it, so the session reconciles the
+    // author's store only on the edit that creates the tangle, not on every keystroke while it
+    // persists. A single author re-formatting a paragraph re-splits products too, but its origin
+    // is never contested, so this ignores it — no wasted reconcile without a real conflict.
+    if (this.reSplitOfContestedOrigin(root)) this.declinedTangleCount += 1;
+  }
+
+  /**
+   * True if `root` is itself a split product whose shared origin two replicas split.
+   *
+   * Walks `splitFrom` from `root` to the run the rounds share. A `root` that is an original run
+   * (no `splitFrom`) is a first round, not a re-split. The bound stops a peer-crafted cycle.
+   */
+  private reSplitOfContestedOrigin(root: LogicalId): boolean {
+    if (nodeRecordSplitFrom(this.nodes.get(root)) === null) return false;
+    let current = root;
+    for (let depth = 0; depth < RE_SPLIT_WALK_LIMIT; depth += 1) {
+      if (this.contestedOrigins.has(current) || this.liveRootedOrigins.has(current)) return true;
+      const parent = nodeRecordSplitFrom(this.nodes.get(current));
+      if (parent === null || parent === current) return false;
+      current = parent;
+    }
+    return false;
   }
 
   /** Index a run that already carries a `splitFrom` (a rebuild scan, or a remote arrival). */

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -28,13 +28,10 @@ import {
  * What the dedup reads about the tree it is projecting, injected so the index stays free of the
  * record walk. `isPresent` is true only for a run that still hangs off its parent — a
  * multi-boundary split leaves an intermediate run detached but neither tombstoned nor deleted,
- * and counting it would double the group's text. `groupText` concatenates the runs' text in
- * document order — the dedup drops a run only when another run already carries the exact same
- * text, so it never loses distinct content.
+ * and materializing it would double the paragraph's text.
  */
 export interface SplitDedupContext {
   readonly isPresent: (id: LogicalId) => boolean;
-  readonly groupText: (runIds: readonly LogicalId[]) => string;
 }
 
 export class SplitDedupIndex {
@@ -51,10 +48,7 @@ export class SplitDedupIndex {
    */
   private liveRootedOrigins = new Set<LogicalId>();
 
-  constructor(
-    private readonly nodes: Y.Map<Y.Map<unknown>>,
-    private readonly maxDepth: number
-  ) {}
+  constructor(private readonly nodes: Y.Map<Y.Map<unknown>>) {}
 
   reset(): void {
     this.runsBySplitOrigin = new Map();
@@ -64,16 +58,16 @@ export class SplitDedupIndex {
   }
 
   /**
-   * Stamp `runId` as split off from `originalId`, resolved to its ROOT origin.
+   * Stamp `runId` as split off from `root`, the run the whole op superseded.
    *
-   * One op splits at both edges, so a later split can target a run the earlier split made.
-   * Resolving to the root — the run the whole op superseded — groups every product of a
-   * multi-boundary split under one id, so the concurrent dedup sees them all.
+   * The caller resolves the root, because only the journal knows which intermediate runs this
+   * same op created and removed (a multi-boundary split) versus a run split in an earlier round.
+   * Both concurrent splits of one run must reach the SAME root, or their products land in
+   * separate groups and both survive.
    */
-  record(originalId: LogicalId, runId: LogicalId): void {
+  record(root: LogicalId, runId: LogicalId): void {
     const rec = this.nodes.get(runId);
     if (!isNodeMap(rec)) return;
-    const root = this.rootOf(originalId, replicaOfLogicalId(runId));
     // A run is not split from itself. Wrapping a run (a TOC bookmark, a hyperlink) removes and
     // reinserts the SAME node, which looks like a replacement but partitions nothing; stamping it
     // would let the dedup drop the run as a copy of itself.
@@ -107,66 +101,63 @@ export class SplitDedupIndex {
   }
 
   /**
-   * The root a `runReplica` split reached, following `splitFrom` only through ancestors that
-   * SAME replica minted.
-   *
-   * A multi-boundary split by one peer chains its own runs, so those steps resolve to the
-   * original run — its whole set groups together. But a LATER peer splitting a run this peer
-   * made is a sequential refinement, not a competing split of the original: stopping at the
-   * replica boundary keeps the two out of one group, so the later split is not mistaken for a
-   * concurrent duplicate and dropped.
-   */
-  private rootOf(id: LogicalId, runReplica: string | null): LogicalId {
-    let current = id;
-    for (let depth = 0; depth < this.maxDepth; depth += 1) {
-      if (replicaOfLogicalId(current) !== runReplica) return current;
-      const parent = nodeRecordSplitFrom(this.nodes.get(current));
-      if (parent === null || parent === current) return current;
-      current = parent;
-    }
-    return current;
-  }
-
-  /**
    * Runs a concurrent split superseded and a replica must not materialize.
    *
-   * An origin with live split children from MORE THAN ONE minting replica was split by two
-   * peers at once. The winner is the replica whose identity sorts first — every replica reads
-   * the same shared state and picks the same winner — and a losing replica's runs are dropped
-   * ONLY when they carry the exact text the winner already carries, so the concurrent case
-   * keeps the text once while a run a peer grew with new typed text is never lost.
+   * An origin split by MORE THAN ONE replica was split by two peers at once. The winner is the
+   * replica whose identity sorts first — every replica reads the same shared state and picks the
+   * same winner — so every other replica's products are dropped and the origin's text is kept
+   * once. If the origin run is live again — an undo restored it — it represents the text on its
+   * own, so every product is dropped instead.
    *
-   * If the origin run itself is live again — an undo restored it — it represents the text on its
-   * own, so every product that merely repeats it is dropped. Without this, undoing the winner's
-   * split would leave the restored origin AND the loser's runs, doubling the text again.
+   * The dedup only claims ONE round of concurrent splitting on a run. A second round — a peer
+   * splitting a run the first round produced — tangles the winning replica's runs at the merge
+   * layer, below what a projection can repair (see the split-replication follow-up). So when a
+   * product of an origin was itself split again, this leaves the whole origin alone: every run
+   * materializes, exactly as it would without this feature. The result stays consistent across
+   * peers — a duplicated but CONVERGENT tree, never one replica disagreeing with another.
    */
+  /**
+   * True if a contested origin was split again in a later round — the tangle the dedup declines.
+   *
+   * The materialized tree then differs from what the local author authored, so the session must
+   * reconcile the author's store to it or the author would keep a clean view while every other
+   * replica sees the duplicated one. Cheap and read straight off shared state, so all replicas
+   * agree.
+   */
+  hasDeclinedTangle(): boolean {
+    for (const root of this.contestedOrigins) if (this.isReSplit(root)) return true;
+    for (const root of this.liveRootedOrigins) if (this.isReSplit(root)) return true;
+    return false;
+  }
+
+  private isReSplit(root: LogicalId): boolean {
+    const runs = this.runsBySplitOrigin.get(root);
+    if (!runs) return false;
+    for (const id of runs) if ((this.runsBySplitOrigin.get(id)?.size ?? 0) > 0) return true;
+    return false;
+  }
+
   loserRuns(ctx: SplitDedupContext): ReadonlySet<LogicalId> {
     const losers = new Set<LogicalId>();
     const examine = new Set<LogicalId>([...this.contestedOrigins, ...this.liveRootedOrigins]);
     for (const root of examine) {
       const runs = this.runsBySplitOrigin.get(root);
       if (!runs) continue;
-      const byReplica = new Map<string, LogicalId[]>();
+      // No-regression guard: a single round collapses every product's origin to `root`, so no
+      // product is itself a split origin. If one is, a later round re-split it — hand the whole
+      // origin back to the plain projection rather than risk a divergent partial drop.
+      if (this.isReSplit(root)) continue;
+      const present = new Set<string>();
       for (const runId of runs) {
-        if (!ctx.isPresent(runId)) continue;
-        const replica = replicaOfLogicalId(runId) ?? '';
-        const group = byReplica.get(replica) ?? [];
-        group.push(runId);
-        byReplica.set(replica, group);
+        if (ctx.isPresent(runId)) present.add(replicaOfLogicalId(runId) ?? '');
       }
-      if (ctx.isPresent(root)) {
-        const rootText = ctx.groupText([root]);
-        for (const runIds of byReplica.values()) {
-          if (ctx.groupText(runIds) === rootText) for (const id of runIds) losers.add(id);
-        }
-        continue;
-      }
-      if (byReplica.size <= 1) continue;
-      const winner = [...byReplica.keys()].sort()[0]!;
-      const winnerText = ctx.groupText(byReplica.get(winner)!);
-      for (const [replica, runIds] of byReplica) {
-        if (replica === winner) continue;
-        if (ctx.groupText(runIds) === winnerText) for (const id of runIds) losers.add(id);
+      const originLive = ctx.isPresent(root);
+      if (!originLive && present.size <= 1) continue;
+      // A live origin beats every product; otherwise the first-sorting present replica wins.
+      const winner = originLive ? null : [...present].sort()[0]!;
+      for (const runId of runs) {
+        if (!originLive && (replicaOfLogicalId(runId) ?? '') === winner) continue;
+        if (ctx.isPresent(runId)) losers.add(runId);
       }
     }
     return losers;

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -47,6 +47,13 @@ export class SplitDedupIndex {
    * the stale products the same way the peer that undid does through its sticky contested set.
    */
   private liveRootedOrigins = new Set<LogicalId>();
+  /**
+   * How many times a local edit re-split a run an earlier round produced — the declined tangle
+   * (#581). Monotonic across the session and NOT cleared by `reset()`: it counts edit events,
+   * not current state, so the session compares it against its last-seen value to reconcile the
+   * author's store exactly once per new tangle instead of on every later keystroke.
+   */
+  private declinedTangleCount = 0;
 
   constructor(private readonly nodes: Y.Map<Y.Map<unknown>>) {}
 
@@ -74,6 +81,10 @@ export class SplitDedupIndex {
     if (root === runId) return;
     rec.set(NODE_SPLIT_FROM_FIELD, root);
     this.index(root, runId);
+    // A root that is ITSELF a split product means a later round re-split a run an earlier round
+    // made — the tangle the dedup declines. Count it, so the session reconciles the author's
+    // store only on the edit that creates the tangle, not on every keystroke while it persists.
+    if (nodeRecordSplitFrom(this.nodes.get(root)) !== null) this.declinedTangleCount += 1;
   }
 
   /** Index a run that already carries a `splitFrom` (a rebuild scan, or a remote arrival). */
@@ -117,17 +128,15 @@ export class SplitDedupIndex {
    * peers — a duplicated but CONVERGENT tree, never one replica disagreeing with another.
    */
   /**
-   * True if a contested origin was split again in a later round — the tangle the dedup declines.
+   * How many declined tangles this replica's local edits have created (#581).
    *
-   * The materialized tree then differs from what the local author authored, so the session must
-   * reconcile the author's store to it or the author would keep a clean view while every other
-   * replica sees the duplicated one. Cheap and read straight off shared state, so all replicas
-   * agree.
+   * The session reconciles the author's store to the materialized tree when this rises, because
+   * the edit that creates a tangle leaves the author with a clean view while every other replica
+   * converges on the duplicated one. It rises only on the tangle-creating edit, so steady typing
+   * in an already-tangled document costs nothing.
    */
-  hasDeclinedTangle(): boolean {
-    for (const root of this.contestedOrigins) if (this.isReSplit(root)) return true;
-    for (const root of this.liveRootedOrigins) if (this.isReSplit(root)) return true;
-    return false;
+  declinedTangleEvents(): number {
+    return this.declinedTangleCount;
   }
 
   private isReSplit(root: LogicalId): boolean {

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+/**
+ * Deterministic de-duplication of concurrent format splits (#581).
+ *
+ * `setRunProperties` splits the target run and replaces it with new runs carrying copies of
+ * the partitioned text. Two peers doing this at once leave both run-sets in the paragraph, so
+ * the text doubles and both replicas agree on the corruption. Each new run records the origin
+ * run it superseded (a scalar the minting peer owns, so there is no shared container to
+ * race); this index groups the concurrent splits under that origin and names the runs a
+ * replica must drop, keeping one replica's set deterministically so every peer converges on
+ * the same tree with the text intact.
+ */
+
+import type * as Y from 'yjs';
+import { replicaOfLogicalId, type LogicalId } from './identity.ts';
+import { NODE_SPLIT_FROM_FIELD, isNodeMap, nodeRecordSplitFrom } from './schema.ts';
+
+export class SplitDedupIndex {
+  /** Root origin run id → the runs split off from it, across all replicas. */
+  private runsBySplitOrigin = new Map<LogicalId, Set<LogicalId>>();
+
+  constructor(
+    private readonly nodes: Y.Map<Y.Map<unknown>>,
+    private readonly maxDepth: number
+  ) {}
+
+  reset(): void {
+    this.runsBySplitOrigin = new Map();
+  }
+
+  /**
+   * Stamp `runId` as split off from `originalId`, resolved to its ROOT origin.
+   *
+   * One op splits at both edges, so a later split can target a run the earlier split made.
+   * Resolving to the root — the run the whole op superseded — groups every product of a
+   * multi-boundary split under one id, so the concurrent dedup sees them all.
+   */
+  record(originalId: LogicalId, runId: LogicalId): void {
+    const rec = this.nodes.get(runId);
+    if (!isNodeMap(rec)) return;
+    const root = this.rootOf(originalId, replicaOfLogicalId(runId));
+    rec.set(NODE_SPLIT_FROM_FIELD, root);
+    this.index(root, runId);
+  }
+
+  /** Index a run that already carries a `splitFrom` (a rebuild scan, or a remote arrival). */
+  indexExisting(runId: LogicalId): void {
+    const root = nodeRecordSplitFrom(this.nodes.get(runId));
+    if (root !== null) this.index(root, runId);
+  }
+
+  private index(root: LogicalId, runId: LogicalId): void {
+    const runs = this.runsBySplitOrigin.get(root) ?? new Set<LogicalId>();
+    runs.add(runId);
+    this.runsBySplitOrigin.set(root, runs);
+  }
+
+  /**
+   * The root a `runReplica` split reached, following `splitFrom` only through ancestors that
+   * SAME replica minted.
+   *
+   * A multi-boundary split by one peer chains its own runs, so those steps resolve to the
+   * original run — its whole set groups together. But a LATER peer splitting a run this peer
+   * made is a sequential refinement, not a competing split of the original: stopping at the
+   * replica boundary keeps the two out of one group, so the later split is not mistaken for a
+   * concurrent duplicate and dropped.
+   */
+  private rootOf(id: LogicalId, runReplica: string | null): LogicalId {
+    let current = id;
+    for (let depth = 0; depth < this.maxDepth; depth += 1) {
+      if (replicaOfLogicalId(current) !== runReplica) return current;
+      const parent = nodeRecordSplitFrom(this.nodes.get(current));
+      if (parent === null || parent === current) return current;
+      current = parent;
+    }
+    return current;
+  }
+
+  /**
+   * Runs a concurrent split superseded and a replica must not materialize.
+   *
+   * An origin with live split children from MORE THAN ONE minting replica was split by two
+   * peers at once. The winner is the replica whose identity sorts first — every replica reads
+   * the same shared state and picks the same winner — and the losing replicas' runs are
+   * dropped, so the text is kept exactly once.
+   */
+  loserRuns(isTombstoned: (id: LogicalId) => boolean): ReadonlySet<LogicalId> {
+    const losers = new Set<LogicalId>();
+    for (const runs of this.runsBySplitOrigin.values()) {
+      const byReplica = new Map<string, LogicalId[]>();
+      for (const runId of runs) {
+        if (!this.nodes.has(runId) || isTombstoned(runId)) continue;
+        const replica = replicaOfLogicalId(runId) ?? '';
+        const group = byReplica.get(replica) ?? [];
+        group.push(runId);
+        byReplica.set(replica, group);
+      }
+      if (byReplica.size <= 1) continue;
+      const winner = [...byReplica.keys()].sort()[0]!;
+      for (const [replica, runIds] of byReplica) {
+        if (replica === winner) continue;
+        for (const runId of runIds) losers.add(runId);
+      }
+    }
+    return losers;
+  }
+}

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -51,10 +51,11 @@ export class SplitDedupIndex {
    */
   private liveRootedOrigins = new Set<LogicalId>();
   /**
-   * How many times a local edit re-split a run an earlier round produced — the declined tangle
-   * (#581). Monotonic across the session and NOT cleared by `reset()`: it counts edit events,
-   * not current state, so the session compares it against its last-seen value to reconcile the
-   * author's store exactly once per new tangle instead of on every later keystroke.
+   * A monotonic marker bumped whenever a local edit re-splits a run inside a contested lineage —
+   * the declined tangle (#581). It rises by however many product runs that one edit mints, so it
+   * is a CHANGE signal, not a tangle count. NOT cleared by `reset()`: the session compares it
+   * against its last-seen value and reconciles the author's store once per tangle-creating edit,
+   * never on the steady keystrokes in between.
    */
   private declinedTangleCount = 0;
 

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -17,11 +17,39 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 
 import type * as Y from 'yjs';
 import { replicaOfLogicalId, type LogicalId } from './identity.ts';
-import { NODE_SPLIT_FROM_FIELD, isNodeMap, nodeRecordSplitFrom } from './schema.ts';
+import {
+  NODE_SPLIT_FROM_FIELD,
+  isNodeMap,
+  nodeRecordSplitFrom,
+  nodeRecordTombstoned,
+} from './schema.ts';
+
+/**
+ * What the dedup reads about the tree it is projecting, injected so the index stays free of the
+ * record walk. `isPresent` is true only for a run that still hangs off its parent — a
+ * multi-boundary split leaves an intermediate run detached but neither tombstoned nor deleted,
+ * and counting it would double the group's text. `groupText` concatenates the runs' text in
+ * document order — the dedup drops a run only when another run already carries the exact same
+ * text, so it never loses distinct content.
+ */
+export interface SplitDedupContext {
+  readonly isPresent: (id: LogicalId) => boolean;
+  readonly groupText: (runIds: readonly LogicalId[]) => string;
+}
 
 export class SplitDedupIndex {
   /** Root origin run id → the runs split off from it, across all replicas. */
   private runsBySplitOrigin = new Map<LogicalId, Set<LogicalId>>();
+  /** Root origin run id → the distinct replicas that minted a run split off from it. */
+  private replicasByOrigin = new Map<LogicalId, Set<string>>();
+  /** Origins that more than one replica split — the only ones a dedup pass has to examine. */
+  private contestedOrigins = new Set<LogicalId>();
+  /**
+   * Origins that are live again while products still point at them — an undo restored the origin.
+   * A cold rebuild reads this straight from current state, so a peer joining after the undo drops
+   * the stale products the same way the peer that undid does through its sticky contested set.
+   */
+  private liveRootedOrigins = new Set<LogicalId>();
 
   constructor(
     private readonly nodes: Y.Map<Y.Map<unknown>>,
@@ -30,6 +58,9 @@ export class SplitDedupIndex {
 
   reset(): void {
     this.runsBySplitOrigin = new Map();
+    this.replicasByOrigin = new Map();
+    this.contestedOrigins = new Set();
+    this.liveRootedOrigins = new Set();
   }
 
   /**
@@ -43,6 +74,10 @@ export class SplitDedupIndex {
     const rec = this.nodes.get(runId);
     if (!isNodeMap(rec)) return;
     const root = this.rootOf(originalId, replicaOfLogicalId(runId));
+    // A run is not split from itself. Wrapping a run (a TOC bookmark, a hyperlink) removes and
+    // reinserts the SAME node, which looks like a replacement but partitions nothing; stamping it
+    // would let the dedup drop the run as a copy of itself.
+    if (root === runId) return;
     rec.set(NODE_SPLIT_FROM_FIELD, root);
     this.index(root, runId);
   }
@@ -50,13 +85,25 @@ export class SplitDedupIndex {
   /** Index a run that already carries a `splitFrom` (a rebuild scan, or a remote arrival). */
   indexExisting(runId: LogicalId): void {
     const root = nodeRecordSplitFrom(this.nodes.get(runId));
-    if (root !== null) this.index(root, runId);
+    if (root !== null && root !== runId) this.index(root, runId);
   }
 
   private index(root: LogicalId, runId: LogicalId): void {
     const runs = this.runsBySplitOrigin.get(root) ?? new Set<LogicalId>();
     runs.add(runId);
     this.runsBySplitOrigin.set(root, runs);
+    const replicas = this.replicasByOrigin.get(root) ?? new Set<string>();
+    replicas.add(replicaOfLogicalId(runId) ?? '');
+    this.replicasByOrigin.set(root, replicas);
+    // Only an origin two replicas split can produce a loser, so the dedup pass examines just
+    // these — a document that only ever split runs single-author keeps this set empty and the
+    // pass does no work.
+    if (replicas.size > 1) this.contestedOrigins.add(root);
+    // A live origin with products means the split was undone; a cold rebuild has no other trace
+    // of it, so record it here off current state. Empty in normal use — splits tombstone the
+    // origin, so this only fills after an undo.
+    const rec = this.nodes.get(root);
+    if (isNodeMap(rec) && !nodeRecordTombstoned(rec)) this.liveRootedOrigins.add(root);
   }
 
   /**
@@ -85,25 +132,41 @@ export class SplitDedupIndex {
    *
    * An origin with live split children from MORE THAN ONE minting replica was split by two
    * peers at once. The winner is the replica whose identity sorts first — every replica reads
-   * the same shared state and picks the same winner — and the losing replicas' runs are
-   * dropped, so the text is kept exactly once.
+   * the same shared state and picks the same winner — and a losing replica's runs are dropped
+   * ONLY when they carry the exact text the winner already carries, so the concurrent case
+   * keeps the text once while a run a peer grew with new typed text is never lost.
+   *
+   * If the origin run itself is live again — an undo restored it — it represents the text on its
+   * own, so every product that merely repeats it is dropped. Without this, undoing the winner's
+   * split would leave the restored origin AND the loser's runs, doubling the text again.
    */
-  loserRuns(isTombstoned: (id: LogicalId) => boolean): ReadonlySet<LogicalId> {
+  loserRuns(ctx: SplitDedupContext): ReadonlySet<LogicalId> {
     const losers = new Set<LogicalId>();
-    for (const runs of this.runsBySplitOrigin.values()) {
+    const examine = new Set<LogicalId>([...this.contestedOrigins, ...this.liveRootedOrigins]);
+    for (const root of examine) {
+      const runs = this.runsBySplitOrigin.get(root);
+      if (!runs) continue;
       const byReplica = new Map<string, LogicalId[]>();
       for (const runId of runs) {
-        if (!this.nodes.has(runId) || isTombstoned(runId)) continue;
+        if (!ctx.isPresent(runId)) continue;
         const replica = replicaOfLogicalId(runId) ?? '';
         const group = byReplica.get(replica) ?? [];
         group.push(runId);
         byReplica.set(replica, group);
       }
+      if (ctx.isPresent(root)) {
+        const rootText = ctx.groupText([root]);
+        for (const runIds of byReplica.values()) {
+          if (ctx.groupText(runIds) === rootText) for (const id of runIds) losers.add(id);
+        }
+        continue;
+      }
       if (byReplica.size <= 1) continue;
       const winner = [...byReplica.keys()].sort()[0]!;
+      const winnerText = ctx.groupText(byReplica.get(winner)!);
       for (const [replica, runIds] of byReplica) {
         if (replica === winner) continue;
-        for (const runId of runIds) losers.add(runId);
+        if (ctx.groupText(runIds) === winnerText) for (const id of runIds) losers.add(id);
       }
     }
     return losers;


### PR DESCRIPTION
Two people formatting the same paragraph at the same time no longer duplicate its text. A concurrent run-property edit now converges deterministically: each split stamps its new runs with the origin run they replace, materialize keeps one replica's runs, and the text stays intact while one side's formatting wins. Undo of a converged split does not re-double the text, and single-author or steady typing pays no extra cost.

The dedup claims a single round of concurrent splitting. A second round on the same run tangles the runs below what this projection repairs, so it declines that case and the session reconciles the author's store to the shared tree — the result is duplicated but convergent, never divergent, matching the behavior before this change. That deeper case is tracked in #592 for a split-replication rework.

Fixes #581.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790528933&installation_model_id=422592&pr_number=594&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F594&signature=c2683d0dc3873fa33cad93fc54e3ffc37e6af22d96f90855990f4bd7afc62397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->