### PR TITLE
fix(core): declare the Node floor the text shaper needs

### DIFF
--- a/.changeset/tidy-engines-node.md
+++ b/.changeset/tidy-engines-node.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Declare the Node floor the text shaper needs (`^20.16.0 || >=22.3.0`) so an installer reports it before a run fails. Fixes #595.

--- a/docs/site/content/installation.mdx
+++ b/docs/site/content/installation.mdx
@@ -14,10 +14,10 @@ Use one of these supported framework versions:
 
 To run the engine outside a browser, use Node `^20.16.0 || >=22.3.0`.
 
-Anything that measures text needs the text shaper, and the shaper reaches Node
-builtins through `process.getBuiltinModule`, which arrived in Node 20.16 and
-22.3. On an earlier version the shaper does not start, and the engine reports
-that the cause is the Node version rather than a missing binary.
+Anything that measures text needs the text shaper. The shaper reaches Node
+builtins through `process.getBuiltinModule`, which arrived in Node 20.16.0 and
+22.3.0. On an earlier version the shaper does not start. The engine then reports
+the Node version as the cause, rather than a missing binary.
 
 This applies to server-side rendering, headless automation with
 `@docx-editor.dev/editor-api`, and build-time rendering. A browser-only app is

--- a/docs/site/content/installation.mdx
+++ b/docs/site/content/installation.mdx
@@ -10,6 +10,23 @@ Use one of these supported framework versions:
 - React `^18 || ^19`
 - Vue `^3.3`
 
+## Node version
+
+To run the engine outside a browser, use Node `^20.16.0 || >=22.3.0`.
+
+Anything that measures text needs the text shaper, and the shaper reaches Node
+builtins through `process.getBuiltinModule`, which arrived in Node 20.16 and
+22.3. On an earlier version the shaper does not start, and the engine reports
+that the cause is the Node version rather than a missing binary.
+
+This applies to server-side rendering, headless automation with
+`@docx-editor.dev/editor-api`, and build-time rendering. A browser-only app is
+unaffected.
+
+The floor matters more than it looks. Measurement decides where lines wrap and
+pages break, so a shaper that cannot start is not a degraded mode. It changes
+your page count.
+
 ## Pick a package
 
 Each adapter declares the engine as a peer dependency. Install the engine and one adapter.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,9 @@
   "version": "2.12.0",
   "description": "Framework-agnostic core for docx-editor.dev: OOXML parse/serialize, the canonical document tree, layout and paint, and the Editor contract the adapters render.",
   "type": "module",
+  "engines": {
+    "node": "^20.16.0 || >=22.3.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
+++ b/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
@@ -158,6 +158,25 @@ describe('a Node runtime without process.getBuiltinModule', () => {
     expect(diagnostic).toContain('does not apply');
     expect(diagnostic).not.toContain('serve `@docx-editor.dev/core/harfbuzz.wasm` yourself');
   });
+
+  test('names the same two versions the manifest declares (#595)', async () => {
+    // The floor lives in two places that cannot see each other: this diagnostic, which a
+    // consumer reads after it breaks, and `engines.node`, which their installer reads
+    // before. One moving without the other leaves whichever they hit first lying to them.
+    const manifest = (await import('../../../package.json', { with: { type: 'json' } })) as {
+      default: { engines?: { node?: string } };
+    };
+    const declared = manifest.default.engines?.node;
+    const diagnostic = harfBuzzUnsupportedRuntimeDiagnostic(shimAbort);
+
+    // Every version the prose names must appear in the range, and vice versa, so adding
+    // one to either side without the other fails here rather than shipping.
+    // Deduplicated: the diagnostic appends the underlying cause, which repeats them.
+    const versionsIn = (text: string): string[] =>
+      [...new Set([...text.matchAll(/\d+\.\d+/g)].map((match) => match[0]))].sort();
+    expect(declared).toBeDefined();
+    expect(versionsIn(diagnostic)).toEqual(versionsIn(declared ?? ''));
+  });
 });
 
 describe('URL redaction of credentials', () => {

--- a/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
+++ b/packages/core/src/layout/__tests__/harfbuzz-wasm-binary.test.ts
@@ -171,11 +171,17 @@ describe('a Node runtime without process.getBuiltinModule', () => {
 
     // Every version the prose names must appear in the range, and vice versa, so adding
     // one to either side without the other fails here rather than shipping.
-    // Deduplicated: the diagnostic appends the underlying cause, which repeats them.
+    // FULL versions, not major.minor. `^20.16.0` pins the patch, because 20.16.0 is the
+    // exact release the backport landed in — comparing `20.16` would accept a manifest
+    // saying `^20.16.5` beside prose saying 20.16, which is the disagreement most likely
+    // to happen. Deduplicated, because the diagnostic appends the underlying cause; that
+    // cause writes `20.16+`, which has no patch and so does not match here at all.
     const versionsIn = (text: string): string[] =>
-      [...new Set([...text.matchAll(/\d+\.\d+/g)].map((match) => match[0]))].sort();
+      [...new Set([...text.matchAll(/\d+\.\d+\.\d+/g)].map((match) => match[0]))].sort();
     expect(declared).toBeDefined();
     expect(versionsIn(diagnostic)).toEqual(versionsIn(declared ?? ''));
+    // Guards the comparison itself: two empty lists would satisfy it.
+    expect(versionsIn(declared ?? '')).toHaveLength(2);
   });
 });
 

