### PR TITLE
docs(fonts): document serving the catalog yourself and running offline

### DIFF
--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -299,8 +299,8 @@ wider the substitute would run.
 ### Serve the catalog from your own origin
 
 `googleFonts()` fetches from a content delivery network. To send those requests
-somewhere else, pass `fetcher`. It replaces the `fetch` the resolver uses, so
-your function decides where every byte comes from:
+somewhere else, pass `fetcher`. It replaces the `fetch` that resolver uses, so
+your function decides where each catalogued face comes from:
 
 ```ts
 googleFonts({
@@ -308,18 +308,26 @@ googleFonts({
 });
 ```
 
-`packagedFonts()` and `defaultFonts()` take the same option. Their assets ship
-inside the package, so they read your own origin either way.
-
 The bytes suit a mirror well. Each face is pinned to an immutable commit and
-carries a `sha256:` value that the engine re-derives on admission, so a
-substituted or corrupted file fails loudly rather than rendering.
+carries a `sha256:` value. The engine re-derives that hash when it admits the
+bytes, so a substituted or corrupted file fails loudly rather than rendering.
 
-Use `fetcher` for caching too. The resolver keeps fetched bytes in memory,
-keyed by the fetcher you passed, which is what a browser tab needs. A server
-that renders in short-lived processes gets no reuse: nothing is written to disk
-and nothing is shared between workers. Wrapping `fetcher` is where you add
-that:
+`packagedFonts()` and `defaultFonts()` accept `fetcher` too, and their assets
+ship inside the package, so they read your own origin with or without it.
+
+Both also register faces for painting, and that step can reach the browser's own
+`FontFace` loader, which takes a URL rather than your function. To be certain
+every byte goes through `fetcher`, pass `install: false` to `packagedFonts()`.
+Measurement is unaffected: painted glyphs then fall back to whatever the
+platform substitutes for the family name. `defaultFonts()` has no such option,
+so call `loadDefaultFonts()` instead when you need that guarantee.
+
+Use `fetcher` for caching too. `googleFonts()` keeps its catalog fetches in
+memory, keyed by the fetcher you passed, which is what a browser tab needs.
+Nothing else caches: the packaged assets are re-read on every call, and a server
+that renders in short-lived processes gets no reuse either way, because nothing
+is written to disk and nothing is shared between workers. Wrapping `fetcher` is
+where you add that:
 
 ```ts
 googleFonts({
@@ -341,8 +349,8 @@ A face that cannot be fetched is dropped, and the family it belonged to measures
 on the engine's fixed fallback instead.
 
 Treat that as a layout problem, not a cosmetic one. Substitute bytes are what
-keep wrapping and pagination close to Word, so a blocked request changes where
-your pages break rather than only how the text looks.
+keep wrapping and pagination close to Word. A blocked request therefore changes
+where your pages break, not only how the text looks.
 
 The document still opens. Each dropped face goes to the resolver's own
 `onFailure` option, which writes a console warning when you pass no handler:
@@ -353,8 +361,8 @@ googleFonts({
 });
 ```
 
-If your deployment cannot reach a content delivery network, either point
-`fetcher` at a mirror you control or leave `googleFonts()` out and use
+Two options work when your deployment cannot reach a content delivery network.
+Point `fetcher` at a mirror you control. Or leave `googleFonts()` out and use
 `packagedFonts()` alone, which reads only the bytes inside the package.
 
 ### Write your own resolver

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -324,9 +324,9 @@ so call `loadDefaultFonts()` instead when you need that guarantee.
 
 Use `fetcher` for caching too. `googleFonts()` keeps its catalog fetches in
 memory, keyed by the fetcher you passed, which is what a browser tab needs.
