### PR TITLE
chore(test): make the parallel test runner machine-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,16 +26,16 @@ the legal license files or `LicenseRef-EigenPal-Pro-Evaluation-1.0` metadata.
 
 One engine. Thin chrome on top.
 
-| Package       | What                                                                                                                                                                                           | Status                         |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `core`        | **The engine.** `store/` (canonical tree, ops, OPC read/write), `layout/` (DOM-free), `output/` (paint), `editor/` (facade, surface, chrome registry), `contracts/`, `binding/`, `automation/` | published, external to `react` |
-| `react`       | The adapter: provider + hooks, holds no editing state                                                                                                                                          | published                      |
-| `i18n`        | Shared strings                                                                                                                                                                                 | published                      |
-| `editor-api`  | `DocxEditor` automation object model, headless/server                                                                                                                                          | published, Pro license         |
-| `pro`         | Review module (comments, tracked changes) + custom nodes, as `EditorModule`s                                                                                                                   | published, Pro license         |
-| `fonts`       | Metric-compatible substitutes for Word's defaults                                                                                                                                              | published                      |
-| `vue`         | The Vue 3 adapter twin, parity-gated against `react`                                                                                                                                           | published                      |
-| `nuxt`        | Nuxt module over the Vue adapter                                                                                                                                                               | WIP, private                   |
+| Package      | What                                                                                                                                                                                           | Status                         |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `core`       | **The engine.** `store/` (canonical tree, ops, OPC read/write), `layout/` (DOM-free), `output/` (paint), `editor/` (facade, surface, chrome registry), `contracts/`, `binding/`, `automation/` | published, external to `react` |
+| `react`      | The adapter: provider + hooks, holds no editing state                                                                                                                                          | published                      |
+| `i18n`       | Shared strings                                                                                                                                                                                 | published                      |
+| `editor-api` | `DocxEditor` automation object model, headless/server                                                                                                                                          | published, Pro license         |
+| `pro`        | Review module (comments, tracked changes) + custom nodes, as `EditorModule`s                                                                                                                   | published, Pro license         |
+| `fonts`      | Metric-compatible substitutes for Word's defaults                                                                                                                                              | published                      |
+| `vue`        | The Vue 3 adapter twin, parity-gated against `react`                                                                                                                                           | published                      |
+| `nuxt`       | Nuxt module over the Vue adapter                                                                                                                                                               | WIP, private                   |
 
 React and Vue both ship; the parity gates below keep them from drifting.
 
@@ -175,6 +175,14 @@ openspec validate typed-ooxml-paragraph-editor --strict
   what CI runs. `bun test` still works and is the one to reach for when you want
   a single file, `-t`, or `--watch`; `bun run test:serial` is the whole suite the
   old way.
+- The pool is machine-aware, and must stay that way: the heavy OOXML-oracle files
+  peak at multiple GiB each and slowest-first starts them together, which once
+  froze a 48 GiB machine (fourteen workers, ~94 GiB footprint, WindowServer
+  watchdog death). The runner caps width by installed memory, splits width and
+  budget between concurrent runs on the machine (tmpdir registry), and gates
+  dispatch on each file's measured peak footprint plus live memory pressure.
+  `--jobs` pins the width but never lifts the gate. A single test file that needs
+  more than a few GiB is a bug to file, not a budget to raise.
 - A file that leaves state on `document` can only be caught by the serial run —
   per-file processes hide it. Scope DOM queries to the container you mounted.
 - `git commit --no-verify` is fine locally, but `bun run format` and `bun run lint` are not

--- a/scripts/test/run-parallel.mjs
+++ b/scripts/test/run-parallel.mjs
@@ -15,12 +15,18 @@
 //
 // Slowest-first, from a duration cache written on every run, so the long poles start immediately
 // instead of landing last and leaving the pool half-idle.