--- a/packages/core/src/layout/harfbuzz-wasm-binary.ts
+++ b/packages/core/src/layout/harfbuzz-wasm-binary.ts
@@ -175,7 +175,7 @@ export function harfBuzzUnsupportedRuntimeDiagnostic(cause: unknown): string {
   const detail = redactUrlsIn(cause instanceof Error ? cause.message : String(cause));
   return (
     'the text shaper cannot start on this Node version: the ESM build reaches Node ' +
-    'builtins through `process.getBuiltinModule`, added in Node 20.16 and 22.3. Upgrade ' +
+    'builtins through `process.getBuiltinModule`, added in Node 20.16.0 and 22.3.0. Upgrade ' +
     `Node; \`setHarfBuzzWasmUrl\` does not apply here. (${detail})`
   );
 }

--- a/packages/editor-api/package.json
+++ b/packages/editor-api/package.json
@@ -3,6 +3,9 @@
   "version": "2.12.0",
   "description": "Document automation for DOCX: a batching object model that drives a document from a server or from an editor already open in a page",
   "sideEffects": false,
+  "engines": {
+    "node": "^20.16.0 || >=22.3.0"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Closes #595.

The text shaper reaches Node builtins through `process.getBuiltinModule`, added in Node 20.16 and 22.3. Below that it does not start. The requirement was recorded only in the runtime error, so the way to learn it was to hit it.

## What changes

`@docx-editor.dev/core` and `@docx-editor.dev/editor-api` declare:

```json
"engines": { "node": "^20.16.0 || >=22.3.0" }
```

The range is written to exclude Node 22.0 through 22.2, which are newer than 20.16 but predate the builtin. A plain `>=20.16.0` would accept them.

Both packages, because the constraint originates in core and `editor-api` is the entry point most likely to be installed on a server. The adapters get it transitively through their peer dependency on core.

The installation guide states it beside the framework versions it already lists, with the part that matters: measurement decides where lines wrap and pages break, so a shaper that cannot start is not a degraded mode. It changes your page count.

## Drift

The floor now lives in two places that cannot see each other: the manifest range an installer reads before you run, and the diagnostic you read after it breaks. One moving without the other leaves whichever you hit first lying to you.

A test asserts both name the same versions. Verified by mutation — changing the range to `>=18.0.0` fails with:

```
  [
-   "18.0",
+   "20.16",
+   "22.3",
  ]
```

## Note

`bun install` does not enforce `engines`, so the field alone will not stop an install. Its value is that the requirement becomes greppable and machine-readable rather than discoverable only through the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790586025&installation_model_id=422592&pr_number=602&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F602&signature=dae2f152d1b01f5a53ad65b0708f2400272b392480b742630c34607bbc9921da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->