### PR TITLE
fix: inherit style-chain numbering when a style sets only the level

### DIFF
--- a/.changeset/style-chain-numpr-inherit.md
+++ b/.changeset/style-chain-numpr-inherit.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Numbered paragraphs now inherit the list id through the style chain when a style sets only the level, so multilevel heading numbering in legal templates renders. Fixes #600.

--- a/packages/core/src/layout/__tests__/list-style-chain-numpr.test.ts
+++ b/packages/core/src/layout/__tests__/list-style-chain-numpr.test.ts
@@ -1,0 +1,335 @@
+// Style-chain `w:numPr` inheritance (§17.3.1.19): `w:ilvl` and `w:numId` inherit
+// INDEPENDENTLY through `basedOn` and the direct `w:pPr`. Word's standard multilevel
+// heading shape states the `w:num` once on Heading1 and only a level on Heading2–Heading9;
+// reading each `w:numPr` node as a full replacement dropped the id at every level-only
+// tier and unnumbered the whole chain. `w:numId w:val="0"` is the null definition
+// (§17.9.18) — it switches numbering off at its tier even when a lower tier set one.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
+import { buildStyleCascadeTable, type StyleCascadeTable } from '../style-cascade.ts';
+import {
+  listFirstLineOffset,
+  listMarkerBox,
+  readNumPr,
+  resolveStoryListItems,
+  withNumberingStyleLinks,
+} from '../list-resolve.ts';
+import { paragraphFragmentsOf } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+function numbering(body: string) {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${body}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildNumberingIndex(result.part.root);
+}
+
+function styles(body: string): StyleCascadeTable {
+  const result = readOoxmlPart(`<w:styles xmlns:w="${W}">${body}</w:styles>`, {
+    name: '/word/styles.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildStyleCascadeTable(result.part.root);
+}
+
+function document(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function paragraphsOf(part: OoxmlPart): OoxmlElement[] {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  return body.children.filter((child): child is OoxmlElement => child.kind === 'paragraph');
+}
+
+/** The multilevel definition the chain numbers with: `1.`, `1.1`, `(a)`, `(i)`. */
+const CHAIN_NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/>
+      <w:lvlText w:val="(%3)"/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="3"><w:start w:val="1"/><w:numFmt w:val="lowerRoman"/>
+      <w:lvlText w:val="(%4)"/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="12"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+/** Heading1 names the num; the deeper headings state only a level; one style opts out. */
+const CHAIN_STYLES = `
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="Heading1"><w:basedOn w:val="Normal"/>
+    <w:pPr><w:numPr><w:numId w:val="12"/></w:numPr></w:pPr></w:style>
+  <w:style w:type="paragraph" w:styleId="Heading2"><w:basedOn w:val="Heading1"/>
+    <w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr></w:style>
+  <w:style w:type="paragraph" w:styleId="Heading3"><w:basedOn w:val="Heading2"/>
+    <w:pPr><w:numPr><w:ilvl w:val="2"/></w:numPr></w:pPr></w:style>
+  <w:style w:type="paragraph" w:styleId="HeadingPara2"><w:basedOn w:val="Heading2"/>
+    <w:pPr><w:numPr><w:numId w:val="0"/></w:numPr></w:pPr></w:style>
+`;
+
+const styled = (styleId: string, text: string, directPPr = '') =>
+  `<w:p><w:pPr><w:pStyle w:val="${styleId}"/>${directPPr}</w:pPr>` +
+  `<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function markersOf(part: OoxmlPart, cascade: StyleCascadeTable): (string | undefined)[] {
+  const paragraphs = paragraphsOf(part);
+  const items = resolveStoryListItems(paragraphs, numbering(CHAIN_NUMBERING), cascade);
+  return paragraphs.map((paragraph) => items.get(paragraph.id)?.markerText);
+}
+
+describe('style-chain w:numPr inherits numId and ilvl independently', () => {
+  test('level-only heading tiers keep the numId stated on the base heading', () => {
+    const part = document(
+      styled('Heading1', 'One') +
+        styled('Heading2', 'One point one') +
+        styled('Heading2', 'One point two') +
+        styled('Heading3', 'Letter a') +
+        styled('Heading1', 'Two') +
+        styled('Heading2', 'Two point one')
+    );
+    expect(markersOf(part, styles(CHAIN_STYLES))).toEqual(['1.', '1.1', '1.2', '(a)', '2.', '2.1']);
+  });
+
+  test('w:numId w:val="0" at a style tier cancels the inherited numbering', () => {
+    // The opted-out paragraph resolves to no numbering AND does not advance the counters:
+    // the headings around it number as though it were plain text.
+    const part = document(
+      styled('Heading1', 'One') +
+        styled('Heading2', 'One point one') +
+        styled('HeadingPara2', 'Body text under the heading') +
+        styled('Heading2', 'One point two')
+    );
+    expect(markersOf(part, styles(CHAIN_STYLES))).toEqual(['1.', '1.1', undefined, '1.2']);
+  });
+
+  test('a direct level-only w:numPr keeps the style numId and changes the level', () => {
+    const part = document(
+      styled('Heading1', 'One') +
+        styled('Heading2', 'One point one') +
+        styled('Heading2', 'Demoted to a letter', '<w:numPr><w:ilvl w:val="2"/></w:numPr>')
+    );
+    expect(markersOf(part, styles(CHAIN_STYLES))).toEqual(['1.', '1.1', '(a)']);
+  });
+
+  test('a direct valid numId re-enables numbering over a cancelling style tier', () => {
+    // HeadingPara2 states numId 0; the paragraph's own tier re-states the id, and the
+    // level it inherited through Heading2 (ilvl 1) still applies — per-field, both ways.
+    const part = document(
+      styled('Heading1', 'One') +
+        styled('HeadingPara2', 'Renumbered', '<w:numPr><w:numId w:val="12"/></w:numPr>')
+    );
+    expect(markersOf(part, styles(CHAIN_STYLES))).toEqual(['1.', '1.1']);
+  });
+
+  test('an ilvl-only chain with no numId anywhere resolves to no numbering', () => {
+    const cascade = styles(`
+      <w:style w:type="paragraph" w:styleId="LevelOnly">
+        <w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr></w:style>
+    `);
+    const part = document(styled('LevelOnly', 'No id below'));
+    expect(markersOf(part, cascade)).toEqual([undefined]);
+  });
+});
+
+describe('readNumPr folds hostile tiers per field', () => {
+  /** Each entry is one cascade tier's `w:pPr`, lowest precedence first. */
+  function foldedNumPr(...tiers: string[]): { numId: string; ilvl: number } | null {
+    const part = document(tiers.map((pPr) => `<w:p><w:pPr>${pPr}</w:pPr></w:p>`).join(''));
+    const nodes = paragraphsOf(part).map(
+      (paragraph) => paragraph.children.find((child) => child.kind === 'paragraphProperties')!
+    );
+    return readNumPr(nodes);
+  }
+
+  test('a later numId-only tier keeps the folded level', () => {
+    expect(
+      foldedNumPr(
+        '<w:numPr><w:ilvl w:val="1"/><w:numId w:val="5"/></w:numPr>',
+        '<w:numPr><w:numId w:val="7"/></w:numPr>'
+      )
+    ).toEqual({ numId: '7', ilvl: 1 });
+  });
+
+  test('an oversized numId cancels like numId 0', () => {
+    const oversized = 'x'.repeat(65);
+    expect(
+      foldedNumPr(
+        '<w:numPr><w:numId w:val="5"/></w:numPr>',
+        `<w:numPr><w:numId w:val="${oversized}"/></w:numPr>`
+      )
+    ).toBeNull();
+  });
+
+  test('an out-of-range ilvl invalidates the tier', () => {
+    expect(
+      foldedNumPr(
+        '<w:numPr><w:numId w:val="5"/></w:numPr>',
+        '<w:numPr><w:ilvl w:val="9"/></w:numPr>'
+      )
+    ).toBeNull();
+  });
+
+  test('an unparseable ilvl reads as level 0, not as a cancellation', () => {
+    expect(foldedNumPr('<w:numPr><w:ilvl w:val="abc"/><w:numId w:val="5"/></w:numPr>')).toEqual({
+      numId: '5',
+      ilvl: 0,
+    });
+  });
+
+  test('a valid tier above a cancelled one re-enables', () => {
+    expect(
+      foldedNumPr(
+        '<w:numPr><w:ilvl w:val="2"/><w:numId w:val="5"/></w:numPr>',
+        '<w:numPr><w:numId w:val="0"/></w:numPr>',
+        '<w:numPr><w:numId w:val="7"/></w:numPr>'
+      )
+    ).toEqual({ numId: '7', ilvl: 2 });
+  });
+});
+
+describe('w:numStyleLink resolution matches the merged read', () => {
+  const LINKED = `
+    <w:abstractNum w:abstractNumId="0"><w:numStyleLink w:val="Leaf"/></w:abstractNum>
+    <w:abstractNum w:abstractNumId="1">
+      <w:styleLink w:val="Leaf"/>
+      <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="•"/>
+        <w:lvlJc w:val="left"/></w:lvl>
+    </w:abstractNum>
+    <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
+    <w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>
+  `;
+
+  test('a level-only linked style walks basedOn for the numId', () => {
+    const cascade = styles(`
+      <w:style w:type="paragraph" w:styleId="Base">
+        <w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr></w:style>
+      <w:style w:type="paragraph" w:styleId="Leaf"><w:basedOn w:val="Base"/>
+        <w:pPr><w:numPr><w:ilvl w:val="0"/></w:numPr></w:pPr></w:style>
+    `);
+    const linked = withNumberingStyleLinks(numbering(LINKED), cascade);
+    expect(linked.abstractNums.get('0')?.levels.get(0)?.lvlText).toBe('•');
+  });
+
+  test('a linked style stating numId 0 resolves inertly, not through its base', () => {
+    const cascade = styles(`
+      <w:style w:type="paragraph" w:styleId="Base">
+        <w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr></w:style>
+      <w:style w:type="paragraph" w:styleId="Leaf"><w:basedOn w:val="Base"/>
+        <w:pPr><w:numPr><w:numId w:val="0"/></w:numPr></w:pPr></w:style>
+    `);
+    const linked = withNumberingStyleLinks(numbering(LINKED), cascade);
+    expect(linked.abstractNums.get('0')?.levels.size).toBe(0);
+  });
+});
+
+describe('a positive-firstLine level places the marker after the text start', () => {
+  // The standard legal-numbering shape: `w:ind w:left="0" w:firstLine="720"` plus a `num`
+  // tab one grid stop further. The marker sits at 0.5" (36pt), the first-line text tabs to
+  // 1" (72pt), and continuation lines return to the margin. `w:hanging` and a positive
+  // `w:firstLine` are one mutually exclusive slot (§17.3.1.10, §17.3.1.12).
+  const FIRSTLINE_NUMBERING = `
+    <w:abstractNum w:abstractNumId="1">
+      <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+        <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/>
+        <w:pPr><w:tabs><w:tab w:val="num" w:pos="1440"/></w:tabs>
+          <w:ind w:left="0" w:firstLine="720"/></w:pPr></w:lvl>
+    </w:abstractNum>
+    <w:num w:numId="20"><w:abstractNumId w:val="1"/></w:num>
+  `;
+  const numbered = (text: string) =>
+    '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="20"/></w:numPr></w:pPr>' +
+    `<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+  test('the marker box starts at left + firstLine and the suffix tab clears it', () => {
+    const part = document(numbered('Section text'));
+    const paragraphs = paragraphsOf(part);
+    const items = resolveStoryListItems(paragraphs, numbering(FIRSTLINE_NUMBERING), undefined);
+    const item = items.get(paragraphs[0]!.id)!;
+    expect(item.indent).toEqual({ left: 0, right: 0, hanging: 0, firstLine: 36 });
+    // `1.` at 6pt/char is 12pt wide; the marker starts at the 36pt first-line indent.
+    const box = listMarkerBox(item, 12, 0, 14)!;
+    expect(box.x).toBe(36);
+    // Marker end 48pt → the next default half-inch stop, 72pt from the text start.
+    expect(listFirstLineOffset(item, measurer)).toBe(72);
+  });
+
+  test('the first line tabs past the marker; continuation lines return to left', () => {
+    const part = document(numbered('aaaa aaaa aaaa aaaa aaaa aaaa'));
+    const items = resolveStoryListItems(paragraphsOf(part), numbering(FIRSTLINE_NUMBERING));
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer,
+      listItems: items,
+      geometry: { width: 220, height: 400, margin: { top: 20, right: 20, bottom: 20, left: 20 } },
+    });
+    const fragment = paragraphFragmentsOf(layout.pages[0]!)[0]!;
+    expect(fragment.marker?.text).toBe('1.');
+    expect(fragment.marker?.box.x).toBe(36);
+    expect(fragment.lines.length).toBeGreaterThan(1);
+    expect(fragment.lines[0]!.contentX).toBe(72);
+    expect(fragment.lines[1]!.contentX).toBe(0);
+  });
+
+  test('a hanging level keeps its old marker box', () => {
+    const HANGING_NUMBERING = `
+      <w:abstractNum w:abstractNumId="1">
+        <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+          <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/>
+          <w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl>
+      </w:abstractNum>
+      <w:num w:numId="20"><w:abstractNumId w:val="1"/></w:num>
+    `;
+    const part = document(numbered('Hanging text'));
+    const paragraphs = paragraphsOf(part);
+    const items = resolveStoryListItems(paragraphs, numbering(HANGING_NUMBERING), undefined);
+    const item = items.get(paragraphs[0]!.id)!;
+    expect(item.indent).toEqual({ left: 36, right: 0, hanging: 18, firstLine: 0 });
+    expect(listMarkerBox(item, 12, 0, 14)!.x).toBe(18);
+    expect(listFirstLineOffset(item, measurer)).toBe(0);
+  });
+});
+
+describe('a style-chain resolution change renumbers an incremental pass', () => {
+  test('a changed heading level reaches the session path', () => {
+    // The resolved marker feeds `cacheToken`, which the break cache and the prepared-block
+    // memo key on — a cascade change must move the fragments, not serve the warm pages.
+    const part = document(styled('Heading1', 'One') + styled('Heading2', 'Nested'));
+    const level = (ilvl: string) =>
+      styles(CHAIN_STYLES.replace('<w:ilvl w:val="1"/>', `<w:ilvl w:val="${ilvl}"/>`));
+    const markers = (
+      cascade: StyleCascadeTable,
+      session?: ReturnType<typeof createLayoutSession>
+    ) =>
+      paragraphFragmentsOf(
+        layoutSemanticDocument(part, 1, {
+          measurer,
+          numberingIndex: numbering(CHAIN_NUMBERING),
+          styleCascade: cascade,
+          ...(session ? { session } : {}),
+        }).pages[0]!
+      ).map((fragment) => fragment.marker?.text);
+
+    const session = createLayoutSession();
+    expect(markers(level('1'), session)).toEqual(['1.', '1.1']);
+    const incremental = markers(level('2'), session);
+    expect(incremental).toEqual(markers(level('2')));
+    expect(incremental).toEqual(['1.', '(a)']);
+  });
+});

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -144,39 +144,65 @@ function childNamed(node: OoxmlElement, localName: string): OoxmlElement | undef
 }
 
 /**
- * Read `w:numPr` from cascaded paragraph-property nodes (last wins).
+ * One `w:numPr` tier read per FIELD. `undefined` means the tier does not state the field.
+ *
+ * `numId: null` is a tier that states "no numbering": `w:val="0"` (§17.9.18 — the null
+ * numbering definition), a `w:numId` with no value, or an oversized value (hostile-input
+ * guard). `ilvl: null` is a stated level outside 0–8, which invalidates the tier's
+ * numbering the same way; an unparseable level reads as 0, as before.
+ */
+function numPrFieldsOf(
+  node: OoxmlNode
+): { numId: string | null | undefined; ilvl: number | null | undefined } | null {
+  if (!isElement(node)) return null;
+  const numPr = childNamed(node, 'numPr');
+  if (!numPr) return null;
+  const numIdNode = childNamed(numPr, 'numId');
+  const ilvlNode = childNamed(numPr, 'ilvl');
+  let numId: string | null | undefined;
+  if (numIdNode) {
+    const val = attrVal(numIdNode, 'val');
+    numId = val !== undefined && val !== '0' && val.length <= 64 ? val : null;
+  }
+  let ilvl: number | null | undefined;
+  if (ilvlNode) {
+    const raw = attrVal(ilvlNode, 'val');
+    const parsed = /^\d{1,2}$/.test(raw ?? '') ? Number(raw) : 0;
+    ilvl = parsed <= 8 ? parsed : null;
+  }
+  return { numId, ilvl };
+}
+
+/**
+ * Read `w:numPr` from cascaded paragraph-property nodes (lowest precedence first).
  *
  * Flat `OoxmlProperty[]` bags drop nested `ilvl`/`numId`, so this walks the tree nodes
  * the same way borders and tabs do.
+ *
+ * `w:ilvl` and `w:numId` inherit INDEPENDENTLY through the style chain and the direct
+ * `w:pPr` (§17.3.1.19): a tier stating only the level keeps the id it inherits — Word's
+ * standard Heading2–Heading9 shape, where only Heading1 names the `w:num` — and a tier
+ * stating only the id keeps the inherited level. Treating each `w:numPr` node as a full
+ * replacement dropped the id at every level-only tier and unnumbered the paragraph. A
+ * stated `w:numId w:val="0"` (or an invalid value) still switches numbering off at that
+ * tier even when a lower tier set one; a higher tier stating a valid id re-enables. A
+ * level-only tier with no id inherited from below resolves to no numbering.
  */
 export function readNumPr(
   paragraphPropertyNodes: readonly OoxmlNode[]
 ): { numId: string; ilvl: number } | null {
-  let found: { numId: string; ilvl: number } | null = null;
+  let numId: string | null = null;
+  let ilvl = 0;
   for (const node of paragraphPropertyNodes) {
-    if (!isElement(node)) continue;
-    const numPr = childNamed(node, 'numPr');
-    if (!numPr) continue;
-    const ilvlNode = childNamed(numPr, 'ilvl');
-    const numIdNode = childNamed(numPr, 'numId');
-    const numId = numIdNode ? attrVal(numIdNode, 'val') : undefined;
-    const ilvlRaw = ilvlNode ? attrVal(ilvlNode, 'val') : '0';
-    if (!numId || numId === '0') {
-      found = null;
-      continue;
+    const fields = numPrFieldsOf(node);
+    if (!fields) continue;
+    if (fields.numId !== undefined) numId = fields.numId;
+    if (fields.ilvl !== undefined) {
+      if (fields.ilvl === null) numId = null;
+      else ilvl = fields.ilvl;
     }
-    if (numId.length > 64) {
-      found = null;
-      continue;
-    }
-    const ilvl = /^\d{1,2}$/.test(ilvlRaw ?? '') ? Number(ilvlRaw) : 0;
-    if (ilvl < 0 || ilvl > 8) {
-      found = null;
-      continue;
-    }
-    found = { numId, ilvl };
   }
-  return found;
+  return numId === null ? null : { numId, ilvl };
 }
 
 /**
@@ -193,8 +219,11 @@ function numIdForStyle(styleCascade: StyleCascadeTable, styleId: string): string
     if (seen.has(current.styleId)) return undefined;
     seen.add(current.styleId);
     const node = current.paragraphPropertiesNode;
-    const numPr = node ? readNumPr([node]) : null;
-    if (numPr) return numPr.numId;
+    const fields = node ? numPrFieldsOf(node) : null;
+    // The NEAREST style that states `w:numId` decides, exactly as the merged read above
+    // does: a stated `w:val="0"` switches numbering off rather than deferring to the
+    // base, and a level-only `w:numPr` keeps walking for the id it inherits.
+    if (fields && fields.numId !== undefined) return fields.numId ?? undefined;
     current = current.basedOn === null ? undefined : styleCascade.styles.get(current.basedOn);
   }
   return undefined;
@@ -795,10 +824,18 @@ function resolveStoryListItemsStable(
 }
 
 /**
- * Horizontal marker box inside the hanging indent slot.
+ * Horizontal marker box inside the first-line indent slot.
  *
  * Coordinates are relative to the same origin as paragraph content (`indent.left` is the
  * text start). Returns null when there is nothing to paint.
+ *
+ * `w:hanging` and a positive `w:firstLine` are one mutually exclusive slot
+ * (§17.3.1.10, §17.3.1.12), so the marker has two placements, not an interaction:
+ * a hanging level puts the marker BEFORE the text start (`left - hanging`); a
+ * positive-firstLine level puts it AFTER (`left + firstLine`) — the standard legal
+ * shape `w:ind w:left="0" w:firstLine="720"` numbers at 0.5" while continuation
+ * lines return to the margin. Reading only the hanging model painted every such
+ * marker at the left margin.
  */
 export function listMarkerBox(
   item: ResolvedListItem,
@@ -813,15 +850,20 @@ export function listMarkerBox(
 
   const textLeft = item.indent.left;
   const hanging = item.indent.hanging;
+  // The hanging spelling wins when a hostile file states both (Word's collapse); a
+  // NEGATIVE firstLine is the hang spelled the other way and stays on the hanging model.
+  const firstLine = hanging > 0 ? 0 : Math.max(0, item.indent.firstLine);
   // Markers stop at the content origin — except for a paragraph the author pulled INTO the
   // margin with a negative `w:ind` (§17.3.1.12), where pinning the marker at zero would put
   // the number to the RIGHT of the text it numbers.
   const floor = Math.min(0, textLeft);
-  const slotLeft = Math.max(floor, textLeft - hanging);
+  const slotLeft = firstLine > 0 ? textLeft + firstLine : Math.max(floor, textLeft - hanging);
   const slotWidth = Math.max(hanging, markerWidth);
   let x = slotLeft;
   if (item.markerAlign === 'right') {
-    x = textLeft - markerWidth;
+    // The alignment anchor is the slot's right edge: the text start for a hanging level,
+    // the shifted slot's end for a first-line level.
+    x = firstLine > 0 ? slotLeft + slotWidth - markerWidth : textLeft - markerWidth;
   } else if (item.markerAlign === 'center') {
     x = slotLeft + (slotWidth - markerWidth) / 2;
   }
@@ -841,6 +883,11 @@ export function listMarkerBox(
  * - `w:suff="tab"` with a marker WIDER than its slot (`viii.`, `%1.%2.%3.`) — the suffix tab
  *   advances to the next tab stop past the marker, so the first line moves right instead of
  *   the marker being painted over its own first word.
+ *
+ * A positive-firstLine level's marker ends PAST the text start, so its suffix tab always
+ * takes the stop lookup. `tabStops` is the PARAGRAPH's resolved stops: a `w:tab` the level
+ * itself states (`w:num` at the next grid stop is the shape Word writes) is not folded in,
+ * and the default half-inch grid lands on the same destination.
  */
 export function listFirstLineOffset(
   item: ResolvedListItem,

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -2056,8 +2056,9 @@ function layoutBlocksPass(
     // The schema treats them as mutually exclusive; where a producer writes both, hanging
     // wins, which is how Word reads it.
     // A NUMBERED/BULLETED paragraph's first-line slot belongs to the MARKER: `listMarkerBox`
-    // places it at `left - hanging`, and Word's `w:suff` puts the text back at `left` — or
-    // after the marker, or at the next tab stop past an overflowing one (§17.9.30).
+    // places it at `left - hanging` (or at `left + firstLine` for a positive-firstLine
+    // level), and Word's `w:suff` puts the text back at `left` — or after the marker, or at
+    // the next tab stop past an overflowing one (§17.9.30).
     let firstLineOffset = firstLineOffsetOf(entry);
     const paragraphId = paragraph.id;
     // `w:between` (§17.3.1.24): consecutive paragraphs with IDENTICAL border settings are ONE

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -455,8 +455,9 @@ function placeCellParagraph(
   // offset. Contextual spacing is a body-flow question (it compares document neighbours),
   // so it is not applied per cell.
   // A NUMBERED/BULLETED paragraph's first-line slot belongs to the MARKER: `listMarkerBox`
-  // places it at `left - hanging`, and Word's `w:suff` puts the text back at `left` — or
-  // after the marker, or at the next tab stop past an overflowing one (§17.9.30).
+  // places it at `left - hanging` (or at `left + firstLine` for a positive-firstLine
+  // level), and Word's `w:suff` puts the text back at `left` — or after the marker, or at
+  // the next tab stop past an overflowing one (§17.9.30).
   const firstLineOffset = firstLineShift(listItem, indent, deps.measurer, tabStops, available);
   const rawZones = deps.pageExclusionZones?.() ?? Object.freeze([]);
   const paragraphOrder = deps.paragraphOrderIndex?.(paragraphId) ?? Number.MAX_SAFE_INTEGER;


### PR DESCRIPTION
Multilevel legal templates number headings through the style chain: one base style names the `w:num`, and each derived style states only a `w:ilvl`. The cascade read treated every `w:numPr` node as a full replacement, so a level-only tier dropped the inherited id and the paragraph lost its number. On a representative document, 202 of 217 numbered paragraphs rendered without markers.

`readNumPr` now folds `w:numId` and `w:ilvl` independently across the cascade, per ISO 29500 §17.3.1.19. A stated `w:numId w:val="0"` still switches numbering off at its tier, and a direct paragraph `w:numPr` still overrides field by field. `numIdForStyle` follows the same semantics on the `basedOn` walk.

`listMarkerBox` also gains the positive `w:firstLine` placement: a level that states `w:ind w:left="0" w:firstLine="720"` puts its marker at the first-line indent and tabs the text past it, while continuation lines return to the left indent. The hanging model is unchanged.

Fixes #600

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790586543&installation_model_id=422592&pr_number=604&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F604&signature=dedfbf1bf654761f54d0a158e40b65b591c30ad874d5cf49ed4782bdace3545f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->