+//
+// The pool is machine-aware: width is capped by installed memory as well as cores and split
+// between concurrent runs on the same machine, and dispatch spends each file's measured peak
+// footprint against the memory the machine actually has available right now, so the heavy files
+// cannot all land at once. `--jobs N` pins the width but never lifts the dispatch gate.
 
-import { spawn } from 'node:child_process';
-import { availableParallelism } from 'node:os';
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { execFile, execFileSync, spawn } from 'node:child_process';
+import { availableParallelism, freemem, tmpdir, totalmem } from 'node:os';
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 // `scripts/` as well as `packages/`: the checks that guard the published manifests and the
@@ -52,6 +58,135 @@ const TEST_FILE = /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/;
  */
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+const GiB = 1024 ** 3;
+
+/**
+ * Memory guards, learned the hard way: slowest-first ordering starts the heaviest files (the
+ * whole-package OOXML oracles, measured at 2–4 GiB each and worse under swap) all at once, and a
+ * pool sized to cores alone once put fourteen multi-GiB bun processes on a 48 GiB machine. The
+ * thrash starved trustd, tccd blocked on it, and the WindowServer watchdog killed the login
+ * session. "Run the suite" must not be able to take down the machine, so the pool is bounded:
+ *
+ * 1. Width is capped by installed memory, not just cores, and split between concurrent runs on
+ *    the same machine (two sessions, two worktrees), which find each other through a tmpdir
+ *    registry. The split is re-read during the run, so the first run shrinks when a second one
+ *    starts instead of only the newcomer paying.
+ * 2. Dispatch spends each file's measured peak footprint against what the machine has available
+ *    RIGHT NOW; commitments not yet materialized (dispatched but not yet grown, tracked from live
+ *    RSS samples) are charged on top. A heavy head file reserves its share so cheap files can
+ *    flow past it without starving it.
+ * 3. Files with no measurement yet (a cold cache, a new file) are additionally limited to a few
+ *    in flight at once, because "unknown" includes "another multi-GiB oracle".
+ * 4. Dispatch pauses outright under real memory pressure. One file may always run, so the gate
+ *    can stall but never deadlock.
+ */
+const WORKER_MEMORY_SLICE = 3 * GiB;
+/** What an unmeasured file is charged against the allowance. */
+const UNKNOWN_PEAK_BYTES = 1 * GiB;
+/** What a file too fast to sample is charged; also the floor under noisy tiny measurements. */
+const PEAK_FLOOR_BYTES = 128 * 1024 * 1024;
+/** What an unmeasured file might REALLY cost — the incident's oracles; sizes the unknown limit. */
+const HEAVY_UNKNOWN_BYTES = 6 * GiB;
+const PEAK_SAMPLE_INTERVAL_MS = 500;
+/** Registry entries older than this are dead runs whatever their pid now maps to. */
+const RUN_ENTRY_MAX_AGE_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * System memory still available, by the accounting the platform's own killer uses where one
+ * exists. Raw free pages understate macOS headroom badly (file cache and inactive pages are
+ * reclaimable), so `os.freemem()` is only the fallback. Cached briefly: the probe forks a
+ * process on macOS, and the gate consults it from every blocked worker every poll.
+ */
+let memorySample = { at: 0, bytes: 0 };
+function availableMemory() {
+  if (Date.now() - memorySample.at < PEAK_SAMPLE_INTERVAL_MS) return memorySample.bytes;
+  let bytes;
+  try {
+    if (process.platform === 'darwin') {
+      const level = Number(
+        execFileSync('sysctl', ['-n', 'kern.memorystatus_level'], { encoding: 'utf8' })
+      );
+      bytes = Number.isFinite(level) ? (level / 100) * totalmem() : freemem();
+    } else if (process.platform === 'linux') {
+      const match = readFileSync('/proc/meminfo', 'utf8').match(/^MemAvailable:\s+(\d+) kB/m);
+      bytes = match ? Number(match[1]) * 1024 : freemem();
+    } else {
+      bytes = freemem();
+    }
+  } catch {
+    bytes = freemem();
+  }
+  memorySample = { at: Date.now(), bytes };
+  return bytes;
+}
+
+/** Real pressure, not just a busy machine: the point where dispatching more work makes it worse. */
+function underMemoryPressure() {
+  return availableMemory() < Math.max(2 * GiB, totalmem() * 0.05);
+}
+
+const RUN_REGISTRY = join(tmpdir(), 'docx-editor-test-runs');
+
+function registerRun() {
+  try {
+    mkdirSync(RUN_REGISTRY, { recursive: true });
+    const own = join(RUN_REGISTRY, String(process.pid));
+    writeFileSync(own, String(Date.now()));
+    process.on('exit', () => {
+      try {
+        rmSync(own, { force: true });
+      } catch {
+        // A stale entry is cleaned up by the next run's liveness check.
+      }
+    });
+    // Signal death skips 'exit' handlers; route the common Ctrl+C through process.exit so the
+    // registry entry is removed instead of haunting every later run's split.
+    process.on('SIGINT', () => process.exit(130));
+    process.on('SIGTERM', () => process.exit(143));
+  } catch {
+    // No registry means no sharing, which only costs politeness between runs.
+  }
+}
+
+/**
+ * How many suite runs are alive on this machine right now, this one included. A pid that no
+ * longer exists, one this user may not signal (EPERM means the pid was recycled by someone
+ * else's process — our runs share a user), or an entry past the age cap is a dead run: removed,
+ * not counted, so a ghost can never permanently halve every future run.
+ */
+function liveRuns() {
+  let count = 0;
+  try {
+    for (const name of readdirSync(RUN_REGISTRY)) {
+      const pid = Number(name);
+      if (!Number.isInteger(pid) || pid <= 0) continue;
+      const entry = join(RUN_REGISTRY, name);
+      let alive = false;
+      try {
+        const born = Number(readFileSync(entry, 'utf8'));
+        if (Number.isFinite(born) && Date.now() - born < RUN_ENTRY_MAX_AGE_MS) {
+          process.kill(pid, 0);
+          alive = true;
+        }
+      } catch {
+        // Not signalable by us: dead or recycled either way.
+      }
+      if (alive) count += 1;
+      else rmSync(entry, { force: true });
+    }
+  } catch {
+    return 1;
+  }
+  return Math.max(1, count);
+}
+
+/** liveRuns is a directory walk with a kill(0) per entry; refresh it, don't spin on it. */
+let runsSample = { at: 0, count: 1 };
+function currentRuns() {
+  if (Date.now() - runsSample.at > 5_000) runsSample = { at: Date.now(), count: liveRuns() };
+  return runsSample.count;
+}
+
 function discover(directory, found = []) {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     if (entry.isDirectory()) {
@@ -65,7 +200,14 @@ function discover(directory, found = []) {
 
 function readDurations() {
   try {
-    return JSON.parse(readFileSync(CACHE_FILE, 'utf8'));
+    const raw = JSON.parse(readFileSync(CACHE_FILE, 'utf8'));
+    // The cache used to hold bare millisecond numbers; now each entry also carries the file's
+    // measured peak footprint. Normalize old entries instead of discarding the ordering they hold.
+    const durations = {};
+    for (const [file, value] of Object.entries(raw)) {
+      durations[file] = typeof value === 'number' ? { ms: value } : value;
+    }
+    return durations;
   } catch {
     return {};
   }
@@ -117,9 +259,17 @@ function parseArguments(argv) {
   return { jobs, passthrough };
 }
 
-function runFile(file, passthrough) {
+/** The child's current resident set in bytes, or 0 when it cannot be read. */
+function sampleRss(pid, onSample) {
+  execFile('ps', ['-o', 'rss=', '-p', String(pid)], { encoding: 'utf8' }, (error, stdout) => {
+    if (!error) onSample(Number(stdout.trim()) * 1024 || 0);
+  });
+}
+
+function runFile(file, passthrough, onRss) {
   return new Promise((settle) => {
     const started = Date.now();
+    let peak = 0;
     // `./` matters: a bare relative path is a FILTER that bun matches against the files its
     // own scan finds, and that scan does not reach everything this one does. With the
     // prefix it is a path, and the file runs whether or not bun would have discovered it.
@@ -132,46 +282,161 @@ function runFile(file, passthrough) {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, FORCE_COLOR: process.stdout.isTTY ? '1' : '0' },
     });
+    const sampler = setInterval(() => {
+      sampleRss(child.pid, (rss) => {
+        peak = Math.max(peak, rss);
+        onRss(rss);
+      });
+    }, PEAK_SAMPLE_INTERVAL_MS);
     let output = '';
     child.stdout.on('data', (chunk) => (output += chunk));
     child.stderr.on('data', (chunk) => (output += chunk));
     child.on('error', (error) => {
-      settle({ file, output: `failed to spawn bun: ${error.message}`, code: 1, ms: 0 });
+      clearInterval(sampler);
+      settle({ file, output: `failed to spawn bun: ${error.message}`, code: 1, ms: 0, peak: 0 });
     });
     child.on('close', (code) => {
-      settle({ file, output, code: code ?? 1, ms: Date.now() - started });
+      clearInterval(sampler);
+      const ms = Date.now() - started;
+      // A file that finished before the sampler ever fired cannot have grown large; record the
+      // floor so it is charged as small next time instead of falling back to "unknown" forever.
+      if (peak === 0 && code !== null && ms <= PEAK_SAMPLE_INTERVAL_MS * 2) peak = PEAK_FLOOR_BYTES;
+      settle({ file, output, code: code ?? 1, ms, peak });
     });
   });
 }
 
 async function main() {
   const { jobs, passthrough } = parseArguments(process.argv.slice(2));
-  const files = SEARCH_ROOTS.flatMap((searchRoot) => discover(searchRoot));
-  if (files.length === 0) {
+  const queue = SEARCH_ROOTS.flatMap((searchRoot) => discover(searchRoot));
+  if (queue.length === 0) {
     console.error('no test files found under packages/, scripts/, docs/ or examples/');
     process.exit(1);
   }
+  const total = queue.length;
+  // A filtered run executes slivers of every file: its timings and peaks describe the filter,
+  // not the file, and caching them would both scramble slowest-first ordering and teach the
+  // memory gate that the multi-GiB oracles are tiny. Leave the cache alone entirely.
+  const filteredRun = passthrough.some(
+    (argument) =>
+      argument === '-t' ||
+      argument === '--test-name-pattern' ||
+      argument.startsWith('--test-name-pattern=')
+  );
 
   const durations = readDurations();
   // Slowest first. An unseen file sorts high so a NEW slow file is not discovered last.
-  files.sort(
-    (a, b) => (durations[b] ?? Number.MAX_SAFE_INTEGER) - (durations[a] ?? Number.MAX_SAFE_INTEGER)
+  queue.sort(
+    (a, b) =>
+      (durations[b]?.ms ?? Number.MAX_SAFE_INTEGER) - (durations[a]?.ms ?? Number.MAX_SAFE_INTEGER)
   );
 
-  const workers = Math.max(1, jobs || availableParallelism());
-  console.log(`Running ${files.length} test files across ${workers} workers`);
+  registerRun();
+  const memoryCap = Math.max(1, Math.floor(totalmem() / WORKER_MEMORY_SLICE));
+  const maxWidth = Math.max(1, jobs || Math.min(availableParallelism(), memoryCap));
+  // `--jobs` pins the width; otherwise it splits across live runs, re-read as the run goes so
+  // the FIRST run shrinks when a second one starts. Workers past the current width park.
+  function currentWidth() {
+    return jobs ? maxWidth : Math.max(1, Math.floor(maxWidth / currentRuns()));
+  }
+  // What dispatch may commit: most of what the machine has available now, split between runs.
+  // Floored so a bad probe stalls the pool at "a few GiB", never at zero.
+  function currentAllowance() {
+    return Math.max(WORKER_MEMORY_SLICE, (availableMemory() * 0.75) / currentRuns());
+  }
+
+  const startWidth = currentWidth();
+  const startRuns = currentRuns();
+  console.log(
+    `Running ${total} test files across ${startWidth} workers` +
+      ` (${(currentAllowance() / GiB).toFixed(0)} GiB allowance` +
+      (startRuns > 1
+        ? `, shared with ${startRuns - 1} concurrent run${startRuns > 2 ? 's' : ''})`
+        : ')')
+  );
 
   const totals = { pass: 0, fail: 0, skip: 0, todo: 0 };
   const failures = [];
   const started = Date.now();
-  let next = 0;
   let done = 0;
+  let pausedLogged = false;
 
-  async function worker() {
-    while (next < files.length) {
-      const file = files[next++];
-      const result = await runFile(file, passthrough);
-      durations[file] = result.ms;
+  /** file → { expected, rss, unknown } for everything dispatched and not yet finished. */
+  const inFlight = new Map();
+
+  function expectedFor(file) {
+    const peak = durations[file]?.peak;
+    if (peak >= PEAK_FLOOR_BYTES) return { bytes: peak, unknown: false };
+    if (peak > 0) return { bytes: PEAK_FLOOR_BYTES, unknown: false };
+    return { bytes: UNKNOWN_PEAK_BYTES, unknown: true };
+  }
+
+  /** Commitment not yet materialized: what dispatched files are still expected to grow by. */
+  function pendingBytes() {
+    let sum = 0;
+    for (const entry of inFlight.values()) sum += Math.max(0, entry.expected - entry.rss);
+    return sum;
+  }
+
+  function unknownInFlight() {
+    let count = 0;
+    for (const entry of inFlight.values()) if (entry.unknown) count += 1;
+    return count;
+  }
+
+  function take(index) {
+    const [file] = queue.splice(index, 1);
+    const { bytes, unknown } = expectedFor(file);
+    const entry = { expected: bytes, rss: 0, unknown };
+    inFlight.set(file, entry);
+    return { file, entry };
+  }
+
+  /**
+   * Pick the next file the machine has room for, or null to wait. The head is preferred and its
+   * share stays reserved when skipping past it, so cheap files flow around a heavy head without
+   * starving it. Taking the head whenever nothing is in flight guarantees forward progress.
+   */
+  function pickNext() {
+    if (queue.length === 0) return null;
+    if (inFlight.size === 0) return take(0);
+    if (underMemoryPressure()) {
+      if (!pausedLogged) {
+        pausedLogged = true;
+        console.warn('\nlow system memory: pausing dispatch until it recovers');
+      }
+      return null;
+    }
+    // Re-arm the warning once pressure clears so a later episode is reported too.
+    pausedLogged = false;
+    const allowance = currentAllowance();
+    const pending = pendingBytes();
+    const unknownSlots =
+      unknownInFlight() < Math.max(4, Math.floor(allowance / HEAVY_UNKNOWN_BYTES));
+    const head = expectedFor(queue[0]);
+    if (pending + head.bytes <= allowance && (!head.unknown || unknownSlots)) return take(0);
+    for (let index = 1; index < queue.length; index += 1) {
+      const candidate = expectedFor(queue[index]);
+      if (candidate.unknown && !unknownSlots) continue;
+      if (pending + head.bytes + candidate.bytes <= allowance) return take(index);
+    }
+    return null;
+  }
+
+  async function worker(index) {
+    while (queue.length > 0) {
+      if (index >= currentWidth()) {
+        await sleep(PEAK_SAMPLE_INTERVAL_MS * 2);
+        continue;
+      }
+      const picked = pickNext();
+      if (!picked) {
+        await sleep(PEAK_SAMPLE_INTERVAL_MS);
+        continue;
+      }
+      const { file, entry } = picked;
+      const result = await runFile(file, passthrough, (rss) => (entry.rss = rss));
+      inFlight.delete(file);
       done += 1;
 
       const counts = tally(result.output);
@@ -183,6 +448,7 @@ async function main() {
       // A crash before the first test prints no tally at all, so the exit code is the authority
       // on whether a file passed — not the absence of a `fail` line.
       const emptyFilter = result.code !== 0 && counts.fail === 0 && NO_MATCHES.test(result.output);
+      if (!filteredRun && !emptyFilter) durations[file] = { ms: result.ms, peak: result.peak };
       if (emptyFilter) {
         // nothing to run here, and nothing to report
       } else if (result.code !== 0 || counts.fail > 0) {
@@ -191,14 +457,14 @@ async function main() {
       } else if (process.stdout.isTTY) {
         // One redrawn line, padded to a fixed width so a shorter path cannot leave the tail of a
         // longer one behind it. Non-TTY output (CI) stays quiet apart from failures.
-        process.stdout.write(`\r${`${done}/${files.length} ${file.slice(-72)}`.padEnd(96)}`);
+        process.stdout.write(`\r${`${done}/${total} ${file.slice(-72)}`.padEnd(96)}`);
       }
     }
   }
 
-  await Promise.all(Array.from({ length: Math.min(workers, files.length) }, worker));
+  await Promise.all(Array.from({ length: Math.min(maxWidth, total) }, (_, index) => worker(index)));
   if (process.stdout.isTTY) process.stdout.write(`\r${''.padEnd(96)}\r`);
-  writeDurations(durations);
+  if (!filteredRun) writeDurations(durations);
 
   for (const failure of failures) {
     console.log(`\n${'─'.repeat(72)}\n${failure.file}\n${'─'.repeat(72)}`);
@@ -208,7 +474,7 @@ async function main() {
   const elapsed = ((Date.now() - started) / 1000).toFixed(2);
   console.log(
     `\n${totals.pass} pass  ${totals.fail} fail  ${totals.skip} skip  ${totals.todo} todo` +
-      `\nRan ${files.length} files across ${workers} workers in ${elapsed}s`
+      `\nRan ${total} files across ${startWidth} workers in ${elapsed}s`
   );
   process.exit(failures.length > 0 ? 1 : 0);
 }


### PR DESCRIPTION
The shard pool in `scripts/test/run-parallel.mjs` sized itself to cores alone. Slowest-first ordering starts the heaviest files together, and fourteen multi-GiB `bun test` processes once exhausted a 48 GiB machine badly enough that the display server watchdog killed the login session.

The runner now bounds itself to the machine:

- Width is capped by installed memory as well as cores, and split between concurrent runs on the same machine through a tmpdir registry that is re-read during the run, expires stale entries, and survives Ctrl+C.
- Dispatch charges each file's measured peak footprint (sampled from RSS, stored in the duration cache) against the memory currently available, reserves the head file's share so cheap files flow past a heavy head without starving it, and limits how many unmeasured files run at once.
- Dispatch pauses under real memory pressure and always lets one file run, so it can stall but never deadlock.
- Filtered runs (`-t`) no longer overwrite the cache with meaningless timings and peaks.

`--jobs N` still pins the width and never lifts the dispatch gate. Full suite passes through the reworked runner (816 files, 10589 pass, 134s at full width). No changeset: test tooling only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790587486&installation_model_id=422592&pr_number=605&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F605&signature=2a63fc454926690c8300cde87ce4dc04c0de0ad907fd7f85c4eb3126f9b1abaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->