-Nothing else caches: the packaged assets are re-read on every call, and a server
-that renders in short-lived processes gets no reuse either way, because nothing
-is written to disk and nothing is shared between workers. Wrapping `fetcher` is
+Nothing else caches. The packaged assets are re-read on every call. A server
+that renders in short-lived processes gets no reuse either way. Nothing is
+written to disk, and nothing is shared between workers. Wrapping `fetcher` is
 where you add that:
 
 ```ts

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -296,6 +296,67 @@ describes itself is not one: `word/fontTable.xml` states a PANOSE
 classification, never an advance width, so nothing in the file bounds how much
 wider the substitute would run.
 
+### Serve the catalog from your own origin
+
+`googleFonts()` fetches from a content delivery network. To send those requests
+somewhere else, pass `fetcher`. It replaces the `fetch` the resolver uses, so
+your function decides where every byte comes from:
+
+```ts
+googleFonts({
+  fetcher: (input) => fetch(rewriteToYourMirror(String(input))),
+});
+```
+
+`packagedFonts()` and `defaultFonts()` take the same option. Their assets ship
+inside the package, so they read your own origin either way.
+
+The bytes suit a mirror well. Each face is pinned to an immutable commit and
+carries a `sha256:` value that the engine re-derives on admission, so a
+substituted or corrupted file fails loudly rather than rendering.
+
+Use `fetcher` for caching too. The resolver keeps fetched bytes in memory,
+keyed by the fetcher you passed, which is what a browser tab needs. A server
+that renders in short-lived processes gets no reuse: nothing is written to disk
+and nothing is shared between workers. Wrapping `fetcher` is where you add
+that:
+
+```ts
+googleFonts({
+  fetcher: async (input) => {
+    const url = String(input);
+    const hit = await yourCache.get(url);
+    if (hit) return new Response(hit);
+    const response = await fetch(url);
+    const bytes = new Uint8Array(await response.clone().arrayBuffer());
+    await yourCache.set(url, bytes);
+    return response;
+  },
+});
+```
+
+### Run without access to the network
+
+A face that cannot be fetched is dropped, and the family it belonged to measures
+on the engine's fixed fallback instead.
+
+Treat that as a layout problem, not a cosmetic one. Substitute bytes are what
+keep wrapping and pagination close to Word, so a blocked request changes where
+your pages break rather than only how the text looks.
+
+The document still opens. Each dropped face goes to the resolver's own
+`onFailure` option, which writes a console warning when you pass no handler:
+
+```ts
+googleFonts({
+  onFailure: ({ family, url, diagnostic }) => report(family, url, diagnostic),
+});
+```
+
+If your deployment cannot reach a content delivery network, either point
+`fetcher` at a mirror you control or leave `googleFonts()` out and use
+`packagedFonts()` alone, which reads only the bytes inside the package.
+
 ### Write your own resolver
 
 Wrap it in `defineFontResolver`. That mark is how `useDocxSource` tells a


### PR DESCRIPTION
Closes #597.

`googleFonts()` fetches from a content delivery network on document open, and `fetcher` is the supported way to send those requests elsewhere. The fonts guide contained no occurrence of `fetcher`, `offline`, `mirror`, or `proxy`, so the capability existed and was undiscoverable.

## What changes

Two sections in `docs/site/content/guides/fonts.mdx`.

**Serve the catalog from your own origin.** How `fetcher` replaces the resolver's `fetch`, why the bytes suit a mirror (each face pinned to an immutable commit, with a `sha256:` the engine re-derives on admission, so a substituted file fails loudly), and that `packagedFonts()` and `defaultFonts()` take the same option.

It also names `fetcher` as the caching seam. The resolver keeps bytes in memory keyed by the fetcher, which is right for a browser tab. A server rendering in short-lived processes gets no reuse, because nothing is written to disk and nothing is shared between workers. Wrapping `fetcher` is where a caller adds that, with a worked example.

**Run without access to the network.** A face that cannot be fetched is dropped and its family falls back to fixed measurement. The section states the consequence plainly: substitute bytes are what keep wrapping close to Word, so a blocked request changes where pages break rather than only how text looks. It gives the two ways out: point `fetcher` at a mirror, or use `packagedFonts()` alone.

## Verified against the code, not written from the issue

- `fetcher` defaults to global `fetch` in both `googleFonts()` and `loadDefaultFonts()`.
- The byte cache is a module-level `WeakMap` keyed by the fetcher, so the doc says "keyed by the fetcher you passed" rather than implying a process-wide cache.
- Failure reporting is the resolver's own `onFailure`, **not** the editor's `onFontError`. My first draft named `onFontError` and was wrong; the record is `{ family, url, diagnostic }`, and `family` is the serving name rather than the name the document wrote.

No changeset: documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790586530&installation_model_id=422592&pr_number=603&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F603&signature=95ad45e1463c08413295fa041aee9706ebcc0264f34fad019c890e2bb993ea36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->