### PR TITLE
fix(fonts): register packaged faces from the bytes already loaded

### DIFF
--- a/.changeset/warm-fonts-register.md
+++ b/.changeset/warm-fonts-register.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/fonts': patch
+---
+
+Register a packaged face from the bytes already loaded, so it costs no second request and an injected `fetcher` sees every byte read for it. A face that fails to load still registers by URL. Fixes #596.

--- a/docs/api/docx-editor-fonts/index.api.md
+++ b/docs/api/docx-editor-fonts/index.api.md
@@ -93,6 +93,7 @@ export interface FontResolverMark {
 // @public
 export function installDefaultFontFaces(options?: LoadDefaultFontsOptions & {
     readonly document?: Document;
+    readonly loaded?: readonly DefaultFontSource[];
 }): Promise<number>;
 
 // @public

--- a/packages/fonts/src/__tests__/install-font-faces.test.ts
+++ b/packages/fonts/src/__tests__/install-font-faces.test.ts
@@ -1,0 +1,149 @@
+// Paint-side registration reuses the bytes the loader already fetched (#596).
+//
+// The measurement half and the paint half both need the same asset. Registering by URL
+// made the browser fetch it a second time, and — the sharper half — put that request
+// outside `fetcher`, so a host routing font traffic through its own mirror had half its
+// traffic escape. These pin that the bytes are reused, and that a standalone call with no
+// loader behind it still works by URL.
+
+import './dom-setup.ts';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { installDefaultFontFaces, loadDefaultFonts } from '../index.ts';
+
+const assetsDir = new URL('../../assets/', import.meta.url);
+
+/** Serves the packaged assets from disk and records every URL asked for. */
+function countingFetcher(): { fetcher: typeof fetch; requested: string[] } {
+  const requested: string[] = [];
+  const fetcher = ((input: RequestInfo | URL) => {
+    const url = String(input);
+    requested.push(url);
+    const file = url.slice(url.lastIndexOf('/') + 1);
+    return Promise.resolve(new Response(new Uint8Array(readFileSync(new URL(file, assetsDir)))));
+  }) as typeof fetch;
+  return { fetcher, requested };
+}
+
+interface Registered {
+  readonly family: string;
+  readonly source: unknown;
+}
+
+/** Captures what `installDefaultFontFaces` hands the browser, without a browser. */
+function captureRegistrations(): {
+  readonly document: Document;
+  readonly registered: Registered[];
+  restore(): void;
+} {
+  const registered: Registered[] = [];
+  const faces = new Set<unknown>();
+  const previous = (globalThis as { FontFace?: unknown }).FontFace;
+  class StubFontFace {
+    readonly family: string;
+    readonly weight: string;
+    readonly style: string;
+    constructor(family: string, source: unknown, descriptors: Record<string, string>) {
+      this.family = family;
+      this.weight = descriptors.weight ?? '400';
+      this.style = descriptors.style ?? 'normal';
+      registered.push({ family, source });
+    }
+    load(): Promise<this> {
+      return Promise.resolve(this);
+    }
+  }
+  (globalThis as { FontFace?: unknown }).FontFace = StubFontFace;
+  const document = { fonts: faces } as unknown as Document;
+  return {
+    document,
+    registered,
+    restore: () => {
+      (globalThis as { FontFace?: unknown }).FontFace = previous;
+    },
+  };
+}
+
+let active: { restore(): void } | undefined;
+afterEach(() => {
+  active?.restore();
+  active = undefined;
+});
+
+describe('installDefaultFontFaces', () => {
+  test('registers from the bytes the loader already fetched, issuing no request of its own', async () => {
+    const { fetcher, requested } = countingFetcher();
+    const fragment = await loadDefaultFonts({ families: ['Calibri'], fetcher });
+    expect(fragment.sources).toHaveLength(4);
+    const loaderRequests = requested.length;
+
+    const capture = captureRegistrations();
+    active = capture;
+    const installed = await installDefaultFontFaces({
+      families: ['Calibri'],
+      fetcher,
+      document: capture.document,
+      loaded: fragment.sources,
+    });
+
+    expect(installed).toBe(4);
+    // The whole point, and the only assertion here that can see it: bytes, not a
+    // `url(...)` descriptor. `requested` cannot carry this claim — registration never
+    // reads `options.fetcher`, so a URL registration would go straight to the browser
+    // and leave the counter untouched. That is exactly why the old behaviour was
+    // invisible to an injected fetcher.
+    for (const entry of capture.registered) {
+      expect(`${entry.family}: ${entry.source instanceof ArrayBuffer}`).toBe(
+        `${entry.family}: true`
+      );
+    }
+    expect(requested).toHaveLength(loaderRequests);
+    // Under the WORD name, so the browser paints Calibri runs with Carlito glyphs.
+    expect(new Set(capture.registered.map((entry) => entry.family))).toEqual(new Set(['Calibri']));
+  });
+
+  test('falls back to the URL form when no loaded sources are supplied', async () => {
+    const capture = captureRegistrations();
+    active = capture;
+    const installed = await installDefaultFontFaces({
+      families: ['Calibri'],
+      document: capture.document,
+    });
+
+    // The source shape is the claim. `installed` cannot carry it: the stub resolves
+    // `load()` whatever it was handed, so it counts 4 for a broken fallback too.
+    expect(capture.registered.map((entry) => typeof entry.source)).toEqual([
+      'string',
+      'string',
+      'string',
+      'string',
+    ]);
+    for (const entry of capture.registered) {
+      expect(String(entry.source)).toMatch(/^url\(.*Carlito-.*\)$/);
+    }
+  });
+
+  test('ignores loaded sources that are not packaged assets', async () => {
+    const capture = captureRegistrations();
+    active = capture;
+    await installDefaultFontFaces({
+      families: ['Calibri'],
+      document: capture.document,
+      // A composed configuration can carry sources from other origins. Only ids this
+      // package minted name a packaged file, so anything else must not be mistaken for one.
+      loaded: [
+        {
+          request: { family: 'Carlito', weight: 400, style: 'normal' },
+          id: 'google-fonts:Carlito-Regular.ttf',
+          bytes: new Uint8Array([1, 2, 3]),
+          hash: 'sha256:0',
+          faceIndex: 0,
+        },
+      ],
+    });
+
+    for (const entry of capture.registered) {
+      expect(typeof entry.source).toBe('string');
+    }
+  });
+});

--- a/packages/fonts/src/__tests__/install-font-faces.test.ts
+++ b/packages/fonts/src/__tests__/install-font-faces.test.ts
@@ -105,13 +105,14 @@ describe('installDefaultFontFaces', () => {
   test('falls back to the URL form when no loaded sources are supplied', async () => {
     const capture = captureRegistrations();
     active = capture;
-    const installed = await installDefaultFontFaces({
+    await installDefaultFontFaces({
       families: ['Calibri'],
       document: capture.document,
     });
 
-    // The source shape is the claim. `installed` cannot carry it: the stub resolves
-    // `load()` whatever it was handed, so it counts 4 for a broken fallback too.
+    // The source shape is the claim, and the return value is deliberately not asserted:
+    // the stub resolves `load()` whatever it was handed, so a count of 4 would hold for a
+    // broken fallback too.
     expect(capture.registered.map((entry) => typeof entry.source)).toEqual([
       'string',
       'string',

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -177,6 +177,16 @@ export const ALL_WORD_DEFAULT_FAMILIES: readonly WordDefaultFamily[] = Object.fr
 ]);
 
 /**
+ * Source id for a packaged file. Built here and parsed by {@link installDefaultFontFaces}
+ * to find bytes it would otherwise refetch, so the two must not drift; keeping both sides
+ * in one place is what stops them.
+ */
+const SOURCE_ID_PREFIX = 'default-fonts:';
+const sourceIdForFile = (file: string): string => `${SOURCE_ID_PREFIX}${file}`;
+const fileFromSourceId = (id: string): string | undefined =>
+  id.startsWith(SOURCE_ID_PREFIX) ? id.slice(SOURCE_ID_PREFIX.length) : undefined;
+
+/**
  * Load the packaged substitute faces for the given Word families
  * ({@link WORD_DOCUMENT_DEFAULT_FAMILIES} by default) and return a configuration
  * fragment: byte-backed sources for the SUBSTITUTE families plus the Word-name →
@@ -233,7 +243,7 @@ export async function loadDefaultFonts(
             }
             sources.push({
               request: { family: plan.substitute, weight: face.weight, style: face.style },
-              id: `default-fonts:${file}`,
+              id: sourceIdForFile(file),
               bytes,
               // Baked at packaging time and CI-verified; the engine's admission path
               // re-derives and compares, so a swapped asset still fails loudly there.
@@ -283,11 +293,24 @@ const startedInstalls = new WeakMap<FontFaceSet, Set<string>>();
  * diagnostic hint rather than a success signal.
  */
 export async function installDefaultFontFaces(
-  options: LoadDefaultFontsOptions & { readonly document?: Document } = {}
+  options: LoadDefaultFontsOptions & {
+    readonly document?: Document;
+    /**
+     * Sources {@link loadDefaultFonts} already produced. A face found here registers from
+     * those bytes; anything missing still registers by URL, so a standalone call with no
+     * loader behind it behaves exactly as before.
+     */
+    readonly loaded?: readonly DefaultFontSource[];
+  } = {}
 ): Promise<number> {
   const doc = options.document ?? (typeof document !== 'undefined' ? document : undefined);
   const fontSet = (doc as { fonts?: FontFaceSet } | undefined)?.fonts;
   if (!doc || !fontSet || typeof FontFace === 'undefined') return 0;
+  const preloaded = new Map<string, Uint8Array>();
+  for (const source of options.loaded ?? []) {
+    const file = fileFromSourceId(source.id);
+    if (file !== undefined) preloaded.set(file, source.bytes);
+  }
   let started = startedInstalls.get(fontSet);
   if (!started) {
     started = new Set();
@@ -315,7 +338,19 @@ export async function installDefaultFontFaces(
       jobs.push(
         (async () => {
           try {
-            const fontFace = new FontFace(family, `url(${assetUrl(file).href})`, {
+            const bytes = preloaded.get(file);
+            // A copy. These exact buffers also go to the engine as `FontSource.bytes` and
+            // get shaped there, so handing the original to the browser's font machinery
+            // would share one ArrayBuffer between the two. Unlike the engine's own
+            // registration, this is not guarding a windowed view — `bytes` is always a
+            // fresh full-length array — it is keeping the two consumers unaliased.
+            //
+            // No bytes means the face failed to load, and the URL form still registers it.
+            // That request is the one `fetcher` cannot intercept.
+            const source: string | ArrayBuffer = bytes
+              ? (bytes.slice().buffer as ArrayBuffer)
+              : `url(${assetUrl(file).href})`;
+            const fontFace = new FontFace(family, source, {
               weight: String(face.weight),
               style: face.style,
             });
@@ -359,7 +394,9 @@ export async function defaultFonts(
   }
   // Not awaited: painting can start on the platform's substitute and swap when the real
   // face arrives, and blocking the document on it would delay first paint for nothing.
-  void installDefaultFontFaces(loadOptions);
+  // The fragment goes with it, so registration reuses these bytes rather than asking the
+  // browser to fetch each face a second time.
+  void installDefaultFontFaces({ ...loadOptions, loaded: fragment.sources });
   return fragment;
 }
 
@@ -457,11 +494,10 @@ export interface PackagedFontsOptions {
    * {@link installDefaultFontFaces} performs. Measurement is unaffected; painted glyphs
    * fall back to whatever the platform substitutes for the Word family name.
    *
-   * The registration goes through the BROWSER's own loader (`new FontFace(family,
-   * 'url(…)')`), which cannot be given {@link PackagedFontsOptions.fetcher} — so an
-   * injected fetcher measures the byte cost of the measurement half only, and a real
-   * browser makes a second request per face. Same-origin and immutable, so it is normally
-   * served from cache; the registration is idempotent per document either way.
+   * Registration reuses the bytes the resolver already loaded, so a face that loaded costs
+   * no second request and {@link PackagedFontsOptions.fetcher} sees every byte read for it.
+   * A face that FAILED to load has no bytes to reuse and still registers by URL, which
+   * `fetcher` cannot intercept. The registration is idempotent per document.
    */
   readonly install?: boolean;
 }
@@ -583,7 +619,9 @@ export function packagedFonts(options: PackagedFontsOptions = {}): PackagedFonts
     }
     // Not awaited, exactly as in `defaultFonts`: painting can start on the platform's
     // substitute and swap when the real face arrives.
-    if (options.install !== false) void installDefaultFontFaces(loadOptions);
+    if (options.install !== false) {
+      void installDefaultFontFaces({ ...loadOptions, loaded: fragment.sources });
+    }
     return { ...fragment, families };
   }
 


### PR DESCRIPTION
Closes #596.

`installDefaultFontFaces` registered each face with `new FontFace(family, 'url(…)')`, so the browser fetched bytes the same process had usually just downloaded.

The second request was the lesser cost. The sharper one: that request bypassed `LoadDefaultFontsOptions.fetcher`. A host injecting a fetcher to route font traffic through its own mirror, or to run without egress, had half its traffic escape the option that claims to control it.

## What changes

`installDefaultFontFaces` accepts the sources `loadDefaultFonts` already produced:

```ts
readonly loaded?: readonly DefaultFontSource[];
```

`defaultFonts()` and `packagedFonts()` pass the fragment they already hold, so a face that loaded registers from those bytes.

Unchanged: a face that **failed** to load has no bytes to reuse and still registers by URL, as does a standalone `installDefaultFontFaces()` call with no loader behind it. Both are stated in the TSDoc rather than glossed, because that URL request is still one `fetcher` cannot intercept.

The source-id template moves into a single `sourceIdForFile` / `fileFromSourceId` pair. It is now built in one function and parsed in another, and two copies of a string format drift.

## Tests

This function had no coverage. Three tests now pin it, using a stub `FontFace` that records what the registration was handed:

- registers from loaded bytes, adding no request of its own
- falls back to the URL form with no `loaded` supplied
- ignores loaded sources this package did not mint, so a composed configuration carrying `google-fonts:` ids cannot be mistaken for packaged assets

Verified by mutation: forcing the lookup to `undefined` fails with `Expected: "Calibri: true" / Received: "Calibri: false"`.

Two assertions were deliberately demoted after review proved they could not fail. `expect(requested).toHaveLength(…)` cannot see a URL registration, because registration never reads `options.fetcher` — which is precisely why the old behavior was invisible to an injected fetcher. And `expect(installed).toBe(4)` passes for a broken fallback, since the stub resolves `load()` whatever it is handed. Both now sit behind the assertion that carries the claim.

## Note on the API snapshot

Regenerating it surfaced a real slip rather than the known dts nondeterminism: the new helper block had landed between `loadDefaultFonts`'s TSDoc and the function, orphaning its documentation and flipping it to `@public (undocumented)`. Moving the block above the comment restored it, and the snapshot now carries only the intended `loaded` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790580360&installation_model_id=422592&pr_number=599&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F599&signature=ff17dfbf2c00ba77968fdd727af50509e9aa4a6ab4af997a8cfbfb02953bf6d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->